### PR TITLE
Add implementation plan steps to Get Started #1

### DIFF
--- a/docs/pages/get-started/deploy-cloud.mdx
+++ b/docs/pages/get-started/deploy-cloud.mdx
@@ -17,20 +17,54 @@ To get started, simply sign up for a 14-day free trial. We'll automatically prov
 
 ## Deploy your cluster
 
+Once you sign up for a Teleport Cloud account, Teleport-managed infrastructure
+spins up the Auth Service and Proxy Service for you. 
+
+### Initial setup
+
 1. Go to [goteleport.com/signup](https://goteleport.com/signup)
 2. Follow the sign-up steps to launch your cluster
 
 When setup is finished, you'll have a production-grade Teleport cluster
 configured with secure defaults, automatic updates, and built-in scalability.
 
-The signup flow creates a local Teleport user with the `editor` and `access`
-roles, allowing the user to perform administrative tasks in your cluster and
-connect to any Teleport-protected resource.
+The signup flow creates a local Teleport user with the following preset roles:
+
+|Role|Permissions|
+|---|---|
+|`editor`|Perform administrative tasks in your cluster|
+|`access`|Connect to any Teleport-protected resource|
+|`auditor`|View audit events and session recordings|
 
 Since this user has almost total privileges, you should treat this identity as a
 fallback after completing initial setup operations. In Step 3 of the Get Started
 series, we will show you how to set up a more authentication and role-based
 access control for day-to-day Teleport usage.
+
+### Create a backup local user
+
+We recommend having more than one local user to prevent lockout. As with the
+default user, we recommend treating this identity as a fallback, rather than
+relying on it for day-to-day usage:
+
+
+1. On your workstation, run the following command. `tctl` is a client tool for
+   configuring the Teleport Auth Service:
+
+   ```code
+   $ sudo tctl users add teleport-admin-backup --roles=editor,access,auditor --logins=root,ubuntu,ec2-user
+   ```
+
+   The command prints a message similar to the following:
+   
+   ```text
+   User "teleport-admin-backup" has been created but requires a password. Share this URL with the user to complete user setup, link is valid for 1h:
+   https://teleport.example.com:443/web/invite/123abc456def789ghi123abc456def78
+   
+   NOTE: Make sure teleport.example.com:443 points at a Teleport proxy which users can access.
+   ```
+
+1. Visit the provided URL in order to create your Teleport user.
 
 ## Save your recovery codes
 

--- a/docs/pages/get-started/deploy-cloud.mdx
+++ b/docs/pages/get-started/deploy-cloud.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Step 1 - Sign up for Teleport Enterprise Cloud"
 description: "Sign up for Teleport Enterprise Cloud and deploy your hosted cluster."
-toc_max_heading_level: 2
 tags:
   - get-started
   - platform-wide
@@ -38,8 +37,8 @@ The signup flow creates a local Teleport user with the following preset roles:
 
 Since this user has almost total privileges, you should treat this identity as a
 fallback after completing initial setup operations. In Step 3 of the Get Started
-series, we will show you how to set up a more authentication and role-based
-access control for day-to-day Teleport usage.
+series, we will show you how to set up a more granular authentication and
+role-based access control for day-to-day Teleport usage.
 
 ### Create a backup local user
 
@@ -47,9 +46,12 @@ We recommend having more than one local user to prevent lockout. As with the
 default user, we recommend treating this identity as a fallback, rather than
 relying on it for day-to-day usage:
 
+1. Install `tctl` on your system. `tctl` is a client tool for configuring the
+   Teleport Auth Service. To install `tctl`, visit [Download Client
+   Tools](https://goteleport.com/download/client-tools/), select your platform,
+   and choose "CLI Client Tools" in the **Download Type** menu.
 
-1. On your workstation, run the following command. `tctl` is a client tool for
-   configuring the Teleport Auth Service:
+1. On your workstation, run the following command:
 
    ```code
    $ sudo tctl users add teleport-admin-backup --roles=editor,access,auditor --logins=root,ubuntu,ec2-user

--- a/docs/pages/get-started/deploy-cloud.mdx
+++ b/docs/pages/get-started/deploy-cloud.mdx
@@ -15,17 +15,45 @@ Infrastructure and certificates are managed for you. All that's left is deployin
 
 To get started, simply sign up for a 14-day free trial. We'll automatically provision and manage a fully featured Teleport cluster in a dedicated tenant with a unique `example.teleport.sh` domain.
 
-**To deploy your cluster:**
+## Deploy your cluster
 
 1. Go to [goteleport.com/signup](https://goteleport.com/signup)
 2. Follow the sign-up steps to launch your cluster
 
-When setup is finished, you'll have a production-grade Teleport cluster configured with secure defaults, automatic updates, and built-in scalability.
+When setup is finished, you'll have a production-grade Teleport cluster
+configured with secure defaults, automatic updates, and built-in scalability.
 
-## Next step: Connect infrastructure
+The signup flow creates a local Teleport user with the `editor` and `access`
+roles, allowing the user to perform administrative tasks in your cluster and
+connect to any Teleport-protected resource.
 
-At this point, you've launched your own Teleport Enterprise Cloud cluster and created a user in the process. You can now move on to the next step of connecting your infrastructure.
+Since this user has almost total privileges, you should treat this identity as a
+fallback after completing initial setup operations. In Step 3 of the Get Started
+series, we will show you how to set up a more authentication and role-based
+access control for day-to-day Teleport usage.
+
+## Save your recovery codes
+
+During signup, Teleport generates recovery codes for your account. Store them
+securely in an offline location. If you lose access to your multi-factor
+authentication device, you will need these codes to regain access.
+
+![A screenshot showing the Teleport recovery code view](../../img/cloud/recovery-codes.png)
+
+If you forgot to copy your recovery codes, you can navigate to
+`/web/account/security` and click **Generate new recovery codes**.
+
+<Admonition type="danger">
+
+If you are locked out of your account and do not have recovery codes, the only
+recourse is to set up a new Teleport Enterprise Cloud account.
+
+</Admonition>
+
+## Next step: Enroll resources
+
+At this point, you've launched your own Teleport Enterprise Cloud cluster and created a local admin user. You can now move on to the next step of enrolling your infrastructure resources.
 
 <div style={{ marginTop: 'var(--m-4)' }}>
-  <Button style={{ padding: '0 var(--m-2)' }} as="link" href="../connect/" variant="primary" shape="lg">Step 2 - Connect infrastructure <Icon name="arrowRight" inline size="sm"/> </Button>
+  <Button style={{ padding: '0 var(--m-2)' }} as="link" href="../connect/" variant="primary" shape="lg">Step 2 - Enroll resources <Icon name="arrowRight" inline size="sm"/> </Button>
 </div>

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -286,7 +286,7 @@ allowed to log into SSH hosts as any of the principals `root`, `ubuntu`, or
    Service:
 
    ```code
-   $ sudo tctl users add teleport-admin --roles=editor,access --logins=root,ubuntu,ec2-user
+   $ sudo tctl users add teleport-admin --roles=editor,access,auditor --logins=root,ubuntu,ec2-user
    ```
 
    The command prints a message similar to the following:
@@ -302,10 +302,14 @@ allowed to log into SSH hosts as any of the principals `root`, `ubuntu`, or
 
 1. Visit the provided URL in order to create your Teleport user.
 
-   The signup flow creates a local Teleport user with the `editor` and `access`
-   roles, allowing the user to perform administrative tasks in your cluster and
-   connect to any Teleport-protected resource.
+   The signup flow creates a local Teleport user with the following preset roles:
    
+   |Role|Permissions|
+   |---|---|
+   |`editor`|Perform administrative tasks in your cluster|
+   |`access`|Connect to any Teleport-protected resource|
+   |`auditor`|View audit events and session recordings|
+
    Since this user has almost total privileges, you should treat this identity
    as a fallback after completing initial setup operations, and define other
    roles and identities for day-to-day usage.
@@ -330,6 +334,11 @@ allowed to log into SSH hosts as any of the principals `root`, `ubuntu`, or
      ```
    
    </Admonition>
+
+1. [Recommended] Repeat these steps to create a second local user with
+   administrative privileges. We recommend more than one local user to prevent
+   lockout. As with the first identity you created, treat this one as a fallback
+   rather than an identity for day-to-day usage.
 
 1. Teleport enforces the use of multi-factor authentication by default. It
    supports one-time passwords (OTP) and multi-factor authenticators (WebAuthn).

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -302,6 +302,14 @@ allowed to log into SSH hosts as any of the principals `root`, `ubuntu`, or
 
 1. Visit the provided URL in order to create your Teleport user.
 
+   The signup flow creates a local Teleport user with the `editor` and `access`
+   roles, allowing the user to perform administrative tasks in your cluster and
+   connect to any Teleport-protected resource.
+   
+   Since this user has almost total privileges, you should treat this identity
+   as a fallback after completing initial setup operations, and define other
+   roles and identities for day-to-day usage.
+
    <Admonition
      type="tip"
      title="OS User Mappings"

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -22,6 +22,9 @@ The Teleport cluster consists of two services:
 - **Teleport Proxy Service:** The cluster frontend, which handles user requests,
   forwards user credentials to the Auth Service, and communicates with Teleport
   instances that enable access to specific resources in your infrastructure.
+- **Teleport SSH Service:** An SSH server that enforces Teleport access
+  controls, records sessions, and logs activity as Teleport audit events,
+  enabling you to protect a Linux server with Teleport.
 
 ![Architecture of the setup you will complete in this
 guide](../../img/linux-server-diagram.png)


### PR DESCRIPTION
See #63019

Add instructions to the Get Started flow that we recommend for new customers following the Teleport implementation plan, including:

1. Explain that a Cloud account comes with a local user with an admin role for initial setup.
1. Tell Cloud users to store their recovery codes.
1. Indicate that the user we create is for initial admin operations.