### PR TITLE
Docs: add server discovery pre flight exit codes

### DIFF
--- a/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
@@ -8,10 +8,10 @@ When enrolling an instance into Teleport, the installation script returns a spec
 - 100: `bash` binary is missing
 - 101: `sudo` binary is missing
 - 102: `curl` binary is missing
-- 103: `/opt` or `/` do not have the required minimum space to install teleport
+- 103: `/opt` or `/` do not have the required minimum space to install Teleport, at least 1250MB is required
 - 104: host is unable to connect to the Teleport Proxy Services's HTTPS endpoint
 
-You can customize the installation script - as describe in the [Use a custom installation script](#use-a-custom-installation-script) section above - and implement other checks with specific exit codes.
+You can customize the installation script - as describe in the **Use a custom installation script** section above - and implement other checks with specific exit codes.
 
 Whether the installation exits with a pre-flight check or with your own custom installation script, the exit code appears in `ssm.run` Teleport audit events, in the `exit_code` field.
 It also appears in AWS Systems Manager -> Node Management -> Run Command -> Command history.

--- a/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
@@ -4,8 +4,8 @@ Select the instance-id of the Target to review Errors.
 
 ### Installation script exit codes
 
-When enrolling an instance into teleport, the installation script returns a specific exit code when facing well known issues.
-The exit code appears in the `ssm.run` Teleport audit events, in the `exit_code` field.
+When enrolling an instance into Teleport, the installation script returns a specific exit code when facing well known issues.
+The exit code appears in `ssm.run` Teleport audit events, in the `exit_code` field.
 
 It also appears in AWS Systems Manager -> Node Management -> Run Command -> Command history.
 
@@ -14,7 +14,7 @@ The following exit codes are used to indicate well-known failures:
 - 101: `sudo` binary is missing
 - 102: `curl` binary is missing
 - 103: `/opt` or `/` do not have the required minimum space to install teleport
-- 104: host is unable to connect to Teleport Proxy's HTTPS endpoint
+- 104: host is unable to connect to the Teleport Proxy Services's HTTPS endpoint
 
 ### `cannot unmarshal object into Go struct field`
 

--- a/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
@@ -4,17 +4,35 @@ Select the instance-id of the Target to review Errors.
 
 ### Installation script exit codes
 
-When enrolling an instance into Teleport, the installation script returns a specific exit code when facing well known issues.
-The exit code appears in `ssm.run` Teleport audit events, in the `exit_code` field.
-
-It also appears in AWS Systems Manager -> Node Management -> Run Command -> Command history.
-
-The following exit codes are used to indicate well-known failures:
+When enrolling an instance into Teleport, the installation script returns a specific exit code when facing well-known issues:
 - 100: `bash` binary is missing
 - 101: `sudo` binary is missing
 - 102: `curl` binary is missing
 - 103: `/opt` or `/` do not have the required minimum space to install teleport
 - 104: host is unable to connect to the Teleport Proxy Services's HTTPS endpoint
+
+You can customize the installation script - as describe in the [Use a custom installation script](#use-a-custom-installation-script) section above - and implement other checks with specific exit codes.
+
+Whether the installation exits with a pre-flight check or with your own custom installation script, the exit code appears in `ssm.run` Teleport audit events, in the `exit_code` field.
+It also appears in AWS Systems Manager -> Node Management -> Run Command -> Command history.
+
+Example of the `ssm.run` event with an exit code:
+```json
+{
+  "code": "TDS00W",
+  "event": "ssm.run",
+  "instance_id": "i-0000",
+  "region": "<region>",
+  "invocation_url": "https://<region>.console.aws.amazon.com/systems-manager/run-command/<uuid>/i-0000",
+  "platform_name": "Ubuntu",
+  "platform_type": "Linux",
+  "platform_version": "24.04",
+  "status": "curl is not installed in the instance. Please install all required tools (bash, sudo, curl) and try again.",
+  "stderr": "failed to run commands: exit status 102",
+  "stdout": "curl is missing\n",
+  "exit_code": 102
+}
+```
 
 ### `cannot unmarshal object into Go struct field`
 

--- a/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
@@ -1,6 +1,20 @@
 If Installs are showing failed or instances are failing to appear check the
-Command history in AWS System Manager -> Node Management -> Run Command.
+Command history in AWS Systems Manager -> Node Management -> Run Command.
 Select the instance-id of the Target to review Errors.
+
+### Installation script exit codes
+
+When enrolling an instance into teleport, the installation script returns a specific exit code when facing well known issues.
+The exit code appears in the `ssm.run` Teleport audit events, in the `exit_code` field.
+
+It also appears in AWS Systems Manager -> Node Management -> Run Command -> Command history.
+
+The following exit codes are used to indicate well-known failures:
+- 100: `bash` binary is missing
+- 101: `sudo` binary is missing
+- 102: `curl` binary is missing
+- 103: `/opt` or `/` do not have the required minimum space to install teleport
+- 104: host is unable to connect to Teleport Proxy's HTTPS endpoint
 
 ### `cannot unmarshal object into Go struct field`
 

--- a/lib/srv/server/installstatus/exitcodes.go
+++ b/lib/srv/server/installstatus/exitcodes.go
@@ -37,6 +37,8 @@ const (
 // InstallerMinFreeDiskMB is the minimum free disk space in megabytes required for Teleport installation.
 // This value might change over time as Teleport's binary size changes, but currently sits at around 990MB: 210MB for the tarball, and around 780MB for the extracted files.
 // Setting this value to 1250MB provides a buffer for future updates, while still being reasonable for most systems.
+//
+// If this value is updated, ensure you also update the docs at "Installation script exit codes" in the Teleport EC2 Server Discovery documentation.
 const InstallerMinFreeDiskMB = 1250
 
 // String returns a human-readable description for the exit code.


### PR DESCRIPTION
After adding the exit codes to the code, we must also document them.

Exit codes added in https://github.com/gravitational/teleport/pull/64025

Demo:

https://marco-docs-server-discovery-exitcodes.d1v2yqnl3ruxch.amplifyapp.com/docs/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided/#installation-script-exit-codes

<img width="2108" height="1112" alt="image" src="https://github.com/user-attachments/assets/085bea66-12db-47aa-8d47-e7ed0ff67a0b" />
