### PR TITLE
[v18] Add missing deletion tests to the k8s operator

### DIFF
--- a/integrations/operator/controllers/resources/appv3_controller_test.go
+++ b/integrations/operator/controllers/resources/appv3_controller_test.go
@@ -126,15 +126,20 @@ func (g *appV3TestingPrimitives) CompareTeleportAndKubernetesResource(tResource 
 
 func TestTeleportAppV3Creation(t *testing.T) {
 	test := &appV3TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.Application, *resourcesv1.TeleportAppV3](t, resources.NewAppV3Reconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewAppV3Reconciler, test)
+}
+
+func TestTeleportAppV3Deletion(t *testing.T) {
+	test := &appV3TestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewAppV3Reconciler, test)
 }
 
 func TestTeleportAppV3DeletionDrift(t *testing.T) {
 	test := &appV3TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.Application, *resourcesv1.TeleportAppV3](t, resources.NewAppV3Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewAppV3Reconciler, test)
 }
 
 func TestTeleportAppV3Update(t *testing.T) {
 	test := &appV3TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.Application, *resourcesv1.TeleportAppV3](t, resources.NewAppV3Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewAppV3Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/autoupdateconfig_controller_test.go
+++ b/integrations/operator/controllers/resources/autoupdateconfig_controller_test.go
@@ -169,7 +169,17 @@ func (g *autoUpdateConfigTestingPrimitives) CompareTeleportAndKubernetesResource
 
 func TestAutoUpdateConfigCreation(t *testing.T) {
 	test := &autoUpdateConfigTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](
+	testlib.ResourceCreationSynchronousTest(
+		t,
+		resources.NewAutoUpdateConfigV1Reconciler,
+		test,
+		testlib.WithResourceName(types.MetaNameAutoUpdateConfig),
+	)
+}
+
+func TestAutoUpdateConfigDeletion(t *testing.T) {
+	test := &autoUpdateConfigTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(
 		t,
 		resources.NewAutoUpdateConfigV1Reconciler,
 		test,
@@ -179,7 +189,7 @@ func TestAutoUpdateConfigCreation(t *testing.T) {
 
 func TestAutoUpdateConfigDeletionDrift(t *testing.T) {
 	test := &autoUpdateConfigTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](
+	testlib.ResourceDeletionDriftSynchronousTest(
 		t,
 		resources.NewAutoUpdateConfigV1Reconciler,
 		test,
@@ -189,7 +199,7 @@ func TestAutoUpdateConfigDeletionDrift(t *testing.T) {
 
 func TestAutoUpdateConfigUpdate(t *testing.T) {
 	test := &autoUpdateConfigTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](
+	testlib.ResourceUpdateTestSynchronous(
 		t,
 		resources.NewAutoUpdateConfigV1Reconciler,
 		test,

--- a/integrations/operator/controllers/resources/autoupdateversion_controller_test.go
+++ b/integrations/operator/controllers/resources/autoupdateversion_controller_test.go
@@ -149,7 +149,17 @@ func (g *autoUpdateVersionTestingPrimitives) CompareTeleportAndKubernetesResourc
 
 func TestAutoUpdateVersionCreation(t *testing.T) {
 	test := &autoUpdateVersionTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](
+	testlib.ResourceCreationSynchronousTest(
+		t,
+		resources.NewAutoUpdateVersionV1Reconciler,
+		test,
+		testlib.WithResourceName("autoupdate-version"),
+	)
+}
+
+func TestAutoUpdateVersionDeletion(t *testing.T) {
+	test := &autoUpdateVersionTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(
 		t,
 		resources.NewAutoUpdateVersionV1Reconciler,
 		test,
@@ -159,7 +169,7 @@ func TestAutoUpdateVersionCreation(t *testing.T) {
 
 func TestAutoUpdateVersionDeletionDrift(t *testing.T) {
 	test := &autoUpdateVersionTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](
+	testlib.ResourceDeletionDriftSynchronousTest(
 		t,
 		resources.NewAutoUpdateVersionV1Reconciler,
 		test,
@@ -169,7 +179,7 @@ func TestAutoUpdateVersionDeletionDrift(t *testing.T) {
 
 func TestAutoUpdateVersionUpdate(t *testing.T) {
 	test := &autoUpdateVersionTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](
+	testlib.ResourceUpdateTestSynchronous(
 		t,
 		resources.NewAutoUpdateVersionV1Reconciler,
 		test,

--- a/integrations/operator/controllers/resources/botv1_controller_test.go
+++ b/integrations/operator/controllers/resources/botv1_controller_test.go
@@ -165,15 +165,20 @@ func (g *botTestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func TestBotCreation(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[*machineidv1.Bot, *resourcesv1.TeleportBotV1](t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewBotV1Reconciler, test)
+}
+
+func TestBotDeletion(t *testing.T) {
+	test := &botTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewBotV1Reconciler, test)
 }
 
 func TestBotDeletionDrift(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[*machineidv1.Bot, *resourcesv1.TeleportBotV1](t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewBotV1Reconciler, test)
 }
 
 func TestBotUpdate(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[*machineidv1.Bot, *resourcesv1.TeleportBotV1](t, resources.NewBotV1Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewBotV1Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/databasev3_controller_test.go
+++ b/integrations/operator/controllers/resources/databasev3_controller_test.go
@@ -119,15 +119,20 @@ func (g *databaseV3TestingPrimitives) CompareTeleportAndKubernetesResource(tReso
 
 func TestTeleportDatabaseV3Creation(t *testing.T) {
 	test := &databaseV3TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.Database, *resourcesv1.TeleportDatabaseV3](t, resources.NewDatabaseV3Reconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewDatabaseV3Reconciler, test)
+}
+
+func TestTeleportDatabaseV3Deletion(t *testing.T) {
+	test := &databaseV3TestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewDatabaseV3Reconciler, test)
 }
 
 func TestTeleportDatabaseV3DeletionDrift(t *testing.T) {
 	test := &databaseV3TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.Database, *resourcesv1.TeleportDatabaseV3](t, resources.NewDatabaseV3Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewDatabaseV3Reconciler, test)
 }
 
 func TestTeleportDatabaseV3Update(t *testing.T) {
 	test := &databaseV3TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.Database, *resourcesv1.TeleportDatabaseV3](t, resources.NewDatabaseV3Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewDatabaseV3Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/github_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/github_connector_controller_test.go
@@ -130,17 +130,22 @@ func (g *githubTestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestGithubConnectorCreation(t *testing.T) {
 	test := &githubTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.GithubConnector, *resourcesv3.TeleportGithubConnector](t, resources.NewGithubConnectorReconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewGithubConnectorReconciler, test)
+}
+
+func TestGithubConnectorDeletion(t *testing.T) {
+	test := &githubTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewGithubConnectorReconciler, test)
 }
 
 func TestGithubConnectorDeletionDrift(t *testing.T) {
 	test := &githubTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.GithubConnector, *resourcesv3.TeleportGithubConnector](t, resources.NewGithubConnectorReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewGithubConnectorReconciler, test)
 }
 
 func TestGithubConnectorUpdate(t *testing.T) {
 	test := &githubTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.GithubConnector, *resourcesv3.TeleportGithubConnector](t, resources.NewGithubConnectorReconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewGithubConnectorReconciler, test)
 }
 
 func TestGithubConnectorSecretLookup(t *testing.T) {

--- a/integrations/operator/controllers/resources/oidc_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller_test.go
@@ -131,17 +131,22 @@ func (g *oidcTestingPrimitives) CompareTeleportAndKubernetesResource(tResource t
 
 func TestOIDCConnectorCreation(t *testing.T) {
 	test := &oidcTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.OIDCConnector, *resourcesv3.TeleportOIDCConnector](t, resources.NewOIDCConnectorReconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewOIDCConnectorReconciler, test)
+}
+
+func TestOIDCConnectorDeletion(t *testing.T) {
+	test := &oidcTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewOIDCConnectorReconciler, test)
 }
 
 func TestOIDCConnectorDeletionDrift(t *testing.T) {
 	test := &oidcTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.OIDCConnector, *resourcesv3.TeleportOIDCConnector](t, resources.NewOIDCConnectorReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewOIDCConnectorReconciler, test)
 }
 
 func TestOIDCConnectorUpdate(t *testing.T) {
 	test := &oidcTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.OIDCConnector, *resourcesv3.TeleportOIDCConnector](t, resources.NewOIDCConnectorReconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewOIDCConnectorReconciler, test)
 }
 
 func TestOIDCConnectorSecretLookup(t *testing.T) {

--- a/integrations/operator/controllers/resources/okta_import_rule_controller_test.go
+++ b/integrations/operator/controllers/resources/okta_import_rule_controller_test.go
@@ -163,17 +163,23 @@ func (g *oktaImportRuleTestingPrimitives) CompareTeleportAndKubernetesResource(t
 func TestOktaImportRuleCreation(t *testing.T) {
 	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, resources.NewOktaImportRuleReconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewOktaImportRuleReconciler, test)
+}
+
+func TestOktaImportRuleDeletion(t *testing.T) {
+	t.Skip("Skipping test since okta reconsider is not available in OSS")
+	test := &oktaImportRuleTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewOktaImportRuleReconciler, test)
 }
 
 func TestOktaImportRuleDeletionDrift(t *testing.T) {
 	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, resources.NewOktaImportRuleReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewOktaImportRuleReconciler, test)
 }
 
 func TestOktaImportRuleUpdate(t *testing.T) {
 	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, resources.NewOktaImportRuleReconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewOktaImportRuleReconciler, test)
 }

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
@@ -126,15 +126,20 @@ func (g *opensshEICEServerV2TestingPrimitives) CompareTeleportAndKubernetesResou
 
 func TestTeleportOpensshEICEServerV2Creation(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewOpenSSHEICEServerV2Reconciler, test)
+}
+
+func TestTeleportOpensshEICEServerV2Deletion(t *testing.T) {
+	test := &opensshEICEServerV2TestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewOpenSSHEICEServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshEICEServerV2DeletionDrift(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewOpenSSHEICEServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshEICEServerV2Update(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewOpenSSHEICEServerV2Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
@@ -118,15 +118,20 @@ func (g *opensshServerV2TestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func TestTeleportOpensshServerV2Creation(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewOpenSSHServerV2Reconciler, test)
+}
+
+func TestTeleportOpensshServerV2Deletion(t *testing.T) {
+	test := &opensshServerV2TestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewOpenSSHServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshServerV2DeletionDrift(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewOpenSSHServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshServerV2Update(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewOpenSSHServerV2Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/provision_token_controller_test.go
+++ b/integrations/operator/controllers/resources/provision_token_controller_test.go
@@ -151,17 +151,22 @@ func (g *tokenTestingPrimitives) CompareTeleportAndKubernetesResource(tResource 
 
 func TestProvisionTokenCreation(t *testing.T) {
 	test := &tokenTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.ProvisionToken, *resourcesv2.TeleportProvisionToken](t, resources.NewProvisionTokenReconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewProvisionTokenReconciler, test)
+}
+
+func TestProvisionTokenDeletion(t *testing.T) {
+	test := &tokenTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewProvisionTokenReconciler, test)
 }
 
 func TestProvisionTokenDeletionDrift(t *testing.T) {
 	test := &tokenTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.ProvisionToken, *resourcesv2.TeleportProvisionToken](t, resources.NewProvisionTokenReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewProvisionTokenReconciler, test)
 }
 
 func TestProvisionTokenUpdate(t *testing.T) {
 	test := &tokenTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.ProvisionToken, *resourcesv2.TeleportProvisionToken](t, resources.NewProvisionTokenReconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewProvisionTokenReconciler, test)
 }
 
 // This test checks the operator can create Token resources in Teleport for a

--- a/integrations/operator/controllers/resources/role_controller_test.go
+++ b/integrations/operator/controllers/resources/role_controller_test.go
@@ -301,15 +301,20 @@ func (g *roleTestingPrimitives) CompareTeleportAndKubernetesResource(tResource t
 
 func TestTeleportRoleCreation(t *testing.T) {
 	test := &roleTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv5.TeleportRole](t, resources.NewRoleReconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewRoleReconciler, test)
+}
+
+func TestTeleportRoleDeletion(t *testing.T) {
+	test := &roleTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewRoleReconciler, test)
 }
 
 func TestTeleportRoleDeletionDrift(t *testing.T) {
 	test := &roleTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv5.TeleportRole](t, resources.NewRoleReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewRoleReconciler, test)
 }
 
 func TestTeleportRoleUpdate(t *testing.T) {
 	test := &roleTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv5.TeleportRole](t, resources.NewRoleReconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewRoleReconciler, test)
 }

--- a/integrations/operator/controllers/resources/rolev6_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev6_controller_test.go
@@ -135,15 +135,20 @@ func (g *roleV6TestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestTeleportRoleV6Creation(t *testing.T) {
 	test := &roleV6TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv1.TeleportRoleV6](t, resources.NewRoleV6Reconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewRoleV6Reconciler, test)
+}
+
+func TestTeleportRoleV6Deletion(t *testing.T) {
+	test := &roleV6TestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewRoleV6Reconciler, test)
 }
 
 func TestTeleportRoleV6DeletionDrift(t *testing.T) {
 	test := &roleV6TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv1.TeleportRoleV6](t, resources.NewRoleV6Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewRoleV6Reconciler, test)
 }
 
 func TestTeleportRoleV6Update(t *testing.T) {
 	test := &roleV6TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv1.TeleportRoleV6](t, resources.NewRoleV6Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewRoleV6Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/rolev7_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev7_controller_test.go
@@ -132,15 +132,20 @@ func (g *roleV7TestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestTeleportRoleV7Creation(t *testing.T) {
 	test := &roleV7TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv1.TeleportRoleV7](t, resources.NewRoleV7Reconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewRoleV7Reconciler, test)
+}
+
+func TestTeleportRoleV7Deletion(t *testing.T) {
+	test := &roleV7TestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewRoleV7Reconciler, test)
 }
 
 func TestTeleportRoleV7DeletionDrift(t *testing.T) {
 	test := &roleV7TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv1.TeleportRoleV7](t, resources.NewRoleV7Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewRoleV7Reconciler, test)
 }
 
 func TestTeleportRoleV7Update(t *testing.T) {
 	test := &roleV7TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv1.TeleportRoleV7](t, resources.NewRoleV7Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewRoleV7Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/rolev8_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev8_controller_test.go
@@ -134,15 +134,20 @@ func (g *roleV8TestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestTeleportRoleV8Creation(t *testing.T) {
 	test := &roleV8TestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv1.TeleportRoleV8](t, resources.NewRoleV8Reconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewRoleV8Reconciler, test)
+}
+
+func TestTeleportRoleV8Deletion(t *testing.T) {
+	test := &roleV8TestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewRoleV8Reconciler, test)
 }
 
 func TestTeleportRoleV8DeletionDrift(t *testing.T) {
 	test := &roleV8TestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv1.TeleportRoleV8](t, resources.NewRoleV8Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewRoleV8Reconciler, test)
 }
 
 func TestTeleportRoleV8Update(t *testing.T) {
 	test := &roleV8TestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv1.TeleportRoleV8](t, resources.NewRoleV8Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewRoleV8Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/saml_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/saml_connector_controller_test.go
@@ -184,15 +184,20 @@ func (g *samlTestingPrimitives) DebugDrifts(t *testing.T, name string) {
 
 func TestSAMLConnectorCreation(t *testing.T) {
 	test := &samlTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.SAMLConnector, *resourcesv2.TeleportSAMLConnector](t, resources.NewSAMLConnectorReconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewSAMLConnectorReconciler, test)
+}
+
+func TestSAMLConnectorDeletion(t *testing.T) {
+	test := &samlTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewSAMLConnectorReconciler, test)
 }
 
 func TestSAMLConnectorDeletionDrift(t *testing.T) {
 	test := &samlTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.SAMLConnector, *resourcesv2.TeleportSAMLConnector](t, resources.NewSAMLConnectorReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewSAMLConnectorReconciler, test)
 }
 
 func TestSAMLConnectorUpdate(t *testing.T) {
 	test := &samlTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.SAMLConnector, *resourcesv2.TeleportSAMLConnector](t, resources.NewSAMLConnectorReconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewSAMLConnectorReconciler, test)
 }

--- a/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
@@ -165,7 +165,17 @@ func (g *accessListTestingPrimitives) CompareTeleportAndKubernetesResource(tReso
 
 func AccessListCreationTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceCreationSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+	ResourceCreationSynchronousTest(
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+	)
+}
+
+func AccessListDeletionTest(t *testing.T, clt *client.Client) {
+	test := &accessListTestingPrimitives{}
+	ResourceDeletionSynchronousTest(
 		t,
 		resources.NewAccessListReconciler,
 		test,
@@ -175,7 +185,7 @@ func AccessListCreationTest(t *testing.T, clt *client.Client) {
 
 func AccessListDeletionDriftTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceDeletionDriftSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+	ResourceDeletionDriftSynchronousTest(
 		t,
 		resources.NewAccessListReconciler,
 		test,
@@ -185,7 +195,7 @@ func AccessListDeletionDriftTest(t *testing.T, clt *client.Client) {
 
 func AccessListUpdateTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceUpdateTestSynchronous[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+	ResourceUpdateTestSynchronous(
 		t,
 		resources.NewAccessListReconciler,
 		test,

--- a/integrations/operator/controllers/resources/testlib/inference_model_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/inference_model_controller_tests.go
@@ -170,6 +170,13 @@ func InferenceModelCreationTest(t *testing.T, clt *client.Client) {
 	)
 }
 
+func InferenceModelDeletionTest(t *testing.T, clt *client.Client) {
+	test := &inferenceModelTestingPrimitives{}
+	ResourceDeletionSynchronousTest(
+		t, resources.NewInferenceModelReconciler, test, WithTeleportClient(clt),
+	)
+}
+
 func InferenceModelDeletionDriftTest(t *testing.T, clt *client.Client) {
 	test := &inferenceModelTestingPrimitives{}
 	ResourceDeletionDriftSynchronousTest(

--- a/integrations/operator/controllers/resources/testlib/inference_policy_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/inference_policy_controller_tests.go
@@ -162,6 +162,13 @@ func InferencePolicyCreationTest(t *testing.T, clt *client.Client) {
 	)
 }
 
+func InferencePolicyDeletionTest(t *testing.T, clt *client.Client) {
+	test := &inferencePolicyTestingPrimitives{}
+	ResourceDeletionSynchronousTest(
+		t, resources.NewInferencePolicyReconciler, test, WithTeleportClient(clt),
+	)
+}
+
 func InferencePolicyDeletionDriftTest(t *testing.T, clt *client.Client) {
 	test := &inferencePolicyTestingPrimitives{}
 	ResourceDeletionDriftSynchronousTest(

--- a/integrations/operator/controllers/resources/testlib/inference_secret_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/inference_secret_controller_tests.go
@@ -163,6 +163,13 @@ func InferenceSecretCreationTest(t *testing.T, clt *client.Client) {
 	)
 }
 
+func InferenceSecretDeletionTest(t *testing.T, clt *client.Client) {
+	test := &inferenceSecretTestingPrimitives{}
+	ResourceDeletionSynchronousTest(
+		t, resources.NewInferenceSecretReconciler, test, WithTeleportClient(clt),
+	)
+}
+
 func InferenceSecretDeletionDriftTest(t *testing.T, clt *client.Client) {
 	test := &inferenceSecretTestingPrimitives{}
 	ResourceDeletionDriftSynchronousTest(

--- a/integrations/operator/controllers/resources/testlib/login_rule_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/login_rule_controller_tests.go
@@ -147,7 +147,17 @@ func (l *loginRuleTestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func LoginRuleCreationTest(t *testing.T, clt *client.Client) {
 	test := &loginRuleTestingPrimitives{}
-	ResourceCreationSynchronousTest[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](
+	ResourceCreationSynchronousTest(
+		t,
+		resources.NewLoginRuleReconciler,
+		test,
+		WithTeleportClient(clt),
+	)
+}
+
+func LoginRuleDeletionTest(t *testing.T, clt *client.Client) {
+	test := &loginRuleTestingPrimitives{}
+	ResourceDeletionSynchronousTest(
 		t,
 		resources.NewLoginRuleReconciler,
 		test,
@@ -157,7 +167,7 @@ func LoginRuleCreationTest(t *testing.T, clt *client.Client) {
 
 func LoginRuleDeletionDriftTest(t *testing.T, clt *client.Client) {
 	test := &loginRuleTestingPrimitives{}
-	ResourceDeletionDriftSynchronousTest[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](
+	ResourceDeletionDriftSynchronousTest(
 		t,
 		resources.NewLoginRuleReconciler,
 		test,
@@ -167,7 +177,7 @@ func LoginRuleDeletionDriftTest(t *testing.T, clt *client.Client) {
 
 func LoginRuleUpdateTest(t *testing.T, clt *client.Client) {
 	test := &loginRuleTestingPrimitives{}
-	ResourceUpdateTestSynchronous[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](
+	ResourceUpdateTestSynchronous(
 		t,
 		resources.NewLoginRuleReconciler,
 		test,

--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -134,7 +134,7 @@ func ResourceDeletionDriftTest[T reconcilers.Resource, K reconcilers.KubernetesC
 	// The operator should handle the failed Teleport deletion gracefully and unlock the Kubernetes resource deletion
 	FastEventually(t, func() bool {
 		_, err = test.GetKubernetesResource(ctx, resourceName)
-		return kerrors.IsNotFound(err)
+		return apimachineryerrors.IsNotFound(err)
 	})
 }
 
@@ -372,6 +372,106 @@ func ResourceCreationSynchronousTest[T reconcilers.Resource, K reconcilers.Kuber
 	// Kicking of a reconciliation to remove the finalizer and let Kube remove the resource.
 	_, err = reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
+}
+
+func ResourceDeletionSynchronousTest[T reconcilers.Resource, K reconcilers.KubernetesCR[T]](
+	t *testing.T, newReconciler resources.ReconcilerFactory, test ResourceTestingPrimitives[T, K], opts ...TestOption,
+) {
+	// Test setup
+	ctx := t.Context()
+
+	setup := SetupFakeKubeTestEnv(t, opts...)
+	test.Init(setup)
+	resourceName := setup.ResourceName
+
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	require.NoError(t, err)
+
+	err = test.SetupTeleportFixtures(ctx)
+	require.NoError(t, err)
+
+	// Test setup: Creating resource in Teleport with Kube origin
+	err = test.CreateTeleportResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test setup: Wait for the resource to be served by Teleport, fail early if Teleport is broken.
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := test.GetTeleportResource(ctx, resourceName)
+		require.NoError(t, err, "Teleport resource still not served by Teleport, Teleport might be stale/with a broken cache.")
+	})
+
+	// Test setup: Creating Kubernetes CR
+	err = test.CreateKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test setup: Wait for the CR to be served by Kubernetes, fail early if Kubernetes is broken.
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := test.GetKubernetesResource(ctx, resourceName)
+		require.NoError(t, err, "Kubernetes resource still not served by Kubernetes, Kubernetes might be stale/with a broken cache.")
+	})
+
+	// Test setup: Kick off the reconciliation, make sure everything is in sync.
+	req := reconcile.Request{
+		NamespacedName: apimachinerytypes.NamespacedName{
+			Namespace: setup.Namespace.Name,
+			Name:      resourceName,
+		},
+	}
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	// Test setup: Check if both Teleport and Kube resources are in-sync.
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		tResource, err := test.GetTeleportResource(ctx, resourceName)
+		require.NoError(t, err)
+
+		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
+		require.NoError(t, err)
+
+		// Kubernetes and Teleport resources are in-sync
+		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
+		require.True(t, equal, "Kubernetes and Teleport resources not sync-ed yet: %s", diff)
+	})
+
+	// Test execution: Delete the Kubernetes CR
+	require.NoError(t, test.DeleteKubernetesResource(ctx, resourceName))
+
+	// Test execution: Trigger reconciliation
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	var testPassed bool
+	debugInfo := func() {
+		// If the test passed, disarm the debugging dump
+		if testPassed {
+			return
+		}
+		// Little type crime
+		var debug any = test
+		if debuggableTest, ok := debug.(interface{ DebugDrifts(*testing.T, string) }); ok {
+			t.Log("Test failed, dumping the state for troubleshooting purposes")
+			debuggableTest.DebugDrifts(t, resourceName)
+		}
+	}
+	t.Cleanup(debugInfo)
+
+	// Test validation: Check the resource got deleted from Kubernetes and Teleport.
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := test.GetKubernetesResource(ctx, resourceName)
+		require.Error(t, err)
+		require.True(
+			t, apimachineryerrors.IsNotFound(err),
+			"expected a NotFound error, got %T: %s", err, err.Error(),
+		)
+
+		_, err = test.GetTeleportResource(ctx, resourceName)
+		require.Error(t, err)
+		require.True(
+			t, trace.IsNotFound(err),
+			"expected a NotFound error, got %T: %s", err, err.Error(),
+		)
+	})
+	testPassed = true
 }
 
 func ResourceDeletionDriftSynchronousTest[T reconcilers.Resource, K reconcilers.KubernetesCR[T]](t *testing.T, newReconciler resources.ReconcilerFactory, test ResourceTestingPrimitives[T, K], opts ...TestOption) {

--- a/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go
+++ b/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go
@@ -186,7 +186,19 @@ func TestTrustedClusterV2Creation(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
 	const remoteClusterName = "remote.example.com"
 	test.setupTest(t, remoteClusterName)
-	testlib.ResourceCreationSynchronousTest[types.TrustedCluster, *resourcesv1.TeleportTrustedClusterV2](
+	testlib.ResourceCreationSynchronousTest(
+		t,
+		resources.NewTrustedClusterV2Reconciler,
+		test,
+		testlib.WithResourceName(remoteClusterName),
+	)
+}
+
+func TestTrustedClusterV2Deletion(t *testing.T) {
+	test := &trustedClusterV2TestingPrimitives{}
+	const remoteClusterName = "remote.example.com"
+	test.setupTest(t, remoteClusterName)
+	testlib.ResourceDeletionSynchronousTest(
 		t,
 		resources.NewTrustedClusterV2Reconciler,
 		test,
@@ -198,7 +210,7 @@ func TestTrustedClusterV2DeletionDrift(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
 	const remoteClusterName = "remote.example.com"
 	test.setupTest(t, remoteClusterName)
-	testlib.ResourceDeletionDriftSynchronousTest[types.TrustedCluster, *resourcesv1.TeleportTrustedClusterV2](
+	testlib.ResourceDeletionDriftSynchronousTest(
 		t,
 		resources.NewTrustedClusterV2Reconciler,
 		test,
@@ -210,7 +222,7 @@ func TestTrustedClusterUpdate(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
 	const remoteClusterName = "remote.example.com"
 	test.setupTest(t, remoteClusterName)
-	testlib.ResourceUpdateTestSynchronous[types.TrustedCluster, *resourcesv1.TeleportTrustedClusterV2](
+	testlib.ResourceUpdateTestSynchronous(
 		t,
 		resources.NewTrustedClusterV2Reconciler,
 		test,

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -145,17 +145,22 @@ func (g *userTestingPrimitives) CompareTeleportAndKubernetesResource(tResource t
 
 func TestTeleportUserCreation(t *testing.T) {
 	test := &userTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[types.User, *v2.TeleportUser](t, resources.NewUserReconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewUserReconciler, test)
+}
+
+func TestTeleportUserDeletion(t *testing.T) {
+	test := &userTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewUserReconciler, test)
 }
 
 func TestTeleportUserDeletionDrift(t *testing.T) {
 	test := &userTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[types.User, *v2.TeleportUser](t, resources.NewUserReconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewUserReconciler, test)
 }
 
 func TestTeleportUserUpdate(t *testing.T) {
 	test := &userTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[types.User, *v2.TeleportUser](t, resources.NewUserReconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewUserReconciler, test)
 }
 
 func TestUserCreationFromYAML(t *testing.T) {

--- a/integrations/operator/controllers/resources/workload_identityv1_controller_test.go
+++ b/integrations/operator/controllers/resources/workload_identityv1_controller_test.go
@@ -188,24 +188,20 @@ func (g *workloadIdentityTestingPrimitives) CompareTeleportAndKubernetesResource
 
 func TestWorkloadIdentityCreation(t *testing.T) {
 	test := &workloadIdentityTestingPrimitives{}
-	testlib.ResourceCreationSynchronousTest[
-		*workloadidentityv1.WorkloadIdentity,
-		*resourcesv1.TeleportWorkloadIdentityV1,
-	](t, resources.NewWorkloadIdentityV1Reconciler, test)
+	testlib.ResourceCreationSynchronousTest(t, resources.NewWorkloadIdentityV1Reconciler, test)
+}
+
+func TestWorkloadIdentityDeletion(t *testing.T) {
+	test := &workloadIdentityTestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest(t, resources.NewWorkloadIdentityV1Reconciler, test)
 }
 
 func TestWorkloadIdentityDeletionDrift(t *testing.T) {
 	test := &workloadIdentityTestingPrimitives{}
-	testlib.ResourceDeletionDriftSynchronousTest[
-		*workloadidentityv1.WorkloadIdentity,
-		*resourcesv1.TeleportWorkloadIdentityV1,
-	](t, resources.NewWorkloadIdentityV1Reconciler, test)
+	testlib.ResourceDeletionDriftSynchronousTest(t, resources.NewWorkloadIdentityV1Reconciler, test)
 }
 
 func TestWorkloadIdentityUpdate(t *testing.T) {
 	test := &workloadIdentityTestingPrimitives{}
-	testlib.ResourceUpdateTestSynchronous[
-		*workloadidentityv1.WorkloadIdentity,
-		*resourcesv1.TeleportWorkloadIdentityV1,
-	](t, resources.NewWorkloadIdentityV1Reconciler, test)
+	testlib.ResourceUpdateTestSynchronous(t, resources.NewWorkloadIdentityV1Reconciler, test)
 }


### PR DESCRIPTION
Backport #63731 to branch/v18

Test plan: no manual tests, this change only affects unit tests.