### PR TITLE
[v18] Replace github.com/fatih/color with github.com/charmbracelet/lipgloss

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,6 @@ require (
 	github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4
 	github.com/evanphx/json-patch v5.9.11+incompatible
-	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/fsouza/fake-gcs-server v1.52.2
 	github.com/fxamacker/cbor/v2 v2.8.0
@@ -384,6 +383,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -35,7 +35,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/fatih/color"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -1012,25 +1012,32 @@ func formatServices(services []*machineidv1pb.BotInstanceServiceHealth) string {
 // formatStatus returns an human-readable representation of a service status.
 // Optionally, it can include a colored dot.
 func formatStatus(status machineidv1pb.BotInstanceHealthStatus, useColor bool) string {
+	var (
+		greenDot  = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
+		redDot    = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+		whiteDot  = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
+		yellowDot = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
+	)
+
 	switch status {
 	case machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_HEALTHY:
 		if useColor {
-			return color.GreenString("\u25CF") + " Healthy"
+			return greenDot.Render("\u25CF") + " Healthy"
 		}
 		return "Healthy"
 	case machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_UNHEALTHY:
 		if useColor {
-			return color.RedString("\u25CF") + " Unhealthy"
+			return redDot.Render("\u25CF") + " Unhealthy"
 		}
 		return "Unhealthy"
 	case machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_INITIALIZING:
 		if useColor {
-			return color.WhiteString("\u25CF") + " Initializing"
+			return whiteDot.Render("\u25CF") + " Initializing"
 		}
 		return "Initializing"
 	default:
 		if useColor {
-			return color.YellowString("\u25CF") + " Unknown"
+			return yellowDot.Render("\u25CF") + " Unknown"
 		}
 		return "Unknown"
 	}

--- a/tool/tctl/common/plugin/entraid.go
+++ b/tool/tctl/common/plugin/entraid.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/fatih/color"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/google/safetext/shsprintf"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -46,8 +46,8 @@ import (
 )
 
 var (
-	bold    = color.New(color.Bold).SprintFunc()
-	boldRed = color.New(color.Bold, color.FgRed).SprintFunc()
+	bold    = lipgloss.NewStyle().Bold(true).Render
+	boldRed = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9")).Render
 
 	step1Template = bold("Step 1: Run the Setup Script") + `
 

--- a/tool/tctl/common/plugin/netiq.go
+++ b/tool/tctl/common/plugin/netiq.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/fatih/color"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
@@ -43,7 +43,7 @@ import (
 )
 
 var (
-	boldGreen          = color.New(color.Bold, color.FgGreen).SprintFunc()
+	boldGreen          = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("10")).Render
 	netIQStep1Template = bold("Step 1: Configure IDM OSP address") + `
 
 Please provide the IDM OSP address to configure the integration.


### PR DESCRIPTION
Backport #64218 to branch/v18

## Manual Test Plan

### Test Environment

A locally built tctl pointed to a local Auth server injected with bot instances with various health statuses.

### Test Cases

- [x] `tctl bots show` output from this branch matches `tctl bots show` from v18.6.8.
- [x] `tctl plugins install entraid` output from this branch matches `tctl plugins install entraid` from v18.6.8.
- [x] `tctl plugins install netiq` output from this branch matches `tctl plugins install entraid` from v18.6.8.