### PR TITLE
[v18] Use flexible matching on sync stamp rendering

### DIFF
--- a/web/packages/design/src/SyncStamp/SyncStamp.test.tsx
+++ b/web/packages/design/src/SyncStamp/SyncStamp.test.tsx
@@ -22,7 +22,7 @@ import { SyncStamp } from './SyncStamp';
 
 test('renders time since date', () => {
   render(<SyncStamp date={new Date()} />);
-  expect(screen.getByText('Last Sync: 0 seconds ago')).toBeInTheDocument();
+  expect(screen.getByText(/Last Sync: \d+ seconds? ago/)).toBeInTheDocument();
 });
 
 test('renders empty state text', () => {

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
@@ -117,7 +117,7 @@ test('renders header and stats cards', async () => {
 
   const ec2 = screen.getByTestId('ec2-stats');
   expect(within(ec2).getByTestId('sync')).toHaveTextContent(
-    'Last Sync: 0 seconds ago'
+    /Last Sync: \d+ seconds? ago/
   );
   expect(within(ec2).getByTestId('rules')).toHaveTextContent(
     'Enrollment Rules 24'


### PR DESCRIPTION
Backport #61566.

Backporting to release branches to address a flaky test. I just got a hit on v17 https://github.com/gravitational/teleport/actions/runs/22664827889/job/65693827118#step:7:932.