### PR TITLE
touchid: add signed helper binary for dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,6 +401,33 @@ $(BUILDDIR)/tsh: rdpdecoder
 	fi
 	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG_TSH) go build -tags "$(FIPS_TAG) $(LIBFIDO2_BUILD_TAG) $(TOUCHID_TAG) $(PIV_BUILD_TAG) $(VNETDAEMON_TAG) $(TSH_RDP_DECODER_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tsh $(BUILDFLAGS) $(TOOLS_LDFLAGS) ./tool/tsh
 
+.PHONY: $(BUILDDIR)/tsh-touchid-helper
+$(BUILDDIR)/tsh-touchid-helper:
+	clang -ObjC -fobjc-arc -mmacosx-version-min=11.0 \
+		-framework CoreFoundation -framework Foundation \
+		-framework LocalAuthentication -framework Security \
+		-o $(BUILDDIR)/tsh-touchid-helper \
+		tool/tsh-touchid-helper/main.m \
+		lib/auth/touchid/register.m \
+		lib/auth/touchid/authenticate.m \
+		lib/auth/touchid/credentials.m \
+		lib/auth/touchid/diag.m \
+		lib/auth/touchid/context.m \
+		lib/auth/touchid/common.m \
+		-Ilib/auth/touchid
+
+.PHONY: sign-tsh-touchid-helper
+sign-tsh-touchid-helper: $(BUILDDIR)/tsh-touchid-helper
+	codesign \
+		--sign '$(DEVELOPER_ID_APPLICATION)' \
+		--identifier "$(TSH_BUNDLEID).helper" \
+		--force \
+		--verbose \
+		--timestamp \
+		--options kill,hard,runtime \
+		--entitlements build.assets/macos/tsh/tsh.entitlements \
+		$(BUILDDIR)/tsh-touchid-helper
+
 .PHONY: $(BUILDDIR)/tbot
 # tbot is CGO-less by default except on Windows because lib/client/terminal/ wants CGO on this OS
 # We force cgo to be disabled, else the compiler might decide to enable it.

--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -175,6 +175,24 @@ func IsAvailable() bool {
 			logger.WarnContext(context.Background(), "self-diagnostics failed", "error", err)
 			return false
 		}
+
+		// If not available due to missing signature/entitlements (typical for
+		// unsigned dev builds), try falling back to a signed helper binary.
+		if !cachedDiag.IsAvailable && !cachedDiag.HasSignature {
+			if helper, helperErr := tryHelperFallback(); helperErr == nil {
+				native = helper
+				cachedDiag, err = native.Diag()
+				if err != nil {
+					logger.WarnContext(context.Background(), "helper diagnostics failed", "error", err)
+					return false
+				}
+				if cachedDiag.IsAvailable {
+					logger.InfoContext(context.Background(), "Touch ID available via helper binary")
+				}
+			} else {
+				logger.DebugContext(context.Background(), "Touch ID helper not available", "error", helperErr)
+			}
+		}
 	}
 
 	return cachedDiag.IsAvailable

--- a/lib/auth/touchid/api_helper.go
+++ b/lib/auth/touchid/api_helper.go
@@ -1,0 +1,343 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package touchid
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const helperBinaryName = "tsh-touchid-helper"
+
+// Compile-time interface checks.
+var _ nativeTID = (*helperNative)(nil)
+var _ AuthContext = (*helperAuthContext)(nil)
+
+// helperNative is a nativeTID implementation that proxies all calls to a helper
+// subprocess via JSON-RPC over stdin/stdout.
+type helperNative struct {
+	mu     sync.Mutex
+	cmd    *exec.Cmd
+	enc    *json.Encoder  // writes to helper's stdin
+	dec    *bufio.Scanner // reads from helper's stdout
+	nextID int
+}
+
+// sendRequest sends a JSON-RPC request to the helper and decodes the response.
+// All calls are serialized via mutex - one at a time.
+func (h *helperNative) sendRequest(method string, params any, result any) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Marshal params to json.RawMessage.
+	var rawParams json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			return fmt.Errorf("helper: marshal params: %w", err)
+		}
+		rawParams = b
+	}
+
+	// Create request with incrementing ID.
+	h.nextID++
+	req := helperRequest{
+		ID:     h.nextID,
+		Method: method,
+		Params: rawParams,
+	}
+
+	// Encode to helper's stdin.
+	if err := h.enc.Encode(req); err != nil {
+		return fmt.Errorf("helper: write request: %w", err)
+	}
+
+	// Read one line from scanner.
+	if !h.dec.Scan() {
+		if err := h.dec.Err(); err != nil {
+			return fmt.Errorf("helper: read response: %w", err)
+		}
+		return fmt.Errorf("helper: process exited unexpectedly")
+	}
+
+	// Decode the response.
+	var resp helperResponse
+	if err := json.Unmarshal(h.dec.Bytes(), &resp); err != nil {
+		return fmt.Errorf("helper: decode response: %w", err)
+	}
+
+	// Check for error field.
+	if resp.Error != "" {
+		return fmt.Errorf("helper: %s", resp.Error)
+	}
+
+	// If result is non-nil, unmarshal response.Result into it.
+	if result != nil && resp.Result != nil {
+		if err := json.Unmarshal(*resp.Result, result); err != nil {
+			return fmt.Errorf("helper: decode result: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// close kills the helper process if it is running.
+func (h *helperNative) close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.cmd != nil && h.cmd.Process != nil {
+		_ = h.cmd.Process.Kill()
+		_ = h.cmd.Wait()
+	}
+}
+
+// Diag implements nativeTID.
+func (h *helperNative) Diag() (*DiagResult, error) {
+	var result diagResult
+	if err := h.sendRequest(helperMethodDiag, nil, &result); err != nil {
+		return nil, err
+	}
+	return &DiagResult{
+		HasCompileSupport:       true, // helper has compile support
+		HasSignature:            result.HasSignature,
+		HasEntitlements:         result.HasEntitlements,
+		PassedLAPolicyTest:      result.PassedLAPolicyTest,
+		PassedSecureEnclaveTest: result.PassedSecureEnclaveTest,
+		IsAvailable:             result.IsAvailable,
+	}, nil
+}
+
+// NewAuthContext implements nativeTID.
+func (h *helperNative) NewAuthContext() AuthContext {
+	var result newAuthContextResult
+	if err := h.sendRequest(helperMethodNewAuthContext, nil, &result); err != nil {
+		// Return a context that will fail on Guard. We cannot return an error
+		// here because the interface does not allow it.
+		return &helperAuthContext{h: h, contextID: -1}
+	}
+	return &helperAuthContext{h: h, contextID: result.ContextID}
+}
+
+// Register implements nativeTID.
+func (h *helperNative) Register(rpID, user string, userHandle []byte) (*CredentialInfo, error) {
+	params := registerParams{
+		RPID:       rpID,
+		User:       user,
+		UserHandle: userHandle,
+	}
+	var result registerResult
+	if err := h.sendRequest(helperMethodRegister, &params, &result); err != nil {
+		return nil, err
+	}
+	return &CredentialInfo{
+		CredentialID: result.CredentialID,
+		publicKeyRaw: result.PubKeyRaw,
+	}, nil
+}
+
+// Authenticate implements nativeTID.
+func (h *helperNative) Authenticate(actx AuthContext, credentialID string, digest []byte) ([]byte, error) {
+	var contextID int
+	if hctx, ok := actx.(*helperAuthContext); ok {
+		contextID = hctx.contextID
+	}
+	params := authenticateParams{
+		ContextID:    contextID,
+		CredentialID: credentialID,
+		Digest:       digest,
+	}
+	var result authenticateResult
+	if err := h.sendRequest(helperMethodAuthenticate, &params, &result); err != nil {
+		return nil, err
+	}
+	return result.Signature, nil
+}
+
+// FindCredentials implements nativeTID.
+func (h *helperNative) FindCredentials(rpID, user string) ([]CredentialInfo, error) {
+	params := findCredentialsParams{
+		RPID: rpID,
+		User: user,
+	}
+	var result findCredentialsResult
+	if err := h.sendRequest(helperMethodFindCredentials, &params, &result); err != nil {
+		return nil, err
+	}
+	return convertCredentialInfos(result.Credentials)
+}
+
+// ListCredentials implements nativeTID.
+func (h *helperNative) ListCredentials() ([]CredentialInfo, error) {
+	var result listCredentialsResult
+	if err := h.sendRequest(helperMethodListCredentials, nil, &result); err != nil {
+		return nil, err
+	}
+	return convertCredentialInfos(result.Credentials)
+}
+
+// DeleteCredential implements nativeTID.
+func (h *helperNative) DeleteCredential(credentialID string) error {
+	params := deleteCredentialParams{
+		CredentialID: credentialID,
+	}
+	return h.sendRequest(helperMethodDeleteCredential, &params, nil)
+}
+
+// DeleteNonInteractive implements nativeTID.
+func (h *helperNative) DeleteNonInteractive(credentialID string) error {
+	params := deleteNonInteractiveParams{
+		CredentialID: credentialID,
+	}
+	return h.sendRequest(helperMethodDeleteNonInteractive, &params, nil)
+}
+
+// convertCredentialInfos converts protocol credentialInfo slices to package
+// CredentialInfo slices, parsing create_time from RFC3339.
+func convertCredentialInfos(creds []credentialInfo) ([]CredentialInfo, error) {
+	infos := make([]CredentialInfo, 0, len(creds))
+	for _, c := range creds {
+		var createTime time.Time
+		if c.CreateTime != "" {
+			var err error
+			createTime, err = time.Parse(time.RFC3339, c.CreateTime)
+			if err != nil {
+				// Best-effort: log but don't fail.
+				logger.WarnContext(context.Background(), "Failed to parse create_time from helper",
+					"create_time", c.CreateTime,
+					"error", err,
+				)
+			}
+		}
+		infos = append(infos, CredentialInfo{
+			CredentialID: c.CredentialID,
+			RPID:         c.RPID,
+			User: UserInfo{
+				UserHandle: c.UserHandle,
+				Name:       c.UserName,
+			},
+			PublicKey:    nil, // Parsed by caller (ListCredentials in api.go).
+			CreateTime:   createTime,
+			publicKeyRaw: c.PubKeyRaw,
+		})
+	}
+	return infos, nil
+}
+
+// helperAuthContext is an AuthContext backed by the helper subprocess.
+type helperAuthContext struct {
+	h         *helperNative
+	contextID int
+}
+
+// Guard implements AuthContext. It sends the AuthContextGuard RPC to the helper.
+// On success (the helper ran the biometric prompt), it runs fn locally.
+func (c *helperAuthContext) Guard(fn func()) error {
+	params := authContextGuardParams{
+		ContextID: c.contextID,
+	}
+	if err := c.h.sendRequest(helperMethodAuthContextGuard, &params, nil); err != nil {
+		return err
+	}
+	// The helper has successfully authenticated the user; run the local callback.
+	fn()
+	return nil
+}
+
+// Close implements AuthContext.
+func (c *helperAuthContext) Close() {
+	params := authContextCloseParams{
+		ContextID: c.contextID,
+	}
+	// Best-effort: ignore errors on close.
+	_ = c.h.sendRequest(helperMethodAuthContextClose, &params, nil)
+}
+
+// findHelperBinary searches for the helper binary in the following order:
+// 1. Same directory as os.Executable()
+// 2. exec.LookPath
+// 3. ~/.tsh/bin/
+func findHelperBinary() (string, error) {
+	// 1. Same directory as the current executable.
+	if exe, err := os.Executable(); err == nil {
+		candidate := filepath.Join(filepath.Dir(exe), helperBinaryName)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	// 2. PATH lookup.
+	if p, err := exec.LookPath(helperBinaryName); err == nil {
+		return p, nil
+	}
+
+	// 3. ~/.tsh/bin/
+	if home, err := os.UserHomeDir(); err == nil {
+		candidate := filepath.Join(home, ".tsh", "bin", helperBinaryName)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("%s: not found", helperBinaryName)
+}
+
+// tryHelperFallback attempts to find and spawn the helper binary.
+// It returns a helperNative ready for use, or an error if the helper cannot be
+// found or started. The caller is responsible for sending the initial Diag RPC.
+func tryHelperFallback() (*helperNative, error) {
+	binPath, err := findHelperBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command(binPath)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("helper: create stdin pipe: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("helper: create stdout pipe: %w", err)
+	}
+
+	// Forward helper's stderr to our stderr so diagnostics are visible.
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("helper: start process: %w", err)
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	// Increase scanner buffer for potentially large responses.
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	return &helperNative{
+		cmd:  cmd,
+		enc:  json.NewEncoder(stdin),
+		dec:  scanner,
+	}, nil
+}

--- a/lib/auth/touchid/api_helper_test.go
+++ b/lib/auth/touchid/api_helper_test.go
@@ -1,0 +1,460 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package touchid
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestHelperNative creates a helperNative wired to a mock helper goroutine.
+// The mock reads JSON-RPC requests and dispatches to the provided handler map.
+// Unrecognized methods return an error response.
+func newTestHelperNative(t *testing.T, handlers map[string]func(json.RawMessage) (any, error)) *helperNative {
+	t.Helper()
+
+	// clientReader reads responses from mock helper.
+	// mockWriter is where the mock writes responses.
+	clientReader, mockWriter := io.Pipe()
+
+	// mockReader reads requests from client.
+	// clientWriter is where the client writes requests.
+	mockReader, clientWriter := io.Pipe()
+
+	// Start mock helper goroutine.
+	go func() {
+		defer mockWriter.Close()
+
+		scanner := bufio.NewScanner(mockReader)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+		enc := json.NewEncoder(mockWriter)
+
+		for scanner.Scan() {
+			var req helperRequest
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				resp := helperResponse{
+					Error: fmt.Sprintf("mock: unmarshal request: %v", err),
+				}
+				_ = enc.Encode(resp)
+				continue
+			}
+
+			handler, ok := handlers[req.Method]
+			if !ok {
+				resp := helperResponse{
+					ID:    req.ID,
+					Error: fmt.Sprintf("mock: unknown method %q", req.Method),
+				}
+				_ = enc.Encode(resp)
+				continue
+			}
+
+			result, err := handler(req.Params)
+			if err != nil {
+				resp := helperResponse{
+					ID:    req.ID,
+					Error: err.Error(),
+				}
+				_ = enc.Encode(resp)
+				continue
+			}
+
+			var rawResult *json.RawMessage
+			if result != nil {
+				b, marshalErr := json.Marshal(result)
+				if marshalErr != nil {
+					resp := helperResponse{
+						ID:    req.ID,
+						Error: fmt.Sprintf("mock: marshal result: %v", marshalErr),
+					}
+					_ = enc.Encode(resp)
+					continue
+				}
+				rm := json.RawMessage(b)
+				rawResult = &rm
+			}
+
+			resp := helperResponse{
+				ID:     req.ID,
+				Result: rawResult,
+			}
+			_ = enc.Encode(resp)
+		}
+	}()
+
+	t.Cleanup(func() {
+		clientWriter.Close()
+	})
+
+	scanner := bufio.NewScanner(clientReader)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	return &helperNative{
+		enc: json.NewEncoder(clientWriter),
+		dec: scanner,
+	}
+}
+
+func TestHelperNativeDiag(t *testing.T) {
+	wantDiag := diagResult{
+		HasSignature:            true,
+		HasEntitlements:         true,
+		PassedLAPolicyTest:      true,
+		PassedSecureEnclaveTest: true,
+		IsAvailable:             true,
+	}
+
+	handlers := map[string]func(json.RawMessage) (any, error){
+		helperMethodDiag: func(_ json.RawMessage) (any, error) {
+			return &wantDiag, nil
+		},
+	}
+
+	h := newTestHelperNative(t, handlers)
+
+	got, err := h.Diag()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	// helperNative.Diag() always sets HasCompileSupport to true.
+	assert.True(t, got.HasCompileSupport, "HasCompileSupport should be true")
+	assert.Equal(t, wantDiag.HasSignature, got.HasSignature, "HasSignature mismatch")
+	assert.Equal(t, wantDiag.HasEntitlements, got.HasEntitlements, "HasEntitlements mismatch")
+	assert.Equal(t, wantDiag.PassedLAPolicyTest, got.PassedLAPolicyTest, "PassedLAPolicyTest mismatch")
+	assert.Equal(t, wantDiag.PassedSecureEnclaveTest, got.PassedSecureEnclaveTest, "PassedSecureEnclaveTest mismatch")
+	assert.Equal(t, wantDiag.IsAvailable, got.IsAvailable, "IsAvailable mismatch")
+}
+
+func TestHelperNativeRegister(t *testing.T) {
+	const (
+		wantCredID = "cred-abc-123"
+		wantRPID   = "example.com"
+		wantUser   = "llama"
+	)
+	wantUserHandle := []byte{1, 2, 3, 4, 5}
+	wantPubKeyRaw := []byte{0x04, 0xAA, 0xBB, 0xCC, 0xDD}
+
+	handlers := map[string]func(json.RawMessage) (any, error){
+		helperMethodRegister: func(raw json.RawMessage) (any, error) {
+			var params registerParams
+			if err := json.Unmarshal(raw, &params); err != nil {
+				return nil, fmt.Errorf("unmarshal params: %w", err)
+			}
+
+			// Verify the client sent the correct parameters.
+			assert.Equal(t, wantRPID, params.RPID, "register RPID mismatch")
+			assert.Equal(t, wantUser, params.User, "register User mismatch")
+			assert.Equal(t, wantUserHandle, params.UserHandle, "register UserHandle mismatch")
+
+			return &registerResult{
+				CredentialID: wantCredID,
+				PubKeyRaw:    wantPubKeyRaw,
+			}, nil
+		},
+	}
+
+	h := newTestHelperNative(t, handlers)
+
+	got, err := h.Register(wantRPID, wantUser, wantUserHandle)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, wantCredID, got.CredentialID, "CredentialID mismatch")
+	assert.Equal(t, wantPubKeyRaw, got.publicKeyRaw, "publicKeyRaw mismatch")
+}
+
+func TestHelperNativeAuthenticate(t *testing.T) {
+	const (
+		wantContextID    = 42
+		wantCredentialID = "cred-auth-456"
+	)
+	wantDigest := []byte("sha256-digest-here")
+	wantSignature := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+
+	handlers := map[string]func(json.RawMessage) (any, error){
+		helperMethodAuthenticate: func(raw json.RawMessage) (any, error) {
+			var params authenticateParams
+			if err := json.Unmarshal(raw, &params); err != nil {
+				return nil, fmt.Errorf("unmarshal params: %w", err)
+			}
+
+			assert.Equal(t, wantContextID, params.ContextID, "authenticate ContextID mismatch")
+			assert.Equal(t, wantCredentialID, params.CredentialID, "authenticate CredentialID mismatch")
+			assert.Equal(t, wantDigest, params.Digest, "authenticate Digest mismatch")
+
+			return &authenticateResult{
+				Signature: wantSignature,
+			}, nil
+		},
+	}
+
+	h := newTestHelperNative(t, handlers)
+
+	actx := &helperAuthContext{h: h, contextID: wantContextID}
+	sig, err := h.Authenticate(actx, wantCredentialID, wantDigest)
+	require.NoError(t, err)
+	assert.Equal(t, wantSignature, sig, "signature mismatch")
+}
+
+func TestHelperNativeFindCredentials(t *testing.T) {
+	createTime1 := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	createTime2 := time.Date(2024, 6, 20, 14, 0, 0, 0, time.UTC)
+
+	wantCreds := []credentialInfo{
+		{
+			CredentialID: "cred-1",
+			RPID:         "example.com",
+			UserName:     "llama",
+			UserHandle:   []byte{1, 2, 3},
+			PubKeyRaw:    []byte{0x04, 0xAA},
+			CreateTime:   createTime1.Format(time.RFC3339),
+		},
+		{
+			CredentialID: "cred-2",
+			RPID:         "example.com",
+			UserName:     "alpaca",
+			UserHandle:   []byte{4, 5, 6},
+			PubKeyRaw:    []byte{0x04, 0xBB},
+			CreateTime:   createTime2.Format(time.RFC3339),
+		},
+	}
+
+	handlers := map[string]func(json.RawMessage) (any, error){
+		helperMethodFindCredentials: func(raw json.RawMessage) (any, error) {
+			var params findCredentialsParams
+			if err := json.Unmarshal(raw, &params); err != nil {
+				return nil, fmt.Errorf("unmarshal params: %w", err)
+			}
+
+			assert.Equal(t, "example.com", params.RPID, "FindCredentials RPID mismatch")
+			assert.Equal(t, "llama", params.User, "FindCredentials User mismatch")
+
+			return &findCredentialsResult{
+				Credentials: wantCreds,
+			}, nil
+		},
+	}
+
+	h := newTestHelperNative(t, handlers)
+
+	got, err := h.FindCredentials("example.com", "llama")
+	require.NoError(t, err)
+	require.Len(t, got, 2, "expected 2 credentials")
+
+	// Verify first credential.
+	assert.Equal(t, "cred-1", got[0].CredentialID, "cred[0] CredentialID mismatch")
+	assert.Equal(t, "example.com", got[0].RPID, "cred[0] RPID mismatch")
+	assert.Equal(t, "llama", got[0].User.Name, "cred[0] User.Name mismatch")
+	assert.Equal(t, []byte{1, 2, 3}, got[0].User.UserHandle, "cred[0] User.UserHandle mismatch")
+	assert.Equal(t, []byte{0x04, 0xAA}, got[0].publicKeyRaw, "cred[0] publicKeyRaw mismatch")
+	assert.True(t, createTime1.Equal(got[0].CreateTime), "cred[0] CreateTime mismatch: got %v, want %v", got[0].CreateTime, createTime1)
+
+	// Verify second credential.
+	assert.Equal(t, "cred-2", got[1].CredentialID, "cred[1] CredentialID mismatch")
+	assert.Equal(t, "example.com", got[1].RPID, "cred[1] RPID mismatch")
+	assert.Equal(t, "alpaca", got[1].User.Name, "cred[1] User.Name mismatch")
+	assert.Equal(t, []byte{4, 5, 6}, got[1].User.UserHandle, "cred[1] User.UserHandle mismatch")
+	assert.Equal(t, []byte{0x04, 0xBB}, got[1].publicKeyRaw, "cred[1] publicKeyRaw mismatch")
+	assert.True(t, createTime2.Equal(got[1].CreateTime), "cred[1] CreateTime mismatch: got %v, want %v", got[1].CreateTime, createTime2)
+}
+
+func TestHelperNativeDeleteCredential(t *testing.T) {
+	const targetCredID = "cred-to-delete"
+
+	handlers := map[string]func(json.RawMessage) (any, error){
+		helperMethodDeleteCredential: func(raw json.RawMessage) (any, error) {
+			var params deleteCredentialParams
+			if err := json.Unmarshal(raw, &params); err != nil {
+				return nil, fmt.Errorf("unmarshal params: %w", err)
+			}
+
+			assert.Equal(t, targetCredID, params.CredentialID, "DeleteCredential CredentialID mismatch")
+			return nil, nil
+		},
+	}
+
+	h := newTestHelperNative(t, handlers)
+
+	err := h.DeleteCredential(targetCredID)
+	assert.NoError(t, err)
+}
+
+func TestHelperNativeError(t *testing.T) {
+	const errorMsg = "secure enclave not available"
+
+	handlers := map[string]func(json.RawMessage) (any, error){
+		helperMethodDiag: func(_ json.RawMessage) (any, error) {
+			return nil, fmt.Errorf("%s", errorMsg)
+		},
+	}
+
+	h := newTestHelperNative(t, handlers)
+
+	_, err := h.Diag()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), errorMsg, "error message should contain the helper error")
+	// The error should be wrapped with "helper:" prefix.
+	assert.Contains(t, err.Error(), "helper:", "error should have helper prefix")
+}
+
+func TestHelperNativeErrorUnknownMethod(t *testing.T) {
+	// An empty handler map means all methods are unknown.
+	handlers := map[string]func(json.RawMessage) (any, error){}
+
+	h := newTestHelperNative(t, handlers)
+
+	_, err := h.Diag()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown method", "error should indicate unknown method")
+}
+
+func TestHelperNativeAuthContext(t *testing.T) {
+	const wantContextID = 7
+
+	var (
+		guardCalled bool
+		closeCalled bool
+	)
+
+	handlers := map[string]func(json.RawMessage) (any, error){
+		helperMethodNewAuthContext: func(_ json.RawMessage) (any, error) {
+			return &newAuthContextResult{
+				ContextID: wantContextID,
+			}, nil
+		},
+		helperMethodAuthContextGuard: func(raw json.RawMessage) (any, error) {
+			var params authContextGuardParams
+			if err := json.Unmarshal(raw, &params); err != nil {
+				return nil, fmt.Errorf("unmarshal params: %w", err)
+			}
+			assert.Equal(t, wantContextID, params.ContextID, "Guard ContextID mismatch")
+			guardCalled = true
+			return nil, nil
+		},
+		helperMethodAuthContextClose: func(raw json.RawMessage) (any, error) {
+			var params authContextCloseParams
+			if err := json.Unmarshal(raw, &params); err != nil {
+				return nil, fmt.Errorf("unmarshal params: %w", err)
+			}
+			assert.Equal(t, wantContextID, params.ContextID, "Close ContextID mismatch")
+			closeCalled = true
+			return nil, nil
+		},
+	}
+
+	h := newTestHelperNative(t, handlers)
+
+	// Step 1: NewAuthContext should return a helperAuthContext with the right ID.
+	actx := h.NewAuthContext()
+	require.NotNil(t, actx)
+
+	hctx, ok := actx.(*helperAuthContext)
+	require.True(t, ok, "NewAuthContext should return *helperAuthContext")
+	assert.Equal(t, wantContextID, hctx.contextID, "contextID mismatch")
+
+	// Step 2: Guard should send AuthContextGuard RPC and call the callback on success.
+	var callbackRan bool
+	err := actx.Guard(func() {
+		callbackRan = true
+	})
+	require.NoError(t, err)
+	assert.True(t, guardCalled, "Guard RPC was not called")
+	assert.True(t, callbackRan, "Guard callback was not called")
+
+	// Step 3: Close should send AuthContextClose RPC.
+	actx.Close()
+	assert.True(t, closeCalled, "Close RPC was not called")
+}
+
+func TestHelperNativeAuthContextGuardError(t *testing.T) {
+	const wantContextID = 9
+	const guardError = "biometric authentication failed"
+
+	handlers := map[string]func(json.RawMessage) (any, error){
+		helperMethodNewAuthContext: func(_ json.RawMessage) (any, error) {
+			return &newAuthContextResult{
+				ContextID: wantContextID,
+			}, nil
+		},
+		helperMethodAuthContextGuard: func(_ json.RawMessage) (any, error) {
+			return nil, fmt.Errorf("%s", guardError)
+		},
+		helperMethodAuthContextClose: func(_ json.RawMessage) (any, error) {
+			return nil, nil
+		},
+	}
+
+	h := newTestHelperNative(t, handlers)
+
+	actx := h.NewAuthContext()
+	require.NotNil(t, actx)
+
+	// Guard should propagate the error and NOT call the callback.
+	var callbackRan bool
+	err := actx.Guard(func() {
+		callbackRan = true
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), guardError, "Guard error should contain helper error message")
+	assert.False(t, callbackRan, "Guard callback should not be called on error")
+
+	// Close should still work.
+	actx.Close()
+}
+
+func TestHelperNativeMultipleRequests(t *testing.T) {
+	// Verify that multiple sequential requests work correctly with
+	// incrementing IDs.
+	diagCount := 0
+
+	handlers := map[string]func(json.RawMessage) (any, error){
+		helperMethodDiag: func(_ json.RawMessage) (any, error) {
+			diagCount++
+			return &diagResult{
+				IsAvailable: true,
+			}, nil
+		},
+		helperMethodDeleteCredential: func(raw json.RawMessage) (any, error) {
+			var params deleteCredentialParams
+			if err := json.Unmarshal(raw, &params); err != nil {
+				return nil, fmt.Errorf("unmarshal params: %w", err)
+			}
+			return nil, nil
+		},
+	}
+
+	h := newTestHelperNative(t, handlers)
+
+	// Send multiple requests of different types.
+	_, err := h.Diag()
+	require.NoError(t, err, "first Diag call failed")
+
+	err = h.DeleteCredential("cred-1")
+	require.NoError(t, err, "DeleteCredential call failed")
+
+	_, err = h.Diag()
+	require.NoError(t, err, "second Diag call failed")
+
+	assert.Equal(t, 2, diagCount, "Diag should have been called twice")
+}

--- a/lib/auth/touchid/helper_protocol.go
+++ b/lib/auth/touchid/helper_protocol.go
@@ -1,0 +1,136 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package touchid
+
+import "encoding/json"
+
+// Method name constants for the helper JSON-RPC protocol.
+const (
+	helperMethodDiag             = "Diag"
+	helperMethodRegister         = "Register"
+	helperMethodAuthenticate     = "Authenticate"
+	helperMethodFindCredentials  = "FindCredentials"
+	helperMethodListCredentials  = "ListCredentials"
+	helperMethodDeleteCredential = "DeleteCredential"
+	helperMethodDeleteNonInteractive = "DeleteNonInteractive"
+	helperMethodNewAuthContext   = "NewAuthContext"
+	helperMethodAuthContextGuard = "AuthContextGuard"
+	helperMethodAuthContextClose = "AuthContextClose"
+)
+
+// helperRequest is the JSON-RPC request envelope sent from tsh to the helper.
+// Encoded as line-delimited JSON over stdin.
+type helperRequest struct {
+	ID     int             `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+// helperResponse is the JSON-RPC response envelope sent from the helper to tsh.
+// Encoded as line-delimited JSON over stdout.
+type helperResponse struct {
+	ID     int              `json:"id"`
+	Result *json.RawMessage `json:"result,omitempty"`
+	Error  string           `json:"error,omitempty"`
+}
+
+// diagResult is the protocol representation of DiagResult.
+type diagResult struct {
+	HasSignature            bool `json:"has_signature"`
+	HasEntitlements         bool `json:"has_entitlements"`
+	PassedLAPolicyTest      bool `json:"passed_la_policy_test"`
+	PassedSecureEnclaveTest bool `json:"passed_secure_enclave_test"`
+	IsAvailable             bool `json:"is_available"`
+}
+
+// registerParams are the parameters for the Register method.
+type registerParams struct {
+	RPID       string `json:"rpid"`
+	User       string `json:"user"`
+	UserHandle []byte `json:"user_handle"`
+}
+
+// registerResult is the result of the Register method.
+type registerResult struct {
+	CredentialID string `json:"credential_id"`
+	PubKeyRaw    []byte `json:"pub_key_raw"`
+}
+
+// authenticateParams are the parameters for the Authenticate method.
+type authenticateParams struct {
+	ContextID    int    `json:"context_id"`
+	CredentialID string `json:"credential_id"`
+	Digest       []byte `json:"digest"`
+}
+
+// authenticateResult is the result of the Authenticate method.
+type authenticateResult struct {
+	Signature []byte `json:"signature"`
+}
+
+// findCredentialsParams are the parameters for the FindCredentials method.
+type findCredentialsParams struct {
+	RPID string `json:"rpid"`
+	User string `json:"user"`
+}
+
+// credentialInfo is the protocol representation of CredentialInfo.
+// Binary fields (user_handle, pub_key_raw) are base64-encoded by
+// encoding/json automatically since they are []byte.
+type credentialInfo struct {
+	CredentialID string `json:"credential_id"`
+	RPID         string `json:"rpid"`
+	UserName     string `json:"user_name"`
+	UserHandle   []byte `json:"user_handle"`
+	PubKeyRaw    []byte `json:"pub_key_raw"`
+	CreateTime   string `json:"create_time"`
+}
+
+// findCredentialsResult is the result of the FindCredentials method.
+type findCredentialsResult struct {
+	Credentials []credentialInfo `json:"credentials"`
+}
+
+// listCredentialsResult is the result of the ListCredentials method.
+type listCredentialsResult struct {
+	Credentials []credentialInfo `json:"credentials"`
+}
+
+// deleteCredentialParams are the parameters for the DeleteCredential method.
+type deleteCredentialParams struct {
+	CredentialID string `json:"credential_id"`
+}
+
+// deleteNonInteractiveParams are the parameters for the DeleteNonInteractive method.
+type deleteNonInteractiveParams struct {
+	CredentialID string `json:"credential_id"`
+}
+
+// newAuthContextResult is the result of the NewAuthContext method.
+type newAuthContextResult struct {
+	ContextID int `json:"context_id"`
+}
+
+// authContextGuardParams are the parameters for the AuthContextGuard method.
+type authContextGuardParams struct {
+	ContextID int `json:"context_id"`
+}
+
+// authContextCloseParams are the parameters for the AuthContextClose method.
+type authContextCloseParams struct {
+	ContextID int `json:"context_id"`
+}

--- a/tool/tsh-touchid-helper/main.m
+++ b/tool/tsh-touchid-helper/main.m
@@ -1,0 +1,517 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// tsh-touchid-helper is a signed helper binary that provides Touch ID
+// operations (Secure Enclave, Keychain) over a JSON-RPC protocol on
+// stdin/stdout. It is used by unsigned dev builds of tsh to access
+// Touch ID functionality.
+
+#import <Foundation/Foundation.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "authenticate.h"
+#include "context.h"
+#include "credential_info.h"
+#include "credentials.h"
+#include "diag.h"
+#include "register.h"
+
+// runGoFuncHandle is declared extern in context.m (normally provided by CGO).
+// In the helper binary, AuthContextGuard calls this after a successful biometric
+// prompt. We provide a no-op since the actual callback runs on the tsh side.
+void runGoFuncHandle(uintptr_t handle) {
+  (void)handle;
+}
+
+static const char *kPromptReason = "authenticate user";
+
+// Auth context storage.
+static NSMutableDictionary<NSNumber *, NSValue *> *authContexts;
+static int nextContextID = 0;
+
+#pragma mark - JSON Helpers
+
+static NSDictionary *errorResponse(int reqID, NSString *msg) {
+  return @{@"id" : @(reqID), @"error" : msg};
+}
+
+static NSDictionary *resultResponse(int reqID, NSDictionary *result) {
+  return @{@"id" : @(reqID), @"result" : result};
+}
+
+static NSDictionary *emptyResultResponse(int reqID) {
+  return @{@"id" : @(reqID), @"result" : @{}};
+}
+
+#pragma mark - Credential Info Conversion
+
+// Convert a C CredentialInfo to a JSON-compatible dictionary.
+// Frees the C strings in the CredentialInfo.
+static NSDictionary *credentialInfoToDict(CredentialInfo *info) {
+  NSString *credID =
+      info->app_label ? [NSString stringWithUTF8String:info->app_label] : @"";
+  NSString *label =
+      info->label ? [NSString stringWithUTF8String:info->label] : @"";
+  NSString *appTag =
+      info->app_tag ? [NSString stringWithUTF8String:info->app_tag] : @"";
+  NSString *pubKeyB64 =
+      info->pub_key_b64 ? [NSString stringWithUTF8String:info->pub_key_b64]
+                        : @"";
+  NSString *createDate =
+      info->creation_date ? [NSString stringWithUTF8String:info->creation_date]
+                          : @"";
+
+  // Parse label to extract RPID and username.
+  // Label format: "t01/{rpid} {user}"
+  NSString *rpid = @"";
+  NSString *userName = @"";
+  NSString *prefix = @"t01/";
+  if ([label hasPrefix:prefix]) {
+    NSString *rest = [label substringFromIndex:prefix.length];
+    NSRange spaceRange = [rest rangeOfString:@" "];
+    if (spaceRange.location != NSNotFound) {
+      rpid = [rest substringToIndex:spaceRange.location];
+      userName = [rest substringFromIndex:spaceRange.location + 1];
+    }
+  }
+
+  // Encode user_handle (appTag is already base64url-encoded, convert to
+  // standard base64 for JSON).
+  NSData *userHandleData =
+      [[NSData alloc] initWithBase64EncodedString:appTag options:0];
+  NSString *userHandleB64 =
+      userHandleData
+          ? [userHandleData base64EncodedStringWithOptions:0]
+          : @"";
+
+  // pub_key_b64 is already standard base64.
+
+  // Free C strings.
+  free((void *)info->label);
+  free((void *)info->app_label);
+  free((void *)info->app_tag);
+  free((void *)info->pub_key_b64);
+  free((void *)info->creation_date);
+
+  return @{
+    @"credential_id" : credID,
+    @"rpid" : rpid,
+    @"user_name" : userName,
+    @"user_handle" : userHandleB64,
+    @"pub_key_raw" : pubKeyB64,
+    @"create_time" : createDate,
+  };
+}
+
+#pragma mark - Handlers
+
+static NSDictionary *handleDiag(int reqID) {
+  DiagResult diag = {0};
+  RunDiag(&diag);
+
+  BOOL isAvailable = diag.has_signature && diag.has_entitlements &&
+                     diag.passed_la_policy_test &&
+                     diag.passed_secure_enclave_test;
+  NSDictionary *result = @{
+    @"has_signature" : @(diag.has_signature),
+    @"has_entitlements" : @(diag.has_entitlements),
+    @"passed_la_policy_test" : @(diag.passed_la_policy_test),
+    @"passed_secure_enclave_test" : @(diag.passed_secure_enclave_test),
+    @"is_available" : @(isAvailable),
+  };
+
+  free((void *)diag.la_error_domain);
+  free((void *)diag.la_error_description);
+
+  return resultResponse(reqID, result);
+}
+
+static NSDictionary *handleRegister(int reqID, NSDictionary *params) {
+  NSString *rpid = params[@"rpid"];
+  NSString *user = params[@"user"];
+  NSString *userHandleB64 = params[@"user_handle"];
+
+  if (!rpid || !user || !userHandleB64) {
+    return errorResponse(reqID, @"missing required params: rpid, user, "
+                                @"user_handle");
+  }
+
+  // Generate a credential ID (UUID).
+  NSString *credentialID =
+      [[NSUUID UUID] UUIDString].lowercaseString;
+
+  // Decode user_handle from base64.
+  NSData *userHandleData =
+      [[NSData alloc] initWithBase64EncodedString:userHandleB64 options:0];
+  if (!userHandleData) {
+    userHandleData = [NSData data];
+  }
+
+  // Re-encode as base64url (no padding) for the app_tag, matching Go's
+  // base64.RawURLEncoding.
+  NSString *userHandleB64URL =
+      [[userHandleData base64EncodedStringWithOptions:0]
+          stringByReplacingOccurrencesOfString:@"+"
+                                   withString:@"-"];
+  userHandleB64URL = [userHandleB64URL
+      stringByReplacingOccurrencesOfString:@"/"
+                                withString:@"_"];
+  // Remove padding.
+  userHandleB64URL = [userHandleB64URL
+      stringByReplacingOccurrencesOfString:@"="
+                                withString:@""];
+
+  // Build label: "t01/{rpid} {user}"
+  NSString *label =
+      [NSString stringWithFormat:@"t01/%@ %@", rpid, user];
+
+  CredentialInfo req = {0};
+  req.label = [label UTF8String];
+  req.app_label = [credentialID UTF8String];
+  req.app_tag = [userHandleB64URL UTF8String];
+
+  char *pubKeyB64 = NULL;
+  char *errMsg = NULL;
+  int res = Register(req, &pubKeyB64, &errMsg);
+  if (res != 0) {
+    NSString *err = errMsg ? [NSString stringWithUTF8String:errMsg]
+                           : @"register failed";
+    free(errMsg);
+    return errorResponse(reqID, err);
+  }
+
+  // Decode the base64 public key and re-encode for JSON transport.
+  NSString *pubKeyB64Str =
+      pubKeyB64 ? [NSString stringWithUTF8String:pubKeyB64] : @"";
+  free(pubKeyB64);
+
+  return resultResponse(reqID, @{
+    @"credential_id" : credentialID,
+    @"pub_key_raw" : pubKeyB64Str,
+  });
+}
+
+static NSDictionary *handleAuthenticate(int reqID, NSDictionary *params) {
+  NSNumber *contextIDNum = params[@"context_id"];
+  NSString *credentialID = params[@"credential_id"];
+  NSString *digestB64 = params[@"digest"];
+
+  if (!credentialID || !digestB64) {
+    return errorResponse(reqID,
+                         @"missing required params: credential_id, digest");
+  }
+
+  // Look up auth context.
+  AuthContext *actx = NULL;
+  if (contextIDNum && [contextIDNum intValue] != 0) {
+    NSValue *val = authContexts[contextIDNum];
+    if (val) {
+      actx = [val pointerValue];
+    } else {
+      return errorResponse(
+          reqID, [NSString stringWithFormat:@"auth context %@ not found",
+                                           contextIDNum]);
+    }
+  }
+
+  // Decode digest from base64.
+  NSData *digestData =
+      [[NSData alloc] initWithBase64EncodedString:digestB64 options:0];
+  if (!digestData) {
+    return errorResponse(reqID, @"invalid base64 digest");
+  }
+
+  AuthenticateRequest authReq = {0};
+  authReq.app_label = [credentialID UTF8String];
+  authReq.digest = (const char *)[digestData bytes];
+  authReq.digest_len = [digestData length];
+
+  char *sigB64 = NULL;
+  char *errMsg = NULL;
+  int res = Authenticate(actx, authReq, &sigB64, &errMsg);
+  if (res != 0) {
+    NSString *err = errMsg ? [NSString stringWithUTF8String:errMsg]
+                           : @"authenticate failed";
+    free(errMsg);
+    return errorResponse(reqID, err);
+  }
+
+  NSString *sigB64Str =
+      sigB64 ? [NSString stringWithUTF8String:sigB64] : @"";
+  free(sigB64);
+
+  return resultResponse(reqID, @{@"signature" : sigB64Str});
+}
+
+static NSDictionary *handleFindCredentials(int reqID, NSDictionary *params) {
+  NSString *rpid = params[@"rpid"];
+  NSString *user = params[@"user"];
+
+  if (!rpid) {
+    return errorResponse(reqID, @"missing required param: rpid");
+  }
+
+  // Build label filter.
+  NSString *label;
+  LabelFilter filter = {0};
+  if (user && user.length > 0) {
+    label = [NSString stringWithFormat:@"t01/%@ %@", rpid, user];
+    filter.kind = LABEL_EXACT;
+  } else {
+    label = [NSString stringWithFormat:@"t01/%@ ", rpid];
+    filter.kind = LABEL_PREFIX;
+  }
+  filter.value = [label UTF8String];
+
+  CredentialInfo *infos = NULL;
+  int count = FindCredentials(filter, &infos);
+  if (count < 0) {
+    free(infos);
+    return errorResponse(
+        reqID,
+        [NSString stringWithFormat:@"find credentials failed: status %d",
+                                   count]);
+  }
+
+  NSMutableArray *creds = [NSMutableArray arrayWithCapacity:count];
+  for (int i = 0; i < count; i++) {
+    [creds addObject:credentialInfoToDict(&infos[i])];
+  }
+  free(infos);
+
+  return resultResponse(reqID, @{@"credentials" : creds});
+}
+
+static NSDictionary *handleListCredentials(int reqID) {
+  CredentialInfo *infos = NULL;
+  char *errMsg = NULL;
+  int count = ListCredentials(kPromptReason, &infos, &errMsg);
+  if (count < 0) {
+    NSString *err = errMsg ? [NSString stringWithUTF8String:errMsg]
+                           : @"list credentials failed";
+    free(errMsg);
+    free(infos);
+    return errorResponse(reqID, err);
+  }
+
+  NSMutableArray *creds = [NSMutableArray arrayWithCapacity:count];
+  for (int i = 0; i < count; i++) {
+    [creds addObject:credentialInfoToDict(&infos[i])];
+  }
+  free(infos);
+
+  return resultResponse(reqID, @{@"credentials" : creds});
+}
+
+static NSDictionary *handleDeleteCredential(int reqID, NSDictionary *params) {
+  NSString *credentialID = params[@"credential_id"];
+  if (!credentialID) {
+    return errorResponse(reqID, @"missing required param: credential_id");
+  }
+
+  char *errMsg = NULL;
+  int res =
+      DeleteCredential(kPromptReason, [credentialID UTF8String], &errMsg);
+  if (res != 0) {
+    NSString *err = errMsg ? [NSString stringWithUTF8String:errMsg]
+                           : @"delete credential failed";
+    free(errMsg);
+    return errorResponse(reqID, err);
+  }
+
+  return emptyResultResponse(reqID);
+}
+
+static NSDictionary *handleDeleteNonInteractive(int reqID,
+                                                NSDictionary *params) {
+  NSString *credentialID = params[@"credential_id"];
+  if (!credentialID) {
+    return errorResponse(reqID, @"missing required param: credential_id");
+  }
+
+  int res = DeleteNonInteractive([credentialID UTF8String]);
+  if (res != 0) {
+    return errorResponse(
+        reqID,
+        [NSString
+            stringWithFormat:@"non-interactive delete failed: status %d", res]);
+  }
+
+  return emptyResultResponse(reqID);
+}
+
+static NSDictionary *handleNewAuthContext(int reqID) {
+  AuthContext *actx = calloc(1, sizeof(AuthContext));
+
+  nextContextID++;
+  NSNumber *key = @(nextContextID);
+  authContexts[key] = [NSValue valueWithPointer:actx];
+
+  return resultResponse(reqID, @{@"context_id" : key});
+}
+
+static NSDictionary *handleAuthContextGuard(int reqID, NSDictionary *params) {
+  NSNumber *contextIDNum = params[@"context_id"];
+  if (!contextIDNum) {
+    return errorResponse(reqID, @"missing required param: context_id");
+  }
+
+  NSValue *val = authContexts[contextIDNum];
+  if (!val) {
+    return errorResponse(
+        reqID, [NSString stringWithFormat:@"auth context %@ not found",
+                                         contextIDNum]);
+  }
+
+  AuthContext *actx = [val pointerValue];
+  char *errMsg = NULL;
+  int res = AuthContextGuard(actx, kPromptReason, 0 /* handle */, &errMsg);
+  if (res != 0) {
+    NSString *err = errMsg ? [NSString stringWithUTF8String:errMsg]
+                           : @"auth context guard failed";
+    free(errMsg);
+    return errorResponse(reqID, err);
+  }
+
+  return emptyResultResponse(reqID);
+}
+
+static NSDictionary *handleAuthContextClose(int reqID, NSDictionary *params) {
+  NSNumber *contextIDNum = params[@"context_id"];
+  if (!contextIDNum) {
+    return errorResponse(reqID, @"missing required param: context_id");
+  }
+
+  NSValue *val = authContexts[contextIDNum];
+  if (!val) {
+    return errorResponse(
+        reqID, [NSString stringWithFormat:@"auth context %@ not found",
+                                         contextIDNum]);
+  }
+
+  AuthContext *actx = [val pointerValue];
+  AuthContextClose(actx);
+  free(actx);
+  [authContexts removeObjectForKey:contextIDNum];
+
+  return emptyResultResponse(reqID);
+}
+
+#pragma mark - Dispatch
+
+static NSDictionary *dispatch(int reqID, NSString *method,
+                              NSDictionary *params) {
+  if ([method isEqualToString:@"Diag"]) {
+    return handleDiag(reqID);
+  } else if ([method isEqualToString:@"Register"]) {
+    return handleRegister(reqID, params);
+  } else if ([method isEqualToString:@"Authenticate"]) {
+    return handleAuthenticate(reqID, params);
+  } else if ([method isEqualToString:@"FindCredentials"]) {
+    return handleFindCredentials(reqID, params);
+  } else if ([method isEqualToString:@"ListCredentials"]) {
+    return handleListCredentials(reqID);
+  } else if ([method isEqualToString:@"DeleteCredential"]) {
+    return handleDeleteCredential(reqID, params);
+  } else if ([method isEqualToString:@"DeleteNonInteractive"]) {
+    return handleDeleteNonInteractive(reqID, params);
+  } else if ([method isEqualToString:@"NewAuthContext"]) {
+    return handleNewAuthContext(reqID);
+  } else if ([method isEqualToString:@"AuthContextGuard"]) {
+    return handleAuthContextGuard(reqID, params);
+  } else if ([method isEqualToString:@"AuthContextClose"]) {
+    return handleAuthContextClose(reqID, params);
+  }
+
+  return errorResponse(
+      reqID, [NSString stringWithFormat:@"unknown method: %@", method]);
+}
+
+#pragma mark - Main
+
+int main(int argc, const char *argv[]) {
+  @autoreleasepool {
+    authContexts = [NSMutableDictionary dictionary];
+
+    // Read stdin line by line.
+    char buf[1024 * 1024]; // 1MB line buffer
+    while (fgets(buf, sizeof(buf), stdin) != NULL) {
+      @autoreleasepool {
+        NSString *line =
+            [[NSString stringWithUTF8String:buf]
+                stringByTrimmingCharactersInSet:
+                    [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if (line.length == 0) {
+          continue;
+        }
+
+        // Parse JSON request.
+        NSData *jsonData = [line dataUsingEncoding:NSUTF8StringEncoding];
+        NSError *parseError = nil;
+        NSDictionary *req =
+            [NSJSONSerialization JSONObjectWithData:jsonData
+                                           options:0
+                                             error:&parseError];
+        if (parseError || ![req isKindOfClass:[NSDictionary class]]) {
+          fprintf(stderr, "ERROR: failed to parse request: %s\n",
+                  parseError ? [[parseError description] UTF8String]
+                             : "not a dictionary");
+          continue;
+        }
+
+        int reqID = [req[@"id"] intValue];
+        NSString *method = req[@"method"];
+        NSDictionary *params = req[@"params"];
+        if (!params || ![params isKindOfClass:[NSDictionary class]]) {
+          params = @{};
+        }
+
+        // Dispatch and get response.
+        NSDictionary *resp = dispatch(reqID, method, params);
+
+        // Encode response as JSON.
+        NSError *encodeError = nil;
+        NSData *respData =
+            [NSJSONSerialization dataWithJSONObject:resp
+                                           options:0
+                                             error:&encodeError];
+        if (encodeError) {
+          fprintf(stderr, "ERROR: failed to encode response: %s\n",
+                  [[encodeError description] UTF8String]);
+          continue;
+        }
+
+        // Write response + newline to stdout.
+        fwrite([respData bytes], 1, [respData length], stdout);
+        fputc('\n', stdout);
+        fflush(stdout);
+      }
+    }
+
+    // Cleanup auth contexts on exit.
+    for (NSNumber *key in [authContexts allKeys]) {
+      AuthContext *actx = [authContexts[key] pointerValue];
+      AuthContextClose(actx);
+      free(actx);
+    }
+    [authContexts removeAllObjects];
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Add a small pure Objective-C helper binary `tsh-touchid-helper` that provides Touch ID operations over JSON-RPC on stdin/stdout. This allows unsigned dev builds of tsh to use Touch ID MFA by delegating Secure Enclave and Keychain operations to the signed helper.

The helper reuses the existing .m files from lib/auth/touchid/ unchanged, with a single no-op stub for the CGO-exported runGoFuncHandle symbol.

On the tsh side, IsAvailable() automatically detects when the binary is unsigned and falls back to the helper if found next to the tsh binary, in PATH, or in ~/.tsh/bin/.