### PR TITLE
Add missing cleanups to `useEffect` calls 

### DIFF
--- a/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.tsx
+++ b/web/packages/shared/components/ButtonFileUpload/ButtonFileUpload.tsx
@@ -88,12 +88,15 @@ export function ButtonFileUpload({
      * on situation where user cancels file picker without
      * selecting a file.
      */
-    fileInputRef.current.addEventListener('cancel', () => {
+    const input = fileInputRef.current;
+    const onCancel = () => {
       if (!fileName) {
         setFileInputError(true);
       }
-    });
-  }, [fileName, fileInputRef]);
+    };
+    input.addEventListener('cancel', onCancel);
+    return () => input.removeEventListener('cancel', onCancel);
+  }, [fileName]);
 
   return (
     <Flex alignItems="center" gap={2}>

--- a/web/packages/shared/components/CanvasRenderer.tsx
+++ b/web/packages/shared/components/CanvasRenderer.tsx
@@ -75,13 +75,22 @@ export const CanvasRenderer = forwardRef<
     onResize,
   } = props;
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const pngRendererRef = useRef<{
+    pushFrame: (frame: PngFrame) => void;
+    stop: () => void;
+  }>(null);
+
+  useEffect(() => {
+    const pngRenderer = makePngFrameRenderer(canvasRef.current);
+    pngRendererRef.current = pngRenderer;
+    return () => pngRenderer.stop();
+  }, []);
 
   useImperativeHandle(ref, () => {
-    const renderPngFrame = makePngFrameRenderer(canvasRef.current);
     const renderBimapFrame = makeBitmapFrameRenderer(canvasRef.current);
     return {
       setPointer: pointer => setPointer(canvasRef.current, pointer),
-      renderPngFrame: frame => renderPngFrame(frame),
+      renderPngFrame: frame => pngRendererRef.current?.pushFrame(frame),
       renderBitmapFrame: frame => renderBimapFrame(frame),
       setResolution: ({ width, height }) => {
         const canvas = canvasRef.current;
@@ -203,13 +212,15 @@ function setPointer(canvas: HTMLCanvasElement, pointer: Pointer): void {
 // This causes the function to run in a loop, 60 times per second
 // (actually x2 because we have two frame renderers).
 // Fix it in the both renderers, check if it improves performance.
-function makePngFrameRenderer(
-  canvas: HTMLCanvasElement
-): (frame: PngFrame) => void {
+function makePngFrameRenderer(canvas: HTMLCanvasElement): {
+  pushFrame: (frame: PngFrame) => void;
+  stop: () => void;
+} {
   const ctx = canvas.getContext('2d');
 
   // Buffered rendering logic
   let pngBuffer: PngFrame[] = [];
+  let rafId: number;
 
   const renderBuffer = () => {
     if (pngBuffer.length) {
@@ -219,11 +230,14 @@ function makePngFrameRenderer(
       }
       pngBuffer = [];
     }
-    requestAnimationFrame(renderBuffer);
+    rafId = requestAnimationFrame(renderBuffer);
   };
-  requestAnimationFrame(renderBuffer);
+  rafId = requestAnimationFrame(renderBuffer);
 
-  return frame => pngBuffer.push(frame);
+  return {
+    pushFrame: frame => pngBuffer.push(frame),
+    stop: () => cancelAnimationFrame(rafId),
+  };
 }
 
 function makeBitmapFrameRenderer(

--- a/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.story.tsx
@@ -78,9 +78,10 @@ export const FileTransferRequests = () => {
 
   useEffect(() => {
     // Wait a little for the DocumentSshWrapper to register listeners.
-    setTimeout(() => {
+    const timerId = setTimeout(() => {
       tty.emit(EventType.FILE_TRANSFER_REQUEST, fileTransferRequest);
     }, 50);
+    return () => clearTimeout(timerId);
   }, [tty]);
 
   return <DocumentSshWrapper ctx={ctx} consoleCtx={consoleCtx} doc={doc} />;

--- a/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
@@ -48,24 +48,28 @@ export function HeadlessRequest() {
   });
 
   useEffect(() => {
-    const setIpAddress = (response: { clientIpAddress: string }) => {
-      setState({
-        ...state,
-        status: 'loaded',
-        ipAddress: response.clientIpAddress,
-      });
-    };
+    const abortController = new AbortController();
 
     auth
-      .headlessSsoGet(requestId)
-      .then(setIpAddress)
-      .catch(e => {
+      .headlessSsoGet(requestId, abortController.signal)
+      .then(response => {
         setState({
           ...state,
-          status: 'error',
-          errorText: e.toString(),
+          status: 'loaded',
+          ipAddress: response.clientIpAddress,
         });
+      })
+      .catch(e => {
+        if (!abortController.signal.aborted) {
+          setState({
+            ...state,
+            status: 'error',
+            errorText: e.toString(),
+          });
+        }
       });
+
+    return () => abortController.abort();
   }, [requestId]);
 
   const setSuccess = () => {

--- a/web/packages/teleport/src/Navigation/RecentHistory.tsx
+++ b/web/packages/teleport/src/Navigation/RecentHistory.tsx
@@ -173,12 +173,14 @@ function AnimatedHistoryItem({
   const itemRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    let rafId: number;
+
     if (item.animationState === 'exiting' && itemRef.current) {
       const height = item.category ? 60 : 40;
       itemRef.current.style.height = `${height}px`;
       itemRef.current.style.opacity = '1';
       void itemRef.current.offsetHeight; // Force reflow
-      requestAnimationFrame(() => {
+      rafId = requestAnimationFrame(() => {
         if (itemRef.current) {
           itemRef.current.style.height = '0px';
           itemRef.current.style.opacity = '0';
@@ -191,13 +193,15 @@ function AnimatedHistoryItem({
       itemRef.current.style.height = `0px`;
       itemRef.current.style.opacity = '0';
       void itemRef.current.offsetHeight; // Force reflow
-      requestAnimationFrame(() => {
+      rafId = requestAnimationFrame(() => {
         if (itemRef.current) {
           itemRef.current.style.height = `${height}px`;
           itemRef.current.style.opacity = '1';
         }
       });
     }
+
+    return () => cancelAnimationFrame(rafId);
   }, [item.animationState]);
 
   return (

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -231,14 +231,16 @@ const auth = {
     return api.put(cfg.api.changeUserPasswordPath, data);
   },
 
-  headlessSsoGet(transactionId: string) {
-    return api.get(cfg.getHeadlessSsoPath(transactionId)).then((json: any) => {
-      json = json || {};
+  headlessSsoGet(transactionId: string, abortSignal?: AbortSignal) {
+    return api
+      .get(cfg.getHeadlessSsoPath(transactionId), abortSignal)
+      .then((json: any) => {
+        json = json || {};
 
-      return {
-        clientIpAddress: json.client_ip_address,
-      };
-    });
+        return {
+          clientIpAddress: json.client_ip_address,
+        };
+      });
   },
 
   headlessSsoAccept(mfa: MfaState, transactionId: string) {


### PR DESCRIPTION
I fed this article to Claude and let it scan our codebase for similar issues. https://stackinsight.dev/blog/memory-leak-empirical-study/

The biggest issue was found in `CanvasRenderer` where the empty `requestAnimationFrame` loop would go on forever even after closing a desktop session. This probably had little effect on the Web UI where AFAIK a desktop session is opened in a separate tab. But in Connect, each desktop session tab would essentially create a new empty infinite loop that does nothing 60 times a second.

I had to nudge Claude slightly, as it'd often pick suboptimal solutions, like using a `cancelled` flag instead of an abort signal or adding an empty `useEffect` with just cleanup code.

I'll backport this after the test plan.

## Test plan

- [x] Verified that desktop sessions in Connect and Web UI still work.
- [x] Verified that `ButtonFileUpload` still shows an error after opening the dialog and then closing it without selecting a file.
- [x] Verified that headless requests in the Web UI still work.
- [x] Verified that the animations in Search > Recent Pages still work.
- [x] Verified that `DocumentSsh` story still works. https://localhost:9002/?path=/story/teleport-console-documentssh--file-transfer-requests