### PR TITLE
[v17] chore: Bump Buf to v1.66.0

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -18,7 +18,7 @@ LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 DEVTOOLSET ?= devtoolset-12
 
 # Protogen related versions.
-BUF_VERSION ?= v1.56.0
+BUF_VERSION ?= v1.66.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
Backport #64107 to branch/v17