### PR TITLE
Add note about v8 role compatibility w/ v17 agents

### DIFF
--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -103,12 +103,17 @@ Label              | `v3` Default   | `v4` and higher Default
 `kubernetes_labels` | `[{"*": "*"}]` | `[]`
 `db_labels`         | `[{"*": "*"}]` | `[]`
 
-Role `v6` introduced a new field `kubernetes_resources` that allows
+Role v6 introduced a new field, `kubernetes_resources`, that allows
 fine-grained control over Kubernetes resources. See [Kubernetes RBAC](../../enroll-resources/kubernetes-access/controls.mdx) for more details.
 
-Role `v7` added support for more `kind` values in the `kubernetes_resources` field.
+Role v7 added support for more `kind` values in the `kubernetes_resources` field.
 
-Role `v8` added support for Kubernetes CRDs and introduced changes for how `kubernetes_resources` behave and are defined.
+Role v8 added support for Kubernetes CRDs and introduced changes in how
+`kubernetes_resources` behave and are defined. Role v8 is not compatible with
+Teleport v17 agents: if your a user has a v8 role, a v17 agent running the
+Teleport Kubernetes Service may silently deny the user access, because the agent
+cannot interpret the fields specific to v8 roles. Upgrade all agents to v18 before using
+role v8.
 
 See [Kubernetes Resources](../../enroll-resources/kubernetes-access/controls.mdx#kubernetes_resources) for more details about the difference between versions.
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/role.mdx
@@ -25,10 +25,16 @@ Roles not [granting Kubernetes access](../../../enroll-resources/kubernetes-acce
 equivalent in the four versions.
 
 Roles v5 and v6 can only restrict actions on pods (e.g. executing in them).
-Role v7 supports restricting some common resource kinds (
-see [the `kubernetes_resource` documentation](../../../enroll-resources/kubernetes-access/controls.mdx#kubernetes_resources)
-for a complete list).
-Role v8 supports restricting all resource kinds, including CRDs. It also changes the format of the `kind` field.
+Role v7 supports restricting some common resource kinds ( see [the
+`kubernetes_resource`
+documentation](../../../enroll-resources/kubernetes-access/controls.mdx#kubernetes_resources)
+for a complete list). Role v8 supports restricting all resource kinds,
+including CRDs. It also changes the format of the `kind` field. 
+
+Role v8 is not compatible with Teleport v17 agents: if your a user has a v8
+role, a v17 agent running the Teleport Kubernetes Service may silently deny the
+user access, because the agent cannot interpret the fields specific to v8 roles.
+Upgrade all agents to v18 before using role v8.
 
 When no `kubernetes_resource` is set:
 - Roles v5, v7 and v8 grant all access by default


### PR DESCRIPTION
Closes #60792

Add text to explanations of role versions in the docs to indicate explicitly that v8 roles are not compatible with v17 agents.