### PR TITLE
Adding headroom to encrypted recording upload size limits

### DIFF
--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -75,6 +75,11 @@ type UploaderConfig struct {
 	// encrypted recording parts before sending them to EncryptedRecordingUploader.
 	// If set to 0, then no maximum is enforced.
 	EncryptedRecordingUploadMaxSize int
+	// EncryptedRecordingUploadMinSize is the minimum size used when aggregating
+	// encrypted recording parts before sending them to EncryptedRecordingUploader.
+	// The EncryptedRecordingUploadMaxSize must be larger than this value.
+	// If set to 0, a default minimum is used.
+	EncryptedRecordingUploadMinSize int
 }
 
 // CheckAndSetDefaults checks and sets default values of UploaderConfig
@@ -102,6 +107,13 @@ func (cfg *UploaderConfig) CheckAndSetDefaults() error {
 	}
 	if cfg.EncryptedRecordingUploadTargetSize == 0 {
 		cfg.EncryptedRecordingUploadTargetSize = events.MinUploadPartSizeBytes
+	}
+	if cfg.EncryptedRecordingUploadMinSize == 0 {
+		cfg.EncryptedRecordingUploadMinSize = reservationSize
+	}
+	if cfg.EncryptedRecordingUploadMaxSize != 0 && cfg.EncryptedRecordingUploadMaxSize < cfg.EncryptedRecordingUploadMinSize {
+
+		return trace.BadParameter("encrypted recording upload max size must be at least as large as encrypted recording upload min size")
 	}
 	return nil
 }
@@ -639,6 +651,12 @@ func (u *Uploader) startUpload(ctx context.Context, fileName string) (err error)
 
 var errNoEncryptedUploader = &trace.BadParameterError{Message: "no encrypted uploader configured while uploading encrypted recording"}
 
+// Allow for some amount of overhead to prevent small inconsistencies in computing upload part wire length from
+// breaking uploads. As of writing, the overhead of the recordingencryptionv1.UploadPartRequest is ~100 bytes. 512
+// bytes was a conservative choice to account for any other potential sources of overhead or future extensions to
+// the recordingencryptionv1.UploadPartRequest message.
+const uploadOverheadAllowance = 512
+
 func (u *Uploader) uploadEncrypted(ctx context.Context, up *upload) error {
 	log := u.log.With(fieldSessionID, up.sessionID)
 	header, err := events.ParsePartHeader(up.file)
@@ -662,13 +680,25 @@ func (u *Uploader) uploadEncrypted(ctx context.Context, up *upload) error {
 		return trace.Wrap(err, "resetting recording for plaintext upload")
 	}
 
+	uploadMaxSize := u.cfg.EncryptedRecordingUploadMaxSize - uploadOverheadAllowance
+	if u.cfg.EncryptedRecordingUploadMaxSize == 0 {
+		uploadMaxSize = 0 // no limit
+	} else if uploadMaxSize < u.cfg.EncryptedRecordingUploadMinSize {
+		// reservationSize approximates the smallest possible encrypted part size in a multipart recording, so we need
+		// to make sure max upload size supports at least that much data
+		return trace.Errorf("Max encrypted recording upload part size %0.2fKiB is smaller than the minimum %0.2fKiB. Increase max gRPC message size using TELEPORT_UNSTABLE_GRPC_RECV_SIZE",
+			float32(uploadMaxSize)/1024,
+			float32(u.cfg.EncryptedRecordingUploadMinSize)/1024,
+		)
+	}
+
 	// The upload parts in the given reader are each ~128KB. Usually these parts are consumed and reconstructed
 	// by Auth in 5MB chunks to meet the minimum upload size of upload providers like S3. Since these uploads
 	// are proxied directly to the uploader from the agent here (see link below), this agent needs to combine
 	// these upload parts into larger, aggregated upload parts.
 	//
 	// https://github.com/gravitational/teleport/blob/master/rfd/0127-encrypted-session-recordings.md#session-recording-modes
-	partIter := encryptedUploadAggregateIter(up.file, u.cfg.EncryptedRecordingUploadTargetSize, u.cfg.EncryptedRecordingUploadMaxSize)
+	partIter := encryptedUploadAggregateIter(up.file, u.cfg.EncryptedRecordingUploadTargetSize, uploadMaxSize)
 
 	u.wg.Go(func() {
 		defer u.releaseSemaphore(ctx)

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -20,6 +20,7 @@ package filesessions
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -515,7 +516,7 @@ func TestMinimumUpload(t *testing.T) {
 	// constrains the maximum size to 133% of the minimum. At small values, this is especially
 	// imprecise, so we give a full 200% of the minimum as overhead.
 	//
-	// Usually, we use 128KB for file parts and 5KB for final upload parts.
+	// Usually, we use 128KB for file parts and 5MB for final upload parts.
 	minFileBytes := 8192
 	maxFileBytes := 2 * minFileBytes
 	minUploadBytes := 33768
@@ -620,7 +621,7 @@ func TestMinimumUpload(t *testing.T) {
 	require.LessOrEqual(t, len(partFiles)/minFactor, len(uploadParts), "expected there to be 1 final upload part for every 4 transient file parts, but got %v and %v respectively", len(uploadParts), len(partFiles))
 }
 
-func TestUploadEncryptedRecording(t *testing.T) {
+func TestUploadEncryptedRecordingSizes(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		minFileSize int
@@ -635,40 +636,41 @@ func TestUploadEncryptedRecording(t *testing.T) {
 	}{
 		{
 			name:                "target size larger than max encrypted upload size",
-			minFileSize:         8192,
-			encryptedTargetSize: 8192 * 4 * 2,
-			encryptedMaxSize:    8192 * 4,
+			minFileSize:         8196,
+			encryptedTargetSize: 8196 * 4 * 2,
+			encryptedMaxSize:    8196 * 4,
 		}, {
 			name:                "target size equals max encrypted upload size",
-			minFileSize:         8192,
-			encryptedTargetSize: 8192 * 4,
-			encryptedMaxSize:    8192 * 4,
+			minFileSize:         8196,
+			encryptedTargetSize: 8196 * 4,
+			encryptedMaxSize:    8196 * 4,
 		}, {
 			name:                "target size smaller than max encrypted upload size",
-			minFileSize:         8192,
-			encryptedTargetSize: 8192 * 4,
-			encryptedMaxSize:    8192 * 4 * 2,
+			minFileSize:         8196,
+			encryptedTargetSize: 8196 * 4,
+			encryptedMaxSize:    8196 * 4 * 2,
 		}, {
 			name:                "target size larger than min upload size",
-			minFileSize:         8192,
-			encryptedTargetSize: 8192 * 4 * 2,
-			minUploadBytes:      8192 * 4,
+			minFileSize:         8196,
+			encryptedTargetSize: 8196 * 4 * 2,
+			minUploadBytes:      8196 * 4,
 		}, {
 			name: "target size equals min upload size",
 			// this test becomes flaky at lower sizes
-			minFileSize:         8192,
-			encryptedTargetSize: 8192 * 4,
-			minUploadBytes:      8192 * 4,
+			minFileSize:         8196,
+			encryptedTargetSize: 8196 * 4,
+			minUploadBytes:      8196 * 4,
 		}, {
 			name: "target size smaller than min upload size",
 			// this test becomes flaky at lower sizes
-			minFileSize:         8192,
-			encryptedTargetSize: 8192 * 4,
-			minUploadBytes:      8192 * 4 * 2,
+			minFileSize:         8196,
+			encryptedTargetSize: 8196 * 4,
+			minUploadBytes:      8196 * 4 * 2,
 		}, {
 			name:                     "min file size larger than max encrypted size",
-			minFileSize:              8192 * 4,
-			encryptedMaxSize:         8192,
+			minFileSize:              8196 * 4,
+			minUploadBytes:           8196 * 4,
+			encryptedMaxSize:         8196,
 			expectEncryptedUploadErr: true,
 		},
 	} {
@@ -792,7 +794,7 @@ func TestUploadEncryptedRecording(t *testing.T) {
 					t.Fatalf("Unexpected upload event")
 				}
 				require.Error(t, event.Error)
-				require.True(t, isSessionError(event.Error))
+				require.True(t, isSessionError(event.Error), event.Error)
 				return
 			case <-ctx.Done():
 				t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
@@ -910,6 +912,105 @@ func TestUploadCorruptEncryptedRecording(t *testing.T) {
 	})
 }
 
+// TestUploadEncryptedRecordingOverhead ensures that the encrypted recording uploader assumes some amount of potential
+// overhead when generating upload parts in order to guard against accidentally exceeding the max upload size.
+func TestUploadEncryptedRecordingOverhead(t *testing.T) {
+	// number of events to generate per session
+	eventsCount := 3096
+	events := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: int64(eventsCount)})
+
+	// captures the total upload size of encrypted session events
+	var totalUploadSize int
+
+	// common config shared between test cases
+	uploadCfg := uploaderPackConfig{
+		minimumUploadBytes:              512,
+		minimumFileUploadBytes:          512,
+		encryptedRecordingUploadMinSize: 512,
+		encrypter:                       &fakeEncryptedIO{},
+	}
+
+	for _, tc := range []struct {
+		name          string
+		cfgFn         func(uploaderPackConfig) uploaderPackConfig
+		expectedParts int
+		expectErrMsg  string
+	}{
+		// it's important that the unbound uploader test runs first because it captures the total expected upload size
+		// used in the bound uploader tests
+		{
+			name:          "unbound uploader",
+			expectedParts: 1,
+		},
+		{
+			name: "bound uploader without enough overhead",
+			cfgFn: func(cfg uploaderPackConfig) uploaderPackConfig {
+				// Adding half the overhead to the total expected upload size should cause two upload parts to be
+				// generated in order to prevent the possibility of exceeding the max upload size.
+				cfg.encryptedRecordingUploadMaxSize = totalUploadSize + uploadOverheadAllowance/2
+				return cfg
+			},
+			expectedParts: 2,
+		},
+		{
+			name: "bound uploader with enough overhead",
+			cfgFn: func(cfg uploaderPackConfig) uploaderPackConfig {
+				// Adding the overhead to the total expected upload size should cause 1 upload part to be generated
+				// since the max upload size allows for enough additional overhead.
+				cfg.encryptedRecordingUploadMaxSize = totalUploadSize + uploadOverheadAllowance
+				return cfg
+			},
+			expectedParts: 1,
+		},
+		{
+			name: "bound uploader that can't support a single upload part",
+			cfgFn: func(cfg uploaderPackConfig) uploaderPackConfig {
+				// Adding half the overhead to the minimum size of a single upload part should cause an error because
+				// we can't reliably upload at least one part.
+				cfg.encryptedRecordingUploadMaxSize = cfg.encryptedRecordingUploadMinSize + uploadOverheadAllowance/2
+				return cfg
+			},
+			expectErrMsg: "Increase max gRPC message size using TELEPORT_UNSTABLE_GRPC_RECV_SIZE",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+				cfg := uploadCfg
+				if tc.cfgFn != nil {
+					cfg = tc.cfgFn(cfg)
+				}
+
+				p := newUploaderPack(ctx, t, cfg)
+				p.emitEvents(ctx, t, events)
+
+				_, err := p.uploader.Scan(ctx)
+				if tc.expectErrMsg != "" {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tc.expectErrMsg)
+				} else {
+					require.NoError(t, err)
+				}
+				synctest.Wait()
+
+				uploads, err := p.memUploader.ListUploads(ctx)
+				require.NoError(t, err)
+
+				for _, upload := range uploads {
+					parts, err := p.memUploader.GetParts(upload.ID)
+					require.NoError(t, err)
+					t.Logf("%s: %d", tc.name, len(parts))
+					require.Len(t, parts, tc.expectedParts)
+					// capture total size for use in the bound uploader tests
+					if tc.name == "unbound uploader" {
+						totalUploadSize = len(parts[0])
+					}
+				}
+			})
+		})
+	}
+}
+
 type uploaderPackConfig struct {
 	minimumFileUploadBytes             int64
 	minimumUploadBytes                 int64
@@ -918,6 +1019,7 @@ type uploaderPackConfig struct {
 	wrapEncryptedUploader              wrapEncryptedUploaderFn
 	encryptedRecordingUploadTargetSize int
 	encryptedRecordingUploadMaxSize    int
+	encryptedRecordingUploadMinSize    int
 	clock                              clockwork.Clock
 	concurrentUploads                  int
 }
@@ -996,6 +1098,7 @@ func newUploaderPack(ctx context.Context, t *testing.T, cfg uploaderPackConfig) 
 		EncryptedRecordingUploader:         pack.memUploader,
 		EncryptedRecordingUploadTargetSize: cfg.encryptedRecordingUploadTargetSize,
 		EncryptedRecordingUploadMaxSize:    cfg.encryptedRecordingUploadMaxSize,
+		EncryptedRecordingUploadMinSize:    cmp.Or(cfg.encryptedRecordingUploadMinSize, 512),
 		ConcurrentUploads:                  cfg.concurrentUploads,
 	}
 	if cfg.wrapEncryptedUploader != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -81,6 +81,7 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	grpcutils "github.com/gravitational/teleport/api/utils/grpc"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -3888,7 +3889,7 @@ func (process *TeleportProcess) initUploaderService() error {
 
 		// encrypted uploads are aggregated and uploaded directly rather than with an event stream.
 		// Since we are using the gRPC client, we must set this maximum for the aggregation step.
-		encryptedRecordingMaxUploadSize = 4 * 1024 * 1024 // 4MiB, default gRPC max msg recv size.
+		encryptedRecordingMaxUploadSize = grpcutils.MaxClientRecvMsgSize()
 	}
 
 	logger.InfoContext(process.ExitContext(), "starting upload completer service")


### PR DESCRIPTION
Fixes #64328
The max upload size limit of a single encrypted recording upload part currently does not account for the size of the message wrapping the upload. Which means uploads with aggregated parts adding up to a length greater than `max_upload_size - size_of(recordingencryptionv1.UploadPartRequest)` can actually end up exceeding the gRPC message size limit. This PR builds in some headroom (currently 512 bytes) to make sure we don't unintentionally exceed this limit.

I used an arbitrary value for the overhead mostly to catch any other small issues we might have with calculating size. We could potentially get more exact by computing the proto size of a real upload part (minus the data length), but we need to know the limit before the parts are aggregated anyway.

changelog: Fixed a bug causing spurious failures to upload encrypted session recordings when 4MB or larger

# Manual Testing
(the conditions that create this broken state are difficult to recreate manually, so these are mostly regression tests)
- [x] Enable [encrypted recordings](https://goteleport.com/docs/enroll-resources/server-access/guides/encrypted-session-recordings/#step-12-configure-teleport) in your cluster
- [x] Start a session with a remote SSH node
  - [x] Generate a bunch of recording data (e.g. `while true; do ls -laR; done`)
  - [x] Complete the SSH session and ensure the recording has been uploaded and can be replayed
- [x] Start a desktop session with a remote windows host
- [x] Complete the desktop session and ensure the recording has been uploaded and can be replayed
