### PR TITLE
fix: "missing required parameter ProxyAddress" in Connect local login

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3272,7 +3272,8 @@ type clientConfig struct {
 // connection to a cluster.
 func (tc *TeleportClient) generateClientConfig(ctx context.Context) (*clientConfig, error) {
 	proxyAddr := tc.Config.SSHProxyAddr
-	if tc.TLSRoutingEnabled {
+	// Fall back to multiplexed WebProxyAddr if SSHProxyAddr is not set or if TLS routing is enabled
+	if tc.TLSRoutingEnabled || proxyAddr == "" {
 		proxyAddr = tc.Config.WebProxyAddr
 	}
 

--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -92,6 +92,10 @@ func (c *Cluster) Logout(ctx context.Context) error {
 func (c *Cluster) LocalLogin(ctx context.Context, user, password, otpToken string) error {
 	c.clusterClient.AuthConnector = constants.LocalConnector
 
+	if _, err := c.updateClientFromPingResponse(ctx); err != nil {
+		return trace.Wrap(err)
+	}
+
 	if err := c.login(ctx, c.localMFALogin(user, password)); err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Branch by @kiosion who is without laptop.

- Fall back to WebProxyAddr when SSHProxyAddr is empty in generateClientConfig to resolve login failing when proxy reports tls_routing_enabled=false without a separate SSH listener
- Add missing updateClientFromPingResponse call to LocalLogin for parity with other login methods