### PR TITLE
Add AWS Account Name and SSO Region Label Constants

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -843,6 +843,8 @@ const (
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
 	AWSAccountIDLabel = TeleportNamespace + "/account-id"
+	// AWSAccountNameLabel is the human-readable AWS account name label.
+	AWSAccountNameLabel = TeleportNamespace + "/account-name"
 	// AWSInstanceIDLabel is used to identify nodes by EC2 instance ID
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
@@ -850,6 +852,8 @@ const (
 	// AWSInstanceRegion is used to identify the region an EC2
 	// instance is running in
 	AWSInstanceRegion = TeleportNamespace + "/aws-region"
+	// AWSSSORegionLabel is the AWS Identity Center SSO region label.
+	AWSSSORegionLabel = TeleportNamespace + "/sso-region"
 	// SubscriptionIDLabel is used to identify virtual machines by Azure
 	// subscription ID found via automatic discovery, to avoid re-running
 	// installation commands on the node.

--- a/tool/tsh/common/aws_profile.go
+++ b/tool/tsh/common/aws_profile.go
@@ -111,7 +111,7 @@ func writeAWSConfig(configPath, ssoRegionOverride string, identityCenterApps []t
 			// set by the Identity Center sync.
 			region := ssoRegionOverride
 			if region == "" {
-				region, _ = app.GetLabel("teleport.dev/aws-sso-region")
+				region, _ = app.GetLabel(types.AWSSSORegionLabel)
 			}
 			if region == "" {
 				return nil, trace.BadParameter("could not determine SSO region for app %q; use --aws-sso-region to specify it", app.GetName())
@@ -125,7 +125,7 @@ func writeAWSConfig(configPath, ssoRegionOverride string, identityCenterApps []t
 
 		awsIC := app.GetIdentityCenter()
 
-		accountName, _ := app.GetLabel("teleport.dev/account-name")
+		accountName, _ := app.GetLabel(types.AWSAccountNameLabel)
 		if accountName == "" {
 			accountName = awsIC.AccountID
 		}

--- a/tool/tsh/common/aws_profile_test.go
+++ b/tool/tsh/common/aws_profile_test.go
@@ -241,7 +241,7 @@ func TestWriteAWSConfig(t *testing.T) {
 	app1, err := types.NewAppV3(types.Metadata{
 		Name: "app1",
 		Labels: map[string]string{
-			"teleport.dev/account-name": "dev",
+			types.AWSAccountNameLabel: "dev",
 		},
 	}, types.AppSpecV3{
 		URI: "https://d-123.awsapps.com/start/#/",
@@ -322,8 +322,8 @@ func TestWriteAWSConfig_RegionFromLabel(t *testing.T) {
 	app1, err := types.NewAppV3(types.Metadata{
 		Name: "app1",
 		Labels: map[string]string{
-			"teleport.dev/account-name":   "dev",
-			"teleport.dev/aws-sso-region": "eu-west-1",
+			types.AWSAccountNameLabel: "dev",
+			types.AWSSSORegionLabel:   "eu-west-1",
 		},
 	}, types.AppSpecV3{
 		URI: "https://d-123.awsapps.com/start/#/",
@@ -352,8 +352,8 @@ func TestWriteAWSConfig_RegionFlagOverridesLabel(t *testing.T) {
 	app1, err := types.NewAppV3(types.Metadata{
 		Name: "app1",
 		Labels: map[string]string{
-			"teleport.dev/account-name":   "dev",
-			"teleport.dev/aws-sso-region": "eu-west-1",
+			types.AWSAccountNameLabel: "dev",
+			types.AWSSSORegionLabel:   "eu-west-1",
 		},
 	}, types.AppSpecV3{
 		URI: "https://d-123.awsapps.com/start/#/",
@@ -402,7 +402,7 @@ region = us-east-1
 	// Now write config for a set of apps that doesn't include the stale one.
 	app1, err := types.NewAppV3(types.Metadata{
 		Name:   "aws-ic-new",
-		Labels: map[string]string{"teleport.dev/account-name": "production"},
+		Labels: map[string]string{types.AWSAccountNameLabel: "production"},
 	}, types.AppSpecV3{
 		URI: "https://production.awsapps.com/start/#/console",
 		IdentityCenter: &types.AppIdentityCenter{


### PR DESCRIPTION
This PR adds two new label constants for use with AWS Identity Center integration, in support of https://github.com/gravitational/teleport.e/pull/8131

Testing steps are the same as in the mentioned PR.