### PR TITLE
test: Fix flaky bots UI test

### DIFF
--- a/web/packages/teleport/src/Bots/List/Bots.test.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.test.tsx
@@ -24,6 +24,7 @@ import {
   userEvent,
   waitFor,
   waitForElementToBeRemoved,
+  within,
 } from 'design/utils/testing';
 import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
 
@@ -105,8 +106,9 @@ describe('Bots', () => {
     expect(actionCells).toHaveLength(botsApiResponseFixture.items.length);
     await userEvent.click(actionCells[0]);
 
-    expect(screen.getByText('Delete...')).toBeInTheDocument();
-    await userEvent.click(screen.getByText('Delete...'));
+    // Wait for the options menu to appear
+    const menu = await screen.findByTestId('Modal');
+    await userEvent.click(within(menu).getByText('Delete...'));
 
     expect(
       screen.getByText(


### PR DESCRIPTION
## Summary
Addresses flakiness in `Bots/List/Bots.test.tsx`. I was unable to repro the flakiness, but [the test logs](https://github.com/gravitational/teleport/actions/runs/22623672981/job/65554659371?pr=64196#step:7:1371) suggest that the options menu was not visible yet when attempting to click the Delete... option. This change adds a wait for the menu to appear before proceeding.

**Will backport to v17 and v18.**

Fixes: https://github.com/gravitational/teleport/issues/64200

## Changes
- Wait for menu to appear, then find delete option within it

## Manual equivalent
<img width="1199" height="665" alt="image" src="https://github.com/user-attachments/assets/de2dc623-18cb-478c-b728-baf15830751d" />
