### PR TITLE
improve unsupported region error for DocDB discovery

### DIFF
--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -109,7 +109,8 @@ db_service:
   #   # 'elasticache-serverless' - Amazon ElastiCache Serverless Redis or Valkey databases.
   #   # 'memorydb' - discovers and registers AWS MemoryDB Redis databases.
   #   # 'opensearch' - discovers and registers AWS OpenSearch domains.
-  # - types: ["rds", "rdsproxy", "redshift", "redshift-serverless", "elasticache", "elasticache-serverless", "memorydb", "opensearch"]
+  #   # 'docdb' - discovers and registers Amazon DocumentDB databases.
+  # - types: ["rds", "rdsproxy", "redshift", "redshift-serverless", "elasticache", "elasticache-serverless", "memorydb", "opensearch", "docdb"]
   #   # AWS regions to register databases from.
   #   regions: ["us-west-1", "us-east-2"]
   #   # AWS resource tags to match when registering databases.

--- a/lib/srv/discovery/fetchers/db/aws.go
+++ b/lib/srv/discovery/fetchers/db/aws.go
@@ -19,6 +19,7 @@
 package db
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"iter"
@@ -88,19 +89,17 @@ func (cfg *awsFetcherConfig) CheckAndSetDefaults(component string) error {
 	if cfg.Region == "" {
 		return trace.BadParameter("missing parameter Region")
 	}
-	if cfg.Logger == nil {
-		credentialsSource := "environment"
-		if cfg.Integration != "" {
-			credentialsSource = fmt.Sprintf("integration:%s", cfg.Integration)
-		}
-		cfg.Logger = slog.With(
-			teleport.ComponentKey, "watch:"+component,
-			"labels", cfg.Labels,
-			"region", cfg.Region,
-			"role", cfg.AssumeRole,
-			"credentials", credentialsSource,
-		)
+	credentialsSource := "environment"
+	if cfg.Integration != "" {
+		credentialsSource = fmt.Sprintf("integration:%s", cfg.Integration)
 	}
+	cfg.Logger = cmp.Or(cfg.Logger, slog.Default()).With(
+		teleport.ComponentKey, "watch:"+component,
+		"labels", cfg.Labels,
+		"region", cfg.Region,
+		"role", cfg.AssumeRole,
+		"credentials", credentialsSource,
+	)
 
 	if cfg.awsClients == nil {
 		cfg.awsClients = defaultAWSClients{}

--- a/lib/srv/discovery/fetchers/db/aws_docdb.go
+++ b/lib/srv/discovery/fetchers/db/aws_docdb.go
@@ -101,6 +101,10 @@ func (f *rdsDocumentDBFetcher) getAllDBClusters(ctx context.Context, clt RDSClie
 	var clusters []rdstypes.DBCluster
 	for page, err := range pagesWithLimit(ctx, pager, log) {
 		if err != nil {
+			if isUnrecognizedAWSEngineNameError(err) {
+				log.WarnContext(ctx, "DocumentDB is not supported in this AWS region. Please check region availability at https://docs.aws.amazon.com/documentdb/latest/developerguide/regions-and-azs.html.", "error", err)
+				return clusters, nil
+			}
 			return nil, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
 		}
 		clusters = append(clusters, page.DBClusters...)

--- a/lib/srv/discovery/fetchers/db/aws_docdb_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_docdb_test.go
@@ -126,6 +126,52 @@ func TestDocumentDBFetcher(t *testing.T) {
 			},
 			wantDatabases: clusterProdDatabases,
 		},
+		{
+			name: "unsupported region",
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: fakeAWSClients{
+					rdsClient: &mocks.RDSClient{
+						// DBEngineVersions is not set, simulating a region where
+						// DocumentDB is not supported.
+					},
+				},
+			},
+			inputMatchers: []types.AWSMatcher{
+				{
+					Types:   []string{types.AWSMatcherDocumentDB},
+					Regions: []string{"us-west-1"},
+					Tags:    toTypeLabels(wildcardLabels),
+				},
+			},
+			wantDatabases: nil,
+			wantLogContains: []string{
+				"DocumentDB is not supported in this AWS region",
+				"region=us-west-1",
+			},
+		},
+		{
+			name: "mixed supported and unsupported regions",
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: newRegionalFakeRDSClientProvider(map[string]RDSClient{
+					"us-east-1": &mocks.RDSClient{
+						DBClusters:       []rdstypes.DBCluster{*clusterProd},
+						DBEngineVersions: []rdstypes.DBEngineVersion{*docdbEngine},
+					},
+					"us-west-1": &mocks.RDSClient{
+						// DBEngineVersions is not set, simulating a region where
+						// DocumentDB is not supported.
+					},
+				}),
+			},
+			inputMatchers: []types.AWSMatcher{
+				{
+					Types:   []string{types.AWSMatcherDocumentDB},
+					Regions: []string{"us-east-1", "us-west-1"},
+					Tags:    toTypeLabels(wildcardLabels),
+				},
+			},
+			wantDatabases: clusterProdDatabases,
+		},
 	}
 	testAWSFetchers(t, tests...)
 }

--- a/lib/srv/discovery/fetchers/db/db.go
+++ b/lib/srv/discovery/fetchers/db/db.go
@@ -194,6 +194,7 @@ func (f *AWSFetcherFactory) MakeFetchers(ctx context.Context, matchers []types.A
 						DiscoveryConfigName: discoveryConfigName,
 						AWSConfigProvider:   f.cfg.AWSConfigProvider,
 						awsClients:          f.cfg.AWSClients,
+						Logger:              f.cfg.Logger,
 					})
 					if err != nil {
 						return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/helpers_test.go
+++ b/lib/srv/discovery/fetchers/db/helpers_test.go
@@ -19,7 +19,9 @@
 package db
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -124,10 +126,11 @@ var testAssumeRole = types.AssumeRole{
 
 // awsFetcherTest is a common test struct for AWS fetchers.
 type awsFetcherTest struct {
-	name          string
-	fetcherCfg    AWSFetcherFactoryConfig
-	inputMatchers []types.AWSMatcher
-	wantDatabases types.Databases
+	name            string
+	fetcherCfg      AWSFetcherFactoryConfig
+	inputMatchers   []types.AWSMatcher
+	wantDatabases   types.Databases
+	wantLogContains []string
 }
 
 // testAWSFetchers is a helper that tests AWS fetchers, since
@@ -142,8 +145,15 @@ func testAWSFetchers(t *testing.T, tests ...awsFetcherTest) {
 		}
 		t.Run(test.name, func(t *testing.T) {
 			t.Helper()
+			var logBuf bytes.Buffer
+			if len(test.wantLogContains) > 0 {
+				test.fetcherCfg.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+			}
 			fetchers := mustMakeAWSFetchers(t, test.fetcherCfg, test.inputMatchers, "" /* discovery config */)
 			require.ElementsMatch(t, test.wantDatabases, mustGetDatabases(t, fetchers))
+			for _, want := range test.wantLogContains {
+				require.Contains(t, logBuf.String(), want)
+			}
 		})
 		t.Run(test.name+" with assume role", func(t *testing.T) {
 			t.Helper()


### PR DESCRIPTION
## Description

When DocDB discovery is configured in a region where DocumentDB is not supported, the fetcher previously returned a generic error. This change detects the unrecognized engine name error from AWS and emits a clear warning log instead, allowing discovery to continue gracefully in other regions.

Additionally, `docdb` is added to the example types list in the `db_service` config comment.

changelog: Improved error message when DocDB discovery is configured in an unsupported AWS region

## Manual Test Plan

### Test Environment

Tested on https://ada-v19.cloud.gravitational.io/ with a v19 nightly build. Agent run locally.

Config used:
```yaml
- types: ["docdb"]
  regions: ["us-west-2", "us-west-1", "us-east-2", "ca-central-1"]
  tags:
    "teleport.dev/creator": "xin.huang@goteleport.com"
```

- `us-west-1` — DocumentDB engine not supported in this region (expect warning, no error)
- `ca-central-1` — Real DocumentDB cluster exists (expect successful discovery)

### Test Cases

#### discovery_service

- [ ] Configure `discovery_service` with `types: ["docdb"]` and regions `["us-west-2", "us-west-1", "us-east-2", "ca-central-1"]`
- [ ] Verify `us-west-1` emits a warning log ("DocumentDB is not supported in this AWS region") instead of returning an error
- [ ] Verify `ca-central-1` successfully discovers and registers the DocumentDB cluster
- [ ] Verify discovery continues for other configured regions when one region is unsupported

#### db_service

- [ ] Configure `db_service` with `types: ["docdb"]` and regions `["us-west-2", "us-west-1", "us-east-2", "ca-central-1"]`
- [ ] Verify `us-west-1` emits a warning log ("DocumentDB is not supported in this AWS region") instead of returning an error
- [ ] Verify `ca-central-1` successfully discovers and registers the DocumentDB cluster
- [ ] Verify discovery continues for other configured regions when one region is unsupported
- [ ] Modify the service YAML created via `teleport db configure create` (updating the comment to include `docdb` as a supported type) and verify the db_service still discovers and registers DocDB clusters correctly