### PR TITLE
[v17] fix: show updated profile info after assuming an access request

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -5109,7 +5109,7 @@ func humanFriendlyValidUntilDuration(validUntil time.Time, clock clockwork.Clock
 }
 
 // printStatus prints the status of the profile.
-func printStatus(debug bool, p *profileInfo, env map[string]string, isActive bool) {
+func printStatus(w io.Writer, debug bool, p *profileInfo, env map[string]string, isActive bool) {
 	clock := clockwork.NewRealClock()
 	var prefix string
 	proxyURL := p.getProxyURLLine(isActive, env)
@@ -5121,74 +5121,74 @@ func printStatus(debug bool, p *profileInfo, env map[string]string, isActive boo
 		prefix = "  "
 	}
 
-	fmt.Printf("%vProfile URL:        %v\n", prefix, proxyURL)
-	fmt.Printf("  Logged in as:       %v\n", p.Username)
+	fmt.Fprintf(w, "%vProfile URL:        %v\n", prefix, proxyURL)
+	fmt.Fprintf(w, "  Logged in as:       %v\n", p.Username)
 	if len(p.ActiveRequests) != 0 {
-		fmt.Printf("  Active requests:    %v\n", strings.Join(p.ActiveRequests, ", "))
+		fmt.Fprintf(w, "  Active requests:    %v\n", strings.Join(p.ActiveRequests, ", "))
 	}
 
 	if cluster != "" {
-		fmt.Printf("  Cluster:            %v\n", cluster)
+		fmt.Fprintf(w, "  Cluster:            %v\n", cluster)
 	}
-	fmt.Printf("  Roles:              %v\n", rolesToString(debug, p.Roles))
+	fmt.Fprintf(w, "  Roles:              %v\n", rolesToString(debug, p.Roles))
 	if debug {
 		var count int
 		for k, v := range p.Traits {
 			if count == 0 {
-				fmt.Printf("  Traits:             %v: %v\n", k, v)
+				fmt.Fprintf(w, "  Traits:             %v: %v\n", k, v)
 			} else {
-				fmt.Printf("                      %v: %v\n", k, v)
+				fmt.Fprintf(w, "                      %v: %v\n", k, v)
 			}
 			count = count + 1
 		}
 	}
 	if len(p.Logins) > 0 {
-		fmt.Printf("  Logins:             %v\n", strings.Join(p.Logins, ", "))
+		fmt.Fprintf(w, "  Logins:             %v\n", strings.Join(p.Logins, ", "))
 	}
 	if p.KubernetesEnabled {
-		fmt.Printf("  Kubernetes:         enabled\n")
+		fmt.Fprintf(w, "  Kubernetes:         enabled\n")
 		if kubeCluster != "" {
-			fmt.Printf("  Kubernetes cluster: %q\n", kubeCluster)
+			fmt.Fprintf(w, "  Kubernetes cluster: %q\n", kubeCluster)
 		}
 		if len(p.KubernetesUsers) > 0 {
-			fmt.Printf("  Kubernetes users:   %v\n", strings.Join(p.KubernetesUsers, ", "))
+			fmt.Fprintf(w, "  Kubernetes users:   %v\n", strings.Join(p.KubernetesUsers, ", "))
 		}
 		if len(p.KubernetesGroups) > 0 {
-			fmt.Printf("  Kubernetes groups:  %v\n", strings.Join(p.KubernetesGroups, ", "))
+			fmt.Fprintf(w, "  Kubernetes groups:  %v\n", strings.Join(p.KubernetesGroups, ", "))
 		}
 	} else {
-		fmt.Printf("  Kubernetes:         disabled\n")
+		fmt.Fprintf(w, "  Kubernetes:         disabled\n")
 	}
 	if len(p.Databases) != 0 {
-		fmt.Printf("  Databases:          %v\n", strings.Join(p.Databases, ", "))
+		fmt.Fprintf(w, "  Databases:          %v\n", strings.Join(p.Databases, ", "))
 	}
 	if len(p.AllowedResourceIDs) > 0 {
 		allowedResourcesStr, err := types.ResourceIDsToString(p.AllowedResourceIDs)
 		if err != nil {
 			log.Warnf("failed to marshal allowed resource IDs to string: %v", err)
 		} else {
-			fmt.Printf("  Allowed Resources:  %s\n", allowedResourcesStr)
+			fmt.Fprintf(w, "  Allowed Resources:  %s\n", allowedResourcesStr)
 		}
 	}
 	if p.GitHubIdentity != nil {
-		fmt.Printf("  GitHub username:    %s\n", p.GitHubIdentity.Username)
+		fmt.Fprintf(w, "  GitHub username:    %s\n", p.GitHubIdentity.Username)
 	}
-	fmt.Printf("  Valid until:        %v [%v]\n", p.ValidUntil, humanFriendlyValidUntilDuration(p.ValidUntil, clock))
-	fmt.Printf("  Extensions:         %v\n", strings.Join(p.Extensions, ", "))
+	fmt.Fprintf(w, "  Valid until:        %v [%v]\n", p.ValidUntil, humanFriendlyValidUntilDuration(p.ValidUntil, clock))
+	fmt.Fprintf(w, "  Extensions:         %v\n", strings.Join(p.Extensions, ", "))
 
 	if debug {
 		first := true
 		for k, v := range p.CriticalOptions {
 			if first {
-				fmt.Printf("  Critical options:   %v: %v\n", k, v)
+				fmt.Fprintf(w, "  Critical options:   %v: %v\n", k, v)
 			} else {
-				fmt.Printf("                      %v: %v\n", k, v)
+				fmt.Fprintf(w, "                      %v: %v\n", k, v)
 			}
 			first = false
 		}
 	}
 
-	fmt.Printf("\n")
+	fmt.Fprintf(w, "\n")
 }
 
 func isOktaRole(role string) bool {
@@ -5240,12 +5240,12 @@ func printLoginInformation(cf *CLIConf, profile *client.ProfileStatus, profiles 
 
 		// Print the active profile.
 		if profile != nil {
-			printStatus(cf.Debug, active, env, true)
+			printStatus(cf.Stdout(), cf.Debug, active, env, true)
 		}
 
 		// Print all other profiles.
 		for _, p := range others {
-			printStatus(cf.Debug, p, env, false)
+			printStatus(cf.Stdout(), cf.Debug, p, env, false)
 		}
 
 		// Print relevant active env vars, if they are set.

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2211,6 +2211,13 @@ func onLogin(cf *CLIConf, reExecArgs ...string) error {
 			if err := updateKubeConfigOnLogin(cf, tc); err != nil {
 				return trace.Wrap(err)
 			}
+
+			// Reload the profile status to show updated active access requests and roles.
+			profile, profiles, err = cf.FullProfileStatus()
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
 			// Print status to show information of the logged in user.
 			return trace.Wrap(printLoginInformation(cf, profile, profiles))
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -615,6 +615,92 @@ func TestOIDCLogin(t *testing.T) {
 	// request to be generated.
 }
 
+// TestLoginRequestIDPrintsUpdatedProfile asserts that tsh login --request-id
+// prints profile information that is up to date with the newly assumed access
+// request.
+func TestLoginRequestIDPrintsUpdatedProfile(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	tmpHomePath := t.TempDir()
+
+	requester, err := types.NewRole("requester", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Roles: []string{"elevated"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	elevated, err := types.NewRole("elevated", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetRoles([]string{requester.GetName()})
+
+	connector := mockConnector(t)
+	authProcess, proxyProcess := makeTestServers(t, withBootstrap(requester, elevated, connector, alice))
+	authServer := authProcess.GetAuthServer()
+	require.NotNil(t, authServer)
+
+	proxyAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Do an initial login without the access request.
+	loginOutput := &output{}
+	err = Run(ctx, []string{
+		"login",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+		"--user", alice.GetName(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, alice, connector.GetName()), func(cf *CLIConf) error {
+		cf.OverrideStdout = loginOutput
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotContains(t, loginOutput.String(), elevated.GetName())
+
+	// Create and approve and access request.
+	requestID := uuid.NewString()
+	req, err := types.NewAccessRequest(requestID, alice.GetName(), elevated.GetName())
+	require.NoError(t, err)
+	accessExpiry := time.Now().Add(time.Hour)
+	req.SetExpiry(accessExpiry)
+	req.SetAccessExpiry(accessExpiry)
+	err = authServer.CreateAccessRequest(ctx, req)
+	require.NoError(t, err)
+	err = authServer.SetAccessRequestState(ctx, types.AccessRequestUpdate{
+		RequestID: requestID,
+		State:     types.RequestState_APPROVED,
+	})
+	require.NoError(t, err)
+
+	// Relogin with a approved access request.
+	requestLoginOutput := &output{}
+	err = Run(ctx, []string{
+		"login",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+		"--request-id", requestID,
+	}, setHomePath(tmpHomePath), func(cf *CLIConf) error {
+		cf.OverrideStdout = requestLoginOutput
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Assert that the output contains the ID of the active request and the
+	// name of the newly assumed role.
+	require.Regexp(t,
+		regexp.MustCompile(`Active requests:\s.*\b`+requestID+`\b`),
+		requestLoginOutput.String(),
+	)
+	require.Regexp(t,
+		regexp.MustCompile(`Roles:\s.*\belevated\b`),
+		requestLoginOutput.String(),
+	)
+}
+
 func findMOTD(t *testing.T, sc *bufio.Scanner, motd string) {
 	t.Helper()
 	for sc.Scan() {


### PR DESCRIPTION
Backport #64274 to branch/v17

## Manual Test Plan

### Test Environment

A teleport cluster with an enterprise license and the preset `requester` and `access` roles.

A user with only the `requester` role, logged in with `tsh`.

An approved access request created in the web UI or with tsh for any resource.

### Test Cases

- [x] `tsh login --request-id=<approved-request-id>` includes the assumed access request ID and role
```
$ tsh login --request-id 019cba1c-eaac-73c0-8832-edaacf555654

Approval received, getting updated certificates...

> Profile URL:        https://one.private:3080
  Logged in as:       nic
  Active requests:    019cba1c-eaac-73c0-8832-edaacf555654
  Cluster:            one.private
  Roles:              access, requester
  Logins:             root, nic
  Kubernetes:         enabled
  Allowed Resources:  ["/one.private/node/6df42bc6-6389-4092-a35f-164a433bbbda"]
  Valid until:        2026-03-04 22:13:46 -0800 PST [valid for 11h23m]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy, teleport-allowed-resource-access-ids
```

changelog: fixed `tsh login --request-id` to display up to date profile information including the assumed access request and roles