### PR TITLE
Downgrade e2e runner to go 1.25.8

### DIFF
--- a/e2e/runner/build.go
+++ b/e2e/runner/build.go
@@ -70,7 +70,8 @@ func runInDir(ctx context.Context, dir, name string, args ...string) error {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			return fmt.Errorf("command exited with code %d: %w", exitErr.ExitCode(), err)
 		}
 

--- a/e2e/runner/go.mod
+++ b/e2e/runner/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/e2e/runner
 
-go 1.26
+go 1.25.8
 
 require (
 	github.com/docker/go-sdk/container v0.1.0-alpha013

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -142,7 +142,8 @@ func (p *playwrightRunner) generateInviteURL(ctx context.Context) (string, error
 
 	out, err := cmd.Output()
 	if err != nil {
-		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			slog.Error("tctl users add failed", "stderr", string(exitErr.Stderr))
 		}
 		return "", fmt.Errorf("tctl users add: %w", err)
@@ -197,7 +198,8 @@ func (p *playwrightRunner) pnpm(ctx context.Context, args []string, env []string
 	cmd.Stdin = os.Stdin
 
 	if err := cmd.Run(); err != nil {
-		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			return fmt.Errorf("command exited with code %d: %w", exitErr.ExitCode(), err)
 		}
 


### PR DESCRIPTION
Downgrades the e2e runner to go 1.25.8 to match Teleport, and changes `errors.AsType` to `errors.As`

Will add to the open e2e runner v18 backport

## Manual Test Plan
### Test Environment

Local machine

### Test Cases
- [x] Verified it still builds and runs
