### PR TITLE
[v17] Remove testutils/synctest package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -156,10 +156,6 @@ linters:
                 google.golang.org/protobuf/protoadapt instead, or, better yet,
                 see if you can move the code generation for that message to the
                 modern protoc-gen-go.
-        synctest:
-          deny:
-            - pkg: testing/synctest
-              desc: 'use "github.com/gravitational/teleport/lib/utils/testutils/synctest" instead'
         test_packages:
           files:
             - '!$test'

--- a/integrations/event-handler/session_events_job_test.go
+++ b/integrations/event-handler/session_events_job_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
-	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 // TestConsumeSessionNoEventsFound tests that the consumeSession method returns without error

--- a/lib/auth/notification_test.go
+++ b/lib/auth/notification_test.go
@@ -21,6 +21,7 @@ package auth_test
 import (
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -33,7 +34,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 func TestNotificationMatchers(t *testing.T) {

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -40,7 +41,6 @@ import (
 	"github.com/gravitational/teleport/lib/inventory/metadata"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 func TestMain(m *testing.M) {

--- a/lib/player/player_test.go
+++ b/lib/player/player_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/jonboulle/clockwork"
@@ -33,7 +34,6 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/player"
 	"github.com/gravitational/teleport/lib/session"
-	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 func TestBasicStream(t *testing.T) {

--- a/lib/proxy/peer/quic/server_test.go
+++ b/lib/proxy/peer/quic/server_test.go
@@ -19,6 +19,7 @@ package quic
 import (
 	"encoding/binary"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	quicpeeringv1a "github.com/gravitational/teleport/gen/proto/go/teleport/quicpeering/v1alpha"
-	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 func TestDialResponseOKEncoding(t *testing.T) {

--- a/lib/srv/desktop/audit_compactor_test.go
+++ b/lib/srv/desktop/audit_compactor_test.go
@@ -23,13 +23,13 @@ import (
 	"math"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/events"
-	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 func newReadEvent(path string, directory directoryID, offset uint64, length uint32) *events.DesktopSharedDirectoryRead {

--- a/lib/srv/discovery/discovery_eks_test.go
+++ b/lib/srv/discovery/discovery_eks_test.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -50,7 +51,6 @@ import (
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services/local"
 	libutils "github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 func discoveryConfigWithAWSMatchers(t *testing.T, discoveryGroup string, m ...types.AWSMatcher) *discoveryconfig.DiscoveryConfig {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"cloud.google.com/go/container/apiv1/containerpb"
@@ -95,7 +96,6 @@ import (
 	"github.com/gravitational/teleport/lib/srv/server"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	libutils "github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 func TestMain(m *testing.M) {

--- a/lib/tbot/internal/heartbeat/service_test.go
+++ b/lib/tbot/internal/heartbeat/service_test.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -39,7 +40,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 type fakeHeartbeatSubmitter struct {


### PR DESCRIPTION
This PR removes the use of `lib/utils/testutils/synctest` now that branch/v17 uses Go 1.25. The package itself can be removed after gravitational/teleport.e#8128.