### PR TITLE
Remove unnecessary `useEffect` from `useClusterLogin`

### DIFF
--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
@@ -72,20 +72,33 @@ export function useClusterLogin(props: Props) {
     ]).then(([authSettings]) => authSettings);
   });
 
-  const [loginAttempt, login, setAttempt] = useAsync((params: LoginParams) => {
-    refAbortCtrl.current = new AbortController();
-    const signal = cloneAbortSignal(refAbortCtrl.current.signal);
-    switch (params.kind) {
-      case 'local':
-        return loginLocal(ctx, params, signal);
-      case 'passwordless':
-        return loginPasswordless(ctx, params, signal);
-      case 'sso':
-        return loginSso(ctx, params, setSsoPrompt, signal);
-      default:
-        params satisfies never;
+  const [loginAttempt, login, setAttempt] = useAsync(
+    async (params: LoginParams) => {
+      refAbortCtrl.current = new AbortController();
+      const signal = cloneAbortSignal(refAbortCtrl.current.signal);
+
+      try {
+        switch (params.kind) {
+          case 'local':
+            await loginLocal(ctx, params, signal);
+            break;
+          case 'passwordless':
+            await loginPasswordless(ctx, params, signal);
+            break;
+          case 'sso':
+            await loginSso(ctx, params, setSsoPrompt, signal);
+            break;
+          default:
+            params satisfies never;
+        }
+
+        onSuccess?.();
+      } finally {
+        setPasswordlessLoginState(null);
+        setSsoPrompt('no-prompt');
+      }
     }
-  });
+  );
 
   const onLoginWithLocal = (username: string, password: string) => {
     login({
@@ -164,17 +177,6 @@ export function useClusterLogin(props: Props) {
   useEffect(() => {
     init();
   }, []);
-
-  useEffect(() => {
-    if (loginAttempt.status !== 'processing') {
-      setPasswordlessLoginState(null);
-      setSsoPrompt('no-prompt');
-    }
-
-    if (loginAttempt.status === 'success') {
-      onSuccess?.();
-    }
-  }, [loginAttempt.status]);
 
   //TODO(gzdunek): We should have a way to listen to config service changes.
   //A workaround for is to update the state, which triggers a re-render.


### PR DESCRIPTION
Closes #58339.

## Test plan

I tested that logging in using these methods still work:

* Local + MFA.
* Passwordless.
* GitHub.
* SAML.

Further testing will be done during the test plan, after which the change will be backported to v18.