### PR TITLE
[v17][tooling] add benchfind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -863,6 +863,10 @@ DIFF_TEST := $(TOOLINGDIR)/bin/difftest
 $(DIFF_TEST): $(wildcard $(TOOLINGDIR)/cmd/difftest/*.go)
 	cd $(TOOLINGDIR) && go build -o "$@" ./cmd/difftest
 
+BENCHFIND := $(TOOLINGDIR)/bin/benchfind
+$(BENCHFIND): $(wildcard $(TOOLINGDIR)/cmd/benchfind/*.go)
+	cd $(TOOLINGDIR) && go build -o "$@" ./cmd/benchfind
+
 RERUN := $(TOOLINGDIR)/bin/rerun
 $(RERUN): $(wildcard $(TOOLINGDIR)/cmd/rerun/*.go)
 	cd $(TOOLINGDIR) && go build -o "$@" ./cmd/rerun
@@ -974,20 +978,27 @@ endif
 # Race detection is not enabled because it significantly slows down benchmarks.
 # todo: Use gotestsum when it is compatible with benchmark output. Currently will consider all benchmarks failed.
 .PHONY: test-go-bench
-test-go-bench: PACKAGES = $(shell grep --exclude-dir api --include "*_test.go" -lr testing.B .  | xargs dirname | xargs go list | sort -u)
 test-go-bench: BENCHMARK_SKIP_PATTERN = "^BenchmarkRoot"
-test-go-bench: BENCH_OUTPUT ?= $(TEST_LOG_DIR)/bench.txt
-test-go-bench: | $(TEST_LOG_DIR)
-	go test -run ^$$ -bench . -skip $(BENCHMARK_SKIP_PATTERN) -benchtime 1x $(PACKAGES) \
-		| tee $(BENCH_OUTPUT)
+test-go-bench: $(BENCHFIND) | $(TEST_LOG_DIR)
+	@PKGS=$$($(BENCHFIND) --tags=$(BUILD_TAGS)) ; \
+	if [ -z "$$PKGS" ]; then \
+		echo "No benchmark packages found"; \
+		exit 1; \
+	fi ; \
+	go test -run ^$$ -bench . -skip $(BENCHMARK_SKIP_PATTERN) -benchtime 1x $$PKGS \
+		| tee $(TEST_LOG_DIR)/bench.txt
 
-test-go-bench-root: PACKAGES = $(shell grep --exclude-dir api --include "*_test.go" -lr BenchmarkRoot .  | xargs dirname | xargs go list | sort -u)
+.PHONY: test-go-bench-root
 test-go-bench-root: BENCHMARK_PATTERN = "^BenchmarkRoot"
 test-go-bench-root: BENCHMARK_SKIP_PATTERN = ""
-test-go-bench-root: BENCH_OUTPUT ?= $(TEST_LOG_DIR)/bench.txt
-test-go-bench-root: | $(TEST_LOG_DIR)
-	go test -run ^$$ -bench $(BENCHMARK_PATTERN) -skip $(BENCHMARK_SKIP_PATTERN) -benchtime 1x $(PACKAGES) \
-		| tee $(BENCH_OUTPUT)
+test-go-bench-root: $(BENCHFIND) | $(TEST_LOG_DIR)
+	@PKGS=$$($(BENCHFIND) --tags=$(BUILD_TAGS)) ; \
+	if [ -z "$$PKGS" ]; then \
+		echo "No benchmark packages found"; \
+		exit 1; \
+	fi ; \
+	go test -run ^$$ -bench $(BENCHMARK_PATTERN) -skip $(BENCHMARK_SKIP_PATTERN) -benchtime 1x $$PKGS \
+		| tee $(TEST_LOG_DIR)/bench.txt
 
 # Make sure untagged vnetdaemon code build/tests.
 .PHONY: test-go-vnet-daemon

--- a/build.assets/tooling/cmd/benchfind/README.md
+++ b/build.assets/tooling/cmd/benchfind/README.md
@@ -1,0 +1,26 @@
+# benchfind
+
+A CLI utility to discover modules with Benchmarks without compilation/linking. 
+
+Example useage:
+
+```sh
+# Find all Benchmark packages in the current dir:
+benchfind
+
+# Find all Benchmark packages matching ./lib/...:
+benchfind ./lib/...
+
+# Find all Benchmark packages matching given tags:
+benchfind --tags=integration,linux
+
+# Find all Benchmark packages and exclude a given package:
+benchfind -e github.com/gravitational/teleport/foo/bar
+```
+
+The reason this is useful in a large codebase is that to run `go test -bench ./...` would require the linking of every test target binary. This can be very computationally heavy. Instead `benchfind` relies on the golang AST to find the relevant packages.
+
+Example use:
+```sh
+go test -run ^$$ -bench .  $(benchfind)
+```

--- a/build.assets/tooling/cmd/benchfind/find.go
+++ b/build.assets/tooling/cmd/benchfind/find.go
@@ -1,0 +1,163 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"go/ast"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/tools/go/packages"
+)
+
+// Config specifies configuration for finding benchmark packages.
+type Config struct {
+	// Patterns specifies package patterns to search. Defaults to './...' if empty.
+	Patterns []string
+	// BuildTags specifies build tags to use when loading packages.
+	BuildTags string
+	// Dir specifies the working directory to run package discovery from.
+	Dir string
+	// Excludes specifies package path prefixes to exclude.
+	Excludes []string
+}
+
+// Loader abstracts package loading.
+type Loader interface {
+	Load(cfg *packages.Config, patterns ...string) ([]*packages.Package, error)
+}
+
+// PackagesLoader is the default Loader using go/packages.
+type PackagesLoader struct{}
+
+func (PackagesLoader) Load(cfg *packages.Config, patterns ...string) ([]*packages.Package, error) {
+	return packages.Load(cfg, patterns...)
+}
+
+// Find finds all packages matching the given patterns that contain benchmarks.
+func Find(cfg Config) ([]string, error) {
+	return findWithLoader(cfg, PackagesLoader{})
+}
+
+func findWithLoader(cfg Config, loader Loader) ([]string, error) {
+	if len(cfg.Patterns) == 0 {
+		cfg.Patterns = []string{"./..."}
+	}
+
+	pkgs, err := loader.Load(&packages.Config{
+		Dir: cfg.Dir,
+		Mode: packages.NeedName |
+			packages.NeedFiles |
+			packages.NeedSyntax, // requires [packages.NeedFiles] to be set.
+		Tests:      true,
+		BuildFlags: buildFlags(cfg.BuildTags),
+	}, cfg.Patterns...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if packages.PrintErrors(pkgs) > 0 {
+		return nil, trace.BadParameter("failed to load packages")
+	}
+
+	return findBenchmarks(pkgs, cfg.Excludes), nil
+}
+
+func findBenchmarks(pkgs []*packages.Package, excludes []string) []string {
+	seen := make(map[string]struct{})
+	var result []string
+
+	packages.Visit(pkgs, nil, func(p *packages.Package) {
+		path := strings.TrimSuffix(p.PkgPath, ".test")
+		path = strings.TrimSuffix(path, "_test")
+
+		if matchesAnyPrefix(path, excludes) {
+			return
+		}
+
+		if pkgsContainBenchmarks(p) {
+			if _, ok := seen[path]; !ok {
+				seen[path] = struct{}{}
+				result = append(result, path)
+			}
+		}
+	})
+
+	return result
+}
+
+func buildFlags(tags string) []string {
+	if tags == "" {
+		return nil
+	}
+	return []string{"-tags=" + tags}
+}
+
+func pkgsContainBenchmarks(pkg *packages.Package) bool {
+	return slices.ContainsFunc(pkg.Syntax, filepkgsContainBenchmarks)
+}
+
+func filepkgsContainBenchmarks(file *ast.File) bool {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if isBenchmark(fn) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesAnyPrefix(path string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func isBenchmark(fn *ast.FuncDecl) bool {
+	if fn.Recv != nil {
+		return false
+	}
+	if fn.Name == nil || !strings.HasPrefix(fn.Name.Name, "Benchmark") {
+		return false
+	}
+	if fn.Type == nil || fn.Type.Params == nil {
+		return false
+	}
+
+	params := fn.Type.Params.List
+	if len(params) != 1 {
+		return false
+	}
+
+	star, ok := params[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := star.X.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	return sel.Sel.Name == "B"
+}

--- a/build.assets/tooling/cmd/benchfind/find_test.go
+++ b/build.assets/tooling/cmd/benchfind/find_test.go
@@ -1,0 +1,238 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+type fakeLoader struct {
+	pkgs []*packages.Package
+	err  error
+}
+
+func (f fakeLoader) Load(_ *packages.Config, _ ...string) ([]*packages.Package, error) {
+	return f.pkgs, f.err
+}
+
+func mustParseFile(t *testing.T, src string) *ast.File {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	require.NoError(t, err)
+	return file
+}
+
+func TestFindWithLoader(t *testing.T) {
+	benchFile := mustParseFile(t, `
+		package p
+		import "testing"
+		func BenchmarkFoo(b *testing.B) {}
+	`)
+
+	nonBenchFile := mustParseFile(t, `
+		package p
+		func Foo() {}
+	`)
+
+	loader := fakeLoader{
+		pkgs: []*packages.Package{
+			{
+				PkgPath: "github.com/foo/bar",
+				Syntax:  []*ast.File{benchFile},
+			},
+			{
+				PkgPath: "github.com/baz/bar",
+				Syntax:  []*ast.File{nonBenchFile},
+			},
+		},
+	}
+
+	cfg := Config{
+		Patterns: []string{"./..."},
+	}
+
+	result, err := findWithLoader(cfg, loader)
+	require.NoError(t, err)
+	require.Equal(t, []string{"github.com/foo/bar"}, result)
+}
+
+func TestFindWithLoader_Excludes(t *testing.T) {
+	benchFile := mustParseFile(t, `
+		package p
+		import "testing"
+		func BenchmarkFoo(b *testing.B) {}
+	`)
+
+	loader := fakeLoader{
+		pkgs: []*packages.Package{
+			{
+				PkgPath: "github.com/foo/bar",
+				Syntax:  []*ast.File{benchFile},
+			},
+		},
+	}
+
+	cfg := Config{
+		Excludes: []string{"github.com/foo"},
+	}
+
+	result, err := findWithLoader(cfg, loader)
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
+
+func TestFindBenchmarks_DeduplicatesTestPackages(t *testing.T) {
+	benchFile := mustParseFile(t, `
+		package p
+		import "testing"
+		func BenchmarkFoo(b *testing.B) {}
+	`)
+
+	pkgs := []*packages.Package{
+		{
+			PkgPath: "github.com/foo/bar",
+			Syntax:  []*ast.File{benchFile},
+		},
+		{
+			PkgPath: "github.com/foo/bar.test",
+			Syntax:  []*ast.File{benchFile},
+		},
+	}
+
+	result := findBenchmarks(pkgs, nil)
+	require.Equal(t, []string{"github.com/foo/bar"}, result)
+}
+
+func TestIsBenchmark(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "valid",
+			src: `
+				package p
+				import "testing"
+				func BenchmarkFoo(b *testing.B) {}
+			`,
+			want: true,
+		},
+		{
+			name: "wrong name",
+			src: `
+				package p
+				import "testing"
+				func TestFoo(b *testing.B) {}
+			`,
+			want: false,
+		},
+		{
+			name: "wrong param type",
+			src: `
+				package p
+				func BenchmarkFoo(i int) {}
+			`,
+			want: false,
+		},
+		{
+			name: "too many params",
+			src: `
+				package p
+				import "testing"
+				func BenchmarkFoo(b *testing.B, i int) {}
+			`,
+			want: false,
+		},
+		{
+			name: "missing params",
+			src: `
+				package p
+				func Foo() {}
+			`,
+			want: false,
+		},
+		{
+			name: "cannot be a method",
+			src: `
+				package p
+				import "testing"
+				type T struct{}
+				func (T) BenchmarkFoo(b *testing.B) {}
+			`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := mustParseFile(t, tt.src)
+
+			var fn *ast.FuncDecl
+			for _, d := range file.Decls {
+				if f, ok := d.(*ast.FuncDecl); ok {
+					fn = f
+					break
+				}
+			}
+			assert.NotNil(t, fn)
+			assert.Equal(t, tt.want, isBenchmark(fn))
+
+			pkg := &packages.Package{
+				Syntax: []*ast.File{file},
+			}
+			assert.Equal(t, tt.want, pkgsContainBenchmarks(pkg))
+		})
+	}
+}
+
+func TestMatchesAnyPrefix(t *testing.T) {
+	require.False(t, matchesAnyPrefix("github.com/foo/bar", nil))
+	require.True(t, matchesAnyPrefix("github.com/foo/bar", []string{"github.com/foo"}))
+	require.False(t, matchesAnyPrefix("github.com/foo/bar", []string{"github.com/other"}))
+}
+
+func TestBuildFlags(t *testing.T) {
+	require.Nil(t, buildFlags(""))
+	require.Equal(t, []string{"-tags=foo"}, buildFlags("foo"))
+	require.Equal(t, []string{"-tags=foo,bar"}, buildFlags("foo,bar"))
+}
+
+// TestFind is a smoketest that ensures Find works end-to-end.
+func TestFind(t *testing.T) {
+	dir := filepath.Join(".", "testdata")
+	expected := []string{
+		"github.com/gravitational/teleport/build.assets/tooling/cmd/benchfind/testdata",
+		"github.com/gravitational/teleport/build.assets/tooling/cmd/benchfind/testdata/nested",
+	}
+
+	pkgs, err := Find(Config{
+		Dir: dir,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expected, pkgs)
+}

--- a/build.assets/tooling/cmd/benchfind/main.go
+++ b/build.assets/tooling/cmd/benchfind/main.go
@@ -1,0 +1,77 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+func run() error {
+	app := kingpin.New(
+		"benchfind",
+		"Find Go packages that define benchmarks without compiling test binaries.",
+	)
+	app.HelpFlag.Short('h')
+
+	tags := app.Flag("tags", "Comma-separated build tags.").Short('t').String()
+	cwd := app.Flag("directory", "Working directory to run package discovery from. (Default: current directory)").Short('d').ExistingDir()
+	excludes := app.Flag("exclude", "List of package prefixes to skip.").Short('e').Strings()
+	patterns := app.Arg("patterns", `Package patterns. (Default: "./...")`).Default("./...").Strings()
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	dir := *cwd
+	if dir == "" {
+		var err error
+		dir, err = os.Getwd()
+		if err != nil {
+			return trace.Wrap(err, "failed to get current working directory")
+		}
+	}
+
+	cfg := Config{
+		Patterns:  *patterns,
+		BuildTags: *tags,
+		Dir:       dir,
+		Excludes:  *excludes,
+	}
+
+	pkgs, err := Find(cfg)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for _, p := range pkgs {
+		fmt.Println(p)
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		if trace.IsBadParameter(err) {
+			fmt.Fprintln(os.Stderr, err.Error())
+		} else {
+			fmt.Fprintln(os.Stderr, trace.DebugReport(err))
+		}
+		os.Exit(1)
+	}
+}

--- a/build.assets/tooling/cmd/benchfind/testdata/bench_test.go
+++ b/build.assets/tooling/cmd/benchfind/testdata/bench_test.go
@@ -1,0 +1,26 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package testdata
+
+import "testing"
+
+// BenchmarkExample is a simple benchmark for testing discovery.
+func BenchmarkExample(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = i * i
+	}
+}

--- a/build.assets/tooling/cmd/benchfind/testdata/nested/bench_test.go
+++ b/build.assets/tooling/cmd/benchfind/testdata/nested/bench_test.go
@@ -1,0 +1,25 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package nested
+
+import "testing"
+
+func BenchmarkAnother(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = i * i
+	}
+}

--- a/build.assets/tooling/cmd/benchfind/testdata/nobench/nobench_test.go
+++ b/build.assets/tooling/cmd/benchfind/testdata/nobench/nobench_test.go
@@ -1,0 +1,19 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package nobench
+
+// This file intentionally left blank to represent a package with no benchmarks.

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -73,7 +73,7 @@ require (
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
-	golang.org/x/tools v0.38.0 // indirect
+	golang.org/x/tools v0.38.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250127172529-29210b9bc287 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250127172529-29210b9bc287 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect


### PR DESCRIPTION
Backports #62981 to branch/v17

This was originally not ported to v17, since differential benchmarks are going to land on v17 it is now being backported. No change to Teleport itself. 