### PR TITLE
Add composite key support to generic.Service

### DIFF
--- a/lib/services/local/autoupdate.go
+++ b/lib/services/local/autoupdate.go
@@ -58,7 +58,7 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateConfig],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateConfig],
 			ValidateFunc:  update.ValidateAutoUpdateConfig,
-			NameKeyFunc: func(name string) backend.Key {
+			NameKeyFunc: func() backend.Key {
 				return backend.NewKey(types.MetaNameAutoUpdateConfig)
 			},
 		})
@@ -73,7 +73,7 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateVersion],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateVersion],
 			ValidateFunc:  update.ValidateAutoUpdateVersion,
-			NameKeyFunc: func(name string) backend.Key {
+			NameKeyFunc: func() backend.Key {
 				return backend.NewKey(types.MetaNameAutoUpdateVersion)
 			},
 		})
@@ -88,7 +88,7 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateAgentRollout],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateAgentRollout],
 			ValidateFunc:  update.ValidateAutoUpdateAgentRollout,
-			NameKeyFunc: func(name string) backend.Key {
+			NameKeyFunc: func() backend.Key {
 				return backend.NewKey(types.MetaNameAutoUpdateAgentRollout)
 			},
 		})

--- a/lib/services/local/autoupdate.go
+++ b/lib/services/local/autoupdate.go
@@ -58,8 +58,8 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateConfig],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateConfig],
 			ValidateFunc:  update.ValidateAutoUpdateConfig,
-			NameKeyFunc: func(string) string {
-				return types.MetaNameAutoUpdateConfig
+			NameKeyFunc: func(name string) backend.Key {
+				return backend.NewKey(types.MetaNameAutoUpdateConfig)
 			},
 		})
 	if err != nil {
@@ -73,8 +73,8 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateVersion],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateVersion],
 			ValidateFunc:  update.ValidateAutoUpdateVersion,
-			NameKeyFunc: func(string) string {
-				return types.MetaNameAutoUpdateVersion
+			NameKeyFunc: func(name string) backend.Key {
+				return backend.NewKey(types.MetaNameAutoUpdateVersion)
 			},
 		})
 	if err != nil {
@@ -88,8 +88,8 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateAgentRollout],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateAgentRollout],
 			ValidateFunc:  update.ValidateAutoUpdateAgentRollout,
-			NameKeyFunc: func(string) string {
-				return types.MetaNameAutoUpdateAgentRollout
+			NameKeyFunc: func(name string) backend.Key {
+				return backend.NewKey(types.MetaNameAutoUpdateAgentRollout)
 			},
 		})
 	if err != nil {

--- a/lib/services/local/backendinfo.go
+++ b/lib/services/local/backendinfo.go
@@ -51,7 +51,7 @@ func NewBackendInfoService(b backend.Backend) (*BackendInfoService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*backendinfov1.BackendInfo],
 			UnmarshalFunc: services.UnmarshalProtoResource[*backendinfov1.BackendInfo],
 			ValidateFunc:  backendinfotype.ValidateBackendInfo,
-			NameKeyFunc: func(name string) backend.Key {
+			NameKeyFunc: func() backend.Key {
 				return backend.NewKey(types.MetaNameBackendInfo)
 			},
 		})

--- a/lib/services/local/backendinfo.go
+++ b/lib/services/local/backendinfo.go
@@ -51,8 +51,8 @@ func NewBackendInfoService(b backend.Backend) (*BackendInfoService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*backendinfov1.BackendInfo],
 			UnmarshalFunc: services.UnmarshalProtoResource[*backendinfov1.BackendInfo],
 			ValidateFunc:  backendinfotype.ValidateBackendInfo,
-			NameKeyFunc: func(string) string {
-				return types.MetaNameBackendInfo
+			NameKeyFunc: func(name string) backend.Key {
+				return backend.NewKey(types.MetaNameBackendInfo)
 			},
 		})
 	if err != nil {

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -71,7 +71,7 @@ type ServiceConfig[T any] struct {
 	// key names. The resulting resource name is still prefixed by the
 	// BackendPrefix.
 	// If unset the item name is created via `BackendPrefix.AppendKey(name)`.
-	NameKeyFunc func(name string) backend.Key
+	NameKeyFunc func() backend.Key
 }
 
 func (c *ServiceConfig[T]) CheckAndSetDefaults() error {
@@ -119,7 +119,7 @@ type Service[T Resource] struct {
 	*serviceState[T]
 
 	backendPrefix backend.Key
-	nameKeyFunc   func(name string) backend.Key
+	nameKeyFunc   func() backend.Key
 }
 
 // NewService will return a new generic service with the given config. This will
@@ -155,7 +155,7 @@ func (s *Service[T]) WithPrefix(parts ...string) *Service[T] {
 }
 
 // WithNameKeyFunc creates a service copy with a distinct NameKeyFunc.
-func (s *Service[T]) WithNameKeyFunc(f func(name string) backend.Key) *Service[T] {
+func (s *Service[T]) WithNameKeyFunc(f func() backend.Key) *Service[T] {
 	s2 := s.clone()
 	s2.nameKeyFunc = f
 	return s2
@@ -172,7 +172,7 @@ func (s *Service[T]) clone() *Service[T] {
 func (s *Service[T]) resourceKey(name string) backend.Key {
 	var suffix backend.Key
 	if s.nameKeyFunc != nil {
-		suffix = s.nameKeyFunc(name)
+		suffix = s.nameKeyFunc()
 	} else {
 		suffix = backend.NewKey(name)
 	}

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -102,17 +102,24 @@ func (c *ServiceConfig[T]) CheckAndSetDefaults() error {
 	return nil
 }
 
-// Service is a generic service for interacting with resources in the backend.
-type Service[T Resource] struct {
+// Immutable service state, created on NewService and copied by WithX methods.
+type serviceState[T Resource] struct {
 	backend                     backend.Backend
 	resourceKind                string
 	pageLimit                   uint
-	backendPrefix               backend.Key
 	marshalFunc                 MarshalFunc[T]
 	unmarshalFunc               UnmarshalFunc[T]
 	validateFunc                func(T) error
 	runWhileLockedRetryInterval time.Duration
 	nameKeyFunc                 func(name string) string
+}
+
+// Service is a generic service for interacting with resources in the backend.
+type Service[T Resource] struct {
+	*serviceState[T]
+
+	backendPrefix backend.Key
+	nameKeyFunc   func(name string) string
 }
 
 // NewService will return a new generic service with the given config. This will
@@ -123,15 +130,18 @@ func NewService[T Resource](cfg *ServiceConfig[T]) (*Service[T], error) {
 	}
 
 	return &Service[T]{
-		backend:                     cfg.Backend,
-		resourceKind:                cfg.ResourceKind,
-		pageLimit:                   cfg.PageLimit,
-		backendPrefix:               cfg.BackendPrefix,
-		marshalFunc:                 cfg.MarshalFunc,
-		unmarshalFunc:               cfg.UnmarshalFunc,
-		validateFunc:                cfg.ValidateFunc,
-		runWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
-		nameKeyFunc:                 cfg.NameKeyFunc,
+		serviceState: &serviceState[T]{
+			backend:                     cfg.Backend,
+			resourceKind:                cfg.ResourceKind,
+			pageLimit:                   cfg.PageLimit,
+			marshalFunc:                 cfg.MarshalFunc,
+			unmarshalFunc:               cfg.UnmarshalFunc,
+			validateFunc:                cfg.ValidateFunc,
+			runWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+			nameKeyFunc:                 cfg.NameKeyFunc,
+		},
+		backendPrefix: cfg.BackendPrefix,
+		nameKeyFunc:   cfg.NameKeyFunc,
 	}, nil
 }
 
@@ -140,9 +150,10 @@ func (s *Service[T]) WithPrefix(parts ...string) *Service[T] {
 	if len(parts) == 0 {
 		return s
 	}
-	s2 := *s
-	s2.backendPrefix = s2.backendPrefix.AppendKey(backend.NewKey(parts...))
-	return &s2
+	return &Service[T]{
+		serviceState:  s.serviceState,
+		backendPrefix: s.backendPrefix.AppendKey(backend.NewKey(parts...)),
+	}
 }
 
 func (s *Service[T]) nameKey(name string) string {

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -67,10 +67,11 @@ type ServiceConfig[T any] struct {
 	// If set to 0, the default interval of 250ms will be used.
 	// WARNING: If set to a negative value, the RunWhileLocked function will retry immediately.
 	RunWhileLockedRetryInterval time.Duration
-	// NameKeyFunc optionally allows resources to have a custom key suffix, by
-	// transforming the name of the resource or the input given to methods that
-	// take a resource name. If unset, the name is used without changes.
-	NameKeyFunc func(name string) string
+	// NameKeyFunc optionally allows resources to have composite and/or customized
+	// key names. The resulting resource name is still prefixed by the
+	// BackendPrefix.
+	// If unset the item name is created via `BackendPrefix.AppendKey(name)`.
+	NameKeyFunc func(name string) backend.Key
 }
 
 func (c *ServiceConfig[T]) CheckAndSetDefaults() error {
@@ -111,7 +112,6 @@ type serviceState[T Resource] struct {
 	unmarshalFunc               UnmarshalFunc[T]
 	validateFunc                func(T) error
 	runWhileLockedRetryInterval time.Duration
-	nameKeyFunc                 func(name string) string
 }
 
 // Service is a generic service for interacting with resources in the backend.
@@ -119,7 +119,7 @@ type Service[T Resource] struct {
 	*serviceState[T]
 
 	backendPrefix backend.Key
-	nameKeyFunc   func(name string) string
+	nameKeyFunc   func(name string) backend.Key
 }
 
 // NewService will return a new generic service with the given config. This will
@@ -138,7 +138,6 @@ func NewService[T Resource](cfg *ServiceConfig[T]) (*Service[T], error) {
 			unmarshalFunc:               cfg.UnmarshalFunc,
 			validateFunc:                cfg.ValidateFunc,
 			runWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
-			nameKeyFunc:                 cfg.NameKeyFunc,
 		},
 		backendPrefix: cfg.BackendPrefix,
 		nameKeyFunc:   cfg.NameKeyFunc,
@@ -150,17 +149,34 @@ func (s *Service[T]) WithPrefix(parts ...string) *Service[T] {
 	if len(parts) == 0 {
 		return s
 	}
+	s2 := s.clone()
+	s2.backendPrefix = s.backendPrefix.AppendKey(backend.NewKey(parts...))
+	return s2
+}
+
+// WithNameKeyFunc creates a service copy with a distinct NameKeyFunc.
+func (s *Service[T]) WithNameKeyFunc(f func(name string) backend.Key) *Service[T] {
+	s2 := s.clone()
+	s2.nameKeyFunc = f
+	return s2
+}
+
+func (s *Service[T]) clone() *Service[T] {
 	return &Service[T]{
 		serviceState:  s.serviceState,
-		backendPrefix: s.backendPrefix.AppendKey(backend.NewKey(parts...)),
+		backendPrefix: s.backendPrefix,
+		nameKeyFunc:   s.nameKeyFunc,
 	}
 }
 
-func (s *Service[T]) nameKey(name string) string {
+func (s *Service[T]) resourceKey(name string) backend.Key {
+	var suffix backend.Key
 	if s.nameKeyFunc != nil {
-		return s.nameKeyFunc(name)
+		suffix = s.nameKeyFunc(name)
+	} else {
+		suffix = backend.NewKey(name)
 	}
-	return name
+	return s.MakeKey(suffix)
 }
 
 // CountResources will return a count of all resources in the prefix range.
@@ -335,7 +351,7 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 
 // GetResource returns the specified resource.
 func (s *Service[T]) GetResource(ctx context.Context, name string) (resource T, err error) {
-	item, err := s.backend.Get(ctx, s.MakeKey(backend.NewKey(s.nameKey(name))))
+	item, err := s.backend.Get(ctx, s.resourceKey(name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return resource, trace.NotFound("%s %q doesn't exist", s.resourceKind, name)
@@ -445,7 +461,7 @@ func (s *Service[T]) UpsertResource(ctx context.Context, resource T) (T, error) 
 
 // DeleteResource removes the specified resource.
 func (s *Service[T]) DeleteResource(ctx context.Context, name string) error {
-	err := s.backend.Delete(ctx, s.MakeKey(backend.NewKey(s.nameKey(name))))
+	err := s.backend.Delete(ctx, s.resourceKey(name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("%s %q doesn't exist", s.resourceKind, name)
@@ -464,7 +480,7 @@ func (s *Service[T]) DeleteAllResources(ctx context.Context) error {
 // UpdateAndSwapResource will get the resource from the backend, modify it, and swap the new value into the backend.
 func (s *Service[T]) UpdateAndSwapResource(ctx context.Context, name string, modify func(T) error) (T, error) {
 	var t T
-	existingItem, err := s.backend.Get(ctx, s.MakeKey(backend.NewKey(s.nameKey(name))))
+	existingItem, err := s.backend.Get(ctx, s.resourceKey(name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return t, trace.NotFound("%s %q doesn't exist", s.resourceKind, name)
@@ -517,7 +533,7 @@ func (s *Service[T]) MakeBackendItem(resource T, _ ...any) (backend.Item, error)
 		return backend.Item{}, trace.Wrap(err)
 	}
 	item := backend.Item{
-		Key:      s.MakeKey(backend.NewKey(s.nameKey(resource.GetName()))),
+		Key:      s.resourceKey(resource.GetName()),
 		Value:    value,
 		Revision: rev,
 	}

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -647,7 +647,7 @@ func TestGenericKeyOverride(t *testing.T) {
 		BackendPrefix: backend.NewKey("generic_prefix"),
 		UnmarshalFunc: unmarshalResource,
 		MarshalFunc:   marshalResource,
-		NameKeyFunc:   func(string) backend.Key { return backend.NewKey("llama") },
+		NameKeyFunc:   func() backend.Key { return backend.NewKey("llama") },
 	})
 	require.NoError(t, err)
 
@@ -728,7 +728,7 @@ func TestGenericKeyOverride(t *testing.T) {
 	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	t.Run("WithNameKeyFunc", func(t *testing.T) {
-		s := service.WithNameKeyFunc(func(name string) backend.Key {
+		s := service.WithNameKeyFunc(func() backend.Key {
 			return backend.NewKey("camelid", "thellama")
 		})
 

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -646,7 +647,7 @@ func TestGenericKeyOverride(t *testing.T) {
 		BackendPrefix: backend.NewKey("generic_prefix"),
 		UnmarshalFunc: unmarshalResource,
 		MarshalFunc:   marshalResource,
-		NameKeyFunc:   func(string) string { return "llama" },
+		NameKeyFunc:   func(string) backend.Key { return backend.NewKey("llama") },
 	})
 	require.NoError(t, err)
 
@@ -725,4 +726,32 @@ func TestGenericKeyOverride(t *testing.T) {
 	require.NoError(t, err)
 	_, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", "llama"))
 	require.ErrorAs(t, err, new(*trace.NotFoundError))
+
+	t.Run("WithNameKeyFunc", func(t *testing.T) {
+		s := service.WithNameKeyFunc(func(name string) backend.Key {
+			return backend.NewKey("camelid", "thellama")
+		})
+
+		ctx := t.Context()
+		r1 := newTestResource("r1")
+
+		// Test a few basic operations to make sure the With is sound.
+		created, err := s.CreateResource(ctx, r1)
+		require.NoError(t, err, "CreateResource")
+
+		// Test that the customized key exists.
+		wantKey := backend.NewKey("generic_prefix", "camelid", "thellama")
+		_, err = memBackend.Get(ctx, wantKey)
+		require.NoError(t, err, "Get by customized key")
+
+		// Get.
+		stored, err := s.GetResource(ctx, "")
+		require.NoError(t, err, "GetResource")
+		assert.Equal(t, created, stored, "GetResource mismatch")
+
+		// Delete.
+		require.NoError(t, s.DeleteResource(ctx, ""), "DeleteResource")
+		// 2nd Delete.
+		require.ErrorAs(t, s.DeleteResource(ctx, ""), new(*trace.NotFoundError), "2nd DeleteResource error mismatch")
+	})
 }

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -76,6 +76,13 @@ func (s *ServiceWrapper[T]) WithPrefix(parts ...string) *ServiceWrapper[T] {
 	return &ServiceWrapper[T]{service: s.service.WithPrefix(parts...)}
 }
 
+// WithNameKeyFunc creates a service copy with a distinct NameKeyFunc.
+func (s *ServiceWrapper[T]) WithNameKeyFunc(f func(name string) backend.Key) *ServiceWrapper[T] {
+	return &ServiceWrapper[T]{
+		service: s.service.WithNameKeyFunc(f),
+	}
+}
+
 // UpsertResource upserts a resource.
 func (s *ServiceWrapper[T]) UpsertResource(ctx context.Context, resource T) (T, error) {
 	adapter, err := s.service.UpsertResource(ctx, newResourceMetadataAdapter(resource))

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -77,7 +77,7 @@ func (s *ServiceWrapper[T]) WithPrefix(parts ...string) *ServiceWrapper[T] {
 }
 
 // WithNameKeyFunc creates a service copy with a distinct NameKeyFunc.
-func (s *ServiceWrapper[T]) WithNameKeyFunc(f func(name string) backend.Key) *ServiceWrapper[T] {
+func (s *ServiceWrapper[T]) WithNameKeyFunc(f func() backend.Key) *ServiceWrapper[T] {
 	return &ServiceWrapper[T]{
 		service: s.service.WithNameKeyFunc(f),
 	}


### PR DESCRIPTION
Refactor NameKeyFunc to support composite keys, in addition to customized/hard-coded keys. NameKeyFunc was almost there, it only needed a small tweak.

This is useful for resources with "non-standard" names, like CAs and the soon-to-be CA overrides (which mimic the CA's composite key).

I've also refactored Service so "With*" functions only need to copy a few pointers, one of them being the pointer to all "immutable" state.

Here's an example of how a resource service might use this:

```go
func (s *FooService) CreateFoo(ctx context.Context, foo *Foo) (*Foo, error) {
  // s.service is a ServiceWrapper.
  service := s.service.WithNameKeyFunc(makeFooNameFunc(foo))
  return service.CreateResource(ctx, foo)
}

func makeFooNameFunc(foo *Foo) func() backend.Key {
  return func() backend.Key {
    return backend.NewKey(foo.GetSubKind(), foo.GetMetadata().GetName())
  }
}
```

https://github.com/gravitational/teleport.e/issues/7675