### PR TITLE
Add a default PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+
+
+
+
+
+<!-- Provide a descriptive entry for the changelog of the next release. -->
+
+Changelog:
+
+
+<!-- Include manual testing efforts to verify the change. -->
+<!-- Detail where the tests where run and what configurations were used. -->
+<!-- Include all the test cases which were run to validate the change. -->
+
+## Manual Test Plan
+### Test Environment
+
+### Test Cases
+- [ ] 


### PR DESCRIPTION
The template includes an entry for the Changelog and Manual Test Plan both to serve as a reminder that they should be included and also so users don't have to go and look up the expected format.


## Manual Test Plan
### Test Environment

I created a testing repository with the template committed.

### Test Cases
- [x] Create a new PR and validate the template is rendered

<img width="1278" height="891" alt="image" src="https://github.com/user-attachments/assets/da374049-b90b-465b-9e53-1bc51dbeae4d" />
<img width="1278" height="891" alt="image" src="https://github.com/user-attachments/assets/bb5a7161-7fc0-4a31-9239-794d00656441" />

- [x] gh pr create -body=foo does not include the template.
```bash
gh pr create --body=foo
? Where should we push the 'tross/test' branch? rosstimothy/test-pr-template

Creating pull request for tross/test into main in rosstimothy/test-pr-template

? Title (required) testing
? What's next? Continue in browser
To github.com:rosstimothy/test-pr-template.git
   80d372f..9c6fbb1  HEAD -> tross/test
branch 'tross/test' set up to track 'origin/tross/test'.
Opening https://github.com/rosstimothy/test-pr-template/compare/main...tross/test in your browser.
```


<img width="1305" height="723" alt="image" src="https://github.com/user-attachments/assets/880977b8-f9cc-4dca-9d03-84f8c319ddf4" />


