### PR TITLE
kube: avoid gzip recompression for in-cluster list filtering

### DIFF
--- a/lib/kube/proxy/compression.go
+++ b/lib/kube/proxy/compression.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 )
 
 const (
@@ -117,5 +119,31 @@ type nopCloserWrapper struct {
 
 // Close has no action on the underlying writer.
 func (*nopCloserWrapper) Close() error {
+	return nil
+}
+
+// compressMemBuffer gzips the contents of a MemoryResponseWriter in-place and sets the encoding header to gzip.
+func compressMemBuffer(mem *responsewriters.MemoryResponseWriter) error {
+	// Copy the plain bytes before resetting.
+	plain := make([]byte, mem.Buffer().Len())
+	copy(plain, mem.Buffer().Bytes())
+
+	gzw := gzipPool.Get().(*gzip.Writer)
+	defer func() {
+		gzw.Reset(nil)
+		gzipPool.Put(gzw)
+	}()
+
+	mem.Buffer().Reset()
+	gzw.Reset(mem.Buffer())
+
+	if _, err := gzw.Write(plain); err != nil {
+		gzw.Close()
+		return trace.Wrap(err)
+	}
+	if err := gzw.Close(); err != nil {
+		return trace.Wrap(err)
+	}
+	mem.Header().Set(contentEncodingHeader, contentEncodingGZIP)
 	return nil
 }

--- a/lib/kube/proxy/compression.go
+++ b/lib/kube/proxy/compression.go
@@ -131,7 +131,7 @@ func headerAcceptsEncoding(h http.Header, encoding string) bool {
 		for part := range strings.SplitSeq(v, ",") {
 			// Split "gzip;q=0.5" into name="gzip" and params="q=0.5".
 			name, params, _ := strings.Cut(strings.TrimSpace(part), ";")
-			if strings.TrimSpace(name) != encoding {
+			if !strings.EqualFold(strings.TrimSpace(name), encoding) {
 				continue
 			}
 			params = strings.TrimSpace(params)

--- a/lib/kube/proxy/compression.go
+++ b/lib/kube/proxy/compression.go
@@ -22,6 +22,8 @@ import (
 	"compress/gzip"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/gravitational/trace"
@@ -120,6 +122,32 @@ type nopCloserWrapper struct {
 // Close has no action on the underlying writer.
 func (*nopCloserWrapper) Close() error {
 	return nil
+}
+
+// headerAcceptsEncoding checks if the Accept-Encoding header includes the specified encoding
+// and that it is not explicitly refused with a q=0 parameter.
+func headerAcceptsEncoding(h http.Header, encoding string) bool {
+	for _, v := range h["Accept-Encoding"] {
+		for part := range strings.SplitSeq(v, ",") {
+			// Split "gzip;q=0.5" into name="gzip" and params="q=0.5".
+			name, params, _ := strings.Cut(strings.TrimSpace(part), ";")
+			if strings.TrimSpace(name) != encoding {
+				continue
+			}
+			params = strings.TrimSpace(params)
+			if params == "" {
+				return true
+			}
+			// q=0 means the encoding is explicitly refused.
+			if _, qval, ok := strings.Cut(params, "q="); ok {
+				if q, err := strconv.ParseFloat(strings.TrimSpace(qval), 64); err == nil && q == 0 {
+					return false
+				}
+			}
+			return true
+		}
+	}
+	return false
 }
 
 // compressMemBuffer gzips the contents of a MemoryResponseWriter in-place and sets the encoding header to gzip.

--- a/lib/kube/proxy/compression.go
+++ b/lib/kube/proxy/compression.go
@@ -127,7 +127,7 @@ func (*nopCloserWrapper) Close() error {
 // headerAcceptsEncoding checks if the Accept-Encoding header includes the specified encoding
 // and that it is not explicitly refused with a q=0 parameter.
 func headerAcceptsEncoding(h http.Header, encoding string) bool {
-	for _, v := range h["Accept-Encoding"] {
+	for _, v := range h.Values("Accept-Encoding") {
 		for part := range strings.SplitSeq(v, ",") {
 			// Split "gzip;q=0.5" into name="gzip" and params="q=0.5".
 			name, params, _ := strings.Cut(strings.TrimSpace(part), ";")

--- a/lib/kube/proxy/resource_filters_test.go
+++ b/lib/kube/proxy/resource_filters_test.go
@@ -21,6 +21,7 @@ package proxy
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"path"
@@ -294,6 +295,115 @@ func newMemoryResponseWriter(t *testing.T, payload []byte, contentEncoding strin
 		return buf, func(dst io.Writer, src io.Reader) error {
 			_, err := io.Copy(dst, src)
 			return trace.Wrap(err)
+		}
+	}
+}
+
+// generatePodListJSON creates a JSON-encoded PodList with n pods.
+// Half the pods are in "default" namespace (nginx-*), half in "kube-system".
+func generatePodListJSON(b *testing.B, n int) []byte {
+	b.Helper()
+	pods := make([]corev1.Pod, 0, n)
+	for i := range n {
+		pod := corev1.Pod{
+			TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"pod-template-hash": "bench"},
+			},
+		}
+
+		if i%2 == 1 {
+			pod.Namespace = "kube-system"
+			pod.Name = fmt.Sprintf("coredns-%d", i)
+		} else {
+			pod.Namespace = "default"
+			pod.Name = fmt.Sprintf("nginx-deployment-%d", i)
+		}
+		pod.Labels["app"] = pod.Name
+		pods = append(pods, pod)
+	}
+	podList := &corev1.PodList{
+		TypeMeta: metav1.TypeMeta{Kind: "PodList", APIVersion: "v1"},
+		ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+		Items:    pods,
+	}
+	data, err := json.Marshal(podList)
+	require.NoError(b, err)
+	return data
+}
+
+// newBenchMemoryResponseWriter creates a MemoryResponseWriter for benchmarks.
+func newBenchMemoryResponseWriter(b *testing.B, payload []byte, contentEncoding string) *responsewriters.MemoryResponseWriter {
+	b.Helper()
+	buf := responsewriters.NewMemoryResponseWriter()
+	buf.Header().Set(contentEncodingHeader, contentEncoding)
+	buf.Header().Set(responsewriters.ContentTypeHeader, responsewriters.DefaultContentType)
+
+	switch contentEncoding {
+	case "gzip":
+		w, err := gzip.NewWriterLevel(buf, defaultGzipContentEncodingLevel)
+		require.NoError(b, err)
+		_, err = w.Write(payload)
+		require.NoError(b, err)
+		require.NoError(b, w.Close())
+	default:
+		_, err := buf.Write(payload)
+		require.NoError(b, err)
+	}
+	return buf
+}
+
+// BenchmarkFilterBuffer compares filterBuffer performance with gzip-compressed
+// vs uncompressed (identity) input. The difference shows the cost eliminated
+// by setting Accept-Encoding: identity on upstream requests.
+func BenchmarkFilterBuffer(b *testing.B) {
+	allowedResources := []types.KubernetesResource{
+		{
+			Kind:      types.KindKubePod,
+			APIGroup:  "*",
+			Namespace: "default",
+			Name:      "nginx-*",
+			Verbs:     []string{types.KubeVerbList},
+		},
+	}
+	mr := metaResource{
+		requestedResource:  apiResource{resourceKind: types.KindKubePod},
+		resourceDefinition: &metav1.APIResource{Namespaced: true},
+		verb:               types.KubeVerbList,
+	}
+
+	for _, podCount := range []int{100, 1000, 5000} {
+		payload := generatePodListJSON(b, podCount)
+
+		for _, encoding := range []string{"", "gzip"} {
+			label := "identity"
+			if encoding == "gzip" {
+				label = "gzip"
+			}
+			name := fmt.Sprintf("pods_%d/%s", podCount, label)
+
+			// Snapshot the buffer bytes so we can reset cheaply each iteration.
+			snapshot := newBenchMemoryResponseWriter(b, payload, encoding)
+			snapshotBytes := make([]byte, snapshot.Buffer().Len())
+			copy(snapshotBytes, snapshot.Buffer().Bytes())
+
+			b.Run(name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(payload)))
+				for b.Loop() {
+					buf := responsewriters.NewMemoryResponseWriter()
+					// Copy headers from snapshot.
+					for k, v := range snapshot.Header() {
+						buf.Header()[k] = v
+					}
+					buf.Buffer().Write(snapshotBytes)
+					err := filterBuffer(
+						newResourceFilterer(mr, &globalKubeCodecs, allowedResources, nil, logtest.NewLogger()),
+						buf,
+					)
+					require.NoError(b, err)
+				}
+			})
 		}
 	}
 }

--- a/lib/kube/proxy/resource_list.go
+++ b/lib/kube/proxy/resource_list.go
@@ -146,7 +146,7 @@ func (f *Forwarder) listResourcesList(req *http.Request, w http.ResponseWriter, 
 	// After filtering, we still recompress for the client if it requested gzip.
 	var clientAcceptsGzip bool
 	if f.cfg.KubeconfigPath == "" {
-		clientAcceptsGzip = strings.Contains(req.Header.Get("Accept-Encoding"), "gzip")
+		clientAcceptsGzip = headerAcceptsEncoding(req.Header, "gzip")
 		req.Header.Set("Accept-Encoding", "identity")
 	}
 

--- a/lib/kube/proxy/resource_list.go
+++ b/lib/kube/proxy/resource_list.go
@@ -139,6 +139,17 @@ func (f *Forwarder) listResourcesList(req *http.Request, w http.ResponseWriter, 
 		return rw.Status(), nil
 	}
 
+	// When the kube_service is running in-cluster (no explicit kubeconfig),
+	// request uncompressed responses from the API server
+	// to avoid the decompression half of the decompress -> filter -> recompress cycle.
+	// The API server is on the local cluster network so the uncompressed transfer is cheap.
+	// After filtering, we still recompress for the client if it requested gzip.
+	var clientAcceptsGzip bool
+	if f.cfg.KubeconfigPath == "" {
+		clientAcceptsGzip = strings.Contains(req.Header.Get("Accept-Encoding"), "gzip")
+		req.Header.Set("Accept-Encoding", "identity")
+	}
+
 	// Filtering is needed - buffer the response in memory.
 	// Creates a memory response writer that collects the response status, headers
 	// and payload into memory.
@@ -160,6 +171,14 @@ func (f *Forwarder) listResourcesList(req *http.Request, w http.ResponseWriter, 
 		return memBuffer.Status(), trace.Wrap(err)
 	}
 	filterSpan.End()
+
+	// If we requested identity from the upstream but the client wanted gzip,
+	// compress the filtered response before sending it back.
+	if clientAcceptsGzip {
+		if err := compressMemBuffer(memBuffer); err != nil {
+			return memBuffer.Status(), trace.Wrap(err)
+		}
+	}
 
 	// Copy the filtered payload into target http.ResponseWriter.
 	err := memBuffer.CopyInto(w)

--- a/lib/kube/proxy/resource_list.go
+++ b/lib/kube/proxy/resource_list.go
@@ -174,7 +174,8 @@ func (f *Forwarder) listResourcesList(req *http.Request, w http.ResponseWriter, 
 
 	// If we requested identity from the upstream but the client wanted gzip,
 	// compress the filtered response before sending it back.
-	if clientAcceptsGzip {
+	alreadyCompressed := memBuffer.Header().Get(contentEncodingHeader) == contentEncodingGZIP
+	if clientAcceptsGzip && !alreadyCompressed {
 		if err := compressMemBuffer(memBuffer); err != nil {
 			return memBuffer.Status(), trace.Wrap(err)
 		}

--- a/lib/kube/proxy/resource_list_test.go
+++ b/lib/kube/proxy/resource_list_test.go
@@ -1,0 +1,151 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
+	tkm "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+)
+
+// TestListResourcesAcceptEncodingIdentity verifies that when RBAC filtering
+// is needed, the upstream Kubernetes API request receives Accept-Encoding: identity
+// so the response comes back uncompressed and avoids the decompress/recompress cycle.
+func TestListResourcesAcceptEncodingIdentity(t *testing.T) {
+	t.Parallel()
+
+	const usernameFiltered = "filtered_user"
+
+	// Track Accept-Encoding headers received by the upstream mock K8s API
+	// for pod list requests only.
+	var mu sync.Mutex
+	var capturedAcceptEncodings []string
+
+	kubeMock, err := tkm.NewKubeAPIMock(
+		tkm.WithRequestCallback(func(r *http.Request) {
+			// Only capture pod list requests, not discovery/version/etc.
+			if !strings.Contains(r.URL.Path, "/pods") {
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			capturedAcceptEncodings = append(capturedAcceptEncodings, r.Header.Get("Accept-Encoding"))
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
+	testCtx := SetupTestContext(
+		t.Context(),
+		t,
+		TestConfig{
+			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+		},
+	)
+	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+
+	// Simulate in-cluster mode so the optimization fires.
+	testCtx.KubeServer.fwd.cfg.KubeconfigPath = ""
+
+	// User with namespace-scoped access triggers RBAC filtering.
+	userFiltered, _ := testCtx.CreateUserAndRole(
+		testCtx.Context,
+		t,
+		usernameFiltered,
+		RoleSpec{
+			Name:       usernameFiltered,
+			KubeUsers:  roleKubeUsers,
+			KubeGroups: roleKubeGroups,
+			SetupRoleFunc: func(r types.Role) {
+				r.SetKubeResources(types.Allow, []types.KubernetesResource{
+					{
+						Kind:      "pods",
+						Name:      "nginx-*",
+						Namespace: metav1.NamespaceDefault,
+						Verbs:     []string{types.Wildcard},
+						APIGroup:  types.Wildcard,
+					},
+				})
+			},
+		},
+	)
+
+	_, restConfig := testCtx.GenTestKubeClientTLSCert(
+		t,
+		userFiltered.GetName(),
+		kubeCluster,
+	)
+
+	// Disable transport-level gzip so the test client sends requests
+	// without Accept-Encoding and receives uncompressed responses.
+	// Recompression for gzip-requesting clients is tested separately
+	// in TestCompressMemBuffer.
+	restConfig.DisableCompression = true
+	client, err := kubernetes.NewForConfig(restConfig)
+	require.NoError(t, err)
+
+	_, err = client.CoreV1().Pods(metav1.NamespaceDefault).List(
+		testCtx.Context,
+		metav1.ListOptions{},
+	)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, capturedAcceptEncodings, "expected at least one pod list request to upstream")
+	for _, ae := range capturedAcceptEncodings {
+		assert.Equal(t, "identity", ae,
+			"upstream request should have Accept-Encoding: identity when RBAC filtering is needed")
+	}
+}
+
+// TestCompressMemBuffer verifies that compressMemBuffer gzip-compresses the
+// buffer contents and sets Content-Encoding: gzip.
+func TestCompressMemBuffer(t *testing.T) {
+	t.Parallel()
+
+	original := []byte(`{"kind":"PodList","apiVersion":"v1","items":[]}`)
+	mem := responsewriters.NewMemoryResponseWriter()
+	mem.Header().Set(responsewriters.ContentTypeHeader, responsewriters.DefaultContentType)
+	_, err := mem.Write(original)
+	require.NoError(t, err)
+
+	require.NoError(t, compressMemBuffer(mem))
+	assert.Equal(t, "gzip", mem.Header().Get(contentEncodingHeader))
+
+	// Decompress and verify round-trip.
+	gr, err := gzip.NewReader(mem.Buffer())
+	require.NoError(t, err)
+	defer gr.Close()
+	decompressed, err := io.ReadAll(gr)
+	require.NoError(t, err)
+	assert.Equal(t, original, decompressed)
+}

--- a/lib/kube/proxy/resource_list_test.go
+++ b/lib/kube/proxy/resource_list_test.go
@@ -127,6 +127,35 @@ func TestListResourcesAcceptEncodingIdentity(t *testing.T) {
 	}
 }
 
+func TestHeaderAcceptsEncoding(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		header   string
+		encoding string
+		want     bool
+	}{
+		{"plain gzip", "gzip", "gzip", true},
+		{"gzip with deflate", "deflate, gzip", "gzip", true},
+		{"quality 1", "gzip;q=1", "gzip", true},
+		{"quality 0.5", "gzip;q=0.5", "gzip", true},
+		{"quality 0 rejects", "gzip;q=0", "gzip", false},
+		{"quality 0.0 rejects", "gzip;q=0.0", "gzip", false},
+		{"empty header", "", "gzip", false},
+		{"no gzip", "deflate, br", "gzip", false},
+		{"spaces around", " gzip ; q=1 ", "gzip", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.Header{}
+			if tt.header != "" {
+				h.Set("Accept-Encoding", tt.header)
+			}
+			assert.Equal(t, tt.want, headerAcceptsEncoding(h, tt.encoding))
+		})
+	}
+}
+
 // TestCompressMemBuffer verifies that compressMemBuffer gzip-compresses the
 // buffer contents and sets Content-Encoding: gzip.
 func TestCompressMemBuffer(t *testing.T) {

--- a/lib/kube/proxy/resource_list_test.go
+++ b/lib/kube/proxy/resource_list_test.go
@@ -154,6 +154,19 @@ func TestHeaderAcceptsEncoding(t *testing.T) {
 			assert.Equal(t, tt.want, headerAcceptsEncoding(h, tt.encoding))
 		})
 	}
+
+	// Verify that random capitalizations of the header key work.
+	for _, key := range []string{
+		"accept-encoding",
+		"ACCEPT-ENCODING",
+		"aCcEpT-eNcOdInG",
+	} {
+		t.Run("key_"+key, func(t *testing.T) {
+			h := http.Header{}
+			h.Set(key, "gzip")
+			assert.True(t, headerAcceptsEncoding(h, "gzip"))
+		})
+	}
 }
 
 // TestCompressMemBuffer verifies that compressMemBuffer gzip-compresses the

--- a/lib/kube/proxy/resource_list_test.go
+++ b/lib/kube/proxy/resource_list_test.go
@@ -144,6 +144,8 @@ func TestHeaderAcceptsEncoding(t *testing.T) {
 		{name: "empty header", header: "", encoding: "gzip", want: false},
 		{name: "no gzip", header: "deflate, br", encoding: "gzip", want: false},
 		{name: "spaces around", header: " gzip ; q=1 ", encoding: "gzip", want: true},
+		{name: "uppercase token GZIP", header: "GZIP", encoding: "gzip", want: true},
+		{name: "mixed case token Gzip", header: "Gzip", encoding: "gzip", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/kube/proxy/resource_list_test.go
+++ b/lib/kube/proxy/resource_list_test.go
@@ -135,15 +135,15 @@ func TestHeaderAcceptsEncoding(t *testing.T) {
 		encoding string
 		want     bool
 	}{
-		{"plain gzip", "gzip", "gzip", true},
-		{"gzip with deflate", "deflate, gzip", "gzip", true},
-		{"quality 1", "gzip;q=1", "gzip", true},
-		{"quality 0.5", "gzip;q=0.5", "gzip", true},
-		{"quality 0 rejects", "gzip;q=0", "gzip", false},
-		{"quality 0.0 rejects", "gzip;q=0.0", "gzip", false},
-		{"empty header", "", "gzip", false},
-		{"no gzip", "deflate, br", "gzip", false},
-		{"spaces around", " gzip ; q=1 ", "gzip", true},
+		{name: "plain gzip", header: "gzip", encoding: "gzip", want: true},
+		{name: "gzip with deflate", header: "deflate, gzip", encoding: "gzip", want: true},
+		{name: "quality 1", header: "gzip;q=1", encoding: "gzip", want: true},
+		{name: "quality 0.5", header: "gzip;q=0.5", encoding: "gzip", want: true},
+		{name: "quality 0 rejects", header: "gzip;q=0", encoding: "gzip", want: false},
+		{name: "quality 0.0 rejects", header: "gzip;q=0.0", encoding: "gzip", want: false},
+		{name: "empty header", header: "", encoding: "gzip", want: false},
+		{name: "no gzip", header: "deflate, br", encoding: "gzip", want: false},
+		{name: "spaces around", header: " gzip ; q=1 ", encoding: "gzip", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -156,6 +156,14 @@ func WithVersion(version *apimachineryversion.Info) Option {
 	}
 }
 
+// WithRequestCallback sets a callback that is invoked for every incoming request
+// before the request is handled. Useful for capturing request headers in tests.
+func WithRequestCallback(cb func(*http.Request)) Option {
+	return func(s *KubeMockServer) {
+		s.requestCallback = cb
+	}
+}
+
 type deletedResource struct {
 	requestID string
 	kind      string
@@ -188,7 +196,8 @@ type KubeMockServer struct {
 
 	nsList *corev1.NamespaceList
 
-	crds map[GVP]*CRD
+	crds            map[GVP]*CRD
+	requestCallback func(*http.Request)
 }
 
 // NewKubeAPIMock creates Kubernetes API server for handling exec calls.
@@ -318,6 +327,9 @@ var routerRe = regexp.MustCompile(`\{([^}]+)\}`)
 // withWriter handles the glue to support stdlib handler.
 func (s *KubeMockServer) withWriter(handler httplib.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if s.requestCallback != nil {
+			s.requestCallback(r)
+		}
 		matches := routerRe.FindAllStringSubmatch(r.Pattern, -1)
 
 		p := httprouter.Params{}


### PR DESCRIPTION
Part of #63204.

When RBAC filtering is needed for list requests and the kube_service is running in-cluster, set `Accept-Encoding: identity` on the upstream request. The API server returns an uncompressed response, eliminating the decompression step. After filtering, the response is recompressed for the client if it requested gzip.

Changelog: Reduced Kubernetes list request latency by avoiding unnecessary gzip decompression when RBAC filtering is needed on in-cluster kube_service.

## Manual Test Plan

### Test Environment

Self-hosted Teleport v18.7.1 on EKS, with Jaeger tracing at 100% sampling.


### Test Cases

- [x] Baseline trace captured with unmodified v18.7.1
- [x] Deploy custom build with Accept-Encoding: identity change
- [x] Filtered list request shows reduced listResources span duration compared to baseline
- [x] Response contains correct filtered configmaps (RBAC filtering still works)
- [x] Non-filtering passthrough requests are unaffected

### Test Results

5,101 configmaps fetched from API server (~250KB), 100 returned after filtering (~1.5KB).

| Metric | Baseline | With optimization | Improvement |
|--------|----------|-------------------|-------------|
| `listResources` span median | 27.0 ms | 25.3 ms | ~6% |
| End-to-end latency (hyperfine) | 1.944s ± 0.134s | 1.712s ± 0.061s | ~12% |
