### PR TITLE
[v17] Fix flaky test `TestChaosUpload`

### DIFF
--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -445,11 +445,20 @@ func (u *Uploader) startUpload(ctx context.Context, fileName string) (err error)
 		file:         sessionFile,
 		fileUnlockFn: unlock,
 	}
+
+	defer func() {
+		// If we get an error, that signals that the upload goroutine (encrypted or nonencrypted)
+		// failed to start, so we must manually close the upload as the defers in the goroutine will
+		// never be called.
+		if err != nil {
+			if err := upload.Close(); err != nil {
+				log.WarnContext(ctx, "Failed to close upload.", "error", err)
+			}
+		}
+	}()
+
 	upload.checkpointFile, err = os.OpenFile(u.checkpointFilePath(sessionID), os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
-		if err := upload.Close(); err != nil {
-			log.WarnContext(ctx, "Failed to close upload.", "error", err)
-		}
 		return trace.ConvertSystemError(err)
 	}
 
@@ -557,6 +566,7 @@ func (u *Uploader) upload(ctx context.Context, up *upload) error {
 	for {
 		event, err := up.reader.Read(ctx)
 		if err != nil {
+			// Note that empty upload files are not treated as a session error.
 			if errors.Is(err, io.EOF) {
 				break
 			}

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -1,6 +1,3 @@
-//go:build !race
-// +build !race
-
 /*
  * Teleport
  * Copyright (C) 2023  Gravitational, Inc.
@@ -42,17 +39,8 @@ import (
 
 // TestChaosUpload introduces failures in all stages of the async
 // upload process and verifies that the system is working correctly.
-//
-// Data race detector slows down the test significantly (10x+),
-// that is why the test is skipped when tests are running with
-// `go test -race` flag or `go test -short` flag
 func TestChaosUpload(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping chaos test in short mode.")
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	eventsC := make(chan events.UploadEvent, 100)
 	memUploader := eventstest.NewMemoryUploader(eventsC)
@@ -114,7 +102,7 @@ func TestChaosUpload(t *testing.T) {
 	uploader, err := NewUploader(UploaderConfig{
 		ScanDir:      scanDir,
 		CorruptedDir: corruptedDir,
-		ScanPeriod:   3 * time.Second,
+		ScanPeriod:   100 * time.Millisecond,
 		Streamer:     faultyStreamer,
 		Clock:        clockwork.NewRealClock(),
 	})


### PR DESCRIPTION
Changelog: Fix error handling around empty uploads to ensure upload resources are consistently cleaned up.

Backport https://github.com/gravitational/teleport/pull/62189 to branch/v17