### PR TITLE
Add AWS region validation for Bedrock inference model

### DIFF
--- a/api/types/summarizer/summarizer.go
+++ b/api/types/summarizer/summarizer.go
@@ -23,6 +23,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/aws"
 )
 
 const (
@@ -103,9 +104,13 @@ func ValidateInferenceModel(m *summarizerv1.InferenceModel) error {
 			return trace.BadParameter("spec.bedrock.region is required")
 		}
 
-		if containsPlaceholderInstruction(p.Bedrock.GetRegion()) &&
-			strings.ReplaceAll(p.Bedrock.GetRegion(), " ", "") != BedrockRegionExpansionPlaceholder {
-			return trace.BadParameter("spec.bedrock.region contains invalid placeholder instructions. Valid placeholder: %s; got %s", BedrockRegionExpansionPlaceholder, p.Bedrock.GetRegion())
+		switch {
+		case containsPlaceholderInstruction(p.Bedrock.GetRegion()):
+			if strings.ReplaceAll(p.Bedrock.GetRegion(), " ", "") != BedrockRegionExpansionPlaceholder {
+				return trace.BadParameter("spec.bedrock.region contains invalid placeholder instructions. Valid placeholder: %s; got %s", BedrockRegionExpansionPlaceholder, p.Bedrock.GetRegion())
+			}
+		case aws.IsValidRegion(p.Bedrock.GetRegion()) != nil:
+			return trace.BadParameter("invalid spec.bedrock.region: %q", p.Bedrock.GetRegion())
 		}
 	}
 

--- a/api/types/summarizer/summarizer_test.go
+++ b/api/types/summarizer/summarizer_test.go
@@ -144,6 +144,20 @@ func TestValidateInferenceModel(t *testing.T) {
 			fn:   func(m *summarizerv1.InferenceModel) {},
 			msg:  "spec.bedrock.region contains invalid placeholder instructions. Valid placeholder: {{env.bedrock_region}}; got {{ env.bedrock_regio}}",
 		},
+		{
+			base: validBedrock,
+			fn: func(m *summarizerv1.InferenceModel) {
+				m.Spec.GetBedrock().Region = "eu-west-1?path"
+			},
+			msg: "invalid spec.bedrock.region: \"eu-west-1?path\"",
+		},
+		{
+			base: validBedrock,
+			fn: func(m *summarizerv1.InferenceModel) {
+				m.Spec.GetBedrock().Region = "eu-west-1.something"
+			},
+			msg: "invalid spec.bedrock.region: \"eu-west-1.something\"",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Validates that the Bedrock region field contains a properly-formatted AWS region identifier, in addition to the existing check for template placeholder instructions. Adds tests for invalid region formats.