### PR TITLE
Fix serialization error due to undefined field

### DIFF
--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
@@ -268,6 +268,7 @@ test('after creating an access request, pending requests and specifiable fields 
     ],
     roles: ['apple', 'banana'],
     suggestedReviewers: ['bob'],
+    resourceAccessIds: [],
   });
   expect(result.current.requestedCount).toBe(2);
 
@@ -305,6 +306,7 @@ test('after creating an access request, pending requests and specifiable fields 
     // These fields gotten cleared after the first create.
     roles: [],
     suggestedReviewers: [],
+    resourceAccessIds: [],
   });
 });
 

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -297,7 +297,7 @@ export default function useAccessRequestCheckout() {
       assumeStartTime: req.start && Timestamp.fromDate(req.start),
       maxDuration: req.maxDuration && Timestamp.fromDate(req.maxDuration),
       requestTtl: req.requestTTL && Timestamp.fromDate(req.requestTTL),
-      resourceAccessIds: undefined,
+      resourceAccessIds: [],
     };
 
     // Don't attempt creating anything if there are no resources selected.


### PR DESCRIPTION
Suggested reviewers were not displaying in request checkout using Teleport Connect due to failing request caused by serialization error of `resourceAccessIds: undefined`. This change sets the value to `[]` which serializes correctly.

## Manual Test Plan

### Test Environment

Local build of Teleport from branch `jakew/teleterm-request-checkout-fix` deployed to https://jwardtest01.cloud.gravitational.io.

Local build of Teleport Connect from branch `jakew/teleterm-request-checkout-fix` running on Ubuntu Linux 24.04.1 6.17.0-14-generic aarch64.

<details>
<summary>Configuration</summary>

```yaml
---
kind: role
version: v8
metadata:
  name: x-requester
spec:
  allow:
    request:
      roles:
      - x-access
      search_as_roles:
      - x-access
  deny: {}
---
kind: role
version: v8
metadata:
  name: x-reviewer
spec:
  allow:
    review_requests:
      preview_as_roles:
      - x-access
      roles:
      - x-access
  deny: {}
---
kind: role
version: v8
metadata:
  name: x-access
spec:
  allow:
    app_labels:
      resource_group: x_rg
  deny: {}
---
kind: user
version: v2
metadata:
  name: madison.kahill@example.com
spec:
  roles:
  - x-reviewer
---
kind: user
version: v2
metadata:
  name: alex.reeves@example.com
spec:
  roles:
  - x-requester
---
kind: access_list
version: v1
metadata:
  name: x-access
spec:
  audit:
    next_audit_date: "2026-08-01T00:00:00Z"
    notifications:
      start: 336h0m0s
    recurrence:
      day_of_month: "1"
      frequency: 6 months
  description: Grants x-access role.
  grants:
    roles:
    - x-access
  owner_grants:
    roles:
    - x-access
  owners:
  - description: Access list x owner.
    membership_kind: MEMBERSHIP_KIND_USER
    name: madison.kahill@example.com
  ownership_requires:
    roles:
    - x-reviewer
  title: x-access
---
kind: app
version: v3
metadata:
  name: resource-x1
  labels:
    resource_group: x_rg
spec:
  public_addr: resource-x1.localhost
  uri: http://localhost:8001
```
</details> 

### Test Cases

- [x] `alex.reeves` requests access to `resource-x1`; dry run request completes successfully and `madison.kahill` is shown as suggested reviewer.

<img width="951" height="685" alt="image" src="https://github.com/user-attachments/assets/7c0449df-88b8-4770-9cbe-782a348f6922" />


---

changelog: Fixed bug in Teleport Connect where suggested reviewers for access requests were not being generated.