### PR TITLE
Run manual test plan workflow on PR edit/label change

### DIFF
--- a/.github/workflows/manual-test-plan.yaml
+++ b/.github/workflows/manual-test-plan.yaml
@@ -2,6 +2,7 @@ name: Manual Test Plan Check
 run-name: Manual Test Plan Check - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 jobs:
   changes:


### PR DESCRIPTION
The manual test plan workflow does not re-run if a PR body that did not have a manual test plan was updated with one, nor does it re-run if the `no-test-plan` label is added after the PR is open