### PR TITLE
kube: validate impersonation principals against RFC 2616

### DIFF
--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -248,7 +248,7 @@ func (f *Forwarder) impersonatedKubeClient(authCtx *authContext, headers http.He
 		return nil, nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
 	}
 	restConfig := details.getKubeRestConfig()
-	kubeUser, kubeGroups, err := computeImpersonatedPrincipals(authCtx.kubeUsers, authCtx.kubeGroups, authCtx.User.GetName(), headers)
+	kubeUser, kubeGroups, err := computeAndValidateImpersonatedPrincipals(authCtx.kubeUsers, authCtx.kubeGroups, authCtx.User.GetName(), headers)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -479,7 +479,7 @@ func (c *authContext) key() string {
 func (c *authContext) eventClusterMeta(req *http.Request) apievents.KubernetesClusterMetadata {
 	var kubeUsers, kubeGroups []string
 
-	if impersonateUser, impersonateGroups, err := computeImpersonatedPrincipals(c.kubeUsers, c.kubeGroups, c.User.GetName(), req.Header); err == nil {
+	if impersonateUser, impersonateGroups, err := computeAndValidateImpersonatedPrincipals(c.kubeUsers, c.kubeGroups, c.User.GetName(), req.Header); err == nil {
 		kubeUsers = []string{impersonateUser}
 		kubeGroups = impersonateGroups
 	} else {
@@ -1989,7 +1989,7 @@ func setupImpersonationHeaders(sess *clusterSession, headers http.Header) error 
 		return nil
 	}
 
-	impersonateUser, impersonateGroups, err := computeImpersonatedPrincipals(sess.kubeUsers, sess.kubeGroups, sess.User.GetName(), headers)
+	impersonateUser, impersonateGroups, err := computeAndValidateImpersonatedPrincipals(sess.kubeUsers, sess.kubeGroups, sess.User.GetName(), headers)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -2024,11 +2024,13 @@ func copyImpersonationHeaders(dst, src http.Header) {
 	}
 }
 
-// computeImpersonatedPrincipals computes the intersection between the information
+// computeAndValidateImpersonatedPrincipals computes the intersection between the information
 // received in the `Impersonate-User` and `Impersonate-Groups` headers and the
 // allowed values. If the user didn't specify any user and groups to impersonate,
 // Teleport will use every group the user is allowed to impersonate.
-func computeImpersonatedPrincipals(kubeUsers, kubeGroups map[string]struct{}, username string, headers http.Header) (string, []string, error) {
+// This function also validates the impersonateUser and impersonateGroups against
+// HTTP header field value requirements to prevent header injection attacks.
+func computeAndValidateImpersonatedPrincipals(kubeUsers, kubeGroups map[string]struct{}, username string, headers http.Header) (string, []string, error) {
 	_, hasUserWildcard := kubeUsers[types.Wildcard]
 
 	var impersonateUser string
@@ -2123,7 +2125,7 @@ func computeImpersonatedPrincipals(kubeUsers, kubeGroups map[string]struct{}, us
 	}
 	for _, group := range impersonateGroups {
 		if !httpguts.ValidHeaderFieldValue(group) {
-			return "", nil, trace.BadParameter("invalid impersonated group header value: %q ", group)
+			return "", nil, trace.BadParameter("invalid impersonated group header value: %q", group)
 		}
 	}
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -43,6 +43,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/net/http/httpguts"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -2112,6 +2113,17 @@ func computeImpersonatedPrincipals(kubeUsers, kubeGroups map[string]struct{}, us
 	if len(impersonateGroups) == 0 {
 		for group := range kubeGroups {
 			impersonateGroups = append(impersonateGroups, group)
+		}
+	}
+	// Validate impersonateUser and impersonateGroups against HTTP header field value
+	// requirements to prevent header injection attacks.
+	// requirements in http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
+	if !httpguts.ValidHeaderFieldValue(impersonateUser) {
+		return "", nil, trace.BadParameter("invalid impersonated user header value: %q", impersonateUser)
+	}
+	for _, group := range impersonateGroups {
+		if !httpguts.ValidHeaderFieldValue(group) {
+			return "", nil, trace.BadParameter("invalid impersonated group header value: %q ", group)
 		}
 	}
 

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -988,6 +988,13 @@ func TestSetupImpersonationHeaders(t *testing.T) {
 			inHeaders:    http.Header{},
 			errAssertion: require.Error,
 		},
+		{
+			desc:         "role with invalid kubernetes user containing null byte",
+			kubeUsers:    []string{"kube-user-\x00a"},
+			kubeGroups:   []string{"kube-group-a"},
+			inHeaders:    http.Header{},
+			errAssertion: require.Error,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -967,6 +967,27 @@ func TestSetupImpersonationHeaders(t *testing.T) {
 			},
 			errAssertion: require.NoError,
 		},
+		{
+			desc:         "role with invalid kubernetes group containing newline",
+			kubeUsers:    []string{"kube-user-a"},
+			kubeGroups:   []string{"kube-group-a\r\nevil-header: injected"},
+			inHeaders:    http.Header{},
+			errAssertion: require.Error,
+		},
+		{
+			desc:         "role with invalid kubernetes user containing newline",
+			kubeUsers:    []string{"kube-user-a\r\nevil-header: injected"},
+			kubeGroups:   []string{"kube-group-a"},
+			inHeaders:    http.Header{},
+			errAssertion: require.Error,
+		},
+		{
+			desc:         "role with invalid kubernetes group containing null byte",
+			kubeUsers:    []string{"kube-user-a"},
+			kubeGroups:   []string{"kube-group-\x00a"},
+			inHeaders:    http.Header{},
+			errAssertion: require.Error,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
@@ -1556,6 +1577,45 @@ func TestKubernetesLicenseEnforcement(t *testing.T) {
 			tt.assertErrFunc(t, err)
 		})
 	}
+}
+
+func TestInvalidImpersonationGroupHeaderInjection(t *testing.T) {
+	t.Parallel()
+	kubeMock, err := testingkubemock.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
+	testCtx := SetupTestContext(
+		t.Context(),
+		t,
+		TestConfig{
+			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+		},
+	)
+	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+
+	// Create a user whose role has a kubernetes_group containing a CRLF sequence,
+	// which is an invalid HTTP header field value and must be rejected to prevent
+	// header injection attacks.
+	invalidHeader := "kube-group-a\r\nevil-header: injected"
+	_, _ = testCtx.CreateUserAndRole(
+		testCtx.Context,
+		t,
+		username,
+		RoleSpec{
+			Name:       roleName,
+			KubeGroups: []string{invalidHeader},
+		},
+	)
+
+	client, _ := testCtx.GenTestKubeClientTLSCert(t, username, kubeCluster)
+
+	_, err = client.CoreV1().Pods(metav1.NamespaceDefault).List(t.Context(), metav1.ListOptions{})
+	require.Error(t, err)
+	var kubeErr *kubeerrors.StatusError
+	require.ErrorAs(t, err, &kubeErr)
+	require.Equal(t, int32(http.StatusBadRequest), kubeErr.ErrStatus.Code)
+	require.Contains(t, kubeErr.ErrStatus.Message, fmt.Sprintf("invalid impersonated group header value: %q", invalidHeader))
 }
 
 func Test_authContext_eventClusterMeta(t *testing.T) {

--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -356,7 +356,7 @@ func deleteResources[T kubeObjectInterface](
 		}
 		allowedKubeUsers, allowedKubeGroups = fillDefaultKubePrincipalDetails(allowedKubeUsers, allowedKubeGroups, params.authCtx.User.GetName())
 
-		impersonatedUsers, impersonatedGroups, err := computeImpersonatedPrincipals(
+		impersonatedUsers, impersonatedGroups, err := computeAndValidateImpersonatedPrincipals(
 			set.New(allowedKubeUsers...), set.New(allowedKubeGroups...),
 			params.authCtx.User.GetName(),
 			params.header,


### PR DESCRIPTION
Validate the kubernetes impersonation user and group values computed in computeImpersonatedPrincipals using httpguts.ValidHeaderFieldValue before they are forwarded as HTTP headers. This rejects values containing CRLF sequences or null bytes that could otherwise be used for header injection attacks via crafted role definitions.

Validation was introduced into `lib/kube/proxy` to avoid breaking any existing role and error during teleport cluster init because the role's kube groups or user isn't conformant with RFC 2616 header value format. 

Changelog: Validate Kubernetes impersonation user and group header values to prevent CRLF or null-byte header injection via crafted role definitions

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
