### PR TITLE
Remove custom scrollbar CSS

### DIFF
--- a/web/packages/design/src/ThemeProvider/globals.js
+++ b/web/packages/design/src/ThemeProvider/globals.js
@@ -46,20 +46,6 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 
-  // custom scrollbars with the ability to use the default scrollbar behavior via adding the attribute [data-scrollbar=default]
-  :not([data-scrollbar="default"])::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
-
-  :not([data-scrollbar="default"])::-webkit-scrollbar-thumb {
-    background: #757575;
-  }
-
-  :not([data-scrollbar="default"])::-webkit-scrollbar-corner {
-    background: rgba(0,0,0,0.5);
-  }
-
   :root {
     color-scheme: ${props =>
       props.theme

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
@@ -137,7 +137,7 @@ function InternalBotInstancesList(
       {hasData ? (
         <>
           {data && data.length > 0 ? (
-            <ContentContainer ref={contentRef} data-scrollbar="default">
+            <ContentContainer ref={contentRef}>
               {data.map((instance, i) => (
                 <React.Fragment key={`${instance.instance_id}`}>
                   {i === 0 ? undefined : <Divider />}

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingsList.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingsList.tsx
@@ -333,7 +333,7 @@ export function RecordingsList({
         </Flex>
       </Flex>
 
-      <ScrollContainer data-scrollbar="default" ref={scrollRef}>
+      <ScrollContainer ref={scrollRef}>
         {items.length === 0 ? (
           <Flex
             alignItems="center"

--- a/web/packages/teleterm/index.html
+++ b/web/packages/teleterm/index.html
@@ -1,10 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="referrer" content="no-referrer" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
   </head>
   <body>
     <div id="app"></div>

--- a/web/packages/teleterm/src/ui/ThemeProvider/globals.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/globals.ts
@@ -16,9 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { createGlobalStyle, css } from 'styled-components';
-
-import { getPlatform, Platform } from 'design/platform';
+import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
 
@@ -61,23 +59,6 @@ const GlobalStyle = createGlobalStyle`
     // theme.fontWeights.bold (600), whereas Connect mostly uses <strong> which by default uses the
     // useragent style.
     font-weight: ${props => props.theme.fontWeights.bold};
-  }
-
-  ${() => getPlatform() !== Platform.macOS && customScrollbar}
-`;
-
-const customScrollbar = css`
-  ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: #757575;
-  }
-
-  ::-webkit-scrollbar-corner {
-    background: rgba(0, 0, 0, 0.5);
   }
 `;
 


### PR DESCRIPTION
Removes the custom scrollbar CSS and the `data-scrollbar="default"` workaround so everything has the OS's scrollbar

Closes https://github.com/gravitational/teleport/issues/64193

[Connect before & after screenshots](https://github.com/gravitational/teleport/pull/64194#discussion_r2879163284)

### Manual testing

- [x] Verify the web app looks correct in common places with a scrollbar
- [x] Verify that Connect looks correct
- [x] Verify that places that used `data-scrollbar="default"` (e.g. bot instance list, list session recordings) look the same
- [x] Verify the results in Safari, Firefox and Chrome