### PR TITLE
[v18] Bump timeout in `WaitForAuditEventTypeWithBackoff`

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -262,7 +262,7 @@ func WaitForProxyCount(t *TeleInstance, clusterName string, count int) error {
 }
 
 func WaitForAuditEventTypeWithBackoff(t *testing.T, cli *auth.Server, startTime time.Time, eventType string) []apievents.AuditEvent {
-	max := time.Second * 2
+	max := time.Second * 10
 	timeout := time.After(max)
 	bf, err := retryutils.NewLinear(retryutils.LinearConfig{
 		Step: max / 10,


### PR DESCRIPTION
Backport #64161 to branch/v18

Manual testing: `N/A`, test-only change.