### PR TITLE
Downgrade pnpm from 10.30.3 to 10.28.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017",
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
   "engines": {
     "node": "^24"
   }


### PR DESCRIPTION
Grzegorz pointed out that the recent pnpm upgrade from #64369 broke the packaged version of Connect. It turns out pnpm 10.29.3 added a new field to the lockfile that electron-builder doesn't parse correctly (https://github.com/electron-userland/electron-builder/issues/9603). This has been fixed in [electron-builder 26.8.2](https://github.com/electron-userland/electron-builder/releases/tag/electron-builder%4026.8.2).

Upgrading electron-builder will take some time, as we have to make new tag builds, so in the meantime we decided to downgrade pnpm to fix the packaged build of Connect on master.

## Manual test plan

- [x] `pnpm build-term && CONNECT_TSH_BIN_PATH=$PWD/build/tsh CSC_IDENTITY_AUTO_DISCOVERY=false pnpm package-term` outputs a working version of Connect