### PR TITLE
docs: update video id on openclaw apps page

### DIFF
--- a/docs/pages/enroll-resources/application-access/protect-apps/openclaw.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/openclaw.mdx
@@ -2,7 +2,7 @@
 title: Access OpenClaw using the Teleport Application Service
 sidebar_label: OpenClaw
 description: Securely access your OpenClaw Control UI with Teleport.
-videoBanner: FWxLcFCmNiQ
+videoBanner: WNva4cGcoNo
 tags:
  - how-to
  - zero-trust


### PR DESCRIPTION
This commit updates the video id on the openclaw apps page `/enroll-resources/application-access/protect-apps/openclaw/`. New video includes a docs guide callout as well as an end screen.