### PR TITLE
[v18] Clarify requirement that `spec.assigned_scope` be equiv or descendent to `scope` for ScopedToken (#64211)

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -144,6 +144,8 @@ func (x *ScopedToken) GetStatus() *ScopedTokenStatus {
 type ScopedTokenSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The scope to which this token is assigned.
+	//
+	// Must be equivalent or descendent to the scope of the token itself.
 	AssignedScope string `protobuf:"bytes,1,opt,name=assigned_scope,json=assignedScope,proto3" json:"assigned_scope,omitempty"`
 	// The list of roles associated with the token. They will be converted
 	// to metadata in the SSH and X509 certificates issued to the user of the

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -51,6 +51,8 @@ message ScopedToken {
 // ScopedTokenSpec is the specification of a scoped token.
 message ScopedTokenSpec {
   // The scope to which this token is assigned.
+  //
+  // Must be equivalent or descendent to the scope of the token itself.
   string assigned_scope = 1;
 
   // The list of roles associated with the token. They will be converted


### PR DESCRIPTION
Backports #64211

Comment change only - no test plan or changelog.