### PR TITLE
tbot: Fix bugs in identity renewal failure recovery

### DIFF
--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -428,6 +428,8 @@ func (s *Service) Run(ctx context.Context) error {
 				s.unblockWaiters()
 				s.cfg.StatusReporter.Report(readyz.Healthy)
 				break
+			} else {
+				s.log.ErrorContext(ctx, "Failed to renew bot identity", "error", err)
 			}
 		}
 	}

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -426,6 +426,7 @@ func (s *Service) Run(ctx context.Context) error {
 
 			if err := s.renew(ctx, storageDestination); err == nil {
 				s.unblockWaiters()
+				s.cfg.StatusReporter.Report(readyz.Healthy)
 				break
 			}
 		}

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -24,11 +24,13 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -70,6 +72,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/internal"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/services/application"
 	"github.com/gravitational/teleport/lib/tbot/services/database"
 	identitysvc "github.com/gravitational/teleport/lib/tbot/services/identity"
@@ -721,6 +724,8 @@ func TestBot_IdentityRenewalFails(t *testing.T) {
 	botConfig.Services = append(botConfig.Services, &identitysvc.OutputConfig{
 		Destination: outputDest,
 	})
+	diagSocketPath := filepath.Join(os.TempDir(), "tbot-diag.sock")
+	botConfig.DiagSocketForUpdater = diagSocketPath
 	thirdBot := New(botConfig, log)
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -741,6 +746,38 @@ func TestBot_IdentityRenewalFails(t *testing.T) {
 		return client != nil
 	}, 5*time.Second, 100*time.Millisecond, "timeout waiting for client to become available")
 
+	diagClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", diagSocketPath)
+			},
+		},
+	}
+	t.Cleanup(diagClient.CloseIdleConnections)
+
+	readIdentityReadyz := func() (readyz.Status, error) {
+		resp, err := diagClient.Get("http://unix/readyz/identity")
+		if err != nil {
+			return readyz.Initializing, err
+		}
+		defer resp.Body.Close()
+
+		var payload struct {
+			Status readyz.Status `json:"status"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			return readyz.Initializing, err
+		}
+		return payload.Status, nil
+	}
+
+	// Check identity service status is not healthy before the network heals.
+	require.Eventually(t, func() bool {
+		status, err := readIdentityReadyz()
+		return err == nil && status != readyz.Healthy
+	}, 5*time.Second, 100*time.Millisecond, "timeout waiting for pre-heal readyz status")
+
 	t.Log("Healing network partition")
 	proxy.setFailing(false)
 
@@ -754,6 +791,12 @@ func TestBot_IdentityRenewalFails(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting for output to be written")
 	}
+
+	// Check identity service status becomes healthy after the network heals.
+	require.Eventually(t, func() bool {
+		status, err := readIdentityReadyz()
+		return err == nil && status == readyz.Healthy
+	}, 5*time.Second, 100*time.Millisecond, "timeout waiting for identity readyz to become healthy")
 }
 
 func newWriteNotifier(dst destination.Destination) *writeNotifier {


### PR DESCRIPTION
## Description

When `tbot` fails to renew its bot identity on-startup, it will make a best effort attempt to continue using the old identity and retrying the renewal. 

This PR fixes a bug where retrying the renewal succeeds, but the identity service remains "unhealthy", and the `/readyz` endpoint continues to return `503 Service Unavailable` until the next natural periodic renewal.

It also adds a missing log for the retried renewal error, as the original error may have been lost if the bot has been running for a while. 

## Manual Test Plan

This case is well-covered by the `TestBot_IdentityRenewalFails` automated test case, but I've also manually tested it.

### Test Environment

Development build of the `master` branch running in a GCP instance.

#### `tbot` command

```shell
$ tbot start noop \
  --proxy-server "$TELEPORT_PROXY_SERVER" \
  --join-method "token" \
  --token "$TBOT_JOIN_TOKEN" \
  --storage "file://$(pwd)/tbot-renewal-bug" \
  --diag-addr "localhost:3031"
```

### Test Cases

- [x] Start `tbot` and check `/readyz/identity` returns healthy

```
$ curl http://localhost:3031/readyz/identity
{
  "status": "healthy",
  "updated_at": "2026-03-09T11:46:54.157337Z"
}
```

- [x] Terminate Teleport, start `tbot`, and check `/readyz/identity` returns unhealthy

```
$ systemctl stop teleport.service
```

```
$ curl http://localhost:3031/readyz/identity
{
  "status": "initializing",
  "updated_at": null
}
```

```
2026-03-09T11:50:46.101Z INFO [TBOT:IDEN] Unable to renew bot identity on startup. Waiting to retry wait:21.010019793s identity/service.go:419
2026-03-09T11:51:16.111Z ERRO [TBOT:IDEN] Failed to renew bot identity error:[
ERROR REPORT:
Original Error: *interceptors.RemoteError connection error: desc = &#34;transport: Error while dialing: failed to dial: [redacted]: connect: connection refused&#34
```

- [x] Start Teleport, and check `/readyz/identity` becomes healthy

```
$ systemctl start teleport.service
```

```
$ curl http://localhost:3031/readyz/identity
{
  "status": "healthy",
  "updated_at": "2026-03-09T11:52:01.725649Z"
}
```

```
2026-03-09T11:52:01.453Z INFO [TBOT:IDEN] Fetching bot identity using existing bot identity identity/service.go:597
2026-03-09T11:52:01.723Z INFO [TBOT:IDEN] Fetched new bot identity identity:renewal, id=e3701124-6226-4e17-a1e0-5a2d92f14236 | valid: after=2026-03-09T11:51:01Z, before=2026-03-09T12:52:01Z, duration=1h1m0s | kind=tls, renewable=true, disallow-reissue=false, roles=[bot-renewal], principals=[-teleport-internal-join], generation=4 identity/service.go:478
```

changelog: Fixed a bug where tbot's `/readyz` endpoint would report "unhealthy" even after identity renewal succeeds on-retry
