### PR TITLE
[v17] app: Fall back to cluster name for auth redirect

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2004,12 +2004,14 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	// Apps are enabled.
 	cfg.Apps.Enabled = true
 
-	// Warn if proxy_service is enabled in the same config but has no
-	// public_addr. Without it, app access does not work.
+	// Log when proxy_service is enabled in the same config but has no
+	// public_addr. The proxy falls back to the cluster name for the
+	// auth redirect. Per-app public_addr controls the app's FQDN but
+	// does not replace this.
 	if fc.Proxy.Enabled() && len(fc.Proxy.PublicAddr) == 0 {
-		slog.WarnContext(context.Background(),
-			"app_service requires proxy_service.public_addr to route requests; app access will not work until it is set",
-		)
+		slog.InfoContext(context.Background(),
+			"proxy_service.public_addr not set; using cluster name for app auth redirects",
+			"nodename", cfg.Hostname)
 	}
 
 	// Enable debugging application if requested.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -455,19 +455,19 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build the proxy address list for app routing. Fall back to the
-	// cluster name when proxy_service.public_addr is not configured,
-	// matching the fallback in redirectToLauncher.
+	// Build the proxy address list for app routing. When
+	// proxy_service.public_addr is not configured, only activate the
+	// cluster-name fallback if the request host is a subdomain of the
+	// cluster name. This avoids misclassifying requests that arrive on
+	// a different hostname (e.g. behind a load balancer) as app requests.
 	proxyAddrs := h.handler.cfg.ProxyPublicAddrs
 	if len(proxyAddrs) == 0 && h.appHandler != nil {
 		clusterName := h.handler.auth.clusterName
-		if clusterName != "" {
-			addr, err := utils.ParseAddr(r.Host)
-			if err == nil {
-				port := addr.Port(443)
-				host := net.JoinHostPort(clusterName, strconv.Itoa(port))
-				proxyAddrs = []utils.NetAddr{{Addr: host}}
-			}
+		raddr, err := utils.ParseAddr(r.Host)
+		if err == nil && clusterName != "" && strings.HasSuffix(raddr.Host(), "."+clusterName) {
+			port := raddr.Port(443)
+			host := net.JoinHostPort(clusterName, strconv.Itoa(port))
+			proxyAddrs = []utils.NetAddr{{Addr: host}}
 		}
 	}
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -455,8 +455,24 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Build the proxy address list for app routing. Fall back to the
+	// cluster name when proxy_service.public_addr is not configured,
+	// matching the fallback in redirectToLauncher.
+	proxyAddrs := h.handler.cfg.ProxyPublicAddrs
+	if len(proxyAddrs) == 0 && h.appHandler != nil {
+		clusterName := h.handler.auth.clusterName
+		if clusterName != "" {
+			addr, err := utils.ParseAddr(r.Host)
+			if err == nil {
+				port := addr.Port(443)
+				host := net.JoinHostPort(clusterName, strconv.Itoa(port))
+				proxyAddrs = []utils.NetAddr{{Addr: host}}
+			}
+		}
+	}
+
 	// if the request is for an app, passthrough OPTIONS requests to the app handler
-	redir, ok := app.HasName(r, h.handler.cfg.ProxyPublicAddrs)
+	redir, ok := app.HasName(r, proxyAddrs)
 	if ok && r.Method == http.MethodOptions {
 		h.handlePreflight(w, r)
 		return
@@ -733,11 +749,6 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		}
 	}
 
-	resp, err := h.cfg.ProxySettings.GetProxySettings(cfg.Context)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// Create application specific handler. This handler handles sessions and
 	// forwarding for application access.
 	var appHandler *app.Handler
@@ -749,7 +760,6 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 			ProxyClient:           cfg.Proxy,
 			CipherSuites:          cfg.CipherSuites,
 			ProxyPublicAddrs:      cfg.ProxyPublicAddrs,
-			WebPublicAddr:         resp.SSH.PublicAddr,
 			IntegrationAppHandler: cfg.IntegrationAppHandler,
 		})
 		if err != nil {

--- a/lib/web/app/auth.go
+++ b/lib/web/app/auth.go
@@ -21,7 +21,9 @@ package app
 import (
 	"crypto/subtle"
 	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -223,30 +225,47 @@ func (h *Handler) completeAppAuthExchange(w http.ResponseWriter, r *http.Request
 	})
 
 	requiredApps := strings.Split(req.RequiredApps, ",")
-	if len(requiredApps) > 1 {
-		requiredApps := requiredApps[1:]
-		nextRequiredApp := requiredApps[0]
+	if len(requiredApps) <= 1 {
+		return nil
+	}
 
-		webLauncherURLParams := launcherURLParams{
-			publicAddr:          nextRequiredApp,
-			requiredAppFQDNs:    strings.Join(requiredApps, ","),
-			requiresAppRedirect: true,
-		}
-		addr, err := utils.ParseAddr(webLauncherURLParams.publicAddr)
+	requiredApps = requiredApps[1:]
+	nextRequiredApp := requiredApps[0]
+
+	webLauncherURLParams := launcherURLParams{
+		publicAddr:          nextRequiredApp,
+		requiredAppFQDNs:    strings.Join(requiredApps, ","),
+		requiresAppRedirect: true,
+	}
+	addr, err := utils.ParseAddr(webLauncherURLParams.publicAddr)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var publicAddrs []string
+	for _, proxyAddr := range h.c.ProxyPublicAddrs {
+		err = h.validateAppAddr(r.Context(), webLauncherURLParams.publicAddr, proxyAddr.Host())
 		if err != nil {
 			return trace.Wrap(err)
 		}
-
-		var publicAddrs []string
-		for _, addr := range h.c.ProxyPublicAddrs {
-			publicAddrs = append(publicAddrs, addr.Host())
-		}
-		proxyDNSName := utils.FindMatchingProxyDNS(addr.String(), publicAddrs)
-		urlString := makeAppRedirectURL(r, proxyDNSName, addr.Host(), webLauncherURLParams)
-		// this request does not return a response, so we can pass this value through a custom header instead
-		w.Header().Set(TeleportNextAppRedirectUrlHeader, urlString)
+		publicAddrs = append(publicAddrs, proxyAddr.Host())
 	}
-
+	if len(publicAddrs) == 0 {
+		err = h.validateAppAddr(r.Context(), webLauncherURLParams.publicAddr, h.clusterName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		reqAddr, err := utils.ParseAddr(r.Host)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		port := reqAddr.Port(443)
+		publicAddrs = []string{net.JoinHostPort(h.clusterName, strconv.Itoa(port))}
+	}
+	proxyDNSName := utils.FindMatchingProxyDNS(addr.String(), publicAddrs)
+	urlString := makeAppRedirectURL(r, proxyDNSName, addr.Host(), webLauncherURLParams)
+	// this request does not return a response, so we can pass this value through a custom header instead
+	w.Header().Set(TeleportNextAppRedirectUrlHeader, urlString)
 	return nil
 }
 

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -62,8 +62,6 @@ type HandlerConfig struct {
 	// CipherSuites is the list of TLS cipher suites that have been configured
 	// for this process.
 	CipherSuites []uint16
-	// WebPublicAddr
-	WebPublicAddr string
 	// IntegrationAppHandler handles App Access requests directly - not requiring an AppService.
 	// Only available for AWS OIDC Integrations.
 	IntegrationAppHandler ServerHandler

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -32,6 +32,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -878,6 +879,52 @@ func TestHandlerAuthenticate(t *testing.T) {
 		_, err := appHandler.authenticate(ctx, request)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
+	})
+}
+
+func TestRedirectToLauncherClusterFallback(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	clusterName := "tp.test"
+	appFQDN := "greeting.tp.test"
+	authClient := &mockAuthClient{clusterName: clusterName}
+
+	appHandler, err := NewHandler(ctx, &HandlerConfig{
+		AuthClient:            authClient,
+		AccessPoint:           authClient,
+		CipherSuites:          utils.DefaultCipherSuites(),
+		IntegrationAppHandler: &mockIntegrationAppHandler{},
+	})
+	require.NoError(t, err)
+
+	t.Run("redirects using cluster name when ProxyPublicAddrs is empty", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "https://"+appFQDN+"/", nil)
+		err := appHandler.redirectToLauncher(w, r, launcherURLParams{stateToken: "tok"})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusFound, w.Code)
+		loc := w.Header().Get("Location")
+		want := "https://" + clusterName + ":443/web/launch/" + appFQDN
+		require.True(t, strings.HasPrefix(loc, want), "got %s, want prefix %s", loc, want)
+	})
+
+	t.Run("rejects app addr matching cluster name", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "https://"+clusterName+"/", nil)
+		err := appHandler.redirectToLauncher(w, r, launcherURLParams{stateToken: "tok", publicAddr: clusterName})
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+	})
+
+	t.Run("preserves request port in fallback redirect", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "https://"+appFQDN+":3080/", nil)
+		err := appHandler.redirectToLauncher(w, r, launcherURLParams{stateToken: "tok"})
+		require.NoError(t, err)
+		loc := w.Header().Get("Location")
+		want := "https://" + clusterName + ":3080/web/launch/" + appFQDN
+		require.True(t, strings.HasPrefix(loc, want), "got %s, want prefix %s", loc, want)
 	})
 }
 

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -19,7 +19,10 @@
 package app
 
 import (
+	"context"
+	"net"
 	"net/http"
+	"strconv"
 
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -61,8 +64,7 @@ func (h *Handler) withAuth(handler handlerAuthFunc) http.HandlerFunc {
 	})
 }
 
-// redirectToLauncher redirects to the proxy web's app launcher if the public
-// address of the proxy is set.
+// redirectToLauncher redirects to the proxy web's app launcher.
 func (h *Handler) redirectToLauncher(w http.ResponseWriter, r *http.Request, p launcherURLParams) error {
 	if p.stateToken == "" && !HasSessionCookie(r) && !p.requiresAppRedirect {
 		// Reaching this block means the application was accessed through the CLI (eg: tsh app login)
@@ -70,18 +72,6 @@ func (h *Handler) redirectToLauncher(w http.ResponseWriter, r *http.Request, p l
 		// Since we can't redirect the user to the app launcher from the CLI,
 		// we just return an error instead.
 		return trace.BadParameter("redirecting to launcher when using client certificate, is not allowed")
-	}
-
-	if h.c.WebPublicAddr == "" {
-		const errMsg = "Application Service requires public_addr to be set in the Teleport Proxy Service configuration. " +
-			"Update the Teleport Proxy Service configuration to include a public_addr. " +
-			"Refer to https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/."
-
-		// Log the error to warn admins 🚩
-		h.log.Error(errMsg)
-
-		// Immediately return an error since this is a critical misconfiguration 🛑
-		return trace.BadParameter(errMsg)
 	}
 
 	addr, err := utils.ParseAddr(r.Host)
@@ -92,27 +82,47 @@ func (h *Handler) redirectToLauncher(w http.ResponseWriter, r *http.Request, p l
 	proxyPublicAddrs := make([]string, 0, len(h.c.ProxyPublicAddrs))
 
 	for _, proxyAddr := range h.c.ProxyPublicAddrs {
-		if p.publicAddr == proxyAddr.Host() {
-			const errMsg = "Application public address conflicts with the Teleport Proxy public address. " +
-				"Configure the application to use a unique public address that does not match the proxy's public addresses. " +
-				"Refer to https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/."
-
-			// Log the error to warn admins 🚩
-			h.log.WithField("launcher_params", p).Error(errMsg)
-
-			// Immediately return an error since this is a critical misconfiguration 🛑
-			return trace.BadParameter(errMsg)
+		err := h.validateAppAddr(r.Context(), p.publicAddr, proxyAddr.Host())
+		if err != nil {
+			return trace.Wrap(err)
 		}
-
-		// Append the full proxy address (host:port) to the list, preserving the port information.
-		// This is necessary to support proxies running on non-standard HTTPS ports and ensure accurate DNS matching.
 		proxyPublicAddrs = append(proxyPublicAddrs, proxyAddr.String())
+	}
+
+	// Fall back to the cluster name when proxy_service.public_addr is
+	// not configured. Derive the port from the incoming request so the
+	// redirect URL matches what the client actually connected to.
+	if len(proxyPublicAddrs) == 0 {
+		err := h.validateAppAddr(r.Context(), p.publicAddr, h.clusterName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		port := addr.Port(443)
+		proxyPublicAddrs = []string{
+			net.JoinHostPort(h.clusterName, strconv.Itoa(port)),
+		}
 	}
 
 	proxyDNSName := utils.FindMatchingProxyDNS(r.Host, proxyPublicAddrs)
 	urlString := makeAppRedirectURL(r, proxyDNSName, addr.Host(), p)
 	http.Redirect(w, r, urlString, http.StatusFound)
 	return nil
+}
+
+// validateAppAddr checks that appAddr does not match proxyHost
+// and returns an error on conflict.
+func (h *Handler) validateAppAddr(_ context.Context, appAddr, proxyHost string) error {
+	if appAddr != proxyHost {
+		return nil
+	}
+	const errMsg = "Application public address conflicts with the " +
+		"Teleport Proxy public address. Configure the application " +
+		"to use a unique public address that does not match the " +
+		"proxy's public addresses. Refer to https://goteleport.com/" +
+		"docs/enroll-resources/application-access/guides/" +
+		"connecting-apps/."
+	h.log.WithField("app_public_addr", appAddr).WithField("proxy_host", proxyHost).Error(errMsg)
+	return trace.BadParameter(errMsg)
 }
 
 // makeRouterHandler creates a httprouter.Handle.


### PR DESCRIPTION
`redirectToLauncher()` hard-errors when `proxy_service.public_addr` is
not set, even though the proxy knows its own identity via the cluster
name (which defaults to the nodename, which defaults to the OS
hostname). In practice this means browser app access fails unless the
admin also sets the proxy-level address, which is not obvious from the
docs.

Fall back to the cluster name when `ProxyPublicAddrs` is empty in three
places: `redirectToLauncher`, `APIHandler.ServeHTTP` (guarded by a
subdomain check so only requests whose host is a subdomain of the
cluster name are treated as app requests), and the required-app redirect
in `completeAppAuthExchange`. Derive the port from the incoming request
(`r.Host`) rather than the internal listen address so the redirect is
correct even behind a load balancer that translates ports (e.g. external
`:443` to internal `:3080`). Remove the now-dead `WebPublicAddr` field
and the `GetProxySettings` call that only existed to populate it. Run
the app/proxy address conflict check against the cluster-name fallback
too. Downgrade the startup log from WARN to INFO since app access now
works without explicit `proxy_service.public_addr`.

Issue: https://github.com/gravitational/teleport/issues/63863
Backport: https://github.com/gravitational/teleport/pull/63868

---

I had to manually create the backport due to merge conflicts around logging.
I've also tested it manually. Looks ok I think.
