### PR TITLE
MWI: Estimate clock drift with ping response

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -91,6 +91,14 @@ type Config struct {
 	// UpdateID is used to vary the webapi response based on the
 	// client's Managed Update ID.
 	UpdateID string
+	// ServerTimestampCallback is an optional callback that, if present,
+	// is given the parsed timestamp from the returned Date header, along with
+	// any parsing errors.
+	// Note that this should not be used for precise time sync, and is intended
+	// to help identify significant clock drift in clients. This does not
+	// account for round trip time, and the HTTP Date header only guarantees
+	// second precision, so assume +/- 1 second.
+	ServerTimestampCallback func(serverTime time.Time, err error)
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -220,6 +228,10 @@ func findWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	if cfg.ServerTimestampCallback != nil {
+		handleTimestampCallback(resp, cfg.ServerTimestampCallback)
+	}
+
 	defer resp.Body.Close()
 	pr := &PingResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(pr); err != nil {
@@ -276,6 +288,10 @@ func pingWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 	}
 	defer resp.Body.Close()
 
+	if cfg.ServerTimestampCallback != nil {
+		handleTimestampCallback(resp, cfg.ServerTimestampCallback)
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		slog.DebugContext(req.Context(), "Received unsuccessful ping response", "code", resp.StatusCode)
 
@@ -299,6 +315,24 @@ func pingWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 	}
 
 	return pr, nil
+}
+
+// handleTimestampCallback extracts the date header from the response and calls
+// the callback with the parse result (or parse error)
+func handleTimestampCallback(resp *http.Response, cb func(serverTime time.Time, err error)) {
+	val := resp.Header.Get("Date")
+	if val == "" {
+		cb(time.Time{}, trace.BadParameter("no date header in response"))
+		return
+	}
+
+	t, err := http.ParseTime(val)
+	if err != nil {
+		cb(time.Time{}, trace.BadParameter("could not parse date header: %v", err))
+		return
+	}
+
+	cb(t, nil)
 }
 
 // GetMOTD retrieves the Message Of The Day from the web proxy.

--- a/lib/tbot/bot/connection/ping.go
+++ b/lib/tbot/bot/connection/ping.go
@@ -21,6 +21,7 @@ package connection
 import (
 	"context"
 	"net"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -37,6 +38,13 @@ type ProxyPinger interface {
 // ProxyPong is the response of a proxy ping request.
 type ProxyPong struct {
 	*webclient.PingResponse
+
+	// ServerTime is the timestamp returned by the server. Will be zero if no
+	// timestamp could be extracted from the pong response.
+	ServerTime time.Time
+
+	// ClientTime is the timestamp at which the ping was received.
+	ClientTime time.Time
 
 	// StaticProxyAddress is the user-configured proxy address when the user
 	// requests their given address is preferred over pinging the proxy or auth
@@ -70,4 +78,18 @@ func (p *ProxyPong) ProxySSHAddr() (string, error) {
 		return "", trace.Wrap(err)
 	}
 	return net.JoinHostPort(host, port), nil
+}
+
+// ClockDriftEstimate attempts to return an estimate of clock drift relative to
+// the server's reported time. If no server time is available, returns
+// (0, false). Client time is subtracted from server time, so positive values
+// indicate the server is ahead of the client; negative values indicate the
+// client is ahead of the server. Note that the HTTP Date header only provides
+// 1 second precision, so assume +/- 1 second accuracy at best.
+func (p *ProxyPong) ClockDriftEstimate() (time.Duration, bool) {
+	if p.ServerTime.IsZero() {
+		return 0, false
+	}
+
+	return p.ServerTime.Sub(p.ClientTime), true
 }

--- a/lib/tbot/internal/caching_proxy_pinger.go
+++ b/lib/tbot/internal/caching_proxy_pinger.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -100,11 +101,23 @@ func (c *CachingProxyPinger) Ping(ctx context.Context) (*connection.ProxyPong, e
 		return nil, trace.BadParameter("unsupported address kind: %v", c.connCfg.AddressKind)
 	}
 
+	var clientTime time.Time
+	var serverTime time.Time
+
 	c.logger.DebugContext(ctx, "Pinging proxy", "addr", addr)
 	res, err := webclient.Find(&webclient.Config{
 		Context:   ctx,
 		ProxyAddr: addr,
 		Insecure:  c.connCfg.Insecure,
+		ServerTimestampCallback: func(t time.Time, err error) {
+			clientTime = time.Now()
+
+			if err != nil {
+				c.logger.DebugContext(ctx, "Could not extract server time to estimate clock drift", "error", err)
+			} else {
+				serverTime = t
+			}
+		},
 	})
 	if err != nil {
 		c.logger.ErrorContext(ctx, "Failed to ping proxy", "error", err)
@@ -112,7 +125,22 @@ func (c *CachingProxyPinger) Ping(ctx context.Context) (*connection.ProxyPong, e
 	}
 	c.logger.DebugContext(ctx, "Successfully pinged proxy", "pong", res)
 
-	c.cachedValue = &connection.ProxyPong{PingResponse: res}
+	c.cachedValue = &connection.ProxyPong{
+		PingResponse: res,
+		ClientTime:   clientTime,
+		ServerTime:   serverTime,
+	}
+
+	if delta, ok := c.cachedValue.ClockDriftEstimate(); ok {
+		c.logger.DebugContext(ctx, "Clock drift estimate",
+			"client_time", clientTime,
+			"server_time", serverTime,
+			"delta", delta,
+		)
+	} else {
+		c.logger.DebugContext(ctx, "No clock drift estimate available")
+	}
+
 	if c.connCfg.AddressKind == connection.AddressKindProxy && c.connCfg.StaticProxyAddress {
 		c.cachedValue.StaticProxyAddress = addr
 	}


### PR DESCRIPTION
This adds an estimate of HTTP clock drift using the proxy ping response's `Date` header, which contains a timestamp from the server. While it can't provide impressive precision, this can help identify cases of severe clock drift.

To avoid changing the `webclient` function signatures, this adds an optional callback to `webapi.Config` which returns the parsed date header if one exists.

Currently, this simply prints the estimated delta relative to the server as a debug log. This could potentially be factored into certificate TTL calcuations, but is probably most valuable as debugging information.

changelog: MWI: Log estimated clock drift relative to the server