### PR TITLE
Handle empty session ID/value in event handler

### DIFF
--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -296,9 +296,19 @@ func (s *State) GetSessions() (map[string]int64, error) {
 	r := make(map[string]int64)
 
 	for key := range s.dv.KeysPrefix(sessionPrefix, nil) {
+		// skip if the key is exactly the sessionPrefix
+		if string(key) == sessionPrefix {
+			continue
+		}
+
 		b, err := s.dv.Read(key)
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+
+		// Assume 0 if empty/unset
+		if len(b) == 0 {
+			b = make([]byte, 8)
 		}
 
 		id := key[len(sessionPrefix):]
@@ -310,6 +320,11 @@ func (s *State) GetSessions() (map[string]int64, error) {
 
 // SetSessionIndex writes current session index into state
 func (s *State) SetSessionIndex(id string, index int64) error {
+	// refuse to set empty session ID
+	if id == "" {
+		return trace.Wrap(errors.New("session ID cannot be empty"))
+	}
+
 	var b = make([]byte, 8)
 
 	binary.BigEndian.PutUint64(b, uint64(index))

--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -113,7 +113,7 @@ func NewState(c *StartCmdConfig, log *slog.Logger) (*State, error) {
 	return &s, nil
 }
 
-// createStorageDir is used to calculate storage dir path and create dir if it does not exits
+// createStorageDir is used to calculate storage dir path and create dir if it does not exist
 func createStorageDir(c *StartCmdConfig, log *slog.Logger) (string, error) {
 	host, port, err := net.SplitHostPort(c.TeleportAddr)
 	if err != nil {
@@ -306,9 +306,10 @@ func (s *State) GetSessions() (map[string]int64, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		// Assume 0 if empty/unset
-		if len(b) == 0 {
+		// Assume 0 if byte count is incorrect
+		if len(b) != 8 {
 			b = make([]byte, 8)
+			binary.BigEndian.PutUint64(b, uint64(0))
 		}
 
 		id := key[len(sessionPrefix):]
@@ -322,7 +323,7 @@ func (s *State) GetSessions() (map[string]int64, error) {
 func (s *State) SetSessionIndex(id string, index int64) error {
 	// refuse to set empty session ID
 	if id == "" {
-		return trace.Wrap(errors.New("session ID cannot be empty"))
+		return trace.BadParameter("session ID cannot be empty")
 	}
 
 	var b = make([]byte, 8)

--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -297,7 +297,7 @@ func (s *State) GetSessions() (map[string]int64, error) {
 
 	for key := range s.dv.KeysPrefix(sessionPrefix, nil) {
 		// skip if the key is exactly the sessionPrefix
-		if string(key) == sessionPrefix {
+		if key == sessionPrefix {
 			continue
 		}
 

--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -308,6 +308,10 @@ func (s *State) GetSessions() (map[string]int64, error) {
 
 		// Assume 0 if byte count is incorrect
 		if len(b) != 8 {
+			s.log.WarnContext(
+				context.TODO(),
+				"Malformed session state key found in storage. Starting over at index 0.", "session", key,
+			)
 			b = make([]byte, 8)
 			binary.BigEndian.PutUint64(b, uint64(0))
 		}

--- a/integrations/event-handler/state.go
+++ b/integrations/event-handler/state.go
@@ -307,7 +307,7 @@ func (s *State) GetSessions() (map[string]int64, error) {
 		}
 
 		// Assume 0 if byte count is incorrect
-		if len(b) != 8 {
+		if len(b) != binary.Size(uint64(0)) {
 			s.log.WarnContext(
 				context.TODO(),
 				"Malformed session state key found in storage. Starting over at index 0.", "session", key,

--- a/integrations/event-handler/state_test.go
+++ b/integrations/event-handler/state_test.go
@@ -155,7 +155,6 @@ func TestGetSessions(t *testing.T) {
 	state, err := NewState(config, slog.Default())
 	require.NoError(t, err)
 
-	expected := make([]session, 0, 10)
 	expectedMap := make(map[string]int64, 10)
 	for i := 0; i < 10; i++ {
 		s := session{
@@ -164,7 +163,6 @@ func TestGetSessions(t *testing.T) {
 			UploadTime: time.Now().UTC(),
 		}
 		err := state.SetSessionIndex(s.ID, 0)
-		expected = append(expected, s)
 		expectedMap[s.ID] = 0
 		assert.NoError(t, err)
 	}

--- a/integrations/event-handler/state_test.go
+++ b/integrations/event-handler/state_test.go
@@ -149,3 +149,69 @@ func TestStateMissingRecordings(t *testing.T) {
 	require.NoError(t, err)
 
 }
+
+func TestGetSessions(t *testing.T) {
+	config := newStartCmdConfig(t)
+	state, err := NewState(config, slog.Default())
+	require.NoError(t, err)
+
+	expected := make([]session, 0, 10)
+	expectedmap := make(map[string]int64, 10)
+	for i := 0; i < 10; i++ {
+		s := session{
+			ID:         strconv.Itoa(i),
+			Index:      int64(i),
+			UploadTime: time.Now().UTC(),
+		}
+		err := state.SetSessionIndex(s.ID, 0)
+		expected = append(expected, s)
+		expectedmap[s.ID] = 0
+		assert.NoError(t, err)
+	}
+
+	// List with GetSessions should work
+	// Iterating find all stored records and validate they match
+	// the original sessions.
+	sessions, err := state.GetSessions()
+	require.NoError(t, err)
+	assert.Equal(t, expectedmap, sessions)
+
+	// add bogus entry by writing a file called `session` to the directory
+	var b = make([]byte, 8)
+	err = state.dv.Write(sessionPrefix, b)
+	require.NoError(t, err)
+
+	// break real entry by writing a zero-byte file
+	b = make([]byte, 0)
+	p := sessionPrefix + strconv.Itoa(2)
+	err = state.dv.Write(p, b)
+	require.NoError(t, err)
+
+	// now with bogus empty file, try GetSessions again
+	sessions, err = state.GetSessions()
+	require.NoError(t, err)
+	assert.Equal(t, expectedmap, sessions)
+
+}
+
+func TestSetSessionIndex(t *testing.T) {
+	config := newStartCmdConfig(t)
+	state, err := NewState(config, slog.Default())
+	require.NoError(t, err)
+
+	s1 := session{
+		ID:         "61ab9b21-172e-40af-bf94-d95da60c94f1",
+		Index:      int64(0),
+		UploadTime: time.Now().UTC(),
+	}
+	err = state.SetSessionIndex(s1.ID, 0)
+	require.NoError(t, err)
+
+	s2 := session{
+		ID:         "",
+		Index:      int64(0),
+		UploadTime: time.Now().UTC(),
+	}
+	err = state.SetSessionIndex(s2.ID, 0)
+	require.Error(t, err, "Should refuse to set an empty Session ID")
+}

--- a/integrations/event-handler/state_test.go
+++ b/integrations/event-handler/state_test.go
@@ -156,7 +156,7 @@ func TestGetSessions(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := make([]session, 0, 10)
-	expectedmap := make(map[string]int64, 10)
+	expectedMap := make(map[string]int64, 10)
 	for i := 0; i < 10; i++ {
 		s := session{
 			ID:         strconv.Itoa(i),
@@ -165,7 +165,7 @@ func TestGetSessions(t *testing.T) {
 		}
 		err := state.SetSessionIndex(s.ID, 0)
 		expected = append(expected, s)
-		expectedmap[s.ID] = 0
+		expectedMap[s.ID] = 0
 		assert.NoError(t, err)
 	}
 
@@ -174,7 +174,7 @@ func TestGetSessions(t *testing.T) {
 	// the original sessions.
 	sessions, err := state.GetSessions()
 	require.NoError(t, err)
-	assert.Equal(t, expectedmap, sessions)
+	assert.Equal(t, expectedMap, sessions)
 
 	// add bogus entry by writing a file called `session` to the directory
 	var b = make([]byte, 8)
@@ -190,7 +190,7 @@ func TestGetSessions(t *testing.T) {
 	// now with bogus empty file, try GetSessions again
 	sessions, err = state.GetSessions()
 	require.NoError(t, err)
-	assert.Equal(t, expectedmap, sessions)
+	assert.Equal(t, expectedMap, sessions)
 
 }
 


### PR DESCRIPTION
This is to fix "index out of range [7] with length 0" or other troubles when reading corrupt/incomplete/edited state data.

Given a state directory with the following:

```
-rw-r--r--    1 1000     1000            32 Mar  1 03:59 cursor
-rw-r--r--    1 1000     1000            36 Mar  1 03:59 id
-rw-r--r--    1 1000     1000            68 Feb 25 08:28 missing_recording0990df47-7f2d-4a7b-9beb-1c1085b29bec
-rw-r--r--    1 1000     1000            68 Feb 25 17:18 missing_recordingff1f24bb-5673-4f7d-b64e-10cbad659adf
-rw-r--r--    1 1000     1000             8 Feb 25 04:46 session
-rw-r--r--    1 1000     1000             8 Mar  1 04:00 session148555b4-2863-4b3c-b62e-75debd520349
-rw-r--r--    1 1000     1000             8 Mar  1 04:00 sessionc338c8b1-f5c1-4c9f-a7ed-7adae8aea846
-rw-r--r--    1 1000     1000             8 Mar  1 04:00 sessionf16233a1-96da-400c-994c-5ecbc015e410
-rw-r--r--    1 1000     1000             0 Mar  1 04:00 sessionfc4f381f-e7f6-4b08-a529-e2b91073efc9
-rw-r--r--    1 1000     1000             8 Mar  1 04:00 sessionff1f24bb-5673-4f7d-b64e-10cbad659adf
-rw-r--r--    1 1000     1000            25 Feb 24 10:51 start_time
-rw-r--r--    1 1000     1000            25 Mar  1 03:59 window_time
```

The empty zero-byte `sessionfc4f381f-e7f6-4b08-a529-e2b91073efc9` file will cause

```
INFO  Using existing storage directory dir:storage/localhost_555 event-handler/state.go:148
panic: runtime error: index out of range [7] with length 0

goroutine 93 [running]:
encoding/binary.bigEndian.Uint64(...)
    encoding/binary/binary.go:202
main.(*State).GetSessions(0xc0007280a8)
    github.com/gravitational/teleport/integrations/event-handler/state.go:305 +0x187
main.(*SessionEventsJob).restartPausedSessions(0xc00059e1e0)
    github.com/gravitational/teleport/integrations/event-handler/session_events_job.go:277 +0x32
main.(*SessionEventsJob).run(0xc00059e1e0, {0x1d86b18, 0xc00018c230})
    github.com/gravitational/teleport/integrations/event-handler/session_events_job.go:109 +0x14c
main.NewSessionEventsJob.NewServiceJob.func1({0x1d86b18?, 0xc00018c230?})
    github.com/gravitational/teleport@v0.0.0/integrations/lib/process.go:234 +0x2a
github.com/gravitational/teleport/integrations/lib.(*serviceJob).DoJob(0x0?, {0x1d86b18?, 0xc00018c230?})
    github.com/gravitational/teleport@v0.0.0/integrations/lib/process.go:255 +0x27
github.com/gravitational/teleport/integrations/lib.NewProcess.func2.1()
    github.com/gravitational/teleport@v0.0.0/integrations/lib/process.go:101 +0x4b
created by github.com/gravitational/teleport/integrations/lib.NewProcess.func2 in goroutine 1
    github.com/gravitational/teleport@v0.0.0/integrations/lib/process.go:100 +0x14a
```

I believe I've seen at least one other case where the empty "session" file causes an issue. I went ahead and added some checks to prevent writing a bare `session` file with no session ID. Instead, it raises an error, which should hopefully shed light if it happens in the wild.

I also made `GetSessions` ignore an existing `session` file with no session ID if it's already on disk.

## Manual Test Plan

### Test Environment
A self hosted v18 cluster using the XXX backend.

### Test Cases
- [x] Event handler runs
- [x] New SSH sessions are ingested
- [x] Event handler can be restarted
- [x] Event handler recovers from a corrupted state directory

changelog: Hardened event handler so it recovers in case of malformed session ID or corrupted data directory