### PR TITLE
Add Networking Reference Troubleshooting section

### DIFF
--- a/docs/pages/reference/deployment/networking.mdx
+++ b/docs/pages/reference/deployment/networking.mdx
@@ -408,17 +408,13 @@ Direct Auth Service joining is only supported for Teleport Agents running the Te
 
 ## Troubleshooting
 
-Logs emitted by `teleport` instances can include the following messages if you
+Logs emitted by a Teleport process can include the following messages if you
 have set up your Teleport cluster network incorrectly.
 
 ### Connection reset by peer
 
-If you see the message, `connection reset by peer`, it means that the component
-of your Teleport cluster that has emitted the log (e.g., a Teleport Agent)
-received a TCP packet with a control bit set to RST (reset). A TCP endpoint
-sends an RST packet over an established connection if it receives a packet that
-is unexpected given its connection state, e.g., if the other side unexpectedly
-exits mid-connection.
+If you see the message, `connection reset by peer`, it means that the remote
+server (usually the Teleport control plane) closed the client's connection.
 
 There is a variety of reasons why an upstream server may reset the connection,
 and they may or may not have to do with the components of a Teleport cluster.
@@ -427,7 +423,7 @@ is behind the Teleport Proxy Service, which closes a connection if it receives
 traffic from an outdated `tsh` client. It could also be that a Teleport Agent
 proxying a connection exited without closing the connection. A device between
 the Teleport component and the other side of the connection, such as a load
-balancer, may also be injecting RST packets.
+balancer, may also be closing the connection.
 
 To investigate:
 
@@ -470,9 +466,8 @@ transport: authentication handshake failed: tls: failed to verify certificate: x
 As explained in
 [Troubleshooting](../../zero-trust-access/management/diagnostics/troubleshooting.mdx#teleportclusterlocal),
 Teleport issues certificates with `teleport.cluster.local` as a Subject
-Alternative Name (SAN) for the Teleport Auth Service and Proxy Service. In this
-case, the certificate your Teleport component received does not include the
-intended SAN.
+Alternative Name (SAN) for the Teleport Auth Service. In this case, the
+certificate your Teleport component received does not include the intended SAN.
 
 One reason this situation could take place is that the cluster is configured to
 use [TLS

--- a/docs/pages/reference/deployment/networking.mdx
+++ b/docs/pages/reference/deployment/networking.mdx
@@ -405,3 +405,85 @@ expose ports directly.
 <Admonition type="important">
 Direct Auth Service joining is only supported for Teleport Agents running the Teleport SSH Service, Kubernetes Service, and Windows Desktop Service. Using Auth Service joining to enroll applications, databases, and for other discovery-based features, is not supported.
 </Admonition>
+
+## Troubleshooting
+
+Logs emitted by `teleport` instances can include the following messages if you
+have set up your Teleport cluster network incorrectly.
+
+### Connection reset by peer
+
+If you see the message, `Connection reset by peer`, it often means that your
+Teleport instance is attempting to connect to an upstream host that either:
+- has no process listening on the required port
+- exited the process that was listening on the required port
+
+You can rule out the latter scenario by checking whether the upstream process
+was running at the time of the error message. If the upstream server is running
+as expected, you can:
+
+1. Check the configuration of the Teleport process reporting the error. Make
+   sure the port it targets matches the one with an associated listener.
+2. Make sure no components of your network are blocking traffic from your
+   Teleport process. 
+
+   For example, you can use tooling built into your cloud provider, such as the
+   AWS [Reachability
+   Analyzer](https://docs.aws.amazon.com/vpc/latest/reachability/what-is-reachability-analyzer.html)
+   , to make sure your Teleport process can dial the target server. There could
+   be a misconfigured security group or internet gateway.
+
+   If possible, you may want to open a shell into your Teleport process's host
+   and use tools like `nc` and `traceroute` to see if your Teleport process can
+   reach the upstream server.
+
+### First record does not look like a TLS handshake
+
+You may see an error similar to the following, indicating an issue with a TLS
+handshake:
+
+```
+transport: authentication handshake failed: tls: first record does not look like a TLS handshake
+```
+
+The library that Teleport uses for TLS prints this error if the server and
+client have not negotiated a TLS version and the TLS record in question is not a
+handshake, or the TLS version is greater or equal than 16.0 (higher than the
+maximum supported version of 3.3). In other words, the Teleport process that
+printed the log was expected a TLS handshake from the other side of the
+connection and did not receive one, i.e., it was replying to the Teleport
+process in a different protocol.
+
+In this case, check the address of the upstream host and make sure it is one
+that is configured to use TLS, rather than (for example) HTTP or unencrypted
+TCP.
+
+### Authentication handshake failed
+
+Your `teleport` or `tbot` logs may report a certificate with a subject that does
+not match an unexpected domain name, a subdomain of `teleport.cluster.local`.
+The following example assumes your cluster's address is `example.teleport.sh`:
+
+```
+transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate is valid for *.example.teleport.sh, example.teleport.sh, not 6578616d706c652e74656c65706f72742e7368.teleport.cluster.local
+```
+
+As explained in
+[Troubleshooting](../../zero-trust-access/management/diagnostics/troubleshooting.mdx#teleportclusterlocal),
+Teleport issues certificates with `teleport.cluster.local` as a Subject
+Alternative Name (SAN) for the Teleport Auth Service and Proxy Service. In this
+case, the certificate your Teleport component received does not include the
+intended SAN.
+
+One reason this situation could take place is that the cluster is configured to
+use [TLS
+multiplexing](../../zero-trust-access/management/tls-routing.mdx), but you
+are running the Teleport Proxy Service behind a Layer 7 load balancer that only
+returns the load balancer's main certificate instead of allowing the Teleport
+internal certficate. Your infrastructure may be interfering with TLS connections
+by altering the certificate that your Teleport instance presents.
+
+Investigate whether the certificate your client receives is signed by, for
+example, a corporate TLS proxy, or has otherwise been transformed between the
+time the Teleport Auth Service issued it and it reached your client during the
+attempted TLS handshake.

--- a/docs/pages/reference/deployment/networking.mdx
+++ b/docs/pages/reference/deployment/networking.mdx
@@ -413,29 +413,29 @@ have set up your Teleport cluster network incorrectly.
 
 ### Connection reset by peer
 
-If you see the message, `Connection reset by peer`, it often means that your
-Teleport instance is attempting to connect to an upstream host that either:
-- has no process listening on the required port
-- exited the process that was listening on the required port
+If you see the message, `connection reset by peer`, it means that the component
+of your Teleport cluster that has emitted the log (e.g., a Teleport Agent)
+received a TCP packet with a control bit set to RST (reset). A TCP endpoint
+sends an RST packet over an established connection if it receives a packet that
+is unexpected given its connection state, e.g., if the other side unexpectedly
+exits mid-connection.
 
-You can rule out the latter scenario by checking whether the upstream process
-was running at the time of the error message. If the upstream server is running
-as expected, you can:
+There is a variety of reasons why an upstream server may reset the connection,
+and they may or may not have to do with the components of a Teleport cluster.
+For example, a `tsh` client can emit a `connection reset by peer` message if it
+is behind the Teleport Proxy Service, which closes a connection if it receives
+traffic from an outdated `tsh` client. It could also be that a Teleport Agent
+proxying a connection exited without closing the connection. A device between
+the Teleport component and the other side of the connection, such as a load
+balancer, may also be injecting RST packets.
 
-1. Check the configuration of the Teleport process reporting the error. Make
-   sure the port it targets matches the one with an associated listener.
-2. Make sure no components of your network are blocking traffic from your
-   Teleport process. 
+To investigate:
 
-   For example, you can use tooling built into your cloud provider, such as the
-   AWS [Reachability
-   Analyzer](https://docs.aws.amazon.com/vpc/latest/reachability/what-is-reachability-analyzer.html)
-   , to make sure your Teleport process can dial the target server. There could
-   be a misconfigured security group or internet gateway.
-
-   If possible, you may want to open a shell into your Teleport process's host
-   and use tools like `nc` and `traceroute` to see if your Teleport process can
-   reach the upstream server.
+1. If the connection involves two Teleport components, make sure their versions
+   abide by the Teleport [version compatibility
+   guarantees](../../upgrading/overview.mdx).
+1. Examine the logs of the remote Teleport process and check whether the process
+   was healthy at the time you saw the error.
 
 ### First record does not look like a TLS handshake
 
@@ -448,10 +448,9 @@ transport: authentication handshake failed: tls: first record does not look like
 
 The library that Teleport uses for TLS prints this error if the server and
 client have not negotiated a TLS version and the TLS record in question is not a
-handshake, or the TLS version is greater or equal than 16.0 (higher than the
-maximum supported version of 3.3). In other words, the Teleport process that
-printed the log was expected a TLS handshake from the other side of the
-connection and did not receive one, i.e., it was replying to the Teleport
+handshake. In other words, the Teleport process that printed the log was
+expecting a TLS handshake from the other side of the connection and did not
+receive one. This can happen if the other side was replying to the Teleport
 process in a different protocol.
 
 In this case, check the address of the upstream host and make sure it is one
@@ -461,7 +460,7 @@ TCP.
 ### Authentication handshake failed
 
 Your `teleport` or `tbot` logs may report a certificate with a subject that does
-not match an unexpected domain name, a subdomain of `teleport.cluster.local`.
+not match the expected domain name, a subdomain of `teleport.cluster.local`.
 The following example assumes your cluster's address is `example.teleport.sh`:
 
 ```
@@ -480,8 +479,8 @@ use [TLS
 multiplexing](../../zero-trust-access/management/tls-routing.mdx), but you
 are running the Teleport Proxy Service behind a Layer 7 load balancer that only
 returns the load balancer's main certificate instead of allowing the Teleport
-internal certficate. Your infrastructure may be interfering with TLS connections
-by altering the certificate that your Teleport instance presents.
+internal certificate. Your infrastructure may be interfering with TLS
+connections by altering the certificate that your Teleport instance presents.
 
 Investigate whether the certificate your client receives is signed by, for
 example, a corporate TLS proxy, or has otherwise been transformed between the


### PR DESCRIPTION
Closes #62997

Edit the Networking Reference to add a Troubleshooting section covering three common networking errors when setting up a Teleport cluster:

- Connection reset by peer
- First record does not look like a TLS handshake
- Authentication handshake failed (teleport.cluster.local)