### PR TITLE
add time till next scan timer to IaCOverview Page

### DIFF
--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.story.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.story.tsx
@@ -66,6 +66,8 @@ Default.parameters = {
   msw: {
     handlers: [
       http.get(cfg.getIntegrationStatsUrl(integrationName), () => {
+        const lastSync = Date.now() - 2 * 60 * 1000;
+
         return HttpResponse.json({
           name: integrationName,
           subKind: IntegrationKind.AwsOidc,
@@ -95,9 +97,9 @@ Default.parameters = {
           awsoidc: {
             roleArn: 'arn:aws:iam::123456789012:role/TeleportRole',
           },
-          awsec2: { enrolled: 5, failed: 1 },
-          awsrds: { enrolled: 3, failed: 0 },
-          awseks: { enrolled: 2, failed: 0 },
+          awsec2: { enrolled: 5, failed: 1, discoverLastSync: lastSync },
+          awsrds: { enrolled: 3, failed: 0, discoverLastSync: lastSync },
+          awseks: { enrolled: 2, failed: 0, discoverLastSync: lastSync },
           isManagedByTerraform: true,
         });
       }),
@@ -188,6 +190,8 @@ Healthy.parameters = {
   msw: {
     handlers: [
       http.get(cfg.getIntegrationStatsUrl(integrationName), () => {
+        const lastSync = Date.now() - 2 * 60 * 1000;
+
         return HttpResponse.json({
           name: integrationName,
           subKind: IntegrationKind.AwsOidc,
@@ -196,9 +200,9 @@ Healthy.parameters = {
           awsoidc: {
             roleArn: 'arn:aws:iam::123456789012:role/TeleportRole',
           },
-          awsec2: { enrolled: 10, failed: 0 },
-          awsrds: { enrolled: 5, failed: 0 },
-          awseks: { enrolled: 3, failed: 0 },
+          awsec2: { enrolled: 10, failed: 0, discoverLastSync: lastSync },
+          awsrds: { enrolled: 5, failed: 0, discoverLastSync: lastSync },
+          awseks: { enrolled: 3, failed: 0, discoverLastSync: lastSync },
           isManagedByTerraform: true,
         });
       }),

--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.tsx
@@ -17,8 +17,8 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { formatDistanceToNowStrict } from 'date-fns';
-import { useState, type ReactNode } from 'react';
+import { formatDistanceStrict, formatDistanceToNowStrict } from 'date-fns';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useParams } from 'react-router';
 import { Link as RouterLink } from 'react-router-dom';
 
@@ -48,6 +48,7 @@ import {
 import { SummaryStatusLabel } from 'teleport/Integrations/shared/StatusLabel';
 import { useNoMinWidth } from 'teleport/Main';
 import {
+  INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS,
   IntegrationKind,
   integrationService,
   IntegrationWithSummary,
@@ -81,6 +82,8 @@ const TABS = [
   { id: 'settings', label: 'Settings' },
 ] as const;
 
+const OVERDUE_REFETCH_INTERVAL_MS = 10 * 1000;
+
 export function IaCIntegrationOverview() {
   const { name } = useParams<{ name: string }>();
 
@@ -89,10 +92,11 @@ export function IaCIntegrationOverview() {
     error,
     isLoading,
     isError,
-  } = useQuery({
+  } = useQuery<IntegrationWithSummary>({
     queryKey: ['integrationStats', name],
     queryFn: () => integrationService.fetchIntegrationStats(name),
     enabled: !!name,
+    refetchInterval: query => getStatsRefetchIntervalMs(query.state.data),
   });
 
   const [activeTab, setActiveTab] = useState<TabId>('overview');
@@ -203,10 +207,22 @@ function IntegrationHealthCard({
   onViewIssues: () => void;
 }) {
   const [isConfigOpen, setIsConfigOpen] = useState(false);
+  const [nowMs, setNowMs] = useState(Date.now);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setNowMs(Date.now());
+    }, 1000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, []);
 
   const hasIssues = stats.unresolvedUserTasks > 0;
   const lastScanDate = getIntegrationLastScan(stats);
   const lastScanText = formatRelativeDate(lastScanDate);
+  const nextScanText = formatTimeUntilNextScan(lastScanDate, nowMs);
   const configDetails = getIntegrationConfigDetails(stats);
 
   return (
@@ -240,7 +256,14 @@ function IntegrationHealthCard({
         </StatusRow>
 
         <StatusRow label="Last verified:">
-          <Text typography="body3">{lastScanText}</Text>
+          <Flex alignItems="center" gap={2} flexWrap="wrap">
+            <Text typography="body3">{lastScanText}</Text>
+            {lastScanDate && nextScanText && (
+              <Text typography="body3" color="text.slightlyMuted">
+                {nextScanText}
+              </Text>
+            )}
+          </Flex>
         </StatusRow>
 
         <StatusRow label="Resources:">
@@ -431,6 +454,43 @@ function formatResourceCounts(stats: IntegrationWithSummary): string {
   }
 
   return `${total} Discovered (${parts.join(', ')})`;
+}
+
+function formatTimeUntilNextScan(
+  lastScanDate: Date | undefined,
+  nowMs: number
+): string {
+  if (!lastScanDate) {
+    return '';
+  }
+
+  const nextScanAt =
+    lastScanDate.getTime() + INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS;
+  const remainingMs = nextScanAt - nowMs;
+
+  if (remainingMs <= 0) {
+    return '';
+  }
+
+  return `Next scan expected in ${formatDistanceStrict(0, remainingMs, {
+    unit: 'minute',
+    roundingMethod: 'ceil',
+  })}`;
+}
+
+function getStatsRefetchIntervalMs(stats: IntegrationWithSummary | undefined) {
+  const lastScanDate = stats ? getIntegrationLastScan(stats) : undefined;
+
+  if (!lastScanDate) {
+    return OVERDUE_REFETCH_INTERVAL_MS;
+  }
+
+  const remainingMs =
+    lastScanDate.getTime() +
+    INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS -
+    Date.now();
+
+  return remainingMs <= 0 ? OVERDUE_REFETCH_INTERVAL_MS : remainingMs;
 }
 
 function getTimestamp(value: unknown): number {

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.test.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.test.tsx
@@ -25,8 +25,41 @@ import {
 
 import { SummaryStatusLabel } from './StatusLabel';
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 test('SummaryStatusLabel shows scanning when no sync timestamps exist', () => {
-  const stats: IntegrationWithSummary = {
+  const stats = makeSummary(0);
+
+  render(<SummaryStatusLabel summary={stats} />);
+
+  expect(screen.getByText('Scanning')).toBeInTheDocument();
+  expect(screen.getByText('(scanning in progress)')).toBeInTheDocument();
+});
+
+test('SummaryStatusLabel shows scanning when sync timestamp is stale', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2026-02-11T12:00:00Z'));
+  const stats = makeSummary(new Date('2026-02-11T11:55:00Z').getTime());
+
+  render(<SummaryStatusLabel summary={stats} />);
+
+  expect(screen.getByText('Scanning')).toBeInTheDocument();
+  expect(screen.getByText('(scanning in progress)')).toBeInTheDocument();
+});
+
+test('SummaryStatusLabel shows healthy when sync timestamp is recent', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2026-02-11T12:00:00Z'));
+  const stats = makeSummary(new Date('2026-02-11T11:55:01Z').getTime());
+
+  render(<SummaryStatusLabel summary={stats} />);
+
+  expect(screen.getByText('Healthy')).toBeInTheDocument();
+  expect(screen.queryByText('(scanning in progress)')).not.toBeInTheDocument();
+});
+
+function makeSummary(lastSyncMs: number): IntegrationWithSummary {
+  return {
     name: 'integration-name',
     subKind: IntegrationKind.AwsOidc,
     unresolvedUserTasks: 0,
@@ -40,7 +73,7 @@ test('SummaryStatusLabel shows scanning when no sync timestamps exist', () => {
       resourcesFound: 0,
       resourcesEnrollmentFailed: 0,
       resourcesEnrollmentSuccess: 0,
-      discoverLastSync: 0,
+      discoverLastSync: lastSyncMs,
       ecsDatabaseServiceCount: 0,
       unresolvedUserTasks: 0,
     },
@@ -64,9 +97,4 @@ test('SummaryStatusLabel shows scanning when no sync timestamps exist', () => {
     },
     rolesAnywhereProfileSync: undefined,
   };
-
-  render(<SummaryStatusLabel summary={stats} />);
-
-  expect(screen.getByText('Scanning')).toBeInTheDocument();
-  expect(screen.getByText('(scanning in progress)')).toBeInTheDocument();
-});
+}

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
@@ -30,6 +30,7 @@ import { HoverTooltip } from 'design/Tooltip';
 import { pluralize } from 'shared/utils/text';
 
 import {
+  INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS,
   IntegrationStatusCode,
   IntegrationWithSummary,
 } from 'teleport/services/integrations';
@@ -231,7 +232,10 @@ function isSummarySyncing(summary: IntegrationWithSummary): boolean {
     getTimestamp(summary.rolesAnywhereProfileSync?.syncEndTime)
   );
 
-  return lastSync === 0;
+  return (
+    lastSync === 0 ||
+    Date.now() >= lastSync + INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS
+  );
 }
 
 function getTimestamp(value: unknown): number {

--- a/web/packages/teleport/src/services/integrations/constants.ts
+++ b/web/packages/teleport/src/services/integrations/constants.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2026 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { integrationService, makeIntegrations } from './integrations';
-
-export * from './constants';
-export * from './types';
+export const INTEGRATION_DISCOVERY_SCAN_INTERVAL_MS = 5 * 60 * 1000;


### PR DESCRIPTION
This will add a "countdown" timer until the next scan, that way users know how long go the last scan was, and also when they can expect the next scan.

this is _techincally_ a best guess based on a formula of "5 minutes since last scan". this is the default, and can be updated, but there is no reliable way yet to know when the next scan is. multiple discovery services can be running with different intervals as well

I think this information is good to have tho for the 99% that let it just run at the default interval. also, the worst case scenario is it says the next scan is a few minutes further out than it actually is.

also, when the "until next scan" time is up, we automatically switch to a "scanning" display, and fetch the new stats in an interval in the background. this lets the page feel real-time.
<img width="575" height="242" alt="Screenshot 2026-03-05 at 6 08 41 PM" src="https://github.com/user-attachments/assets/bff5b554-a8da-4169-828b-4615a91f4cce" />

<img width="669" height="314" alt="Screenshot 2026-03-05 at 6 09 34 PM" src="https://github.com/user-attachments/assets/de2d4c51-d10b-41e1-87de-443ffc0d483c" />


### Manual Tests
- [ ] created a real discovery config/integration (using terraform) and see that the last scan text is shown
- [ ] let last scan get to 0 seconds and see the status icon switch to "Scanning"
- [ ] wait until the background fetch happens and see the text switch back to "Healthy" (or issues if you have them)