### PR TITLE
[v18] fix: set listener before starting node heartbeats in Serve

### DIFF
--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -616,7 +616,10 @@ func (s *server) Wait(ctx context.Context) {
 }
 
 func (s *server) Start() error {
-	go s.srv.Serve(s.Listener)
+	if err := s.srv.SetListener(s.Listener); err != nil {
+		return trace.Wrap(err)
+	}
+	go s.srv.Serve()
 	return nil
 }
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -449,8 +449,14 @@ func (s *Server) Start() error {
 
 // Serve servers service on started listener
 func (s *Server) Serve(l net.Listener) error {
+	// Set the listener before starting heartbeats so the first node heartbeat
+	// does not advertise an empty address.
+	if err := s.srv.SetListener(l); err != nil {
+		return trace.Wrap(err)
+	}
+
 	s.startPeriodicOperations()
-	return trace.Wrap(s.srv.Serve(l))
+	return trace.Wrap(s.srv.Serve())
 }
 
 func (s *Server) startPeriodicOperations() {

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -318,9 +318,11 @@ func (s *Server) Addr() string {
 	return s.listener.Addr().String()
 }
 
-func (s *Server) Serve(listener net.Listener) error {
-	if err := s.SetListener(listener); err != nil {
-		return trace.Wrap(err)
+// Serve serves SSH connections using an already configured listener and blocks
+// until the listener is closed.
+func (s *Server) Serve() error {
+	if s.Addr() == "" {
+		return trace.BadParameter("listener is not set")
 	}
 	s.acceptConnections()
 	return nil
@@ -350,6 +352,9 @@ func (s *Server) Start() error {
 func (s *Server) SetListener(l net.Listener) error {
 	s.Lock()
 	defer s.Unlock()
+	if l == nil {
+		return trace.BadParameter("listener is nil")
+	}
 	if s.listener != nil {
 		return trace.BadParameter("listener is already set to %v", s.listener.Addr())
 	}


### PR DESCRIPTION
Backport #64326 to branch/v18

`TestIntegrations/AuthLocalNodeControlStream` caught a race where Serve started periodic operations before the ssh listener was attached, allowing the first control-stream heartbeat to report an empty node address (missing parameter address).

Reproduced locally by setting a temporary startup delay. This fix removes the race by setting the listener first.

## Manual Test Plan

- [x] SSH to direct dial SSH node still works

changelog: fixed a rare race condition causing initial node heartbeats to be missing an address