### PR TITLE
Update pnpm to 10.30.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
+  "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017",
   "engines": {
     "node": "^24"
   }


### PR DESCRIPTION
No notable changes since 10.28.2. FWIW, [10.30.0](https://github.com/pnpm/pnpm/releases/tag/v10.30.0) made it so `pnpm why` now shows a _reverse_ dep tree.