### PR TITLE
Docs: remove `virtualMachines/read` required permission for Azure Server Discovery

### DIFF
--- a/docs/pages/enroll-resources/agents/azure.mdx
+++ b/docs/pages/enroll-resources/agents/azure.mdx
@@ -41,51 +41,7 @@ your Azure joining token.
 Every virtual machine hosting a Teleport process using the Azure method to join
 your Teleport cluster needs a Managed Identity assigned to it.
 
-<Tabs>
-<TabItem label="Azure Portal">
-
-To set up a Managed Identity:
-1. Navigate to [Virtual machines view](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Compute%2FVirtualMachines)
-if you're hosting Teleport on an Azure VM,
-or navigate to [Virtual machine scale sets view](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Compute%2FVirtualMachineScaleSets)
-if you're hosting Teleport on an Azure VMSS.
-2. Select the VM or VMSS hosting your Teleport Service.
-3. In the right-side panel, click the **Security/Identity** tab.
-4. Under the **Identity** section, select the **System assigned** tab.
-5. Toggle the **Status** switch to **On**.
-6. Click **Save**.
-
-If you're using VMSS and it is configured with manual upgrade mode, you must
-update the VM instances for the identity changes to take effect:
-- Click the **Instances** tab in the right panel.
-- Select the VM instances to update.
-- Click **Restart**.
-
-</TabItem>
-<TabItem label="Azure CLI">
-
-To attach a system-assigned identity to a regular VM, run:
-
-```code
-$ az vm identity assign --resource-group <resource-group> --name <vm-name>
-```
-
-To attach a system-assigned identity to an Azure VMSS, run:
-
-```code
-$ az vmss identity assign --resource-group <resource-group> --name <vmss-name>
-```
-
-If you're using VMSS and it is configured with manual upgrade mode, you must
-update the VM instances for the identity changes to take effect. Run the following
-command to propagate the identity change:
-
-```code
-$ az vmss update-instances --resource-group <resource-group> --name <vmss-name> --instance-ids *
-```
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/provision-token/azure-join-enable-identity.mdx!)
 
 ## Step 2/5. Create the Azure joining token
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -203,15 +203,14 @@ and replace the subscription in `assignableScopes` with your own subscription id
 
 (!docs/pages/includes/server-access/azure-assign-service-principal.mdx!)
 
-## Step 3/5. Set up managed identities for discovered nodes
+## Step 3/5. Set up identity for discovered nodes
 
-Every Azure VM to be discovered must have a managed identity assigned to it
-with at least the `Microsoft.Compute/virtualMachines/read` permission.
+Every Azure VM to be discovered must have an identity assigned to it: either system assigned or user assigned managed identity.
 
-(!docs/pages/includes/server-access/azure-join-managed-identity.mdx!)
+(!docs/pages/includes/provision-token/azure-join-enable-identity.mdx!)
 
-If the VMs to be discovered have more than one managed identity assigned to
-them, save the client ID of the identity you just created for step 5.
+If the VMs to be discovered have no system managed identity and more than one user managed identity assigned to them,
+copy the client ID of one of your user managed identity for step 5.
 
 ## Step 4/5. Install the Teleport Discovery Service
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -203,14 +203,14 @@ and replace the subscription in `assignableScopes` with your own subscription id
 
 (!docs/pages/includes/server-access/azure-assign-service-principal.mdx!)
 
-## Step 3/5. Set up identity for discovered nodes
+## Step 3/5. Set up an identity for discovered nodes
 
 Every Azure VM to be discovered must have an identity assigned to it: either system assigned or user assigned managed identity.
 
 (!docs/pages/includes/provision-token/azure-join-enable-identity.mdx!)
 
-If the VMs to be discovered have no system managed identity and more than one user managed identity assigned to them,
-copy the client ID of one of your user managed identity for step 5.
+If the VMs to be discovered have no system-managed identity and more than one user-managed identity assigned to them,
+copy the client ID of one of your user-managed identities for Step 5.
 
 ## Step 4/5. Install the Teleport Discovery Service
 

--- a/docs/pages/includes/provision-token/azure-join-enable-identity.mdx
+++ b/docs/pages/includes/provision-token/azure-join-enable-identity.mdx
@@ -1,0 +1,45 @@
+<Tabs>
+<TabItem label="Azure Portal">
+
+To set up a Managed Identity:
+1. Navigate to [Virtual machines view](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Compute%2FVirtualMachines)
+if you're hosting Teleport on an Azure VM,
+or navigate to [Virtual machine scale sets view](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Compute%2FVirtualMachineScaleSets)
+if you're hosting Teleport on an Azure VMSS.
+2. Select the VM or VMSS hosting your Teleport Service.
+3. In the right-side panel, click the **Security/Identity** tab.
+4. Under the **Identity** section, select the **System assigned** tab.
+5. Toggle the **Status** switch to **On**.
+6. Click **Save**.
+
+If you're using VMSS and it is configured with manual upgrade mode, you must
+update the VM instances for the identity changes to take effect:
+- Click the **Instances** tab in the right panel.
+- Select the VM instances to update.
+- Click **Restart**.
+
+</TabItem>
+<TabItem label="Azure CLI">
+
+To attach a system-assigned identity to a regular VM, run:
+
+```code
+$ az vm identity assign --resource-group <resource-group> --name <vm-name>
+```
+
+To attach a system-assigned identity to an Azure VMSS, run:
+
+```code
+$ az vmss identity assign --resource-group <resource-group> --name <vmss-name>
+```
+
+If you're using VMSS and it is configured with manual upgrade mode, you must
+update the VM instances for the identity changes to take effect. Run the following
+command to propagate the identity change:
+
+```code
+$ az vmss update-instances --resource-group <resource-group> --name <vmss-name> --instance-ids *
+```
+
+</TabItem>
+</Tabs>


### PR DESCRIPTION
Azure Join method does not require the `Microsoft.Compute/virtualMachines/read`.

This PR changes the Azure Server Discovery to remove that requirement.
Users are now asked to enable System identity or user managed identity, the same way we describe in the [Joining Services via Azure Managed Identity](https://goteleport.com/docs/enroll-resources/agents/azure/#step-15-set-up-a-managed-identity)


Fixes https://github.com/gravitational/teleport/issues/64111

<img width="2122" height="1478" alt="image" src="https://github.com/user-attachments/assets/45e53e37-2114-4d50-a3e9-8e0a5b47847f" />
