### PR TITLE
Update timeline events renderer to render command analysis errors

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.ts
@@ -148,14 +148,25 @@ export class EventsRenderer extends TimelineCanvasRenderer {
         const width = endX - startX;
 
         const styles = getEventStyles(this.theme, event);
+        const isError =
+          event.type === SessionRecordingEventType.Risk && event.isError;
 
-        this.ctx.fillStyle = styles.background;
         this.ctx.beginPath();
-
         this.ctx.roundRect(x, y, width, EVENT_HEIGHT, EVENT_RADIUS);
-        this.ctx.fill();
 
-        this.ctx.fillStyle = styles.text;
+        if (isError) {
+          this.ctx.strokeStyle =
+            this.theme.colors.sessionRecording.riskLevels.critical;
+          this.ctx.lineWidth = 2;
+          this.ctx.stroke();
+        } else {
+          this.ctx.fillStyle = styles.background;
+          this.ctx.fill();
+        }
+
+        this.ctx.fillStyle = isError
+          ? this.theme.colors.sessionRecording.riskLevels.critical
+          : styles.text;
 
         this.ctx.font = `bold 12px ${CANVAS_FONT}`;
 

--- a/web/packages/teleport/src/services/recordings/types.ts
+++ b/web/packages/teleport/src/services/recordings/types.ts
@@ -140,6 +140,7 @@ export interface SessionRecordingRiskEvent extends BaseSessionRecordingEvent {
   type: SessionRecordingEventType.Risk;
   riskLevel: RiskLevel;
   description: string;
+  isError?: boolean;
 }
 
 export interface SessionRecordingResizeEvent extends BaseSessionRecordingEvent {


### PR DESCRIPTION
Update the session timeline events renderer to handle risk events that have an error (i.e. a command failed to analyze)

<img width="933" height="382" alt="image" src="https://github.com/user-attachments/assets/c84aea71-f44b-4f70-ab64-59f905550c46" />

<img width="876" height="315" alt="image" src="https://github.com/user-attachments/assets/9b8287ad-103b-442b-ad15-d1b23c14656a" />

## Manual Test Plan
### Test Environment

Local machine as this is just a minor code change that doesn't require a full e2e test, that'll be part of the `e` PR that uses this new code path

### Test Cases
- [x] Verified that errors show up as outlined boxes that look good in light and dark theme
- [x] Verified that other events still show up as expected (e.g. inactivity)
