### PR TITLE
[v18] Fix oversized events breaking session uploads in sync mode

### DIFF
--- a/api/client/auditstreamer.go
+++ b/api/client/auditstreamer.go
@@ -25,6 +25,7 @@ import (
 	ggzip "google.golang.org/grpc/encoding/gzip"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types/events"
 )
 
@@ -107,8 +108,19 @@ func (s *auditStreamer) Status() <-chan events.StreamStatus {
 }
 
 // RecordEvent records adds an event to a session recording.
-func (s *auditStreamer) RecordEvent(ctx context.Context, event events.PreparedSessionEvent) error {
-	oneof, err := events.ToOneOf(event.GetAuditEvent())
+func (s *auditStreamer) RecordEvent(ctx context.Context, pe events.PreparedSessionEvent) error {
+	event := pe.GetAuditEvent()
+	messageSize := event.Size()
+	if messageSize > constants.MaxProtoMessageSizeBytes {
+		event = event.TrimToMaxSize(constants.MaxProtoMessageSizeBytes)
+		if event.Size() > constants.MaxProtoMessageSizeBytes {
+			return trace.BadParameter(
+				"unable to trim %q event %s (%d bytes) to max message size (%d bytes), event cannot be recorded. This is likely a bug",
+				event.GetType(), event.GetID(), messageSize, constants.MaxProtoMessageSizeBytes,
+			)
+		}
+	}
+	oneof, err := events.ToOneOf(event)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -35,9 +35,11 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
 	clusterconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
@@ -45,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/events"
 )
 
 func TestMain(m *testing.M) {
@@ -554,6 +557,7 @@ func TestListResources(t *testing.T) {
 	// Create client
 	clt, err := New(ctx, srv.clientCfg())
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clt.Close()) })
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -630,6 +634,7 @@ func TestGetResources(t *testing.T) {
 	// Create client
 	clt, err := New(ctx, srv.clientCfg())
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clt.Close()) })
 
 	t.Run("DatabaseServer", func(t *testing.T) {
 		t.Parallel()
@@ -670,6 +675,7 @@ func TestGetResourcesWithFilters(t *testing.T) {
 	// Create client
 	clt, err := New(ctx, srv.clientCfg())
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clt.Close()) })
 
 	testCases := map[string]struct {
 		resourceType string
@@ -807,6 +813,7 @@ func TestUploadEncryptedRecording(t *testing.T) {
 
 	clt, err := New(ctx, srv.clientCfg())
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clt.Close()) })
 
 	sessionID, err := uuid.NewV7()
 	require.NoError(t, err)
@@ -875,6 +882,110 @@ func (s *uploadRecordingService) CompleteUpload(ctx context.Context, req *record
 	return nil, nil
 }
 
+func TestAuditStream(t *testing.T) {
+	t.Parallel()
+	streamer := &mockAuditStreamer{}
+	srv := startMockServer(t, mockServices{auth: streamer})
+	clt, err := New(t.Context(), srv.clientCfg())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clt.Close()) })
+
+	stream, err := clt.CreateAuditStream(t.Context(), uuid.NewString())
+	require.NoError(t, err)
+	// Check for initial status.
+	status := <-stream.Status()
+	require.Equal(t, int64(-1), status.LastEventIndex)
+
+	normalEvent := &events.SessionPrint{
+		Metadata: events.Metadata{
+			Index: 1,
+		},
+		DelayMilliseconds: 100,
+		Data:              []byte("test"),
+	}
+	oversizedEvent := &events.DatabaseSessionQuery{
+		Metadata: events.Metadata{
+			Index: 2,
+		},
+		DatabaseQuery: strings.Repeat("ab", constants.MaxProtoMessageSizeBytes),
+	}
+
+	statusDone := make(chan struct{})
+	go func() {
+		// Check for status for each recorded event.
+		defer close(statusDone)
+		status := <-stream.Status()
+		assert.Equal(t, normalEvent.GetIndex(), status.LastEventIndex)
+		status = <-stream.Status()
+		assert.Equal(t, oversizedEvent.GetIndex(), status.LastEventIndex)
+	}()
+
+	require.NoError(t, stream.RecordEvent(t.Context(), preparedSessionEvent{normalEvent}))
+	require.NoError(t, stream.RecordEvent(t.Context(), preparedSessionEvent{oversizedEvent}))
+	<-statusDone
+	require.NoError(t, stream.Complete(t.Context()))
+	require.Len(t, streamer.gotEvents, 2)
+	assert.Equal(t, normalEvent, streamer.gotEvents[0])
+	assert.Equal(t, oversizedEvent.GetIndex(), streamer.gotEvents[1].GetIndex())
+	// Check that oversized event was trimmed.
+	assert.True(t, strings.HasPrefix(oversizedEvent.DatabaseQuery, streamer.gotEvents[1].(*events.DatabaseSessionQuery).DatabaseQuery))
+}
+
+type mockAuditStreamer struct {
+	proto.UnimplementedAuthServiceServer
+	gotEvents []events.AuditEvent
+}
+
+func (m *mockAuditStreamer) CreateAuditStream(srv grpc.BidiStreamingServer[proto.AuditStreamRequest, events.StreamStatus]) error {
+	msg, err := srv.Recv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	createMsg, ok := msg.Request.(*proto.AuditStreamRequest_CreateStream)
+	if !ok {
+		return trace.BadParameter("expected message to be %T, got %T", createMsg, msg)
+	}
+	uploadID := uuid.NewString()
+	if err := srv.Send(&events.StreamStatus{
+		UploadID:       uploadID,
+		LastEventIndex: -1,
+		LastUploadTime: time.Now(),
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	for {
+		msg, err = srv.Recv()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		switch msg := msg.Request.(type) {
+		case *proto.AuditStreamRequest_CompleteStream, *proto.AuditStreamRequest_FlushAndCloseStream:
+			return nil
+		case *proto.AuditStreamRequest_Event:
+			event, err := events.FromOneOf(*msg.Event)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			m.gotEvents = append(m.gotEvents, event)
+			if err := srv.Send(&events.StreamStatus{
+				UploadID:       uploadID,
+				LastEventIndex: event.GetIndex(),
+				LastUploadTime: time.Now(),
+			}); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+}
+
+type preparedSessionEvent struct {
+	event events.AuditEvent
+}
+
+func (p preparedSessionEvent) GetAuditEvent() events.AuditEvent {
+	return p.event
+}
+
 func TestWindowsCAFallback(t *testing.T) {
 	t.Parallel()
 
@@ -913,6 +1024,7 @@ func TestWindowsCAFallback(t *testing.T) {
 
 	c, err := New(ctx, server.clientCfg())
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, c.Close()) })
 
 	id := types.CertAuthID{
 		Type:       types.WindowsCA,

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -295,6 +295,9 @@ const (
 	LockingModeBestEffort = LockingMode("best_effort")
 )
 
+// MaxProtoMessageSizeBytes is maximum protobuf marshaled message size.
+const MaxProtoMessageSizeBytes = 64 * 1024
+
 // DeviceTrustMode is the mode of verification for trusted devices.
 // DeviceTrustMode is always "off" for OSS.
 // Defaults to "optional" for Enterprise.

--- a/lib/events/auditwriter_internal_test.go
+++ b/lib/events/auditwriter_internal_test.go
@@ -24,11 +24,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
 )
 
 func TestBytesToSessionPrintEvents(t *testing.T) {
-	b := make([]byte, MaxProtoMessageSizeBytes+1)
+	b := make([]byte, constants.MaxProtoMessageSizeBytes+1)
 	_, err := rand.Read(b)
 	require.NoError(t, err)
 

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
@@ -72,9 +73,9 @@ func GetOpenFileFunc() utils.OpenFileWithFlagsFunc {
 
 const (
 	// minUploadBytes is the minimum part file size required to trigger its upload.
-	minUploadBytes = events.MaxProtoMessageSizeBytes * 2
+	minUploadBytes = constants.MaxProtoMessageSizeBytes * 2
 	// reservationSize is the size new reservations will preallocate.
-	reservationSize = minUploadBytes + events.MaxProtoMessageSizeBytes
+	reservationSize = minUploadBytes + constants.MaxProtoMessageSizeBytes
 )
 
 type StreamerConfig struct {

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/api/option"
@@ -461,9 +462,12 @@ func convertGCSError(err error) error {
 		return nil
 	}
 
+	var ae *apierror.APIError
 	switch {
 	case errors.Is(err, storage.ErrBucketNotExist), errors.Is(err, storage.ErrObjectNotExist):
 		return trace.NotFound("%s", err)
+	case errors.As(err, &ae):
+		return trace.ReadError(ae.HTTPCode(), []byte(ae.Error()))
 	default:
 		return trace.Wrap(err)
 	}

--- a/lib/events/gcssessions/gcsstream.go
+++ b/lib/events/gcssessions/gcsstream.go
@@ -77,7 +77,11 @@ func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*even
 	uploadLatencies.Observe(time.Since(start).Seconds())
 	uploadRequests.Inc()
 	if err != nil {
-		return nil, convertGCSError(err)
+		gcsErr := convertGCSError(err)
+		if trace.IsCompareFailed(gcsErr) {
+			return nil, trace.AlreadyExists("upload at %q already exists, this is a bug", uploadPath)
+		}
+		return nil, gcsErr
 	}
 	return &upload, nil
 }
@@ -100,7 +104,11 @@ func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, pa
 	uploadLatencies.Observe(time.Since(start).Seconds())
 	uploadRequests.Inc()
 	if err != nil {
-		return nil, convertGCSError(err)
+		gcsErr := convertGCSError(err)
+		if trace.IsCompareFailed(gcsErr) {
+			return nil, trace.AlreadyExists("part at %q already exists, create a new part instead", partPath)
+		}
+		return nil, gcsErr
 	}
 	return &events.StreamPart{Number: partNumber, LastModified: writer.Attrs().Created}, nil
 }
@@ -144,14 +152,23 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 		composer := mergeObject.If(storage.Conditions{DoesNotExist: true}).ComposerFrom(objectsToMerge...)
 		_, err = h.OnComposerRun(ctx, composer)
 		if err != nil {
-			return convertGCSError(err)
+			gcsErr := convertGCSError(err)
+			// If composer object already existed, no need to make it again.
+			if !trace.IsCompareFailed(gcsErr) {
+				return gcsErr
+			}
 		}
 		objects = append([]*storage.ObjectHandle{mergeObject}, objects[maxParts:]...)
 	}
 	composer := sessionObject.If(storage.Conditions{DoesNotExist: true}).ComposerFrom(objects...)
 	_, err = h.OnComposerRun(ctx, composer)
 	if err != nil {
-		return convertGCSError(err)
+		gcsErr := convertGCSError(err)
+		if trace.IsCompareFailed(gcsErr) {
+			h.logger.WarnContext(ctx, "Upload attempted to replace a completed recording, will not overwrite", "upload", upload)
+		} else {
+			return gcsErr
+		}
 	}
 	h.logger.DebugContext(ctx, "Completed upload after merging multiple objects", "objects", len(objects), "upload", upload)
 	return h.cleanupUpload(ctx, upload)

--- a/lib/events/session_writer.go
+++ b/lib/events/session_writer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/session"
@@ -141,8 +142,8 @@ func bytesToSessionPrintEvents(b []byte) []apievents.AuditEvent {
 			},
 			Data: b,
 		}
-		if printEvent.Size() > MaxProtoMessageSizeBytes {
-			extraBytes := printEvent.Size() - MaxProtoMessageSizeBytes
+		if printEvent.Size() > constants.MaxProtoMessageSizeBytes {
+			extraBytes := printEvent.Size() - constants.MaxProtoMessageSizeBytes
 			printEvent.Data = b[:extraBytes]
 			printEvent.Bytes = int64(len(printEvent.Data))
 			b = b[extraBytes:]

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
+	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth/recordingencryption"
@@ -64,9 +65,6 @@ const (
 	// ConcurrentUploadsPerStream limits the amount of concurrent uploads
 	// per stream
 	ConcurrentUploadsPerStream = 1
-
-	// MaxProtoMessageSizeBytes is maximum protobuf marshaled message size
-	MaxProtoMessageSizeBytes = 64 * 1024
 
 	// MinUploadPartSizeBytes is the minimum upload part size when uploading session recordings
 	// through a [MultipartUploader]. All uploaded parts are expected to meet this minimum size.
@@ -166,7 +164,7 @@ func NewProtoStreamer(cfg ProtoStreamerConfig) (*ProtoStreamer, error) {
 		// Min upload bytes + some overhead to prevent buffer growth (gzip writer is not precise)
 		bufferPool: utils.NewBufferSyncPool(cfg.MinUploadBytes + cfg.MinUploadBytes/3),
 		// MaxProtoMessage size + length of the message record
-		slicePool: utils.NewSliceSyncPool(MaxProtoMessageSizeBytes + ProtoStreamV1RecordHeaderSize),
+		slicePool: utils.NewSliceSyncPool(constants.MaxProtoMessageSizeBytes + ProtoStreamV1RecordHeaderSize),
 	}, nil
 }
 
@@ -467,10 +465,10 @@ func (s *ProtoStream) Done() <-chan struct{} {
 func (s *ProtoStream) RecordEvent(ctx context.Context, pe apievents.PreparedSessionEvent) error {
 	event := pe.GetAuditEvent()
 	messageSize := event.Size()
-	if messageSize > MaxProtoMessageSizeBytes {
-		event = event.TrimToMaxSize(MaxProtoMessageSizeBytes)
-		if event.Size() > MaxProtoMessageSizeBytes {
-			return trace.BadParameter("record size %v exceeds max message size of %v bytes", messageSize, MaxProtoMessageSizeBytes)
+	if messageSize > constants.MaxProtoMessageSizeBytes {
+		event = event.TrimToMaxSize(constants.MaxProtoMessageSizeBytes)
+		if event.Size() > constants.MaxProtoMessageSizeBytes {
+			return trace.BadParameter("record size %v exceeds max message size of %v bytes", messageSize, constants.MaxProtoMessageSizeBytes)
 		}
 	}
 
@@ -935,7 +933,7 @@ func (w *sliceWriter) startUpload(partNumber int64, slice *slice) (*activeUpload
 			log.WarnContext(w.proto.cancelCtx, "failed to upload part", "error", err)
 
 			// upload is not found is not a transient error, so abort the operation
-			if errors.Is(trace.Unwrap(err), context.Canceled) || trace.IsNotFound(err) {
+			if errors.Is(trace.Unwrap(err), context.Canceled) || trace.IsNotFound(err) || trace.IsAlreadyExists(err) {
 				log.InfoContext(w.proto.cancelCtx, "aborting part upload")
 				activeUpload.setError(err)
 				return
@@ -1140,11 +1138,13 @@ const (
 
 // ProtoReader reads protobuf encoding from reader
 type ProtoReader struct {
-	gzipReader   *gzipReader
-	padding      int64
-	reader       io.Reader
-	sizeBytes    [Int64Size]byte
-	messageBytes [MaxProtoMessageSizeBytes]byte
+	gzipReader *gzipReader
+	padding    int64
+	reader     io.Reader
+	sizeBytes  [Int64Size]byte
+	// Extra metadata added after trimming can slightly increase message size,
+	// so include a little wiggle room.
+	messageBytes [constants.MaxProtoMessageSizeBytes + 4*1024]byte
 	state        int
 	error        error
 	lastIndex    int64

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -184,12 +185,12 @@ func TestProtoStreamLargeEvent(t *testing.T) {
 	}{
 		{
 			name:         "large trimmable event is trimmed",
-			event:        makeQueryEvent("1", strings.Repeat("A", events.MaxProtoMessageSizeBytes)),
+			event:        makeQueryEvent("1", strings.Repeat("A", constants.MaxProtoMessageSizeBytes)),
 			errAssertion: require.NoError,
 		},
 		{
 			name:         "large untrimmable event returns error",
-			event:        makeAccessRequestEvent("1", strings.Repeat("A", events.MaxProtoMessageSizeBytes)),
+			event:        makeAccessRequestEvent("1", strings.Repeat("A", constants.MaxProtoMessageSizeBytes)),
 			errAssertion: require.Error,
 		},
 	}

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
@@ -991,7 +992,7 @@ func (s *WindowsService) makeTDPSendHandler(
 				Message:           b,
 				DelayMilliseconds: delay(),
 			}
-			if e.Size() > libevents.MaxProtoMessageSizeBytes {
+			if e.Size() > constants.MaxProtoMessageSizeBytes {
 				// Technically a PNG frame is unbounded and could be too big for a single protobuf.
 				// In practice though, Windows limits RDP bitmaps to 64x64 pixels, and we compress
 				// the PNGs before they get here, so most PNG frames are under 500 bytes. The largest
@@ -1065,7 +1066,7 @@ func (s *WindowsService) makeTDPReceiveHandler(
 				Message:           b,
 				DelayMilliseconds: delay(),
 			}
-			if e.Size() > libevents.MaxProtoMessageSizeBytes {
+			if e.Size() > constants.MaxProtoMessageSizeBytes {
 				// screen spec, mouse button, and mouse move are fixed size messages,
 				// so they cannot exceed the maximum size
 				s.cfg.Logger.WarnContext(ctx, "refusing to record message", "len", len(b), "type", logutils.TypeAttr(m))

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -337,7 +338,7 @@ func TestSkipsExtremelyLargePNGs(t *testing.T) {
 	emitterPreparer := libevents.WithNoOpPreparer(emitter)
 
 	// a fake PNG Frame message, which is way too big to be legitimate
-	maliciousPNG := make([]byte, libevents.MaxProtoMessageSizeBytes+1)
+	maliciousPNG := make([]byte, constants.MaxProtoMessageSizeBytes+1)
 	rand.Read(maliciousPNG)
 	maliciousPNG[0] = byte(tdp.TypePNGFrame)
 


### PR DESCRIPTION
Backport #63903 to branch/v18

Changelog: Fixed failures to record extra large session events in synchronous recording modes

# Test plan
Create a cluster with sync recording and a SQL database. Run the following command and confirm that the session is successfully recorded and can be played back in the web UI:
```
echo "SELECT '"$(yes a | head -c 20000000)"';" | tsh db connect <db connection params>
```
- [x] `node-sync` mode
- [x] `proxy-sync` mode
- [x] `node` mode
- [x] `proxy` mode