### PR TITLE
Improve performance of recovery code generation

### DIFF
--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -522,13 +522,16 @@ func generateRecoveryCodes() ([]string, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		words := make([]string, 0, 1+len(wordIDs))
-		words = append(words, "tele")
+		const prefix = "tele"
+		var sb strings.Builder
+		sb.Grow(len(prefix) + len(wordIDs)*6)
+		sb.WriteString(prefix)
 		for _, id := range wordIDs {
-			words = append(words, encodeProquint(id))
+			sb.WriteRune('-')
+			sb.Write(encodeProquint(id))
 		}
 
-		tokenList = append(tokenList, strings.Join(words, "-"))
+		tokenList = append(tokenList, sb.String())
 	}
 
 	return tokenList, nil
@@ -538,7 +541,7 @@ func generateRecoveryCodes() ([]string, error) {
 // This proquint implementation is adapted from upspin.io:
 // https://github.com/upspin/upspin/blob/master/key/proquint/proquint.go
 // For the algorithm, see https://arxiv.org/html/0901.4016
-func encodeProquint(x uint16) string {
+func encodeProquint(x uint16) []byte {
 	const consonants = "bdfghjklmnprstvz"
 	const vowels = "aiou"
 
@@ -548,11 +551,11 @@ func encodeProquint(x uint16) string {
 	vow1 := (x >> 10) & 0b11
 	cons1 := x >> 12
 
-	return string([]byte{
+	return []byte{
 		consonants[cons1],
 		vowels[vow1],
 		consonants[cons2],
 		vowels[vow2],
 		consonants[cons3],
-	})
+	}
 }

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -258,7 +258,7 @@ func UpdateAccessRequestWithAdditionalReviewers(ctx context.Context, req types.A
 }
 
 func EncodeProquint(x uint16) string {
-	return encodeProquint(x)
+	return string(encodeProquint(x))
 }
 
 func EmitSSOLoginFailureEvent(ctx context.Context, emitter apievents.Emitter, method string, err error, testFlow bool) {

--- a/lib/auth/recovery_codes_test.go
+++ b/lib/auth/recovery_codes_test.go
@@ -1,0 +1,31 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkRecoveryCodeGeneration(b *testing.B) {
+	for b.Loop() {
+		codes, err := generateRecoveryCodes()
+		require.NoError(b, err)
+		require.Len(b, codes, numOfRecoveryCodes)
+	}
+}


### PR DESCRIPTION
Leverages a strings.Builder to reduce resource consumption required to generate recovery codes.

```
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/lib/auth
cpu: Apple M2 Pro
                          │   old.txt    │               new.txt               │
                          │    sec/op    │   sec/op     vs base                │
RecoveryCodeGeneration-12   12.533µ ± 1%   9.521µ ± 1%  -24.03% (p=0.000 n=10)

                          │   old.txt   │               new.txt               │
                          │    B/op     │    B/op      vs base                │
RecoveryCodeGeneration-12   1128.0 ± 7%   312.0 ± 11%  -72.34% (p=0.000 n=10)

                          │   old.txt   │              new.txt               │
                          │  allocs/op  │ allocs/op   vs base                │
RecoveryCodeGeneration-12   35.000 ± 0%   8.000 ± 0%  -77.14% (p=0.000 n=10)
```