### PR TITLE
Fix typos in v8 role caveats

### DIFF
--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -110,10 +110,10 @@ Role v7 added support for more `kind` values in the `kubernetes_resources` field
 
 Role v8 added support for Kubernetes CRDs and introduced changes in how
 `kubernetes_resources` behave and are defined. Role v8 is not compatible with
-Teleport v17 agents: if your a user has a v8 role, a v17 agent running the
+Teleport v17 agents: if your user has a v8 role, a v17 agent running the
 Teleport Kubernetes Service may silently deny the user access, because the agent
-cannot interpret the fields specific to v8 roles. Upgrade all agents to v18 before using
-role v8.
+cannot interpret the fields specific to v8 roles. Upgrade all agents to v18
+before using role v8.
 
 See [Kubernetes Resources](../../enroll-resources/kubernetes-access/controls.mdx#kubernetes_resources) for more details about the difference between versions.
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/role.mdx
@@ -31,9 +31,9 @@ documentation](../../../enroll-resources/kubernetes-access/controls.mdx#kubernet
 for a complete list). Role v8 supports restricting all resource kinds,
 including CRDs. It also changes the format of the `kind` field. 
 
-Role v8 is not compatible with Teleport v17 agents: if your a user has a v8
-role, a v17 agent running the Teleport Kubernetes Service may silently deny the
-user access, because the agent cannot interpret the fields specific to v8 roles.
+Role v8 is not compatible with Teleport v17 agents: if your user has a v8 role,
+a v17 agent running the Teleport Kubernetes Service may silently deny the user
+access, because the agent cannot interpret the fields specific to v8 roles.
 Upgrade all agents to v18 before using role v8.
 
 When no `kubernetes_resource` is set:


### PR DESCRIPTION
The changes in #64102 inadvertently introduced two typos, which the current change fixes.