### PR TITLE
docs: update migrating identity center guide

### DIFF
--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -319,7 +319,7 @@ and switch back to Teleport.
 #### Create the Teleport SAML Service Provider
 
 Create a SAML Service Provider in Teleport following the (Using Teleport as a SAML
-Identity Provider)[../idps/saml-guide.mdx] guide. Use the Identity Center SAML
+Identity Provider)[../../idps/saml-guide.mdx] guide. Use the Identity Center SAML
 Metadata file from the previous step to provide the Identity Center metadata to
 Teleport.
 
@@ -360,7 +360,7 @@ $ tctl edit plugins/aws-identity-center
 ```
 
 To enable Full hand-off mode, set the `saml_idp_service_provider_name` field in
-the `aws_ic` block to the name of the SAML Service Provider created in (Step 1)[#step-14-create-a-teleport-saml-idp-service-provider] above. 
+the `aws_ic` block to the name of the SAML Service Provider created in (Step 1)[#step-16-install-okta-saml-connector] above. 
 
 ```YAML
 kind: plugin

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -318,8 +318,8 @@ and switch back to Teleport.
 
 #### Create the Teleport SAML Service Provider
 
-Create a SAML Service Provider in Teleport following the (Using Teleport as a SAML
-Identity Provider)[../../idps/saml-guide.mdx] guide. Use the Identity Center SAML
+Create a SAML Service Provider in Teleport following the [Using Teleport as a SAML
+Identity Provider](../../idps/saml-guide.mdx) guide. Use the Identity Center SAML
 Metadata file from the previous step to provide the Identity Center metadata to
 Teleport.
 

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -360,7 +360,7 @@ $ tctl edit plugins/aws-identity-center
 ```
 
 To enable Full hand-off mode, set the `saml_idp_service_provider_name` field in
-the `aws_ic` block to the name of the SAML Service Provider created in (Step 1)[#step-16-install-okta-saml-connector] above. 
+the `aws_ic` block to the name of the SAML Service Provider created in [Step 1](#step-16-install-okta-saml-connector) above. 
 
 ```YAML
 kind: plugin

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -34,7 +34,8 @@ Center groups and manage Group membership.
 
 ## Prerequisites
 
-- A Teleport cluster.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - An AWS role configured as per the [AWS IAM Identity Center guide](./guide.mdx#step-17-configure-aws-integration)
   for the integration to use.
 - AWS credentials configured for the Teleport Auth Service to pick up and use
@@ -44,6 +45,7 @@ Center groups and manage Group membership.
   - View groups and their details.
   - View applications and their details.
 - The AWS IAM Identity Center ARN, AWS region, SCIM base address and SCIM bearer token.
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Partial hand-off (Hybrid setup)
 


### PR DESCRIPTION
`tsh` and `tctl` are used as steps in this guide so adding as prereqs.

Links have been fixed.