### PR TITLE
Implement local.SubCAService CRUD operations

### DIFF
--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -83,6 +83,12 @@ type SubCAServiceParams struct {
 
 // SubCAService manages backend storage of CertAuthorityOverride resources.
 //
+// SubCAService does not perform lateral validation against CA objects, it only
+// ensures CertAuthorityOverride resources are valid within themselves. This
+// allows callers with direct storage access to re-create storage configurations
+// that were valid on conception but drifted over time (CA keyset changed,
+// certificates expired, etc).
+//
 // Follows RFD 153 / generic.Service semantics.
 type SubCAService struct {
 	service *generic.ServiceWrapper[*subcav1.CertAuthorityOverride]
@@ -117,13 +123,38 @@ func (s *SubCAService) CreateCertAuthorityOverride(
 		return nil, trace.Wrap(err)
 	}
 
-	// TODO(codingllama): Create CRLs.
-
-	// TODO(codingllama): Take a condition on the sibling CA resource.
-	//  We optimistically skip this for now: CAs can change independently anyway
-	//  so they can always become "out of sync" with overrides.
 	created, err := service.CreateResource(ctx, resource)
 	return created, trace.Wrap(err)
+}
+
+// UpdateCertAuthorityOverride conditionally updates a CA override in the
+// backend.
+func (s *SubCAService) UpdateCertAuthorityOverride(
+	ctx context.Context,
+	resource *subcav1.CertAuthorityOverride,
+) (*subcav1.CertAuthorityOverride, error) {
+	service, err := s.serviceForResource(resource)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	updated, err := service.ConditionalUpdateResource(ctx, resource)
+	return updated, trace.Wrap(err)
+}
+
+// UpsertCertAuthorityOverride unconditionally creates or updates a CA override
+// in the backend.
+func (s *SubCAService) UpsertCertAuthorityOverride(
+	ctx context.Context,
+	resource *subcav1.CertAuthorityOverride,
+) (*subcav1.CertAuthorityOverride, error) {
+	service, err := s.serviceForResource(resource)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	updated, err := service.UpsertResource(ctx, resource)
+	return updated, trace.Wrap(err)
 }
 
 // GetCertAuthorityOverride reads a CA override from the backend.
@@ -138,6 +169,33 @@ func (s *SubCAService) GetCertAuthorityOverride(
 
 	resource, err := service.GetResource(ctx, "")
 	return resource, trace.Wrap(err)
+}
+
+// ListCertAuthorityOverrides lists all CA overrides from the backend, using
+// paginated responses.
+func (s *SubCAService) ListCertAuthorityOverrides(
+	ctx context.Context,
+	pageSize int,
+	pageToken string,
+) (_ []*subcav1.CertAuthorityOverride, nextPageToken string, _ error) {
+	// Note: We don't use serviceForClusterAndType here, it lists all clusters.
+	resp, nextPageToken, err := s.service.ListResources(ctx, pageSize, pageToken)
+	return resp, nextPageToken, trace.Wrap(err)
+}
+
+// DeleteCertAuthorityOverride unconditionally deletes a CA override from the
+// backend.
+// Returns a trace.NotFoundError if the resource cannot be found.
+func (s *SubCAService) DeleteCertAuthorityOverride(
+	ctx context.Context,
+	id CertAuthorityOverrideID,
+) error {
+	service, err := s.serviceForClusterAndType(id.ClusterName, id.CAType)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(service.DeleteResource(ctx, ""))
 }
 
 func (s *SubCAService) serviceForResource(

--- a/lib/services/local/subca_service_test.go
+++ b/lib/services/local/subca_service_test.go
@@ -66,13 +66,12 @@ func TestSubCAService_CRUD(t *testing.T) {
 			CATypesToCreate: []types.CertAuthType{caType},
 		})
 		service := env.SubCA
-		ctx := t.Context()
 
 		caOverride := env.NewOverrideForCAType(t, caType)
 		want := proto.Clone(caOverride).(*subcav1.CertAuthorityOverride)
 
 		// Upsert and verify response.
-		created, err := service.UpsertCertAuthorityOverride(ctx, caOverride)
+		created, err := service.UpsertCertAuthorityOverride(t.Context(), caOverride)
 		require.NoError(t, err, "UpsertCertAuthorityOverride errored")
 		want.Metadata.Revision = created.Metadata.Revision
 		if diff := cmp.Diff(want, created, protocmp.Transform()); diff != "" {
@@ -87,12 +86,12 @@ func TestSubCAService_CRUD(t *testing.T) {
 		const wantInvalidErr = "certificate: expected PEM"
 
 		t.Run("Upsert (invalid)", func(t *testing.T) {
-			_, err := service.UpsertCertAuthorityOverride(ctx, invalid)
+			_, err := service.UpsertCertAuthorityOverride(t.Context(), invalid)
 			assert.ErrorContains(t, err, wantInvalidErr, "UpsertCertAuthorityOverride error mismatch")
 		})
 
 		t.Run("Update (invalid)", func(t *testing.T) {
-			_, err := service.UpdateCertAuthorityOverride(ctx, invalid)
+			_, err := service.UpdateCertAuthorityOverride(t.Context(), invalid)
 			assert.ErrorContains(t, err, wantInvalidErr, "UpdateCertAuthorityOverride error mismatch")
 		})
 
@@ -102,7 +101,7 @@ func TestSubCAService_CRUD(t *testing.T) {
 
 			want := proto.Clone(created).(*subcav1.CertAuthorityOverride)
 
-			updated, err := service.UpsertCertAuthorityOverride(ctx, created)
+			updated, err := service.UpsertCertAuthorityOverride(t.Context(), created)
 			require.NoError(t, err, "UpsertCertAuthorityOverride errored")
 			assert.NotEqual(t,
 				want.Metadata.Revision, updated.Metadata.Revision,
@@ -116,6 +115,8 @@ func TestSubCAService_CRUD(t *testing.T) {
 		})
 
 		t.Run("Update", func(t *testing.T) {
+			ctx := t.Context()
+
 			// Create an altogether different override.
 			caOverride2 := env.NewOverrideForCAType(t, caType)
 			// Enable, like the previous update.
@@ -146,6 +147,7 @@ func TestSubCAService_CRUD(t *testing.T) {
 		})
 
 		t.Run("Delete", func(t *testing.T) {
+			ctx := t.Context()
 			id := local.CertAuthorityOverrideIDFromResource(created)
 
 			// 1st delete succeeds.
@@ -565,4 +567,31 @@ func TestSubCAService_Create(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubCAService_Update_wrongRevision(t *testing.T) {
+	t.Parallel()
+
+	const caType = types.WindowsCA
+	env := subcaenv.New(t, subcaenv.EnvParams{
+		CATypesToCreate: []types.CertAuthType{caType},
+	})
+	service := env.SubCA
+	ctx := t.Context()
+
+	caOverride := env.NewOverrideForCAType(t, caType)
+	caOverride, err := service.CreateCertAuthorityOverride(ctx, caOverride)
+	require.NoError(t, err)
+	rev1 := caOverride.Metadata.Revision
+
+	caOverride, err = service.UpdateCertAuthorityOverride(ctx, caOverride)
+	require.NoError(t, err)
+	rev2 := caOverride.Metadata.Revision
+	require.NotEqual(t, rev1, rev2, "Revision didn't change on update")
+
+	// Update using an old revision.
+	caOverride.Metadata.Revision = rev1
+	_, err = service.UpdateCertAuthorityOverride(ctx, caOverride)
+	assert.ErrorAs(t, err, new(*trace.CompareFailedError),
+		"UpdateCertAuthorityOverride() revision mismatch error")
 }

--- a/lib/services/local/subca_service_test.go
+++ b/lib/services/local/subca_service_test.go
@@ -35,6 +35,175 @@ import (
 	subcaenv "github.com/gravitational/teleport/lib/subca/testenv"
 )
 
+// TestSubCAService_CRUD tests the CRUD operations of SubCAService, with the
+// exclusion of Create which is extensively tested elsewhere.
+//
+// Most corner-cases and validation scenarios are covered by
+// TestSubCAService_Create, this focus more on the happy path.
+func TestSubCAService_CRUD(t *testing.T) {
+	t.Parallel()
+
+	assertStored := func(
+		t *testing.T,
+		service *local.SubCAService,
+		want *subcav1.CertAuthorityOverride,
+	) {
+		t.Helper()
+
+		id := local.CertAuthorityOverrideIDFromResource(want)
+		got, err := service.GetCertAuthorityOverride(t.Context(), id)
+		require.NoError(t, err)
+		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+			t.Errorf("Stored CA override mismatch (-want +got)\n%s", diff)
+		}
+	}
+
+	t.Run("Upsert (create)", func(t *testing.T) {
+		t.Parallel()
+
+		const caType = types.WindowsCA
+		env := subcaenv.New(t, subcaenv.EnvParams{
+			CATypesToCreate: []types.CertAuthType{caType},
+		})
+		service := env.SubCA
+		ctx := t.Context()
+
+		caOverride := env.NewOverrideForCAType(t, caType)
+		want := proto.Clone(caOverride).(*subcav1.CertAuthorityOverride)
+
+		// Upsert and verify response.
+		created, err := service.UpsertCertAuthorityOverride(ctx, caOverride)
+		require.NoError(t, err, "UpsertCertAuthorityOverride errored")
+		want.Metadata.Revision = created.Metadata.Revision
+		if diff := cmp.Diff(want, created, protocmp.Transform()); diff != "" {
+			t.Errorf("Upsert mismatch (-want +got)\n%s", diff)
+		}
+
+		// Assert against storage.
+		assertStored(t, service, want)
+
+		invalid := proto.Clone(created).(*subcav1.CertAuthorityOverride)
+		invalid.Spec.CertificateOverrides[0].Certificate = "ceci n'est pas a certificate"
+		const wantInvalidErr = "certificate: expected PEM"
+
+		t.Run("Upsert (invalid)", func(t *testing.T) {
+			_, err := service.UpsertCertAuthorityOverride(ctx, invalid)
+			assert.ErrorContains(t, err, wantInvalidErr, "UpsertCertAuthorityOverride error mismatch")
+		})
+
+		t.Run("Update (invalid)", func(t *testing.T) {
+			_, err := service.UpdateCertAuthorityOverride(ctx, invalid)
+			assert.ErrorContains(t, err, wantInvalidErr, "UpdateCertAuthorityOverride error mismatch")
+		})
+
+		t.Run("Upsert (update)", func(t *testing.T) {
+			co := created.Spec.CertificateOverrides[0]
+			co.Disabled = false // Enable override.
+
+			want := proto.Clone(created).(*subcav1.CertAuthorityOverride)
+
+			updated, err := service.UpsertCertAuthorityOverride(ctx, created)
+			require.NoError(t, err, "UpsertCertAuthorityOverride errored")
+			assert.NotEqual(t,
+				want.Metadata.Revision, updated.Metadata.Revision,
+				"Revision unchanged after update")
+			want.Metadata.Revision = updated.Metadata.Revision
+			if diff := cmp.Diff(want, updated, protocmp.Transform()); diff != "" {
+				t.Errorf("Upsert mismatch (-want +got)\n%s", diff)
+			}
+
+			assertStored(t, service, updated)
+		})
+
+		t.Run("Update", func(t *testing.T) {
+			// Create an altogether different override.
+			caOverride2 := env.NewOverrideForCAType(t, caType)
+			// Enable, like the previous update.
+			caOverride2.Spec.CertificateOverrides[0].Disabled = false
+
+			// Fetch stored override...
+			id := local.CertAuthorityOverrideIDFromResource(created)
+			stored, err := service.GetCertAuthorityOverride(ctx, id)
+			require.NoError(t, err, "GetCertAuthorityOverride errored")
+
+			// ...and replace its contents with "caOverride2".
+			in := stored
+			in.Spec.CertificateOverrides = caOverride2.Spec.CertificateOverrides
+
+			want := proto.Clone(in).(*subcav1.CertAuthorityOverride)
+
+			updated, err := service.UpdateCertAuthorityOverride(ctx, in)
+			require.NoError(t, err, "UpdateCertAuthorityOverride errored")
+			assert.NotEqual(t,
+				want.Metadata.Revision, updated.Metadata.Revision,
+				"Revision unchanged after update")
+			want.Metadata.Revision = updated.Metadata.Revision
+			if diff := cmp.Diff(want, updated, protocmp.Transform()); diff != "" {
+				t.Errorf("Upsert mismatch (-want +got)\n%s", diff)
+			}
+
+			assertStored(t, service, updated)
+		})
+
+		t.Run("Delete", func(t *testing.T) {
+			id := local.CertAuthorityOverrideIDFromResource(created)
+
+			// 1st delete succeeds.
+			require.NoError(t,
+				service.DeleteCertAuthorityOverride(ctx, id),
+				"DeleteCertAuthorityOverride errored")
+
+			// 2nd delete errors with NotFound.
+			assert.ErrorAs(t,
+				service.DeleteCertAuthorityOverride(ctx, id),
+				new(*trace.NotFoundError),
+				"DeleteCertAuthorityOverride error mismatch")
+
+			// Get also NotFounds.
+			_, err := service.GetCertAuthorityOverride(ctx, id)
+			assert.ErrorAs(t,
+				err,
+				new(*trace.NotFoundError),
+				"GetCertAuthorityOverride error mismatch")
+		})
+	})
+
+	t.Run("List", func(t *testing.T) {
+		t.Parallel()
+
+		const caType1 = types.DatabaseClientCA
+		const caType2 = types.WindowsCA
+		env := subcaenv.New(t, subcaenv.EnvParams{
+			CATypesToCreate: []types.CertAuthType{
+				caType1,
+				caType2,
+			},
+		})
+
+		service := env.SubCA
+		ctx := t.Context()
+
+		caOverride1, err := service.UpsertCertAuthorityOverride(ctx, env.NewOverrideForCAType(t, caType1))
+		require.NoError(t, err)
+		caOverride2, err := service.UpsertCertAuthorityOverride(ctx, env.NewOverrideForCAType(t, caType2))
+		require.NoError(t, err)
+
+		const pageSize = 0 // use defaults
+		pageToken := ""
+		resp, nextPageToken, err := service.ListCertAuthorityOverrides(ctx, pageSize, pageToken)
+		require.NoError(t, err, "ListCertAuthorityOverrides errored")
+		assert.Empty(t, nextPageToken, "nextPageToken is not empty, this is unexpected")
+
+		want := []*subcav1.CertAuthorityOverride{
+			caOverride1, // Note: already in key/list order.
+			caOverride2,
+		}
+		if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
+			t.Errorf("List mismatch (-want +got)\n%s", diff)
+		}
+	})
+}
+
 func TestSubCAService_Create(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Implement the missing CRUD operations for Sub CAs: Update, Upsert, List and Delete.

Validation is extensively covered by existing Create tests and the implementation uses generic.Service, so it mainly tests that everything is wired correctly.

https://github.com/gravitational/teleport.e/issues/7675