### PR TITLE
Check err != nil before calling err.Error() in tbot db tunnel service

### DIFF
--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -241,7 +241,9 @@ func (s *TunnelService) Run(ctx context.Context) error {
 	case <-ctx.Done():
 		return nil
 	case err := <-errCh:
-		s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
+        if err != nil {
+            s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
+        }
 		return trace.Wrap(err, "local proxy failed")
 	}
 }

--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -243,6 +243,8 @@ func (s *TunnelService) Run(ctx context.Context) error {
 	case err := <-errCh:
 		if err != nil {
 			s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
+		} else {
+			s.statusReporter.Report(readyz.Unhealthy)
 		}
 		return trace.Wrap(err, "local proxy failed")
 	}

--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -241,9 +241,9 @@ func (s *TunnelService) Run(ctx context.Context) error {
 	case <-ctx.Done():
 		return nil
 	case err := <-errCh:
-        if err != nil {
-            s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
-        }
+		if err != nil {
+			s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
+		}
 		return trace.Wrap(err, "local proxy failed")
 	}
 }


### PR DESCRIPTION
If the local proxy `Start()` method returns a nil error, we do a nil pointer deference. This does a check first.

No test plan for this since it's adding a `nil` check which would have caused error anyways.