### PR TITLE
Fix error message when mongo database file write fails

### DIFF
--- a/lib/tbot/services/database/output_service.go
+++ b/lib/tbot/services/database/output_service.go
@@ -215,7 +215,7 @@ func (s *OutputService) render(
 		if err := writeMongoDatabaseFiles(
 			ctx, s.log, routedIdentity, databaseCAs, s.cfg.Destination,
 		); err != nil {
-			return trace.Wrap(err, "writing cockroach database files")
+			return trace.Wrap(err, "writing mongo database files")
 		}
 	case CockroachDatabaseFormat:
 		if err := writeCockroachDatabaseFiles(


### PR DESCRIPTION
Minor fix. Looks like it was copied over from the Cockroach block.

## Manual Test Plan

No manual testing. Error message string change, testing not relevant.
