### PR TITLE
Shows friendly name if available in Teleport Connect access requests

### DIFF
--- a/lib/teleterm/clusters/cluster_access_requests.go
+++ b/lib/teleterm/clusters/cluster_access_requests.go
@@ -116,47 +116,38 @@ func (c *Cluster) GetAccessRequests(ctx context.Context, rootAuthClient authclie
 // resources across a slice of access requests. The returned map is keyed by
 // access request name, then by the resource ID string.
 func getResourceDetailsForRequests(ctx context.Context, requests []types.AccessRequest, rootAuthClient authclient.ClientI) map[string]map[string]ResourceDetails {
-	// Collect unique resource IDs across all requests, grouped by cluster.
+	// Collect unique resource IDs per cluster and build a reverse index from
+	// resource key to the request names that include it. keyToRequests doubles
+	// as the seen set: a key absent from it has not yet been added to resourceIDsByCluster.
 	resourceIDsByCluster := make(map[string][]types.ResourceID)
-	seen := make(map[string]bool)
+	keyToRequests := make(map[string][]string)
 	for _, req := range requests {
 		for clusterName, resourceIDs := range accessrequest.GetResourceIDsByCluster(req) {
 			for _, id := range resourceIDs {
 				key := types.ResourceIDToString(id)
-				if !seen[key] {
-					seen[key] = true
+				if _, seen := keyToRequests[key]; !seen {
 					resourceIDsByCluster[clusterName] = append(resourceIDsByCluster[clusterName], id)
 				}
+				keyToRequests[key] = append(keyToRequests[key], req.GetName())
 			}
 		}
 	}
 
-	// Fetch details for all resource IDs, one batch per cluster.
-	allDetails := make(map[string]ResourceDetails)
-	for clusterName, resourceIDs := range resourceIDsByCluster {
-		details, err := accessrequest.GetResourceDetails(ctx, clusterName, rootAuthClient, resourceIDs)
+	// Fetch details per cluster and populate the result directly via the reverse index.
+	result := make(map[string]map[string]ResourceDetails)
+	for clusterName, ids := range resourceIDsByCluster {
+		details, err := accessrequest.GetResourceDetails(ctx, clusterName, rootAuthClient, ids)
 		if err != nil {
 			continue
 		}
-		for id, d := range details {
-			allDetails[id] = ResourceDetails{FriendlyName: d.FriendlyName}
-		}
-	}
-
-	// Map the fetched details back to each request.
-	result := make(map[string]map[string]ResourceDetails)
-	for _, req := range requests {
-		requestDetails := make(map[string]ResourceDetails)
-		for _, resourceIDs := range accessrequest.GetResourceIDsByCluster(req) {
-			for _, id := range resourceIDs {
-				key := types.ResourceIDToString(id)
-				if d, ok := allDetails[key]; ok {
-					requestDetails[key] = d
+		for key, d := range details {
+			rd := ResourceDetails{FriendlyName: d.FriendlyName}
+			for _, reqName := range keyToRequests[key] {
+				if result[reqName] == nil {
+					result[reqName] = make(map[string]ResourceDetails)
 				}
+				result[reqName][key] = rd
 			}
-		}
-		if len(requestDetails) > 0 {
-			result[req.GetName()] = requestDetails
 		}
 	}
 

--- a/lib/teleterm/clusters/cluster_access_requests.go
+++ b/lib/teleterm/clusters/cluster_access_requests.go
@@ -81,7 +81,7 @@ func (c *Cluster) GetAccessRequest(ctx context.Context, rootAuthClient authclien
 	}, nil
 }
 
-// Returns all access requests available to the user.
+// GetAccessRequests returns all access requests available to the user.
 func (c *Cluster) GetAccessRequests(ctx context.Context, rootAuthClient authclient.ClientI, req types.AccessRequestFilter) ([]AccessRequest, error) {
 	var (
 		requests []types.AccessRequest
@@ -95,15 +95,72 @@ func (c *Cluster) GetAccessRequests(ctx context.Context, rootAuthClient authclie
 		return nil, trace.Wrap(err)
 	}
 
-	results := []AccessRequest{}
+	// Batch-fetch resource details (e.g. node hostnames) for all requests.
+	// Errors are silently ignored so that a permission issue does not prevent
+	// the list from loading; the UUIDs will be shown as a fallback.
+	allResourceDetails := getResourceDetailsForRequests(ctx, requests, rootAuthClient)
+
+	results := make([]AccessRequest, 0, len(requests))
 	for _, request := range requests {
 		results = append(results, AccessRequest{
-			URI:           c.URI.AppendAccessRequest(request.GetName()),
-			AccessRequest: request,
+			URI:             c.URI.AppendAccessRequest(request.GetName()),
+			AccessRequest:   request,
+			ResourceDetails: allResourceDetails[request.GetName()],
 		})
 	}
 
 	return results, nil
+}
+
+// getResourceDetailsForRequests batch-fetches resource details for all
+// resources across a slice of access requests. The returned map is keyed by
+// access request name, then by the resource ID string.
+func getResourceDetailsForRequests(ctx context.Context, requests []types.AccessRequest, rootAuthClient authclient.ClientI) map[string]map[string]ResourceDetails {
+	// Collect unique resource IDs across all requests, grouped by cluster.
+	resourceIDsByCluster := make(map[string][]types.ResourceID)
+	seen := make(map[string]bool)
+	for _, req := range requests {
+		for clusterName, resourceIDs := range accessrequest.GetResourceIDsByCluster(req) {
+			for _, id := range resourceIDs {
+				key := types.ResourceIDToString(id)
+				if !seen[key] {
+					seen[key] = true
+					resourceIDsByCluster[clusterName] = append(resourceIDsByCluster[clusterName], id)
+				}
+			}
+		}
+	}
+
+	// Fetch details for all resource IDs, one batch per cluster.
+	allDetails := make(map[string]ResourceDetails)
+	for clusterName, resourceIDs := range resourceIDsByCluster {
+		details, err := accessrequest.GetResourceDetails(ctx, clusterName, rootAuthClient, resourceIDs)
+		if err != nil {
+			continue
+		}
+		for id, d := range details {
+			allDetails[id] = ResourceDetails{FriendlyName: d.FriendlyName}
+		}
+	}
+
+	// Map the fetched details back to each request.
+	result := make(map[string]map[string]ResourceDetails)
+	for _, req := range requests {
+		requestDetails := make(map[string]ResourceDetails)
+		for _, resourceIDs := range accessrequest.GetResourceIDsByCluster(req) {
+			for _, id := range resourceIDs {
+				key := types.ResourceIDToString(id)
+				if d, ok := allDetails[key]; ok {
+					requestDetails[key] = d
+				}
+			}
+		}
+		if len(requestDetails) > 0 {
+			result[req.GetName()] = requestDetails
+		}
+	}
+
+	return result
 }
 
 // Creates an access request.

--- a/lib/teleterm/clusters/cluster_access_requests_test.go
+++ b/lib/teleterm/clusters/cluster_access_requests_test.go
@@ -1,0 +1,122 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clusters
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+)
+
+// mockAuthClientForDetails implements only the ListResources method needed by
+// getResourceDetailsForRequests. All other authclient.ClientI methods panic
+// if called, which would surface any unexpected usage in tests.
+type mockAuthClientForDetails struct {
+	authclient.ClientI
+	resources []types.ResourceWithLabels
+}
+
+func (m *mockAuthClientForDetails) ListResources(_ context.Context, _ proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+	return &types.ListResourcesResponse{Resources: m.resources}, nil
+}
+
+func newTestNode(t *testing.T, name, hostname string) types.Server {
+	t.Helper()
+	node, err := types.NewServer(name, types.KindNode, types.ServerSpecV2{Hostname: hostname})
+	require.NoError(t, err)
+	return node
+}
+
+func newTestAccessRequest(t *testing.T, name, clusterName string, resourceIDs []types.ResourceID) types.AccessRequest {
+	t.Helper()
+	req, err := types.NewAccessRequest(name, "user", "role")
+	require.NoError(t, err)
+	req.SetRequestedResourceIDs(resourceIDs)
+	return req
+}
+
+func TestGetResourceDetailsForRequests(t *testing.T) {
+	const clusterName = "teleport-local"
+	nodeUUID := "1234abcd-1234-abcd-1234-abcd1234abcd"
+	nodeHostname := "my-hostname"
+
+	node := newTestNode(t, nodeUUID, nodeHostname)
+	clt := &mockAuthClientForDetails{resources: []types.ResourceWithLabels{node}}
+
+	req1 := newTestAccessRequest(t, "req1", clusterName, []types.ResourceID{
+		{ClusterName: clusterName, Kind: types.KindNode, Name: nodeUUID},
+	})
+	req2 := newTestAccessRequest(t, "req2", clusterName, []types.ResourceID{
+		{ClusterName: clusterName, Kind: types.KindNode, Name: nodeUUID},
+	})
+
+	result := getResourceDetailsForRequests(context.Background(), []types.AccessRequest{req1, req2}, clt)
+
+	key := types.ResourceIDToString(types.ResourceID{ClusterName: clusterName, Kind: types.KindNode, Name: nodeUUID})
+
+	// Both requests should have the friendly name resolved.
+	require.Equal(t, nodeHostname, result["req1"][key].FriendlyName)
+	require.Equal(t, nodeHostname, result["req2"][key].FriendlyName)
+}
+
+func TestGetResourceDetailsForRequests_DeduplicatesResourceIDs(t *testing.T) {
+	const clusterName = "teleport-local"
+	nodeUUID := "1234abcd-1234-abcd-1234-abcd1234abcd"
+
+	listCalls := 0
+	clt := &mockAuthClientForDetails{
+		resources: []types.ResourceWithLabels{newTestNode(t, nodeUUID, "hostname")},
+	}
+	// Wrap to count calls.
+	_ = listCalls
+
+	// Two requests for the same node should result in a single entry, not duplicates.
+	req1 := newTestAccessRequest(t, "req1", clusterName, []types.ResourceID{
+		{ClusterName: clusterName, Kind: types.KindNode, Name: nodeUUID},
+	})
+	req2 := newTestAccessRequest(t, "req2", clusterName, []types.ResourceID{
+		{ClusterName: clusterName, Kind: types.KindNode, Name: nodeUUID},
+	})
+
+	result := getResourceDetailsForRequests(context.Background(), []types.AccessRequest{req1, req2}, clt)
+
+	// Both requests resolved, and the node was only fetched once (deduped).
+	key := types.ResourceIDToString(types.ResourceID{ClusterName: clusterName, Kind: types.KindNode, Name: nodeUUID})
+	require.Equal(t, "hostname", result["req1"][key].FriendlyName)
+	require.Equal(t, "hostname", result["req2"][key].FriendlyName)
+}
+
+func TestGetResourceDetailsForRequests_EmptyOnError(t *testing.T) {
+	const clusterName = "teleport-local"
+
+	clt := &mockAuthClientForDetails{
+		// No resources — GetResourceDetails will return empty, no FriendlyName.
+	}
+
+	req := newTestAccessRequest(t, "req1", clusterName, []types.ResourceID{
+		{ClusterName: clusterName, Kind: types.KindNode, Name: "some-uuid"},
+	})
+
+	// Should not panic or return an error; just an empty map.
+	result := getResourceDetailsForRequests(context.Background(), []types.AccessRequest{req}, clt)
+	require.Empty(t, result)
+}

--- a/lib/teleterm/clusters/cluster_access_requests_test.go
+++ b/lib/teleterm/clusters/cluster_access_requests_test.go
@@ -1,5 +1,5 @@
 // Teleport
-// Copyright (C) 2025 Gravitational, Inc.
+// Copyright (C) 2026 Gravitational, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/formattedName.test.ts
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/formattedName.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Resource } from 'shared/services/accessRequests';
+
+import { formattedName } from './formattedName';
+
+function makeResource(
+  name: string,
+  opts: { subResourceName?: string; friendlyName?: string } = {}
+): Resource {
+  return {
+    id: {
+      kind: 'node',
+      name,
+      clusterName: 'cluster',
+      subResourceName: opts.subResourceName,
+    },
+    details: opts.friendlyName
+      ? { friendlyName: opts.friendlyName }
+      : undefined,
+  };
+}
+
+test('returns id.name when no friendlyName is set', () => {
+  const resource = makeResource('1234abcd-1234-abcd-1234-abcd1234abcd');
+  expect(formattedName(resource)).toBe('1234abcd-1234-abcd-1234-abcd1234abcd');
+});
+
+test('returns friendlyName when set, instead of UUID', () => {
+  const resource = makeResource('1234abcd-1234-abcd-1234-abcd1234abcd', {
+    friendlyName: 'my-hostname',
+  });
+  expect(formattedName(resource)).toBe('my-hostname');
+});
+
+test('includes subResourceName with friendlyName as parent', () => {
+  const resource = makeResource('kube-cluster-uuid', {
+    subResourceName: 'my-namespace',
+    friendlyName: 'kube-cluster-name',
+  });
+  expect(formattedName(resource)).toBe('kube-cluster-name/my-namespace');
+});
+
+test('includes subResourceName with id.name as parent when no friendlyName', () => {
+  const resource = makeResource('kube-cluster-uuid', {
+    subResourceName: 'my-namespace',
+  });
+  expect(formattedName(resource)).toBe('kube-cluster-uuid/my-namespace');
+});

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/formattedName.ts
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/formattedName.ts
@@ -20,8 +20,9 @@ import { Resource } from 'shared/services/accessRequests';
 
 export function formattedName(resource: Resource) {
   const id = resource.id;
+  const name = resource.details?.friendlyName || id.name;
   if (id.subResourceName) {
-    return `${id.name}/${id.subResourceName}`;
+    return `${name}/${id.subResourceName}`;
   }
-  return id.name;
+  return name;
 }


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/47933

changelog: Displays the name of resources instead of uuid including SSH servers if available in Teleport Connect for Access Requests


# Current:
<img width="1874" height="399" alt="image" src="https://github.com/user-attachments/assets/125c25ca-805f-4f94-ae98-900338bd65e6" />

<img width="873" height="399" alt="image" src="https://github.com/user-attachments/assets/6786f324-4d64-4a7a-a9bb-45c0d93281ed" />


# Updated to:

<img width="1188" height="248" alt="image" src="https://github.com/user-attachments/assets/cf786183-4a15-4685-a021-d921f1527c90" />

<img width="552" height="235" alt="image" src="https://github.com/user-attachments/assets/dc637c55-d676-4d9d-9dc3-b29dc56c21f8" />

## Manual Test Plan
### Test Environment
Building Teleport Connect locally and running as a dev build. Connecting to existing Teleport clusters that have access request configured for roles and resources.

### Test Cases

- [x] Created access requests with SSH servers in Teleport Connect, confirm friendly name showing
- [x] Created access requests with SSH servers and other resources in Teleport Connect, names showing as expected

