### PR TITLE
Server Discovery: add error to stdout when preflight checks fail

### DIFF
--- a/lib/srv/server/installer_script.go
+++ b/lib/srv/server/installer_script.go
@@ -184,22 +184,29 @@ func preFlightInstallerChecks(proxyAddr string) map[installstatus.ExitCode]strin
 		Path:   path.Join("webapi", "find"),
 	}
 
+	orExitWithMessageScriptSnippet := func(exitCode installstatus.ExitCode, message string) string {
+		return fmt.Sprintf(`|| { echo "%s"; exit %d; }`, message, exitCode)
+	}
+
 	return map[installstatus.ExitCode]string{
 		// Basic command checks for bash, sudo and curl.
-		installstatus.BashNotFound: fmt.Sprintf(`command -v bash > /dev/null 2>&1 || exit %d`, installstatus.BashNotFound),
-		installstatus.SudoNotFound: fmt.Sprintf(`command -v sudo > /dev/null 2>&1 || exit %d`, installstatus.SudoNotFound),
-		installstatus.CurlNotFound: fmt.Sprintf(`command -v curl > /dev/null 2>&1 || exit %d`, installstatus.CurlNotFound),
+		installstatus.BashNotFound: fmt.Sprintf(`command -v bash > /dev/null 2>&1 %s`, orExitWithMessageScriptSnippet(installstatus.BashNotFound, "bash is missing")),
+		installstatus.SudoNotFound: fmt.Sprintf(`command -v sudo > /dev/null 2>&1 %s`, orExitWithMessageScriptSnippet(installstatus.SudoNotFound, "sudo is missing")),
+		installstatus.CurlNotFound: fmt.Sprintf(`command -v curl > /dev/null 2>&1 %s`, orExitWithMessageScriptSnippet(installstatus.CurlNotFound, "curl is missing")),
 
 		// check if there's enough disk space for the installation
 		// df -Pm outputs disk usage in megabytes; awk selects the data row (NR==2) and
 		// exits non-zero if the available column ($4) is below the required threshold.
 		// Falls back to checking "/" if "/opt" does not exist.
-		installstatus.InsufficientDiskSpace: fmt.Sprintf(`df -Pm $([ -d /opt ] && echo /opt || echo /) | awk 'NR==2{exit($4<%d)}' || exit %d`, installstatus.InstallerMinFreeDiskMB, installstatus.InsufficientDiskSpace),
+		installstatus.InsufficientDiskSpace: fmt.Sprintf(`df -Pm $([ -d /opt ] && echo /opt || echo /) | awk 'NR==2{exit($4<%d)}' %s`,
+			installstatus.InstallerMinFreeDiskMB,
+			orExitWithMessageScriptSnippet(installstatus.InsufficientDiskSpace, "insufficient disk space"),
+		),
 
 		// check if network connection to the proxy is available
-		installstatus.ProxyPingError: fmt.Sprintf(`curl --silent --max-time 10 --output /dev/null %s || exit %d`,
+		installstatus.ProxyPingError: fmt.Sprintf(`curl --silent --max-time 10 --output /dev/null %s %s`,
 			shsprintf.EscapeDefaultContext(proxyFindURL.String()),
-			installstatus.ProxyPingError,
+			orExitWithMessageScriptSnippet(installstatus.ProxyPingError, "proxy is unreachable"),
 		),
 	}
 }

--- a/lib/srv/server/installer_script_test.go
+++ b/lib/srv/server/installer_script_test.go
@@ -31,11 +31,11 @@ import (
 // installerScriptChecksFor returns the expected shell checks prefix for a given proxy address.
 // It mirrors the logic in installerScriptChecks so that tests stay in sync with the implementation.
 func installerScriptChecksFor(proxyAddr string) string {
-	return `command -v bash > /dev/null 2>&1 || exit 100` +
-		`; command -v sudo > /dev/null 2>&1 || exit 101` +
-		`; command -v curl > /dev/null 2>&1 || exit 102` +
-		`; df -Pm $([ -d /opt ] && echo /opt || echo /) | awk 'NR==2{exit($4<1250)}' || exit 103` +
-		`; curl --silent --max-time 10 --output /dev/null https://` + proxyAddr + `/webapi/find || exit 104` +
+	return `command -v bash > /dev/null 2>&1 || { echo "bash is missing"; exit 100; }` +
+		`; command -v sudo > /dev/null 2>&1 || { echo "sudo is missing"; exit 101; }` +
+		`; command -v curl > /dev/null 2>&1 || { echo "curl is missing"; exit 102; }` +
+		`; df -Pm $([ -d /opt ] && echo /opt || echo /) | awk 'NR==2{exit($4<1250)}' || { echo "insufficient disk space"; exit 103; }` +
+		`; curl --silent --max-time 10 --output /dev/null https://` + proxyAddr + `/webapi/find || { echo "proxy is unreachable"; exit 104; }` +
 		`; `
 }
 


### PR DESCRIPTION
After adding the pre flight checks, we exit with a specific code when some requirement is missing.

If users look up the exit code or status (for ec2 discovery) that's enough to debug the problem.

However, for Azure and GCP, we don't have any audit event, so there's no status field which we could use to explain the meaning of each exit code.
We are adding the exit codes to the docs, but that's probably not enough.

For Azure, specifically, users have to look for the exit code in the `run-command-handler` log.
```
$ cat /var/log/azure/run-command-handler/handler.log
...

time=2026-03-06T15:37:32Z version=v1.3.14/git@- operation=enable extensionName=teleport-install event="failed to execute command" error="command terminated with exit status=104" output=/var/lib/waagent/run-command-handler/download/teleport-install/0
```
At this point, files at `/var/lib/waagent/run-command-handler/download/teleport-install/*/std{out,err}` would also be empty, which makes it even harder to diagnose the issue.

After this PR, the stdout file will contain the error:

<img width="1692" height="160" alt="image" src="https://github.com/user-attachments/assets/3a4a65f4-d1f4-4044-8dcb-676a748a7b50" />

For EC2 SSM installations, even if a bit redundant, we also include the error in the event:

<img width="2314" height="1268" alt="image" src="https://github.com/user-attachments/assets/1b999d30-0cb8-4c5b-927f-fd6e65ed0170" />


Tests:
- [x] AWS EC2: success and failure (see print above)
- [x] Azure VM: failure (see print above)