### PR TITLE
[ci] add additional triggers to manual plan checker

### DIFF
--- a/.github/workflows/manual-test-plan.yaml
+++ b/.github/workflows/manual-test-plan.yaml
@@ -2,6 +2,12 @@ name: Manual Test Plan Check
 run-name: Manual Test Plan Check - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
 
 jobs:
   changes:
@@ -26,7 +32,7 @@ jobs:
               - '!(docs|rfd)/**'
 
   build:
-    name: Validate Manual Test Plan 
+    name: Validate Manual Test Plan
     needs: changes
     if: ${{ !startsWith(github.head_ref, 'dependabot/') && needs.changes.outputs.changed == 'true' }}
     runs-on: ubuntu-22.04-16core
@@ -37,7 +43,7 @@ jobs:
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19
 
-    steps:     
+    steps:
       - name: Checkout shared-workflows
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
The flow will also be trigger on:
* PR edited (if the author adds or removes the plan)
* labels added/removed

This is a QoL change so the author does not need to rerun the workflow manually after change. 

Removed trailing space. 



