### PR TITLE
[v18] Add update scoped token rpc

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -6017,8 +6017,17 @@ func (c *Client) CreateScopedToken(ctx context.Context, token *joiningv1.ScopedT
 	return res.GetToken(), trace.Wrap(err)
 }
 
+// UpsertScopedToken upserts a scoped token.
 func (c *Client) UpsertScopedToken(ctx context.Context, token *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
 	res, err := c.grpc.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{
+		Token: token,
+	})
+	return res.GetToken(), trace.Wrap(err)
+}
+
+// UpdateScopedToken updates an existing scoped token.
+func (c *Client) UpdateScopedToken(ctx context.Context, token *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
+	res, err := c.grpc.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{
 		Token: token,
 	})
 	return res.GetToken(), trace.Wrap(err)

--- a/api/gen/proto/go/teleport/scopes/joining/v1/service.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/service.pb.go
@@ -568,6 +568,98 @@ func (*DeleteScopedTokenResponse) Descriptor() ([]byte, []int) {
 	return file_teleport_scopes_joining_v1_service_proto_rawDescGZIP(), []int{9}
 }
 
+// UpdateScopedTokenRequest is the request to update a scoped token.
+type UpdateScopedTokenRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Token is the scoped token to update.
+	Token         *ScopedToken `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateScopedTokenRequest) Reset() {
+	*x = UpdateScopedTokenRequest{}
+	mi := &file_teleport_scopes_joining_v1_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateScopedTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateScopedTokenRequest) ProtoMessage() {}
+
+func (x *UpdateScopedTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateScopedTokenRequest.ProtoReflect.Descriptor instead.
+func (*UpdateScopedTokenRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *UpdateScopedTokenRequest) GetToken() *ScopedToken {
+	if x != nil {
+		return x.Token
+	}
+	return nil
+}
+
+// UpdateScopedTokenResponse is the response to update a scoped token.
+type UpdateScopedTokenResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Token is the post-update scoped token.
+	Token         *ScopedToken `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateScopedTokenResponse) Reset() {
+	*x = UpdateScopedTokenResponse{}
+	mi := &file_teleport_scopes_joining_v1_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateScopedTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateScopedTokenResponse) ProtoMessage() {}
+
+func (x *UpdateScopedTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateScopedTokenResponse.ProtoReflect.Descriptor instead.
+func (*UpdateScopedTokenResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_service_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *UpdateScopedTokenResponse) GetToken() *ScopedToken {
+	if x != nil {
+		return x.Token
+	}
+	return nil
+}
+
 var File_teleport_scopes_joining_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_service_proto_rawDesc = "" +
@@ -604,13 +696,18 @@ const file_teleport_scopes_joining_v1_service_proto_rawDesc = "" +
 	"\x18DeleteScopedTokenRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\brevision\x18\x02 \x01(\tR\brevision\"\x1b\n" +
-	"\x19DeleteScopedTokenResponse2\x97\x05\n" +
+	"\x19DeleteScopedTokenResponse\"Y\n" +
+	"\x18UpdateScopedTokenRequest\x12=\n" +
+	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"Z\n" +
+	"\x19UpdateScopedTokenResponse\x12=\n" +
+	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token2\x9a\x06\n" +
 	"\x14ScopedJoiningService\x12w\n" +
 	"\x0eGetScopedToken\x121.teleport.scopes.joining.v1.GetScopedTokenRequest\x1a2.teleport.scopes.joining.v1.GetScopedTokenResponse\x12}\n" +
 	"\x10ListScopedTokens\x123.teleport.scopes.joining.v1.ListScopedTokensRequest\x1a4.teleport.scopes.joining.v1.ListScopedTokensResponse\x12\x80\x01\n" +
 	"\x11CreateScopedToken\x124.teleport.scopes.joining.v1.CreateScopedTokenRequest\x1a5.teleport.scopes.joining.v1.CreateScopedTokenResponse\x12\x80\x01\n" +
 	"\x11UpsertScopedToken\x124.teleport.scopes.joining.v1.UpsertScopedTokenRequest\x1a5.teleport.scopes.joining.v1.UpsertScopedTokenResponse\x12\x80\x01\n" +
-	"\x11DeleteScopedToken\x124.teleport.scopes.joining.v1.DeleteScopedTokenRequest\x1a5.teleport.scopes.joining.v1.DeleteScopedTokenResponseBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x11DeleteScopedToken\x124.teleport.scopes.joining.v1.DeleteScopedTokenRequest\x1a5.teleport.scopes.joining.v1.DeleteScopedTokenResponse\x12\x80\x01\n" +
+	"\x11UpdateScopedToken\x124.teleport.scopes.joining.v1.UpdateScopedTokenRequest\x1a5.teleport.scopes.joining.v1.UpdateScopedTokenResponseBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_service_proto_rawDescOnce sync.Once
@@ -624,7 +721,7 @@ func file_teleport_scopes_joining_v1_service_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_service_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_teleport_scopes_joining_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_teleport_scopes_joining_v1_service_proto_goTypes = []any{
 	(*GetScopedTokenRequest)(nil),     // 0: teleport.scopes.joining.v1.GetScopedTokenRequest
 	(*GetScopedTokenResponse)(nil),    // 1: teleport.scopes.joining.v1.GetScopedTokenResponse
@@ -636,35 +733,41 @@ var file_teleport_scopes_joining_v1_service_proto_goTypes = []any{
 	(*UpsertScopedTokenResponse)(nil), // 7: teleport.scopes.joining.v1.UpsertScopedTokenResponse
 	(*DeleteScopedTokenRequest)(nil),  // 8: teleport.scopes.joining.v1.DeleteScopedTokenRequest
 	(*DeleteScopedTokenResponse)(nil), // 9: teleport.scopes.joining.v1.DeleteScopedTokenResponse
-	nil,                               // 10: teleport.scopes.joining.v1.ListScopedTokensRequest.LabelsEntry
-	(*ScopedToken)(nil),               // 11: teleport.scopes.joining.v1.ScopedToken
-	(*v1.Filter)(nil),                 // 12: teleport.scopes.v1.Filter
+	(*UpdateScopedTokenRequest)(nil),  // 10: teleport.scopes.joining.v1.UpdateScopedTokenRequest
+	(*UpdateScopedTokenResponse)(nil), // 11: teleport.scopes.joining.v1.UpdateScopedTokenResponse
+	nil,                               // 12: teleport.scopes.joining.v1.ListScopedTokensRequest.LabelsEntry
+	(*ScopedToken)(nil),               // 13: teleport.scopes.joining.v1.ScopedToken
+	(*v1.Filter)(nil),                 // 14: teleport.scopes.v1.Filter
 }
 var file_teleport_scopes_joining_v1_service_proto_depIdxs = []int32{
-	11, // 0: teleport.scopes.joining.v1.GetScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	12, // 1: teleport.scopes.joining.v1.ListScopedTokensRequest.resource_scope:type_name -> teleport.scopes.v1.Filter
-	12, // 2: teleport.scopes.joining.v1.ListScopedTokensRequest.assigned_scope:type_name -> teleport.scopes.v1.Filter
-	10, // 3: teleport.scopes.joining.v1.ListScopedTokensRequest.labels:type_name -> teleport.scopes.joining.v1.ListScopedTokensRequest.LabelsEntry
-	11, // 4: teleport.scopes.joining.v1.ListScopedTokensResponse.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	11, // 5: teleport.scopes.joining.v1.CreateScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	11, // 6: teleport.scopes.joining.v1.CreateScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	11, // 7: teleport.scopes.joining.v1.UpsertScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	11, // 8: teleport.scopes.joining.v1.UpsertScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	0,  // 9: teleport.scopes.joining.v1.ScopedJoiningService.GetScopedToken:input_type -> teleport.scopes.joining.v1.GetScopedTokenRequest
-	2,  // 10: teleport.scopes.joining.v1.ScopedJoiningService.ListScopedTokens:input_type -> teleport.scopes.joining.v1.ListScopedTokensRequest
-	4,  // 11: teleport.scopes.joining.v1.ScopedJoiningService.CreateScopedToken:input_type -> teleport.scopes.joining.v1.CreateScopedTokenRequest
-	6,  // 12: teleport.scopes.joining.v1.ScopedJoiningService.UpsertScopedToken:input_type -> teleport.scopes.joining.v1.UpsertScopedTokenRequest
-	8,  // 13: teleport.scopes.joining.v1.ScopedJoiningService.DeleteScopedToken:input_type -> teleport.scopes.joining.v1.DeleteScopedTokenRequest
-	1,  // 14: teleport.scopes.joining.v1.ScopedJoiningService.GetScopedToken:output_type -> teleport.scopes.joining.v1.GetScopedTokenResponse
-	3,  // 15: teleport.scopes.joining.v1.ScopedJoiningService.ListScopedTokens:output_type -> teleport.scopes.joining.v1.ListScopedTokensResponse
-	5,  // 16: teleport.scopes.joining.v1.ScopedJoiningService.CreateScopedToken:output_type -> teleport.scopes.joining.v1.CreateScopedTokenResponse
-	7,  // 17: teleport.scopes.joining.v1.ScopedJoiningService.UpsertScopedToken:output_type -> teleport.scopes.joining.v1.UpsertScopedTokenResponse
-	9,  // 18: teleport.scopes.joining.v1.ScopedJoiningService.DeleteScopedToken:output_type -> teleport.scopes.joining.v1.DeleteScopedTokenResponse
-	14, // [14:19] is the sub-list for method output_type
-	9,  // [9:14] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	13, // 0: teleport.scopes.joining.v1.GetScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	14, // 1: teleport.scopes.joining.v1.ListScopedTokensRequest.resource_scope:type_name -> teleport.scopes.v1.Filter
+	14, // 2: teleport.scopes.joining.v1.ListScopedTokensRequest.assigned_scope:type_name -> teleport.scopes.v1.Filter
+	12, // 3: teleport.scopes.joining.v1.ListScopedTokensRequest.labels:type_name -> teleport.scopes.joining.v1.ListScopedTokensRequest.LabelsEntry
+	13, // 4: teleport.scopes.joining.v1.ListScopedTokensResponse.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	13, // 5: teleport.scopes.joining.v1.CreateScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	13, // 6: teleport.scopes.joining.v1.CreateScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	13, // 7: teleport.scopes.joining.v1.UpsertScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	13, // 8: teleport.scopes.joining.v1.UpsertScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	13, // 9: teleport.scopes.joining.v1.UpdateScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	13, // 10: teleport.scopes.joining.v1.UpdateScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	0,  // 11: teleport.scopes.joining.v1.ScopedJoiningService.GetScopedToken:input_type -> teleport.scopes.joining.v1.GetScopedTokenRequest
+	2,  // 12: teleport.scopes.joining.v1.ScopedJoiningService.ListScopedTokens:input_type -> teleport.scopes.joining.v1.ListScopedTokensRequest
+	4,  // 13: teleport.scopes.joining.v1.ScopedJoiningService.CreateScopedToken:input_type -> teleport.scopes.joining.v1.CreateScopedTokenRequest
+	6,  // 14: teleport.scopes.joining.v1.ScopedJoiningService.UpsertScopedToken:input_type -> teleport.scopes.joining.v1.UpsertScopedTokenRequest
+	8,  // 15: teleport.scopes.joining.v1.ScopedJoiningService.DeleteScopedToken:input_type -> teleport.scopes.joining.v1.DeleteScopedTokenRequest
+	10, // 16: teleport.scopes.joining.v1.ScopedJoiningService.UpdateScopedToken:input_type -> teleport.scopes.joining.v1.UpdateScopedTokenRequest
+	1,  // 17: teleport.scopes.joining.v1.ScopedJoiningService.GetScopedToken:output_type -> teleport.scopes.joining.v1.GetScopedTokenResponse
+	3,  // 18: teleport.scopes.joining.v1.ScopedJoiningService.ListScopedTokens:output_type -> teleport.scopes.joining.v1.ListScopedTokensResponse
+	5,  // 19: teleport.scopes.joining.v1.ScopedJoiningService.CreateScopedToken:output_type -> teleport.scopes.joining.v1.CreateScopedTokenResponse
+	7,  // 20: teleport.scopes.joining.v1.ScopedJoiningService.UpsertScopedToken:output_type -> teleport.scopes.joining.v1.UpsertScopedTokenResponse
+	9,  // 21: teleport.scopes.joining.v1.ScopedJoiningService.DeleteScopedToken:output_type -> teleport.scopes.joining.v1.DeleteScopedTokenResponse
+	11, // 22: teleport.scopes.joining.v1.ScopedJoiningService.UpdateScopedToken:output_type -> teleport.scopes.joining.v1.UpdateScopedTokenResponse
+	17, // [17:23] is the sub-list for method output_type
+	11, // [11:17] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_service_proto_init() }
@@ -679,7 +782,7 @@ func file_teleport_scopes_joining_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_service_proto_rawDesc), len(file_teleport_scopes_joining_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   11,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/scopes/joining/v1/service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/service_grpc.pb.go
@@ -38,6 +38,7 @@ const (
 	ScopedJoiningService_CreateScopedToken_FullMethodName = "/teleport.scopes.joining.v1.ScopedJoiningService/CreateScopedToken"
 	ScopedJoiningService_UpsertScopedToken_FullMethodName = "/teleport.scopes.joining.v1.ScopedJoiningService/UpsertScopedToken"
 	ScopedJoiningService_DeleteScopedToken_FullMethodName = "/teleport.scopes.joining.v1.ScopedJoiningService/DeleteScopedToken"
+	ScopedJoiningService_UpdateScopedToken_FullMethodName = "/teleport.scopes.joining.v1.ScopedJoiningService/UpdateScopedToken"
 )
 
 // ScopedJoiningServiceClient is the client API for ScopedJoiningService service.
@@ -56,6 +57,8 @@ type ScopedJoiningServiceClient interface {
 	UpsertScopedToken(ctx context.Context, in *UpsertScopedTokenRequest, opts ...grpc.CallOption) (*UpsertScopedTokenResponse, error)
 	// DeleteScopedToken deletes a scoped token.
 	DeleteScopedToken(ctx context.Context, in *DeleteScopedTokenRequest, opts ...grpc.CallOption) (*DeleteScopedTokenResponse, error)
+	// UpdateScopedToken updates a scoped token.
+	UpdateScopedToken(ctx context.Context, in *UpdateScopedTokenRequest, opts ...grpc.CallOption) (*UpdateScopedTokenResponse, error)
 }
 
 type scopedJoiningServiceClient struct {
@@ -116,6 +119,16 @@ func (c *scopedJoiningServiceClient) DeleteScopedToken(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *scopedJoiningServiceClient) UpdateScopedToken(ctx context.Context, in *UpdateScopedTokenRequest, opts ...grpc.CallOption) (*UpdateScopedTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpdateScopedTokenResponse)
+	err := c.cc.Invoke(ctx, ScopedJoiningService_UpdateScopedToken_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ScopedJoiningServiceServer is the server API for ScopedJoiningService service.
 // All implementations must embed UnimplementedScopedJoiningServiceServer
 // for forward compatibility.
@@ -132,6 +145,8 @@ type ScopedJoiningServiceServer interface {
 	UpsertScopedToken(context.Context, *UpsertScopedTokenRequest) (*UpsertScopedTokenResponse, error)
 	// DeleteScopedToken deletes a scoped token.
 	DeleteScopedToken(context.Context, *DeleteScopedTokenRequest) (*DeleteScopedTokenResponse, error)
+	// UpdateScopedToken updates a scoped token.
+	UpdateScopedToken(context.Context, *UpdateScopedTokenRequest) (*UpdateScopedTokenResponse, error)
 	mustEmbedUnimplementedScopedJoiningServiceServer()
 }
 
@@ -156,6 +171,9 @@ func (UnimplementedScopedJoiningServiceServer) UpsertScopedToken(context.Context
 }
 func (UnimplementedScopedJoiningServiceServer) DeleteScopedToken(context.Context, *DeleteScopedTokenRequest) (*DeleteScopedTokenResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteScopedToken not implemented")
+}
+func (UnimplementedScopedJoiningServiceServer) UpdateScopedToken(context.Context, *UpdateScopedTokenRequest) (*UpdateScopedTokenResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateScopedToken not implemented")
 }
 func (UnimplementedScopedJoiningServiceServer) mustEmbedUnimplementedScopedJoiningServiceServer() {}
 func (UnimplementedScopedJoiningServiceServer) testEmbeddedByValue()                              {}
@@ -268,6 +286,24 @@ func _ScopedJoiningService_DeleteScopedToken_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ScopedJoiningService_UpdateScopedToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateScopedTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ScopedJoiningServiceServer).UpdateScopedToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ScopedJoiningService_UpdateScopedToken_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ScopedJoiningServiceServer).UpdateScopedToken(ctx, req.(*UpdateScopedTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ScopedJoiningService_ServiceDesc is the grpc.ServiceDesc for ScopedJoiningService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -294,6 +330,10 @@ var ScopedJoiningService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteScopedToken",
 			Handler:    _ScopedJoiningService_DeleteScopedToken_Handler,
+		},
+		{
+			MethodName: "UpdateScopedToken",
+			Handler:    _ScopedJoiningService_UpdateScopedToken_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/proto/teleport/scopes/joining/v1/service.proto
+++ b/api/proto/teleport/scopes/joining/v1/service.proto
@@ -37,6 +37,9 @@ service ScopedJoiningService {
 
   // DeleteScopedToken deletes a scoped token.
   rpc DeleteScopedToken(DeleteScopedTokenRequest) returns (DeleteScopedTokenResponse);
+
+  // UpdateScopedToken updates a scoped token.
+  rpc UpdateScopedToken(UpdateScopedTokenRequest) returns (UpdateScopedTokenResponse);
 }
 
 // GetScopedTokenRequest is the request to get a scoped token.
@@ -122,3 +125,15 @@ message DeleteScopedTokenRequest {
 
 // DeleteScopedTokenResponse is the response to delete a scoped token.
 message DeleteScopedTokenResponse {}
+
+// UpdateScopedTokenRequest is the request to update a scoped token.
+message UpdateScopedTokenRequest {
+  // Token is the scoped token to update.
+  ScopedToken token = 1;
+}
+
+// UpdateScopedTokenResponse is the response to update a scoped token.
+message UpdateScopedTokenResponse {
+  // Token is the post-update scoped token.
+  ScopedToken token = 1;
+}

--- a/lib/auth/scopes/joining/service.go
+++ b/lib/auth/scopes/joining/service.go
@@ -24,20 +24,16 @@ import (
 	"iter"
 	"log/slog"
 
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/gravitational/teleport"
-	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 const defaultTokenPageSize = 100
@@ -96,33 +92,6 @@ func (s *Server) CreateScopedToken(ctx context.Context, req *scopedjoiningv1.Cre
 	}); err != nil {
 		s.logger.WarnContext(ctx, "user does not have permission to create scoped tokens in the requested scope", "user", authzContext.User.GetName(), "scope", req.GetToken().GetScope())
 		return nil, trace.Wrap(err)
-	}
-
-	token := req.GetToken()
-	if token.GetMetadata().GetName() == "" {
-		if token.Metadata == nil {
-			token.Metadata = &headerv1.Metadata{}
-		}
-		name, err := uuid.NewRandom()
-		if err != nil {
-			return nil, trace.Wrap(err, "generating token name")
-		}
-		token.Metadata.Name = name.String()
-	}
-
-	if token.GetSpec() != nil && token.GetSpec().GetJoinMethod() == "" {
-		token.Spec.JoinMethod = string(types.JoinMethodToken)
-	}
-
-	if token.GetSpec().GetJoinMethod() == string(types.JoinMethodToken) {
-		if token.Status == nil {
-			token.Status = &scopedjoiningv1.ScopedTokenStatus{}
-		}
-		secret, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
-		if err != nil {
-			return nil, trace.Wrap(err, "generating token secret")
-		}
-		token.Status.Secret = secret
 	}
 
 	res, err := s.backend.CreateScopedToken(ctx, req)
@@ -308,5 +277,41 @@ func (s *Server) UpsertScopedToken(ctx context.Context, req *scopedjoiningv1.Ups
 	}
 
 	res, err := s.backend.UpsertScopedToken(ctx, req)
+	return res, trace.Wrap(err)
+}
+
+// UpdateScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) UpdateScopedToken(ctx context.Context, req *scopedjoiningv1.UpdateScopedTokenRequest) (*scopedjoiningv1.UpdateScopedTokenResponse, error) {
+	authzContext, err := s.authorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authzContext.RuleContext()
+
+	// do a pre-check to weed out requests that definitely won't be authorized.
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	extant, err := s.backend.GetScopedToken(ctx, &scopedjoiningv1.GetScopedTokenRequest{
+		Name: req.GetToken().GetMetadata().GetName(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if scopes.Compare(req.GetToken().GetScope(), extant.GetToken().GetScope()) != scopes.Equivalent {
+		return nil, trace.BadParameter("cannot modify the resource scope of scoped token %q (%q -> %q)", req.GetToken().GetMetadata().GetName(), extant.GetToken().GetScope(), req.GetToken().GetScope())
+	}
+
+	if err := authzContext.CheckerContext.Decision(ctx, req.GetToken().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbUpdate)
+	}); err != nil {
+		s.logger.WarnContext(ctx, "user does not have permission to update scoped tokens in the requested scope", "user", authzContext.User.GetName(), "scope", req.GetToken().GetScope())
+		return nil, trace.Wrap(err)
+	}
+
+	res, err := s.backend.UpdateScopedToken(ctx, req)
 	return res, trace.Wrap(err)
 }

--- a/lib/auth/scopes/joining/service_test.go
+++ b/lib/auth/scopes/joining/service_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,8 +47,12 @@ import (
 )
 
 func createToken(ctx context.Context, server *joining.Server, token *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
+	cloned := proto.CloneOf(token)
+	cloned.Metadata = &headerv1.Metadata{
+		Name: uuid.New().String(),
+	}
 	res, err := server.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
-		Token: proto.CloneOf(token),
+		Token: cloned,
 	})
 	if err != nil {
 		return nil, err
@@ -417,6 +422,58 @@ func TestScopedJoiningService(t *testing.T) {
 				Token: tokenUpdate,
 			})
 			require.True(t, trace.IsAccessDenied(err))
+		})
+
+		t.Run("ensure updater can update a token at accessible scope", func(t *testing.T) {
+			tokenForUpdate, err := createToken(ctx, admin, baseToken)
+			require.NoError(t, err)
+
+			tokenUpdate := proto.CloneOf(tokenForUpdate)
+			tokenUpdate.Metadata.Labels = map[string]string{"env": "updated"}
+
+			_, err = updater.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{
+				Token: tokenUpdate,
+			})
+			require.NoError(t, err)
+
+			// Update should fail after updating if revisions don't match.
+			staleUpdate := proto.CloneOf(tokenForUpdate)
+			staleUpdate.Metadata.Labels = map[string]string{"bad": "update"}
+			_, err = updater.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{
+				Token: staleUpdate,
+			})
+			require.True(t, trace.IsCompareFailed(err))
+
+			t.Run("non updater role cannot update a token", func(t *testing.T) {
+				nonUpdaterIdents := []*joining.Server{reader, readerNoSecrets, writer}
+				for _, ident := range nonUpdaterIdents {
+					_, err := ident.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{
+						Token: tokenUpdate,
+					})
+					require.True(t, trace.IsAccessDenied(err))
+				}
+			})
+		})
+
+		t.Run("ensure updater cannot update a token at an orthogonal scope", func(t *testing.T) {
+			tokenUpdate := proto.CloneOf(stageTokenBB)
+			tokenUpdate.Metadata.Labels = map[string]string{"env": "test"}
+
+			_, err := updater.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{
+				Token: tokenUpdate,
+			})
+			require.True(t, trace.IsAccessDenied(err))
+		})
+
+		t.Run("ensure updater cannot bypass scope auth by spoofing scope in request", func(t *testing.T) {
+			tokenUpdate := proto.CloneOf(stageTokenBB)
+			tokenUpdate.Scope = "/staging/aa"
+			tokenUpdate.Spec.AssignedScope = "/staging/aa"
+
+			_, err := updater.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{
+				Token: tokenUpdate,
+			})
+			require.True(t, trace.IsBadParameter(err))
 		})
 	})
 }

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -237,7 +237,8 @@ func ValidateTokenUpdate(oldToken *joiningv1.ScopedToken, newToken *joiningv1.Sc
 		return trace.BadParameter("cannot modify usage mode of existing scoped token %s from usage mode %s to %s", tokenName, oldToken.GetSpec().GetUsageMode(), newToken.GetSpec().GetUsageMode())
 	}
 
-	if oldToken.GetStatus().GetSecret() != newToken.GetStatus().GetSecret() {
+	// If the new Token does not have a status, this should indicate that the status was not sent, meaning no change to the underlying secret
+	if newToken.GetStatus() != nil && oldToken.GetStatus().GetSecret() != newToken.GetStatus().GetSecret() {
 		return trace.BadParameter("cannot modify secret of existing scoped token %s", tokenName)
 	}
 

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -627,6 +627,12 @@ func TestValidateTokenUpdate(t *testing.T) {
 				t.Spec.AssignedScope = "/test/one/two"
 			},
 		},
+		{
+			name: "status is nil in update (no change)",
+			modifyTokenFunc: func(t *joiningv1.ScopedToken) {
+				t.Status = nil
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			modified := proto.CloneOf(baseToken)

--- a/lib/services/local/scoped_tokens.go
+++ b/lib/services/local/scoped_tokens.go
@@ -33,10 +33,12 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
@@ -95,23 +97,29 @@ func itemFromScopedToken(token *joiningv1.ScopedToken) (backend.Item, error) {
 
 // CreateScopedToken adds a scoped token to the auth server.
 func (s *ScopedTokenService) CreateScopedToken(ctx context.Context, req *joiningv1.CreateScopedTokenRequest) (*joiningv1.CreateScopedTokenResponse, error) {
-	if err := joining.StrongValidateToken(req.GetToken()); err != nil {
+	token := req.GetToken()
+
+	if err := maybeSetTokenSecret(token); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	item, err := itemFromScopedToken(req.GetToken())
+	if err := joining.StrongValidateToken(token); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item, err := itemFromScopedToken(token)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	revision, err := s.backend.AtomicWrite(ctx, []backend.ConditionalAction{
 		{
-			Key:       backend.NewKey(scopedTokenPrefix, req.GetToken().GetMetadata().GetName()),
+			Key:       backend.NewKey(scopedTokenPrefix, token.GetMetadata().GetName()),
 			Condition: backend.NotExists(),
 			Action:    backend.Put(item),
 		},
 		{
-			Key:       backend.NewKey(tokensPrefix, req.GetToken().GetMetadata().GetName()),
+			Key:       backend.NewKey(tokensPrefix, token.GetMetadata().GetName()),
 			Condition: backend.NotExists(),
 			// the second action is a no-op because we only need to
 			// execute a single action to create the scoped token,
@@ -320,10 +328,6 @@ func (s *ScopedTokenService) DeleteScopedToken(ctx context.Context, req *joining
 func (s *ScopedTokenService) UpsertScopedToken(ctx context.Context, req *joiningv1.UpsertScopedTokenRequest) (*joiningv1.UpsertScopedTokenResponse, error) {
 	tokenUpsert := req.GetToken()
 
-	if err := joining.StrongValidateToken(tokenUpsert); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// We handle 4 retry attempts to try and handle some concurrency. Handling more retries than this
 	// indicates that something may be going wrong.
 	for attempt := range maxTokenUpsertAttempts {
@@ -342,17 +346,25 @@ func (s *ScopedTokenService) UpsertScopedToken(ctx context.Context, req *joining
 			}
 		}
 
-		// We enforce this validating the updates here in order for the access-control layer's checks to be sound.
-		// Changing this would require rethinking or additional changes to the access-control checks.
-		if err := joining.ValidateTokenUpdate(existingToken, tokenUpsert); err != nil {
-			return nil, trace.Wrap(err)
-		}
-
 		if existingToken != nil {
+			// We enforce this validating the updates here in order for the access-control layer's checks to be sound.
+			// Changing this would require rethinking or additional changes to the access-control checks.
+			if err := joining.ValidateTokenUpdate(existingToken, tokenUpsert); err != nil {
+				return nil, trace.Wrap(err)
+			}
 			// Use conditional update with revision checking to ensure the token hasn't changed since we validated it.
 			// This prevents race conditions where the token could be deleted and recreated with
 			// different properties between our validation check and the write.
 			tokenUpsert.GetMetadata().Revision = existingToken.GetMetadata().GetRevision()
+
+			// The status and its secret shouldn't ever change, so preserve it when updates occur. The secret is
+			// should not be changed after creation
+			tokenUpsert.Status = existingToken.GetStatus()
+
+			if err := joining.StrongValidateToken(tokenUpsert); err != nil {
+				return nil, trace.Wrap(err)
+			}
+
 			upsertedToken, err := s.svc.ConditionalUpdateResource(ctx, tokenUpsert)
 			if err != nil {
 				if trace.IsCompareFailed(err) {
@@ -364,6 +376,14 @@ func (s *ScopedTokenService) UpsertScopedToken(ctx context.Context, req *joining
 			return &joiningv1.UpsertScopedTokenResponse{
 				Token: upsertedToken,
 			}, nil
+		}
+
+		if err := maybeSetTokenSecret(tokenUpsert); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if err := joining.StrongValidateToken(tokenUpsert); err != nil {
+			return nil, trace.Wrap(err)
 		}
 
 		createdToken, err := s.svc.CreateResource(ctx, tokenUpsert)
@@ -382,6 +402,36 @@ func (s *ScopedTokenService) UpsertScopedToken(ctx context.Context, req *joining
 	}
 
 	return nil, trace.LimitExceeded("exceeded max retries attempting to upsert scoped token - too many concurrent modifications")
+}
+
+// UpdateScopedToken updates an existing scoped token. Scope and usage mode changes are not allowed. Changes to status will be ignored.
+func (s *ScopedTokenService) UpdateScopedToken(ctx context.Context, req *joiningv1.UpdateScopedTokenRequest) (*joiningv1.UpdateScopedTokenResponse, error) {
+	tokenUpdate := req.GetToken()
+
+	existingToken, err := s.svc.GetResource(ctx, tokenUpdate.GetMetadata().GetName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := joining.ValidateTokenUpdate(existingToken, tokenUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// The status and its secret shouldn't ever change, so preserve it when updates occur. The secret
+	// should not be changed after creation.
+	tokenUpdate.Status = existingToken.GetStatus()
+
+	if err := joining.StrongValidateToken(tokenUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	updatedToken, err := s.svc.ConditionalUpdateResource(ctx, tokenUpdate)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &joiningv1.UpdateScopedTokenResponse{
+		Token: updatedToken,
+	}, nil
 }
 
 func setScopedTokenWithoutSecret(token ...*joiningv1.ScopedToken) {
@@ -464,4 +514,24 @@ func (p *staticScopedTokenParser) parse(event backend.Event) (types.Resource, er
 	default:
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
 	}
+}
+
+// maybeSetTokenSecret sets a random secret if not provided.
+func maybeSetTokenSecret(token *joiningv1.ScopedToken) error {
+
+	if token.GetSpec().GetJoinMethod() == string(types.JoinMethodToken) {
+		if token.Status == nil {
+			token.Status = &joiningv1.ScopedTokenStatus{}
+		}
+
+		if token.Status.Secret == "" {
+			secret, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
+			if err != nil {
+				return trace.Wrap(err, "generating token secret")
+			}
+			token.Status.Secret = secret
+		}
+	}
+
+	return nil
 }

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -63,12 +63,9 @@ func TestScopedTokenService(t *testing.T) {
 		Scope: "/test",
 		Spec: &joiningv1.ScopedTokenSpec{
 			AssignedScope: "/test/one",
-			JoinMethod:    "token",
 			Roles:         []string{types.RoleNode.String()},
 			UsageMode:     string(joining.TokenUsageModeUnlimited),
-		},
-		Status: &joiningv1.ScopedTokenStatus{
-			Secret: "secret",
+			JoinMethod:    string(types.JoinMethodToken),
 		},
 	}
 
@@ -81,6 +78,9 @@ func TestScopedTokenService(t *testing.T) {
 		protocmp.Transform(),
 	}
 	assert.Empty(t, gocmp.Diff(token, created.Token, cmpOpts...))
+	// ensure the token secret was set if not specified
+	assert.NotEmpty(t, created.Token.GetStatus().GetSecret())
+	token = created.Token
 
 	updatedToken := proto.CloneOf(token)
 	updatedToken.Spec.AssignedScope = "/test/test"
@@ -579,6 +579,135 @@ func TestScopedTokenUse(t *testing.T) {
 	})
 }
 
+func newToken() *joiningv1.ScopedToken {
+	return &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: uuid.New().String(),
+		},
+		Scope: "/test",
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: "/test/one",
+			JoinMethod:    "token",
+			Roles:         []string{types.RoleNode.String()},
+			UsageMode:     string(joining.TokenUsageModeUnlimited),
+		},
+		Status: &joiningv1.ScopedTokenStatus{
+			Secret: "secret",
+		},
+	}
+}
+
+func TestScopedTokenUpdate(t *testing.T) {
+	t.Parallel()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	service, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	cases := []struct {
+		name   string
+		mutate func(t *testing.T, update *joiningv1.ScopedToken)
+		assert func(t *testing.T, created, result *joiningv1.ScopedToken, err error)
+	}{
+		{
+			name: "mutable fields are updated",
+			mutate: func(t *testing.T, update *joiningv1.ScopedToken) {
+				update.Metadata.Labels = map[string]string{"env": "test"}
+				update.Spec.AssignedScope = "/test/one/two"
+			},
+			assert: func(t *testing.T, created, result *joiningv1.ScopedToken, err error) {
+				require.Equal(t, "/test/one/two", result.GetSpec().GetAssignedScope())
+				require.Equal(t, "test", result.GetMetadata().GetLabels()["env"])
+			},
+		},
+		{
+			name: "scope changes result in an error",
+			mutate: func(t *testing.T, update *joiningv1.ScopedToken) {
+				update.Scope = "/other"
+			},
+			assert: func(t *testing.T, created, result *joiningv1.ScopedToken, err error) {
+				require.ErrorContains(t, err, "cannot modify scope of existing scoped token")
+
+			},
+		},
+		{
+			name: "usage mode changes result in an error",
+			mutate: func(t *testing.T, update *joiningv1.ScopedToken) {
+				update.Spec.UsageMode = string(joining.TokenUsageModeSingle)
+			},
+			assert: func(t *testing.T, created, result *joiningv1.ScopedToken, err error) {
+				require.ErrorContains(t, err, "cannot modify usage mode of existing scoped token")
+			},
+		},
+		{
+			name: "secret change is not allowed",
+			mutate: func(t *testing.T, update *joiningv1.ScopedToken) {
+				update.Status = &joiningv1.ScopedTokenStatus{Secret: "new-secret"}
+			},
+			assert: func(t *testing.T, created, result *joiningv1.ScopedToken, err error) {
+				require.ErrorContains(t, err, "cannot modify secret of existing scoped token")
+			},
+		},
+		{
+			name: "assigned scope changed to a non-descendant scope fails",
+			mutate: func(t *testing.T, update *joiningv1.ScopedToken) {
+				update.Spec.AssignedScope = "/notadescendant"
+			},
+			assert: func(t *testing.T, created, result *joiningv1.ScopedToken, err error) {
+				require.ErrorContains(t, err, "scoped token assigned scope must be descendant of its resource scope")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			token := newToken()
+			created, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{Token: token})
+			require.NoError(t, err)
+
+			updated := proto.CloneOf(created.GetToken())
+			tc.mutate(t, updated)
+
+			res, err := service.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{Token: updated})
+
+			tc.assert(t, created.GetToken(), res.GetToken(), err)
+		})
+	}
+
+	t.Run("fails for nonexistent token", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+		_, err := service.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{Token: token})
+		require.True(t, trace.IsNotFound(err))
+	})
+
+	t.Run("editing concurrently fails since revision doesn't match", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+		created, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+
+		updated := proto.CloneOf(created.GetToken())
+		updated.Metadata.Labels = map[string]string{"env": "test"}
+		updated.Spec.AssignedScope = "/test/one/two"
+
+		updated2 := proto.CloneOf(updated)
+		updated2.Metadata.Labels = map[string]string{"env": "production"}
+
+		updateRes1, err := service.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{Token: updated})
+		require.NoError(t, err)
+		require.Equal(t, "test", updateRes1.GetToken().GetMetadata().GetLabels()["env"])
+
+		_, err = service.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{Token: updated2})
+		require.True(t, trace.IsCompareFailed(err))
+	})
+}
+
 func TestScopedTokenUpsert(t *testing.T) {
 	t.Parallel()
 	bk, err := memory.New(memory.Config{})
@@ -588,25 +717,6 @@ func TestScopedTokenUpsert(t *testing.T) {
 
 	ctx := t.Context()
 
-	newToken := func() *joiningv1.ScopedToken {
-		return &joiningv1.ScopedToken{
-			Kind:    types.KindScopedToken,
-			Version: types.V1,
-			Metadata: &headerv1.Metadata{
-				Name: uuid.New().String(),
-			},
-			Scope: "/test",
-			Spec: &joiningv1.ScopedTokenSpec{
-				AssignedScope: "/test/one",
-				JoinMethod:    "token",
-				Roles:         []string{types.RoleNode.String()},
-				UsageMode:     string(joining.TokenUsageModeUnlimited),
-			},
-			Status: &joiningv1.ScopedTokenStatus{
-				Secret: "secret",
-			},
-		}
-	}
 	cmpOpts := []gocmp.Option{
 		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
@@ -625,6 +735,32 @@ func TestScopedTokenUpsert(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Empty(t, gocmp.Diff(upsertedToken.GetToken(), fetched.GetToken(), cmpOpts...))
+	})
+
+	t.Run("upsert creates a new secret when creating a new token with no secret set", func(t *testing.T) {
+		t.Parallel()
+		// Submit a minimal token with no name, join method, or secret — the
+		// create path of UpsertScopedToken will fill in missing information
+		token := &joiningv1.ScopedToken{
+			Kind:    types.KindScopedToken,
+			Version: types.V1,
+			Scope:   "/test",
+			Metadata: &headerv1.Metadata{
+				Name: uuid.New().String(),
+			},
+			Spec: &joiningv1.ScopedTokenSpec{
+				AssignedScope: "/test/one",
+				Roles:         []string{types.RoleNode.String()},
+				UsageMode:     string(joining.TokenUsageModeUnlimited),
+				JoinMethod:    string(types.JoinMethodToken),
+			},
+		}
+
+		upserted, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+		require.NotEmpty(t, upserted.GetToken().GetMetadata().GetName(), "name should be generated")
+		require.Equal(t, string(types.JoinMethodToken), upserted.GetToken().GetSpec().GetJoinMethod(), "join method should default to token")
+		require.NotEmpty(t, upserted.GetToken().GetStatus().GetSecret(), "secret should be generated")
 	})
 
 	t.Run("upsert updates existing entry", func(t *testing.T) {
@@ -648,46 +784,67 @@ func TestScopedTokenUpsert(t *testing.T) {
 		assert.Empty(t, gocmp.Diff(updatedToken.GetToken(), fetched.GetToken(), cmpOpts...))
 	})
 
-	t.Run("upsert fails because the scope is changed", func(t *testing.T) {
+	rejectCases := []struct {
+		name    string
+		mutate  func(t *testing.T, update *joiningv1.ScopedToken)
+		wantErr string
+	}{
+		{
+			name: "scope is changed",
+			mutate: func(t *testing.T, update *joiningv1.ScopedToken) {
+				update.Scope = "/other"
+				update.Spec.AssignedScope = "/other/one"
+			},
+			wantErr: "cannot modify scope of existing scoped token",
+		},
+		{
+			name: "usage mode is changed",
+			mutate: func(t *testing.T, update *joiningv1.ScopedToken) {
+				update.Spec = proto.CloneOf(update.Spec)
+				update.Spec.UsageMode = string(joining.TokenUsageModeSingle)
+			},
+			wantErr: "cannot modify usage mode of existing scoped token",
+		},
+	}
+
+	for _, tc := range rejectCases {
+		t.Run("upsert fails because "+tc.name, func(t *testing.T) {
+			t.Parallel()
+			token := newToken()
+			_, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+			require.NoError(t, err)
+
+			updated := proto.CloneOf(token)
+			tc.mutate(t, updated)
+
+			_, err = service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: updated})
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+
+	t.Run("secret is preserved when not included", func(t *testing.T) {
 		t.Parallel()
 		token := newToken()
-		_, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+		created, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+		originalSecret := created.GetToken().GetStatus().GetSecret()
+		require.NotEmpty(t, originalSecret)
+
+		// attempt to overwrite the secret via upsert
+		updated := proto.CloneOf(token)
+		updated.Status = nil
+
+		// upsert should succeed but preserve the original secret
+		_, err = service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: updated})
 		require.NoError(t, err)
 
-		updated := proto.CloneOf(token)
-		updated.Scope = "/other"
-		updated.Spec.AssignedScope = "/other/one"
-
-		_, err = service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: updated})
-		require.ErrorContains(t, err, "cannot modify scope of existing scoped token")
-	})
-
-	t.Run("upsert fails because the usage status is changed", func(t *testing.T) {
-		t.Parallel()
-		token := newToken()
-		_, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+		// confirm the original secret is still in place
+		fetched, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name:       token.GetMetadata().GetName(),
+			WithSecret: true,
+		})
 		require.NoError(t, err)
-
-		updated := proto.CloneOf(token)
-		updated.Spec = proto.CloneOf(token.Spec)
-		updated.Spec.UsageMode = string(joining.TokenUsageModeSingle)
-
-		_, err = service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: updated})
-		require.ErrorContains(t, err, "cannot modify usage mode of existing scoped token")
-	})
-
-	t.Run("upsert fails because the secret is changed", func(t *testing.T) {
-		t.Parallel()
-		token := newToken()
-		_, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
-		require.NoError(t, err)
-
-		updated := proto.CloneOf(token)
-		updated.Status = proto.CloneOf(token.Status)
-		updated.Status.Secret = "new-secret"
-
-		_, err = service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: updated})
-		require.ErrorContains(t, err, "cannot modify secret of existing scoped token")
+		require.Equal(t, originalSecret, fetched.GetToken().GetStatus().GetSecret())
 	})
 
 	t.Run("upsert succeeds when revisions don't match", func(t *testing.T) {

--- a/lib/services/scoped_tokens.go
+++ b/lib/services/scoped_tokens.go
@@ -42,6 +42,11 @@ type ScopedTokenService interface {
 	// this returns trace.NotFound error if the token doesn't exist
 	DeleteScopedToken(ctx context.Context, req *joiningv1.DeleteScopedTokenRequest) (*joiningv1.DeleteScopedTokenResponse, error)
 
-	// UpsertScopedToken updates or creates a scoped join token. If updating an existing token, the scope and status must not be modified.
+	// UpsertScopedToken updates or creates a scoped join token. If updating an existing token, the scope and usage mode must not be modified.
+	// Updates to the status will also be ignored.
 	UpsertScopedToken(ctx context.Context, req *joiningv1.UpsertScopedTokenRequest) (*joiningv1.UpsertScopedTokenResponse, error)
+
+	// UpdateScopedToken updates an existing scoped join token. Returns trace.NotFound if the token doesn't exist.
+	// The scope and usage mode must not be modified. Any changes to status will be ignored.
+	UpdateScopedToken(ctx context.Context, req *joiningv1.UpdateScopedTokenRequest) (*joiningv1.UpdateScopedTokenResponse, error)
 }

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -34,6 +34,7 @@ import (
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/autoupdate"
@@ -108,6 +109,10 @@ func TestEditResources(t *testing.T) {
 		{
 			kind: types.KindHealthCheckConfig,
 			edit: testEditHealthCheckConfig,
+		},
+		{
+			kind: types.KindScopedToken,
+			edit: testEditScopedToken,
 		},
 	}
 
@@ -684,6 +689,58 @@ func testEditDynamicWindowsDesktop(t *testing.T, clt *authclient.Client) {
 	require.NoError(t, err)
 	expected.SetRevision(actual.GetRevision())
 	require.Empty(t, cmp.Diff(expected, actual, protocmp.Transform()))
+}
+
+func testEditScopedToken(t *testing.T, clt *authclient.Client) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	created, err := clt.CreateScopedToken(ctx, &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Scope:   "/staging",
+		Metadata: &headerv1.Metadata{
+			Name: "test-token",
+		},
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: "/staging/aa",
+			Roles:         []string{string(types.RoleNode)},
+			UsageMode:     "unlimited",
+			JoinMethod:    string(types.JoinMethodToken),
+		},
+	})
+	require.NoError(t, err)
+
+	initialRevision := created.GetMetadata().GetRevision()
+
+	editor := func(name string) error {
+		f, err := os.Create(name)
+		if err != nil {
+			return trace.Wrap(err, "opening file to edit")
+		}
+		// Always use the original revision — it becomes stale after the first edit.
+		created.GetMetadata().Revision = initialRevision
+		if created.Metadata.Labels == nil {
+			created.Metadata.Labels = make(map[string]string)
+		}
+		created.Metadata.Labels["env"] = "test"
+
+		collection := &scopedTokenCollection{tokens: []*joiningv1.ScopedToken{created}}
+		return trace.NewAggregate(writeYAML(collection, f), f.Close())
+	}
+
+	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken + "/" + created.GetMetadata().GetName()}, withEditor(editor))
+	require.NoError(t, err)
+
+	actual, err := clt.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{Name: created.GetMetadata().GetName()})
+	require.NoError(t, err)
+	require.Equal(t, "test", actual.GetMetadata().GetLabels()["env"])
+
+	// Second edit with the stale original revision should fail.
+	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken + "/" + created.GetMetadata().GetName()}, withEditor(editor))
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err))
 }
 
 func TestMultipleRoles(t *testing.T) {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1314,6 +1314,20 @@ func (rc *ResourceCommand) createScopedToken(ctx context.Context, client *authcl
 	return nil
 }
 
+func (rc *ResourceCommand) updateScopedToken(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	token, err := services.UnmarshalProtoResource[*joiningv1.ScopedToken](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := client.UpdateScopedToken(ctx, token); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf("%v %q has been updated\n", types.KindScopedToken, token.GetMetadata().GetName())
+	return nil
+}
+
 func (rc *ResourceCommand) createScopedRoleAssignment(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	if rc.IsForced() {
 		return trace.BadParameter("scoped role assignment creation does not support --force")
@@ -1342,10 +1356,6 @@ func (rc *ResourceCommand) createScopedRoleAssignment(ctx context.Context, clien
 
 func (rc *ResourceCommand) updateScopedRoleAssignment(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	return trace.NotImplemented("scoped_role_assignment resources do not support updates")
-}
-
-func (rc *ResourceCommand) updateScopedToken(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	return trace.NotImplemented("scoped_token resources do not support updates")
 }
 
 func (rc *ResourceCommand) createSigstorePolicy(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v3"
@@ -116,7 +117,6 @@ func (c *ScopedTokensCommand) Initialize(scopedCmd *kingpin.CmdClause, config *s
 	c.tokenAdd.Flag("mode", "Usage mode of a token (default: unlimited, single_use)").StringVar(&c.mode)
 	c.tokenAdd.Flag("labels", "Set token labels, e.g. env=prod,region=us-west").StringVar(&c.labels)
 	c.tokenAdd.Flag("ssh-labels", "Set immutable ssh labels the token should assign to provisioned resources, e.g. env=prod,region=us-west").StringVar(&c.sshLabels)
-
 	// "tctl scoped tokens rm ..."
 	c.tokenDel = tokens.Command("rm", "Delete/revoke a scoped invitation token.").Alias("del")
 	c.tokenDel.Arg("token", "Token to delete").StringVar(&c.name)
@@ -170,6 +170,14 @@ func (c *ScopedTokensCommand) Add(ctx context.Context, client *authclient.Client
 
 	tokenName := c.name
 
+	if tokenName == "" {
+		name, err := uuid.NewV7()
+		if err != nil {
+			return trace.Wrap(err, "generating token name")
+		}
+		tokenName = name.String()
+	}
+
 	var labels map[string]string
 	if c.labels != "" {
 		labels, err = libclient.ParseLabelSpec(c.labels)
@@ -188,6 +196,7 @@ func (c *ScopedTokensCommand) Add(ctx context.Context, client *authclient.Client
 			Ssh: sshLabels,
 		}
 	}
+
 	expires := time.Now().UTC().Add(c.ttl)
 	tok := &joiningv1.ScopedToken{
 		Kind:    types.KindScopedToken,
@@ -203,6 +212,7 @@ func (c *ScopedTokensCommand) Add(ctx context.Context, client *authclient.Client
 			AssignedScope:   c.assignedScope,
 			UsageMode:       cmp.Or(c.mode, joining.TokenUsageModeUnlimited),
 			ImmutableLabels: immutableLabels,
+			JoinMethod:      string(types.JoinMethodToken),
 		},
 	}
 


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/64189

Testing:

edit:
- [x] Use tctl edit scoped_tokens command - verify that scope/usage_mode/secret cannot be modified
- [x] use tctl edit scoped_tokens command with a user that doesn't have the update permission
- [x] update should return not found error when updating nonexistent token
- [x]  run tctl edit scoped_tokens/<name> for the same token in two terminal windows concurrently. Make different edits in each, then complete both. The first edit should complete, the second should be rejected (because the revision doesn't match).
- [x] updating the token secret should fail
- [x] updating the token without the status field should succeed and no changes to the secret occur

upsert:
- [x] tctl create -f scoped_tokens and ensure that changing scope and usage mode still fails. 
- [x]  tctl create -f with a bare minimum token will fail when  name, usage mode, and the secret are missing
- [x]  tctl create -f with a secret changed will fail
- [x] tctl create -f with no status succeeds. A new token upsert will have a new secret created. An update will have secret unchanged

changelog: add update scoped token support to tctl and update upsert scoped token rpc to not require status