### PR TITLE
make test-logs mkdir idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -903,7 +903,7 @@ tooling: $(DIFF_TEST)
 test: test-helm test-sh test-api test-go test-rust test-operator test-terraform-provider
 
 $(TEST_LOG_DIR):
-	mkdir $(TEST_LOG_DIR)
+	mkdir -p $(TEST_LOG_DIR)
 
 .PHONY: helmunit/installed
 helmunit/installed:


### PR DESCRIPTION
There is a chance that for parallel targets that check the order only deps the dir is not found for both leading to one mkdir failing.

This is a test logs file only change.