### PR TITLE
Display human-friendly string for MFA flow_type in the audit log

### DIFF
--- a/web/packages/teleport/src/services/audit/makeEvent.test.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import makeEvent from './makeEvent';
+import { eventCodes } from './types';
+
+describe('formatRawEventForUI', () => {
+  test.each([
+    [eventCodes.CREATE_MFA_AUTH_CHALLENGE, 0, 'UNSPECIFIED'],
+    [eventCodes.CREATE_MFA_AUTH_CHALLENGE, 1, 'PER_SESSION_CERTIFICATE'],
+    [eventCodes.CREATE_MFA_AUTH_CHALLENGE, 2, 'IN_BAND'],
+    [eventCodes.VALIDATE_MFA_AUTH_RESPONSE, 0, 'UNSPECIFIED'],
+    [eventCodes.VALIDATE_MFA_AUTH_RESPONSE, 1, 'PER_SESSION_CERTIFICATE'],
+    [eventCodes.VALIDATE_MFA_AUTH_RESPONSE, 2, 'IN_BAND'],
+  ])(
+    'formats raw event for MFA event code %s with flow_type %s to %s',
+    (code, flowType, expectedFlowType) => {
+      const input = {
+        code,
+        event: 'mfa.auth',
+        user: 'alice',
+        time: '2026-01-01T00:00:00.000Z',
+        flow_type: flowType,
+      };
+
+      const event = makeEvent(input);
+
+      expect(event.raw).toEqual({
+        code,
+        event: 'mfa.auth',
+        user: 'alice',
+        time: '2026-01-01T00:00:00.000Z',
+        flow_type: expectedFlowType,
+      });
+      expect(input.flow_type).toBe(flowType);
+    }
+  );
+
+  test('leaves non-MFA events unchanged', () => {
+    const input = {
+      code: eventCodes.USER_LOCAL_LOGIN,
+      event: 'user.login',
+      user: 'alice',
+      time: '2026-01-01T00:00:00.000Z',
+    };
+
+    const event = makeEvent(input);
+
+    expect(event.raw).toBe(input);
+  });
+});

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -2601,6 +2601,7 @@ const mfaFlowTypeLabels: Record<number, string> = {
   2: 'IN_BAND',
 };
 
+// TODO(cthach): DELETE IN v20.0 once the only supported MFA flow_type is IN_BAND.
 function formatRawEventForUI(json: any): any {
   // For MFA events, convert the flow_type from a number to a human readable string.
   if (

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -2594,9 +2594,35 @@ const unknownFormatter = {
   format: () => 'Unknown',
 };
 
+// MFA flow types are defined in api/proto/teleport/legacy/types/events/events.proto.
+const mfaFlowTypeLabels: Record<number, string> = {
+  0: 'UNSPECIFIED',
+  1: 'PER_SESSION_CERTIFICATE',
+  2: 'IN_BAND',
+};
+
+function formatRawEventForUI(json: any): any {
+  // For MFA events, convert the flow_type from a number to a human readable string.
+  if (
+    json?.code == eventCodes.CREATE_MFA_AUTH_CHALLENGE ||
+    json?.code == eventCodes.VALIDATE_MFA_AUTH_RESPONSE
+  ) {
+    return {
+      ...json,
+      flow_type: mfaFlowTypeLabels[json.flow_type] ?? json.flow_type,
+    };
+  }
+
+  return json;
+}
+
 export default function makeEvent(json: any): Event {
   // lookup event formatter by code
   const formatter = formatters[json.code as EventCode] || unknownFormatter;
+
+  // format raw event for UI
+  const raw = formatRawEventForUI(json);
+
   return {
     codeDesc:
       typeof formatter.desc === 'function'
@@ -2607,7 +2633,7 @@ export default function makeEvent(json: any): Event {
     code: json.code,
     user: json.user,
     time: new Date(json.time),
-    raw: json,
+    raw: raw,
   };
 }
 

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -2620,7 +2620,6 @@ export default function makeEvent(json: any): Event {
   // lookup event formatter by code
   const formatter = formatters[json.code as EventCode] || unknownFormatter;
 
-  // format raw event for UI
   const raw = formatRawEventForUI(json);
 
   return {


### PR DESCRIPTION
Resolves https://github.com/gravitational/teleport/issues/63386

Before:

<img width="774" height="800" alt="Screenshot 2026-03-05 at 7 07 36 PM" src="https://github.com/user-attachments/assets/ed6f3bf2-5e4b-4368-aab9-8d3402ed8e96" />


After:

<img width="975" height="843" alt="Screenshot 2026-03-05 at 6 58 24 PM" src="https://github.com/user-attachments/assets/2b3bf0e5-ffa9-4498-bac4-52750f780fe9" />

## Manual tests

- [x] SSH to a host and ensure audit log in UI displays the `flow_type` as a string for the successful event
- [x] Attempt to SSH to a host and ensure audit log in UI displays the `flow_type` as a string for the failed attempt event

