### PR TITLE
Remove reference to deprecated `tsh` flag

### DIFF
--- a/docs/pages/connect-your-client/teleport-clients/tsh.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/tsh.mdx
@@ -600,10 +600,12 @@ $ ssh-add -L
 The SSH agent can be used to feed the certificate to other SSH clients, for example
 to OpenSSH (`ssh`).
 
-If you wish to disable SSH agent integration, pass `--no-use-local-ssh-agent`
-to `tsh`. You can also set the `TELEPORT_USE_LOCAL_SSH_AGENT` environment
-variable to `false` in your shell profile to make this permanent.
+If you wish to disable SSH agent integration, pass `--add-keys-to-agent=no` to
+`tsh`. You can also set the `TELEPORT_ADD_KEYS_TO_AGENT` environment variable to
+`no` in your shell profile to make this permanent.
 
+For a full reference of `tsh` flags and environment variables, see the [`tsh
+Reference`](../../reference/cli/tsh.mdx).
 
 ### SSH jump host
 


### PR DESCRIPTION
Fixes #63440

Update a reference to the deprecated `TELEPORT_USE_LOCAL_SSH_AGENT` environment variable and `--use-local-ssh-agent` flag for `tsh` to use `--add-keys-to-agent` and `TELEPORT_ADD_KEYS_TO_AGENT`.
