### PR TITLE
Add label constraints to discovery examples

### DIFF
--- a/build.assets/tooling/cmd/resource-ref-generator/resource_examples/discovery_config.yaml
+++ b/build.assets/tooling/cmd/resource-ref-generator/resource_examples/discovery_config.yaml
@@ -202,4 +202,5 @@ spec:
           no_proxy: my-local-domain
       # GCP resource label filters used to match resources.
       labels:
-        "*": "*"
+        # Matches resources with the label "environment:production"
+        "environment": "production"

--- a/docs/pages/enroll-resources/application-access/reference.mdx
+++ b/docs/pages/enroll-resources/application-access/reference.mdx
@@ -31,7 +31,9 @@ app_service:
   # Matchers for application resources created with "tctl create" command.
   resources:
   - labels:
-      "*": "*"
+      # Limit discovered apps to those with the environment:production
+      # label
+      "environment": "production" 
   # This section contains definitions of all applications proxied by this
   # service. It can contain multiple items.
   apps:

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
@@ -358,7 +358,9 @@ kubernetes_service:
   enabled: true
   resources:
   - labels:
-      "*": "*"
+      # Limit discovered GKE clusters to those with the
+      # environment:production label
+      "environment": "production" 
 ```
 
 <details>
@@ -385,7 +387,9 @@ kubernetes_service:
   enabled: true
   resources:
   - labels:
-      "*": "*"
+      # Limit discovered GKE clusters to those with the label
+      # environment:production
+      "environment": "production" 
 ```
 
 On the Discovery Service host, the file will include the following:

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/kubernetes.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/kubernetes.mdx
@@ -145,7 +145,9 @@ kubernetes_service:
     # Matchers for dynamic Kubernetes cluster resources created with the "tctl create" command or by Kubernetes auto-discovery.
     resources:
     - labels:
-        "*": "*" # can be configured to limit the clusters to watched by this service.
+        # Limit discovered clusters to those with the label
+        # environment:production
+        "environment": "production" 
       aws:
        # AWS role to assume when accessing EKS clusters in the AWS Account.
        # This value is an optional AWS role ARN to assume when forwarding requests

--- a/docs/pages/includes/config-reference/app-service.yaml
+++ b/docs/pages/includes/config-reference/app-service.yaml
@@ -19,7 +19,9 @@ app_service:
     # "config": application resources defined in the "apps" array below
     resources:
       - labels:
-          "*": "*"
+          # limit discovered apps to those with the 
+          # environment:production label
+          "environment": "production" 
 
     apps:
     - name: "kubernetes-dashboard"

--- a/docs/pages/includes/config-reference/kubernetes-config.yaml
+++ b/docs/pages/includes/config-reference/kubernetes-config.yaml
@@ -23,7 +23,9 @@ kubernetes_service:
     # When resources were created by 'discovery_service', ' kubernetes_service' must have the required permissions.
     resources:
     - labels:
-        "*": "*"
+        # limit discovered Kubernetes clusters to those with the 
+        # environment:production label
+        "environment": "production" 
       # Optional AWS role that the Teleport Kubernetes Service will assume to access
       # EKS clusters.
       aws:

--- a/docs/pages/includes/discovery/discovery-config.yaml
+++ b/docs/pages/includes/discovery/discovery-config.yaml
@@ -201,7 +201,8 @@ discovery_service:
             no_proxy: my-local-domain
         # GCP resource label filters used to match resources.
         labels:
-          "*": "*"
+          # Matches resources with label "environment:production"
+          "environment": "production"
     # Matchers for discovering services inside Kubernetes clusters and exposing them as Teleport apps
     # When the `kubernetes` value is set, the `discovery_group` parameter is mandatory and should be set to
     # the name of Kubernetes cluster where the discovery service is running.

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
@@ -219,7 +219,8 @@ spec:
           no_proxy: my-local-domain
       # GCP resource label filters used to match resources.
       labels:
-        "*": "*"
+        # Matches resources with the label "environment:production"
+        "environment": "production"
 
 ```
 


### PR DESCRIPTION
In `discovery_service` configuration examples, replace wildcard matchers with explicit label constraints.