### PR TITLE
skip operator flaky TC test

### DIFF
--- a/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go
+++ b/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go
@@ -218,8 +218,10 @@ func TestTrustedClusterV2DeletionDrift(t *testing.T) {
 	)
 }
 
-func TestTrustedClusterUpdate(t *testing.T) {
+func TestTrustedClusterV2Update(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
+	// TODO(hugoShaka): fix this test by watching all CAs and returning once they all have the same revision id.
+	t.Skip("This test is currently flaky because of the cert authorities internal.")
 	const remoteClusterName = "remote.example.com"
 	test.setupTest(t, remoteClusterName)
 	testlib.ResourceUpdateTestSynchronous(


### PR DESCRIPTION
The operator trusted cluster test is flaky because of a race between the trusted cluster resource and the associated cert authorities objects. The test waits until the updated TC resource enters the cache, but this does not mean the the updated CA cert resources have entered the cache.

When a TC resource is updated, server-side teleport reads te CAs from the cache, creates a bunch of conditaional actions, and sends an atomic write. The stale cache causes the condacts to fail, and the client gets a conflict error.

This is arguably not something the client should care about because the client's input is up-to-date and teleport is the one reading and writing CAs.

Aproper fix would be to establish a CA watcherm and block the test until all the CAs have the same revision ID. But we don't currently know all CAs created/updated by the trust service. The test is currently very flaky and I already spent 2 days tracking the operator flaky test, I don't have the bandwidth to fix it now so I'll skip the test.