### PR TITLE
Prefer authtest.AuthServer in tests that don't make API calls

### DIFF
--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -57,17 +57,22 @@ import (
 //   - reusing a used or non-existing token returns error
 func TestGenerateAndUpsertRecoveryCodes(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
 	ctx := context.Background()
 
 	user := "fake@fake.com"
-	rc, err := srv.Auth().GenerateAndUpsertRecoveryCodes(ctx, user)
+	rc, err := as.AuthServer.GenerateAndUpsertRecoveryCodes(ctx, user)
 	require.NoError(t, err)
 	require.Len(t, rc.Codes, auth.NumOfRecoveryCodes)
 	require.NotEmpty(t, rc.Created)
 
 	// Test codes are not marked used.
-	recovery, err := srv.Auth().GetRecoveryCodes(ctx, user, true /* withSecrets */)
+	recovery, err := as.AuthServer.GetRecoveryCodes(ctx, user, true /* withSecrets */)
 	require.NoError(t, err)
 	for _, token := range recovery.GetCodes() {
 		require.False(t, token.IsUsed)
@@ -82,55 +87,57 @@ func TestGenerateAndUpsertRecoveryCodes(t *testing.T) {
 		require.True(t, strings.HasPrefix(code, "tele-"))
 
 		// Test codes match.
-		err := srv.Auth().VerifyRecoveryCode(ctx, user, []byte(code))
+		err := as.AuthServer.VerifyRecoveryCode(ctx, user, []byte(code))
 		require.NoError(t, err)
 	}
 
 	// Test used codes are marked used.
-	recovery, err = srv.Auth().GetRecoveryCodes(ctx, user, true /* withSecrets */)
+	recovery, err = as.AuthServer.GetRecoveryCodes(ctx, user, true /* withSecrets */)
 	require.NoError(t, err)
 	for _, token := range recovery.GetCodes() {
 		require.True(t, token.IsUsed)
 	}
 
 	// Test with a used code returns error.
-	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
+	err = as.AuthServer.VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Test with invalid recovery code returns error.
-	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte("invalidcode"))
+	err = as.AuthServer.VerifyRecoveryCode(ctx, user, []byte("invalidcode"))
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Test with non-existing user returns error.
-	err = srv.Auth().VerifyRecoveryCode(ctx, "doesnotexist", []byte(rc.Codes[0]))
+	err = as.AuthServer.VerifyRecoveryCode(ctx, "doesnotexist", []byte(rc.Codes[0]))
 	require.True(t, trace.IsAccessDenied(err))
 }
 
 func TestRecoveryCodeEventsEmitted(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	ctx := context.Background()
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().SetEmitter(mockEmitter)
+	as.AuthServer.SetEmitter(mockEmitter)
 
 	user := "fake@fake.com"
 
 	// Test generated recovery codes event.
-	rc, err := srv.Auth().GenerateAndUpsertRecoveryCodes(ctx, user)
+	rc, err := as.AuthServer.GenerateAndUpsertRecoveryCodes(ctx, user)
 	require.NoError(t, err)
 	event := mockEmitter.LastEvent()
 	require.Equal(t, events.RecoveryCodeGeneratedEvent, event.GetType())
 	require.Equal(t, events.RecoveryCodesGenerateCode, event.GetCode())
 
 	// Test used recovery code event.
-	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
+	err = as.AuthServer.VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
 	require.NoError(t, err)
 	event = mockEmitter.LastEvent()
 	require.Equal(t, events.RecoveryCodeUsedEvent, event.GetType())
 	require.Equal(t, events.RecoveryCodeUseSuccessCode, event.GetCode())
 
 	// Re-using the same token emits failed event.
-	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
+	err = as.AuthServer.VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
 	require.Error(t, err)
 	event = mockEmitter.LastEvent()
 	require.Equal(t, events.RecoveryCodeUsedEvent, event.GetType())
@@ -1019,7 +1026,9 @@ func TestAccountRecoveryFlow(t *testing.T) {
 
 func TestGetAccountRecoveryToken(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	ctx := context.Background()
 
 	cases := []struct {
@@ -1032,14 +1041,14 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 			name:    "invalid token type",
 			wantErr: true,
 			getRequest: func() *proto.GetAccountRecoveryTokenRequest {
-				wrongTokenType, err := srv.Auth().NewUserToken(ctx, authclient.CreateUserTokenRequest{
+				wrongTokenType, err := as.AuthServer.NewUserToken(ctx, authclient.CreateUserTokenRequest{
 					Name: "llama",
 					TTL:  5 * time.Minute,
 					Type: authclient.UserTokenTypeResetPassword,
 				})
 				require.NoError(t, err)
 
-				_, err = srv.Auth().CreateUserToken(ctx, wrongTokenType)
+				_, err = as.AuthServer.CreateUserToken(ctx, wrongTokenType)
 				require.NoError(t, err)
 
 				return &proto.GetAccountRecoveryTokenRequest{
@@ -1060,7 +1069,7 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 			name:      "recovery start token",
 			tokenType: authclient.UserTokenTypeRecoveryStart,
 			getRequest: func() *proto.GetAccountRecoveryTokenRequest {
-				token, err := srv.Auth().CreateRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := as.AuthServer.CreateRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.GetAccountRecoveryTokenRequest{
@@ -1072,7 +1081,7 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 			name:      "recovery approve token",
 			tokenType: authclient.UserTokenTypeRecoveryApproved,
 			getRequest: func() *proto.GetAccountRecoveryTokenRequest {
-				token, err := srv.Auth().CreateRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := as.AuthServer.CreateRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.GetAccountRecoveryTokenRequest{
@@ -1086,7 +1095,7 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			retToken, err := srv.Auth().GetAccountRecoveryToken(ctx, c.getRequest())
+			retToken, err := as.AuthServer.GetAccountRecoveryToken(ctx, c.getRequest())
 
 			switch {
 			case c.wantErr:
@@ -1100,7 +1109,15 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 }
 
 func TestCreateAccountRecoveryCodes(t *testing.T) {
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+		AuthPreferenceSpec: &types.AuthPreferenceSpecV2{
+			Type:          constants.Local,
+			SecondFactors: []types.SecondFactorType{types.SecondFactorType_SECOND_FACTOR_TYPE_OTP},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	ctx := context.Background()
 
 	modulestest.SetTestModules(t, modulestest.Modules{
@@ -1109,18 +1126,8 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 		},
 	})
 
-	// Enable second factors.
-	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
-		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorOTP,
-	})
-	require.NoError(t, err)
-
-	_, err = srv.Auth().UpsertAuthPreference(ctx, ap)
-	require.NoError(t, err)
-
 	const user = "llama@example.com"
-	_, _, err = authtest.CreateUserAndRole(srv.Auth(), user, []string{user}, nil /* allowRules */)
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, user, []string{user}, nil /* allowRules */)
 	require.NoError(t, err, "CreateUserAndRole failed")
 
 	cases := []struct {
@@ -1132,7 +1139,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 			name:    "invalid token type",
 			wantErr: true,
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().CreateRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := as.AuthServer.CreateRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1153,7 +1160,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 			name:    "invalid user name",
 			wantErr: true,
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().CreateRecoveryToken(ctx, "invalid-username", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := as.AuthServer.CreateRecoveryToken(ctx, "invalid-username", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1164,7 +1171,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 		{
 			name: "recovery approved token",
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().CreateRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := as.AuthServer.CreateRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1175,7 +1182,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 		{
 			name: "privilege token",
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := auth.CreatePrivilegeToken(ctx, srv.Auth(), user, authclient.UserTokenTypePrivilege)
+				token, err := auth.CreatePrivilegeToken(ctx, as.AuthServer, user, authclient.UserTokenTypePrivilege)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1188,7 +1195,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			req := c.getRequest()
-			res, err := srv.Auth().CreateAccountRecoveryCodes(ctx, req)
+			res, err := as.AuthServer.CreateAccountRecoveryCodes(ctx, req)
 
 			switch {
 			case c.wantErr:
@@ -1200,7 +1207,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 				require.NotEmpty(t, res.GetCreated())
 
 				// Check token is deleted after success.
-				_, err = srv.Auth().GetUserToken(ctx, req.TokenID)
+				_, err = as.AuthServer.GetUserToken(ctx, req.TokenID)
 				require.True(t, trace.IsNotFound(err))
 			}
 		})

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -900,12 +900,14 @@ func TestServer_AuthenticateUser_passwordOnly(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	const username = "bowman"
 	const password = "it's full of stars!"
-	_, _, err := authtest.CreateUserAndRole(authServer, username, nil, nil)
+	_, _, err = authtest.CreateUserAndRole(authServer, username, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, authServer.UpsertPassword(username, []byte(password)))
 
@@ -1121,8 +1123,10 @@ func TestServer_AuthenticateUser_passwordOnly_failure(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	const username = "capybara"
 
@@ -1198,12 +1202,14 @@ func TestServer_AuthenticateUser_setsPasswordState(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	const username = "bowman"
 	const password = "it's full of stars!"
-	_, _, err := authtest.CreateUserAndRole(authServer, username, nil, nil)
+	_, _, err = authtest.CreateUserAndRole(authServer, username, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, authServer.UpsertPassword(username, []byte(password)))
 

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1588,8 +1588,14 @@ func TestEmitSSOLoginFailureEvent(t *testing.T) {
 func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	t.Parallel()
 
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	clock := clockwork.NewFakeClock()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 	emitter := &eventstest.MockRecorderEmitter{}
 	authServer.SetEmitter(emitter)
 	ctx := context.Background()
@@ -1603,7 +1609,7 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	principals := []string{"login0", username, "-teleport-internal-join"}
 
 	// Prepare the user to test with.
-	_, _, err := authtest.CreateUserAndRole(authServer, username, principals, nil)
+	_, _, err = authtest.CreateUserAndRole(authServer, username, principals, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	require.NoError(t,
 		authServer.UpsertPassword(username, []byte(pass)),
@@ -1626,12 +1632,6 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	const devID = "deviceid1"
 	const devTag = "devicetag1"
 	const devCred = "devicecred1"
-
-	advanceClock := func(d time.Duration) {
-		if fc, ok := testServer.Clock().(*clockwork.FakeClock); ok {
-			fc.Advance(d)
-		}
-	}
 
 	tests := []struct {
 		name           string
@@ -1691,14 +1691,14 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 				Username: username,
 				Identity: *identity,
 			})
-			authCtx, err := testServer.APIConfig.Authorizer.Authorize(ctx)
+			authCtx, err := as.Authorizer.Authorize(ctx)
 			require.NoError(t, err, "Authorize failed")
 
 			// Advance time before issuing new certs. This makes timestamp checks
 			// effective under fake clocks.
 			// 1m is enough to make tests fail if the timestamps aren't correct.
-			advanceClock(1 * time.Minute)
-			validAfter := testServer.Clock().Now().UTC().Add(-61 * time.Second)
+			clock.Advance(1 * time.Minute)
+			validAfter := clock.Now().UTC().Add(-61 * time.Second)
 
 			// Test!
 			certs, err := authServer.AugmentContextUserCertificates(ctx, authCtx, test.opts)
@@ -1751,8 +1751,10 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	t.Parallel()
 
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 	ctx := context.Background()
 
 	const pass1 = "secret!!1!!!"
@@ -1830,7 +1832,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	// Build an invalid version of xCert1 (signed using wrongKey).
 	userCA, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.UserCA,
-		DomainName: testServer.ClusterName(),
+		DomainName: as.ClusterName,
 	}, true /* loadKeys */)
 	require.NoError(t, err, "GetCertAuthority failed")
 	caXPEM := userCA.GetActiveKeys().TLS[0].Cert
@@ -1852,7 +1854,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 
 	// Issue augmented certs for user1.
 	// Used to test that re-issue of augmented certs is not allowed.
-	ctxFromAuthorize := testServer.APIConfig.Authorizer.Authorize
+	ctxFromAuthorize := as.Authorizer.Authorize
 	aCtx := authz.ContextWithUserCertificate(context.Background(), xCert1)
 	aCtx = authz.ContextWithUser(aCtx, authz.LocalUser{
 		Username: identity1.Username,
@@ -2064,7 +2066,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			identity: identity1,
 			createOpts: func(t *testing.T) *auth.AugmentUserCertificateOpts {
 				// Fake a 1h TTL, expired cert.
-				now := testServer.Clock().Now()
+				now := as.Clock().Now()
 				after := now.Add(-1 * time.Hour)
 				before := now.Add(-1 * time.Minute)
 
@@ -2204,11 +2206,13 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 	t.Parallel()
 
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 	ctx := context.Background()
 
-	userData := setupUserForAugmentWebSessionCertificatesTest(t, testServer)
+	userData := setupUserForAugmentWebSessionCertificatesTest(t, authServer)
 
 	// Safe to reuse, user-independent.
 	deviceExts := &auth.DeviceExtensions{
@@ -2265,7 +2269,7 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 		})
 	})
 
-	user2Data := setupUserForAugmentWebSessionCertificatesTest(t, testServer)
+	user2Data := setupUserForAugmentWebSessionCertificatesTest(t, authServer)
 	user2Opts := &auth.AugmentWebSessionCertificatesOpts{
 		WebSessionID:     user2Data.webSessionID,
 		User:             user2Data.user,
@@ -2333,11 +2337,13 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 func TestServer_ExtendWebSession_deviceExtensions(t *testing.T) {
 	t.Parallel()
 
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 	ctx := context.Background()
 
-	userData := setupUserForAugmentWebSessionCertificatesTest(t, testServer)
+	userData := setupUserForAugmentWebSessionCertificatesTest(t, authServer)
 
 	deviceExts := &auth.DeviceExtensions{
 		DeviceID:     "my-device-id",
@@ -2346,7 +2352,7 @@ func TestServer_ExtendWebSession_deviceExtensions(t *testing.T) {
 	}
 
 	// Augment the user's session, then later extend it.
-	err := authServer.AugmentWebSessionCertificates(ctx, &auth.AugmentWebSessionCertificatesOpts{
+	err = authServer.AugmentWebSessionCertificates(ctx, &auth.AugmentWebSessionCertificatesOpts{
 		WebSessionID:     userData.webSessionID,
 		User:             userData.user,
 		DeviceExtensions: deviceExts,
@@ -2404,8 +2410,7 @@ type augmentUserData struct {
 	webSessionID string
 }
 
-func setupUserForAugmentWebSessionCertificatesTest(t *testing.T, testServer *authtest.TLSServer) *augmentUserData {
-	authServer := testServer.Auth()
+func setupUserForAugmentWebSessionCertificatesTest(t *testing.T, authServer *auth.Server) *augmentUserData {
 	ctx := context.Background()
 
 	user := &augmentUserData{
@@ -4848,8 +4853,10 @@ func TestCreateAccessListReminderNotifications_LargeOverdueSet(t *testing.T) {
 	modulestest.SetTestModules(t, *modulestest.EnterpriseModules())
 
 	// Setup test auth server
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir(), CacheEnabled: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	testRole, err := types.NewRole("test", types.RoleSpecV6{
 		Allow: types.RoleConditions{
@@ -4882,7 +4889,7 @@ func TestCreateAccessListReminderNotifications_LargeOverdueSet(t *testing.T) {
 	}
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		lists, err := testServer.Auth().Cache.GetAccessLists(ctx)
+		lists, err := authServer.Cache.GetAccessLists(ctx)
 		assert.NoError(t, err)
 		assert.Len(t, lists, numAccessLists, "should have created all %d overdue access lists", numAccessLists)
 	}, 5*time.Minute, 500*time.Millisecond)

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7362,13 +7362,15 @@ func newScopedTestServerForHost(t *testing.T, srv *authtest.AuthServer, hostID, 
 func TestGenerateHostCertsScoped(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	scope := "/aa/bb"
 	hostID := "testhost"
 	roles := types.SystemRoles{types.RoleNode}
 
-	s := newScopedTestServerForHost(t, srv.AuthServer, hostID, scope, types.RoleNode)
+	s := newScopedTestServerForHost(t, as, hostID, scope, types.RoleNode)
 
 	_, sshPub, err := testauthority.GenerateKeyPair()
 	require.NoError(t, err)
@@ -10347,8 +10349,11 @@ func collectWatchKind(kinds []types.WatchKind) []string {
 
 func TestKubeKeepAliveServer(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
-	domainName, err := srv.Auth().GetDomainName()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
+	domainName, err := authServer.GetDomainName()
 	require.NoError(t, err)
 
 	tests := map[string]struct {
@@ -10400,7 +10405,7 @@ func TestKubeKeepAliveServer(t *testing.T) {
 			)
 			require.NoError(t, err)
 			// Upsert the kubernetes server into the backend.
-			_, err = srv.Auth().UpsertKubernetesServer(context.Background(), kubeServer)
+			_, err = authServer.UpsertKubernetesServer(context.Background(), kubeServer)
 			require.NoError(t, err)
 
 			// Create a built-in role.
@@ -10415,7 +10420,7 @@ func TestKubeKeepAliveServer(t *testing.T) {
 
 			// Create a server with the built-in role.
 			srv := auth.NewServerWithRoles(
-				srv.Auth(),
+				authServer,
 				events.NewDiscardAuditLog(),
 				*authContext,
 			)
@@ -10648,9 +10653,11 @@ func TestCloudDefaultPasswordless(t *testing.T) {
 func TestRoleRequestReasonModeValidation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
-	s := newTestServerWithRoles(t, srv.AuthServer, types.RoleAdmin)
+	s := newTestServerWithRoles(t, as, types.RoleAdmin)
 
 	testCases := []struct {
 		desc          string
@@ -11097,9 +11104,11 @@ func createTestMCPAppServer(t *testing.T, auth *auth.Server, name string, labels
 func TestSAMLIdPRoleOptionCreateUpdateValidation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
-	s := newTestServerWithRoles(t, srv.AuthServer, types.RoleAdmin)
+	s := newTestServerWithRoles(t, as, types.RoleAdmin)
 
 	const errMsg = "supported in role version 7 and below"
 	testCases := []struct {
@@ -11339,7 +11348,9 @@ func TestRegisterInventoryControlStreamScopes(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	const serverID = "test-server"
 	const agentScope = "/test/one"
@@ -11371,7 +11382,7 @@ func TestRegisterInventoryControlStreamScopes(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			h := newInventoryControlStreamHarness(t, srv.AuthServer, serverID, agentScope, "", types.RoleNode)
+			h := newInventoryControlStreamHarness(t, as, serverID, agentScope, "", types.RoleNode)
 			type registerResult struct {
 				hello *proto.UpstreamInventoryHello
 				err   error
@@ -11419,8 +11430,9 @@ func TestRegisterInventoryControlStreamImmutableLabels(t *testing.T) {
 	}
 	helloHash := joining.HashImmutableLabels(helloLabels)
 
-	srv := newTestTLSServer(t)
-	t.Cleanup(func() { srv.Close() })
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	cases := []struct {
 		name        string
@@ -11461,7 +11473,7 @@ func TestRegisterInventoryControlStreamImmutableLabels(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			h := newInventoryControlStreamHarness(t, srv.AuthServer, serverID, "", c.identHash, types.RoleNode)
+			h := newInventoryControlStreamHarness(t, as, serverID, "", c.identHash, types.RoleNode)
 			type registerResult struct {
 				hello *proto.UpstreamInventoryHello
 				err   error

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -160,7 +160,11 @@ type ServerConfig struct {
 	TLS *TLSServerConfig
 }
 
-// NewTestServer creates a new test server configuration
+// NewTestServer creates a new test server configuration and exposes
+// the Auth Service on a random local address. It is the callers
+// responsibility close the server when it is no longer needed.
+//
+// Prefer NewAuthServer if Auth Service RPCs are never invoked.
 func NewTestServer(cfg ServerConfig) (*Server, error) {
 	authServer, err := NewAuthServer(cfg.Auth)
 	if err != nil {
@@ -274,8 +278,11 @@ const (
 	FakeRecoveryCodeHash = `$2a$04$04QoQDbwYTwSIppmJLQQkebbFrMS9V02ttus3rHi2cwujcnDHKbL6`
 )
 
-// NewAuthServer returns a new test auth server.
-// The caller should close the server when it is no longer needed.
+// NewAuthServer returns a new test auth server. It is the callers
+// responsibility close the server when it is no longer needed.
+//
+// Prefer using this over NewTestTLSServer if Auth Service RPCs are
+// never invoked.
 func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 	ctx := context.Background()
 
@@ -854,7 +861,8 @@ func (a *AuthServer) Trust(ctx context.Context, remote *AuthServer, roleMap type
 	return nil
 }
 
-// NewTestTLSServer returns new test TLS server
+// NewTestTLSServer creates a test TLS server configured to use
+// this AuthServer.
 func (a *AuthServer) NewTestTLSServer(opts ...TestTLSServerOption) (*TLSServer, error) {
 	apiConfig := &auth.APIConfig{
 		AuthServer:       a.AuthServer,
@@ -990,7 +998,10 @@ func (cfg *TLSServerConfig) CheckAndSetDefaults() error {
 }
 
 // NewTestTLSServer returns new test TLS server that is started and is listening
-// on 127.0.0.1 loopback on any available port
+// on 127.0.0.1 loopback on any available port. It is the callers responsibility
+// close the server when it is no longer needed.
+//
+// Prefer using authtest.AuthServer directly if Auth Service RPCs are never used.
 func NewTestTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	err := cfg.CheckAndSetDefaults()
 	if err != nil {

--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -1497,8 +1497,10 @@ func TestServer_CreateBoundKeypairToken(t *testing.T) {
 	// at this layer to generate the default registration secret if needed we
 	// should test.
 	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
-	srv := newTestTLSServer(t, withClock(clock))
-	authServer := srv.Auth()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir(), Clock: clock})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	tests := []struct {
 		name      string

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -26,14 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
@@ -44,103 +42,23 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authcatest"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
-	authority "github.com/gravitational/teleport/lib/auth/testauthority"
-	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/services/local"
 )
-
-type passwordSuite struct {
-	bk          backend.Backend
-	a           *auth.Server
-	mockEmitter *eventstest.MockRecorderEmitter
-	clock       *clockwork.FakeClock
-}
-
-func setupPasswordSuite(t *testing.T) *passwordSuite {
-	s := passwordSuite{
-		clock: clockwork.NewFakeClock(),
-	}
-
-	ctx := t.Context()
-
-	var err error
-	s.bk, err = memory.New(memory.Config{
-		Context: ctx,
-		Clock:   s.clock,
-	})
-	require.NoError(t, err)
-
-	// set cluster name
-	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		s.bk.Close()
-	})
-
-	a, err := authority.NewKeygen(modules.BuildOSS, s.clock.Now)
-	require.NoError(t, err)
-
-	identity, err := local.NewTestIdentityService(s.bk)
-	require.NoError(t, err)
-
-	authConfig := &auth.InitConfig{
-		ClusterName:            clusterName,
-		Backend:                s.bk,
-		VersionStorage:         authtest.NewFakeTeleportVersion(),
-		Authority:              a,
-		SkipPeriodicOperations: true,
-		HostUUID:               uuid.NewString(),
-		Clock:                  s.clock,
-		Identity:               identity,
-		FakePasswordHash:       []byte(authtest.FakePasswordHash),
-		FakeRecoveryCodeHash:   []byte(authtest.FakeRecoveryCodeHash),
-	}
-	s.a, err = auth.NewServer(authConfig)
-	require.NoError(t, err)
-
-	err = s.a.SetClusterName(clusterName)
-	require.NoError(t, err)
-
-	// set lock watcher
-	lockWatcher, err := services.NewLockWatcher(ctx, services.LockWatcherConfig{
-		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: teleport.ComponentAuth,
-			Client:    s.a,
-		},
-	})
-	require.NoError(t, err, "NewLockWatcher")
-	s.a.SetLockWatcher(lockWatcher)
-
-	// set static tokens
-	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
-		StaticTokens: []types.ProvisionTokenV1{},
-	})
-	require.NoError(t, err)
-	err = s.a.SetStaticTokens(staticTokens)
-	require.NoError(t, err)
-
-	s.mockEmitter = &eventstest.MockRecorderEmitter{}
-	s.a.SetEmitter(s.mockEmitter)
-	return &s
-}
 
 func TestUserNotFound(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	s := setupPasswordSuite(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	username := "unknown-user"
 	password := "feefiefoefum"
 
-	err := s.a.CheckPasswordWOToken(ctx, username, []byte(password))
+	err = as.AuthServer.CheckPasswordWOToken(ctx, username, []byte(password))
 	require.Error(t, err)
 	// Make sure the error is not a NotFound. That would be a username oracle.
 	require.True(t, trace.IsBadParameter(err))
@@ -183,59 +101,75 @@ func TestChangePassword(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
-	s := setupPasswordSuite(t)
-	req, err := s.prepareForPasswordChange("user1", []byte("abcdef123456"), constants.SecondFactorOff)
+	clock := clockwork.NewFakeClock()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	mockEmitter := &eventstest.MockRecorderEmitter{}
+	as.AuthServer.SetEmitter(mockEmitter)
+
+	req, err := prepareForPasswordChange(as.AuthServer, "user1", []byte("abcdef123456"), constants.SecondFactorOff)
 	require.NoError(t, err)
 
 	req.NewPassword = []byte("defceba654321")
 
-	err = s.a.ChangePassword(ctx, req)
+	err = as.AuthServer.ChangePassword(ctx, req)
 	require.NoError(t, err)
-	require.Equal(t, events.UserPasswordChangeEvent, s.mockEmitter.LastEvent().GetType())
-	require.Equal(t, "user1", s.mockEmitter.LastEvent().(*apievents.UserPasswordChange).User)
-	s.shouldLockAfterFailedAttempts(t, req)
+	require.Equal(t, events.UserPasswordChangeEvent, mockEmitter.LastEvent().GetType())
+	require.Equal(t, "user1", mockEmitter.LastEvent().(*apievents.UserPasswordChange).User)
+	shouldLockAfterFailedAttempts(t, as.AuthServer, req)
 
 	// advance time and make sure we can login again
-	s.clock.Advance(defaults.AccountLockInterval + time.Second)
+	clock.Advance(defaults.AccountLockInterval + time.Second)
 	req.OldPassword = req.NewPassword
 	req.NewPassword = []byte("123456abcdef")
-	err = s.a.ChangePassword(ctx, req)
+	err = as.AuthServer.ChangePassword(ctx, req)
 	require.NoError(t, err)
 }
 
 func TestChangePasswordWithOTP(t *testing.T) {
 	t.Parallel()
 
-	s := setupPasswordSuite(t)
-	req, err := s.prepareForPasswordChange("user2", []byte("abcdef123456"), constants.SecondFactorOTP)
+	clock := clockwork.NewFakeClock()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	req, err := prepareForPasswordChange(as.AuthServer, "user2", []byte("abcdef123456"), constants.SecondFactorOTP)
 	require.NoError(t, err)
 
 	otpSecret := base32.StdEncoding.EncodeToString([]byte("def456"))
-	dev, err := services.NewTOTPDevice("otp", otpSecret, s.clock.Now())
+	dev, err := services.NewTOTPDevice("otp", otpSecret, clock.Now())
 	require.NoError(t, err)
 	ctx := context.Background()
-	err = s.a.UpsertMFADevice(ctx, req.User, dev)
+	err = as.AuthServer.UpsertMFADevice(ctx, req.User, dev)
 	require.NoError(t, err)
 
-	validToken, err := totp.GenerateCode(otpSecret, s.a.GetClock().Now())
+	validToken, err := totp.GenerateCode(otpSecret, clock.Now())
 	require.NoError(t, err)
 
 	// change password
 	req.NewPassword = []byte("defceba654321")
 	req.SecondFactorToken = validToken
-	err = s.a.ChangePassword(ctx, req)
+	err = as.AuthServer.ChangePassword(ctx, req)
 	require.NoError(t, err)
 
-	s.shouldLockAfterFailedAttempts(t, req)
+	shouldLockAfterFailedAttempts(t, as.AuthServer, req)
 
 	// advance time and make sure we can login again
-	s.clock.Advance(defaults.AccountLockInterval + time.Second)
+	clock.Advance(defaults.AccountLockInterval + time.Second)
 
-	validToken, _ = totp.GenerateCode(otpSecret, s.a.GetClock().Now())
+	validToken, _ = totp.GenerateCode(otpSecret, clock.Now())
 	req.OldPassword = req.NewPassword
 	req.NewPassword = []byte("123456abcdef")
 	req.SecondFactorToken = validToken
-	err = s.a.ChangePassword(ctx, req)
+	err = as.AuthServer.ChangePassword(ctx, req)
 	require.NoError(t, err)
 }
 
@@ -505,9 +439,11 @@ func TestServer_ChangePassword_Fails(t *testing.T) {
 func TestChangeUserAuthentication(t *testing.T) {
 	t.Parallel()
 
-	testServer := newTestTLSServer(t)
-	authServer := testServer.Auth()
-	clock := testServer.Clock()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
+	clock := as.Clock()
 	ctx := context.Background()
 
 	tests := []struct {
@@ -774,19 +710,26 @@ func TestChangeUserAuthentication(t *testing.T) {
 func TestChangeUserAuthenticationWithErrors(t *testing.T) {
 	t.Parallel()
 
-	s := setupPasswordSuite(t)
-	ctx := context.Background()
 	authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
-		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorOTP,
+		Type:          constants.Local,
+		SecondFactors: []types.SecondFactorType{types.SecondFactorType_SECOND_FACTOR_TYPE_OTP},
 	})
 	require.NoError(t, err)
 
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:                t.TempDir(),
+		AuthPreferenceSpec: &authPreference.(*types.AuthPreferenceV2).Spec,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	ctx := context.Background()
+
 	username := "joe@example.com"
-	_, _, err = authtest.CreateUserAndRole(s.a, username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, username, []string{username}, nil)
 	require.NoError(t, err)
 
-	token, err := s.a.CreateResetPasswordToken(ctx, authclient.CreateUserTokenRequest{
+	token, err := as.AuthServer.CreateResetPasswordToken(ctx, authclient.CreateUserTokenRequest{
 		Name: username,
 	})
 	require.NoError(t, err)
@@ -841,25 +784,25 @@ func TestChangeUserAuthenticationWithErrors(t *testing.T) {
 	for _, tc := range testCases {
 		// set new auth preference settings
 		authPreference.SetSecondFactor(tc.secondFactor)
-		authPreference, err = s.a.UpsertAuthPreference(ctx, authPreference)
+		authPreference, err = as.AuthServer.UpsertAuthPreference(ctx, authPreference)
 		require.NoError(t, err)
 
-		_, err = auth.ChangeUserAuthentication(ctx, s.a, tc.req)
+		_, err = auth.ChangeUserAuthentication(ctx, as.AuthServer, tc.req)
 		require.Error(t, err, "test case %q", tc.desc)
 	}
 
 	authPreference.SetSecondFactor(constants.SecondFactorOff)
-	_, err = s.a.UpsertAuthPreference(ctx, authPreference)
+	_, err = as.AuthServer.UpsertAuthPreference(ctx, authPreference)
 	require.NoError(t, err)
 
-	_, err = auth.ChangeUserAuthentication(ctx, s.a, &proto.ChangeUserAuthenticationRequest{
+	_, err = auth.ChangeUserAuthentication(ctx, as.AuthServer, &proto.ChangeUserAuthenticationRequest{
 		TokenID:     validTokenID,
 		NewPassword: validPassword,
 	})
 	require.NoError(t, err)
 
 	// invite token cannot be reused
-	_, err = auth.ChangeUserAuthentication(ctx, s.a, &proto.ChangeUserAuthenticationRequest{
+	_, err = auth.ChangeUserAuthentication(ctx, as.AuthServer, &proto.ChangeUserAuthenticationRequest{
 		TokenID:     validTokenID,
 		NewPassword: validPassword,
 	})
@@ -868,48 +811,52 @@ func TestChangeUserAuthenticationWithErrors(t *testing.T) {
 
 func TestResetPassword(t *testing.T) {
 	t.Parallel()
-	s := setupPasswordSuite(t)
 
-	_, _, err := authtest.CreateUserAndRole(s.a, "dave", []string{"dave"}, nil)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, "dave", []string{"dave"}, nil)
 	require.NoError(t, err)
 
 	// Using the Identity service makes it easier to set up the test case.
-	err = s.a.Identity.UpsertPassword("dave", []byte("it's full of stars!"))
+	err = as.AuthServer.Identity.UpsertPassword("dave", []byte("it's full of stars!"))
 	require.NoError(t, err)
 
 	// Reset password.
 	ctx := context.Background()
-	err = s.a.ResetPassword(ctx, "dave")
+	err = as.AuthServer.ResetPassword(ctx, "dave")
 	require.NoError(t, err)
 
 	// Make sure that the password has been reset.
-	u, err := s.a.Identity.GetUser(ctx, "dave", true /* withSecrets */)
+	u, err := as.AuthServer.Identity.GetUser(ctx, "dave", true /* withSecrets */)
 	require.NoError(t, err)
 	assert.Nil(t, u.GetLocalAuth(), "user LocalAuth not nil")
 	assert.Equal(t, types.PasswordState_PASSWORD_STATE_UNSET, u.GetPasswordState())
 
 	// Make sure that we can reset once again (i.e. we don't complain if there's
 	// no password).
-	err = s.a.ResetPassword(ctx, "dave")
+	err = as.AuthServer.ResetPassword(ctx, "dave")
 	require.NoError(t, err)
 }
 
-func (s *passwordSuite) shouldLockAfterFailedAttempts(t *testing.T, req *proto.ChangePasswordRequest) {
-	ctx := context.Background()
-	loginAttempts, _ := s.a.GetUserLoginAttempts(req.User)
+func shouldLockAfterFailedAttempts(t *testing.T, as *auth.Server, req *proto.ChangePasswordRequest) {
+	loginAttempts, _ := as.GetUserLoginAttempts(req.User)
 	require.Empty(t, loginAttempts)
 	for i := range defaults.MaxLoginAttempts {
-		err := s.a.ChangePassword(ctx, req)
+		err := as.ChangePassword(t.Context(), req)
 		require.Error(t, err)
-		loginAttempts, _ = s.a.GetUserLoginAttempts(req.User)
+		loginAttempts, _ = as.GetUserLoginAttempts(req.User)
 		require.Len(t, loginAttempts, i+1)
 	}
 
-	err := s.a.ChangePassword(ctx, req)
+	err := as.ChangePassword(t.Context(), req)
 	require.True(t, trace.IsAccessDenied(err))
 }
 
-func (s *passwordSuite) prepareForPasswordChange(user string, pass []byte, secondFactorType constants.SecondFactorType) (*proto.ChangePasswordRequest, error) {
+func prepareForPasswordChange(as *auth.Server, user string, pass []byte, secondFactorType constants.SecondFactorType) (*proto.ChangePasswordRequest, error) {
 	ctx := context.Background()
 	req := &proto.ChangePasswordRequest{
 		User:        user,
@@ -920,7 +867,7 @@ func (s *passwordSuite) prepareForPasswordChange(user string, pass []byte, secon
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := s.a.UpsertCertAuthority(ctx, userCA); err != nil {
+	if err := as.UpsertCertAuthority(ctx, userCA); err != nil {
 		return nil, err
 	}
 
@@ -928,7 +875,7 @@ func (s *passwordSuite) prepareForPasswordChange(user string, pass []byte, secon
 	if err != nil {
 		return nil, err
 	}
-	if err := s.a.UpsertCertAuthority(ctx, hostCA); err != nil {
+	if err := as.UpsertCertAuthority(ctx, hostCA); err != nil {
 		return nil, err
 	}
 
@@ -940,14 +887,14 @@ func (s *passwordSuite) prepareForPasswordChange(user string, pass []byte, secon
 		return nil, err
 	}
 
-	if _, err := s.a.UpsertAuthPreference(ctx, ap); err != nil {
+	if _, err := as.UpsertAuthPreference(ctx, ap); err != nil {
 		return nil, err
 	}
 
-	if _, _, err := authtest.CreateUserAndRole(s.a, user, []string{user}, nil); err != nil {
+	if _, _, err := authtest.CreateUserAndRole(as, user, []string{user}, nil); err != nil {
 		return nil, err
 	}
-	if err := s.a.UpsertPassword(user, pass); err != nil {
+	if err := as.UpsertPassword(user, pass); err != nil {
 		return nil, err
 	}
 

--- a/lib/auth/recording_authorizer_test.go
+++ b/lib/auth/recording_authorizer_test.go
@@ -19,8 +19,6 @@
 package auth_test
 
 import (
-	"errors"
-	"net"
 	"testing"
 	"time"
 
@@ -42,8 +40,10 @@ import (
 func TestSessionRecordingAuthorized_RBAC(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestTLSServerForRecording(t)
-	authServer := srv.AuthServer.AuthServer
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
 
 	session1 := createTestSession(t, authServer, "alice", []string{"alice", "bob"})
 	session2 := createTestSession(t, authServer, "bob", []string{"bob", "charlie"})
@@ -83,7 +83,7 @@ func TestSessionRecordingAuthorized_RBAC(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, role, err := authtest.CreateUserAndRole(
-				srv.Auth(),
+				authServer,
 				tc.username,
 				[]string{},
 				[]types.Rule{
@@ -103,7 +103,7 @@ func TestSessionRecordingAuthorized_RBAC(t *testing.T) {
 					Groups:   []string{role.GetName()},
 				},
 			}
-			authContext, err := authz.ContextForLocalUser(t.Context(), localUser, srv.Auth(), srv.ClusterName(), true /* disableDeviceAuthz */)
+			authContext, err := authz.ContextForLocalUser(t.Context(), localUser, authServer, as.ClusterName, true /* disableDeviceAuthz */)
 			require.NoError(t, err)
 
 			authorizer := &mockAuthorizer{
@@ -128,27 +128,6 @@ func TestSessionRecordingAuthorized_RBAC(t *testing.T) {
 			}
 		})
 	}
-}
-
-func newTestTLSServerForRecording(t testing.TB) *authtest.TLSServer {
-	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Dir: t.TempDir(),
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, as.Close()) })
-
-	srv, err := as.NewTestTLSServer()
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		err := srv.Close()
-		if errors.Is(err, net.ErrClosed) {
-			return
-		}
-		require.NoError(t, err)
-	})
-
-	return srv
 }
 
 func createTestSession(t *testing.T, authServer *auth.Server, user string, participants []string) session.ID {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1741,35 +1741,37 @@ func TestPasswordCRUD(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.AuthServerConfig.Clock
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	clock := as.Clock()
 
 	// Create a user.
 	u, err := types.NewUser("user1")
 	require.NoError(t, err)
-	_, err = testSrv.Auth().CreateUser(ctx, u)
+	_, err = as.AuthServer.CreateUser(ctx, u)
 	require.NoError(t, err)
 
 	pass := []byte("abcdef123456")
 	rawSecret := "def456"
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, "123456")
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, "123456")
 	require.Error(t, err)
 
-	err = testSrv.Auth().UpsertPassword("user1", pass)
+	err = as.AuthServer.UpsertPassword("user1", pass)
 	require.NoError(t, err)
 
 	dev, err := services.NewTOTPDevice("otp", otpSecret, clock.Now())
 	require.NoError(t, err)
 
-	err = testSrv.Auth().UpsertMFADevice(ctx, "user1", dev)
+	err = as.AuthServer.UpsertMFADevice(ctx, "user1", dev)
 	require.NoError(t, err)
 
-	validToken, err := totp.GenerateCode(otpSecret, testSrv.Clock().Now())
+	validToken, err := totp.GenerateCode(otpSecret, clock.Now())
 	require.NoError(t, err)
 
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, validToken)
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, validToken)
 	require.NoError(t, err)
 }
 
@@ -1777,8 +1779,10 @@ func TestOTPCRUD(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.AuthServerConfig.Clock
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	clock := as.Clock()
 
 	user := "user1"
 	pass := []byte("abcdef123456")
@@ -1788,20 +1792,20 @@ func TestOTPCRUD(t *testing.T) {
 	// Create a user.
 	u, err := types.NewUser(user)
 	require.NoError(t, err)
-	_, err = testSrv.Auth().CreateUser(ctx, u)
+	_, err = as.AuthServer.CreateUser(ctx, u)
 	require.NoError(t, err)
 
 	// upsert a password and totp secret
-	err = testSrv.Auth().UpsertPassword("user1", pass)
+	err = as.AuthServer.UpsertPassword("user1", pass)
 	require.NoError(t, err)
 	dev, err := services.NewTOTPDevice("otp", otpSecret, clock.Now())
 	require.NoError(t, err)
 
-	err = testSrv.Auth().UpsertMFADevice(ctx, user, dev)
+	err = as.AuthServer.UpsertMFADevice(ctx, user, dev)
 	require.NoError(t, err)
 
 	// a completely invalid token should return access denied
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, "123456")
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, "123456")
 	require.Error(t, err)
 
 	// an invalid token should return access denied
@@ -1811,20 +1815,20 @@ func TestOTPCRUD(t *testing.T) {
 	// valid for 30 seconds + 30 second skew before and after for a usability
 	// reasons. so a token made between seconds 31 and 60 is still valid, and
 	// invalidity starts at 61 seconds in the future.
-	invalidToken, err := totp.GenerateCode(otpSecret, testSrv.Clock().Now().Add(61*time.Second))
+	invalidToken, err := totp.GenerateCode(otpSecret, clock.Now().Add(61*time.Second))
 	require.NoError(t, err)
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, invalidToken)
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, invalidToken)
 	require.Error(t, err)
 
 	// a valid token (created right now and from a valid key) should return success
-	validToken, err := totp.GenerateCode(otpSecret, testSrv.Clock().Now())
+	validToken, err := totp.GenerateCode(otpSecret, clock.Now())
 	require.NoError(t, err)
 
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, validToken)
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, validToken)
 	require.NoError(t, err)
 
 	// try the same valid token now it should fail because we don't allow re-use of tokens
-	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, validToken)
+	err = as.AuthServer.CheckPassword(ctx, "user1", pass, validToken)
 	require.Error(t, err)
 }
 
@@ -5737,10 +5741,10 @@ func withBufconnListener() testTLSServerOption {
 }
 
 // newTestTLSServer is a helper that returns a *authtest.TLSServer with sensible
-// defaults for most tests that are exercising Auth Service RPCs.
+// defaults for most tests that are exercising Auth Service RPCs. For more advanced
+// use-cases, NewTestTLSServer to provide a more detailed configuration.
 //
-// For more advanced use-cases, call NewTestAuthServer and NewTestTLSServer
-// to provide a more detailed configuration.
+// Prefer using authtest.AuthServer directly if Auth Service RPCs are never used.
 func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *authtest.TLSServer {
 	var options testTLSServerOptions
 	for _, opt := range opts {

--- a/lib/auth/usertoken_test.go
+++ b/lib/auth/usertoken_test.go
@@ -97,11 +97,13 @@ func TestCreateResetPasswordToken(t *testing.T) {
 
 func TestCreateResetPasswordTokenErrors(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	ctx := context.Background()
 
 	username := "joe@example.com"
-	_, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, username, []string{username}, nil)
 	require.NoError(t, err)
 
 	type testCase struct {
@@ -149,7 +151,7 @@ func TestCreateResetPasswordTokenErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := srv.Auth().CreateResetPasswordToken(ctx, tc.req)
+			_, err := as.AuthServer.CreateResetPasswordToken(ctx, tc.req)
 			require.Error(t, err)
 		})
 	}
@@ -230,10 +232,12 @@ func TestFormatAccountName(t *testing.T) {
 
 func TestUserTokenSecretsCreationSettings(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	username := "joe@example.com"
-	_, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, username, []string{username}, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -243,16 +247,16 @@ func TestUserTokenSecretsCreationSettings(t *testing.T) {
 		TTL:  time.Hour,
 	}
 
-	token, err := srv.Auth().CreateResetPasswordToken(ctx, req)
+	token, err := as.AuthServer.CreateResetPasswordToken(ctx, req)
 	require.NoError(t, err)
 
-	_, err = srv.Auth().CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
+	_, err = as.AuthServer.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
 		TokenID:    token.GetName(),
 		DeviceType: proto.DeviceType_DEVICE_TYPE_TOTP,
 	})
 	require.NoError(t, err)
 
-	secrets, err := srv.Auth().GetUserTokenSecrets(ctx, token.GetName())
+	secrets, err := as.AuthServer.GetUserTokenSecrets(ctx, token.GetName())
 	require.NoError(t, err)
 
 	require.NoError(t, err)
@@ -264,11 +268,13 @@ func TestUserTokenSecretsCreationSettings(t *testing.T) {
 
 func TestUserTokenCreationSettings(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
 	ctx := t.Context()
 
 	username := "joe@example.com"
-	_, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(as.AuthServer, username, []string{username}, nil)
 	require.NoError(t, err)
 
 	req := authclient.CreateUserTokenRequest{
@@ -277,7 +283,7 @@ func TestUserTokenCreationSettings(t *testing.T) {
 		Type: authclient.UserTokenTypeResetPasswordInvite,
 	}
 
-	token, err := srv.Auth().NewUserToken(ctx, req)
+	token, err := as.AuthServer.NewUserToken(ctx, req)
 	require.NoError(t, err)
 	require.Equal(t, req.Name, token.GetUser())
 	require.Equal(t, req.Type, token.GetSubKind())


### PR DESCRIPTION
Several tests were using `newTestTLSServer` to create an auth server though never created an api client or made any external calls to the exposed authtest.TLSServer. To reduce resource consumption and improve the speed of the tests calls to `newTestTLSServer` were replaced with authtest.NewAuthServer.


Comparing lib/auth times in CI from this PR and another one that was run within the last day shows ~5s reduction.


https://github.com/gravitational/teleport/actions/runs/22494869482/job/65166607669?pr=64135
`✓  lib/auth (39.65s)`

https://github.com/gravitational/teleport/actions/runs/22505274366/job/65202258497?pr=64065
`✓  lib/auth (35.139s)`

