### PR TITLE
Make Connect use Ubuntu as default sans-serif font

### DIFF
--- a/web/packages/teleterm/src/ui/ThemeProvider/globals.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/globals.ts
@@ -52,12 +52,14 @@ const GlobalStyle = createGlobalStyle`
   }
 
   b, strong {
-    // Overrides the default font-weight: bolder which results in the bold font not being bold
-    // enough. That's because if the regular font-weight is set to 300, "bolder" means it'll go to
-    // just 400.
+    // Overrides the default useragent style of  font-weight: bolder which results in the bold font
+    // not being bold enough. That's because if the regular font-weight is set to 300, "bolder"
+    // means it'll go to just 400.
     // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#meaning_of_relative_weights
     //
-    // The Web UI uses <Text bold> to render bold text, whereas Connect mostly uses <strong>.
+    // The Web UI uses <Text bold> to render bold text which always explicitly sets the weight to
+    // theme.fontWeights.bold (600), whereas Connect mostly uses <strong> which by default uses the
+    // useragent style.
     font-weight: ${props => props.theme.fontWeights.bold};
   }
 

--- a/web/packages/teleterm/src/ui/ThemeProvider/theme.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/theme.ts
@@ -16,28 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  darkTheme as designDarkTheme,
-  lightTheme as designLightTheme,
-} from 'design/theme';
-import { fonts } from 'design/theme/fonts';
-
-const sansSerif = 'system-ui';
-
-export const darkTheme = {
-  ...designDarkTheme,
-  font: sansSerif,
-  fonts: {
-    sansSerif,
-    mono: fonts.mono,
-  },
-};
-
-export const lightTheme = {
-  ...designLightTheme,
-  font: sansSerif,
-  fonts: {
-    sansSerif,
-    mono: fonts.mono,
-  },
-};
+// In the past, Connect used to have different set of fonts compared to the default design theme.
+// Nowadays it uses the same exact theme, but the existing exports are kept in case we ever need to
+// introduce changes to Connect's theme again.
+export { darkTheme, lightTheme } from 'design/theme';


### PR DESCRIPTION
Closes #55592.

This aligns Connect with the Web UI. Read the linked issue for rationale.

This won't be backported until it goes through the test plan and there's an upcoming minor release of Teleport.

The global style that makes `b` and `strong` use `theme.fontWeights.bold` (#55463) is kept as it still has a purpose. Most bold text in Web UI uses `<Text bold>` which always explicitly sets `font-weight` to `600`, whereas Connect often uses just `<strong>` instead which by default sets the useragent style of `font-weight: bolder`, which bumps the weight only to 400 if the original weight is 300.

The Windows screenshots are a bit weird, but I think that's due to the way my VM is set up – Windows always looked a bit off.

| Before | After |
| --- | --- |
| <img width="1471" height="961" alt="resource-before" src="https://github.com/user-attachments/assets/5e7f3ff7-f891-40d8-8411-b90faf52ae77" /> | <img width="1471" height="961" alt="resources-after" src="https://github.com/user-attachments/assets/f1d9bf1d-6c06-456f-9c22-aa6306eec5a7" /> |
| <img width="1471" height="961" alt="db-before" src="https://github.com/user-attachments/assets/e1902659-684c-4b52-b699-ae2c747508f7" /> | <img width="1471" height="961" alt="db-after" src="https://github.com/user-attachments/assets/4b4321c0-36f8-4697-99aa-483f646449a1" /> |
| <img width="1460" height="788" alt="image" src="https://github.com/user-attachments/assets/7bcdbeee-b247-492b-8370-0cf611d66f2d" /> | <img width="1460" height="788" alt="image" src="https://github.com/user-attachments/assets/ee58cd51-1f8a-4e07-9e45-8b8526ec85f0" /> |
| <img width="1460" height="788" alt="image" src="https://github.com/user-attachments/assets/7545be4b-96ae-40f9-a587-9f39a5acc274" /> | <img width="1460" height="788" alt="image" src="https://github.com/user-attachments/assets/832a1462-f156-4252-8a5b-d384f40c4dd1" /> |
