### PR TITLE
Use vite-plugin-compression2 instead of vite-plugin-compression

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,9 +294,9 @@ importers:
       typescript-eslint:
         specifier: ^8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      vite-plugin-compression:
-        specifier: ^0.5.1
-        version: 0.5.1(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(yaml@2.8.2))
+      vite-plugin-compression2:
+        specifier: ^2.5.0
+        version: 2.5.0(rollup@4.57.1)
       vite-plugin-wasm:
         specifier: ^3.5.0
         version: 3.5.0(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(yaml@2.8.2))
@@ -6417,6 +6417,9 @@ packages:
   tar-fs@3.1.1:
     resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
 
+  tar-mini@0.2.0:
+    resolution: {integrity: sha512-+qfUHz700DWnRutdUsxRRVZ38G1Qr27OetwaMYTdg8hcPxf46U0S1Zf76dQMWRBmusOt2ZCK5kbIaiLkoGO7WQ==}
+
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
@@ -6698,10 +6701,8 @@ packages:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
 
-  vite-plugin-compression@0.5.1:
-    resolution: {integrity: sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==}
-    peerDependencies:
-      vite: '>=2.0.0'
+  vite-plugin-compression2@2.5.0:
+    resolution: {integrity: sha512-bHxtBibPxxSn5eZSe0IAzvYucP/hg8Bz8ppjbH7lndU5kIHT+92qTkB4z9xWYfnyV0YHuir1SjOuyO0fzU4Vgg==}
 
   vite-plugin-wasm@3.5.0:
     resolution: {integrity: sha512-X5VWgCnqiQEGb+omhlBVsvTfxikKtoOgAzQ95+BZ8gQ+VfMHIjSHr0wyvXFQCa0eKQ0fKyaL0kWcEnYqBac4lQ==}
@@ -13858,6 +13859,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-buffer
 
+  tar-mini@0.2.0: {}
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.6.7
@@ -14153,14 +14156,12 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite-plugin-compression@0.5.1(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(yaml@2.8.2)):
+  vite-plugin-compression2@2.5.0(rollup@4.57.1):
     dependencies:
-      chalk: 4.1.2
-      debug: 4.4.3
-      fs-extra: 10.1.0
-      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(yaml@2.8.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
+      tar-mini: 0.2.0
     transitivePeerDependencies:
-      - supports-color
+      - rollup
 
   vite-plugin-wasm@3.5.0(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(yaml@2.8.2)):
     dependencies:

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -34,7 +34,7 @@
     "jsdom": "^28.1.0",
     "rollup-plugin-visualizer": "^6.0.5",
     "typescript-eslint": "^8.56.1",
-    "vite-plugin-compression": "^0.5.1",
+    "vite-plugin-compression2": "^2.5.0",
     "vite-plugin-wasm": "^3.5.0",
     "vite-tsconfig-paths": "^6.1.1"
   }

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -21,7 +21,7 @@ import { resolve } from 'path';
 
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, type UserConfig } from 'vite';
-import compression from 'vite-plugin-compression';
+import { compression } from 'vite-plugin-compression2';
 import wasm from 'vite-plugin-wasm';
 
 import { generateAppHashFile } from './apphash';
@@ -119,11 +119,11 @@ export function createViteConfig(
       if (!process.env.VITE_DISABLE_COMPRESSION) {
         config.plugins.push(
           compression({
-            algorithm: 'brotliCompress',
-            deleteOriginFile: true,
-            filter: /\.(js|svg|wasm)$/,
+            algorithms: ['brotliCompress'],
+            deleteOriginalAssets: true,
+            include: /\.(js|svg|wasm)$/,
             threshold: 1024 * 10, // 10KB
-            verbose: false,
+            logLevel: 'silent',
           })
         );
       }


### PR DESCRIPTION
[`vite-plugin-compression`](https://github.com/vbenjs/vite-plugin-compression) has been unmaintained for ~4 years now, whereas [`vite-plugin-compression2`](https://github.com/nonzzz/vite-plugin-compression) is actively maintained. This swaps them over.

Main differences - the old plugin would do the compression after, so whilst the build took ~6.2s, the whole build would take ~15.2s (measured using `time`). The new plugin does the compression before the assets are emitted, so the build takes ~13s and the whole thing takes ~14.5s (also measured using `time`). It also shows us the final brotli compressed size in the logs rather than the non-compressed and gzipped compressed sizes.

#### Output before

```
../../../webassets/e/teleport/app/control-workflows.svg                             956.06 kB │ gzip:   257.94 kB
../../../webassets/e/teleport/app/control-workflows-light.svg                     2,316.39 kB │ gzip: 1,160.48 kB
../../../webassets/e/teleport/app/index.css                                          13.88 kB │ gzip:     2.84 kB
../../../webassets/e/teleport/app/index.js                                            4.30 kB │ gzip:     1.93 kB
../../../webassets/e/teleport/app/telemetry-boot.js                                 119.88 kB │ gzip:    38.05 kB
../../../webassets/e/teleport/app/app.js                                          5,777.26 kB │ gzip: 1,711.35 kB

(!) Some chunks are larger than 500 kB after minification. Consider:                                                                                                                                                                                                                                                                                                                                       
- Using dynamic import() to code-split the application                                                                                                                                                                                                                                                                                                                                                     
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks                                                                                                                                                                                                                                                                         
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.                                                                                                                                                                                                                                                                                                                                
✓ built in 6.24s
pnpm build-ui-e  28.83s user 3.05s system 208% cpu 15.268 total
```

#### Output after

```
../../../webassets/e/teleport/app/Ubuntu-Italic.ttf                                    326.02 kB
../../../webassets/e/teleport/app/Ubuntu-LightItalic.ttf                               349.16 kB
../../../webassets/e/teleport/app/Ubuntu-Light.ttf                                     361.31 kB
../../../webassets/e/teleport/app/control-workflows-light.svg.br                     1,043.52 kB
../../../webassets/e/teleport/app/app.js.br                                          1,327.35 kB
../../../webassets/e/teleport/app/index.js                                               4.30 kB │ gzip: 1.93 kB
✓ built in 13.04s

pnpm build-ui-e  27.15s user 2.74s system 205% cpu 14.535 total
```

(wasm build was skipped for these timings)

### Manual testing

- [x] Verified that a webassets build compressed with the new plugin is rendered correctly
  - [x] Ubuntu font is loaded correctly
  - [x] No errors in dev tools
  - [x] Everything looks the same 