### PR TITLE
Update summarizer proto for a command failing to analyze

### DIFF
--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
@@ -349,6 +349,9 @@ const (
 	NeedsReviewReason_NEEDS_REVIEW_REASON_UNSPECIFIED NeedsReviewReason = 0
 	// NeedsReviewReasonTooLarge indicates that the session is too large to be fully analyzed.
 	NeedsReviewReason_NEEDS_REVIEW_REASON_TOO_LARGE NeedsReviewReason = 1
+	// NeedsReviewReasonCommandAnalysisFailed indicates that one or more commands failed to be analyzed by the
+	// inference provider.
+	NeedsReviewReason_NEEDS_REVIEW_REASON_COMMAND_ANALYSIS_FAILED NeedsReviewReason = 2
 )
 
 // Enum value maps for NeedsReviewReason.
@@ -356,10 +359,12 @@ var (
 	NeedsReviewReason_name = map[int32]string{
 		0: "NEEDS_REVIEW_REASON_UNSPECIFIED",
 		1: "NEEDS_REVIEW_REASON_TOO_LARGE",
+		2: "NEEDS_REVIEW_REASON_COMMAND_ANALYSIS_FAILED",
 	}
 	NeedsReviewReason_value = map[string]int32{
-		"NEEDS_REVIEW_REASON_UNSPECIFIED": 0,
-		"NEEDS_REVIEW_REASON_TOO_LARGE":   1,
+		"NEEDS_REVIEW_REASON_UNSPECIFIED":             0,
+		"NEEDS_REVIEW_REASON_TOO_LARGE":               1,
+		"NEEDS_REVIEW_REASON_COMMAND_ANALYSIS_FAILED": 2,
 	}
 )
 
@@ -1192,9 +1197,11 @@ type CommandAnalysis struct {
 	// StartOffset is the start time of the command, relative to the start of the session.
 	StartOffset *durationpb.Duration `protobuf:"bytes,21,opt,name=start_offset,json=startOffset,proto3" json:"start_offset,omitempty"`
 	// EndOffset is the end time of the command, relative to the start of the session.
-	EndOffset     *durationpb.Duration `protobuf:"bytes,22,opt,name=end_offset,json=endOffset,proto3" json:"end_offset,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	EndOffset *durationpb.Duration `protobuf:"bytes,22,opt,name=end_offset,json=endOffset,proto3" json:"end_offset,omitempty"`
+	// InferenceErrorMessage is an error message if the inference provider failed to analyze this command.
+	InferenceErrorMessage string `protobuf:"bytes,23,opt,name=inference_error_message,json=inferenceErrorMessage,proto3" json:"inference_error_message,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *CommandAnalysis) Reset() {
@@ -1379,6 +1386,13 @@ func (x *CommandAnalysis) GetEndOffset() *durationpb.Duration {
 		return x.EndOffset
 	}
 	return nil
+}
+
+func (x *CommandAnalysis) GetInferenceErrorMessage() string {
+	if x != nil {
+		return x.InferenceErrorMessage
+	}
+	return ""
 }
 
 // SecurityRecommendation represents a security recommendation related to a command
@@ -1611,7 +1625,7 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"model_name\x18\x06 \x01(\tR\tmodelName\x12C\n" +
 	"\x11session_end_event\x18\a \x01(\v2\x17.google.protobuf.StructR\x0fsessionEndEvent\x12#\n" +
 	"\rerror_message\x18\b \x01(\tR\ferrorMessage\x12R\n" +
-	"\x10enhanced_summary\x18\t \x01(\v2'.teleport.summarizer.v1.EnhancedSummaryR\x0fenhancedSummary\"\x82\b\n" +
+	"\x10enhanced_summary\x18\t \x01(\v2'.teleport.summarizer.v1.EnhancedSummaryR\x0fenhancedSummary\"\xba\b\n" +
 	"\x0fCommandAnalysis\x12\x18\n" +
 	"\acommand\x18\x01 \x01(\tR\acommand\x12C\n" +
 	"\bcategory\x18\x02 \x01(\x0e2'.teleport.summarizer.v1.CommandCategoryR\bcategory\x12\x18\n" +
@@ -1638,7 +1652,8 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\vpersistence\x18\x14 \x01(\bR\vpersistence\x12<\n" +
 	"\fstart_offset\x18\x15 \x01(\v2\x19.google.protobuf.DurationR\vstartOffset\x128\n" +
 	"\n" +
-	"end_offset\x18\x16 \x01(\v2\x19.google.protobuf.DurationR\tendOffset\"\x8f\x01\n" +
+	"end_offset\x18\x16 \x01(\v2\x19.google.protobuf.DurationR\tendOffset\x126\n" +
+	"\x17inference_error_message\x18\x17 \x01(\tR\x15inferenceErrorMessage\"\x8f\x01\n" +
 	"\x16SecurityRecommendation\x12\x14\n" +
 	"\x05title\x18\x01 \x01(\tR\x05title\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12=\n" +
@@ -1688,10 +1703,11 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\x1cTHREAT_CATEGORY_EXFILTRATION\x10\n" +
 	"\x12\x1a\n" +
 	"\x16THREAT_CATEGORY_IMPACT\x10\v\x12\x18\n" +
-	"\x14THREAT_CATEGORY_NONE\x10\f*[\n" +
+	"\x14THREAT_CATEGORY_NONE\x10\f*\x8c\x01\n" +
 	"\x11NeedsReviewReason\x12#\n" +
 	"\x1fNEEDS_REVIEW_REASON_UNSPECIFIED\x10\x00\x12!\n" +
-	"\x1dNEEDS_REVIEW_REASON_TOO_LARGE\x10\x01BXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
+	"\x1dNEEDS_REVIEW_REASON_TOO_LARGE\x10\x01\x12/\n" +
+	"+NEEDS_REVIEW_REASON_COMMAND_ANALYSIS_FAILED\x10\x02BXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
 
 var (
 	file_teleport_summarizer_v1_summarizer_proto_rawDescOnce sync.Once

--- a/api/proto/teleport/summarizer/v1/summarizer.proto
+++ b/api/proto/teleport/summarizer/v1/summarizer.proto
@@ -322,6 +322,8 @@ message CommandAnalysis {
   google.protobuf.Duration start_offset = 21;
   // EndOffset is the end time of the command, relative to the start of the session.
   google.protobuf.Duration end_offset = 22;
+  // InferenceErrorMessage is an error message if the inference provider failed to analyze this command.
+  string inference_error_message = 23;
 }
 
 // SecurityRecommendation represents a security recommendation related to a command
@@ -341,6 +343,9 @@ enum NeedsReviewReason {
   NEEDS_REVIEW_REASON_UNSPECIFIED = 0;
   // NeedsReviewReasonTooLarge indicates that the session is too large to be fully analyzed.
   NEEDS_REVIEW_REASON_TOO_LARGE = 1;
+  // NeedsReviewReasonCommandAnalysisFailed indicates that one or more commands failed to be analyzed by the
+  // inference provider.
+  NEEDS_REVIEW_REASON_COMMAND_ANALYSIS_FAILED = 2;
 }
 
 // EnhancedSummary represents an enhanced summary of a session recording,


### PR DESCRIPTION
Adds a field to each command analysis to hold the summarization error, and adds a needs further review reason for when a command fails to analyze