### PR TITLE
[v18] Stream session recordings directly without temporary files

### DIFF
--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata_test.go
@@ -860,19 +860,19 @@ func (m *mockUploadHandler) UploadThumbnail(ctx context.Context, sessionID sessi
 	return path, nil
 }
 
-func (m *mockUploadHandler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (m *mockUploadHandler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return nil
 }
 
-func (m *mockUploadHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (m *mockUploadHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return nil
 }
 
-func (m *mockUploadHandler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (m *mockUploadHandler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return nil
 }
 
-func (m *mockUploadHandler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (m *mockUploadHandler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return nil
 }
 

--- a/lib/auth/recordingmetadata/recordingmetadatav1/service.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/service.go
@@ -59,9 +59,9 @@ type Authorizer interface {
 // DownloadHandler downloads session recording metadata and thumbnails.
 type DownloadHandler interface {
 	// DownloadMetadata downloads session metadata and writes it to a writer.
-	DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error
+	DownloadMetadata(ctx context.Context, sessionID session.ID, writer io.Writer) error
 	// DownloadThumbnail downloads a session thumbnail and writes it to a writer.
-	DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error
+	DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error
 }
 
 // ServiceConfig holds the configuration for the recording metadata service.

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -544,7 +544,9 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 			startCb(evt, nil)
 		}()
 	}
-
+	// TODO(tigrato): consider changing the implementation of Download* to return
+	// an io.ReadCloser instead of writing to a provided writer, which would allow
+	// us to avoid using io.Pipe here.
 	reader, writer := io.Pipe()
 
 	go func() {

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -545,57 +545,26 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 		}()
 	}
 
-	rawSession, err := os.CreateTemp(l.playbackDir, string(sessionID)+".stream.tar.*")
-	if err != nil {
-		e <- trace.Wrap(trace.ConvertSystemError(err), "creating temporary stream file")
-		close(sessionStartCh)
-		return c, e
-	}
-	// The file is still perfectly usable after unlinking it, and the space it's
-	// using on disk will get reclaimed as soon as the file is closed (or the
-	// process terminates) - and if the session is small enough and we go
-	// through it quickly enough, we're likely not even going to end up with any
-	// bytes on the physical disk, anyway. We're using the same playback
-	// directory as the GetSessionChunk flow, which means that if we crash
-	// between creating the empty file and unlinking it, we'll end up with an
-	// empty file that will eventually be cleaned up by periodicCleanupPlaybacks
-	//
-	// TODO(espadolini): investigate the use of O_TMPFILE on Linux, so we don't
-	// even have to bother with the unlink and we avoid writing on the directory
-	if err := os.Remove(rawSession.Name()); err != nil {
-		_ = rawSession.Close()
-		e <- trace.Wrap(trace.ConvertSystemError(err), "removing temporary stream file")
-		close(sessionStartCh)
-		return c, e
-	}
+	reader, writer := io.Pipe()
 
-	start := time.Now()
-	if err := l.UploadHandler.Download(ctx, sessionID, rawSession); err != nil {
-		_ = rawSession.Close()
+	go func() {
+		err := l.UploadHandler.Download(ctx, sessionID, writer)
 		if errors.Is(err, fs.ErrNotExist) {
 			err = trace.NotFound("a recording for session %v was not found", sessionID)
 		}
-		e <- trace.Wrap(err)
-		close(sessionStartCh)
-		return c, e
-	}
-	l.log.DebugContext(ctx, "Downloaded session to a temporary file for streaming.",
-		"duration", time.Since(start),
-		"session_id", string(sessionID),
-	)
+
+		// if the error is nil, it means the download was successful and closing the
+		// writer will signal the reader with io.EOF.
+		if err := writer.CloseWithError(err); err != nil {
+			l.log.WarnContext(ctx, "Failed to close the writer with error", "session_id", string(sessionID), "error", err)
+		}
+	}()
 
 	go func() {
-		defer rawSession.Close()
 		defer close(sessionStartCh)
+		defer reader.Close()
 
-		// this shouldn't be necessary as the position should be already 0 (Download
-		// takes an io.WriterAt), but it's better to be safe than sorry
-		if _, err := rawSession.Seek(0, io.SeekStart); err != nil {
-			e <- trace.Wrap(err)
-			return
-		}
-
-		protoReader := NewProtoReader(rawSession, l.decrypter)
+		protoReader := NewProtoReader(reader, l.decrypter)
 		defer protoReader.Close()
 
 		firstEvent := true

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -380,13 +380,13 @@ func (h *Handler) uploadBlob(
 }
 
 // Download implements [events.UploadHandler] and downloads a session recording.
-func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(h.downloadBlob(ctx, sessionID, h.sessionBlob(sessionID), writer))
 }
 
 // DownloadSummary implements [events.UploadHandler] and downloads a final
 // session summary.
-func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	// Happy path: the final summary exists.
 	err := h.downloadBlob(ctx, sessionID, h.summaryBlob(sessionID), writer)
 	if trace.IsNotFound(err) {
@@ -403,16 +403,16 @@ func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, wri
 }
 
 // DownloadMetadata implements [events.UploadHandler] and downloads a session's metadata.
-func (h *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(h.downloadBlob(ctx, sessionID, h.metadataBlob(sessionID), writer))
 }
 
 // DownloadThumbnail implements [events.UploadHandler] and downloads a session's thumbnail.
-func (h *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(h.downloadBlob(ctx, sessionID, h.thumbnailBlob(sessionID), writer))
 }
 
-func (h *Handler) downloadBlob(ctx context.Context, sessionID session.ID, blob *blockblob.Client, writer events.RandomAccessWriter) error {
+func (h *Handler) downloadBlob(ctx context.Context, sessionID session.ID, blob *blockblob.Client, writer io.Writer) error {
 	resp, err := cErr(blob.DownloadStream(ctx, nil))
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -87,7 +87,7 @@ type MemoryUpload struct {
 	parts map[int64]part
 	// sessionID is the session ID associated with the upload
 	sessionID session.ID
-	//completed specifies upload as completed
+	// completed specifies upload as completed
 	completed bool
 	// Initiated contains the timestamp of when the upload
 	// was initiated, not always initialized
@@ -359,7 +359,7 @@ func (m *MemoryUploader) UploadThumbnail(ctx context.Context, sessionID session.
 }
 
 // Download downloads session tarball and writes it to writer
-func (m *MemoryUploader) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (m *MemoryUploader) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -374,7 +374,7 @@ func (m *MemoryUploader) Download(ctx context.Context, sessionID session.ID, wri
 	return nil
 }
 
-func (m *MemoryUploader) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (m *MemoryUploader) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -393,7 +393,7 @@ func (m *MemoryUploader) DownloadSummary(ctx context.Context, sessionID session.
 }
 
 // DownloadMetadata downloads session metadata and writes it to writer
-func (m *MemoryUploader) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (m *MemoryUploader) DownloadMetadata(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -409,7 +409,7 @@ func (m *MemoryUploader) DownloadMetadata(ctx context.Context, sessionID session
 }
 
 // DownloadThumbnail downloads session thumbnail and writes it to writer
-func (m *MemoryUploader) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (m *MemoryUploader) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -117,12 +117,12 @@ func (l *Handler) Close() error {
 }
 
 // Download reads a session recording from a local directory.
-func (l *Handler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (l *Handler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(downloadFile(l.recordingPath(sessionID), writer))
 }
 
 // DownloadSummary reads a session summary from a local directory.
-func (l *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (l *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	// Happy path: the final summary exists.
 	err := downloadFile(l.summaryPath(sessionID), writer)
 	if trace.IsNotFound(err) {
@@ -139,16 +139,16 @@ func (l *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, wri
 }
 
 // DownloadMetadata reads session metadata from a local directory.
-func (l *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (l *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(downloadFile(l.metadataPath(sessionID), writer))
 }
 
 // DownloadThumbnail reads a session thumbnail from a local directory.
-func (l *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (l *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(downloadFile(l.thumbnailPath(sessionID), writer))
 }
 
-func downloadFile(path string, writer events.RandomAccessWriter) error {
+func downloadFile(path string, writer io.Writer) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return trace.ConvertSystemError(err)
@@ -223,7 +223,7 @@ func uploadFile(path string, reader io.Reader, opts ...fileUploadOption) (string
 	if !cfg.overwrite {
 		flags |= os.O_EXCL
 	}
-	f, err := os.OpenFile(path, flags, 0666)
+	f, err := os.OpenFile(path, flags, 0o666)
 	if err != nil {
 		return "", trace.ConvertSystemError(err)
 	}

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -37,7 +37,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/session"
 )
@@ -331,14 +330,14 @@ func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader,
 // Download downloads a session recording from a GCS bucket and writes the
 // result into a writer. Returns trace.NotFound error if the recording is not
 // found.
-func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(h.downloadFile(ctx, h.recordingPath(sessionID), writer))
 }
 
 // DownloadSummary downloads a session summary from a GCS bucket and writes the
 // result into a writer. Returns trace.NotFound error if the recording is not
 // found.
-func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	// Happy path: the final summary exists.
 	err := h.downloadFile(ctx, h.summaryPath(sessionID), writer)
 	if trace.IsNotFound(err) {
@@ -357,18 +356,18 @@ func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, wri
 // DownloadMetadata downloads a session's metadata from a GCS bucket and writes the
 // result into a writer. Returns trace.NotFound error if the recording is not
 // found.
-func (h *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(h.downloadFile(ctx, h.metadataPath(sessionID), writer))
 }
 
 // DownloadThumbnail downloads a session's thumbnail from a GCS bucket and writes the
 // result into a writer. Returns trace.NotFound error if the recording is not
 // found.
-func (h *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(h.downloadFile(ctx, h.thumbnailPath(sessionID), writer))
 }
 
-func (h *Handler) downloadFile(ctx context.Context, path string, writer events.RandomAccessWriter) error {
+func (h *Handler) downloadFile(ctx context.Context, path string, writer io.Writer) error {
 	h.logger.DebugContext(ctx, "Downloading object from GCS.", "path", path)
 	reader, err := h.gcsClient.Bucket(h.Config.Bucket).Object(path).NewReader(ctx)
 	if err != nil {

--- a/lib/events/s3sessions/s3client.go
+++ b/lib/events/s3sessions/s3client.go
@@ -28,6 +28,7 @@ type s3Client interface {
 	DeleteBucket(ctx context.Context, params *s3.DeleteBucketInput, optFns ...func(*s3.Options)) (*s3.DeleteBucketOutput, error)
 	HeadBucket(ctx context.Context, params *s3.HeadBucketInput, optFns ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
 	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
 	PutBucketEncryption(ctx context.Context, params *s3.PutBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.PutBucketEncryptionOutput, error)
 	CreateBucket(ctx context.Context, params *s3.CreateBucketInput, optFns ...func(*s3.Options)) (*s3.CreateBucketOutput, error)
 	PutBucketVersioning(ctx context.Context, params *s3.PutBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.PutBucketVersioningOutput, error)

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -544,9 +544,6 @@ func (h *Handler) downloadFile(
 
 		// copy the body to the writer
 		n, err := io.Copy(writer, output.Body)
-
-		// ensure the body is fully read and closed to allow connection reuse
-		_, _ = io.Copy(io.Discard, output.Body)
 		_ = output.Body.Close()
 
 		offset += n

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -21,6 +21,7 @@ package s3sessions
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -274,14 +275,12 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 	client := s3.NewFromConfig(awsConfig, s3Opts...)
 
 	uploader := manager.NewUploader(client)
-	downloader := manager.NewDownloader(client)
 
 	h := &Handler{
-		logger:     logger,
-		Config:     cfg,
-		uploader:   uploader,
-		downloader: downloader,
-		client:     client,
+		logger:   logger,
+		Config:   cfg,
+		uploader: uploader,
+		client:   client,
 	}
 
 	start := time.Now()
@@ -308,10 +307,9 @@ type Handler struct {
 	// Config is handler configuration
 	Config
 	// logger emits log messages
-	logger     *slog.Logger
-	uploader   *manager.Uploader
-	downloader *manager.Downloader
-	client     s3Client
+	logger   *slog.Logger
+	uploader *manager.Uploader
+	client   s3Client
 }
 
 // Close releases connection and resources associated with log if any
@@ -448,32 +446,32 @@ func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader,
 // Download downloads a session recording from an S3 bucket and writes the
 // result into a writer. Returns trace.NotFound error if the recording is not
 // found.
-func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(h.downloadOriginalFile(ctx, h.recordingPath(sessionID), writer))
 }
 
 // DownloadSummary downloads a final session summary from an S3 bucket and
 // writes the results into a writer. Returns trace.NotFound error if the
 // summary is not found or is not final.
-func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(h.downloadFile(ctx, h.summaryPath(sessionID), writer, nil /* versionID */))
 }
 
 // DownloadMetadata downloads a session's metadata from an S3 bucket and writes the
 // results into a writer. Returns trace.NotFound error if the metadata is not
 // found.
-func (h *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(h.downloadOriginalFile(ctx, h.metadataPath(sessionID), writer))
 }
 
 // DownloadThumbnail downloads a session's thumbnail from an S3 bucket and writes the
 // results into a writer. Returns trace.NotFound error if the thumbnail is not
 // found.
-func (h *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return trace.Wrap(h.downloadOriginalFile(ctx, h.thumbnailPath(sessionID), writer))
 }
 
-func (h *Handler) downloadOriginalFile(ctx context.Context, path string, writer events.RandomAccessWriter) error {
+func (h *Handler) downloadOriginalFile(ctx context.Context, path string, writer io.Writer) error {
 	// Get the oldest version of this object. This has to be done because S3
 	// allows overwriting objects in a bucket. To prevent corruption of recording
 	// data, get all versions and always return the first.
@@ -492,17 +490,91 @@ func (h *Handler) downloadOriginalFile(ctx context.Context, path string, writer 
 }
 
 func (h *Handler) downloadFile(
-	ctx context.Context, path string, writer events.RandomAccessWriter, versionID *string,
+	ctx context.Context, path string, writer io.Writer, versionID *string,
 ) error {
-	_, err := h.downloader.Download(ctx, writer, &s3.GetObjectInput{
+	// maxDownloadRetries is the maximum number of retries for the body.
+	const maxDownloadRetries = 3
+
+	// get the file head to find out the size.
+	headInput := &s3.HeadObjectInput{
 		Bucket:    aws.String(h.Bucket),
 		Key:       aws.String(path),
 		VersionId: versionID,
-	})
+	}
+
+	headOutput, err := h.client.HeadObject(ctx, headInput)
 	if err != nil {
 		return awsutils.ConvertS3Error(err)
 	}
-	return nil
+
+	contentLength := aws.ToInt64(headOutput.ContentLength)
+	if contentLength == 0 {
+		return nil
+	}
+
+	// offset tracks how many bytes have been successfully copied to the writer so far
+	var offset int64
+	var lastErr error
+	for attempt := range maxDownloadRetries {
+		if attempt > 0 {
+			h.logger.DebugContext(ctx, "Retrying download from last position",
+				"bucket", h.Bucket,
+				"path", path,
+				"offset", offset,
+				"attempt", attempt+1,
+			)
+		}
+
+		// send the range header to download only the remaining part of the file
+		rangeStr := fmt.Sprintf("bytes=%d-%d", offset, contentLength-1)
+
+		getInput := &s3.GetObjectInput{
+			Bucket:    aws.String(h.Bucket),
+			Key:       aws.String(path),
+			VersionId: versionID,
+			Range:     aws.String(rangeStr),
+		}
+
+		output, err := h.client.GetObject(ctx, getInput)
+		if err != nil {
+			return trace.Wrap(awsutils.ConvertS3Error(err))
+		}
+
+		// copy the body to the writer
+		n, err := io.Copy(writer, output.Body)
+
+		// ensure the body is fully read and closed to allow connection reuse
+		_, _ = io.Copy(io.Discard, output.Body)
+		_ = output.Body.Close()
+
+		offset += n
+
+		if err != nil {
+			// If we haven't reached the end, continue
+			// the AWS manager.Downloader retries on every error when reading the error.
+			if offset < contentLength && !errors.Is(err, io.ErrClosedPipe) {
+				lastErr = err
+				continue
+			}
+			return trace.Wrap(err)
+		}
+
+		if offset < contentLength {
+			lastErr = fmt.Errorf("downloaded %d bytes, expected %d", offset, contentLength)
+			continue
+		}
+
+		// this case should never happen given that we force the version and the file
+		// shouldn't be changing under us, but if it does, we want to know about it
+		//  instead of silently truncating the recording
+		if offset != contentLength {
+			return trace.BadParameter("expected %d bytes, got %d when downloading file %q", contentLength, offset, path)
+		}
+
+		return nil
+	}
+
+	return trace.Wrap(lastErr, "failed to download file after %d attempts", maxDownloadRetries)
 }
 
 // versionID is used to store versions of a key to allow sorting by timestamp.

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -32,7 +32,7 @@ type UploadHandler interface {
 	// case of success.
 	Upload(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// Download downloads a session recording and writes it to a writer.
-	Download(ctx context.Context, sessionID session.ID, writer RandomAccessWriter) error
+	Download(ctx context.Context, sessionID session.ID, writer io.Writer) error
 	// UploadPendingSummary uploads a pending session summary and returns a URL
 	// with uploaded file in case of success. This function can be called
 	// multiple times for a given sessionID to update the state. A pending
@@ -46,26 +46,21 @@ type UploadHandler interface {
 	UploadSummary(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// DownloadSummary downloads a session summary and writes it to a writer.
 	// Returns a "not found" error if there's no such summary.
-	DownloadSummary(ctx context.Context, sessionID session.ID, writer RandomAccessWriter) error
+	DownloadSummary(ctx context.Context, sessionID session.ID, writer io.Writer) error
 	// UploadMetadata uploads session metadata and returns a URL with the uploaded
 	// file in case of success. Session metadata is a file with a [recordingmetadatav1.SessionRecordingMetadata]
 	// protobuf message containing info about the session (duration, events, etc), as well as
 	// multiple [recordingmetadatav1.SessionRecordingThumbnail] messages (thumbnails).
 	UploadMetadata(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// DownloadMetadata downloads session metadata and writes it to a writer.
-	DownloadMetadata(ctx context.Context, sessionID session.ID, writer RandomAccessWriter) error
+	DownloadMetadata(ctx context.Context, sessionID session.ID, writer io.Writer) error
 	// UploadThumbnail uploads a session thumbnail and returns a URL with uploaded
 	// file in case of success. A thumbnail is [recordingmetadatav1.SessionRecordingThumbnail]
 	// protobuf message which contains the thumbnail as an SVG, and some basic details about the
 	// state of the terminal at the time of the thumbnail capture (terminal size, cursor position).
 	UploadThumbnail(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// DownloadThumbnail downloads a session thumbnail and writes it to a writer.
-	DownloadThumbnail(ctx context.Context, sessionID session.ID, writer RandomAccessWriter) error
-}
-
-type RandomAccessWriter interface {
-	io.Writer
-	io.WriterAt
+	DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error
 }
 
 // MultipartHandler handles both multipart and standalone uploads and

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -63,6 +63,9 @@ type UploadHandler interface {
 	DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error
 }
 
+// TODO(tigrato): remove this type once `e` no longer references it.
+type RandomAccessWriter = io.Writer
+
 // MultipartHandler handles both multipart and standalone uploads and
 // downloads.
 type MultipartHandler interface {

--- a/lib/integrations/externalauditstorage/error_counter.go
+++ b/lib/integrations/externalauditstorage/error_counter.go
@@ -402,28 +402,28 @@ func (c *ErrorCountingSessionHandler) UploadThumbnail(ctx context.Context, sessi
 }
 
 // Download calls [c.wrapped.Download] and counts the error or success.
-func (c *ErrorCountingSessionHandler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (c *ErrorCountingSessionHandler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	err := c.wrapped.Download(ctx, sessionID, writer)
 	c.downloads.observe(err)
 	return err
 }
 
 // DownloadSummary calls [c.wrapped.DownloadSummary] and counts the error or success.
-func (c *ErrorCountingSessionHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (c *ErrorCountingSessionHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	err := c.wrapped.DownloadSummary(ctx, sessionID, writer)
 	c.downloads.observe(err)
 	return err
 }
 
 // DownloadMetadata calls [c.wrapped.DownloadMetadata] and counts the error or success.
-func (c *ErrorCountingSessionHandler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (c *ErrorCountingSessionHandler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	err := c.wrapped.DownloadMetadata(ctx, sessionID, writer)
 	c.downloads.observe(err)
 	return err
 }
 
 // DownloadThumbnail calls [c.wrapped.DownloadThumbnail()] and counts the error or success.
-func (c *ErrorCountingSessionHandler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (c *ErrorCountingSessionHandler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	err := c.wrapped.DownloadThumbnail(ctx, sessionID, writer)
 	c.downloads.observe(err)
 	return err

--- a/lib/integrations/externalauditstorage/error_counter_test.go
+++ b/lib/integrations/externalauditstorage/error_counter_test.go
@@ -313,7 +313,6 @@ func TestErrorCounter(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 type testPack struct {
@@ -390,18 +389,18 @@ func (h *errorHandler) UploadThumbnail(ctx context.Context, sessionID session.ID
 	return "", h.err
 }
 
-func (h *errorHandler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *errorHandler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return h.err
 }
 
-func (h *errorHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *errorHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return h.err
 }
 
-func (h *errorHandler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *errorHandler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return h.err
 }
 
-func (h *errorHandler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
+func (h *errorHandler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return h.err
 }


### PR DESCRIPTION
Backport #63597 to branch/v18

Manual test plan:
- [x] Tested windows sessions on cloud
- [x] Tested windows sessions locally
- [x] Tested SSH sessions with timeline locally
- [x] Tested SSH sessions in Cloud - without timeline
- [x] Tested pgsql sessions
- [x] Session summarization still works