### PR TITLE
[v17] make update-tag: Add `GOWORK=off` to `go run ./cmd/check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1413,7 +1413,7 @@ $(VERSRC) &: Makefile version.mk
 update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
-	cd build.assets/tooling && CGO_ENABLED=0 go run ./cmd/check -check valid -tag $(GITTAG)
+	cd build.assets/tooling && GOWORK=off CGO_ENABLED=0 go run ./cmd/check -check valid -tag $(GITTAG)
 	git tag $(GITTAG)
 	git tag api/$(GITTAG)
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))


### PR DESCRIPTION
Backport #64463 to branch/v17