### PR TITLE
Remove `authorization_header` option from app auth config JWT

### DIFF
--- a/api/gen/proto/go/teleport/appauthconfig/v1/appauthconfig.pb.go
+++ b/api/gen/proto/go/teleport/appauthconfig/v1/appauthconfig.pb.go
@@ -209,9 +209,6 @@ type AppAuthConfigJWTSpec struct {
 	// UsernameClaim specifies which token claim name's value will be used as the
 	// username. Defaults to `email`.
 	UsernameClaim string `protobuf:"bytes,3,opt,name=username_claim,json=usernameClaim,proto3" json:"username_claim,omitempty"`
-	// AuthorizationHeader is the HTTP header name that will contain the token.
-	// Defaults to `Authorization`.
-	AuthorizationHeader string `protobuf:"bytes,4,opt,name=authorization_header,json=authorizationHeader,proto3" json:"authorization_header,omitempty"`
 	// Types that are valid to be assigned to KeysSource:
 	//
 	//	*AppAuthConfigJWTSpec_JwksUrl
@@ -272,13 +269,6 @@ func (x *AppAuthConfigJWTSpec) GetUsernameClaim() string {
 	return ""
 }
 
-func (x *AppAuthConfigJWTSpec) GetAuthorizationHeader() string {
-	if x != nil {
-		return x.AuthorizationHeader
-	}
-	return ""
-}
-
 func (x *AppAuthConfigJWTSpec) GetKeysSource() isAppAuthConfigJWTSpec_KeysSource {
 	if x != nil {
 		return x.KeysSource
@@ -310,13 +300,13 @@ type isAppAuthConfigJWTSpec_KeysSource interface {
 
 type AppAuthConfigJWTSpec_JwksUrl struct {
 	// JwksUrl is the JSON Web Key Set (JWKS) URL used to fetch signing keys.
-	JwksUrl string `protobuf:"bytes,5,opt,name=jwks_url,json=jwksUrl,proto3,oneof"`
+	JwksUrl string `protobuf:"bytes,4,opt,name=jwks_url,json=jwksUrl,proto3,oneof"`
 }
 
 type AppAuthConfigJWTSpec_StaticJwks struct {
 	// StaticJwks is the JSON Web Key Set (JWKS) formatted public keys of the
 	// token issuer in JSON format.
-	StaticJwks string `protobuf:"bytes,6,opt,name=static_jwks,json=staticJwks,proto3,oneof"`
+	StaticJwks string `protobuf:"bytes,5,opt,name=static_jwks,json=staticJwks,proto3,oneof"`
 }
 
 func (*AppAuthConfigJWTSpec_JwksUrl) isAppAuthConfigJWTSpec_KeysSource() {}
@@ -338,14 +328,13 @@ const file_teleport_appauthconfig_v1_appauthconfig_proto_rawDesc = "" +
 	"\n" +
 	"app_labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\tappLabels\x12C\n" +
 	"\x03jwt\x18\x02 \x01(\v2/.teleport.appauthconfig.v1.AppAuthConfigJWTSpecH\x00R\x03jwtB\x0f\n" +
-	"\rsub_kind_spec\"\xf3\x01\n" +
+	"\rsub_kind_spec\"\xc0\x01\n" +
 	"\x14AppAuthConfigJWTSpec\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1a\n" +
 	"\baudience\x18\x02 \x01(\tR\baudience\x12%\n" +
-	"\x0eusername_claim\x18\x03 \x01(\tR\rusernameClaim\x121\n" +
-	"\x14authorization_header\x18\x04 \x01(\tR\x13authorizationHeader\x12\x1b\n" +
-	"\bjwks_url\x18\x05 \x01(\tH\x00R\ajwksUrl\x12!\n" +
-	"\vstatic_jwks\x18\x06 \x01(\tH\x00R\n" +
+	"\x0eusername_claim\x18\x03 \x01(\tR\rusernameClaim\x12\x1b\n" +
+	"\bjwks_url\x18\x04 \x01(\tH\x00R\ajwksUrl\x12!\n" +
+	"\vstatic_jwks\x18\x05 \x01(\tH\x00R\n" +
 	"staticJwksB\r\n" +
 	"\vkeys_sourceB^Z\\github.com/gravitational/teleport/api/gen/proto/go/teleport/appauthconfig/v1;appauthconfigv1b\x06proto3"
 

--- a/api/gen/proto/go/teleport/appauthconfig/v1/appauthconfig.pb.go
+++ b/api/gen/proto/go/teleport/appauthconfig/v1/appauthconfig.pb.go
@@ -300,13 +300,13 @@ type isAppAuthConfigJWTSpec_KeysSource interface {
 
 type AppAuthConfigJWTSpec_JwksUrl struct {
 	// JwksUrl is the JSON Web Key Set (JWKS) URL used to fetch signing keys.
-	JwksUrl string `protobuf:"bytes,4,opt,name=jwks_url,json=jwksUrl,proto3,oneof"`
+	JwksUrl string `protobuf:"bytes,5,opt,name=jwks_url,json=jwksUrl,proto3,oneof"`
 }
 
 type AppAuthConfigJWTSpec_StaticJwks struct {
 	// StaticJwks is the JSON Web Key Set (JWKS) formatted public keys of the
 	// token issuer in JSON format.
-	StaticJwks string `protobuf:"bytes,5,opt,name=static_jwks,json=staticJwks,proto3,oneof"`
+	StaticJwks string `protobuf:"bytes,6,opt,name=static_jwks,json=staticJwks,proto3,oneof"`
 }
 
 func (*AppAuthConfigJWTSpec_JwksUrl) isAppAuthConfigJWTSpec_KeysSource() {}
@@ -328,15 +328,15 @@ const file_teleport_appauthconfig_v1_appauthconfig_proto_rawDesc = "" +
 	"\n" +
 	"app_labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\tappLabels\x12C\n" +
 	"\x03jwt\x18\x02 \x01(\v2/.teleport.appauthconfig.v1.AppAuthConfigJWTSpecH\x00R\x03jwtB\x0f\n" +
-	"\rsub_kind_spec\"\xc0\x01\n" +
+	"\rsub_kind_spec\"\xdc\x01\n" +
 	"\x14AppAuthConfigJWTSpec\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1a\n" +
 	"\baudience\x18\x02 \x01(\tR\baudience\x12%\n" +
 	"\x0eusername_claim\x18\x03 \x01(\tR\rusernameClaim\x12\x1b\n" +
-	"\bjwks_url\x18\x04 \x01(\tH\x00R\ajwksUrl\x12!\n" +
-	"\vstatic_jwks\x18\x05 \x01(\tH\x00R\n" +
+	"\bjwks_url\x18\x05 \x01(\tH\x00R\ajwksUrl\x12!\n" +
+	"\vstatic_jwks\x18\x06 \x01(\tH\x00R\n" +
 	"staticJwksB\r\n" +
-	"\vkeys_sourceB^Z\\github.com/gravitational/teleport/api/gen/proto/go/teleport/appauthconfig/v1;appauthconfigv1b\x06proto3"
+	"\vkeys_sourceJ\x04\b\x04\x10\x05R\x14authorization_headerB^Z\\github.com/gravitational/teleport/api/gen/proto/go/teleport/appauthconfig/v1;appauthconfigv1b\x06proto3"
 
 var (
 	file_teleport_appauthconfig_v1_appauthconfig_proto_rawDescOnce sync.Once

--- a/api/proto/teleport/appauthconfig/v1/appauthconfig.proto
+++ b/api/proto/teleport/appauthconfig/v1/appauthconfig.proto
@@ -50,6 +50,9 @@ message AppAuthConfigSpec {
 
 // AppAuthConfigJWTSpec contains the spec for JWT authentication config.
 message AppAuthConfigJWTSpec {
+  reserved 4;
+  reserved "authorization_header";
+
   // Issuer is the JWT token issuer name. This value is used to verify the token.
   string issuer = 1;
   // Audience is the expected token audience. It will usually be a OAuth
@@ -61,9 +64,9 @@ message AppAuthConfigJWTSpec {
 
   oneof keys_source {
     // JwksUrl is the JSON Web Key Set (JWKS) URL used to fetch signing keys.
-    string jwks_url = 4;
+    string jwks_url = 5;
     // StaticJwks is the JSON Web Key Set (JWKS) formatted public keys of the
     // token issuer in JSON format.
-    string static_jwks = 5;
+    string static_jwks = 6;
   }
 }

--- a/api/proto/teleport/appauthconfig/v1/appauthconfig.proto
+++ b/api/proto/teleport/appauthconfig/v1/appauthconfig.proto
@@ -58,15 +58,12 @@ message AppAuthConfigJWTSpec {
   // UsernameClaim specifies which token claim name's value will be used as the
   // username. Defaults to `email`.
   string username_claim = 3;
-  // AuthorizationHeader is the HTTP header name that will contain the token.
-  // Defaults to `Authorization`.
-  string authorization_header = 4;
 
   oneof keys_source {
     // JwksUrl is the JSON Web Key Set (JWKS) URL used to fetch signing keys.
-    string jwks_url = 5;
+    string jwks_url = 4;
     // StaticJwks is the JSON Web Key Set (JWKS) formatted public keys of the
     // token issuer in JSON format.
-    string static_jwks = 6;
+    string static_jwks = 5;
   }
 }

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-auth-config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-auth-config.mdx
@@ -26,9 +26,6 @@ spec:
     audience: teleport
     # username_claim (optional) is the claim name used as username. Defaults to `email`.
     username_claim: preferred_username
-    # authorization_header (optional) defines the header name that will contain
-    # the token. Defaults to `Authorization`.
-    authorization_header: JWT-Authorization
     # jwks_url is the JWKS URL address used to fetch signing keys.
     #
     # Only required, when static_jwks is not set.

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app_auth_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app_auth_config.mdx
@@ -64,7 +64,6 @@ Optional:
 Optional:
 
 - `audience` (String) Audience is the expected token audience. It will usually be a OAuth client_id issued for Teleport use.
-- `authorization_header` (String) AuthorizationHeader is the HTTP header name that will contain the token. Defaults to `Authorization`.
 - `issuer` (String) Issuer is the JWT token issuer name. This value is used to verify the token.
 - `jwks_url` (String) JwksUrl is the JSON Web Key Set (JWKS) URL used to fetch signing keys.
 - `static_jwks` (String) StaticJwks is the JSON Web Key Set (JWKS) formatted public keys of the token issuer in JSON format.

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app_auth_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app_auth_config.mdx
@@ -90,7 +90,6 @@ Optional:
 Optional:
 
 - `audience` (String) Audience is the expected token audience. It will usually be a OAuth client_id issued for Teleport use.
-- `authorization_header` (String) AuthorizationHeader is the HTTP header name that will contain the token. Defaults to `Authorization`.
 - `issuer` (String) Issuer is the JWT token issuer name. This value is used to verify the token.
 - `jwks_url` (String) JwksUrl is the JSON Web Key Set (JWKS) URL used to fetch signing keys.
 - `static_jwks` (String) StaticJwks is the JSON Web Key Set (JWKS) formatted public keys of the token issuer in JSON format.

--- a/integrations/terraform/tfschema/appauthconfig/v1/appauthconfig_terraform.go
+++ b/integrations/terraform/tfschema/appauthconfig/v1/appauthconfig_terraform.go
@@ -127,11 +127,6 @@ func GenSchemaAppAuthConfig(ctx context.Context) (github_com_hashicorp_terraform
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
-						"authorization_header": {
-							Description: "AuthorizationHeader is the HTTP header name that will contain the token. Defaults to `Authorization`.",
-							Optional:    true,
-							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-						},
 						"issuer": {
 							Description: "Issuer is the JWT token issuer name. This value is used to verify the token.",
 							Optional:    true,
@@ -498,23 +493,6 @@ func CopyAppAuthConfigFromTerraform(_ context.Context, tf github_com_hashicorp_t
 													t = string(v.Value)
 												}
 												obj.UsernameClaim = t
-											}
-										}
-									}
-									{
-										a, ok := tf.Attrs["authorization_header"]
-										if !ok {
-											diags.Append(attrReadMissingDiag{"AppAuthConfig.spec.jwt.authorization_header"})
-										} else {
-											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-											if !ok {
-												diags.Append(attrReadConversionFailureDiag{"AppAuthConfig.spec.jwt.authorization_header", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-											} else {
-												var t string
-												if !v.Null && !v.Unknown {
-													t = string(v.Value)
-												}
-												obj.AuthorizationHeader = t
 											}
 										}
 									}
@@ -1073,28 +1051,6 @@ func CopyAppAuthConfigToTerraform(ctx context.Context, obj *github_com_gravitati
 											v.Value = string(obj.UsernameClaim)
 											v.Unknown = false
 											tf.Attrs["username_claim"] = v
-										}
-									}
-									{
-										t, ok := tf.AttrTypes["authorization_header"]
-										if !ok {
-											diags.Append(attrWriteMissingDiag{"AppAuthConfig.spec.jwt.authorization_header"})
-										} else {
-											v, ok := tf.Attrs["authorization_header"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-											if !ok {
-												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-												if err != nil {
-													diags.Append(attrWriteGeneralError{"AppAuthConfig.spec.jwt.authorization_header", err})
-												}
-												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-												if !ok {
-													diags.Append(attrWriteConversionFailureDiag{"AppAuthConfig.spec.jwt.authorization_header", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-												}
-												v.Null = string(obj.AuthorizationHeader) == ""
-											}
-											v.Value = string(obj.AuthorizationHeader)
-											v.Unknown = false
-											tf.Attrs["authorization_header"] = v
 										}
 									}
 									{

--- a/lib/auth/appauthconfig/appauthconfigv1/sessions_service_test.go
+++ b/lib/auth/appauthconfig/appauthconfigv1/sessions_service_test.go
@@ -341,7 +341,6 @@ func TestVerifyJWTToken(t *testing.T) {
 
 func TestCreateAppSessionWithJWT(t *testing.T) {
 	issuer := "https://external-idp/"
-	header := "Authorization"
 	audience := "teleport"
 	usernameClaim := "email"
 
@@ -354,10 +353,9 @@ func TestCreateAppSessionWithJWT(t *testing.T) {
 	require.NoError(t, err)
 
 	config := appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{
-		Issuer:              issuer,
-		AuthorizationHeader: header,
-		Audience:            audience,
-		UsernameClaim:       usernameClaim,
+		Issuer:        issuer,
+		Audience:      audience,
+		UsernameClaim: usernameClaim,
 		KeysSource: &appauthconfigv1.AppAuthConfigJWTSpec_StaticJwks{
 			StaticJwks: string(encodedJwks),
 		},


### PR DESCRIPTION
More context in [this PR thread](https://github.com/gravitational/teleport/pull/62975#discussion_r2874288511). In short, we decided to remove the ability to customize the HTTP header name used to carry the JWT token (for app auth config flows). The reason is that, without this customization option, we can significantly simplify the processing flow and avoid backend retrieval and app matching for every request using the app auth config.

## Manual testing

Not applicable, the code changes aren't currently being used at `master`.