### PR TITLE
Fix flaky operator TeleportUserUpdate test

### DIFF
--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -113,7 +113,6 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 	require.NoError(t, err)
 
 	var reconciledResource T
-
 	// Test setup: Check if both Teleport and Kube resources are in-sync.
 	FastEventuallyWithT(t, func(t *assert.CollectT) {
 		reconciledResource, err = test.GetTeleportResource(ctx, resourceName)
@@ -125,6 +124,8 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 		// Kubernetes and Teleport resources are in-sync
 		equal, diff := test.CompareTeleportAndKubernetesResource(reconciledResource, kubeResource)
 		require.True(t, equal, "Kubernetes and Teleport resources not sync-ed yet: %s", diff)
+		// Resources might be equal but this does not mean the update passed yet. We must wait for the revision to change.
+		require.NotEqual(t, test.GetResourceRevision(tResource), test.GetResourceRevision(reconciledResource), "Teleport resource revision did not change.")
 	})
 
 	// Test execution: Induce a drift by updating the Kubernetes CR
@@ -159,12 +160,14 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
 		require.NoError(t, err)
 
-		tResource, err := test.GetTeleportResource(ctx, resourceName)
+		finalResource, err := test.GetTeleportResource(ctx, resourceName)
 		require.NoError(t, err)
 
 		// Kubernetes and Teleport resources are in-sync
-		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
+		equal, diff := test.CompareTeleportAndKubernetesResource(finalResource, kubeResource)
 		require.True(t, equal, "Kubernetes and Teleport resources not sync-ed yet: %s", diff)
+		// Resources might be equal but this does not mean the update passed yet. We must wait for the revision to change.
+		require.NotEqual(t, test.GetResourceRevision(reconciledResource), test.GetResourceRevision(finalResource), "Teleport resource revision did not change.")
 	})
 	testPassed = true
 

--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -125,7 +125,10 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 		equal, diff := test.CompareTeleportAndKubernetesResource(reconciledResource, kubeResource)
 		require.True(t, equal, "Kubernetes and Teleport resources not sync-ed yet: %s", diff)
 		// Resources might be equal but this does not mean the update passed yet. We must wait for the revision to change.
-		require.NotEqual(t, test.GetResourceRevision(tResource), test.GetResourceRevision(reconciledResource), "Teleport resource revision did not change.")
+		// Note: some resources don't support revisions, this is a workaround.
+		if previousRevision, newRevision := test.GetResourceRevision(reconciledResource), test.GetResourceRevision(tResource); newRevision != "" && previousRevision != "" {
+			require.NotEqual(t, previousRevision, newRevision, "Teleport resource revision did not change.")
+		}
 	})
 
 	// Test execution: Induce a drift by updating the Kubernetes CR
@@ -167,7 +170,10 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 		equal, diff := test.CompareTeleportAndKubernetesResource(finalResource, kubeResource)
 		require.True(t, equal, "Kubernetes and Teleport resources not sync-ed yet: %s", diff)
 		// Resources might be equal but this does not mean the update passed yet. We must wait for the revision to change.
-		require.NotEqual(t, test.GetResourceRevision(reconciledResource), test.GetResourceRevision(finalResource), "Teleport resource revision did not change.")
+		// Note: some resources don't support revisions, this is a workaround.
+		if previousRevision, newRevision := test.GetResourceRevision(reconciledResource), test.GetResourceRevision(finalResource); newRevision != "" && previousRevision != "" {
+			require.NotEqual(t, previousRevision, newRevision, "Teleport resource revision did not change.")
+		}
 	})
 	testPassed = true
 


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/63759

The synchronous update operator test was only comparing resource spec to know if a resource got propagated into cache.

However, some updates were not changing the spec (only bumping the revision), hence the operator tests were not waiting for them properly. This allowed the test to proceed while the cache was not up-to-date yet, causing the operator to read stale data and face a conflict when calling the update RPC.

This fix waits for the revision to change before allowing the test to continue. With both the spec and revision change check, we are more confident that the previous reconciliation change entered the cache.