### PR TITLE
[v17] Lint to enforce using t.Context() instead of context.TODO() 👮🏾

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - testifylint
     - unconvert
     - unused
+    - usetesting
   settings:
     depguard:
       rules:
@@ -332,6 +333,15 @@ linters:
         - len
         - suite-extra-assert-call
         - suite-thelper
+    usetesting:
+        context-todo: true
+        # TODO: Enable the following after the issues are fixed.
+        context-background: false
+        os-chdir: false
+        os-create-temp: false
+        os-mkdir-temp: false
+        os-setenv: false
+        os-temp-dir: false
   exclusions:
     generated: lax
     presets:

--- a/api/utils/keys/privatekey_test.go
+++ b/api/utils/keys/privatekey_test.go
@@ -56,7 +56,7 @@ func TestMarshalAndParseKey(t *testing.T) {
 		ClusterName: "billy.io",
 	}
 	s := hardwarekey.NewMockHardwareKeyService(nil /*prompt*/)
-	hwPriv, err := s.NewPrivateKey(context.TODO(), hardwarekey.PrivateKeyConfig{
+	hwPriv, err := s.NewPrivateKey(t.Context(), hardwarekey.PrivateKeyConfig{
 		ContextualKeyInfo: contextualKeyInfo,
 	})
 	require.NoError(t, err)

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -362,7 +362,7 @@ func NewInstance(t *testing.T, cfg InstanceConfig) *TeleInstance {
 	sshSigner, err := ssh.NewSignerFromSigner(key)
 	fatalIf(err)
 
-	keygen := keygen.New(context.TODO())
+	keygen := keygen.New(t.Context())
 	hostCert, err := keygen.GenerateHostCert(sshca.HostCertificateRequest{
 		CASigner:      sshSigner,
 		PublicHostKey: cfg.Pub,

--- a/integration/helpers/trustedclusters.go
+++ b/integration/helpers/trustedclusters.go
@@ -58,7 +58,7 @@ func WaitForTunnelConnections(t *testing.T, authServer *auth.Server, clusterName
 // Duplicated in tool/tsh/tsh_test.go
 func TryCreateTrustedCluster(t *testing.T, authServer *auth.Server, trustedCluster types.TrustedCluster) {
 	t.Helper()
-	ctx := context.TODO()
+	ctx := t.Context()
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v.", trustedCluster, i)
 		_, err := authServer.CreateTrustedCluster(ctx, trustedCluster)
@@ -85,7 +85,7 @@ func TryCreateTrustedCluster(t *testing.T, authServer *auth.Server, trustedClust
 // propagate and services to start
 func TryUpdateTrustedCluster(t *testing.T, authServer *auth.Server, trustedCluster types.TrustedCluster) {
 	t.Helper()
-	ctx := context.TODO()
+	ctx := t.Context()
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v.", trustedCluster, i)
 		_, err := authServer.UpdateTrustedCluster(ctx, trustedCluster)
@@ -112,7 +112,7 @@ func TryUpdateTrustedCluster(t *testing.T, authServer *auth.Server, trustedClust
 // propagate and services to start
 func TryUpsertTrustedCluster(t *testing.T, authServer *auth.Server, trustedCluster types.TrustedCluster, skipNameValidation bool) {
 	t.Helper()
-	ctx := context.TODO()
+	ctx := t.Context()
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v.", trustedCluster, i)
 		var err error

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -466,7 +466,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 				cl.Stdout = myTerm
 				cl.Stdin = myTerm
 
-				err = cl.SSH(context.TODO(), []string{})
+				err = cl.SSH(t.Context(), []string{})
 				endC <- err
 			}()
 
@@ -675,7 +675,7 @@ func testInteroperability(t *testing.T, suite *integrationTestSuite) {
 			go func() {
 				// don't check for err, because sometimes this process should fail
 				// with an error and that's what the test is checking for.
-				cl.SSH(context.TODO(), []string{tt.inCommand})
+				cl.SSH(t.Context(), []string{tt.inCommand})
 				sessionEndC <- true
 			}()
 			err = waitFor(sessionEndC, time.Second*10)
@@ -1604,7 +1604,7 @@ func verifySessionJoin(t *testing.T, username string, teleport *helpers.TeleInst
 		cl.Stdin = personA
 		// Person A types something into the terminal (including "exit")
 		personA.Type("\aecho hi\n\r\aexit\n\r\a")
-		sessionA <- cl.SSH(context.TODO(), []string{})
+		sessionA <- cl.SSH(t.Context(), []string{})
 	}
 
 	// PersonB: wait for a session to become available, then join:
@@ -1641,7 +1641,7 @@ func verifySessionJoin(t *testing.T, username string, teleport *helpers.TeleInst
 				return
 
 			case <-ticker.C:
-				err := cl.Join(context.TODO(), types.SessionPeerMode, defaults.Namespace, session.ID(sessionID), personB)
+				err := cl.Join(t.Context(), types.SessionPeerMode, defaults.Namespace, session.ID(sessionID), personB)
 				if err == nil {
 					sessionB <- nil
 					return
@@ -2745,7 +2745,7 @@ func testMapRoles(t *testing.T, suite *integrationTestSuite) {
 	// and 'tc' (client) is also supposed to reconnect
 	for i := 0; i < 10; i++ {
 		time.Sleep(time.Millisecond * 50)
-		err = tc.SSH(context.TODO(), cmd)
+		err = tc.SSH(t.Context(), cmd)
 		if err == nil {
 			break
 		}
@@ -3687,7 +3687,7 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 	for i := 0; i < 10; i++ {
 		time.Sleep(time.Millisecond * 50)
-		err = tc.SSH(context.TODO(), cmd)
+		err = tc.SSH(t.Context(), cmd)
 		if err == nil {
 			break
 		}
@@ -5207,7 +5207,7 @@ func testPAM(t *testing.T, suite *integrationTestSuite) {
 				cl.Stdin = termSession
 
 				termSession.Type("\aecho hi\n\r\aexit\n\r\a")
-				err = cl.SSH(context.TODO(), []string{})
+				err = cl.SSH(t.Context(), []string{})
 				if !isSSHError(err) {
 					errCh <- err
 					return
@@ -5345,7 +5345,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// client works as is before servers have been rotated
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 	checkSSHPrincipals(svc)
 
@@ -5373,7 +5373,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// new client works
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 	checkSSHPrincipals(svc)
 
@@ -5394,7 +5394,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	waitForCredentialsUpdated()
 
 	// new client still works
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 	checkSSHPrincipals(svc)
 
@@ -5506,7 +5506,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// client works as is before servers have been rotated
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 	checkSSHPrincipals(svc)
 
@@ -5535,7 +5535,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	waitForCredentialsUpdated()
 
 	// old client works
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 	checkSSHPrincipals(svc)
 
@@ -5659,7 +5659,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	clt, err := main.NewClientWithCreds(cfg, *initialCreds)
 	require.NoError(t, err)
 
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 
 	t.Logf("Setting rotation state to %v", types.RotationPhaseInit)
@@ -5712,7 +5712,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	waitForPhase(types.RotationPhaseUpdateClients)
 
 	// old client should work as is
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 
 	t.Logf("Service reloaded. Setting rotation state to %v", types.RotationPhaseUpdateServers)
@@ -5737,7 +5737,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// new client works
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 
 	t.Logf("Service reloaded. Setting rotation state to %v.", types.RotationPhaseStandby)
@@ -5756,7 +5756,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	t.Log("Phase completed.")
 
 	// new client still works
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 
 	t.Log("Service reloaded. Rotation has completed. Shutting down service.")
@@ -5789,12 +5789,12 @@ func waitForProcessEvent(svc *service.TeleportProcess, event string, timeout tim
 }
 
 // runAndMatch runs command and makes sure it matches the pattern
-func runAndMatch(tc *client.TeleportClient, attempts int, command []string, pattern string) error {
+func runAndMatch(ctx context.Context, tc *client.TeleportClient, attempts int, command []string, pattern string) error {
 	output := &bytes.Buffer{}
 	tc.Stdout = output
 	var err error
 	for i := 0; i < attempts; i++ {
-		err = tc.SSH(context.TODO(), command)
+		err = tc.SSH(ctx, command)
 		if err != nil {
 			time.Sleep(500 * time.Millisecond)
 			continue
@@ -6306,7 +6306,7 @@ func testBPFInteractive(t *testing.T, suite *integrationTestSuite) {
 
 				// "Type" a command into the terminal.
 				term.Type(fmt.Sprintf("\a%v\n\r\aexit\n\r\a", lsPath))
-				err = client.SSH(context.TODO(), []string{})
+				err = client.SSH(t.Context(), []string{})
 				require.NoError(t, err)
 
 				// Signal that the client has finished the interactive session.
@@ -7052,7 +7052,7 @@ func runCommandWithCertReissue(t *testing.T, instance *helpers.TeleInstance, cmd
 	out := &bytes.Buffer{}
 	tc.Stdout = out
 
-	err = tc.SSH(context.TODO(), cmd)
+	err = tc.SSH(t.Context(), cmd)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -237,7 +237,7 @@ func (p *Suite) mustConnectToClusterAndRunSSHCommand(t *testing.T, config helper
 
 	cmd := []string{"echo", "hello world"}
 	err = retryutils.RetryStaticFor(deadline, nextIterWaitTime, func() error {
-		err = tc.SSH(context.TODO(), cmd)
+		err = tc.SSH(t.Context(), cmd)
 		return trace.Wrap(err)
 	})
 	require.NoError(t, err)
@@ -520,7 +520,7 @@ func mustStartALPNLocalProxyWithConfig(t *testing.T, config alpnproxy.LocalProxy
 		config.Listener = helpers.MustCreateListener(t)
 	}
 	if config.ParentContext == nil {
-		config.ParentContext = context.TODO()
+		config.ParentContext = t.Context()
 	}
 
 	lp, err := alpnproxy.NewLocalProxy(config)
@@ -654,7 +654,7 @@ func mustRegisterUsingIAMMethod(t *testing.T, proxyAddr utils.NetAddr, token str
 	t.Setenv("AWS_REGION", "us-west-2")
 
 	node := uuid.NewString()
-	_, err = join.Register(context.TODO(), join.RegisterParams{
+	_, err = join.Register(t.Context(), join.RegisterParams{
 		Token: token,
 		ID: state.IdentityID{
 			Role:     types.RoleNode,

--- a/integrations/terraform/testlib/access_list_test.go
+++ b/integrations/terraform/testlib/access_list_test.go
@@ -35,9 +35,9 @@ type nextAuditDateComparer struct {
 	nextAuditDate time.Time
 }
 
-func (c *nextAuditDateComparer) CaptureNextAuditDate(name string) resource.TestCheckFunc {
+func (c *nextAuditDateComparer) CaptureNextAuditDate(ctx context.Context, name string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		al, err := c.client.AccessListClient().GetAccessList(context.TODO(), name)
+		al, err := c.client.AccessListClient().GetAccessList(ctx, name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -46,9 +46,9 @@ func (c *nextAuditDateComparer) CaptureNextAuditDate(name string) resource.TestC
 	}
 }
 
-func (c *nextAuditDateComparer) TestNextAuditDateUnchanged(name string) resource.TestCheckFunc {
+func (c *nextAuditDateComparer) TestNextAuditDateUnchanged(ctx context.Context, name string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		al, err := c.client.AccessListClient().GetAccessList(context.TODO(), name)
+		al, err := c.client.AccessListClient().GetAccessList(ctx, name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -60,14 +60,14 @@ func (c *nextAuditDateComparer) TestNextAuditDateUnchanged(name string) resource
 	}
 }
 
-func (s *TerraformSuiteEnterprise) TestAccessList() {
+func (s *TerraformSuiteEnterprise) TestAccessList(ctx context.Context) {
 	require.True(s.T(),
 		s.teleportFeatures.GetAdvancedAccessWorkflows(),
 		"Test requires Advanced Access Workflows",
 	)
 
 	checkAccessListDestroyed := func(state *terraform.State) error {
-		_, err := s.client.AccessListClient().GetAccessList(context.TODO(), "test")
+		_, err := s.client.AccessListClient().GetAccessList(ctx, "test")
 		if trace.IsNotFound(err) {
 			return nil
 		}
@@ -91,7 +91,7 @@ func (s *TerraformSuiteEnterprise) TestAccessList() {
 					resource.TestCheckResourceAttr(name, "spec.membership_requires.roles.0", "minion"),
 					resource.TestCheckResourceAttr(name, "spec.grants.roles.0", "crane-operator"),
 					resource.TestCheckResourceAttr(name, "spec.audit.recurrence.frequency", "3"),
-					auditDateChecker.CaptureNextAuditDate("test"),
+					auditDateChecker.CaptureNextAuditDate(ctx, "test"),
 				),
 			},
 			{
@@ -104,7 +104,7 @@ func (s *TerraformSuiteEnterprise) TestAccessList() {
 					resource.TestCheckResourceAttr(name, "spec.grants.traits.0.key", "allowed-machines"),
 					resource.TestCheckResourceAttr(name, "spec.grants.traits.0.values.0", "crane"),
 					resource.TestCheckResourceAttr(name, "spec.grants.traits.0.values.1", "forklift"),
-					auditDateChecker.TestNextAuditDateUnchanged("test"),
+					auditDateChecker.TestNextAuditDateUnchanged(ctx, "test"),
 				),
 			},
 			{
@@ -115,7 +115,8 @@ func (s *TerraformSuiteEnterprise) TestAccessList() {
 				Config: s.getFixture("access_list_2_expiring.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "header.metadata.expires", "2038-01-01T00:00:00Z"),
-					auditDateChecker.TestNextAuditDateUnchanged("test"),
+					auditDateChecker.TestNextAuditDateUnchanged(ctx,
+						"test"),
 				),
 			},
 			{

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -1479,7 +1479,7 @@ func toSet(items []string) map[string]struct{} {
 func setupConfig(t *testing.T) auth.InitConfig {
 	tempDir := t.TempDir()
 
-	bk, err := lite.New(context.TODO(), backend.Params{"path": tempDir})
+	bk, err := lite.New(t.Context(), backend.Params{"path": tempDir})
 	require.NoError(t, err)
 
 	processStorage, err := storage.NewProcessStorage(

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -556,14 +556,14 @@ func testKeepAlive(t *testing.T, newBackend Constructor) {
 	require.Equal(t, bigValue[:], event.Item.Value)
 	require.WithinDuration(t, updatedAt, event.Item.Expires, 2*time.Second)
 
-	err = uut.Delete(context.TODO(), item.Key)
+	err = uut.Delete(t.Context(), item.Key)
 	require.NoError(t, err)
 
-	_, err = uut.Get(context.TODO(), item.Key)
+	_, err = uut.Get(t.Context(), item.Key)
 	require.True(t, trace.IsNotFound(err))
 
 	// keep alive on deleted or expired object should fail
-	err = uut.KeepAlive(context.TODO(), lease, updatedAt.Add(1*time.Second))
+	err = uut.KeepAlive(t.Context(), lease, updatedAt.Add(1*time.Second))
 	require.True(t, trace.IsNotFound(err))
 }
 
@@ -806,7 +806,7 @@ func testLocking(t *testing.T, newBackend Constructor) {
 	// has probably gone bad (e.g. db server has ceased to exist), so it's
 	// probably best to bail out with a sensible error (& call stack) rather
 	// than wait for the test to time out
-	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	// Manually drive the clock at ~10x speed to make sure anyone waiting on it
@@ -941,7 +941,7 @@ func testConcurrentOperations(t *testing.T, newBackend Constructor) {
 	defer func() { require.NoError(t, uutB.Close()) }()
 
 	prefix := MakePrefix()
-	ctx := context.TODO()
+	ctx := t.Context()
 	value1 := "this first value should not be corrupted by concurrent ops"
 	value2 := "this second value should not be corrupted too"
 	const attempts = 50

--- a/lib/cloud/azure/kubernetes_test.go
+++ b/lib/cloud/azure/kubernetes_test.go
@@ -219,7 +219,7 @@ func Test_AKSClient_ClusterCredentials(t *testing.T) {
 			c := NewAKSClustersClient(tt.fields.api, func(options *azidentity.DefaultAzureCredentialOptions) (GetToken, error) {
 				return azIdentity, nil
 			})
-			got, _, err := c.ClusterCredentials(context.TODO(), tt.args.cfg)
+			got, _, err := c.ClusterCredentials(t.Context(), tt.args.cfg)
 			tt.checkErr(t, err)
 
 			if tt.validateRestConfig != nil {

--- a/lib/cloud/azure/redis_enterprise_test.go
+++ b/lib/cloud/azure/redis_enterprise_test.go
@@ -19,7 +19,6 @@
 package azure
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -73,7 +72,7 @@ func TestRedisEnterpriseClient(t *testing.T) {
 				t.Parallel()
 
 				c := NewRedisEnterpriseClientByAPI(nil, test.mockDatabaseAPI)
-				token, err := c.GetToken(context.TODO(), test.resourceID)
+				token, err := c.GetToken(t.Context(), test.resourceID)
 
 				if test.expectError {
 					require.Error(t, err)
@@ -113,7 +112,7 @@ func TestRedisEnterpriseClient(t *testing.T) {
 			}
 
 			c := NewRedisEnterpriseClientByAPI(mockClusterAPI, mockDatabaseAPI)
-			clusters, err := c.ListAll(context.TODO())
+			clusters, err := c.ListAll(t.Context())
 			require.NoError(t, err)
 			requireClusterDatabases(t, expectClusterDatabases, clusters)
 		})
@@ -126,7 +125,7 @@ func TestRedisEnterpriseClient(t *testing.T) {
 			}
 
 			c := NewRedisEnterpriseClientByAPI(mockClusterAPI, mockDatabaseAPI)
-			clusters, err := c.ListWithinGroup(context.TODO(), "group-prod")
+			clusters, err := c.ListWithinGroup(t.Context(), "group-prod")
 			require.NoError(t, err)
 			requireClusterDatabases(t, expectClusterDatabases, clusters)
 		})

--- a/lib/cloud/azure/redis_test.go
+++ b/lib/cloud/azure/redis_test.go
@@ -19,7 +19,6 @@
 package azure
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -58,7 +57,7 @@ func TestRedisClient(t *testing.T) {
 				t.Parallel()
 
 				c := NewRedisClientByAPI(test.mockAPI)
-				token, err := c.GetToken(context.TODO(), "/subscriptions/sub-id/resourceGroups/group-name/providers/Microsoft.Cache/Redis/example-teleport")
+				token, err := c.GetToken(t.Context(), "/subscriptions/sub-id/resourceGroups/group-name/providers/Microsoft.Cache/Redis/example-teleport")
 				if test.expectError {
 					require.Error(t, err)
 				} else {
@@ -85,7 +84,7 @@ func TestRedisClient(t *testing.T) {
 			expectServers := []string{"redis-prod-1", "redis-prod-2", "redis-dev"}
 
 			c := NewRedisClientByAPI(mockAPI)
-			resources, err := c.ListAll(context.TODO())
+			resources, err := c.ListAll(t.Context())
 			require.NoError(t, err)
 			requireRedisServers(t, expectServers, resources)
 		})
@@ -95,7 +94,7 @@ func TestRedisClient(t *testing.T) {
 			expectServers := []string{"redis-prod-1", "redis-prod-2"}
 
 			c := NewRedisClientByAPI(mockAPI)
-			resources, err := c.ListWithinGroup(context.TODO(), "group-prod")
+			resources, err := c.ListWithinGroup(t.Context(), "group-prod")
 			require.NoError(t, err)
 			requireRedisServers(t, expectServers, resources)
 		})

--- a/lib/events/filelog_test.go
+++ b/lib/events/filelog_test.go
@@ -309,7 +309,7 @@ func makeAccessRequestEvent(id string, in string) *events.AccessRequestDelete {
 }
 
 func mustSearchEvent(t *testing.T, log *FileLog, start time.Time) []events.AuditEvent {
-	ctx := context.TODO()
+	ctx := t.Context()
 	result, _, err := log.SearchEvents(ctx, SearchEventsRequest{
 		From:  start,
 		To:    start.Add(time.Hour),

--- a/lib/events/session_writer_test.go
+++ b/lib/events/session_writer_test.go
@@ -211,7 +211,7 @@ func TestSessionWriter(t *testing.T) {
 		terminateConnection.Store(1)
 
 		submitEvents := 600
-		hangCtx, hangCancel := context.WithCancel(context.TODO())
+		hangCtx, hangCancel := context.WithCancel(t.Context())
 		defer hangCancel()
 
 		test := newSessionWriterTest(t, func(streamer events.Streamer) (*events.CallbackStreamer, error) {
@@ -367,7 +367,7 @@ func newSessionWriterTest(t *testing.T, newStreamer newStreamerFn, opts ...sessi
 		streamer = protoStreamer
 	}
 
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 
 	sid := session.NewID()
 	preparer, err := events.NewPreparer(events.PreparerConfig{

--- a/lib/events/test/streamsuite.go
+++ b/lib/events/test/streamsuite.go
@@ -190,7 +190,7 @@ func StreamEmpty(t *testing.T, handler events.MultipartHandler) {
 
 // StreamWithParameters tests stream upload and subsequent download and reads the results
 func StreamWithParameters(t *testing.T, handler events.MultipartHandler, params StreamParams) {
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: params.PrintEvents})
 	sid := session.ID(inEvents[0].(events.SessionMetadataGetter).GetSessionID())
@@ -265,7 +265,7 @@ func StreamWithParameters(t *testing.T, handler events.MultipartHandler, params 
 // StreamResumeWithParameters expects initial complete attempt to fail
 // but subsequent resume to succeed
 func StreamResumeWithParameters(t *testing.T, handler events.MultipartHandler, params StreamParams) {
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: params.PrintEvents})
 	sid := session.ID(inEvents[0].(events.SessionMetadataGetter).GetSessionID())

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -47,7 +47,7 @@ import (
 func UploadDownload(t *testing.T, handler events.MultipartHandler) {
 	val := "hello, how is it going? this is the uploaded file"
 	id := session.NewID()
-	_, err := handler.Upload(context.TODO(), id, bytes.NewBuffer([]byte(val)))
+	_, err := handler.Upload(t.Context(), id, bytes.NewBuffer([]byte(val)))
 	require.NoError(t, err)
 
 	f, err := os.CreateTemp("", string(id))
@@ -55,7 +55,7 @@ func UploadDownload(t *testing.T, handler events.MultipartHandler) {
 	defer os.Remove(f.Name())
 	defer f.Close()
 
-	err = handler.Download(context.TODO(), id, f)
+	err = handler.Download(t.Context(), id, f)
 	require.NoError(t, err)
 
 	_, err = f.Seek(0, 0)
@@ -75,7 +75,7 @@ func DownloadNotFound(t *testing.T, handler events.MultipartHandler) {
 	defer os.Remove(f.Name())
 	defer f.Close()
 
-	err = handler.Download(context.TODO(), id, f)
+	err = handler.Download(t.Context(), id, f)
 	require.True(t, trace.IsNotFound(err))
 }
 

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -141,7 +141,7 @@ func TestGetKubeCreds(t *testing.T) {
 	rbacSupportedTypes[allowedResourcesKey{apiGroup: "resources.teleport.dev", resourceKind: "teleportroles/status"}] = utils.KubeCustomResource
 
 	logger := utils.NewLoggerForTests()
-	ctx := context.TODO()
+	ctx := t.Context()
 	const teleClusterName = "teleport-cluster"
 	dir := t.TempDir()
 	kubeconfigPath := filepath.Join(dir, "kubeconfig")

--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -689,7 +689,7 @@ func TestInteractiveSessionsNoAuth(t *testing.T) {
 
 			exec, err := remotecommand.NewSPDYExecutor(tt.config, http.MethodPost, req.URL())
 			require.NoError(t, err)
-			err = exec.StreamWithContext(context.TODO(), streamOpts)
+			err = exec.StreamWithContext(t.Context(), streamOpts)
 			tt.assertErr(t, err)
 		})
 	}

--- a/lib/kube/proxy/self_subject_reviews_test.go
+++ b/lib/kube/proxy/self_subject_reviews_test.go
@@ -394,7 +394,7 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 			)
 
 			rsp, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(
-				context.TODO(),
+				t.Context(),
 				&authv1.SelfSubjectAccessReview{
 					Spec: authv1.SelfSubjectAccessReviewSpec{
 						ResourceAttributes: &authv1.ResourceAttributes{

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -631,7 +631,7 @@ func TestMux(t *testing.T) {
 
 		gclient := test.NewPingerClient(conn)
 
-		out, err := gclient.Ping(context.TODO(), &test.Request{})
+		out, err := gclient.Ping(t.Context(), &test.Request{})
 		require.NoError(t, err)
 		require.Equal(t, "grpc backend", out.GetPayload())
 

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -435,7 +435,7 @@ func TestServiceCheckPrincipals(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		ok := checkServerIdentity(context.TODO(), testConnector, tt.inPrincipals, tt.inDNS, slog.Default().With("test", "TestServiceCheckPrincipals"))
+		ok := checkServerIdentity(t.Context(), testConnector, tt.inPrincipals, tt.inDNS, slog.Default().With("test", "TestServiceCheckPrincipals"))
 		require.Equal(t, tt.outRegenerate, ok, "test %d", i)
 	}
 }

--- a/lib/services/local/access_graph_test.go
+++ b/lib/services/local/access_graph_test.go
@@ -19,7 +19,6 @@
 package local
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -39,7 +38,7 @@ func TestAccessGraphAuthorizedKeys(t *testing.T) {
 	service, err := NewAccessGraphSecretsService(backend)
 	require.NoError(t, err)
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	pageSize := 10
 	pageToken := ""
 
@@ -149,7 +148,7 @@ func TestAccessGraphPrivateKeys(t *testing.T) {
 	service, err := NewAccessGraphSecretsService(backend)
 	require.NoError(t, err)
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	pageSize := 10
 	pageToken := ""
 

--- a/lib/services/local/perf_test.go
+++ b/lib/services/local/perf_test.go
@@ -72,7 +72,7 @@ func BenchmarkGetNodes(b *testing.B) {
 			} else {
 				dir := b.TempDir()
 
-				bk, err = lite.NewWithConfig(context.TODO(), lite.Config{
+				bk, err = lite.NewWithConfig(b.Context(), lite.Config{
 					Path: dir,
 				})
 				require.NoError(b, err)

--- a/lib/srv/db/common/auth_test.go
+++ b/lib/srv/db/common/auth_test.go
@@ -90,7 +90,7 @@ func TestAuthGetAzureCacheForRedisToken(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			token, err := auth.GetAzureCacheForRedisToken(context.TODO(), newAzureRedisDatabase(t, test.resourceID))
+			token, err := auth.GetAzureCacheForRedisToken(t.Context(), newAzureRedisDatabase(t, test.resourceID))
 			if test.expectError {
 				require.Error(t, err)
 			} else {
@@ -120,7 +120,7 @@ func TestAuthGetRedshiftServerlessAuthToken(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	dbUser, dbPassword, err := auth.GetRedshiftServerlessAuthToken(context.TODO(),
+	dbUser, dbPassword, err := auth.GetRedshiftServerlessAuthToken(t.Context(),
 		newRedshiftServerlessDatabase(t),
 		"some-user",
 		"some-database",
@@ -239,7 +239,7 @@ func TestAuthGetTLSConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tlsConfig, err := auth.GetTLSConfig(context.TODO(),
+			tlsConfig, err := auth.GetTLSConfig(t.Context(),
 				time.Now().Add(time.Hour),
 				test.sessionDatabase,
 				"defaultUser")

--- a/lib/srv/discovery/fetchers/db/helpers_test.go
+++ b/lib/srv/discovery/fetchers/db/helpers_test.go
@@ -86,7 +86,7 @@ func mustGetDatabases(t *testing.T, fetchers []common.Fetcher) types.Databases {
 
 	var all types.Databases
 	for _, fetcher := range fetchers {
-		resources, err := fetcher.Get(context.TODO())
+		resources, err := fetcher.Get(t.Context())
 		require.NoError(t, err)
 
 		databases, err := resources.AsDatabases()

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -98,7 +98,7 @@ func TestShutdown(t *testing.T) {
 	_, signer, err := cert.CreateTestEd25519Certificate("foo", ssh.HostCert)
 	require.NoError(t, err)
 
-	closeContext, cancel := context.WithCancel(context.TODO())
+	closeContext, cancel := context.WithCancel(t.Context())
 	fn := NewChanHandlerFunc(func(_ context.Context, ccx *ConnectionContext, nch ssh.NewChannel) {
 		ch, _, err := nch.Accept()
 		require.NoError(t, err)
@@ -132,18 +132,18 @@ func TestShutdown(t *testing.T) {
 	require.NoError(t, err)
 
 	// context will timeout because there is a connection around
-	ctx, ctxc := context.WithTimeout(context.TODO(), 50*time.Millisecond)
+	ctx, ctxc := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer ctxc()
 	require.True(t, trace.IsConnectionProblem(srv.Shutdown(ctx)))
 
 	// now shutdown will return
 	cancel()
-	ctx2, ctxc2 := context.WithTimeout(context.TODO(), time.Second)
+	ctx2, ctxc2 := context.WithTimeout(t.Context(), time.Second)
 	defer ctxc2()
 	require.NoError(t, srv.Shutdown(ctx2))
 
 	// shutdown is re-entrable
-	ctx3, ctxc3 := context.WithTimeout(context.TODO(), time.Second)
+	ctx3, ctxc3 := context.WithTimeout(t.Context(), time.Second)
 	defer ctxc3()
 	require.NoError(t, srv.Shutdown(ctx3))
 }

--- a/lib/tbot/services/application/helpers_test.go
+++ b/lib/tbot/services/application/helpers_test.go
@@ -20,7 +20,6 @@ package application
 
 import (
 	"bytes"
-	"context"
 	"log/slog"
 	"net"
 	"strconv"
@@ -112,7 +111,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 
 // makeBot creates a server-side bot and returns joining parameters.
 func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*onboarding.Config, *machineidv1pb.Bot) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Helper()
 
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{

--- a/lib/tbot/services/awsra/helpers_test.go
+++ b/lib/tbot/services/awsra/helpers_test.go
@@ -149,7 +149,7 @@ func (m *staticOverrideGetter) GetWorkloadIdentityX509CAOverride(ctx context.Con
 
 // makeBot creates a server-side bot and returns joining parameters.
 func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*onboarding.Config, *machineidv1pb.Bot) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Helper()
 
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{

--- a/lib/tbot/services/legacyspiffe/helpers_test.go
+++ b/lib/tbot/services/legacyspiffe/helpers_test.go
@@ -20,7 +20,6 @@ package legacyspiffe
 
 import (
 	"bytes"
-	"context"
 	"log/slog"
 	"net"
 	"strconv"
@@ -112,7 +111,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 
 // makeBot creates a server-side bot and returns joining parameters.
 func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*onboarding.Config, *machineidv1pb.Bot) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Helper()
 
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{

--- a/lib/tbot/services/workloadidentity/helpers_test.go
+++ b/lib/tbot/services/workloadidentity/helpers_test.go
@@ -149,7 +149,7 @@ func (m *staticOverrideGetter) GetWorkloadIdentityX509CAOverride(ctx context.Con
 
 // makeBot creates a server-side bot and returns joining parameters.
 func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*onboarding.Config, *machineidv1pb.Bot) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Helper()
 
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -116,7 +116,7 @@ func defaultTestServerOpts(log *slog.Logger) testenv.TestServerOptFunc {
 
 // makeBot creates a server-side bot and returns joining parameters.
 func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*onboarding.Config, *machineidv1pb.Bot) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Helper()
 
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -299,7 +299,7 @@ func TestHandleDatabasesGetIAMPolicy(t *testing.T) {
 
 	// Add database servers for above databases.
 	for _, db := range []*types.DatabaseV3{redshift, elasticache, selfHosted} {
-		_, err = env.server.Auth().UpsertDatabaseServer(context.TODO(), mustCreateDatabaseServer(t, db))
+		_, err = env.server.Auth().UpsertDatabaseServer(t.Context(), mustCreateDatabaseServer(t, db))
 		require.NoError(t, err)
 	}
 
@@ -341,7 +341,7 @@ func TestHandleDatabasesGetIAMPolicy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.inputDatabaseName, func(t *testing.T) {
-			resp, err := pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "databases", test.inputDatabaseName, "iam", "policy"), nil)
+			resp, err := pack.clt.Get(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "databases", test.inputDatabaseName, "iam", "policy"), nil)
 			test.verifyResponse(t, resp, err)
 		})
 	}

--- a/lib/web/notifications_test.go
+++ b/lib/web/notifications_test.go
@@ -149,7 +149,7 @@ func TestNotifications(t *testing.T) {
 
 	// Upsert last seen timestamp.
 	lastSeenTimeString := "2024-05-08T19:00:47.836Z"
-	_, err = pack.clt.PutJSON(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "lastseennotification"),
+	_, err = pack.clt.PutJSON(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "lastseennotification"),
 		UpsertUserLastSeenNotificationRequest{
 			Time: lastSeenTimeString,
 		})
@@ -180,7 +180,7 @@ func TestNotifications(t *testing.T) {
 	var fetchedNotifications []ui.Notification
 
 	// Get a page of 4.
-	notificationsResp, err := pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
+	notificationsResp, err := pack.clt.Get(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
 		"limit": []string{"4"},
 	})
 	require.NoError(t, err)
@@ -194,7 +194,7 @@ func TestNotifications(t *testing.T) {
 	require.Equal(t, expectedNextKeys, unmarshaledNotificationsResp.NextKey)
 
 	// Get a page of 10, starting from the previously returned keys.
-	notificationsResp, err = pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
+	notificationsResp, err = pack.clt.Get(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
 		"limit":    []string{"10"},
 		"startKey": []string{unmarshaledNotificationsResp.NextKey},
 	})
@@ -207,7 +207,7 @@ func TestNotifications(t *testing.T) {
 	require.Equal(t, lastSeenTimeString, unmarshaledNotificationsResp.UserLastSeenNotification)
 
 	// Mark the most recent notification as clicked.
-	_, err = pack.clt.PutJSON(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notificationstate"),
+	_, err = pack.clt.PutJSON(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notificationstate"),
 		upsertUserNotificationStateRequest{
 			NotificationId:    notificationIdMap["auditor-7"],
 			NotificationState: notificationsv1.NotificationState_NOTIFICATION_STATE_CLICKED,
@@ -215,7 +215,7 @@ func TestNotifications(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mark the last notification as dismissed.
-	_, err = pack.clt.PutJSON(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notificationstate"),
+	_, err = pack.clt.PutJSON(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notificationstate"),
 		upsertUserNotificationStateRequest{
 			NotificationId:    notificationIdMap["auditor-1"],
 			NotificationState: notificationsv1.NotificationState_NOTIFICATION_STATE_DISMISSED,
@@ -223,7 +223,7 @@ func TestNotifications(t *testing.T) {
 	require.NoError(t, err)
 
 	// List all notifications again.
-	notificationsResp, err = pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
+	notificationsResp, err = pack.clt.Get(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
 		"limit": []string{"10"},
 	})
 	require.NoError(t, err)

--- a/tool/tctl/common/bots_command_test.go
+++ b/tool/tctl/common/bots_command_test.go
@@ -231,7 +231,7 @@ func TestUpdateBotRoles(t *testing.T) {
 				botRoles: tt.set,
 			}
 
-			err = cmd.updateBotRoles(context.TODO(), &mockClient, bot, fieldMask)
+			err = cmd.updateBotRoles(t.Context(), &mockClient, bot, fieldMask)
 			tt.assert(t, bot, fieldMask, err)
 		})
 	}

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -2742,7 +2742,7 @@ func TestSSHCommands(t *testing.T) {
 //
 // Duplicated in integration/integration_test.go
 func tryCreateTrustedCluster(t *testing.T, authServer *auth.Server, trustedCluster types.TrustedCluster) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v.", trustedCluster, i)
 		_, err := authServer.UpsertTrustedClusterV2(ctx, trustedCluster)


### PR DESCRIPTION
Backport #63596 to branch/v17

## Manual Test Plan

### Test Environment

Since these changes only affect automated tests, there was no need to deploy the changes for testing.

### Test Cases

List the various tests that were run to validate the change. Cases should be as exhaustive as possible.

- [x] Run the linter using `make lint-go`
- [x] Run the linter against the `e/` submodule using `golangci-lint run --config ./.golangci.yml e/...`
- [x] Ensure CI passes