### PR TITLE
Minor test cleanup

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -455,7 +455,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 				cl, err := teleport.NewClient(helpers.ClientConfig{
 					Login:        suite.Me.Username,
 					Cluster:      helpers.Site,
-					Host:         Host,
+					Host:         nodeConf.Hostname,
 					Port:         helpers.Port(t, nodeConf.SSH.Addr.Addr),
 					ForwardAgent: tt.inForwardAgent,
 				})

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1630,8 +1630,6 @@ func TestDebugService(t *testing.T) {
 		Clock:   fakeClock,
 		DataDir: dataDir,
 	}
-	cfg.Clock = fakeClock
-	cfg.DataDir = dataDir
 
 	log := logtest.NewLogger()
 
@@ -1668,25 +1666,27 @@ func TestDebugService(t *testing.T) {
 	require.NoError(t, process.initDebugService(true))
 	require.NoError(t, process.Start())
 
+	assertStatus := func(t *testing.T, status int, url string) string {
+		t.Helper()
+		resp, err := httpClient.Get(url)
+		if !assert.NoError(t, err) {
+			return ""
+		}
+
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+
+		assert.Equal(t, status, resp.StatusCode, "fetching %s: %s", url, string(body))
+		return string(body)
+	}
+
 	// Testing the debug listener.
 	// Fetch a random path, it should return 404 error.
-	req, err := httpClient.Get("http://debug/random")
-	require.NoError(t, err)
-	defer req.Body.Close()
-	require.Equal(t, http.StatusNotFound, req.StatusCode)
+	assertStatus(t, http.StatusNotFound, "http://debug/random")
 
 	// Test the healthcheck endpoints.
-	// Fetch the liveness path
-	req, err = httpClient.Get("http://debug/healthz")
-	require.NoError(t, err)
-	defer req.Body.Close()
-	require.Equal(t, http.StatusOK, req.StatusCode)
-
-	// Fetch the readiness path
-	req, err = httpClient.Get("http://debug/readyz")
-	require.NoError(t, err)
-	defer req.Body.Close()
-	require.Equal(t, http.StatusOK, req.StatusCode)
+	assertStatus(t, http.StatusOK, "http://debug/healthz") // liveness
+	assertStatus(t, http.StatusOK, "http://debug/readyz")  // readiness
 
 	// Testing the metrics endpoint.
 	// Test setup: create our test metrics.
@@ -1708,37 +1708,25 @@ func TestDebugService(t *testing.T) {
 	require.NoError(t, additionalRegistry.Register(additionalMetric))
 
 	// Test execution: hit the metrics endpoint.
-	resp, err := httpClient.Get("http://debug/metrics")
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
+	body := assertStatus(t, http.StatusOK, "http://debug/metrics")
 
 	// Test validation: check that the metrics server served both the local and global registry.
-	require.Contains(t, string(body), "local_metric_"+nonce)
-	require.Contains(t, string(body), "global_metric_"+nonce)
+	assert.Contains(t, body, "local_metric_"+nonce)
+	assert.Contains(t, body, "global_metric_"+nonce)
 	// the additional registry is not yet added
-	require.NotContains(t, string(body), "additional_metric_"+nonce)
+	assert.NotContains(t, body, "additional_metric_"+nonce)
 
 	// Test execution: add the additional registry and lookup again
 	process.AddGatherer(additionalRegistry)
 
 	// Test execution: hit the metrics endpoint.
-	resp, err = httpClient.Get("http://debug/metrics")
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err = io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
+	body = assertStatus(t, http.StatusOK, "http://debug/metrics")
 
 	// Test validation: check that the metrics server served both the local and global registry.
-	require.Contains(t, string(body), "local_metric_"+nonce)
-	require.Contains(t, string(body), "global_metric_"+nonce)
+	assert.Contains(t, body, "local_metric_"+nonce)
+	assert.Contains(t, body, "global_metric_"+nonce)
 	// Metric has been added
-	require.Contains(t, string(body), "additional_metric_"+nonce)
+	assert.Contains(t, body, "additional_metric_"+nonce)
 }
 
 type mockInstanceMetadata struct {

--- a/lib/srv/app/cloud_test.go
+++ b/lib/srv/app/cloud_test.go
@@ -185,28 +185,28 @@ func TestCheckAndSetDefaults(t *testing.T) {
 }
 
 func TestCloudGetAWSSigninToken(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name                    string
 		federationServerHandler http.HandlerFunc
 		expectedToken           string
-		expectedErrorIs         func(error) bool
-		expectedError           bool
+		errorAssertionFn        require.ErrorAssertionFunc
 	}{
 		{
 			name: "get failed",
 			federationServerHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
 			}),
-			expectedErrorIs: trace.IsBadParameter,
+			errorAssertionFn: func(t require.TestingT, err error, i ...any) {
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter error, got %v", err)
+			},
 		},
 		{
 			name: "bad response",
 			federationServerHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte("not valid json"))
 			}),
-			expectedError: true,
+			errorAssertionFn: require.Error,
 		},
 		{
 			name: "validate URL parameters",
@@ -216,7 +216,8 @@ func TestCloudGetAWSSigninToken(t *testing.T) {
 				require.Equal(t, `{"sessionId":"FAKEACCESSKEYID","sessionKey":"secret","sessionToken":"token"}`, values.Get("Session"))
 				w.Write([]byte(`{"SigninToken":"generated-token"}`))
 			}),
-			expectedToken: "generated-token",
+			expectedToken:    "generated-token",
+			errorAssertionFn: require.NoError,
 		},
 		{
 			name: "validate URL parameters temporary session",
@@ -227,12 +228,12 @@ func TestCloudGetAWSSigninToken(t *testing.T) {
 				require.Empty(t, values.Get("SessionDuration"))
 				w.Write([]byte(`{"SigninToken":"generated-token"}`))
 			}),
-			expectedToken: "generated-token",
+			expectedToken:    "generated-token",
+			errorAssertionFn: require.NoError,
 		},
 	}
 
 	for _, test := range tests {
-		// capture range variable
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			mockFederationServer := httptest.NewServer(test.federationServerHandler)
@@ -242,9 +243,7 @@ func TestCloudGetAWSSigninToken(t *testing.T) {
 				AWSConfigOptions: []awsconfig.OptionsFn{
 					// Ensures the base config has the mocked credentials.
 					awsconfig.WithBaseCredentialsProvider(credentials.NewStaticCredentialsProvider("FAKEACCESSKEYID", "secret", "token")),
-					awsconfig.WithSTSClientProvider(
-						mocks.NewAssumeRoleClientProviderFunc(&mocks.STSClient{}),
-					),
+					awsconfig.WithSTSClientProvider(mocks.NewAssumeRoleClientProviderFunc(&mocks.STSClient{})),
 				},
 				Logger: slog.New(slog.DiscardHandler),
 			})
@@ -263,15 +262,9 @@ func TestCloudGetAWSSigninToken(t *testing.T) {
 				Issuer: "test",
 			}
 
-			actualToken, err := cloud.getAWSSigninToken(ctx, req, mockFederationServer.URL)
-			if test.expectedErrorIs != nil {
-				require.True(t, test.expectedErrorIs(err))
-			} else if test.expectedError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, test.expectedToken, actualToken)
-			}
+			actualToken, err := cloud.getAWSSigninToken(t.Context(), req, mockFederationServer.URL)
+			test.errorAssertionFn(t, err)
+			require.Equal(t, test.expectedToken, actualToken)
 		})
 	}
 }


### PR DESCRIPTION
Removes some unnecessary code and refactors TestDebugService so that it returns better errors and does multiple assertions instead of bailing on the first failure.