### PR TITLE
[v18] Fix external audit storage CTA spacing in list session recordings

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/list/ListSessionRecordingsRoute.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/ListSessionRecordingsRoute.tsx
@@ -129,7 +129,7 @@ export function ListSessionRecordings({
         </Flex>
       </FeatureHeader>
 
-      <ExternalAuditStorageCta />
+      <ExternalAuditStorageCta mx="40px" mb={3} />
 
       <Flex flex={1} minHeight={0} overflow="hidden" width="100%">
         <ErrorSuspenseWrapper

--- a/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.tsx
+++ b/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.tsx
@@ -20,7 +20,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-import Box from 'design/Box';
+import Box, { type BoxProps } from 'design/Box';
 import { ButtonPrimary, ButtonSecondary } from 'design/Button';
 import Flex from 'design/Flex';
 import * as Icons from 'design/Icon';
@@ -35,7 +35,7 @@ import useTeleport from 'teleport/useTeleport';
 
 import { ButtonLockedFeature } from '../ButtonLockedFeature';
 
-export const ExternalAuditStorageCta = () => {
+export const ExternalAuditStorageCta = (props: BoxProps) => {
   const [showCta, setShowCta] = useState<boolean>(false);
   const ctx = useTeleport();
   const featureEnabled = cfg.externalAuditStorage;
@@ -60,6 +60,7 @@ export const ExternalAuditStorageCta = () => {
 
   return (
     <CtaContainer
+      {...props}
       css={`
         grid-column: span 2;
         @media screen and (max-width: ${props =>


### PR DESCRIPTION
Backport #64359 to branch/v18

## Manual Test Plan
### Test Environment
Deployed to https://ryantest.cloud.gravitational.io/

### Test Cases
- [x] Verified that when the CTA is shown it has the correct margin