### PR TITLE
[v18] api/utils/retryutils: Do not log stack trace when waiting to retry

### DIFF
--- a/api/utils/retryutils/retry.go
+++ b/api/utils/retryutils/retry.go
@@ -190,7 +190,15 @@ func (r *Linear) For(ctx context.Context, retryFn func() error) error {
 		if errors.As(trace.Unwrap(err), &permanentRetryError) {
 			return trace.Wrap(err)
 		}
-		slog.DebugContext(ctx, "Waiting to retry operation again", "wait", r.Duration().String(), "error", err)
+		slog.DebugContext(ctx,
+			"Waiting to retry operation again",
+			"wait", r.Duration().String(),
+
+			// Unwrap the error so we do not log the stack trace, which can make
+			// a totally benign/expected error (e.g. failing to acquire a leader
+			// lock) appear more serious.
+			"error", trace.Unwrap(err),
+		)
 		select {
 		case <-r.After():
 			r.Inc()


### PR DESCRIPTION
Backports #62725 to branch/v18.
