### PR TITLE
[v17] Fix oversized events breaking session uploads in sync mode

### DIFF
--- a/api/client/auditstreamer.go
+++ b/api/client/auditstreamer.go
@@ -25,6 +25,7 @@ import (
 	ggzip "google.golang.org/grpc/encoding/gzip"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types/events"
 )
 
@@ -107,8 +108,19 @@ func (s *auditStreamer) Status() <-chan events.StreamStatus {
 }
 
 // RecordEvent records adds an event to a session recording.
-func (s *auditStreamer) RecordEvent(ctx context.Context, event events.PreparedSessionEvent) error {
-	oneof, err := events.ToOneOf(event.GetAuditEvent())
+func (s *auditStreamer) RecordEvent(ctx context.Context, pe events.PreparedSessionEvent) error {
+	event := pe.GetAuditEvent()
+	messageSize := event.Size()
+	if messageSize > constants.MaxProtoMessageSizeBytes {
+		event = event.TrimToMaxSize(constants.MaxProtoMessageSizeBytes)
+		if event.Size() > constants.MaxProtoMessageSizeBytes {
+			return trace.BadParameter(
+				"unable to trim %q event %s (%d bytes) to max message size (%d bytes), event cannot be recorded. This is likely a bug",
+				event.GetType(), event.GetID(), messageSize, constants.MaxProtoMessageSizeBytes,
+			)
+		}
+	}
+	oneof, err := events.ToOneOf(event)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -604,6 +604,7 @@ func TestListResources(t *testing.T) {
 	// Create client
 	clt, err := New(ctx, srv.clientCfg())
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clt.Close()) })
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -680,6 +681,7 @@ func TestGetResources(t *testing.T) {
 	// Create client
 	clt, err := New(ctx, srv.clientCfg())
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clt.Close()) })
 
 	t.Run("DatabaseServer", func(t *testing.T) {
 		t.Parallel()
@@ -725,6 +727,7 @@ func TestGetResourcesWithFilters(t *testing.T) {
 	// Create client
 	clt, err := New(ctx, srv.clientCfg())
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clt.Close()) })
 
 	testCases := map[string]struct {
 		resourceType string

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -281,6 +281,9 @@ const (
 	LockingModeBestEffort = LockingMode("best_effort")
 )
 
+// MaxProtoMessageSizeBytes is maximum protobuf marshaled message size.
+const MaxProtoMessageSizeBytes = 64 * 1024
+
 // DeviceTrustMode is the mode of verification for trusted devices.
 // DeviceTrustMode is always "off" for OSS.
 // Defaults to "optional" for Enterprise.

--- a/lib/events/auditwriter_internal_test.go
+++ b/lib/events/auditwriter_internal_test.go
@@ -24,11 +24,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
 )
 
 func TestBytesToSessionPrintEvents(t *testing.T) {
-	b := make([]byte, MaxProtoMessageSizeBytes+1)
+	b := make([]byte, constants.MaxProtoMessageSizeBytes+1)
 	_, err := rand.Read(b)
 	require.NoError(t, err)
 

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
@@ -69,7 +70,7 @@ func GetOpenFileFunc() utils.OpenFileWithFlagsFunc {
 }
 
 // minUploadBytes is the minimum part file size required to trigger its upload.
-const minUploadBytes = events.MaxProtoMessageSizeBytes * 2
+const minUploadBytes = constants.MaxProtoMessageSizeBytes * 2
 
 // NewStreamer creates a streamer sending uploads to disk
 func NewStreamer(dir string) (*events.ProtoStreamer, error) {
@@ -376,7 +377,7 @@ func (h *Handler) ReserveUploadPart(ctx context.Context, upload events.StreamUpl
 	}
 
 	// Create a buffer with the max size that a part file can have.
-	buf := make([]byte, minUploadBytes+events.MaxProtoMessageSizeBytes)
+	buf := make([]byte, minUploadBytes+constants.MaxProtoMessageSizeBytes)
 
 	_, err = file.Write(buf)
 	if err = trace.NewAggregate(err, file.Close()); err != nil {

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/api/option"
@@ -337,9 +338,12 @@ func convertGCSError(err error) error {
 		return nil
 	}
 
+	var ae *apierror.APIError
 	switch {
 	case errors.Is(err, storage.ErrBucketNotExist), errors.Is(err, storage.ErrObjectNotExist):
 		return trace.NotFound("%s", err)
+	case errors.As(err, &ae):
+		return trace.ReadError(ae.HTTPCode(), []byte(ae.Error()))
 	default:
 		return trace.Wrap(err)
 	}

--- a/lib/events/gcssessions/gcsstream.go
+++ b/lib/events/gcssessions/gcsstream.go
@@ -77,7 +77,11 @@ func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*even
 	uploadLatencies.Observe(time.Since(start).Seconds())
 	uploadRequests.Inc()
 	if err != nil {
-		return nil, convertGCSError(err)
+		gcsErr := convertGCSError(err)
+		if trace.IsCompareFailed(gcsErr) {
+			return nil, trace.AlreadyExists("upload at %q already exists, this is a bug", uploadPath)
+		}
+		return nil, gcsErr
 	}
 	return &upload, nil
 }
@@ -100,7 +104,11 @@ func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, pa
 	uploadLatencies.Observe(time.Since(start).Seconds())
 	uploadRequests.Inc()
 	if err != nil {
-		return nil, convertGCSError(err)
+		gcsErr := convertGCSError(err)
+		if trace.IsCompareFailed(gcsErr) {
+			return nil, trace.AlreadyExists("part at %q already exists, create a new part instead", partPath)
+		}
+		return nil, gcsErr
 	}
 	return &events.StreamPart{Number: partNumber, LastModified: writer.Attrs().Created}, nil
 }
@@ -144,14 +152,23 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 		composer := mergeObject.If(storage.Conditions{DoesNotExist: true}).ComposerFrom(objectsToMerge...)
 		_, err = h.OnComposerRun(ctx, composer)
 		if err != nil {
-			return convertGCSError(err)
+			gcsErr := convertGCSError(err)
+			// If composer object already existed, no need to make it again.
+			if !trace.IsCompareFailed(gcsErr) {
+				return gcsErr
+			}
 		}
 		objects = append([]*storage.ObjectHandle{mergeObject}, objects[maxParts:]...)
 	}
 	composer := sessionObject.If(storage.Conditions{DoesNotExist: true}).ComposerFrom(objects...)
 	_, err = h.OnComposerRun(ctx, composer)
 	if err != nil {
-		return convertGCSError(err)
+		gcsErr := convertGCSError(err)
+		if trace.IsCompareFailed(gcsErr) {
+			h.logger.WarnContext(ctx, "Upload attempted to replace a completed recording, will not overwrite", "upload", upload)
+		} else {
+			return gcsErr
+		}
 	}
 	h.logger.DebugContext(ctx, "Completed upload after merging multiple objects", "objects", len(objects), "upload", upload)
 	return h.cleanupUpload(ctx, upload)

--- a/lib/events/session_writer.go
+++ b/lib/events/session_writer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/session"
@@ -141,8 +142,8 @@ func bytesToSessionPrintEvents(b []byte) []apievents.AuditEvent {
 			},
 			Data: b,
 		}
-		if printEvent.Size() > MaxProtoMessageSizeBytes {
-			extraBytes := printEvent.Size() - MaxProtoMessageSizeBytes
+		if printEvent.Size() > constants.MaxProtoMessageSizeBytes {
+			extraBytes := printEvent.Size() - constants.MaxProtoMessageSizeBytes
 			printEvent.Data = b[:extraBytes]
 			printEvent.Bytes = int64(len(printEvent.Data))
 			b = b[extraBytes:]

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
+	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -51,9 +52,6 @@ const (
 	// ConcurrentUploadsPerStream limits the amount of concurrent uploads
 	// per stream
 	ConcurrentUploadsPerStream = 1
-
-	// MaxProtoMessageSizeBytes is maximum protobuf marshaled message size
-	MaxProtoMessageSizeBytes = 64 * 1024
 
 	// MinUploadPartSizeBytes is the minimum allowed part size when uploading a part to
 	// Amazon S3.
@@ -116,7 +114,7 @@ func NewProtoStreamer(cfg ProtoStreamerConfig) (*ProtoStreamer, error) {
 		// Min upload bytes + some overhead to prevent buffer growth (gzip writer is not precise)
 		bufferPool: utils.NewBufferSyncPool(cfg.MinUploadBytes + cfg.MinUploadBytes/3),
 		// MaxProtoMessage size + length of the message record
-		slicePool: utils.NewSliceSyncPool(MaxProtoMessageSizeBytes + ProtoStreamV1RecordHeaderSize),
+		slicePool: utils.NewSliceSyncPool(constants.MaxProtoMessageSizeBytes + ProtoStreamV1RecordHeaderSize),
 	}, nil
 }
 
@@ -391,10 +389,10 @@ func (s *ProtoStream) Done() <-chan struct{} {
 func (s *ProtoStream) RecordEvent(ctx context.Context, pe apievents.PreparedSessionEvent) error {
 	event := pe.GetAuditEvent()
 	messageSize := event.Size()
-	if messageSize > MaxProtoMessageSizeBytes {
-		event = event.TrimToMaxSize(MaxProtoMessageSizeBytes)
-		if event.Size() > MaxProtoMessageSizeBytes {
-			return trace.BadParameter("record size %v exceeds max message size of %v bytes", messageSize, MaxProtoMessageSizeBytes)
+	if messageSize > constants.MaxProtoMessageSizeBytes {
+		event = event.TrimToMaxSize(constants.MaxProtoMessageSizeBytes)
+		if event.Size() > constants.MaxProtoMessageSizeBytes {
+			return trace.BadParameter("record size %v exceeds max message size of %v bytes", messageSize, constants.MaxProtoMessageSizeBytes)
 		}
 	}
 
@@ -766,7 +764,7 @@ func (w *sliceWriter) startUpload(partNumber int64, slice *slice) (*activeUpload
 			log.WarnContext(w.proto.cancelCtx, "failed to upload part", "error", err)
 
 			// upload is not found is not a transient error, so abort the operation
-			if errors.Is(trace.Unwrap(err), context.Canceled) || trace.IsNotFound(err) {
+			if errors.Is(trace.Unwrap(err), context.Canceled) || trace.IsNotFound(err) || trace.IsAlreadyExists(err) {
 				log.InfoContext(w.proto.cancelCtx, "aborting part upload")
 				activeUpload.setError(err)
 				return
@@ -960,11 +958,13 @@ const (
 
 // ProtoReader reads protobuf encoding from reader
 type ProtoReader struct {
-	gzipReader   *gzipReader
-	padding      int64
-	reader       io.Reader
-	sizeBytes    [Int64Size]byte
-	messageBytes [MaxProtoMessageSizeBytes]byte
+	gzipReader *gzipReader
+	padding    int64
+	reader     io.Reader
+	sizeBytes  [Int64Size]byte
+	// Extra metadata added after trimming can slightly increase message size,
+	// so include a little wiggle room.
+	messageBytes [constants.MaxProtoMessageSizeBytes + 4*1024]byte
 	state        int
 	error        error
 	lastIndex    int64

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -175,12 +176,12 @@ func TestProtoStreamLargeEvent(t *testing.T) {
 	}{
 		{
 			name:         "large trimmable event is trimmed",
-			event:        makeQueryEvent("1", strings.Repeat("A", events.MaxProtoMessageSizeBytes)),
+			event:        makeQueryEvent("1", strings.Repeat("A", constants.MaxProtoMessageSizeBytes)),
 			errAssertion: require.NoError,
 		},
 		{
 			name:         "large untrimmable event returns error",
-			event:        makeAccessRequestEvent("1", strings.Repeat("A", events.MaxProtoMessageSizeBytes)),
+			event:        makeAccessRequestEvent("1", strings.Repeat("A", constants.MaxProtoMessageSizeBytes)),
 			errAssertion: require.Error,
 		},
 	}

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
@@ -1120,7 +1121,7 @@ func (s *WindowsService) makeTDPSendHandler(
 				Message:           b,
 				DelayMilliseconds: delay(),
 			}
-			if e.Size() > libevents.MaxProtoMessageSizeBytes {
+			if e.Size() > constants.MaxProtoMessageSizeBytes {
 				// Technically a PNG frame is unbounded and could be too big for a single protobuf.
 				// In practice though, Windows limits RDP bitmaps to 64x64 pixels, and we compress
 				// the PNGs before they get here, so most PNG frames are under 500 bytes. The largest
@@ -1194,7 +1195,7 @@ func (s *WindowsService) makeTDPReceiveHandler(
 				Message:           b,
 				DelayMilliseconds: delay(),
 			}
-			if e.Size() > libevents.MaxProtoMessageSizeBytes {
+			if e.Size() > constants.MaxProtoMessageSizeBytes {
 				// screen spec, mouse button, and mouse move are fixed size messages,
 				// so they cannot exceed the maximum size
 				s.cfg.Logger.WarnContext(ctx, "refusing to record message", "len", len(b), "type", logutils.TypeAttr(m))

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authtest"
@@ -264,7 +265,7 @@ func TestSkipsExtremelyLargePNGs(t *testing.T) {
 	emitterPreparer := libevents.WithNoOpPreparer(emitter)
 
 	// a fake PNG Frame message, which is way too big to be legitimate
-	maliciousPNG := make([]byte, libevents.MaxProtoMessageSizeBytes+1)
+	maliciousPNG := make([]byte, constants.MaxProtoMessageSizeBytes+1)
 	rand.Read(maliciousPNG)
 	maliciousPNG[0] = byte(tdp.TypePNGFrame)
 


### PR DESCRIPTION
Backport #63903 to branch/v17

Changelog: Fixed failures to record extra large session events in synchronous recording modes

# Test plan
Create a cluster with sync recording and a SQL database. Run the following command and confirm that the session is successfully recorded and can be played back in the web UI:
```
echo "SELECT '"$(yes a | head -c 20000000)"';" | tsh db connect <db connection params>
```
- [x] `node-sync` mode
- [x] `proxy-sync` mode
- [x] `node` mode
- [x] `proxy` mode