### PR TITLE
Stop comparing Users with go-cmp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,8 +93,6 @@ linters:
             - '!**/e/lib/auth/saml.go'
             - '!**lib/services/compare.go'
             - '!**/lib/services/local/access_list.go'
-            - '!**/lib/services/local/users.go'
-            - '!**/lib/services/user.go'
           deny:
             - pkg: github.com/google/go-cmp/cmp
               desc: '"github.com/google/go-cmp/cmp" should only be used in tests'

--- a/api/types/derived.gen.go
+++ b/api/types/derived.gen.go
@@ -194,6 +194,58 @@ func deriveTeleportEqualAWSOrganizationMatcher(this, that *AWSOrganizationMatche
 			deriveTeleportEqual_20(this.OrganizationalUnits, that.OrganizationalUnits)
 }
 
+// deriveTeleportEqualMetadata returns whether this and that are equal.
+func deriveTeleportEqualMetadata(this, that *Metadata) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Name == that.Name &&
+			this.Namespace == that.Namespace &&
+			this.Description == that.Description &&
+			deriveTeleportEqual_10(this.Labels, that.Labels) &&
+			((this.Expires == nil && that.Expires == nil) || (this.Expires != nil && that.Expires != nil && (*(this.Expires)).Equal(*(that.Expires))))
+}
+
+// deriveTeleportEqualTOTPDevice returns whether this and that are equal.
+func deriveTeleportEqualTOTPDevice(this, that *TOTPDevice) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Key == that.Key
+}
+
+// deriveTeleportEqualU2FDevice returns whether this and that are equal.
+func deriveTeleportEqualU2FDevice(this, that *U2FDevice) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			bytes.Equal(this.KeyHandle, that.KeyHandle) &&
+			bytes.Equal(this.PubKey, that.PubKey) &&
+			this.Counter == that.Counter
+}
+
+// deriveTeleportEqualWebauthnDevice returns whether this and that are equal.
+func deriveTeleportEqualWebauthnDevice(this, that *WebauthnDevice) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			bytes.Equal(this.CredentialId, that.CredentialId) &&
+			bytes.Equal(this.PublicKeyCbor, that.PublicKeyCbor) &&
+			this.AttestationType == that.AttestationType &&
+			bytes.Equal(this.Aaguid, that.Aaguid) &&
+			this.SignatureCounter == that.SignatureCounter &&
+			bytes.Equal(this.AttestationObject, that.AttestationObject) &&
+			this.ResidentKey == that.ResidentKey &&
+			this.CredentialRpId == that.CredentialRpId &&
+			this.CredentialBackupEligible.Equal(that.CredentialBackupEligible) &&
+			this.CredentialBackedUp.Equal(that.CredentialBackedUp)
+}
+
+// deriveTeleportEqualSSOMFADevice returns whether this and that are equal.
+func deriveTeleportEqualSSOMFADevice(this, that *SSOMFADevice) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.ConnectorId == that.ConnectorId &&
+			this.ConnectorType == that.ConnectorType &&
+			this.DisplayName == that.DisplayName
+}
+
 // deriveTeleportEqualOktaAssignmentV1 returns whether this and that are equal.
 func deriveTeleportEqualOktaAssignmentV1(this, that *OktaAssignmentV1) bool {
 	return (this == nil && that == nil) ||
@@ -210,17 +262,6 @@ func deriveTeleportEqualResourceHeader(this, that *ResourceHeader) bool {
 			this.SubKind == that.SubKind &&
 			this.Version == that.Version &&
 			deriveTeleportEqualMetadata(&this.Metadata, &that.Metadata)
-}
-
-// deriveTeleportEqualMetadata returns whether this and that are equal.
-func deriveTeleportEqualMetadata(this, that *Metadata) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.Name == that.Name &&
-			this.Namespace == that.Namespace &&
-			this.Description == that.Description &&
-			deriveTeleportEqual_10(this.Labels, that.Labels) &&
-			((this.Expires == nil && that.Expires == nil) || (this.Expires != nil && that.Expires != nil && (*(this.Expires)).Equal(*(that.Expires))))
 }
 
 // deriveTeleportEqualRoleV6 returns whether this and that are equal.
@@ -245,6 +286,17 @@ func deriveTeleportEqualSAMLConnectorV2(this, that *SAMLConnectorV2) bool {
 			deriveTeleportEqual_23(&this.Spec, &that.Spec)
 }
 
+// deriveTeleportEqualUser returns whether this and that are equal.
+func deriveTeleportEqualUser(this, that *UserV2) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Kind == that.Kind &&
+			this.SubKind == that.SubKind &&
+			this.Version == that.Version &&
+			deriveTeleportEqualMetadata(&this.Metadata, &that.Metadata) &&
+			deriveTeleportEqual_24(&this.Spec, &that.Spec)
+}
+
 // deriveTeleportEqualExternalIdentity returns whether this and that are equal.
 func deriveTeleportEqualExternalIdentity(this, that *ExternalIdentity) bool {
 	return (this == nil && that == nil) ||
@@ -260,7 +312,7 @@ func deriveTeleportEqualUserGroupV1(this, that *UserGroupV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqualResourceHeader(&this.ResourceHeader, &that.ResourceHeader) &&
-			deriveTeleportEqual_24(&this.Spec, &that.Spec)
+			deriveTeleportEqual_25(&this.Spec, &that.Spec)
 }
 
 // deriveTeleportEqual returns whether this and that are equal.
@@ -269,19 +321,19 @@ func deriveTeleportEqual(this, that *AppSpecV3) bool {
 		this != nil && that != nil &&
 			this.URI == that.URI &&
 			this.PublicAddr == that.PublicAddr &&
-			deriveTeleportEqual_25(this.DynamicLabels, that.DynamicLabels) &&
+			deriveTeleportEqual_26(this.DynamicLabels, that.DynamicLabels) &&
 			this.InsecureSkipVerify == that.InsecureSkipVerify &&
-			deriveTeleportEqual_26(this.Rewrite, that.Rewrite) &&
-			deriveTeleportEqual_27(this.AWS, that.AWS) &&
+			deriveTeleportEqual_27(this.Rewrite, that.Rewrite) &&
+			deriveTeleportEqual_28(this.AWS, that.AWS) &&
 			this.Cloud == that.Cloud &&
-			deriveTeleportEqual_28(this.UserGroups, that.UserGroups) &&
+			deriveTeleportEqual_29(this.UserGroups, that.UserGroups) &&
 			this.Integration == that.Integration &&
-			deriveTeleportEqual_28(this.RequiredAppNames, that.RequiredAppNames) &&
-			deriveTeleportEqual_29(this.CORS, that.CORS) &&
-			deriveTeleportEqual_30(this.IdentityCenter, that.IdentityCenter) &&
-			deriveTeleportEqual_31(this.TCPPorts, that.TCPPorts) &&
+			deriveTeleportEqual_29(this.RequiredAppNames, that.RequiredAppNames) &&
+			deriveTeleportEqual_30(this.CORS, that.CORS) &&
+			deriveTeleportEqual_31(this.IdentityCenter, that.IdentityCenter) &&
+			deriveTeleportEqual_32(this.TCPPorts, that.TCPPorts) &&
 			this.UseAnyProxyPublicAddr == that.UseAnyProxyPublicAddr &&
-			deriveTeleportEqual_32(this.MCP, that.MCP)
+			deriveTeleportEqual_33(this.MCP, that.MCP)
 }
 
 // deriveTeleportEqual_ returns whether this and that are equal.
@@ -291,12 +343,12 @@ func deriveTeleportEqual_(this, that *AppServerSpecV3) bool {
 			this.Version == that.Version &&
 			this.Hostname == that.Hostname &&
 			this.HostID == that.HostID &&
-			deriveTeleportEqual_33(&this.Rotation, &that.Rotation) &&
+			deriveTeleportEqual_34(&this.Rotation, &that.Rotation) &&
 			deriveTeleportEqualAppV3(this.App, that.App) &&
-			deriveTeleportEqual_28(this.ProxyIDs, that.ProxyIDs) &&
+			deriveTeleportEqual_29(this.ProxyIDs, that.ProxyIDs) &&
 			this.RelayGroup == that.RelayGroup &&
-			deriveTeleportEqual_28(this.RelayIds, that.RelayIds) &&
-			deriveTeleportEqual_34(this.ComponentFeatures, that.ComponentFeatures)
+			deriveTeleportEqual_29(this.RelayIds, that.RelayIds) &&
+			deriveTeleportEqual_35(this.ComponentFeatures, that.ComponentFeatures)
 }
 
 // deriveTeleportEqual_1 returns whether this and that are equal.
@@ -305,12 +357,12 @@ func deriveTeleportEqual_1(this, that *CertAuthoritySpecV2) bool {
 		this != nil && that != nil &&
 			this.Type == that.Type &&
 			this.ClusterName == that.ClusterName &&
-			deriveTeleportEqual_28(this.Roles, that.Roles) &&
-			deriveTeleportEqual_35(this.RoleMap, that.RoleMap) &&
-			deriveTeleportEqual_33(this.Rotation, that.Rotation) &&
+			deriveTeleportEqual_29(this.Roles, that.Roles) &&
+			deriveTeleportEqual_36(this.RoleMap, that.RoleMap) &&
+			deriveTeleportEqual_34(this.Rotation, that.Rotation) &&
 			this.SigningAlg == that.SigningAlg &&
-			deriveTeleportEqual_36(&this.ActiveKeys, &that.ActiveKeys) &&
-			deriveTeleportEqual_36(&this.AdditionalTrustedKeys, &that.AdditionalTrustedKeys)
+			deriveTeleportEqual_37(&this.ActiveKeys, &that.ActiveKeys) &&
+			deriveTeleportEqual_37(&this.AdditionalTrustedKeys, &that.AdditionalTrustedKeys)
 }
 
 // deriveTeleportEqual_2 returns whether this and that are equal.
@@ -328,9 +380,9 @@ func deriveTeleportEqual_3(this, that *RDS) bool {
 			this.ClusterID == that.ClusterID &&
 			this.ResourceID == that.ResourceID &&
 			this.IAMAuth == that.IAMAuth &&
-			deriveTeleportEqual_28(this.Subnets, that.Subnets) &&
+			deriveTeleportEqual_29(this.Subnets, that.Subnets) &&
 			this.VPCID == that.VPCID &&
-			deriveTeleportEqual_28(this.SecurityGroups, that.SecurityGroups)
+			deriveTeleportEqual_29(this.SecurityGroups, that.SecurityGroups)
 }
 
 // deriveTeleportEqual_4 returns whether this and that are equal.
@@ -338,7 +390,7 @@ func deriveTeleportEqual_4(this, that *ElastiCache) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ReplicationGroupID == that.ReplicationGroupID &&
-			deriveTeleportEqual_28(this.UserGroupIDs, that.UserGroupIDs) &&
+			deriveTeleportEqual_29(this.UserGroupIDs, that.UserGroupIDs) &&
 			this.TransitEncryptionEnabled == that.TransitEncryptionEnabled &&
 			this.EndpointType == that.EndpointType
 }
@@ -438,16 +490,16 @@ func deriveTeleportEqual_14(this, that *DatabaseSpecV3) bool {
 			this.Protocol == that.Protocol &&
 			this.URI == that.URI &&
 			this.CACert == that.CACert &&
-			deriveTeleportEqual_25(this.DynamicLabels, that.DynamicLabels) &&
+			deriveTeleportEqual_26(this.DynamicLabels, that.DynamicLabels) &&
 			deriveTeleportEqualAWS(&this.AWS, &that.AWS) &&
 			deriveTeleportEqualGCPCloudSQL(&this.GCP, &that.GCP) &&
 			deriveTeleportEqualAzure(&this.Azure, &that.Azure) &&
-			deriveTeleportEqual_37(&this.TLS, &that.TLS) &&
-			deriveTeleportEqual_38(&this.AD, &that.AD) &&
-			deriveTeleportEqual_39(&this.MySQL, &that.MySQL) &&
-			deriveTeleportEqual_40(this.AdminUser, that.AdminUser) &&
-			deriveTeleportEqual_41(&this.MongoAtlas, &that.MongoAtlas) &&
-			deriveTeleportEqual_42(&this.Oracle, &that.Oracle)
+			deriveTeleportEqual_38(&this.TLS, &that.TLS) &&
+			deriveTeleportEqual_39(&this.AD, &that.AD) &&
+			deriveTeleportEqual_40(&this.MySQL, &that.MySQL) &&
+			deriveTeleportEqual_41(this.AdminUser, that.AdminUser) &&
+			deriveTeleportEqual_42(&this.MongoAtlas, &that.MongoAtlas) &&
+			deriveTeleportEqual_43(&this.Oracle, &that.Oracle)
 }
 
 // deriveTeleportEqual_15 returns whether this and that are equal.
@@ -457,7 +509,7 @@ func deriveTeleportEqual_15(this, that *DynamicWindowsDesktopSpecV1) bool {
 			this.Addr == that.Addr &&
 			this.Domain == that.Domain &&
 			this.NonAD == that.NonAD &&
-			deriveTeleportEqual_43(this.ScreenSize, that.ScreenSize)
+			deriveTeleportEqual_44(this.ScreenSize, that.ScreenSize)
 }
 
 // deriveTeleportEqual_16 returns whether this and that are equal.
@@ -468,14 +520,14 @@ func deriveTeleportEqual_16(this, that *WindowsDesktopSpecV3) bool {
 			this.Domain == that.Domain &&
 			this.HostID == that.HostID &&
 			this.NonAD == that.NonAD &&
-			deriveTeleportEqual_43(this.ScreenSize, that.ScreenSize)
+			deriveTeleportEqual_44(this.ScreenSize, that.ScreenSize)
 }
 
 // deriveTeleportEqual_17 returns whether this and that are equal.
 func deriveTeleportEqual_17(this, that *KubernetesClusterSpecV3) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_25(this.DynamicLabels, that.DynamicLabels) &&
+			deriveTeleportEqual_26(this.DynamicLabels, that.DynamicLabels) &&
 			bytes.Equal(this.Kubeconfig, that.Kubeconfig) &&
 			deriveTeleportEqualKubeAzure(&this.Azure, &that.Azure) &&
 			deriveTeleportEqualKubeAWS(&this.AWS, &that.AWS) &&
@@ -486,7 +538,7 @@ func deriveTeleportEqual_17(this, that *KubernetesClusterSpecV3) bool {
 func deriveTeleportEqual_18(this, that *KubernetesClusterDiscoveryStatus) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_44(this.Aws, that.Aws)
+			deriveTeleportEqual_45(this.Aws, that.Aws)
 }
 
 // deriveTeleportEqual_19 returns whether this and that are equal.
@@ -496,19 +548,19 @@ func deriveTeleportEqual_19(this, that *KubernetesServerSpecV3) bool {
 			this.Version == that.Version &&
 			this.Hostname == that.Hostname &&
 			this.HostID == that.HostID &&
-			deriveTeleportEqual_33(&this.Rotation, &that.Rotation) &&
+			deriveTeleportEqual_34(&this.Rotation, &that.Rotation) &&
 			deriveTeleportEqualKubernetesClusterV3(this.Cluster, that.Cluster) &&
-			deriveTeleportEqual_28(this.ProxyIDs, that.ProxyIDs) &&
+			deriveTeleportEqual_29(this.ProxyIDs, that.ProxyIDs) &&
 			this.RelayGroup == that.RelayGroup &&
-			deriveTeleportEqual_28(this.RelayIds, that.RelayIds)
+			deriveTeleportEqual_29(this.RelayIds, that.RelayIds)
 }
 
 // deriveTeleportEqual_20 returns whether this and that are equal.
 func deriveTeleportEqual_20(this, that *AWSOrganizationUnitsMatcher) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Include, that.Include) &&
-			deriveTeleportEqual_28(this.Exclude, that.Exclude)
+			deriveTeleportEqual_29(this.Include, that.Include) &&
+			deriveTeleportEqual_29(this.Exclude, that.Exclude)
 }
 
 // deriveTeleportEqual_21 returns whether this and that are equal.
@@ -516,7 +568,7 @@ func deriveTeleportEqual_21(this, that *OktaAssignmentSpecV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.User == that.User &&
-			deriveTeleportEqual_45(this.Targets, that.Targets) &&
+			deriveTeleportEqual_46(this.Targets, that.Targets) &&
 			this.CleanupTime.Equal(that.CleanupTime) &&
 			this.Status == that.Status &&
 			this.LastTransition.Equal(that.LastTransition) &&
@@ -527,9 +579,9 @@ func deriveTeleportEqual_21(this, that *OktaAssignmentSpecV1) bool {
 func deriveTeleportEqual_22(this, that *RoleSpecV6) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_46(&this.Options, &that.Options) &&
-			deriveTeleportEqual_47(&this.Allow, &that.Allow) &&
-			deriveTeleportEqual_47(&this.Deny, &that.Deny)
+			deriveTeleportEqual_47(&this.Options, &that.Options) &&
+			deriveTeleportEqual_48(&this.Allow, &that.Allow) &&
+			deriveTeleportEqual_48(&this.Deny, &that.Deny)
 }
 
 // deriveTeleportEqual_23 returns whether this and that are equal.
@@ -545,29 +597,45 @@ func deriveTeleportEqual_23(this, that *SAMLConnectorSpecV2) bool {
 			this.ServiceProviderIssuer == that.ServiceProviderIssuer &&
 			this.EntityDescriptor == that.EntityDescriptor &&
 			this.EntityDescriptorURL == that.EntityDescriptorURL &&
-			deriveTeleportEqual_48(this.AttributesToRoles, that.AttributesToRoles) &&
-			deriveTeleportEqual_49(this.SigningKeyPair, that.SigningKeyPair) &&
+			deriveTeleportEqual_49(this.AttributesToRoles, that.AttributesToRoles) &&
+			deriveTeleportEqual_50(this.SigningKeyPair, that.SigningKeyPair) &&
 			this.Provider == that.Provider &&
-			deriveTeleportEqual_49(this.EncryptionKeyPair, that.EncryptionKeyPair) &&
+			deriveTeleportEqual_50(this.EncryptionKeyPair, that.EncryptionKeyPair) &&
 			this.AllowIDPInitiated == that.AllowIDPInitiated &&
-			deriveTeleportEqual_50(this.ClientRedirectSettings, that.ClientRedirectSettings) &&
+			deriveTeleportEqual_51(this.ClientRedirectSettings, that.ClientRedirectSettings) &&
 			this.SingleLogoutURL == that.SingleLogoutURL &&
-			deriveTeleportEqual_51(this.MFASettings, that.MFASettings) &&
+			deriveTeleportEqual_52(this.MFASettings, that.MFASettings) &&
 			this.ForceAuthn == that.ForceAuthn &&
 			this.PreferredRequestBinding == that.PreferredRequestBinding &&
-			deriveTeleportEqual_28(this.UserMatchers, that.UserMatchers) &&
+			deriveTeleportEqual_29(this.UserMatchers, that.UserMatchers) &&
 			this.IncludeSubject == that.IncludeSubject
 }
 
 // deriveTeleportEqual_24 returns whether this and that are equal.
-func deriveTeleportEqual_24(this, that *UserGroupSpecV1) bool {
+func deriveTeleportEqual_24(this, that *UserSpecV2) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Applications, that.Applications)
+			deriveTeleportEqual_53(this.OIDCIdentities, that.OIDCIdentities) &&
+			deriveTeleportEqual_53(this.SAMLIdentities, that.SAMLIdentities) &&
+			deriveTeleportEqual_53(this.GithubIdentities, that.GithubIdentities) &&
+			deriveTeleportEqual_29(this.Roles, that.Roles) &&
+			deriveTeleportEqual_54(this.Traits, that.Traits) &&
+			deriveTeleportEqual_55(&this.Status, &that.Status) &&
+			this.Expires.Equal(that.Expires) &&
+			deriveTeleportEqual_56(&this.CreatedBy, &that.CreatedBy) &&
+			deriveTeleportEqual_57(this.LocalAuth, that.LocalAuth) &&
+			deriveTeleportEqual_29(this.TrustedDeviceIDs, that.TrustedDeviceIDs)
 }
 
 // deriveTeleportEqual_25 returns whether this and that are equal.
-func deriveTeleportEqual_25(this, that map[string]CommandLabelV2) bool {
+func deriveTeleportEqual_25(this, that *UserGroupSpecV1) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_29(this.Applications, that.Applications)
+}
+
+// deriveTeleportEqual_26 returns whether this and that are equal.
+func deriveTeleportEqual_26(this, that map[string]CommandLabelV2) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -579,32 +647,32 @@ func deriveTeleportEqual_25(this, that map[string]CommandLabelV2) bool {
 		if !ok {
 			return false
 		}
-		if !(deriveTeleportEqual_52(&v, &thatv)) {
+		if !(deriveTeleportEqual_58(&v, &thatv)) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveTeleportEqual_26 returns whether this and that are equal.
-func deriveTeleportEqual_26(this, that *Rewrite) bool {
+// deriveTeleportEqual_27 returns whether this and that are equal.
+func deriveTeleportEqual_27(this, that *Rewrite) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Redirect, that.Redirect) &&
-			deriveTeleportEqual_53(this.Headers, that.Headers) &&
+			deriveTeleportEqual_29(this.Redirect, that.Redirect) &&
+			deriveTeleportEqual_59(this.Headers, that.Headers) &&
 			this.JWTClaims == that.JWTClaims
 }
 
-// deriveTeleportEqual_27 returns whether this and that are equal.
-func deriveTeleportEqual_27(this, that *AppAWS) bool {
+// deriveTeleportEqual_28 returns whether this and that are equal.
+func deriveTeleportEqual_28(this, that *AppAWS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ExternalID == that.ExternalID &&
-			deriveTeleportEqual_54(this.RolesAnywhereProfile, that.RolesAnywhereProfile)
+			deriveTeleportEqual_60(this.RolesAnywhereProfile, that.RolesAnywhereProfile)
 }
 
-// deriveTeleportEqual_28 returns whether this and that are equal.
-func deriveTeleportEqual_28(this, that []string) bool {
+// deriveTeleportEqual_29 returns whether this and that are equal.
+func deriveTeleportEqual_29(this, that []string) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -619,28 +687,28 @@ func deriveTeleportEqual_28(this, that []string) bool {
 	return true
 }
 
-// deriveTeleportEqual_29 returns whether this and that are equal.
-func deriveTeleportEqual_29(this, that *CORSPolicy) bool {
+// deriveTeleportEqual_30 returns whether this and that are equal.
+func deriveTeleportEqual_30(this, that *CORSPolicy) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.AllowedOrigins, that.AllowedOrigins) &&
-			deriveTeleportEqual_28(this.AllowedMethods, that.AllowedMethods) &&
-			deriveTeleportEqual_28(this.AllowedHeaders, that.AllowedHeaders) &&
+			deriveTeleportEqual_29(this.AllowedOrigins, that.AllowedOrigins) &&
+			deriveTeleportEqual_29(this.AllowedMethods, that.AllowedMethods) &&
+			deriveTeleportEqual_29(this.AllowedHeaders, that.AllowedHeaders) &&
 			this.AllowCredentials == that.AllowCredentials &&
 			this.MaxAge == that.MaxAge &&
-			deriveTeleportEqual_28(this.ExposedHeaders, that.ExposedHeaders)
-}
-
-// deriveTeleportEqual_30 returns whether this and that are equal.
-func deriveTeleportEqual_30(this, that *AppIdentityCenter) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.AccountID == that.AccountID &&
-			deriveTeleportEqual_55(this.PermissionSets, that.PermissionSets)
+			deriveTeleportEqual_29(this.ExposedHeaders, that.ExposedHeaders)
 }
 
 // deriveTeleportEqual_31 returns whether this and that are equal.
-func deriveTeleportEqual_31(this, that []*PortRange) bool {
+func deriveTeleportEqual_31(this, that *AppIdentityCenter) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.AccountID == that.AccountID &&
+			deriveTeleportEqual_61(this.PermissionSets, that.PermissionSets)
+}
+
+// deriveTeleportEqual_32 returns whether this and that are equal.
+func deriveTeleportEqual_32(this, that []*PortRange) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -648,24 +716,24 @@ func deriveTeleportEqual_31(this, that []*PortRange) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_56(this[i], that[i])) {
+		if !(deriveTeleportEqual_62(this[i], that[i])) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveTeleportEqual_32 returns whether this and that are equal.
-func deriveTeleportEqual_32(this, that *MCP) bool {
+// deriveTeleportEqual_33 returns whether this and that are equal.
+func deriveTeleportEqual_33(this, that *MCP) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Command == that.Command &&
-			deriveTeleportEqual_28(this.Args, that.Args) &&
+			deriveTeleportEqual_29(this.Args, that.Args) &&
 			this.RunAsHostUser == that.RunAsHostUser
 }
 
-// deriveTeleportEqual_33 returns whether this and that are equal.
-func deriveTeleportEqual_33(this, that *Rotation) bool {
+// deriveTeleportEqual_34 returns whether this and that are equal.
+func deriveTeleportEqual_34(this, that *Rotation) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.State == that.State &&
@@ -675,18 +743,18 @@ func deriveTeleportEqual_33(this, that *Rotation) bool {
 			this.Started.Equal(that.Started) &&
 			this.GracePeriod == that.GracePeriod &&
 			this.LastRotated.Equal(that.LastRotated) &&
-			deriveTeleportEqual_57(&this.Schedule, &that.Schedule)
-}
-
-// deriveTeleportEqual_34 returns whether this and that are equal.
-func deriveTeleportEqual_34(this, that *componentfeaturesv1.ComponentFeatures) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			deriveTeleportEqual_58(this.Features, that.Features)
+			deriveTeleportEqual_63(&this.Schedule, &that.Schedule)
 }
 
 // deriveTeleportEqual_35 returns whether this and that are equal.
-func deriveTeleportEqual_35(this, that []RoleMapping) bool {
+func deriveTeleportEqual_35(this, that *componentfeaturesv1.ComponentFeatures) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_64(this.Features, that.Features)
+}
+
+// deriveTeleportEqual_36 returns whether this and that are equal.
+func deriveTeleportEqual_36(this, that []RoleMapping) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -694,24 +762,24 @@ func deriveTeleportEqual_35(this, that []RoleMapping) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_59(&this[i], &that[i])) {
+		if !(deriveTeleportEqual_65(&this[i], &that[i])) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveTeleportEqual_36 returns whether this and that are equal.
-func deriveTeleportEqual_36(this, that *CAKeySet) bool {
+// deriveTeleportEqual_37 returns whether this and that are equal.
+func deriveTeleportEqual_37(this, that *CAKeySet) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_60(this.SSH, that.SSH) &&
-			deriveTeleportEqual_61(this.TLS, that.TLS) &&
-			deriveTeleportEqual_62(this.JWT, that.JWT)
+			deriveTeleportEqual_66(this.SSH, that.SSH) &&
+			deriveTeleportEqual_67(this.TLS, that.TLS) &&
+			deriveTeleportEqual_68(this.JWT, that.JWT)
 }
 
-// deriveTeleportEqual_37 returns whether this and that are equal.
-func deriveTeleportEqual_37(this, that *DatabaseTLS) bool {
+// deriveTeleportEqual_38 returns whether this and that are equal.
+func deriveTeleportEqual_38(this, that *DatabaseTLS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Mode == that.Mode &&
@@ -720,8 +788,8 @@ func deriveTeleportEqual_37(this, that *DatabaseTLS) bool {
 			this.TrustSystemCertPool == that.TrustSystemCertPool
 }
 
-// deriveTeleportEqual_38 returns whether this and that are equal.
-func deriveTeleportEqual_38(this, that *AD) bool {
+// deriveTeleportEqual_39 returns whether this and that are equal.
+func deriveTeleportEqual_39(this, that *AD) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.KeytabFile == that.KeytabFile &&
@@ -734,30 +802,30 @@ func deriveTeleportEqual_38(this, that *AD) bool {
 			this.LDAPServiceAccountSID == that.LDAPServiceAccountSID
 }
 
-// deriveTeleportEqual_39 returns whether this and that are equal.
-func deriveTeleportEqual_39(this, that *MySQLOptions) bool {
+// deriveTeleportEqual_40 returns whether this and that are equal.
+func deriveTeleportEqual_40(this, that *MySQLOptions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ServerVersion == that.ServerVersion
 }
 
-// deriveTeleportEqual_40 returns whether this and that are equal.
-func deriveTeleportEqual_40(this, that *DatabaseAdminUser) bool {
+// deriveTeleportEqual_41 returns whether this and that are equal.
+func deriveTeleportEqual_41(this, that *DatabaseAdminUser) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.DefaultDatabase == that.DefaultDatabase
 }
 
-// deriveTeleportEqual_41 returns whether this and that are equal.
-func deriveTeleportEqual_41(this, that *MongoAtlas) bool {
+// deriveTeleportEqual_42 returns whether this and that are equal.
+func deriveTeleportEqual_42(this, that *MongoAtlas) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name
 }
 
-// deriveTeleportEqual_42 returns whether this and that are equal.
-func deriveTeleportEqual_42(this, that *OracleOptions) bool {
+// deriveTeleportEqual_43 returns whether this and that are equal.
+func deriveTeleportEqual_43(this, that *OracleOptions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.AuditUser == that.AuditUser &&
@@ -765,25 +833,25 @@ func deriveTeleportEqual_42(this, that *OracleOptions) bool {
 			this.ShuffleHostnames == that.ShuffleHostnames
 }
 
-// deriveTeleportEqual_43 returns whether this and that are equal.
-func deriveTeleportEqual_43(this, that *Resolution) bool {
+// deriveTeleportEqual_44 returns whether this and that are equal.
+func deriveTeleportEqual_44(this, that *Resolution) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Width == that.Width &&
 			this.Height == that.Height
 }
 
-// deriveTeleportEqual_44 returns whether this and that are equal.
-func deriveTeleportEqual_44(this, that *KubernetesClusterAWSStatus) bool {
+// deriveTeleportEqual_45 returns whether this and that are equal.
+func deriveTeleportEqual_45(this, that *KubernetesClusterAWSStatus) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.SetupAccessForArn == that.SetupAccessForArn &&
 			this.Integration == that.Integration &&
-			deriveTeleportEqual_63(this.DiscoveryAssumedRole, that.DiscoveryAssumedRole)
+			deriveTeleportEqual_69(this.DiscoveryAssumedRole, that.DiscoveryAssumedRole)
 }
 
-// deriveTeleportEqual_45 returns whether this and that are equal.
-func deriveTeleportEqual_45(this, that []*OktaAssignmentTargetV1) bool {
+// deriveTeleportEqual_46 returns whether this and that are equal.
+func deriveTeleportEqual_46(this, that []*OktaAssignmentTargetV1) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -791,83 +859,83 @@ func deriveTeleportEqual_45(this, that []*OktaAssignmentTargetV1) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_64(this[i], that[i])) {
+		if !(deriveTeleportEqual_70(this[i], that[i])) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveTeleportEqual_46 returns whether this and that are equal.
-func deriveTeleportEqual_46(this, that *RoleOptions) bool {
+// deriveTeleportEqual_47 returns whether this and that are equal.
+func deriveTeleportEqual_47(this, that *RoleOptions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ForwardAgent == that.ForwardAgent &&
 			this.MaxSessionTTL == that.MaxSessionTTL &&
-			deriveTeleportEqual_65(this.PortForwarding, that.PortForwarding) &&
+			deriveTeleportEqual_71(this.PortForwarding, that.PortForwarding) &&
 			this.CertificateFormat == that.CertificateFormat &&
 			this.ClientIdleTimeout == that.ClientIdleTimeout &&
 			this.DisconnectExpiredCert == that.DisconnectExpiredCert &&
-			deriveTeleportEqual_28(this.BPF, that.BPF) &&
+			deriveTeleportEqual_29(this.BPF, that.BPF) &&
 			this.PermitX11Forwarding == that.PermitX11Forwarding &&
 			this.MaxConnections == that.MaxConnections &&
 			this.MaxSessions == that.MaxSessions &&
 			this.RequestAccess == that.RequestAccess &&
 			this.RequestPrompt == that.RequestPrompt &&
 			this.Lock == that.Lock &&
-			deriveTeleportEqual_66(this.RecordSession, that.RecordSession) &&
-			deriveTeleportEqual_65(this.DesktopClipboard, that.DesktopClipboard) &&
-			deriveTeleportEqual_67(this.CertExtensions, that.CertExtensions) &&
+			deriveTeleportEqual_72(this.RecordSession, that.RecordSession) &&
+			deriveTeleportEqual_71(this.DesktopClipboard, that.DesktopClipboard) &&
+			deriveTeleportEqual_73(this.CertExtensions, that.CertExtensions) &&
 			this.MaxKubernetesConnections == that.MaxKubernetesConnections &&
-			deriveTeleportEqual_65(this.DesktopDirectorySharing, that.DesktopDirectorySharing) &&
-			deriveTeleportEqual_65(this.CreateHostUser, that.CreateHostUser) &&
+			deriveTeleportEqual_71(this.DesktopDirectorySharing, that.DesktopDirectorySharing) &&
+			deriveTeleportEqual_71(this.CreateHostUser, that.CreateHostUser) &&
 			this.PinSourceIP == that.PinSourceIP &&
-			deriveTeleportEqual_65(this.SSHFileCopy, that.SSHFileCopy) &&
+			deriveTeleportEqual_71(this.SSHFileCopy, that.SSHFileCopy) &&
 			this.RequireMFAType == that.RequireMFAType &&
 			this.DeviceTrustMode == that.DeviceTrustMode &&
-			deriveTeleportEqual_68(this.IDP, that.IDP) &&
-			deriveTeleportEqual_65(this.CreateDesktopUser, that.CreateDesktopUser) &&
-			deriveTeleportEqual_65(this.CreateDatabaseUser, that.CreateDatabaseUser) &&
+			deriveTeleportEqual_74(this.IDP, that.IDP) &&
+			deriveTeleportEqual_71(this.CreateDesktopUser, that.CreateDesktopUser) &&
+			deriveTeleportEqual_71(this.CreateDatabaseUser, that.CreateDatabaseUser) &&
 			this.CreateHostUserMode == that.CreateHostUserMode &&
 			this.CreateDatabaseUserMode == that.CreateDatabaseUserMode &&
 			this.MFAVerificationInterval == that.MFAVerificationInterval &&
 			this.CreateHostUserDefaultShell == that.CreateHostUserDefaultShell &&
-			deriveTeleportEqual_69(this.SSHPortForwarding, that.SSHPortForwarding)
+			deriveTeleportEqual_75(this.SSHPortForwarding, that.SSHPortForwarding)
 }
 
-// deriveTeleportEqual_47 returns whether this and that are equal.
-func deriveTeleportEqual_47(this, that *RoleConditions) bool {
+// deriveTeleportEqual_48 returns whether this and that are equal.
+func deriveTeleportEqual_48(this, that *RoleConditions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Logins, that.Logins) &&
-			deriveTeleportEqual_28(this.Namespaces, that.Namespaces) &&
-			deriveTeleportEqual_70(this.NodeLabels, that.NodeLabels) &&
-			deriveTeleportEqual_71(this.Rules, that.Rules) &&
-			deriveTeleportEqual_28(this.KubeGroups, that.KubeGroups) &&
-			deriveTeleportEqual_72(this.Request, that.Request) &&
-			deriveTeleportEqual_28(this.KubeUsers, that.KubeUsers) &&
-			deriveTeleportEqual_70(this.AppLabels, that.AppLabels) &&
-			deriveTeleportEqual_70(this.ClusterLabels, that.ClusterLabels) &&
-			deriveTeleportEqual_70(this.KubernetesLabels, that.KubernetesLabels) &&
-			deriveTeleportEqual_70(this.DatabaseLabels, that.DatabaseLabels) &&
-			deriveTeleportEqual_28(this.DatabaseNames, that.DatabaseNames) &&
-			deriveTeleportEqual_28(this.DatabaseUsers, that.DatabaseUsers) &&
-			deriveTeleportEqual_73(this.Impersonate, that.Impersonate) &&
-			deriveTeleportEqual_74(this.ReviewRequests, that.ReviewRequests) &&
-			deriveTeleportEqual_28(this.AWSRoleARNs, that.AWSRoleARNs) &&
-			deriveTeleportEqual_28(this.WindowsDesktopLogins, that.WindowsDesktopLogins) &&
-			deriveTeleportEqual_70(this.WindowsDesktopLabels, that.WindowsDesktopLabels) &&
-			deriveTeleportEqual_75(this.RequireSessionJoin, that.RequireSessionJoin) &&
-			deriveTeleportEqual_76(this.JoinSessions, that.JoinSessions) &&
-			deriveTeleportEqual_28(this.HostGroups, that.HostGroups) &&
-			deriveTeleportEqual_28(this.HostSudoers, that.HostSudoers) &&
-			deriveTeleportEqual_28(this.AzureIdentities, that.AzureIdentities) &&
-			deriveTeleportEqual_77(this.KubernetesResources, that.KubernetesResources) &&
-			deriveTeleportEqual_28(this.GCPServiceAccounts, that.GCPServiceAccounts) &&
-			deriveTeleportEqual_70(this.DatabaseServiceLabels, that.DatabaseServiceLabels) &&
-			deriveTeleportEqual_70(this.GroupLabels, that.GroupLabels) &&
-			deriveTeleportEqual_28(this.DesktopGroups, that.DesktopGroups) &&
-			deriveTeleportEqual_28(this.DatabaseRoles, that.DatabaseRoles) &&
+			deriveTeleportEqual_29(this.Logins, that.Logins) &&
+			deriveTeleportEqual_29(this.Namespaces, that.Namespaces) &&
+			deriveTeleportEqual_76(this.NodeLabels, that.NodeLabels) &&
+			deriveTeleportEqual_77(this.Rules, that.Rules) &&
+			deriveTeleportEqual_29(this.KubeGroups, that.KubeGroups) &&
+			deriveTeleportEqual_78(this.Request, that.Request) &&
+			deriveTeleportEqual_29(this.KubeUsers, that.KubeUsers) &&
+			deriveTeleportEqual_76(this.AppLabels, that.AppLabels) &&
+			deriveTeleportEqual_76(this.ClusterLabels, that.ClusterLabels) &&
+			deriveTeleportEqual_76(this.KubernetesLabels, that.KubernetesLabels) &&
+			deriveTeleportEqual_76(this.DatabaseLabels, that.DatabaseLabels) &&
+			deriveTeleportEqual_29(this.DatabaseNames, that.DatabaseNames) &&
+			deriveTeleportEqual_29(this.DatabaseUsers, that.DatabaseUsers) &&
+			deriveTeleportEqual_79(this.Impersonate, that.Impersonate) &&
+			deriveTeleportEqual_80(this.ReviewRequests, that.ReviewRequests) &&
+			deriveTeleportEqual_29(this.AWSRoleARNs, that.AWSRoleARNs) &&
+			deriveTeleportEqual_29(this.WindowsDesktopLogins, that.WindowsDesktopLogins) &&
+			deriveTeleportEqual_76(this.WindowsDesktopLabels, that.WindowsDesktopLabels) &&
+			deriveTeleportEqual_81(this.RequireSessionJoin, that.RequireSessionJoin) &&
+			deriveTeleportEqual_82(this.JoinSessions, that.JoinSessions) &&
+			deriveTeleportEqual_29(this.HostGroups, that.HostGroups) &&
+			deriveTeleportEqual_29(this.HostSudoers, that.HostSudoers) &&
+			deriveTeleportEqual_29(this.AzureIdentities, that.AzureIdentities) &&
+			deriveTeleportEqual_83(this.KubernetesResources, that.KubernetesResources) &&
+			deriveTeleportEqual_29(this.GCPServiceAccounts, that.GCPServiceAccounts) &&
+			deriveTeleportEqual_76(this.DatabaseServiceLabels, that.DatabaseServiceLabels) &&
+			deriveTeleportEqual_76(this.GroupLabels, that.GroupLabels) &&
+			deriveTeleportEqual_29(this.DesktopGroups, that.DesktopGroups) &&
+			deriveTeleportEqual_29(this.DatabaseRoles, that.DatabaseRoles) &&
 			this.NodeLabelsExpression == that.NodeLabelsExpression &&
 			this.AppLabelsExpression == that.AppLabelsExpression &&
 			this.ClusterLabelsExpression == that.ClusterLabelsExpression &&
@@ -876,20 +944,20 @@ func deriveTeleportEqual_47(this, that *RoleConditions) bool {
 			this.DatabaseServiceLabelsExpression == that.DatabaseServiceLabelsExpression &&
 			this.WindowsDesktopLabelsExpression == that.WindowsDesktopLabelsExpression &&
 			this.GroupLabelsExpression == that.GroupLabelsExpression &&
-			deriveTeleportEqual_78(this.DatabasePermissions, that.DatabasePermissions) &&
-			deriveTeleportEqual_79(this.SPIFFE, that.SPIFFE) &&
-			deriveTeleportEqual_80(this.AccountAssignments, that.AccountAssignments) &&
-			deriveTeleportEqual_81(this.GitHubPermissions, that.GitHubPermissions) &&
-			deriveTeleportEqual_70(this.WorkloadIdentityLabels, that.WorkloadIdentityLabels) &&
+			deriveTeleportEqual_84(this.DatabasePermissions, that.DatabasePermissions) &&
+			deriveTeleportEqual_85(this.SPIFFE, that.SPIFFE) &&
+			deriveTeleportEqual_86(this.AccountAssignments, that.AccountAssignments) &&
+			deriveTeleportEqual_87(this.GitHubPermissions, that.GitHubPermissions) &&
+			deriveTeleportEqual_76(this.WorkloadIdentityLabels, that.WorkloadIdentityLabels) &&
 			this.WorkloadIdentityLabelsExpression == that.WorkloadIdentityLabelsExpression &&
-			deriveTeleportEqual_82(this.MCP, that.MCP) &&
-			deriveTeleportEqual_28(this.LinuxDesktopLogins, that.LinuxDesktopLogins) &&
-			deriveTeleportEqual_70(this.LinuxDesktopLabels, that.LinuxDesktopLabels) &&
+			deriveTeleportEqual_88(this.MCP, that.MCP) &&
+			deriveTeleportEqual_29(this.LinuxDesktopLogins, that.LinuxDesktopLogins) &&
+			deriveTeleportEqual_76(this.LinuxDesktopLabels, that.LinuxDesktopLabels) &&
 			this.LinuxDesktopLabelsExpression == that.LinuxDesktopLabelsExpression
 }
 
-// deriveTeleportEqual_48 returns whether this and that are equal.
-func deriveTeleportEqual_48(this, that []AttributeMapping) bool {
+// deriveTeleportEqual_49 returns whether this and that are equal.
+func deriveTeleportEqual_49(this, that []AttributeMapping) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -897,31 +965,31 @@ func deriveTeleportEqual_48(this, that []AttributeMapping) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_83(&this[i], &that[i])) {
+		if !(deriveTeleportEqual_89(&this[i], &that[i])) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveTeleportEqual_49 returns whether this and that are equal.
-func deriveTeleportEqual_49(this, that *AsymmetricKeyPair) bool {
+// deriveTeleportEqual_50 returns whether this and that are equal.
+func deriveTeleportEqual_50(this, that *AsymmetricKeyPair) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.PrivateKey == that.PrivateKey &&
 			this.Cert == that.Cert
 }
 
-// deriveTeleportEqual_50 returns whether this and that are equal.
-func deriveTeleportEqual_50(this, that *SSOClientRedirectSettings) bool {
+// deriveTeleportEqual_51 returns whether this and that are equal.
+func deriveTeleportEqual_51(this, that *SSOClientRedirectSettings) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.AllowedHttpsHostnames, that.AllowedHttpsHostnames) &&
-			deriveTeleportEqual_28(this.InsecureAllowedCidrRanges, that.InsecureAllowedCidrRanges)
+			deriveTeleportEqual_29(this.AllowedHttpsHostnames, that.AllowedHttpsHostnames) &&
+			deriveTeleportEqual_29(this.InsecureAllowedCidrRanges, that.InsecureAllowedCidrRanges)
 }
 
-// deriveTeleportEqual_51 returns whether this and that are equal.
-func deriveTeleportEqual_51(this, that *SAMLConnectorMFASettings) bool {
+// deriveTeleportEqual_52 returns whether this and that are equal.
+func deriveTeleportEqual_52(this, that *SAMLConnectorMFASettings) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Enabled == that.Enabled &&
@@ -933,17 +1001,8 @@ func deriveTeleportEqual_51(this, that *SAMLConnectorMFASettings) bool {
 			this.Cert == that.Cert
 }
 
-// deriveTeleportEqual_52 returns whether this and that are equal.
-func deriveTeleportEqual_52(this, that *CommandLabelV2) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.Period == that.Period &&
-			deriveTeleportEqual_28(this.Command, that.Command) &&
-			this.Result == that.Result
-}
-
 // deriveTeleportEqual_53 returns whether this and that are equal.
-func deriveTeleportEqual_53(this, that []*Header) bool {
+func deriveTeleportEqual_53(this, that []ExternalIdentity) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -951,7 +1010,7 @@ func deriveTeleportEqual_53(this, that []*Header) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_84(this[i], that[i])) {
+		if !(deriveTeleportEqualExternalIdentity(&this[i], &that[i])) {
 			return false
 		}
 	}
@@ -959,15 +1018,64 @@ func deriveTeleportEqual_53(this, that []*Header) bool {
 }
 
 // deriveTeleportEqual_54 returns whether this and that are equal.
-func deriveTeleportEqual_54(this, that *AppAWSRolesAnywhereProfile) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.ProfileARN == that.ProfileARN &&
-			this.AcceptRoleSessionName == that.AcceptRoleSessionName
+func deriveTeleportEqual_54(this, that map[string][]string) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for k, v := range this {
+		thatv, ok := that[k]
+		if !ok {
+			return false
+		}
+		if !(deriveTeleportEqual_29(v, thatv)) {
+			return false
+		}
+	}
+	return true
 }
 
 // deriveTeleportEqual_55 returns whether this and that are equal.
-func deriveTeleportEqual_55(this, that []*IdentityCenterPermissionSet) bool {
+func deriveTeleportEqual_55(this, that *LoginStatus) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.IsLocked == that.IsLocked &&
+			this.LockedMessage == that.LockedMessage &&
+			this.LockedTime.Equal(that.LockedTime) &&
+			this.LockExpires.Equal(that.LockExpires)
+}
+
+// deriveTeleportEqual_56 returns whether this and that are equal.
+func deriveTeleportEqual_56(this, that *CreatedBy) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_90(this.Connector, that.Connector) &&
+			this.Time.Equal(that.Time) &&
+			deriveTeleportEqual_91(&this.User, &that.User)
+}
+
+// deriveTeleportEqual_57 returns whether this and that are equal.
+func deriveTeleportEqual_57(this, that *LocalAuthSecrets) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			bytes.Equal(this.PasswordHash, that.PasswordHash) &&
+			this.TOTPKey == that.TOTPKey &&
+			deriveTeleportEqual_92(this.Webauthn, that.Webauthn)
+}
+
+// deriveTeleportEqual_58 returns whether this and that are equal.
+func deriveTeleportEqual_58(this, that *CommandLabelV2) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Period == that.Period &&
+			deriveTeleportEqual_29(this.Command, that.Command) &&
+			this.Result == that.Result
+}
+
+// deriveTeleportEqual_59 returns whether this and that are equal.
+func deriveTeleportEqual_59(this, that []*Header) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -975,23 +1083,47 @@ func deriveTeleportEqual_55(this, that []*IdentityCenterPermissionSet) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_85(this[i], that[i])) {
+		if !(deriveTeleportEqual_93(this[i], that[i])) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveTeleportEqual_56 returns whether this and that are equal.
-func deriveTeleportEqual_56(this, that *PortRange) bool {
+// deriveTeleportEqual_60 returns whether this and that are equal.
+func deriveTeleportEqual_60(this, that *AppAWSRolesAnywhereProfile) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.ProfileARN == that.ProfileARN &&
+			this.AcceptRoleSessionName == that.AcceptRoleSessionName
+}
+
+// deriveTeleportEqual_61 returns whether this and that are equal.
+func deriveTeleportEqual_61(this, that []*IdentityCenterPermissionSet) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_94(this[i], that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_62 returns whether this and that are equal.
+func deriveTeleportEqual_62(this, that *PortRange) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Port == that.Port &&
 			this.EndPort == that.EndPort
 }
 
-// deriveTeleportEqual_57 returns whether this and that are equal.
-func deriveTeleportEqual_57(this, that *RotationSchedule) bool {
+// deriveTeleportEqual_63 returns whether this and that are equal.
+func deriveTeleportEqual_63(this, that *RotationSchedule) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.UpdateClients.Equal(that.UpdateClients) &&
@@ -999,8 +1131,8 @@ func deriveTeleportEqual_57(this, that *RotationSchedule) bool {
 			this.Standby.Equal(that.Standby)
 }
 
-// deriveTeleportEqual_58 returns whether this and that are equal.
-func deriveTeleportEqual_58(this, that []componentfeaturesv1.ComponentFeatureID) bool {
+// deriveTeleportEqual_64 returns whether this and that are equal.
+func deriveTeleportEqual_64(this, that []componentfeaturesv1.ComponentFeatureID) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -1015,16 +1147,16 @@ func deriveTeleportEqual_58(this, that []componentfeaturesv1.ComponentFeatureID)
 	return true
 }
 
-// deriveTeleportEqual_59 returns whether this and that are equal.
-func deriveTeleportEqual_59(this, that *RoleMapping) bool {
+// deriveTeleportEqual_65 returns whether this and that are equal.
+func deriveTeleportEqual_65(this, that *RoleMapping) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Remote == that.Remote &&
-			deriveTeleportEqual_28(this.Local, that.Local)
+			deriveTeleportEqual_29(this.Local, that.Local)
 }
 
-// deriveTeleportEqual_60 returns whether this and that are equal.
-func deriveTeleportEqual_60(this, that []*SSHKeyPair) bool {
+// deriveTeleportEqual_66 returns whether this and that are equal.
+func deriveTeleportEqual_66(this, that []*SSHKeyPair) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -1039,73 +1171,8 @@ func deriveTeleportEqual_60(this, that []*SSHKeyPair) bool {
 	return true
 }
 
-// deriveTeleportEqual_61 returns whether this and that are equal.
-func deriveTeleportEqual_61(this, that []*TLSKeyPair) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_86(this[i], that[i])) {
-			return false
-		}
-	}
-	return true
-}
-
-// deriveTeleportEqual_62 returns whether this and that are equal.
-func deriveTeleportEqual_62(this, that []*JWTKeyPair) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_87(this[i], that[i])) {
-			return false
-		}
-	}
-	return true
-}
-
-// deriveTeleportEqual_63 returns whether this and that are equal.
-func deriveTeleportEqual_63(this, that *AssumeRole) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.RoleARN == that.RoleARN &&
-			this.ExternalID == that.ExternalID &&
-			this.RoleName == that.RoleName
-}
-
-// deriveTeleportEqual_64 returns whether this and that are equal.
-func deriveTeleportEqual_64(this, that *OktaAssignmentTargetV1) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.Type == that.Type &&
-			this.Id == that.Id
-}
-
-// deriveTeleportEqual_65 returns whether this and that are equal.
-func deriveTeleportEqual_65(this, that *BoolOption) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.Value == that.Value
-}
-
-// deriveTeleportEqual_66 returns whether this and that are equal.
-func deriveTeleportEqual_66(this, that *RecordSession) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			deriveTeleportEqual_65(this.Desktop, that.Desktop) &&
-			this.Default == that.Default &&
-			this.SSH == that.SSH
-}
-
 // deriveTeleportEqual_67 returns whether this and that are equal.
-func deriveTeleportEqual_67(this, that []*CertExtension) bool {
+func deriveTeleportEqual_67(this, that []*TLSKeyPair) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -1113,7 +1180,7 @@ func deriveTeleportEqual_67(this, that []*CertExtension) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_88(this[i], that[i])) {
+		if !(deriveTeleportEqual_95(this[i], that[i])) {
 			return false
 		}
 	}
@@ -1121,22 +1188,87 @@ func deriveTeleportEqual_67(this, that []*CertExtension) bool {
 }
 
 // deriveTeleportEqual_68 returns whether this and that are equal.
-func deriveTeleportEqual_68(this, that *IdPOptions) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			deriveTeleportEqual_89(this.SAML, that.SAML)
+func deriveTeleportEqual_68(this, that []*JWTKeyPair) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_96(this[i], that[i])) {
+			return false
+		}
+	}
+	return true
 }
 
 // deriveTeleportEqual_69 returns whether this and that are equal.
-func deriveTeleportEqual_69(this, that *SSHPortForwarding) bool {
+func deriveTeleportEqual_69(this, that *AssumeRole) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_90(this.Local, that.Local) &&
-			deriveTeleportEqual_91(this.Remote, that.Remote)
+			this.RoleARN == that.RoleARN &&
+			this.ExternalID == that.ExternalID &&
+			this.RoleName == that.RoleName
 }
 
 // deriveTeleportEqual_70 returns whether this and that are equal.
-func deriveTeleportEqual_70(this, that map[string]utils.Strings) bool {
+func deriveTeleportEqual_70(this, that *OktaAssignmentTargetV1) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Type == that.Type &&
+			this.Id == that.Id
+}
+
+// deriveTeleportEqual_71 returns whether this and that are equal.
+func deriveTeleportEqual_71(this, that *BoolOption) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Value == that.Value
+}
+
+// deriveTeleportEqual_72 returns whether this and that are equal.
+func deriveTeleportEqual_72(this, that *RecordSession) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_71(this.Desktop, that.Desktop) &&
+			this.Default == that.Default &&
+			this.SSH == that.SSH
+}
+
+// deriveTeleportEqual_73 returns whether this and that are equal.
+func deriveTeleportEqual_73(this, that []*CertExtension) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_97(this[i], that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_74 returns whether this and that are equal.
+func deriveTeleportEqual_74(this, that *IdPOptions) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_98(this.SAML, that.SAML)
+}
+
+// deriveTeleportEqual_75 returns whether this and that are equal.
+func deriveTeleportEqual_75(this, that *SSHPortForwarding) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_99(this.Local, that.Local) &&
+			deriveTeleportEqual_100(this.Remote, that.Remote)
+}
+
+// deriveTeleportEqual_76 returns whether this and that are equal.
+func deriveTeleportEqual_76(this, that map[string]utils.Strings) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -1148,89 +1280,7 @@ func deriveTeleportEqual_70(this, that map[string]utils.Strings) bool {
 		if !ok {
 			return false
 		}
-		if !(deriveTeleportEqual_28(v, thatv)) {
-			return false
-		}
-	}
-	return true
-}
-
-// deriveTeleportEqual_71 returns whether this and that are equal.
-func deriveTeleportEqual_71(this, that []Rule) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_92(&this[i], &that[i])) {
-			return false
-		}
-	}
-	return true
-}
-
-// deriveTeleportEqual_72 returns whether this and that are equal.
-func deriveTeleportEqual_72(this, that *AccessRequestConditions) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Roles, that.Roles) &&
-			deriveTeleportEqual_93(this.ClaimsToRoles, that.ClaimsToRoles) &&
-			deriveTeleportEqual_94(this.Annotations, that.Annotations) &&
-			deriveTeleportEqual_95(this.Thresholds, that.Thresholds) &&
-			deriveTeleportEqual_28(this.SuggestedReviewers, that.SuggestedReviewers) &&
-			deriveTeleportEqual_28(this.SearchAsRoles, that.SearchAsRoles) &&
-			this.MaxDuration == that.MaxDuration &&
-			deriveTeleportEqual_96(this.KubernetesResources, that.KubernetesResources) &&
-			deriveTeleportEqual_97(this.Reason, that.Reason)
-}
-
-// deriveTeleportEqual_73 returns whether this and that are equal.
-func deriveTeleportEqual_73(this, that *ImpersonateConditions) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Users, that.Users) &&
-			deriveTeleportEqual_28(this.Roles, that.Roles) &&
-			this.Where == that.Where
-}
-
-// deriveTeleportEqual_74 returns whether this and that are equal.
-func deriveTeleportEqual_74(this, that *AccessReviewConditions) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Roles, that.Roles) &&
-			deriveTeleportEqual_93(this.ClaimsToRoles, that.ClaimsToRoles) &&
-			this.Where == that.Where &&
-			deriveTeleportEqual_28(this.PreviewAsRoles, that.PreviewAsRoles)
-}
-
-// deriveTeleportEqual_75 returns whether this and that are equal.
-func deriveTeleportEqual_75(this, that []*SessionRequirePolicy) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_98(this[i], that[i])) {
-			return false
-		}
-	}
-	return true
-}
-
-// deriveTeleportEqual_76 returns whether this and that are equal.
-func deriveTeleportEqual_76(this, that []*SessionJoinPolicy) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_99(this[i], that[i])) {
+		if !(deriveTeleportEqual_29(v, thatv)) {
 			return false
 		}
 	}
@@ -1238,23 +1288,7 @@ func deriveTeleportEqual_76(this, that []*SessionJoinPolicy) bool {
 }
 
 // deriveTeleportEqual_77 returns whether this and that are equal.
-func deriveTeleportEqual_77(this, that []KubernetesResource) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_100(&this[i], &that[i])) {
-			return false
-		}
-	}
-	return true
-}
-
-// deriveTeleportEqual_78 returns whether this and that are equal.
-func deriveTeleportEqual_78(this, that []DatabasePermission) bool {
+func deriveTeleportEqual_77(this, that []Rule) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -1269,40 +1303,42 @@ func deriveTeleportEqual_78(this, that []DatabasePermission) bool {
 	return true
 }
 
+// deriveTeleportEqual_78 returns whether this and that are equal.
+func deriveTeleportEqual_78(this, that *AccessRequestConditions) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_29(this.Roles, that.Roles) &&
+			deriveTeleportEqual_102(this.ClaimsToRoles, that.ClaimsToRoles) &&
+			deriveTeleportEqual_54(this.Annotations, that.Annotations) &&
+			deriveTeleportEqual_103(this.Thresholds, that.Thresholds) &&
+			deriveTeleportEqual_29(this.SuggestedReviewers, that.SuggestedReviewers) &&
+			deriveTeleportEqual_29(this.SearchAsRoles, that.SearchAsRoles) &&
+			this.MaxDuration == that.MaxDuration &&
+			deriveTeleportEqual_104(this.KubernetesResources, that.KubernetesResources) &&
+			deriveTeleportEqual_105(this.Reason, that.Reason)
+}
+
 // deriveTeleportEqual_79 returns whether this and that are equal.
-func deriveTeleportEqual_79(this, that []*SPIFFERoleCondition) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_102(this[i], that[i])) {
-			return false
-		}
-	}
-	return true
+func deriveTeleportEqual_79(this, that *ImpersonateConditions) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_29(this.Users, that.Users) &&
+			deriveTeleportEqual_29(this.Roles, that.Roles) &&
+			this.Where == that.Where
 }
 
 // deriveTeleportEqual_80 returns whether this and that are equal.
-func deriveTeleportEqual_80(this, that []IdentityCenterAccountAssignment) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_103(&this[i], &that[i])) {
-			return false
-		}
-	}
-	return true
+func deriveTeleportEqual_80(this, that *AccessReviewConditions) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_29(this.Roles, that.Roles) &&
+			deriveTeleportEqual_102(this.ClaimsToRoles, that.ClaimsToRoles) &&
+			this.Where == that.Where &&
+			deriveTeleportEqual_29(this.PreviewAsRoles, that.PreviewAsRoles)
 }
 
 // deriveTeleportEqual_81 returns whether this and that are equal.
-func deriveTeleportEqual_81(this, that []GitHubPermission) bool {
+func deriveTeleportEqual_81(this, that []*SessionRequirePolicy) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -1310,7 +1346,7 @@ func deriveTeleportEqual_81(this, that []GitHubPermission) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_104(&this[i], &that[i])) {
+		if !(deriveTeleportEqual_106(this[i], that[i])) {
 			return false
 		}
 	}
@@ -1318,31 +1354,150 @@ func deriveTeleportEqual_81(this, that []GitHubPermission) bool {
 }
 
 // deriveTeleportEqual_82 returns whether this and that are equal.
-func deriveTeleportEqual_82(this, that *MCPPermissions) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Tools, that.Tools)
+func deriveTeleportEqual_82(this, that []*SessionJoinPolicy) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_107(this[i], that[i])) {
+			return false
+		}
+	}
+	return true
 }
 
 // deriveTeleportEqual_83 returns whether this and that are equal.
-func deriveTeleportEqual_83(this, that *AttributeMapping) bool {
+func deriveTeleportEqual_83(this, that []KubernetesResource) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_108(&this[i], &that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_84 returns whether this and that are equal.
+func deriveTeleportEqual_84(this, that []DatabasePermission) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_109(&this[i], &that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_85 returns whether this and that are equal.
+func deriveTeleportEqual_85(this, that []*SPIFFERoleCondition) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_110(this[i], that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_86 returns whether this and that are equal.
+func deriveTeleportEqual_86(this, that []IdentityCenterAccountAssignment) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_111(&this[i], &that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_87 returns whether this and that are equal.
+func deriveTeleportEqual_87(this, that []GitHubPermission) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_112(&this[i], &that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_88 returns whether this and that are equal.
+func deriveTeleportEqual_88(this, that *MCPPermissions) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_29(this.Tools, that.Tools)
+}
+
+// deriveTeleportEqual_89 returns whether this and that are equal.
+func deriveTeleportEqual_89(this, that *AttributeMapping) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.Value == that.Value &&
-			deriveTeleportEqual_28(this.Roles, that.Roles)
+			deriveTeleportEqual_29(this.Roles, that.Roles)
 }
 
-// deriveTeleportEqual_84 returns whether this and that are equal.
-func deriveTeleportEqual_84(this, that *Header) bool {
+// deriveTeleportEqual_90 returns whether this and that are equal.
+func deriveTeleportEqual_90(this, that *ConnectorRef) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Type == that.Type &&
+			this.ID == that.ID &&
+			this.Identity == that.Identity
+}
+
+// deriveTeleportEqual_91 returns whether this and that are equal.
+func deriveTeleportEqual_91(this, that *UserRef) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Name == that.Name
+}
+
+// deriveTeleportEqual_92 returns whether this and that are equal.
+func deriveTeleportEqual_92(this, that *WebauthnLocalAuth) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			bytes.Equal(this.UserID, that.UserID)
+}
+
+// deriveTeleportEqual_93 returns whether this and that are equal.
+func deriveTeleportEqual_93(this, that *Header) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.Value == that.Value
 }
 
-// deriveTeleportEqual_85 returns whether this and that are equal.
-func deriveTeleportEqual_85(this, that *IdentityCenterPermissionSet) bool {
+// deriveTeleportEqual_94 returns whether this and that are equal.
+func deriveTeleportEqual_94(this, that *IdentityCenterPermissionSet) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ARN == that.ARN &&
@@ -1350,8 +1505,8 @@ func deriveTeleportEqual_85(this, that *IdentityCenterPermissionSet) bool {
 			this.AssignmentID == that.AssignmentID
 }
 
-// deriveTeleportEqual_86 returns whether this and that are equal.
-func deriveTeleportEqual_86(this, that *TLSKeyPair) bool {
+// deriveTeleportEqual_95 returns whether this and that are equal.
+func deriveTeleportEqual_95(this, that *TLSKeyPair) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			bytes.Equal(this.Cert, that.Cert) &&
@@ -1360,8 +1515,8 @@ func deriveTeleportEqual_86(this, that *TLSKeyPair) bool {
 			bytes.Equal(this.CRL, that.CRL)
 }
 
-// deriveTeleportEqual_87 returns whether this and that are equal.
-func deriveTeleportEqual_87(this, that *JWTKeyPair) bool {
+// deriveTeleportEqual_96 returns whether this and that are equal.
+func deriveTeleportEqual_96(this, that *JWTKeyPair) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			bytes.Equal(this.PublicKey, that.PublicKey) &&
@@ -1369,8 +1524,8 @@ func deriveTeleportEqual_87(this, that *JWTKeyPair) bool {
 			this.PrivateKeyType == that.PrivateKeyType
 }
 
-// deriveTeleportEqual_88 returns whether this and that are equal.
-func deriveTeleportEqual_88(this, that *CertExtension) bool {
+// deriveTeleportEqual_97 returns whether this and that are equal.
+func deriveTeleportEqual_97(this, that *CertExtension) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Type == that.Type &&
@@ -1379,39 +1534,39 @@ func deriveTeleportEqual_88(this, that *CertExtension) bool {
 			this.Value == that.Value
 }
 
-// deriveTeleportEqual_89 returns whether this and that are equal.
-func deriveTeleportEqual_89(this, that *IdPSAMLOptions) bool {
+// deriveTeleportEqual_98 returns whether this and that are equal.
+func deriveTeleportEqual_98(this, that *IdPSAMLOptions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_65(this.Enabled, that.Enabled)
+			deriveTeleportEqual_71(this.Enabled, that.Enabled)
 }
 
-// deriveTeleportEqual_90 returns whether this and that are equal.
-func deriveTeleportEqual_90(this, that *SSHLocalPortForwarding) bool {
+// deriveTeleportEqual_99 returns whether this and that are equal.
+func deriveTeleportEqual_99(this, that *SSHLocalPortForwarding) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_65(this.Enabled, that.Enabled)
+			deriveTeleportEqual_71(this.Enabled, that.Enabled)
 }
 
-// deriveTeleportEqual_91 returns whether this and that are equal.
-func deriveTeleportEqual_91(this, that *SSHRemotePortForwarding) bool {
+// deriveTeleportEqual_100 returns whether this and that are equal.
+func deriveTeleportEqual_100(this, that *SSHRemotePortForwarding) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_65(this.Enabled, that.Enabled)
+			deriveTeleportEqual_71(this.Enabled, that.Enabled)
 }
 
-// deriveTeleportEqual_92 returns whether this and that are equal.
-func deriveTeleportEqual_92(this, that *Rule) bool {
+// deriveTeleportEqual_101 returns whether this and that are equal.
+func deriveTeleportEqual_101(this, that *Rule) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Resources, that.Resources) &&
-			deriveTeleportEqual_28(this.Verbs, that.Verbs) &&
+			deriveTeleportEqual_29(this.Resources, that.Resources) &&
+			deriveTeleportEqual_29(this.Verbs, that.Verbs) &&
 			this.Where == that.Where &&
-			deriveTeleportEqual_28(this.Actions, that.Actions)
+			deriveTeleportEqual_29(this.Actions, that.Actions)
 }
 
-// deriveTeleportEqual_93 returns whether this and that are equal.
-func deriveTeleportEqual_93(this, that []ClaimMapping) bool {
+// deriveTeleportEqual_102 returns whether this and that are equal.
+func deriveTeleportEqual_102(this, that []ClaimMapping) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -1419,35 +1574,15 @@ func deriveTeleportEqual_93(this, that []ClaimMapping) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_105(&this[i], &that[i])) {
+		if !(deriveTeleportEqual_113(&this[i], &that[i])) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveTeleportEqual_94 returns whether this and that are equal.
-func deriveTeleportEqual_94(this, that map[string][]string) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for k, v := range this {
-		thatv, ok := that[k]
-		if !ok {
-			return false
-		}
-		if !(deriveTeleportEqual_28(v, thatv)) {
-			return false
-		}
-	}
-	return true
-}
-
-// deriveTeleportEqual_95 returns whether this and that are equal.
-func deriveTeleportEqual_95(this, that []AccessReviewThreshold) bool {
+// deriveTeleportEqual_103 returns whether this and that are equal.
+func deriveTeleportEqual_103(this, that []AccessReviewThreshold) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -1462,8 +1597,8 @@ func deriveTeleportEqual_95(this, that []AccessReviewThreshold) bool {
 	return true
 }
 
-// deriveTeleportEqual_96 returns whether this and that are equal.
-func deriveTeleportEqual_96(this, that []RequestKubernetesResource) bool {
+// deriveTeleportEqual_104 returns whether this and that are equal.
+func deriveTeleportEqual_104(this, that []RequestKubernetesResource) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -1471,97 +1606,97 @@ func deriveTeleportEqual_96(this, that []RequestKubernetesResource) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_106(&this[i], &that[i])) {
+		if !(deriveTeleportEqual_114(&this[i], &that[i])) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveTeleportEqual_97 returns whether this and that are equal.
-func deriveTeleportEqual_97(this, that *AccessRequestConditionsReason) bool {
+// deriveTeleportEqual_105 returns whether this and that are equal.
+func deriveTeleportEqual_105(this, that *AccessRequestConditionsReason) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Mode == that.Mode &&
 			this.Prompt == that.Prompt
 }
 
-// deriveTeleportEqual_98 returns whether this and that are equal.
-func deriveTeleportEqual_98(this, that *SessionRequirePolicy) bool {
+// deriveTeleportEqual_106 returns whether this and that are equal.
+func deriveTeleportEqual_106(this, that *SessionRequirePolicy) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.Filter == that.Filter &&
-			deriveTeleportEqual_28(this.Kinds, that.Kinds) &&
+			deriveTeleportEqual_29(this.Kinds, that.Kinds) &&
 			this.Count == that.Count &&
-			deriveTeleportEqual_28(this.Modes, that.Modes) &&
+			deriveTeleportEqual_29(this.Modes, that.Modes) &&
 			this.OnLeave == that.OnLeave
 }
 
-// deriveTeleportEqual_99 returns whether this and that are equal.
-func deriveTeleportEqual_99(this, that *SessionJoinPolicy) bool {
+// deriveTeleportEqual_107 returns whether this and that are equal.
+func deriveTeleportEqual_107(this, that *SessionJoinPolicy) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
-			deriveTeleportEqual_28(this.Roles, that.Roles) &&
-			deriveTeleportEqual_28(this.Kinds, that.Kinds) &&
-			deriveTeleportEqual_28(this.Modes, that.Modes)
+			deriveTeleportEqual_29(this.Roles, that.Roles) &&
+			deriveTeleportEqual_29(this.Kinds, that.Kinds) &&
+			deriveTeleportEqual_29(this.Modes, that.Modes)
 }
 
-// deriveTeleportEqual_100 returns whether this and that are equal.
-func deriveTeleportEqual_100(this, that *KubernetesResource) bool {
+// deriveTeleportEqual_108 returns whether this and that are equal.
+func deriveTeleportEqual_108(this, that *KubernetesResource) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Kind == that.Kind &&
 			this.Namespace == that.Namespace &&
 			this.Name == that.Name &&
-			deriveTeleportEqual_28(this.Verbs, that.Verbs) &&
+			deriveTeleportEqual_29(this.Verbs, that.Verbs) &&
 			this.APIGroup == that.APIGroup
 }
 
-// deriveTeleportEqual_101 returns whether this and that are equal.
-func deriveTeleportEqual_101(this, that *DatabasePermission) bool {
+// deriveTeleportEqual_109 returns whether this and that are equal.
+func deriveTeleportEqual_109(this, that *DatabasePermission) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Permissions, that.Permissions) &&
-			deriveTeleportEqual_70(this.Match, that.Match)
+			deriveTeleportEqual_29(this.Permissions, that.Permissions) &&
+			deriveTeleportEqual_76(this.Match, that.Match)
 }
 
-// deriveTeleportEqual_102 returns whether this and that are equal.
-func deriveTeleportEqual_102(this, that *SPIFFERoleCondition) bool {
+// deriveTeleportEqual_110 returns whether this and that are equal.
+func deriveTeleportEqual_110(this, that *SPIFFERoleCondition) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Path == that.Path &&
-			deriveTeleportEqual_28(this.DNSSANs, that.DNSSANs) &&
-			deriveTeleportEqual_28(this.IPSANs, that.IPSANs)
+			deriveTeleportEqual_29(this.DNSSANs, that.DNSSANs) &&
+			deriveTeleportEqual_29(this.IPSANs, that.IPSANs)
 }
 
-// deriveTeleportEqual_103 returns whether this and that are equal.
-func deriveTeleportEqual_103(this, that *IdentityCenterAccountAssignment) bool {
+// deriveTeleportEqual_111 returns whether this and that are equal.
+func deriveTeleportEqual_111(this, that *IdentityCenterAccountAssignment) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.PermissionSet == that.PermissionSet &&
 			this.Account == that.Account
 }
 
-// deriveTeleportEqual_104 returns whether this and that are equal.
-func deriveTeleportEqual_104(this, that *GitHubPermission) bool {
+// deriveTeleportEqual_112 returns whether this and that are equal.
+func deriveTeleportEqual_112(this, that *GitHubPermission) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_28(this.Organizations, that.Organizations)
+			deriveTeleportEqual_29(this.Organizations, that.Organizations)
 }
 
-// deriveTeleportEqual_105 returns whether this and that are equal.
-func deriveTeleportEqual_105(this, that *ClaimMapping) bool {
+// deriveTeleportEqual_113 returns whether this and that are equal.
+func deriveTeleportEqual_113(this, that *ClaimMapping) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Claim == that.Claim &&
 			this.Value == that.Value &&
-			deriveTeleportEqual_28(this.Roles, that.Roles)
+			deriveTeleportEqual_29(this.Roles, that.Roles)
 }
 
-// deriveTeleportEqual_106 returns whether this and that are equal.
-func deriveTeleportEqual_106(this, that *RequestKubernetesResource) bool {
+// deriveTeleportEqual_114 returns whether this and that are equal.
+func deriveTeleportEqual_114(this, that *RequestKubernetesResource) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Kind == that.Kind &&

--- a/api/types/mfa.go
+++ b/api/types/mfa.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"bytes"
+	"slices"
 	"time"
 
 	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
@@ -172,4 +173,100 @@ func (d *MFADevice) UnmarshalJSON(buf []byte) error {
 	unmarshaler := jsonpb.Unmarshaler{AllowUnknownFields: true}
 	err := unmarshaler.Unmarshal(bytes.NewReader(buf), d)
 	return trace.Wrap(err)
+}
+
+// mfaDevicesEqual compares two MFA device slices independent of ordering.
+// This cannot be done via goderive entirely because it does not support
+// interfaces.
+func mfaDevicesEqual(a, b []*MFADevice) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	// Check devices assuming that they are in the same order first.
+	ordered := true
+	for i := range a {
+		if !mfaDeviceEqual(a[i], b[i]) {
+			ordered = false
+			break
+		}
+	}
+	if ordered {
+		return true
+	}
+
+	// Fallback to order-independent comparison. Shallow-copy `a` so
+	// swap-removing matched entries is possible without mutating
+	// the provided slice.
+	//  With typical MFA device counts (<10) the
+	// scan is faster than building a map.
+	remaining := slices.Clone(a)
+
+	for _, bd := range b {
+		matched := false
+		for i, ad := range remaining {
+			if !mfaDeviceEqual(ad, bd) {
+				continue
+			}
+
+			remaining[i] = remaining[len(remaining)-1]
+			remaining = remaining[:len(remaining)-1]
+			matched = true
+		}
+
+		if !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+// mfaDeviceEqual compares all fields of two MFA devices.
+func mfaDeviceEqual(a, b *MFADevice) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if a.Kind != b.Kind ||
+		a.SubKind != b.SubKind ||
+		a.Version != b.Version ||
+		a.Id != b.Id ||
+		!a.AddedAt.Equal(b.AddedAt) ||
+		!a.LastUsed.Equal(b.LastUsed) ||
+		!deriveTeleportEqualMetadata(&a.Metadata, &b.Metadata) {
+		return false
+	}
+	return mfaDeviceDeviceEqual(a.Device, b.Device)
+}
+
+// mfaDeviceDeviceEqual compares all fields of two isMFADevice_Devices.
+func mfaDeviceDeviceEqual(a, b isMFADevice_Device) bool {
+	switch av := a.(type) {
+	case *MFADevice_Totp:
+		bv, ok := b.(*MFADevice_Totp)
+		if !ok {
+			return false
+		}
+		return deriveTeleportEqualTOTPDevice(av.Totp, bv.Totp)
+	case *MFADevice_U2F:
+		bv, ok := b.(*MFADevice_U2F)
+		if !ok {
+			return false
+		}
+		return deriveTeleportEqualU2FDevice(av.U2F, bv.U2F)
+	case *MFADevice_Webauthn:
+		bv, ok := b.(*MFADevice_Webauthn)
+		if !ok {
+			return false
+		}
+		return deriveTeleportEqualWebauthnDevice(av.Webauthn, bv.Webauthn)
+	case *MFADevice_Sso:
+		bv, ok := b.(*MFADevice_Sso)
+		if !ok {
+			return false
+		}
+		return deriveTeleportEqualSSOMFADevice(av.Sso, bv.Sso)
+	default:
+		return a == nil && b == nil
+	}
 }

--- a/api/types/mfa_test.go
+++ b/api/types/mfa_test.go
@@ -1,0 +1,514 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+	"time"
+
+	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/require"
+)
+
+func newTOTPDev(t *testing.T, name, id string) *MFADevice {
+	t.Helper()
+	dev, err := NewMFADevice(name, id, time.Now(), &MFADevice_Totp{
+		Totp: &TOTPDevice{Key: "totp-key-" + id},
+	})
+	require.NoError(t, err)
+	return dev
+}
+
+func newU2FDev(t *testing.T, name, id string) *MFADevice {
+	t.Helper()
+	dev, err := NewMFADevice(name, id, time.Now(), &MFADevice_U2F{
+		U2F: &U2FDevice{
+			KeyHandle: []byte("handle-" + id),
+			PubKey:    []byte("pubkey-" + id),
+			Counter:   42,
+		},
+	})
+	require.NoError(t, err)
+	return dev
+}
+
+func newWebauthnDev(t *testing.T, name, id string) *MFADevice {
+	t.Helper()
+	dev, err := NewMFADevice(name, id, time.Now(), &MFADevice_Webauthn{
+		Webauthn: &WebauthnDevice{
+			CredentialId:             []byte("cred-" + id),
+			PublicKeyCbor:            []byte("cbor-" + id),
+			AttestationType:          "none",
+			Aaguid:                   []byte("aaguid"),
+			SignatureCounter:         10,
+			AttestationObject:        []byte("att-obj"),
+			ResidentKey:              true,
+			CredentialRpId:           "example.com",
+			CredentialBackupEligible: &gogotypes.BoolValue{Value: true},
+			CredentialBackedUp:       &gogotypes.BoolValue{Value: false},
+		},
+	})
+	require.NoError(t, err)
+	return dev
+}
+
+func newSSODev(t *testing.T, name, id string) *MFADevice {
+	t.Helper()
+	dev, err := NewMFADevice(name, id, time.Now(), &MFADevice_Sso{
+		Sso: &SSOMFADevice{
+			ConnectorId:   "connector-" + id,
+			ConnectorType: "saml",
+			DisplayName:   "SSO " + id,
+		},
+	})
+	require.NoError(t, err)
+	return dev
+}
+
+func TestMFADevicesEqual(t *testing.T) {
+	totp1 := newTOTPDev(t, "totp-1", "id-totp-1")
+	totp2 := newTOTPDev(t, "totp-2", "id-totp-2")
+	u2f1 := newU2FDev(t, "u2f-1", "id-u2f-1")
+	webauthn1 := newWebauthnDev(t, "webauthn-1", "id-webauthn-1")
+	sso1 := newSSODev(t, "sso-1", "id-sso-1")
+	fixedNow := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	dupNameA, err := NewMFADevice("dup-name", "id-dup-a", fixedNow, &MFADevice_Totp{
+		Totp: &TOTPDevice{Key: "dup-key-a"},
+	})
+	require.NoError(t, err)
+	dupNameB, err := NewMFADevice("dup-name", "id-dup-b", fixedNow, &MFADevice_Totp{
+		Totp: &TOTPDevice{Key: "dup-key-b"},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		a, b []*MFADevice
+		want bool
+	}{
+		{
+			name: "both nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "both empty",
+			a:    []*MFADevice{},
+			b:    []*MFADevice{},
+			want: true,
+		},
+		{
+			name: "nil vs empty",
+			a:    nil,
+			b:    []*MFADevice{},
+			want: true,
+		},
+		{
+			name: "different lengths",
+			a:    []*MFADevice{totp1},
+			b:    []*MFADevice{totp1, totp2},
+			want: false,
+		},
+		{
+			name: "single TOTP, same order",
+			a:    []*MFADevice{totp1},
+			b:    []*MFADevice{totp1},
+			want: true,
+		},
+		{
+			name: "single U2F, same order",
+			a:    []*MFADevice{u2f1},
+			b:    []*MFADevice{u2f1},
+			want: true,
+		},
+		{
+			name: "single Webauthn, same order",
+			a:    []*MFADevice{webauthn1},
+			b:    []*MFADevice{webauthn1},
+			want: true,
+		},
+		{
+			name: "single SSO, same order",
+			a:    []*MFADevice{sso1},
+			b:    []*MFADevice{sso1},
+			want: true,
+		},
+		{
+			name: "all types, same order",
+			a:    []*MFADevice{totp1, u2f1, webauthn1, sso1},
+			b:    []*MFADevice{totp1, u2f1, webauthn1, sso1},
+			want: true,
+		},
+		{
+			name: "all types, reversed order",
+			a:    []*MFADevice{totp1, u2f1, webauthn1, sso1},
+			b:    []*MFADevice{sso1, webauthn1, u2f1, totp1},
+			want: true,
+		},
+		{
+			name: "all types, shuffled order",
+			a:    []*MFADevice{totp1, u2f1, webauthn1, sso1},
+			b:    []*MFADevice{webauthn1, totp1, sso1, u2f1},
+			want: true,
+		},
+		{
+			name: "two TOTPs, same order",
+			a:    []*MFADevice{totp1, totp2},
+			b:    []*MFADevice{totp1, totp2},
+			want: true,
+		},
+		{
+			name: "two TOTPs, swapped order",
+			a:    []*MFADevice{totp1, totp2},
+			b:    []*MFADevice{totp2, totp1},
+			want: true,
+		},
+		{
+			name: "nil entries reordered",
+			a:    []*MFADevice{nil, totp1},
+			b:    []*MFADevice{totp1, nil},
+			want: true,
+		},
+		{
+			name: "duplicate names do not collapse multiplicity",
+			a:    []*MFADevice{dupNameA, dupNameB},
+			b:    []*MFADevice{dupNameB, dupNameB},
+			want: false,
+		},
+		{
+			name: "TOTP vs U2F",
+			a:    []*MFADevice{totp1},
+			b:    []*MFADevice{u2f1},
+			want: false,
+		},
+		{
+			name: "TOTP vs Webauthn",
+			a:    []*MFADevice{totp1},
+			b:    []*MFADevice{webauthn1},
+			want: false,
+		},
+		{
+			name: "TOTP vs SSO",
+			a:    []*MFADevice{totp1},
+			b:    []*MFADevice{sso1},
+			want: false,
+		},
+		{
+			name: "U2F vs Webauthn",
+			a:    []*MFADevice{u2f1},
+			b:    []*MFADevice{webauthn1},
+			want: false,
+		},
+		{
+			name: "U2F vs SSO",
+			a:    []*MFADevice{u2f1},
+			b:    []*MFADevice{sso1},
+			want: false,
+		},
+		{
+			name: "Webauthn vs SSO",
+			a:    []*MFADevice{webauthn1},
+			b:    []*MFADevice{sso1},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, mfaDevicesEqual(tt.a, tt.b))
+		})
+	}
+}
+
+func TestMFADevicesEqual_DeviceFieldDifferences(t *testing.T) {
+	now := time.Now()
+
+	baseTOTP := func() *MFADevice {
+		d, err := NewMFADevice("totp", "id-totp", now, &MFADevice_Totp{
+			Totp: &TOTPDevice{Key: "secret"},
+		})
+		require.NoError(t, err)
+		return d
+	}
+
+	baseU2F := func() *MFADevice {
+		d, err := NewMFADevice("u2f", "id-u2f", now, &MFADevice_U2F{
+			U2F: &U2FDevice{
+				KeyHandle: []byte("handle"),
+				PubKey:    []byte("pubkey"),
+				Counter:   1,
+			},
+		})
+		require.NoError(t, err)
+		return d
+	}
+
+	baseWebauthn := func() *MFADevice {
+		d, err := NewMFADevice("webauthn", "id-webauthn", now, &MFADevice_Webauthn{
+			Webauthn: &WebauthnDevice{
+				CredentialId:             []byte("cred"),
+				PublicKeyCbor:            []byte("cbor"),
+				AttestationType:          "none",
+				Aaguid:                   []byte("aaguid"),
+				SignatureCounter:         5,
+				AttestationObject:        []byte("att"),
+				ResidentKey:              true,
+				CredentialRpId:           "example.com",
+				CredentialBackupEligible: &gogotypes.BoolValue{Value: true},
+				CredentialBackedUp:       &gogotypes.BoolValue{Value: false},
+			},
+		})
+		require.NoError(t, err)
+		return d
+	}
+
+	baseSSO := func() *MFADevice {
+		d, err := NewMFADevice("sso", "id-sso", now, &MFADevice_Sso{
+			Sso: &SSOMFADevice{
+				ConnectorId:   "conn",
+				ConnectorType: "saml",
+				DisplayName:   "My SSO",
+			},
+		})
+		require.NoError(t, err)
+		return d
+	}
+
+	tests := []struct {
+		name    string
+		a, b    func() *MFADevice
+		mutateB func(d *MFADevice)
+		want    bool
+	}{
+		{
+			name: "TOTP identical",
+			a:    baseTOTP,
+			b:    baseTOTP,
+			want: true,
+		},
+		{
+			name: "TOTP different key",
+			a:    baseTOTP,
+			b:    baseTOTP,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Totp).Totp.Key = "other"
+			},
+			want: false,
+		},
+		{
+			name: "U2F identical",
+			a:    baseU2F,
+			b:    baseU2F,
+			want: true,
+		},
+		{
+			name: "U2F different KeyHandle",
+			a:    baseU2F,
+			b:    baseU2F,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_U2F).U2F.KeyHandle = []byte("other")
+			},
+			want: false,
+		},
+		{
+			name: "U2F different PubKey",
+			a:    baseU2F,
+			b:    baseU2F,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_U2F).U2F.PubKey = []byte("other")
+			},
+			want: false,
+		},
+		{
+			name: "U2F different Counter",
+			a:    baseU2F,
+			b:    baseU2F,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_U2F).U2F.Counter = 999
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn identical",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			want: true,
+		},
+		{
+			name: "Webauthn different CredentialId",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.CredentialId = []byte("other")
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn different PublicKeyCbor",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.PublicKeyCbor = []byte("other")
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn different AttestationType",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.AttestationType = "packed"
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn different Aaguid",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.Aaguid = []byte("other")
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn different SignatureCounter",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.SignatureCounter = 999
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn different AttestationObject",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.AttestationObject = []byte("other")
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn different ResidentKey",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.ResidentKey = false
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn different CredentialRpId",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.CredentialRpId = "other.com"
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn different CredentialBackupEligible value",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.CredentialBackupEligible = &gogotypes.BoolValue{Value: false}
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn CredentialBackupEligible nil vs set",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.CredentialBackupEligible = nil
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn different CredentialBackedUp value",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.CredentialBackedUp = &gogotypes.BoolValue{Value: true}
+			},
+			want: false,
+		},
+		{
+			name: "Webauthn CredentialBackedUp nil vs set",
+			a:    baseWebauthn,
+			b:    baseWebauthn,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Webauthn).Webauthn.CredentialBackedUp = nil
+			},
+			want: false,
+		},
+		{
+			name: "SSO identical",
+			a:    baseSSO,
+			b:    baseSSO,
+			want: true,
+		},
+		{
+			name: "SSO different ConnectorId",
+			a:    baseSSO,
+			b:    baseSSO,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Sso).Sso.ConnectorId = "other"
+			},
+			want: false,
+		},
+		{
+			name: "SSO different ConnectorType",
+			a:    baseSSO,
+			b:    baseSSO,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Sso).Sso.ConnectorType = "oidc"
+			},
+			want: false,
+		},
+		{
+			name: "SSO different DisplayName",
+			a:    baseSSO,
+			b:    baseSSO,
+			mutateB: func(d *MFADevice) {
+				d.Device.(*MFADevice_Sso).Sso.DisplayName = "Other"
+			},
+			want: false,
+		},
+		{
+			name: "different Id",
+			a:    baseTOTP,
+			b:    baseTOTP,
+			mutateB: func(d *MFADevice) {
+				d.Id = "different-id"
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			da := tt.a()
+			db := tt.b()
+			if tt.mutateB != nil {
+				tt.mutateB(db)
+			}
+			require.Equal(t, tt.want, mfaDevicesEqual([]*MFADevice{da}, []*MFADevice{db}))
+		})
+	}
+}

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -57,6 +57,7 @@ type User interface {
 	ResourceWithSecrets
 	ResourceWithOrigin
 	ResourceWithLabels
+	IsEqual(other User) bool
 	// SetMetadata sets object metadata
 	SetMetadata(meta Metadata)
 	// GetOIDCIdentities returns a list of connected OIDC identities
@@ -187,6 +188,33 @@ func NewUser(name string) (User, error) {
 // same ID/type as this one
 func (r *ConnectorRef) IsSameProvider(other *ConnectorRef) bool {
 	return other != nil && other.Type == r.Type && other.ID == r.ID
+}
+
+func (u *UserV2) IsEqual(other User) bool {
+	otherV2, ok := other.(*UserV2)
+	if !ok {
+		return false
+	}
+	if !deriveTeleportEqualUser(u, otherV2) {
+		return false
+	}
+
+	if u == nil && otherV2 == nil {
+		return true
+	}
+
+	// The derived equality function skips MFA because the Device
+	// interface is not handled by goderive. If every other aspect
+	// of the users is equivalent, then evualate whether the devices
+	// are as well manually.
+	var thisMFA, thatMFA []*MFADevice
+	if u != nil && u.Spec.LocalAuth != nil {
+		thisMFA = u.Spec.LocalAuth.MFA
+	}
+	if otherV2 != nil && otherV2.Spec.LocalAuth != nil {
+		thatMFA = otherV2.Spec.LocalAuth.MFA
+	}
+	return mfaDevicesEqual(thisMFA, thatMFA)
 }
 
 // GetVersion returns resource version

--- a/api/types/user_test.go
+++ b/api/types/user_test.go
@@ -1,0 +1,420 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newUser returns a fully populated UserV2 with LocalAuth including MFA
+// devices of every type.
+func newUser(t *testing.T) *UserV2 {
+	t.Helper()
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	exp := now.Add(24 * time.Hour)
+	return &UserV2{
+		Kind:    KindUser,
+		Version: V2,
+		Metadata: Metadata{
+			Name:      "alice",
+			Namespace: "default",
+			Expires:   &exp,
+			Labels:    map[string]string{"env": "prod"},
+		},
+		Spec: UserSpecV2{
+			Roles: []string{"admin", "dev"},
+			Traits: map[string][]string{
+				"logins": {"root", "alice"},
+			},
+			OIDCIdentities:   []ExternalIdentity{{ConnectorID: "oidc-1", Username: "alice@oidc"}},
+			SAMLIdentities:   []ExternalIdentity{{ConnectorID: "saml-1", Username: "alice@saml"}},
+			GithubIdentities: []ExternalIdentity{{ConnectorID: "github-1", Username: "alice@github"}},
+			CreatedBy: CreatedBy{
+				Time: now,
+				User: UserRef{Name: "admin"},
+			},
+			Expires:          now.Add(time.Hour),
+			TrustedDeviceIDs: []string{"device-1"},
+			Status: LoginStatus{
+				IsLocked:      false,
+				LockedMessage: "",
+			},
+			LocalAuth: &LocalAuthSecrets{
+				PasswordHash: []byte("hash"),
+				TOTPKey:      "totp-key",
+				MFA: []*MFADevice{
+					mustNewMFADevice(t, "totp-dev", "id-1", now, &MFADevice_Totp{
+						Totp: &TOTPDevice{Key: "secret-1"},
+					}),
+					mustNewMFADevice(t, "webauthn-dev", "id-2", now, &MFADevice_Webauthn{
+						Webauthn: &WebauthnDevice{
+							CredentialId:  []byte("cred-1"),
+							PublicKeyCbor: []byte("cbor-1"),
+						},
+					}),
+				},
+				Webauthn: &WebauthnLocalAuth{UserID: []byte("webauthn-user")},
+			},
+		},
+	}
+}
+
+func mustNewMFADevice(t *testing.T, name, id string, addedAt time.Time, device isMFADevice_Device) *MFADevice {
+	t.Helper()
+	d, err := NewMFADevice(name, id, addedAt, device)
+	require.NoError(t, err)
+	return d
+}
+
+func TestUserV2IsEqual(t *testing.T) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// mockUser is a minimal implemention of the User interface to exercise
+	// the non-*UserV2 type assertion path in IsEqual.
+	type mockUser struct {
+		UserV2
+	}
+
+	tests := []struct {
+		name string
+		a, b func(t *testing.T) User
+		want bool
+	}{
+		{
+			name: "both typed nil *UserV2",
+			a: func(t *testing.T) User {
+				var u *UserV2
+				return u
+			},
+			b: func(t *testing.T) User {
+				var u *UserV2
+				return u
+			},
+			want: true,
+		},
+		{
+			name: "typed nil *UserV2 vs populated user",
+			a: func(t *testing.T) User {
+				var u *UserV2
+				return u
+			},
+			b:    func(t *testing.T) User { return newUser(t) },
+			want: false,
+		},
+		{
+			name: "identical users",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b:    func(t *testing.T) User { return newUser(t) },
+			want: true,
+		},
+		{
+			name: "both nil LocalAuth",
+			a: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth = nil
+				return u
+			},
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth = nil
+				return u
+			},
+			want: true,
+		},
+		{
+			name: "Revision difference ignored",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Metadata.SetRevision("different-revision")
+				return u
+			},
+			want: true,
+		},
+		{
+			name: "top-level Status difference ignored",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Status.PasswordState = 42
+				return u
+			},
+			want: true,
+		},
+		{
+			name: "MFA devices in different order",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				mfa := u.Spec.LocalAuth.MFA
+				mfa[0], mfa[1] = mfa[1], mfa[0]
+				return u
+			},
+			want: true,
+		},
+		{
+			name: "non-UserV2 type returns false",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b:    func(t *testing.T) User { return &mockUser{} },
+			want: false,
+		},
+		{
+			name: "different Name",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Metadata.Name = "bob"
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different Namespace",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Metadata.Namespace = "other"
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different Labels",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Metadata.Labels = map[string]string{"env": "staging"}
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different Metadata.Expires",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				exp := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+				u.Metadata.Expires = &exp
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different Roles",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.Roles = []string{"viewer"}
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different Traits",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.Traits = map[string][]string{"logins": {"nobody"}}
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different OIDCIdentities",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.OIDCIdentities = []ExternalIdentity{{ConnectorID: "other", Username: "x"}}
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different SAMLIdentities",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.SAMLIdentities = []ExternalIdentity{{ConnectorID: "other", Username: "x"}}
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different GithubIdentities",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.GithubIdentities = []ExternalIdentity{{ConnectorID: "other", Username: "x"}}
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different CreatedBy",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.CreatedBy = CreatedBy{User: UserRef{Name: "other"}}
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different Spec.Expires",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.Expires = time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different TrustedDeviceIDs",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.TrustedDeviceIDs = []string{"device-other"}
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different Spec.Status (LoginStatus)",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.Status = LoginStatus{IsLocked: true, LockedMessage: "banned"}
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different PasswordHash",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth.PasswordHash = []byte("other")
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different TOTPKey",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth.TOTPKey = "other"
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different Webauthn LocalAuth",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth.Webauthn = &WebauthnLocalAuth{UserID: []byte("other")}
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "nil vs non-nil LocalAuth",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth = nil
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different MFA device count",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth.MFA = u.Spec.LocalAuth.MFA[:1]
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different TOTP key in MFA device",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth.MFA[0].Device.(*MFADevice_Totp).Totp.Key = "changed"
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "different Webauthn CredentialId in MFA device",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth.MFA[1].Device.(*MFADevice_Webauthn).Webauthn.CredentialId = []byte("changed")
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "swapped device type (TOTP replaced with SSO)",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth.MFA[0] = mustNewMFADevice(t, "totp-dev", "id-1", now, &MFADevice_Sso{
+					Sso: &SSOMFADevice{ConnectorId: "c", ConnectorType: "saml", DisplayName: "d"},
+				})
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "nil MFA vs non-nil MFA",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth.MFA = nil
+				return u
+			},
+			want: false,
+		},
+		{
+			name: "empty MFA vs populated MFA",
+			a:    func(t *testing.T) User { return newUser(t) },
+			b: func(t *testing.T) User {
+				u := newUser(t)
+				u.Spec.LocalAuth.MFA = []*MFADevice{}
+				return u
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := tt.a(t)
+			b := tt.b(t)
+			require.Equal(t, tt.want, a.IsEqual(b))
+		})
+	}
+}

--- a/build.assets/tooling/cmd/goderive/plugin/teleportequal/teleportequal.go
+++ b/build.assets/tooling/cmd/goderive/plugin/teleportequal/teleportequal.go
@@ -128,6 +128,13 @@ func removeIgnoredFieldsFromStruct(name string, strct *types.Struct) types.Type 
 			continue
 		}
 
+		// Ignore MFA on LocalAuthSecrets; the Device oneof interface
+		// is not handled by goderive. It is up to UserV2.IsEqual to
+		// account for this manually.
+		if name == "LocalAuthSecrets" && fieldName == "MFA" {
+			continue
+		}
+
 		filteredFields = append(filteredFields, field)
 		filteredTags = append(filteredTags, strct.Tag(i))
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4090,30 +4090,6 @@ func hasOneNonPresetUser(users []types.User) bool {
 	return qtyNonPreset == 1
 }
 
-// CompareAndSwapUser updates an existing user in a backend, but fails if the
-// backend's value does not match the expected value.
-// Captures the auth user who modified the user record.
-func (a *ServerWithRoles) CompareAndSwapUser(ctx context.Context, new, existing types.User) error {
-	if err := a.authorizeAction(types.KindUser, types.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-
-	if err := okta.CheckOrigin(&a.context, new); err != nil {
-		return trace.Wrap(err)
-	}
-
-	// Checking the `existing` origin should be enough to assert that okta has
-	// write access to the user, because if the backend record says something
-	// different then the `CompareAndSwap()` will fail anyway, and this way we
-	// save ourselves a backend user lookup.
-
-	if err := okta.CheckAccess(&a.context, existing, types.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return a.authServer.CompareAndSwapUser(ctx, new, existing)
-}
-
 // UpsertOIDCConnector creates or updates an OIDC connector.
 func (a *ServerWithRoles) UpsertOIDCConnector(ctx context.Context, connector types.OIDCConnector) (types.OIDCConnector, error) {
 	if err := a.authConnectorAction(types.KindOIDC, types.VerbCreate); err != nil {

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -118,16 +118,16 @@ func runUserResourceTest(
 	require.NoError(t, err)
 	b, err := s.GetUser(ctx, "bob", withSecrets)
 	require.NoError(t, err)
-	require.True(t, services.UsersEquals(bob, b), "dynamically inserted user does not match")
+	require.True(t, bob.IsEqual(b), "dynamically inserted user does not match")
 	allUsers, err := s.GetUsers(ctx, withSecrets)
 	require.NoError(t, err)
 	require.Len(t, allUsers, 2, "expected exactly two users")
 	for _, user := range allUsers {
 		switch user.GetName() {
 		case "alice":
-			require.True(t, services.UsersEquals(alice, user), "alice does not match")
+			require.True(t, alice.IsEqual(user), "alice does not match")
 		case "bob":
-			require.True(t, services.UsersEquals(bob, user), "bob does not match")
+			require.True(t, bob.IsEqual(user), "bob does not match")
 		default:
 			t.Errorf("Unexpected user %q", user.GetName())
 		}

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -98,7 +98,7 @@ func userSlicesEqual(t *testing.T, a []types.User, b []types.User) {
 }
 
 func usersEqual(t *testing.T, a types.User, b types.User) {
-	require.True(t, services.UsersEquals(a, b), cmp.Diff(a, b))
+	require.True(t, a.IsEqual(b), cmp.Diff(a, b))
 }
 
 func newUser(name string, roles []string) types.User {

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -537,7 +537,7 @@ func (s *IdentityService) CompareAndSwapUser(ctx context.Context, new, existing 
 			return trace.Wrap(err)
 		}
 
-		if !services.UsersEquals(existingWithoutSecrets, currentWithoutSecrets) {
+		if !existingWithoutSecrets.IsEqual(currentWithoutSecrets) {
 			return trace.CompareFailed("user %v did not match expected existing value", new.GetName())
 		}
 

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -1582,22 +1582,22 @@ func TestCompareAndSwapUser(t *testing.T) {
 	require.NoError(err)
 	bob2.SetLogins([]string{"bob", "alice"})
 
-	require.False(services.UsersEquals(bob1, bob2))
+	require.False(bob1.IsEqual(bob2))
 
 	currentBob, err := identity.UpsertUser(ctx, bob1)
 	require.NoError(err)
-	require.True(services.UsersEquals(currentBob, bob1))
+	require.True(currentBob.IsEqual(bob1))
 
 	currentBob, err = identity.GetUser(ctx, "bob", false)
 	require.NoError(err)
-	require.True(services.UsersEquals(currentBob, bob1))
+	require.True(currentBob.IsEqual(bob1))
 
 	err = identity.CompareAndSwapUser(ctx, bob2, bob1)
 	require.NoError(err)
 
 	bob2, err = identity.GetUser(ctx, "bob", false)
 	require.NoError(err)
-	require.True(services.UsersEquals(currentBob, bob1))
+	require.True(currentBob.IsEqual(bob1))
 
 	item, err := identity.Backend.Get(ctx, backend.NewKey(local.WebPrefix, local.UsersPrefix, "bob", local.ParamsPrefix))
 	require.NoError(err)
@@ -1611,14 +1611,14 @@ func TestCompareAndSwapUser(t *testing.T) {
 
 	currentBob, err = identity.GetUser(ctx, "bob", true)
 	require.NoError(err)
-	require.True(services.UsersEquals(currentBob, bob2))
+	require.True(currentBob.IsEqual(bob2))
 	bob2.SetWeakestDevice(currentBob.GetWeakestDevice())
 	err = identity.CompareAndSwapUser(ctx, bob1, bob2)
 	require.NoError(err)
 
 	currentBob, err = identity.GetUser(ctx, "bob", false)
 	require.NoError(err)
-	require.True(services.UsersEquals(currentBob, bob1))
+	require.True(currentBob.IsEqual(bob1))
 }
 
 func TestWeakestMFADeviceKind(t *testing.T) {

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -24,8 +24,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
@@ -54,17 +52,6 @@ func ValidateUserRoles(ctx context.Context, u types.User, roleGetter RoleGetter)
 		}
 	}
 	return nil
-}
-
-// UsersEquals checks if the users are equal
-func UsersEquals(u types.User, other types.User) bool {
-	return cmp.Equal(u, other,
-		ignoreProtoXXXFields(),
-		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
-		cmpopts.SortSlices(func(a, b *types.MFADevice) bool {
-			return a.Metadata.Name < b.Metadata.Name
-		}),
-	)
 }
 
 // LoginAttempt represents successful or unsuccessful attempt for user to login


### PR DESCRIPTION
`(UserV2) IsEqual` was added with a goderived implementation to remove go-cmp comparisons outside test files. This was not as straightforward as other resources due to a goderive not being able to handle interfaces. Due to the Device oneof in LocalAuth goderive would silently fail with a partially generated equality function for users.

The TeleportEqual derive plugin was updated to ignore the devices field. They are manually validated in `(UserV2) IsEqual` if all other user fields match. `mfaDevicesEqual` manually validates device fields and relies on goderived quality functions for each concrete device type.


## Manual Test Plan

### Test Environment

Deployed this branch to https://timr-test-users2.cloud.gravitational.io. Created and added an Okta integration with User Sync enabled.

### Test Cases

The cases below all exercise the services.GenericReconciler[types.User] used by User Sync. It indirectly exercises `(UserV2) IsEqual` via services.CompareResources.

- [x] Updates to Okta users are reflected in Teleport
- [x] Removal of Okta users are reflected in Teleport
- [x] New Okta users are reflected in Teleport  