### PR TITLE
Extend OktaAssignmentV1.String() with more useful info

### DIFF
--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -371,8 +371,8 @@ func (o *OktaAssignmentV1) Copy() OktaAssignment {
 
 // String returns the Okta assignment rule string representation.
 func (o *OktaAssignmentV1) String() string {
-	return fmt.Sprintf("OktaAssignmentV1(Name=%v, Labels=%v)",
-		o.GetName(), o.GetAllLabels())
+	return fmt.Sprintf("OktaAssignmentV1(Name=%v, Labels=%v, User=%s, Status=%s, LastTransition=%s, CleanupTime=%s)",
+		o.GetName(), o.GetAllLabels(), o.Spec.User, o.Spec.Status, o.Spec.LastTransition.Format(time.RFC3339), o.Spec.CleanupTime.UTC().Format(time.RFC3339))
 }
 
 // MatchSearch goes through select field values and tries to

--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -372,7 +372,7 @@ func (o *OktaAssignmentV1) Copy() OktaAssignment {
 // String returns the Okta assignment rule string representation.
 func (o *OktaAssignmentV1) String() string {
 	return fmt.Sprintf("OktaAssignmentV1(Name=%v, Labels=%v, User=%s, Status=%s, LastTransition=%s, CleanupTime=%s)",
-		o.GetName(), o.GetAllLabels(), o.Spec.User, o.Spec.Status, o.Spec.LastTransition.Format(time.RFC3339), o.Spec.CleanupTime.UTC().Format(time.RFC3339))
+		o.GetName(), o.GetAllLabels(), o.GetUser(), o.GetStatus(), o.Spec.LastTransition.UTC().Format(time.RFC3339), o.Spec.CleanupTime.UTC().Format(time.RFC3339))
 }
 
 // MatchSearch goes through select field values and tries to


### PR DESCRIPTION
I added those while debugging integration tests. But I think this information is useful when printing OktaAssignment information in general.

### Backports

- https://github.com/gravitational/teleport/pull/65210