### PR TITLE
Run auth tests in parallel

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1549,6 +1549,7 @@ func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
 }
 
 func TestEmitSSOLoginFailureEvent(t *testing.T) {
+	t.Parallel()
 	mockE := &eventstest.MockRecorderEmitter{}
 
 	auth.EmitSSOLoginFailureEvent(context.Background(), mockE, "test", trace.BadParameter("some error"), false)
@@ -3067,6 +3068,7 @@ func TestGenerateUserCertWithHardwareKeySupport(t *testing.T) {
 }
 
 func TestGenerateKubernetesUserCert(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	p := newAuthSuite(t)
 
@@ -4052,6 +4054,7 @@ func (f *fakeAuthPreferenceGetter) GetAuthPreference(context.Context) (types.Aut
 }
 
 func TestCAGeneration(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	const (
 		clusterName = "cluster1"
@@ -4090,6 +4093,7 @@ func TestCAGeneration(t *testing.T) {
 }
 
 func TestGetLicense(t *testing.T) {
+	t.Parallel()
 	s := newAuthSuite(t)
 
 	// GetLicense should return error if license is not set
@@ -4543,6 +4547,7 @@ func TestAccessRequestDryRunEnrichment(t *testing.T) {
 }
 
 func TestCleanupNotifications(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/lib/auth/auth_with_roles_okta_rbac_test.go
+++ b/lib/auth/auth_with_roles_okta_rbac_test.go
@@ -71,6 +71,7 @@ func newTestServerWithRoles(t *testing.T, srv *authtest.AuthServer, role types.S
 }
 
 func TestOktaMayNotResetPasswords(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Given an auth server...
@@ -134,6 +135,7 @@ func newTestLock(t *testing.T, target types.User, origin string) types.Lock {
 }
 
 func TestOktaServiceLockCRUD(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Given an auth server...

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -346,6 +346,7 @@ func TestLocalUserCanReissueCerts(t *testing.T) {
 // TestSSOUserCanReissueCert makes sure that SSO user can reissue certificate
 // for themselves.
 func TestSSOUserCanReissueCert(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -372,6 +373,7 @@ func TestSSOUserCanReissueCert(t *testing.T) {
 }
 
 func TestInstaller(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -772,6 +774,7 @@ func TestGithubAuthCompat(t *testing.T) {
 }
 
 func TestAWSRolesAnywhereCredentialGenerationForApps(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	srv := newTestTLSServer(t)
 
@@ -875,6 +878,7 @@ func TestAWSRolesAnywhereCredentialGenerationForApps(t *testing.T) {
 }
 
 func TestAppAccessUsingAWSOIDC_doesntGenerateClientCredentials(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	srv := newTestTLSServer(t)
 
@@ -966,6 +970,7 @@ func TestAppAccessUsingAWSOIDC_doesntGenerateClientCredentials(t *testing.T) {
 }
 
 func TestSSODiagnosticInfo(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -1323,6 +1328,7 @@ func TestGenerateUserCertsWithMFAVerification(t *testing.T) {
 }
 
 func TestGenerateUserCertsWithRoleRequest(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -1581,6 +1587,7 @@ func TestGenerateUserCertsWithRoleRequest(t *testing.T) {
 // impersonated client can reissue certificates but that role impersonation
 // cannot be escaped.
 func TestRolesRequestsExplicitAllowReissue(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -1730,6 +1737,7 @@ func TestRolesRequestsExplicitAllowReissue(t *testing.T) {
 // re-escalate privileges using a (perhaps compromised) set of role
 // impersonated certs.
 func TestRoleRequestDenyReimpersonation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -3792,6 +3800,7 @@ func TestReplaceRemoteLocksRBAC(t *testing.T) {
 // TestIsMFARequired_databaseProtocols tests the MFA requirement logic per
 // database protocol where different role matchers are used.
 func TestIsMFARequired_databaseProtocols(t *testing.T) {
+	t.Parallel()
 	const (
 		databaseName = "test-database"
 		userName     = "test-username"
@@ -5056,6 +5065,7 @@ func createUserGroup(t *testing.T, s *auth.Server, name string, labels map[strin
 }
 
 func TestDeleteUserAppSessions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	srv := newTestTLSServer(t)
@@ -6573,6 +6583,7 @@ func withAccountAssignment(condition types.RoleConditionType, accountID, permiss
 }
 
 func TestUnifiedResources_IdentityCenter(t *testing.T) {
+	t.Parallel()
 	const (
 		validAccountID        = "11111111"
 		validPermissionSetARN = "some:ps:arn"
@@ -7349,6 +7360,7 @@ func newScopedTestServerForHost(t *testing.T, srv *authtest.AuthServer, hostID, 
 }
 
 func TestGenerateHostCertsScoped(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -7395,6 +7407,7 @@ func TestGenerateHostCertsScoped(t *testing.T) {
 // This is because only one uploader service runs per Teleport process, and it will use
 // the first available identity.
 func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
+	t.Parallel()
 	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err, trace.DebugReport(err))
 	t.Cleanup(func() { require.NoError(t, srv.Close()) })
@@ -7836,6 +7849,7 @@ func TestGetActiveSessionTrackers(t *testing.T) {
 }
 
 func TestListReleasesPermissions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -7891,6 +7905,7 @@ func TestListReleasesPermissions(t *testing.T) {
 }
 
 func TestGetLicensePermissions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -7948,6 +7963,7 @@ func TestGetLicensePermissions(t *testing.T) {
 const errSAMLAppLabelsDenied = "access to saml_idp_service_provider denied"
 
 func TestCreateSAMLIdPServiceProvider(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -8100,6 +8116,7 @@ func TestCreateSAMLIdPServiceProvider(t *testing.T) {
 }
 
 func TestUpdateSAMLIdPServiceProvider(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -8273,6 +8290,7 @@ func TestUpdateSAMLIdPServiceProvider(t *testing.T) {
 }
 
 func TestCreateSAMLIdPServiceProviderInvalidInputs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 	user := createSAMLIdPTestUser(t, srv.Auth(), types.RoleSpecV6{Allow: samlIdPRoleCondition(types.Labels{"*": []string{"*"}}, types.VerbCreate)})
@@ -8377,6 +8395,7 @@ func TestCreateSAMLIdPServiceProviderInvalidInputs(t *testing.T) {
 }
 
 func TestUpdateSAMLIdPServiceProviderInvalidInputs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 	user := createSAMLIdPTestUser(t, srv.Auth(), types.RoleSpecV6{Allow: samlIdPRoleCondition(types.Labels{"*": []string{"*"}}, types.VerbCreate, types.VerbUpdate)})
@@ -8456,6 +8475,7 @@ func TestUpdateSAMLIdPServiceProviderInvalidInputs(t *testing.T) {
 }
 
 func TestDeleteSAMLIdPServiceProvider(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -8558,6 +8578,7 @@ func TestDeleteSAMLIdPServiceProvider(t *testing.T) {
 }
 
 func TestDeleteAllSAMLIdPServiceProviders(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -10438,6 +10459,7 @@ func inlineEventually(t *testing.T, cond func() bool, waitFor time.Duration, tic
 }
 
 func TestIsMFARequired_AdminAction(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name                 string
 		adminActionAuthState authz.AdminActionAuthState
@@ -10624,6 +10646,7 @@ func TestCloudDefaultPasswordless(t *testing.T) {
 }
 
 func TestRoleRequestReasonModeValidation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -10739,6 +10762,7 @@ func testUserName(testName string) string {
 }
 
 func TestFilterIdentityCenterPermissionSets(t *testing.T) {
+	t.Parallel()
 	const (
 		allAccessRoleName      = "all-access"
 		accountID              = "1234567890"
@@ -11071,6 +11095,7 @@ func createTestMCPAppServer(t *testing.T, auth *auth.Server, name string, labels
 }
 
 func TestSAMLIdPRoleOptionCreateUpdateValidation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 

--- a/lib/auth/autoupdate_agent_version_report_test.go
+++ b/lib/auth/autoupdate_agent_version_report_test.go
@@ -92,6 +92,7 @@ type fakeServer struct {
 }
 
 func TestServer_generateAgentVersionReport(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	now := time.Now()
 	twoMinutesAgo := now.Add(-time.Minute * 2)
@@ -298,6 +299,7 @@ func TestServer_generateAgentVersionReport(t *testing.T) {
 }
 
 func TestServer_reportAgentVersions(t *testing.T) {
+	t.Parallel()
 	// Test setup: create auth.
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)

--- a/lib/auth/autoupdate_rollout_test.go
+++ b/lib/auth/autoupdate_rollout_test.go
@@ -42,6 +42,7 @@ import (
 )
 
 func TestSampleAgentsFromGroup(t *testing.T) {
+	t.Parallel()
 	clock := clockwork.NewFakeClock()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
@@ -146,6 +147,7 @@ func TestSampleAgentsFromGroup(t *testing.T) {
 }
 
 func TestLookupAgentInInventory(t *testing.T) {
+	t.Parallel()
 	clock := clockwork.NewFakeClock()
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
@@ -227,6 +229,7 @@ func (f *fakeHandle) Hello() *proto.UpstreamInventoryHello {
 }
 
 func TestHandlerSampler(t *testing.T) {
+	t.Parallel()
 	filterOK := func(handle inventory.UpstreamHandle) bool {
 		return true
 	}

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -39,6 +39,7 @@ import (
 )
 
 func Test_getSnowflakeJWTParams(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		accountName string
 		userName    string
@@ -246,6 +247,7 @@ func mustVerifyCert(t *testing.T, rootPEM, leafPEM []byte, cdps []string, keyUsa
 }
 
 func TestFilterExtensions(t *testing.T) {
+	t.Parallel()
 	oidA := asn1.ObjectIdentifier{1, 2, 3, 4}
 	oidB := asn1.ObjectIdentifier{1, 2, 3, 5}
 	extA := pkix.Extension{Id: oidA, Value: []byte("a")}

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -110,6 +110,7 @@ func (tt *githubContext) Close() error {
 }
 
 func TestPopulateClaims(t *testing.T) {
+	t.Parallel()
 	client := &testGithubAPIClient{}
 	user, err := client.getUser()
 	require.NoError(t, err)
@@ -130,6 +131,7 @@ func TestPopulateClaims(t *testing.T) {
 }
 
 func TestCreateGithubUser(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tt := setupGithubContext(ctx, t)
 
@@ -193,6 +195,7 @@ func (c *testGithubAPIClient) getTeams() ([]auth.GithubTeamResponse, error) {
 }
 
 func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
+	t.Parallel()
 	clientAddr := &net.TCPAddr{IP: net.IPv4(10, 255, 0, 0)}
 	ctx := authz.ContextWithClientSrcAddr(context.Background(), clientAddr)
 	tt := setupGithubContext(ctx, t)
@@ -292,6 +295,7 @@ func (m *mockedGithubManager) ValidateGithubAuthRedirect(ctx context.Context, di
 }
 
 func TestCalculateGithubUserNoTeams(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	a := &auth.Server{}
 	connector, err := types.NewGithubConnector("github", types.GithubConnectorSpecV3{
@@ -321,6 +325,7 @@ func TestCalculateGithubUserNoTeams(t *testing.T) {
 // Test that calculateGithubUser calls the login rule evaluator, evaluated
 // traits end up in the user params, and traits are evaluated exactly once.
 func TestCalculateGithubUserWithLoginRules(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Create a test role so that FetchRoles can succeed.
@@ -555,6 +560,7 @@ func TestCheckGithubOrgSSOSupport(t *testing.T) {
 }
 
 func TestGithubURLFormat(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		host   string
 		path   string
@@ -583,6 +589,7 @@ func TestGithubURLFormat(t *testing.T) {
 }
 
 func TestBuildAPIEndpoint(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -94,6 +94,7 @@ import (
 )
 
 func TestMFADeviceManagement(t *testing.T) {
+	t.Parallel()
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	clock := testServer.Clock().(*clockwork.FakeClock)
@@ -457,6 +458,7 @@ func TestMFADeviceManagement(t *testing.T) {
 }
 
 func TestMFADeviceManagement_SSO(t *testing.T) {
+	t.Parallel()
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	ctx := context.Background()
@@ -574,6 +576,7 @@ func TestMFADeviceManagement_SSO(t *testing.T) {
 }
 
 func TestDeletingLastPasswordlessDevice(t *testing.T) {
+	t.Parallel()
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	clock := testServer.Clock().(*clockwork.FakeClock)
@@ -884,6 +887,7 @@ func testDeleteMFADevice(ctx context.Context, t *testing.T, authClient *authclie
 }
 
 func TestCreateAppSession_deviceExtensions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
@@ -969,6 +973,7 @@ func TestCreateAppSession_deviceExtensions(t *testing.T) {
 }
 
 func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testServer := newTestTLSServer(t)
 
@@ -2647,6 +2652,7 @@ func TestIsMFARequired(t *testing.T) {
 }
 
 func TestIsMFARequired_unauthorized(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -2833,6 +2839,7 @@ func TestIsMFARequired_nodeMatch(t *testing.T) {
 }
 
 func TestIsMFARequired_App(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -5668,6 +5675,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 }
 
 func TestGetVnetConfig(t *testing.T) {
+	t.Parallel()
 	server := newTestTLSServer(t)
 	user, _, err := authtest.CreateUserAndRole(server.Auth(), "test", []string{"role"}, nil)
 	require.NoError(t, err)
@@ -6515,6 +6523,7 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 }
 
 func TestGRPCServingStatus(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	srv := newTestTLSServer(t)
 	defer srv.Close()

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -85,6 +85,7 @@ import (
 // TestReadIdentity makes parses identity from private key and certificate
 // and checks that all parameters are valid
 func TestReadIdentity(t *testing.T) {
+	t.Parallel()
 	clock := clockwork.NewFakeClock()
 	a, err := testauthority.NewKeygen(modules.BuildOSS, clock.Now)
 	require.NoError(t, err)
@@ -135,6 +136,7 @@ func TestReadIdentity(t *testing.T) {
 }
 
 func TestBadIdentity(t *testing.T) {
+	t.Parallel()
 	a, err := testauthority.NewKeygen(modules.BuildOSS, time.Now)
 	require.NoError(t, err)
 
@@ -878,6 +880,7 @@ func TestSessionRecordingConfig(t *testing.T) {
 }
 
 func TestClusterID(t *testing.T) {
+	t.Parallel()
 	conf := setupConfig(t)
 	ctx := context.Background()
 	authServer, err := auth.Init(ctx, conf)
@@ -901,6 +904,7 @@ func TestClusterID(t *testing.T) {
 
 // TestClusterName ensures that a cluster can not be renamed.
 func TestClusterName(t *testing.T) {
+	t.Parallel()
 	conf := setupConfig(t)
 	ctx := context.Background()
 	authServer, err := auth.Init(ctx, conf)
@@ -935,6 +939,7 @@ func (t *failingTrustInternal) CreateCertAuthority(ctx context.Context, ca types
 // TestInitCertFailureRecovery ensures the auth server is able to recover from
 // a failure in the cert creation process.
 func TestInitCertFailureRecovery(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	cap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type: constants.SAML,
@@ -1414,6 +1419,7 @@ func TestDashboardMode(t *testing.T) {
 }
 
 func TestGetPresetUsers(t *testing.T) {
+	t.Parallel()
 	// no preset users for OSS
 	require.Empty(t, auth.GetPresetUsers(modules.BuildOSS))
 
@@ -2092,6 +2098,7 @@ func newHealthCheckConfig(t *testing.T, opts ...func(*healthcheckconfigv1.Health
 // TestSyncUpgadeWindowStartHour verifies the core logic of the upgrade window start
 // hour behavior.
 func TestSyncUpgradeWindowStartHour(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	conf := setupConfig(t)
@@ -2232,6 +2239,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 // TestIdentityChecker verifies auth identity properly validates host
 // certificates when connecting to an SSH server.
 func TestIdentityChecker(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	conf := setupConfig(t)
@@ -2326,6 +2334,7 @@ func TestIdentityChecker(t *testing.T) {
 }
 
 func TestInitCreatesCertsIfMissing(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	conf := setupConfig(t)
 	auth, err := auth.Init(ctx, conf)

--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -47,6 +47,7 @@ import (
 )
 
 func TestAuth_RegisterUsingToken(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	p := newAuthSuite(t)
 

--- a/lib/auth/methods_test.go
+++ b/lib/auth/methods_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestServerAuthenticateUserUserAgentTrim(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	emitter := &eventstest.MockRecorderEmitter{}
 	r := authclient.AuthenticateUserRequest{
@@ -50,6 +51,7 @@ func TestServerAuthenticateUserUserAgentTrim(t *testing.T) {
 }
 
 func Test_trimUserAgent(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		inputUserAgent string

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -61,6 +61,7 @@ func (f *fakeConn) RemoteAddr() net.Addr {
 }
 
 func TestValidateClientVersion(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name          string
 		middleware    *auth.Middleware
@@ -144,6 +145,7 @@ func TestValidateClientVersion(t *testing.T) {
 }
 
 func TestRejectedClientClusterAlertContents(t *testing.T) {
+	t.Parallel()
 	var alerts []types.ClusterAlert
 	mw := auth.Middleware{
 		OldestSupportedVersion: teleport.MinClientSemVer(),
@@ -226,6 +228,7 @@ func TestRejectedClientClusterAlertContents(t *testing.T) {
 }
 
 func TestRejectedClientClusterAlert(t *testing.T) {
+	t.Parallel()
 	var alerts []types.ClusterAlert
 	mw := auth.Middleware{
 		OldestSupportedVersion: teleport.MinClientSemVer(),

--- a/lib/auth/periodic_test.go
+++ b/lib/auth/periodic_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestTotalInstances(t *testing.T) {
+	t.Parallel()
 	instances := []*proto.UpstreamInventoryHello{
 		{},
 		{Version: "15.0.0"},
@@ -48,6 +49,7 @@ func TestTotalInstances(t *testing.T) {
 }
 
 func TestTotalEnrolledInUpgrades(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		desc      string
 		instances []*proto.UpstreamInventoryHello
@@ -99,6 +101,7 @@ func TestTotalEnrolledInUpgrades(t *testing.T) {
 }
 
 func TestUpgraderCounts(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		desc      string
 		instances []*proto.UpstreamInventoryHello
@@ -180,6 +183,7 @@ func TestUpgraderCounts(t *testing.T) {
 }
 
 func TestInstallMethodCounts(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		desc     string
 		metadata []*proto.UpstreamInventoryAgentMetadata
@@ -237,6 +241,7 @@ func TestInstallMethodCounts(t *testing.T) {
 }
 
 func TestRegisteredAgentsCounts(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		desc     string
 		instance []*proto.UpstreamInventoryHello
@@ -298,6 +303,7 @@ func TestRegisteredAgentsCounts(t *testing.T) {
 }
 
 func TestUpgradeEnrollPeriodic(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		desc          string
 		enrolled      map[string]int

--- a/lib/auth/requestable_roles_test.go
+++ b/lib/auth/requestable_roles_test.go
@@ -36,6 +36,7 @@ import (
 
 // TestListRequestableRoles tests listing requestable roles with pagination.
 func TestListRequestableRoles(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	tlsServer := newTestTLSServer(t)
 	a := tlsServer.Auth()

--- a/lib/auth/sso_diag_context_test.go
+++ b/lib/auth/sso_diag_context_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func Test_ssoDiagContext_writeToBackend(t *testing.T) {
+	t.Parallel()
 	diag := &SSODiagContext{
 		AuthKind:  types.KindSAML,
 		RequestID: "123",

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1438,6 +1438,7 @@ func TestGetCurrentUser(t *testing.T) {
 }
 
 func TestGetCurrentUserRoles(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -3098,6 +3099,7 @@ func TestGenerateCerts(t *testing.T) {
 // TestGenerateAppToken checks the identity of the caller and makes sure only
 // certain roles can request JWT tokens.
 func TestGenerateAppToken(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.AuthServerConfig.Clock
@@ -3209,6 +3211,7 @@ func TestGenerateAppToken(t *testing.T) {
 // TestCertificateFormat makes sure that certificates are generated with the
 // correct format.
 func TestCertificateFormat(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
@@ -3605,6 +3608,7 @@ func TestLoginNoLocalAuth(t *testing.T) {
 // TestCipherSuites makes sure that clients with invalid cipher suites can
 // not connect.
 func TestCipherSuites(t *testing.T) {
+	t.Parallel()
 	testSrv := newTestTLSServer(t)
 	ctx := context.Background()
 

--- a/lib/auth/transport_credentials_test.go
+++ b/lib/auth/transport_credentials_test.go
@@ -329,6 +329,7 @@ func (f fakeUserGetter) GetUser(context.Context, tls.ConnectionState) (authz.Ide
 }
 
 func TestTransportCredentialsDisconnection(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name   string
 		expiry time.Duration

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -47,6 +47,7 @@ import (
 )
 
 func TestRemoteClusterStatus(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	a := newTestAuthServer(ctx, t)
 
@@ -479,6 +480,7 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *auth.
 }
 
 func TestUpsertTrustedCluster(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testAuth, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "localcluster",
@@ -620,6 +622,7 @@ func TestUpsertTrustedCluster(t *testing.T) {
 }
 
 func TestUpdateTrustedCluster(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	testAuth, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "localcluster",


### PR DESCRIPTION
All tests in lib/auth that do not modify global variables (modules, insecure dev mode) or make use of t.Setenv directly are now run in parallel.