### PR TITLE
Fix flaky test `TestIntegrations/AuditOn`

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1978,8 +1978,8 @@ func (i *TeleInstance) StopAll() error {
 }
 
 // WaitForNodeCount waits for a certain number of nodes in the provided cluster
-// to be visible to the Proxy. This should be called prior to any client dialing
-// of nodes to be sure that the node is registered and routable.
+// to be connected to the cluster. This should be called prior to any client
+// dialing of nodes to be sure that the node is registered and routable.
 func (i *TeleInstance) WaitForNodeCount(ctx context.Context, clusterName string, count int) error {
 	const (
 		deadline     = time.Second * 30
@@ -2008,6 +2008,23 @@ func (i *TeleInstance) WaitForNodeCount(ctx context.Context, clusterName string,
 		}
 		if len(nodes) != count {
 			return trace.BadParameter("cache contained %v nodes, but wanted to find %v nodes", len(nodes), count)
+		}
+
+		// Validate that the nodes are connected to the cluster.
+		for _, n := range nodes {
+			conn, err := cluster.DialTCP(reversetunnelclient.DialParams{
+				ConnType:     types.NodeTunnel,
+				ServerID:     fmt.Sprintf("%s.%s", n.GetName(), clusterName),
+				TargetServer: n,
+				To: &utils.NetAddr{
+					AddrNetwork: "tcp",
+					Addr:        n.GetAddr(),
+				},
+			})
+			if err != nil {
+				return trace.BadParameter("node tunnel preflight dial failed")
+			}
+			conn.Close()
 		}
 
 		// Validate that the site watcher contains the expected count.

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -2014,7 +2014,7 @@ func (i *TeleInstance) WaitForNodeCount(ctx context.Context, clusterName string,
 		for _, n := range nodes {
 			conn, err := cluster.DialTCP(reversetunnelclient.DialParams{
 				ConnType:     types.NodeTunnel,
-				ServerID:     fmt.Sprintf("%s.%s", n.GetName(), clusterName),
+				ServerID:     n.GetName() + "." + clusterName,
 				TargetServer: n,
 				To: &utils.NetAddr{
 					AddrNetwork: "tcp",

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -2022,7 +2022,7 @@ func (i *TeleInstance) WaitForNodeCount(ctx context.Context, clusterName string,
 				},
 			})
 			if err != nil {
-				return trace.BadParameter("node tunnel preflight dial failed")
+				return trace.Wrap(err, "node tunnel preflight dial failed")
 			}
 			conn.Close()
 		}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -9445,12 +9445,7 @@ func startSSHServer(t *testing.T, caPubKeys []ssh.PublicKey, hostKey ssh.Signer)
 		require.NoError(t, lis.Close())
 	})
 
-	go func() {
-		nConn, err := lis.Accept()
-		if utils.IsOKNetworkError(err) {
-			return
-		}
-		assert.NoError(t, err)
+	handleConn := func(nConn net.Conn) {
 		t.Cleanup(func() {
 			if nConn != nil {
 				// the error is ignored here to avoid failing on net.ErrClosed
@@ -9459,7 +9454,15 @@ func startSSHServer(t *testing.T, caPubKeys []ssh.PublicKey, hostKey ssh.Signer)
 		})
 
 		conn, channels, reqs, err := ssh.NewServerConn(nConn, &sshCfg)
-		assert.NoError(t, err)
+		if err != nil {
+			// If the connection does not perform an SSH handshake, then this is just
+			// a readiness probe (raw TCP Dial) from the test.
+			if utils.IsOKNetworkError(err) {
+				return
+			}
+			assert.NoError(t, err)
+			return
+		}
 		t.Cleanup(func() {
 			if conn != nil {
 				// the error is ignored here to avoid failing on net.ErrClosed
@@ -9542,6 +9545,19 @@ func startSSHServer(t *testing.T, caPubKeys []ssh.PublicKey, hostKey ssh.Signer)
 				}
 				assert.True(t, (agentForwarded && shellRequested) || execRequested || sftpRequested)
 			}()
+		}
+	}
+
+	go func() {
+		for {
+			nConn, err := lis.Accept()
+			if utils.IsOKNetworkError(err) || errors.Is(err, net.ErrClosed) {
+				return
+			}
+			if !assert.NoError(t, err) {
+				return
+			}
+			handleConn(nConn)
 		}
 	}()
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -446,6 +446,8 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 			require.NoError(t, err)
 			require.Empty(t, sessions)
 
+			// create interactive session (this goroutine is this user's terminal time)
+			myTerm := NewTerminal(250)
 			cl, err := teleport.NewClient(helpers.ClientConfig{
 				Login:        suite.Me.Username,
 				Cluster:      helpers.Site,
@@ -453,23 +455,14 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 				Port:         helpers.Port(t, nodeConf.SSH.Addr.Addr),
 				ForwardAgent: tt.inForwardAgent,
 			})
-			// create interactive session (this goroutine is this user's terminal time)
-			endC := make(chan error)
-			myTerm := NewTerminal(250)
-			go func() {
-				if err != nil {
-					endC <- err
-					return
-				}
-				cl.Stdout = myTerm
-				cl.Stdin = myTerm
-
-				err = cl.SSH(ctx, nil)
-				endC <- err
-			}()
+			require.NoError(t, err)
+			cl.Stdout = myTerm
+			cl.Stdin = myTerm
 
 			// wait until the session tracker exists.
-			tracker := waitForSessionToBeEstablished(t, site, 1)
+			tracker, endC, err := startSessionAndWaitForTracker(t, site, cl, nil)
+			require.NoError(t, err)
+
 			// make sure it's us who joined! :)
 			require.Equal(t, suite.Me.Username, tracker.GetParticipants()[0].User)
 			sessionID := tracker.GetSessionID()
@@ -4948,26 +4941,21 @@ func testAuditOff(t *testing.T, suite *integrationTestSuite) {
 
 	beforeSession := time.Now()
 
-	// create interactive session (this goroutine is this user's terminal time)
-	endCh := make(chan error, 1)
-
 	myTerm := NewTerminal(250)
 	cl, err := teleport.NewClient(helpers.ClientConfig{
 		Login:   suite.Me.Username,
 		Cluster: helpers.Site,
 		Host:    Host,
 		Port:    helpers.Port(t, teleport.SSH),
+		Stdout:  myTerm,
+		Stdin:   myTerm,
 	})
 	require.NoError(t, err)
-	go func() {
-		cl.Stdout = myTerm
-		cl.Stdin = myTerm
-		err = cl.SSH(ctx, []string{})
-		endCh <- err
-	}()
 
-	// wait for the user to join this session
-	tracker := waitForSessionToBeEstablished(t, site, 1)
+	// create interactive session
+	tracker, endCh, err := startSessionAndWaitForTracker(t, site, cl, nil)
+	require.NoError(t, err)
+
 	// make sure it's us who joined! :)
 	require.Equal(t, suite.Me.Username, tracker.GetParticipants()[0].User)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -460,7 +460,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 			cl.Stdin = myTerm
 
 			// wait until the session tracker exists.
-			tracker, endC, err := startSessionAndWaitForTracker(t, site, cl, nil)
+			tracker, endC, err := startSessionAndWaitForTracker(t, site, cl, 1, nil)
 			require.NoError(t, err)
 
 			// make sure it's us who joined! :)
@@ -4953,7 +4953,7 @@ func testAuditOff(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// create interactive session
-	tracker, endCh, err := startSessionAndWaitForTracker(t, site, cl, nil)
+	tracker, endCh, err := startSessionAndWaitForTracker(t, site, cl, 1, nil)
 	require.NoError(t, err)
 
 	// make sure it's us who joined! :)
@@ -9446,12 +9446,7 @@ func startSSHServer(t *testing.T, caPubKeys []ssh.PublicKey, hostKey ssh.Signer)
 	})
 
 	handleConn := func(nConn net.Conn) {
-		t.Cleanup(func() {
-			if nConn != nil {
-				// the error is ignored here to avoid failing on net.ErrClosed
-				_ = nConn.Close()
-			}
-		})
+		defer nConn.Close()
 
 		conn, channels, reqs, err := ssh.NewServerConn(nConn, &sshCfg)
 		if err != nil {
@@ -9463,12 +9458,8 @@ func startSSHServer(t *testing.T, caPubKeys []ssh.PublicKey, hostKey ssh.Signer)
 			assert.NoError(t, err)
 			return
 		}
-		t.Cleanup(func() {
-			if conn != nil {
-				// the error is ignored here to avoid failing on net.ErrClosed
-				_ = conn.Close()
-			}
-		})
+		defer conn.Close()
+
 		go ssh.DiscardRequests(reqs)
 
 		for {
@@ -9487,10 +9478,7 @@ func startSSHServer(t *testing.T, caPubKeys []ssh.PublicKey, hostKey ssh.Signer)
 			}
 			channel, reqs, err := channelReq.Accept()
 			assert.NoError(t, err)
-			t.Cleanup(func() {
-				// the error is ignored here to avoid failing on net.ErrClosed
-				_ = channel.Close()
-			})
+			defer channel.Close()
 
 			go func() {
 				var agentForwarded, shellRequested, execRequested, sftpRequested bool
@@ -9554,7 +9542,7 @@ func startSSHServer(t *testing.T, caPubKeys []ssh.PublicKey, hostKey ssh.Signer)
 			if !assert.NoError(t, err) {
 				return
 			}
-			handleConn(nConn)
+			go handleConn(nConn)
 		}
 	}()
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -9471,10 +9471,6 @@ func startSSHServer(t *testing.T, caPubKeys []ssh.PublicKey, hostKey ssh.Signer)
 		})
 		go ssh.DiscardRequests(reqs)
 
-		var agentForwarded bool
-		var shellRequested bool
-		var execRequested bool
-		var sftpRequested bool
 		for {
 			var channelReq ssh.NewChannel
 			select {
@@ -9497,6 +9493,7 @@ func startSSHServer(t *testing.T, caPubKeys []ssh.PublicKey, hostKey ssh.Signer)
 			})
 
 			go func() {
+				var agentForwarded, shellRequested, execRequested, sftpRequested bool
 			outer:
 				for {
 					var req *ssh.Request

--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -76,6 +76,50 @@ func waitForSessionToBeEstablished(t *testing.T, clt authclient.ClientI, partici
 	return tracker
 }
 
+// startSessionAndWaitForTracker starts a session and waits for a session tracker to exist in the backend
+// Returns the tracker and a session error channel.
+func startSessionAndWaitForTracker(t *testing.T, auth authclient.ClientI, clt *client.TeleportClient, cmd []string) (types.SessionTracker, <-chan error, error) {
+	t.Helper()
+	ctx := t.Context()
+
+	errC := make(chan error, 1)
+	go func() {
+		errC <- clt.SSH(ctx, cmd)
+	}()
+
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	timeout := time.NewTimer(30 * time.Second)
+	defer timeout.Stop()
+
+	lastTrackerErr := trace.BadParameter("session tracker not yet present")
+	for {
+		select {
+		case err := <-errC:
+			if err != nil {
+				return nil, errC, trace.Wrap(err, "encountered session error while waiting for tracker creation")
+			}
+			return nil, errC, trace.BadParameter("session exited before tracker creation")
+		case <-ticker.C:
+			trackers, err := auth.GetActiveSessionTrackers(ctx)
+			if err != nil {
+				lastTrackerErr = trace.Wrap(err, "getting session trackers")
+				continue
+			}
+			if len(trackers) != 1 {
+				lastTrackerErr = trace.BadParameter("no active sessions found")
+				continue
+			}
+			return trackers[0], errC, nil
+		case <-timeout.C:
+			return nil, errC, trace.Wrap(lastTrackerErr)
+		case <-ctx.Done():
+			return nil, errC, trace.Wrap(ctx.Err(), "waiting for session tracker")
+		}
+	}
+}
+
 func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 	invalidOSLogin := testutils.GenerateLocalUsername(t)
 

--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -78,7 +78,7 @@ func waitForSessionToBeEstablished(t *testing.T, clt authclient.ClientI, partici
 
 // startSessionAndWaitForTracker starts a session and waits for a session tracker to exist in the backend
 // Returns the tracker and a session error channel.
-func startSessionAndWaitForTracker(t *testing.T, auth authclient.ClientI, clt *client.TeleportClient, cmd []string) (types.SessionTracker, <-chan error, error) {
+func startSessionAndWaitForTracker(t *testing.T, auth authclient.ClientI, clt *client.TeleportClient, participants int, cmd []string) (types.SessionTracker, <-chan error, error) {
 	t.Helper()
 	ctx := t.Context()
 
@@ -98,9 +98,9 @@ func startSessionAndWaitForTracker(t *testing.T, auth authclient.ClientI, clt *c
 		select {
 		case err := <-errC:
 			if err != nil {
-				return nil, errC, trace.Wrap(err, "encountered session error while waiting for tracker creation")
+				return nil, nil, trace.Wrap(err, "encountered session error while waiting for tracker creation")
 			}
-			return nil, errC, trace.BadParameter("session exited before tracker creation")
+			return nil, nil, trace.BadParameter("session exited before tracker creation")
 		case <-ticker.C:
 			trackers, err := auth.GetActiveSessionTrackers(ctx)
 			if err != nil {
@@ -111,11 +111,15 @@ func startSessionAndWaitForTracker(t *testing.T, auth authclient.ClientI, clt *c
 				lastTrackerErr = trace.BadParameter("no active sessions found")
 				continue
 			}
+			if len(trackers[0].GetParticipants()) != participants {
+				lastTrackerErr = trace.BadParameter("session tracker found with only %v/%v expected participants", len(trackers[0].GetParticipants()), participants)
+				continue
+			}
 			return trackers[0], errC, nil
 		case <-timeout.C:
-			return nil, errC, trace.Wrap(lastTrackerErr)
+			return nil, nil, trace.Wrap(lastTrackerErr)
 		case <-ctx.Done():
-			return nil, errC, trace.Wrap(ctx.Err(), "waiting for session tracker")
+			return nil, nil, trace.Wrap(ctx.Err(), "waiting for session tracker")
 		}
 	}
 }


### PR DESCRIPTION
Fixed `TestIntegrations/AuditOn` flakiness by updating `WaitForNodeCount` to check that the nodes counted are also reachable. This ensures that ssh attempts immediately after `WaitForNodeCount` are not doomed to fail.

I wasn't able to reproduce the flake locally, but I was able to force the test failure I suspected by forcing [reverse tunnel node dials to fail](https://github.com/gravitational/teleport/blob/f6f2352fa532640c9f057c4571e94b0361881291/lib/reversetunnel/local_cluster.go#L715). The initial `WaitForNodeCount` succeeds, but the tracker creation waiter times out as the session itself fails immediately on dial.

Additionally, the actual test failure described above was being masked due to error check only happening conditionally after the session tracker is created, meaning session failures would result in a timeout waiting for the session tracker creation. I updated the logic here to fail fast on unexpected session errors.

Note: this might also fix some other flaky tests calling `WaitForNodeCount`, but I checked the `WaitForNodeCount` call sites against open flaky test issues and didn't get any matches. This is likely due to the fact that `AuditOn` has limited setup and goes straight from creating the cluster to starting an SSH session.

Closes https://github.com/gravitational/teleport/issues/17224
Closes https://github.com/gravitational/teleport/issues/63322
Closes https://github.com/gravitational/teleport/issues/62705