### PR TITLE
Stop comparing ExternalIdentities with go-cmp

### DIFF
--- a/api/types/derived.gen.go
+++ b/api/types/derived.gen.go
@@ -198,6 +198,16 @@ func deriveTeleportEqualMetadata(this, that *Metadata) bool {
 			((this.Expires == nil && that.Expires == nil) || (this.Expires != nil && that.Expires != nil && (*(this.Expires)).Equal(*(that.Expires))))
 }
 
+// deriveTeleportEqualExternalIdentity returns whether this and that are equal.
+func deriveTeleportEqualExternalIdentity(this, that *ExternalIdentity) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.ConnectorID == that.ConnectorID &&
+			this.Username == that.Username &&
+			this.SAMLSingleLogoutURL == that.SAMLSingleLogoutURL &&
+			this.UserID == that.UserID
+}
+
 // deriveTeleportEqualUserGroupV1 returns whether this and that are equal.
 func deriveTeleportEqualUserGroupV1(this, that *UserGroupV1) bool {
 	return (this == nil && that == nil) ||

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -648,3 +648,8 @@ func (i *ExternalIdentity) Check() error {
 	}
 	return nil
 }
+
+// IsEqual determines if two user group resources are equivalent to one another.
+func (i *ExternalIdentity) IsEqual(other *ExternalIdentity) bool {
+	return deriveTeleportEqualExternalIdentity(i, other)
+}

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -34,7 +34,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -652,7 +651,7 @@ func (s *IdentityService) GetUserByOIDCIdentity(id types.ExternalIdentity) (type
 	}
 	for _, u := range users {
 		for _, uid := range u.GetOIDCIdentities() {
-			if cmp.Equal(uid, &id) {
+			if uid.IsEqual(&id) {
 				return u, nil
 			}
 		}
@@ -669,7 +668,7 @@ func (s *IdentityService) GetUserBySAMLIdentity(id types.ExternalIdentity) (type
 	}
 	for _, u := range users {
 		for _, uid := range u.GetSAMLIdentities() {
-			if cmp.Equal(uid, &id) {
+			if uid.IsEqual(&id) {
 				return u, nil
 			}
 		}
@@ -685,7 +684,7 @@ func (s *IdentityService) GetUserByGithubIdentity(id types.ExternalIdentity) (ty
 	}
 	for _, u := range users {
 		for _, uid := range u.GetGithubIdentities() {
-			if cmp.Equal(uid, &id) {
+			if uid.IsEqual(&id) {
 				return u, nil
 			}
 		}


### PR DESCRIPTION
`(ExternalIdentity) IsEqual` was added with a goderived implementation to remove go-cmp comparisons outside test files.