### PR TITLE
make update-tag: Add `GOWORK=off` to `go run ./cmd/check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1454,7 +1454,7 @@ $(VERSRC) &: Makefile version.mk
 update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
-	cd build.assets/tooling && CGO_ENABLED=0 go run ./cmd/check -check valid -tag $(GITTAG)
+	cd build.assets/tooling && GOWORK=off CGO_ENABLED=0 go run ./cmd/check -check valid -tag $(GITTAG)
 	git tag $(GITTAG)
 	git tag api/$(GITTAG)
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))


### PR DESCRIPTION
This makes `make update-tag` work without specifying `GOWORK=off` if `go.work` is present. This makes it so that when I want to make a dev build, I can run `make version`, `make update-tag` and `make tag-build` without having to remember about `GOWORK=off`.

`version.mk` already specifies this env var when running the same tool:

https://github.com/gravitational/teleport/blob/9bdf577a04bd80b5dbe96d94a04d5a23542dc219/version.mk#L37-L40

## Manual Test Plan

### Test Environment

My laptop.

### Test Cases

- [x] `make update-tag` works without specifying `GOWORK=off` 
