### PR TITLE
[v18] Disable CTMU for tsh.exe during Windows service install and runtime

### DIFF
--- a/tool/tsh/common/autoupdate_other.go
+++ b/tool/tsh/common/autoupdate_other.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+func isWindowsService() (bool, error) {
+	return false, nil
+}

--- a/tool/tsh/common/autoupdate_windows.go
+++ b/tool/tsh/common/autoupdate_windows.go
@@ -1,0 +1,27 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"github.com/gravitational/trace"
+	"golang.org/x/sys/windows/svc"
+)
+
+func isWindowsService() (bool, error) {
+	isSvc, err := svc.IsWindowsService()
+	return isSvc, trace.Wrap(err)
+}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -861,10 +861,21 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	if _, err := muApp.Parse(utils.FilterArguments(args, muApp.Model())); err != nil {
 		slog.WarnContext(ctx, "can't identify current profile", "error", err)
 	}
-	// Check local update for specific proxy from configuration.
-	name := utils.TryHost(strings.TrimPrefix(strings.ToLower(proxyArg), "https://"))
-	if err := autoupdatetools.CheckAndUpdateLocal(ctx, name, args); err != nil {
-		return trace.Wrap(err)
+	// Detect whether the process is running as a Windows service in order to disable automatic updates.
+	// We use this approach because setting `TELEPORT_TOOLS_VERSION=off` for a Windows service via environment variables is cumbersome.
+	//
+	// This is required for VNet, whose system service is implemented by `tsh.exe vnet-service`.
+	// Its service binary must not change unexpectedly.
+	isWinService, err := isWindowsService()
+	if err != nil {
+		logger.ErrorContext(ctx, "Could not determine whether tsh is running as a service; client tools managed updates will not be disabled", "error", err)
+	}
+	if !isWinService {
+		// Check local update for specific proxy from configuration.
+		name := utils.TryHost(strings.TrimPrefix(strings.ToLower(proxyArg), "https://"))
+		if err := autoupdatetools.CheckAndUpdateLocal(ctx, name, args); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	moduleCfg := modules.GetModules()

--- a/tool/tsh/common/vnet_windows.go
+++ b/tool/tsh/common/vnet_windows.go
@@ -40,18 +40,17 @@ func newPlatformVnetServiceCommand(app *kingpin.Application) *vnetServiceCommand
 }
 
 func (c *vnetServiceCommand) run(_ *CLIConf) error {
-	if !isWindowsService() {
+	isSvc, err := svc.IsWindowsService()
+	if err != nil {
+		return trace.Wrap(err, "failed to determine if running as a Windows service, cannot run %s command", vnet.ServiceCommand)
+	}
+	if !isSvc {
 		return trace.Errorf("not running as a Windows service, cannot run %s command", vnet.ServiceCommand)
 	}
 	if err := vnet.ServiceMain(); err != nil {
 		return trace.Wrap(err, "running VNet Windows service")
 	}
 	return nil
-}
-
-func isWindowsService() bool {
-	isSvc, err := svc.IsWindowsService()
-	return err == nil && isSvc
 }
 
 type vnetInstallServiceCommand struct {

--- a/web/packages/teleterm/build_resources/installer.nsh
+++ b/web/packages/teleterm/build_resources/installer.nsh
@@ -14,6 +14,10 @@
     EnVar::SetHKLM
     EnVar::AddValue "Path" $INSTDIR\resources\bin
 
+    # Disable client tools managed updates for the bundled tsh.exe commands below.
+    # This function has no effect on the system environment variables or the environment variables of other processes.
+    System::Call 'kernel32::SetEnvironmentVariable(t, t)i("TELEPORT_TOOLS_VERSION", "off").r0'
+
     nsExec::ExecToStack '"$INSTDIR\resources\bin\tsh.exe" vnet-install-service'
     Pop $0 # ExitCode
     Pop $1 # Output
@@ -30,6 +34,10 @@
     # Fortunately, electron-builder puts the uninstaller directly into the actual installation dir.
     # https://nsis.sourceforge.io/Docs/Chapter4.html#varother
     EnVar::DeleteValue "Path" $INSTDIR\resources\bin
+
+    # Disable client tools managed updates for the bundled tsh.exe commands below.
+    # This function has no effect on the system environment variables or the environment variables of other processes.
+    System::Call 'kernel32::SetEnvironmentVariable(t, t)i("TELEPORT_TOOLS_VERSION", "off").r0'
 
     nsExec::ExecToStack '"$INSTDIR\resources\bin\tsh.exe" vnet-uninstall-service'
     Pop $0 # ExitCode


### PR DESCRIPTION
Backport #63760 to branch/v18 

changelog: Fixed an issue where VNet on Windows could fail to start after an update with the error: `The specified service does not exist as an installed service.`

### Manual testing
1. Set `TELEPORT_TOOLS_VERSION=18.0.0` env variable for the entire system to force updates.
2. Made sure there's no `bin` folder in `~\.tsh` and in `C:\Windows\System32\config\systemprofile\.tsh`.
  - [x] Ran the updated installer, `~\.tsh\bin` is not be recreated.
  - [x] Ran the VNet service, `C:\Windows\System32\config\systemprofile\.tsh\bin` is not be recreated.
  - [x] VNet service works.