### PR TITLE
[v18] Inline IronRDP WASM Module

### DIFF
--- a/web/packages/build/jest/config.js
+++ b/web/packages/build/jest/config.js
@@ -27,6 +27,9 @@ module.exports = {
       __dirname,
       'mockFiles.js'
     ),
+    // mock ironrdp wasm module
+    '^shared/libs/ironrdp/pkg/ironrdp_bg.wasm\\?inline$':
+      '<rootDir>/web/packages/shared/libs/ironrdp/mock_ironrdp.js',
     '^shared/(.*)$': '<rootDir>/web/packages/shared/$1',
     '^design($|/.*)': '<rootDir>/web/packages/design/src/$1',
     '^teleport($|/.*)': '<rootDir>/web/packages/teleport/src/$1',

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -79,6 +79,21 @@ export function createViteConfig(
             // this will remove hashing from asset (non-js) files.
             assetFileNames: `app/[name].[ext]`,
           },
+          plugins: [
+            {
+              // The wasm module is embedded into the main app earlier in the build.
+              // Exclude it here, otherwise rollup still emits it as a static asset
+              // by default.
+              name: 'drop-wasm-assets',
+              generateBundle(_, bundle) {
+                for (const file of Object.keys(bundle)) {
+                  if (file.endsWith('.wasm')) {
+                    delete bundle[file];
+                  }
+                }
+              },
+            },
+          ],
         },
       },
       plugins: [
@@ -88,6 +103,7 @@ export function createViteConfig(
         generateAppHashFile(outputDirectory, ENTRY_FILE_NAME),
         wasm(),
       ],
+      assetsInclude: ['**/shared/libs/ironrdp/**/*.wasm'],
       define: {
         'process.env': { NODE_ENV: process.env.NODE_ENV },
       },

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -79,21 +79,6 @@ export function createViteConfig(
             // this will remove hashing from asset (non-js) files.
             assetFileNames: `app/[name].[ext]`,
           },
-          plugins: [
-            {
-              // The wasm module is embedded into the main app earlier in the build.
-              // Exclude it here, otherwise rollup still emits it as a static asset
-              // by default.
-              name: 'drop-wasm-assets',
-              generateBundle(_, bundle) {
-                for (const file of Object.keys(bundle)) {
-                  if (file.endsWith('.wasm')) {
-                    delete bundle[file];
-                  }
-                }
-              },
-            },
-          ],
         },
       },
       plugins: [

--- a/web/packages/shared/libs/ironrdp/mock_ironrdp.js
+++ b/web/packages/shared/libs/ironrdp/mock_ironrdp.js
@@ -1,0 +1,1 @@
+module.exports = new Uint8Array();

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -24,9 +24,9 @@ import init, {
   FastPathProcessor,
   init_wasm_log,
 } from 'shared/libs/ironrdp/pkg/ironrdp';
-import Logger from 'shared/libs/logger';
 // Inlines the wasm module as a static asset bundled with our app.
 import wasmUrl from 'shared/libs/ironrdp/pkg/ironrdp_bg.wasm?inline';
+import Logger from 'shared/libs/logger';
 import { ensureError, isAbortError } from 'shared/utils/error';
 
 import Codec, {

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -25,6 +25,8 @@ import init, {
   init_wasm_log,
 } from 'shared/libs/ironrdp/pkg/ironrdp';
 import Logger from 'shared/libs/logger';
+// Inlines the wasm module as a static asset bundled with our app.
+import wasmUrl from 'shared/libs/ironrdp/pkg/ironrdp_bg.wasm?inline';
 import { ensureError, isAbortError } from 'shared/utils/error';
 
 import Codec, {
@@ -323,7 +325,14 @@ export class TdpClient extends EventEmitter<EventMap> {
       wasmLogLevel = LogType.TRACE;
     }
 
-    await init();
+    // Convert the inlined (base64) WASM to a raw buffer. The init function will
+    // load this directly which plays nicely with our current Content Security Policy.
+    const wasmBytes = Uint8Array.from(
+      atob(wasmUrl.slice(wasmUrl.indexOf(',') + 1)),
+      c => c.charCodeAt(0)
+    );
+
+    await init({ module_or_path: wasmBytes });
     init_wasm_log(wasmLogLevel);
   }
 

--- a/web/packages/teleterm/electron.vite.config.mts
+++ b/web/packages/teleterm/electron.vite.config.mts
@@ -112,6 +112,18 @@ const config = defineConfig(env => {
         reactPlugin(env.mode),
         cspPlugin(getConnectCsp(env.mode === 'development')),
         tsConfigPathsPlugin,
+        {
+          // The IronRDP wasm module is embedded into the renderer app earlier in the build.
+          // Exclude it here, otherwise rollup still emits it as a static asset by default.
+          name: 'drop-wasm-assets',
+          generateBundle(_, bundle) {
+            for (const file of Object.keys(bundle)) {
+              if (file.endsWith('.wasm')) {
+                delete bundle[file];
+              }
+            }
+          },
+        },
       ],
       define: {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),

--- a/web/packages/teleterm/electron.vite.config.mts
+++ b/web/packages/teleterm/electron.vite.config.mts
@@ -91,6 +91,7 @@ const config = defineConfig(env => {
       },
     },
     renderer: {
+      assetsInclude: ['**/shared/libs/ironrdp/**/*.wasm'],
       root: '.',
       build: {
         outDir: path.resolve(outputDirectory, 'renderer'),


### PR DESCRIPTION
Backports #63503 and follow on fix #63997

changelog: Fixed a bug that could cause desktop connection errors during proxy upgrades for some cluster configurations.

Manual test plan:

- [x] Ensure that both Teleport and Teleport Connect build
- [x] Stand up a cluster two v18 proxy instances (one with this change and the other without) behind an L4 load balancer. Ensure that desktop connections succeed with both versions of the app bundle (inspect source to determine the version served)
- [x] Manually validate that the "new" proxy instance still serves the WASM module at `/web/app/ironrdp_bg.wasm`
- [x] Validate that desktop connections succeed using Teleport Connect