### PR TITLE
Adding support for kubernetes join methods when using scoped tokens

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -170,7 +170,9 @@ type ScopedTokenSpec struct {
 	// The Azure Devops-specific configuration used with the "azure_devops" join method.
 	AzureDevops *AzureDevops `protobuf:"bytes,9,opt,name=azure_devops,json=azureDevops,proto3" json:"azure_devops,omitempty"`
 	// The Oracle-specific configuration used with the "oracle" join method.
-	Oracle        *Oracle `protobuf:"bytes,10,opt,name=oracle,proto3" json:"oracle,omitempty"`
+	Oracle *Oracle `protobuf:"bytes,10,opt,name=oracle,proto3" json:"oracle,omitempty"`
+	// The Kubernetes-specific configuration used with the "kubernetes" join method.
+	Kubernetes    *Kubernetes `protobuf:"bytes,11,opt,name=kubernetes,proto3" json:"kubernetes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -271,6 +273,13 @@ func (x *ScopedTokenSpec) GetAzureDevops() *AzureDevops {
 func (x *ScopedTokenSpec) GetOracle() *Oracle {
 	if x != nil {
 		return x.Oracle
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetKubernetes() *Kubernetes {
+	if x != nil {
+		return x.Kubernetes
 	}
 	return nil
 }
@@ -1012,6 +1021,84 @@ func (x *Oracle) GetAllow() []*Oracle_Rule {
 	return nil
 }
 
+// The Kubernetes-specific configuration used with the "kubernetes" join method.
+type Kubernetes struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow []*Kubernetes_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values:
+	// - `in_cluster`
+	// - `static_jwks`
+	// - `oidc`
+	// If unset, this defaults to `in_cluster`.
+	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	// The configuration specific to the `static_jwks` type.
+	StaticJwks *Kubernetes_StaticJWKSConfig `protobuf:"bytes,3,opt,name=static_jwks,json=staticJwks,proto3" json:"static_jwks,omitempty"`
+	// The configuration specific to the `oidc` type.
+	Oidc          *Kubernetes_OIDCConfig `protobuf:"bytes,4,opt,name=oidc,proto3" json:"oidc,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Kubernetes) Reset() {
+	*x = Kubernetes{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Kubernetes) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Kubernetes) ProtoMessage() {}
+
+func (x *Kubernetes) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Kubernetes.ProtoReflect.Descriptor instead.
+func (*Kubernetes) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *Kubernetes) GetAllow() []*Kubernetes_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *Kubernetes) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *Kubernetes) GetStaticJwks() *Kubernetes_StaticJWKSConfig {
+	if x != nil {
+		return x.StaticJwks
+	}
+	return nil
+}
+
+func (x *Kubernetes) GetOidc() *Kubernetes_OIDCConfig {
+	if x != nil {
+		return x.Oidc
+	}
+	return nil
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -1036,7 +1123,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1048,7 +1135,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1115,7 +1202,7 @@ type GCP_Rule struct {
 
 func (x *GCP_Rule) Reset() {
 	*x = GCP_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1127,7 +1214,7 @@ func (x *GCP_Rule) String() string {
 func (*GCP_Rule) ProtoMessage() {}
 
 func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1178,7 +1265,7 @@ type Azure_Rule struct {
 
 func (x *Azure_Rule) Reset() {
 	*x = Azure_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1190,7 +1277,7 @@ func (x *Azure_Rule) String() string {
 func (*Azure_Rule) ProtoMessage() {}
 
 func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1262,7 +1349,7 @@ type AzureDevops_Rule struct {
 
 func (x *AzureDevops_Rule) Reset() {
 	*x = AzureDevops_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1274,7 +1361,7 @@ func (x *AzureDevops_Rule) String() string {
 func (*AzureDevops_Rule) ProtoMessage() {}
 
 func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1367,7 +1454,7 @@ type Oracle_Rule struct {
 
 func (x *Oracle_Rule) Reset() {
 	*x = Oracle_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1379,7 +1466,7 @@ func (x *Oracle_Rule) String() string {
 func (*Oracle_Rule) ProtoMessage() {}
 
 func (x *Oracle_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1423,6 +1510,157 @@ func (x *Oracle_Rule) GetInstances() []string {
 	return nil
 }
 
+// The configuration specific to the `static_jwks` type.
+type Kubernetes_StaticJWKSConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The JSON Web Key Set formatted public keys that the Kubernetes Cluster uses to sign service
+	// account tokens. This can be fetched from /openid/v1/jwks on the Kubernetes API Server.
+	Jwks          string `protobuf:"bytes,1,opt,name=jwks,proto3" json:"jwks,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Kubernetes_StaticJWKSConfig) Reset() {
+	*x = Kubernetes_StaticJWKSConfig{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Kubernetes_StaticJWKSConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Kubernetes_StaticJWKSConfig) ProtoMessage() {}
+
+func (x *Kubernetes_StaticJWKSConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Kubernetes_StaticJWKSConfig.ProtoReflect.Descriptor instead.
+func (*Kubernetes_StaticJWKSConfig) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{14, 0}
+}
+
+func (x *Kubernetes_StaticJWKSConfig) GetJwks() string {
+	if x != nil {
+		return x.Jwks
+	}
+	return ""
+}
+
+// The configuration specific to the `oidc` type.
+type Kubernetes_OIDCConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/oidc-configuration`
+	// endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT.
+	// For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...
+	Issuer string `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`
+	// If set, disables the requirement that the issuer must use HTTPS.
+	InsecureAllowHttpIssuer bool `protobuf:"varint,2,opt,name=insecure_allow_http_issuer,json=insecureAllowHttpIssuer,proto3" json:"insecure_allow_http_issuer,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *Kubernetes_OIDCConfig) Reset() {
+	*x = Kubernetes_OIDCConfig{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Kubernetes_OIDCConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Kubernetes_OIDCConfig) ProtoMessage() {}
+
+func (x *Kubernetes_OIDCConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Kubernetes_OIDCConfig.ProtoReflect.Descriptor instead.
+func (*Kubernetes_OIDCConfig) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{14, 1}
+}
+
+func (x *Kubernetes_OIDCConfig) GetIssuer() string {
+	if x != nil {
+		return x.Issuer
+	}
+	return ""
+}
+
+func (x *Kubernetes_OIDCConfig) GetInsecureAllowHttpIssuer() bool {
+	if x != nil {
+		return x.InsecureAllowHttpIssuer
+	}
+	return false
+}
+
+// A rule that a joining node must match in order to use the associated token
+// with the "kubernetes" join method.
+type Kubernetes_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The namespaced name of the Kubernetes service account. Its format is "namespace:service-account".
+	ServiceAccount string `protobuf:"bytes,1,opt,name=service_account,json=serviceAccount,proto3" json:"service_account,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *Kubernetes_Rule) Reset() {
+	*x = Kubernetes_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Kubernetes_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Kubernetes_Rule) ProtoMessage() {}
+
+func (x *Kubernetes_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Kubernetes_Rule.ProtoReflect.Descriptor instead.
+func (*Kubernetes_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{14, 2}
+}
+
+func (x *Kubernetes_Rule) GetServiceAccount() string {
+	if x != nil {
+		return x.ServiceAccount
+	}
+	return ""
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -1435,7 +1673,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x8d\x04\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xd5\x04\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -1449,7 +1687,10 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x05azure\x18\b \x01(\v2!.teleport.scopes.joining.v1.AzureR\x05azure\x12J\n" +
 	"\fazure_devops\x18\t \x01(\v2'.teleport.scopes.joining.v1.AzureDevopsR\vazureDevops\x12:\n" +
 	"\x06oracle\x18\n" +
-	" \x01(\v2\".teleport.scopes.joining.v1.OracleR\x06oracle\"\xb6\x01\n" +
+	" \x01(\v2\".teleport.scopes.joining.v1.OracleR\x06oracle\x12F\n" +
+	"\n" +
+	"kubernetes\x18\v \x01(\v2&.teleport.scopes.joining.v1.KubernetesR\n" +
+	"kubernetes\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -1525,7 +1766,22 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\atenancy\x18\x01 \x01(\tR\atenancy\x12/\n" +
 	"\x13parent_compartments\x18\x02 \x03(\tR\x12parentCompartments\x12\x18\n" +
 	"\aregions\x18\x03 \x03(\tR\aregions\x12\x1c\n" +
-	"\tinstances\x18\x04 \x03(\tR\tinstancesBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\tinstances\x18\x04 \x03(\tR\tinstances\"\xc0\x03\n" +
+	"\n" +
+	"Kubernetes\x12A\n" +
+	"\x05allow\x18\x01 \x03(\v2+.teleport.scopes.joining.v1.Kubernetes.RuleR\x05allow\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12X\n" +
+	"\vstatic_jwks\x18\x03 \x01(\v27.teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfigR\n" +
+	"staticJwks\x12E\n" +
+	"\x04oidc\x18\x04 \x01(\v21.teleport.scopes.joining.v1.Kubernetes.OIDCConfigR\x04oidc\x1a&\n" +
+	"\x10StaticJWKSConfig\x12\x12\n" +
+	"\x04jwks\x18\x01 \x01(\tR\x04jwks\x1aa\n" +
+	"\n" +
+	"OIDCConfig\x12\x16\n" +
+	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12;\n" +
+	"\x1ainsecure_allow_http_issuer\x18\x02 \x01(\bR\x17insecureAllowHttpIssuer\x1a/\n" +
+	"\x04Rule\x12'\n" +
+	"\x0fservice_account\x18\x01 \x01(\tR\x0eserviceAccountBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -1539,33 +1795,37 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
-	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
-	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
-	(*HostCertParams)(nil),         // 2: teleport.scopes.joining.v1.HostCertParams
-	(*SingleUseStatus)(nil),        // 3: teleport.scopes.joining.v1.SingleUseStatus
-	(*UsageStatus)(nil),            // 4: teleport.scopes.joining.v1.UsageStatus
-	(*ScopedTokenStatus)(nil),      // 5: teleport.scopes.joining.v1.ScopedTokenStatus
-	(*ImmutableLabels)(nil),        // 6: teleport.scopes.joining.v1.ImmutableLabels
-	(*StaticScopedTokens)(nil),     // 7: teleport.scopes.joining.v1.StaticScopedTokens
-	(*StaticScopedTokensSpec)(nil), // 8: teleport.scopes.joining.v1.StaticScopedTokensSpec
-	(*AWS)(nil),                    // 9: teleport.scopes.joining.v1.AWS
-	(*GCP)(nil),                    // 10: teleport.scopes.joining.v1.GCP
-	(*Azure)(nil),                  // 11: teleport.scopes.joining.v1.Azure
-	(*AzureDevops)(nil),            // 12: teleport.scopes.joining.v1.AzureDevops
-	(*Oracle)(nil),                 // 13: teleport.scopes.joining.v1.Oracle
-	nil,                            // 14: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),               // 15: teleport.scopes.joining.v1.AWS.Rule
-	(*GCP_Rule)(nil),               // 16: teleport.scopes.joining.v1.GCP.Rule
-	(*Azure_Rule)(nil),             // 17: teleport.scopes.joining.v1.Azure.Rule
-	(*AzureDevops_Rule)(nil),       // 18: teleport.scopes.joining.v1.AzureDevops.Rule
-	(*Oracle_Rule)(nil),            // 19: teleport.scopes.joining.v1.Oracle.Rule
-	(*v1.Metadata)(nil),            // 20: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 21: google.protobuf.Timestamp
+	(*ScopedToken)(nil),                 // 0: teleport.scopes.joining.v1.ScopedToken
+	(*ScopedTokenSpec)(nil),             // 1: teleport.scopes.joining.v1.ScopedTokenSpec
+	(*HostCertParams)(nil),              // 2: teleport.scopes.joining.v1.HostCertParams
+	(*SingleUseStatus)(nil),             // 3: teleport.scopes.joining.v1.SingleUseStatus
+	(*UsageStatus)(nil),                 // 4: teleport.scopes.joining.v1.UsageStatus
+	(*ScopedTokenStatus)(nil),           // 5: teleport.scopes.joining.v1.ScopedTokenStatus
+	(*ImmutableLabels)(nil),             // 6: teleport.scopes.joining.v1.ImmutableLabels
+	(*StaticScopedTokens)(nil),          // 7: teleport.scopes.joining.v1.StaticScopedTokens
+	(*StaticScopedTokensSpec)(nil),      // 8: teleport.scopes.joining.v1.StaticScopedTokensSpec
+	(*AWS)(nil),                         // 9: teleport.scopes.joining.v1.AWS
+	(*GCP)(nil),                         // 10: teleport.scopes.joining.v1.GCP
+	(*Azure)(nil),                       // 11: teleport.scopes.joining.v1.Azure
+	(*AzureDevops)(nil),                 // 12: teleport.scopes.joining.v1.AzureDevops
+	(*Oracle)(nil),                      // 13: teleport.scopes.joining.v1.Oracle
+	(*Kubernetes)(nil),                  // 14: teleport.scopes.joining.v1.Kubernetes
+	nil,                                 // 15: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),                    // 16: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),                    // 17: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),                  // 18: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),            // 19: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*Oracle_Rule)(nil),                 // 20: teleport.scopes.joining.v1.Oracle.Rule
+	(*Kubernetes_StaticJWKSConfig)(nil), // 21: teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
+	(*Kubernetes_OIDCConfig)(nil),       // 22: teleport.scopes.joining.v1.Kubernetes.OIDCConfig
+	(*Kubernetes_Rule)(nil),             // 23: teleport.scopes.joining.v1.Kubernetes.Rule
+	(*v1.Metadata)(nil),                 // 24: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),       // 25: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	20, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	24, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
@@ -1574,25 +1834,29 @@ var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
 	11, // 6: teleport.scopes.joining.v1.ScopedTokenSpec.azure:type_name -> teleport.scopes.joining.v1.Azure
 	12, // 7: teleport.scopes.joining.v1.ScopedTokenSpec.azure_devops:type_name -> teleport.scopes.joining.v1.AzureDevops
 	13, // 8: teleport.scopes.joining.v1.ScopedTokenSpec.oracle:type_name -> teleport.scopes.joining.v1.Oracle
-	21, // 9: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	21, // 10: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 11: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 12: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 13: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	14, // 14: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	20, // 15: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 16: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 17: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	15, // 18: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	16, // 19: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
-	17, // 20: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
-	18, // 21: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
-	19, // 22: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
-	23, // [23:23] is the sub-list for method output_type
-	23, // [23:23] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	14, // 9: teleport.scopes.joining.v1.ScopedTokenSpec.kubernetes:type_name -> teleport.scopes.joining.v1.Kubernetes
+	25, // 10: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	25, // 11: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 12: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 13: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 14: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	15, // 15: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	24, // 16: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 17: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 18: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	16, // 19: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	17, // 20: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	18, // 21: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	19, // 22: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	20, // 23: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
+	23, // 24: teleport.scopes.joining.v1.Kubernetes.allow:type_name -> teleport.scopes.joining.v1.Kubernetes.Rule
+	21, // 25: teleport.scopes.joining.v1.Kubernetes.static_jwks:type_name -> teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
+	22, // 26: teleport.scopes.joining.v1.Kubernetes.oidc:type_name -> teleport.scopes.joining.v1.Kubernetes.OIDCConfig
+	27, // [27:27] is the sub-list for method output_type
+	27, // [27:27] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -1609,7 +1873,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   20,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -87,6 +87,9 @@ message ScopedTokenSpec {
 
   // The Oracle-specific configuration used with the "oracle" join method.
   Oracle oracle = 10;
+
+  // The Kubernetes-specific configuration used with the "kubernetes" join method.
+  Kubernetes kubernetes = 11;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -306,4 +309,43 @@ message Oracle {
   // A list of Rules for allowing use of this token. A node must match at least one
   // allow rule in order to use this token.
   repeated Rule allow = 1;
+}
+
+// The Kubernetes-specific configuration used with the "kubernetes" join method.
+message Kubernetes {
+  // The configuration specific to the `static_jwks` type.
+  message StaticJWKSConfig {
+    // The JSON Web Key Set formatted public keys that the Kubernetes Cluster uses to sign service
+    // account tokens. This can be fetched from /openid/v1/jwks on the Kubernetes API Server.
+    string jwks = 1;
+  }
+  // The configuration specific to the `oidc` type.
+  message OIDCConfig {
+    // The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/oidc-configuration`
+    // endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT.
+    // For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...
+    string issuer = 1;
+
+    // If set, disables the requirement that the issuer must use HTTPS.
+    bool insecure_allow_http_issuer = 2;
+  }
+  // A rule that a joining node must match in order to use the associated token
+  // with the "kubernetes" join method.
+  message Rule {
+    // The namespaced name of the Kubernetes service account. Its format is "namespace:service-account".
+    string service_account = 1;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+  // Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values:
+  // - `in_cluster`
+  // - `static_jwks`
+  // - `oidc`
+  // If unset, this defaults to `in_cluster`.
+  string type = 2;
+  // The configuration specific to the `static_jwks` type.
+  StaticJWKSConfig static_jwks = 3;
+  // The configuration specific to the `oidc` type.
+  OIDCConfig oidc = 4;
 }

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -165,6 +165,9 @@ type ProvisionToken interface {
 	GetAzureDevops() *ProvisionTokenSpecV2AzureDevops
 	// GetOracle will return the Oracle specific configuration for this token.
 	GetOracle() *ProvisionTokenSpecV2Oracle
+	// GetKubernetes will return the Kubernetes specific configuration for this
+	// token.
+	GetKubernetes() *ProvisionTokenSpecV2Kubernetes
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -569,6 +572,11 @@ func (p *ProvisionTokenV2) GetAzureDevops() *ProvisionTokenSpecV2AzureDevops {
 // GetOracle will return the Oracle specific configuration for this token.
 func (p *ProvisionTokenV2) GetOracle() *ProvisionTokenSpecV2Oracle {
 	return p.Spec.Oracle
+}
+
+// GetKubernetes will return the Kubernetes specific configuration for this token.
+func (p *ProvisionTokenV2) GetKubernetes() *ProvisionTokenSpecV2Kubernetes {
+	return p.Spec.Kubernetes
 }
 
 // GetJoinMethod returns joining method that must be used with this token.

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
@@ -37,6 +37,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |gcp|[object](#specgcp)|The GCP-specific configuration used with the "gcp" join method.|
 |immutable_labels|[object](#specimmutable_labels)|Immutable labels that should be applied to any resulting resources provisioned using this token.|
 |join_method|string|The joining method required in order to use this token. Supported joining methods for scoped tokens only include 'token'.|
+|kubernetes|[object](#speckubernetes)|The Kubernetes-specific configuration used with the "kubernetes" join method.|
 |oracle|[object](#specoracle)|The Oracle-specific configuration used with the "oracle" join method.|
 |roles|[]string|The list of roles associated with the token. They will be converted to metadata in the SSH and X509 certificates issued to the user of the token.|
 |usage_mode|string|The usage mode of the token. Can be "single_use" or "unlimited". Single use tokens can only be used to provision a single resource. Unlimited tokens can be be used to provision any number of resources until it expires.|
@@ -118,6 +119,34 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |---|---|---|
 |key|string||
 |value|string||
+
+### spec.kubernetes
+
+|Field|Type|Description|
+|---|---|---|
+|allow|[][object](#speckubernetesallow-items)|A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token.|
+|oidc|[object](#speckubernetesoidc)|The configuration specific to the `oidc` type.|
+|static_jwks|[object](#speckubernetesstatic_jwks)|The configuration specific to the `static_jwks` type.|
+|type|string|Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.|
+
+### spec.kubernetes.allow items
+
+|Field|Type|Description|
+|---|---|---|
+|service_account|string||
+
+### spec.kubernetes.oidc
+
+|Field|Type|Description|
+|---|---|---|
+|insecure_allow_http_issuer|boolean||
+|issuer|string||
+
+### spec.kubernetes.static_jwks
+
+|Field|Type|Description|
+|---|---|---|
+|jwks|string||
 
 ### spec.oracle
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -61,6 +61,7 @@ Optional:
 - `azure_devops` (Attributes) The Azure Devops-specific configuration used with the "azure_devops" join method. (see [below for nested schema](#nested-schema-for-specazure_devops))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))
+- `kubernetes` (Attributes) The Kubernetes-specific configuration used with the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
 - `oracle` (Attributes) The Oracle-specific configuration used with the "oracle" join method. (see [below for nested schema](#nested-schema-for-specoracle))
 
 ### Nested Schema for `spec.aws`
@@ -141,6 +142,38 @@ Optional:
 Optional:
 
 - `ssh` (Map of String) Labels that should be applied to SSH nodes.
+
+
+### Nested Schema for `spec.kubernetes`
+
+Optional:
+
+- `allow` (Attributes List) A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token. (see [below for nested schema](#nested-schema-for-speckubernetesallow))
+- `oidc` (Attributes) The configuration specific to the `oidc` type. (see [below for nested schema](#nested-schema-for-speckubernetesoidc))
+- `static_jwks` (Attributes) The configuration specific to the `static_jwks` type. (see [below for nested schema](#nested-schema-for-speckubernetesstatic_jwks))
+- `type` (String) Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.
+
+### Nested Schema for `spec.kubernetes.allow`
+
+Optional:
+
+- `service_account` (String) The namespaced name of the Kubernetes service account. Its format is "namespace:service-account".
+
+
+### Nested Schema for `spec.kubernetes.oidc`
+
+Optional:
+
+- `insecure_allow_http_issuer` (Boolean) If set, disables the requirement that the issuer must use HTTPS.
+- `issuer` (String) The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/oidc-configuration` endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT. For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...
+
+
+### Nested Schema for `spec.kubernetes.static_jwks`
+
+Optional:
+
+- `jwks` (String) The JSON Web Key Set formatted public keys that the Kubernetes Cluster uses to sign service account tokens. This can be fetched from /openid/v1/jwks on the Kubernetes API Server.
+
 
 
 ### Nested Schema for `spec.oracle`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -105,6 +105,7 @@ Optional:
 - `azure_devops` (Attributes) The Azure Devops-specific configuration used with the "azure_devops" join method. (see [below for nested schema](#nested-schema-for-specazure_devops))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))
+- `kubernetes` (Attributes) The Kubernetes-specific configuration used with the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
 - `oracle` (Attributes) The Oracle-specific configuration used with the "oracle" join method. (see [below for nested schema](#nested-schema-for-specoracle))
 
 ### Nested Schema for `spec.aws`
@@ -185,6 +186,38 @@ Optional:
 Optional:
 
 - `ssh` (Map of String) Labels that should be applied to SSH nodes.
+
+
+### Nested Schema for `spec.kubernetes`
+
+Optional:
+
+- `allow` (Attributes List) A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token. (see [below for nested schema](#nested-schema-for-speckubernetesallow))
+- `oidc` (Attributes) The configuration specific to the `oidc` type. (see [below for nested schema](#nested-schema-for-speckubernetesoidc))
+- `static_jwks` (Attributes) The configuration specific to the `static_jwks` type. (see [below for nested schema](#nested-schema-for-speckubernetesstatic_jwks))
+- `type` (String) Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.
+
+### Nested Schema for `spec.kubernetes.allow`
+
+Optional:
+
+- `service_account` (String) The namespaced name of the Kubernetes service account. Its format is "namespace:service-account".
+
+
+### Nested Schema for `spec.kubernetes.oidc`
+
+Optional:
+
+- `insecure_allow_http_issuer` (Boolean) If set, disables the requirement that the issuer must use HTTPS.
+- `issuer` (String) The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/oidc-configuration` endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT. For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...
+
+
+### Nested Schema for `spec.kubernetes.static_jwks`
+
+Optional:
+
+- `jwks` (String) The JSON Web Key Set formatted public keys that the Kubernetes Cluster uses to sign service account tokens. This can be fetched from /openid/v1/jwks on the Kubernetes API Server.
+
 
 
 ### Nested Schema for `spec.oracle`

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -184,6 +184,44 @@ spec:
                 description: The joining method required in order to use this token.
                   Supported joining methods for scoped tokens only include 'token'.
                 type: string
+              kubernetes:
+                description: The Kubernetes-specific configuration used with the "kubernetes"
+                  join method.
+                nullable: true
+                properties:
+                  allow:
+                    description: A list of Rules for allowing use of this token. A
+                      node must match at least one allow rule in order to use this
+                      token.
+                    items:
+                      properties:
+                        service_account:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  oidc:
+                    description: The configuration specific to the `oidc` type.
+                    nullable: true
+                    properties:
+                      insecure_allow_http_issuer:
+                        type: boolean
+                      issuer:
+                        type: string
+                    type: object
+                  static_jwks:
+                    description: The configuration specific to the `static_jwks` type.
+                    nullable: true
+                    properties:
+                      jwks:
+                        type: string
+                    type: object
+                  type:
+                    description: 'Controls which behavior should be used for validating
+                      the Kubernetes Service Account token. Supported values: - `in_cluster`
+                      - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.'
+                    type: string
+                type: object
               oracle:
                 description: The Oracle-specific configuration used with the "oracle"
                   join method.

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -184,6 +184,44 @@ spec:
                 description: The joining method required in order to use this token.
                   Supported joining methods for scoped tokens only include 'token'.
                 type: string
+              kubernetes:
+                description: The Kubernetes-specific configuration used with the "kubernetes"
+                  join method.
+                nullable: true
+                properties:
+                  allow:
+                    description: A list of Rules for allowing use of this token. A
+                      node must match at least one allow rule in order to use this
+                      token.
+                    items:
+                      properties:
+                        service_account:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  oidc:
+                    description: The configuration specific to the `oidc` type.
+                    nullable: true
+                    properties:
+                      insecure_allow_http_issuer:
+                        type: boolean
+                      issuer:
+                        type: string
+                    type: object
+                  static_jwks:
+                    description: The configuration specific to the `static_jwks` type.
+                    nullable: true
+                    properties:
+                      jwks:
+                        type: string
+                    type: object
+                  type:
+                    description: 'Controls which behavior should be used for validating
+                      the Kubernetes Service Account token. Supported values: - `in_cluster`
+                      - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.'
+                    type: string
+                type: object
               oracle:
                 description: The Oracle-specific configuration used with the "oracle"
                   join method.

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -276,6 +276,51 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 					Required:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
+				"kubernetes": {
+					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"allow": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"service_account": {
+								Description: "The namespaced name of the Kubernetes service account. Its format is \"namespace:service-account\".",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							}}),
+							Description: "A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token.",
+							Optional:    true,
+						},
+						"oidc": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"insecure_allow_http_issuer": {
+									Description: "If set, disables the requirement that the issuer must use HTTPS.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+								},
+								"issuer": {
+									Description: "The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/oidc-configuration` endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT. For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+							}),
+							Description: "The configuration specific to the `oidc` type.",
+							Optional:    true,
+						},
+						"static_jwks": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"jwks": {
+								Description: "The JSON Web Key Set formatted public keys that the Kubernetes Cluster uses to sign service account tokens. This can be fetched from /openid/v1/jwks on the Kubernetes API Server.",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							}}),
+							Description: "The configuration specific to the `static_jwks` type.",
+							Optional:    true,
+						},
+						"type": {
+							Description: "Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+					}),
+					Description: "The Kubernetes-specific configuration used with the \"kubernetes\" join method.",
+					Optional:    true,
+				},
 				"oracle": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"allow": {
 						Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
@@ -1391,6 +1436,174 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 																}
 															}
 															obj.Allow[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						a, ok := tf.Attrs["kubernetes"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"ScopedToken.spec.kubernetes"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.kubernetes", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+							} else {
+								obj.Kubernetes = nil
+								if !v.Null && !v.Unknown {
+									tf := v
+									obj.Kubernetes = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Kubernetes{}
+									obj := obj.Kubernetes
+									{
+										a, ok := tf.Attrs["allow"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.kubernetes.allow"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.kubernetes.allow", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.Allow = make([]*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Kubernetes_Rule, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.kubernetes.allow", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+														} else {
+															var t *github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Kubernetes_Rule
+															if !v.Null && !v.Unknown {
+																tf := v
+																t = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Kubernetes_Rule{}
+																obj := t
+																{
+																	a, ok := tf.Attrs["service_account"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.kubernetes.allow.service_account"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.kubernetes.allow.service_account", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.ServiceAccount = t
+																		}
+																	}
+																}
+															}
+															obj.Allow[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["type"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.kubernetes.type"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.kubernetes.type", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Type = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["static_jwks"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.kubernetes.static_jwks"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.kubernetes.static_jwks", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.StaticJwks = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.StaticJwks = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Kubernetes_StaticJWKSConfig{}
+													obj := obj.StaticJwks
+													{
+														a, ok := tf.Attrs["jwks"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedToken.spec.kubernetes.static_jwks.jwks"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.kubernetes.static_jwks.jwks", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															} else {
+																var t string
+																if !v.Null && !v.Unknown {
+																	t = string(v.Value)
+																}
+																obj.Jwks = t
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["oidc"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.kubernetes.oidc"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.kubernetes.oidc", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.Oidc = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.Oidc = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Kubernetes_OIDCConfig{}
+													obj := obj.Oidc
+													{
+														a, ok := tf.Attrs["issuer"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedToken.spec.kubernetes.oidc.issuer"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.kubernetes.oidc.issuer", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															} else {
+																var t string
+																if !v.Null && !v.Unknown {
+																	t = string(v.Value)
+																}
+																obj.Issuer = t
+															}
+														}
+													}
+													{
+														a, ok := tf.Attrs["insecure_allow_http_issuer"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedToken.spec.kubernetes.oidc.insecure_allow_http_issuer"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.kubernetes.oidc.insecure_allow_http_issuer", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+															} else {
+																var t bool
+																if !v.Null && !v.Unknown {
+																	t = bool(v.Value)
+																}
+																obj.InsecureAllowHttpIssuer = t
+															}
 														}
 													}
 												}
@@ -3155,6 +3368,270 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 								}
 								v.Unknown = false
 								tf.Attrs["oracle"] = v
+							}
+						}
+					}
+					{
+						a, ok := tf.AttrTypes["kubernetes"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.kubernetes"})
+						} else {
+							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+							if !ok {
+								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.kubernetes", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+							} else {
+								v, ok := tf.Attrs["kubernetes"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+								if !ok {
+									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+										AttrTypes: o.AttrTypes,
+										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+									}
+								} else {
+									if v.Attrs == nil {
+										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+									}
+								}
+								if obj.Kubernetes == nil {
+									v.Null = true
+								} else {
+									obj := obj.Kubernetes
+									tf := &v
+									{
+										a, ok := tf.AttrTypes["allow"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.kubernetes.allow"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.kubernetes.allow", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["allow"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Allow)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Allow))
+													}
+												}
+												if obj.Allow != nil {
+													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+													if len(obj.Allow) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Allow))
+													}
+													for k, a := range obj.Allow {
+														v, ok := tf.Attrs["allow"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																AttrTypes: o.AttrTypes,
+																Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+															}
+														} else {
+															if v.Attrs == nil {
+																v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+															}
+														}
+														if a == nil {
+															v.Null = true
+														} else {
+															obj := a
+															tf := &v
+															{
+																t, ok := tf.AttrTypes["service_account"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.kubernetes.allow.service_account"})
+																} else {
+																	v, ok := tf.Attrs["service_account"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.kubernetes.allow.service_account", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.kubernetes.allow.service_account", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.ServiceAccount) == ""
+																	}
+																	v.Value = string(obj.ServiceAccount)
+																	v.Unknown = false
+																	tf.Attrs["service_account"] = v
+																}
+															}
+														}
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.Allow) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["allow"] = c
+											}
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["type"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.kubernetes.type"})
+										} else {
+											v, ok := tf.Attrs["type"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedToken.spec.kubernetes.type", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.kubernetes.type", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Type) == ""
+											}
+											v.Value = string(obj.Type)
+											v.Unknown = false
+											tf.Attrs["type"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["static_jwks"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.kubernetes.static_jwks"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.kubernetes.static_jwks", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["static_jwks"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.StaticJwks == nil {
+													v.Null = true
+												} else {
+													obj := obj.StaticJwks
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["jwks"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedToken.spec.kubernetes.static_jwks.jwks"})
+														} else {
+															v, ok := tf.Attrs["jwks"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedToken.spec.kubernetes.static_jwks.jwks", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.kubernetes.static_jwks.jwks", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																}
+																v.Null = string(obj.Jwks) == ""
+															}
+															v.Value = string(obj.Jwks)
+															v.Unknown = false
+															tf.Attrs["jwks"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["static_jwks"] = v
+											}
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["oidc"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.kubernetes.oidc"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.kubernetes.oidc", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["oidc"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.Oidc == nil {
+													v.Null = true
+												} else {
+													obj := obj.Oidc
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["issuer"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedToken.spec.kubernetes.oidc.issuer"})
+														} else {
+															v, ok := tf.Attrs["issuer"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedToken.spec.kubernetes.oidc.issuer", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.kubernetes.oidc.issuer", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																}
+																v.Null = string(obj.Issuer) == ""
+															}
+															v.Value = string(obj.Issuer)
+															v.Unknown = false
+															tf.Attrs["issuer"] = v
+														}
+													}
+													{
+														t, ok := tf.AttrTypes["insecure_allow_http_issuer"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedToken.spec.kubernetes.oidc.insecure_allow_http_issuer"})
+														} else {
+															v, ok := tf.Attrs["insecure_allow_http_issuer"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedToken.spec.kubernetes.oidc.insecure_allow_http_issuer", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.kubernetes.oidc.insecure_allow_http_issuer", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+																}
+																v.Null = bool(obj.InsecureAllowHttpIssuer) == false
+															}
+															v.Value = bool(obj.InsecureAllowHttpIssuer)
+															v.Unknown = false
+															tf.Attrs["insecure_allow_http_issuer"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["oidc"] = v
+											}
+										}
+									}
+								}
+								v.Unknown = false
+								tf.Attrs["kubernetes"] = v
 							}
 						}
 					}

--- a/lib/join/join_kubernetes_test.go
+++ b/lib/join/join_kubernetes_test.go
@@ -20,18 +20,24 @@ package join_test
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/join/jointest"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
+	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 type mockK8STokenReviewValidator struct {
@@ -45,6 +51,13 @@ func (m *mockK8STokenReviewValidator) Validate(_ context.Context, token, _ strin
 	}
 
 	return result, nil
+}
+
+func newFakeIDP(t *testing.T) *fakeissuer.IDP {
+	idp, err := fakeissuer.NewIDP(slog.Default())
+	require.NoError(t, err)
+	t.Cleanup(idp.Close)
+	return idp
 }
 
 func TestJoinKubernetes(t *testing.T) {
@@ -84,6 +97,19 @@ func TestJoinKubernetes(t *testing.T) {
 		return result, nil
 	})
 
+	oidcIDP := newFakeIDP(t)
+	wrongOIDCIDP := newFakeIDP(t)
+	oidcIssuerURL := oidcIDP.IssuerURL()
+
+	oidcIDToken, err := oidcIDP.IssueKubeToken("oidc-pod", "oidc-namespace", "oidc-service-account", authServer.ClusterName())
+	require.NoError(t, err)
+	oidcAllowMismatchToken, err := oidcIDP.IssueKubeToken("oidc-pod", "oidc-namespace", "other-service-account", authServer.ClusterName())
+	require.NoError(t, err)
+	oidcInvalidAudienceToken, err := oidcIDP.IssueKubeToken("oidc-pod", "oidc-namespace", "oidc-service-account", "wrong-audience")
+	require.NoError(t, err)
+	oidcInvalidIssuerToken, err := wrongOIDCIDP.IssueKubeToken("oidc-pod", "oidc-namespace", "oidc-service-account", authServer.ClusterName())
+	require.NoError(t, err)
+
 	// Creating and loading our two Kubernetes ProvisionTokens
 	implicitInClusterPT, err := types.NewProvisionTokenFromSpec("implicit-in-cluster", time.Now().Add(10*time.Minute), types.ProvisionTokenSpecV2{
 		JoinMethod: types.JoinMethodKubernetes,
@@ -122,9 +148,43 @@ func TestJoinKubernetes(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	oidcPT, err := types.NewProvisionTokenFromSpec("oidc", time.Now().Add(10*time.Minute), types.ProvisionTokenSpecV2{
+		JoinMethod: types.JoinMethodKubernetes,
+		Roles:      []types.SystemRole{types.RoleNode},
+		Kubernetes: &types.ProvisionTokenSpecV2Kubernetes{
+			Type: types.KubernetesJoinTypeOIDC,
+			Allow: []*types.ProvisionTokenSpecV2Kubernetes_Rule{
+				{ServiceAccount: "oidc-namespace:oidc-service-account"},
+			},
+			OIDC: &types.ProvisionTokenSpecV2Kubernetes_OIDCConfig{
+				Issuer:                  oidcIssuerURL,
+				InsecureAllowHTTPIssuer: true,
+			},
+		},
+	})
+	require.NoError(t, err)
 	require.NoError(t, auth.CreateToken(ctx, implicitInClusterPT))
 	require.NoError(t, auth.CreateToken(ctx, explicitInClusterPT))
 	require.NoError(t, auth.CreateToken(ctx, staticJWKSPT))
+	require.NoError(t, auth.CreateToken(ctx, oidcPT))
+
+	for _, pt := range []types.ProvisionToken{implicitInClusterPT, explicitInClusterPT, staticJWKSPT, oidcPT} {
+		ptv2, ok := pt.(*types.ProvisionTokenV2)
+		require.True(t, ok, "expected provision token to be types.ProvisionTokenSpecV2")
+		scoped, err := jointest.ScopedTokenFromProvisionTokenSpec(ptv2.Spec, &joiningv1.ScopedToken{
+			Scope: "/test",
+			Metadata: &headerv1.Metadata{
+				Name: "scoped_" + pt.GetName(),
+			},
+			Spec: &joiningv1.ScopedTokenSpec{
+				AssignedScope: "/test/one",
+				UsageMode:     string(joining.TokenUsageModeUnlimited),
+			},
+		})
+		require.NoError(t, err)
+		_, err = auth.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{Token: scoped})
+		require.NoError(t, err)
+	}
 
 	// Building a joinRequest builder
 	sshPrivateKey, sshPublicKey, err := testauthority.GenerateKeyPair()
@@ -207,6 +267,36 @@ func TestJoinKubernetes(t *testing.T) {
 				require.ErrorContains(t, err, "invalid token")
 			},
 		},
+		{
+			"oidc: success",
+			oidcIDToken,
+			oidcPT,
+			require.NoError,
+		},
+		{
+			"oidc: allow rule mismatch",
+			oidcAllowMismatchToken,
+			oidcPT,
+			func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "kubernetes token did not match any allow rules")
+			},
+		},
+		{
+			"oidc: invalid audience",
+			oidcInvalidAudienceToken,
+			oidcPT,
+			func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "audience is not valid")
+			},
+		},
+		{
+			"oidc: invalid issuer",
+			oidcInvalidIssuerToken,
+			oidcPT,
+			func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "issuer does not match")
+			},
+		},
 	}
 
 	// Doing the real test
@@ -238,6 +328,20 @@ func TestJoinKubernetes(t *testing.T) {
 			t.Run("new joinclient", func(t *testing.T) {
 				_, err := joinclient.Join(t.Context(), joinclient.JoinParams{
 					Token:      tt.provisionToken.GetName(),
+					JoinMethod: types.JoinMethodKubernetes,
+					ID: state.IdentityID{
+						Role:     types.RoleInstance, // RoleNode is not allowed
+						NodeName: "testnode",
+					},
+					IDToken:    tt.kubeToken,
+					AuthClient: nopClient,
+				})
+				tt.assertError(t, err)
+			})
+
+			t.Run("scoped join", func(t *testing.T) {
+				_, err := joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token:      "scoped_" + tt.provisionToken.GetName(),
 					JoinMethod: types.JoinMethodKubernetes,
 					ID: state.IdentityID{
 						Role:     types.RoleInstance, // RoleNode is not allowed

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -141,6 +141,38 @@ func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override
 		scopedToken.Spec.Oracle = &joiningv1.Oracle{
 			Allow: allow,
 		}
+	case types.JoinMethodKubernetes:
+		if base.Kubernetes == nil {
+			return nil, trace.BadParameter("kubernetes configuration must be defined for kubernetes join method")
+		}
+		allow := make([]*joiningv1.Kubernetes_Rule, len(base.Kubernetes.Allow))
+		for i, rule := range base.Kubernetes.Allow {
+			allow[i] = &joiningv1.Kubernetes_Rule{
+				ServiceAccount: rule.ServiceAccount,
+			}
+		}
+
+		var staticJWKS *joiningv1.Kubernetes_StaticJWKSConfig
+		if base.Kubernetes.StaticJWKS != nil {
+			staticJWKS = &joiningv1.Kubernetes_StaticJWKSConfig{
+				Jwks: base.Kubernetes.StaticJWKS.JWKS,
+			}
+		}
+
+		var oidc *joiningv1.Kubernetes_OIDCConfig
+		if base.Kubernetes.OIDC != nil {
+			oidc = &joiningv1.Kubernetes_OIDCConfig{
+				Issuer:                  base.Kubernetes.OIDC.Issuer,
+				InsecureAllowHttpIssuer: base.Kubernetes.OIDC.InsecureAllowHTTPIssuer,
+			}
+		}
+
+		scopedToken.Spec.Kubernetes = &joiningv1.Kubernetes{
+			Allow:      allow,
+			Type:       string(base.Kubernetes.Type),
+			StaticJwks: staticJWKS,
+			Oidc:       oidc,
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.JoinMethod)
 	}

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -66,4 +66,6 @@ type Token interface {
 	GetAzureDevops() *types.ProvisionTokenSpecV2AzureDevops
 	// GetOracle returns the Oracle-specific configuration for this token.
 	GetOracle() *types.ProvisionTokenSpecV2Oracle
+	// GetKubernetes returns the Kubernetes-specific configuration for this token.
+	GetKubernetes() *types.ProvisionTokenSpecV2Kubernetes
 }

--- a/lib/kube/token/join.go
+++ b/lib/kube/token/join.go
@@ -82,22 +82,23 @@ func CheckIDToken(
 		return nil, trace.Wrap(err)
 	}
 
-	token, ok := params.ProvisionToken.(*types.ProvisionTokenV2)
-	if !ok {
-		return nil, trace.BadParameter(
-			"kubernetes join method only supports ProvisionTokenV2, '%T' was provided",
-			params.ProvisionToken,
-		)
+	kubeConfig := params.ProvisionToken.GetKubernetes()
+	if kubeConfig == nil {
+		return nil, trace.BadParameter("kubernetes token configuration must be defined in order to join with a kubernetes ID token")
 	}
 
 	// Switch to join method subtype token validation.
 	var result *ValidationResult
 	var err error
-	switch token.Spec.Kubernetes.Type {
+	switch kubeConfig.Type {
 	case types.KubernetesJoinTypeStaticJWKS:
+		if kubeConfig.StaticJWKS == nil {
+			return nil, trace.BadParameter("static jwks configuration must provide a jwks string")
+		}
+
 		result, err = params.JWKSValidator(
 			params.Clock.Now(),
-			[]byte(token.Spec.Kubernetes.StaticJWKS.JWKS),
+			[]byte(kubeConfig.StaticJWKS.JWKS),
 			params.ClusterName,
 			string(params.IDToken),
 		)
@@ -105,9 +106,12 @@ func CheckIDToken(
 			return nil, trace.WrapWithMessage(err, "reviewing kubernetes token with static_jwks")
 		}
 	case types.KubernetesJoinTypeOIDC:
+		if kubeConfig.OIDC == nil {
+			return nil, trace.BadParameter("kubernetes OIDC joining must provide an OIDC configuration")
+		}
 		result, err = params.OIDCValidator.ValidateToken(
 			ctx,
-			token.Spec.Kubernetes.OIDC.Issuer,
+			kubeConfig.OIDC.Issuer,
 			params.ClusterName,
 			string(params.IDToken),
 		)
@@ -122,21 +126,21 @@ func CheckIDToken(
 	default:
 		return nil, trace.BadParameter(
 			"unsupported kubernetes join method type (%s)",
-			token.Spec.Kubernetes.Type,
+			kubeConfig.Type,
 		)
 	}
 
 	log.InfoContext(ctx, "Kubernetes workload trying to join cluster",
 		"validated_identity", result,
-		"token", token.GetName(),
+		"token", params.ProvisionToken.GetName(),
 	)
 
-	return result, trace.Wrap(checkKubernetesAllowRules(token, result))
+	return result, trace.Wrap(checkKubernetesAllowRules(kubeConfig.Allow, result))
 }
 
-func checkKubernetesAllowRules(pt *types.ProvisionTokenV2, got *ValidationResult) error {
+func checkKubernetesAllowRules(allow []*types.ProvisionTokenSpecV2Kubernetes_Rule, got *ValidationResult) error {
 	// If a single rule passes, accept the token
-	for _, rule := range pt.Spec.Kubernetes.Allow {
+	for _, rule := range allow {
 		wantUsername := fmt.Sprintf("%s:%s", ServiceAccountNamePrefix, rule.ServiceAccount)
 		if wantUsername != got.Username {
 			continue

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -21,7 +21,9 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"net/url"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -48,6 +50,74 @@ const (
 	// TokenUsageModeUnlimited denotes a token that can provision any number of resources.
 	TokenUsageModeUnlimited = "unlimited"
 )
+
+func validateKubernetes(kube *joiningv1.Kubernetes) error {
+	if kube == nil || len(kube.GetAllow()) == 0 {
+		return trace.BadParameter("at least one allow rule must be set")
+	}
+
+	for i, rule := range kube.GetAllow() {
+		if rule.ServiceAccount == "" {
+			return trace.BadParameter("allow[%d].service_account must be set", i)
+		}
+
+		namespace, name, found := strings.Cut(rule.ServiceAccount, ":")
+		if !found || namespace == "" || name == "" {
+			return trace.BadParameter("allow[%d].service_account should be in format \"namespace:service_account\", got %q instead", i, rule.ServiceAccount)
+		}
+
+	}
+
+	switch types.KubernetesJoinType(kube.GetType()) {
+	case types.KubernetesJoinTypeInCluster:
+		if kube.GetStaticJwks() != nil {
+			return trace.BadParameter("static_jwks must not be set when type is %q", kube.GetType())
+		}
+
+		if kube.GetOidc() != nil {
+			return trace.BadParameter("oidc must not be set when type is %q", kube.GetType())
+		}
+	case types.KubernetesJoinTypeStaticJWKS:
+		if kube.GetStaticJwks().GetJwks() == "" {
+			return trace.BadParameter("static_jwks must be set when type is %q", kube.GetType())
+		}
+		if kube.GetOidc() != nil {
+			return trace.BadParameter("oidc must not be set when type is %q", kube.GetType())
+		}
+	case types.KubernetesJoinTypeOIDC:
+		if kube.GetOidc().GetIssuer() == "" {
+			return trace.BadParameter("oidc.issuer issuer must be set when type is %q", kube.GetType())
+		}
+		if kube.GetStaticJwks() != nil {
+			return trace.BadParameter("static_jwks must not be set when type is %q", kube.GetType())
+		}
+
+		parsed, err := url.Parse(kube.GetOidc().GetIssuer())
+		if err != nil {
+			return trace.BadParameter("oidc.issuer must be a valid URL")
+		}
+
+		if parsed.Scheme == "http" {
+			if !kube.GetOidc().GetInsecureAllowHttpIssuer() {
+				return trace.BadParameter("oidc.issuer must be https:// unless insecure_allow_http_issuer is set")
+			}
+		} else if parsed.Scheme != "https" {
+			return trace.BadParameter("invalid oidc.issuer URL scheme, must be https://")
+		}
+	default:
+		return trace.BadParameter(
+			"unrecognized join type %q, must be one of (%s)",
+			kube.GetType(),
+			strings.Join([]string{
+				string(types.KubernetesJoinTypeInCluster),
+				string(types.KubernetesJoinTypeStaticJWKS),
+				string(types.KubernetesJoinTypeOIDC),
+			}, ", "),
+		)
+	}
+
+	return nil
+}
 
 func validateJoinMethod(token *joiningv1.ScopedToken) error {
 	switch types.JoinMethod(token.GetSpec().GetJoinMethod()) {
@@ -81,6 +151,8 @@ func validateJoinMethod(token *joiningv1.ScopedToken) error {
 		if len(token.GetSpec().GetOracle().GetAllow()) == 0 {
 			return trace.BadParameter("oracle configuration must be defined for a scoped token when using the oracle join method")
 		}
+	case types.JoinMethodKubernetes:
+		return trace.Wrap(validateKubernetes(token.GetSpec().GetKubernetes()), "kubernetes join method")
 	default:
 		return trace.BadParameter("join method %q does not support scoping", token.GetSpec().GetJoinMethod())
 	}
@@ -436,6 +508,38 @@ func (t *Token) GetOracle() *types.ProvisionTokenSpecV2Oracle {
 
 	return &types.ProvisionTokenSpecV2Oracle{
 		Allow: allow,
+	}
+}
+
+// GetKubernetes returns the Kubernetes-specific configuration for this token.
+func (t *Token) GetKubernetes() *types.ProvisionTokenSpecV2Kubernetes {
+	allow := make([]*types.ProvisionTokenSpecV2Kubernetes_Rule, len(t.scoped.GetSpec().GetKubernetes().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetKubernetes().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2Kubernetes_Rule{
+			ServiceAccount: rule.GetServiceAccount(),
+		}
+	}
+
+	var staticJWKS *types.ProvisionTokenSpecV2Kubernetes_StaticJWKSConfig
+	if jwks := t.scoped.GetSpec().GetKubernetes().GetStaticJwks().GetJwks(); jwks != "" {
+		staticJWKS = &types.ProvisionTokenSpecV2Kubernetes_StaticJWKSConfig{
+			JWKS: jwks,
+		}
+	}
+
+	var oidcConfig *types.ProvisionTokenSpecV2Kubernetes_OIDCConfig
+	if oidc := t.scoped.GetSpec().GetKubernetes().GetOidc(); oidc != nil {
+		oidcConfig = &types.ProvisionTokenSpecV2Kubernetes_OIDCConfig{
+			Issuer:                  oidc.GetIssuer(),
+			InsecureAllowHTTPIssuer: oidc.GetInsecureAllowHttpIssuer(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2Kubernetes{
+		Allow:      allow,
+		Type:       types.KubernetesJoinType(t.scoped.GetSpec().GetKubernetes().GetType()),
+		StaticJWKS: staticJWKS,
+		OIDC:       oidcConfig,
 	}
 }
 

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -290,6 +290,201 @@ func TestValidateScopedToken(t *testing.T) {
 			expectedWeakErr:   "oracle configuration must be defined for a scoped token when using the oracle join method",
 		},
 		{
+			name: "kubernetes token without configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+			},
+			expectedStrongErr: "at least one allow rule must be set",
+			expectedWeakErr:   "at least one allow rule must be set",
+		},
+		{
+			name: "kubernetes token with empty allow rules",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Allow: []*joiningv1.Kubernetes_Rule{},
+				}
+			},
+			expectedStrongErr: "at least one allow rule must be set",
+			expectedWeakErr:   "at least one allow rule must be set",
+		},
+		{
+			name: "kubernetes token with empty service account allow rule",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Allow: []*joiningv1.Kubernetes_Rule{{ServiceAccount: ""}},
+					Type:  string(types.KubernetesJoinTypeInCluster),
+				}
+			},
+			expectedStrongErr: "allow[0].service_account must be set",
+			expectedWeakErr:   "allow[0].service_account must be set",
+		},
+		{
+			name: "kubernetes token with malformed service account allow rule",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Allow: []*joiningv1.Kubernetes_Rule{{ServiceAccount: "malformed"}},
+					Type:  string(types.KubernetesJoinTypeInCluster),
+				}
+			},
+			expectedStrongErr: "allow[0].service_account should be in format \"namespace:service_account\"",
+			expectedWeakErr:   "allow[0].service_account should be in format \"namespace:service_account\"",
+		},
+		{
+			name: "kubernetes token with unrecognized join type",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Type: "unknown",
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+				}
+			},
+			expectedStrongErr: "unrecognized join type \"unknown\"",
+			expectedWeakErr:   "unrecognized join type \"unknown\"",
+		},
+		{
+			name: "kubernetes static_jwks token without configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Type: "static_jwks",
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+				}
+			},
+			expectedStrongErr: "static_jwks must be set when type is \"static_jwks\"",
+			expectedWeakErr:   "static_jwks must be set when type is \"static_jwks\"",
+		},
+		{
+			name: "kubernetes in_cluster token with static_jwks configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Type: string(types.KubernetesJoinTypeInCluster),
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+					StaticJwks: &joiningv1.Kubernetes_StaticJWKSConfig{},
+				}
+			},
+			expectedStrongErr: "static_jwks must not be set when type is \"in_cluster\"",
+			expectedWeakErr:   "static_jwks must not be set when type is \"in_cluster\"",
+		},
+		{
+			name: "kubernetes in_cluster token with oidc configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Type: string(types.KubernetesJoinTypeInCluster),
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+					Oidc: &joiningv1.Kubernetes_OIDCConfig{},
+				}
+			},
+			expectedStrongErr: "oidc must not be set when type is \"in_cluster\"",
+			expectedWeakErr:   "oidc must not be set when type is \"in_cluster\"",
+		},
+		{
+			name: "kubernetes static_jwks token with oidc configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Type: string(types.KubernetesJoinTypeStaticJWKS),
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+					StaticJwks: &joiningv1.Kubernetes_StaticJWKSConfig{Jwks: "{\"keys\":[]}"},
+					Oidc:       &joiningv1.Kubernetes_OIDCConfig{},
+				}
+			},
+			expectedStrongErr: "oidc must not be set when type is \"static_jwks\"",
+			expectedWeakErr:   "oidc must not be set when type is \"static_jwks\"",
+		},
+		{
+			name: "kubernetes oidc token without configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Type: "oidc",
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+				}
+			},
+			expectedStrongErr: "oidc.issuer issuer must be set when type is \"oidc\"",
+			expectedWeakErr:   "oidc.issuer issuer must be set when type is \"oidc\"",
+		},
+		{
+			name: "kubernetes oidc token with static_jwks configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Type: string(types.KubernetesJoinTypeOIDC),
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+					Oidc:       &joiningv1.Kubernetes_OIDCConfig{Issuer: "https://oidc.example.com"},
+					StaticJwks: &joiningv1.Kubernetes_StaticJWKSConfig{},
+				}
+			},
+			expectedStrongErr: "static_jwks must not be set when type is \"oidc\"",
+			expectedWeakErr:   "static_jwks must not be set when type is \"oidc\"",
+		},
+		{
+			name: "kubernetes oidc token with malformed issuer",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Type: string(types.KubernetesJoinTypeOIDC),
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+					Oidc: &joiningv1.Kubernetes_OIDCConfig{Issuer: "://bad-url"},
+				}
+			},
+			expectedStrongErr: "oidc.issuer must be a valid URL",
+			expectedWeakErr:   "oidc.issuer must be a valid URL",
+		},
+		{
+			name: "kubernetes oidc token with http issuer and insecure flag disabled",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Type: string(types.KubernetesJoinTypeOIDC),
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+					Oidc: &joiningv1.Kubernetes_OIDCConfig{Issuer: "http://oidc.example.com"},
+				}
+			},
+			expectedStrongErr: "oidc.issuer must be https:// unless insecure_allow_http_issuer is set",
+			expectedWeakErr:   "oidc.issuer must be https:// unless insecure_allow_http_issuer is set",
+		},
+		{
 			name: "valid scoped token",
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Spec.Roles = types.SystemRoles{types.RoleNode, types.RoleKube, types.RoleApp, types.RoleDiscovery}.StringSlice()
@@ -383,6 +578,54 @@ func TestValidateScopedToken(t *testing.T) {
 						{
 							Tenancy: "1234567890",
 						},
+					},
+				}
+			},
+		},
+		{
+			name: "valid kubernetes in_cluster scoped token",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+					Type: string(types.KubernetesJoinTypeInCluster),
+				}
+			},
+		},
+		{
+			name: "valid kubernetes static_jwks scoped token",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+					Type: string(types.KubernetesJoinTypeStaticJWKS),
+					StaticJwks: &joiningv1.Kubernetes_StaticJWKSConfig{
+						Jwks: "{\"keys\":[]}",
+					},
+				}
+			},
+		},
+		{
+			name: "valid kubernetes oidc scoped token",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+					Type: string(types.KubernetesJoinTypeOIDC),
+					Oidc: &joiningv1.Kubernetes_OIDCConfig{
+						Issuer: "https://oidc.example.com/my-cluster",
 					},
 				}
 			},


### PR DESCRIPTION
This PR adds support for kubernetes join methods when using scoped tokens.

# Manual testing
- [x] Create a scoped token using in-cluster config
```yaml
# in_cluster_token.yaml
kind: scoped_token
version: v1
scope: /test
metadata:
  name: kube-in-cluster
spec:
  assigned_scope: /test/in_cluster
  usage_mode: unlimited
  roles: [Node]
  join_method: kubernetes
  kubernetes:
    type: in_cluster
    allow:
      - service_account: "namespace:serviceaccount"
```
`tctl create -f in_cluster_token.yaml`
- [x] Create a scoped token using JWKS config
```yaml
# jwks_token.yaml
kind: scoped_token
version: v1
scope: /test
metadata:
  name: kube-static-jwks
spec:
  assigned_scope: /test/jwks
  usage_mode: unlimited
  roles: [Node]
  join_method: kubernetes
  kubernetes:
    type: static_jwks
    static_jwks:
      jwks: |
        # Place the kubernetes JWKS here (`kubectl get --raw /openid/v1/jwks`)
        {"keys":[--snip--]}
    allow:
      - service_account: "namespace:serviceaccount"
```
`tctl create -f jwks_token.yaml`
- [x] Create a scoped token using OIDC config
```yaml
# oidc_token.yaml
kind: scoped_token
version: v1
scope: /test
metadata:
  name: kube-oidc
spec:
  assigned_scope: /test/oidc
  usage_mode: unlimited
  roles: [Node]
  join_method: kubernetes
  kubernetes:
    type: oidc
    oidc:
      issuer: "https://oidc.eks.us-west-2.amazonaws.com/id/my-cluster"
    allow:
      - service_account: "namespace:serviceaccount"
```
`tctl create -f oidc_token.yaml`
- [x] Join a node using the in-cluster token
- [x] Verify scope is applied to resource (`tctl get`)
- [x] Join a node using the JWKS token
- [x] Verify scope is applied to resource (`tctl get`)
- [x] Join a node using the OIDC token
- [x] Verify scope is applied to resource (`tctl get`)