### PR TITLE
[v18] Fix bug causing the expiry service to spin infinite loop

### DIFF
--- a/api/client/proto/authservice.pb.go
+++ b/api/client/proto/authservice.pb.go
@@ -16017,7 +16017,7 @@ type ListAccessRequestsRequest struct {
 	Limit int32 `protobuf:"varint,4,opt,name=Limit,proto3" json:"Limit,omitempty"`
 	// StartKey is used to resume a query in order to enable pagination.
 	// If the previous response had NextKey set then this should be
-	// set to its value. Otherwise leave empty.
+	// set to its value. Should be empty on the first request.
 	StartKey             string   `protobuf:"bytes,5,opt,name=StartKey,proto3" json:"StartKey,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/api/proto/teleport/legacy/client/proto/authservice.proto
+++ b/api/proto/teleport/legacy/client/proto/authservice.proto
@@ -2866,7 +2866,7 @@ message ListAccessRequestsRequest {
 
   // StartKey is used to resume a query in order to enable pagination.
   // If the previous response had NextKey set then this should be
-  // set to its value. Otherwise leave empty.
+  // set to its value. Should be empty on the first request.
   string StartKey = 5;
 }
 

--- a/api/types/access_request_test.go
+++ b/api/types/access_request_test.go
@@ -162,3 +162,24 @@ func TestValidateAssumeStartTime(t *testing.T) {
 		})
 	}
 }
+
+func Test_AccessRequest_SetExpiry(t *testing.T) {
+	// Access requests expiry is a bit special. It is not handled by the backend because we
+	// need to emit audit event before they are expired and deleted from the backend.  To
+	// achieve SetExpiry method from the Metadata is overwritten (to not set Metadata.Expires)
+	// to set expiry in Spec.ResourceExpiry.
+	req, err := NewAccessRequest("test_request_1", "alice", "test_role_1")
+	require.NoError(t, err)
+
+	reqV3 := req.(*AccessRequestV3)
+
+	require.Nil(t, reqV3.Metadata.Expires)
+	require.Nil(t, reqV3.Spec.ResourceExpiry)
+
+	t1 := time.Now().UTC()
+	req.SetExpiry(t1)
+
+	require.Nil(t, reqV3.Metadata.Expires)
+	require.NotNil(t, reqV3.Spec.ResourceExpiry)
+	require.Equal(t, t1, *reqV3.Spec.ResourceExpiry)
+}

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -950,18 +950,6 @@ type DiscoveryAccessPoint interface {
 	UpsertUserTask(ctx context.Context, req *usertasksv1.UserTask) (*usertasksv1.UserTask, error)
 }
 
-// ExpiryAccessPoint is the API used by the expiry service.
-type ExpiryAccessPoint interface {
-	// Semaphores provides semaphore operations
-	types.Semaphores
-
-	// ListAccessRequests is an access request getter with pagination and sorting options.
-	ListAccessRequests(ctx context.Context, req *proto.ListAccessRequestsRequest) (*proto.ListAccessRequestsResponse, error)
-
-	// DeleteAccessRequest deletes an access request.
-	DeleteAccessRequest(ctx context.Context, reqID string) error
-}
-
 // ReadOktaAccessPoint is a read only API interface to be
 // used by an Okta component.
 //

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2931,7 +2931,6 @@ func (process *TeleportProcess) initAuthService() error {
 		),
 		Emitter:     authServer,
 		AccessPoint: authServer.Services,
-		Clock:       process.Clock,
 		HostID:      connector.HostUUID(),
 	})
 	if err != nil {

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -361,6 +361,10 @@ type DynamicAccessExt interface {
 	CreateAccessRequestAllowedPromotions(ctx context.Context, req types.AccessRequest, accessLists *types.AccessRequestAllowedPromotions) error
 	// GetAccessRequestAllowedPromotions returns a lists of allowed access list promotions for the given access request.
 	GetAccessRequestAllowedPromotions(ctx context.Context, req types.AccessRequest) (*types.AccessRequestAllowedPromotions, error)
+	// ListExpiredAccessRequests lists all access requests that are expired. This is used by
+	// the expiry service. Access requests expiration handling is done outside the backend
+	// because we need to emit audit events on the access requests expiry.
+	ListExpiredAccessRequests(ctx context.Context, limit int, pageToken string) ([]*types.AccessRequestV3, string, error)
 }
 
 // reviewParamsContext is a simplified view of an access review

--- a/lib/services/expiry/expiry_test.go
+++ b/lib/services/expiry/expiry_test.go
@@ -19,27 +19,184 @@
 package expiry
 
 import (
-	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/utils/interval"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
-func TestExpiry(t *testing.T) {
-	clock := clockwork.NewFakeClock()
+func TestExpiryBasic(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		expiry, authServer, emitter := setupExpiryService(t)
+		go func() {
+			err := expiry.Run(ctx)
+			require.NoError(t, err)
+		}()
+
+		const expiry1, expiry2 = 10 * scanInterval, 20 * scanInterval
+		_ = createAccessRequest(t, authServer, types.RequestState_NONE, time.Now().Add(expiry1))
+		_ = createAccessRequest(t, authServer, types.RequestState_PROMOTED, time.Now().Add(expiry2))
+
+		synctest.Wait()
+		require.Len(t, mustListAccessRequests(t, authServer), 2)
+		require.Empty(t, emitter.Events())
+
+		sleep1 := expiry1 + scanInterval*3 // *2 to accommodate for the jitter and initial duration
+		time.Sleep(sleep1)
+		synctest.Wait()
+		require.Len(t, mustListAccessRequests(t, authServer), 1)
+		require.Len(t, emitter.Events(), 1)
+
+		sleep2 := expiry2 + scanInterval*3 - sleep1
+		time.Sleep(sleep2)
+		synctest.Wait()
+		require.Empty(t, mustListAccessRequests(t, authServer))
+		require.Len(t, emitter.Events(), 2)
+	})
+}
+
+func TestExpiryInterval(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		const testInterval = time.Hour
+
+		expiry, authServer, emitter := setupExpiryService(t)
+		go func() {
+			// Run with rigid intervals.
+			err := expiry.run(ctx, interval.Config{
+				Duration:      testInterval,
+				FirstDuration: testInterval,
+			})
+			require.NoError(t, err)
+		}()
+
+		// Create a request with minimal expiry after each interval.
+		_ = createAccessRequest(t, authServer, types.RequestState_DENIED, time.Now().Add(1))
+		_ = createAccessRequest(t, authServer, types.RequestState_DENIED, time.Now().Add(1+testInterval))
+		_ = createAccessRequest(t, authServer, types.RequestState_DENIED, time.Now().Add(1+2*testInterval))
+
+		// Stop just before the first sweep.
+		time.Sleep(testInterval - time.Nanosecond)
+		synctest.Wait()
+
+		require.Len(t, mustListAccessRequests(t, authServer), 3)
+		require.Empty(t, emitter.Events())
+
+		// First sweep.
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+
+		require.Len(t, mustListAccessRequests(t, authServer), 2)
+		require.Len(t, emitter.Events(), 1)
+
+		// Stop just before the second sweep.
+		time.Sleep(testInterval - time.Nanosecond)
+		synctest.Wait()
+
+		require.Len(t, mustListAccessRequests(t, authServer), 2)
+		require.Len(t, emitter.Events(), 1)
+
+		// Second sweep.
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+
+		require.Len(t, mustListAccessRequests(t, authServer), 1)
+		require.Len(t, emitter.Events(), 2)
+
+		// Stop just before the third sweep.
+		time.Sleep(testInterval - time.Nanosecond)
+		synctest.Wait()
+
+		require.Len(t, mustListAccessRequests(t, authServer), 1)
+		require.Len(t, emitter.Events(), 2)
+
+		// Third sweep.
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+
+		require.Empty(t, mustListAccessRequests(t, authServer))
+		require.Len(t, emitter.Events(), 3)
+	})
+}
+
+func TestExpiryPendingGracePeriod(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		const testInterval = time.Hour
+
+		expiryService, authServer, emitter := setupExpiryService(t)
+		go func() {
+			// Run with rigid intervals.
+			err := expiryService.run(ctx, interval.Config{
+				Duration:      testInterval,
+				FirstDuration: testInterval,
+			})
+			require.NoError(t, err)
+		}()
+
+		expiryTime := time.Now().Add(testInterval - pendingRequestGracePeriod + time.Nanosecond)
+
+		pendingRequest := createAccessRequest(t, authServer, types.RequestState_PENDING, expiryTime)
+		approvedRequest := createAccessRequest(t, authServer, types.RequestState_APPROVED, expiryTime)
+
+		// Check both are in the backend.
+		require.Len(t, mustListAccessRequests(t, authServer), 2)
+		require.Empty(t, emitter.Events())
+
+		// Wait for the expiry service sweep.
+		time.Sleep(testInterval)
+		synctest.Wait()
+
+		// Make sure both are expired.
+		require.True(t, time.Now().After(pendingRequest.Expiry()))
+		require.True(t, time.Now().After(approvedRequest.Expiry()))
+
+		// Make sure both are expired within the pending request grace period.
+		require.Less(t, time.Since(pendingRequest.Expiry()), pendingRequestGracePeriod)
+		require.Less(t, time.Since(approvedRequest.Expiry()), pendingRequestGracePeriod)
+
+		// Check the approved one expired, but the pending one is still within the grace period.
+		require.Len(t, mustListAccessRequests(t, authServer), 1)
+		require.Equal(t, types.RequestState_PENDING, mustListAccessRequests(t, authServer)[0].GetState())
+		require.Len(t, emitter.Events(), 1)
+
+		// Wait for the second expiry service sweep.
+		time.Sleep(testInterval)
+		synctest.Wait()
+
+		// We are after the grace period so check everything is cleared now.
+		require.Greater(t, testInterval, pendingRequestGracePeriod)
+		require.Empty(t, mustListAccessRequests(t, authServer))
+		require.Len(t, emitter.Events(), 2)
+	})
+}
+
+func setupExpiryService(t *testing.T) (*Service, *auth.Server, *eventstest.MockRecorderEmitter) {
+	t.Helper()
+
+	logger := logtest.NewLogger()
+	emitter := &eventstest.MockRecorderEmitter{}
 
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Dir:   t.TempDir(),
-		Clock: clock,
+		Dir: t.TempDir(),
 		AuthPreferenceSpec: &types.AuthPreferenceSpecV2{
 			SecondFactor: constants.SecondFactorOn,
 			Webauthn: &types.Webauthn{
@@ -47,48 +204,41 @@ func TestExpiry(t *testing.T) {
 			},
 		},
 	})
-
 	require.NoError(t, err)
 	t.Cleanup(func() { authServer.Close() })
 
-	logger := logtest.NewLogger()
-	mockEmitter := &eventstest.MockRecorderEmitter{}
-	cfg := &Config{
+	expiry, err := New(&Config{
 		Log:         logger,
-		Emitter:     mockEmitter,
+		Emitter:     emitter,
 		AccessPoint: authServer.AuthServer,
-		Clock:       clock,
-	}
-
-	ctx := context.Background()
-
-	expiry, err := New(cfg)
+	})
 	require.NoError(t, err)
 
-	scanInterval = time.Second
-	pendingRequestGracePeriod = time.Second
+	return expiry, authServer.AuthServer, emitter
+}
 
-	go func() {
-		err := expiry.Run(ctx)
-		require.NoError(t, err)
-	}()
+func createAccessRequest(t *testing.T, auth *auth.Server, state types.RequestState, expiry time.Time) types.AccessRequest {
+	t.Helper()
+	ctx := t.Context()
 
-	req1Name := uuid.New().String()
-	req1, err := types.NewAccessRequest(req1Name, "someUser", "someRole")
+	req, err := types.NewAccessRequest(uuid.NewString(), "alice", "test_role_1")
 	require.NoError(t, err)
-	req1.SetExpiry(clock.Now().Add(scanInterval))
-	err = authServer.AuthServer.CreateAccessRequest(ctx, req1)
-	require.NoError(t, err)
+	req.SetExpiry(expiry)
+	req.SetState(state)
 
-	req2Name := uuid.New().String()
-	req2, err := types.NewAccessRequest(req2Name, "someUser", "someRole")
-	require.NoError(t, err)
-	req2.SetExpiry(clock.Now().Add(scanInterval * 2))
-	err = authServer.AuthServer.CreateAccessRequest(ctx, req2)
+	err = auth.CreateAccessRequest(ctx, req)
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
-		clock.Advance(scanInterval * 5)
-		return len(mockEmitter.Events()) == 2
-	}, scanInterval*5, time.Second/2)
+	return req
+}
+
+func mustListAccessRequests(t *testing.T, auth *auth.Server) []*types.AccessRequestV3 {
+	t.Helper()
+	ctx := t.Context()
+
+	resp, err := auth.Services.ListAccessRequests(ctx, &proto.ListAccessRequestsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, resp.NextKey)
+
+	return resp.AccessRequests
 }

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -351,7 +351,7 @@ func (s *DynamicAccessService) collectPage(ctx context.Context, limit int, start
 		return nil, "", trace.BadParameter("page size of %d is too large", limit)
 	}
 
-	startKey := backend.ExactKey(start)
+	startKey := backend.ExactKey(accessRequestsPrefix)
 	if start != "" {
 		startKey = backend.NewKey(accessRequestsPrefix, start)
 	}
@@ -461,7 +461,6 @@ func (s *DynamicAccessService) GetAccessRequestAllowedPromotions(ctx context.Con
 }
 
 func itemFromAccessRequest(req types.AccessRequest) (backend.Item, error) {
-	rev := req.GetRevision()
 	value, err := services.MarshalAccessRequest(req)
 	if err != nil {
 		return backend.Item{}, trace.Wrap(err)
@@ -469,7 +468,7 @@ func itemFromAccessRequest(req types.AccessRequest) (backend.Item, error) {
 	return backend.Item{
 		Key:      accessRequestKey(req.GetName()),
 		Value:    value,
-		Revision: rev,
+		Revision: req.GetRevision(),
 	}, nil
 }
 

--- a/lib/services/local/dynamic_access_test.go
+++ b/lib/services/local/dynamic_access_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package local
+
+package local
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+)
+
+func Test_DynamicAccessService_ListExpiredAccessRequests(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		service, _ := setupDynamicAccessService(t)
+
+		// create 2 non-expired, 100 expired, 2 non-expired, 100 expired, 2 non-expired
+		// 206 in total
+		for range 2 {
+			createAccessRequestWithExpiry(t, service, time.Now().Add(1*time.Hour))
+		}
+		for range 100 {
+			createAccessRequestWithExpiry(t, service, time.Now().Add(-1*time.Hour))
+		}
+		for range 2 {
+			createAccessRequestWithExpiry(t, service, time.Now().Add(1*time.Hour))
+		}
+		for range 100 {
+			createAccessRequestWithExpiry(t, service, time.Now().Add(-1*time.Hour))
+		}
+		for range 2 {
+			createAccessRequestWithExpiry(t, service, time.Now().Add(1*time.Hour))
+		}
+
+		// List all.
+		requests, err := stream.Collect(clientutils.Resources(ctx, service.ListExpiredAccessRequests))
+		require.NoError(t, err)
+		require.Len(t, requests, 200)
+
+		// List all with an arbitrary page size.
+		requests, err = stream.Collect(clientutils.ResourcesWithPageSize(ctx, service.ListExpiredAccessRequests, 27))
+		require.NoError(t, err)
+		require.Len(t, requests, 200)
+
+		// List all with with a page size of 1.
+		requests, err = stream.Collect(clientutils.ResourcesWithPageSize(ctx, service.ListExpiredAccessRequests, 1))
+		require.NoError(t, err)
+		require.Len(t, requests, 200)
+
+		// List single page.
+		requests, nextToken, err := service.ListExpiredAccessRequests(ctx, 83, "")
+		require.NoError(t, err)
+		require.NotEmpty(t, nextToken)
+		require.Len(t, requests, 83)
+
+		// Expire all.
+		time.Sleep(1*time.Hour + 1*time.Second)
+		synctest.Wait()
+
+		// List all expecting to have all listed as expired.
+		requests, err = stream.Collect(clientutils.Resources(ctx, service.ListExpiredAccessRequests))
+		require.NoError(t, err)
+		require.Len(t, requests, 206)
+	})
+}
+
+func setupDynamicAccessService(t *testing.T) (*DynamicAccessService, *memory.Memory) {
+	t.Helper()
+	ctx := t.Context()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+	})
+	require.NoError(t, err)
+
+	return NewDynamicAccessService(backend.NewSanitizer(mem)), mem
+}
+
+func createAccessRequestWithExpiry(t *testing.T, service *DynamicAccessService, expiry time.Time) types.AccessRequest {
+	t.Helper()
+	ctx := t.Context()
+
+	req, err := types.NewAccessRequest(uuid.NewString(), "alice", "test_role_1")
+	require.NoError(t, err)
+	req.SetExpiry(expiry)
+
+	req, err = service.CreateAccessRequestV2(ctx, req)
+	require.NoError(t, err)
+
+	return req
+}

--- a/lib/services/local/dynamic_access_test.go
+++ b/lib/services/local/dynamic_access_test.go
@@ -15,6 +15,7 @@
 package local
 
 import (
+	"context"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -22,11 +23,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 func Test_DynamicAccessService_ListExpiredAccessRequests(t *testing.T) {
@@ -85,6 +88,39 @@ func Test_DynamicAccessService_ListExpiredAccessRequests(t *testing.T) {
 	})
 }
 
+func Test_DynamicAccessService_range_boundary(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, syncTest_DynamicAccessService_range_boundary)
+}
+
+func syncTest_DynamicAccessService_range_boundary(t *testing.T) {
+	ctx := t.Context()
+	service, _ := setupDynamicAccessService(t)
+
+	ongoingRequest := createAccessRequestWithExpiry(t, service, time.Now().Add(1))
+	expiredRequest := createAccessRequestWithExpiry(t, service, time.Now().Add(-1))
+	// Create some access requests outside the expected key range to validate they are
+	// not listed.
+	mustUpsertAccessRequestCustomKey(t, service, backend.NewKey("aaa", paramsPrefix), newAccessRequestWithExpiry(t, time.Now().Add(1)))
+	mustUpsertAccessRequestCustomKey(t, service, backend.NewKey("aaa", paramsPrefix), newAccessRequestWithExpiry(t, time.Now().Add(-1)))
+	mustUpsertAccessRequestCustomKey(t, service, backend.NewKey("zzz", paramsPrefix), newAccessRequestWithExpiry(t, time.Now().Add(1)))
+	mustUpsertAccessRequestCustomKey(t, service, backend.NewKey("zzz", paramsPrefix), newAccessRequestWithExpiry(t, time.Now().Add(-1)))
+
+	listAccessRequestsFn := func(ctx context.Context, limit int, pageToken string) ([]*types.AccessRequestV3, string, error) {
+		resp, err := service.ListAccessRequests(ctx, &proto.ListAccessRequestsRequest{Limit: int32(limit), StartKey: pageToken})
+		return resp.GetAccessRequests(), resp.GetNextKey(), err
+	}
+	allRequests, err := stream.Collect(clientutils.ResourcesWithPageSize(ctx, listAccessRequestsFn, 1))
+	require.NoError(t, err)
+	require.Len(t, allRequests, 2)
+	require.ElementsMatch(t, resourceNames(ongoingRequest, expiredRequest), resourceNames(allRequests...))
+
+	expiredRequests, err := stream.Collect(clientutils.ResourcesWithPageSize(ctx, service.ListExpiredAccessRequests, 1))
+	require.NoError(t, err)
+	require.Len(t, expiredRequests, 1)
+	require.Equal(t, expiredRequest.GetName(), expiredRequests[0].GetName())
+}
+
 func setupDynamicAccessService(t *testing.T) (*DynamicAccessService, *memory.Memory) {
 	t.Helper()
 	ctx := t.Context()
@@ -97,16 +133,48 @@ func setupDynamicAccessService(t *testing.T) (*DynamicAccessService, *memory.Mem
 	return NewDynamicAccessService(backend.NewSanitizer(mem)), mem
 }
 
-func createAccessRequestWithExpiry(t *testing.T, service *DynamicAccessService, expiry time.Time) types.AccessRequest {
+func newAccessRequestWithExpiry(t *testing.T, expiry time.Time) types.AccessRequest {
 	t.Helper()
-	ctx := t.Context()
 
 	req, err := types.NewAccessRequest(uuid.NewString(), "alice", "test_role_1")
 	require.NoError(t, err)
 	req.SetExpiry(expiry)
 
-	req, err = service.CreateAccessRequestV2(ctx, req)
+	return req
+}
+
+func createAccessRequestWithExpiry(t *testing.T, service *DynamicAccessService, expiry time.Time) types.AccessRequest {
+	t.Helper()
+	ctx := t.Context()
+
+	req, err := service.CreateAccessRequestV2(ctx, newAccessRequestWithExpiry(t, expiry))
 	require.NoError(t, err)
 
 	return req
+}
+
+func mustUpsertAccessRequestCustomKey(t *testing.T, service *DynamicAccessService, key backend.Key, req types.AccessRequest) types.AccessRequest {
+	t.Helper()
+	ctx := t.Context()
+
+	err := services.ValidateAccessRequest(req)
+	require.NoError(t, err)
+
+	item, err := itemFromAccessRequest(req)
+	require.NoError(t, err)
+	item.Key = key
+
+	lease, err := service.Put(ctx, item)
+	require.NoError(t, err)
+
+	req.SetRevision(lease.Revision)
+	return req
+}
+
+func resourceNames[T types.Resource](resources ...T) []string {
+	var names []string
+	for _, r := range resources {
+		names = append(names, r.GetName())
+	}
+	return names
 }


### PR DESCRIPTION
Backport #63615 + #64184 to branch/v18

### Manual tests

`teleport backend ls | grep access_requests` can be used to verify access requests were cleaned up in the backend.

1. Create access request and leave pending.
2. Create access request and approve.
3. Create access request and deny.
4. Wait for until after .spec.expiry for pending access request to expire. See if it's expired in the backend.
5. Wait for until after .spec.expiry for approved access request to expire. See if it's expired in the backend.
6. Wait for until after .spec.expiry for denied access request to expire. See if it's expired in the backend.
7. Verify expiry.go logs.

- - -

changelog: Fix a bug where audit events could be created forever for an expired access request.