### PR TITLE
Refactor Label status cases to use Status component instead

### DIFF
--- a/web/packages/design/src/Icon/Icons.story.tsx
+++ b/web/packages/design/src/Icon/Icons.story.tsx
@@ -117,6 +117,7 @@ export const Icons = () => (
     <IconBox IconCmpt={Icon.Detective} text="Detective" />
     <IconBox IconCmpt={Icon.DeviceMobileCamera} text="DeviceMobileCamera" />
     <IconBox IconCmpt={Icon.Devices} text="Devices" />
+    <IconBox IconCmpt={Icon.Dot} text="Dot" />
     <IconBox IconCmpt={Icon.Download} text="Download" />
     <IconBox IconCmpt={Icon.Earth} text="Earth" />
     <IconBox IconCmpt={Icon.Edit} text="Edit" />

--- a/web/packages/design/src/Icon/Icons/Dot.tsx
+++ b/web/packages/design/src/Icon/Icons/Dot.tsx
@@ -1,0 +1,69 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* MIT License
+
+Copyright (c) 2020 Phosphor Icons
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+import { forwardRef } from 'react';
+
+import { Icon, IconProps } from '../Icon';
+
+/*
+
+THIS FILE IS GENERATED. DO NOT EDIT.
+
+*/
+
+export const Dot = forwardRef<HTMLSpanElement, IconProps>(
+  ({ size = 24, color, ...otherProps }, ref) => (
+    <Icon
+      size={size}
+      color={color}
+      className="icon icon-dot"
+      {...otherProps}
+      ref={ref}
+    >
+      <path
+        fillRule="evenodd"
+        d="M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16"
+        clipRule="evenodd"
+      />
+    </Icon>
+  )
+);

--- a/web/packages/design/src/Icon/assets/Dot.svg
+++ b/web/packages/design/src/Icon/assets/Dot.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill-rule="evenodd" d="M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z" clip-rule="evenodd"/>
+</svg>

--- a/web/packages/design/src/Icon/index.ts
+++ b/web/packages/design/src/Icon/index.ts
@@ -106,6 +106,7 @@ export { Desktop } from './Icons/Desktop';
 export { Detective } from './Icons/Detective';
 export { DeviceMobileCamera } from './Icons/DeviceMobileCamera';
 export { Devices } from './Icons/Devices';
+export { Dot } from './Icons/Dot';
 export { Download } from './Icons/Download';
 export { Earth } from './Icons/Earth';
 export { Edit } from './Icons/Edit';

--- a/web/packages/design/src/Status/Status.story.tsx
+++ b/web/packages/design/src/Status/Status.story.tsx
@@ -17,8 +17,10 @@
  */
 
 import { Flex, Text } from 'design';
+import { Dot } from 'design/Icon';
 
-import { Status, StatusKind, StatusVariant } from './Status';
+import { Status, StatusKind, StatusProps, StatusVariant } from './Status';
+import { StatusDot } from './StatusDot';
 
 export default {
   title: 'Design/Status',
@@ -33,96 +35,86 @@ const kinds: StatusKind[] = [
   'primary',
 ];
 
-const variants: StatusVariant[] = ['filled', 'filled-tonal', 'border'];
+const variants: StatusVariant[] = [
+  'filled',
+  'filled-tonal',
+  'filled-subtle',
+  'border',
+];
 
-export const AllVariants = () => (
-  <Flex flexDirection="column" gap={6} p={4} bg="levels.surface">
-    <Flex gap={6}>
-      <Text
-        typography="body2"
-        bold
-        css={{ width: '100px', textAlign: 'right' }}
-      >
-        {/* empty for alignment */}
-      </Text>
-      {variants.map(variant => (
+function StatusGrid({ iconProp }: { iconProp?: StatusProps['icon'] }) {
+  return (
+    <Flex flexDirection="column" gap={6} p={4} bg="levels.surface">
+      <Flex gap={6}>
         <Text
-          key={variant}
           typography="body2"
           bold
-          css={{ width: '160px', textAlign: 'center' }}
+          css={{ width: '100px', textAlign: 'right' }}
         >
-          {variant}
+          {/* empty for alignment */}
         </Text>
+        {variants.map(variant => (
+          <Text
+            key={variant}
+            typography="body2"
+            bold
+            css={{ width: '160px', textAlign: 'center' }}
+          >
+            {variant}
+          </Text>
+        ))}
+      </Flex>
+
+      {kinds.map(kind => (
+        <Flex key={kind} gap={6} alignItems="center">
+          <Text
+            typography="body2"
+            color="text.slightlyMuted"
+            css={{ width: '100px', textAlign: 'right' }}
+          >
+            {kind}
+          </Text>
+          {variants.map(variant => (
+            <Flex
+              key={variant}
+              css={{ width: '160px', justifyContent: 'center' }}
+            >
+              <Status kind={kind} variant={variant} icon={iconProp}>
+                {kind.charAt(0).toUpperCase() + kind.slice(1)}
+              </Status>
+            </Flex>
+          ))}
+        </Flex>
+      ))}
+    </Flex>
+  );
+}
+
+export const AllVariants = () => <StatusGrid />;
+
+export const WithoutIcons = () => <StatusGrid iconProp={false} />;
+
+export const Dots = () => (
+  <Flex flexDirection="column" gap={6} p={4} bg="levels.surface">
+    <Text typography="h3">Standalone StatusDot</Text>
+    <Flex gap={4} alignItems="center">
+      {kinds.map(kind => (
+        <Flex key={kind} gap={2} alignItems="center">
+          <StatusDot kind={kind} />
+          <Text typography="body2">{kind}</Text>
+        </Flex>
       ))}
     </Flex>
 
-    {kinds.map(kind => (
-      <Flex key={kind} gap={6} alignItems="center">
-        <Text
-          typography="body2"
-          color="text.slightlyMuted"
-          css={{ width: '100px', textAlign: 'right' }}
-        >
-          {kind}
-        </Text>
-        {variants.map(variant => (
-          <Flex
-            key={variant}
-            css={{ width: '160px', justifyContent: 'center' }}
-          >
-            <Status kind={kind} variant={variant}>
-              {kind.charAt(0).toUpperCase() + kind.slice(1)}
-            </Status>
-          </Flex>
-        ))}
-      </Flex>
-    ))}
-  </Flex>
-);
-
-export const WithoutIcons = () => (
-  <Flex flexDirection="column" gap={6} p={4} bg="levels.surface">
-    <Flex gap={6}>
-      <Text
-        typography="body2"
-        bold
-        css={{ width: '100px', textAlign: 'right' }}
-      >
-        {/* empty for alignment */}
-      </Text>
-      {variants.map(variant => (
-        <Text
-          key={variant}
-          typography="body2"
-          bold
-          css={{ width: '160px', textAlign: 'center' }}
-        >
-          {variant}
-        </Text>
+    <Text typography="h3" mt={4}>
+      Dot icon inside Status
+    </Text>
+    <Flex gap={4} alignItems="center" flexWrap="wrap">
+      {kinds.map(kind => (
+        <Status key={kind} kind={kind} icon={Dot}>
+          {kind.charAt(0).toUpperCase() + kind.slice(1)}
+        </Status>
       ))}
     </Flex>
-
-    {kinds.map(kind => (
-      <Flex key={kind} gap={6} alignItems="center">
-        <Text
-          typography="body2"
-          color="text.slightlyMuted"
-          css={{ width: '100px', textAlign: 'right' }}
-        >
-          {kind}
-        </Text>
-        {variants.map(variant => (
-          <Flex
-            key={variant}
-            css={{ width: '160px', justifyContent: 'center' }}
-          >
-            <Status kind={kind} variant={variant} noIcon>
-              {kind.charAt(0).toUpperCase() + kind.slice(1)}
-            </Status>
-          </Flex>
-        ))}
-      </Flex>
-    ))}
   </Flex>
 );

--- a/web/packages/design/src/Status/Status.test.tsx
+++ b/web/packages/design/src/Status/Status.test.tsx
@@ -20,57 +20,25 @@ import { screen } from '@testing-library/react';
 
 import { render } from 'design/utils/testing';
 
-import { Status, StatusKind, StatusVariant } from './Status';
+import { Status } from './Status';
 
 describe('design/Status', () => {
-  const kinds: StatusKind[] = [
-    'success',
-    'warning',
-    'info',
-    'danger',
-    'neutral',
-    'primary',
-  ];
-
-  const variants: StatusVariant[] = ['filled', 'filled-tonal', 'border'];
-
-  it.each(kinds)('renders kind="%s"', kind => {
-    render(<Status kind={kind}>Label</Status>);
-    expect(screen.getByText('Label')).toBeInTheDocument();
-  });
-
-  it.each(variants)('renders variant="%s"', variant => {
-    render(
-      <Status kind="success" variant={variant}>
-        Label
-      </Status>
-    );
-    expect(screen.getByText('Label')).toBeInTheDocument();
-  });
-
-  it('renders a custom icon component', () => {
+  it('renders a component reference icon with color and size', () => {
     const CustomIcon = (props: any) => (
-      <span data-testid="custom-icon" {...props} />
+      <span
+        data-testid="comp-icon"
+        data-color={props.color}
+        data-size={props.size}
+      />
     );
     render(
-      <Status kind="info" icon={CustomIcon}>
-        Info
+      <Status kind="success" icon={CustomIcon}>
+        Custom
       </Status>
     );
-    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
-  });
-
-  it('hides icon when noIcon is set', () => {
-    const CustomIcon = (props: any) => (
-      <span data-testid="custom-icon" {...props} />
-    );
-
-    render(
-      <Status kind="success" noIcon icon={CustomIcon}>
-        No Icon
-      </Status>
-    );
-
-    expect(screen.queryByTestId('custom-icon')).not.toBeInTheDocument();
+    const icon = screen.getByTestId('comp-icon');
+    expect(icon).toBeInTheDocument();
+    expect(icon.dataset.color).toBeTruthy();
+    expect(icon.dataset.size).toBeTruthy();
   });
 });

--- a/web/packages/design/src/Status/Status.tsx
+++ b/web/packages/design/src/Status/Status.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type ComponentType, type HTMLAttributes, type ReactNode } from 'react';
+import { type ComponentType, type ReactNode } from 'react';
 import styled, { css, useTheme } from 'styled-components';
 
 import { CircleCheck, CircleCross, Info, Question, Warning } from 'design/Icon';
@@ -24,6 +24,8 @@ import type { IconProps } from 'design/Icon/Icon';
 import { pillBase } from 'design/pillStyles';
 import { space, type SpaceProps } from 'design/system';
 import type { Theme } from 'design/theme';
+
+import { getVariantColors } from './statusColors';
 
 export type StatusKind =
   | 'success'
@@ -33,56 +35,15 @@ export type StatusKind =
   | 'neutral'
   | 'primary';
 
-export type StatusVariant = 'filled' | 'filled-tonal' | 'border';
-
-interface KindColors {
-  solid: string;
-  tonal: string;
-  accent: string;
-}
-
-function getKindColors(theme: Theme, kind: StatusKind): KindColors {
-  const { interactive, dataVisualisation } = theme.colors;
-
-  switch (kind) {
-    case 'success':
-      return {
-        solid: interactive.solid.success.default,
-        tonal: interactive.tonal.success[1],
-        accent: dataVisualisation.tertiary.caribbean,
-      };
-    case 'warning':
-      return {
-        solid: interactive.solid.alert.default,
-        tonal: interactive.tonal.alert[2],
-        accent: dataVisualisation.tertiary.sunflower,
-      };
-    case 'info':
-      return {
-        solid: interactive.solid.accent.default,
-        tonal: interactive.tonal.informational[2],
-        accent: dataVisualisation.tertiary.picton,
-      };
-    case 'danger':
-      return {
-        solid: interactive.solid.danger.default,
-        tonal: interactive.tonal.danger[2],
-        accent: interactive.solid.danger.active,
-      };
-    case 'neutral':
-      return {
-        solid: theme.colors.text.muted,
-        tonal: interactive.tonal.neutral[1],
-        accent: theme.colors.text.slightlyMuted,
-      };
-    case 'primary':
-      return {
-        solid: interactive.solid.primary.default,
-        tonal: interactive.tonal.primary[0],
-        accent: dataVisualisation.tertiary.purple,
-      };
-  }
-}
+export type StatusVariant =
+  // Primary actions, critical states (APPROVED/DENIED badges).
+  | 'filled'
+  // General status indicators (default).
+  | 'filled-tonal'
+  // Secondary context alongside other UI (version pills, health dots).
+  | 'border'
+  // Background metadata that shouldn't compete for attention.
+  | 'filled-subtle';
 
 const defaultIcons: Record<StatusKind, ComponentType<IconProps>> = {
   success: CircleCheck,
@@ -92,17 +53,6 @@ const defaultIcons: Record<StatusKind, ComponentType<IconProps>> = {
   neutral: Question,
   primary: CircleCheck,
 };
-
-function getIconColor(
-  colors: KindColors,
-  variant: StatusVariant,
-  theme: Theme
-): string {
-  if (variant === 'filled') {
-    return theme.colors.text.primaryInverse;
-  }
-  return colors.accent;
-}
 
 interface StyledStatusProps extends SpaceProps {
   $kind: StatusKind;
@@ -114,28 +64,12 @@ function variantStyles({
   $variant,
   theme,
 }: StyledStatusProps & { theme: Theme }) {
-  const c = getKindColors(theme, $kind);
-
-  switch ($variant) {
-    case 'filled':
-      return css`
-        background: ${c.solid};
-        color: ${theme.colors.text.primaryInverse};
-        border: 1px solid transparent;
-      `;
-    case 'filled-tonal':
-      return css`
-        background: ${c.tonal};
-        color: ${theme.colors.text.main};
-        border: 1px solid ${c.accent};
-      `;
-    case 'border':
-      return css`
-        background: transparent;
-        color: ${theme.colors.text.main};
-        border: 1px solid ${c.accent};
-      `;
-  }
+  const c = getVariantColors(theme, $kind, $variant);
+  return css`
+    background: ${c.bg};
+    color: ${c.fg};
+    border: 1px solid ${c.border};
+  `;
 }
 
 const StyledStatus = styled.span<StyledStatusProps>`
@@ -145,14 +79,21 @@ const StyledStatus = styled.span<StyledStatusProps>`
   ${space}
 `;
 
-export interface StatusProps
-  extends SpaceProps, Omit<HTMLAttributes<HTMLSpanElement>, 'color'> {
+function renderIcon(
+  icon: StatusProps['icon'],
+  kind: StatusKind,
+  color: string
+): ReactNode {
+  if (icon === false) return null;
+  const Icon = icon ?? defaultIcons[kind];
+  return <Icon size="small" color={color} />;
+}
+
+export interface StatusProps extends SpaceProps {
   kind: StatusKind;
   variant?: StatusVariant;
-  // Provide a custom icon to override the default
-  icon?: ComponentType<IconProps>;
-  // Render the badge without an icon
-  noIcon?: boolean;
+  // Custom icon component reference, or `false` to hide the icon entirely.
+  icon?: ComponentType<IconProps> | false;
   children: ReactNode;
 }
 
@@ -160,27 +101,15 @@ export function Status({
   kind,
   variant = 'filled-tonal',
   icon,
-  noIcon,
   children,
   ...rest
 }: StatusProps) {
   const theme = useTheme() as Theme;
-
-  let iconElement: ReactNode = null;
-  if (!noIcon) {
-    const IconComponent = icon ?? defaultIcons[kind];
-    const colors = getKindColors(theme, kind);
-    iconElement = (
-      <IconComponent
-        size="small"
-        color={getIconColor(colors, variant, theme)}
-      />
-    );
-  }
+  const v = getVariantColors(theme, kind, variant);
 
   return (
-    <StyledStatus $kind={kind} $variant={variant} {...rest}>
-      {iconElement}
+    <StyledStatus role="status" $kind={kind} $variant={variant} {...rest}>
+      {renderIcon(icon, kind, v.iconColor)}
       {children}
     </StyledStatus>
   );

--- a/web/packages/design/src/Status/StatusDot.tsx
+++ b/web/packages/design/src/Status/StatusDot.tsx
@@ -16,7 +16,27 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Status } from './Status';
-export { StatusDot } from './StatusDot';
-export type { StatusDotProps } from './StatusDot';
-export type { StatusKind, StatusVariant, StatusProps } from './Status';
+import { useTheme } from 'styled-components';
+
+import { Dot } from 'design/Icon';
+import type { IconProps } from 'design/Icon/Icon';
+import type { Theme } from 'design/theme';
+
+import type { StatusKind } from './Status';
+import { getKindColors } from './statusColors';
+
+export interface StatusDotProps extends IconProps {
+  kind?: StatusKind;
+}
+
+// A small colored dot to indicate status kind.
+export function StatusDot({
+  kind = 'neutral',
+  size = 'small',
+  ...rest
+}: StatusDotProps) {
+  const theme = useTheme() as Theme;
+  const color = getKindColors(theme, kind).solid;
+
+  return <Dot size={size} color={color} {...rest} />;
+}

--- a/web/packages/design/src/Status/statusColors.ts
+++ b/web/packages/design/src/Status/statusColors.ts
@@ -1,0 +1,113 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Theme } from 'design/theme';
+
+import type { StatusKind, StatusVariant } from './Status';
+
+export interface KindColors {
+  solid: string;
+  tonal: string;
+  accent: string;
+}
+
+export function getKindColors(theme: Theme, kind: StatusKind): KindColors {
+  const { interactive, dataVisualisation } = theme.colors;
+
+  switch (kind) {
+    case 'success':
+      return {
+        solid: interactive.solid.success.default,
+        tonal: interactive.tonal.success[1],
+        accent: dataVisualisation.tertiary.caribbean,
+      };
+    case 'warning':
+      return {
+        solid: interactive.solid.alert.default,
+        tonal: interactive.tonal.alert[2],
+        accent: dataVisualisation.tertiary.sunflower,
+      };
+    case 'info':
+      return {
+        solid: interactive.solid.accent.default,
+        tonal: interactive.tonal.informational[2],
+        accent: dataVisualisation.tertiary.picton,
+      };
+    case 'danger':
+      return {
+        solid: interactive.solid.danger.default,
+        tonal: interactive.tonal.danger[2],
+        accent: interactive.solid.danger.active,
+      };
+    case 'neutral':
+      return {
+        solid: theme.colors.text.muted,
+        tonal: interactive.tonal.neutral[1],
+        accent: theme.colors.text.slightlyMuted,
+      };
+    case 'primary':
+      return {
+        solid: interactive.solid.primary.default,
+        tonal: interactive.tonal.primary[0],
+        accent: dataVisualisation.tertiary.purple,
+      };
+  }
+}
+
+export interface VariantStyles {
+  bg: string;
+  fg: string;
+  border: string;
+  iconColor: string;
+}
+
+export function getVariantColors(
+  theme: Theme,
+  kind: StatusKind,
+  variant: StatusVariant
+): VariantStyles {
+  const c = getKindColors(theme, kind);
+  const inverse = theme.colors.text.primaryInverse;
+  const main = theme.colors.text.main;
+
+  switch (variant) {
+    case 'filled':
+      return {
+        bg: c.solid,
+        fg: inverse,
+        border: 'transparent',
+        iconColor: inverse,
+      };
+    case 'filled-tonal':
+      return { bg: c.tonal, fg: main, border: c.accent, iconColor: c.accent };
+    case 'filled-subtle':
+      return {
+        bg: c.tonal,
+        fg: main,
+        border: 'transparent',
+        iconColor: c.accent,
+      };
+    case 'border':
+      return {
+        bg: 'transparent',
+        fg: main,
+        border: c.accent,
+        iconColor: c.accent,
+      };
+  }
+}

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestList/RequestList.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestList/RequestList.tsx
@@ -16,10 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Flex, LabelState, Text } from 'design';
+import { Flex, Text } from 'design';
 import { Cell } from 'design/DataTable';
 import { ArrowFatLinesUp } from 'design/Icon';
-import { LabelKind } from 'design/LabelState/LabelState';
+import { StatusDot, type StatusKind } from 'design/Status';
 import { AccessRequest } from 'shared/services/accessRequests';
 
 export const renderUserCell = ({ user }: AccessRequest) => {
@@ -66,25 +66,24 @@ export const renderStatusCell = ({ state }: AccessRequest) => {
     );
   }
 
-  let kind: LabelKind = 'warning';
+  return (
+    <Cell>
+      <Flex alignItems="center">
+        <StateDot state={state} />
+        <Text typography="body3" ml={2}>
+          {state}
+        </Text>
+      </Flex>
+    </Cell>
+  );
+};
+
+function StateDot({ state }: { state: string }) {
+  let kind: StatusKind = 'warning';
   if (state === 'APPROVED') {
     kind = 'success';
   } else if (state === 'DENIED') {
     kind = 'danger';
   }
-
-  return (
-    <Cell>
-      <Flex alignItems="center">
-        <LabelState
-          kind={kind}
-          mr={2}
-          width="10px"
-          p={0}
-          style={{ minHeight: '10px' }}
-        />
-        <Text typography="body3">{state}</Text>
-      </Flex>
-    </Cell>
-  );
-};
+  return <StatusDot kind={kind} />;
+}

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -28,7 +28,6 @@ import {
   H3,
   Indicator,
   Label,
-  LabelState,
   Text,
 } from 'design';
 import Table from 'design/DataTable';
@@ -40,7 +39,7 @@ import {
   CircleCross,
   Key,
 } from 'design/Icon';
-import { LabelKind } from 'design/LabelState/LabelState';
+import { Status, StatusDot, StatusKind } from 'design/Status';
 import { TeleportGearIcon } from 'design/SVGIcon';
 import { HoverTooltip } from 'design/Tooltip';
 import ResourcesRequested from 'shared/components/AccessRequests/ReviewRequests/RequestView/ResourcesRequested';
@@ -118,11 +117,11 @@ export function RequestView({
   }
 
   if (fetchRequestAttempt.status === 'error') {
-    return <Alert kind="danger" children={fetchRequestAttempt.statusText} />;
+    return <Alert kind="danger">{fetchRequestAttempt.statusText}</Alert>;
   }
 
   if (assumeRoleAttempt.status === 'error') {
-    return <Alert kind="danger" children={assumeRoleAttempt.statusText} />;
+    return <Alert kind="danger">{assumeRoleAttempt.statusText}</Alert>;
   }
 
   const request =
@@ -217,7 +216,6 @@ export function RequestView({
                   state={request.state}
                   mr={3}
                   px={3}
-                  py={1}
                   style={{ fontWeight: 'bold' }}
                 />
                 <H3>
@@ -579,12 +577,7 @@ function Comment({
 
 function Reviewers({ reviewers }: { reviewers: AccessRequestReviewer[] }) {
   const $reviewers = reviewers.map((reviewer, index) => {
-    let kind: LabelKind = 'warning';
-    if (reviewer.state === 'APPROVED' || reviewer.state === 'PROMOTED') {
-      kind = 'success';
-    } else if (reviewer.state === 'DENIED') {
-      kind = 'danger';
-    }
+    let dotKind: StatusKind = stateToStatusKind(reviewer.state);
 
     return (
       <Flex
@@ -613,15 +606,7 @@ function Reviewers({ reviewers }: { reviewers: AccessRequestReviewer[] }) {
         >
           {reviewer.name}
         </Text>
-        <LabelState
-          kind={kind}
-          width="10px"
-          p={0}
-          style={{
-            minHeight: '10px',
-            minWidth: '10px',
-          }}
-        />
+        <StatusDot kind={dotKind} />
       </Flex>
     );
   });
@@ -661,29 +646,33 @@ function Reviewers({ reviewers }: { reviewers: AccessRequestReviewer[] }) {
   );
 }
 
-function StateLabel(props: { state: RequestState; [key: string]: any }) {
-  const { state, ...styles } = props;
+function stateToStatusKind(state: RequestState): StatusKind {
   switch (state) {
     case 'APPROVED':
     case 'PROMOTED':
-      return (
-        <LabelState kind="success" {...styles}>
-          {state}
-        </LabelState>
-      );
+      return 'success';
     case 'DENIED':
-      return (
-        <LabelState kind="danger" {...styles}>
-          {state}
-        </LabelState>
-      );
+      return 'danger';
+    case 'NONE':
     case 'PENDING':
-      return (
-        <LabelState kind="warning" {...styles}>
-          {state}
-        </LabelState>
-      );
+    case 'APPLIED':
+    case '':
+      return 'warning';
+    default:
+      state satisfies never;
+      return 'warning';
   }
+}
+
+function StateLabel(props: { state: RequestState; [key: string]: any }) {
+  const { state, ...styles } = props;
+  let kind: StatusKind = stateToStatusKind(state);
+
+  return (
+    <Status kind={kind} variant="filled" icon={false} {...styles}>
+      {state}
+    </Status>
+  );
 }
 
 function Reviews({ reviews }: { reviews: AccessRequestReview[] }) {

--- a/web/packages/teleport/src/BotInstances/Details/HealthTab.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/HealthTab.tsx
@@ -21,7 +21,8 @@ import { formatDistanceToNowStrict } from 'date-fns/formatDistanceToNowStrict';
 import styled from 'styled-components';
 
 import Flex from 'design/Flex';
-import { SecondaryOutlined } from 'design/Label/Label';
+import { Dot } from 'design/Icon';
+import { Status, StatusKind } from 'design/Status';
 import Text from 'design/Text';
 import { HoverTooltip } from 'design/Tooltip/HoverTooltip';
 
@@ -74,20 +75,13 @@ export function HealthTab(props: { data: GetBotInstanceResponse }) {
                         <TimeText>{`Reported ${formatDistanceToNowStrict(new Date(h.updated_at.seconds * 1000))} ago`}</TimeText>
                       </HoverTooltip>
                     ) : undefined}
-                    <SecondaryOutlined>
-                      <Flex
-                        alignItems={'center'}
-                        gap={2}
-                        padding={1}
-                        paddingLeft={2}
-                        paddingRight={0}
-                      >
-                        <Text typography="body3">
-                          {makeHealthLabel(h.status)}
-                        </Text>
-                        <HealthStatusDot $status={h.status} />
-                      </Flex>
-                    </SecondaryOutlined>
+                    <Status
+                      kind={healthStatusToKind(h.status)}
+                      variant="border"
+                      icon={Dot}
+                    >
+                      {makeHealthLabel(h.status)}
+                    </Status>
                   </Flex>
                 </Flex>
 
@@ -123,25 +117,6 @@ const ItemContainer = styled(Flex)`
   border-radius: ${({ theme }) => theme.space[1]}px;
   padding: ${({ theme }) => theme.space[3]}px;
   gap: ${({ theme }) => theme.space[3]}px;
-`;
-
-export const HealthStatusDot = styled.div<{
-  $status: BotInstanceServiceHealthStatus | undefined;
-}>`
-  width: ${({ theme }) => theme.space[3] - theme.space[1]}px;
-  height: ${({ theme }) => theme.space[3] - theme.space[1]}px;
-  border-radius: 999px;
-  background-color: ${({ theme, $status }) =>
-    $status ===
-    BotInstanceServiceHealthStatus.BOT_INSTANCE_HEALTH_STATUS_HEALTHY
-      ? theme.colors.interactive.solid.success.default
-      : $status ===
-          BotInstanceServiceHealthStatus.BOT_INSTANCE_HEALTH_STATUS_UNHEALTHY
-        ? theme.colors.interactive.solid.danger.default
-        : $status ===
-            BotInstanceServiceHealthStatus.BOT_INSTANCE_HEALTH_STATUS_INITIALIZING
-          ? theme.colors.interactive.tonal.neutral[1]
-          : theme.colors.interactive.solid.alert.default};
 `;
 
 const ReasonContainer = styled.div<{
@@ -192,6 +167,21 @@ const TimeText = styled(Text).attrs({
 })`
   white-space: nowrap;
 `;
+
+export function healthStatusToKind(
+  status: BotInstanceServiceHealthStatus | undefined
+): StatusKind {
+  switch (status) {
+    case BotInstanceServiceHealthStatus.BOT_INSTANCE_HEALTH_STATUS_HEALTHY:
+      return 'success';
+    case BotInstanceServiceHealthStatus.BOT_INSTANCE_HEALTH_STATUS_UNHEALTHY:
+      return 'danger';
+    case BotInstanceServiceHealthStatus.BOT_INSTANCE_HEALTH_STATUS_INITIALIZING:
+      return 'neutral';
+    default:
+      return 'warning';
+  }
+}
 
 function makeHealthLabel(status: BotInstanceServiceHealthStatus | undefined) {
   if (

--- a/web/packages/teleport/src/BotInstances/Details/InfoTab.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/InfoTab.tsx
@@ -22,7 +22,8 @@ import styled from 'styled-components';
 
 import Box from 'design/Box/Box';
 import Flex from 'design/Flex/Flex';
-import { SecondaryOutlined } from 'design/Label/Label';
+import { Dot } from 'design/Icon';
+import { Status } from 'design/Status';
 import Text from 'design/Text';
 import { HoverTooltip } from 'design/Tooltip/HoverTooltip';
 import { IconTooltip } from 'design/Tooltip/IconTooltip';
@@ -38,7 +39,7 @@ import {
   GetBotInstanceResponseJoinAttrs,
 } from 'teleport/services/bot/types';
 
-import { HealthStatusDot } from './HealthTab';
+import { healthStatusToKind } from './HealthTab';
 
 export function InfoTab(props: {
   data: GetBotInstanceResponse;
@@ -148,18 +149,13 @@ export function InfoTab(props: {
                     placement="top"
                     tipContent={makeHealthTooltip(h.status)}
                   >
-                    <SecondaryOutlined>
-                      <Flex
-                        alignItems={'center'}
-                        gap={2}
-                        padding={1}
-                        paddingLeft={0}
-                        paddingRight={2}
-                      >
-                        <HealthStatusDot $status={h.status} />
-                        <HealthLabelText>{h.service.name}</HealthLabelText>
-                      </Flex>
-                    </SecondaryOutlined>
+                    <Status
+                      kind={healthStatusToKind(h.status)}
+                      variant="border"
+                      icon={Dot}
+                    >
+                      {h.service.name}
+                    </Status>
                   </HoverTooltip>
                 ) : undefined
               )}
@@ -245,12 +241,6 @@ const HealthLabelsContainer = styled(Flex)`
   flex-wrap: wrap;
   overflow: hidden;
   gap: ${props => props.theme.space[1]}px;
-`;
-
-const HealthLabelText = styled(Text).attrs({
-  typography: 'body3',
-})`
-  white-space: nowrap;
 `;
 
 const AccentCountText = styled(Text)`

--- a/web/packages/teleport/src/Bots/Details/Instance.tsx
+++ b/web/packages/teleport/src/Bots/Details/Instance.tsx
@@ -19,17 +19,13 @@
 import { format } from 'date-fns/format';
 import { formatDistanceToNowStrict } from 'date-fns/formatDistanceToNowStrict';
 import { parseISO } from 'date-fns/parseISO';
-import { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 
 import Flex from 'design/Flex/Flex';
 import { ArrowFatLinesUp } from 'design/Icon/Icons/ArrowFatLinesUp';
-import {
-  DangerOutlined,
-  SecondaryOutlined,
-  WarningOutlined,
-} from 'design/Label/Label';
 import { ResourceIcon } from 'design/ResourceIcon';
+import { Status, StatusKind } from 'design/Status';
+import { Tag } from 'design/Tag';
 import Text from 'design/Text/Text';
 import { HoverTooltip } from 'design/Tooltip/HoverTooltip';
 import { CopyButton } from 'shared/components/CopyButton/CopyButton';
@@ -108,9 +104,9 @@ export function Instance(props: {
                 placement="top"
                 tipContent={`Hostname: ${hostname}`}
               >
-                <SecondaryOutlined borderRadius={2}>
+                <Tag>
                   <HostnameText>{hostname}</HostnameText>
-                </SecondaryOutlined>
+                </Tag>
               </HoverTooltip>
             ) : undefined}
           </Flex>
@@ -230,19 +226,19 @@ function Version(props: { version: string | undefined }) {
   const { checkCompatibility } = useClusterVersion();
   const versionCompatibility = checkCompatibility(version);
 
-  let Wrapper = SecondaryOutlined;
-  let icon: ReactElement | null = <ArrowFatLinesUp size={'small'} />;
+  let kind: StatusKind = 'neutral';
+  let showUpgradeIcon = true;
   let tooltip = 'Version is up to date';
   if (versionCompatibility?.isCompatible) {
     switch (versionCompatibility.reason) {
       case 'match':
-        icon = null;
+        showUpgradeIcon = false;
         break;
       case 'upgrade-minor':
         tooltip = 'An upgrade is available';
         break;
       case 'upgrade-major':
-        Wrapper = WarningOutlined;
+        kind = 'warning';
         tooltip =
           'Version is one major version behind. Consider upgrading soon.';
         break;
@@ -250,12 +246,12 @@ function Version(props: { version: string | undefined }) {
   } else {
     switch (versionCompatibility?.reason) {
       case 'too-old':
-        Wrapper = DangerOutlined;
+        kind = 'danger';
         tooltip =
           'Version is two or more major versions behind, and is no longer compatible.';
         break;
       case 'too-new':
-        Wrapper = DangerOutlined;
+        kind = 'danger';
         tooltip = 'Version is ahead, and is not compatible.';
         break;
     }
@@ -264,12 +260,9 @@ function Version(props: { version: string | undefined }) {
   return version ? (
     <VersionContainer>
       <HoverTooltip placement="top" tipContent={tooltip}>
-        <Wrapper borderRadius={2}>
-          <Flex gap={1}>
-            {icon}
-            <Text typography="body3">v{version}</Text>
-          </Flex>
-        </Wrapper>
+        <Status kind={kind} icon={showUpgradeIcon ? ArrowFatLinesUp : false}>
+          v{version}
+        </Status>
       </HoverTooltip>
     </VersionContainer>
   ) : undefined;

--- a/web/packages/teleport/src/Clusters/ClusterList/ClusterList.tsx
+++ b/web/packages/teleport/src/Clusters/ClusterList/ClusterList.tsx
@@ -21,7 +21,7 @@ import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
 import Table, { Cell } from 'design/DataTable';
-import { Primary, Secondary } from 'design/Label';
+import { Status } from 'design/Status';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 
 import cfg from 'teleport/config';
@@ -62,7 +62,15 @@ function renderRootLabelCell({ clusterId }: Cluster) {
   const isRoot = cfg.proxyCluster === clusterId;
   return (
     <Cell style={{ width: '40px' }}>
-      {isRoot ? <Primary>ROOT</Primary> : <Secondary>LEAF</Secondary>}
+      {isRoot ? (
+        <Status kind="primary" variant="filled" icon={false}>
+          ROOT
+        </Status>
+      ) : (
+        <Status kind="neutral" variant="filled-subtle" icon={false}>
+          LEAF
+        </Status>
+      )}
     </Cell>
   );
 }
@@ -85,7 +93,7 @@ function renderActionCell({ clusterId }: Cluster, flags: MenuFlags) {
   }
 
   return (
-    <Cell align="right">{$items && <MenuButton children={$items} />}</Cell>
+    <Cell align="right">{$items && <MenuButton>{$items}</MenuButton>}</Cell>
   );
 }
 

--- a/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
+++ b/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
@@ -26,8 +26,8 @@ import { ButtonBorder, ButtonPrimary } from 'design/Button';
 import Table, { Cell } from 'design/DataTable';
 import { TableColumn } from 'design/DataTable/types';
 import { displayDateTime } from 'design/datetime';
-import { CircleCross, Cross, Link as LinkIcon, Warning } from 'design/Icon';
-import { LabelButtonWithIcon } from 'design/Label/LabelButtonWithIcon';
+import { Cross, Link as LinkIcon } from 'design/Icon';
+import { Status } from 'design/Status';
 import { P } from 'design/Text/Text';
 import { Markdown } from 'shared/components/Markdown/Markdown';
 import { useToastNotifications } from 'shared/components/ToastNotification';
@@ -174,15 +174,11 @@ export function UserTaskDrawer(props: {
 
 function TaskTypePill({ task }: { task: UserTaskDetail }) {
   const eventType = getTaskEventType(task);
-  const IconLeft = eventType === 'Error' ? CircleCross : Warning;
 
   return (
-    <LabelButtonWithIcon
-      IconLeft={IconLeft}
-      kind={eventType === 'Error' ? 'outline-danger' : 'outline-warning'}
-    >
+    <Status kind={eventType === 'Error' ? 'danger' : 'warning'}>
       {eventType}
-    </LabelButtonWithIcon>
+    </Status>
   );
 }
 

--- a/web/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClusterItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClusterItem.tsx
@@ -19,7 +19,8 @@
 import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
-import { Flex, Label, Text } from 'design';
+import { Flex, Text } from 'design';
+import { Status } from 'design/Status';
 
 import { Cluster } from 'teleterm/services/tshd/types';
 import { useKeyboardArrowsNavigation } from 'teleterm/ui/components/KeyboardArrowsNavigation';
@@ -63,16 +64,16 @@ export function ClusterItem(props: ClusterItemProps) {
           {clusterName}
         </Text>
         <Flex>
-          {!props.item.leaf ? (
-            <Label ml={1} kind="primary">
+          {!props.item.leaf && (
+            <Status ml={1} kind="primary" variant="filled" icon={false}>
               root
-            </Label>
-          ) : null}
-          {props.isSelected ? (
-            <Label ml={1} kind="success">
+            </Status>
+          )}
+          {props.isSelected && (
+            <Status ml={1} kind="success" variant="filled" icon={false}>
               active
-            </Label>
-          ) : null}
+            </Status>
+          )}
         </Flex>
       </Flex>
     </StyledListItem>


### PR DESCRIPTION
As part of the Label deprecation, this is refactoring `Label` cases that represent statuses to the new `Status` component. Some cleanup of unnecessary customization and lint warnings.

<img width="439" height="447" alt="Screenshot 2026-03-02 at 10 26 03 PM" src="https://github.com/user-attachments/assets/fc42d937-dce4-40c1-8352-dd0c989ed3f2" />
<img width="981" height="420" alt="Screenshot 2026-03-02 at 10 26 25 PM" src="https://github.com/user-attachments/assets/ad65844f-a9e8-4713-854e-d50472e1601f" />
<img width="909" height="117" alt="Screenshot 2026-03-02 at 10 26 53 PM" src="https://github.com/user-attachments/assets/250636ef-3822-4688-83cb-99854afbab96" />
<img width="920" height="449" alt="Screenshot 2026-03-02 at 10 27 34 PM" src="https://github.com/user-attachments/assets/369b71db-9667-4494-acd3-ca61f62044db" />
<img width="751" height="366" alt="Screenshot 2026-03-02 at 10 28 26 PM" src="https://github.com/user-attachments/assets/b9b2e255-8b83-4462-a24d-f6dcbbf621b9" />
<img width="1053" height="209" alt="Screenshot 2026-03-02 at 10 28 54 PM" src="https://github.com/user-attachments/assets/4beb1295-28fe-48dc-b2c1-ed11d1971e59" />
<img width="750" height="296" alt="Screenshot 2026-03-02 at 10 29 16 PM" src="https://github.com/user-attachments/assets/b9ebc0e2-9996-40ef-a31f-c854bb334d3f" />
<img width="903" height="224" alt="Screenshot 2026-03-02 at 10 29 31 PM" src="https://github.com/user-attachments/assets/a47e7675-9f98-45fd-9481-724e1ebcb241" />


Test Plan:
- [x] Screenshot all components before refactoring
- [x] Screenshot all components after refactoring
- [x] Check for any unexpected style issues from the refactor
- [x] Check for working functionality, effects, hover tooltips.