### PR TITLE
Fix StyledTable broken styles

### DIFF
--- a/web/packages/design/src/DataTable/StyledTable.tsx
+++ b/web/packages/design/src/DataTable/StyledTable.tsx
@@ -100,6 +100,7 @@ export const StyledTable = styled.table<BorderRadiusProps>`
     }
 
     ${borderRadius}
+  }
 `;
 
 export const StyledPanel = styled.nav`


### PR DESCRIPTION
Looks like the styled components upgrade caused this error to surface. Table row styles were no longer being applied. Closing the selector fixes it.

Test Plan
Staging tenant built from 18.7.1
- [x] - Observe table rows without styles (Integrations List).
- [x] - Deploy style fix
- [x] - Observe table rows with styles (Integration List, + looked around other pages).