### PR TITLE
Replace TCP socket with unix socket for VNet user-admin IPC for Linux

### DIFF
--- a/lib/vnet/admin_process_linux.go
+++ b/lib/vnet/admin_process_linux.go
@@ -28,24 +28,16 @@ const (
 
 // LinuxAdminProcessConfig configures RunLinuxAdminProcess.
 type LinuxAdminProcessConfig struct {
-	// ClientApplicationServiceAddr is the address of the client application
-	// service the admin process connects to.
-	ClientApplicationServiceAddr string
-	// ServiceCredentialPath is the path to IPC credentials used to authenticate
-	// with the client application service.
-	ServiceCredentialPath string
+	// ClientApplicationServiceSocketPath is the unix socket path of the client
+	// application service.
+	ClientApplicationServiceSocketPath string
 }
 
 // RunLinuxAdminProcess must run as root.
 func RunLinuxAdminProcess(ctx context.Context, config LinuxAdminProcessConfig) error {
 	log.InfoContext(ctx, "Running VNet admin process")
 
-	serviceCreds, err := readCredentials(config.ServiceCredentialPath)
-	if err != nil {
-		return trace.Wrap(err, "reading service IPC credentials")
-	}
-	// TODO(tangyatsu): change to gRPC client over unix socket instead of TCP.
-	clt, err := newClientApplicationServiceClient(ctx, serviceCreds, config.ClientApplicationServiceAddr)
+	clt, err := newUnixClientApplicationServiceClient(ctx, config.ClientApplicationServiceSocketPath)
 	if err != nil {
 		return trace.Wrap(err, "creating user process client")
 	}

--- a/lib/vnet/client_application_service_client.go
+++ b/lib/vnet/client_application_service_client.go
@@ -40,6 +40,8 @@ type clientApplicationServiceClient struct {
 	conn *grpc.ClientConn
 }
 
+// newClientApplicationServiceClient creates a gRPC client over a TCP
+// socket using mTLS credentials.
 func newClientApplicationServiceClient(ctx context.Context, creds *credentials, addr string) (*clientApplicationServiceClient, error) {
 	tlsConfig, err := creds.clientTLSConfig()
 	if err != nil {

--- a/lib/vnet/client_application_service_client_linux.go
+++ b/lib/vnet/client_application_service_client_linux.go
@@ -1,0 +1,49 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+)
+
+// newUnixClientApplicationServiceClient creates a gRPC client over a Unix
+// socket without TLS.
+func newUnixClientApplicationServiceClient(ctx context.Context, socketPath string) (*clientApplicationServiceClient, error) {
+	if socketPath == "" {
+		return nil, trace.BadParameter("missing unix socket path")
+	}
+	conn, err := grpc.NewClient(fmt.Sprintf("unix://%s", socketPath),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(interceptors.GRPCClientUnaryErrorInterceptor),
+		grpc.WithStreamInterceptor(interceptors.GRPCClientStreamErrorInterceptor),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating user process gRPC client")
+	}
+	return &clientApplicationServiceClient{
+		clt:  vnetv1.NewClientApplicationServiceClient(conn),
+		conn: conn,
+	}, nil
+}

--- a/lib/vnet/client_application_service_client_linux.go
+++ b/lib/vnet/client_application_service_client_linux.go
@@ -30,7 +30,7 @@ import (
 
 // newUnixClientApplicationServiceClient creates a gRPC client over a Unix
 // socket without TLS.
-func newUnixClientApplicationServiceClient(ctx context.Context, socketPath string) (*clientApplicationServiceClient, error) {
+func newUnixClientApplicationServiceClient(_ context.Context, socketPath string) (*clientApplicationServiceClient, error) {
 	if socketPath == "" {
 		return nil, trace.BadParameter("missing unix socket path")
 	}

--- a/lib/vnet/dbus_client_linux.go
+++ b/lib/vnet/dbus_client_linux.go
@@ -26,7 +26,7 @@ import (
 // startService is called from the normal user process to start
 // the privileged VNet daemon. It connects to the system D-Bus
 // and calls the corresponding Start method, exposed on the VNet
-// D-Bus interface, passing the client service address and credential path.
+// D-Bus interface, passing the client service unix socket path.
 func startService(ctx context.Context, cfg LinuxAdminProcessConfig) error {
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
@@ -35,7 +35,7 @@ func startService(ctx context.Context, cfg LinuxAdminProcessConfig) error {
 	defer conn.Close()
 
 	// basically this corresponds to calling something like
-	// `busctl --system call org.teleport.vnet1 /org/teleport/vnet1 org.teleport.vnet1.Daemon Start ss "<addr>" "<credPath>"`
+	// `busctl --system call org.teleport.vnet1 /org/teleport/vnet1 org.teleport.vnet1.Daemon Start s "<socketPath>"`
 	// each D-Bus service owns a well-known name you refer to, then you specify an
 	// object path. object path is for granularity (a service can expose
 	// multiple objects, but it rarely used, so in our case it is the same as the name but
@@ -44,7 +44,7 @@ func startService(ctx context.Context, cfg LinuxAdminProcessConfig) error {
 	// interface exposes the same methods as dbusDaemon, so we can call them over
 	// D-Bus.
 	obj := conn.Object(vnetDBusServiceName, dbus.ObjectPath(vnetDBusObjectPath))
-	call := obj.CallWithContext(ctx, vnetDBusStartMethod, 0, cfg.ClientApplicationServiceAddr, cfg.ServiceCredentialPath)
+	call := obj.CallWithContext(ctx, vnetDBusStartMethod, 0, cfg.ClientApplicationServiceSocketPath)
 	if call.Err != nil {
 		return trace.Wrap(call.Err, "calling D-Bus Start")
 	}

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -43,8 +43,7 @@ var introspectNode = &introspect.Node{
 				{
 					Name: "Start",
 					Args: []introspect.Arg{
-						{Name: "addr", Type: "s", Direction: "in"},
-						{Name: "credPath", Type: "s", Direction: "in"},
+						{Name: "socketPath", Type: "s", Direction: "in"},
 					},
 				},
 				{Name: "Stop"},
@@ -85,10 +84,9 @@ func newDBusDaemon() (_ *dbusDaemon, err error) {
 	daemon := &dbusDaemon{
 		conn: conn,
 		done: make(chan error, 1),
-		startAdminProcess: func(addr, credPath string) error {
+		startAdminProcess: func(socketPath string) error {
 			return trace.Wrap(RunLinuxAdminProcess(ctx, LinuxAdminProcessConfig{
-				ClientApplicationServiceAddr: addr,
-				ServiceCredentialPath:        credPath,
+				ClientApplicationServiceSocketPath: socketPath,
 			}))
 		},
 		cancelAdminProcess: cancel,
@@ -124,7 +122,7 @@ type dbusDaemon struct {
 	closing bool
 	done    chan error // buffered 1; receives the admin process error or nil
 
-	startAdminProcess  func(addr, credPath string) error
+	startAdminProcess  func(socketPath string) error
 	cancelAdminProcess context.CancelFunc
 }
 
@@ -155,10 +153,10 @@ func (d *dbusDaemon) Wait() error {
 	return nil
 }
 
-// Start starts actual VNet admin process with passed address and credential path.
+// Start starts actual VNet admin process with passed unix socket path.
 // It uses polkit to authorize the calling D-Bus sender.
 // It returns an error if the admin process has already been started.
-func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Error {
+func (d *dbusDaemon) Start(socketPath string, sender dbus.Sender) *dbus.Error {
 	uid, err := d.authorize(sender)
 	if err != nil {
 		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
@@ -176,7 +174,7 @@ func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Erro
 	log.InfoContext(context.Background(), "Starting VNet admin process", "uid", uid)
 
 	go func() {
-		err := d.startAdminProcess(addr, credPath)
+		err := d.startAdminProcess(socketPath)
 		// TODO(tangyatsu): D-Bus supports signals, we might want to emit a signal when the admin process exits.
 		if err != nil && !errors.Is(err, context.Canceled) {
 			log.ErrorContext(context.Background(), "VNet admin process exited with error", "error", err)

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -33,6 +33,14 @@ const polkitAuthorizationTimeout = 30 * time.Second
 
 // introspectNode describes the exported D-Bus API. Update it if any method
 // signature is changed or new methods are added.
+//
+// D-Bus is strict about method signatures. If a client sends a different number
+// or type of arguments than the service expects, the call fails with an error.
+// There is no built-in forward or backward compatibility for method arguments.
+//
+// In practice this is unlikely to be a concern because the systemd unit
+// typically runs the same tsh binary as the client, so both sides are expected
+// to be the same version.
 var introspectNode = &introspect.Node{
 	Name: vnetDBusObjectPath,
 	Interfaces: []introspect.Interface{

--- a/lib/vnet/escalate_linux.go
+++ b/lib/vnet/escalate_linux.go
@@ -191,8 +191,7 @@ func runAdminSubcommand(ctx context.Context, cfg LinuxAdminProcessConfig) error 
 
 	cmd := exec.CommandContext(ctx, executableName, "-d",
 		teleport.VnetAdminSetupSubCommand,
-		"--addr", cfg.ClientApplicationServiceAddr,
-		"--cred-path", cfg.ServiceCredentialPath,
+		"--socket", cfg.ClientApplicationServiceSocketPath,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/lib/vnet/user_process_linux.go
+++ b/lib/vnet/user_process_linux.go
@@ -42,13 +42,22 @@ const clientApplicationServiceSocketName = "vnet.sock"
 // certificates for apps. If successful it sets p.processManager and
 // p.networkStackInfo.
 func (p *UserProcess) runPlatformUserProcess(processCtx context.Context) error {
-	socketDir, err := os.MkdirTemp("", "vnet_service")
+	// Prefer XDG_RUNTIME_DIR for runtime sockets.
+	// Paths must be absolute, ignore relative values.
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if runtimeDir == "" || !filepath.IsAbs(runtimeDir) {
+		runtimeDir = os.TempDir()
+	}
+	socketDir, err := os.MkdirTemp(runtimeDir, "vnet_service")
 	if err != nil {
 		return trace.Wrap(err, "creating temp dir for service socket")
 	}
 
 	listener, socketPath, err := listenUnixSocket(socketDir)
 	if err != nil {
+		if removeErr := os.RemoveAll(socketDir); removeErr != nil {
+			log.ErrorContext(processCtx, "Failed to remove service socket directory", "error", removeErr)
+		}
 		return trace.Wrap(err, "listening on unix socket")
 	}
 	// grpcServer.Serve takes ownership of (and closes) the listener.
@@ -101,9 +110,6 @@ func (p *UserProcess) runPlatformUserProcess(processCtx context.Context) error {
 
 func listenUnixSocket(dir string) (net.Listener, string, error) {
 	socketPath := filepath.Join(dir, clientApplicationServiceSocketName)
-	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
-		return nil, "", trace.Wrap(err, "removing stale unix socket %s", socketPath)
-	}
 	listener, err := net.Listen("unix", socketPath)
 	if err != nil {
 		return nil, "", trace.Wrap(err, "creating unix socket listener")

--- a/lib/vnet/user_process_linux.go
+++ b/lib/vnet/user_process_linux.go
@@ -20,14 +20,21 @@ import (
 	"context"
 	"net"
 	"os"
+	"path/filepath"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc"
-	grpccredentials "google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+	"github.com/gravitational/teleport/lib/uds"
 )
+
+const clientApplicationServiceSocketName = "vnet.sock"
 
 // runPlatformUserProcess launches a daemon in the background that will handle
 // all networking and OS configuration. The user process exposes a gRPC
@@ -35,55 +42,43 @@ import (
 // certificates for apps. If successful it sets p.processManager and
 // p.networkStackInfo.
 func (p *UserProcess) runPlatformUserProcess(processCtx context.Context) error {
-	ipcCreds, err := newIPCCredentials()
+	socketDir, err := os.MkdirTemp("", "vnet_service")
 	if err != nil {
-		return trace.Wrap(err, "creating credentials for IPC")
-	}
-	serverTLSConfig, err := ipcCreds.server.serverTLSConfig()
-	if err != nil {
-		return trace.Wrap(err, "generating gRPC server TLS config")
+		return trace.Wrap(err, "creating temp dir for service socket")
 	}
 
-	credDir, err := os.MkdirTemp("", "vnet_service_certs")
+	listener, socketPath, err := listenUnixSocket(socketDir)
 	if err != nil {
-		return trace.Wrap(err, "creating temp dir for service certs")
-	}
-	// Write credentials with 0200 so that only root can read them and no user
-	// processes should be able to connect to the service.
-	if err := ipcCreds.client.write(credDir, 0200); err != nil {
-		return trace.Wrap(err, "writing service IPC credentials")
-	}
-
-	listener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		return trace.Wrap(err, "listening on tcp socket")
+		return trace.Wrap(err, "listening on unix socket")
 	}
 	// grpcServer.Serve takes ownership of (and closes) the listener.
 	grpcServer := grpc.NewServer(
-		grpc.Creds(grpccredentials.NewTLS(serverTLSConfig)),
-		grpc.UnaryInterceptor(interceptors.GRPCServerUnaryErrorInterceptor),
-		grpc.StreamInterceptor(interceptors.GRPCServerStreamErrorInterceptor),
+		grpc.Creds(uds.NewTransportCredentials(insecure.NewCredentials())),
+		grpc.ChainUnaryInterceptor(
+			rootOnlyUnixSocketUnaryInterceptor,
+			interceptors.GRPCServerUnaryErrorInterceptor,
+		),
+		grpc.ChainStreamInterceptor(
+			rootOnlyUnixSocketStreamInterceptor,
+			interceptors.GRPCServerStreamErrorInterceptor,
+		),
 	)
 	vnetv1.RegisterClientApplicationServiceServer(grpcServer, p.clientApplicationService)
 
 	p.processManager.AddCriticalBackgroundTask("admin process", func() error {
 		defer func() {
-			// Delete service credentials after the service terminates.
-			if ipcCreds.client.remove(credDir); err != nil {
-				log.ErrorContext(processCtx, "Failed to remove service credential files", "error", err)
-			}
-			if err := os.RemoveAll(credDir); err != nil {
-				log.ErrorContext(processCtx, "Failed to remove service credential directory", "error", err)
+			// Delete vnet socket after the service terminates.
+			if err := os.RemoveAll(socketDir); err != nil {
+				log.ErrorContext(processCtx, "Failed to remove service socket directory", "error", err)
 			}
 		}()
 		return trace.Wrap(execAdminProcess(processCtx, LinuxAdminProcessConfig{
-			ServiceCredentialPath:        credDir,
-			ClientApplicationServiceAddr: listener.Addr().String(),
+			ClientApplicationServiceSocketPath: socketPath,
 		}))
 	})
 	p.processManager.AddCriticalBackgroundTask("gRPC service", func() error {
 		log.InfoContext(processCtx, "Starting gRPC service",
-			"addr", listener.Addr().String())
+			"socket", socketPath)
 		return trace.Wrap(grpcServer.Serve(listener),
 			"serving VNet user process gRPC service")
 	})
@@ -102,4 +97,59 @@ func (p *UserProcess) runPlatformUserProcess(processCtx context.Context) error {
 	case <-processCtx.Done():
 		return trace.Wrap(p.processManager.Wait(), "process manager exited before network stack info was received")
 	}
+}
+
+func listenUnixSocket(dir string) (net.Listener, string, error) {
+	socketPath := filepath.Join(dir, clientApplicationServiceSocketName)
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return nil, "", trace.Wrap(err, "removing stale unix socket %s", socketPath)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, "", trace.Wrap(err, "creating unix socket listener")
+	}
+	if err := os.Chmod(socketPath, 0600); err != nil {
+		_ = listener.Close()
+		return nil, "", trace.Wrap(err, "chmod unix socket %s", socketPath)
+	}
+	return listener, socketPath, nil
+}
+
+func rootOnlyUnixSocketUnaryInterceptor(
+	ctx context.Context,
+	req any,
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (any, error) {
+	if err := requireRootUnixSocketPeer(ctx); err != nil {
+		return nil, trace.Wrap(err, "validating unix socket peer for unary call %s", info.FullMethod)
+	}
+	return handler(ctx, req)
+}
+
+func rootOnlyUnixSocketStreamInterceptor(
+	srv any,
+	ss grpc.ServerStream,
+	info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+) error {
+	if err := requireRootUnixSocketPeer(ss.Context()); err != nil {
+		return trace.Wrap(err, "validating unix socket peer for stream call %s", info.FullMethod)
+	}
+	return handler(srv, ss)
+}
+
+func requireRootUnixSocketPeer(ctx context.Context) error {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "gRPC peer not found in context")
+	}
+	authInfo, ok := p.AuthInfo.(uds.AuthInfo)
+	if !ok || authInfo.Creds == nil {
+		return status.Error(codes.Unauthenticated, "missing unix socket peer credentials")
+	}
+	if authInfo.Creds.UID != 0 {
+		return status.Errorf(codes.PermissionDenied, "unix socket peer uid %d is not root", authInfo.Creds.UID)
+	}
+	return nil
 }

--- a/tool/tsh/common/vnet_linux.go
+++ b/tool/tsh/common/vnet_linux.go
@@ -42,8 +42,7 @@ func newPlatformVnetAdminSetupCommand(app *kingpin.Application) *vnetAdminSetupC
 	cmd := &vnetAdminSetupCommand{
 		CmdClause: app.Command(teleport.VnetAdminSetupSubCommand, "Start the VNet admin subprocess.").Hidden(),
 	}
-	cmd.Flag("addr", "Client application service address.").Required().StringVar(&cmd.cfg.ClientApplicationServiceAddr)
-	cmd.Flag("cred-path", "Path to TLS credentials for connecting to client application.").Required().StringVar(&cmd.cfg.ServiceCredentialPath)
+	cmd.Flag("socket", "Client application service unix socket path.").Required().StringVar(&cmd.cfg.ClientApplicationServiceSocketPath)
 	return cmd
 }
 


### PR DESCRIPTION
VNet admin and user processes currently communicate over gRPC on a TCP socket, mainly due to Windows. The user process runs a gRPC server, and the admin process connects to it as a client.

For Linux, this changes the transport from a TCP socket with mTLS to a Unix socket.

This change uses the existing teleport/lib/uds gRPC transport helper to validate peer credentials on the server side, and enforces that only root can call the service.

## Manual Test Plan
### Test Environment

To make it work, you need to install the required polkit and D-Bus configuration [files](https://github.com/gravitational/teleport/blob/tangyatsu/vnet-linux-unix-socket-ipc/examples/systemd/vnet/README.md#manual-install-example).


I tested this on a cluster with:
- PostgreSQL as a TCP app
- dummy NGINX server as an HTTP app

I also set `google.com` as a custom DNS zone for VNet and checked access to `workspace.google.com` with VNet turned on.

It is actually convenient to inspect DNS behavior with `resolvectl`.

`resolvectl status` shows all active links.  
`resolvectl domain` shows domains attached to each link, for example:

`Link 37 (TeleportVNet): ~internal.example.com ~google.com ~teleport.tangyatsu.com ~teleport.dev`

You can query and verify which link handled DNS:

```bash
resolvectl query workspace.google.com --legend=yes
```

Example output:

```bash
workspace.google.com: 165.xxx.xxx.xxx  -- link: TeleportVNet
```

### Test Cases

- [x] can start VNet with `tsh vnet`
- [x] can connect to TCP app over VNet
- [x] HTTP app access continues to work with VNet on and off
- [x] public URIs under a custom DNS zone are still reachable (with VNet on and off)
- [x] can view daemon logs with `journalctl -u teleport-vnet.service`
