### PR TITLE
allow custom error for disabled secreports service

### DIFF
--- a/lib/auth/secreports/secreportsv1/service.go
+++ b/lib/auth/secreports/secreportsv1/service.go
@@ -30,83 +30,91 @@ import (
 // is required to use the service.
 type NotImplementedService struct {
 	secreportsv1pb.UnsafeSecReportsServiceServer
+
+	// CustomError sets a custom error that the service will return for all
+	// methods, it should contain information about why the security reports
+	// service is disabled.
+	CustomError error
 }
 
-func (n NotImplementedService) requireEnterprise() error {
-	return trace.AccessDenied("Security Reports are only available with an enterprise license")
+func (n NotImplementedService) error() error {
+	if n.CustomError == nil {
+		return trace.AccessDenied("Security Reports are only available with an enterprise license including Access Monitoring in clusters using the Athena audit backend")
+	}
+	return trace.Wrap(n.CustomError)
 }
 
 // DeleteAuditQuery implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) DeleteAuditQuery(context.Context, *secreportsv1pb.DeleteAuditQueryRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, n.requireEnterprise()
+	return &emptypb.Empty{}, n.error()
 }
 
 // DeleteReport implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) DeleteReport(context.Context, *secreportsv1pb.DeleteReportRequest) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, n.requireEnterprise()
+	return &emptypb.Empty{}, n.error()
 }
 
 // GetAuditQuery implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) GetAuditQuery(context.Context, *secreportsv1pb.GetAuditQueryRequest) (*secreportsv1pb.AuditQuery, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // GetAuditQueryResult implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) GetAuditQueryResult(context.Context, *secreportsv1pb.GetAuditQueryResultRequest) (*secreportsv1pb.GetAuditQueryResultResponse, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // GetReport implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) GetReport(context.Context, *secreportsv1pb.GetReportRequest) (*secreportsv1pb.Report, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // GetReportResult implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) GetReportResult(context.Context, *secreportsv1pb.GetReportResultRequest) (*secreportsv1pb.GetReportResultResponse, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // GetReportState implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) GetReportState(context.Context, *secreportsv1pb.GetReportStateRequest) (*secreportsv1pb.ReportState, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // GetSchema implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) GetSchema(context.Context, *secreportsv1pb.GetSchemaRequest) (*secreportsv1pb.GetSchemaResponse, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // ListAuditQueries implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) ListAuditQueries(context.Context, *secreportsv1pb.ListAuditQueriesRequest) (*secreportsv1pb.ListAuditQueriesResponse, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // ListReportStates implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) ListReportStates(context.Context, *secreportsv1pb.ListReportStatesRequest) (*secreportsv1pb.ListReportStatesResponse, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // ListReports implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) ListReports(context.Context, *secreportsv1pb.ListReportsRequest) (*secreportsv1pb.ListReportsResponse, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // RunAuditQuery implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) RunAuditQuery(context.Context, *secreportsv1pb.RunAuditQueryRequest) (*secreportsv1pb.RunAuditQueryResponse, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // RunReport implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) RunReport(context.Context, *secreportsv1pb.RunReportRequest) (*emptypb.Empty, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // UpsertAuditQuery implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) UpsertAuditQuery(context.Context, *secreportsv1pb.UpsertAuditQueryRequest) (*emptypb.Empty, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }
 
 // UpsertReport implements secreportsv1.SecReportsServiceServer.
 func (n NotImplementedService) UpsertReport(context.Context, *secreportsv1pb.UpsertReportRequest) (*emptypb.Empty, error) {
-	return nil, n.requireEnterprise()
+	return nil, n.error()
 }


### PR DESCRIPTION
Add `CustomError` to `secreportsv1.NotImplementedService` so callers can return actionable `AccessDenied` messages when the security reports service is unavailable.

The existing error message always said "Security Reports are only available with an enterprise license" and this was a common source of confusion for enterprise customers who either didn't have the Access Monitoring entitlement or weren't using the Athena backend (those being alternate reasons security reports could be unavailable).

This will be used in a followup PR to teleport.e

Keep fallback behavior for existing callers, and update the default message to mention Access Monitoring and Athena backend requirements.

## Manual Testplan

- [x] `tctl audit query ls` returns the expected error in OSS