### PR TITLE
Update instructions for adding an agent service

### DIFF
--- a/docs/pages/installation/agents/add-service-to-agent.mdx
+++ b/docs/pages/installation/agents/add-service-to-agent.mdx
@@ -23,9 +23,11 @@ the agent.
 
 When a Teleport Agent joins a cluster, the Teleport Auth Service issues a
 certificate for the agent. The certificate contains the Teleport services that
-it authorizes the agent to run. To run new services on an agent, you must repeat
-the initial join procedure for those services. The agent needs to re-join the
-cluster with the new token and receive a new certificate.
+it authorizes the agent to run. To run new services on an agent, update the
+agent's join token to one that authorizes the new services, enable the new
+services in the agent's configuration file, then restart the agent. The agent
+will detect the additional services authorized by the new token and obtain a new
+certificate for them.
 
 ## Prerequisites
 
@@ -275,18 +277,49 @@ receives a certificate that authorizes the additional service you want to run.
 
 ### Linux server
 
-If your Teleport Agent runs on a Linux server:
+If your Teleport Agent runs on a Linux server, restart the agent:
 
-1. Delete the agent's state directory, which is `/var/lib/teleport` by default.
-   (Check the `teleport.data_dir` field of the Agent's configuration file.) With
-   no data directory, the agent will obtain its initial credentials from the
-   Auth Service instead of reading existing credentials.
+```code
+$ sudo systemctl restart teleport
+```
 
-1. Restart the agent:
+On the first restart with the new token, the agent will detect the additional
+authorized services and retrieve a new certificate for them.
+
+Run the following command to determine if you added the new service,
+substituting <Var name="hostname" /> with the hostname of your agent:
+
+```code
+$ tctl inventory ls --format=json | \
+  jq '.[] | select(.spec.hostname == "<Var name="hostname" />") | .spec.services'
+[
+  "Node",
+  "Db",
+  "App"
+]
+```
+
+The output should include the role of the new service.
+
+<details>
+<summary>If the new service has not started</summary>
+
+If the agent fails to acquire the new role after restarting, you can force it
+to re-join from scratch by deleting its state directory.
+
+1. Check the `teleport.data_dir` field in the agent's configuration file for the
+   location of the data directory. The default is `/var/lib/teleport`.
+
+1. Stop the agent, delete the data directory at 
+   <Var name="/var/lib/teleport" />, and start the agent again:
 
    ```code
-   $ sudo systemctl reload teleport
+   $ sudo systemctl stop teleport
+   $ sudo rm -rf <Var name="/var/lib/teleport" />
+   $ sudo systemctl start teleport
    ```
+
+</details>
 
 ### Helm chart
 


### PR DESCRIPTION
Closes #58612

Indicate how to update the services a Teleport Agent runs without deleting its data directory. Include a `tctl` command to check that the expected service is running on the agent.