### PR TITLE
[v18][vnet] fix: forward proxy-port traffic to support web apps invisible to VNet

### DIFF
--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -116,7 +117,20 @@ type undecidedHandler struct {
 	// decidedHandler will be set when it's decided which target this handler
 	// should actually forward connections to.
 	decidedHandler tcpHandler
+	// softWebHandler is a temporary fallback for proxy-port traffic when the
+	// FQDN currently only matches a cluster.
+	//
+	// We keep this as a short-lived decision to avoid re-querying ResolveFQDN on
+	// every browser connection while still allowing the handler to refresh and
+	// pick up later app/role state changes.
+	softWebHandler       tcpHandler
+	softWebHandlerExpiry time.Time
 }
+
+// softWebHandlerTTL bounds how long we keep the temporary proxy-port fallback.
+// It should be short enough to pick up newly available app matches quickly,
+// while long enough to avoid excessive resolver RPCs for normal web traffic.
+const softWebHandlerTTL = 15 * time.Second
 
 type undecidedHandlerConfig struct {
 	*tcpHandlerResolverConfig
@@ -151,9 +165,35 @@ func (h *undecidedHandler) setDecidedHandler(handler tcpHandler) {
 	h.decidedHandler = handler
 }
 
+func (h *undecidedHandler) getSoftWebHandler(localPort uint16) tcpHandler {
+	if localPort != h.webProxyPort {
+		return nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.softWebHandler == nil {
+		return nil
+	}
+	if h.cfg.clock.Now().After(h.softWebHandlerExpiry) {
+		h.softWebHandler = nil
+		return nil
+	}
+	return h.softWebHandler
+}
+
+func (h *undecidedHandler) setSoftWebHandler(handler tcpHandler) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.softWebHandler = handler
+	h.softWebHandlerExpiry = h.cfg.clock.Now().Add(softWebHandlerTTL)
+}
+
 func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uint16, connector func() (net.Conn, error)) error {
 	if decidedHandler := h.getDecidedHandler(); decidedHandler != nil {
 		return decidedHandler.handleTCPConnector(ctx, localPort, connector)
+	}
+	if softWebHandler := h.getSoftWebHandler(localPort); softWebHandler != nil {
+		return softWebHandler.handleTCPConnector(ctx, localPort, connector)
 	}
 
 	// Handling an incoming TCP connection but we're not sure what this
@@ -182,6 +222,16 @@ func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uin
 		log.DebugContext(ctx, "Resolved FQDN to a matched web app")
 		webAppHandler := newWebAppHandler(h.cfg.webProxyAddr, h.webProxyPort)
 		h.setDecidedHandler(webAppHandler)
+		return webAppHandler.handleTCPConnector(ctx, localPort, connector)
+	}
+	if matchedCluster := resp.GetMatchedCluster(); matchedCluster != nil && localPort == h.webProxyPort {
+		// If matched a cluster on the proxy port, temporarily treat this as a
+		// web app target and proxy to the web proxy. This preserves browser
+		// access when role assumptions visible to web and Connect are temporarily
+		// out of sync (e.g. when an access request was assumed in web UI only).
+		log.DebugContext(ctx, "Resolved FQDN to a matched cluster on web proxy port")
+		webAppHandler := newWebAppHandler(h.cfg.webProxyAddr, h.webProxyPort)
+		h.setSoftWebHandler(webAppHandler)
 		return webAppHandler.handleTCPConnector(ctx, localPort, connector)
 	}
 	if matchedCluster := resp.GetMatchedCluster(); matchedCluster != nil && localPort == 22 {

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -33,6 +33,7 @@ import (
 	"net"
 	"os"
 	"slices"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -1619,6 +1619,11 @@ func TestPriority(t *testing.T) {
 		return conn
 	}
 
+	_, webProxyPortString, err := net.SplitHostPort(clientApp.dialOpts.GetWebProxyAddr())
+	require.NoError(t, err)
+	webProxyPort, err := strconv.Atoi(webProxyPortString)
+	require.NoError(t, err)
+
 	lookupShouldFailFast := func(t *testing.T, host string) {
 		t.Helper()
 		lookupCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
@@ -1688,6 +1693,38 @@ func TestPriority(t *testing.T) {
 		defer sshConn.Close()
 
 		testConnectionToSshEchoServer(t, sshConn, chans, reqs)
+	})
+
+	t.Run("cluster match on proxy port is reachable", func(t *testing.T) {
+		t.Parallel()
+		// Regression test for #63980: this hostname only matches a cluster
+		// subdomain and not any app that is visible to VNet. Historically VNet
+		// could assign it to an undecided handler and then reject proxy-port
+		// traffic, breaking browser/web UI access when an access request
+		// assumed only in the web UI granted access to the web app. We now
+		// expect proxy-port traffic to be forwarded to the proxy.
+
+		conn := dialAndAssertCIDR(t, "invisible-webapp.example.com", webProxyPort, rootCIDR)
+		t.Cleanup(func() { assert.NoError(t, conn.Close()) })
+
+		roots := x509.NewCertPool()
+		require.True(t, roots.AppendCertsFromPEM(clientApp.dialOpts.GetRootClusterCaCertPool()))
+		tlsConn := tls.Client(conn, &tls.Config{
+			RootCAs:    roots,
+			ServerName: clientApp.dialOpts.GetSni(),
+		})
+		buf, err := io.ReadAll(tlsConn)
+		require.NoError(t, err)
+		require.Equal(t, `you dialed the proxy with alpn=""`, string(buf))
+	})
+
+	t.Run("cluster match still rejects non-SSH non-proxy port", func(t *testing.T) {
+		t.Parallel()
+		// Guard case for the same cluster-subdomain behavior: non-SSH and
+		// non-proxy ports should still be rejected.
+
+		_, err := p.dialHost(ctx, "invisible-webapp.example.com", 12345)
+		require.Error(t, err)
 	})
 
 	t.Run("root app beats leaf app when both match", func(t *testing.T) {
@@ -1915,7 +1952,7 @@ func mustStartFakeWebProxy(
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{proxyCert},
-		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientAuth:   tls.VerifyClientCertIfGiven,
 		ClientCAs:    roots,
 		NextProtos: []string{
 			string(alpncommon.ProtocolProxySSH),
@@ -1999,6 +2036,12 @@ func mustStartFakeWebProxy(
 						t.Log("error completing tls handshake")
 						return
 					}
+					protocol := tlsConn.ConnectionState().NegotiatedProtocol
+					handler, ok := protocolHandlers[alpncommon.Protocol(protocol)]
+					if !ok {
+						_, _ = io.WriteString(tlsConn, fmt.Sprintf("you dialed the proxy with alpn=%q", protocol))
+						return
+					}
 					clientCerts := tlsConn.ConnectionState().PeerCertificates
 					if len(clientCerts) == 0 {
 						t.Log("client has no certs")
@@ -2011,13 +2054,6 @@ func mustStartFakeWebProxy(
 					// satisfied.
 					if cfg.clock.Now().After(clientCerts[0].NotAfter) {
 						t.Logf("client cert is expired: currentTime=%s expiry=%s", cfg.clock.Now(), clientCerts[0].NotAfter)
-						return
-					}
-
-					protocol := tlsConn.ConnectionState().NegotiatedProtocol
-					handler, ok := protocolHandlers[alpncommon.Protocol(protocol)]
-					if !ok {
-						t.Logf("unhandled proxy protocol %s", protocol)
 						return
 					}
 					if err := handler(conn); err != nil {


### PR DESCRIPTION
Backport #63992 to branch/v18

## Manual Test Plan

- [x] Repro path (Web UI-only role): Start VNet in Connect, assume app access in Web UI only (not Connect), then open the cluster-subdomain web hostname on proxy port; confirm it is reachable.
- [x] SSH guard: Using the same environment, verify SSH to a valid node on :22 still works as expected.
- [x] Port guard: Attempt a dial to the same hostname on a non-proxy, non-22 port (e.g. :12345); confirm it is rejected.
- [x] Soft-cache sanity: Hit the same web hostname multiple times quickly for >15s; confirm behavior stays stable (no intermittent reject).
- [x] Connect parity control: Assume the same access request in Connect and retry; confirm access still works (no regression when Connect-side visibility is present).

changelog: Fixed a VNet regression where web app access could fail when access was assumed in the Web UI only while VNet was already running
