### PR TITLE
Fix Terraform codegen defaults and GetMethod usage in templates

### DIFF
--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -398,6 +398,10 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{.VarName}}Resource := {{.VarName}}
 {{end}}
 
+	{{- if .ForceSetKind }}
+	{{.VarName}}Resource.Kind = {{.ForceSetKind}}
+	{{- end}}
+
 	{{if .HasCheckAndSetDefaults -}}
 	if err := {{.VarName}}Resource.CheckAndSetDefaults(); err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", err, "{{.Kind}}"))

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -108,7 +108,7 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	}
 	{{- end}}
 
-	{{.VarName}}Before, err := r.p.Client.Get{{.Name}}(ctx)
+	{{.VarName}}Before, err := r.p.Client.{{.GetMethod}}(ctx)
 	if err != nil && !trace.IsNotFound(err) {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
@@ -233,7 +233,7 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 		return
 	}
 
-	{{.VarName}}I, err := r.p.Client.Get{{.Name}}(ctx)
+	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
@@ -278,6 +278,10 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		return
 	}
 
+{{- if .ForceSetKind }}
+	{{.VarName}}.Kind = {{.ForceSetKind}}
+{{- end}}
+
 {{- if .HasCheckAndSetDefaults }}
 
 	err := {{.VarName}}.CheckAndSetDefaults()
@@ -287,7 +291,16 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	}
 {{- end}}
 
-	{{.VarName}}Before, err := r.p.Client.Get{{.Name}}(ctx)
+	{{- if .DefaultName }}
+	if {{.VarName}}.GetMetadata() == nil {
+		{{.VarName}}.Metadata = &headerv1.Metadata{}
+	}
+	if {{ .VarName }}.GetMetadata().GetName() == "" {
+		{{ .VarName }}.Metadata.Name = {{ .DefaultName }}
+	}
+	{{- end}}
+
+	{{.VarName}}Before, err := r.p.Client.{{.GetMethod}}(ctx)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
@@ -381,7 +394,7 @@ func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteR
 
 // ImportState imports {{.Name}} state
 func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	{{.VarName}}I, err := r.p.Client.Get{{.Name}}(ctx)
+	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return

--- a/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
+++ b/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
@@ -219,6 +219,7 @@ func (r resourceTeleportAccessMonitoringRule) Update(ctx context.Context, req tf
 	}
 	accessMonitoringRuleResource := accessMonitoringRule
 
+	accessMonitoringRuleResource.Kind = apitypes.KindAccessMonitoringRule
 
 	
 	name := accessMonitoringRuleResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_app_auth_config.go
+++ b/integrations/terraform/provider/resource_teleport_app_auth_config.go
@@ -219,6 +219,7 @@ func (r resourceTeleportAppAuthConfig) Update(ctx context.Context, req tfsdk.Upd
 	}
 	appauthconfigResource := appauthconfig
 
+	appauthconfigResource.Kind = apitypes.KindAppAuthConfig
 
 	
 	name := appauthconfigResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_autoupdate_config.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_config.go
@@ -223,6 +223,13 @@ func (r resourceTeleportAutoUpdateConfig) Update(ctx context.Context, req tfsdk.
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	autoUpdateConfig.Kind = apitypes.KindAutoUpdateConfig
+	if autoUpdateConfig.GetMetadata() == nil {
+		autoUpdateConfig.Metadata = &headerv1.Metadata{}
+	}
+	if autoUpdateConfig.GetMetadata().GetName() == "" {
+		autoUpdateConfig.Metadata.Name = apitypes.MetaNameAutoUpdateConfig
+	}
 
 	autoUpdateConfigBefore, err := r.p.Client.GetAutoUpdateConfig(ctx)
 	if err != nil {

--- a/integrations/terraform/provider/resource_teleport_autoupdate_version.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_version.go
@@ -223,6 +223,13 @@ func (r resourceTeleportAutoUpdateVersion) Update(ctx context.Context, req tfsdk
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	autoUpdateVersion.Kind = apitypes.KindAutoUpdateVersion
+	if autoUpdateVersion.GetMetadata() == nil {
+		autoUpdateVersion.Metadata = &headerv1.Metadata{}
+	}
+	if autoUpdateVersion.GetMetadata().GetName() == "" {
+		autoUpdateVersion.Metadata.Name = apitypes.MetaNameAutoUpdateVersion
+	}
 
 	autoUpdateVersionBefore, err := r.p.Client.GetAutoUpdateVersion(ctx)
 	if err != nil {

--- a/integrations/terraform/provider/resource_teleport_discovery_config.go
+++ b/integrations/terraform/provider/resource_teleport_discovery_config.go
@@ -226,6 +226,7 @@ func (r resourceTeleportDiscoveryConfig) Update(ctx context.Context, req tfsdk.U
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading DiscoveryConfig", trace.Errorf("Can not convert %T to DiscoveryConfig: %s", discoveryConfigResource, err), "discovery_config"))
 		return
 	}
+	discoveryConfigResource.Kind = apitypes.KindDiscoveryConfig
 
 	
 	name := discoveryConfigResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_health_check_config.go
+++ b/integrations/terraform/provider/resource_teleport_health_check_config.go
@@ -219,6 +219,7 @@ func (r resourceTeleportHealthCheckConfig) Update(ctx context.Context, req tfsdk
 	}
 	healthCheckConfigResource := healthCheckConfig
 
+	healthCheckConfigResource.Kind = apitypes.KindHealthCheckConfig
 
 	
 	name := healthCheckConfigResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_inference_model.go
+++ b/integrations/terraform/provider/resource_teleport_inference_model.go
@@ -219,6 +219,7 @@ func (r resourceTeleportInferenceModel) Update(ctx context.Context, req tfsdk.Up
 	}
 	inferenceModelResource := inferenceModel
 
+	inferenceModelResource.Kind = apitypes.KindInferenceModel
 
 	
 	name := inferenceModelResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_inference_policy.go
+++ b/integrations/terraform/provider/resource_teleport_inference_policy.go
@@ -219,6 +219,7 @@ func (r resourceTeleportInferencePolicy) Update(ctx context.Context, req tfsdk.U
 	}
 	inferencePolicyResource := inferencePolicy
 
+	inferencePolicyResource.Kind = apitypes.KindInferencePolicy
 
 	
 	name := inferencePolicyResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_inference_secret.go
+++ b/integrations/terraform/provider/resource_teleport_inference_secret.go
@@ -227,6 +227,7 @@ func (r resourceTeleportInferenceSecret) Update(ctx context.Context, req tfsdk.U
 	}
 	inferenceSecretResource := inferenceSecret
 
+	inferenceSecretResource.Kind = apitypes.KindInferenceSecret
 
 	
 	name := inferenceSecretResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_server.go
+++ b/integrations/terraform/provider/resource_teleport_server.go
@@ -230,6 +230,7 @@ func (r resourceTeleportServer) Update(ctx context.Context, req tfsdk.UpdateReso
 	}
 	serverResource := server
 
+	serverResource.Kind = apitypes.KindNode
 
 	if err := serverResource.CheckAndSetDefaults(); err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating Server", err, "node"))

--- a/integrations/terraform/provider/resource_teleport_static_host_user.go
+++ b/integrations/terraform/provider/resource_teleport_static_host_user.go
@@ -219,6 +219,7 @@ func (r resourceTeleportStaticHostUser) Update(ctx context.Context, req tfsdk.Up
 	}
 	staticHostUserResource := staticHostUser
 
+	staticHostUserResource.Kind = apitypes.KindStaticHostUser
 
 	
 	name := staticHostUserResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_vnet_config.go
+++ b/integrations/terraform/provider/resource_teleport_vnet_config.go
@@ -82,7 +82,7 @@ func (r resourceTeleportVnetConfig) Create(ctx context.Context, req tfsdk.Create
 		vnetConfig.Metadata.Name = apitypes.MetaNameVnetConfig
 	}
 
-	vnetConfigBefore, err := r.p.Client.GetVnetConfig(ctx)
+	vnetConfigBefore, err := r.p.Client.VnetConfigClient().GetVnetConfig(ctx)
 	if err != nil && !trace.IsNotFound(err) {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading VnetConfig", trace.Wrap(err), "vnet_config"))
 		return
@@ -183,7 +183,7 @@ func (r resourceTeleportVnetConfig) Read(ctx context.Context, req tfsdk.ReadReso
 		return
 	}
 
-	vnetConfigI, err := r.p.Client.GetVnetConfig(ctx)
+	vnetConfigI, err := r.p.Client.VnetConfigClient().GetVnetConfig(ctx)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading VnetConfig", trace.Wrap(err), "vnet_config"))
 		return
@@ -223,8 +223,15 @@ func (r resourceTeleportVnetConfig) Update(ctx context.Context, req tfsdk.Update
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	vnetConfig.Kind = apitypes.KindVnetConfig
+	if vnetConfig.GetMetadata() == nil {
+		vnetConfig.Metadata = &headerv1.Metadata{}
+	}
+	if vnetConfig.GetMetadata().GetName() == "" {
+		vnetConfig.Metadata.Name = apitypes.MetaNameVnetConfig
+	}
 
-	vnetConfigBefore, err := r.p.Client.GetVnetConfig(ctx)
+	vnetConfigBefore, err := r.p.Client.VnetConfigClient().GetVnetConfig(ctx)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading VnetConfig", trace.Wrap(err), "vnet_config"))
 		return
@@ -296,7 +303,7 @@ func (r resourceTeleportVnetConfig) Delete(ctx context.Context, req tfsdk.Delete
 
 // ImportState imports VnetConfig state
 func (r resourceTeleportVnetConfig) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	vnetConfigI, err := r.p.Client.GetVnetConfig(ctx)
+	vnetConfigI, err := r.p.Client.VnetConfigClient().GetVnetConfig(ctx)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating VnetConfig", trace.Wrap(err), "vnet_config"))
 		return

--- a/integrations/terraform/provider/resource_teleport_workload_identity.go
+++ b/integrations/terraform/provider/resource_teleport_workload_identity.go
@@ -218,6 +218,7 @@ func (r resourceTeleportWorkloadIdentity) Update(ctx context.Context, req tfsdk.
 	}
 	workloadIdentityResource := workloadIdentity
 
+	workloadIdentityResource.Kind = "workload_identity"
 
 	
 	name := workloadIdentityResource.Metadata.Name


### PR DESCRIPTION
# What

Apply `ForceSetKind` and `DefaultName` in `Update` method for generated resources.
Use `GetMethod` everywhere in templates instead of hardcoded `Get{{.Name}}`.

# Manual Tests
Created and updated Terraform resources

Example for VNet config:

* Create Terraform resource:
  ```
  resource "teleport_vnet_config" "example" {
    version = "v1"
    metadata = {
      labels = {
        example = "yes"
      }
    }
    spec = {
      ipv4_cidr_range = "100.64.0.0/11"
    }
  }
  ```
* Apply with Terraform:
  ```
  terraform apply
  ```
* Verify the VNet config in Teleport:
  * `tctl edit vnet_config` shows `ipv4_cidr_range = 100.64.0.0/11`
* Update the CIDR mask in Terraform from `/11` to `/12`:
  ```
  resource "teleport_vnet_config" "example" {
    version = "v1"
    metadata = {
      labels = {
        example = "yes"
      }
    }
    spec = {
      ipv4_cidr_range = "100.64.0.0/12"
    }
  }
  ```
* Apply with Terraform:
  ```
  terraform apply
  ```
* Verify the VNet config in Teleport::
  * `tctl edit vnet_config` shows `ipv4_cidr_range = 100.64.0.0/12`
* Destroy with Terraform:
  ```
  terraform destroy
  ```
* Confirm the VNet config is reset:
  * `tctl edit vnet_config` shows `ipv4_cidr_range = 100.64.0.0/10`
