### PR TITLE
[v18] add summaries_generated count to SessionSummariesGeneratedRecord

### DIFF
--- a/gen/proto/go/prehog/v1/teleport.pb.go
+++ b/gen/proto/go/prehog/v1/teleport.pb.go
@@ -1173,8 +1173,10 @@ type SessionSummariesGeneratedRecord struct {
 	TotalInputTokens uint64 `protobuf:"varint,4,opt,name=total_input_tokens,json=totalInputTokens,proto3" json:"total_input_tokens,omitempty"`
 	// total_output_tokens is number of total output tokens generated during the summary.
 	TotalOutputTokens uint64 `protobuf:"varint,5,opt,name=total_output_tokens,json=totalOutputTokens,proto3" json:"total_output_tokens,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// number of summaries generated for this session type and resource combination.
+	SummariesGenerated uint64 `protobuf:"varint,6,opt,name=summaries_generated,json=summariesGenerated,proto3" json:"summaries_generated,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *SessionSummariesGeneratedRecord) Reset() {
@@ -1231,6 +1233,13 @@ func (x *SessionSummariesGeneratedRecord) GetTotalInputTokens() uint64 {
 func (x *SessionSummariesGeneratedRecord) GetTotalOutputTokens() uint64 {
 	if x != nil {
 		return x.TotalOutputTokens
+	}
+	return 0
+}
+
+func (x *SessionSummariesGeneratedRecord) GetSummariesGenerated() uint64 {
+	if x != nil {
+		return x.SummariesGenerated
 	}
 	return 0
 }
@@ -1438,12 +1447,13 @@ const file_prehog_v1_teleport_proto_rawDesc = "" +
 	"\x0freporter_hostid\x18\x03 \x01(\fR\x0ereporterHostid\x129\n" +
 	"\n" +
 	"start_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12D\n" +
-	"\arecords\x18\x05 \x03(\v2*.prehog.v1.SessionSummariesGeneratedRecordR\arecords\"\xc7\x01\n" +
+	"\arecords\x18\x05 \x03(\v2*.prehog.v1.SessionSummariesGeneratedRecordR\arecords\"\xf8\x01\n" +
 	"\x1fSessionSummariesGeneratedRecord\x12!\n" +
 	"\fsession_type\x18\x01 \x01(\tR\vsessionType\x12#\n" +
 	"\rresource_name\x18\x02 \x01(\tR\fresourceName\x12,\n" +
 	"\x12total_input_tokens\x18\x04 \x01(\x04R\x10totalInputTokens\x12.\n" +
-	"\x13total_output_tokens\x18\x05 \x01(\x04R\x11totalOutputTokens\"\x8c\x03\n" +
+	"\x13total_output_tokens\x18\x05 \x01(\x04R\x11totalOutputTokens\x12/\n" +
+	"\x13summaries_generated\x18\x06 \x01(\x04R\x12summariesGenerated\"\x8c\x03\n" +
 	"\x19SubmitUsageReportsRequest\x12B\n" +
 	"\ruser_activity\x18\x01 \x03(\v2\x1d.prehog.v1.UserActivityReportR\fuserActivity\x12N\n" +
 	"\x11resource_presence\x18\x02 \x03(\v2!.prehog.v1.ResourcePresenceReportR\x10resourcePresence\x12X\n" +

--- a/gen/proto/ts/prehog/v1/teleport_pb.ts
+++ b/gen/proto/ts/prehog/v1/teleport_pb.ts
@@ -521,6 +521,12 @@ export interface SessionSummariesGeneratedRecord {
      * @generated from protobuf field: uint64 total_output_tokens = 5;
      */
     totalOutputTokens: bigint;
+    /**
+     * number of summaries generated for this session type and resource combination.
+     *
+     * @generated from protobuf field: uint64 summaries_generated = 6;
+     */
+    summariesGenerated: bigint;
 }
 /**
  * @generated from protobuf message prehog.v1.SubmitUsageReportsRequest
@@ -1535,7 +1541,8 @@ class SessionSummariesGeneratedRecord$Type extends MessageType<SessionSummariesG
             { no: 1, name: "session_type", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "resource_name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "total_input_tokens", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
-            { no: 5, name: "total_output_tokens", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
+            { no: 5, name: "total_output_tokens", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 6, name: "summaries_generated", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<SessionSummariesGeneratedRecord>): SessionSummariesGeneratedRecord {
@@ -1544,6 +1551,7 @@ class SessionSummariesGeneratedRecord$Type extends MessageType<SessionSummariesG
         message.resourceName = "";
         message.totalInputTokens = 0n;
         message.totalOutputTokens = 0n;
+        message.summariesGenerated = 0n;
         if (value !== undefined)
             reflectionMergePartial<SessionSummariesGeneratedRecord>(this, message, value);
         return message;
@@ -1564,6 +1572,9 @@ class SessionSummariesGeneratedRecord$Type extends MessageType<SessionSummariesG
                     break;
                 case /* uint64 total_output_tokens */ 5:
                     message.totalOutputTokens = reader.uint64().toBigInt();
+                    break;
+                case /* uint64 summaries_generated */ 6:
+                    message.summariesGenerated = reader.uint64().toBigInt();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1589,6 +1600,9 @@ class SessionSummariesGeneratedRecord$Type extends MessageType<SessionSummariesG
         /* uint64 total_output_tokens = 5; */
         if (message.totalOutputTokens !== 0n)
             writer.tag(5, WireType.Varint).uint64(message.totalOutputTokens);
+        /* uint64 summaries_generated = 6; */
+        if (message.summariesGenerated !== 0n)
+            writer.tag(6, WireType.Varint).uint64(message.summariesGenerated);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/usagereporter/teleport/aggregating/reporter.go
+++ b/lib/usagereporter/teleport/aggregating/reporter.go
@@ -344,6 +344,7 @@ func (r *Reporter) run(ctx context.Context) {
 		}
 		record.TotalInputTokens += inputTokens
 		record.TotalOutputTokens += outputTokens
+		record.SummariesGenerated++
 	}
 
 	botInstanceActivityStartTime := r.clock.Now().UTC().Truncate(botInstanceActivityReportGranularity)

--- a/lib/usagereporter/teleport/aggregating/reporter_test.go
+++ b/lib/usagereporter/teleport/aggregating/reporter_test.go
@@ -615,12 +615,14 @@ func TestReporterIdentitySecuritySummariesGenerated(t *testing.T) {
 			require.Equal(t, anonymizer.AnonymizeString("server-01"), sshRecord.ResourceName)
 			require.Equal(t, uint64(250), sshRecord.TotalInputTokens)  // 100 + 150
 			require.Equal(t, uint64(125), sshRecord.TotalOutputTokens) // 50 + 75
+			require.Equal(t, uint64(2), sshRecord.SummariesGenerated)  // 2 successful summaries
 
 			require.NotNil(t, kubeRecord)
 			require.Equal(t, string(types.KubernetesSessionKind), kubeRecord.SessionType)
 			require.Equal(t, anonymizer.AnonymizeString("kube-cluster-01"), kubeRecord.ResourceName)
 			require.Equal(t, uint64(200), kubeRecord.TotalInputTokens)
 			require.Equal(t, uint64(100), kubeRecord.TotalOutputTokens)
+			require.Equal(t, uint64(1), kubeRecord.SummariesGenerated)
 
 			require.NoError(t, svc.deleteIdentitySecuritySummariesGeneratedReport(ctx, reports[0]))
 			require.Equal(t, types.OpDelete, recvBackendEvent().Type)

--- a/proto/prehog/v1/teleport.proto
+++ b/proto/prehog/v1/teleport.proto
@@ -341,6 +341,9 @@ message SessionSummariesGeneratedRecord {
 
   // total_output_tokens is number of total output tokens generated during the summary.
   uint64 total_output_tokens = 5;
+
+  // number of summaries generated for this session type and resource combination.
+  uint64 summaries_generated = 6;
 }
 
 message SubmitUsageReportsRequest {


### PR DESCRIPTION
Backport #64278 to branch/v18


Manual test plan:
- [x] report total number of summaries per host