### PR TITLE
[v17] Move error boundary to a child of theme provider so it displays properly

### DIFF
--- a/web/packages/teleport/src/Teleport.tsx
+++ b/web/packages/teleport/src/Teleport.tsx
@@ -90,9 +90,9 @@ const Teleport: React.FC<Props> = props => {
   }, []);
 
   return (
-    <CatchError>
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <CatchError>
           <LayoutContextProvider>
             <Router history={history}>
               <Suspense fallback={null}>
@@ -117,9 +117,9 @@ const Teleport: React.FC<Props> = props => {
               </Suspense>
             </Router>
           </LayoutContextProvider>
-        </ThemeProvider>
-      </QueryClientProvider>
-    </CatchError>
+        </CatchError>
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 };
 


### PR DESCRIPTION
Backport #63964 to branch/v17

changelog: Fixed an issue where the UI would display a white screen and no error when an error occurred
