### PR TITLE
Improve `--help` output for `tsh`, `tctl`, `tbot`, `teleport-update` and `teleport`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ other services. The limit is aggregated across all apps on the
 `connection_limits` configured, those values apply to app access
 connections after upgrading to v19.
 
+#### CLI --help Output Improvements
+
+In the past, Teleport CLI programs printed all subcommands, subcommands'
+subcommands, and so on, when the `--help` option was specified. Additionally,
+the output was written to stderr, rather than stdout. `--help` output now
+goes to stdout, and contains info on only one level of subcommands. Affected
+programs include `teleport`, `tsh`, `tctl`, `tbot`, and `teleport-update`.
+
 ## 18.5.0 (12/04/25)
 
 ### Kubernetes support for Relay Service

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -341,6 +341,9 @@ func InitCLIParser(appName, appHelp string) (app *kingpin.Application) {
 	app.HelpFlag.Hidden()
 	app.HelpFlag.NoEnvar()
 
+	// write --help output to stdout instead of stderr
+	app.UsageWriter(os.Stdout)
+
 	// set our own help template
 	app.UsageFuncs(template.FuncMap{
 		"CommandPrintfWidth": func(cmds []*kingpin.CmdModel) int {

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -349,7 +349,7 @@ func InitCLIParser(appName, appHelp string) (app *kingpin.Application) {
 		"CommandPrintfWidth": func(cmds []*kingpin.CmdModel) int {
 			cmdWidth := defaultCommandPrintfWidth
 			for _, cmd := range cmds {
-				cmdWidth = max(cmdWidth, len(cmd.FullCommand))
+				cmdWidth = max(cmdWidth, len(cmd.Name))
 			}
 			return cmdWidth
 		},
@@ -452,10 +452,10 @@ const defaultUsageTemplate = `{{define "FormatCommand" -}}
 {{end -}}
 
 {{define "FormatCommands" -}}
-{{- $cmdWidth := .FlattenedCommands | CommandPrintfWidth -}}
-{{range .FlattenedCommands -}}
+{{- $cmdWidth := .Commands | CommandPrintfWidth -}}
+{{range .Commands -}}
 {{if not .Hidden -}}
-{{"  "}}{{printf (printf "%%-%ds" $cmdWidth) .FullCommand}}{{if .Default}} (Default){{end}} {{ .Help }}
+{{"  "}}{{printf (printf "%%-%ds" $cmdWidth) .Name}}{{if .Default}} (Default){{end}} {{ .Help }}
 {{end -}}
 {{end -}}
 {{end -}}

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -349,6 +349,9 @@ func InitCLIParser(appName, appHelp string) (app *kingpin.Application) {
 		"CommandPrintfWidth": func(cmds []*kingpin.CmdModel) int {
 			cmdWidth := defaultCommandPrintfWidth
 			for _, cmd := range cmds {
+				if cmd.Hidden {
+					continue
+				}
 				cmdWidth = max(cmdWidth, len(cmd.Name))
 			}
 			return cmdWidth

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -267,6 +267,7 @@ func TestInitCLIParser(t *testing.T) {
 		app.Terminate(func(int) {})
 
 		app.Command("hello", "Hello.")
+		app.Command("very-long-command", "Very long command.")
 
 		create := app.Command("create", "Create.")
 		create.Command("box", "Box.")
@@ -275,6 +276,7 @@ func TestInitCLIParser(t *testing.T) {
 		start := app.Command("start", "Start.")
 		start.Command("legacy", "Legacy.").Default()
 		start.Command("workload-identity", "Workload identity.")
+
 		return app
 	}
 

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -268,6 +268,7 @@ func TestInitCLIParser(t *testing.T) {
 
 		app.Command("hello", "Hello.")
 		app.Command("very-long-command", "Very long command.")
+		app.Command("hidden-very-long-command", "This command is hidden.").Hidden()
 
 		create := app.Command("create", "Create.")
 		create.Command("box", "Box.")

--- a/lib/utils/testdata/TestInitCLIParser/command_width_aligned_for_subcommand_help.golden
+++ b/lib/utils/testdata/TestInitCLIParser/command_width_aligned_for_subcommand_help.golden
@@ -5,8 +5,8 @@ Create.
 Flags:
 
 Commands:
-  create box    Box.
-  create rocket Rocket.
+  box          Box.
+  rocket       Rocket.
 
 Aliases:
 

--- a/lib/utils/testdata/TestInitCLIParser/command_width_aligned_on_unknown_command_error.golden
+++ b/lib/utils/testdata/TestInitCLIParser/command_width_aligned_on_unknown_command_error.golden
@@ -5,12 +5,11 @@ some help message
 Flags:
 
 Commands:
-  help                    Show help.
-  hello                   Hello.
-  create box              Box.
-  create rocket           Rocket.
-  start legacy            (Default) Legacy.
-  start workload-identity Workload identity.
+  help              Show help.
+  hello             Hello.
+  very-long-command Very long command.
+  create            Create.
+  start             Start.
 
 Try 'test help [command]' to get help for a given command.
 

--- a/lib/utils/testdata/TestInitCLIParser/command_width_expands_to_longest_command.golden
+++ b/lib/utils/testdata/TestInitCLIParser/command_width_expands_to_longest_command.golden
@@ -5,12 +5,11 @@ some help message
 Flags:
 
 Commands:
-  help                    Show help.
-  hello                   Hello.
-  create box              Box.
-  create rocket           Rocket.
-  start legacy            (Default) Legacy.
-  start workload-identity Workload identity.
+  help              Show help.
+  hello             Hello.
+  very-long-command Very long command.
+  create            Create.
+  start             Start.
 
 Try 'test help [command]' to get help for a given command.
 

--- a/lib/utils/testdata/TestInitCLIParser/default_subcommand_does_not_affect_column_width.golden
+++ b/lib/utils/testdata/TestInitCLIParser/default_subcommand_does_not_affect_column_width.golden
@@ -5,8 +5,8 @@ Start.
 Flags:
 
 Commands:
-  start legacy            (Default) Legacy.
-  start workload-identity Workload identity.
+  legacy            (Default) Legacy.
+  workload-identity Workload identity.
 
 Aliases:
 


### PR DESCRIPTION
When I started learning about Teleport, one of the first things I noticed was that the `--help` output of our command line tools is verbose. This results in a "paper cut" for new Teleport users: it is harder to get an idea of what a command does from reading its usage. There are a few problems:

- We print out every subcommand, and every subcommand's subcommands, et cetera.
- `--help` output goes to stderr, not stdout. So when a user pipes the command's verbose `--help` to `less` (or equivalent), they discover this, and then must redirect stderr to stdout, at which point viewing the output via `less` works as expected.

This PR fixes these problems.

Changelog: Improve `--help` output of `tsh`, `tctl`, `tbot`, `teleport-update` and `teleport`.

## Manual Test Plan

### Test Environment

All tests were performed locally on macOS. There is one exception: `teleport-update` does not build for macOS, so I tested it inside a container on my macOS machine.

### Test Cases

- [x] `<command> --help` generally looks good.
  - [x] tbot
  - [x] tsh
  - [x] tctl
  - [x] teleport-update
  - [x] teleport
- [x] `<command> --help` prints only one level of subcommands.
  - [x] tbot
  - [x] tsh
  - [x] tctl
  - [x] teleport-update
  - [x] teleport
- [x] `<command> --help` outputs to stdout, not stderr.
  - [x] tbot
  - [x] tsh
  - [x] tctl
  - [x] teleport-update
  - [x] teleport
- [x] `<command> <subcommand> --help` generally looks good.
  - [x] tbot
  - [x] tsh
  - [x] tctl
  - [x] teleport-update
  - [x] teleport
- [x] `<command> <subcommand> --help` prints only one level of subcommands.
  - [x] tbot
  - [x] tsh
  - [x] tctl
  - [x] teleport-update
  - [x] teleport
- [x] `<command> <subcommand> --help` outputs to stdout, not stderr.
  - [x] tbot
  - [x] tsh
  - [x] tctl
  - [x] teleport-update
  - [x] teleport