### PR TITLE
Add the tlscatest.GenerateSelfSignedCA helper

### DIFF
--- a/lib/tlsca/parsegen.go
+++ b/lib/tlsca/parsegen.go
@@ -85,8 +85,16 @@ type GenerateCAConfig struct {
 	Entity      pkix.Name
 	DNSNames    []string
 	IPAddresses []net.IP
-	TTL         time.Duration
-	Clock       clockwork.Clock
+
+	// TTL and Clock are used to create the NotBefore and NotAfter timestamps.
+	// TTL is an offset from the NotBefore.
+	// Optional if NotBefore/NotAfter are supplied.
+	TTL   time.Duration
+	Clock clockwork.Clock
+
+	// NotBefore and NotAfter are the certificate timestamps.
+	// Optional. If unset then TTL and Clock are used.
+	NotBefore, NotAfter time.Time
 }
 
 // setDefaults imposes defaults on this configuration
@@ -101,8 +109,15 @@ func (r *GenerateCAConfig) setDefaults() {
 // Returns PEM-encoded private key/certificate payloads upon success
 func GenerateSelfSignedCAWithConfig(config GenerateCAConfig) (certPEM []byte, err error) {
 	config.setDefaults()
-	notBefore := config.Clock.Now()
-	notAfter := notBefore.Add(config.TTL)
+
+	notBefore := config.NotBefore
+	if notBefore.IsZero() {
+		notBefore = config.Clock.Now()
+	}
+	notAfter := config.NotAfter
+	if notAfter.IsZero() {
+		notAfter = notBefore.Add(config.TTL)
+	}
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
@@ -145,6 +160,9 @@ func GenerateSelfSignedCAWithConfig(config GenerateCAConfig) (certPEM []byte, er
 }
 
 // GenerateSelfSignedCA generates self-signed certificate authority used for tests.
+//
+// Prefer GenerateSelfSignedCAForTesting, which operates on a higher level of
+// abstraction and always creates a valid-looking CA certificate.
 func GenerateSelfSignedCA(entity pkix.Name, dnsNames []string, ttl time.Duration) ([]byte, []byte, error) {
 	signer, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 	if err != nil {
@@ -156,6 +174,53 @@ func GenerateSelfSignedCA(entity pkix.Name, dnsNames []string, ttl time.Duration
 	}
 	certPEM, err := GenerateSelfSignedCAWithSigner(signer, entity, dnsNames, ttl)
 	return keyPEM, certPEM, err
+}
+
+// GenerateTestCAConfig is the input for GenerateSelfSignedCAForTesting.
+type GenerateTestCAConfig struct {
+	// ClusterName is the Teleport cluster name.
+	ClusterName string
+	// NotBefore and NotAfter are the certificate timestamps.
+	// Optional.
+	NotBefore, NotAfter time.Time
+}
+
+// GenerateSelfSignedCAForTesting creates a self-signed Teleport CA certificate
+// for testing.
+//
+// The private key is marshaled using [keys.MarshalPrivateKey].
+//
+// Returns the key and certificate in PEM form.
+func GenerateSelfSignedCAForTesting(config GenerateTestCAConfig) (keyPEM, certPEM []byte, _ error) {
+	if config.ClusterName == "" {
+		return nil, nil, trace.BadParameter("cluster name required")
+	}
+
+	signer, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	keyPEM, err = keys.MarshalPrivateKey(signer)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	certPEM, err = GenerateSelfSignedCAWithConfig(GenerateCAConfig{
+		Signer: signer,
+		Entity: pkix.Name{
+			Organization: []string{config.ClusterName},
+			CommonName:   config.ClusterName,
+		},
+		// Default to 1h / real time...
+		TTL: 1 * time.Hour,
+		// ...but allow customized timestamps.
+		NotBefore: config.NotBefore,
+		NotAfter:  config.NotAfter,
+	})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return keyPEM, certPEM, nil
 }
 
 // ParseCertificateRequestPEM parses PEM-encoded certificate signing request

--- a/lib/tlsca/parsegen.go
+++ b/lib/tlsca/parsegen.go
@@ -161,7 +161,7 @@ func GenerateSelfSignedCAWithConfig(config GenerateCAConfig) (certPEM []byte, er
 
 // GenerateSelfSignedCA generates self-signed certificate authority used for tests.
 //
-// Prefer GenerateSelfSignedCAForTesting, which operates on a higher level of
+// Prefer tlscatest.GenerateSelfSignedCA, which operates on a higher level of
 // abstraction and always creates a valid-looking CA certificate.
 func GenerateSelfSignedCA(entity pkix.Name, dnsNames []string, ttl time.Duration) ([]byte, []byte, error) {
 	signer, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
@@ -174,53 +174,6 @@ func GenerateSelfSignedCA(entity pkix.Name, dnsNames []string, ttl time.Duration
 	}
 	certPEM, err := GenerateSelfSignedCAWithSigner(signer, entity, dnsNames, ttl)
 	return keyPEM, certPEM, err
-}
-
-// GenerateTestCAConfig is the input for GenerateSelfSignedCAForTesting.
-type GenerateTestCAConfig struct {
-	// ClusterName is the Teleport cluster name.
-	ClusterName string
-	// NotBefore and NotAfter are the certificate timestamps.
-	// Optional.
-	NotBefore, NotAfter time.Time
-}
-
-// GenerateSelfSignedCAForTesting creates a self-signed Teleport CA certificate
-// for testing.
-//
-// The private key is marshaled using [keys.MarshalPrivateKey].
-//
-// Returns the key and certificate in PEM form.
-func GenerateSelfSignedCAForTesting(config GenerateTestCAConfig) (keyPEM, certPEM []byte, _ error) {
-	if config.ClusterName == "" {
-		return nil, nil, trace.BadParameter("cluster name required")
-	}
-
-	signer, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	keyPEM, err = keys.MarshalPrivateKey(signer)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	certPEM, err = GenerateSelfSignedCAWithConfig(GenerateCAConfig{
-		Signer: signer,
-		Entity: pkix.Name{
-			Organization: []string{config.ClusterName},
-			CommonName:   config.ClusterName,
-		},
-		// Default to 1h / real time...
-		TTL: 1 * time.Hour,
-		// ...but allow customized timestamps.
-		NotBefore: config.NotBefore,
-		NotAfter:  config.NotAfter,
-	})
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	return keyPEM, certPEM, nil
 }
 
 // ParseCertificateRequestPEM parses PEM-encoded certificate signing request

--- a/lib/tlsca/parsegen_test.go
+++ b/lib/tlsca/parsegen_test.go
@@ -19,12 +19,9 @@ package tlsca_test
 import (
 	"crypto/x509/pkix"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -107,47 +104,4 @@ func TestClusterName(t *testing.T) {
 			assert.Equal(t, test.want, got, "Cluster name mismatch")
 		})
 	}
-}
-
-func TestGenerateSelfSignedCAForTesting(t *testing.T) {
-	t.Parallel()
-
-	t.Run("ok", func(t *testing.T) {
-		t.Parallel()
-
-		keyPEM, certPEM, err := tlsca.GenerateSelfSignedCAForTesting(tlsca.GenerateTestCAConfig{
-			ClusterName: "localhost",
-		})
-		require.NoError(t, err)
-
-		_, err = keys.ParsePrivateKey(keyPEM)
-		require.NoError(t, err, "Parse private key")
-
-		cert, err := tlsca.ParseCertificatePEM(certPEM)
-		require.NoError(t, err, "Parse certificate")
-
-		now := time.Now().Add(1 * time.Nanosecond) // add 1ns just to extra safe.
-		assert.True(t, cert.NotBefore.Before(now), "NotBefore in the future")
-		assert.True(t, cert.NotAfter.After(now), "NotAfter in the past")
-	})
-
-	t.Run("custom timestamps", func(t *testing.T) {
-		t.Parallel()
-
-		// Timestamps need to be UTC and at second precision.
-		notBefore := time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC)
-		notAfter := time.Date(2126, 2, 2, 0, 0, 0, 0, time.UTC)
-
-		_, certPEM, err := tlsca.GenerateSelfSignedCAForTesting(tlsca.GenerateTestCAConfig{
-			ClusterName: "localhost",
-			NotBefore:   notBefore,
-			NotAfter:    notAfter,
-		})
-		require.NoError(t, err)
-
-		cert, err := tlsca.ParseCertificatePEM(certPEM)
-		require.NoError(t, err)
-		assert.Equal(t, notBefore, cert.NotBefore, "NotBefore mismatch")
-		assert.Equal(t, notAfter, cert.NotAfter, "NotAfter mismatch")
-	})
 }

--- a/lib/tlsca/parsegen_test.go
+++ b/lib/tlsca/parsegen_test.go
@@ -19,9 +19,12 @@ package tlsca_test
 import (
 	"crypto/x509/pkix"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -104,4 +107,47 @@ func TestClusterName(t *testing.T) {
 			assert.Equal(t, test.want, got, "Cluster name mismatch")
 		})
 	}
+}
+
+func TestGenerateSelfSignedCAForTesting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		keyPEM, certPEM, err := tlsca.GenerateSelfSignedCAForTesting(tlsca.GenerateTestCAConfig{
+			ClusterName: "localhost",
+		})
+		require.NoError(t, err)
+
+		_, err = keys.ParsePrivateKey(keyPEM)
+		require.NoError(t, err, "Parse private key")
+
+		cert, err := tlsca.ParseCertificatePEM(certPEM)
+		require.NoError(t, err, "Parse certificate")
+
+		now := time.Now().Add(1 * time.Nanosecond) // add 1ns just to extra safe.
+		assert.True(t, cert.NotBefore.Before(now), "NotBefore in the future")
+		assert.True(t, cert.NotAfter.After(now), "NotAfter in the past")
+	})
+
+	t.Run("custom timestamps", func(t *testing.T) {
+		t.Parallel()
+
+		// Timestamps need to be UTC and at second precision.
+		notBefore := time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC)
+		notAfter := time.Date(2126, 2, 2, 0, 0, 0, 0, time.UTC)
+
+		_, certPEM, err := tlsca.GenerateSelfSignedCAForTesting(tlsca.GenerateTestCAConfig{
+			ClusterName: "localhost",
+			NotBefore:   notBefore,
+			NotAfter:    notAfter,
+		})
+		require.NoError(t, err)
+
+		cert, err := tlsca.ParseCertificatePEM(certPEM)
+		require.NoError(t, err)
+		assert.Equal(t, notBefore, cert.NotBefore, "NotBefore mismatch")
+		assert.Equal(t, notAfter, cert.NotAfter, "NotAfter mismatch")
+	})
 }

--- a/lib/tlscatest/generate_self_signed.go
+++ b/lib/tlscatest/generate_self_signed.go
@@ -1,0 +1,75 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tlscatest
+
+import (
+	"crypto/x509/pkix"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+// GenerateCAConfig is the input for [GenerateSelfSignedCA].
+type GenerateCAConfig struct {
+	// ClusterName is the Teleport cluster name.
+	ClusterName string
+	// NotBefore and NotAfter are the certificate timestamps.
+	// Optional.
+	NotBefore, NotAfter time.Time
+}
+
+// GenerateSelfSignedCA creates a self-signed Teleport CA certificate for
+// testing.
+//
+// The private key is marshaled using [keys.MarshalPrivateKey].
+//
+// Returns the key and certificate in PEM form.
+func GenerateSelfSignedCA(config GenerateCAConfig) (keyPEM, certPEM []byte, _ error) {
+	if config.ClusterName == "" {
+		return nil, nil, trace.BadParameter("cluster name required")
+	}
+
+	signer, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	keyPEM, err = keys.MarshalPrivateKey(signer)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	certPEM, err = tlsca.GenerateSelfSignedCAWithConfig(tlsca.GenerateCAConfig{
+		Signer: signer,
+		Entity: pkix.Name{
+			Organization: []string{config.ClusterName},
+			CommonName:   config.ClusterName,
+		},
+		// Default to 1h / real time...
+		TTL: 1 * time.Hour,
+		// ...but allow customized timestamps.
+		NotBefore: config.NotBefore,
+		NotAfter:  config.NotAfter,
+	})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return keyPEM, certPEM, nil
+}

--- a/lib/tlscatest/generate_self_signed_test.go
+++ b/lib/tlscatest/generate_self_signed_test.go
@@ -34,20 +34,29 @@ func TestGenerateSelfSignedCA(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		t.Parallel()
 
+		const clusterName = "localhost"
 		keyPEM, certPEM, err := tlscatest.GenerateSelfSignedCA(tlscatest.GenerateCAConfig{
-			ClusterName: "localhost",
+			ClusterName: clusterName,
 		})
 		require.NoError(t, err)
 
+		// Parse key.
 		_, err = keys.ParsePrivateKey(keyPEM)
 		require.NoError(t, err, "Parse private key")
 
+		// Parse cert.
 		cert, err := tlsca.ParseCertificatePEM(certPEM)
 		require.NoError(t, err, "Parse certificate")
 
+		// Verify timestamps.
 		now := time.Now().Add(1 * time.Nanosecond) // add 1ns just to extra safe.
 		assert.True(t, cert.NotBefore.Before(now), "NotBefore in the future")
 		assert.True(t, cert.NotAfter.After(now), "NotAfter in the past")
+
+		// Verify cluster name in certificate.
+		gotClusterName, err := tlsca.ClusterName(cert.Subject)
+		require.NoError(t, err, "Extract cluster name from certificate")
+		assert.Equal(t, clusterName, gotClusterName, "Cluster name mismatch")
 	})
 
 	t.Run("custom timestamps", func(t *testing.T) {

--- a/lib/tlscatest/generate_self_signed_test.go
+++ b/lib/tlscatest/generate_self_signed_test.go
@@ -1,0 +1,72 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tlscatest_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/tlscatest"
+)
+
+func TestGenerateSelfSignedCA(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		keyPEM, certPEM, err := tlscatest.GenerateSelfSignedCA(tlscatest.GenerateCAConfig{
+			ClusterName: "localhost",
+		})
+		require.NoError(t, err)
+
+		_, err = keys.ParsePrivateKey(keyPEM)
+		require.NoError(t, err, "Parse private key")
+
+		cert, err := tlsca.ParseCertificatePEM(certPEM)
+		require.NoError(t, err, "Parse certificate")
+
+		now := time.Now().Add(1 * time.Nanosecond) // add 1ns just to extra safe.
+		assert.True(t, cert.NotBefore.Before(now), "NotBefore in the future")
+		assert.True(t, cert.NotAfter.After(now), "NotAfter in the past")
+	})
+
+	t.Run("custom timestamps", func(t *testing.T) {
+		t.Parallel()
+
+		// Timestamps need to be UTC and at second precision.
+		notBefore := time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC)
+		notAfter := time.Date(2126, 2, 2, 0, 0, 0, 0, time.UTC)
+
+		_, certPEM, err := tlscatest.GenerateSelfSignedCA(tlscatest.GenerateCAConfig{
+			ClusterName: "localhost",
+			NotBefore:   notBefore,
+			NotAfter:    notAfter,
+		})
+		require.NoError(t, err)
+
+		cert, err := tlsca.ParseCertificatePEM(certPEM)
+		require.NoError(t, err)
+		assert.Equal(t, notBefore, cert.NotBefore, "NotBefore mismatch")
+		assert.Equal(t, notAfter, cert.NotAfter, "NotAfter mismatch")
+	})
+}


### PR DESCRIPTION
Add a tlsca helper that operates at a higher level than GenerateSelfSignedCA, so callers don't need to known the specifics of Teleport CA Subjects.

https://github.com/gravitational/teleport.e/issues/7675