### PR TITLE
Use unwrapped connections to the Auth API in agents connected to a control plane in multiplex mode

### DIFF
--- a/api/client/alpn_conn_upgrade.go
+++ b/api/client/alpn_conn_upgrade.go
@@ -66,7 +66,10 @@ func IsALPNConnUpgradeRequired(ctx context.Context, addr string, insecure bool, 
 	)
 
 	tlsConfig := &tls.Config{
-		NextProtos:         []string{string(constants.ALPNSNIProtocolReverseTunnel)},
+		NextProtos: []string{
+			constants.ALPNSNIProtocolReverseTunnelV2,
+			constants.ALPNSNIProtocolReverseTunnel,
+		},
 		InsecureSkipVerify: insecure,
 	}
 	testConn, err := tlsutils.TLSDial(ctx, baseDialer, "tcp", addr, tlsConfig)

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -360,6 +360,11 @@ const (
 	ALPNSNIAuthProtocol = "teleport-auth@"
 	// ALPNSNIProtocolReverseTunnel is TLS ALPN protocol value used to indicate Proxy reversetunnel protocol.
 	ALPNSNIProtocolReverseTunnel = "teleport-reversetunnel"
+	// ALPNSNIProtocolReverseTunnelV2 is the pseudo ALPN protocol used to
+	// indicate that a TLS-tunneled reverse tunnel connection is initiated by a
+	// client that understands proxy peering (and, as such, can be routed to a
+	// subset of all available proxies).
+	ALPNSNIProtocolReverseTunnelV2 = "teleport-reversetunnelv2"
 	// ALPNSNIProtocolSSH is the TLS ALPN protocol value used to indicate Proxy SSH protocol.
 	ALPNSNIProtocolSSH = "teleport-proxy-ssh"
 )

--- a/integration/tctl_terraform_env_test.go
+++ b/integration/tctl_terraform_env_test.go
@@ -261,7 +261,7 @@ func getAuthClientForProxy(t *testing.T, tc *helpers.TeleInstance, username stri
 		nil /* clock */)
 	require.NoError(t, err)
 
-	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
+	dialer, err := reversetunnelclient.NewAuthDialerThroughProxy(reversetunnelclient.AuthDialerThroughProxyConfig{
 		Resolver:              resolver,
 		ClientConfig:          clientConfig.SSH,
 		Log:                   slog.Default(),

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -822,7 +822,7 @@ func authClientForRegisterResult(t *testing.T, ctx context.Context, addr *utils.
 	require.NoError(t, err)
 
 	log := logtest.NewLogger()
-	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
+	dialer, err := reversetunnelclient.NewAuthDialerThroughProxy(reversetunnelclient.AuthDialerThroughProxyConfig{
 		Resolver:              resolver,
 		ClientConfig:          sshConfig,
 		Log:                   log,

--- a/lib/reversetunnelclient/transport.go
+++ b/lib/reversetunnelclient/transport.go
@@ -55,6 +55,10 @@ type TunnelAuthDialerConfig struct {
 	Log *slog.Logger
 	// InsecureSkipTLSVerify is whether to skip certificate validation.
 	InsecureSkipTLSVerify bool
+	// AllowALPNRouting allows the dialer to return connections to the auth
+	// service that will only succeed when carrying the correct ALPN tag for
+	// auth connections.
+	AllowALPNRouting bool
 	// GetClusterCAs contains cluster CAs.
 	GetClusterCAs client.GetClusterCAsFunc
 }
@@ -94,6 +98,17 @@ func (t *TunnelAuthDialer) DialContext(ctx context.Context, _, _ string) (net.Co
 	}
 
 	if mode == types.ProxyListenerMode_Multiplex {
+		alpnConnUpgradeRequired := client.IsALPNConnUpgradeRequired(ctx, addr.Addr, t.InsecureSkipTLSVerify)
+		if t.AllowALPNRouting && !alpnConnUpgradeRequired {
+			// in multiplex mode the address of the tunnel returned by the
+			// resolver is also the address of the web listener which also
+			// allows ALPN-tagged connections to the auth without further
+			// wrapping
+			t.Log.DebugContext(ctx, "Dialing auth directly")
+			dialer := proxy.DialerFromEnvironment(addr.Addr, opts...)
+			return dialer.DialTimeout(ctx, addr.AddrNetwork, addr.Addr, t.ClientConfig.Timeout)
+		}
+
 		opts = append(opts, proxy.WithALPNDialer(client.ALPNDialerConfig{
 			TLSConfig: &tls.Config{
 				NextProtos: []string{
@@ -103,7 +118,7 @@ func (t *TunnelAuthDialer) DialContext(ctx context.Context, _, _ string) (net.Co
 				InsecureSkipVerify: t.InsecureSkipTLSVerify,
 			},
 			DialTimeout:             t.ClientConfig.Timeout,
-			ALPNConnUpgradeRequired: client.IsALPNConnUpgradeRequired(ctx, addr.Addr, t.InsecureSkipTLSVerify),
+			ALPNConnUpgradeRequired: alpnConnUpgradeRequired,
 			GetClusterCAs:           t.GetClusterCAs,
 		}))
 	}

--- a/lib/reversetunnelclient/transport.go
+++ b/lib/reversetunnelclient/transport.go
@@ -35,18 +35,19 @@ import (
 	"github.com/gravitational/teleport/lib/utils/proxy"
 )
 
-// NewTunnelAuthDialer creates a new instance of TunnelAuthDialer
-func NewTunnelAuthDialer(config TunnelAuthDialerConfig) (*TunnelAuthDialer, error) {
+// NewAuthDialerThroughProxy creates a new instance of [AuthDialerThroughProxy].
+func NewAuthDialerThroughProxy(config AuthDialerThroughProxyConfig) (*AuthDialerThroughProxy, error) {
 	if err := config.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &TunnelAuthDialer{
-		TunnelAuthDialerConfig: config,
+	return &AuthDialerThroughProxy{
+		AuthDialerThroughProxyConfig: config,
 	}, nil
 }
 
-// TunnelAuthDialerConfig specifies TunnelAuthDialer configuration.
-type TunnelAuthDialerConfig struct {
+// AuthDialerThroughProxyConfig is the configuration of
+// [AuthDialerThroughProxy].
+type AuthDialerThroughProxyConfig struct {
 	// Resolver retrieves the address of the proxy
 	Resolver Resolver
 	// ClientConfig is SSH tunnel client config
@@ -63,7 +64,7 @@ type TunnelAuthDialerConfig struct {
 	GetClusterCAs client.GetClusterCAsFunc
 }
 
-func (c *TunnelAuthDialerConfig) CheckAndSetDefaults() error {
+func (c *AuthDialerThroughProxyConfig) CheckAndSetDefaults() error {
 	switch {
 	case c.Resolver == nil:
 		return trace.BadParameter("missing tunnel address resolver")
@@ -75,14 +76,18 @@ func (c *TunnelAuthDialerConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-// TunnelAuthDialer connects to the Auth Server through the reverse tunnel.
-type TunnelAuthDialer struct {
-	// TunnelAuthDialerConfig is the TunnelAuthDialer configuration.
-	TunnelAuthDialerConfig
+// AuthDialerThroughProxy is a dialer to open connections to the Auth service
+// through a Proxy. Depending on the configuration and the environment, it might
+// connect directly through the use of ALPN tags or through the reverse tunnel
+// SSH server, and, if necessary, it will connect through the Proxy webapi
+// connection upgrade mechanism, to get connections through TLS terminators and
+// HTTP-level reverse proxies.
+type AuthDialerThroughProxy struct {
+	AuthDialerThroughProxyConfig
 }
 
 // DialContext opens a connection to the Auth service through a Proxy.
-func (t *TunnelAuthDialer) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+func (t *AuthDialerThroughProxy) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
 	// Connect to the reverse tunnel server.
 	opts := []proxy.DialerOptionFunc{
 		proxy.WithInsecureSkipTLSVerify(t.InsecureSkipTLSVerify),

--- a/lib/reversetunnelclient/transport.go
+++ b/lib/reversetunnelclient/transport.go
@@ -81,7 +81,7 @@ type TunnelAuthDialer struct {
 	TunnelAuthDialerConfig
 }
 
-// DialContext dials auth server via SSH tunnel
+// DialContext opens a connection to the Auth service through a Proxy.
 func (t *TunnelAuthDialer) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
 	// Connect to the reverse tunnel server.
 	opts := []proxy.DialerOptionFunc{

--- a/lib/reversetunnelclient/transport.go
+++ b/lib/reversetunnelclient/transport.go
@@ -104,7 +104,7 @@ func (t *TunnelAuthDialer) DialContext(ctx context.Context, _, _ string) (net.Co
 			// resolver is also the address of the web listener which also
 			// allows ALPN-tagged connections to the auth without further
 			// wrapping
-			t.Log.DebugContext(ctx, "Dialing auth directly")
+			t.Log.DebugContext(ctx, "Connecting to the Auth Server through a proxy using an unwrapped connection")
 			dialer := proxy.DialerFromEnvironment(addr.Addr, opts...)
 			return dialer.DialTimeout(ctx, addr.AddrNetwork, addr.Addr, t.ClientConfig.Timeout)
 		}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1554,7 +1554,7 @@ func (process *TeleportProcess) breakerConfigForRole(role types.SystemRole) brea
 }
 
 func (process *TeleportProcess) newClientThroughProxy(tlsConfig *tls.Config, sshConfig ssh.ClientConfig, role types.SystemRole, clusterName string, getClusterCAs func() (*x509.CertPool, error)) (*authclient.Client, *proto.PingResponse, error) {
-	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
+	dialer, err := reversetunnelclient.NewAuthDialerThroughProxy(reversetunnelclient.AuthDialerThroughProxyConfig{
 		Resolver:              process.resolver,
 		ClientConfig:          sshConfig,
 		Log:                   process.logger,

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1497,7 +1497,7 @@ func (process *TeleportProcess) newClient(connector *Connector) (*authclient.Cli
 		logger.DebugContext(process.ExitContext(), "Attempting to discover reverse tunnel address.")
 		logger.DebugContext(process.ExitContext(), "Attempting to connect to Auth Server through tunnel.")
 
-		tunnelClient, pingResponse, err := process.newClientThroughTunnel(tlsConfig, sshClientConfig, connector.Role(), connector.ClientGetPool)
+		tunnelClient, pingResponse, err := process.newClientThroughProxy(tlsConfig, sshClientConfig, connector.Role(), connector.ClusterName(), connector.ClientGetPool)
 		if err != nil {
 			process.logger.ErrorContext(process.ExitContext(), "Node failed to establish connection to Teleport Proxy. We have tried the following endpoints:")
 			process.logger.ErrorContext(process.ExitContext(), "- connecting to auth server directly", "error", directErr)
@@ -1521,7 +1521,7 @@ func (process *TeleportProcess) newClient(connector *Connector) (*authclient.Cli
 		if !proxyServer.IsEmpty() {
 			logger := process.logger.With("proxy_server", proxyServer.String())
 			logger.DebugContext(process.ExitContext(), "Attempting to connect to Auth Server through tunnel.")
-			tunnelClient, pingResponse, err := process.newClientThroughTunnel(tlsConfig, sshClientConfig, connector.Role(), connector.ClientGetPool)
+			tunnelClient, pingResponse, err := process.newClientThroughProxy(tlsConfig, sshClientConfig, connector.Role(), connector.ClusterName(), connector.ClientGetPool)
 			if err != nil {
 				return nil, nil, trace.Errorf("Failed to connect to Proxy Server through tunnel: %v", err)
 			}
@@ -1553,7 +1553,7 @@ func (process *TeleportProcess) breakerConfigForRole(role types.SystemRole) brea
 	return servicebreaker.InstrumentBreakerForConnector(role, process.Config.CircuitBreakerConfig)
 }
 
-func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, sshConfig ssh.ClientConfig, role types.SystemRole, getClusterCAs func() (*x509.CertPool, error)) (*authclient.Client, *proto.PingResponse, error) {
+func (process *TeleportProcess) newClientThroughProxy(tlsConfig *tls.Config, sshConfig ssh.ClientConfig, role types.SystemRole, clusterName string, getClusterCAs func() (*x509.CertPool, error)) (*authclient.Client, *proto.PingResponse, error) {
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              process.resolver,
 		ClientConfig:          sshConfig,
@@ -1562,6 +1562,7 @@ func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, ss
 		GetClusterCAs: func(context.Context) (*x509.CertPool, error) {
 			return getClusterCAs()
 		},
+		AllowALPNRouting: true,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -1574,6 +1575,11 @@ func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, ss
 		},
 		CircuitBreakerConfig: process.breakerConfigForRole(role),
 		DialTimeout:          process.Config.Testing.ClientTimeout,
+		// we are using a dialer that's confirming that we are connecting to an
+		// address that responds to /webapi/find by virtue of using a resolver,
+		// so there's no chance that we're going to get confused if we are
+		// accidentally pointed to an auth as if it was a proxy
+		ALPNSNIAuthDialClusterName: clusterName,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/service/connect_test.go
+++ b/lib/service/connect_test.go
@@ -19,14 +19,25 @@
 package service
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
+	apiconstants "github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	apissh "github.com/gravitational/teleport/api/ssh"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/state"
@@ -34,7 +45,9 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -171,4 +184,91 @@ func TestMakeJoinParams_BoundKeypair(t *testing.T) {
 			tt.assertJoinParams(t, params)
 		})
 	}
+}
+
+func TestUnwrappedConnection(t *testing.T) {
+	t.Setenv(apidefaults.TLSRoutingConnUpgradeEnvVar, "false")
+
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	p := &TeleportProcess{
+		Supervisor: &LocalSupervisor{
+			exitContext: t.Context(),
+		},
+		Config:   &servicecfg.Config{},
+		logger:   logtest.NewLogger(),
+		resolver: reversetunnelclient.StaticResolver(l.Addr().String(), types.ProxyListenerMode_Multiplex),
+	}
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		c, err := l.Accept()
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+
+		var clientHelloInfo *tls.ClientHelloInfo
+		_ = tls.Server(c, &tls.Config{
+			GetConfigForClient: func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+				clientHelloInfo = chi
+				return nil, errors.New("no")
+			},
+		}).Handshake()
+		if clientHelloInfo == nil {
+			return errors.New("missing client hello")
+		}
+		if len(clientHelloInfo.SupportedProtos) < 1 || !strings.HasPrefix(clientHelloInfo.SupportedProtos[0], apiconstants.ALPNSNIAuthProtocol) {
+			return fmt.Errorf("expected teleport-auth@, got %+q next protos", clientHelloInfo.SupportedProtos)
+		}
+		return nil
+	})
+
+	_, _, err = p.newClientThroughProxy(
+		&tls.Config{},
+		apissh.ClientConfig{},
+		types.RoleNode,
+		"foo",
+		func() (*x509.CertPool, error) { return nil, nil },
+	)
+	require.Error(t, err)
+	require.NoError(t, eg.Wait())
+
+	eg = *new(errgroup.Group)
+	eg.Go(func() error {
+		c, err := l.Accept()
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+
+		var clientHelloInfo *tls.ClientHelloInfo
+		_ = tls.Server(c, &tls.Config{
+			GetConfigForClient: func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+				clientHelloInfo = chi
+				return nil, errors.New("no")
+			},
+		}).Handshake()
+		if clientHelloInfo == nil {
+			return errors.New("missing client hello")
+		}
+
+		if slices.ContainsFunc(clientHelloInfo.SupportedProtos, func(s string) bool {
+			return strings.HasPrefix(s, apiconstants.ALPNSNIAuthProtocol)
+		}) {
+			return errors.New("expected direct connection, got teleport-auth@ alpn")
+		}
+
+		return nil
+	})
+
+	_, _, err = p.newClientDirect(
+		[]utils.NetAddr{{Addr: l.Addr().String(), AddrNetwork: l.Addr().Network()}},
+		&tls.Config{},
+		types.RoleNode,
+	)
+	require.Error(t, err)
+	require.NoError(t, eg.Wait())
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -614,7 +614,7 @@ func (c *Connector) TunnelProxyResolver() reversetunnelclient.Resolver {
 	}
 
 	switch dialer := c.Client.Dialer().(type) {
-	case *reversetunnelclient.TunnelAuthDialer:
+	case *reversetunnelclient.AuthDialerThroughProxy:
 		return dialer.Resolver
 	default:
 		return nil

--- a/lib/srv/alpnproxy/common/protocols.go
+++ b/lib/srv/alpnproxy/common/protocols.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	apiconstants "github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/defaults"
 )
@@ -79,13 +80,13 @@ const (
 	ProtocolProxySSHGRPC Protocol = "teleport-proxy-ssh-grpc"
 
 	// ProtocolReverseTunnel is TLS ALPN protocol value used to indicate Proxy reversetunnel protocol.
-	ProtocolReverseTunnel Protocol = "teleport-reversetunnel"
+	ProtocolReverseTunnel Protocol = apiconstants.ALPNSNIProtocolReverseTunnel
 
 	// ProtocolReverseTunnelV2 is TLS ALPN protocol value used to indicate reversetunnel clients
 	// that are aware of proxy peering. This is only used on the client side to allow intermediate
 	// load balancers to make decisions based on the ALPN header. ProtocolReverseTunnel should still
 	// be included in the list of ALPN header for the proxy server to handle the connection properly.
-	ProtocolReverseTunnelV2 Protocol = "teleport-reversetunnelv2"
+	ProtocolReverseTunnelV2 Protocol = apiconstants.ALPNSNIProtocolReverseTunnelV2
 
 	// ProtocolHTTP is TLS ALPN protocol value used to indicate HTTP 1.1 protocol
 	ProtocolHTTP Protocol = "http/1.1"

--- a/lib/tbot/client/client.go
+++ b/lib/tbot/client/client.go
@@ -182,7 +182,7 @@ func dialViaProxy(ctx context.Context, cfg Config) (*client.Client, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
+	dialer, err := reversetunnelclient.NewAuthDialerThroughProxy(reversetunnelclient.AuthDialerThroughProxyConfig{
 		Resolver:              cfg.Resolver,
 		ClientConfig:          sshConfig,
 		Log:                   cfg.Logger,

--- a/tool/tctl/common/client/auth.go
+++ b/tool/tctl/common/client/auth.go
@@ -69,7 +69,7 @@ func GetInitFunc(ccf tctlcfg.GlobalCLIFlags, cfg *servicecfg.Config) InitFunc {
 			return nil, nil, trace.Wrap(err)
 		}
 
-		dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
+		dialer, err := reversetunnelclient.NewAuthDialerThroughProxy(reversetunnelclient.AuthDialerThroughProxyConfig{
 			Resolver:              resolver,
 			ClientConfig:          clientConfig.SSH,
 			Log:                   cfg.Logger,


### PR DESCRIPTION
This PR tweaks agent connectivity by allowing connections that make use of the `teleport-auth@<hex cluster name>.teleport.cluster.local` ALPN destination tag for control plane API connections of agents, matching the standard behavior of the API client used by client tools. This applies when the cluster is using TLS routing and the agent is pointed to a proxy (either with config v3 and `proxy_server` or with config v2 and `auth_servers` pointed at the proxy web endpoint), and the connection upgrade middlebox bypass is not used.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: reduced the load on the Proxy Service from agent control plane API connections in TLS routing mode 

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Cloud staging control plane (with or without this patch, it doesn't affect the control plane), locally configured control plane to play with multiplex/separate proxy listener mode and split listeners. Teleport agent with this PR.

### Test Cases
- [x] Multiplex mode with a single listener
- [x] Multiplex mode with a single listener (agent using config v2 and `auth_servers` pointed at the proxy)
- [x] Multiplex mode with a separate tunnel listener configured (and unused by anything)
- [x] Multiplex mode with `TELEPORT_TUNNEL_PUBLIC_ADDR` pointed to a web listener different than the normal one
- [x] Multiplex mode with `TELEPORT_TLS_ROUTING_CONN_UPGRADE=true` (forcing the old connection mode)
- [x] Separate mode (old connection mode)
- [x] Agent pointed directly at the auth with config v3 `auth_server`
- [x] Agent pointed directly at the auth with config v2 and `auth_servers`
- [x] Agent pointed directly at the auth with config v3 and `proxy_server` (required to fail)

In all these test cases, debug logs on the agent and `teleport_alpn_proxy_active_connections` metric on the proxy show the correct result (a `teleport-auth@` connection when using unwrapped connectivity, an additional `teleport-reversetunnel` connection when falling back to the current mode).