### PR TITLE
Add Device Trust for iOS docs

### DIFF
--- a/docs/pages/identity-governance/device-trust/ios-admin-guide.mdx
+++ b/docs/pages/identity-governance/device-trust/ios-admin-guide.mdx
@@ -1,0 +1,257 @@
+---
+title: Set Up Device Trust for iOS and iPadOS
+sidebar_label: iOS & iPadOS Setup (Admin)
+description: Set up Device Trust for iOS and iPadOS devices
+tags:
+ - how-to
+ - identity-governance
+ - resiliency
+enterprise: Identity Governance
+---
+
+{/* TODO: Replace (=teleport.major_version=) placeholder once version is known. */}
+
+<Admonition type="note">
+Device Trust for iOS requires Teleport v(=teleport.major_version=) or later.
+</Admonition>
+
+This guide explains how to configure Device Trust for iOS and iPadOS devices.
+After completing this guide, users on managed iPhones and iPads will be able to
+enroll their devices and access resources protected by Device Trust through the
+Web UI.
+
+Device Trust for iOS and iPadOS works through a mobile app (**TODO: app name**) that
+performs enrollment and device authentication on behalf of the Web UI. The app
+communicates with Teleport directly and requires a Managed App Configuration
+from your MDM to identify the device.
+
+## How it works
+
+The mobile app uses the device's Secure Enclave to generate and store a private key,
+and it reads the device serial number from a configuration pushed by your MDM.
+
+The overall flow has two parts:
+
+1. **Enrollment** - A one-time process where the user enrolls their mobile
+   device as a trusted device.
+2. **Device authentication** - On each Web UI login from the mobile device, the
+   user is prompted to open the app, which performs a device authentication
+   ceremony. Upon success, the web session is upgraded with Device Trust
+   extensions.
+
+Both parts require the device to be managed by an MDM and to have received a
+Managed App Configuration containing the device serial number.
+
+## Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)
+
+- An MDM solution that supports [Managed App
+  Configuration](https://developer.apple.com/library/archive/samplecode/sc2279/Introduction/Intro.html)
+  (for example, Jamf Pro or Microsoft Intune).
+- iOS or iPadOS devices enrolled in the MDM. The MDM must be used to push the
+  Teleport mobile app (**TODO: app name**) to these devices.
+- Devices registered in Teleport's inventory. If you use Jamf Pro or Intune,
+  see the [Jamf Pro Integration](./jamf-integration.mdx) or [Microsoft Intune
+  Integration](./intune-integration.mdx) guides to set up automatic inventory
+  sync. If you use a different MDM, you will need to sync the inventory
+  yourself, for example by using `tctl devices add`.
+
+<Admonition type="tip">
+Any MDM that supports Managed App Configuration can be used to push the serial
+number to the mobile app. However, you also need to sync devices into
+Teleport's inventory. If your MDM does not have a built-in Teleport integration,
+you will need to implement the inventory sync yourself.
+</Admonition>
+
+## Step 1/3. Configure the MDM
+
+You must use your MDM to push the Teleport mobile app to managed devices and
+create a Managed App Configuration that provides the device serial number to the
+app.
+
+<Tabs>
+<TabItem label="Jamf Pro">
+
+#### Push the app to devices
+
+1. In Jamf Pro, go to **Devices** > **Mobile Device Apps**.
+2. Add the Teleport mobile app (**TODO: app name**) from the App Store if it is
+   not already listed.
+3. Under **Scope**, assign the app to the devices that should use Device Trust.
+4. Save and distribute the app.
+
+#### Configure the app with the device serial number
+
+1. In Jamf Pro, go to **Devices** > **Mobile Device Apps** and select the
+   Teleport mobile app.
+2. Go to **App Configuration**.
+3. Under **Preferences**, add the following configuration:
+
+```xml
+<dict>
+  <key>serialNumber</key>
+  <string>$SERIALNUMBER</string>
+</dict>
+```
+
+Jamf Pro replaces `$SERIALNUMBER` with the actual serial number of each device
+at the time of deployment.
+
+4. Save the configuration.
+
+</TabItem>
+<TabItem label="Microsoft Intune">
+
+#### Push the app to devices
+
+1. In the [Microsoft Intune admin center](https://intune.microsoft.com), go to
+   **Apps** > **All apps** and select **Create**.
+2. Select **iOS store app** as the app type and search for the Teleport mobile
+   app (**TODO: app name**).
+3. Under **Assignments**, assign the app as **Required** for the device groups
+   that should use Device Trust.
+4. Select **Create** to save.
+
+#### Configure the app with the device serial number
+
+1. Go to **Apps** > **Manage apps** > **Configuration** and select **Create** >
+   **Managed devices**.
+2. Enter a name for the policy (for example, "Teleport Device Trust").
+3. Select **iOS/iPadOS** as the platform.
+4. Select the Teleport mobile app (**TODO: app name**) as the targeted app.
+5. Under **Configuration settings format**, select **Use configuration designer** and
+   add:
+
+   | Configuration key | Value type | Configuration value |
+   |---|---|---|
+   | `serialNumber` | `String` | `{{serialnumber}}` |
+
+   Intune replaces `{{serialnumber}}` with the actual serial number of each
+   device.
+
+6. Under **Assignments**, assign the policy to the same device groups as above.
+7. Select **Create** to save the policy.
+
+</TabItem>
+<TabItem label="Other MDMs">
+
+#### Push the app to devices
+
+Use your MDM to distribute the Teleport mobile app (**TODO: app name**) to the
+devices that should use Device Trust. Consult your MDM's documentation for
+instructions on distributing iOS apps.
+
+#### Configure the app with the device serial number
+
+Create a Managed App Configuration policy targeting the Teleport mobile app
+with the following payload:
+
+```xml
+<dict>
+  <key>serialNumber</key>
+  <string>DEVICE_SERIAL_NUMBER</string>
+</dict>
+```
+
+Replace `DEVICE_SERIAL_NUMBER` with your MDM's template variable for the
+device serial number. Consult your MDM's documentation for the correct variable
+syntax.
+
+</TabItem>
+</Tabs>
+
+## Step 2/3. Configure user permissions
+
+Users who enroll mobile devices need the `mobile_device.create_enroll_token`
+permission. This permission allows the enrollment flow to issue a token that
+authorizes the mobile app to complete enrollment on behalf of the user.
+
+Create a role that grants this permission. Save the following as
+`mobile-device-enrollment.yaml`:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: mobile-device-enrollment
+spec:
+  allow:
+    rules:
+    - resources: ['mobile_device']
+      verbs: ['create_enroll_token']
+```
+
+Create the role and assign it to users who should be able to enroll mobile
+devices:
+
+```code
+$ tctl create -f mobile-device-enrollment.yaml
+$ tctl edit users/alice
+```
+
+```diff
+kind: user
+metadata:
+  name: alice
+  # (...)
+spec:
+  roles:
+  - access
+  - editor
++ - mobile-device-enrollment
+  # (...)
+version: v2
+```
+
+(!docs/pages/includes/create-role-using-web.mdx!)
+
+## Step 3/3. Verify the setup
+
+To verify that the setup is complete:
+
+1. Confirm that the MDM configuration policy is deployed to at least one test
+   device.
+2. Confirm that the device is registered in Teleport's inventory:
+   ```code
+   $ tctl devices ls
+   Asset Tag    OS    Source Enroll Status Owner Device ID
+   ------------ ----- ------ ------------- ----- ------------------------------------
+   DNQMV0X1Q2   iOS          not enrolled        3f8a2b1c-9d4e-5f6a-7b8c-9d0e1f2a3b4c
+   ```
+3. Confirm that the user has the `mobile-device-enrollment` role (or another
+   role with the `mobile_device.create_enroll_token` permission).
+4. Ask the user to follow the [Enroll a Mobile Device](./ios-user-guide.mdx)
+   guide.
+
+## Troubleshooting
+
+### The mobile app says the MDM configuration was not received
+
+The device has not received the Managed App Configuration from the MDM. Check
+the following:
+
+- The configuration policy targets the correct app and the correct device group.
+- The device has synced with the MDM recently. Some MDMs let the user manually
+  trigger a sync (for example, Intune), while others require waiting for the
+  next scheduled sync.
+
+### The mobile app says the serial number is missing
+
+The device received a Managed App Configuration, but the `serialNumber` key
+is missing or empty. Check that the configuration payload includes the
+`serialNumber` key with the correct MDM template variable.
+
+### Enrollment fails with a permission error
+
+The user does not have the `mobile_device.create_enroll_token` permission.
+Assign a role with this permission to the user, as described in [Step
+2/3](#step-23-configure-user-permissions).
+
+## Next steps
+
+- [Enroll a Mobile Device (User Guide)](./ios-user-guide.mdx)
+- [Enforce Device Trust](./enforcing-device-trust.mdx)
+- [Device Management](./device-management.mdx)
+- [Jamf Pro Integration](./jamf-integration.mdx)
+- [Microsoft Intune Integration](./intune-integration.mdx)

--- a/docs/pages/identity-governance/device-trust/ios-user-guide.mdx
+++ b/docs/pages/identity-governance/device-trust/ios-user-guide.mdx
@@ -1,0 +1,152 @@
+---
+title: Device Trust on iOS & iPadOS
+sidebar_label: iOS & iPadOS User Guide
+description: Enroll your iPhone or iPad and use Device Trust with the Web UI
+tags:
+ - how-to
+ - identity-governance
+ - resiliency
+enterprise: Identity Governance
+---
+
+{/* TODO: Replace (=teleport.major_version=) placeholder once version is known. */}
+
+<Admonition type="note">
+Device Trust for iOS requires Teleport v(=teleport.major_version=) or later.
+</Admonition>
+
+This guide explains how to enroll your iPhone or iPad as a trusted device and
+use Device Trust when accessing Teleport resources through the Web UI on your
+mobile device.
+
+## Prerequisites
+
+- Your device must be managed by your organization's MDM (Mobile Device
+  Management). If you are unsure, check with your IT administrator.
+- The Teleport mobile app (**TODO: app name**) must be installed on your device.
+  Your IT administrator pushes the app to managed devices through MDM. If the
+  app is not installed, contact your IT administrator.
+- Access to the Teleport Web UI from a desktop or laptop computer (used during
+  enrollment to scan a QR code and approve the enrollment request).
+
+## Enroll your device
+
+Enrollment is a one-time process that registers your mobile device as a trusted
+device in Teleport. After enrollment, you can use Device Trust on the Web UI
+every time you log in from this device.
+
+### Step 1/4. Start enrollment in the Web UI
+
+Open the Teleport Web UI on a desktop or laptop computer and navigate to
+**Account Settings**. Click **Enroll Mobile Device**. A modal will appear with
+a QR code.
+
+<Admonition type="tip">
+If you are starting this process from the mobile device itself (rather than a
+desktop), the modal will include a direct link in addition to the QR code. Tap
+the link instead of scanning.
+</Admonition>
+
+### Step 2/4. Scan the QR code with your mobile device
+
+On the iPhone or iPad you want to enroll, scan the QR code using the camera
+app or any QR code reader. This opens a page in Safari with step-by-step
+instructions:
+
+1. **Verify the app is installed** - The page will remind you that the Teleport
+   mobile app must be installed. The app is pushed to your device by your IT
+   administrator through MDM. If it is not installed, contact your IT
+   administrator before continuing.
+2. **Open the app** - Tap the link on the page to open the Teleport mobile app.
+
+<Admonition type="note">
+If you see a message that "Safari cannot open the page because the address is
+invalid", the Teleport mobile app is not installed on your device. Contact your
+IT administrator to have the app pushed to your device through MDM.
+</Admonition>
+
+### Step 3/4. Approve enrollment with MFA
+
+After the app opens, it collects device information and sends an enrollment
+request to Teleport. You need to approve this request from the Web UI.
+
+Go back to your desktop or laptop computer where you opened the **Enroll Mobile
+Device** modal. The modal will show a pending enrollment request. Approve it
+using your MFA method (for example, a hardware security key or biometric
+authenticator).
+
+<Admonition type="tip">
+If you started the process on your mobile device and cannot use your MFA method
+on it, open the Teleport Web UI on a desktop or laptop computer and navigate to
+**Account Settings** > **Enroll Mobile Device**. The modal will show the pending
+request, and you can approve it from there.
+</Admonition>
+
+### Step 4/4. Enrollment complete
+
+Once the enrollment request is approved, the mobile app completes the enrollment
+ceremony automatically. You will see a confirmation in the app that your device
+is now enrolled.
+
+Your device is now registered as a trusted device in Teleport.
+
+## Log in with Device Trust
+
+After enrollment, Device Trust is used automatically each time you log in to the
+Teleport Web UI from your enrolled mobile device.
+
+1. Open the Teleport Web UI in Safari (or any browser) on your iPhone or iPad.
+2. Log in as usual.
+3. After login, the Web UI will prompt you to complete Device Trust
+   verification. Tap the prompt to open the Teleport mobile app.
+4. The app will ask you to confirm your identity using biometrics if available
+   (Face ID or Touch ID) or your device passcode.
+5. After verification, the app opens your browser and the Web UI confirms the
+   device authentication. Your session is now protected by Device Trust.
+
+## Troubleshooting
+
+### The app says the MDM configuration was not received
+
+Your device has not received the necessary configuration from your
+organization's MDM. Contact your IT administrator and ask them to verify that:
+
+- The Teleport mobile app is targeted by the MDM configuration policy.
+- Your device has synced with the MDM recently.
+
+Some MDMs let you manually trigger a sync from the device settings. For
+example, on Intune, open the Company Portal app and tap **Check status**.
+
+### The app says the serial number is missing
+
+Your device received a configuration from the MDM, but the serial number is
+not included. Contact your IT administrator and ask them to check the Managed
+App Configuration for the Teleport mobile app.
+
+### The app shows an error about the device not being registered
+
+Your device's serial number is not in Teleport's inventory. Contact your IT
+administrator and ask them to verify that your device appears in Teleport's
+device inventory (`tctl devices ls`).
+
+### The enrollment request was not approved in time
+
+Enrollment requests expire after 5 minutes. If the request timed out, start the
+enrollment process again from **Account Settings** > **Enroll Mobile Device** in
+the Web UI.
+
+### The Device Trust prompt does not appear after login
+
+This can happen if your device is not enrolled. Follow [the enrollment steps](#enroll-your-device)
+above.
+
+### Safari says the address is invalid when tapping the link
+
+The Teleport mobile app is not installed on your device. Contact your IT
+administrator to have the app pushed to your device through MDM.
+
+## Next steps
+
+- If you are an administrator setting up Device Trust for iOS, see [Set Up
+  Device Trust for iOS](./ios-admin-guide.mdx).
+- To learn more about Device Trust concepts, see [Device Trust](./device-trust.mdx).


### PR DESCRIPTION
* [Admin guide](https://r7s-device-trust-ios-docs.d1v2yqnl3ruxch.amplifyapp.com/docs/identity-governance/device-trust/ios-admin-guide/)
* [User guide](https://r7s-device-trust-ios-docs.d1v2yqnl3ruxch.amplifyapp.com/docs/identity-governance/device-trust/ios-user-guide/)

## TODO

- [ ] Add a note about Private Relay (https://github.com/gravitational/teleport.e/pull/7959#discussion_r3413446777).
  - Put it in prerequisites. 

## Related links

* [RFD 32e](https://github.com/gravitational/teleport.e/pull/7959)
* [Demo of logging in to the Web UI using a proof-of-concept version of the app](https://drive.google.com/file/d/1NzrrNf5BX8-QOw0DhP_gn5woKELsO--H/view?usp=sharing)
* [Enrollment diagram](https://github.com/gravitational/teleport.e/blob/rfd/0032e-device-trust-ios/rfd/0032e-device-trust-ios.md#enrollment)
* [Device auth diagram](https://github.com/gravitational/teleport.e/blob/rfd/0032e-device-trust-ios/rfd/0032e-device-trust-ios.md#device-auth)