### PR TITLE
[wip]: speed up tests in lib/auth

### DIFF
--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -54,11 +54,6 @@ const (
 	completeRecoveryGenericErrMsg = "unable to recover your account, please contact your system administrator"
 )
 
-// fakeRecoveryCodeHash is bcrypt hash for "fake-barbaz x 8".
-// This is a fake hash used to mitigate timing attacks against invalid usernames or if user does
-// exist but does not have recovery codes.
-var fakeRecoveryCodeHash = []byte(`$2a$10$c2.h4pF9AA25lbrWo6U0D.ZmnYpFDaNzN3weNNYNC3jAkYEX9kpzu`)
-
 // StartAccountRecovery implements AuthService.StartAccountRecovery.
 func (a *Server) StartAccountRecovery(ctx context.Context, req *proto.StartAccountRecoveryRequest) (types.UserToken, error) {
 	if err := a.isAccountRecoveryAllowed(ctx); err != nil {
@@ -164,7 +159,7 @@ func (a *Server) verifyRecoveryCode(ctx context.Context, username string, recove
 			"user", username,
 		)
 		for i := range numOfRecoveryCodes {
-			hashedCodes[i].HashedCode = fakeRecoveryCodeHash
+			hashedCodes[i].HashedCode = a.fakeRecoveryCodeHash
 		}
 	} else {
 		hasRecoveryCodes = true
@@ -527,13 +522,18 @@ func generateRecoveryCodes() ([]string, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		words := make([]string, 0, 1+len(wordIDs))
-		words = append(words, "tele")
-		for _, id := range wordIDs {
-			words = append(words, encodeProquint(id))
+		var sb strings.Builder
+		const prefix = "tele-"
+		sb.Grow(len(prefix) + len(wordIDs)*6)
+		sb.WriteString("tele-")
+		for i, id := range wordIDs {
+			sb.Write(encodeProquint(id))
+			if i < len(wordIDs)-1 {
+				sb.WriteRune('-')
+			}
 		}
 
-		tokenList = append(tokenList, strings.Join(words, "-"))
+		tokenList = append(tokenList, sb.String())
 	}
 
 	return tokenList, nil
@@ -543,7 +543,7 @@ func generateRecoveryCodes() ([]string, error) {
 // This proquint implementation is adapted from upspin.io:
 // https://github.com/upspin/upspin/blob/master/key/proquint/proquint.go
 // For the algorithm, see https://arxiv.org/html/0901.4016
-func encodeProquint(x uint16) string {
+func encodeProquint(x uint16) []byte {
 	const consonants = "bdfghjklmnprstvz"
 	const vowels = "aiou"
 
@@ -553,11 +553,11 @@ func encodeProquint(x uint16) string {
 	vow1 := (x >> 10) & 0b11
 	cons1 := x >> 12
 
-	return string([]byte{
+	return []byte{
 		consonants[cons1],
 		vowels[vow1],
 		consonants[cons2],
 		vowels[vow2],
 		consonants[cons3],
-	})
+	}
 }

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -57,17 +57,22 @@ import (
 //   - reusing a used or non-existing token returns error
 func TestGenerateAndUpsertRecoveryCodes(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
 	user := "fake@fake.com"
-	rc, err := srv.Auth().GenerateAndUpsertRecoveryCodes(ctx, user)
+	rc, err := as.AuthServer.GenerateAndUpsertRecoveryCodes(ctx, user)
 	require.NoError(t, err)
 	require.Len(t, rc.Codes, auth.NumOfRecoveryCodes)
 	require.NotEmpty(t, rc.Created)
 
 	// Test codes are not marked used.
-	recovery, err := srv.Auth().GetRecoveryCodes(ctx, user, true /* withSecrets */)
+	recovery, err := as.AuthServer.GetRecoveryCodes(ctx, user, true /* withSecrets */)
 	require.NoError(t, err)
 	for _, token := range recovery.GetCodes() {
 		require.False(t, token.IsUsed)
@@ -82,27 +87,27 @@ func TestGenerateAndUpsertRecoveryCodes(t *testing.T) {
 		require.True(t, strings.HasPrefix(code, "tele-"))
 
 		// Test codes match.
-		err := srv.Auth().VerifyRecoveryCode(ctx, user, []byte(code))
+		err := as.AuthServer.VerifyRecoveryCode(ctx, user, []byte(code))
 		require.NoError(t, err)
 	}
 
 	// Test used codes are marked used.
-	recovery, err = srv.Auth().GetRecoveryCodes(ctx, user, true /* withSecrets */)
+	recovery, err = as.AuthServer.GetRecoveryCodes(ctx, user, true /* withSecrets */)
 	require.NoError(t, err)
 	for _, token := range recovery.GetCodes() {
 		require.True(t, token.IsUsed)
 	}
 
 	// Test with a used code returns error.
-	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
+	err = as.AuthServer.VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Test with invalid recovery code returns error.
-	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte("invalidcode"))
+	err = as.AuthServer.VerifyRecoveryCode(ctx, user, []byte("invalidcode"))
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Test with non-existing user returns error.
-	err = srv.Auth().VerifyRecoveryCode(ctx, "doesnotexist", []byte(rc.Codes[0]))
+	err = as.AuthServer.VerifyRecoveryCode(ctx, "doesnotexist", []byte(rc.Codes[0]))
 	require.True(t, trace.IsAccessDenied(err))
 }
 

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -113,29 +113,31 @@ func TestGenerateAndUpsertRecoveryCodes(t *testing.T) {
 
 func TestRecoveryCodeEventsEmitted(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	ctx := context.Background()
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().SetEmitter(mockEmitter)
+	as.AuthServer.SetEmitter(mockEmitter)
 
 	user := "fake@fake.com"
 
 	// Test generated recovery codes event.
-	rc, err := srv.Auth().GenerateAndUpsertRecoveryCodes(ctx, user)
+	rc, err := as.AuthServer.GenerateAndUpsertRecoveryCodes(ctx, user)
 	require.NoError(t, err)
 	event := mockEmitter.LastEvent()
 	require.Equal(t, events.RecoveryCodeGeneratedEvent, event.GetType())
 	require.Equal(t, events.RecoveryCodesGenerateCode, event.GetCode())
 
 	// Test used recovery code event.
-	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
+	err = as.AuthServer.VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
 	require.NoError(t, err)
 	event = mockEmitter.LastEvent()
 	require.Equal(t, events.RecoveryCodeUsedEvent, event.GetType())
 	require.Equal(t, events.RecoveryCodeUseSuccessCode, event.GetCode())
 
 	// Re-using the same token emits failed event.
-	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
+	err = as.AuthServer.VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
 	require.Error(t, err)
 	event = mockEmitter.LastEvent()
 	require.Equal(t, events.RecoveryCodeUsedEvent, event.GetType())
@@ -1024,7 +1026,9 @@ func TestAccountRecoveryFlow(t *testing.T) {
 
 func TestGetAccountRecoveryToken(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	ctx := context.Background()
 
 	cases := []struct {
@@ -1037,14 +1041,14 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 			name:    "invalid token type",
 			wantErr: true,
 			getRequest: func() *proto.GetAccountRecoveryTokenRequest {
-				wrongTokenType, err := srv.Auth().NewUserToken(ctx, authclient.CreateUserTokenRequest{
+				wrongTokenType, err := as.AuthServer.NewUserToken(ctx, authclient.CreateUserTokenRequest{
 					Name: "llama",
 					TTL:  5 * time.Minute,
 					Type: authclient.UserTokenTypeResetPassword,
 				})
 				require.NoError(t, err)
 
-				_, err = srv.Auth().CreateUserToken(ctx, wrongTokenType)
+				_, err = as.AuthServer.CreateUserToken(ctx, wrongTokenType)
 				require.NoError(t, err)
 
 				return &proto.GetAccountRecoveryTokenRequest{
@@ -1065,7 +1069,7 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 			name:      "recovery start token",
 			tokenType: authclient.UserTokenTypeRecoveryStart,
 			getRequest: func() *proto.GetAccountRecoveryTokenRequest {
-				token, err := srv.Auth().CreateRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := as.AuthServer.CreateRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.GetAccountRecoveryTokenRequest{
@@ -1077,7 +1081,7 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 			name:      "recovery approve token",
 			tokenType: authclient.UserTokenTypeRecoveryApproved,
 			getRequest: func() *proto.GetAccountRecoveryTokenRequest {
-				token, err := srv.Auth().CreateRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := as.AuthServer.CreateRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.GetAccountRecoveryTokenRequest{
@@ -1091,7 +1095,7 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			retToken, err := srv.Auth().GetAccountRecoveryToken(ctx, c.getRequest())
+			retToken, err := as.AuthServer.GetAccountRecoveryToken(ctx, c.getRequest())
 
 			switch {
 			case c.wantErr:
@@ -1105,7 +1109,15 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 }
 
 func TestCreateAccountRecoveryCodes(t *testing.T) {
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+		AuthPreferenceSpec: &types.AuthPreferenceSpecV2{
+			Type:         constants.Local,
+			SecondFactors: []types.SecondFactorType{types.SecondFactorType_SECOND_FACTOR_TYPE_OTP},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	ctx := context.Background()
 
 	modulestest.SetTestModules(t, modulestest.Modules{
@@ -1114,18 +1126,8 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 		},
 	})
 
-	// Enable second factors.
-	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
-		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorOTP,
-	})
-	require.NoError(t, err)
-
-	_, err = srv.Auth().UpsertAuthPreference(ctx, ap)
-	require.NoError(t, err)
-
 	const user = "llama@example.com"
-	_, _, err = authtest.CreateUserAndRole(srv.Auth(), user, []string{user}, nil /* allowRules */)
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, user, []string{user}, nil /* allowRules */)
 	require.NoError(t, err, "CreateUserAndRole failed")
 
 	cases := []struct {
@@ -1137,7 +1139,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 			name:    "invalid token type",
 			wantErr: true,
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().CreateRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := as.AuthServer.CreateRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1158,7 +1160,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 			name:    "invalid user name",
 			wantErr: true,
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().CreateRecoveryToken(ctx, "invalid-username", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := as.AuthServer.CreateRecoveryToken(ctx, "invalid-username", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1169,7 +1171,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 		{
 			name: "recovery approved token",
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().CreateRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := as.AuthServer.CreateRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1180,7 +1182,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 		{
 			name: "privilege token",
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := auth.CreatePrivilegeToken(ctx, srv.Auth(), user, authclient.UserTokenTypePrivilege)
+				token, err := auth.CreatePrivilegeToken(ctx, as.AuthServer, user, authclient.UserTokenTypePrivilege)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1193,7 +1195,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			req := c.getRequest()
-			res, err := srv.Auth().CreateAccountRecoveryCodes(ctx, req)
+			res, err := as.AuthServer.CreateAccountRecoveryCodes(ctx, req)
 
 			switch {
 			case c.wantErr:
@@ -1205,7 +1207,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 				require.NotEmpty(t, res.GetCreated())
 
 				// Check token is deleted after success.
-				_, err = srv.Auth().GetUserToken(ctx, req.TokenID)
+				_, err = as.AuthServer.GetUserToken(ctx, req.TokenID)
 				require.True(t, trace.IsNotFound(err))
 			}
 		})

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -716,6 +716,11 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		WorkloadClusterService:          cfg.WorkloadClusterService,
 	}
 
+	if cfg.FakePasswordHash == nil {
+		// This is a bcrypt hash for password "barbaz" with the default bcrypt cost.
+		cfg.FakePasswordHash = []byte(`$2a$10$Yy.e6BmS2SrGbBDsyDLVkOANZmvjjMR890nUGSXFJHBXWzxe7T44m`)
+	}
+
 	as = &Server{
 		bk:                           cfg.Backend,
 		clock:                        cfg.Clock,
@@ -1221,6 +1226,8 @@ type Server struct {
 
 	closeCtx   context.Context
 	cancelFunc context.CancelFunc
+
+	fakePasswordHash []byte
 
 	samlAuthService SAMLService
 	oidcAuthService OIDCService

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -721,9 +721,17 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		cfg.FakePasswordHash = []byte(`$2a$10$Yy.e6BmS2SrGbBDsyDLVkOANZmvjjMR890nUGSXFJHBXWzxe7T44m`)
 	}
 
+	if cfg.FakeRecoveryCodeHash == nil {
+		// This is a bcrypt hash for "fake-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz" with the default bcrypt cost.
+		cfg.FakeRecoveryCodeHash = []byte(`$2a$10$c2.h4pF9AA25lbrWo6U0D.ZmnYpFDaNzN3weNNYNC3jAkYEX9kpzu`)
+
+	}
+
 	as = &Server{
 		bk:                           cfg.Backend,
 		clock:                        cfg.Clock,
+		fakePasswordHash:             cfg.FakePasswordHash,
+		fakeRecoveryCodeHash:         cfg.FakeRecoveryCodeHash,
 		limiter:                      limiter,
 		Authority:                    cfg.Authority,
 		AuthServiceName:              cfg.AuthServiceName,
@@ -1227,7 +1235,8 @@ type Server struct {
 	closeCtx   context.Context
 	cancelFunc context.CancelFunc
 
-	fakePasswordHash []byte
+	fakePasswordHash     []byte
+	fakeRecoveryCodeHash []byte
 
 	samlAuthService SAMLService
 	oidcAuthService OIDCService

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -900,12 +900,14 @@ func TestServer_AuthenticateUser_passwordOnly(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	const username = "bowman"
 	const password = "it's full of stars!"
-	_, _, err := authtest.CreateUserAndRole(authServer, username, nil, nil)
+	_, _, err = authtest.CreateUserAndRole(authServer, username, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, authServer.UpsertPassword(username, []byte(password)))
 
@@ -1121,8 +1123,10 @@ func TestServer_AuthenticateUser_passwordOnly_failure(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	const username = "capybara"
 
@@ -1198,12 +1202,14 @@ func TestServer_AuthenticateUser_setsPasswordState(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	const username = "bowman"
 	const password = "it's full of stars!"
-	_, _, err := authtest.CreateUserAndRole(authServer, username, nil, nil)
+	_, _, err = authtest.CreateUserAndRole(authServer, username, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, authServer.UpsertPassword(username, []byte(password)))
 

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1372,7 +1372,7 @@ func TestTrustedClusterCRUDEventEmitted(t *testing.T) {
 }
 
 func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
-	t.Parallel()
+	modulestest.SetTestModules(t, *modulestest.EnterpriseModules())
 	s := newAuthSuite(t)
 
 	clientAddr := &net.TCPAddr{IP: net.IPv4(10, 255, 0, 0)}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1588,8 +1588,14 @@ func TestEmitSSOLoginFailureEvent(t *testing.T) {
 func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	t.Parallel()
 
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	clock := clockwork.NewFakeClock()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 	emitter := &eventstest.MockRecorderEmitter{}
 	authServer.SetEmitter(emitter)
 	ctx := context.Background()
@@ -1603,7 +1609,7 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	principals := []string{"login0", username, "-teleport-internal-join"}
 
 	// Prepare the user to test with.
-	_, _, err := authtest.CreateUserAndRole(authServer, username, principals, nil)
+	_, _, err = authtest.CreateUserAndRole(authServer, username, principals, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	require.NoError(t,
 		authServer.UpsertPassword(username, []byte(pass)),
@@ -1626,12 +1632,6 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	const devID = "deviceid1"
 	const devTag = "devicetag1"
 	const devCred = "devicecred1"
-
-	advanceClock := func(d time.Duration) {
-		if fc, ok := testServer.Clock().(*clockwork.FakeClock); ok {
-			fc.Advance(d)
-		}
-	}
 
 	tests := []struct {
 		name           string
@@ -1691,14 +1691,14 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 				Username: username,
 				Identity: *identity,
 			})
-			authCtx, err := testServer.APIConfig.Authorizer.Authorize(ctx)
+			authCtx, err := as.Authorizer.Authorize(ctx)
 			require.NoError(t, err, "Authorize failed")
 
 			// Advance time before issuing new certs. This makes timestamp checks
 			// effective under fake clocks.
 			// 1m is enough to make tests fail if the timestamps aren't correct.
-			advanceClock(1 * time.Minute)
-			validAfter := testServer.Clock().Now().UTC().Add(-61 * time.Second)
+			clock.Advance(1 * time.Minute)
+			validAfter := clock.Now().UTC().Add(-61 * time.Second)
 
 			// Test!
 			certs, err := authServer.AugmentContextUserCertificates(ctx, authCtx, test.opts)
@@ -1751,8 +1751,10 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	t.Parallel()
 
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 	ctx := context.Background()
 
 	const pass1 = "secret!!1!!!"
@@ -1830,7 +1832,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	// Build an invalid version of xCert1 (signed using wrongKey).
 	userCA, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.UserCA,
-		DomainName: testServer.ClusterName(),
+		DomainName: as.ClusterName,
 	}, true /* loadKeys */)
 	require.NoError(t, err, "GetCertAuthority failed")
 	caXPEM := userCA.GetActiveKeys().TLS[0].Cert
@@ -1852,7 +1854,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 
 	// Issue augmented certs for user1.
 	// Used to test that re-issue of augmented certs is not allowed.
-	ctxFromAuthorize := testServer.APIConfig.Authorizer.Authorize
+	ctxFromAuthorize := as.Authorizer.Authorize
 	aCtx := authz.ContextWithUserCertificate(context.Background(), xCert1)
 	aCtx = authz.ContextWithUser(aCtx, authz.LocalUser{
 		Username: identity1.Username,
@@ -2064,7 +2066,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			identity: identity1,
 			createOpts: func(t *testing.T) *auth.AugmentUserCertificateOpts {
 				// Fake a 1h TTL, expired cert.
-				now := testServer.Clock().Now()
+				now := as.Clock().Now()
 				after := now.Add(-1 * time.Hour)
 				before := now.Add(-1 * time.Minute)
 
@@ -2204,11 +2206,13 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 	t.Parallel()
 
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 	ctx := context.Background()
 
-	userData := setupUserForAugmentWebSessionCertificatesTest(t, testServer)
+	userData := setupUserForAugmentWebSessionCertificatesTest(t, authServer)
 
 	// Safe to reuse, user-independent.
 	deviceExts := &auth.DeviceExtensions{
@@ -2265,7 +2269,7 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 		})
 	})
 
-	user2Data := setupUserForAugmentWebSessionCertificatesTest(t, testServer)
+	user2Data := setupUserForAugmentWebSessionCertificatesTest(t, authServer)
 	user2Opts := &auth.AugmentWebSessionCertificatesOpts{
 		WebSessionID:     user2Data.webSessionID,
 		User:             user2Data.user,
@@ -2333,11 +2337,13 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 func TestServer_ExtendWebSession_deviceExtensions(t *testing.T) {
 	t.Parallel()
 
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 	ctx := context.Background()
 
-	userData := setupUserForAugmentWebSessionCertificatesTest(t, testServer)
+	userData := setupUserForAugmentWebSessionCertificatesTest(t, authServer)
 
 	deviceExts := &auth.DeviceExtensions{
 		DeviceID:     "my-device-id",
@@ -2346,7 +2352,7 @@ func TestServer_ExtendWebSession_deviceExtensions(t *testing.T) {
 	}
 
 	// Augment the user's session, then later extend it.
-	err := authServer.AugmentWebSessionCertificates(ctx, &auth.AugmentWebSessionCertificatesOpts{
+	err = authServer.AugmentWebSessionCertificates(ctx, &auth.AugmentWebSessionCertificatesOpts{
 		WebSessionID:     userData.webSessionID,
 		User:             userData.user,
 		DeviceExtensions: deviceExts,
@@ -2404,8 +2410,7 @@ type augmentUserData struct {
 	webSessionID string
 }
 
-func setupUserForAugmentWebSessionCertificatesTest(t *testing.T, testServer *authtest.TLSServer) *augmentUserData {
-	authServer := testServer.Auth()
+func setupUserForAugmentWebSessionCertificatesTest(t *testing.T, authServer *auth.Server) *augmentUserData {
 	ctx := context.Background()
 
 	user := &augmentUserData{
@@ -4848,8 +4853,10 @@ func TestCreateAccessListReminderNotifications_LargeOverdueSet(t *testing.T) {
 	modulestest.SetTestModules(t, *modulestest.EnterpriseModules())
 
 	// Setup test auth server
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir(), CacheEnabled: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	testRole, err := types.NewRole("test", types.RoleSpecV6{
 		Allow: types.RoleConditions{
@@ -4882,7 +4889,7 @@ func TestCreateAccessListReminderNotifications_LargeOverdueSet(t *testing.T) {
 	}
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		lists, err := testServer.Auth().Cache.GetAccessLists(ctx)
+		lists, err := authServer.Cache.GetAccessLists(ctx)
 		assert.NoError(t, err)
 		assert.Len(t, lists, numAccessLists, "should have created all %d overdue access lists", numAccessLists)
 	}, 5*time.Minute, 500*time.Millisecond)

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1549,6 +1549,7 @@ func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
 }
 
 func TestEmitSSOLoginFailureEvent(t *testing.T) {
+	t.Parallel()
 	mockE := &eventstest.MockRecorderEmitter{}
 
 	auth.EmitSSOLoginFailureEvent(context.Background(), mockE, "test", trace.BadParameter("some error"), false)
@@ -3067,6 +3068,7 @@ func TestGenerateUserCertWithHardwareKeySupport(t *testing.T) {
 }
 
 func TestGenerateKubernetesUserCert(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	p := newAuthSuite(t)
 
@@ -4052,6 +4054,7 @@ func (f *fakeAuthPreferenceGetter) GetAuthPreference(context.Context) (types.Aut
 }
 
 func TestCAGeneration(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	const (
 		clusterName = "cluster1"
@@ -4090,6 +4093,7 @@ func TestCAGeneration(t *testing.T) {
 }
 
 func TestGetLicense(t *testing.T) {
+	t.Parallel()
 	s := newAuthSuite(t)
 
 	// GetLicense should return error if license is not set
@@ -4543,6 +4547,7 @@ func TestAccessRequestDryRunEnrichment(t *testing.T) {
 }
 
 func TestCleanupNotifications(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/lib/auth/auth_with_roles_okta_rbac_test.go
+++ b/lib/auth/auth_with_roles_okta_rbac_test.go
@@ -71,6 +71,7 @@ func newTestServerWithRoles(t *testing.T, srv *authtest.AuthServer, role types.S
 }
 
 func TestOktaMayNotResetPasswords(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Given an auth server...
@@ -134,6 +135,7 @@ func newTestLock(t *testing.T, target types.User, origin string) types.Lock {
 }
 
 func TestOktaServiceLockCRUD(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Given an auth server...

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -464,6 +464,7 @@ func TestInstaller(t *testing.T) {
 }
 
 func TestGithubAuthRequest(t *testing.T) {
+	modulestest.SetTestModules(t, *modulestest.EnterpriseModules())
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -533,7 +534,7 @@ func TestGithubAuthRequest(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	upserted, err := auth.UpsertGithubConnector(context.Background(), srv.Auth(), conn)
+	upserted, err := auth.UpsertGithubConnector(ctx, srv.Auth(), conn)
 	require.NoError(t, err)
 	require.NotNil(t, upserted)
 
@@ -648,6 +649,7 @@ func TestGithubAuthRequest(t *testing.T) {
 // github/requests/validate which must have the same format as the requested
 // keys to support both old and new proxies.
 func TestGithubAuthCompat(t *testing.T) {
+	modulestest.SetTestModules(t, *modulestest.EnterpriseModules())
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -663,7 +665,7 @@ func TestGithubAuthCompat(t *testing.T) {
 		}},
 	})
 	require.NoError(t, err)
-	_, err = auth.UpsertGithubConnector(context.Background(), srv.Auth(), connector)
+	_, err = auth.UpsertGithubConnector(ctx, srv.Auth(), connector)
 	require.NoError(t, err)
 
 	srv.Auth().GithubUserAndTeamsOverride = func() (*auth.GithubUserResponse, []auth.GithubTeamResponse, error) {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7341,13 +7341,15 @@ func newScopedTestServerForHost(t *testing.T, srv *authtest.AuthServer, hostID, 
 func TestGenerateHostCertsScoped(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	scope := "/aa/bb"
 	hostID := "testhost"
 	roles := types.SystemRoles{types.RoleNode}
 
-	s := newScopedTestServerForHost(t, srv.AuthServer, hostID, scope, types.RoleNode)
+	s := newScopedTestServerForHost(t, as, hostID, scope, types.RoleNode)
 
 	_, sshPub, err := testauthority.GenerateKeyPair()
 	require.NoError(t, err)
@@ -10326,8 +10328,11 @@ func collectWatchKind(kinds []types.WatchKind) []string {
 
 func TestKubeKeepAliveServer(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
-	domainName, err := srv.Auth().GetDomainName()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
+	domainName, err := authServer.GetDomainName()
 	require.NoError(t, err)
 
 	tests := map[string]struct {
@@ -10379,7 +10384,7 @@ func TestKubeKeepAliveServer(t *testing.T) {
 			)
 			require.NoError(t, err)
 			// Upsert the kubernetes server into the backend.
-			_, err = srv.Auth().UpsertKubernetesServer(context.Background(), kubeServer)
+			_, err = authServer.UpsertKubernetesServer(context.Background(), kubeServer)
 			require.NoError(t, err)
 
 			// Create a built-in role.
@@ -10394,7 +10399,7 @@ func TestKubeKeepAliveServer(t *testing.T) {
 
 			// Create a server with the built-in role.
 			srv := auth.NewServerWithRoles(
-				srv.Auth(),
+				authServer,
 				events.NewDiscardAuditLog(),
 				*authContext,
 			)
@@ -10627,9 +10632,11 @@ func TestCloudDefaultPasswordless(t *testing.T) {
 func TestRoleRequestReasonModeValidation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
-	s := newTestServerWithRoles(t, srv.AuthServer, types.RoleAdmin)
+	s := newTestServerWithRoles(t, as, types.RoleAdmin)
 
 	testCases := []struct {
 		desc          string
@@ -11076,9 +11083,11 @@ func createTestMCPAppServer(t *testing.T, auth *auth.Server, name string, labels
 func TestSAMLIdPRoleOptionCreateUpdateValidation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
-	s := newTestServerWithRoles(t, srv.AuthServer, types.RoleAdmin)
+	s := newTestServerWithRoles(t, as, types.RoleAdmin)
 
 	const errMsg = "supported in role version 7 and below"
 	testCases := []struct {
@@ -11318,7 +11327,9 @@ func TestRegisterInventoryControlStreamScopes(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	const serverID = "test-server"
 	const agentScope = "/test/one"
@@ -11350,7 +11361,7 @@ func TestRegisterInventoryControlStreamScopes(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			h := newInventoryControlStreamHarness(t, srv.AuthServer, serverID, agentScope, "", types.RoleNode)
+			h := newInventoryControlStreamHarness(t, as, serverID, agentScope, "", types.RoleNode)
 			type registerResult struct {
 				hello *proto.UpstreamInventoryHello
 				err   error
@@ -11398,8 +11409,9 @@ func TestRegisterInventoryControlStreamImmutableLabels(t *testing.T) {
 	}
 	helloHash := joining.HashImmutableLabels(helloLabels)
 
-	srv := newTestTLSServer(t)
-	t.Cleanup(func() { srv.Close() })
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	cases := []struct {
 		name        string
@@ -11440,7 +11452,7 @@ func TestRegisterInventoryControlStreamImmutableLabels(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			h := newInventoryControlStreamHarness(t, srv.AuthServer, serverID, "", c.identHash, types.RoleNode)
+			h := newInventoryControlStreamHarness(t, as, serverID, "", c.identHash, types.RoleNode)
 			type registerResult struct {
 				hello *proto.UpstreamInventoryHello
 				err   error

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -346,6 +346,7 @@ func TestLocalUserCanReissueCerts(t *testing.T) {
 // TestSSOUserCanReissueCert makes sure that SSO user can reissue certificate
 // for themselves.
 func TestSSOUserCanReissueCert(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -372,6 +373,7 @@ func TestSSOUserCanReissueCert(t *testing.T) {
 }
 
 func TestInstaller(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -772,6 +774,7 @@ func TestGithubAuthCompat(t *testing.T) {
 }
 
 func TestAWSRolesAnywhereCredentialGenerationForApps(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	srv := newTestTLSServer(t)
 
@@ -875,6 +878,7 @@ func TestAWSRolesAnywhereCredentialGenerationForApps(t *testing.T) {
 }
 
 func TestAppAccessUsingAWSOIDC_doesntGenerateClientCredentials(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	srv := newTestTLSServer(t)
 
@@ -966,6 +970,7 @@ func TestAppAccessUsingAWSOIDC_doesntGenerateClientCredentials(t *testing.T) {
 }
 
 func TestSSODiagnosticInfo(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -1323,6 +1328,7 @@ func TestGenerateUserCertsWithMFAVerification(t *testing.T) {
 }
 
 func TestGenerateUserCertsWithRoleRequest(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -1581,6 +1587,7 @@ func TestGenerateUserCertsWithRoleRequest(t *testing.T) {
 // impersonated client can reissue certificates but that role impersonation
 // cannot be escaped.
 func TestRolesRequestsExplicitAllowReissue(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -1730,6 +1737,7 @@ func TestRolesRequestsExplicitAllowReissue(t *testing.T) {
 // re-escalate privileges using a (perhaps compromised) set of role
 // impersonated certs.
 func TestRoleRequestDenyReimpersonation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -3792,6 +3800,7 @@ func TestReplaceRemoteLocksRBAC(t *testing.T) {
 // TestIsMFARequired_databaseProtocols tests the MFA requirement logic per
 // database protocol where different role matchers are used.
 func TestIsMFARequired_databaseProtocols(t *testing.T) {
+	t.Parallel()
 	const (
 		databaseName = "test-database"
 		userName     = "test-username"
@@ -5035,6 +5044,7 @@ func createUserGroup(t *testing.T, s *auth.Server, name string, labels map[strin
 }
 
 func TestDeleteUserAppSessions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	srv := newTestTLSServer(t)
@@ -6552,6 +6562,7 @@ func withAccountAssignment(condition types.RoleConditionType, accountID, permiss
 }
 
 func TestUnifiedResources_IdentityCenter(t *testing.T) {
+	t.Parallel()
 	const (
 		validAccountID        = "11111111"
 		validPermissionSetARN = "some:ps:arn"
@@ -7328,6 +7339,7 @@ func newScopedTestServerForHost(t *testing.T, srv *authtest.AuthServer, hostID, 
 }
 
 func TestGenerateHostCertsScoped(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -7374,6 +7386,7 @@ func TestGenerateHostCertsScoped(t *testing.T) {
 // This is because only one uploader service runs per Teleport process, and it will use
 // the first available identity.
 func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
+	t.Parallel()
 	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err, trace.DebugReport(err))
 	t.Cleanup(func() { require.NoError(t, srv.Close()) })
@@ -7815,6 +7828,7 @@ func TestGetActiveSessionTrackers(t *testing.T) {
 }
 
 func TestListReleasesPermissions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -7870,6 +7884,7 @@ func TestListReleasesPermissions(t *testing.T) {
 }
 
 func TestGetLicensePermissions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -7927,6 +7942,7 @@ func TestGetLicensePermissions(t *testing.T) {
 const errSAMLAppLabelsDenied = "access to saml_idp_service_provider denied"
 
 func TestCreateSAMLIdPServiceProvider(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -8079,6 +8095,7 @@ func TestCreateSAMLIdPServiceProvider(t *testing.T) {
 }
 
 func TestUpdateSAMLIdPServiceProvider(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -8252,6 +8269,7 @@ func TestUpdateSAMLIdPServiceProvider(t *testing.T) {
 }
 
 func TestCreateSAMLIdPServiceProviderInvalidInputs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 	user := createSAMLIdPTestUser(t, srv.Auth(), types.RoleSpecV6{Allow: samlIdPRoleCondition(types.Labels{"*": []string{"*"}}, types.VerbCreate)})
@@ -8356,6 +8374,7 @@ func TestCreateSAMLIdPServiceProviderInvalidInputs(t *testing.T) {
 }
 
 func TestUpdateSAMLIdPServiceProviderInvalidInputs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 	user := createSAMLIdPTestUser(t, srv.Auth(), types.RoleSpecV6{Allow: samlIdPRoleCondition(types.Labels{"*": []string{"*"}}, types.VerbCreate, types.VerbUpdate)})
@@ -8435,6 +8454,7 @@ func TestUpdateSAMLIdPServiceProviderInvalidInputs(t *testing.T) {
 }
 
 func TestDeleteSAMLIdPServiceProvider(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -8537,6 +8557,7 @@ func TestDeleteSAMLIdPServiceProvider(t *testing.T) {
 }
 
 func TestDeleteAllSAMLIdPServiceProviders(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -10417,6 +10438,7 @@ func inlineEventually(t *testing.T, cond func() bool, waitFor time.Duration, tic
 }
 
 func TestIsMFARequired_AdminAction(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name                 string
 		adminActionAuthState authz.AdminActionAuthState
@@ -10603,6 +10625,7 @@ func TestCloudDefaultPasswordless(t *testing.T) {
 }
 
 func TestRoleRequestReasonModeValidation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -10718,6 +10741,7 @@ func testUserName(testName string) string {
 }
 
 func TestFilterIdentityCenterPermissionSets(t *testing.T) {
+	t.Parallel()
 	const (
 		allAccessRoleName      = "all-access"
 		accountID              = "1234567890"
@@ -11050,6 +11074,7 @@ func createTestMCPAppServer(t *testing.T, auth *auth.Server, name string, labels
 }
 
 func TestSAMLIdPRoleOptionCreateUpdateValidation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -10063,7 +10063,7 @@ func TestWatchHeadlessAuthentications_usersCanOnlyWatchThemselves(t *testing.T) 
 					t.Fatalf("Watcher unexpectedly closed with error: %v", watcher.Error())
 				}
 
-				// If the watcher was intitialized successfully, attach it to the
+				// If the watcher was initialized successfully, attach it to the
 				// test case for the watch_events portion of the test.
 				tc.watcher = watcher
 			})
@@ -10088,19 +10088,19 @@ func TestWatchHeadlessAuthentications_usersCanOnlyWatchThemselves(t *testing.T) 
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
-				var events []types.Event
-			loop:
+				events := make([]types.Event, 0, len(tc.expectEvents))
 				for {
 					select {
 					case event := <-tc.watcher.Events():
 						events = append(events, event)
-					case <-time.After(500 * time.Millisecond):
-						break loop
+						if len(events) == len(tc.expectEvents) {
+							require.Equal(t, tc.expectEvents, events)
+							return
+						}
 					case <-tc.watcher.Done():
 						t.Fatalf("Watcher unexpectedly closed with error: %v", tc.watcher.Error())
 					}
 				}
-				require.Equal(t, tc.expectEvents, events)
 			})
 		}
 	})

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -262,10 +262,16 @@ type AuthServer struct {
 	LockWatcher *services.LockWatcher
 }
 
-// FakePasswordHash is bcrypt hash for password "barbaz", the same as the default used
-// by auth.Server, except, it is generated with the minimum cost instead of the default
-// cost to speed tests up.
-const FakePasswordHash = `$2a$04$uTNg/AhzeGARChkxBsddyeHuCI7SBr2SG7PYhu63mIXqzuqRD.cgq`
+const (
+	// FakePasswordHash is bcrypt hash for password "barbaz", the same as the default used
+	// by auth.Server, except, it is generated with the minimum cost instead of the default
+	// cost to speed tests up.
+	FakePasswordHash = `$2a$04$uTNg/AhzeGARChkxBsddyeHuCI7SBr2SG7PYhu63mIXqzuqRD.cgq`
+	// FakePasswordHash is bcrypt hash for password "fake-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz", \
+	//the same as the default used by auth.Server, except, it is generated with the minimum
+	//cost instead of the default cost to speed tests up.
+	FakeRecoveryCodeHash = `$2a$04$04QoQDbwYTwSIppmJLQQkebbFrMS9V02ttus3rHi2cwujcnDHKbL6`
+)
 
 // NewAuthServer returns a new test auth server.
 // The caller should close the server when it is no longer needed.
@@ -365,6 +371,7 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 		RecordingMetadataProvider:    cfg.RecordingMetadataProvider,
 		AWSOrganizationsClientGetter: cfg.AWSOrganizationsClientGetter,
 		FakePasswordHash:             []byte(FakePasswordHash),
+		FakeRecoveryCodeHash:         []byte(FakeRecoveryCodeHash),
 	},
 		// Reduce auth.Server bcrypt costs when testing.
 		WithBcryptCost(bcrypt.MinCost),

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -262,6 +262,11 @@ type AuthServer struct {
 	LockWatcher *services.LockWatcher
 }
 
+// FakePasswordHash is bcrypt hash for password "barbaz", the same as the default used
+// by auth.Server, except, it is generated with the minimum cost instead of the default
+// cost to speed tests up.
+const FakePasswordHash = `$2a$04$uTNg/AhzeGARChkxBsddyeHuCI7SBr2SG7PYhu63mIXqzuqRD.cgq`
+
 // NewAuthServer returns a new test auth server.
 // The caller should close the server when it is no longer needed.
 func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
@@ -359,6 +364,7 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 		SessionSummarizerProvider:    cfg.SessionSummarizerProvider,
 		RecordingMetadataProvider:    cfg.RecordingMetadataProvider,
 		AWSOrganizationsClientGetter: cfg.AWSOrganizationsClientGetter,
+		FakePasswordHash:             []byte(FakePasswordHash),
 	},
 		// Reduce auth.Server bcrypt costs when testing.
 		WithBcryptCost(bcrypt.MinCost),

--- a/lib/auth/autoupdate_agent_version_report_test.go
+++ b/lib/auth/autoupdate_agent_version_report_test.go
@@ -92,6 +92,7 @@ type fakeServer struct {
 }
 
 func TestServer_generateAgentVersionReport(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	now := time.Now()
 	twoMinutesAgo := now.Add(-time.Minute * 2)
@@ -298,6 +299,7 @@ func TestServer_generateAgentVersionReport(t *testing.T) {
 }
 
 func TestServer_reportAgentVersions(t *testing.T) {
+	t.Parallel()
 	// Test setup: create auth.
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)

--- a/lib/auth/autoupdate_rollout_test.go
+++ b/lib/auth/autoupdate_rollout_test.go
@@ -42,6 +42,7 @@ import (
 )
 
 func TestSampleAgentsFromGroup(t *testing.T) {
+	t.Parallel()
 	clock := clockwork.NewFakeClock()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
@@ -146,6 +147,7 @@ func TestSampleAgentsFromGroup(t *testing.T) {
 }
 
 func TestLookupAgentInInventory(t *testing.T) {
+	t.Parallel()
 	clock := clockwork.NewFakeClock()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
@@ -227,6 +229,7 @@ func (f *fakeHandle) Hello() *proto.UpstreamInventoryHello {
 }
 
 func TestHandlerSampler(t *testing.T) {
+	t.Parallel()
 	filterOK := func(handle inventory.UpstreamHandle) bool {
 		return true
 	}

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -39,6 +39,7 @@ import (
 )
 
 func Test_getSnowflakeJWTParams(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		accountName string
 		userName    string
@@ -246,6 +247,7 @@ func mustVerifyCert(t *testing.T, rootPEM, leafPEM []byte, cdps []string, keyUsa
 }
 
 func TestFilterExtensions(t *testing.T) {
+	t.Parallel()
 	oidA := asn1.ObjectIdentifier{1, 2, 3, 4}
 	oidB := asn1.ObjectIdentifier{1, 2, 3, 5}
 	extA := pkix.Extension{Id: oidA, Value: []byte("a")}

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -258,7 +258,7 @@ func UpdateAccessRequestWithAdditionalReviewers(ctx context.Context, req types.A
 }
 
 func EncodeProquint(x uint16) string {
-	return encodeProquint(x)
+	return string(encodeProquint(x))
 }
 
 func EmitSSOLoginFailureEvent(ctx context.Context, emitter apievents.Emitter, method string, err error, testFlow bool) {

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -110,6 +110,7 @@ func (tt *githubContext) Close() error {
 }
 
 func TestPopulateClaims(t *testing.T) {
+	t.Parallel()
 	client := &testGithubAPIClient{}
 	user, err := client.getUser()
 	require.NoError(t, err)
@@ -130,6 +131,7 @@ func TestPopulateClaims(t *testing.T) {
 }
 
 func TestCreateGithubUser(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tt := setupGithubContext(ctx, t)
 
@@ -193,6 +195,7 @@ func (c *testGithubAPIClient) getTeams() ([]auth.GithubTeamResponse, error) {
 }
 
 func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
+	t.Parallel()
 	clientAddr := &net.TCPAddr{IP: net.IPv4(10, 255, 0, 0)}
 	ctx := authz.ContextWithClientSrcAddr(context.Background(), clientAddr)
 	tt := setupGithubContext(ctx, t)
@@ -292,6 +295,7 @@ func (m *mockedGithubManager) ValidateGithubAuthRedirect(ctx context.Context, di
 }
 
 func TestCalculateGithubUserNoTeams(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	a := &auth.Server{}
 	connector, err := types.NewGithubConnector("github", types.GithubConnectorSpecV3{
@@ -321,6 +325,7 @@ func TestCalculateGithubUserNoTeams(t *testing.T) {
 // Test that calculateGithubUser calls the login rule evaluator, evaluated
 // traits end up in the user params, and traits are evaluated exactly once.
 func TestCalculateGithubUserWithLoginRules(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Create a test role so that FetchRoles can succeed.
@@ -555,6 +560,7 @@ func TestCheckGithubOrgSSOSupport(t *testing.T) {
 }
 
 func TestGithubURLFormat(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		host   string
 		path   string
@@ -583,6 +589,7 @@ func TestGithubURLFormat(t *testing.T) {
 }
 
 func TestBuildAPIEndpoint(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -94,6 +94,7 @@ import (
 )
 
 func TestMFADeviceManagement(t *testing.T) {
+	t.Parallel()
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	clock := testServer.Clock().(*clockwork.FakeClock)
@@ -457,6 +458,7 @@ func TestMFADeviceManagement(t *testing.T) {
 }
 
 func TestMFADeviceManagement_SSO(t *testing.T) {
+	t.Parallel()
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	ctx := context.Background()
@@ -574,6 +576,7 @@ func TestMFADeviceManagement_SSO(t *testing.T) {
 }
 
 func TestDeletingLastPasswordlessDevice(t *testing.T) {
+	t.Parallel()
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	clock := testServer.Clock().(*clockwork.FakeClock)
@@ -884,6 +887,7 @@ func testDeleteMFADevice(ctx context.Context, t *testing.T, authClient *authclie
 }
 
 func TestCreateAppSession_deviceExtensions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
@@ -969,6 +973,7 @@ func TestCreateAppSession_deviceExtensions(t *testing.T) {
 }
 
 func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testServer := newTestTLSServer(t)
 
@@ -2647,6 +2652,7 @@ func TestIsMFARequired(t *testing.T) {
 }
 
 func TestIsMFARequired_unauthorized(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -2833,6 +2839,7 @@ func TestIsMFARequired_nodeMatch(t *testing.T) {
 }
 
 func TestIsMFARequired_App(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -5638,6 +5645,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 }
 
 func TestGetVnetConfig(t *testing.T) {
+	t.Parallel()
 	server := newTestTLSServer(t)
 	user, _, err := authtest.CreateUserAndRole(server.Auth(), "test", []string{"role"}, nil)
 	require.NoError(t, err)
@@ -6485,6 +6493,7 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 }
 
 func TestGRPCServingStatus(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	srv := newTestTLSServer(t)
 	defer srv.Close()

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -4284,88 +4284,58 @@ func TestServerInfoCRUD(t *testing.T) {
 		Name: "serverInfo1",
 	}, types.ServerInfoSpecV1{})
 	require.NoError(t, err)
-	serverInfo1.SetSubKind(types.SubKindCloudInfo)
 	serverInfo2, err := types.NewServerInfo(types.Metadata{
 		Name: "serverInfo2",
 	}, types.ServerInfoSpecV1{})
 	require.NoError(t, err)
-	serverInfo2.SetSubKind(types.SubKindCloudInfo)
 
-	createServerInfos := func(t *testing.T) {
-		// Initially expect no server info to be returned.
-		serverInfos, err := stream.Collect(clt.GetServerInfos(ctx))
-		require.NoError(t, err)
-		require.Empty(t, serverInfos)
+	// Initially expect no server info to be returned.
+	serverInfos, err := stream.Collect(clt.GetServerInfos(ctx))
+	require.NoError(t, err)
+	require.Empty(t, serverInfos)
 
-		// Create server info.
-		require.NoError(t, clt.UpsertServerInfo(ctx, serverInfo1))
-		require.NoError(t, clt.UpsertServerInfo(ctx, serverInfo2))
-	}
-
-	deleteAllServerInfos := func(t *testing.T) {
-		// Delete server infos.
-		require.NoError(t, clt.DeleteAllServerInfos(ctx))
-
-		// Expect no server infos to be returned.
-		serverInfos, err := stream.Collect(clt.GetServerInfos(ctx))
-		require.NoError(t, err)
-		require.Empty(t, serverInfos)
-	}
+	// Create server info.
+	require.NoError(t, clt.UpsertServerInfo(ctx, serverInfo1))
+	require.NoError(t, clt.UpsertServerInfo(ctx, serverInfo2))
 
 	requireResourcesEqual := func(t *testing.T, expected, actual any) {
 		require.Empty(t, cmp.Diff(expected, actual, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 	}
 
-	t.Run("ServerInfoGetters", func(t *testing.T) {
-		createServerInfos(t)
-		t.Cleanup(func() { deleteAllServerInfos(t) })
+	// Get all server infos.
+	serverInfos, err = stream.Collect(clt.GetServerInfos(ctx))
+	require.NoError(t, err)
+	require.Len(t, serverInfos, 2)
+	requireResourcesEqual(t, []types.ServerInfo{serverInfo1, serverInfo2}, serverInfos)
 
-		t.Run("GetServerInfos", func(t *testing.T) {
-			t.Parallel()
-			// Get all server infos.
-			serverInfos, err := stream.Collect(clt.GetServerInfos(ctx))
-			require.NoError(t, err)
-			require.Len(t, serverInfos, 2)
-			requireResourcesEqual(t, []types.ServerInfo{serverInfo1, serverInfo2}, serverInfos)
-		})
+	// Get a single server info by name.
+	si, err := clt.GetServerInfo(ctx, serverInfo1.GetName())
+	require.NoError(t, err)
+	requireResourcesEqual(t, serverInfo1, si)
 
-		t.Run("GetServerInfo", func(t *testing.T) {
-			t.Parallel()
-			// Get server info.
-			si, err := clt.GetServerInfo(ctx, serverInfo1.GetName())
-			require.NoError(t, err)
-			requireResourcesEqual(t, serverInfo1, si)
+	// GetServerInfo should fail if name isn't provided.
+	_, err = clt.GetServerInfo(ctx, "")
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err))
 
-			// GetServerInfo should fail if name isn't provided.
-			_, err = clt.GetServerInfo(ctx, "")
-			require.Error(t, err)
-			require.True(t, trace.IsBadParameter(err))
-		})
-	})
+	// DeleteServerInfo should fail if name isn't provided.
+	err = clt.DeleteServerInfo(ctx, "")
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err))
 
-	t.Run("DeleteServerInfo", func(t *testing.T) {
-		createServerInfos(t)
-		t.Cleanup(func() { deleteAllServerInfos(t) })
+	// Delete server info.
+	err = clt.DeleteServerInfo(ctx, serverInfo1.GetName())
+	require.NoError(t, err)
 
-		// DeleteServerInfo should fail if name isn't provided.
-		err := clt.DeleteServerInfo(ctx, "")
-		require.Error(t, err)
-		require.True(t, trace.IsBadParameter(err))
+	// Expect server info not found.
+	_, err = clt.GetServerInfo(ctx, serverInfo1.GetName())
+	require.Error(t, err)
+	require.True(t, trace.IsNotFound(err))
 
-		// Delete server info.
-		err = clt.DeleteServerInfo(ctx, serverInfo1.GetName())
-		require.NoError(t, err)
-
-		// Expect server info not found.
-		_, err = clt.GetServerInfo(ctx, serverInfo1.GetName())
-		require.Error(t, err)
-		require.True(t, trace.IsNotFound(err))
-
-		// Expect other server info still exists.
-		si, err := clt.GetServerInfo(ctx, serverInfo2.GetName())
-		require.NoError(t, err)
-		requireResourcesEqual(t, serverInfo2, si)
-	})
+	// Expect other server info still exists.
+	si, err = clt.GetServerInfo(ctx, serverInfo2.GetName())
+	require.NoError(t, err)
+	requireResourcesEqual(t, serverInfo2, si)
 }
 
 // TestSAMLIdPServiceProvidersCRUD tests SAMLIdPServiceProviders resource operations.

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -446,6 +446,10 @@ type InitConfig struct {
 	// This helps eliminate timing attacks by ensuring that all authentication attempts
 	// with a password do a bcrypt comparison.
 	FakePasswordHash []byte
+	// FakeRecoveryCodeHash is the recovery code hash given to all users without codes.
+	// This helps eliminate timing attacks by ensuring that all recovery attempts
+	// with codes do a bcrypt comparison.
+	FakeRecoveryCodeHash []byte
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -441,6 +441,11 @@ type InitConfig struct {
 
 	// WorkloadClusterService is the service that manages WorkloadClusters.
 	WorkloadClusterService services.WorkloadClusterService
+
+	// FakePasswordHash is the password hash given to all users without a password.
+	// This helps eliminate timing attacks by ensuring that all authentication attempts
+	// with a password do a bcrypt comparison.
+	FakePasswordHash []byte
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -85,6 +85,7 @@ import (
 // TestReadIdentity makes parses identity from private key and certificate
 // and checks that all parameters are valid
 func TestReadIdentity(t *testing.T) {
+	t.Parallel()
 	clock := clockwork.NewFakeClock()
 	a, err := testauthority.NewKeygen(modules.BuildOSS, clock.Now)
 	require.NoError(t, err)
@@ -135,6 +136,7 @@ func TestReadIdentity(t *testing.T) {
 }
 
 func TestBadIdentity(t *testing.T) {
+	t.Parallel()
 	a, err := testauthority.NewKeygen(modules.BuildOSS, time.Now)
 	require.NoError(t, err)
 
@@ -878,6 +880,7 @@ func TestSessionRecordingConfig(t *testing.T) {
 }
 
 func TestClusterID(t *testing.T) {
+	t.Parallel()
 	conf := setupConfig(t)
 	ctx := context.Background()
 	authServer, err := auth.Init(ctx, conf)
@@ -901,6 +904,7 @@ func TestClusterID(t *testing.T) {
 
 // TestClusterName ensures that a cluster can not be renamed.
 func TestClusterName(t *testing.T) {
+	t.Parallel()
 	conf := setupConfig(t)
 	ctx := context.Background()
 	authServer, err := auth.Init(ctx, conf)
@@ -935,6 +939,7 @@ func (t *failingTrustInternal) CreateCertAuthority(ctx context.Context, ca types
 // TestInitCertFailureRecovery ensures the auth server is able to recover from
 // a failure in the cert creation process.
 func TestInitCertFailureRecovery(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	cap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type: constants.SAML,
@@ -1414,6 +1419,7 @@ func TestDashboardMode(t *testing.T) {
 }
 
 func TestGetPresetUsers(t *testing.T) {
+	t.Parallel()
 	// no preset users for OSS
 	require.Empty(t, auth.GetPresetUsers(modules.BuildOSS))
 
@@ -2092,6 +2098,7 @@ func newHealthCheckConfig(t *testing.T, opts ...func(*healthcheckconfigv1.Health
 // TestSyncUpgadeWindowStartHour verifies the core logic of the upgrade window start
 // hour behavior.
 func TestSyncUpgradeWindowStartHour(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	conf := setupConfig(t)
@@ -2232,6 +2239,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 // TestIdentityChecker verifies auth identity properly validates host
 // certificates when connecting to an SSH server.
 func TestIdentityChecker(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	conf := setupConfig(t)
@@ -2326,6 +2334,7 @@ func TestIdentityChecker(t *testing.T) {
 }
 
 func TestInitCreatesCertsIfMissing(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	conf := setupConfig(t)
 	auth, err := auth.Init(ctx, conf)

--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -1497,8 +1497,10 @@ func TestServer_CreateBoundKeypairToken(t *testing.T) {
 	// at this layer to generate the default registration secret if needed we
 	// should test.
 	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
-	srv := newTestTLSServer(t, withClock(clock))
-	authServer := srv.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir(), Clock: clock})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	tests := []struct {
 		name      string

--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -47,6 +47,7 @@ import (
 )
 
 func TestAuth_RegisterUsingToken(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	p := newAuthSuite(t)
 

--- a/lib/auth/methods_test.go
+++ b/lib/auth/methods_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestServerAuthenticateUserUserAgentTrim(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	emitter := &eventstest.MockRecorderEmitter{}
 	r := authclient.AuthenticateUserRequest{
@@ -50,6 +51,7 @@ func TestServerAuthenticateUserUserAgentTrim(t *testing.T) {
 }
 
 func Test_trimUserAgent(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		inputUserAgent string

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -61,6 +61,7 @@ func (f *fakeConn) RemoteAddr() net.Addr {
 }
 
 func TestValidateClientVersion(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name          string
 		middleware    *auth.Middleware
@@ -144,6 +145,7 @@ func TestValidateClientVersion(t *testing.T) {
 }
 
 func TestRejectedClientClusterAlertContents(t *testing.T) {
+	t.Parallel()
 	var alerts []types.ClusterAlert
 	mw := auth.Middleware{
 		OldestSupportedVersion: teleport.MinClientSemVer(),
@@ -226,6 +228,7 @@ func TestRejectedClientClusterAlertContents(t *testing.T) {
 }
 
 func TestRejectedClientClusterAlert(t *testing.T) {
+	t.Parallel()
 	var alerts []types.ClusterAlert
 	mw := auth.Middleware{
 		OldestSupportedVersion: teleport.MinClientSemVer(),

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -43,9 +43,6 @@ import (
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
-// This is bcrypt hash for password "barbaz".
-var fakePasswordHash = []byte(`$2a$10$Yy.e6BmS2SrGbBDsyDLVkOANZmvjjMR890nUGSXFJHBXWzxe7T44m`)
-
 // ChangeUserAuthentication implements AuthService.ChangeUserAuthentication.
 func (a *Server) ChangeUserAuthentication(ctx context.Context, req *proto.ChangeUserAuthenticationRequest) (*proto.ChangeUserAuthenticationResponse, error) {
 	user, err := a.changeUserAuthentication(ctx, req)
@@ -184,7 +181,7 @@ func (a *Server) checkPasswordWOToken(ctx context.Context, user string, password
 	if trace.IsNotFound(err) {
 		userFound = false
 		a.logger.DebugContext(ctx, "Password for username not found, using fake hash to mitigate timing attacks", "user", user)
-		hash = fakePasswordHash
+		hash = a.fakePasswordHash
 	}
 
 	if err = bcrypt.CompareHashAndPassword(hash, password); err != nil {

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/bcrypt"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
@@ -54,7 +53,6 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 type passwordSuite struct {
@@ -102,6 +100,8 @@ func setupPasswordSuite(t *testing.T) *passwordSuite {
 		HostUUID:               uuid.NewString(),
 		Clock:                  s.clock,
 		Identity:               identity,
+		FakePasswordHash:       []byte(authtest.FakePasswordHash),
+		FakeRecoveryCodeHash:   []byte(authtest.FakeRecoveryCodeHash),
 	}
 	s.a, err = auth.NewServer(authConfig)
 	require.NoError(t, err)
@@ -149,33 +149,32 @@ func TestUserNotFound(t *testing.T) {
 func TestPasswordLengthChange(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	srv := newTestTLSServer(t)
-	authServer := srv.Auth()
-
-	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
-		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorOff,
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+		AuthPreferenceSpec: &types.AuthPreferenceSpecV2{
+			Type:         constants.Local,
+			SecondFactor: constants.SecondFactorOff,
+		},
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
-	_, err = authServer.UpsertAuthPreference(ctx, ap)
-	require.NoError(t, err)
+	const (
+		username     = "llama@goteleport.com"
+		password     = "a"
+		passwordHash = `$2a$10$xyxHFtG04s0kegyq1jwGB.faThKRIzDTCArbvKPxH6UKHriWz79H6`
+	)
 
-	username := fmt.Sprintf("llama%v@goteleport.com", rand.Int())
-	password := []byte("a")
-	u, _, err := authtest.CreateUserAndRole(authServer, username, []string{username}, nil)
-	require.NoError(t, err)
-
-	hash, err := utils.BcryptFromPassword(password, bcrypt.DefaultCost)
+	u, _, err := authtest.CreateUserAndRole(as.AuthServer, username, []string{username}, nil)
 	require.NoError(t, err)
 
 	// Set an initial password that is shorter than minimum length
-	u.SetLocalAuth(&types.LocalAuthSecrets{PasswordHash: hash})
-	authServer.UpsertUser(ctx, u)
+	u.SetLocalAuth(&types.LocalAuthSecrets{PasswordHash: []byte(passwordHash)})
+	_, err = as.AuthServer.UpsertUser(ctx, u)
 	require.NoError(t, err)
 
 	// Ensure that a shorter password still works for auth
-	err = authServer.CheckPasswordWOToken(ctx, username, password)
+	err = as.AuthServer.CheckPasswordWOToken(ctx, username, []byte(password))
 	require.NoError(t, err)
 }
 

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -89,6 +90,9 @@ func setupPasswordSuite(t *testing.T) *passwordSuite {
 	a, err := authority.NewKeygen(modules.BuildOSS, s.clock.Now)
 	require.NoError(t, err)
 
+	identity, err := local.NewTestIdentityService(s.bk)
+	require.NoError(t, err)
+
 	authConfig := &auth.InitConfig{
 		ClusterName:            clusterName,
 		Backend:                s.bk,
@@ -97,6 +101,7 @@ func setupPasswordSuite(t *testing.T) *passwordSuite {
 		SkipPeriodicOperations: true,
 		HostUUID:               uuid.NewString(),
 		Clock:                  s.clock,
+		Identity:               identity,
 	}
 	s.a, err = auth.NewServer(authConfig)
 	require.NoError(t, err)

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -26,14 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
@@ -44,103 +42,23 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authcatest"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
-	authority "github.com/gravitational/teleport/lib/auth/testauthority"
-	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/services/local"
 )
-
-type passwordSuite struct {
-	bk          backend.Backend
-	a           *auth.Server
-	mockEmitter *eventstest.MockRecorderEmitter
-	clock       *clockwork.FakeClock
-}
-
-func setupPasswordSuite(t *testing.T) *passwordSuite {
-	s := passwordSuite{
-		clock: clockwork.NewFakeClock(),
-	}
-
-	ctx := t.Context()
-
-	var err error
-	s.bk, err = memory.New(memory.Config{
-		Context: ctx,
-		Clock:   s.clock,
-	})
-	require.NoError(t, err)
-
-	// set cluster name
-	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		s.bk.Close()
-	})
-
-	a, err := authority.NewKeygen(modules.BuildOSS, s.clock.Now)
-	require.NoError(t, err)
-
-	identity, err := local.NewTestIdentityService(s.bk)
-	require.NoError(t, err)
-
-	authConfig := &auth.InitConfig{
-		ClusterName:            clusterName,
-		Backend:                s.bk,
-		VersionStorage:         authtest.NewFakeTeleportVersion(),
-		Authority:              a,
-		SkipPeriodicOperations: true,
-		HostUUID:               uuid.NewString(),
-		Clock:                  s.clock,
-		Identity:               identity,
-		FakePasswordHash:       []byte(authtest.FakePasswordHash),
-		FakeRecoveryCodeHash:   []byte(authtest.FakeRecoveryCodeHash),
-	}
-	s.a, err = auth.NewServer(authConfig)
-	require.NoError(t, err)
-
-	err = s.a.SetClusterName(clusterName)
-	require.NoError(t, err)
-
-	// set lock watcher
-	lockWatcher, err := services.NewLockWatcher(ctx, services.LockWatcherConfig{
-		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: teleport.ComponentAuth,
-			Client:    s.a,
-		},
-	})
-	require.NoError(t, err, "NewLockWatcher")
-	s.a.SetLockWatcher(lockWatcher)
-
-	// set static tokens
-	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
-		StaticTokens: []types.ProvisionTokenV1{},
-	})
-	require.NoError(t, err)
-	err = s.a.SetStaticTokens(staticTokens)
-	require.NoError(t, err)
-
-	s.mockEmitter = &eventstest.MockRecorderEmitter{}
-	s.a.SetEmitter(s.mockEmitter)
-	return &s
-}
 
 func TestUserNotFound(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	s := setupPasswordSuite(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	username := "unknown-user"
 	password := "feefiefoefum"
 
-	err := s.a.CheckPasswordWOToken(ctx, username, []byte(password))
+	err = as.AuthServer.CheckPasswordWOToken(ctx, username, []byte(password))
 	require.Error(t, err)
 	// Make sure the error is not a NotFound. That would be a username oracle.
 	require.True(t, trace.IsBadParameter(err))
@@ -182,59 +100,75 @@ func TestChangePassword(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
-	s := setupPasswordSuite(t)
-	req, err := s.prepareForPasswordChange("user1", []byte("abcdef123456"), constants.SecondFactorOff)
+	clock := clockwork.NewFakeClock()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	mockEmitter := &eventstest.MockRecorderEmitter{}
+	as.AuthServer.SetEmitter(mockEmitter)
+
+	req, err := prepareForPasswordChange(as.AuthServer, "user1", []byte("abcdef123456"), constants.SecondFactorOff)
 	require.NoError(t, err)
 
 	req.NewPassword = []byte("defceba654321")
 
-	err = s.a.ChangePassword(ctx, req)
+	err = as.AuthServer.ChangePassword(ctx, req)
 	require.NoError(t, err)
-	require.Equal(t, events.UserPasswordChangeEvent, s.mockEmitter.LastEvent().GetType())
-	require.Equal(t, "user1", s.mockEmitter.LastEvent().(*apievents.UserPasswordChange).User)
-	s.shouldLockAfterFailedAttempts(t, req)
+	require.Equal(t, events.UserPasswordChangeEvent, mockEmitter.LastEvent().GetType())
+	require.Equal(t, "user1", mockEmitter.LastEvent().(*apievents.UserPasswordChange).User)
+	shouldLockAfterFailedAttempts(t, as.AuthServer, req)
 
 	// advance time and make sure we can login again
-	s.clock.Advance(defaults.AccountLockInterval + time.Second)
+	clock.Advance(defaults.AccountLockInterval + time.Second)
 	req.OldPassword = req.NewPassword
 	req.NewPassword = []byte("123456abcdef")
-	err = s.a.ChangePassword(ctx, req)
+	err = as.AuthServer.ChangePassword(ctx, req)
 	require.NoError(t, err)
 }
 
 func TestChangePasswordWithOTP(t *testing.T) {
 	t.Parallel()
 
-	s := setupPasswordSuite(t)
-	req, err := s.prepareForPasswordChange("user2", []byte("abcdef123456"), constants.SecondFactorOTP)
+	clock := clockwork.NewFakeClock()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	req, err := prepareForPasswordChange(as.AuthServer, "user2", []byte("abcdef123456"), constants.SecondFactorOTP)
 	require.NoError(t, err)
 
 	otpSecret := base32.StdEncoding.EncodeToString([]byte("def456"))
-	dev, err := services.NewTOTPDevice("otp", otpSecret, s.clock.Now())
+	dev, err := services.NewTOTPDevice("otp", otpSecret, clock.Now())
 	require.NoError(t, err)
 	ctx := context.Background()
-	err = s.a.UpsertMFADevice(ctx, req.User, dev)
+	err = as.AuthServer.UpsertMFADevice(ctx, req.User, dev)
 	require.NoError(t, err)
 
-	validToken, err := totp.GenerateCode(otpSecret, s.a.GetClock().Now())
+	validToken, err := totp.GenerateCode(otpSecret, clock.Now())
 	require.NoError(t, err)
 
 	// change password
 	req.NewPassword = []byte("defceba654321")
 	req.SecondFactorToken = validToken
-	err = s.a.ChangePassword(ctx, req)
+	err = as.AuthServer.ChangePassword(ctx, req)
 	require.NoError(t, err)
 
-	s.shouldLockAfterFailedAttempts(t, req)
+	shouldLockAfterFailedAttempts(t, as.AuthServer, req)
 
 	// advance time and make sure we can login again
-	s.clock.Advance(defaults.AccountLockInterval + time.Second)
+	clock.Advance(defaults.AccountLockInterval + time.Second)
 
-	validToken, _ = totp.GenerateCode(otpSecret, s.a.GetClock().Now())
+	validToken, _ = totp.GenerateCode(otpSecret, clock.Now())
 	req.OldPassword = req.NewPassword
 	req.NewPassword = []byte("123456abcdef")
 	req.SecondFactorToken = validToken
-	err = s.a.ChangePassword(ctx, req)
+	err = as.AuthServer.ChangePassword(ctx, req)
 	require.NoError(t, err)
 }
 
@@ -504,9 +438,11 @@ func TestServer_ChangePassword_Fails(t *testing.T) {
 func TestChangeUserAuthentication(t *testing.T) {
 	t.Parallel()
 
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
-	clock := testServer.Clock()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
+	clock := as.Clock()
 	ctx := context.Background()
 
 	tests := []struct {
@@ -773,19 +709,26 @@ func TestChangeUserAuthentication(t *testing.T) {
 func TestChangeUserAuthenticationWithErrors(t *testing.T) {
 	t.Parallel()
 
-	s := setupPasswordSuite(t)
-	ctx := context.Background()
 	authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
-		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorOTP,
+		Type:          constants.Local,
+		SecondFactors: []types.SecondFactorType{types.SecondFactorType_SECOND_FACTOR_TYPE_OTP},
 	})
 	require.NoError(t, err)
 
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:                t.TempDir(),
+		AuthPreferenceSpec: &authPreference.(*types.AuthPreferenceV2).Spec,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	ctx := context.Background()
+
 	username := "joe@example.com"
-	_, _, err = authtest.CreateUserAndRole(s.a, username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, username, []string{username}, nil)
 	require.NoError(t, err)
 
-	token, err := s.a.CreateResetPasswordToken(ctx, authclient.CreateUserTokenRequest{
+	token, err := as.AuthServer.CreateResetPasswordToken(ctx, authclient.CreateUserTokenRequest{
 		Name: username,
 	})
 	require.NoError(t, err)
@@ -840,25 +783,25 @@ func TestChangeUserAuthenticationWithErrors(t *testing.T) {
 	for _, tc := range testCases {
 		// set new auth preference settings
 		authPreference.SetSecondFactor(tc.secondFactor)
-		authPreference, err = s.a.UpsertAuthPreference(ctx, authPreference)
+		authPreference, err = as.AuthServer.UpsertAuthPreference(ctx, authPreference)
 		require.NoError(t, err)
 
-		_, err = auth.ChangeUserAuthentication(ctx, s.a, tc.req)
+		_, err = auth.ChangeUserAuthentication(ctx, as.AuthServer, tc.req)
 		require.Error(t, err, "test case %q", tc.desc)
 	}
 
 	authPreference.SetSecondFactor(constants.SecondFactorOff)
-	_, err = s.a.UpsertAuthPreference(ctx, authPreference)
+	_, err = as.AuthServer.UpsertAuthPreference(ctx, authPreference)
 	require.NoError(t, err)
 
-	_, err = auth.ChangeUserAuthentication(ctx, s.a, &proto.ChangeUserAuthenticationRequest{
+	_, err = auth.ChangeUserAuthentication(ctx, as.AuthServer, &proto.ChangeUserAuthenticationRequest{
 		TokenID:     validTokenID,
 		NewPassword: validPassword,
 	})
 	require.NoError(t, err)
 
 	// invite token cannot be reused
-	_, err = auth.ChangeUserAuthentication(ctx, s.a, &proto.ChangeUserAuthenticationRequest{
+	_, err = auth.ChangeUserAuthentication(ctx, as.AuthServer, &proto.ChangeUserAuthenticationRequest{
 		TokenID:     validTokenID,
 		NewPassword: validPassword,
 	})
@@ -867,48 +810,52 @@ func TestChangeUserAuthenticationWithErrors(t *testing.T) {
 
 func TestResetPassword(t *testing.T) {
 	t.Parallel()
-	s := setupPasswordSuite(t)
 
-	_, _, err := authtest.CreateUserAndRole(s.a, "dave", []string{"dave"}, nil)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, "dave", []string{"dave"}, nil)
 	require.NoError(t, err)
 
 	// Using the Identity service makes it easier to set up the test case.
-	err = s.a.Identity.UpsertPassword("dave", []byte("it's full of stars!"))
+	err = as.AuthServer.Identity.UpsertPassword("dave", []byte("it's full of stars!"))
 	require.NoError(t, err)
 
 	// Reset password.
 	ctx := context.Background()
-	err = s.a.ResetPassword(ctx, "dave")
+	err = as.AuthServer.ResetPassword(ctx, "dave")
 	require.NoError(t, err)
 
 	// Make sure that the password has been reset.
-	u, err := s.a.Identity.GetUser(ctx, "dave", true /* withSecrets */)
+	u, err := as.AuthServer.Identity.GetUser(ctx, "dave", true /* withSecrets */)
 	require.NoError(t, err)
 	assert.Nil(t, u.GetLocalAuth(), "user LocalAuth not nil")
 	assert.Equal(t, types.PasswordState_PASSWORD_STATE_UNSET, u.GetPasswordState())
 
 	// Make sure that we can reset once again (i.e. we don't complain if there's
 	// no password).
-	err = s.a.ResetPassword(ctx, "dave")
+	err = as.AuthServer.ResetPassword(ctx, "dave")
 	require.NoError(t, err)
 }
 
-func (s *passwordSuite) shouldLockAfterFailedAttempts(t *testing.T, req *proto.ChangePasswordRequest) {
-	ctx := context.Background()
-	loginAttempts, _ := s.a.GetUserLoginAttempts(req.User)
+func shouldLockAfterFailedAttempts(t *testing.T, as *auth.Server, req *proto.ChangePasswordRequest) {
+	loginAttempts, _ := as.GetUserLoginAttempts(req.User)
 	require.Empty(t, loginAttempts)
 	for i := range defaults.MaxLoginAttempts {
-		err := s.a.ChangePassword(ctx, req)
+		err := as.ChangePassword(t.Context(), req)
 		require.Error(t, err)
-		loginAttempts, _ = s.a.GetUserLoginAttempts(req.User)
+		loginAttempts, _ = as.GetUserLoginAttempts(req.User)
 		require.Len(t, loginAttempts, i+1)
 	}
 
-	err := s.a.ChangePassword(ctx, req)
+	err := as.ChangePassword(t.Context(), req)
 	require.True(t, trace.IsAccessDenied(err))
 }
 
-func (s *passwordSuite) prepareForPasswordChange(user string, pass []byte, secondFactorType constants.SecondFactorType) (*proto.ChangePasswordRequest, error) {
+func prepareForPasswordChange(as *auth.Server, user string, pass []byte, secondFactorType constants.SecondFactorType) (*proto.ChangePasswordRequest, error) {
 	ctx := context.Background()
 	req := &proto.ChangePasswordRequest{
 		User:        user,
@@ -919,7 +866,7 @@ func (s *passwordSuite) prepareForPasswordChange(user string, pass []byte, secon
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := s.a.UpsertCertAuthority(ctx, userCA); err != nil {
+	if err := as.UpsertCertAuthority(ctx, userCA); err != nil {
 		return nil, err
 	}
 
@@ -927,7 +874,7 @@ func (s *passwordSuite) prepareForPasswordChange(user string, pass []byte, secon
 	if err != nil {
 		return nil, err
 	}
-	if err := s.a.UpsertCertAuthority(ctx, hostCA); err != nil {
+	if err := as.UpsertCertAuthority(ctx, hostCA); err != nil {
 		return nil, err
 	}
 
@@ -939,14 +886,14 @@ func (s *passwordSuite) prepareForPasswordChange(user string, pass []byte, secon
 		return nil, err
 	}
 
-	if _, err := s.a.UpsertAuthPreference(ctx, ap); err != nil {
+	if _, err := as.UpsertAuthPreference(ctx, ap); err != nil {
 		return nil, err
 	}
 
-	if _, _, err := authtest.CreateUserAndRole(s.a, user, []string{user}, nil); err != nil {
+	if _, _, err := authtest.CreateUserAndRole(as, user, []string{user}, nil); err != nil {
 		return nil, err
 	}
-	if err := s.a.UpsertPassword(user, pass); err != nil {
+	if err := as.UpsertPassword(user, pass); err != nil {
 		return nil, err
 	}
 

--- a/lib/auth/periodic_test.go
+++ b/lib/auth/periodic_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestTotalInstances(t *testing.T) {
+	t.Parallel()
 	instances := []*proto.UpstreamInventoryHello{
 		{},
 		{Version: "15.0.0"},
@@ -48,6 +49,7 @@ func TestTotalInstances(t *testing.T) {
 }
 
 func TestTotalEnrolledInUpgrades(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		desc      string
 		instances []*proto.UpstreamInventoryHello
@@ -99,6 +101,7 @@ func TestTotalEnrolledInUpgrades(t *testing.T) {
 }
 
 func TestUpgraderCounts(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		desc      string
 		instances []*proto.UpstreamInventoryHello
@@ -180,6 +183,7 @@ func TestUpgraderCounts(t *testing.T) {
 }
 
 func TestInstallMethodCounts(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		desc     string
 		metadata []*proto.UpstreamInventoryAgentMetadata
@@ -237,6 +241,7 @@ func TestInstallMethodCounts(t *testing.T) {
 }
 
 func TestRegisteredAgentsCounts(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		desc     string
 		instance []*proto.UpstreamInventoryHello
@@ -298,6 +303,7 @@ func TestRegisteredAgentsCounts(t *testing.T) {
 }
 
 func TestUpgradeEnrollPeriodic(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		desc          string
 		enrolled      map[string]int

--- a/lib/auth/recording_authorizer_test.go
+++ b/lib/auth/recording_authorizer_test.go
@@ -19,8 +19,6 @@
 package auth_test
 
 import (
-	"errors"
-	"net"
 	"testing"
 	"time"
 
@@ -42,8 +40,10 @@ import (
 func TestSessionRecordingAuthorized_RBAC(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestTLSServerForRecording(t)
-	authServer := srv.AuthServer.AuthServer
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	session1 := createTestSession(t, authServer, "alice", []string{"alice", "bob"})
 	session2 := createTestSession(t, authServer, "bob", []string{"bob", "charlie"})
@@ -83,7 +83,7 @@ func TestSessionRecordingAuthorized_RBAC(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, role, err := authtest.CreateUserAndRole(
-				srv.Auth(),
+				authServer,
 				tc.username,
 				[]string{},
 				[]types.Rule{
@@ -103,7 +103,7 @@ func TestSessionRecordingAuthorized_RBAC(t *testing.T) {
 					Groups:   []string{role.GetName()},
 				},
 			}
-			authContext, err := authz.ContextForLocalUser(t.Context(), localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
+			authContext, err := authz.ContextForLocalUser(t.Context(), localUser, authServer, as.ClusterName, true /* disableDeviceAuthz */)
 			require.NoError(t, err)
 
 			authorizer := &mockAuthorizer{
@@ -130,26 +130,6 @@ func TestSessionRecordingAuthorized_RBAC(t *testing.T) {
 	}
 }
 
-func newTestTLSServerForRecording(t testing.TB) *authtest.TLSServer {
-	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Dir: t.TempDir(),
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, as.Close()) })
-
-	srv, err := as.NewTestTLSServer()
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		err := srv.Close()
-		if errors.Is(err, net.ErrClosed) {
-			return
-		}
-		require.NoError(t, err)
-	})
-
-	return srv
-}
 
 func createTestSession(t *testing.T, authServer *auth.Server, user string, participants []string) session.ID {
 	id := session.NewID()

--- a/lib/auth/recovery_codes_test.go
+++ b/lib/auth/recovery_codes_test.go
@@ -1,0 +1,31 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkRecoveryCodeGeneration(b *testing.B) {
+	for b.Loop() {
+		codes, err := generateRecoveryCodes()
+		require.NoError(b, err)
+		require.Len(b, codes, numOfRecoveryCodes)
+	}
+}

--- a/lib/auth/requestable_roles_test.go
+++ b/lib/auth/requestable_roles_test.go
@@ -36,6 +36,7 @@ import (
 
 // TestListRequestableRoles tests listing requestable roles with pagination.
 func TestListRequestableRoles(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	tlsServer := newTestTLSServer(t)
 	a := tlsServer.Auth()

--- a/lib/auth/sso_diag_context_test.go
+++ b/lib/auth/sso_diag_context_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func Test_ssoDiagContext_writeToBackend(t *testing.T) {
+	t.Parallel()
 	diag := &SSODiagContext{
 		AuthKind:  types.KindSAML,
 		RequestID: "123",

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1744,35 +1744,37 @@ func TestPasswordCRUD(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.AuthServerConfig.Clock
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	clock := as.Clock()
 
 	// Create a user.
 	u, err := types.NewUser("user1")
 	require.NoError(t, err)
-	_, err = testSrv.Auth().CreateUser(ctx, u)
+	_, err = as.AuthServer.CreateUser(ctx, u)
 	require.NoError(t, err)
 
 	pass := []byte("abcdef123456")
 	rawSecret := "def456"
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, "123456")
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, "123456")
 	require.Error(t, err)
 
-	err = testSrv.Auth().UpsertPassword("user1", pass)
+	err = as.AuthServer.UpsertPassword("user1", pass)
 	require.NoError(t, err)
 
 	dev, err := services.NewTOTPDevice("otp", otpSecret, clock.Now())
 	require.NoError(t, err)
 
-	err = testSrv.Auth().UpsertMFADevice(ctx, "user1", dev)
+	err = as.AuthServer.UpsertMFADevice(ctx, "user1", dev)
 	require.NoError(t, err)
 
-	validToken, err := totp.GenerateCode(otpSecret, testSrv.Clock().Now())
+	validToken, err := totp.GenerateCode(otpSecret, clock.Now())
 	require.NoError(t, err)
 
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, validToken)
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, validToken)
 	require.NoError(t, err)
 }
 
@@ -1780,8 +1782,10 @@ func TestOTPCRUD(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.AuthServerConfig.Clock
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	clock := as.Clock()
 
 	user := "user1"
 	pass := []byte("abcdef123456")
@@ -1791,20 +1795,20 @@ func TestOTPCRUD(t *testing.T) {
 	// Create a user.
 	u, err := types.NewUser(user)
 	require.NoError(t, err)
-	_, err = testSrv.Auth().CreateUser(ctx, u)
+	_, err = as.AuthServer.CreateUser(ctx, u)
 	require.NoError(t, err)
 
 	// upsert a password and totp secret
-	err = testSrv.Auth().UpsertPassword("user1", pass)
+	err = as.AuthServer.UpsertPassword("user1", pass)
 	require.NoError(t, err)
 	dev, err := services.NewTOTPDevice("otp", otpSecret, clock.Now())
 	require.NoError(t, err)
 
-	err = testSrv.Auth().UpsertMFADevice(ctx, user, dev)
+	err = as.AuthServer.UpsertMFADevice(ctx, user, dev)
 	require.NoError(t, err)
 
 	// a completely invalid token should return access denied
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, "123456")
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, "123456")
 	require.Error(t, err)
 
 	// an invalid token should return access denied
@@ -1814,20 +1818,20 @@ func TestOTPCRUD(t *testing.T) {
 	// valid for 30 seconds + 30 second skew before and after for a usability
 	// reasons. so a token made between seconds 31 and 60 is still valid, and
 	// invalidity starts at 61 seconds in the future.
-	invalidToken, err := totp.GenerateCode(otpSecret, testSrv.Clock().Now().Add(61*time.Second))
+	invalidToken, err := totp.GenerateCode(otpSecret, clock.Now().Add(61*time.Second))
 	require.NoError(t, err)
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, invalidToken)
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, invalidToken)
 	require.Error(t, err)
 
 	// a valid token (created right now and from a valid key) should return success
-	validToken, err := totp.GenerateCode(otpSecret, testSrv.Clock().Now())
+	validToken, err := totp.GenerateCode(otpSecret, clock.Now())
 	require.NoError(t, err)
 
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, validToken)
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, validToken)
 	require.NoError(t, err)
 
 	// try the same valid token now it should fail because we don't allow re-use of tokens
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, validToken)
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, validToken)
 	require.Error(t, err)
 }
 

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1722,8 +1722,11 @@ func TestUsersCRUD(t *testing.T) {
 func TestPasswordGarbage(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	testSrv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	garbage := [][]byte{
 		nil,
@@ -1731,7 +1734,7 @@ func TestPasswordGarbage(t *testing.T) {
 		make([]byte, defaults.MinPasswordLength-1),
 	}
 	for _, g := range garbage {
-		err := testSrv.Auth().CheckPassword(ctx, "user1", g, "123456")
+		err := as.AuthServer.CheckPassword(t.Context(), "user1", g, "123456")
 		require.True(t, trace.IsBadParameter(err))
 	}
 }

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1438,6 +1438,7 @@ func TestGetCurrentUser(t *testing.T) {
 }
 
 func TestGetCurrentUserRoles(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -3101,6 +3102,7 @@ func TestGenerateCerts(t *testing.T) {
 // TestGenerateAppToken checks the identity of the caller and makes sure only
 // certain roles can request JWT tokens.
 func TestGenerateAppToken(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.AuthServerConfig.Clock
@@ -3212,6 +3214,7 @@ func TestGenerateAppToken(t *testing.T) {
 // TestCertificateFormat makes sure that certificates are generated with the
 // correct format.
 func TestCertificateFormat(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
@@ -3608,6 +3611,7 @@ func TestLoginNoLocalAuth(t *testing.T) {
 // TestCipherSuites makes sure that clients with invalid cipher suites can
 // not connect.
 func TestCipherSuites(t *testing.T) {
+	t.Parallel()
 	testSrv := newTestTLSServer(t)
 	ctx := context.Background()
 

--- a/lib/auth/transport_credentials_test.go
+++ b/lib/auth/transport_credentials_test.go
@@ -329,6 +329,7 @@ func (f fakeUserGetter) GetUser(context.Context, tls.ConnectionState) (authz.Ide
 }
 
 func TestTransportCredentialsDisconnection(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name   string
 		expiry time.Duration

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -47,6 +47,7 @@ import (
 )
 
 func TestRemoteClusterStatus(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	a := newTestAuthServer(ctx, t)
 
@@ -124,6 +125,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 }
 
 func TestRefreshRemoteClusters(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	tests := []struct {
@@ -479,6 +481,7 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *auth.
 }
 
 func TestUpsertTrustedCluster(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testAuth, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "localcluster",
@@ -620,6 +623,7 @@ func TestUpsertTrustedCluster(t *testing.T) {
 }
 
 func TestUpdateTrustedCluster(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testAuth, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "localcluster",

--- a/lib/auth/usertoken_test.go
+++ b/lib/auth/usertoken_test.go
@@ -97,11 +97,13 @@ func TestCreateResetPasswordToken(t *testing.T) {
 
 func TestCreateResetPasswordTokenErrors(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	ctx := context.Background()
 
 	username := "joe@example.com"
-	_, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, username, []string{username}, nil)
 	require.NoError(t, err)
 
 	type testCase struct {
@@ -149,7 +151,7 @@ func TestCreateResetPasswordTokenErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := srv.Auth().CreateResetPasswordToken(ctx, tc.req)
+			_, err := as.AuthServer.CreateResetPasswordToken(ctx, tc.req)
 			require.Error(t, err)
 		})
 	}
@@ -230,10 +232,12 @@ func TestFormatAccountName(t *testing.T) {
 
 func TestUserTokenSecretsCreationSettings(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	username := "joe@example.com"
-	_, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, username, []string{username}, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -243,16 +247,16 @@ func TestUserTokenSecretsCreationSettings(t *testing.T) {
 		TTL:  time.Hour,
 	}
 
-	token, err := srv.Auth().CreateResetPasswordToken(ctx, req)
+	token, err := as.AuthServer.CreateResetPasswordToken(ctx, req)
 	require.NoError(t, err)
 
-	_, err = srv.Auth().CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
+	_, err = as.AuthServer.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
 		TokenID:    token.GetName(),
 		DeviceType: proto.DeviceType_DEVICE_TYPE_TOTP,
 	})
 	require.NoError(t, err)
 
-	secrets, err := srv.Auth().GetUserTokenSecrets(ctx, token.GetName())
+	secrets, err := as.AuthServer.GetUserTokenSecrets(ctx, token.GetName())
 	require.NoError(t, err)
 
 	require.NoError(t, err)
@@ -264,11 +268,13 @@ func TestUserTokenSecretsCreationSettings(t *testing.T) {
 
 func TestUserTokenCreationSettings(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	ctx := t.Context()
 
 	username := "joe@example.com"
-	_, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, username, []string{username}, nil)
 	require.NoError(t, err)
 
 	req := authclient.CreateUserTokenRequest{
@@ -277,7 +283,7 @@ func TestUserTokenCreationSettings(t *testing.T) {
 		Type: authclient.UserTokenTypeResetPasswordInvite,
 	}
 
-	token, err := srv.Auth().NewUserToken(ctx, req)
+	token, err := as.AuthServer.NewUserToken(ctx, req)
 	require.NoError(t, err)
 	require.Equal(t, req.Name, token.GetUser())
 	require.Equal(t, req.Type, token.GetSubKind())


### PR DESCRIPTION
Baseline from a previous [CI run](https://github.com/gravitational/teleport/actions/runs/22325690709/job/64595445434)

```
lib/auth/accesspoint
✓  lib/auth (40.708s)
```


From [CI](https://github.com/gravitational/teleport/actions/runs/22326561762/job/64598462000?pr=64053) on this PR

```
lib/auth/accesspoint
✓  lib/auth (23.661s)
```