### PR TITLE
Update app auth config session ID generation to include a prefix

### DIFF
--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -29,6 +29,9 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/services \
     FuzzParseRefs fuzz_parse_refs
 
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/services \
+    FuzzGenerateAppAuthConfigSessionID fuzz_generate_app_auth_config_session_id
+
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/srv/db/cassandra/protocol \
     FuzzReadPacket fuzz_cassandra_read_packet
 

--- a/lib/auth/appauthconfig/appauthconfigv1/sessions_service.go
+++ b/lib/auth/appauthconfig/appauthconfigv1/sessions_service.go
@@ -61,8 +61,8 @@ type CreateAppSessionForAppAuthRequest struct {
 	Traits map[string][]string
 	// TTL is the session validity period.
 	TTL time.Duration
-	// SuggestedSessionID is the session ID suggested by the requester.
-	SuggestedSessionID string
+	// SessionID is the session ID set by the request.
+	SessionID string
 	// AppName is the name of the app.
 	AppName string
 	// AppURI is the URI of the app. This is the internal endpoint where the application is running and isn't user-facing.
@@ -159,7 +159,7 @@ func (s *SessionsService) CreateAppSessionWithJWT(ctx context.Context, req *appa
 		return nil, trace.AccessDenied("this request can be only executed by a proxy")
 	}
 
-	sid := services.GenerateAppSessionIDFromJWT(req.Jwt)
+	sid := services.GenerateAppSessionIDFromAuthValue(req.Jwt)
 	if err := validateCreateAppSessionWithJWTRequest(req); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -190,16 +190,16 @@ func (s *SessionsService) CreateAppSessionWithJWT(ctx context.Context, req *appa
 	}
 
 	ws, err := s.sessions.CreateAppSessionForAppAuth(ctx, &CreateAppSessionForAppAuthRequest{
-		Username:           username,
-		ClusterName:        req.App.ClusterName,
-		AppName:            req.App.AppName,
-		AppURI:             req.App.Uri,
-		AppPublicAddr:      req.App.PublicAddr,
-		LoginIP:            req.RemoteAddr,
-		Roles:              user.GetRoles(),
-		Traits:             user.GetTraits(),
-		TTL:                time.Until(tokenTTL),
-		SuggestedSessionID: sid,
+		Username:      username,
+		ClusterName:   req.App.ClusterName,
+		AppName:       req.App.AppName,
+		AppURI:        req.App.Uri,
+		AppPublicAddr: req.App.PublicAddr,
+		LoginIP:       req.RemoteAddr,
+		Roles:         user.GetRoles(),
+		Traits:        user.GetTraits(),
+		TTL:           time.Until(tokenTTL),
+		SessionID:     sid,
 	})
 	if err != nil {
 		s.logger.WarnContext(ctx, "failed to create a web session from jwt token", "error", err)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -449,8 +449,9 @@ type NewAppSessionRequest struct {
 	Identity tlsca.Identity
 	// ClientAddr is a client (user's) address.
 	ClientAddr string
-	// SuggestedSessionID is a session ID suggested by the requester.
-	SuggestedSessionID string
+	// SessionID is used to define a custom session ID for the new session. If
+	// empty the server will generate a session ID.
+	SessionID string
 
 	// BotName is the name of the bot that is creating this session.
 	// Empty if not a bot.
@@ -557,7 +558,7 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		return nil, trace.Wrap(err)
 	}
 
-	sessionID := req.SuggestedSessionID
+	sessionID := req.SessionID
 	if sessionID == "" {
 		// Create services.WebSession for this session.
 		sessionID, err = utils.CryptoRandomHex(defaults.SessionTokenBytes)
@@ -875,11 +876,11 @@ func (a *Server) CreateAppSessionForAppAuth(ctx context.Context, req *appauthcon
 			// auth and proxy instances.
 			AttestWebSession: true,
 		},
-		ClusterName:        req.ClusterName,
-		AppName:            req.AppName,
-		AppURI:             req.AppURI,
-		PublicAddr:         req.AppPublicAddr,
-		SuggestedSessionID: req.SuggestedSessionID,
+		ClusterName: req.ClusterName,
+		AppName:     req.AppName,
+		AppURI:      req.AppURI,
+		PublicAddr:  req.AppPublicAddr,
+		SessionID:   req.SessionID,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/events/pgevents/pgevents_test.go
+++ b/lib/events/pgevents/pgevents_test.go
@@ -37,6 +37,7 @@ import (
 	pgcommon "github.com/gravitational/teleport/lib/backend/pgbk/common"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -86,11 +87,51 @@ func TestPostgresEvents(t *testing.T) {
 func TestLog_nonStandardSessionID(t *testing.T) {
 	// Don't t.Parallel(), relies on the database backed by urlEnvVar.
 	eventsLog := newLogForTesting(t)
-
-	// Example app event. Only the session ID matters for the test, everything
-	// else is realistic but irrelevant here.
 	eventTime := time.Now()
-	appStartEvent := &apievents.AppSessionStart{
+
+	// IMPORTANT: not an UUID in both cases!
+	for i, tc := range []struct {
+		name string
+		sid  string
+	}{
+		{"regular session", "f8571503d72f35938ce5001b792baebcce3183719ae947fde1ed685f7848facc"},
+		{"app auth config session", services.GenerateAppSessionIDFromAuthValue("random-auth-value")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			// To prevent events from appearing in each other’s search results, space them by an hour.
+			eventTime = time.Now().Add(time.Hour * time.Duration(i+1))
+			appStartEvent := newAppSessionStartEvent(eventTime, tc.sid)
+
+			// Emit event with non-standard session ID.
+			require.NoError(t,
+				eventsLog.EmitAuditEvent(ctx, appStartEvent),
+				"emit audit event",
+			)
+
+			// Search event by the same (non-standard) session ID.
+			// SearchSessionEvents has a hard-coded list of eventTypes that excludes App
+			// events, so we must use searchEvents instead.
+			before := eventTime.Add(-1 * time.Second)
+			after := eventTime.Add(1 * time.Second)
+			appEvents, _, err := eventsLog.SearchEvents(ctx, events.SearchEventsRequest{
+				From:       before,
+				To:         after,
+				EventTypes: []string{appStartEvent.Metadata.Type},
+				Limit:      2,
+				Order:      types.EventOrderAscending,
+			})
+			require.NoError(t, err, "search session events")
+			want := []apievents.AuditEvent{appStartEvent}
+			require.Empty(t, cmp.Diff(want, appEvents, protocmp.Transform()))
+		})
+	}
+}
+
+// newAppSessionStartEvent returns an app session start event. Only the session
+// ID matters for the test, everything else is realistic but irrelevant here.
+func newAppSessionStartEvent(eventTime time.Time, sessionID string) *apievents.AppSessionStart {
+	return &apievents.AppSessionStart{
 		Metadata: apievents.Metadata{
 			Type:        events.AppSessionStartEvent,
 			Code:        events.AppSessionStartCode,
@@ -103,8 +144,7 @@ func TestLog_nonStandardSessionID(t *testing.T) {
 			ServerNamespace: apidefaults.Namespace,
 		},
 		SessionMetadata: apievents.SessionMetadata{
-			// IMPORTANT: not an UUID!
-			SessionID: "f8571503d72f35938ce5001b792baebcce3183719ae947fde1ed685f7848facc",
+			SessionID: sessionID,
 		},
 		UserMetadata: apievents.UserMetadata{
 			User:     "alpaca",
@@ -116,35 +156,6 @@ func TestLog_nonStandardSessionID(t *testing.T) {
 			AppPublicAddr: "dumper.zarq.dev",
 			AppName:       "dumper",
 		},
-	}
-
-	ctx := context.Background()
-
-	// Emit event with non-standard session ID.
-	require.NoError(t,
-		eventsLog.EmitAuditEvent(ctx, appStartEvent),
-		"emit audit event",
-	)
-
-	// Search event by the same (non-standard) session ID.
-	// SearchSessionEvents has a hard-coded list of eventTypes that excludes App
-	// events, so we must use searchEvents instead.
-	before := eventTime.Add(-1 * time.Second)
-	after := eventTime.Add(1 * time.Second)
-	appEvents, _, err := eventsLog.searchEvents(ctx,
-		before,                                // fromTime
-		after,                                 // toTime
-		[]string{appStartEvent.Metadata.Type}, // eventTypes
-		nil,                                   // cond
-		appStartEvent.SessionID,
-		2, // limit
-		types.EventOrderAscending,
-		"", // startKey
-	)
-	require.NoError(t, err, "search session events")
-	want := []apievents.AuditEvent{appStartEvent}
-	if diff := cmp.Diff(want, appEvents, protocmp.Transform()); diff != "" {
-		t.Errorf("searchEvents mismatch (-want +got)\n%s", diff)
 	}
 }
 

--- a/lib/services/appauthconfig.go
+++ b/lib/services/appauthconfig.go
@@ -107,8 +107,15 @@ func validateJWTAppAuthConfig(s *appauthconfigv1.AppAuthConfigJWTSpec) error {
 	return nil
 }
 
-// GenerateAppSessionIDFromJWT generates a app session id based on JWT token.
-func GenerateAppSessionIDFromJWT(jwtToken string) string {
-	jwtHash := sha256.Sum256([]byte(jwtToken))
-	return hex.EncodeToString(jwtHash[:])
+// GenerateAppSessionIDFromAuthValue generates a app session id based on JWT
+// token.
+func GenerateAppSessionIDFromAuthValue(authValue string) string {
+	jwtHash := sha256.Sum256([]byte(authValue))
+	sid := hex.EncodeToString(jwtHash[:])
+	return appAuthConfigSessionIDPrefix + sid[:len(sid)-len(appAuthConfigSessionIDPrefix)]
 }
+
+// appAuthConfigSessionIDPrefix is a prefix added to app auth config session
+// IDs. The prefix includes a non-hex character ("u") so that it will never
+// conflict with regular app session ID (which are hex values).
+const appAuthConfigSessionIDPrefix = "auth"

--- a/lib/services/appauthconfig_test.go
+++ b/lib/services/appauthconfig_test.go
@@ -17,14 +17,21 @@
 package services
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/require"
 
 	appauthconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/appauthconfig/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/defaults"
 )
 
 func TestValidatAppAuthConfig(t *testing.T) {
@@ -171,4 +178,45 @@ func TestValidatAppAuthConfig(t *testing.T) {
 			})
 		}
 	})
+}
+
+// FuzzGenerateAppAuthConfigSessionID ensures the generated session ID is within
+// size and is deterministic.
+func FuzzGenerateAppAuthConfigSessionID(f *testing.F) {
+	jwtToken := generateSignedJWT(f)
+	f.Add("")
+	f.Add(jwtToken)
+	f.Add("$%^&*()")
+	f.Add("random-auth-header")
+
+	f.Fuzz(func(t *testing.T, authValue string) {
+		sid := GenerateAppSessionIDFromAuthValue(authValue)
+		require.Len(t, sid, hex.EncodedLen(defaults.SessionTokenBytes))
+		require.True(t, strings.HasPrefix(sid, appAuthConfigSessionIDPrefix), "expected value %q to contain prefix %q", sid, appAuthConfigSessionIDPrefix)
+		require.Equal(t, sid, GenerateAppSessionIDFromAuthValue(authValue))
+	})
+}
+
+func generateSignedJWT(t testing.TB) string {
+	privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: privateKey},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+
+	token, err := jwt.Signed(signer).Claims(jwt.Claims{
+		Issuer:   "https://issuer",
+		Audience: jwt.Audience{"teleport"},
+		IssuedAt: jwt.NewNumericDate(time.Now()),
+		Expiry:   jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}).Claims(
+		struct {
+			Email string `json:"email"`
+		}{Email: "example@example.com"},
+	).Serialize()
+	require.NoError(t, err)
+
+	return token
 }


### PR DESCRIPTION
Raised in [this thread](https://github.com/gravitational/teleport/pull/62975#discussion_r2802200150).

With the addition of [app auth config sessions](https://github.com/gravitational/teleport.e/blob/c6fb7c51e3e8860253391c0a5b039e2c66bb27e5/rfd/0030e-remote-mcp.md), we can now generate session IDs from other values (using SHA256) instead of having them generated using [a "crypto-strong pseudo-random generator"](https://github.com/gravitational/teleport/blob/cf0adecf790066d5d384b32d42781f5a90a9a79f/lib/auth/sessions.go#L563). This change increased the chances of conflicting session IDs. Although the chances are still small, a conflict would cause the session to be overwritten, and existing clients would access a different session.

Given this, in this PR, we add a non-hex prefix to app auth config sessions, eliminating the chance of conflicting with regular app sessions.

**IMPORTANT: The regular app session IDs remain unchanged, and this affects only sessions using app auth config.**

## Manual Test Plan

### Test Environment

The environment requires using the branch from https://github.com/gravitational/teleport/pull/62975, which introduces MCP sessions using app auth config. The test environment used was the same as the other PR; you can check there for more details.

With that setup, we need to generate a few (tested with 5) sessions (by starting the MCP client).

### Test Cases

For each audit storage backend:
- [x] PostgreSQL (pgevents)
- [x] Athena (athena)
- [x] Firestore (firestoreevents)
- [x] DyanamoDB (dynamoevents)
- [x] Filelog (filelog)

The following was tested:

- WebUI list audit events
- WebUI list session recordings
- WebUI watch SSH session recording
- `tsh recordings ls`
- `tsh play ssh-session-id`
  
Although programmatically those other parts are not affected, I also tested them since touch audit events:

- Events handler export to Fluentd (doesn't unmarshal/inspect app sessions IDs, but it is on the events).
- `tsh play -f json chunk-id` (doesn't directly use the session ID, but has it on the events)
