### PR TITLE
[v18] Use vite-plugin-compression2 instead of vite-plugin-compression

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,9 +291,9 @@ importers:
       typescript-eslint:
         specifier: ^8.32.0
         version: 8.32.0(eslint@9.26.0(jiti@2.6.1))(typescript@5.8.3)
-      vite-plugin-compression:
-        specifier: ^0.5.1
-        version: 0.5.1(vite@6.3.5(@types/node@24.10.10)(jiti@2.6.1)(yaml@2.7.1))
+      vite-plugin-compression2:
+        specifier: ^2.5.0
+        version: 2.5.0(rollup@4.40.2)
       vite-plugin-wasm:
         specifier: ^3.4.1
         version: 3.4.1(vite@6.3.5(@types/node@24.10.10)(jiti@2.6.1)(yaml@2.7.1))
@@ -6573,6 +6573,9 @@ packages:
   tar-fs@3.1.1:
     resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
 
+  tar-mini@0.2.0:
+    resolution: {integrity: sha512-+qfUHz700DWnRutdUsxRRVZ38G1Qr27OetwaMYTdg8hcPxf46U0S1Zf76dQMWRBmusOt2ZCK5kbIaiLkoGO7WQ==}
+
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
@@ -6858,10 +6861,8 @@ packages:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
 
-  vite-plugin-compression@0.5.1:
-    resolution: {integrity: sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==}
-    peerDependencies:
-      vite: '>=2.0.0'
+  vite-plugin-compression2@2.5.0:
+    resolution: {integrity: sha512-bHxtBibPxxSn5eZSe0IAzvYucP/hg8Bz8ppjbH7lndU5kIHT+92qTkB4z9xWYfnyV0YHuir1SjOuyO0fzU4Vgg==}
 
   vite-plugin-wasm@3.4.1:
     resolution: {integrity: sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==}
@@ -14316,6 +14317,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-buffer
 
+  tar-mini@0.2.0: {}
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.6.7
@@ -14616,14 +14619,12 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite-plugin-compression@0.5.1(vite@6.3.5(@types/node@24.10.10)(jiti@2.6.1)(yaml@2.7.1)):
+  vite-plugin-compression2@2.5.0(rollup@4.40.2):
     dependencies:
-      chalk: 4.1.2
-      debug: 4.4.0
-      fs-extra: 10.1.0
-      vite: 6.3.5(@types/node@24.10.10)(jiti@2.6.1)(yaml@2.7.1)
+      '@rollup/pluginutils': 5.1.4(rollup@4.40.2)
+      tar-mini: 0.2.0
     transitivePeerDependencies:
-      - supports-color
+      - rollup
 
   vite-plugin-wasm@3.4.1(vite@6.3.5(@types/node@24.10.10)(jiti@2.6.1)(yaml@2.7.1)):
     dependencies:

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -34,7 +34,7 @@
     "jsdom": "^26.1.0",
     "rollup-plugin-visualizer": "^5.14.0",
     "typescript-eslint": "^8.32.0",
-    "vite-plugin-compression": "^0.5.1",
+    "vite-plugin-compression2": "^2.5.0",
     "vite-plugin-wasm": "^3.4.1",
     "vite-tsconfig-paths": "^5.1.4"
   }

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -21,7 +21,7 @@ import { resolve } from 'path';
 
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, type UserConfig } from 'vite';
-import compression from 'vite-plugin-compression';
+import { compression } from 'vite-plugin-compression2';
 import wasm from 'vite-plugin-wasm';
 
 import { generateAppHashFile } from './apphash';
@@ -104,11 +104,11 @@ export function createViteConfig(
       if (!process.env.VITE_DISABLE_COMPRESSION) {
         config.plugins.push(
           compression({
-            algorithm: 'brotliCompress',
-            deleteOriginFile: true,
-            filter: /\.(js|svg|wasm)$/,
+            algorithms: ['brotliCompress'],
+            deleteOriginalAssets: true,
+            include: /\.(js|svg|wasm)$/,
             threshold: 1024 * 10, // 10KB
-            verbose: false,
+            logLevel: 'silent',
           })
         );
       }


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/64360 to branch/v18

## Manual Test Plan
### Test Environment

Deployed to https://ryantest.cloud.gravitational.io

### Test Cases
- [x] Verified that a webassets build compressed with the new plugin is rendered correctly
  - [x] Ubuntu font is loaded correctly
  - [x] No errors in dev tools
  - [x] Everything looks the same 
