### PR TITLE
[v18] Fix agent forwarding in proxy recording mode

### DIFF
--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -287,11 +287,8 @@ func (h *AuthHandlers) CheckAgentForward(ctx *ServerContext) error {
 	}
 
 	if ctx.Identity.ProxyingPermit != nil && h.c.Component == teleport.ComponentForwardingNode {
-		// we are a proxy and not the access-controlling boundary. allow agent forwarding
-		// in order to ensure that session recording functions correctly. Note that it is
-		// the ForwardingNode component that actually does session recording, but the
-		// proxy component is the one that wants agent forwarding enabled in order to set up the
-		// prerequisite conditions for recording.
+		// we are a proxy and not the access-controlling boundary. Allow Agent forwarding requests to pass through
+		// the recording layer and down to the enforcing node.
 		return nil
 	}
 

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -286,7 +286,7 @@ func (h *AuthHandlers) CheckAgentForward(ctx *ServerContext) error {
 		return nil
 	}
 
-	if ctx.Identity.ProxyingPermit != nil && h.c.Component == teleport.ComponentProxy {
+	if ctx.Identity.ProxyingPermit != nil && h.c.Component == teleport.ComponentForwardingNode {
 		// we are a proxy and not the access-controlling boundary. allow agent forwarding
 		// in order to ensure that session recording functions correctly. Note that it is
 		// the ForwardingNode component that actually does session recording, but the

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -286,9 +286,10 @@ func (h *AuthHandlers) CheckAgentForward(ctx *ServerContext) error {
 		return nil
 	}
 
-	if ctx.Identity.ProxyingPermit != nil && h.c.Component == teleport.ComponentForwardingNode {
-		// we are a proxy and not the access-controlling boundary. Allow Agent forwarding requests to pass through
-		// the recording layer and down to the enforcing node.
+	if ctx.Identity.ProxyingPermit != nil &&
+		(h.c.Component == teleport.ComponentProxy || h.c.Component == teleport.ComponentForwardingNode) {
+		// We are in the proxying path and not the access-controlling boundary.
+		// Allow agent forwarding requests to pass through to the enforcing node.
 		return nil
 	}
 

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -742,6 +742,58 @@ func TestForwardingGitLocalOnly(t *testing.T) {
 	require.Contains(t, err.Error(), "cross-cluster git forwarding is not supported")
 }
 
+func TestCheckAgentForwardProxyingPermit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		component      string
+		proxyingPermit *proxyingPermit
+		expectAllowed  bool
+	}{
+		{
+			name:           "forwarding node allows proxying permit",
+			component:      teleport.ComponentForwardingNode,
+			proxyingPermit: &proxyingPermit{},
+			expectAllowed:  true,
+		},
+		{
+			name:           "non-forwarding node denies proxying permit",
+			component:      teleport.ComponentNode,
+			proxyingPermit: &proxyingPermit{},
+			expectAllowed:  false,
+		},
+		{
+			name:           "forwarding node denies without proxying permit",
+			component:      teleport.ComponentForwardingNode,
+			proxyingPermit: nil,
+			expectAllowed:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ah := &AuthHandlers{c: &AuthHandlerConfig{
+				Component: tt.component,
+			}}
+			ctx := &ServerContext{
+				Identity: IdentityContext{
+					ProxyingPermit: tt.proxyingPermit,
+				},
+			}
+
+			err := ah.CheckAgentForward(ctx)
+			if tt.expectAllowed {
+				require.NoError(t, err)
+				return
+			}
+
+			var accessDenied *trace.AccessDeniedError
+			require.ErrorAs(t, err, &accessDenied)
+		})
+	}
+}
+
 // TestRBACJoinMFA tests that MFA is enforced correctly when joining
 // sessions depending on the cluster auth preference and roles presented.
 func TestRBACJoinMFA(t *testing.T) {

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -777,9 +777,10 @@ func TestCheckAgentForward(t *testing.T) {
 			expectAllowed:  false,
 		},
 		{
-			name:          "proxy denies without permit",
-			component:     teleport.ComponentProxy,
-			expectAllowed: false,
+			name:           "proxy denies without permit",
+			component:      teleport.ComponentProxy,
+			proxyingPermit: nil,
+			expectAllowed:  false,
 		},
 		{
 			name:           "forwarding node denies without proxying permit",

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -742,15 +742,28 @@ func TestForwardingGitLocalOnly(t *testing.T) {
 	require.Contains(t, err.Error(), "cross-cluster git forwarding is not supported")
 }
 
-func TestCheckAgentForwardProxyingPermit(t *testing.T) {
+func TestCheckAgentForward(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name           string
 		component      string
+		accessPermit   *decisionpb.SSHAccessPermit
 		proxyingPermit *proxyingPermit
 		expectAllowed  bool
 	}{
+		{
+			name:          "access permit allows agent forwarding",
+			component:     teleport.ComponentNode,
+			accessPermit:  &decisionpb.SSHAccessPermit{ForwardAgent: true},
+			expectAllowed: true,
+		},
+		{
+			name:           "proxy allows proxying permit",
+			component:      teleport.ComponentProxy,
+			proxyingPermit: &proxyingPermit{},
+			expectAllowed:  true,
+		},
 		{
 			name:           "forwarding node allows proxying permit",
 			component:      teleport.ComponentForwardingNode,
@@ -758,10 +771,15 @@ func TestCheckAgentForwardProxyingPermit(t *testing.T) {
 			expectAllowed:  true,
 		},
 		{
-			name:           "non-forwarding node denies proxying permit",
+			name:           "non-proxy component denies proxying permit",
 			component:      teleport.ComponentNode,
 			proxyingPermit: &proxyingPermit{},
 			expectAllowed:  false,
+		},
+		{
+			name:          "proxy denies without permit",
+			component:     teleport.ComponentProxy,
+			expectAllowed: false,
 		},
 		{
 			name:           "forwarding node denies without proxying permit",
@@ -778,6 +796,7 @@ func TestCheckAgentForwardProxyingPermit(t *testing.T) {
 			}}
 			ctx := &ServerContext{
 				Identity: IdentityContext{
+					AccessPermit:   tt.accessPermit,
 					ProxyingPermit: tt.proxyingPermit,
 				},
 			}


### PR DESCRIPTION
Backport #62318 to branch/v18

changelog: Fix agent forwarding in proxy recording mode.

<details>
<summary>Manual Tests</summary>

- [x] Agent forwarding permitted
  - [x] Agent forwarding succeeds when connecting to a Teleport Node
     - [x] Connecting via the WebUI also succeeds
  - [x] Agent forwarding succeeds when connecting to an OpenSSH Node
    - [x] Connecting via the WebUI also succeeds
- [x] Agent forwarding not permitted
  - [x] Agent forwarding fails when connecting to a Teleport Node
    - [x] Connecting via the WebUI still succeeds w/o agent forwarding
  - [x] Agent forwarding fails when connecting to an OpenSSH Node
    - [x] Connecting via the WebUI still succeeds w/o agent forwarding

</details>