### PR TITLE
Document RemoveCertificateOverride's non-idempotent behavior

### DIFF
--- a/api/gen/proto/go/teleport/subca/v1/subca_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/subca/v1/subca_service_grpc.pb.go
@@ -120,6 +120,10 @@ type SubCAServiceClient interface {
 	// consequence of this RPC, then the entire CertAuthorityOverride resource is
 	// removed by the server, as if DeleteCertAuthorityOverride was called.
 	//
+	// Removals, like Deletes, are not idempotent and will fail if either the
+	// CertificateOverride (FailedPrecondition) or the CertAuthorityOverride
+	// (NotFound) are not found.
+	//
 	// Removals are only allowed for disabled overrides, or overrides that target
 	// removed certificates. See
 	// RemoveCertificateOverrideRequest.force_immediate_delete.
@@ -318,6 +322,10 @@ type SubCAServiceServer interface {
 	// If the last CertificateOverride of a CertAuthorityOverride is removed as a
 	// consequence of this RPC, then the entire CertAuthorityOverride resource is
 	// removed by the server, as if DeleteCertAuthorityOverride was called.
+	//
+	// Removals, like Deletes, are not idempotent and will fail if either the
+	// CertificateOverride (FailedPrecondition) or the CertAuthorityOverride
+	// (NotFound) are not found.
 	//
 	// Removals are only allowed for disabled overrides, or overrides that target
 	// removed certificates. See

--- a/api/proto/teleport/subca/v1/subca_service.proto
+++ b/api/proto/teleport/subca/v1/subca_service.proto
@@ -103,6 +103,10 @@ service SubCAService {
   // consequence of this RPC, then the entire CertAuthorityOverride resource is
   // removed by the server, as if DeleteCertAuthorityOverride was called.
   //
+  // Removals, like Deletes, are not idempotent and will fail if either the
+  // CertificateOverride (FailedPrecondition) or the CertAuthorityOverride
+  // (NotFound) are not found.
+  //
   // Removals are only allowed for disabled overrides, or overrides that target
   // removed certificates. See
   // RemoveCertificateOverrideRequest.force_immediate_delete.


### PR DESCRIPTION
Document that RemoveCertificateOverride, [like other Delete RPCs][1], is not idempotent.

[1]: https://github.com/gravitational/teleport/blob/master/rfd/0153-resource-guidelines.md#delete

https://github.com/gravitational/teleport.e/issues/7675