### PR TITLE
Clarify requirement that `spec.assigned_scope` be equiv or descendent to `scope` for ScopedToken

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -144,6 +144,8 @@ func (x *ScopedToken) GetStatus() *ScopedTokenStatus {
 type ScopedTokenSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The scope to which this token is assigned.
+	//
+	// Must be a equivalent or descendent to the scope of the token itself.
 	AssignedScope string `protobuf:"bytes,1,opt,name=assigned_scope,json=assignedScope,proto3" json:"assigned_scope,omitempty"`
 	// The list of roles associated with the token. They will be converted
 	// to metadata in the SSH and X509 certificates issued to the user of the

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -145,7 +145,7 @@ type ScopedTokenSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The scope to which this token is assigned.
 	//
-	// Must be a equivalent or descendent to the scope of the token itself.
+	// Must be equivalent or descendent to the scope of the token itself.
 	AssignedScope string `protobuf:"bytes,1,opt,name=assigned_scope,json=assignedScope,proto3" json:"assigned_scope,omitempty"`
 	// The list of roles associated with the token. They will be converted
 	// to metadata in the SSH and X509 certificates issued to the user of the

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -51,6 +51,8 @@ message ScopedToken {
 // ScopedTokenSpec is the specification of a scoped token.
 message ScopedTokenSpec {
   // The scope to which this token is assigned.
+  //
+  // Must be a equivalent or descendent to the scope of the token itself.
   string assigned_scope = 1;
 
   // The list of roles associated with the token. They will be converted

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -52,7 +52,7 @@ message ScopedToken {
 message ScopedTokenSpec {
   // The scope to which this token is assigned.
   //
-  // Must be a equivalent or descendent to the scope of the token itself.
+  // Must be equivalent or descendent to the scope of the token itself.
   string assigned_scope = 1;
 
   // The list of roles associated with the token. They will be converted

--- a/rfd/0229a-scoped-join-tokens.md
+++ b/rfd/0229a-scoped-join-tokens.md
@@ -87,7 +87,7 @@ to facilitate existing provisioning semantics.
 -  // AssignedScope is the scope to which this token is assigned.
 +  // The scope to which this token is assigned.
 +  //
-*  // Must be a equivalent or descendent to the scope of the token itself.
+*  // Must be equivalent or descendent to the scope of the token itself.
    string assigned_scope = 1;
 
 -  // TODO(fspmarshall): port relevant token features to scoped tokens.

--- a/rfd/0229a-scoped-join-tokens.md
+++ b/rfd/0229a-scoped-join-tokens.md
@@ -86,6 +86,8 @@ to facilitate existing provisioning semantics.
  message ScopedTokenSpec {
 -  // AssignedScope is the scope to which this token is assigned.
 +  // The scope to which this token is assigned.
++  //
+*  // Must be a equivalent or descendent to the scope of the token itself.
    string assigned_scope = 1;
 
 -  // TODO(fspmarshall): port relevant token features to scoped tokens.
@@ -166,6 +168,10 @@ the token's name is no longer the secret. This is similar to how the bounded
 keypair join method manages the registration secret. The `token` join method
 will require specifying both the token's name and secret when using scoped
 tokens.
+
+The `spec.assigned_scope` field specifies the scope that will be assigned to any
+resource provisioned using this token. This must be specified and must be
+equivalent or descendent to the `scope` of the token resource itself.
 
 ### Provisioning
 


### PR DESCRIPTION
Whilst working on Scoped MWI, I've stumbled across a fairly key "requirement" that the `spec.assigned_scope` of a ScopedToken be descendent or equivalent to the `scope` of the ScopedToken itself. This is a key requirement to maintain scope isolation and prevent escape.

Inspecting the implementation of `StrongValidateToken` confirms that our implementation today already enforces this requirement:

```go
func StrongValidateToken(token *joiningv1.ScopedToken) error {
// ...snip...
	if !scopes.ResourceScope(spec.AssignedScope).IsSubjectToPolicyScope(token.GetScope()) {
		return trace.BadParameter("scoped token assigned scope must be descendant of its resource scope")
	}
// ...snip...
}
```

This PR updates the RFD and the proto comment to make this requirement explicit for the benefit of any future engineers getting to grips with scopes.