### PR TITLE
MWI: Add certificate expiry check leeway for tbot

### DIFF
--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -435,8 +435,11 @@ func (l *LocalProxy) getCert() tls.Certificate {
 	return l.cfg.Cert
 }
 
-// CheckDBCert checks the proxy certificates for expiration and that the cert subject matches a database route.
-func (l *LocalProxy) CheckDBCert(ctx context.Context, dbRoute tlsca.RouteToDatabase) error {
+// CheckDBCertWithLeeway checks the proxy certificates for expiration and that
+// the cert subject matches a database route. The provided leeway value is added
+// to the current time when checking certificate expiration and can be used to
+// account for potential client-side clock drift.
+func (l *LocalProxy) CheckDBCertWithLeeway(ctx context.Context, dbRoute tlsca.RouteToDatabase, leeway time.Duration) error {
 	l.cfg.Log.DebugContext(ctx, "checking local proxy database certs")
 	l.certMu.RLock()
 	defer l.certMu.RUnlock()
@@ -451,11 +454,16 @@ func (l *LocalProxy) CheckDBCert(ctx context.Context, dbRoute tlsca.RouteToDatab
 	}
 
 	// Check for cert expiration.
-	if err := utils.VerifyCertificateExpiry(cert, l.cfg.Clock); err != nil {
+	if err := utils.VerifyCertificateExpiryWithLeeway(cert, l.cfg.Clock, leeway); err != nil {
 		return trace.Wrap(err)
 	}
 
 	return trace.Wrap(CheckDBCertSubject(cert, dbRoute))
+}
+
+// CheckDBCert checks the proxy certificates for expiration and that the cert subject matches a database route.
+func (l *LocalProxy) CheckDBCert(ctx context.Context, dbRoute tlsca.RouteToDatabase) error {
+	return l.CheckDBCertWithLeeway(ctx, dbRoute, 0)
 }
 
 // CheckCertExpiryWithLeeway checks the proxy certificates for expiration. The

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -30,6 +30,7 @@ import (
 	"net/http/httputil"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jackc/pgproto3/v2"
@@ -457,8 +458,10 @@ func (l *LocalProxy) CheckDBCert(ctx context.Context, dbRoute tlsca.RouteToDatab
 	return trace.Wrap(CheckDBCertSubject(cert, dbRoute))
 }
 
-// CheckCertExpiry checks the proxy certificates for expiration.
-func (l *LocalProxy) CheckCertExpiry(ctx context.Context) error {
+// CheckCertExpiryWithLeeway checks the proxy certificates for expiration. The
+// provided leeway value is added to the current time when compared to the cert
+// expiration and can be used to account for potential client-side clock drift.
+func (l *LocalProxy) CheckCertExpiryWithLeeway(ctx context.Context, leeway time.Duration) error {
 	l.cfg.Log.DebugContext(ctx, "checking local proxy certs")
 	l.certMu.RLock()
 	defer l.certMu.RUnlock()
@@ -472,7 +475,12 @@ func (l *LocalProxy) CheckCertExpiry(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(utils.VerifyCertificateExpiry(cert, l.cfg.Clock))
+	return trace.Wrap(utils.VerifyCertificateExpiryWithLeeway(cert, l.cfg.Clock, leeway))
+}
+
+// CheckCertExpiry checks the proxy certificates for expiration.
+func (l *LocalProxy) CheckCertExpiry(ctx context.Context) error {
+	return trace.Wrap(l.CheckCertExpiryWithLeeway(ctx, 0))
 }
 
 // CheckDBCertSubject checks if the route to the database from the cert matches the provided route in

--- a/lib/tbot/bot/bot.go
+++ b/lib/tbot/bot/bot.go
@@ -355,6 +355,7 @@ func (b *Bot) buildIdentityService(
 		Destination:     b.cfg.InternalStorage,
 		TTL:             b.cfg.CredentialLifetime.TTL,
 		RenewalInterval: b.cfg.CredentialLifetime.RenewalInterval,
+		Leeway:          b.cfg.Leeway,
 		FIPS:            b.cfg.FIPS,
 		Logger: b.cfg.Logger.With(
 			teleport.ComponentKey,

--- a/lib/tbot/bot/config.go
+++ b/lib/tbot/bot/config.go
@@ -20,6 +20,7 @@ package bot
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
@@ -51,6 +52,12 @@ type Config struct {
 	// CredentialLifetime controls the TTL and renewal interval of the bot's
 	// internal credentials.
 	CredentialLifetime CredentialLifetime
+
+	// Leeway is a duration added to local system time when checking for expired
+	// certificates in certain cases, particularly with app and database
+	// tunnels. It can be useful to account for clock drift, or if a negative
+	// duration is provided, to simulate clock drift.
+	Leeway time.Duration `yaml:"leeway,omitempty"`
 
 	// FIPS controls whether the bot will run in a mode designed to comply with
 	// Federal Information Processing Standards.

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -56,6 +56,7 @@ import (
 const (
 	DefaultCertificateTTL = 60 * time.Minute
 	DefaultRenewInterval  = 20 * time.Minute
+	DefaultLeeway         = 1 * time.Minute
 )
 
 var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentTBot)
@@ -87,7 +88,15 @@ type BotConfig struct {
 	JoinURI string `yaml:"join_uri,omitempty"`
 
 	CredentialLifetime bot.CredentialLifetime `yaml:",inline"`
-	Oneshot            bool                   `yaml:"oneshot"`
+
+	// Leeway is a duration added to local system time when checking for expired
+	// certificates in certain cases, particularly with app and database
+	// tunnels. It can be useful to account for clock drift, or if a negative
+	// duration is provided, to simulate clock drift.
+	Leeway time.Duration `yaml:"leeway,omitempty"`
+
+	Oneshot bool `yaml:"oneshot"`
+
 	// FIPS instructs `tbot` to run in a mode designed to comply with FIPS
 	// regulations. This means the bot should:
 	// - Refuse to run if not compiled with boringcrypto
@@ -257,6 +266,10 @@ func (conf *BotConfig) CheckAndSetDefaults() error {
 
 	if conf.CredentialLifetime.RenewalInterval == 0 {
 		conf.CredentialLifetime.RenewalInterval = DefaultRenewInterval
+	}
+
+	if conf.Leeway == 0 {
+		conf.Leeway = DefaultLeeway
 	}
 
 	// We require the join method for `configure` and `start` but not for `init`

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -63,6 +63,7 @@ type Config struct {
 
 	TTL             time.Duration
 	RenewalInterval time.Duration
+	Leeway          time.Duration
 
 	FIPS bool
 
@@ -547,9 +548,12 @@ func renewIdentity(
 	// solution to determine when to discard an existing identity: the client
 	// could have severe clock drift, or there could be non-expiry related
 	// reasons that an identity should be thrown out. We may improve this
-	// discard logic in the future if we determine we're still creating  excess
+	// discard logic in the future if we determine we're still creating excess
 	// bot instances.
-	now := time.Now()
+	// To allow users to manually compensate for clock drift if e.g. using very
+	// tight renewal/TTL values, we expose a configurable leeway to trigger
+	// modestly early renewal.
+	now := time.Now().Add(cfg.Leeway)
 	if expiry, ok := facade.Expiry(); !ok || now.After(expiry) {
 		slog.WarnContext(
 			ctx,
@@ -564,6 +568,7 @@ func renewIdentity(
 			"expiry", expiry,
 			"ttl", cfg.TTL,
 			"renewal_interval", cfg.RenewalInterval,
+			"leeway", cfg.Leeway,
 		)
 
 		newIdentity, err := botIdentityFromToken(ctx, log, cfg, nil)

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -544,6 +544,9 @@ func renewIdentity(
 		return newIdentity, nil
 	}
 
+	// Note: This leeway cap check is simpler than app/db tunnel services as the
+	// main renewal loop is, well, a loop, and will not attempt to renew more
+	// often than the configured renewal interval.
 	leeway := cfg.Leeway
 	if leeway >= cfg.TTL {
 		log.WarnContext(ctx, "leeway is greater than credential lifetime and "+

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -563,7 +563,7 @@ func renewIdentity(
 	// To allow users to manually compensate for clock drift if e.g. using very
 	// tight renewal/TTL values, we expose a configurable leeway to trigger
 	// modestly early renewal.
-	now := time.Now().Add(cfg.Leeway)
+	now := time.Now().Add(leeway)
 	if expiry, ok := facade.Expiry(); !ok || now.After(expiry) {
 		slog.WarnContext(
 			ctx,

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -544,6 +544,16 @@ func renewIdentity(
 		return newIdentity, nil
 	}
 
+	leeway := cfg.Leeway
+	if leeway >= cfg.TTL {
+		log.WarnContext(ctx, "leeway is greater than credential lifetime and "+
+			"will be ignored, be aware of potential failures due to clock drift",
+			"credential_ttl", cfg.TTL,
+			"configured_leeway", cfg.Leeway,
+		)
+		leeway = 0
+	}
+
 	// Note: This simple expiration check is probably not the best possible
 	// solution to determine when to discard an existing identity: the client
 	// could have severe clock drift, or there could be non-expiry related

--- a/lib/tbot/services/application/tunnel_config.go
+++ b/lib/tbot/services/application/tunnel_config.go
@@ -21,6 +21,7 @@ package application
 import (
 	"net"
 	"net/url"
+	"time"
 
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
@@ -54,6 +55,10 @@ type TunnelConfig struct {
 	// Listener overrides "listen" and directly provides an opened listener to
 	// use.
 	Listener net.Listener `yaml:"-"`
+
+	// Leeway is a duration added to the current time when checking if the
+	// tunnel's internal certificate needs to be renewed.
+	Leeway *time.Duration `yaml:"leeway,omitempty"`
 }
 
 // GetName returns the user-given name of the service, used for validation purposes.
@@ -94,6 +99,14 @@ func (s *TunnelConfig) CheckAndSetDefaults() error {
 	if _, err := url.Parse(s.Listen); err != nil {
 		return trace.Wrap(err, "parsing listen")
 	}
+
+	// Leeway is a pointer to explicitly allow users to override this for zero
+	// leeway if desired.
+	if s.Leeway == nil {
+		v := time.Minute
+		s.Leeway = &v
+	}
+
 	return nil
 }
 

--- a/lib/tbot/services/application/tunnel_config.go
+++ b/lib/tbot/services/application/tunnel_config.go
@@ -58,7 +58,7 @@ type TunnelConfig struct {
 
 	// Leeway is a duration added to the current time when checking if the
 	// tunnel's internal certificate needs to be renewed.
-	Leeway *time.Duration `yaml:"leeway,omitempty"`
+	Leeway time.Duration `yaml:"leeway,omitempty"`
 }
 
 // GetName returns the user-given name of the service, used for validation purposes.
@@ -100,11 +100,8 @@ func (s *TunnelConfig) CheckAndSetDefaults() error {
 		return trace.Wrap(err, "parsing listen")
 	}
 
-	// Leeway is a pointer to explicitly allow users to override this for zero
-	// leeway if desired.
-	if s.Leeway == nil {
-		v := time.Minute
-		s.Leeway = &v
+	if s.Leeway == 0 {
+		s.Leeway = time.Minute
 	}
 
 	return nil

--- a/lib/tbot/services/application/tunnel_config.go
+++ b/lib/tbot/services/application/tunnel_config.go
@@ -21,9 +21,9 @@ package application
 import (
 	"net"
 	"net/url"
-	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/teleport/lib/tbot/bot"
@@ -56,9 +56,13 @@ type TunnelConfig struct {
 	// use.
 	Listener net.Listener `yaml:"-"`
 
-	// Leeway is a duration added to the current time when checking if the
-	// tunnel's internal certificate needs to be renewed.
-	Leeway time.Duration `yaml:"leeway,omitempty"`
+	// Clock is a clock. If unset, the standard system clock is used. Used in
+	// tests.
+	clock clockwork.Clock `yaml:"-"`
+
+	// certIssuedHook is an optional hook called when the tunnel requests a new
+	// certificate. Used in tests.
+	certIssuedHook func() `yaml:"-"`
 }
 
 // GetName returns the user-given name of the service, used for validation purposes.
@@ -99,9 +103,8 @@ func (s *TunnelConfig) CheckAndSetDefaults() error {
 	if _, err := url.Parse(s.Listen); err != nil {
 		return trace.Wrap(err, "parsing listen")
 	}
-
-	if s.Leeway == 0 {
-		s.Leeway = time.Minute
+	if s.clock == nil {
+		s.clock = clockwork.NewRealClock()
 	}
 
 	return nil

--- a/lib/tbot/services/application/tunnel_config_test.go
+++ b/lib/tbot/services/application/tunnel_config_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/jonboulle/clockwork"
 )
 
 func TestApplicationTunnelService_YAML(t *testing.T) {
@@ -47,6 +48,8 @@ func TestApplicationTunnelService_YAML(t *testing.T) {
 func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 
+	clock := clockwork.NewFakeClock()
+
 	tests := []testCheckAndSetDefaultsCase[*TunnelConfig]{
 		{
 			name: "valid",
@@ -55,12 +58,14 @@ func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 					Listen:  "tcp://0.0.0.0:3621",
 					Roles:   []string{"role1", "role2"},
 					AppName: "my-app",
+					clock:   clock,
 				}
 			},
 			want: &TunnelConfig{
 				Listen:  "tcp://0.0.0.0:3621",
 				Roles:   []string{"role1", "role2"},
 				AppName: "my-app",
+				clock:   clock,
 			},
 			wantErr: "",
 		},

--- a/lib/tbot/services/application/tunnel_config_test.go
+++ b/lib/tbot/services/application/tunnel_config_test.go
@@ -57,6 +57,30 @@ func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 					AppName: "my-app",
 				}
 			},
+			want: &TunnelConfig{
+				Listen:  "tcp://0.0.0.0:3621",
+				Roles:   []string{"role1", "role2"},
+				AppName: "my-app",
+				Leeway:  time.Minute,
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid with explicit leeway",
+			in: func() *TunnelConfig {
+				return &TunnelConfig{
+					Listen:  "tcp://0.0.0.0:3621",
+					Roles:   []string{"role1", "role2"},
+					AppName: "my-app",
+					Leeway:  5 * time.Minute,
+				}
+			},
+			want: &TunnelConfig{
+				Listen:  "tcp://0.0.0.0:3621",
+				Roles:   []string{"role1", "role2"},
+				AppName: "my-app",
+				Leeway:  5 * time.Minute,
+			},
 			wantErr: "",
 		},
 		{

--- a/lib/tbot/services/application/tunnel_config_test.go
+++ b/lib/tbot/services/application/tunnel_config_test.go
@@ -61,25 +61,6 @@ func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 				Listen:  "tcp://0.0.0.0:3621",
 				Roles:   []string{"role1", "role2"},
 				AppName: "my-app",
-				Leeway:  time.Minute,
-			},
-			wantErr: "",
-		},
-		{
-			name: "valid with explicit leeway",
-			in: func() *TunnelConfig {
-				return &TunnelConfig{
-					Listen:  "tcp://0.0.0.0:3621",
-					Roles:   []string{"role1", "role2"},
-					AppName: "my-app",
-					Leeway:  5 * time.Minute,
-				}
-			},
-			want: &TunnelConfig{
-				Listen:  "tcp://0.0.0.0:3621",
-				Roles:   []string{"role1", "role2"},
-				AppName: "my-app",
-				Leeway:  5 * time.Minute,
 			},
 			wantErr: "",
 		},

--- a/lib/tbot/services/application/tunnel_config_test.go
+++ b/lib/tbot/services/application/tunnel_config_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/lib/tbot/bot"
 )
 
 func TestApplicationTunnelService_YAML(t *testing.T) {

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -188,11 +188,12 @@ func (s *TunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnpr
 	s.log.DebugContext(ctx, "Issued initial certificate for local proxy.")
 
 	leeway := s.leeway
-	if leeway >= s.defaultCredentialLifetime.TTL {
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
+	if leeway >= effectiveLifetime.TTL {
 		s.log.WarnContext(ctx,
 			"leeway is greater than the credential lifetime and will be "+
 				"ignored, be aware of potential failures due to clock drift",
-			"credential_ttl", s.defaultCredentialLifetime.TTL,
+			"credential_ttl", effectiveLifetime.TTL,
 			"configured_leeway", leeway,
 		)
 		leeway = 0

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -183,13 +184,21 @@ func (s *TunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnpr
 	}
 	s.log.DebugContext(ctx, "Issued initial certificate for local proxy.")
 
+	var leeway time.Duration = 0
+	if l := s.cfg.Leeway; l != nil {
+		leeway = *l
+	}
+
 	middleware := internal.ALPNProxyMiddleware{
 		OnNewConnectionFunc: func(ctx context.Context, lp *alpnproxy.LocalProxy) error {
 			ctx, span := tracer.Start(ctx, "TunnelService/OnNewConnection")
 			defer span.End()
 
-			if err := lp.CheckCertExpiry(ctx); err != nil {
-				s.log.InfoContext(ctx, "Certificate for tunnel needs reissuing.", "reason", err.Error())
+			if err := lp.CheckCertExpiryWithLeeway(ctx, leeway); err != nil {
+				s.log.InfoContext(ctx, "Certificate for tunnel needs reissuing.",
+					"reason", err.Error(),
+					"leeway", leeway,
+				)
 				cert, _, err := s.issueCert(ctx)
 				if err != nil {
 					return trace.Wrap(err, "issuing cert")

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -44,6 +45,7 @@ func TunnelServiceBuilder(
 	cfg *TunnelConfig,
 	connCfg connection.Config,
 	defaultCredentialLifetime bot.CredentialLifetime,
+	leeway time.Duration,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
@@ -52,6 +54,7 @@ func TunnelServiceBuilder(
 		svc := &TunnelService{
 			connCfg:                   connCfg,
 			defaultCredentialLifetime: defaultCredentialLifetime,
+			leeway:                    leeway,
 			getBotIdentity:            deps.BotIdentity,
 			botIdentityReadyCh:        deps.BotIdentityReadyCh,
 			proxyPinger:               deps.ProxyPinger,
@@ -74,6 +77,7 @@ func TunnelServiceBuilder(
 type TunnelService struct {
 	connCfg                   connection.Config
 	defaultCredentialLifetime bot.CredentialLifetime
+	leeway                    time.Duration
 	cfg                       *TunnelConfig
 	proxyPinger               connection.ProxyPinger
 	log                       *slog.Logger
@@ -183,7 +187,7 @@ func (s *TunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnpr
 	}
 	s.log.DebugContext(ctx, "Issued initial certificate for local proxy.")
 
-	leeway := s.cfg.Leeway
+	leeway := s.leeway
 	if leeway >= s.defaultCredentialLifetime.TTL {
 		s.log.WarnContext(ctx,
 			"leeway is greater than the credential lifetime and will be "+
@@ -222,6 +226,7 @@ func (s *TunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnpr
 		Protocols:          []common.Protocol{alpnProtocolForApp(app)},
 		Cert:               *appCert,
 		InsecureSkipVerify: s.connCfg.Insecure,
+		Clock:              s.cfg.clock,
 	}
 	if apiclient.IsALPNConnUpgradeRequired(
 		ctx,
@@ -277,6 +282,11 @@ func (s *TunnelService) issueCert(
 		return nil, nil, trace.Wrap(err)
 	}
 	s.log.InfoContext(ctx, "Certificate issued for tunnel proxy.")
+
+	// In tests, notify the test that a cert has been issued.
+	if s.cfg.certIssuedHook != nil {
+		s.cfg.certIssuedHook()
+	}
 
 	return routedIdent.TLSCert, app, nil
 }

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -24,7 +24,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/gravitational/trace"
 
@@ -184,9 +183,15 @@ func (s *TunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnpr
 	}
 	s.log.DebugContext(ctx, "Issued initial certificate for local proxy.")
 
-	var leeway time.Duration = 0
-	if l := s.cfg.Leeway; l != nil {
-		leeway = *l
+	leeway := s.cfg.Leeway
+	if leeway >= s.defaultCredentialLifetime.TTL {
+		s.log.WarnContext(ctx,
+			"leeway is greater than the credential lifetime and will be "+
+				"ignored, be aware of potential failures due to clock drift",
+			"credential_ttl", s.defaultCredentialLifetime.TTL,
+			"configured_leeway", leeway,
+		)
+		leeway = 0
 	}
 
 	middleware := internal.ALPNProxyMiddleware{

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -187,14 +187,26 @@ func (s *TunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnpr
 	}
 	s.log.DebugContext(ctx, "Issued initial certificate for local proxy.")
 
-	leeway := s.leeway
+	// Attempt to provide a sensible cap for leeway values based on the
+	// configured and actual cert TTL to guard against rapid renewals. This
+	// doesn't attempt to be perfect, and it's still possible to force a new
+	// cert to be issued on every connection with the right set of unreasonable
+	// values. However, we want it to be possible to specify  nearly-too-large
+	// values for testing purposes (i.e. using negative leeway to simulate clock
+	// drift) and do not want to be in the business of calculating leeway-leeway
+	// so we'll keep the check somewhat simple.
+	issuedCertLifetime := appCert.Leaf.NotAfter.Sub(appCert.Leaf.NotBefore)
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
-	if leeway >= effectiveLifetime.TTL {
+	effectiveTTL := min(issuedCertLifetime, effectiveLifetime.TTL)
+
+	leeway := s.leeway
+	if leeway >= effectiveTTL {
 		s.log.WarnContext(ctx,
 			"leeway is greater than the credential lifetime and will be "+
 				"ignored, be aware of potential failures due to clock drift",
-			"credential_ttl", effectiveLifetime.TTL,
+			"configured_ttl", effectiveLifetime.TTL,
 			"configured_leeway", leeway,
+			"issued_cert_ttl", issuedCertLifetime,
 		)
 		leeway = 0
 	}
@@ -289,7 +301,12 @@ func (s *TunnelService) issueCert(
 		s.cfg.certIssuedHook()
 	}
 
-	return routedIdent.TLSCert, app, nil
+	// The leaf isn't appended by the stdlib, so add it here so we can inspect
+	// the TTL downstream.
+	cert := routedIdent.TLSCert
+	cert.Leaf = routedIdent.X509Cert
+
+	return cert, app, nil
 }
 
 // String returns a human-readable string that can uniquely identify the

--- a/lib/tbot/services/application/tunnel_service_test.go
+++ b/lib/tbot/services/application/tunnel_service_test.go
@@ -204,8 +204,6 @@ func TestE2E_ApplicationTunnelService_Leeway(t *testing.T) {
 		t.TempDir(),
 		defaultTestServerOpts(log),
 		testenv.WithConfig(func(cfg *servicecfg.Config) {
-			//cfg.Clock = clock
-
 			cfg.Apps.Enabled = true
 			cfg.Apps.Apps = []servicecfg.App{
 				{

--- a/lib/tbot/services/application/tunnel_service_test.go
+++ b/lib/tbot/services/application/tunnel_service_test.go
@@ -26,9 +26,11 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -119,6 +121,7 @@ func TestE2E_ApplicationTunnelService(t *testing.T) {
 				},
 				connCfg,
 				bot.DefaultCredentialLifetime,
+				time.Minute,
 			),
 		},
 	})
@@ -155,4 +158,158 @@ func TestE2E_ApplicationTunnelService(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, wantBody, body)
 	}, 10*time.Second, 100*time.Millisecond)
+}
+
+func makeTunnelRequest(t *testing.T, botListener net.Listener, wantStatus int, wantBody []byte) {
+	t.Helper()
+
+	// Need a custom client: the default http.Client will "helpfully" reuse the
+	// connection and keep our `OnNewConnectionFunc` from triggering, preventing
+	// cert refreshes.
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		proxyUrl := url.URL{
+			Scheme: "http",
+			Host:   botListener.Addr().String(),
+		}
+		resp, err := client.Get(proxyUrl.String())
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, wantStatus, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, wantBody, body)
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
+func TestE2E_ApplicationTunnelService_Leeway(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := logtest.NewLogger()
+	clock := clockwork.NewFakeClockAt(time.Now())
+
+	// Spin up a test HTTP server
+	wantStatus := http.StatusTeapot
+	wantBody := []byte("hello this is a test")
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(wantStatus)
+		w.Write(wantBody)
+	}))
+	t.Cleanup(httpSrv.Close)
+
+	// Make a new auth server.
+	appName := "my-test-app"
+	process, err := testenv.NewTeleportProcess(
+		t.TempDir(),
+		defaultTestServerOpts(log),
+		testenv.WithConfig(func(cfg *servicecfg.Config) {
+			//cfg.Clock = clock
+
+			cfg.Apps.Enabled = true
+			cfg.Apps.Apps = []servicecfg.App{
+				{
+					Name: appName,
+					URI:  httpSrv.URL,
+				},
+			}
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+	rootClient, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rootClient.Close() })
+
+	// Create role that allows the bot to access the app.
+	role, err := types.NewRole("app-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{
+				"*": apiutils.Strings{"*"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	role, err = rootClient.UpsertRole(t.Context(), role)
+	require.NoError(t, err)
+
+	botListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		botListener.Close()
+	})
+
+	onboarding, _ := makeBot(t, rootClient, "test", role.GetName())
+
+	proxyAddr, err := process.ProxyWebAddr()
+	require.NoError(t, err)
+
+	certsIssued := atomic.Uint32{}
+
+	connCfg := connection.Config{
+		Address:     proxyAddr.Addr,
+		AddressKind: connection.AddressKindProxy,
+		Insecure:    true,
+	}
+	b, err := bot.New(bot.Config{
+		Connection: connCfg,
+		Logger:     log,
+		Onboarding: *onboarding,
+		Services: []bot.ServiceBuilder{
+			TunnelServiceBuilder(
+				&TunnelConfig{
+					Listener: botListener,
+					AppName:  appName,
+					clock:    clock,
+					certIssuedHook: func() {
+						t.Logf("!! new cert issued")
+						certsIssued.Add(1)
+					},
+				},
+				connCfg,
+				bot.DefaultCredentialLifetime,
+				5*time.Minute,
+			),
+		},
+	})
+	require.NoError(t, err)
+
+	// Spin up goroutine for bot to run in
+	ctx, cancel := context.WithCancel(ctx)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := b.Run(ctx)
+		assert.NoError(t, err, "bot should not exit with error")
+		cancel()
+	}()
+	t.Cleanup(func() {
+		// Shut down bot and make sure it exits.
+		cancel()
+		wg.Wait()
+	})
+
+	// One cert should be issued at startup (eventually).
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.EqualValues(t, 1, certsIssued.Load())
+	}, 10*time.Second, 20*time.Millisecond)
+
+	// Make a first request. It should not cause a new cert to be issued.
+	makeTunnelRequest(t, botListener, wantStatus, wantBody)
+	require.EqualValues(t, 1, certsIssued.Load())
+
+	// Advance the clock a bit and try again. No cert should be issued (<TTL)
+	clock.Advance(bot.DefaultCredentialLifetime.RenewalInterval)
+	makeTunnelRequest(t, botListener, wantStatus, wantBody)
+	require.EqualValues(t, 1, certsIssued.Load())
+
+	// Advance the clock into the leeway period, and try once more. A new cert
+	// should be issued.
+	clock.Advance(bot.DefaultCredentialLifetime.TTL - bot.DefaultCredentialLifetime.RenewalInterval - time.Minute)
+	makeTunnelRequest(t, botListener, wantStatus, wantBody)
+	require.EqualValues(t, 2, certsIssued.Load())
 }

--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -143,14 +143,22 @@ func (s *TunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnpr
 	}
 	s.log.DebugContext(ctx, "Issued initial certificate for local proxy.")
 
+	// Attempt to provide a sensible cap for leeway values based on the
+	// configured and actual cert TTLs. This check is simple and imperfect, and
+	// the right set of unreasonable values can still trigger vaguely bad
+	// behavior.
+	issuedCertTTL := dbCert.Leaf.NotAfter.Sub(dbCert.Leaf.NotBefore)
+	effectiveConfiguredLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
+	realTTL := min(issuedCertTTL, effectiveConfiguredLifetime.TTL)
+
 	leeway := s.leeway
-	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
-	if leeway >= effectiveLifetime.TTL {
+	if leeway >= realTTL {
 		s.log.WarnContext(ctx,
 			"leeway is greater than the credential lifetime and will be "+
 				"ignored, be aware of potential failures due to clock drift",
-			"credential_ttl", effectiveLifetime.TTL,
+			"configured_ttl", effectiveConfiguredLifetime.TTL,
 			"configured_leeway", leeway,
+			"issued_cert_ttl", issuedCertTTL,
 		)
 		leeway = 0
 	}
@@ -312,7 +320,12 @@ func (s *TunnelService) issueCert(
 	}
 	s.log.InfoContext(ctx, "Certificate issued for tunnel proxy.")
 
-	return ident.TLSCert, nil
+	// The leaf isn't appended by the stdlib, so add it here so we can inspect
+	// the TTL downstream.
+	cert := ident.TLSCert
+	cert.Leaf = ident.X509Cert
+
+	return cert, nil
 }
 
 // String returns a human-readable string that can uniquely identify the

--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -144,11 +144,12 @@ func (s *TunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnpr
 	s.log.DebugContext(ctx, "Issued initial certificate for local proxy.")
 
 	leeway := s.leeway
-	if leeway >= s.defaultCredentialLifetime.TTL {
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
+	if leeway >= effectiveLifetime.TTL {
 		s.log.WarnContext(ctx,
 			"leeway is greater than the credential lifetime and will be "+
 				"ignored, be aware of potential failures due to clock drift",
-			"credential_ttl", s.defaultCredentialLifetime.TTL,
+			"credential_ttl", effectiveLifetime.TTL,
 			"configured_leeway", leeway,
 		)
 		leeway = 0

--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -45,6 +46,7 @@ func TunnelServiceBuilder(
 	cfg *TunnelConfig,
 	connCfg connection.Config,
 	defaultCredentialLifetime bot.CredentialLifetime,
+	leeway time.Duration,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
@@ -53,6 +55,7 @@ func TunnelServiceBuilder(
 		svc := &TunnelService{
 			connCfg:                   connCfg,
 			defaultCredentialLifetime: defaultCredentialLifetime,
+			leeway:                    leeway,
 			cfg:                       cfg,
 			proxyPinger:               deps.ProxyPinger,
 			botClient:                 deps.Client,
@@ -74,6 +77,7 @@ func TunnelServiceBuilder(
 type TunnelService struct {
 	connCfg                   connection.Config
 	defaultCredentialLifetime bot.CredentialLifetime
+	leeway                    time.Duration
 	cfg                       *TunnelConfig
 	proxyPinger               connection.ProxyPinger
 	log                       *slog.Logger
@@ -139,18 +143,29 @@ func (s *TunnelService) buildLocalProxyConfig(ctx context.Context) (lpCfg alpnpr
 	}
 	s.log.DebugContext(ctx, "Issued initial certificate for local proxy.")
 
+	leeway := s.leeway
+	if leeway >= s.defaultCredentialLifetime.TTL {
+		s.log.WarnContext(ctx,
+			"leeway is greater than the credential lifetime and will be "+
+				"ignored, be aware of potential failures due to clock drift",
+			"credential_ttl", s.defaultCredentialLifetime.TTL,
+			"configured_leeway", leeway,
+		)
+		leeway = 0
+	}
+
 	middleware := internal.ALPNProxyMiddleware{
 		OnNewConnectionFunc: func(ctx context.Context, lp *alpnproxy.LocalProxy) error {
 			ctx, span := tracer.Start(ctx, "TunnelService/OnNewConnection")
 			defer span.End()
 
 			// Check if the certificate needs reissuing, if so, reissue.
-			if err := lp.CheckDBCert(ctx, tlsca.RouteToDatabase{
+			if err := lp.CheckDBCertWithLeeway(ctx, tlsca.RouteToDatabase{
 				ServiceName: routeToDatabase.ServiceName,
 				Protocol:    routeToDatabase.Protocol,
 				Database:    routeToDatabase.Database,
 				Username:    routeToDatabase.Username,
-			}); err != nil {
+			}, leeway); err != nil {
 				s.log.InfoContext(ctx, "Certificate for tunnel needs reissuing.", "reason", err.Error())
 				cert, err := s.issueCert(ctx, routeToDatabase)
 				if err != nil {

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -243,7 +243,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 		// Convert the service config into the actual service type.
 		switch svcCfg := svcCfg.(type) {
 		case *database.TunnelConfig:
-			services = append(services, database.TunnelServiceBuilder(svcCfg, b.cfg.ConnectionConfig(), b.cfg.CredentialLifetime))
+			services = append(services, database.TunnelServiceBuilder(svcCfg, b.cfg.ConnectionConfig(), b.cfg.CredentialLifetime, b.cfg.Leeway))
 		case *example.Config:
 			services = append(services, example.ServiceBuilder(svcCfg))
 		case *ssh.MultiplexerConfig:
@@ -270,7 +270,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 		case *clientcredentials.UnstableConfig:
 			services = append(services, clientcredentials.ServiceBuilder(svcCfg, b.cfg.CredentialLifetime))
 		case *application.TunnelConfig:
-			services = append(services, application.TunnelServiceBuilder(svcCfg, b.cfg.ConnectionConfig(), b.cfg.CredentialLifetime))
+			services = append(services, application.TunnelServiceBuilder(svcCfg, b.cfg.ConnectionConfig(), b.cfg.CredentialLifetime, b.cfg.Leeway))
 		case *application.ProxyServiceConfig:
 			services = append(services, application.ProxyServiceBuilder(svcCfg, b.cfg.ConnectionConfig(), b.cfg.CredentialLifetime, alpnUpgradeCache))
 		case *workloadidentitysvc.X509OutputConfig:
@@ -292,6 +292,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 		Onboarding:         b.cfg.Onboarding,
 		InternalStorage:    b.cfg.Storage.Destination,
 		CredentialLifetime: b.cfg.CredentialLifetime,
+		Leeway:             b.cfg.Leeway,
 		FIPS:               b.cfg.FIPS,
 		Logger:             b.log,
 		ReloadCh:           b.cfg.ReloadCh,

--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -120,7 +120,10 @@ func ParsePrivateKeyPEM(bytes []byte) (crypto.Signer, error) {
 
 // VerifyCertificateExpiryWithLeeway checks the certificate's expiration status
 // with leeway. The provided leeway value is added to the current time and can
-// be used to account for potential client-side clock drift.
+// be used to account for potential client-side clock drift. Clients validating
+// a certificate is valid to attempt to connect to a server should use positive
+// leeway; servers that might want to give clients leeway should use a negative
+// value.
 func VerifyCertificateExpiryWithLeeway(c *x509.Certificate, clock clockwork.Clock, leeway time.Duration) error {
 	if clock == nil {
 		clock = clockwork.NewRealClock()

--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -118,12 +118,14 @@ func ParsePrivateKeyPEM(bytes []byte) (crypto.Signer, error) {
 	return keys.ParsePrivateKey(bytes)
 }
 
-// VerifyCertificateExpiry checks the certificate's expiration status.
-func VerifyCertificateExpiry(c *x509.Certificate, clock clockwork.Clock) error {
+// VerifyCertificateExpiryWithLeeway checks the certificate's expiration status
+// with leeway. The provided leeway value is added to the current time and can
+// be used to account for potential client-side clock drift.
+func VerifyCertificateExpiryWithLeeway(c *x509.Certificate, clock clockwork.Clock, leeway time.Duration) error {
 	if clock == nil {
 		clock = clockwork.NewRealClock()
 	}
-	now := clock.Now()
+	now := clock.Now().Add(leeway)
 
 	if now.Before(c.NotBefore) {
 		return x509.CertificateInvalidError{
@@ -140,6 +142,12 @@ func VerifyCertificateExpiry(c *x509.Certificate, clock clockwork.Clock) error {
 		}
 	}
 	return nil
+}
+
+// VerifyCertificateExpiryWithLeeway checks the certificate's expiration status
+// with zero leeway.
+func VerifyCertificateExpiry(c *x509.Certificate, clock clockwork.Clock) error {
+	return trace.Wrap(VerifyCertificateExpiryWithLeeway(c, clock, 0))
 }
 
 // VerifyTLSCertLeafExpiry checks a TLS certificate's expiration status.

--- a/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/file.golden
+++ b/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/file.golden
@@ -11,5 +11,6 @@ debug: false
 proxy_server: proxy.example.com:443
 credential_ttl: 1h0m0s
 renewal_interval: 20m0s
+leeway: 1m0s
 oneshot: false
 fips: false

--- a/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/stdout.golden
+++ b/tool/tbot/testdata/TestRun_Configure/all_parameters_provided#01/stdout.golden
@@ -11,5 +11,6 @@ debug: false
 proxy_server: proxy.example.com:443
 credential_ttl: 1h0m0s
 renewal_interval: 20m0s
+leeway: 1m0s
 oneshot: false
 fips: false

--- a/tool/tbot/testdata/TestRun_Configure/all_parameters_provided/file.golden
+++ b/tool/tbot/testdata/TestRun_Configure/all_parameters_provided/file.golden
@@ -14,5 +14,6 @@ debug: false
 auth_server: example.com
 credential_ttl: 42m0s
 renewal_interval: 21m0s
+leeway: 1m0s
 oneshot: true
 fips: true

--- a/tool/tbot/testdata/TestRun_Configure/all_parameters_provided/stdout.golden
+++ b/tool/tbot/testdata/TestRun_Configure/all_parameters_provided/stdout.golden
@@ -14,5 +14,6 @@ debug: false
 auth_server: example.com
 credential_ttl: 42m0s
 renewal_interval: 21m0s
+leeway: 1m0s
 oneshot: true
 fips: true

--- a/tool/tbot/testdata/TestRun_Configure/no_parameters_provided/file.golden
+++ b/tool/tbot/testdata/TestRun_Configure/no_parameters_provided/file.golden
@@ -10,5 +10,6 @@ storage:
 debug: false
 credential_ttl: 1h0m0s
 renewal_interval: 20m0s
+leeway: 1m0s
 oneshot: false
 fips: false

--- a/tool/tbot/testdata/TestRun_Configure/no_parameters_provided/stdout.golden
+++ b/tool/tbot/testdata/TestRun_Configure/no_parameters_provided/stdout.golden
@@ -10,5 +10,6 @@ storage:
 debug: false
 credential_ttl: 1h0m0s
 renewal_interval: 20m0s
+leeway: 1m0s
 oneshot: false
 fips: false


### PR DESCRIPTION
This adds some leeway to various parts of `tbot`, including the main identity renewal loop, the `application-tunnel`, and the `database-tunnel` service.

For context, the app and database tunnel services do not follow Machine ID's usual certificate renewal cycle and instead opt to renew certificates just-in-time when opening a connection if the certificate has expired per the local clock.

Unfortunately, the local clock is not always accurate, and if the certificate or underlying app session has already expired from the server's perspective, client requests can still fail until the local clock catches up and the certificate is refreshed.

To mitigate this, this change adds a `leeway` parameter to the service, configurable via YAML, with a default value of 1m. This is added to the current time when certificate validity is checked. This means that, in the worst case, certificates will be refreshed to early rather than too late.

See also: #64284

changelog: MWI: Add 1 minute configurable leeway to `application-tunnel` certificate renewals

## Manual Test Plan

Recommended config:
```yaml
# tbot config file generated by `configure` command
version: v2
storage:
  type: directory
  path: ./storage
  symlinks: try-secure
  acls: "off"
services:
  - type: application-tunnel
    name: application-tunnel-1
    listen: tcp://localhost:1234
    app_name: dumper
debug: false
join_uri: ...
credential_ttl: 1m30s
renewal_interval: 30s
oneshot: false
fips: false
leeway: 1m
```

Note the very short `credential_ttl` and `renewal_interval`. Since `renewal_interval + leeway >= credential_ttl`, it should trigger the internal identity expiry detection and force an early renewal, e.g.:
```
2026-03-06T22:12:39.843-07:00 WARN  The bot identity appears to be expired and will not be used to authenticate the identity renewal. If it is possible to rejoin, a new bot instance will be created. If this occurs repeatedly, ensure the local machine's clock is properly synchronized, the certificate TTL is adjusted to your environment, and that no external issues will prevent the bot from renewing its identity on schedule. now:2026-03-06T22:13:39.842-07:00 expiry:2026-03-07T05:13:39.000Z ttl:1m30s renewal_interval:30s leeway:1m0s identity/service.go:558
```

- [x] Internal identity: observe renewal failure with negative leeway
- [x] Internal identity: observe early renewal with positive leeway (if expiry detection is triggered, requires renewal interval config as noted above) 
- [x] App tunnel: observe failures with negative leeway
- [x] App tunnel: observe early renewal with positive leeway