### PR TITLE
Format e2e tests, run lint UI on `e2e/` changes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,6 +81,7 @@ jobs:
             has_ui:
               - '.github/workflows/lint.yaml'
               - 'web/**'
+              - 'e2e/**'
               - 'gen/proto/js/**'
               - 'gen/proto/ts/**'
               - 'package.json'

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -22,7 +22,10 @@ import { fileURLToPath } from 'node:url';
 import { login } from '../helpers/login';
 import { test as setup } from '../helpers/test';
 
-const authFile = join(dirname(fileURLToPath(import.meta.url)), '../.auth/user.json');
+const authFile = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../.auth/user.json'
+);
 
 setup('authenticate', async ({ page }) => {
   await login(page);


### PR DESCRIPTION
Runs `pnpm format` which updates `e2e/tests/auth.setup.ts`, and updates the CI workflow to run when there are changes inside `e2e/` so we can't merge incorrectly formatted code

Will add manually to the v18 e2e runner backport