### PR TITLE
Reduce bcrypt impact on auth tests

### DIFF
--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -54,11 +54,6 @@ const (
 	completeRecoveryGenericErrMsg = "unable to recover your account, please contact your system administrator"
 )
 
-// fakeRecoveryCodeHash is bcrypt hash for "fake-barbaz x 8".
-// This is a fake hash used to mitigate timing attacks against invalid usernames or if user does
-// exist but does not have recovery codes.
-var fakeRecoveryCodeHash = []byte(`$2a$10$c2.h4pF9AA25lbrWo6U0D.ZmnYpFDaNzN3weNNYNC3jAkYEX9kpzu`)
-
 // StartAccountRecovery implements AuthService.StartAccountRecovery.
 func (a *Server) StartAccountRecovery(ctx context.Context, req *proto.StartAccountRecoveryRequest) (types.UserToken, error) {
 	if err := a.isAccountRecoveryAllowed(ctx); err != nil {
@@ -164,7 +159,7 @@ func (a *Server) verifyRecoveryCode(ctx context.Context, username string, recove
 			"user", username,
 		)
 		for i := range numOfRecoveryCodes {
-			hashedCodes[i].HashedCode = fakeRecoveryCodeHash
+			hashedCodes[i].HashedCode = a.fakeRecoveryCodeHash
 		}
 	} else {
 		hasRecoveryCodes = true

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -716,9 +716,21 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		WorkloadClusterService:          cfg.WorkloadClusterService,
 	}
 
+	if cfg.FakePasswordHash == nil {
+		// This is a bcrypt hash for password "barbaz" with the default bcrypt cost.
+		cfg.FakePasswordHash = []byte(`$2a$10$Yy.e6BmS2SrGbBDsyDLVkOANZmvjjMR890nUGSXFJHBXWzxe7T44m`)
+	}
+
+	if cfg.FakeRecoveryCodeHash == nil {
+		// This is a bcrypt hash for "fake-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz" with the default bcrypt cost.
+		cfg.FakeRecoveryCodeHash = []byte(`$2a$10$c2.h4pF9AA25lbrWo6U0D.ZmnYpFDaNzN3weNNYNC3jAkYEX9kpzu`)
+	}
+
 	as = &Server{
 		bk:                           cfg.Backend,
 		clock:                        cfg.Clock,
+		fakePasswordHash:             cfg.FakePasswordHash,
+		fakeRecoveryCodeHash:         cfg.FakeRecoveryCodeHash,
 		limiter:                      limiter,
 		Authority:                    cfg.Authority,
 		AuthServiceName:              cfg.AuthServiceName,
@@ -1221,6 +1233,9 @@ type Server struct {
 
 	closeCtx   context.Context
 	cancelFunc context.CancelFunc
+
+	fakePasswordHash     []byte
+	fakeRecoveryCodeHash []byte
 
 	samlAuthService SAMLService
 	oidcAuthService OIDCService

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -262,6 +262,18 @@ type AuthServer struct {
 	LockWatcher *services.LockWatcher
 }
 
+const (
+	// FakePasswordHash is the bcrypt hash for password "barbaz", the same as the default used
+	// by auth.Server, except, it is generated with the minimum cost instead of the default
+	// cost to speed tests up.
+	FakePasswordHash = `$2a$04$uTNg/AhzeGARChkxBsddyeHuCI7SBr2SG7PYhu63mIXqzuqRD.cgq`
+
+	// FakeRecoveryCodeHash is the bcrypt hash for recovery code "fake-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz-barbaz",
+	// the same as the default used by auth.Server, except, it is generated with the minimum
+	// cost instead of the default cost to speed tests up.
+	FakeRecoveryCodeHash = `$2a$04$04QoQDbwYTwSIppmJLQQkebbFrMS9V02ttus3rHi2cwujcnDHKbL6`
+)
+
 // NewAuthServer returns a new test auth server.
 // The caller should close the server when it is no longer needed.
 func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
@@ -359,6 +371,8 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 		SessionSummarizerProvider:    cfg.SessionSummarizerProvider,
 		RecordingMetadataProvider:    cfg.RecordingMetadataProvider,
 		AWSOrganizationsClientGetter: cfg.AWSOrganizationsClientGetter,
+		FakePasswordHash:             []byte(FakePasswordHash),
+		FakeRecoveryCodeHash:         []byte(FakeRecoveryCodeHash),
 	},
 		// Reduce auth.Server bcrypt costs when testing.
 		WithBcryptCost(bcrypt.MinCost),

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -441,6 +441,15 @@ type InitConfig struct {
 
 	// WorkloadClusterService is the service that manages WorkloadClusters.
 	WorkloadClusterService services.WorkloadClusterService
+
+	// FakePasswordHash is the password hash given to all users without a password.
+	// This helps eliminate timing attacks by ensuring that all authentication attempts
+	// with a password do a bcrypt comparison.
+	FakePasswordHash []byte
+	// FakeRecoveryCodeHash is the recovery code hash given to all users without codes.
+	// This helps eliminate timing attacks by ensuring that all recovery attempts
+	// with codes do a bcrypt comparison.
+	FakeRecoveryCodeHash []byte
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -43,9 +43,6 @@ import (
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
-// This is bcrypt hash for password "barbaz".
-var fakePasswordHash = []byte(`$2a$10$Yy.e6BmS2SrGbBDsyDLVkOANZmvjjMR890nUGSXFJHBXWzxe7T44m`)
-
 // ChangeUserAuthentication implements AuthService.ChangeUserAuthentication.
 func (a *Server) ChangeUserAuthentication(ctx context.Context, req *proto.ChangeUserAuthenticationRequest) (*proto.ChangeUserAuthenticationResponse, error) {
 	user, err := a.changeUserAuthentication(ctx, req)
@@ -184,7 +181,7 @@ func (a *Server) checkPasswordWOToken(ctx context.Context, user string, password
 	if trace.IsNotFound(err) {
 		userFound = false
 		a.logger.DebugContext(ctx, "Password for username not found, using fake hash to mitigate timing attacks", "user", user)
-		hash = fakePasswordHash
+		hash = a.fakePasswordHash
 	}
 
 	if err = bcrypt.CompareHashAndPassword(hash, password); err != nil {


### PR DESCRIPTION
This follows a similar pattern used in other tests to override the bcrypt cost in tests to improve their performance. The fake password hash and fake recovery code hash has been moved from a global to an injected dependency of the auth server so that tests can provide a hash with a lower cost. The authtest now by default injects a hash of the same original string values but with the minimum cost.