### PR TITLE
Okta: Add TimeBetweenAssignmentProcessLoops setting to gRPC requests

### DIFF
--- a/api/gen/proto/go/teleport/okta/v1/okta_service.pb.go
+++ b/api/gen/proto/go/teleport/okta/v1/okta_service.pb.go
@@ -289,11 +289,20 @@ type CreateIntegrationRequest struct {
 	DisableAssignDefaultRoles bool `protobuf:"varint,12,opt,name=disable_assign_default_roles,json=disableAssignDefaultRoles,proto3" json:"disable_assign_default_roles,omitempty"`
 	// TimeBetweenImports controls the time between Okta syncs. I.e. importing Okta users, apps and
 	// groups to teleport. This doesn't affect how quickly Teleport changes are propagated to Okta if
-	// bidirectional sync is enabled. It will be rounded down to the nearest second The default value
-	// is 1800 (30 minutes).
+	// bidirectional sync is enabled. The default value is 30m.
 	TimeBetweenImports *durationpb.Duration `protobuf:"bytes,13,opt,name=time_between_imports,json=timeBetweenImports,proto3" json:"time_between_imports,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// TimeBetweenAssignmentProcessLoops controls the time between periodic synchronizations of the
+	// Okta assignments to Teleport and reconciliation of all existing assignments that are failed or
+	// out of sync.
+	//
+	// An empty string results in the default value of 10min.
+	//
+	// NOTE: This has an impact on other parts of the Okta sync. In particual it changes the how
+	// often the cached Okta client for assignments is being invalidated. It is not advised to change
+	// this setting without prior recommendation.
+	TimeBetweenAssignmentProcessLoops *durationpb.Duration `protobuf:"bytes,14,opt,name=time_between_assignment_process_loops,json=timeBetweenAssignmentProcessLoops,proto3" json:"time_between_assignment_process_loops,omitempty"`
+	unknownFields                     protoimpl.UnknownFields
+	sizeCache                         protoimpl.SizeCache
 }
 
 func (x *CreateIntegrationRequest) Reset() {
@@ -417,6 +426,13 @@ func (x *CreateIntegrationRequest) GetTimeBetweenImports() *durationpb.Duration 
 	return nil
 }
 
+func (x *CreateIntegrationRequest) GetTimeBetweenAssignmentProcessLoops() *durationpb.Duration {
+	if x != nil {
+		return x.TimeBetweenAssignmentProcessLoops
+	}
+	return nil
+}
+
 // UpdateIntegrationRequest is the request message for updating an existing Okta integration.
 type UpdateIntegrationRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -442,11 +458,20 @@ type UpdateIntegrationRequest struct {
 	DisableAssignDefaultRoles bool `protobuf:"varint,12,opt,name=disable_assign_default_roles,json=disableAssignDefaultRoles,proto3" json:"disable_assign_default_roles,omitempty"`
 	// TimeBetweenImports controls the time between Okta syncs. I.e. importing Okta users, apps and
 	// groups to teleport. This doesn't affect how quickly Teleport changes are propagated to Okta if
-	// bidirectional sync is enabled. It will be rounded down to the nearest second. The default
-	// value is 1800 (30 minutes).
+	// bidirectional sync is enabled. The default value is 30m.
 	TimeBetweenImports *durationpb.Duration `protobuf:"bytes,13,opt,name=time_between_imports,json=timeBetweenImports,proto3" json:"time_between_imports,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// TimeBetweenAssignmentProcessLoops controls the time between periodic synchronizations of the
+	// Okta assignments to Teleport and reconciliation of all existing assignments that are failed or
+	// out of sync.
+	//
+	// An empty string results in the default value of 10min.
+	//
+	// NOTE: This has an impact on other parts of the Okta sync. In particual it changes the how
+	// often the cached Okta client for assignments is being invalidated. It is not advised to change
+	// this setting without prior recommendation.
+	TimeBetweenAssignmentProcessLoops *durationpb.Duration `protobuf:"bytes,14,opt,name=time_between_assignment_process_loops,json=timeBetweenAssignmentProcessLoops,proto3" json:"time_between_assignment_process_loops,omitempty"`
+	unknownFields                     protoimpl.UnknownFields
+	sizeCache                         protoimpl.SizeCache
 }
 
 func (x *UpdateIntegrationRequest) Reset() {
@@ -545,6 +570,13 @@ func (x *UpdateIntegrationRequest) GetDisableAssignDefaultRoles() bool {
 func (x *UpdateIntegrationRequest) GetTimeBetweenImports() *durationpb.Duration {
 	if x != nil {
 		return x.TimeBetweenImports
+	}
+	return nil
+}
+
+func (x *UpdateIntegrationRequest) GetTimeBetweenAssignmentProcessLoops() *durationpb.Duration {
+	if x != nil {
+		return x.TimeBetweenAssignmentProcessLoops
 	}
 	return nil
 }
@@ -1832,7 +1864,7 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	"\x06groups\x18\x01 \x03(\v2).teleport.okta.v1.GetGroupsResponse.GroupR\x06groups\x1a=\n" +
 	"\x05Group\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
-	"\vdescription\x18\x02 \x01(\tR\vdescription\"\xfe\x05\n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\"\xeb\x06\n" +
 	"\x18CreateIntegrationRequest\x122\n" +
 	"\x15okta_organization_url\x18\x01 \x01(\tR\x13oktaOrganizationUrl\x12M\n" +
 	"\x0fapi_credentials\x18\x02 \x01(\v2$.teleport.okta.v1.OktaAPICredentialsR\x0eapiCredentials\x12\x1d\n" +
@@ -1848,7 +1880,8 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	" \x01(\bR\x17enableBidirectionalSync\x127\n" +
 	"\x18enable_system_log_export\x18\v \x01(\bR\x15enableSystemLogExport\x12?\n" +
 	"\x1cdisable_assign_default_roles\x18\f \x01(\bR\x19disableAssignDefaultRoles\x12K\n" +
-	"\x14time_between_imports\x18\r \x01(\v2\x19.google.protobuf.DurationR\x12timeBetweenImports\"\xa6\x05\n" +
+	"\x14time_between_imports\x18\r \x01(\v2\x19.google.protobuf.DurationR\x12timeBetweenImports\x12k\n" +
+	"%time_between_assignment_process_loops\x18\x0e \x01(\v2\x19.google.protobuf.DurationR!timeBetweenAssignmentProcessLoops\"\x93\x06\n" +
 	"\x18UpdateIntegrationRequest\x12M\n" +
 	"\x0fapi_credentials\x18\x02 \x01(\v2$.teleport.okta.v1.OktaAPICredentialsR\x0eapiCredentials\x12\x1d\n" +
 	"\n" +
@@ -1861,7 +1894,8 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	" \x01(\bR\x17enableBidirectionalSync\x127\n" +
 	"\x18enable_system_log_export\x18\v \x01(\bR\x15enableSystemLogExport\x12?\n" +
 	"\x1cdisable_assign_default_roles\x18\f \x01(\bR\x19disableAssignDefaultRoles\x12K\n" +
-	"\x14time_between_imports\x18\r \x01(\v2\x19.google.protobuf.DurationR\x12timeBetweenImportsJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"\x14time_between_imports\x18\r \x01(\v2\x19.google.protobuf.DurationR\x12timeBetweenImports\x12k\n" +
+	"%time_between_assignment_process_loops\x18\x0e \x01(\v2\x19.google.protobuf.DurationR!timeBetweenAssignmentProcessLoopsJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
 	"R\x0freuse_connectorR\x10sso_metadata_url\"\x7f\n" +
 	"\x12AccessListSettings\x12#\n" +
 	"\rgroup_filters\x18\x02 \x03(\tR\fgroupFilters\x12\x1f\n" +
@@ -2008,63 +2042,65 @@ var file_teleport_okta_v1_okta_service_proto_depIdxs = []int32{
 	7,  // 4: teleport.okta.v1.CreateIntegrationRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
 	6,  // 5: teleport.okta.v1.CreateIntegrationRequest.access_list_settings:type_name -> teleport.okta.v1.AccessListSettings
 	30, // 6: teleport.okta.v1.CreateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
-	7,  // 7: teleport.okta.v1.UpdateIntegrationRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
-	6,  // 8: teleport.okta.v1.UpdateIntegrationRequest.access_list_settings:type_name -> teleport.okta.v1.AccessListSettings
-	30, // 9: teleport.okta.v1.UpdateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
-	31, // 10: teleport.okta.v1.CreateIntegrationResponse.plugin:type_name -> types.PluginV1
-	10, // 11: teleport.okta.v1.CreateIntegrationResponse.connector_info:type_name -> teleport.okta.v1.ConnectorInfo
-	31, // 12: teleport.okta.v1.UpdateIntegrationResponse.plugin:type_name -> types.PluginV1
-	10, // 13: teleport.okta.v1.UpdateIntegrationResponse.connector_info:type_name -> teleport.okta.v1.ConnectorInfo
-	7,  // 14: teleport.okta.v1.ValidateClientCredentialsRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
-	32, // 15: teleport.okta.v1.ListOktaImportRulesResponse.import_rules:type_name -> types.OktaImportRuleV1
-	32, // 16: teleport.okta.v1.CreateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
-	32, // 17: teleport.okta.v1.UpdateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
-	33, // 18: teleport.okta.v1.ListOktaAssignmentsResponse.assignments:type_name -> types.OktaAssignmentV1
-	33, // 19: teleport.okta.v1.CreateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
-	33, // 20: teleport.okta.v1.UpdateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
-	34, // 21: teleport.okta.v1.UpdateOktaAssignmentStatusRequest.status:type_name -> types.OktaAssignmentSpecV1.OktaAssignmentStatus
-	30, // 22: teleport.okta.v1.UpdateOktaAssignmentStatusRequest.time_has_passed:type_name -> google.protobuf.Duration
-	13, // 23: teleport.okta.v1.OktaService.ListOktaImportRules:input_type -> teleport.okta.v1.ListOktaImportRulesRequest
-	15, // 24: teleport.okta.v1.OktaService.GetOktaImportRule:input_type -> teleport.okta.v1.GetOktaImportRuleRequest
-	16, // 25: teleport.okta.v1.OktaService.CreateOktaImportRule:input_type -> teleport.okta.v1.CreateOktaImportRuleRequest
-	17, // 26: teleport.okta.v1.OktaService.UpdateOktaImportRule:input_type -> teleport.okta.v1.UpdateOktaImportRuleRequest
-	18, // 27: teleport.okta.v1.OktaService.DeleteOktaImportRule:input_type -> teleport.okta.v1.DeleteOktaImportRuleRequest
-	19, // 28: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:input_type -> teleport.okta.v1.DeleteAllOktaImportRulesRequest
-	20, // 29: teleport.okta.v1.OktaService.ListOktaAssignments:input_type -> teleport.okta.v1.ListOktaAssignmentsRequest
-	22, // 30: teleport.okta.v1.OktaService.GetOktaAssignment:input_type -> teleport.okta.v1.GetOktaAssignmentRequest
-	23, // 31: teleport.okta.v1.OktaService.CreateOktaAssignment:input_type -> teleport.okta.v1.CreateOktaAssignmentRequest
-	24, // 32: teleport.okta.v1.OktaService.UpdateOktaAssignment:input_type -> teleport.okta.v1.UpdateOktaAssignmentRequest
-	25, // 33: teleport.okta.v1.OktaService.UpdateOktaAssignmentStatus:input_type -> teleport.okta.v1.UpdateOktaAssignmentStatusRequest
-	26, // 34: teleport.okta.v1.OktaService.DeleteOktaAssignment:input_type -> teleport.okta.v1.DeleteOktaAssignmentRequest
-	27, // 35: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:input_type -> teleport.okta.v1.DeleteAllOktaAssignmentsRequest
-	11, // 36: teleport.okta.v1.OktaService.ValidateClientCredentials:input_type -> teleport.okta.v1.ValidateClientCredentialsRequest
-	4,  // 37: teleport.okta.v1.OktaService.CreateIntegration:input_type -> teleport.okta.v1.CreateIntegrationRequest
-	5,  // 38: teleport.okta.v1.OktaService.UpdateIntegration:input_type -> teleport.okta.v1.UpdateIntegrationRequest
-	0,  // 39: teleport.okta.v1.OktaService.GetApps:input_type -> teleport.okta.v1.GetAppsRequest
-	2,  // 40: teleport.okta.v1.OktaService.GetGroups:input_type -> teleport.okta.v1.GetGroupsRequest
-	14, // 41: teleport.okta.v1.OktaService.ListOktaImportRules:output_type -> teleport.okta.v1.ListOktaImportRulesResponse
-	32, // 42: teleport.okta.v1.OktaService.GetOktaImportRule:output_type -> types.OktaImportRuleV1
-	32, // 43: teleport.okta.v1.OktaService.CreateOktaImportRule:output_type -> types.OktaImportRuleV1
-	32, // 44: teleport.okta.v1.OktaService.UpdateOktaImportRule:output_type -> types.OktaImportRuleV1
-	35, // 45: teleport.okta.v1.OktaService.DeleteOktaImportRule:output_type -> google.protobuf.Empty
-	35, // 46: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:output_type -> google.protobuf.Empty
-	21, // 47: teleport.okta.v1.OktaService.ListOktaAssignments:output_type -> teleport.okta.v1.ListOktaAssignmentsResponse
-	33, // 48: teleport.okta.v1.OktaService.GetOktaAssignment:output_type -> types.OktaAssignmentV1
-	33, // 49: teleport.okta.v1.OktaService.CreateOktaAssignment:output_type -> types.OktaAssignmentV1
-	33, // 50: teleport.okta.v1.OktaService.UpdateOktaAssignment:output_type -> types.OktaAssignmentV1
-	35, // 51: teleport.okta.v1.OktaService.UpdateOktaAssignmentStatus:output_type -> google.protobuf.Empty
-	35, // 52: teleport.okta.v1.OktaService.DeleteOktaAssignment:output_type -> google.protobuf.Empty
-	35, // 53: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:output_type -> google.protobuf.Empty
-	12, // 54: teleport.okta.v1.OktaService.ValidateClientCredentials:output_type -> teleport.okta.v1.ValidateClientCredentialsResponse
-	8,  // 55: teleport.okta.v1.OktaService.CreateIntegration:output_type -> teleport.okta.v1.CreateIntegrationResponse
-	9,  // 56: teleport.okta.v1.OktaService.UpdateIntegration:output_type -> teleport.okta.v1.UpdateIntegrationResponse
-	1,  // 57: teleport.okta.v1.OktaService.GetApps:output_type -> teleport.okta.v1.GetAppsResponse
-	3,  // 58: teleport.okta.v1.OktaService.GetGroups:output_type -> teleport.okta.v1.GetGroupsResponse
-	41, // [41:59] is the sub-list for method output_type
-	23, // [23:41] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	30, // 7: teleport.okta.v1.CreateIntegrationRequest.time_between_assignment_process_loops:type_name -> google.protobuf.Duration
+	7,  // 8: teleport.okta.v1.UpdateIntegrationRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
+	6,  // 9: teleport.okta.v1.UpdateIntegrationRequest.access_list_settings:type_name -> teleport.okta.v1.AccessListSettings
+	30, // 10: teleport.okta.v1.UpdateIntegrationRequest.time_between_imports:type_name -> google.protobuf.Duration
+	30, // 11: teleport.okta.v1.UpdateIntegrationRequest.time_between_assignment_process_loops:type_name -> google.protobuf.Duration
+	31, // 12: teleport.okta.v1.CreateIntegrationResponse.plugin:type_name -> types.PluginV1
+	10, // 13: teleport.okta.v1.CreateIntegrationResponse.connector_info:type_name -> teleport.okta.v1.ConnectorInfo
+	31, // 14: teleport.okta.v1.UpdateIntegrationResponse.plugin:type_name -> types.PluginV1
+	10, // 15: teleport.okta.v1.UpdateIntegrationResponse.connector_info:type_name -> teleport.okta.v1.ConnectorInfo
+	7,  // 16: teleport.okta.v1.ValidateClientCredentialsRequest.api_credentials:type_name -> teleport.okta.v1.OktaAPICredentials
+	32, // 17: teleport.okta.v1.ListOktaImportRulesResponse.import_rules:type_name -> types.OktaImportRuleV1
+	32, // 18: teleport.okta.v1.CreateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
+	32, // 19: teleport.okta.v1.UpdateOktaImportRuleRequest.import_rule:type_name -> types.OktaImportRuleV1
+	33, // 20: teleport.okta.v1.ListOktaAssignmentsResponse.assignments:type_name -> types.OktaAssignmentV1
+	33, // 21: teleport.okta.v1.CreateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
+	33, // 22: teleport.okta.v1.UpdateOktaAssignmentRequest.assignment:type_name -> types.OktaAssignmentV1
+	34, // 23: teleport.okta.v1.UpdateOktaAssignmentStatusRequest.status:type_name -> types.OktaAssignmentSpecV1.OktaAssignmentStatus
+	30, // 24: teleport.okta.v1.UpdateOktaAssignmentStatusRequest.time_has_passed:type_name -> google.protobuf.Duration
+	13, // 25: teleport.okta.v1.OktaService.ListOktaImportRules:input_type -> teleport.okta.v1.ListOktaImportRulesRequest
+	15, // 26: teleport.okta.v1.OktaService.GetOktaImportRule:input_type -> teleport.okta.v1.GetOktaImportRuleRequest
+	16, // 27: teleport.okta.v1.OktaService.CreateOktaImportRule:input_type -> teleport.okta.v1.CreateOktaImportRuleRequest
+	17, // 28: teleport.okta.v1.OktaService.UpdateOktaImportRule:input_type -> teleport.okta.v1.UpdateOktaImportRuleRequest
+	18, // 29: teleport.okta.v1.OktaService.DeleteOktaImportRule:input_type -> teleport.okta.v1.DeleteOktaImportRuleRequest
+	19, // 30: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:input_type -> teleport.okta.v1.DeleteAllOktaImportRulesRequest
+	20, // 31: teleport.okta.v1.OktaService.ListOktaAssignments:input_type -> teleport.okta.v1.ListOktaAssignmentsRequest
+	22, // 32: teleport.okta.v1.OktaService.GetOktaAssignment:input_type -> teleport.okta.v1.GetOktaAssignmentRequest
+	23, // 33: teleport.okta.v1.OktaService.CreateOktaAssignment:input_type -> teleport.okta.v1.CreateOktaAssignmentRequest
+	24, // 34: teleport.okta.v1.OktaService.UpdateOktaAssignment:input_type -> teleport.okta.v1.UpdateOktaAssignmentRequest
+	25, // 35: teleport.okta.v1.OktaService.UpdateOktaAssignmentStatus:input_type -> teleport.okta.v1.UpdateOktaAssignmentStatusRequest
+	26, // 36: teleport.okta.v1.OktaService.DeleteOktaAssignment:input_type -> teleport.okta.v1.DeleteOktaAssignmentRequest
+	27, // 37: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:input_type -> teleport.okta.v1.DeleteAllOktaAssignmentsRequest
+	11, // 38: teleport.okta.v1.OktaService.ValidateClientCredentials:input_type -> teleport.okta.v1.ValidateClientCredentialsRequest
+	4,  // 39: teleport.okta.v1.OktaService.CreateIntegration:input_type -> teleport.okta.v1.CreateIntegrationRequest
+	5,  // 40: teleport.okta.v1.OktaService.UpdateIntegration:input_type -> teleport.okta.v1.UpdateIntegrationRequest
+	0,  // 41: teleport.okta.v1.OktaService.GetApps:input_type -> teleport.okta.v1.GetAppsRequest
+	2,  // 42: teleport.okta.v1.OktaService.GetGroups:input_type -> teleport.okta.v1.GetGroupsRequest
+	14, // 43: teleport.okta.v1.OktaService.ListOktaImportRules:output_type -> teleport.okta.v1.ListOktaImportRulesResponse
+	32, // 44: teleport.okta.v1.OktaService.GetOktaImportRule:output_type -> types.OktaImportRuleV1
+	32, // 45: teleport.okta.v1.OktaService.CreateOktaImportRule:output_type -> types.OktaImportRuleV1
+	32, // 46: teleport.okta.v1.OktaService.UpdateOktaImportRule:output_type -> types.OktaImportRuleV1
+	35, // 47: teleport.okta.v1.OktaService.DeleteOktaImportRule:output_type -> google.protobuf.Empty
+	35, // 48: teleport.okta.v1.OktaService.DeleteAllOktaImportRules:output_type -> google.protobuf.Empty
+	21, // 49: teleport.okta.v1.OktaService.ListOktaAssignments:output_type -> teleport.okta.v1.ListOktaAssignmentsResponse
+	33, // 50: teleport.okta.v1.OktaService.GetOktaAssignment:output_type -> types.OktaAssignmentV1
+	33, // 51: teleport.okta.v1.OktaService.CreateOktaAssignment:output_type -> types.OktaAssignmentV1
+	33, // 52: teleport.okta.v1.OktaService.UpdateOktaAssignment:output_type -> types.OktaAssignmentV1
+	35, // 53: teleport.okta.v1.OktaService.UpdateOktaAssignmentStatus:output_type -> google.protobuf.Empty
+	35, // 54: teleport.okta.v1.OktaService.DeleteOktaAssignment:output_type -> google.protobuf.Empty
+	35, // 55: teleport.okta.v1.OktaService.DeleteAllOktaAssignments:output_type -> google.protobuf.Empty
+	12, // 56: teleport.okta.v1.OktaService.ValidateClientCredentials:output_type -> teleport.okta.v1.ValidateClientCredentialsResponse
+	8,  // 57: teleport.okta.v1.OktaService.CreateIntegration:output_type -> teleport.okta.v1.CreateIntegrationResponse
+	9,  // 58: teleport.okta.v1.OktaService.UpdateIntegration:output_type -> teleport.okta.v1.UpdateIntegrationResponse
+	1,  // 59: teleport.okta.v1.OktaService.GetApps:output_type -> teleport.okta.v1.GetAppsResponse
+	3,  // 60: teleport.okta.v1.OktaService.GetGroups:output_type -> teleport.okta.v1.GetGroupsResponse
+	43, // [43:61] is the sub-list for method output_type
+	25, // [25:43] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_teleport_okta_v1_okta_service_proto_init() }

--- a/api/proto/teleport/okta/v1/okta_service.proto
+++ b/api/proto/teleport/okta/v1/okta_service.proto
@@ -140,9 +140,18 @@ message CreateIntegrationRequest {
   bool disable_assign_default_roles = 12;
   // TimeBetweenImports controls the time between Okta syncs. I.e. importing Okta users, apps and
   // groups to teleport. This doesn't affect how quickly Teleport changes are propagated to Okta if
-  // bidirectional sync is enabled. It will be rounded down to the nearest second The default value
-  // is 1800 (30 minutes).
+  // bidirectional sync is enabled. The default value is 30m.
   google.protobuf.Duration time_between_imports = 13;
+  // TimeBetweenAssignmentProcessLoops controls the time between periodic synchronizations of the
+  // Okta assignments to Teleport and reconciliation of all existing assignments that are failed or
+  // out of sync.
+  //
+  // An empty string results in the default value of 10min.
+  //
+  // NOTE: This has an impact on other parts of the Okta sync. In particual it changes the how
+  // often the cached Okta client for assignments is being invalidated. It is not advised to change
+  // this setting without prior recommendation.
+  google.protobuf.Duration time_between_assignment_process_loops = 14;
 }
 
 // UpdateIntegrationRequest is the request message for updating an existing Okta integration.
@@ -173,9 +182,18 @@ message UpdateIntegrationRequest {
   bool disable_assign_default_roles = 12;
   // TimeBetweenImports controls the time between Okta syncs. I.e. importing Okta users, apps and
   // groups to teleport. This doesn't affect how quickly Teleport changes are propagated to Okta if
-  // bidirectional sync is enabled. It will be rounded down to the nearest second. The default
-  // value is 1800 (30 minutes).
+  // bidirectional sync is enabled. The default value is 30m.
   google.protobuf.Duration time_between_imports = 13;
+  // TimeBetweenAssignmentProcessLoops controls the time between periodic synchronizations of the
+  // Okta assignments to Teleport and reconciliation of all existing assignments that are failed or
+  // out of sync.
+  //
+  // An empty string results in the default value of 10min.
+  //
+  // NOTE: This has an impact on other parts of the Okta sync. In particual it changes the how
+  // often the cached Okta client for assignments is being invalidated. It is not advised to change
+  // this setting without prior recommendation.
+  google.protobuf.Duration time_between_assignment_process_loops = 14;
 }
 
 // AccessListSettings contains the settings for access list synchronization.


### PR DESCRIPTION
This adds time_between_assignment_process_loops to both CreateIntegration and UpdateIntegration in Okta service.
