### PR TITLE
[v17] Stream session recordings directly without temporary files

### DIFF
--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -521,58 +521,29 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 			startCb(evt, nil)
 		}()
 	}
+	// TODO(tigrato): consider changing the implementation of Download* to return
+	// an io.ReadCloser instead of writing to a provided writer, which would allow
+	// us to avoid using io.Pipe here.
+	reader, writer := io.Pipe()
 
-	rawSession, err := os.CreateTemp(l.playbackDir, string(sessionID)+".stream.tar.*")
-	if err != nil {
-		e <- trace.Wrap(trace.ConvertSystemError(err), "creating temporary stream file")
-		close(sessionStartCh)
-		return c, e
-	}
-	// The file is still perfectly usable after unlinking it, and the space it's
-	// using on disk will get reclaimed as soon as the file is closed (or the
-	// process terminates) - and if the session is small enough and we go
-	// through it quickly enough, we're likely not even going to end up with any
-	// bytes on the physical disk, anyway. We're using the same playback
-	// directory as the GetSessionChunk flow, which means that if we crash
-	// between creating the empty file and unlinking it, we'll end up with an
-	// empty file that will eventually be cleaned up by periodicCleanupPlaybacks
-	//
-	// TODO(espadolini): investigate the use of O_TMPFILE on Linux, so we don't
-	// even have to bother with the unlink and we avoid writing on the directory
-	if err := os.Remove(rawSession.Name()); err != nil {
-		_ = rawSession.Close()
-		e <- trace.Wrap(trace.ConvertSystemError(err), "removing temporary stream file")
-		close(sessionStartCh)
-		return c, e
-	}
-
-	start := time.Now()
-	if err := l.UploadHandler.Download(ctx, sessionID, rawSession); err != nil {
-		_ = rawSession.Close()
+	go func() {
+		err := l.UploadHandler.Download(ctx, sessionID, writer)
 		if errors.Is(err, fs.ErrNotExist) {
 			err = trace.NotFound("a recording for session %v was not found", sessionID)
 		}
-		e <- trace.Wrap(err)
-		close(sessionStartCh)
-		return c, e
-	}
-	l.log.DebugContext(ctx, "Downloaded session to a temporary file for streaming.",
-		"duration", time.Since(start),
-		"session_id", string(sessionID),
-	)
+
+		// if the error is nil, it means the download was successful and closing the
+		// writer will signal the reader with io.EOF.
+		if err := writer.CloseWithError(err); err != nil {
+			l.log.WarnContext(ctx, "Failed to close the writer with error", "session_id", string(sessionID), "error", err)
+		}
+	}()
 
 	go func() {
-		defer rawSession.Close()
 		defer close(sessionStartCh)
+		defer reader.Close()
 
-		// this shouldn't be necessary as the position should be already 0 (Download
-		// takes an io.WriterAt), but it's better to be safe than sorry
-		if _, err := rawSession.Seek(0, io.SeekStart); err != nil {
-			e <- trace.Wrap(err)
-			return
-		}
-
-		protoReader := NewProtoReader(rawSession)
+		protoReader := NewProtoReader(reader)
 		defer protoReader.Close()
 
 		firstEvent := true

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -278,7 +278,7 @@ func (h *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Re
 }
 
 // Download implements [events.UploadHandler].
-func (h *Handler) Download(ctx context.Context, sessionID session.ID, writerAt io.WriterAt) error {
+func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	resp, err := cErr(h.sessionBlob(sessionID).DownloadStream(ctx, nil))
 	if err != nil {
 		return trace.Wrap(err)
@@ -289,11 +289,6 @@ func (h *Handler) Download(ctx context.Context, sessionID session.ID, writerAt i
 			h.log.WarnContext(ctx, "Error closing downloaded session blob.", "error", err, fieldSessionID, sessionID)
 		}
 	}()
-
-	writer, ok := writerAt.(io.Writer)
-	if !ok {
-		writer = io.NewOffsetWriter(writerAt, 0)
-	}
 
 	if _, err := io.Copy(writer, resp.Body); err != nil {
 		return trace.ConvertSystemError(cErr0(err))

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -68,7 +68,7 @@ type MemoryUpload struct {
 	parts map[int64]part
 	// sessionID is the session ID associated with the upload
 	sessionID session.ID
-	//completed specifies upload as completed
+	// completed specifies upload as completed
 	completed bool
 	// Initiated contains the timestamp of when the upload
 	// was initiated, not always initialized
@@ -269,7 +269,7 @@ func (m *MemoryUploader) Upload(ctx context.Context, sessionID session.ID, readC
 }
 
 // Download downloads session tarball and writes it to writer
-func (m *MemoryUploader) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (m *MemoryUploader) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -277,7 +277,7 @@ func (m *MemoryUploader) Download(ctx context.Context, sessionID session.ID, wri
 	if !ok {
 		return trace.NotFound("session %q is not found", sessionID)
 	}
-	_, err := io.Copy(writer.(io.Writer), bytes.NewReader(data))
+	_, err := io.Copy(writer, bytes.NewReader(data))
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -95,14 +95,14 @@ func (l *Handler) Close() error {
 
 // Download downloads session recording from storage, in case of file handler reads the
 // file from local directory
-func (l *Handler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (l *Handler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	path := l.path(sessionID)
 	f, err := os.Open(path)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
 	defer f.Close()
-	_, err = io.Copy(writer.(io.Writer), f)
+	_, err = io.Copy(writer, f)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -267,13 +267,9 @@ func (h *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Re
 
 // Download downloads recorded session from GCS bucket and writes the results into writer
 // return trace.NotFound error is object is not found
-func (h *Handler) Download(ctx context.Context, sessionID session.ID, writerAt io.WriterAt) error {
+func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	path := h.path(sessionID)
 	h.logger.DebugContext(ctx, "Downloading object from GCS.", "path", path)
-	writer, ok := writerAt.(io.Writer)
-	if !ok {
-		return trace.BadParameter("the provided writerAt is %T which does not implement io.Writer", writerAt)
-	}
 	reader, err := h.gcsClient.Bucket(h.Config.Bucket).Object(path).NewReader(ctx)
 	if err != nil {
 		return convertGCSError(err)

--- a/lib/events/s3sessions/s3client.go
+++ b/lib/events/s3sessions/s3client.go
@@ -38,4 +38,6 @@ type s3Client interface {
 	ListParts(ctx context.Context, params *s3.ListPartsInput, optFns ...func(*s3.Options)) (*s3.ListPartsOutput, error)
 	ListMultipartUploads(ctx context.Context, params *s3.ListMultipartUploadsInput, optFns ...func(*s3.Options)) (*s3.ListMultipartUploadsOutput, error)
 	UploadPart(ctx context.Context, params *s3.UploadPartInput, optFns ...func(*s3.Options)) (*s3.UploadPartOutput, error)
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 }

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -266,14 +266,12 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 	client := s3.NewFromConfig(awsConfig, s3Opts...)
 
 	uploader := manager.NewUploader(client)
-	downloader := manager.NewDownloader(client)
 
 	h := &Handler{
-		logger:     logger,
-		Config:     cfg,
-		uploader:   uploader,
-		downloader: downloader,
-		client:     client,
+		logger:   logger,
+		Config:   cfg,
+		uploader: uploader,
+		client:   client,
 	}
 
 	start := time.Now()
@@ -300,10 +298,9 @@ type Handler struct {
 	// Config is handler configuration
 	Config
 	// logger emits log messages
-	logger     *slog.Logger
-	uploader   *manager.Uploader
-	downloader *manager.Downloader
-	client     s3Client
+	logger   *slog.Logger
+	uploader *manager.Uploader
+	client   s3Client
 }
 
 // Close releases connection and resources associated with log if any
@@ -339,7 +336,7 @@ func (h *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Re
 
 // Download downloads recorded session from S3 bucket and writes the results
 // into writer return trace.NotFound error is object is not found.
-func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	// Get the oldest version of this object. This has to be done because S3
 	// allows overwriting objects in a bucket. To prevent corruption of recording
 	// data, get all versions and always return the first.
@@ -350,15 +347,99 @@ func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.
 
 	h.logger.DebugContext(ctx, "Downloading recording from S3", "bucket", h.Bucket, "path", h.path(sessionID), "version_id", versionID)
 
-	_, err = h.downloader.Download(ctx, writer, &s3.GetObjectInput{
-		Bucket:    aws.String(h.Bucket),
-		Key:       aws.String(h.path(sessionID)),
-		VersionId: aws.String(versionID),
-	})
+	err = h.downloadFile(ctx, h.path(sessionID), writer, aws.String(versionID))
 	if err != nil {
 		return awsutils.ConvertS3Error(err)
 	}
 	return nil
+}
+
+func (h *Handler) downloadFile(
+	ctx context.Context, path string, writer io.Writer, versionID *string,
+) error {
+	// maxDownloadRetries is the maximum number of retries for the body.
+	const maxDownloadRetries = 3
+
+	// get the file head to find out the size.
+	headInput := &s3.HeadObjectInput{
+		Bucket:    aws.String(h.Bucket),
+		Key:       aws.String(path),
+		VersionId: versionID,
+	}
+
+	headOutput, err := h.client.HeadObject(ctx, headInput)
+	if err != nil {
+		return awsutils.ConvertS3Error(err)
+	}
+
+	contentLength := aws.ToInt64(headOutput.ContentLength)
+	if contentLength == 0 {
+		return nil
+	}
+
+	// offset tracks how many bytes have been successfully copied to the writer so far
+	var offset int64
+	var lastErr error
+	for attempt := range maxDownloadRetries {
+		if err := ctx.Err(); err != nil {
+			return trace.Wrap(err)
+		}
+		if attempt > 0 {
+			h.logger.DebugContext(ctx, "Retrying download from last position",
+				"bucket", h.Bucket,
+				"path", path,
+				"offset", offset,
+				"attempt", attempt+1,
+			)
+		}
+
+		// send the range header to download only the remaining part of the file
+		rangeStr := fmt.Sprintf("bytes=%d-%d", offset, contentLength-1)
+
+		getInput := &s3.GetObjectInput{
+			Bucket:    aws.String(h.Bucket),
+			Key:       aws.String(path),
+			VersionId: versionID,
+			Range:     aws.String(rangeStr),
+		}
+
+		output, err := h.client.GetObject(ctx, getInput)
+		if err != nil {
+			return trace.Wrap(awsutils.ConvertS3Error(err))
+		}
+
+		// copy the body to the writer
+		n, err := io.Copy(writer, output.Body)
+		_ = output.Body.Close()
+
+		offset += n
+
+		if err != nil {
+			// If we haven't reached the end, continue
+			// the AWS manager.Downloader retries on every error when reading the error.
+			if offset < contentLength {
+				lastErr = err
+				continue
+			}
+			return trace.Wrap(err)
+		}
+
+		if offset < contentLength {
+			lastErr = fmt.Errorf("downloaded %d bytes, expected %d", offset, contentLength)
+			continue
+		}
+
+		// this case should never happen given that we force the version and the file
+		// shouldn't be changing under us, but if it does, we want to know about it
+		//  instead of silently truncating the recording
+		if offset != contentLength {
+			return trace.BadParameter("expected %d bytes, got %d when downloading file %q", contentLength, offset, path)
+		}
+
+		return nil
+	}
+
+	return trace.Wrap(lastErr, "failed to download file after %d attempts", maxDownloadRetries)
 }
 
 // versionID is used to store versions of a key to allow sorting by timestamp.

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -33,10 +33,11 @@ type UploadHandler interface {
 	// in case of success.
 	Upload(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// Download downloads session tarball and writes it to writer
-	Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error
+	Download(ctx context.Context, sessionID session.ID, writer io.Writer) error
 }
 
-// MultipartHandler handles both multipart uploads and downloads
+// MultipartHandler handles both multipart and standalone uploads and
+// downloads.
 type MultipartHandler interface {
 	UploadHandler
 	MultipartUploader

--- a/lib/integrations/externalauditstorage/error_counter.go
+++ b/lib/integrations/externalauditstorage/error_counter.go
@@ -365,7 +365,7 @@ func (c *ErrorCountingSessionHandler) Upload(ctx context.Context, sessionID sess
 }
 
 // Download calls [c.wrapped.Download] and counts the error or success.
-func (c *ErrorCountingSessionHandler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (c *ErrorCountingSessionHandler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	err := c.wrapped.Download(ctx, sessionID, writer)
 	c.downloads.observe(err)
 	return err

--- a/lib/integrations/externalauditstorage/error_counter_test.go
+++ b/lib/integrations/externalauditstorage/error_counter_test.go
@@ -211,7 +211,6 @@ func TestErrorCounter(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 type testPack struct {
@@ -276,6 +275,6 @@ func (h *errorHandler) Upload(ctx context.Context, sessionID session.ID, reader 
 	return "", h.err
 }
 
-func (h *errorHandler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (h *errorHandler) Download(ctx context.Context, sessionID session.ID, writer io.Writer) error {
 	return h.err
 }


### PR DESCRIPTION
Backport of #63597 to branch/v17


Manual test plan:
- [x] Tested windows sessions on cloud
- [x] Tested windows sessions locally
- [x] Tested SSH sessions with timeline locally
- [x] Tested SSH sessions in Cloud - without timeline
- [x] Tested pgsql sessions
- [x] Session summarization still works