### PR TITLE
[v18] feat: add scoped roles field to access list types

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
@@ -820,12 +820,12 @@ func (x *AccessListRequires) GetTraits() []*v11.Trait {
 // List.
 type AccessListGrants struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// roles are the roles that are granted to users who are members of the Access
-	// List.
+	// roles are the names of roles to be granted to users.
 	Roles []string `protobuf:"bytes,1,rep,name=roles,proto3" json:"roles,omitempty"`
-	// traits are the traits that are granted to users who are members of the
-	// Access List.
-	Traits        []*v11.Trait `protobuf:"bytes,2,rep,name=traits,proto3" json:"traits,omitempty"`
+	// traits are the traits to be granted to users.
+	Traits []*v11.Trait `protobuf:"bytes,2,rep,name=traits,proto3" json:"traits,omitempty"`
+	// scoped_roles are scoped roles to be granted to users.
+	ScopedRoles   []*ScopedRoleGrant `protobuf:"bytes,3,rep,name=scoped_roles,json=scopedRoles,proto3" json:"scoped_roles,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -874,6 +874,69 @@ func (x *AccessListGrants) GetTraits() []*v11.Trait {
 	return nil
 }
 
+func (x *AccessListGrants) GetScopedRoles() []*ScopedRoleGrant {
+	if x != nil {
+		return x.ScopedRoles
+	}
+	return nil
+}
+
+// ScopedRoleGrant describes a scoped role granted at a specific scope.
+type ScopedRoleGrant struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// role is the name of the scoped role to be granted.
+	Role string `protobuf:"bytes,1,opt,name=role,proto3" json:"role,omitempty"`
+	// scope is the scope the role will be assigned at. It must be an assignable
+	// scope of the role.
+	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScopedRoleGrant) Reset() {
+	*x = ScopedRoleGrant{}
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRoleGrant) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRoleGrant) ProtoMessage() {}
+
+func (x *ScopedRoleGrant) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedRoleGrant.ProtoReflect.Descriptor instead.
+func (*ScopedRoleGrant) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ScopedRoleGrant) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
+func (x *ScopedRoleGrant) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 // Member describes a member of an Access List.
 type Member struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -887,7 +950,7 @@ type Member struct {
 
 func (x *Member) Reset() {
 	*x = Member{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[8]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -899,7 +962,7 @@ func (x *Member) String() string {
 func (*Member) ProtoMessage() {}
 
 func (x *Member) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[8]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -912,7 +975,7 @@ func (x *Member) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Member.ProtoReflect.Descriptor instead.
 func (*Member) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{8}
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Member) GetHeader() *v1.ResourceHeader {
@@ -956,7 +1019,7 @@ type MemberSpec struct {
 
 func (x *MemberSpec) Reset() {
 	*x = MemberSpec{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[9]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -968,7 +1031,7 @@ func (x *MemberSpec) String() string {
 func (*MemberSpec) ProtoMessage() {}
 
 func (x *MemberSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[9]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -981,7 +1044,7 @@ func (x *MemberSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MemberSpec.ProtoReflect.Descriptor instead.
 func (*MemberSpec) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{9}
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *MemberSpec) GetAccessList() string {
@@ -1053,7 +1116,7 @@ type Review struct {
 
 func (x *Review) Reset() {
 	*x = Review{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[10]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1065,7 +1128,7 @@ func (x *Review) String() string {
 func (*Review) ProtoMessage() {}
 
 func (x *Review) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[10]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1078,7 +1141,7 @@ func (x *Review) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Review.ProtoReflect.Descriptor instead.
 func (*Review) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{10}
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Review) GetHeader() *v1.ResourceHeader {
@@ -1115,7 +1178,7 @@ type ReviewSpec struct {
 
 func (x *ReviewSpec) Reset() {
 	*x = ReviewSpec{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1127,7 +1190,7 @@ func (x *ReviewSpec) String() string {
 func (*ReviewSpec) ProtoMessage() {}
 
 func (x *ReviewSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[11]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1140,7 +1203,7 @@ func (x *ReviewSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReviewSpec.ProtoReflect.Descriptor instead.
 func (*ReviewSpec) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{11}
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ReviewSpec) GetAccessList() string {
@@ -1198,7 +1261,7 @@ type ReviewChanges struct {
 
 func (x *ReviewChanges) Reset() {
 	*x = ReviewChanges{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1210,7 +1273,7 @@ func (x *ReviewChanges) String() string {
 func (*ReviewChanges) ProtoMessage() {}
 
 func (x *ReviewChanges) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[12]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1223,7 +1286,7 @@ func (x *ReviewChanges) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReviewChanges.ProtoReflect.Descriptor instead.
 func (*ReviewChanges) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{12}
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ReviewChanges) GetMembershipRequirementsChanged() *AccessListRequires {
@@ -1267,7 +1330,7 @@ type CurrentUserAssignments struct {
 
 func (x *CurrentUserAssignments) Reset() {
 	*x = CurrentUserAssignments{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1279,7 +1342,7 @@ func (x *CurrentUserAssignments) String() string {
 func (*CurrentUserAssignments) ProtoMessage() {}
 
 func (x *CurrentUserAssignments) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1292,7 +1355,7 @@ func (x *CurrentUserAssignments) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CurrentUserAssignments.ProtoReflect.Descriptor instead.
 func (*CurrentUserAssignments) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{13}
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CurrentUserAssignments) GetOwnershipType() AccessListUserAssignmentType {
@@ -1322,7 +1385,7 @@ type UserAssignments struct {
 
 func (x *UserAssignments) Reset() {
 	*x = UserAssignments{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1334,7 +1397,7 @@ func (x *UserAssignments) String() string {
 func (*UserAssignments) ProtoMessage() {}
 
 func (x *UserAssignments) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1347,7 +1410,7 @@ func (x *UserAssignments) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserAssignments.ProtoReflect.Descriptor instead.
 func (*UserAssignments) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{14}
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *UserAssignments) GetOwnershipType() AccessListUserAssignmentType {
@@ -1385,7 +1448,7 @@ type AccessListStatus struct {
 
 func (x *AccessListStatus) Reset() {
 	*x = AccessListStatus{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1397,7 +1460,7 @@ func (x *AccessListStatus) String() string {
 func (*AccessListStatus) ProtoMessage() {}
 
 func (x *AccessListStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1410,7 +1473,7 @@ func (x *AccessListStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListStatus.ProtoReflect.Descriptor instead.
 func (*AccessListStatus) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{15}
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *AccessListStatus) GetMemberCount() uint32 {
@@ -1498,10 +1561,14 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x05start\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\x05start\"\\\n" +
 	"\x12AccessListRequires\x12\x14\n" +
 	"\x05roles\x18\x01 \x03(\tR\x05roles\x120\n" +
-	"\x06traits\x18\x02 \x03(\v2\x18.teleport.trait.v1.TraitR\x06traits\"Z\n" +
+	"\x06traits\x18\x02 \x03(\v2\x18.teleport.trait.v1.TraitR\x06traits\"\xa6\x01\n" +
 	"\x10AccessListGrants\x12\x14\n" +
 	"\x05roles\x18\x01 \x03(\tR\x05roles\x120\n" +
-	"\x06traits\x18\x02 \x03(\v2\x18.teleport.trait.v1.TraitR\x06traits\"|\n" +
+	"\x06traits\x18\x02 \x03(\v2\x18.teleport.trait.v1.TraitR\x06traits\x12J\n" +
+	"\fscoped_roles\x18\x03 \x03(\v2'.teleport.accesslist.v1.ScopedRoleGrantR\vscopedRoles\";\n" +
+	"\x0fScopedRoleGrant\x12\x12\n" +
+	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"|\n" +
 	"\x06Member\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x126\n" +
 	"\x04spec\x18\x02 \x01(\v2\".teleport.accesslist.v1.MemberSpecR\x04spec\"\x98\x03\n" +
@@ -1588,7 +1655,7 @@ func file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_accesslist_v1_accesslist_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_teleport_accesslist_v1_accesslist_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_teleport_accesslist_v1_accesslist_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_teleport_accesslist_v1_accesslist_proto_goTypes = []any{
 	(ReviewFrequency)(0),              // 0: teleport.accesslist.v1.ReviewFrequency
 	(ReviewDayOfMonth)(0),             // 1: teleport.accesslist.v1.ReviewDayOfMonth
@@ -1603,23 +1670,24 @@ var file_teleport_accesslist_v1_accesslist_proto_goTypes = []any{
 	(*Notifications)(nil),             // 10: teleport.accesslist.v1.Notifications
 	(*AccessListRequires)(nil),        // 11: teleport.accesslist.v1.AccessListRequires
 	(*AccessListGrants)(nil),          // 12: teleport.accesslist.v1.AccessListGrants
-	(*Member)(nil),                    // 13: teleport.accesslist.v1.Member
-	(*MemberSpec)(nil),                // 14: teleport.accesslist.v1.MemberSpec
-	(*Review)(nil),                    // 15: teleport.accesslist.v1.Review
-	(*ReviewSpec)(nil),                // 16: teleport.accesslist.v1.ReviewSpec
-	(*ReviewChanges)(nil),             // 17: teleport.accesslist.v1.ReviewChanges
-	(*CurrentUserAssignments)(nil),    // 18: teleport.accesslist.v1.CurrentUserAssignments
-	(*UserAssignments)(nil),           // 19: teleport.accesslist.v1.UserAssignments
-	(*AccessListStatus)(nil),          // 20: teleport.accesslist.v1.AccessListStatus
-	(*v1.ResourceHeader)(nil),         // 21: teleport.header.v1.ResourceHeader
-	(*timestamppb.Timestamp)(nil),     // 22: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),       // 23: google.protobuf.Duration
-	(*v11.Trait)(nil),                 // 24: teleport.trait.v1.Trait
+	(*ScopedRoleGrant)(nil),           // 13: teleport.accesslist.v1.ScopedRoleGrant
+	(*Member)(nil),                    // 14: teleport.accesslist.v1.Member
+	(*MemberSpec)(nil),                // 15: teleport.accesslist.v1.MemberSpec
+	(*Review)(nil),                    // 16: teleport.accesslist.v1.Review
+	(*ReviewSpec)(nil),                // 17: teleport.accesslist.v1.ReviewSpec
+	(*ReviewChanges)(nil),             // 18: teleport.accesslist.v1.ReviewChanges
+	(*CurrentUserAssignments)(nil),    // 19: teleport.accesslist.v1.CurrentUserAssignments
+	(*UserAssignments)(nil),           // 20: teleport.accesslist.v1.UserAssignments
+	(*AccessListStatus)(nil),          // 21: teleport.accesslist.v1.AccessListStatus
+	(*v1.ResourceHeader)(nil),         // 22: teleport.header.v1.ResourceHeader
+	(*timestamppb.Timestamp)(nil),     // 23: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),       // 24: google.protobuf.Duration
+	(*v11.Trait)(nil),                 // 25: teleport.trait.v1.Trait
 }
 var file_teleport_accesslist_v1_accesslist_proto_depIdxs = []int32{
-	21, // 0: teleport.accesslist.v1.AccessList.header:type_name -> teleport.header.v1.ResourceHeader
+	22, // 0: teleport.accesslist.v1.AccessList.header:type_name -> teleport.header.v1.ResourceHeader
 	6,  // 1: teleport.accesslist.v1.AccessList.spec:type_name -> teleport.accesslist.v1.AccessListSpec
-	20, // 2: teleport.accesslist.v1.AccessList.status:type_name -> teleport.accesslist.v1.AccessListStatus
+	21, // 2: teleport.accesslist.v1.AccessList.status:type_name -> teleport.accesslist.v1.AccessListStatus
 	7,  // 3: teleport.accesslist.v1.AccessListSpec.owners:type_name -> teleport.accesslist.v1.AccessListOwner
 	8,  // 4: teleport.accesslist.v1.AccessListSpec.audit:type_name -> teleport.accesslist.v1.AccessListAudit
 	11, // 5: teleport.accesslist.v1.AccessListSpec.membership_requires:type_name -> teleport.accesslist.v1.AccessListRequires
@@ -1628,38 +1696,39 @@ var file_teleport_accesslist_v1_accesslist_proto_depIdxs = []int32{
 	12, // 8: teleport.accesslist.v1.AccessListSpec.owner_grants:type_name -> teleport.accesslist.v1.AccessListGrants
 	3,  // 9: teleport.accesslist.v1.AccessListOwner.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
 	2,  // 10: teleport.accesslist.v1.AccessListOwner.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
-	22, // 11: teleport.accesslist.v1.AccessListAudit.next_audit_date:type_name -> google.protobuf.Timestamp
+	23, // 11: teleport.accesslist.v1.AccessListAudit.next_audit_date:type_name -> google.protobuf.Timestamp
 	9,  // 12: teleport.accesslist.v1.AccessListAudit.recurrence:type_name -> teleport.accesslist.v1.Recurrence
 	10, // 13: teleport.accesslist.v1.AccessListAudit.notifications:type_name -> teleport.accesslist.v1.Notifications
 	0,  // 14: teleport.accesslist.v1.Recurrence.frequency:type_name -> teleport.accesslist.v1.ReviewFrequency
 	1,  // 15: teleport.accesslist.v1.Recurrence.day_of_month:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
-	23, // 16: teleport.accesslist.v1.Notifications.start:type_name -> google.protobuf.Duration
-	24, // 17: teleport.accesslist.v1.AccessListRequires.traits:type_name -> teleport.trait.v1.Trait
-	24, // 18: teleport.accesslist.v1.AccessListGrants.traits:type_name -> teleport.trait.v1.Trait
-	21, // 19: teleport.accesslist.v1.Member.header:type_name -> teleport.header.v1.ResourceHeader
-	14, // 20: teleport.accesslist.v1.Member.spec:type_name -> teleport.accesslist.v1.MemberSpec
-	22, // 21: teleport.accesslist.v1.MemberSpec.joined:type_name -> google.protobuf.Timestamp
-	22, // 22: teleport.accesslist.v1.MemberSpec.expires:type_name -> google.protobuf.Timestamp
-	3,  // 23: teleport.accesslist.v1.MemberSpec.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
-	2,  // 24: teleport.accesslist.v1.MemberSpec.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
-	21, // 25: teleport.accesslist.v1.Review.header:type_name -> teleport.header.v1.ResourceHeader
-	16, // 26: teleport.accesslist.v1.Review.spec:type_name -> teleport.accesslist.v1.ReviewSpec
-	22, // 27: teleport.accesslist.v1.ReviewSpec.review_date:type_name -> google.protobuf.Timestamp
-	17, // 28: teleport.accesslist.v1.ReviewSpec.changes:type_name -> teleport.accesslist.v1.ReviewChanges
-	11, // 29: teleport.accesslist.v1.ReviewChanges.membership_requirements_changed:type_name -> teleport.accesslist.v1.AccessListRequires
-	0,  // 30: teleport.accesslist.v1.ReviewChanges.review_frequency_changed:type_name -> teleport.accesslist.v1.ReviewFrequency
-	1,  // 31: teleport.accesslist.v1.ReviewChanges.review_day_of_month_changed:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
-	4,  // 32: teleport.accesslist.v1.CurrentUserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	4,  // 33: teleport.accesslist.v1.CurrentUserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	4,  // 34: teleport.accesslist.v1.UserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	4,  // 35: teleport.accesslist.v1.UserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	18, // 36: teleport.accesslist.v1.AccessListStatus.current_user_assignments:type_name -> teleport.accesslist.v1.CurrentUserAssignments
-	19, // 37: teleport.accesslist.v1.AccessListStatus.user_assignments:type_name -> teleport.accesslist.v1.UserAssignments
-	38, // [38:38] is the sub-list for method output_type
-	38, // [38:38] is the sub-list for method input_type
-	38, // [38:38] is the sub-list for extension type_name
-	38, // [38:38] is the sub-list for extension extendee
-	0,  // [0:38] is the sub-list for field type_name
+	24, // 16: teleport.accesslist.v1.Notifications.start:type_name -> google.protobuf.Duration
+	25, // 17: teleport.accesslist.v1.AccessListRequires.traits:type_name -> teleport.trait.v1.Trait
+	25, // 18: teleport.accesslist.v1.AccessListGrants.traits:type_name -> teleport.trait.v1.Trait
+	13, // 19: teleport.accesslist.v1.AccessListGrants.scoped_roles:type_name -> teleport.accesslist.v1.ScopedRoleGrant
+	22, // 20: teleport.accesslist.v1.Member.header:type_name -> teleport.header.v1.ResourceHeader
+	15, // 21: teleport.accesslist.v1.Member.spec:type_name -> teleport.accesslist.v1.MemberSpec
+	23, // 22: teleport.accesslist.v1.MemberSpec.joined:type_name -> google.protobuf.Timestamp
+	23, // 23: teleport.accesslist.v1.MemberSpec.expires:type_name -> google.protobuf.Timestamp
+	3,  // 24: teleport.accesslist.v1.MemberSpec.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
+	2,  // 25: teleport.accesslist.v1.MemberSpec.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
+	22, // 26: teleport.accesslist.v1.Review.header:type_name -> teleport.header.v1.ResourceHeader
+	17, // 27: teleport.accesslist.v1.Review.spec:type_name -> teleport.accesslist.v1.ReviewSpec
+	23, // 28: teleport.accesslist.v1.ReviewSpec.review_date:type_name -> google.protobuf.Timestamp
+	18, // 29: teleport.accesslist.v1.ReviewSpec.changes:type_name -> teleport.accesslist.v1.ReviewChanges
+	11, // 30: teleport.accesslist.v1.ReviewChanges.membership_requirements_changed:type_name -> teleport.accesslist.v1.AccessListRequires
+	0,  // 31: teleport.accesslist.v1.ReviewChanges.review_frequency_changed:type_name -> teleport.accesslist.v1.ReviewFrequency
+	1,  // 32: teleport.accesslist.v1.ReviewChanges.review_day_of_month_changed:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
+	4,  // 33: teleport.accesslist.v1.CurrentUserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 34: teleport.accesslist.v1.CurrentUserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 35: teleport.accesslist.v1.UserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 36: teleport.accesslist.v1.UserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	19, // 37: teleport.accesslist.v1.AccessListStatus.current_user_assignments:type_name -> teleport.accesslist.v1.CurrentUserAssignments
+	20, // 38: teleport.accesslist.v1.AccessListStatus.user_assignments:type_name -> teleport.accesslist.v1.UserAssignments
+	39, // [39:39] is the sub-list for method output_type
+	39, // [39:39] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_teleport_accesslist_v1_accesslist_proto_init() }
@@ -1667,14 +1736,14 @@ func file_teleport_accesslist_v1_accesslist_proto_init() {
 	if File_teleport_accesslist_v1_accesslist_proto != nil {
 		return
 	}
-	file_teleport_accesslist_v1_accesslist_proto_msgTypes[15].OneofWrappers = []any{}
+	file_teleport_accesslist_v1_accesslist_proto_msgTypes[16].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_accesslist_v1_accesslist_proto_rawDesc), len(file_teleport_accesslist_v1_accesslist_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   16,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -162,13 +162,23 @@ message AccessListRequires {
 // AccessListGrants describes what access is granted by membership to the Access
 // List.
 message AccessListGrants {
-  // roles are the roles that are granted to users who are members of the Access
-  // List.
+  // roles are the names of roles to be granted to users.
   repeated string roles = 1;
 
-  // traits are the traits that are granted to users who are members of the
-  // Access List.
+  // traits are the traits to be granted to users.
   repeated teleport.trait.v1.Trait traits = 2;
+
+  // scoped_roles are scoped roles to be granted to users.
+  repeated ScopedRoleGrant scoped_roles = 3;
+}
+
+// ScopedRoleGrant describes a scoped role granted at a specific scope.
+message ScopedRoleGrant {
+  // role is the name of the scoped role to be granted.
+  string role = 1;
+  // scope is the scope the role will be assigned at. It must be an assignable
+  // scope of the role.
+  string scope = 2;
 }
 
 // Member describes a member of an Access List.

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -309,6 +309,19 @@ type Grants struct {
 
 	// Traits are the traits that are granted to users who are members of the access list.
 	Traits trait.Traits `json:"traits" yaml:"traits"`
+
+	// ScopedRoles are the scoped roels that are granted to users who are
+	// members of the access list.
+	ScopedRoles []ScopedRoleGrant `json:"scoped_roles" yaml:"scoped_roles"`
+}
+
+// ScopedRoleGrant describes a scoped role granted at a specific scope.
+type ScopedRoleGrant struct {
+	// Role is the name of the scoped role to be granted.
+	Role string `json:"role" yaml:"role"`
+	// Scope is the scope the role will be assigned at. It must be an assignable
+	// scope of the role.
+	Scope string `json:"scope" yaml:"scope"`
 }
 
 // Status contains dynamic fields calculated during retrieval.

--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -144,8 +144,27 @@ func convertGrantsFromProto(protoGrants *accesslistv1.AccessListGrants) accessli
 		return accesslist.Grants{}
 	}
 	return accesslist.Grants{
-		Roles:  protoGrants.GetRoles(),
-		Traits: traitv1.FromProto(protoGrants.GetTraits()),
+		Roles:       protoGrants.GetRoles(),
+		Traits:      traitv1.FromProto(protoGrants.GetTraits()),
+		ScopedRoles: convertScopedRoleGrantsFromProto(protoGrants.GetScopedRoles()),
+	}
+}
+
+func convertScopedRoleGrantsFromProto(scopedRoleGrants []*accesslistv1.ScopedRoleGrant) []accesslist.ScopedRoleGrant {
+	if scopedRoleGrants == nil {
+		return nil
+	}
+	out := make([]accesslist.ScopedRoleGrant, len(scopedRoleGrants))
+	for i, scopedRoleGrant := range scopedRoleGrants {
+		out[i] = convertScopedRoleGrantFromProto(scopedRoleGrant)
+	}
+	return out
+}
+
+func convertScopedRoleGrantFromProto(scopedRoleGrant *accesslistv1.ScopedRoleGrant) accesslist.ScopedRoleGrant {
+	return accesslist.ScopedRoleGrant{
+		Role:  scopedRoleGrant.GetRole(),
+		Scope: scopedRoleGrant.GetScope(),
 	}
 }
 
@@ -296,8 +315,27 @@ func convertOwnersToProto(owners []accesslist.Owner) []*accesslistv1.AccessListO
 
 func convertGrantsToProto(grants accesslist.Grants) *accesslistv1.AccessListGrants {
 	return &accesslistv1.AccessListGrants{
-		Roles:  grants.Roles,
-		Traits: traitv1.ToProto(grants.Traits),
+		Roles:       grants.Roles,
+		Traits:      traitv1.ToProto(grants.Traits),
+		ScopedRoles: convertScopedRolesToProto(grants.ScopedRoles),
+	}
+}
+
+func convertScopedRolesToProto(scopedRoleGrants []accesslist.ScopedRoleGrant) []*accesslistv1.ScopedRoleGrant {
+	if scopedRoleGrants == nil {
+		return nil
+	}
+	out := make([]*accesslistv1.ScopedRoleGrant, len(scopedRoleGrants))
+	for i, scopedRoleGrant := range scopedRoleGrants {
+		out[i] = toScopedRoleGrantProto(scopedRoleGrant)
+	}
+	return out
+}
+
+func toScopedRoleGrantProto(scopedRoleGrant accesslist.ScopedRoleGrant) *accesslistv1.ScopedRoleGrant {
+	return &accesslistv1.ScopedRoleGrant{
+		Role:  scopedRoleGrant.Role,
+		Scope: scopedRoleGrant.Scope,
 	}
 }
 

--- a/api/types/accesslist/derived.gen.go
+++ b/api/types/accesslist/derived.gen.go
@@ -316,7 +316,8 @@ func deriveTeleportEqual_5(this, that *Grants) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqual_7(this.Roles, that.Roles) &&
-			deriveTeleportEqual_8(this.Traits, that.Traits)
+			deriveTeleportEqual_8(this.Traits, that.Traits) &&
+			deriveTeleportEqual_9(this.ScopedRoles, that.ScopedRoles)
 }
 
 // deriveDeepCopy_4 recursively copies the contents of src into dst.
@@ -401,6 +402,24 @@ func deriveDeepCopy_7(dst, src *Grants) {
 		deriveDeepCopy_11(dst.Traits, src.Traits)
 	} else {
 		dst.Traits = nil
+	}
+	if src.ScopedRoles == nil {
+		dst.ScopedRoles = nil
+	} else {
+		if dst.ScopedRoles != nil {
+			if len(src.ScopedRoles) > len(dst.ScopedRoles) {
+				if cap(dst.ScopedRoles) >= len(src.ScopedRoles) {
+					dst.ScopedRoles = (dst.ScopedRoles)[:len(src.ScopedRoles)]
+				} else {
+					dst.ScopedRoles = make([]ScopedRoleGrant, len(src.ScopedRoles))
+				}
+			} else if len(src.ScopedRoles) < len(dst.ScopedRoles) {
+				dst.ScopedRoles = (dst.ScopedRoles)[:len(src.ScopedRoles)]
+			}
+		} else {
+			dst.ScopedRoles = make([]ScopedRoleGrant, len(src.ScopedRoles))
+		}
+		copy(dst.ScopedRoles, src.ScopedRoles)
 	}
 }
 
@@ -489,6 +508,22 @@ func deriveTeleportEqual_8(this, that map[string][]string) bool {
 			return false
 		}
 		if !(deriveTeleportEqual_7(v, thatv)) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_9 returns whether this and that are equal.
+func deriveTeleportEqual_9(this, that []ScopedRoleGrant) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(this[i] == that[i]) {
 			return false
 		}
 	}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -61,7 +61,15 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |roles|[]string|roles are the roles that are granted to users who are members of the Access List.|
+|scoped_roles|[][object](#specgrantsscoped_roles-items)|scoped_roles are scoped roles to be granted to users.|
 |traits|[object](#specgrantstraits)|traits are the traits that are granted to users who are members of the Access List.|
+
+### spec.grants.scoped_roles items
+
+|Field|Type|Description|
+|---|---|---|
+|role|string|role is the name of the scoped role to be granted.|
+|scope|string|scope is the scope the role will be assigned at. It must be an assignable scope of the role.|
 
 ### spec.grants.traits
 
@@ -88,8 +96,16 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|roles|[]string|roles are the roles that are granted to users who are members of the Access List.|
+ |roles|[]string|roles are the roles that are granted to users who are members of the Access List.|
+|scoped_roles|[][object](#specowner_grantsscoped_roles-items)|scoped_roles are scoped roles to be granted to users.|
 |traits|[object](#specowner_grantstraits)|traits are the traits that are granted to users who are members of the Access List.|
+
+### spec.owner_grants.scoped_roles items
+
+|Field|Type|Description|
+|---|---|---|
+|role|string|role is the name of the scoped role to be granted.|
+|scope|string|scope is the scope the role will be assigned at. It must be an assignable scope of the role.|
 
 ### spec.owner_grants.traits
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -60,9 +60,9 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|roles|[]string|roles are the roles that are granted to users who are members of the Access List.|
+|roles|[]string|roles are the names of roles to be granted to users.|
 |scoped_roles|[][object](#specgrantsscoped_roles-items)|scoped_roles are scoped roles to be granted to users.|
-|traits|[object](#specgrantstraits)|traits are the traits that are granted to users who are members of the Access List.|
+|traits|[object](#specgrantstraits)|traits are the traits to be granted to users.|
 
 ### spec.grants.scoped_roles items
 
@@ -96,9 +96,9 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
- |roles|[]string|roles are the roles that are granted to users who are members of the Access List.|
+|roles|[]string|roles are the names of roles to be granted to users.|
 |scoped_roles|[][object](#specowner_grantsscoped_roles-items)|scoped_roles are scoped roles to be granted to users.|
-|traits|[object](#specowner_grantstraits)|traits are the traits that are granted to users who are members of the Access List.|
+|traits|[object](#specowner_grantstraits)|traits are the traits to be granted to users.|
 
 ### spec.owner_grants.scoped_roles items
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
@@ -104,8 +104,17 @@ Optional:
 
 Optional:
 
-- `roles` (List of String) roles are the roles that are granted to users who are members of the Access List.
-- `traits` (Attributes List) traits are the traits that are granted to users who are members of the Access List. (see [below for nested schema](#nested-schema-for-specgrantstraits))
+- `roles` (List of String) roles are the names of roles to be granted to users.
+- `scoped_roles` (Attributes List) scoped_roles are scoped roles to be granted to users. (see [below for nested schema](#nested-schema-for-specgrantsscoped_roles))
+- `traits` (Attributes List) traits are the traits to be granted to users. (see [below for nested schema](#nested-schema-for-specgrantstraits))
+
+### Nested Schema for `spec.grants.scoped_roles`
+
+Optional:
+
+- `role` (String) role is the name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+
 
 ### Nested Schema for `spec.grants.traits`
 
@@ -136,8 +145,17 @@ Optional:
 
 Optional:
 
-- `roles` (List of String) roles are the roles that are granted to users who are members of the Access List.
-- `traits` (Attributes List) traits are the traits that are granted to users who are members of the Access List. (see [below for nested schema](#nested-schema-for-specowner_grantstraits))
+- `roles` (List of String) roles are the names of roles to be granted to users.
+- `scoped_roles` (Attributes List) scoped_roles are scoped roles to be granted to users. (see [below for nested schema](#nested-schema-for-specowner_grantsscoped_roles))
+- `traits` (Attributes List) traits are the traits to be granted to users. (see [below for nested schema](#nested-schema-for-specowner_grantstraits))
+
+### Nested Schema for `spec.owner_grants.scoped_roles`
+
+Optional:
+
+- `role` (String) role is the name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+
 
 ### Nested Schema for `spec.owner_grants.traits`
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
@@ -147,8 +147,17 @@ Optional:
 
 Optional:
 
-- `roles` (List of String) roles are the roles that are granted to users who are members of the Access List.
-- `traits` (Attributes List) traits are the traits that are granted to users who are members of the Access List. (see [below for nested schema](#nested-schema-for-specgrantstraits))
+- `roles` (List of String) roles are the names of roles to be granted to users.
+- `scoped_roles` (Attributes List) scoped_roles are scoped roles to be granted to users. (see [below for nested schema](#nested-schema-for-specgrantsscoped_roles))
+- `traits` (Attributes List) traits are the traits to be granted to users. (see [below for nested schema](#nested-schema-for-specgrantstraits))
+
+### Nested Schema for `spec.grants.scoped_roles`
+
+Optional:
+
+- `role` (String) role is the name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+
 
 ### Nested Schema for `spec.grants.traits`
 
@@ -179,8 +188,17 @@ Optional:
 
 Optional:
 
-- `roles` (List of String) roles are the roles that are granted to users who are members of the Access List.
-- `traits` (Attributes List) traits are the traits that are granted to users who are members of the Access List. (see [below for nested schema](#nested-schema-for-specowner_grantstraits))
+- `roles` (List of String) roles are the names of roles to be granted to users.
+- `scoped_roles` (Attributes List) scoped_roles are scoped roles to be granted to users. (see [below for nested schema](#nested-schema-for-specowner_grantsscoped_roles))
+- `traits` (Attributes List) traits are the traits to be granted to users. (see [below for nested schema](#nested-schema-for-specowner_grantstraits))
+
+### Nested Schema for `spec.owner_grants.scoped_roles`
+
+Optional:
+
+- `role` (String) role is the name of the scoped role to be granted.
+- `scope` (String) scope is the scope the role will be assigned at. It must be an assignable scope of the role.
+
 
 ### Nested Schema for `spec.owner_grants.traits`
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
@@ -81,10 +81,23 @@ spec:
                 nullable: true
                 properties:
                   roles:
-                    description: roles are the roles that are granted to users who
-                      are members of the Access List.
+                    description: roles are the names of roles to be granted to users.
                     items:
                       type: string
+                    nullable: true
+                    type: array
+                  scoped_roles:
+                    description: scoped_roles are scoped roles to be granted to users.
+                    items:
+                      properties:
+                        role:
+                          description: role is the name of the scoped role to be granted.
+                          type: string
+                        scope:
+                          description: scope is the scope the role will be assigned
+                            at. It must be an assignable scope of the role.
+                          type: string
+                      type: object
                     nullable: true
                     type: array
                   traits:
@@ -92,8 +105,7 @@ spec:
                       items:
                         type: string
                       type: array
-                    description: traits are the traits that are granted to users who
-                      are members of the Access List.
+                    description: traits are the traits to be granted to users.
                     type: object
                 type: object
               membership_requires:
@@ -125,10 +137,23 @@ spec:
                 nullable: true
                 properties:
                   roles:
-                    description: roles are the roles that are granted to users who
-                      are members of the Access List.
+                    description: roles are the names of roles to be granted to users.
                     items:
                       type: string
+                    nullable: true
+                    type: array
+                  scoped_roles:
+                    description: scoped_roles are scoped roles to be granted to users.
+                    items:
+                      properties:
+                        role:
+                          description: role is the name of the scoped role to be granted.
+                          type: string
+                        scope:
+                          description: scope is the scope the role will be assigned
+                            at. It must be an assignable scope of the role.
+                          type: string
+                      type: object
                     nullable: true
                     type: array
                   traits:
@@ -136,8 +161,7 @@ spec:
                       items:
                         type: string
                       type: array
-                    description: traits are the traits that are granted to users who
-                      are members of the Access List.
+                    description: traits are the traits to be granted to users.
                     type: object
                 type: object
               owners:

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -252,19 +252,43 @@ export interface AccessListRequires {
  */
 export interface AccessListGrants {
     /**
-     * roles are the roles that are granted to users who are members of the Access
-     * List.
+     * roles are the names of roles to be granted to users.
      *
      * @generated from protobuf field: repeated string roles = 1;
      */
     roles: string[];
     /**
-     * traits are the traits that are granted to users who are members of the
-     * Access List.
+     * traits are the traits to be granted to users.
      *
      * @generated from protobuf field: repeated teleport.trait.v1.Trait traits = 2;
      */
     traits: Trait[];
+    /**
+     * scoped_roles are scoped roles to be granted to users.
+     *
+     * @generated from protobuf field: repeated teleport.accesslist.v1.ScopedRoleGrant scoped_roles = 3;
+     */
+    scopedRoles: ScopedRoleGrant[];
+}
+/**
+ * ScopedRoleGrant describes a scoped role granted at a specific scope.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.ScopedRoleGrant
+ */
+export interface ScopedRoleGrant {
+    /**
+     * role is the name of the scoped role to be granted.
+     *
+     * @generated from protobuf field: string role = 1;
+     */
+    role: string;
+    /**
+     * scope is the scope the role will be assigned at. It must be an assignable
+     * scope of the role.
+     *
+     * @generated from protobuf field: string scope = 2;
+     */
+    scope: string;
 }
 /**
  * Member describes a member of an Access List.
@@ -1115,13 +1139,15 @@ class AccessListGrants$Type extends MessageType<AccessListGrants> {
     constructor() {
         super("teleport.accesslist.v1.AccessListGrants", [
             { no: 1, name: "roles", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "traits", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Trait }
+            { no: 2, name: "traits", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Trait },
+            { no: 3, name: "scoped_roles", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => ScopedRoleGrant }
         ]);
     }
     create(value?: PartialMessage<AccessListGrants>): AccessListGrants {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.roles = [];
         message.traits = [];
+        message.scopedRoles = [];
         if (value !== undefined)
             reflectionMergePartial<AccessListGrants>(this, message, value);
         return message;
@@ -1136,6 +1162,9 @@ class AccessListGrants$Type extends MessageType<AccessListGrants> {
                     break;
                 case /* repeated teleport.trait.v1.Trait traits */ 2:
                     message.traits.push(Trait.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* repeated teleport.accesslist.v1.ScopedRoleGrant scoped_roles */ 3:
+                    message.scopedRoles.push(ScopedRoleGrant.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1155,6 +1184,9 @@ class AccessListGrants$Type extends MessageType<AccessListGrants> {
         /* repeated teleport.trait.v1.Trait traits = 2; */
         for (let i = 0; i < message.traits.length; i++)
             Trait.internalBinaryWrite(message.traits[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* repeated teleport.accesslist.v1.ScopedRoleGrant scoped_roles = 3; */
+        for (let i = 0; i < message.scopedRoles.length; i++)
+            ScopedRoleGrant.internalBinaryWrite(message.scopedRoles[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1165,6 +1197,61 @@ class AccessListGrants$Type extends MessageType<AccessListGrants> {
  * @generated MessageType for protobuf message teleport.accesslist.v1.AccessListGrants
  */
 export const AccessListGrants = new AccessListGrants$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ScopedRoleGrant$Type extends MessageType<ScopedRoleGrant> {
+    constructor() {
+        super("teleport.accesslist.v1.ScopedRoleGrant", [
+            { no: 1, name: "role", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "scope", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ScopedRoleGrant>): ScopedRoleGrant {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.role = "";
+        message.scope = "";
+        if (value !== undefined)
+            reflectionMergePartial<ScopedRoleGrant>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ScopedRoleGrant): ScopedRoleGrant {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string role */ 1:
+                    message.role = reader.string();
+                    break;
+                case /* string scope */ 2:
+                    message.scope = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ScopedRoleGrant, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string role = 1; */
+        if (message.role !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.role);
+        /* string scope = 2; */
+        if (message.scope !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.scope);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.ScopedRoleGrant
+ */
+export const ScopedRoleGrant = new ScopedRoleGrant$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class Member$Type extends MessageType<Member> {
     constructor() {

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
@@ -81,10 +81,23 @@ spec:
                 nullable: true
                 properties:
                   roles:
-                    description: roles are the roles that are granted to users who
-                      are members of the Access List.
+                    description: roles are the names of roles to be granted to users.
                     items:
                       type: string
+                    nullable: true
+                    type: array
+                  scoped_roles:
+                    description: scoped_roles are scoped roles to be granted to users.
+                    items:
+                      properties:
+                        role:
+                          description: role is the name of the scoped role to be granted.
+                          type: string
+                        scope:
+                          description: scope is the scope the role will be assigned
+                            at. It must be an assignable scope of the role.
+                          type: string
+                      type: object
                     nullable: true
                     type: array
                   traits:
@@ -92,8 +105,7 @@ spec:
                       items:
                         type: string
                       type: array
-                    description: traits are the traits that are granted to users who
-                      are members of the Access List.
+                    description: traits are the traits to be granted to users.
                     type: object
                 type: object
               membership_requires:
@@ -125,10 +137,23 @@ spec:
                 nullable: true
                 properties:
                   roles:
-                    description: roles are the roles that are granted to users who
-                      are members of the Access List.
+                    description: roles are the names of roles to be granted to users.
                     items:
                       type: string
+                    nullable: true
+                    type: array
+                  scoped_roles:
+                    description: scoped_roles are scoped roles to be granted to users.
+                    items:
+                      properties:
+                        role:
+                          description: role is the name of the scoped role to be granted.
+                          type: string
+                        scope:
+                          description: scope is the scope the role will be assigned
+                            at. It must be an assignable scope of the role.
+                          type: string
+                      type: object
                     nullable: true
                     type: array
                   traits:
@@ -136,8 +161,7 @@ spec:
                       items:
                         type: string
                       type: array
-                    description: traits are the traits that are granted to users who
-                      are members of the Access List.
+                    description: traits are the traits to be granted to users.
                     type: object
                 type: object
               owners:

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -166,9 +166,25 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 				"grants": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						"roles": {
-							Description: "roles are the roles that are granted to users who are members of the Access List.",
+							Description: "roles are the names of roles to be granted to users.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+						},
+						"scoped_roles": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"role": {
+									Description: "role is the name of the scoped role to be granted.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"scope": {
+									Description: "scope is the scope the role will be assigned at. It must be an assignable scope of the role.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+							}),
+							Description: "scoped_roles are scoped roles to be granted to users.",
+							Optional:    true,
 						},
 						"traits": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
@@ -183,7 +199,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 								},
 							}),
-							Description: "traits are the traits that are granted to users who are members of the Access List.",
+							Description: "traits are the traits to be granted to users.",
 							Optional:    true,
 						},
 					}),
@@ -220,9 +236,25 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 				"owner_grants": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						"roles": {
-							Description: "roles are the roles that are granted to users who are members of the Access List.",
+							Description: "roles are the names of roles to be granted to users.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+						},
+						"scoped_roles": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"role": {
+									Description: "role is the name of the scoped role to be granted.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"scope": {
+									Description: "scope is the scope the role will be assigned at. It must be an assignable scope of the role.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+							}),
+							Description: "scoped_roles are scoped roles to be granted to users.",
+							Optional:    true,
 						},
 						"traits": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
@@ -237,7 +269,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 								},
 							}),
-							Description: "traits are the traits that are granted to users who are members of the Access List.",
+							Description: "traits are the traits to be granted to users.",
 							Optional:    true,
 						},
 					}),
@@ -1190,6 +1222,69 @@ func CopyAccessListFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 											}
 										}
 									}
+									{
+										a, ok := tf.Attrs["scoped_roles"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AccessList.spec.grants.scoped_roles"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AccessList.spec.grants.scoped_roles", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.ScopedRoles = make([]*github_com_gravitational_teleport_api_gen_proto_go_teleport_accesslist_v1.ScopedRoleGrant, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"AccessList.spec.grants.scoped_roles", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+														} else {
+															var t *github_com_gravitational_teleport_api_gen_proto_go_teleport_accesslist_v1.ScopedRoleGrant
+															if !v.Null && !v.Unknown {
+																tf := v
+																t = &github_com_gravitational_teleport_api_gen_proto_go_teleport_accesslist_v1.ScopedRoleGrant{}
+																obj := t
+																{
+																	a, ok := tf.Attrs["role"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"AccessList.spec.grants.scoped_roles.role"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"AccessList.spec.grants.scoped_roles.role", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Role = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["scope"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"AccessList.spec.grants.scoped_roles.scope"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"AccessList.spec.grants.scoped_roles.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Scope = t
+																		}
+																	}
+																}
+															}
+															obj.ScopedRoles[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
 								}
 							}
 						}
@@ -1319,6 +1414,69 @@ func CopyAccessListFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 																}
 															}
 															obj.Traits[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["scoped_roles"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"AccessList.spec.owner_grants.scoped_roles"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"AccessList.spec.owner_grants.scoped_roles", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.ScopedRoles = make([]*github_com_gravitational_teleport_api_gen_proto_go_teleport_accesslist_v1.ScopedRoleGrant, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"AccessList.spec.owner_grants.scoped_roles", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+														} else {
+															var t *github_com_gravitational_teleport_api_gen_proto_go_teleport_accesslist_v1.ScopedRoleGrant
+															if !v.Null && !v.Unknown {
+																tf := v
+																t = &github_com_gravitational_teleport_api_gen_proto_go_teleport_accesslist_v1.ScopedRoleGrant{}
+																obj := t
+																{
+																	a, ok := tf.Attrs["role"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"AccessList.spec.owner_grants.scoped_roles.role"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"AccessList.spec.owner_grants.scoped_roles.role", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Role = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["scope"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"AccessList.spec.owner_grants.scoped_roles.scope"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"AccessList.spec.owner_grants.scoped_roles.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Scope = t
+																		}
+																	}
+																}
+															}
+															obj.ScopedRoles[k] = t
 														}
 													}
 												}
@@ -2616,6 +2774,108 @@ func CopyAccessListToTerraform(ctx context.Context, obj *github_com_gravitationa
 											}
 										}
 									}
+									{
+										a, ok := tf.AttrTypes["scoped_roles"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AccessList.spec.grants.scoped_roles"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"AccessList.spec.grants.scoped_roles", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["scoped_roles"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.ScopedRoles)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.ScopedRoles))
+													}
+												}
+												if obj.ScopedRoles != nil {
+													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+													if len(obj.ScopedRoles) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.ScopedRoles))
+													}
+													for k, a := range obj.ScopedRoles {
+														v, ok := tf.Attrs["scoped_roles"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																AttrTypes: o.AttrTypes,
+																Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+															}
+														} else {
+															if v.Attrs == nil {
+																v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+															}
+														}
+														if a == nil {
+															v.Null = true
+														} else {
+															obj := a
+															tf := &v
+															{
+																t, ok := tf.AttrTypes["role"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"AccessList.spec.grants.scoped_roles.role"})
+																} else {
+																	v, ok := tf.Attrs["role"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"AccessList.spec.grants.scoped_roles.role", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"AccessList.spec.grants.scoped_roles.role", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Role) == ""
+																	}
+																	v.Value = string(obj.Role)
+																	v.Unknown = false
+																	tf.Attrs["role"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["scope"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"AccessList.spec.grants.scoped_roles.scope"})
+																} else {
+																	v, ok := tf.Attrs["scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"AccessList.spec.grants.scoped_roles.scope", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"AccessList.spec.grants.scoped_roles.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Scope) == ""
+																	}
+																	v.Value = string(obj.Scope)
+																	v.Unknown = false
+																	tf.Attrs["scope"] = v
+																}
+															}
+														}
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.ScopedRoles) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["scoped_roles"] = c
+											}
+										}
+									}
 								}
 								v.Unknown = false
 								tf.Attrs["grants"] = v
@@ -2853,6 +3113,108 @@ func CopyAccessListToTerraform(ctx context.Context, obj *github_com_gravitationa
 												}
 												c.Unknown = false
 												tf.Attrs["traits"] = c
+											}
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["scoped_roles"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"AccessList.spec.owner_grants.scoped_roles"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"AccessList.spec.owner_grants.scoped_roles", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["scoped_roles"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.ScopedRoles)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.ScopedRoles))
+													}
+												}
+												if obj.ScopedRoles != nil {
+													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+													if len(obj.ScopedRoles) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.ScopedRoles))
+													}
+													for k, a := range obj.ScopedRoles {
+														v, ok := tf.Attrs["scoped_roles"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																AttrTypes: o.AttrTypes,
+																Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+															}
+														} else {
+															if v.Attrs == nil {
+																v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+															}
+														}
+														if a == nil {
+															v.Null = true
+														} else {
+															obj := a
+															tf := &v
+															{
+																t, ok := tf.AttrTypes["role"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"AccessList.spec.owner_grants.scoped_roles.role"})
+																} else {
+																	v, ok := tf.Attrs["role"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"AccessList.spec.owner_grants.scoped_roles.role", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"AccessList.spec.owner_grants.scoped_roles.role", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Role) == ""
+																	}
+																	v.Value = string(obj.Role)
+																	v.Unknown = false
+																	tf.Attrs["role"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["scope"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"AccessList.spec.owner_grants.scoped_roles.scope"})
+																} else {
+																	v, ok := tf.Attrs["scope"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"AccessList.spec.owner_grants.scoped_roles.scope", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"AccessList.spec.owner_grants.scoped_roles.scope", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Scope) == ""
+																	}
+																	v.Value = string(obj.Scope)
+																	v.Unknown = false
+																	tf.Attrs["scope"] = v
+																}
+															}
+														}
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.ScopedRoles) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["scoped_roles"] = c
 											}
 										}
 									}

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -75,6 +75,16 @@ func TestAccessListUnmarshal(t *testing.T) {
 					"gtrait1": {"gvalue1", "gvalue2"},
 					"gtrait2": {"gvalue3", "gvalue4"},
 				},
+				ScopedRoles: []accesslist.ScopedRoleGrant{
+					{
+						Role:  "scoped-role-1",
+						Scope: "/foo",
+					},
+					{
+						Role:  "scoped-role-2",
+						Scope: "/bar",
+					},
+				},
 			},
 		},
 	)
@@ -127,6 +137,16 @@ func TestAccessListMarshal(t *testing.T) {
 				Traits: map[string][]string{
 					"gtrait1": {"gvalue1", "gvalue2"},
 					"gtrait2": {"gvalue3", "gvalue4"},
+				},
+				ScopedRoles: []accesslist.ScopedRoleGrant{
+					{
+						Role:  "scoped-role-1",
+						Scope: "/foo",
+					},
+					{
+						Role:  "scoped-role-2",
+						Scope: "/bar",
+					},
 				},
 			},
 		},
@@ -489,6 +509,11 @@ spec:
       gtrait2:
       - gvalue3
       - gvalue4
+    scoped_roles:
+    - role: scoped-role-1
+      scope: /foo
+    - role: scoped-role-2
+      scope: /bar
 `
 
 var accessListMemberYAML = `---

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -152,6 +152,58 @@ func TestAccessListCRUD(t *testing.T) {
 	require.ElementsMatch(t, expectedAccessList, created.Spec.Owners)
 }
 
+func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+
+	accessList := newAccessList(t, "accessList-scoped", clock)
+	accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+		{
+			Role:  "scoped-role-1",
+			Scope: "/eng",
+		},
+		{
+			Role:  "scoped-role-2",
+			Scope: "/platform",
+		},
+	}
+
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+	}
+
+	created, err := service.UpsertAccessList(ctx, accessList)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(accessList, created, cmpOpts...))
+
+	fetched, err := service.GetAccessList(ctx, accessList.GetName())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(accessList, fetched, cmpOpts...))
+
+	fetched.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+		{
+			Role:  "scoped-role-3",
+			Scope: "/ops",
+		},
+	}
+
+	updated, err := service.UpdateAccessList(ctx, fetched)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(fetched, updated, cmpOpts...))
+
+	fetched, err = service.GetAccessList(ctx, accessList.GetName())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(updated, fetched, cmpOpts...))
+}
+
 func requireAccessDenied(t require.TestingT, err error, i ...any) {
 	require.True(
 		t,


### PR DESCRIPTION
Backport #63919 to branch/v18

## Manual Test Plan

- [x] An access list including scoped_role grants can be created with `tctl create` from a yaml spec
- [x] `tctl get access_lists` and `tctl get access_list/name` return the access list including scoped role grants