### PR TITLE
Fix package declaration in web_e2e_test.go

### DIFF
--- a/e2e/web_e2e_test.go
+++ b/e2e/web_e2e_test.go
@@ -1,5 +1,7 @@
 //go:build webassets_embed
 
+package e2e
+
 /*
  * Teleport
  * Copyright (C) 2025  Gravitational, Inc.
@@ -17,8 +19,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-package integration
 
 import (
 	"context"


### PR DESCRIPTION
package import in the wrong place, breaks code analysis. Moving to the top and using the dir name.