### PR TITLE
Update ZTA web features

### DIFF
--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -819,7 +819,7 @@ export class FeatureWorkloadIdentity implements TeleportFeature {
 }
 
 class FeatureDeviceTrust implements TeleportFeature {
-  category = NavigationCategory.IdentityGovernance;
+  category = NavigationCategory.ZeroTrustAccess;
   route = {
     title: 'Trusted Devices',
     path: cfg.routes.deviceTrust,
@@ -953,6 +953,7 @@ export function getOSSFeatures(): TeleportFeature[] {
     new FeatureAddBotsShortcut(),
     new FeatureJoinTokens(),
     new FeatureRoles(),
+    new FeatureDeviceTrust(),
     new FeatureAuthConnectors(),
     new FeatureIntegrations(),
     new FeatureManagedUpdates(),
@@ -965,7 +966,6 @@ export function getOSSFeatures(): TeleportFeature[] {
     new AccessRequests(),
     new FeatureLocks(),
     new FeatureNewLock(),
-    new FeatureDeviceTrust(),
     new FeatureWorkloadIdentity(),
 
     // - Audit


### PR DESCRIPTION
Move Device Trust section from Identity Governance to Zero Trust Access on Teleport OSS web UI.

Buddy PR: [#8142](https://github.com/gravitational/teleport.e/pull/8142)

Addresses second point in [#7490](https://github.com/gravitational/teleport.e/issues/7490)

changelog: Device Trust is now accessible under Zero Trust Access in the web UI

## Manual Test Plan
### Test Environment
Tested locally with Teleport v18.7

### Test Cases
- [x] Device Trust should now be listed under the Roles feature in the web UI for OSS users