### PR TITLE
(OLD APPROACH) Offer to add MFA when missing and required by tsh ssh

### DIFF
--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -194,6 +194,11 @@ func printMFADevices(devs []*types.MFADevice, verbose bool) {
 
 type mfaAddCommand struct {
 	*kingpin.CmdClause
+	mfaAdder
+}
+
+// mfaAdder adds an MFA device by interacting with the user.
+type mfaAdder struct {
 	devName string
 	devType string
 
@@ -205,6 +210,8 @@ type mfaAddCommand struct {
 	// Note that Touch ID registrations are always passwordless-capable,
 	// regardless of other settings.
 	allowPasswordless, allowPasswordlessSet bool
+
+	webauthnRegister WebauthnRegisterFunc
 }
 
 func newMFAAddCommand(parent *kingpin.CmdClause) *mfaAddCommand {
@@ -223,12 +230,24 @@ func newMFAAddCommand(parent *kingpin.CmdClause) *mfaAddCommand {
 }
 
 func (c *mfaAddCommand) run(cf *CLIConf) error {
+	c.setWebauthnRegisterFunc(cf.WebauthnRegister)
 	tc, err := makeClient(cf)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	ctx := cf.Context
+	return trace.Wrap(c.addMFA(ctx, tc))
+}
 
+func (a *mfaAdder) setWebauthnRegisterFunc(reg WebauthnRegisterFunc) {
+	if reg != nil {
+		a.webauthnRegister = reg
+	} else {
+		a.webauthnRegister = wancli.Register
+	}
+}
+
+func (a *mfaAdder) addMFA(ctx context.Context, tc *client.TeleportClient) error {
 	// Attempt to diagnose clamshell failures.
 	if !slices.Contains(defaultDeviceTypes, touchIDDeviceType) {
 		diag, err := touchid.Diag()
@@ -237,7 +256,7 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 		}
 	}
 
-	if c.devType == "" {
+	if a.devType == "" {
 		// If we are prompting the user for the device type, then take a glimpse at
 		// server-side settings and adjust the options accordingly.
 		// This is undesirable to do during flag setup, but we can do it here.
@@ -246,7 +265,7 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 
-		c.devType, err = prompt.PickOne(
+		a.devType, err = prompt.PickOne(
 			ctx, os.Stdout, prompt.Stdin(),
 			"Choose device type", deviceTypesFromSecondFactor(pingResp.Auth.SecondFactor))
 		if err != nil {
@@ -254,35 +273,35 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 		}
 	}
 
-	if c.devName == "" {
+	if a.devName == "" {
 		var err error
-		c.devName, err = prompt.Input(ctx, os.Stdout, prompt.Stdin(), "Enter device name")
+		a.devName, err = prompt.Input(ctx, os.Stdout, prompt.Stdin(), "Enter device name")
 		if err != nil {
 			return trace.Wrap(err)
 		}
 	}
-	c.devName = strings.TrimSpace(c.devName)
-	if c.devName == "" {
+	a.devName = strings.TrimSpace(a.devName)
+	if a.devName == "" {
 		return trace.BadParameter("device name cannot be empty")
 	}
 
-	switch c.devType {
+	switch a.devType {
 	case webauthnDeviceType:
 		// Ask the user?
-		if !c.allowPasswordlessSet && wancli.IsFIDO2Available() {
+		if !a.allowPasswordlessSet && wancli.IsFIDO2Available() {
 			answer, err := prompt.PickOne(ctx, os.Stdout, prompt.Stdin(), "Allow passwordless logins", []string{"YES", "NO"})
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			c.allowPasswordless = answer == "YES"
+			a.allowPasswordless = answer == "YES"
 		}
 	case touchIDDeviceType:
 		// Touch ID is always a resident key/passwordless
-		c.allowPasswordless = true
+		a.allowPasswordless = true
 	}
-	logger.DebugContext(ctx, "tsh using passwordless registration?", "allow_passwordless", c.allowPasswordless)
+	logger.DebugContext(ctx, "tsh using passwordless registration?", "allow_passwordless", a.allowPasswordless)
 
-	dev, err := c.addDeviceRPC(ctx, tc)
+	dev, err := a.addDeviceRPC(ctx, tc)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -302,15 +321,15 @@ func deviceTypesFromSecondFactor(sf constants.SecondFactorType) []string {
 	}
 }
 
-func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportClient) (*types.MFADevice, error) {
+func (a *mfaAdder) addDeviceRPC(ctx context.Context, tc *client.TeleportClient) (*types.MFADevice, error) {
 	devTypePB := map[string]proto.DeviceType{
 		totpDeviceType:     proto.DeviceType_DEVICE_TYPE_TOTP,
 		webauthnDeviceType: proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
 		touchIDDeviceType:  proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
-	}[c.devType]
+	}[a.devType]
 	// Sanity check.
 	if devTypePB == proto.DeviceType_DEVICE_TYPE_UNSPECIFIED {
-		return nil, trace.BadParameter("unexpected device type: %q", c.devType)
+		return nil, trace.BadParameter("unexpected device type: %q", a.devType)
 	}
 
 	var dev *types.MFADevice
@@ -330,7 +349,7 @@ func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportCli
 		// to the server logic. The CLI layer should ideally be thin.
 
 		usage := proto.DeviceUsage_DEVICE_USAGE_MFA
-		if c.allowPasswordless {
+		if a.allowPasswordless {
 			usage = proto.DeviceUsage_DEVICE_USAGE_PASSWORDLESS
 		}
 
@@ -366,14 +385,14 @@ func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportCli
 
 		// Prompt for registration.
 		wanwin.SetPromptPlatformMessage(newMsg)
-		registerResp, registerCallback, err := promptRegisterChallenge(ctx, tc.WebProxyAddr, c.devType, registerChallenge)
+		registerResp, registerCallback, err := a.promptRegisterChallenge(ctx, tc.WebProxyAddr, a.devType, registerChallenge)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
 		// Complete registration and confirm new key.
 		addResp, err := rootAuthClient.AddMFADeviceSync(ctx, &proto.AddMFADeviceSyncRequest{
-			NewDeviceName:  c.devName,
+			NewDeviceName:  a.devName,
 			NewMFAResponse: registerResp,
 			DeviceUsage:    usage,
 		})
@@ -408,7 +427,7 @@ func (n noopRegisterCallback) Confirm() error {
 	return nil
 }
 
-func promptRegisterChallenge(ctx context.Context, proxyAddr, devType string, c *proto.MFARegisterChallenge) (*proto.MFARegisterResponse, registerCallback, error) {
+func (a *mfaAdder) promptRegisterChallenge(ctx context.Context, proxyAddr, devType string, c *proto.MFARegisterChallenge) (*proto.MFARegisterResponse, registerCallback, error) {
 	switch c.Request.(type) {
 	case *proto.MFARegisterChallenge_TOTP:
 		resp, err := promptTOTPRegisterChallenge(ctx, c.GetTOTP())
@@ -425,7 +444,7 @@ func promptRegisterChallenge(ctx context.Context, proxyAddr, devType string, c *
 			return promptTouchIDRegisterChallenge(origin, cc)
 		}
 
-		resp, err := promptWebauthnRegisterChallenge(ctx, origin, cc)
+		resp, err := a.promptWebauthnRegisterChallenge(ctx, origin, cc)
 		return resp, noopRegisterCallback{}, err
 
 	default:
@@ -514,7 +533,7 @@ func promptTOTPRegisterChallenge(ctx context.Context, c *proto.TOTPRegisterChall
 	}, nil
 }
 
-func promptWebauthnRegisterChallenge(ctx context.Context, origin string, cc *wantypes.CredentialCreation) (*proto.MFARegisterResponse, error) {
+func (a *mfaAdder) promptWebauthnRegisterChallenge(ctx context.Context, origin string, cc *wantypes.CredentialCreation) (*proto.MFARegisterResponse, error) {
 	logger.DebugContext(ctx, "prompting MFA devices with origin",
 		teleport.ComponentKey, "WebAuthn",
 		"origin", origin,
@@ -525,7 +544,7 @@ func promptWebauthnRegisterChallenge(ctx context.Context, origin string, cc *wan
 	prompt.FirstTouchMessage = "Tap your *new* security key"
 	prompt.SecondTouchMessage = "Tap your *new* security key again to complete registration"
 
-	resp, err := wancli.Register(ctx, origin, cc, prompt)
+	resp, err := a.webauthnRegister(ctx, origin, cc, prompt)
 	return resp, trace.Wrap(err)
 }
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -78,6 +78,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
+	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	autoupdateagent "github.com/gravitational/teleport/lib/autoupdate/agent"
 	autoupdatetools "github.com/gravitational/teleport/lib/autoupdate/tools"
 	"github.com/gravitational/teleport/lib/benchmark"
@@ -151,6 +152,15 @@ var accessRequestModes = []string{
 // ClientInitFunc defines a function that initiates a connection to
 // the Teleport cluster using the CLI configuration.
 type ClientInitFunc func(cf *CLIConf) (*client.TeleportClient, error)
+
+// WebauthnLoginFunc is a function that performs WebAuthn registration.
+// Mimics the signature of [wancli.Register].
+type WebauthnRegisterFunc func(
+	ctx context.Context,
+	origin string,
+	cc *wantypes.CredentialCreation,
+	prompt wancli.RegisterPrompt,
+) (*proto.MFARegisterResponse, error)
 
 // CLIConf stores command line arguments and flags:
 type CLIConf struct {
@@ -614,6 +624,10 @@ type CLIConf struct {
 	// Defaults to [wancli.Login].
 	WebauthnLogin client.WebauthnLoginFunc
 
+	// WebauthnRegister allows tests to override the Webauthn Register func.
+	// Defaults to [wancli.Register].
+	WebauthnRegister WebauthnRegisterFunc
+
 	// LeafClusterName is the optional name of a leaf cluster to connect to instead
 	LeafClusterName string
 
@@ -680,6 +694,10 @@ type CLIConf struct {
 
 	// checkManagedUpdates initiates check of managed update after client connects to cluster.
 	checkManagedUpdates bool
+
+	// addMFAIfRequired tells `tsh ssh` to offer adding an MFA device if it's
+	// required, but the user doesn't have one.
+	addMFAIfRequired bool
 }
 
 func (c *CLIConf) isForkAuthChild() bool {
@@ -994,6 +1012,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	ssh.Flag("no-resume", "Disable SSH connection resumption.").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
 	ssh.Flag("relogin", "Permit performing an authentication attempt on a failed command.").Default("true").BoolVar(&cf.Relogin)
 	ssh.Flag("fork-after-authentication", "Run in background after authentication is complete.").Short('f').BoolVar(&cf.ForkAfterAuthentication)
+	ssh.Flag("add-mfa", "Offer registering an MFA device if required").Default("true").BoolVar(&cf.addMFAIfRequired)
 	// The following flags are OpenSSH compatibility flags. They are used for
 	// users that alias "ssh" to "tsh ssh." The following OpenSSH flags are
 	// implemented. From "man 1 ssh":
@@ -4136,6 +4155,23 @@ func getAutoRoleRequest(ctx context.Context, clt *client.ClusterClient, requestR
 	return req, nil
 }
 
+// retryWithAccessRequests calls the given fn function and attempts to resolve
+// errors by creating an access request and/or adding an MFA device.
+func retryIfCouldObtainAccess(
+	cf *CLIConf,
+	tc *client.TeleportClient,
+	fn func() error,
+	onAccessRequestCreator func(ctx context.Context, cf *CLIConf, tc *client.TeleportClient) (types.AccessRequest, error),
+	resource string,
+) error {
+	return retryWithAddingMFA(cf, tc, func() error {
+		return retryWithAccessRequest(cf, tc, fn, onAccessRequestCreator, resource)
+	})
+}
+
+// retryWithAccessRequests calls the given fn function. If fn returns an error
+// that is [trace.IsAccessDenied], fn will be called once again after creating
+// an access request and waiting for approval.
 func retryWithAccessRequest(
 	cf *CLIConf,
 	tc *client.TeleportClient,
@@ -4175,6 +4211,38 @@ func retryWithAccessRequest(
 
 	// Retry now that request has been approved and certs updated.
 	// Clear the original exit status.
+	tc.SetExitStatus(0)
+	return trace.Wrap(fn())
+}
+
+// retryWithAddingMFA calls the given fn function. If fn returns an
+// [authclient.ErrNoMFADevice] error, fn will be called once again after giving
+// the user an opportunity to register an MFA device.
+func retryWithAddingMFA(cf *CLIConf, tc *client.TeleportClient, fn func() error) error {
+	ctx := cf.Context
+	origErr := fn()
+	if !cf.addMFAIfRequired || !errors.Is(origErr, authclient.ErrNoMFADevices) {
+		return trace.Wrap(origErr)
+	}
+
+	yes, err := prompt.Confirmation(ctx, cf.Stdout(), prompt.Stdin(),
+		"\nYou have no MFA devices registered. Do you want to register a new one?",
+	)
+	if err != nil {
+		return err
+	}
+	if !yes {
+		return trace.Wrap(origErr)
+	}
+
+	adder := mfaAdder{}
+	adder.setWebauthnRegisterFunc(cf.WebauthnRegister)
+	err = adder.addMFA(ctx, tc)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Fprintln(cf.Stdout())
 	tc.SetExitStatus(0)
 	return trace.Wrap(fn())
 }
@@ -4468,7 +4536,7 @@ func onSSH(cf *CLIConf, initFunc ClientInitFunc) error {
 	}
 
 	tc.Stdin = cf.Stdin()
-	err = retryWithAccessRequest(cf, tc, func() error {
+	err = retryIfCouldObtainAccess(cf, tc, func() error {
 		sshFunc := func() error {
 			var opts []func(*client.SSHOptions)
 			if cf.LocalExec {

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -2634,6 +2634,380 @@ func TestAccessRequestOnLeaf(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestSSHAddingMFA tests that a user can automatically add an MFA device when
+// "tsh ssh" fails with NoMFADevices
+func TestSSHAddingMFA(t *testing.T) {
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
+	ctx := t.Context()
+
+	localUser, err := user.Current()
+	require.NoError(t, err)
+
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetRoles([]string{"access"})
+	alice.SetLogins([]string{localUser.Username})
+
+	connector := mockConnector(t)
+
+	// Create a test server that requires per-session Webauthn MFA.
+	sshHostname := "test-ssh-host"
+	server, err := testserver.NewTeleportProcess(t.TempDir(),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.Hostname = sshHostname
+			cfg.Auth.Enabled = true
+			cfg.Proxy.Enabled = true
+			cfg.SSH.Enabled = true
+			cfg.SSH.DisableCreateHostUser = true
+
+			cfg.Auth.BootstrapResources = []types.Resource{alice, connector}
+			cfg.Auth.Preference = &types.AuthPreferenceV2{
+				Metadata: types.Metadata{
+					Labels: map[string]string{types.OriginLabel: types.OriginConfigFile},
+				},
+				Spec: types.AuthPreferenceSpecV2{
+					Type:          constants.Local,
+					SecondFactors: []types.SecondFactorType{types.SecondFactorType_SECOND_FACTOR_TYPE_WEBAUTHN},
+					Webauthn: &types.Webauthn{
+						RPID: "127.0.0.1",
+					},
+					RequireMFAType: types.RequireMFAType_SESSION,
+				},
+			}
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+		require.NoError(t, server.Wait())
+	})
+
+	// Wait for the node to appear.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		found, err := server.GetAuthServer().GetNodes(ctx, apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Len(t, found, 1)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	proxyAddr, err := server.ProxyWebAddr()
+	require.NoError(t, err)
+
+	tmpHomePath := t.TempDir()
+
+	// Log the user in.
+	err = Run(ctx, []string{
+		"login",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+		"--user", "alice@example.com",
+	}, setHomePath(tmpHomePath), setMockSSOLogin(server.GetAuthServer(), alice, connector.GetName()))
+	require.NoError(t, err)
+
+	// Create a mock MFA device and set up the MFA registration and login
+	// functions.
+	device, err := mocku2f.Create()
+	require.NoError(t, err)
+
+	webauthnRegister := func(
+		ctx context.Context, origin string, cc *wantypes.CredentialCreation, _ wancli.RegisterPrompt,
+	) (*proto.MFARegisterResponse, error) {
+		ccr, err := device.SignCredentialCreation(origin, cc)
+		if err != nil {
+			return nil, err
+		}
+		println(ccr)
+
+		return &proto.MFARegisterResponse{
+			Response: &proto.MFARegisterResponse_Webauthn{
+				Webauthn: wantypes.CredentialCreationResponseToProto(ccr),
+			},
+		}, nil
+	}
+
+	webauthnLogin := func(
+		ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, _ wancli.LoginPrompt, _ *wancli.LoginOpts,
+	) (*proto.MFAAuthenticateResponse, string, error) {
+		car, err := device.SignAssertion(origin, assertion)
+		if err != nil {
+			return nil, "", err
+		}
+		return &proto.MFAAuthenticateResponse{
+			Response: &proto.MFAAuthenticateResponse_Webauthn{
+				Webauthn: wantypes.CredentialAssertionResponseToProto(car),
+			},
+		}, "", nil
+	}
+
+	oldStdin := prompt.Stdin()
+	t.Cleanup(func() {
+		prompt.SetStdin(oldStdin)
+	})
+
+	const greeting = "Hello from the other side"
+	const mfaPromptQuestion = "You have no MFA devices registered. Do you want to register a new one?"
+
+	testCases := []struct {
+		name      string
+		extraArgs []string
+		stdin     *prompt.FakeReader
+		assertFn  func(t *testing.T, stdout string, err error)
+	}{
+		{
+			name:  "refuse to create device",
+			stdin: prompt.NewFakeReader().AddString("n"),
+			assertFn: func(t *testing.T, stdout string, err error) {
+				var exiterr *common.ExitCodeError
+				require.ErrorAs(t, err, &exiterr)
+				assert.Equal(t, 1, exiterr.Code)
+				assert.Contains(t, stdout, mfaPromptQuestion)
+				assert.NotContains(t, stdout, greeting)
+			},
+		},
+		{
+			name:      "--no-add-mfa flag skips registration prompt",
+			extraArgs: []string{"--no-add-mfa"},
+			stdin:     prompt.NewFakeReader(),
+			assertFn: func(t *testing.T, stdout string, err error) {
+				var exiterr *common.ExitCodeError
+				require.ErrorAs(t, err, &exiterr)
+				assert.Equal(t, 1, exiterr.Code)
+				// In this case, tsh ssh shouldn't even ask.
+				assert.NotContains(t, stdout, mfaPromptQuestion)
+				assert.NotContains(t, stdout, greeting)
+			},
+		},
+		{
+			name: "accept and register device",
+			stdin: prompt.NewFakeReader().
+				AddString("y").        // Yes, create a new one
+				AddString("webauthn"). // Device type
+				AddString("mykey").    // Device name
+				AddString("n"),        // Don't allow passwordless
+			assertFn: func(t *testing.T, stdout string, err error) {
+				require.NoError(t, err)
+				assert.Contains(t, stdout, mfaPromptQuestion)
+				// The actual MFA registration dialog output goes directly to the system
+				// stream, not the injected stdout, so we can't easily verify it.
+				assert.Contains(t, stdout, greeting)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			prompt.SetStdin(tc.stdin)
+
+			stdout := output{}
+			args := []string{
+				"ssh",
+				"--insecure",
+			}
+			args = append(args, tc.extraArgs...)
+			args = append(args,
+				fmt.Sprintf("%s@%s", localUser.Username, sshHostname),
+				"echo", greeting,
+			)
+
+			err := Run(ctx, args, setHomePath(tmpHomePath), func(cf *CLIConf) error {
+				cf.OverrideStdout = &stdout
+				cf.WebauthnRegister = webauthnRegister
+				cf.WebauthnLogin = webauthnLogin
+				return nil
+			})
+
+			tc.assertFn(t, stdout.String(), err)
+		})
+	}
+}
+
+// TestSSHAccessRequestAndAddingMFA tests that tsh ssh can both auto-create an
+// access request and enroll an MFA device when the requested role enforces
+// per-session MFA.
+func TestSSHAccessRequestAndAddingMFA(t *testing.T) {
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
+	ctx := t.Context()
+
+	localUser, err := user.Current()
+	require.NoError(t, err)
+
+	requester, err := types.NewRole("requester", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Roles:         []string{"node-access-mfa"},
+				SearchAsRoles: []string{"node-access-mfa"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	nodeAccessMFA, err := types.NewRole("node-access-mfa", types.RoleSpecV6{
+		Options: types.RoleOptions{RequireMFAType: types.RequireMFAType_SESSION},
+		Allow: types.RoleConditions{
+			Logins: []string{localUser.Username},
+			NodeLabels: types.Labels{
+				"access": {"true"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetRoles([]string{"requester"})
+	alice.SetTraits(map[string][]string{
+		constants.TraitLogins: {localUser.Username},
+	})
+
+	connector := mockConnector(t)
+	sshHostname := "test-ssh-host"
+
+	server, err := testserver.NewTeleportProcess(t.TempDir(),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.Hostname = sshHostname
+			cfg.Auth.Enabled = true
+			cfg.Proxy.Enabled = true
+			cfg.SSH.Enabled = true
+			cfg.SSH.DisableCreateHostUser = true
+			cfg.SSH.Labels = map[string]string{"access": "true"}
+
+			cfg.Auth.BootstrapResources = []types.Resource{requester, nodeAccessMFA, alice, connector}
+			cfg.Auth.Preference = &types.AuthPreferenceV2{
+				Metadata: types.Metadata{
+					Labels: map[string]string{types.OriginLabel: types.OriginConfigFile},
+				},
+				Spec: types.AuthPreferenceSpecV2{
+					Type:          constants.Local,
+					SecondFactors: []types.SecondFactorType{types.SecondFactorType_SECOND_FACTOR_TYPE_WEBAUTHN},
+					Webauthn:      &types.Webauthn{RPID: "127.0.0.1"},
+				},
+			}
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+		require.NoError(t, server.Wait())
+	})
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		found, err := server.GetAuthServer().GetNodes(ctx, apidefaults.Namespace)
+		require.NoError(ct, err)
+		require.Len(ct, found, 1)
+	}, 10*time.Second, 100*time.Millisecond, "nodes never showed up")
+
+	// approve all requests as they're created
+	approverCtx, approverCancel := context.WithCancel(ctx)
+	errChan := make(chan error)
+	t.Cleanup(func() {
+		require.ErrorIs(t, <-errChan, context.Canceled, "unexpected error from approveAllAccessRequests")
+	})
+	go func() {
+		err := approveAllAccessRequests(approverCtx, server.GetAuthServer())
+		// Cancel the context, so Run calls don't block
+		approverCancel()
+		errChan <- err
+	}()
+
+	proxyAddr, err := server.ProxyWebAddr()
+	require.NoError(t, err)
+
+	tmpHomePath := t.TempDir()
+	err = Run(ctx, []string{
+		"login",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+		"--user", "alice@example.com",
+	}, setHomePath(tmpHomePath), setMockSSOLogin(server.GetAuthServer(), alice, connector.GetName()))
+	require.NoError(t, err)
+
+	device, err := mocku2f.Create()
+	require.NoError(t, err)
+
+	webauthnRegister := func(
+		ctx context.Context, origin string, cc *wantypes.CredentialCreation, _ wancli.RegisterPrompt,
+	) (*proto.MFARegisterResponse, error) {
+		ccr, err := device.SignCredentialCreation(origin, cc)
+		if err != nil {
+			return nil, err
+		}
+
+		return &proto.MFARegisterResponse{
+			Response: &proto.MFARegisterResponse_Webauthn{
+				Webauthn: wantypes.CredentialCreationResponseToProto(ccr),
+			},
+		}, nil
+	}
+
+	webauthnLogin := func(
+		ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, _ wancli.LoginPrompt, _ *wancli.LoginOpts,
+	) (*proto.MFAAuthenticateResponse, string, error) {
+		car, err := device.SignAssertion(origin, assertion)
+		if err != nil {
+			return nil, "", err
+		}
+		return &proto.MFAAuthenticateResponse{
+			Response: &proto.MFAAuthenticateResponse_Webauthn{
+				Webauthn: wantypes.CredentialAssertionResponseToProto(car),
+			},
+		}, "", nil
+	}
+
+	oldStdin := prompt.Stdin()
+	t.Cleanup(func() {
+		prompt.SetStdin(oldStdin)
+	})
+	prompt.SetStdin(prompt.NewFakeReader().
+		AddString("y").
+		AddString("webauthn").
+		AddString("mykey").
+		AddString("n"))
+
+	const greeting = "hello-from-the-other-side"
+	const mfaPromptQuestion = "You have no MFA devices registered. Do you want to register a new one?"
+	requestReason := uuid.NewString()
+
+	var stdout string
+	require.Eventually(t, func() bool {
+		prompt.SetStdin(prompt.NewFakeReader().
+			AddString("y").
+			AddString("webauthn").
+			AddString("mykey").
+			AddString("n"))
+
+		attemptOut := &output{}
+		err = Run(ctx, []string{
+			"ssh",
+			"--debug",
+			"--insecure",
+			"--request-mode", accessRequestModeRole,
+			"--request-reason", requestReason,
+			fmt.Sprintf("%s@%s", localUser.Username, sshHostname),
+			"echo", greeting,
+		}, setHomePath(tmpHomePath), func(cf *CLIConf) error {
+			cf.OverrideStdout = attemptOut
+			cf.WebauthnRegister = webauthnRegister
+			cf.WebauthnLogin = webauthnLogin
+			return nil
+		})
+		if err != nil {
+			t.Logf("Got error while trying to SSH to node, retrying. Error: %v", err)
+			return false
+		}
+
+		stdout = attemptOut.String()
+		return true
+	}, 10*time.Second, 100*time.Millisecond, "failed to ssh with retries")
+
+	require.Contains(t, stdout, mfaPromptQuestion)
+	require.Contains(t, stdout, greeting)
+
+	requests, err := server.GetAuthServer().GetAccessRequests(ctx, types.AccessRequestFilter{})
+	require.NoError(t, err)
+	require.True(t, slices.ContainsFunc(requests, func(request types.AccessRequest) bool {
+		return request.GetRequestReason() == requestReason
+	}), "access request with the specified reason was not found")
+}
+
 // TestSSHAccessRequestWait tests that "tsh ssh" automatically creates an
 // access request when required and properly waits for it to be approved.
 func TestSSHAccessRequestWait(t *testing.T) {


### PR DESCRIPTION
Changelog: `tsh ssh` now offers to register an MFA device if user has none and per-session MFA is required

## Manual Test Plan
### Test Environment
Local Teleport cluster, two server nodes, GitHub SSO, per-session Webauthn MFA enforced on the cluster config level.

### Test Cases
- [ ] Starting an interactive shell
   - [ ] On Windows
   - [ ] Using Webauthn and OTP
- [ ] Starting an interactive shell, per-session MFA turned off
- [ ] Starting a shell in the fork mode (`-f`)
- [ ] Running a command on multiple nodes (confirm it's not broken; here, tsh won't attempt adding an MFA)
- [ ] Joining a session
- [ ] Transferring a file using SFTP
- [ ] Starting a shell on a leaf cluster
- [ ] Adding MFA using `tsh mfa add` (confirming it's not broken)
   - [ ] In a clamshell mode
   - [ ] On Windows
   - [ ] Adding a second one
   - [ ] Adding Webauthn and OTP
- [ ] Starting an interactive shell session on web and Teleport Connect (confirming it's not broken)
- [ ] With MFA enforcement turned off globally and a MFA-enforcing role created
   - [ ] Starting an interactive shell
   - [ ] Starting an interactive shell by user who don't even have the role, combining it with creating an access request.

For each case involving starting a shell with per-session MFA, test three subcases:
- Refusing to create an MFA device
- Creating an MFA device
- MFA device already created

Updates https://github.com/gravitational/teleport/issues/46455