### PR TITLE
WIP: Fix test flakiness for TestTrustedClusterUpdate and TestTeleportUserUpdate

### DIFF
--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -21,6 +21,7 @@ package testlib
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
@@ -100,17 +101,44 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 			Name:      resourceName,
 		},
 	}
+
+	// Reconcile can transiently return compare-failed while Teleport revisions propagate. Retry those conflicts
+	// briefly, but fail fast on any other error to keep test failures actionable.
+	reconcileWithRetry := func(expectedResource T) {
+		require.Eventually(
+			t,
+			func() bool {
+				_, err = reconciler.Reconcile(ctx, req)
+
+				switch {
+				case err == nil:
+					return true
+
+				case trace.IsCompareFailed(err):
+					return false
+
+				default:
+					require.NoError(t, err)
+					return false
+				}
+			},
+			5*time.Second,
+			100*time.Millisecond,
+		)
+
+		if err != nil {
+			// Fetch the latest resource state so conflict failures include a diff against what we expected to upsert.
+			unexpectedResource, getErr := test.GetTeleportResource(ctx, resourceName)
+			require.NoError(t, getErr, "retrieving the resource after an unexpected conflict")
+			require.Failf(t, ConflictErrorMessage, cmp.Diff(expectedResource, unexpectedResource, protocmp.Transform()))
+		}
+	}
+
 	// First reconcile adds the finalizer
 	_, err = reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
 	// Second reconcile actually does the Teleport call.
-	_, err = reconciler.Reconcile(ctx, req)
-	if trace.IsCompareFailed(err) {
-		unexpectedResource, err := test.GetTeleportResource(ctx, resourceName)
-		require.NoError(t, err, "Retrieving the user after an unexpected conflict")
-		require.Failf(t, ConflictErrorMessage, cmp.Diff(tResource, unexpectedResource, protocmp.Transform()))
-	}
-	require.NoError(t, err)
+	reconcileWithRetry(tResource)
 
 	var reconciledResource T
 
@@ -131,13 +159,7 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 	require.NoError(t, test.ModifyKubernetesResource(ctx, resourceName))
 
 	// Test execution: Trigger reconciliation
-	_, err = reconciler.Reconcile(ctx, req)
-	if trace.IsCompareFailed(err) {
-		unexpectedResource, err := test.GetTeleportResource(ctx, resourceName)
-		require.NoError(t, err, "Retrieving the user after an unexpected conflict")
-		require.Failf(t, ConflictErrorMessage, cmp.Diff(reconciledResource, unexpectedResource, protocmp.Transform()))
-	}
-	require.NoError(t, err)
+	reconcileWithRetry(reconciledResource)
 
 	var testPassed bool
 	debugInfo := func() {


### PR DESCRIPTION
Resolves https://github.com/gravitational/teleport/issues/64176

Adds a retry to the reconcile on transient compare-failed errors; fail hard with resource diff on other errors.

Before:
```
❯ go test ./integrations/operator/controllers/resources -run 'TestTrustedClusterUpdate|TestTeleportUserUpdate' -count=20 
--- FAIL: TestTeleportUserUpdate (0.43s)
    teleport_reconciler_tests.go:138: 
                Error Trace:    /Users/christhach/projects/teleport/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go:138
                                                        /Users/christhach/projects/teleport/integrations/operator/controllers/resources/user_controller_test.go:163
                Error:          An unexpected conflict happened. The resource changed since the last time it was edited.
                                Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.
                Test:           TestTeleportUserUpdate
--- FAIL: TestTeleportUserUpdate (0.47s)
    teleport_reconciler_tests.go:138: 
                Error Trace:    /Users/christhach/projects/teleport/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go:138
                                                        /Users/christhach/projects/teleport/integrations/operator/controllers/resources/user_controller_test.go:163
                Error:          An unexpected conflict happened. The resource changed since the last time it was edited.
                                Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.
                Test:           TestTeleportUserUpdate
--- FAIL: TestTeleportUserUpdate (0.47s)
    teleport_reconciler_tests.go:138: 
                Error Trace:    /Users/christhach/projects/teleport/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go:138
                                                        /Users/christhach/projects/teleport/integrations/operator/controllers/resources/user_controller_test.go:163
                Error:          An unexpected conflict happened. The resource changed since the last time it was edited.
                                Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.
                Test:           TestTeleportUserUpdate
--- FAIL: TestTrustedClusterUpdate (0.91s)
    teleport_reconciler_tests.go:138: 
                Error Trace:    /Users/christhach/projects/teleport/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go:138
                                                        /Users/christhach/projects/teleport/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go:225
                Error:          An unexpected conflict happened. The resource changed since the last time it was edited.
                                Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.
                Test:           TestTrustedClusterUpdate
--- FAIL: TestTrustedClusterUpdate (0.90s)
    teleport_reconciler_tests.go:138: 
                Error Trace:    /Users/christhach/projects/teleport/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go:138
                                                        /Users/christhach/projects/teleport/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go:225
                Error:          An unexpected conflict happened. The resource changed since the last time it was edited.
                                Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.
                Test:           TestTrustedClusterUpdate
--- FAIL: TestTeleportUserUpdate (0.62s)
    teleport_reconciler_tests.go:138: 
                Error Trace:    /Users/christhach/projects/teleport/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go:138
                                                        /Users/christhach/projects/teleport/integrations/operator/controllers/resources/user_controller_test.go:163
                Error:          An unexpected conflict happened. The resource changed since the last time it was edited.
                                Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.
                Test:           TestTeleportUserUpdate
--- FAIL: TestTrustedClusterUpdate (1.03s)
    teleport_reconciler_tests.go:138: 
                Error Trace:    /Users/christhach/projects/teleport/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go:138
                                                        /Users/christhach/projects/teleport/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go:225
                Error:          An unexpected conflict happened. The resource changed since the last time it was edited.
                                Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.
                Test:           TestTrustedClusterUpdate
--- FAIL: TestTeleportUserUpdate (0.43s)
    teleport_reconciler_tests.go:138: 
                Error Trace:    /Users/christhach/projects/teleport/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go:138
                                                        /Users/christhach/projects/teleport/integrations/operator/controllers/resources/user_controller_test.go:163
                Error:          An unexpected conflict happened. The resource changed since the last time it was edited.
                                Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.
                Test:           TestTeleportUserUpdate
--- FAIL: TestTrustedClusterUpdate (0.89s)
    teleport_reconciler_tests.go:138: 
                Error Trace:    /Users/christhach/projects/teleport/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go:138
                                                        /Users/christhach/projects/teleport/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go:225
                Error:          An unexpected conflict happened. The resource changed since the last time it was edited.
                                Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.
                Test:           TestTrustedClusterUpdate
FAIL
FAIL    github.com/gravitational/teleport/integrations/operator/controllers/resources   30.541s
FAIL
```

After:
```
❯ go test ./integrations/operator/controllers/resources -run 'TestTrustedClusterUpdate|TestTeleportUserUpdate' -count=20
ok      github.com/gravitational/teleport/integrations/operator/controllers/resources   32.370s
```

## Manual tests

- [x] Run `go test ./integrations/operator/controllers/resources -run 'TestTrustedClusterUpdate|TestTeleportUserUpdate' -count=100` and ensure it passes consistently
