### PR TITLE
[terraform] add test coverage for data sources

### DIFF
--- a/integrations/terraform/testlib/access_monitoring_rule_test.go
+++ b/integrations/terraform/testlib/access_monitoring_rule_test.go
@@ -30,12 +30,94 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+func (s *TerraformSuiteOSS) TestAccessMonitoringRuleDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	amr := &accessmonitoringrules.AccessMonitoringRule{
+		Kind:    types.KindAccessMonitoringRule,
+		Version: types.V1,
+		Metadata: &v1.Metadata{
+			Name: "test",
+		},
+		Spec: &accessmonitoringrules.AccessMonitoringRuleSpec{
+			Subjects: []string{
+				types.KindAccessRequest,
+			},
+			Condition: "true",
+			Notification: &accessmonitoringrules.Notification{
+				Name:       "example-plugin",
+				Recipients: []string{"example-recipient"},
+			},
+			AutomaticReview: &accessmonitoringrules.AutomaticReview{
+				Integration: "example-integration",
+				Decision:    types.RequestState_APPROVED.String(),
+			},
+			DesiredState: types.AccessMonitoringRuleStateReviewed,
+			Schedules: map[string]*accessmonitoringrules.Schedule{
+				"default": {
+					Time: &accessmonitoringrules.TimeSchedule{
+						Timezone: "UTC",
+						Shifts: []*accessmonitoringrules.TimeSchedule_Shift{
+							{
+								Weekday: "Monday",
+								Start:   "00:00",
+								End:     "23:59",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	amr, err := s.client.AccessMonitoringRulesClient().CreateAccessMonitoringRule(ctx, amr)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.AccessMonitoringRulesClient().GetAccessMonitoringRule(ctx, amr.GetMetadata().GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.AccessMonitoringRulesClient().DeleteAccessMonitoringRule(ctx, amr.GetMetadata().GetName()))
+	})
+
+	name := "data.teleport_access_monitoring_rule.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("access_monitoring_rule_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "access_monitoring_rule"),
+					resource.TestCheckResourceAttr(name, "version", "v1"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.subjects.0", "access_request"),
+					resource.TestCheckResourceAttr(name, "spec.condition", "true"),
+					resource.TestCheckResourceAttr(name, "spec.notification.name", "example-plugin"),
+					resource.TestCheckResourceAttr(name, "spec.notification.recipients.0", "example-recipient"),
+					resource.TestCheckResourceAttr(name, "spec.automatic_review.integration", "example-integration"),
+					resource.TestCheckResourceAttr(name, "spec.automatic_review.decision", "APPROVED"),
+					resource.TestCheckResourceAttr(name, "spec.desired_state", "reviewed"),
+					resource.TestCheckResourceAttr(name, "spec.schedules.default.time.timezone", "UTC"),
+					resource.TestCheckResourceAttr(name, "spec.schedules.default.time.shifts.0.weekday", "Monday"),
+					resource.TestCheckResourceAttr(name, "spec.schedules.default.time.shifts.0.start", "00:00"),
+					resource.TestCheckResourceAttr(name, "spec.schedules.default.time.shifts.0.end", "23:59"),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestAccessMonitoringRule() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)
 
 	checkDestroyed := func(state *terraform.State) error {
-		_, err := s.client.GetApp(ctx, "test")
+		_, err := s.client.AccessMonitoringRulesClient().GetAccessMonitoringRule(ctx, "test")
 		if trace.IsNotFound(err) {
 			return nil
 		}

--- a/integrations/terraform/testlib/app_auth_config_test.go
+++ b/integrations/terraform/testlib/app_auth_config_test.go
@@ -30,6 +30,57 @@ import (
 	"github.com/gravitational/teleport/api/types/appauthconfig"
 )
 
+func (s *TerraformSuiteOSS) TestAppAuthConfigDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	config := appauthconfig.NewAppAuthConfigJWT(
+		"test",
+		[]*labelv1.Label{{Name: "*", Values: []string{"*"}}},
+		&appauthconfigv1.AppAuthConfigJWTSpec{
+			Audience: "teleport",
+			Issuer:   "https://issuer-url",
+			KeysSource: &appauthconfigv1.AppAuthConfigJWTSpec_JwksUrl{
+				JwksUrl: "https://issuer-url/.well-known/jwks.json",
+			},
+		},
+	)
+
+	_, err := s.client.CreateAppAuthConfig(ctx, config)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetAppAuthConfig(ctx, config.GetMetadata().GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteAppAuthConfig(ctx, config.GetMetadata().GetName()))
+	})
+
+	name := "data.teleport_app_auth_config.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("app_auth_config_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "app_auth_config"),
+					resource.TestCheckResourceAttr(name, "version", "v1"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.app_labels.0.name", "*"),
+					resource.TestCheckResourceAttr(name, "spec.app_labels.0.values.0", "*"),
+					resource.TestCheckResourceAttr(name, "spec.jwt.issuer", "https://issuer-url"),
+					resource.TestCheckResourceAttr(name, "spec.jwt.audience", "teleport"),
+					resource.TestCheckResourceAttr(name, "spec.jwt.jwks_url", "https://issuer-url/.well-known/jwks.json"),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestAppAuthConfig() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)

--- a/integrations/terraform/testlib/app_test.go
+++ b/integrations/terraform/testlib/app_test.go
@@ -28,6 +28,66 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+func (s *TerraformSuiteOSS) TestAppDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	app := &types.AppV3{
+		Metadata: types.Metadata{
+			Name: "test",
+		},
+		Spec: types.AppSpecV3{
+			URI:        "localhost:3000",
+			PublicAddr: "example.teleport.sh:443",
+			Rewrite: &types.Rewrite{
+				Redirect: []string{"example.teleport.sh"},
+				Headers: []*types.Header{
+					{
+						Name:  "X-Custom-Header",
+						Value: "value",
+					},
+				},
+			},
+		},
+	}
+	err := app.CheckAndSetDefaults()
+	require.NoError(s.T(), err)
+
+	err = s.client.CreateApp(ctx, app)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetApp(ctx, app.GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteApp(ctx, app.GetName()))
+	})
+
+	name := "data.teleport_app.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("app_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "app"),
+					resource.TestCheckResourceAttr(name, "version", "v3"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.uri", "localhost:3000"),
+					resource.TestCheckResourceAttr(name, "spec.public_addr", "example.teleport.sh:443"),
+					resource.TestCheckResourceAttr(name, "spec.rewrite.redirect.0", "example.teleport.sh"),
+					resource.TestCheckResourceAttr(name, "spec.rewrite.headers.0.name", "X-Custom-Header"),
+					resource.TestCheckResourceAttr(name, "spec.rewrite.headers.0.value", "value"),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestApp() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)

--- a/integrations/terraform/testlib/auth_preference_test.go
+++ b/integrations/terraform/testlib/auth_preference_test.go
@@ -24,9 +24,79 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
 	clusterconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 )
+
+func (s *TerraformSuiteOSS) TestAuthPreferenceDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	authPreference := &types.AuthPreferenceV2{
+		Metadata: types.Metadata{
+			Name: "test",
+		},
+		Spec: types.AuthPreferenceSpecV2{
+			Type:                       constants.Local,
+			ConnectorName:              constants.LocalConnector,
+			SecondFactor:               constants.SecondFactorOTP,
+			AllowLocalAuth:             types.NewBoolOption(true),
+			AllowBrowserAuthentication: types.NewBoolOption(false),
+			MessageOfTheDay:            "test message",
+			LockingMode:                constants.LockingModeBestEffort,
+			IDP: &types.IdPOptions{
+				SAML: &types.IdPSAMLOptions{
+					Enabled: types.NewBoolOption(false),
+				},
+			},
+			Webauthn: &types.Webauthn{
+				RPID: "example.com",
+			},
+		},
+	}
+
+	err := authPreference.CheckAndSetDefaults()
+	require.NoError(s.T(), err)
+
+	authPreferencesBefore, err := s.client.GetAuthPreference(ctx)
+	require.NoError(s.T(), err)
+
+	_, err = s.client.ClusterConfigClient().UpsertAuthPreference(ctx, &clusterconfigv1.UpsertAuthPreferenceRequest{AuthPreference: authPreference})
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		authPreferencesCurrent, err := s.client.GetAuthPreference(ctx)
+		require.NoError(s.T(), err)
+
+		return authPreferencesBefore.GetMetadata().Revision != authPreferencesCurrent.GetMetadata().Revision
+	}, 5*time.Second, time.Second)
+
+	name := "data.teleport_auth_preference.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("auth_preference_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "cluster_auth_preference"),
+					resource.TestCheckResourceAttr(name, "version", "v2"),
+					resource.TestCheckResourceAttr(name, "spec.allow_local_auth", "true"),
+					resource.TestCheckResourceAttr(name, "spec.allow_browser_authentication", "false"),
+					resource.TestCheckResourceAttr(name, "spec.allow_headless", "false"),
+					resource.TestCheckResourceAttr(name, "spec.idp.saml.enabled", "false"),
+					resource.TestCheckResourceAttr(name, "spec.locking_mode", "best_effort"),
+					resource.TestCheckResourceAttr(name, "spec.message_of_the_day", "test message"),
+					resource.TestCheckResourceAttr(name, "spec.second_factor", "otp"),
+					resource.TestCheckResourceAttr(name, "spec.type", "local"),
+					resource.TestCheckResourceAttr(name, "spec.webauthn.rp_id", "example.com"),
+				),
+			},
+		},
+	})
+}
 
 func (s *TerraformSuiteOSS) TestAuthPreference() {
 	name := "teleport_auth_preference.test"

--- a/integrations/terraform/testlib/autoupdate_config_test.go
+++ b/integrations/terraform/testlib/autoupdate_config_test.go
@@ -28,6 +28,71 @@ import (
 	"github.com/gravitational/teleport/api/types/autoupdate"
 )
 
+func (s *TerraformSuiteOSS) TestAutoUpdateConfigDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	testMode := "enabled"
+	testStrategy := "halt-on-error"
+
+	config, err := autoupdate.NewAutoUpdateConfig(
+		&autoupdatev1pb.AutoUpdateConfigSpec{
+			Tools: &autoupdatev1pb.AutoUpdateConfigSpecTools{
+				Mode: testMode,
+			},
+			Agents: &autoupdatev1pb.AutoUpdateConfigSpecAgents{
+				Mode:     testMode,
+				Strategy: testStrategy,
+				Schedules: &autoupdatev1pb.AgentAutoUpdateSchedules{
+					Regular: []*autoupdatev1pb.AgentAutoUpdateGroup{
+						{
+							Name:      "dev",
+							Days:      []string{"Mon"},
+							StartHour: 4,
+						},
+					},
+				},
+			},
+		},
+	)
+	require.NoError(s.T(), err)
+
+	_, err = s.client.CreateAutoUpdateConfig(ctx, config)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetAutoUpdateConfig(ctx)
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteAutoUpdateConfig(ctx))
+	})
+
+	name := "data.teleport_autoupdate_config.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("autoupdate_config_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "autoupdate_config"),
+					resource.TestCheckResourceAttr(name, "version", "v1"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "autoupdate-config"),
+					resource.TestCheckResourceAttr(name, "spec.tools.mode", "enabled"),
+					resource.TestCheckResourceAttr(name, "spec.agents.mode", "enabled"),
+					resource.TestCheckResourceAttr(name, "spec.agents.strategy", "halt-on-error"),
+					resource.TestCheckResourceAttr(name, "spec.agents.schedules.regular.0.name", "dev"),
+					resource.TestCheckResourceAttr(name, "spec.agents.schedules.regular.0.days.0", "Mon"),
+					resource.TestCheckResourceAttr(name, "spec.agents.schedules.regular.0.start_hour", "4"),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestAutoUpdateConfig() {
 	name := "teleport_autoupdate_config.test"
 
@@ -111,14 +176,12 @@ func (s *TerraformSuiteOSS) TestImportAutoUpdateConfig() {
 	)
 	require.NoError(s.T(), err)
 
-	autoUpdateConfig, err = s.client.CreateAutoUpdateConfig(ctx, autoUpdateConfig)
+	_, err = s.client.CreateAutoUpdateConfig(ctx, autoUpdateConfig)
 	require.NoError(s.T(), err)
 
 	require.Eventually(s.T(), func() bool {
-		autoUpdateConfigCurrent, err := s.client.GetAutoUpdateConfig(ctx)
-		require.NoError(s.T(), err)
-
-		return autoUpdateConfig.GetMetadata().GetRevision() != autoUpdateConfigCurrent.GetMetadata().GetName()
+		_, err := s.client.GetAutoUpdateConfig(ctx)
+		return err == nil
 	}, 5*time.Second, 200*time.Millisecond)
 
 	resource.Test(s.T(), resource.TestCase{

--- a/integrations/terraform/testlib/autoupdate_version_test.go
+++ b/integrations/terraform/testlib/autoupdate_version_test.go
@@ -28,6 +28,66 @@ import (
 	"github.com/gravitational/teleport/api/types/autoupdate"
 )
 
+func (s *TerraformSuiteOSS) TestAutoUpdateVersionDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	testToolsTargetVersion := "1.2.3"
+	testStartVersion := "1.2.3"
+	testTargetVersion := "1.2.4"
+	testSchedule := "regular"
+	testMode := "enabled"
+
+	version, err := autoupdate.NewAutoUpdateVersion(
+		&autoupdatev1pb.AutoUpdateVersionSpec{
+			Tools: &autoupdatev1pb.AutoUpdateVersionSpecTools{
+				TargetVersion: testToolsTargetVersion,
+			},
+			Agents: &autoupdatev1pb.AutoUpdateVersionSpecAgents{
+				StartVersion:  testStartVersion,
+				TargetVersion: testTargetVersion,
+				Schedule:      testSchedule,
+				Mode:          testMode,
+			},
+		},
+	)
+	require.NoError(s.T(), err)
+
+	_, err = s.client.CreateAutoUpdateVersion(ctx, version)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetAutoUpdateVersion(ctx)
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteAutoUpdateVersion(ctx))
+	})
+
+	name := "data.teleport_autoupdate_version.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("autoupdate_version_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "autoupdate_version"),
+					resource.TestCheckResourceAttr(name, "version", "v1"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "autoupdate-version"),
+					resource.TestCheckResourceAttr(name, "spec.tools.target_version", testToolsTargetVersion),
+					resource.TestCheckResourceAttr(name, "spec.agents.start_version", testStartVersion),
+					resource.TestCheckResourceAttr(name, "spec.agents.target_version", testTargetVersion),
+					resource.TestCheckResourceAttr(name, "spec.agents.schedule", testSchedule),
+					resource.TestCheckResourceAttr(name, "spec.agents.mode", testMode),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestAutoUpdateVersion() {
 	name := "teleport_autoupdate_version.test"
 
@@ -97,14 +157,12 @@ func (s *TerraformSuiteOSS) TestImportAutoUpdateVersion() {
 	)
 	require.NoError(s.T(), err)
 
-	autoUpdateVersion, err = s.client.CreateAutoUpdateVersion(ctx, autoUpdateVersion)
+	_, err = s.client.CreateAutoUpdateVersion(ctx, autoUpdateVersion)
 	require.NoError(s.T(), err)
 
 	require.Eventually(s.T(), func() bool {
-		autoUpdateVersionCurrent, err := s.client.GetAutoUpdateVersion(ctx)
-		require.NoError(s.T(), err)
-
-		return autoUpdateVersion.GetMetadata().GetRevision() != autoUpdateVersionCurrent.GetMetadata().GetName()
+		_, err := s.client.GetAutoUpdateVersion(ctx)
+		return err == nil
 	}, 5*time.Second, time.Second)
 
 	resource.Test(s.T(), resource.TestCase{

--- a/integrations/terraform/testlib/cluster_maintenance_config_test.go
+++ b/integrations/terraform/testlib/cluster_maintenance_config_test.go
@@ -17,8 +17,58 @@ limitations under the License.
 package testlib
 
 import (
+	"context"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
+
+func (s *TerraformSuiteOSS) TestClusterMaintenanceConfigDataSource() {
+	ctx, cancel := context.WithCancel(s.T().Context())
+	s.T().Cleanup(cancel)
+
+	name := "data.teleport_cluster_maintenance_config.test"
+
+	config := &types.ClusterMaintenanceConfigV1{
+		Spec: types.ClusterMaintenanceConfigSpecV1{
+			AgentUpgrades: &types.AgentUpgradeWindow{
+				UTCStartHour: 8,
+				Weekdays:     []string{"Mon"},
+			},
+		},
+	}
+
+	err := config.CheckAndSetDefaults()
+	require.NoError(s.T(), err)
+
+	err = s.client.UpdateClusterMaintenanceConfig(ctx, config)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetClusterMaintenanceConfig(ctx)
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("maintenance_config_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "cluster_maintenance_config"),
+					resource.TestCheckResourceAttr(name, "version", "v1"),
+					resource.TestCheckResourceAttr(name, "id", "cluster-maintenance-config"),
+					resource.TestCheckResourceAttr(name, "spec.agent_upgrades.utc_start_hour", "8"),
+					resource.TestCheckResourceAttr(name, "spec.agent_upgrades.weekdays.0", "Mon"),
+				),
+			},
+		},
+	})
+}
 
 func (s *TerraformSuiteOSS) TestClusterMaintenanceConfig() {
 	name := "teleport_cluster_maintenance_config.test"

--- a/integrations/terraform/testlib/cluster_networking_config_test.go
+++ b/integrations/terraform/testlib/cluster_networking_config_test.go
@@ -28,6 +28,34 @@ import (
 )
 
 func (s *TerraformSuiteOSS) TestClusterNetworkingConfigDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	clusterNetworkingConfig := &types.ClusterNetworkingConfigV2{
+		Spec: types.ClusterNetworkingConfigSpecV2{
+			ClientIdleTimeout: types.Duration(30 * time.Minute),
+			KeepAliveInterval: types.Duration(15 * time.Second),
+			KeepAliveCountMax: 7,
+			ProxyListenerMode: types.ProxyListenerMode_Multiplex,
+			RoutingStrategy:   types.RoutingStrategy_MOST_RECENT,
+		},
+	}
+	err := clusterNetworkingConfig.CheckAndSetDefaults()
+	require.NoError(s.T(), err)
+
+	clusterNetworkConfigBefore, err := s.client.GetClusterNetworkingConfig(ctx)
+	require.NoError(s.T(), err)
+
+	_, err = s.client.UpsertClusterNetworkingConfig(ctx, clusterNetworkingConfig)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		clusterNetworkConfigCurrent, err := s.client.GetClusterNetworkingConfig(ctx)
+		require.NoError(s.T(), err)
+
+		return clusterNetworkConfigBefore.GetRevision() != clusterNetworkConfigCurrent.GetRevision()
+	}, 5*time.Second, time.Second)
+
 	name := "data.teleport_cluster_networking_config.test"
 
 	resource.Test(s.T(), resource.TestCase{
@@ -40,6 +68,11 @@ func (s *TerraformSuiteOSS) TestClusterNetworkingConfigDataSource() {
 					resource.TestCheckResourceAttr(name, "kind", "cluster_networking_config"),
 					resource.TestCheckResourceAttr(name, "version", "v2"),
 					resource.TestCheckResourceAttr(name, "id", "cluster-networking-config"),
+					resource.TestCheckResourceAttr(name, "spec.client_idle_timeout", "30m0s"),
+					resource.TestCheckResourceAttr(name, "spec.keep_alive_interval", "15s"),
+					resource.TestCheckResourceAttr(name, "spec.keep_alive_count_max", "7"),
+					resource.TestCheckResourceAttr(name, "spec.proxy_listener_mode", "1"),
+					resource.TestCheckResourceAttr(name, "spec.routing_strategy", "1"),
 				),
 			},
 		},

--- a/integrations/terraform/testlib/database_test.go
+++ b/integrations/terraform/testlib/database_test.go
@@ -28,6 +28,64 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+func (s *TerraformSuiteOSS) TestDatabaseDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	checkDestroyed := func(state *terraform.State) error {
+		_, err := s.client.GetDatabase(ctx, "test")
+		if trace.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	database := &types.DatabaseV3{
+		Metadata: types.Metadata{
+			Name: "test",
+		},
+		Spec: types.DatabaseSpecV3{
+			Protocol: "postgres",
+			URI:      "localhost:5432",
+		},
+	}
+	err := database.CheckAndSetDefaults()
+	require.NoError(s.T(), err)
+
+	err = s.client.CreateDatabase(ctx, database)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetDatabase(ctx, database.GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteDatabase(ctx, database.GetName()))
+	})
+
+	name := "data.teleport_database.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		CheckDestroy:             checkDestroyed,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("database_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "db"),
+					resource.TestCheckResourceAttr(name, "version", "v3"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.protocol", "postgres"),
+					resource.TestCheckResourceAttr(name, "spec.uri", "localhost:5432"),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestDatabase() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)

--- a/integrations/terraform/testlib/discovery_config_test.go
+++ b/integrations/terraform/testlib/discovery_config_test.go
@@ -20,14 +20,80 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/header"
 )
+
+func (s *TerraformSuiteOSS) TestDiscoveryConfigDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	discoveryCfg, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{
+			Name: "test",
+		},
+		discoveryconfig.Spec{
+			DiscoveryGroup: "test-group",
+			AWS: []types.AWSMatcher{
+				{
+					Types:   []string{"ec2"},
+					Regions: []string{"us-west-2"},
+					Tags: types.Labels{
+						"env": []string{"test"},
+					},
+					Params: &types.InstallerParams{
+						JoinMethod: "iam",
+						JoinToken:  "test-token",
+						ScriptName: "test-installer",
+					},
+				},
+			},
+		},
+	)
+	require.NoError(s.T(), err)
+
+	_, err = s.client.DiscoveryConfigClient().CreateDiscoveryConfig(ctx, discoveryCfg)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.DiscoveryConfigClient().GetDiscoveryConfig(ctx, discoveryCfg.GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DiscoveryConfigClient().DeleteDiscoveryConfig(ctx, discoveryCfg.GetName()))
+	})
+
+	name := "data.teleport_discovery_config.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("discovery_config_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "header.metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "header.version", "v1"),
+					resource.TestCheckResourceAttr(name, "spec.discovery_group", "test-group"),
+					resource.TestCheckResourceAttr(name, "spec.aws.0.types.0", "ec2"),
+					resource.TestCheckResourceAttr(name, "spec.aws.0.regions.0", "us-west-2"),
+					resource.TestCheckResourceAttr(name, "spec.aws.0.tags.env.0", "test"),
+					resource.TestCheckResourceAttr(name, "spec.aws.0.install.join_method", "iam"),
+					resource.TestCheckResourceAttr(name, "spec.aws.0.install.join_token", "test-token"),
+					resource.TestCheckResourceAttr(name, "spec.aws.0.install.script_name", "test-installer"),
+				),
+			},
+		},
+	})
+}
 
 func (s *TerraformSuiteOSS) TestDiscoveryConfig() {
 	t := s.T()

--- a/integrations/terraform/testlib/dynamic_windows_desktop_test.go
+++ b/integrations/terraform/testlib/dynamic_windows_desktop_test.go
@@ -28,6 +28,70 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+func (s *TerraformSuiteOSS) TestDynamicWindowsDesktopDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	checkDestroyed := func(state *terraform.State) error {
+		_, err := s.client.DynamicDesktopClient().GetDynamicWindowsDesktop(ctx, "test")
+		if trace.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	desktop, err := types.NewDynamicWindowsDesktopV1(
+		"test",
+		nil,
+		types.DynamicWindowsDesktopSpecV1{
+			Addr:   "localhost:3000",
+			NonAD:  true,
+			Domain: "my.domain",
+			ScreenSize: &types.Resolution{
+				Width:  800,
+				Height: 600,
+			},
+		},
+	)
+	require.NoError(s.T(), err)
+
+	_, err = s.client.DynamicDesktopClient().CreateDynamicWindowsDesktop(ctx, desktop)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.DynamicDesktopClient().GetDynamicWindowsDesktop(ctx, desktop.GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DynamicDesktopClient().DeleteDynamicWindowsDesktop(ctx, desktop.GetName()))
+	})
+
+	name := "data.teleport_dynamic_windows_desktop.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		CheckDestroy:             checkDestroyed,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("dynamic_windows_desktop_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "dynamic_windows_desktop"),
+					resource.TestCheckResourceAttr(name, "version", "v1"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.addr", "localhost:3000"),
+					resource.TestCheckResourceAttr(name, "spec.non_ad", "true"),
+					resource.TestCheckResourceAttr(name, "spec.domain", "my.domain"),
+					resource.TestCheckResourceAttr(name, "spec.screen_size.width", "800"),
+					resource.TestCheckResourceAttr(name, "spec.screen_size.height", "600"),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestDynamicWindowsDesktop() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)

--- a/integrations/terraform/testlib/fixtures/access_monitoring_rule_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/access_monitoring_rule_data_source.tf
@@ -1,0 +1,10 @@
+data "teleport_access_monitoring_rule" "test" {
+  kind    = "access_monitoring_rule"
+  version = "v1"
+  metadata = {
+    name = "test"
+  }
+  spec = {
+    subjects = []
+  }
+}

--- a/integrations/terraform/testlib/fixtures/app_auth_config_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/app_auth_config_data_source.tf
@@ -1,0 +1,8 @@
+data "teleport_app_auth_config" "test" {
+  kind    = "app_auth_config"
+  version = "v1"
+  metadata = {
+    name = "test"
+  }
+  spec = {}
+}

--- a/integrations/terraform/testlib/fixtures/app_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/app_data_source.tf
@@ -1,0 +1,7 @@
+data "teleport_app" "test" {
+  kind    = "app"
+  version = "v3"
+  metadata = {
+    name = "test"
+  }
+}

--- a/integrations/terraform/testlib/fixtures/auth_preference_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/auth_preference_data_source.tf
@@ -1,0 +1,8 @@
+data "teleport_auth_preference" "test" {
+  kind    = "auth_preference"
+  version = "v2"
+  metadata = {
+    name = "test"
+  }
+  spec = {}
+}

--- a/integrations/terraform/testlib/fixtures/autoupdate_config_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/autoupdate_config_data_source.tf
@@ -1,0 +1,5 @@
+data "teleport_autoupdate_config" "test" {
+  kind    = "autoupdate_config"
+  version = "v1"
+  spec    = {}
+}

--- a/integrations/terraform/testlib/fixtures/autoupdate_version_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/autoupdate_version_data_source.tf
@@ -1,0 +1,5 @@
+data "teleport_autoupdate_version" "test" {
+  kind    = "autoupdate_version"
+  version = "v1"
+  spec    = {}
+}

--- a/integrations/terraform/testlib/fixtures/database_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/database_data_source.tf
@@ -1,0 +1,7 @@
+data "teleport_database" "test" {
+  kind    = "db"
+  version = "v3"
+  metadata = {
+    name = "test"
+  }
+}

--- a/integrations/terraform/testlib/fixtures/discovery_config_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/discovery_config_data_source.tf
@@ -1,0 +1,11 @@
+data "teleport_discovery_config" "test" {
+  header = {
+    metadata = {
+      name = "test"
+    }
+    version = "v1"
+  }
+  spec = {
+    discovery_group = ""
+  }
+}

--- a/integrations/terraform/testlib/fixtures/dynamic_windows_desktop_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/dynamic_windows_desktop_data_source.tf
@@ -1,0 +1,10 @@
+data "teleport_dynamic_windows_desktop" "test" {
+  kind    = "dynamic_windows_desktop"
+  version = "v1"
+  metadata = {
+    name = "test"
+  }
+  spec = {
+    addr = ""
+  }
+}

--- a/integrations/terraform/testlib/fixtures/github_connector_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/github_connector_data_source.tf
@@ -1,0 +1,11 @@
+data "teleport_github_connector" "test" {
+  kind    = "github"
+  version = "v3"
+  metadata = {
+    name = "test"
+  }
+  spec = {
+    client_id     = ""
+    client_secret = ""
+  }
+}

--- a/integrations/terraform/testlib/fixtures/health_check_config_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/health_check_config_data_source.tf
@@ -1,0 +1,9 @@
+data "teleport_health_check_config" "test" {
+  metadata = {
+    name = "test"
+  }
+  version = "v1"
+  spec = {
+    match = {}
+  }
+}

--- a/integrations/terraform/testlib/fixtures/installer_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/installer_data_source.tf
@@ -1,0 +1,9 @@
+data "teleport_installer" "test" {
+  version = "v1"
+  metadata = {
+    name = "test"
+  }
+  spec = {
+    script = ""
+  }
+}

--- a/integrations/terraform/testlib/fixtures/integration_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/integration_data_source.tf
@@ -1,0 +1,8 @@
+data "teleport_integration" "test" {
+  version  = "v1"
+  sub_kind = "aws-oidc"
+  metadata = {
+    name = "aws-oidc"
+  }
+  spec = {}
+}

--- a/integrations/terraform/testlib/fixtures/maintenance_config_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/maintenance_config_data_source.tf
@@ -1,0 +1,4 @@
+data "teleport_cluster_maintenance_config" "test" {
+  version = "v1"
+  kind    = "cluster_maintenance_config"
+}

--- a/integrations/terraform/testlib/fixtures/provision_token_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/provision_token_data_source.tf
@@ -1,0 +1,10 @@
+data "teleport_provision_token" "test" {
+  kind    = "token"
+  version = "v2"
+  metadata = {
+    name = "test"
+  }
+  spec = {
+    roles = []
+  }
+}

--- a/integrations/terraform/testlib/fixtures/session_recording_config_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/session_recording_config_data_source.tf
@@ -1,0 +1,4 @@
+data "teleport_session_recording_config" "test" {
+  version = "v2"
+  kind    = "session_recording_config"
+}

--- a/integrations/terraform/testlib/fixtures/static_host_user_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/static_host_user_data_source.tf
@@ -1,0 +1,9 @@
+data "teleport_static_host_user" "test" {
+  version = "v2"
+  metadata = {
+    name = "test"
+  }
+  spec = {
+    matchers = []
+  }
+}

--- a/integrations/terraform/testlib/fixtures/workload_identity_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/workload_identity_data_source.tf
@@ -1,0 +1,6 @@
+data "teleport_workload_identity" "test" {
+  version = "v1"
+  metadata = {
+    name = "test"
+  }
+}

--- a/integrations/terraform/testlib/github_connector_test.go
+++ b/integrations/terraform/testlib/github_connector_test.go
@@ -19,6 +19,7 @@ package testlib
 import (
 	"context"
 	"regexp"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -27,6 +28,64 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 )
+
+func (s *TerraformSuiteOSS) TestGithubConnectorDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	githubConnector := &types.GithubConnectorV3{
+		Metadata: types.Metadata{
+			Name: "test",
+		},
+		Spec: types.GithubConnectorSpecV3{
+			ClientID:     "example-id",
+			ClientSecret: "example-secret",
+			TeamsToRoles: []types.TeamRolesMapping{
+				{
+					Organization: "example-org",
+					Team:         "example-team",
+					Roles:        []string{"example-role"},
+				},
+			},
+		},
+	}
+	err := githubConnector.CheckAndSetDefaults()
+	require.NoError(s.T(), err)
+
+	_, err = s.client.CreateGithubConnector(ctx, githubConnector)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetGithubConnector(ctx, githubConnector.GetName(), false)
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteGithubConnector(ctx, githubConnector.GetName()))
+	})
+
+	name := "data.teleport_github_connector.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("github_connector_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "github"),
+					resource.TestCheckResourceAttr(name, "version", "v3"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.client_id", "example-id"),
+					resource.TestCheckResourceAttr(name, "spec.client_secret", "example-secret"),
+					resource.TestCheckResourceAttr(name, "spec.teams_to_roles.0.organization", "example-org"),
+					resource.TestCheckResourceAttr(name, "spec.teams_to_roles.0.team", "example-team"),
+					resource.TestCheckResourceAttr(name, "spec.teams_to_roles.0.roles.0", "example-role"),
+				),
+			},
+		},
+	})
+}
 
 func (s *TerraformSuiteOSS) TestGithubConnector() {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/integrations/terraform/testlib/health_check_config_test.go
+++ b/integrations/terraform/testlib/health_check_config_test.go
@@ -32,6 +32,65 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
+func (s *TerraformSuiteOSS) TestHealthCheckConfigDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	healthCfg, err := healthcheckconfig.NewHealthCheckConfig("test",
+		&healthcheckconfigv1.HealthCheckConfigSpec{
+			Interval:           durationpb.New(60 * time.Second),
+			Timeout:            durationpb.New(5 * time.Second),
+			HealthyThreshold:   3,
+			UnhealthyThreshold: 2,
+			Match: &healthcheckconfigv1.Matcher{
+				DbLabels: []*labelv1.Label{{
+					Name:   "env",
+					Values: []string{"foo", "bar"},
+				}},
+				DbLabelsExpression: "labels.foo == `bar`",
+			},
+		},
+	)
+	require.NoError(s.T(), err)
+
+	_, err = s.client.CreateHealthCheckConfig(ctx, healthCfg)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetHealthCheckConfig(ctx, healthCfg.GetMetadata().GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteHealthCheckConfig(ctx, healthCfg.GetMetadata().GetName()))
+	})
+
+	name := "data.teleport_health_check_config.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("health_check_config_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "health_check_config"),
+					resource.TestCheckResourceAttr(name, "version", "v1"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.interval", "1m0s"),
+					resource.TestCheckResourceAttr(name, "spec.timeout", "5s"),
+					resource.TestCheckResourceAttr(name, "spec.healthy_threshold", "3"),
+					resource.TestCheckResourceAttr(name, "spec.unhealthy_threshold", "2"),
+					resource.TestCheckResourceAttr(name, "spec.match.db_labels.0.name", "env"),
+					resource.TestCheckResourceAttr(name, "spec.match.db_labels.0.values.0", "foo"),
+					resource.TestCheckResourceAttr(name, "spec.match.db_labels.0.values.1", "bar"),
+					resource.TestCheckResourceAttr(name, "spec.match.db_labels_expression", "labels.foo == `bar`"),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestHealthCheckConfig() {
 	t := s.T()
 	name := "teleport_health_check_config.test"

--- a/integrations/terraform/testlib/installer_test.go
+++ b/integrations/terraform/testlib/installer_test.go
@@ -20,11 +20,53 @@ package testlib
 
 import (
 	"context"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
+
+func (s *TerraformSuiteOSS) TestInstallerDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	installer, err := types.NewInstallerV1("test", "example-script")
+	require.NoError(s.T(), err)
+
+	err = s.client.SetInstaller(ctx, installer)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetInstaller(ctx, installer.GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteInstaller(ctx, installer.GetName()))
+	})
+
+	name := "data.teleport_installer.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("installer_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "installer"),
+					resource.TestCheckResourceAttr(name, "version", "v1"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.script", "example-script"),
+				),
+			},
+		},
+	})
+}
 
 func (s *TerraformSuiteOSS) TestInstaller() {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/integrations/terraform/testlib/integration_test.go
+++ b/integrations/terraform/testlib/integration_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testlib
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -28,6 +29,53 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 )
+
+func (s *TerraformSuiteOSS) TestIntegrationDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	integration, err := types.NewIntegrationAWSOIDC(types.Metadata{
+		Name: "aws-oidc",
+	}, &types.AWSOIDCIntegrationSpecV1{
+		Audience:    "aws-identity-center",
+		IssuerS3URI: "s3://test-s3-bucket/some-prefix",
+		RoleARN:     "arn:aws:iam::123456789012:role/test-role",
+	})
+	require.NoError(s.T(), err)
+
+	_, err = s.client.CreateIntegration(ctx, integration)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetIntegration(ctx, integration.GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteIntegration(ctx, integration.GetName()))
+	})
+
+	name := "data.teleport_integration.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("integration_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "integration"),
+					resource.TestCheckResourceAttr(name, "sub_kind", "aws-oidc"),
+					resource.TestCheckResourceAttr(name, "version", "v1"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "aws-oidc"),
+					resource.TestCheckResourceAttr(name, "spec.aws_oidc.audience", "aws-identity-center"),
+					resource.TestCheckResourceAttr(name, "spec.aws_oidc.issuer_s3_uri", "s3://test-s3-bucket/some-prefix"),
+					resource.TestCheckResourceAttr(name, "spec.aws_oidc.role_arn", "arn:aws:iam::123456789012:role/test-role"),
+				),
+			},
+		},
+	})
+}
 
 func (s *TerraformSuiteOSS) TestIntegration() {
 	const (

--- a/integrations/terraform/testlib/provision_token_test.go
+++ b/integrations/terraform/testlib/provision_token_test.go
@@ -19,6 +19,7 @@ package testlib
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -27,6 +28,62 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 )
+
+func (s *TerraformSuiteOSS) TestProvisionTokenDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	token := &types.ProvisionTokenV2{
+		Metadata: types.Metadata{
+			Name: "test",
+		},
+		Spec: types.ProvisionTokenSpecV2{
+			Roles:      []types.SystemRole{"Bot"},
+			BotName:    "mybot",
+			JoinMethod: types.JoinMethodIAM,
+			Allow: []*types.TokenRule{
+				{
+					AWSAccount: "example-account",
+				},
+			},
+		},
+	}
+	err := token.CheckAndSetDefaults()
+	require.NoError(s.T(), err)
+
+	err = s.client.CreateToken(ctx, token)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetToken(ctx, token.GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteToken(ctx, token.GetName()))
+	})
+
+	name := "data.teleport_provision_token.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("provision_token_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "token"),
+					resource.TestCheckResourceAttr(name, "version", "v2"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.roles.0", "Bot"),
+					resource.TestCheckResourceAttr(name, "spec.bot_name", "mybot"),
+					resource.TestCheckResourceAttr(name, "spec.join_method", "iam"),
+					resource.TestCheckResourceAttr(name, "spec.allow.0.aws_account", "example-account"),
+				),
+			},
+		},
+	})
+}
 
 func (s *TerraformSuiteOSS) TestProvisionToken() {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/integrations/terraform/testlib/role_test.go
+++ b/integrations/terraform/testlib/role_test.go
@@ -37,15 +37,6 @@ func (s *TerraformSuiteOSS) TestRoleDataSource() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)
 
-	checkDestroyed := func(state *terraform.State) error {
-		_, err := s.client.GetRole(ctx, "test")
-		if trace.IsNotFound(err) {
-			return nil
-		}
-
-		return err
-	}
-
 	role := &types.RoleV6{
 		Kind:    "role",
 		Version: "v8",
@@ -96,14 +87,23 @@ func (s *TerraformSuiteOSS) TestRoleDataSource() {
 	err := role.CheckAndSetDefaults()
 	require.NoError(s.T(), err)
 
-	_, err = s.client.UpsertRole(ctx, role)
+	_, err = s.client.CreateRole(ctx, role)
 	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetRole(ctx, role.GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteRole(ctx, role.GetName()))
+	})
 
 	name := "data.teleport_role.test"
 
 	resource.Test(s.T(), resource.TestCase{
 		ProtoV6ProviderFactories: s.terraformProviders,
-		CheckDestroy:             checkDestroyed,
+		IsUnitTest:               true,
 		Steps: []resource.TestStep{
 			{
 				Config: s.getFixture("role_data_source.tf"),
@@ -111,7 +111,6 @@ func (s *TerraformSuiteOSS) TestRoleDataSource() {
 					resource.TestCheckResourceAttr(name, "kind", "role"),
 					resource.TestCheckResourceAttr(name, "version", "v8"),
 					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
-
 					resource.TestCheckResourceAttr(name, "spec.options.cert_format", "standard"),
 					resource.TestCheckResourceAttr(name, "spec.options.client_idle_timeout", "1h0m0s"),
 					resource.TestCheckResourceAttr(name, "spec.options.create_db_user", "false"),
@@ -169,6 +168,10 @@ func (s *TerraformSuiteOSS) TestRole() {
 					resource.TestCheckNoResourceAttr(name, "spec.options"),
 					resource.TestCheckResourceAttr(name, "version", "v8"),
 					resource.TestCheckResourceAttr(name, "spec.allow.logins.0", "anonymous"),
+
+					// Computed fields
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.default", "best_effort"),
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.desktop", "true"),
 				),
 			},
 			{
@@ -189,6 +192,10 @@ func (s *TerraformSuiteOSS) TestRole() {
 					resource.TestCheckResourceAttr(name, "spec.allow.request.claims_to_roles.0.roles.0", "example"),
 					resource.TestCheckResourceAttr(name, "spec.allow.node_labels.example.0", "yes"),
 					resource.TestCheckResourceAttr(name, "spec.allow.node_labels.example.1", "no"),
+
+					// Computed fields
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.default", "best_effort"),
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.desktop", "true"),
 
 					resource.TestCheckResourceAttr(name, "version", "v8"),
 				),

--- a/integrations/terraform/testlib/session_recording_config_test.go
+++ b/integrations/terraform/testlib/session_recording_config_test.go
@@ -28,6 +28,54 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+func (s *TerraformSuiteOSS) TestSessionRecordingConfigDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	sessionRecordingConfig := &types.SessionRecordingConfigV2{
+		Spec: types.SessionRecordingConfigSpecV2{
+			Mode:                "node",
+			ProxyChecksHostKeys: types.NewBoolOption(true),
+		},
+	}
+	err := sessionRecordingConfig.CheckAndSetDefaults()
+	require.NoError(s.T(), err)
+
+	sessionRecordingConfigBefore, err := s.client.GetSessionRecordingConfig(ctx)
+	require.NoError(s.T(), err)
+
+	_, err = s.client.ClusterConfigClient().UpsertSessionRecordingConfig(ctx, &clusterconfigv1.UpsertSessionRecordingConfigRequest{
+		SessionRecordingConfig: sessionRecordingConfig,
+	})
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		sessionRecordingConfigCurrent, err := s.client.GetSessionRecordingConfig(ctx)
+		require.NoError(s.T(), err)
+
+		return sessionRecordingConfigBefore.GetRevision() != sessionRecordingConfigCurrent.GetRevision()
+	}, 5*time.Second, time.Second)
+
+	name := "data.teleport_session_recording_config.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("session_recording_config_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "session_recording_config"),
+					resource.TestCheckResourceAttr(name, "version", "v2"),
+					resource.TestCheckResourceAttr(name, "id", "session-recording-config"),
+					resource.TestCheckResourceAttr(name, "spec.mode", "node"),
+					resource.TestCheckResourceAttr(name, "spec.proxy_checks_host_keys", "true"),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestSessionRecordingConfig() {
 	name := "teleport_session_recording_config.test"
 

--- a/integrations/terraform/testlib/static_host_user_test.go
+++ b/integrations/terraform/testlib/static_host_user_test.go
@@ -32,6 +32,72 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+func (s *TerraformSuiteOSS) TestStaticHostUserDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	shu := &userprovisioningv2.StaticHostUser{
+		Metadata: &v1.Metadata{
+			Name: "test",
+		},
+		Kind:    types.KindStaticHostUser,
+		Version: types.V2,
+		Spec: &userprovisioningv2.StaticHostUserSpec{
+			Matchers: []*userprovisioningv2.Matcher{
+				{
+					NodeLabels: []*labelv1.Label{
+						{
+							Name:   "foo",
+							Values: []string{"bar"},
+						},
+					},
+					Groups:       []string{"foo", "bar"},
+					Sudoers:      []string{"example"},
+					Uid:          1234,
+					Gid:          1234,
+					DefaultShell: "/bin/bash",
+				},
+			},
+		},
+	}
+	shu, err := s.client.StaticHostUserClient().CreateStaticHostUser(ctx, shu)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.StaticHostUserClient().GetStaticHostUser(ctx, shu.GetMetadata().GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.StaticHostUserClient().DeleteStaticHostUser(ctx, shu.GetMetadata().GetName()))
+	})
+
+	name := "data.teleport_static_host_user.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("static_host_user_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "static_host_user"),
+					resource.TestCheckResourceAttr(name, "version", "v2"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.matchers.0.node_labels.0.name", "foo"),
+					resource.TestCheckResourceAttr(name, "spec.matchers.0.node_labels.0.values.0", "bar"),
+					resource.TestCheckResourceAttr(name, "spec.matchers.0.groups.0", "foo"),
+					resource.TestCheckResourceAttr(name, "spec.matchers.0.groups.1", "bar"),
+					resource.TestCheckResourceAttr(name, "spec.matchers.0.sudoers.0", "example"),
+					resource.TestCheckResourceAttr(name, "spec.matchers.0.uid", "1234"),
+					resource.TestCheckResourceAttr(name, "spec.matchers.0.gid", "1234"),
+					resource.TestCheckResourceAttr(name, "spec.matchers.0.default_shell", "/bin/bash"),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestStaticHostUser() {
 	t := s.T()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/integrations/terraform/testlib/user_test.go
+++ b/integrations/terraform/testlib/user_test.go
@@ -33,15 +33,6 @@ func (s *TerraformSuiteOSS) TestUserDataSource() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.T().Cleanup(cancel)
 
-	checkUserDestroyed := func(state *terraform.State) error {
-		_, err := s.client.GetUser(ctx, "test", false)
-		if trace.IsNotFound(err) {
-			return nil
-		}
-
-		return err
-	}
-
 	expires := time.Date(2035, 10, 12, 0, 0, 0, 0, time.UTC)
 	user := &types.UserV2{
 		Metadata: types.Metadata{
@@ -80,11 +71,20 @@ func (s *TerraformSuiteOSS) TestUserDataSource() {
 	_, err = s.client.CreateUser(ctx, user)
 	require.NoError(s.T(), err)
 
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetUser(ctx, user.GetName(), false)
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteUser(ctx, user.GetName()))
+	})
+
 	name := "data.teleport_user.test"
 
 	resource.Test(s.T(), resource.TestCase{
 		ProtoV6ProviderFactories: s.terraformProviders,
-		CheckDestroy:             checkUserDestroyed,
+		IsUnitTest:               true,
 		Steps: []resource.TestStep{
 			{
 				Config: s.getFixture("user_data_source.tf"),
@@ -102,6 +102,8 @@ func (s *TerraformSuiteOSS) TestUserDataSource() {
 					resource.TestCheckResourceAttr(name, "spec.github_identities.0.username", "example"),
 					resource.TestCheckResourceAttr(name, "spec.saml_identities.0.connector_id", "saml"),
 					resource.TestCheckResourceAttr(name, "spec.saml_identities.0.username", "example"),
+					resource.TestCheckResourceAttr(name, "status.password_state", "1"),
+					resource.TestCheckResourceAttr(name, "status.mfa_weakest_device", "1"),
 				),
 			},
 		},
@@ -142,6 +144,8 @@ func (s *TerraformSuiteOSS) TestUser() {
 					resource.TestCheckResourceAttr(name, "spec.github_identities.0.username", "example"),
 					resource.TestCheckResourceAttr(name, "spec.saml_identities.0.connector_id", "saml"),
 					resource.TestCheckResourceAttr(name, "spec.saml_identities.0.username", "example"),
+					resource.TestCheckResourceAttr(name, "status.password_state", "1"),
+					resource.TestCheckResourceAttr(name, "status.mfa_weakest_device", "1"),
 				),
 			},
 			{
@@ -160,6 +164,8 @@ func (s *TerraformSuiteOSS) TestUser() {
 					resource.TestCheckResourceAttr(name, "spec.oidc_identities.0.username", "example"),
 					resource.TestCheckNoResourceAttr(name, "spec.github_identities"),
 					resource.TestCheckNoResourceAttr(name, "spec.saml_identities"),
+					resource.TestCheckResourceAttr(name, "status.password_state", "1"),
+					resource.TestCheckResourceAttr(name, "status.mfa_weakest_device", "1"),
 				),
 			},
 			{

--- a/integrations/terraform/testlib/workload_identity_test.go
+++ b/integrations/terraform/testlib/workload_identity_test.go
@@ -29,6 +29,73 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+func (s *TerraformSuiteOSS) TestWorkloadIdentityDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	wi := &workloadidentityv1pb.WorkloadIdentity{
+		Metadata: &v1.Metadata{
+			Name: "test",
+		},
+		Kind:    types.KindWorkloadIdentity,
+		Version: types.V1,
+		Spec: &workloadidentityv1pb.WorkloadIdentitySpec{
+			Rules: &workloadidentityv1pb.WorkloadIdentityRules{
+				Allow: []*workloadidentityv1pb.WorkloadIdentityRule{
+					{
+						Conditions: []*workloadidentityv1pb.WorkloadIdentityCondition{
+							{
+								Attribute: "user.name",
+								Operator: &workloadidentityv1pb.WorkloadIdentityCondition_Eq{
+									Eq: &workloadidentityv1pb.WorkloadIdentityConditionEq{
+										Value: "example",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Spiffe: &workloadidentityv1pb.WorkloadIdentitySPIFFE{
+				Id:   "/example-id",
+				Hint: "example-hint",
+			},
+		},
+	}
+	wi, err := s.client.CreateWorkloadIdentity(ctx, wi)
+	require.NoError(s.T(), err)
+
+	require.Eventually(s.T(), func() bool {
+		_, err := s.client.GetWorkloadIdentity(ctx, wi.GetMetadata().GetName())
+		return err == nil
+	}, 5*time.Second, time.Second)
+
+	s.T().Cleanup(func() {
+		require.NoError(s.T(), s.client.DeleteWorkloadIdentity(ctx, wi.GetMetadata().GetName()))
+	})
+
+	name := "data.teleport_workload_identity.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("workload_identity_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "workload_identity"),
+					resource.TestCheckResourceAttr(name, "version", "v1"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "spec.rules.allow.0.conditions.0.attribute", "user.name"),
+					resource.TestCheckResourceAttr(name, "spec.rules.allow.0.conditions.0.eq.value", "example"),
+					resource.TestCheckResourceAttr(name, "spec.spiffe.id", "/example-id"),
+					resource.TestCheckResourceAttr(name, "spec.spiffe.hint", "example-hint"),
+				),
+			},
+		},
+	})
+}
+
 func (s *TerraformSuiteOSS) TestWorkloadIdentity() {
 	t := s.T()
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This PR adds basic test coverage for Terraform data sources.

Test coverage added for the following data sources:
- access_monitoring_rule
- app_auth_config
- app
- auth_preference
- autoupdate_config
- autoupdate_version
- cluster_maintenance_config
- cluster_networking_config
- database
- discovery_config
- dynamic_windows_desktop
- github_connector
- health_check_config
- installer
- integration
- provision_token
- role
- session_recording_config
- static_host_user
- user
- workload_identity

Test coverage not added for the following data sources due to enterprise requirements or other limitations:
- oidc_connector
- saml_connector
- trusted_cluster
- login_rule
- trusted_device
- okta_import_rule
- access_list
- access_list_member
- vnet_config