### PR TITLE
Improve MOTD responsiveness

### DIFF
--- a/web/packages/teleport/src/Login/Login.story.tsx
+++ b/web/packages/teleport/src/Login/Login.story.tsx
@@ -63,6 +63,17 @@ export const MessageOfTheDay = () => {
     />
   );
 };
+export const LongMessageOfTheDay = () => {
+  return (
+    <Login
+      {...sample}
+      motd={'One often meets his destiny on the road he takes to avoid it.\n'.repeat(
+        20
+      )}
+      showMotd={true}
+    />
+  );
+};
 export const Success = () => <LoginSuccess />;
 export const TerminalRedirect = () => (
   <MemoryRouter initialEntries={[cfg.routes.loginTerminalRedirect]}>

--- a/web/packages/teleport/src/Login/Motd/Motd.tsx
+++ b/web/packages/teleport/src/Login/Motd/Motd.tsx
@@ -18,19 +18,17 @@
 
 import styled from 'styled-components';
 
-import { Box, ButtonPrimary, Card, Text } from 'design';
+import { ButtonPrimary, Card, Text } from 'design';
 
 export function Motd({ message, onClick }: Props) {
   return (
-    <StyledCard bg="levels.surface" my={6} mx="auto">
-      <Box p={6}>
-        <StyledText typography="body1" mb={3} textAlign="left">
-          {message}
-        </StyledText>
-        <ButtonPrimary width="100%" mt={3} size="large" onClick={onClick}>
-          Acknowledge
-        </ButtonPrimary>
-      </Box>
+    <StyledCard bg="levels.surface" my={6} p={6} mx="auto">
+      <StyledText typography="body1" mb={3} textAlign="left">
+        {message}
+      </StyledText>
+      <ButtonPrimary width="100%" mt={3} size="large" onClick={onClick}>
+        Acknowledge
+      </ButtonPrimary>
     </StyledCard>
   );
 }
@@ -41,12 +39,14 @@ type Props = {
 };
 
 const StyledCard = styled(Card)`
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   max-width: 600px;
-  max-height: 500px;
-  opacity: 1;
+  max-height: calc(75vh - ${({ theme }) => theme.space[11]}px);
 `;
 
 const StyledText = styled(Text)`
   white-space: pre-wrap;
+  flex: 1 1 auto;
+  overflow-y: auto;
 `;


### PR DESCRIPTION
- Allow the message of the day to take up more vertical space.
- Keep the acknowledge button visible even when the MOTD is large enough to require vertical scroll.

Closes #64136

Changelog: Improve the layout of the web UI's message of the day.