### PR TITLE
[v17] Fix Desktop Connection Error When HostID Is Not a UUID (#63908)

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -72,7 +72,6 @@ import "C"
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"net"
 	"os"
@@ -83,7 +82,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
@@ -328,19 +326,6 @@ func (c *Client) startRustRDP(ctx context.Context, certDER, keyDER []byte) error
 		return trace.BadParameter("user key was nil")
 	}
 
-	hostID, err := uuid.Parse(c.cfg.HostID)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	nextHostID := hostID[:]
-	cHostID := [4]C.uint32_t{}
-	for i := 0; i < len(cHostID); i++ {
-		const uint32Len = 4
-		cHostID[i] = (C.uint32_t)(binary.LittleEndian.Uint32(nextHostID[:uint32Len]))
-		nextHostID = nextHostID[uint32Len:]
-	}
-
 	res := C.client_run(
 		C.uintptr_t(c.handle),
 		C.CGOConnectParams{
@@ -361,7 +346,7 @@ func (c *Client) startRustRDP(ctx context.Context, certDER, keyDER []byte) error
 			allow_clipboard:         C.bool(c.cfg.AllowClipboard),
 			allow_directory_sharing: C.bool(c.cfg.AllowDirectorySharing),
 			show_desktop_wallpaper:  C.bool(c.cfg.ShowDesktopWallpaper),
-			client_id:               cHostID,
+			client_id:               rdpClientIDToUint32Array[C.uint32_t](newRDPClientID(c.cfg.HostID)),
 		},
 	)
 

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -21,9 +21,12 @@ package rdpclient
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/binary"
 	"image/png"
 	"log/slog"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
@@ -118,4 +121,37 @@ func (c *Config) checkAndSetDefaults() error {
 // a given desktop.
 func (c *Config) hasSizeOverride() bool { //nolint:unused // used in client.go that is behind desktop_access_rdp build flag
 	return c.Width != 0 && c.Height != 0
+}
+
+type rdpClientID [16]byte
+
+type uint32Like interface {
+	~uint32
+}
+
+//nolint:unused // only used in client.go which is ignored by linter
+func rdpClientIDToUint32Array[T uint32Like](h rdpClientID) [4]T {
+	cArray := [4]T{}
+	for idx := range cArray {
+		cArray[idx] = T(binary.LittleEndian.Uint32(h[idx*4:]))
+	}
+	return cArray
+}
+
+func newRDPClientID(id string) rdpClientID {
+	// In previous revisions of this code, we incorrectly assumed
+	// that rdpClientID would always be a UUID. This is not always the case,
+	// however, we should continue to attempt to parse rdpClientID as a UUID
+	// so that the client ID stays the same for existing users as this
+	// may affect RDP licensing.
+	// See https://github.com/gravitational/teleport/issues/63766
+	parsedUUID, err := uuid.Parse(id)
+	if err == nil {
+		return rdpClientID(parsedUUID)
+	}
+
+	// Fall back to taking a hash of the rdpClientID
+	hash := [16]byte{}
+	copy(hash[:], md5.New().Sum([]byte(id)))
+	return rdpClientID(hash)
 }

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -151,7 +151,5 @@ func newRDPClientID(id string) rdpClientID {
 	}
 
 	// Fall back to taking a hash of the rdpClientID
-	hash := [16]byte{}
-	copy(hash[:], md5.New().Sum([]byte(id)))
-	return rdpClientID(hash)
+	return md5.Sum([]byte(id))
 }

--- a/lib/srv/desktop/rdp/rdpclient/client_test.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_test.go
@@ -1,0 +1,70 @@
+/*
+ * *
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package rdpclient
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRDPClientID(t *testing.T) {
+	nilID := rdpClientID{}
+	// The MD5 hash of an empty string
+	emptyHash := rdpClientID([16]byte{0xD4, 0x1D, 0x8C, 0xD9, 0x8F, 0x00, 0xB2, 0x04, 0xE9, 0x80, 0x09, 0x98, 0xEC, 0xF8, 0x42, 0x7E})
+
+	invalidIDs := []rdpClientID{nilID, emptyHash}
+	t.Run("from uuid", func(t *testing.T) {
+		// We must continue to attempt to parse strings
+		// as UUIDs first.
+		newUUID := uuid.New()
+		id := newRDPClientID(newUUID.String())
+		parsed, err := uuid.FromBytes(id[:])
+		require.NoError(t, err)
+		// The rdpClientID should just be a UUID under the hood.
+		require.Equal(t, newUUID, parsed)
+	})
+
+	t.Run("from other string", func(t *testing.T) {
+		otherID := "some-other-identifier"
+		id := newRDPClientID(otherID)
+		// At make sure it's not nil or the empty hash.
+		require.NotContains(t, invalidIDs, id)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		// Should match the empty hash.
+		require.Equal(t, newRDPClientID(""), emptyHash)
+	})
+
+	t.Run("uint32 conversion", func(t *testing.T) {
+		// The MD5 hash of an empty string is:
+		// d41d8cd9 8f00b204 e9800998 ecf8427e
+		// Then represent each 32-bit word as little endian and we get:
+		expected := [4]uint32{0xd98c1dd4, 0x04b2008f, 0x980980e9, 0x7e42f8ec}
+
+		// Our [4]uint32 representation of the rdpClientID should
+		// match the above. As a bonus, this will serve as a regression
+		// test to ensure that we don't switch hash algorithms by mistake.
+		got := rdpClientIDToUint32Array[uint32](newRDPClientID(""))
+		require.Equal(t, expected, got)
+	})
+}


### PR DESCRIPTION
Backports #63908



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed bug that causes Windows desktop connection errors on EC2 joined nodes.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Local cluster with Windows Desktop Service and a reachable Windows Desktop instance in EC2.
### Test Cases
- [x] Unit test coverage validates proper handling of UUID strings, non-UUID strings, and empty strings.
- [x] Manual validation of RDP client connection.
