### PR TITLE
Add modules.Modules to Auth config

### DIFF
--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -118,6 +118,8 @@ type AuthServerConfig struct {
 	// KeystoreConfig is configuration for the CA keystore.
 	KeystoreConfig servicecfg.KeystoreConfig
 	InsecureMode   bool
+	// Modules defines build time constraints and licensed features.
+	Modules modules.Modules
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -143,6 +145,12 @@ func (cfg *AuthServerConfig) CheckAndSetDefaults() error {
 	if cfg.UploadHandler == nil {
 		cfg.UploadHandler = eventstest.NewMemoryUploader()
 	}
+
+	if cfg.Modules == nil {
+		// TODO(tross) return an error after all callers are updated
+		cfg.Modules = modules.GetModules()
+	}
+
 	return nil
 }
 
@@ -336,8 +344,7 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 
 	accessLists, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
 		Backend: srv.Backend,
-		// TODO(tross): replace with cfg.Modules
-		Modules: modules.GetModules(),
+		Modules: cfg.Modules,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -351,8 +358,7 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// TODO(tross): replace with cfg.Modules.BuildType
-	authority, err := authority.NewKeygen(modules.GetModules().BuildType(), cfg.Clock.Now)
+	authority, err := authority.NewKeygen(cfg.Modules.BuildType(), cfg.Clock.Now)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -453,6 +453,8 @@ type InitConfig struct {
 	// This helps eliminate timing attacks by ensuring that all recovery attempts
 	// with codes do a bcrypt comparison.
 	FakeRecoveryCodeHash []byte
+	// Modules defines build time constraints and licensed features.
+	Modules modules.Modules
 }
 
 // Init instantiates and configures an instance of AuthServer
@@ -465,6 +467,11 @@ func Init(ctx context.Context, cfg InitConfig, opts ...ServerOption) (*Server, e
 	}
 	if cfg.HostUUID == "" {
 		return nil, trace.BadParameter("HostUUID: host UUID can not be empty")
+	}
+
+	// TODO(tross): return an error once modules are injected everywhere.
+	if cfg.Modules == nil {
+		cfg.Modules = modules.GetModules()
 	}
 
 	asrv, err := NewServer(&cfg, opts...)


### PR DESCRIPTION
The modules are not yet consumed, and default to modules.GetModules(), if not provided. Their existence is meant to bridge the transitional period without breaking enterprise. Once this lands, enterprise will be updated to both inject the modules to Auth and specify them via either modules.SetModules or modulestest.SetTestModules. This will ensure that enterprise does not break when Auth exclusively consumes the dependency injected modules over the global modules. After the enterprise update lands a follow up will convert Auth.