### PR TITLE
docs: include self-hosted note on trusted clusters arch

### DIFF
--- a/docs/pages/reference/architecture/trustedclusters.mdx
+++ b/docs/pages/reference/architecture/trustedclusters.mdx
@@ -8,6 +8,10 @@ tags:
  - infrastructure-identity
 ---
 
+<Admonition type="note">
+Trusted clusters are only available for self-hosted Teleport clusters.
+</Admonition>
+
 Teleport can partition compute infrastructure into multiple clusters. A cluster
 is a group of Teleport connected resources. Each cluster
 manages a set of certificate authorities (CAs) for its users and resources.


### PR DESCRIPTION
Include this note as in other trusted cluster doc pages to avoid confusion on Teleport Ent Cloud usage.