### PR TITLE
Update AGENTS.md to refer to docs and drop bold formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # AGENTS.md
 
 ## Mission
-Use Codex/LLMs to explore ideas, prototypes, and design alternatives only. Any LLM-produced code or content must **not** be committed to the repository.
+Use Codex/LLMs to explore ideas, prototypes, and design alternatives only. Any LLM-produced code or content must not be committed to the repository.
 
 ## Absolute Rules
-- **No LLM-written code may be committed.** This includes direct code, generated tests, configs, migrations, scripts, or documentation intended for production use.
-- LLM work is for **experimentation and throwaway prototypes** only. If a change is worth keeping, a human must rewrite or re-implement it from scratch before committing.
-- Do **not** stage, commit, or open PRs containing LLM-authored code or text. If you created files, clearly mark them as prototypes and remove them before any commit.
+- No LLM-written code may be committed. This includes direct code, generated tests, configs, migrations, scripts, or documentation intended for production use.
+- LLM work is for experimentation and throwaway prototypes only. If a change is worth keeping, a human must rewrite or re-implement it from scratch before committing.
+- Do not stage, commit, or open PRs containing LLM-authored code or text. If you created files, clearly mark them as prototypes and remove them before any commit.
 
 ## Review Guidelines
 - Focus only on critical security, reliability, performance, and scalability issues.
@@ -22,3 +22,7 @@ Use Codex/LLMs to explore ideas, prototypes, and design alternatives only. Any L
 - Data corruption, durability failures, or irreversible loss scenarios
 - Concurrency hazards that can cause outages or data races
 - Reliability regressions: crash loops, panics, deadlocks, unbounded retries
+
+### Documentation
+
+When you are looking at a given product area find the relevant documentation in the docs/ directory to ensure you understand the context in which the code is used.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,5 @@
 # AGENTS.md
 
-## Mission
-Use Codex/LLMs to explore ideas, prototypes, and design alternatives only. Any LLM-produced code or content must not be committed to the repository.
-
 ## Review Guidelines
 - Focus only on critical security, reliability, performance, and scalability issues.
 - Ignore style, performance micro-optimizations, and readability nits unless they are tied to a significant failure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,6 @@
 ## Mission
 Use Codex/LLMs to explore ideas, prototypes, and design alternatives only. Any LLM-produced code or content must not be committed to the repository.
 
-## Absolute Rules
-- No LLM-written code may be committed. This includes direct code, generated tests, configs, migrations, scripts, or documentation intended for production use.
-- LLM work is for experimentation and throwaway prototypes only. If a change is worth keeping, a human must rewrite or re-implement it from scratch before committing.
-- Do not stage, commit, or open PRs containing LLM-authored code or text. If you created files, clearly mark them as prototypes and remove them before any commit.
-
 ## Review Guidelines
 - Focus only on critical security, reliability, performance, and scalability issues.
 - Ignore style, performance micro-optimizations, and readability nits unless they are tied to a significant failure


### PR DESCRIPTION
We want to specifically guide agents to read the markdown doc files.

Also drop some of the bold formatting since that's sloppy.