### PR TITLE
Add lib/subca.HashPublicKey

### DIFF
--- a/lib/subca/public_key_hash.go
+++ b/lib/subca/public_key_hash.go
@@ -1,0 +1,43 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+)
+
+// HashCertificatePublicKey hashes a certificate's public key in the
+// standardized Sub CA public key representation.
+//
+// Equivalent to `HEX(SHA256(cert.RawSubjectPublicKeyInfo))`.
+func HashCertificatePublicKey(cert *x509.Certificate) string {
+	if cert == nil {
+		return ""
+	}
+	return HashPublicKey(cert.RawSubjectPublicKeyInfo)
+}
+
+// HashPublicKey hashes a RawSubjectPublicKeyInfo in the
+// standardized Sub CA public key representation.
+//
+// Equivalent to `HEX(SHA256(rawSubjectPublicKeyInfo))`.
+func HashPublicKey(rawSubjectPublicKeyInfo []byte) string {
+	sum := sha256.Sum256(rawSubjectPublicKeyInfo)
+	return hex.EncodeToString(sum[:])
+}

--- a/lib/subca/public_key_hash_test.go
+++ b/lib/subca/public_key_hash_test.go
@@ -1,0 +1,51 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca_test
+
+import (
+	"crypto/x509"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/subca"
+)
+
+func TestHashPublicKey(t *testing.T) {
+	t.Parallel()
+
+	// RawSubjectPublicKeyInfo extracted from a test certificate.
+	const hexSubjPKInfo = `3059301306072a8648ce3d020106082a8648ce3d030107034200047a625150220aced3b42f7d18eec6c77bb4d66b97de02e5a265963d0a11035fa3a490f27ad35aab7701cded5c88836decfcf442936696e7fe6f0694dca5cdfda6`
+	rawSubjPKInfo, err := hex.DecodeString(hexSubjPKInfo)
+	require.NoError(t, err)
+
+	const want = `99c968f51266531bde14cbb0cd1cc52d0cc5590bde0a760da27f9be8a7ea7ad7`
+
+	t.Run("HashCertificatePublicKey", func(t *testing.T) {
+		got := subca.HashCertificatePublicKey(&x509.Certificate{
+			RawSubjectPublicKeyInfo: rawSubjPKInfo,
+		})
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("HashPublicKey", func(t *testing.T) {
+		got := subca.HashPublicKey(rawSubjPKInfo)
+		assert.Equal(t, want, got)
+	})
+}


### PR DESCRIPTION
Add a function to hash Sub CA certificate public keys, as described by the [Sub CA APIs][1].

[1]: https://github.com/gravitational/teleport/blob/344d500df8018eb53182fdcd028818b919908e1a/api/proto/teleport/subca/v1/public_key_hash.proto#L21-L23

https://github.com/gravitational/teleport.e/issues/7675