### PR TITLE
feat: added reauthentication support for mcp clients on ssh certificate expiry

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -870,7 +870,8 @@ func IsErrorResolvableWithRelogin(err error) bool {
 		// errors returned explicitly, as described below by codingllama.
 		isClientCredentialsHaveExpired := errors.Is(err, client.ErrClientCredentialsHaveExpired)
 		isTLSExpiredCertificate := strings.Contains(err.Error(), "tls: expired certificate")
-		return isClientCredentialsHaveExpired || isTLSExpiredCertificate
+		isSSHCertExpired := strings.Contains(err.Error(), "ssh: cert has expired")
+		return isClientCredentialsHaveExpired || isTLSExpiredCertificate || isSSHCertExpired
 	}
 
 	// TODO(codingllama): Retrying BadParameter is a terrible idea.

--- a/lib/client/mcp/errors.go
+++ b/lib/client/mcp/errors.go
@@ -30,11 +30,12 @@ import (
 
 const (
 	// ReloginRequiredErrorMessage is the message returned to the MCP client
-	// when the tsh session expired.
-	ReloginRequiredErrorMessage = `It looks like your Teleport session expired,
-you must relogin (using "tsh login" on a terminal) before continue using this
-tool. After that, there is no need to update or relaunch the MCP client - just
-try using it again.`
+	// when the tsh session expired and browser login could not be triggered
+	// automatically (e.g. the login attempt itself failed).
+	ReloginRequiredErrorMessage = `Your Teleport session has expired.
+If a browser login window did not open automatically, run "tsh login" in a
+terminal and then try again. There is no need to update or relaunch the MCP client - 
+just try using it again.`
 )
 
 // IsLikelyTemporaryNetworkError returns true if the error is likely a temporary

--- a/lib/client/mcp/reconnect.go
+++ b/lib/client/mcp/reconnect.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils/mcputils"
 )
@@ -53,6 +54,9 @@ type ProxyStdioConnConfig struct {
 	AutoReconnect bool
 	// HTTPHeaders defines extra custom headers for HTTP transports.
 	HTTPHeaders map[string]string
+
+	// OnSessionExpired is called when DialServer fails with a session-expired error.
+	OnSessionExpired func(ctx context.Context) error
 
 	// Logger is the slog logger.
 	Logger *slog.Logger
@@ -279,6 +283,11 @@ func (r *serverConnWithAutoReconnect) getServerRequestWriterLocked(ctx context.C
 	}
 
 	serverTransportReader, serverWriter, err := r.makeServerTransport(ctx)
+	if err != nil && r.OnSessionExpired != nil && client.IsErrorResolvableWithRelogin(err) {
+		if reloginErr := r.OnSessionExpired(ctx); reloginErr == nil {
+			serverTransportReader, serverWriter, err = r.makeServerTransport(ctx)
+		}
+	}
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/common/mcp_app.go
+++ b/tool/tsh/common/mcp_app.go
@@ -498,8 +498,30 @@ func (c *mcpConnectCommand) run() error {
 			MakeReconnectUserMessage: makeMCPReconnectUserMessage,
 			AutoReconnect:            c.autoReconnect,
 			HTTPHeaders:              httpHeaders,
+			OnSessionExpired:         makeMCPBrowserRelogin(tc),
 		},
 	)
+}
+
+// makeMCPBrowserRelogin opens the browser for SSO login on session expiration.
+func makeMCPBrowserRelogin(tc *client.TeleportClient) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		tc.NonInteractive = false
+		defer func() { tc.NonInteractive = true }()
+
+		keyRing, err := tc.Login(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		clusterClient, rootAuthClient, err := tc.ConnectToRootCluster(ctx, keyRing)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		rootAuthClient.Close()
+		clusterClient.Close()
+		return trace.Wrap(tc.SaveProfile(false))
+	}
 }
 
 func parseHTTPHeaders(headerArgs []string) (map[string]string, error) {

--- a/tool/tsh/common/mcp_app_test.go
+++ b/tool/tsh/common/mcp_app_test.go
@@ -350,6 +350,21 @@ func Test_mcpConfigCommand(t *testing.T) {
 	}
 }
 
+func Test_makeMCPBrowserRelogin(t *testing.T) {
+	tc := &client.TeleportClient{
+		Config: client.Config{
+			WebProxyAddr: "127.0.0.1:0",
+		},
+	}
+	tc.Tracer = tracing.NoopTracer(teleport.ComponentTSH)
+	tc.NonInteractive = true
+
+	reloginFn := makeMCPBrowserRelogin(tc)
+	err := reloginFn(context.Background())
+	require.Error(t, err, "expected Login to fail with no real server")
+	require.True(t, tc.NonInteractive, "NonInteractive must be restored to true after relogin attempt")
+}
+
 func Test_parseHTTPHeaders(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## What Changed
Currently, when a customer's tsh session expires, there is no user-friendly way to reauthenticate. Non-technical users must run tsh login from the terminal, but not all end users who use MCP clients interact with a terminal.

To address this, this change enables the client to automatically open a browser window when reauthentication is required. Users can then log in to their Teleport cluster using SSO through the browser. This allows the MCP client session to be refreshed without requiring terminal interaction, making the experience significantly more accessible for non-technical users.

## Screenshot
<img width="1385" height="749" alt="image" src="https://github.com/user-attachments/assets/aa7fbe76-8e67-4ed4-bbc2-ae53322f89e9" />


