### PR TITLE
Log the app_service ID for failed app requests

### DIFF
--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -386,7 +386,8 @@ func (t *transport) DialContext(ctx context.Context, _, _ string) (conn net.Conn
 
 		conn, err = dialAppServer(ctx, clusterClient, appServer)
 		if err != nil && isReverseTunnelDownError(err) {
-			t.c.log.WarnContext(ctx, "Failed to connect to application server", "app_server", appServer.GetName(), "error", err)
+			t.c.log.WarnContext(ctx, "Failed to connect to application server",
+				"app_server", appServer.GetName(), "host_id", appServer.GetHostID(), "error", err)
 			// Continue to the next server if there is an issue
 			// establishing a connection because the tunnel is not
 			// healthy. Reset the error to avoid returning it if


### PR DESCRIPTION
When an app_service fails to dial a target app, the error message shown to the user includes the Host ID of the app_service that failed to connect, but the proxy logs don't capture this information.

Closes #27411