### PR TITLE
[v17] docs: Clarify proxy public_addr for app access

### DIFF
--- a/docs/pages/includes/config-reference/proxy-service.yaml
+++ b/docs/pages/includes/config-reference/proxy-service.yaml
@@ -66,8 +66,8 @@ proxy_service:
     # The DNS name of the proxy HTTPS endpoint as accessible by cluster users.
     # Defaults to the proxy's hostname if not specified. If running multiple
     # proxies behind a load balancer, this name must point to the load balancer
-    # If application access is enabled, public_addr is used to write correct
-    # redirects
+    # Used for app access auth redirects. Falls back to the cluster name
+    # if not set.
     # If database access is enabled, Database clients will connect to the Proxy
     # over this hostname
     public_addr: proxy.example.com:3080

--- a/docs/pages/includes/config-reference/proxy-service.yaml
+++ b/docs/pages/includes/config-reference/proxy-service.yaml
@@ -66,8 +66,9 @@ proxy_service:
     # The DNS name of the proxy HTTPS endpoint as accessible by cluster users.
     # Defaults to the proxy's hostname if not specified. If running multiple
     # proxies behind a load balancer, this name must point to the load balancer
-    # Used for app access auth redirects. Falls back to the cluster name
-    # if not set.
+    # When a user opens a proxied application, they are redirected to the
+    # proxy for authentication. public_addr is used to build this redirect
+    # URL. If not set, the proxy falls back to the cluster name.
     # If database access is enabled, Database clients will connect to the Proxy
     # over this hostname
     public_addr: proxy.example.com:3080

--- a/docs/pages/includes/config-reference/proxy-service.yaml
+++ b/docs/pages/includes/config-reference/proxy-service.yaml
@@ -67,8 +67,8 @@ proxy_service:
     # Defaults to the proxy's hostname if not specified. If running multiple
     # proxies behind a load balancer, this name must point to the load balancer
     # When a user opens a proxied application, they are redirected to the
-    # proxy for authentication. public_addr is used to build this redirect
-    # URL. If not set, the proxy falls back to the cluster name.
+    # Teleport Proxy Service for authentication. public_addr is used to build
+    # this redirect URL. If not set, the proxy falls back to the cluster name.
     # If database access is enabled, Database clients will connect to the Proxy
     # over this hostname
     public_addr: proxy.example.com:3080


### PR DESCRIPTION
Update the `proxy-service.yaml` config reference comment for`public_addr` to note it is used for app access auth redirects and falls back to the cluster name if not set.

Issue: https://github.com/gravitational/teleport/issues/63863
Backport: https://github.com/gravitational/teleport/pull/63865