### PR TITLE
MWI Scopes[1]: Bot resource and RPCs

### DIFF
--- a/api/gen/proto/go/teleport/machineid/v1/bot.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot.pb.go
@@ -54,7 +54,11 @@ type Bot struct {
 	Spec *BotSpec `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
 	// Fields that are set by the server as results of operations. These should
 	// not be modified by users.
-	Status        *BotStatus `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
+	Status *BotStatus `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
+	// The scope of the Bot. If unset, the Bot is unscoped (classic behavior) and
+	// if set, the Bot is scoped. When the Bot is scoped, the `spec.roles`,
+	// `spec.traits` and `spec.max_session_ttl` fields must not be set.
+	Scope         string `protobuf:"bytes,7,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -131,6 +135,13 @@ func (x *Bot) GetStatus() *BotStatus {
 	return nil
 }
 
+func (x *Bot) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 // Trait is an individual trait that will be applied to the bot user.
 type Trait struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -191,16 +202,22 @@ func (x *Trait) GetValues() []string {
 type BotSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The roles that the bot should be able to impersonate.
+	//
+	// Cannot be set for a scoped Bot.
 	Roles []string `protobuf:"bytes,1,rep,name=roles,proto3" json:"roles,omitempty"`
 	// The traits that will be associated with the bot for the purposes of role
 	// templating.
 	//
 	// Where multiple specified with the same name, these will be merged by the
 	// server.
+	//
+	// Cannot be set for a scoped Bot.
 	Traits []*Trait `protobuf:"bytes,2,rep,name=traits,proto3" json:"traits,omitempty"`
 	// The max session TTL value for the bot's internal role. Unless specified,
 	// bots may not request a value beyond the default maximum TTL of 12 hours.
 	// This value may not be larger than 7 days (168 hours).
+	//
+	// Cannot be set for a scoped Bot.
 	MaxSessionTtl *durationpb.Duration `protobuf:"bytes,3,opt,name=max_session_ttl,json=maxSessionTtl,proto3" json:"max_session_ttl,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -317,14 +334,15 @@ var File_teleport_machineid_v1_bot_proto protoreflect.FileDescriptor
 
 const file_teleport_machineid_v1_bot_proto_rawDesc = "" +
 	"\n" +
-	"\x1fteleport/machineid/v1/bot.proto\x12\x15teleport.machineid.v1\x1a\x1egoogle/protobuf/duration.proto\x1a!teleport/header/v1/metadata.proto\"\xf6\x01\n" +
+	"\x1fteleport/machineid/v1/bot.proto\x12\x15teleport.machineid.v1\x1a\x1egoogle/protobuf/duration.proto\x1a!teleport/header/v1/metadata.proto\"\x8c\x02\n" +
 	"\x03Bot\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x122\n" +
 	"\x04spec\x18\x05 \x01(\v2\x1e.teleport.machineid.v1.BotSpecR\x04spec\x128\n" +
-	"\x06status\x18\x06 \x01(\v2 .teleport.machineid.v1.BotStatusR\x06status\"3\n" +
+	"\x06status\x18\x06 \x01(\v2 .teleport.machineid.v1.BotStatusR\x06status\x12\x14\n" +
+	"\x05scope\x18\a \x01(\tR\x05scope\"3\n" +
 	"\x05Trait\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06values\x18\x02 \x03(\tR\x06values\"\x98\x01\n" +

--- a/api/proto/teleport/machineid/v1/bot.proto
+++ b/api/proto/teleport/machineid/v1/bot.proto
@@ -38,6 +38,10 @@ message Bot {
   // Fields that are set by the server as results of operations. These should
   // not be modified by users.
   BotStatus status = 6;
+  // The scope of the Bot. If unset, the Bot is unscoped (classic behavior) and
+  // if set, the Bot is scoped. When the Bot is scoped, the `spec.roles`,
+  // `spec.traits` and `spec.max_session_ttl` fields must not be set.
+  string scope = 7;
 }
 
 // Trait is an individual trait that will be applied to the bot user.
@@ -52,16 +56,22 @@ message Trait {
 // The configured properties of a Bot.
 message BotSpec {
   // The roles that the bot should be able to impersonate.
+  //
+  // Cannot be set for a scoped Bot.
   repeated string roles = 1;
   // The traits that will be associated with the bot for the purposes of role
   // templating.
   //
   // Where multiple specified with the same name, these will be merged by the
   // server.
+  //
+  // Cannot be set for a scoped Bot.
   repeated Trait traits = 2;
   // The max session TTL value for the bot's internal role. Unless specified,
   // bots may not request a value beyond the default maximum TTL of 12 hours.
   // This value may not be larger than 7 days (168 hours).
+  //
+  // Cannot be set for a scoped Bot.
   google.protobuf.Duration max_session_ttl = 3;
 }
 

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1179,6 +1179,11 @@ const (
 	// BotGenerationLabel is a label used to record the certificate generation counter.
 	BotGenerationLabel = TeleportInternalLabelPrefix + "bot-generation"
 
+	// BotScopeLabel is a label used to identify the scope in which a Bot
+	// exists. It is stored on the user resource to allow the Bot to be hydrated
+	// from a user.
+	BotScopeLabel = TeleportInternalLabelPrefix + "bot-scope"
+
 	// InternalResourceIDLabel is a label used to store an ID to correlate between two resources
 	// A pratical example of this is to create a correlation between a Node Provision Token and
 	// the Node that used that token to join the cluster

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
@@ -29,9 +29,9 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 
 |Field|Type|Description|
 |---|---|---|
-|max_session_ttl|string|The max session TTL value for the bot's internal role. Unless specified, bots may not request a value beyond the default maximum TTL of 12 hours. This value may not be larger than 7 days (168 hours).|
-|roles|[]string|The roles that the bot should be able to impersonate.|
-|traits|[][object](#spectraits-items)|The traits that will be associated with the bot for the purposes of role templating.  Where multiple specified with the same name, these will be merged by the server.|
+|max_session_ttl|string|The max session TTL value for the bot's internal role. Unless specified, bots may not request a value beyond the default maximum TTL of 12 hours. This value may not be larger than 7 days (168 hours).  Cannot be set for a scoped Bot.|
+|roles|[]string|The roles that the bot should be able to impersonate.  Cannot be set for a scoped Bot.|
+|traits|[][object](#spectraits-items)|The traits that will be associated with the bot for the purposes of role templating.  Where multiple specified with the same name, these will be merged by the server.  Cannot be set for a scoped Bot.|
 
 ### spec.traits items
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_botsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_botsv1.yaml
@@ -38,11 +38,12 @@ spec:
                 description: The max session TTL value for the bot's internal role.
                   Unless specified, bots may not request a value beyond the default
                   maximum TTL of 12 hours. This value may not be larger than 7 days
-                  (168 hours).
+                  (168 hours).  Cannot be set for a scoped Bot.
                 format: duration
                 type: string
               roles:
-                description: The roles that the bot should be able to impersonate.
+                description: The roles that the bot should be able to impersonate.  Cannot
+                  be set for a scoped Bot.
                 items:
                   type: string
                 nullable: true
@@ -50,7 +51,8 @@ spec:
               traits:
                 description: The traits that will be associated with the bot for the
                   purposes of role templating.  Where multiple specified with the
-                  same name, these will be merged by the server.
+                  same name, these will be merged by the server.  Cannot be set for
+                  a scoped Bot.
                 items:
                   properties:
                     name:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_botsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_botsv1.yaml
@@ -38,11 +38,12 @@ spec:
                 description: The max session TTL value for the bot's internal role.
                   Unless specified, bots may not request a value beyond the default
                   maximum TTL of 12 hours. This value may not be larger than 7 days
-                  (168 hours).
+                  (168 hours).  Cannot be set for a scoped Bot.
                 format: duration
                 type: string
               roles:
-                description: The roles that the bot should be able to impersonate.
+                description: The roles that the bot should be able to impersonate.  Cannot
+                  be set for a scoped Bot.
                 items:
                   type: string
                 nullable: true
@@ -50,7 +51,8 @@ spec:
               traits:
                 description: The traits that will be associated with the bot for the
                   purposes of role templating.  Where multiple specified with the
-                  same name, these will be merged by the server.
+                  same name, these will be merged by the server.  Cannot be set for
+                  a scoped Bot.
                 items:
                   properties:
                     name:

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6155,13 +6155,13 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	inventorypb.RegisterInventoryServiceServer(server, inventoryService)
 
 	botService, err := machineidv1.NewBotService(machineidv1.BotServiceConfig{
-		Authorizer: cfg.Authorizer,
-		Cache:      cfg.AuthServer.Cache,
-		Backend:    cfg.AuthServer.Services,
-		Reporter:   cfg.AuthServer.Services.UsageReporter,
-		Emitter:    cfg.Emitter,
-		Clock:      cfg.AuthServer.GetClock(),
-		Logger:     cfg.AuthServer.logger.With(teleport.ComponentKey, "bot.service"),
+		ScopedAuthorizer: cfg.ScopedAuthorizer,
+		Cache:            cfg.AuthServer.Cache,
+		Backend:          cfg.AuthServer.Services,
+		Reporter:         cfg.AuthServer.Services.UsageReporter,
+		Emitter:          cfg.Emitter,
+		Clock:            cfg.AuthServer.GetClock(),
+		Logger:           cfg.AuthServer.logger.With(teleport.ComponentKey, "bot.service"),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating bot service")

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -19,7 +19,6 @@
 package machineidv1
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -196,7 +195,7 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 
 	ruleCtx.Resource153 = bot
 	if err := authCtx.CheckerContext.Decision(
-		ctx, cmp.Or(bot.Scope, scopes.Root), func(checker *services.ScopedAccessChecker) error {
+		ctx, bot.Scope, func(checker *services.ScopedAccessChecker) error {
 			return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbReadNoSecrets)
 		},
 	); err != nil {
@@ -312,7 +311,7 @@ func (bs *BotService) ListBots(
 		// Check if user can access this specific Bot.
 		ruleCtx := authCtx.RuleContext()
 		ruleCtx.Resource153 = bot
-		if err := authCtx.CheckerContext.Decision(ctx, cmp.Or(bot.Scope, scopes.Root), func(checker *services.ScopedAccessChecker) error {
+		if err := authCtx.CheckerContext.Decision(ctx, bot.Scope, func(checker *services.ScopedAccessChecker) error {
 			return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbList)
 		}); err != nil {
 			// Ignore resources the user cannot access.
@@ -349,14 +348,14 @@ func (bs *BotService) CreateBot(
 
 	ruleCtx := authCtx.RuleContext()
 	ruleCtx.Resource153 = req.Bot
-	if err := authCtx.CheckerContext.Decision(ctx, cmp.Or(req.Bot.Scope, scopes.Root), func(checker *services.ScopedAccessChecker) error {
+	if err := authCtx.CheckerContext.Decision(ctx, req.Bot.Scope, func(checker *services.ScopedAccessChecker) error {
 		return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbCreate)
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if unscoped, ok := authCtx.UnscopedContext(); ok {
 		// We can only perform MFA checks on unscoped identities.
-		// TODO(noah): When scopes supports MFA, add check here :')
+		// TODO(noah/scopes): When scopes supports MFA, add check here :')
 		if err := unscoped.AuthorizeAdminActionAllowReusedMFA(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -577,7 +576,7 @@ func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (
 	ruleCtx.Resource153 = req.Bot
 	if err := authCtx.CheckerContext.Decision(
 		ctx,
-		cmp.Or(req.Bot.Scope, scopes.Root),
+		req.Bot.Scope,
 		func(checker *services.ScopedAccessChecker) error {
 			return checker.CheckAccessToRules(
 				&ruleCtx, types.KindBot, types.VerbCreate, types.VerbUpdate,
@@ -588,7 +587,7 @@ func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (
 	}
 	if unscoped, ok := authCtx.UnscopedContext(); ok {
 		// We can only perform MFA checks on unscoped identities.
-		// TODO(noah): When scopes supports MFA, add check here :')
+		// TODO(noah/scopes): When scopes supports MFA, add check here :')
 		// Allow re-use for bulk upserts.
 		if err := unscoped.AuthorizeAdminActionAllowReusedMFA(); err != nil {
 			return nil, trace.Wrap(err)
@@ -829,13 +828,13 @@ func (bs *BotService) DeleteBot(
 	scope := user.GetMetadata().Labels[types.BotScopeLabel]
 
 	ruleCtx.Resource153 = dummyBotWithName(req.BotName)
-	if err := authCtx.CheckerContext.Decision(ctx, cmp.Or(scope, scopes.Root), func(checker *services.ScopedAccessChecker) error {
+	if err := authCtx.CheckerContext.Decision(ctx, scope, func(checker *services.ScopedAccessChecker) error {
 		return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbDelete)
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	// If identity is unscoped, perform admin action MFA.
-	// TODO(noah): When scope identities support MFA, enforce it!
+	// TODO(noah/scopes): When scope identities support MFA, enforce it!
 	if unscoped, ok := authCtx.UnscopedContext(); ok {
 		if err := unscoped.AuthorizeAdminAction(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -19,6 +19,7 @@
 package machineidv1
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -40,8 +41,10 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
+	"github.com/gravitational/teleport/lib/utils/set"
 )
 
 // SupportedJoinMethods should match SupportedJoinMethods declared in
@@ -112,13 +115,13 @@ type Backend interface {
 // BotServiceConfig holds configuration options for
 // the bots gRPC service.
 type BotServiceConfig struct {
-	Authorizer authz.Authorizer
-	Cache      Cache
-	Backend    Backend
-	Logger     *slog.Logger
-	Emitter    apievents.Emitter
-	Reporter   usagereporter.UsageReporter
-	Clock      clockwork.Clock
+	ScopedAuthorizer authz.ScopedAuthorizer
+	Cache            Cache
+	Backend          Backend
+	Logger           *slog.Logger
+	Emitter          apievents.Emitter
+	Reporter         usagereporter.UsageReporter
+	Clock            clockwork.Clock
 }
 
 // NewBotService returns a new instance of the BotService.
@@ -128,8 +131,8 @@ func NewBotService(cfg BotServiceConfig) (*BotService, error) {
 		return nil, trace.BadParameter("cache service is required")
 	case cfg.Backend == nil:
 		return nil, trace.BadParameter("backend service is required")
-	case cfg.Authorizer == nil:
-		return nil, trace.BadParameter("authorizer is required")
+	case cfg.ScopedAuthorizer == nil:
+		return nil, trace.BadParameter("scoped authorizer is required")
 	case cfg.Emitter == nil:
 		return nil, trace.BadParameter("emitter is required")
 	case cfg.Reporter == nil:
@@ -143,13 +146,13 @@ func NewBotService(cfg BotServiceConfig) (*BotService, error) {
 	}
 
 	return &BotService{
-		logger:     cfg.Logger,
-		authorizer: cfg.Authorizer,
-		cache:      cfg.Cache,
-		backend:    cfg.Backend,
-		emitter:    cfg.Emitter,
-		reporter:   cfg.Reporter,
-		clock:      cfg.Clock,
+		logger:           cfg.Logger,
+		scopedAuthorizer: cfg.ScopedAuthorizer,
+		cache:            cfg.Cache,
+		backend:          cfg.Backend,
+		emitter:          cfg.Emitter,
+		reporter:         cfg.Reporter,
+		clock:            cfg.Clock,
 	}, nil
 }
 
@@ -157,24 +160,27 @@ func NewBotService(cfg BotServiceConfig) (*BotService, error) {
 type BotService struct {
 	pb.UnimplementedBotServiceServer
 
-	cache      Cache
-	backend    Backend
-	authorizer authz.Authorizer
-	logger     *slog.Logger
-	emitter    apievents.Emitter
-	reporter   usagereporter.UsageReporter
-	clock      clockwork.Clock
+	cache            Cache
+	backend          Backend
+	scopedAuthorizer authz.ScopedAuthorizer
+	logger           *slog.Logger
+	emitter          apievents.Emitter
+	reporter         usagereporter.UsageReporter
+	clock            clockwork.Clock
 }
 
 // GetBot gets a bot by name. It will throw an error if the bot does not exist.
 func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bot, error) {
-	authCtx, err := bs.authorizer.Authorize(ctx)
+	authCtx, err := bs.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.MaybeAccessToKind(
-		types.KindBot, types.VerbRead,
+	// Check if it's feasible that user has access before hitting the cluster
+	// state backend.
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
+		&ruleCtx, types.KindBot, types.VerbReadNoSecrets,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -183,22 +189,16 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 		return nil, trace.BadParameter("bot_name: must be non-empty")
 	}
 
-	user, err := bs.cache.GetUser(ctx, BotResourceName(req.BotName), false)
+	bot, err := bs.getBot(ctx, req.BotName)
 	if err != nil {
-		return nil, trace.Wrap(err, "fetching bot user")
-	}
-	role, err := bs.cache.GetRole(ctx, BotResourceName(req.BotName))
-	if err != nil {
-		return nil, trace.Wrap(err, "fetching bot role")
+		return nil, trace.Wrap(err, "fetching bot")
 	}
 
-	bot, err := botFromUserAndRole(user, role)
-	if err != nil {
-		return nil, trace.Wrap(err, "converting from resources")
-	}
-
-	if err := authCtx.CheckAccessToResource153(
-		bot, types.VerbRead,
+	ruleCtx.Resource153 = bot
+	if err := authCtx.CheckerContext.Decision(
+		ctx, cmp.Or(bot.Scope, scopes.Root), func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbReadNoSecrets)
+		},
 	); err != nil {
 		// Return NotFound rather than Forbidden to avoid leaking existence of
 		// bot.
@@ -208,25 +208,55 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 	return bot, nil
 }
 
+func (bs *BotService) getBot(
+	ctx context.Context, botName string,
+) (*pb.Bot, error) {
+	user, err := bs.cache.GetUser(ctx, BotResourceName(botName), false)
+	if err != nil {
+		return nil, trace.Wrap(err, "fetching bot user")
+	}
+
+	if scope, _ := user.GetLabel(types.BotScopeLabel); scope != "" {
+		bot, err := scopedBotFromUser(user)
+		if err != nil {
+			return nil, trace.Wrap(err, "converting from resources")
+		}
+		return bot, nil
+	}
+
+	role, err := bs.cache.GetRole(ctx, BotResourceName(botName))
+	if err != nil {
+		return nil, trace.Wrap(err, "fetching bot role")
+	}
+	bot, err := botFromUserAndRole(user, role)
+	if err != nil {
+		return nil, trace.Wrap(err, "converting from resources")
+	}
+
+	return bot, nil
+}
+
 // ListBots lists all bots.
 func (bs *BotService) ListBots(
 	ctx context.Context, req *pb.ListBotsRequest,
 ) (*pb.ListBotsResponse, error) {
-	authCtx, err := bs.authorizer.Authorize(ctx)
+	authCtx, err := bs.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
+	ruleCtx := authCtx.RuleContext()
 	// Check generally if this user may have the ability to list bots - ignoring
 	// where conditions.
-	if err := authCtx.MaybeAccessToKind(
-		types.KindBot, types.VerbList,
+	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
+		&ruleCtx, types.KindBot, types.VerbList,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// TODO(noah): Rewrite this to be less janky/better performing.
-	// - Concurrency for fetching roles
+	// TODO(noah): We should add pre-hydrated Bot support to the cache to avoid
+	// needing to iterate over all users here. This is currently a fairly
+	// expensive implementation.
 	bots := []*pb.Bot{}
 	rsp, err := bs.cache.ListUsers(ctx, &userspb.ListUsersRequest{
 		PageSize:  req.PageSize,
@@ -241,32 +271,51 @@ func (bs *BotService) ListBots(
 			continue
 		}
 
-		role, err := bs.cache.GetRole(ctx, BotResourceName(botName))
-		if err != nil {
-			bs.logger.WarnContext(
-				ctx,
-				"Failed to fetch role for bot during ListBots. Bot will be omitted from results",
-				"error", err,
-				"bot_name", botName,
-			)
-			continue
-		}
+		scope, _ := u.GetLabel(types.BotScopeLabel)
+		var bot *pb.Bot
+		if scope == "" {
+			// We only need to fetch the bot role for unscoped bots.
+			role, err := bs.cache.GetRole(ctx, BotResourceName(botName))
+			if err != nil {
+				bs.logger.WarnContext(
+					ctx,
+					"Failed to fetch role for bot during ListBots. Bot will be omitted from results",
+					"error", err,
+					"bot_name", botName,
+				)
+				continue
+			}
 
-		bot, err := botFromUserAndRole(u, role)
-		if err != nil {
-			bs.logger.WarnContext(
-				ctx,
-				"Failed to convert bot during ListBots. Bot will be omitted from results",
-				"error", err,
-				"bot_name", botName,
-			)
-			continue
+			bot, err = botFromUserAndRole(u, role)
+			if err != nil {
+				bs.logger.WarnContext(
+					ctx,
+					"Failed to convert bot during ListBots. Bot will be omitted from results",
+					"error", err,
+					"bot_name", botName,
+				)
+				continue
+			}
+		} else {
+			bot, err = scopedBotFromUser(u)
+			if err != nil {
+				bs.logger.WarnContext(
+					ctx,
+					"Failed to convert scoped bot during ListBots. Bot will be omitted from results",
+					"error", err,
+					"bot_name", botName,
+				)
+				continue
+			}
 		}
 
 		// Check if user can access this specific Bot.
-		if err := authCtx.CheckAccessToResource153(
-			bot, types.VerbList,
-		); err != nil {
+		ruleCtx := authCtx.RuleContext()
+		ruleCtx.Resource153 = bot
+		if err := authCtx.CheckerContext.Decision(ctx, cmp.Or(bot.Scope, scopes.Root), func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbList)
+		}); err != nil {
+			// Ignore resources the user cannot access.
 			continue
 		}
 
@@ -287,44 +336,43 @@ func (bs *BotService) CreateBot(
 	if err := setKindAndVersion(req.Bot); err != nil {
 		return nil, trace.Wrap(err, "setting kind and version")
 	}
-	authCtx, err := bs.authorizer.Authorize(ctx)
+	authCtx, err := bs.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToResource153(
-		req.Bot,
-		types.VerbCreate,
-	); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := validateBot(req.Bot); err != nil {
+	if err := StrongValidateBot(req.Bot); err != nil {
 		return nil, trace.Wrap(err, "validating bot")
 	}
+	// Validation comes before authz checks so we know that scope etc is
+	// well-formed.
 
-	user, role, err := botToUserAndRole(
-		req.Bot, bs.clock.Now(), authCtx.User.GetName(),
-	)
-	if err != nil {
-		return nil, trace.Wrap(err, "converting to resources")
+	ruleCtx := authCtx.RuleContext()
+	ruleCtx.Resource153 = req.Bot
+	if err := authCtx.CheckerContext.Decision(ctx, cmp.Or(req.Bot.Scope, scopes.Root), func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbCreate)
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if unscoped, ok := authCtx.UnscopedContext(); ok {
+		// We can only perform MFA checks on unscoped identities.
+		// TODO(noah): When scopes supports MFA, add check here :')
+		if err := unscoped.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
-	user, err = bs.backend.CreateUser(ctx, user)
-	if err != nil {
-		return nil, trace.Wrap(err, "creating bot user")
-	}
-	role, err = bs.backend.CreateRole(ctx, role)
-	if err != nil {
-		return nil, trace.Wrap(err, "creating bot role")
-	}
-
-	bot, err := botFromUserAndRole(user, role)
-	if err != nil {
-		return nil, trace.Wrap(err, "converting from resources")
+	var bot *pb.Bot
+	if req.Bot.Scope != "" {
+		bot, err = bs.createScopedBot(ctx, authCtx, req.Bot)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		bot, err = bs.createUnscopedBot(ctx, authCtx, req.Bot)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	bs.reporter.AnonymizeAndSubmit(&usagereporter.BotCreateEvent{
@@ -353,6 +401,64 @@ func (bs *BotService) CreateBot(
 	return bot, nil
 }
 
+func (bs *BotService) createScopedBot(
+	ctx context.Context,
+	authCtx *authz.ScopedContext,
+	bot *pb.Bot,
+) (*pb.Bot, error) {
+	if err := scopes.AssertFeatureEnabled(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	user, err := scopedBotToUser(bot, bs.clock.Now(), authCtx.User.GetName())
+	if err != nil {
+		return nil, trace.Wrap(err, "converting to user resource")
+	}
+
+	user, err = bs.backend.CreateUser(ctx, user)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating bot user")
+	}
+
+	bot, err = scopedBotFromUser(user)
+	if err != nil {
+		return nil, trace.Wrap(err, "converting from user resource")
+	}
+
+	return bot, nil
+}
+
+func (bs *BotService) createUnscopedBot(
+	ctx context.Context,
+	authCtx *authz.ScopedContext,
+	bot *pb.Bot,
+) (*pb.Bot, error) {
+	user, role, err := botToUserAndRole(
+		bot, bs.clock.Now(), authCtx.User.GetName(),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err, "converting to resources")
+	}
+
+	user, err = bs.backend.CreateUser(ctx, user)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating bot user")
+	}
+	role, err = bs.backend.CreateRole(ctx, role)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating bot role")
+	}
+
+	// Convert back from user and role, this ensures some consistency in what
+	// we return (i.e if client has provided a bot config that does not
+	// roundtrip).
+	bot, err = botFromUserAndRole(user, role)
+	if err != nil {
+		return nil, trace.Wrap(err, "converting from resources")
+	}
+	return bot, nil
+}
+
 // UpsertBot creates a new bot or forcefully updates an existing bot. This is
 // a function rather than a method so that it can be used by both the gRPC
 // service and the auth server init code when dealing with resources to be
@@ -364,17 +470,58 @@ func UpsertBot(
 	now time.Time,
 	createdBy string,
 ) (*pb.Bot, error) {
-	if err := validateBot(bot); err != nil {
+	if bot.Scope != "" {
+		if err := scopes.AssertFeatureEnabled(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	if err := StrongValidateBot(bot); err != nil {
 		return nil, trace.Wrap(err, "validating bot")
 	}
-	user, role, err := botToUserAndRole(bot, now, createdBy)
-	if err != nil {
-		return nil, trace.Wrap(err, "converting to resources")
+
+	// Fetch pre-existing user, we'll use this to preserve generation and
+	// check for scope transitions.
+	existingUser, err := backend.GetUser(
+		ctx, BotResourceName(bot.Metadata.Name), false,
+	)
+	if err != nil && !trace.IsNotFound(err) {
+		// We'll happily ignore a not-found error, in this case, we have an
+		// upsert for a non-existent bot. If we have any other kind of error,
+		// we want to propagate this up.
+		return nil, trace.Wrap(err, "fetching existing bot user")
+	}
+	if existingUser != nil {
+		// If the bot already exists, we need to check that the upsert does not
+		// cause a scope transition (i.e change of scope, including from/to
+		// unscoped). This is because our RBAC does not account for this.
+		// This restriction may be loosened in future if we evaluate pre-upsert
+		// and post-upsert scope authz.
+		existingScope, _ := existingUser.GetLabel(types.BotScopeLabel)
+		if existingScope != bot.Scope {
+			return nil, trace.BadParameter(
+				"upserts cannot cause the scope of a bot to change, delete and recreate the bot to change its scope",
+			)
+		}
 	}
 
-	// Copy in generation from existing user if exists
-	existingUser, err := backend.GetUser(ctx, BotResourceName(bot.Metadata.Name), false)
-	if err == nil {
+	// Create User (and maybe Role if unscoped) from the Bot.
+	var user types.User
+	var role types.Role
+	if bot.Scope != "" {
+		user, err = scopedBotToUser(bot, now, createdBy)
+		if err != nil {
+			return nil, trace.Wrap(err, "converting scoped bot to user resource")
+		}
+	} else {
+		user, role, err = botToUserAndRole(bot, now, createdBy)
+		if err != nil {
+			return nil, trace.Wrap(err, "converting unscoped bot to resources")
+		}
+	}
+	// If the bot already exists, we need to copy across the generation label.
+	// TODO(noah): When we fully deprecate generation labels, we also need to
+	// remove this - https://github.com/gravitational/teleport/issues/64484
+	if existingUser != nil {
 		if existingGeneration, ok := existingUser.GetLabel(types.BotGenerationLabel); ok {
 			meta := user.GetMetadata()
 			meta.Labels[types.BotGenerationLabel] = existingGeneration
@@ -388,15 +535,24 @@ func UpsertBot(
 	if err != nil {
 		return nil, trace.Wrap(err, "upserting bot user")
 	}
-	role, err = backend.UpsertRole(ctx, role)
-	if err != nil {
-		return nil, trace.Wrap(err, "upserting bot role")
+	if role != nil {
+		// Bot role only exists for unscoped bots.
+		role, err = backend.UpsertRole(ctx, role)
+		if err != nil {
+			return nil, trace.Wrap(err, "upserting bot role")
+		}
+		bot, err = botFromUserAndRole(user, role)
+		if err != nil {
+			return nil, trace.Wrap(err, "converting unscoped bot from resources")
+		}
+		return bot, nil
 	}
 
-	bot, err = botFromUserAndRole(user, role)
+	bot, err = scopedBotFromUser(user)
 	if err != nil {
-		return nil, trace.Wrap(err, "converting from resources")
+		return nil, trace.Wrap(err, "converting scoped bot from user resource")
 	}
+
 	return bot, nil
 }
 
@@ -406,19 +562,37 @@ func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (
 		return nil, trace.Wrap(err, "setting kind and version")
 	}
 
-	authCtx, err := bs.authorizer.Authorize(ctx)
+	authCtx, err := bs.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := authCtx.CheckAccessToResource153(
-		req.Bot,
-		types.VerbCreate, types.VerbUpdate,
+
+	if err := StrongValidateBot(req.Bot); err != nil {
+		return nil, trace.Wrap(err, "validating bot")
+	}
+	// Validation comes before authz checks so that we know scope (if present)
+	// is well-formed.
+
+	ruleCtx := authCtx.RuleContext()
+	ruleCtx.Resource153 = req.Bot
+	if err := authCtx.CheckerContext.Decision(
+		ctx,
+		cmp.Or(req.Bot.Scope, scopes.Root),
+		func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(
+				&ruleCtx, types.KindBot, types.VerbCreate, types.VerbUpdate,
+			)
+		},
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// Support reused MFA for bulk tctl create requests.
-	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
-		return nil, trace.Wrap(err)
+	if unscoped, ok := authCtx.UnscopedContext(); ok {
+		// We can only perform MFA checks on unscoped identities.
+		// TODO(noah): When scopes supports MFA, add check here :')
+		// Allow re-use for bulk upserts.
+		if err := unscoped.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	bot, err := UpsertBot(
@@ -463,10 +637,19 @@ func (bs *BotService) UpdateBot(
 		return nil, trace.Wrap(err, "setting kind and version")
 	}
 
-	authCtx, err := bs.authorizer.Authorize(ctx)
+	scopedAuthCtx, err := bs.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// Out of an abundance of caution, we're avoiding scoped identities/bots
+	// and the update RPC for now. There's no meaningful fields a scoped
+	// identity would need to interact with on a Bot or any identity on a
+	// scoped Bot.
+	authCtx, ok := scopedAuthCtx.UnscopedContext()
+	if !ok {
+		return nil, trace.AccessDenied("scoped identity cannot call update Bot RPC")
+	}
+
 	if err := authCtx.CheckAccessToResource153(
 		req.Bot,
 		types.VerbUpdate,
@@ -495,6 +678,9 @@ func (bs *BotService) UpdateBot(
 	user, err := bs.backend.GetUser(ctx, BotResourceName(req.Bot.Metadata.Name), false)
 	if err != nil {
 		return nil, trace.Wrap(err, "getting bot user")
+	}
+	if scope := user.GetMetadata().Labels[types.BotScopeLabel]; scope != "" {
+		return nil, trace.BadParameter("cannot update scoped bot")
 	}
 	role, err := bs.backend.GetRole(ctx, BotResourceName(req.Bot.Metadata.Name))
 	if err != nil {
@@ -570,12 +756,9 @@ func (bs *BotService) UpdateBot(
 	return bot, nil
 }
 
-func (bs *BotService) deleteBotUser(ctx context.Context, botName string) error {
-	// Check the user that's being deleted is linked to the bot.
-	user, err := bs.backend.GetUser(ctx, BotResourceName(botName), false)
-	if err != nil {
-		return trace.Wrap(err, "fetching bot user")
-	}
+func (bs *BotService) deleteBotUser(
+	ctx context.Context, botName string, user types.User,
+) error {
 	if v := user.GetMetadata().Labels[types.BotLabel]; v != botName {
 		return trace.BadParameter(
 			"user missing bot label matching bot name; consider manually deleting user",
@@ -620,27 +803,54 @@ func (bs *BotService) DeleteBot(
 	// seem to be any automatic deletion of locks in teleport today (other
 	// than expiration). Consistency around security controls seems important
 	// but we can revisit this if desired.
-	authCtx, err := bs.authorizer.Authorize(ctx)
+	authCtx, err := bs.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	if req.BotName == "" {
 		return nil, trace.BadParameter("bot_name: must be non-empty")
 	}
 
-	if err := authCtx.CheckAccessToResource153(
-		dummyBotWithName(req.BotName), types.VerbDelete,
+	// Perform maybe-check before we hit the backend.
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
+		&ruleCtx, types.KindBot, types.VerbDelete,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := authCtx.AuthorizeAdminAction(); err != nil {
+
+	// Fetch user to determine if bot is scoped or unscoped.
+	user, err := bs.backend.GetUser(
+		ctx, BotResourceName(req.BotName), false,
+	)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	scope := user.GetMetadata().Labels[types.BotScopeLabel]
 
+	ruleCtx.Resource153 = dummyBotWithName(req.BotName)
+	if err := authCtx.CheckerContext.Decision(ctx, cmp.Or(scope, scopes.Root), func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbDelete)
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// If identity is unscoped, perform admin action MFA.
+	// TODO(noah): When scope identities support MFA, enforce it!
+	if unscoped, ok := authCtx.UnscopedContext(); ok {
+		if err := unscoped.AuthorizeAdminAction(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	userErr := bs.deleteBotUser(ctx, req.BotName, user)
+	var roleErr error
+	if scope == "" {
+		// Only unscoped bots have a Bot role for us to delete.
+		roleErr = bs.deleteBotRole(ctx, req.BotName)
+	}
 	err = trace.NewAggregate(
-		trace.Wrap(bs.deleteBotUser(ctx, req.BotName), "deleting bot user"),
-		trace.Wrap(bs.deleteBotRole(ctx, req.BotName), "deleting bot role"),
+		trace.Wrap(userErr, "deleting bot user"),
+		trace.Wrap(roleErr, "deleting bot role"),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -686,7 +896,10 @@ func setKindAndVersion(b *pb.Bot) error {
 	return nil
 }
 
-func validateBot(b *pb.Bot) error {
+// StrongValidateBot performs strong validation on scoped and unscoped bots,
+// and is suitable for being called on write operations. This should not be
+// called on read operations.
+func StrongValidateBot(b *pb.Bot) error {
 	if b == nil {
 		return trace.BadParameter("must be non-nil")
 	}
@@ -702,6 +915,26 @@ func validateBot(b *pb.Bot) error {
 	if slices.Contains(b.Spec.Roles, "") {
 		return trace.BadParameter("spec.roles: must not contain empty strings")
 	}
+
+	// Scoped bot only validation
+	if b.Scope != "" {
+		// Validate scope-specific fields
+		if err := scopes.StrongValidate(b.Scope); err != nil {
+			return trace.Wrap(err, "scope:")
+		}
+
+		// Validate unsupported fields aren't set.
+		if len(b.Spec.Roles) > 0 {
+			return trace.BadParameter("spec.roles: cannot be set on scoped bot")
+		}
+		if b.Spec.MaxSessionTtl.AsDuration() != 0 {
+			return trace.BadParameter("spec.max_session_ttl: cannot be set on scoped bot")
+		}
+		if len(b.Spec.Traits) > 0 {
+			return trace.BadParameter("spec.traits: cannot be set on scoped bot")
+		}
+	}
+
 	return nil
 }
 
@@ -709,12 +942,14 @@ func validateBot(b *pb.Bot) error {
 // Bot when converting a User and Role to a Bot. Typically, these are internal
 // labels that are managed by this service and exposing them to the end user
 // would allow for misconfiguration.
-var nonPropagatedLabels = map[string]struct{}{
-	types.BotLabel:           {},
-	types.BotGenerationLabel: {},
-}
+var nonPropagatedLabels = set.New(
+	types.BotLabel,
+	types.BotGenerationLabel,
+	types.BotScopeLabel,
+)
 
-// botFromUserAndRole
+// botFromUserAndRole converts a user and role to an unscoped bot. This should
+// not be called on a scoped bot user.
 //
 // Typically, we treat the bot user as the "canonical" source of information
 // where possible. The bot role should be used for information which cannot
@@ -725,15 +960,17 @@ func botFromUserAndRole(user types.User, role types.Role) (*pb.Bot, error) {
 	if !ok {
 		return nil, trace.BadParameter("user missing bot label")
 	}
-
-	expiry := botExpiryFromUser(user)
+	scope, _ := user.GetLabel(types.BotScopeLabel)
+	if scope != "" {
+		return nil, trace.BadParameter("botFromUserAndRole called on user with scope label")
+	}
 
 	b := &pb.Bot{
 		Kind:    types.KindBot,
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:        botName,
-			Expires:     expiry,
+			Expires:     botExpiryFromUser(user),
 			Description: user.GetMetadata().Description,
 		},
 		Status: &pb.BotStatus{
@@ -751,7 +988,7 @@ func botFromUserAndRole(user types.User, role types.Role) (*pb.Bot, error) {
 	for k, v := range user.GetMetadata().Labels {
 		// We exclude the labels that are implicitly added to the user by the
 		// bot service.
-		if _, ok := nonPropagatedLabels[k]; ok {
+		if nonPropagatedLabels.Contains(k) {
 			continue
 		}
 		b.Metadata.Labels[k] = v
@@ -771,7 +1008,51 @@ func botFromUserAndRole(user types.User, role types.Role) (*pb.Bot, error) {
 	return b, nil
 }
 
+func scopedBotFromUser(user types.User) (*pb.Bot, error) {
+	// User label is canonical source of bot name
+	botName, ok := user.GetLabel(types.BotLabel)
+	if !ok {
+		return nil, trace.BadParameter("user missing bot label")
+	}
+	scope, ok := user.GetLabel(types.BotScopeLabel)
+	if !ok || scope == "" {
+		return nil, trace.BadParameter("scopedBotFromUser called on user without scope label")
+	}
+
+	b := &pb.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
+		Scope:   scope,
+		Metadata: &headerv1.Metadata{
+			Name:        botName,
+			Expires:     botExpiryFromUser(user),
+			Description: user.GetMetadata().Description,
+		},
+		Status: &pb.BotStatus{
+			UserName: user.GetName(),
+		},
+		Spec: &pb.BotSpec{},
+	}
+
+	// Copy in labels from the user
+	b.Metadata.Labels = map[string]string{}
+	for k, v := range user.GetMetadata().Labels {
+		// We exclude the labels that are implicitly added to the user by the
+		// bot service.
+		if nonPropagatedLabels.Contains(k) {
+			continue
+		}
+		b.Metadata.Labels[k] = v
+	}
+
+	return b, nil
+}
+
 func botToUserAndRole(bot *pb.Bot, now time.Time, createdBy string) (types.User, types.Role, error) {
+	if bot.Scope != "" {
+		return nil, nil, trace.BadParameter("botToUserAndRole called on scoped bot")
+	}
+
 	// Setup role
 	resourceName := BotResourceName(bot.Metadata.Name)
 
@@ -826,6 +1107,8 @@ func botToUserAndRole(bot *pb.Bot, now time.Time, createdBy string) (types.User,
 	// We always set this to zero here - but in Upsert, we copy from the
 	// previous user before writing if necessary
 	userMeta.Labels[types.BotGenerationLabel] = "0"
+	// Clears scope label that user should not be able to set.
+	delete(userMeta.Labels, types.BotScopeLabel)
 	userMeta.Expires = userAndRoleExpiryFromBot(bot)
 	// We track the Bot description within the User description field because
 	// the Role description already has a message.
@@ -849,6 +1132,42 @@ func botToUserAndRole(bot *pb.Bot, now time.Time, createdBy string) (types.User,
 	})
 
 	return user, role, nil
+}
+
+func scopedBotToUser(bot *pb.Bot, now time.Time, createdBy string) (types.User, error) {
+	if bot.Scope == "" {
+		return nil, trace.BadParameter("scopedBotToUser called on unscoped bot")
+	}
+
+	// Setup user
+	user, err := types.NewUser(BotResourceName(bot.Metadata.Name))
+	if err != nil {
+		return nil, trace.Wrap(err, "new user")
+	}
+	userMeta := user.GetMetadata()
+
+	// First copy in the labels from the Bot resource
+	userMeta.Labels = map[string]string{}
+	maps.Copy(userMeta.Labels, bot.Metadata.Labels)
+	// Then set these labels over the top - we exclude these when converting
+	// back.
+	userMeta.Labels[types.BotLabel] = bot.Metadata.Name
+	// We always set this to zero here - but in Upsert, we copy from the
+	// previous user before writing if necessary
+	userMeta.Labels[types.BotGenerationLabel] = "0"
+	userMeta.Labels[types.BotScopeLabel] = bot.Scope
+	userMeta.Expires = userAndRoleExpiryFromBot(bot)
+	// We track the Bot description within the User description field because
+	// the Role description already has a message.
+	userMeta.Description = bot.Metadata.Description
+	user.SetMetadata(userMeta)
+
+	user.SetCreatedBy(types.CreatedBy{
+		User: types.UserRef{Name: createdBy},
+		Time: now,
+	})
+
+	return user, nil
 }
 
 func userAndRoleExpiryFromBot(bot *pb.Bot) *time.Time {

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -21,6 +21,7 @@ package machineidv1_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"testing"
@@ -28,9 +29,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -40,12 +44,14 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
 func TestMain(m *testing.M) {
@@ -68,7 +74,7 @@ func TestBotResourceName(t *testing.T) {
 
 // TestCreateBot is an integration test that uses a real gRPC client/server.
 func TestCreateBot(t *testing.T) {
-	t.Parallel()
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	srv, _ := newTestTLSServer(t)
 	ctx := context.Background()
 
@@ -124,10 +130,56 @@ func TestCreateBot(t *testing.T) {
 	require.NoError(t, err)
 	expiry := time.Now().Add(time.Hour)
 
+	scopedSvc := client.ScopedAccessServiceClient()
+	scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-bot-creator",
+			},
+			Scope: "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
+				Rules: []*scopedaccessv1.ScopedRule{
+					{
+						Verbs:     []string{types.VerbCreate},
+						Resources: []string{types.KindBot},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user")
+	require.NoError(t, err)
+
+	// Create scoped role assignments linking users to scoped roles.
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			SubKind: scopedaccess.SubKindDynamic,
+			Scope:   "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/granted"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+
 	tests := []struct {
-		name string
-		user string
-		req  *machineidv1pb.CreateBotRequest
+		name     string
+		identity authtest.TestIdentity
+		req      *machineidv1pb.CreateBotRequest
 
 		assertError require.ErrorAssertionFunc
 		want        *machineidv1pb.Bot
@@ -135,8 +187,8 @@ func TestCreateBot(t *testing.T) {
 		wantRole    *types.RoleV6
 	}{
 		{
-			name: "success",
-			user: botCreator.GetName(),
+			name:     "success",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:    types.KindBot,
@@ -146,6 +198,9 @@ func TestCreateBot(t *testing.T) {
 						Labels: map[string]string{
 							"my-label":       "my-value",
 							"my-other-label": "my-other-value",
+							// Maliciously set label that we want to ensure
+							// is not propagated
+							types.BotScopeLabel: "/please-unset-me",
 						},
 						Description: "Property of US Robotics and Mechanical Men.",
 					},
@@ -251,8 +306,8 @@ func TestCreateBot(t *testing.T) {
 			},
 		},
 		{
-			name: "success with expiry",
-			user: botCreator.GetName(),
+			name:     "success with expiry",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:    types.KindBot,
@@ -368,8 +423,8 @@ func TestCreateBot(t *testing.T) {
 			},
 		},
 		{
-			name: "success with max ttl",
-			user: botCreator.GetName(),
+			name:     "success with max ttl",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Metadata: &headerv1.Metadata{
@@ -454,8 +509,8 @@ func TestCreateBot(t *testing.T) {
 			},
 		},
 		{
-			name: "success with where on name",
-			user: botCreatorWhere.GetName(),
+			name:     "success with where on name",
+			identity: authtest.TestUser(botCreatorWhere.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Metadata: &headerv1.Metadata{
@@ -471,8 +526,8 @@ func TestCreateBot(t *testing.T) {
 			assertError: require.NoError,
 		},
 		{
-			name: "failure with where on name",
-			user: botCreatorWhere.GetName(),
+			name:     "failure with where on name",
+			identity: authtest.TestUser(botCreatorWhere.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Metadata: &headerv1.Metadata{
@@ -488,8 +543,8 @@ func TestCreateBot(t *testing.T) {
 			assertError: require.Error,
 		},
 		{
-			name: "bot already exists",
-			user: botCreator.GetName(),
+			name:     "bot already exists",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: preExistingBot,
 			},
@@ -499,8 +554,8 @@ func TestCreateBot(t *testing.T) {
 			},
 		},
 		{
-			name: "no permissions",
-			user: unprivilegedUser.GetName(),
+			name:     "no permissions",
+			identity: authtest.TestUser(unprivilegedUser.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: preExistingBot,
 			},
@@ -510,8 +565,8 @@ func TestCreateBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - nil bot",
-			user: botCreator.GetName(),
+			name:     "validation - nil bot",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: nil,
 			},
@@ -521,8 +576,8 @@ func TestCreateBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - nil metadata",
-			user: botCreator.GetName(),
+			name:     "validation - nil metadata",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:     types.KindBot,
@@ -539,8 +594,8 @@ func TestCreateBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - no name",
-			user: botCreator.GetName(),
+			name:     "validation - no name",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:     types.KindBot,
@@ -557,8 +612,8 @@ func TestCreateBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - nil spec",
-			user: botCreator.GetName(),
+			name:     "validation - nil spec",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:    types.KindBot,
@@ -575,8 +630,8 @@ func TestCreateBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - empty role",
-			user: botCreator.GetName(),
+			name:     "validation - empty role",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:    types.KindBot,
@@ -595,10 +650,95 @@ func TestCreateBot(t *testing.T) {
 				require.True(t, trace.IsBadParameter(err), "error should be bad parameter")
 			},
 		},
+		{
+			name:     "scoped identity creates scoped bot",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.CreateBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{
+						Name: "scoped-bot-success",
+					},
+					Scope: "/scopes/granted",
+					Spec:  &machineidv1pb.BotSpec{},
+				},
+			},
+			assertError: require.NoError,
+			want: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "scoped-bot-success",
+				},
+				Scope: "/scopes/granted",
+				Spec:  &machineidv1pb.BotSpec{},
+				Status: &machineidv1pb.BotStatus{
+					UserName: "bot-scoped-bot-success",
+				},
+			},
+		},
+		{
+			name:     "unscoped identity creates scoped bot",
+			identity: authtest.TestUser(botCreator.GetName()),
+			req: &machineidv1pb.CreateBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{
+						Name: "scoped-bot-from-unscoped",
+					},
+					Scope: "/scopes/granted",
+					Spec:  &machineidv1pb.BotSpec{},
+				},
+			},
+			assertError: require.NoError,
+			want: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "scoped-bot-from-unscoped",
+				},
+				Scope: "/scopes/granted",
+				Spec:  &machineidv1pb.BotSpec{},
+				Status: &machineidv1pb.BotStatus{
+					UserName: "bot-scoped-bot-from-unscoped",
+				},
+			},
+		},
+		{
+			name:     "scoped identity wrong scope",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.CreateBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{
+						Name: "scoped-bot-denied",
+					},
+					Scope: "/scopes/ungranted",
+					Spec:  &machineidv1pb.BotSpec{},
+				},
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+			},
+		},
+		{
+			name:     "scoped identity cannot create unscoped bot",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.CreateBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{
+						Name: "unscoped-from-scoped",
+					},
+					Spec: &machineidv1pb.BotSpec{
+						Roles: []string{testRole.GetName()},
+					},
+				},
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := srv.NewClient(authtest.TestUser(tt.user))
+			client, err := srv.NewClient(tt.identity)
 			require.NoError(t, err)
 
 			bot, err := client.BotServiceClient().CreateBot(ctx, tt.req)
@@ -1040,7 +1180,7 @@ func TestUpdateBot(t *testing.T) {
 
 // TestUpsertBot is an integration test that uses a real gRPC client/server.
 func TestUpsertBot(t *testing.T) {
-	t.Parallel()
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	srv, _ := newTestTLSServer(t)
 	ctx := context.Background()
 
@@ -1098,10 +1238,66 @@ func TestUpsertBot(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// Scoped identity setup.
+	scopedSvc := client.ScopedAccessServiceClient()
+	scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-bot-upserter",
+			},
+			Scope: "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
+				Rules: []*scopedaccessv1.ScopedRule{
+					{
+						Verbs:     []string{types.VerbCreate, types.VerbUpdate},
+						Resources: []string{types.KindBot},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user")
+	require.NoError(t, err)
+
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			SubKind: scopedaccess.SubKindDynamic,
+			Scope:   "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/granted"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+
+	// Pre-existing scoped bot for scope-transition tests.
+	_, err = client.BotServiceClient().UpsertBot(ctx, &machineidv1pb.UpsertBotRequest{
+		Bot: &machineidv1pb.Bot{
+			Metadata: &headerv1.Metadata{Name: "scope-change-test"},
+			Scope:    "/scopes/granted",
+			Spec:     &machineidv1pb.BotSpec{},
+		},
+	})
+	require.NoError(t, err)
+
 	tests := []struct {
-		name string
-		user string
-		req  *machineidv1pb.UpsertBotRequest
+		name     string
+		identity authtest.TestIdentity
+		req      *machineidv1pb.UpsertBotRequest
 
 		assertError require.ErrorAssertionFunc
 		want        *machineidv1pb.Bot
@@ -1109,8 +1305,8 @@ func TestUpsertBot(t *testing.T) {
 		wantRole    *types.RoleV6
 	}{
 		{
-			name: "new",
-			user: botCreator.GetName(),
+			name:     "new",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:    types.KindBot,
@@ -1210,8 +1406,8 @@ func TestUpsertBot(t *testing.T) {
 			},
 		},
 		{
-			name: "new with expiry",
-			user: botCreator.GetName(),
+			name:     "new with expiry",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:    types.KindBot,
@@ -1315,8 +1511,8 @@ func TestUpsertBot(t *testing.T) {
 			},
 		},
 		{
-			name: "already exists",
-			user: botCreator.GetName(),
+			name:     "already exists",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: preExistingBot,
 			},
@@ -1374,8 +1570,8 @@ func TestUpsertBot(t *testing.T) {
 			},
 		},
 		{
-			name: "already exists with max session ttl",
-			user: botCreator.GetName(),
+			name:     "already exists with max session ttl",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Metadata: &headerv1.Metadata{
@@ -1463,8 +1659,8 @@ func TestUpsertBot(t *testing.T) {
 			},
 		},
 		{
-			name: "new with where",
-			user: botWhereCreator.GetName(),
+			name:     "new with where",
+			identity: authtest.TestUser(botWhereCreator.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:    types.KindBot,
@@ -1480,8 +1676,8 @@ func TestUpsertBot(t *testing.T) {
 			assertError: require.NoError,
 		},
 		{
-			name: "failed new with where",
-			user: botWhereCreator.GetName(),
+			name:     "failed new with where",
+			identity: authtest.TestUser(botWhereCreator.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:    types.KindBot,
@@ -1499,8 +1695,8 @@ func TestUpsertBot(t *testing.T) {
 			},
 		},
 		{
-			name: "no permissions",
-			user: unprivilegedUser.GetName(),
+			name:     "no permissions",
+			identity: authtest.TestUser(unprivilegedUser.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:    types.KindBot,
@@ -1519,8 +1715,8 @@ func TestUpsertBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - nil bot",
-			user: botCreator.GetName(),
+			name:     "validation - nil bot",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: nil,
 			},
@@ -1530,8 +1726,8 @@ func TestUpsertBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - nil metadata",
-			user: botCreator.GetName(),
+			name:     "validation - nil metadata",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:     types.KindBot,
@@ -1548,8 +1744,8 @@ func TestUpsertBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - no name",
-			user: botCreator.GetName(),
+			name:     "validation - no name",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:     types.KindBot,
@@ -1566,8 +1762,8 @@ func TestUpsertBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - empty role",
-			user: botCreator.GetName(),
+			name:     "validation - empty role",
+			identity: authtest.TestUser(botCreator.GetName()),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
 					Kind:    types.KindBot,
@@ -1586,10 +1782,136 @@ func TestUpsertBot(t *testing.T) {
 				require.True(t, trace.IsBadParameter(err), "error should be bad parameter")
 			},
 		},
+		{
+			name:     "scoped identity upserts scoped bot",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.UpsertBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{
+						Name: "scoped-upsert-success",
+					},
+					Scope: "/scopes/granted",
+					Spec:  &machineidv1pb.BotSpec{},
+				},
+			},
+			assertError: require.NoError,
+			want: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "scoped-upsert-success",
+				},
+				Scope: "/scopes/granted",
+				Spec:  &machineidv1pb.BotSpec{},
+				Status: &machineidv1pb.BotStatus{
+					UserName: "bot-scoped-upsert-success",
+				},
+			},
+		},
+		{
+			name:     "unscoped identity upserts scoped bot",
+			identity: authtest.TestUser(botCreator.GetName()),
+			req: &machineidv1pb.UpsertBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{
+						Name: "scoped-upsert-from-unscoped",
+					},
+					Scope: "/scopes/granted",
+					Spec:  &machineidv1pb.BotSpec{},
+				},
+			},
+			assertError: require.NoError,
+			want: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "scoped-upsert-from-unscoped",
+				},
+				Scope: "/scopes/granted",
+				Spec:  &machineidv1pb.BotSpec{},
+				Status: &machineidv1pb.BotStatus{
+					UserName: "bot-scoped-upsert-from-unscoped",
+				},
+			},
+		},
+		{
+			name:     "scoped identity wrong scope",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.UpsertBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{
+						Name: "scoped-upsert-denied",
+					},
+					Scope: "/scopes/ungranted",
+					Spec:  &machineidv1pb.BotSpec{},
+				},
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+			},
+		},
+		{
+			name:     "scoped identity cannot upsert unscoped bot",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.UpsertBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{
+						Name: "unscoped-from-scoped",
+					},
+					Spec: &machineidv1pb.BotSpec{
+						Roles: []string{testRole.GetName()},
+					},
+				},
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+			},
+		},
+		{
+			name:     "cannot change scope: scoped to unscoped",
+			identity: authtest.TestUser(botCreator.GetName()),
+			req: &machineidv1pb.UpsertBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{Name: "scope-change-test"},
+					Spec:     &machineidv1pb.BotSpec{Roles: []string{testRole.GetName()}},
+				},
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+			},
+		},
+		{
+			name:     "cannot change scope: unscoped to scoped",
+			identity: authtest.TestUser(botCreator.GetName()),
+			req: &machineidv1pb.UpsertBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{Name: "pre-existing"},
+					Scope:    "/scopes/granted",
+					Spec:     &machineidv1pb.BotSpec{},
+				},
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+			},
+		},
+		{
+			name:     "cannot change scope: scoped to different scope",
+			identity: authtest.TestUser(botCreator.GetName()),
+			req: &machineidv1pb.UpsertBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Metadata: &headerv1.Metadata{Name: "scope-change-test"},
+					Scope:    "/scopes/ungranted",
+					Spec:     &machineidv1pb.BotSpec{},
+				},
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := srv.NewClient(authtest.TestUser(tt.user))
+			client, err := srv.NewClient(tt.identity)
 			require.NoError(t, err)
 
 			bot, err := client.BotServiceClient().UpsertBot(ctx, tt.req)
@@ -1627,7 +1949,7 @@ func TestUpsertBot(t *testing.T) {
 
 // TestGetBot is an integration test that uses a real gRPC client/server.
 func TestGetBot(t *testing.T) {
-	t.Parallel()
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	srv, _ := newTestTLSServer(t)
 	ctx := context.Background()
 
@@ -1703,16 +2025,87 @@ func TestGetBot(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	// Scoped identity setup.
+	scopedSvc := client.ScopedAccessServiceClient()
+	scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-bot-getter",
+			},
+			Scope: "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
+				Rules: []*scopedaccessv1.ScopedRule{
+					{
+						Verbs:     []string{types.VerbReadNoSecrets},
+						Resources: []string{types.KindBot},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user")
+	require.NoError(t, err)
+
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			SubKind: scopedaccess.SubKindDynamic,
+			Scope:   "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/granted"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+
+	scopedPreExisting, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
+		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-pre-existing",
+			},
+			Spec:  &machineidv1pb.BotSpec{},
+			Scope: "/scopes/granted",
+		},
+	})
+	require.NoError(t, err)
+	_, err = client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
+		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-pre-existing-wrong-scope",
+			},
+			Spec:  &machineidv1pb.BotSpec{},
+			Scope: "/scopes/ungranted",
+		},
+	})
+	require.NoError(t, err)
+
 	tests := []struct {
 		name        string
-		user        string
+		identity    authtest.TestIdentity
 		req         *machineidv1pb.GetBotRequest
 		assertError require.ErrorAssertionFunc
 		want        *machineidv1pb.Bot
 	}{
 		{
-			name: "success",
-			user: botGetterUser.GetName(),
+			name:     "success",
+			identity: authtest.TestUser(botGetterUser.GetName()),
 			req: &machineidv1pb.GetBotRequest{
 				BotName: preExistingBot.Metadata.Name,
 			},
@@ -1721,8 +2114,8 @@ func TestGetBot(t *testing.T) {
 			want:        preExistingBot,
 		},
 		{
-			name: "success with where",
-			user: botGetterWhereUser.GetName(),
+			name:     "success with where",
+			identity: authtest.TestUser(botGetterWhereUser.GetName()),
 			req: &machineidv1pb.GetBotRequest{
 				BotName: preExistingBot2.Metadata.Name,
 			},
@@ -1731,8 +2124,8 @@ func TestGetBot(t *testing.T) {
 			want:        preExistingBot2,
 		},
 		{
-			name: "no permissions with where",
-			user: botGetterWhereUser.GetName(),
+			name:     "no permissions with where",
+			identity: authtest.TestUser(botGetterWhereUser.GetName()),
 			req: &machineidv1pb.GetBotRequest{
 				BotName: preExistingBot.Metadata.Name,
 			},
@@ -1741,8 +2134,8 @@ func TestGetBot(t *testing.T) {
 			},
 		},
 		{
-			name: "no permissions",
-			user: unprivilegedUser.GetName(),
+			name:     "no permissions",
+			identity: authtest.TestUser(unprivilegedUser.GetName()),
 			req: &machineidv1pb.GetBotRequest{
 				BotName: preExistingBot.Metadata.Name,
 			},
@@ -1751,8 +2144,8 @@ func TestGetBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - no bot name",
-			user: botGetterUser.GetName(),
+			name:     "validation - no bot name",
+			identity: authtest.TestUser(botGetterUser.GetName()),
 			req: &machineidv1pb.GetBotRequest{
 				BotName: "",
 			},
@@ -1762,8 +2155,8 @@ func TestGetBot(t *testing.T) {
 			},
 		},
 		{
-			name: "bot doesnt exist",
-			user: botGetterUser.GetName(),
+			name:     "bot doesnt exist",
+			identity: authtest.TestUser(botGetterUser.GetName()),
 			req: &machineidv1pb.GetBotRequest{
 				BotName: "non-existent",
 			},
@@ -1771,10 +2164,50 @@ func TestGetBot(t *testing.T) {
 				require.True(t, trace.IsNotFound(err), "error should be bad parameter")
 			},
 		},
+		{
+			name:     "scoped identity gets scoped bot",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.GetBotRequest{
+				BotName: scopedPreExisting.Metadata.Name,
+			},
+			assertError: require.NoError,
+			want:        scopedPreExisting,
+		},
+		{
+			name:     "unscoped identity gets scoped bot",
+			identity: authtest.TestUser(botGetterUser.GetName()),
+			req: &machineidv1pb.GetBotRequest{
+				BotName: scopedPreExisting.Metadata.Name,
+			},
+			assertError: require.NoError,
+			want:        scopedPreExisting,
+		},
+		{
+			name:     "scoped identity wrong scope",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.GetBotRequest{
+				BotName: "scoped-pre-existing-wrong-scope",
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				// GetBot returns NotFound rather than AccessDenied to avoid leaking existence.
+				require.True(t, trace.IsNotFound(err), "expected not found, got: %v", err)
+			},
+		},
+		{
+			name:     "scoped identity cannot get unscoped bot",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.GetBotRequest{
+				BotName: preExistingBot.Metadata.Name,
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				// GetBot returns NotFound rather than AccessDenied to avoid leaking existence.
+				require.True(t, trace.IsNotFound(err), "expected not found, got: %v", err)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := srv.NewClient(authtest.TestUser(tt.user))
+			client, err := srv.NewClient(tt.identity)
 			require.NoError(t, err)
 
 			bot, err := client.BotServiceClient().GetBot(ctx, tt.req)
@@ -1789,7 +2222,7 @@ func TestGetBot(t *testing.T) {
 
 // TestListBots is an integration test that uses a real gRPC client/server.
 func TestListBots(t *testing.T) {
-	t.Parallel()
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	srv, _ := newTestTLSServer(t)
 	ctx := context.Background()
 
@@ -1880,16 +2313,97 @@ func TestListBots(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	// Scoped identity setup.
+	scopedSvc := client.ScopedAccessServiceClient()
+	scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-bot-lister",
+			},
+			Scope: "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
+				Rules: []*scopedaccessv1.ScopedRule{
+					{
+						Verbs:     []string{types.VerbList},
+						Resources: []string{types.KindBot},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user")
+	require.NoError(t, err)
+
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			Scope:   "/scopes",
+			SubKind: scopedaccess.SubKindDynamic,
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/granted"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Create a 2nd scoped user with assignment at /scopes/ungranted (where no bots exist).
+	scopedUser2, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user-2")
+	require.NoError(t, err)
+	sraResp2, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			SubKind: scopedaccess.SubKindDynamic,
+			Scope:   "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser2.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/ungranted"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp, sraResp2)
+
+	scopedPreExisting, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
+		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-pre-existing",
+			},
+			Spec:  &machineidv1pb.BotSpec{},
+			Scope: "/scopes/granted",
+		},
+	})
+	require.NoError(t, err)
+
 	tests := []struct {
 		name        string
-		user        string
+		identity    authtest.TestIdentity
 		req         *machineidv1pb.ListBotsRequest
 		assertError require.ErrorAssertionFunc
 		want        *machineidv1pb.ListBotsResponse
 	}{
 		{
 			name:        "success",
-			user:        botListerUser.GetName(),
+			identity:    authtest.TestUser(botListerUser.GetName()),
 			req:         &machineidv1pb.ListBotsRequest{},
 			assertError: require.NoError,
 			want: &machineidv1pb.ListBotsResponse{
@@ -1897,12 +2411,13 @@ func TestListBots(t *testing.T) {
 					preExistingBot,
 					preExistingBot2,
 					preExistingBot3,
+					scopedPreExisting,
 				},
 			},
 		},
 		{
 			name:        "success with where",
-			user:        botListWhereUser.GetName(),
+			identity:    authtest.TestUser(botListWhereUser.GetName()),
 			req:         &machineidv1pb.ListBotsRequest{},
 			assertError: require.NoError,
 			want: &machineidv1pb.ListBotsResponse{
@@ -1912,17 +2427,38 @@ func TestListBots(t *testing.T) {
 			},
 		},
 		{
-			name: "no permissions",
-			user: unprivilegedUser.GetName(),
-			req:  &machineidv1pb.ListBotsRequest{},
+			name:     "no permissions",
+			identity: authtest.TestUser(unprivilegedUser.GetName()),
+			req:      &machineidv1pb.ListBotsRequest{},
 			assertError: func(t require.TestingT, err error, i ...any) {
 				require.True(t, trace.IsAccessDenied(err), "error should be access denied")
+			},
+		},
+		{
+			name:        "scoped identity lists scoped bots",
+			identity:    authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req:         &machineidv1pb.ListBotsRequest{},
+			assertError: require.NoError,
+			want: &machineidv1pb.ListBotsResponse{
+				Bots: []*machineidv1pb.Bot{
+					scopedPreExisting,
+				},
+			},
+		},
+		{
+			// Scoped user at /scopes/ungranted where no bots exist: returns empty list.
+			name:        "scoped identity at scope with no bots lists nothing",
+			identity:    authtest.TestScopedUser(scopedUser2.GetName(), "/scopes/ungranted"),
+			req:         &machineidv1pb.ListBotsRequest{},
+			assertError: require.NoError,
+			want: &machineidv1pb.ListBotsResponse{
+				Bots: []*machineidv1pb.Bot{},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := srv.NewClient(authtest.TestUser(tt.user))
+			client, err := srv.NewClient(tt.identity)
 			require.NoError(t, err)
 
 			res, err := client.BotServiceClient().ListBots(ctx, tt.req)
@@ -1944,7 +2480,7 @@ func TestListBots(t *testing.T) {
 
 // TestDeleteBot is an integration test that uses a real gRPC client/server.
 func TestDeleteBot(t *testing.T) {
-	t.Parallel()
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	srv, _ := newTestTLSServer(t)
 	ctx := context.Background()
 
@@ -2058,16 +2594,112 @@ func TestDeleteBot(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	// Scoped identity setup: create a scoped role, user, and assignment.
+	scopedSvc := client.ScopedAccessServiceClient()
+	scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-bot-deleter",
+			},
+			Scope: "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
+				Rules: []*scopedaccessv1.ScopedRule{
+					{
+						Verbs:     []string{types.VerbDelete},
+						Resources: []string{types.KindBot},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user")
+	require.NoError(t, err)
+
+	// Create scoped role assignment linking user to scoped role.
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			SubKind: scopedaccess.SubKindDynamic,
+			Scope:   "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/granted"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+
+	// Create scoped bots for delete tests.
+	// Note: scoped bots cannot have roles set.
+	scopedPreExisting, err := client.BotServiceClient().CreateBot(
+		ctx,
+		&machineidv1pb.CreateBotRequest{
+			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "scoped-pre-existing",
+				},
+				Spec:  &machineidv1pb.BotSpec{},
+				Scope: "/scopes/granted",
+			},
+		},
+	)
+	require.NoError(t, err)
+	scopedPreExistingUnscoped, err := client.BotServiceClient().CreateBot(
+		ctx,
+		&machineidv1pb.CreateBotRequest{
+			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "scoped-pre-existing-unscoped",
+				},
+				Spec:  &machineidv1pb.BotSpec{},
+				Scope: "/scopes/granted",
+			},
+		},
+	)
+	require.NoError(t, err)
+	scopedPreExistingWrongScope, err := client.BotServiceClient().CreateBot(
+		ctx,
+		&machineidv1pb.CreateBotRequest{
+			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "scoped-pre-existing-wrong-scope",
+				},
+				Spec:  &machineidv1pb.BotSpec{},
+				Scope: "/scopes/ungranted",
+			},
+		},
+	)
+	require.NoError(t, err)
+
 	tests := []struct {
 		name                  string
-		user                  string
+		identity              authtest.TestIdentity
 		req                   *machineidv1pb.DeleteBotRequest
 		assertError           require.ErrorAssertionFunc
 		checkResourcesDeleted bool
+		scoped                bool
 	}{
 		{
-			name: "success",
-			user: botDeleterUser.GetName(),
+			name:     "success",
+			identity: authtest.TestUser(botDeleterUser.GetName()),
 			req: &machineidv1pb.DeleteBotRequest{
 				BotName: preExistingBot.Metadata.Name,
 			},
@@ -2075,8 +2707,8 @@ func TestDeleteBot(t *testing.T) {
 			checkResourcesDeleted: true,
 		},
 		{
-			name: "success with where",
-			user: botWhereDeleterUser.GetName(),
+			name:     "success with where",
+			identity: authtest.TestUser(botWhereDeleterUser.GetName()),
 			req: &machineidv1pb.DeleteBotRequest{
 				BotName: preExistingBot4.Metadata.Name,
 			},
@@ -2084,8 +2716,8 @@ func TestDeleteBot(t *testing.T) {
 			checkResourcesDeleted: true,
 		},
 		{
-			name: "no permissions with where",
-			user: botWhereDeleterUser.GetName(),
+			name:     "no permissions with where",
+			identity: authtest.TestUser(botWhereDeleterUser.GetName()),
 			req: &machineidv1pb.DeleteBotRequest{
 				BotName: preExistingBot5.Metadata.Name,
 			},
@@ -2094,8 +2726,8 @@ func TestDeleteBot(t *testing.T) {
 			},
 		},
 		{
-			name: "no permissions",
-			user: unprivilegedUser.GetName(),
+			name:     "no permissions",
+			identity: authtest.TestUser(unprivilegedUser.GetName()),
 			req: &machineidv1pb.DeleteBotRequest{
 				BotName: preExistingBot3.Metadata.Name,
 			},
@@ -2104,8 +2736,8 @@ func TestDeleteBot(t *testing.T) {
 			},
 		},
 		{
-			name: "non existent",
-			user: botDeleterUser.GetName(),
+			name:     "non existent",
+			identity: authtest.TestUser(botDeleterUser.GetName()),
 			req: &machineidv1pb.DeleteBotRequest{
 				BotName: "does-not-exist",
 			},
@@ -2114,8 +2746,8 @@ func TestDeleteBot(t *testing.T) {
 			},
 		},
 		{
-			name: "non-bot role",
-			user: botDeleterUser.GetName(),
+			name:     "non-bot role",
+			identity: authtest.TestUser(botDeleterUser.GetName()),
 			req: &machineidv1pb.DeleteBotRequest{
 				BotName: "not-bot",
 			},
@@ -2124,8 +2756,8 @@ func TestDeleteBot(t *testing.T) {
 			},
 		},
 		{
-			name: "validation - no bot name",
-			user: botDeleterUser.GetName(),
+			name:     "validation - no bot name",
+			identity: authtest.TestUser(botDeleterUser.GetName()),
 			req: &machineidv1pb.DeleteBotRequest{
 				BotName: "",
 			},
@@ -2134,10 +2766,50 @@ func TestDeleteBot(t *testing.T) {
 				require.True(t, trace.IsBadParameter(err), "error should be access denied")
 			},
 		},
+		{
+			name:     "scoped identity deletes scoped bot",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.DeleteBotRequest{
+				BotName: scopedPreExisting.Metadata.Name,
+			},
+			assertError:           require.NoError,
+			checkResourcesDeleted: true,
+			scoped:                true,
+		},
+		{
+			name:     "unscoped identity deletes scoped bot",
+			identity: authtest.TestUser(botDeleterUser.GetName()),
+			req: &machineidv1pb.DeleteBotRequest{
+				BotName: scopedPreExistingUnscoped.Metadata.Name,
+			},
+			assertError:           require.NoError,
+			checkResourcesDeleted: true,
+			scoped:                true,
+		},
+		{
+			name:     "scoped identity wrong scope",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.DeleteBotRequest{
+				BotName: scopedPreExistingWrongScope.Metadata.Name,
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+			},
+		},
+		{
+			name:     "scoped identity cannot delete unscoped bot",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			req: &machineidv1pb.DeleteBotRequest{
+				BotName: preExistingBot3.Metadata.Name,
+			},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := srv.NewClient(authtest.TestUser(tt.user))
+			client, err := srv.NewClient(tt.identity)
 			require.NoError(t, err)
 
 			_, err = client.BotServiceClient().DeleteBot(ctx, tt.req)
@@ -2145,11 +2817,270 @@ func TestDeleteBot(t *testing.T) {
 			if tt.checkResourcesDeleted {
 				_, err := srv.Auth().GetUser(ctx, machineidv1.BotResourceName(tt.req.BotName), false)
 				require.True(t, trace.IsNotFound(err), "bot user should be deleted")
-				_, err = srv.Auth().GetRole(ctx, machineidv1.BotResourceName(tt.req.BotName))
-				require.True(t, trace.IsNotFound(err), "bot role should be deleted")
+				if !tt.scoped {
+					_, err = srv.Auth().GetRole(ctx, machineidv1.BotResourceName(tt.req.BotName))
+					require.True(t, trace.IsNotFound(err), "bot role should be deleted")
+				}
 			}
 		})
 	}
+}
+
+func TestStrongValidateBot(t *testing.T) {
+	newBot := func(mutate func(bot *machineidv1pb.Bot)) *machineidv1pb.Bot {
+		bot := &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "test-bot",
+			},
+			Spec: &machineidv1pb.BotSpec{
+				Roles: []string{"test-role"},
+			},
+		}
+		if mutate != nil {
+			mutate(bot)
+		}
+		return bot
+	}
+	newScopedBot := func(mutate func(bot *machineidv1pb.Bot)) *machineidv1pb.Bot {
+		bot := &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "test-bot",
+			},
+			Scope: "/test/scope",
+			Spec:  &machineidv1pb.BotSpec{},
+		}
+		if mutate != nil {
+			mutate(bot)
+		}
+		return bot
+	}
+
+	isBadParam := func(t require.TestingT, err error, i ...any) {
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter error, got: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		bot         *machineidv1pb.Bot
+		assertError require.ErrorAssertionFunc
+	}{
+		{
+			name:        "nil bot",
+			bot:         nil,
+			assertError: isBadParam,
+		},
+		{
+			name:        "nil metadata",
+			bot:         newBot(func(b *machineidv1pb.Bot) { b.Metadata = nil }),
+			assertError: isBadParam,
+		},
+		{
+			name:        "empty name",
+			bot:         newBot(func(b *machineidv1pb.Bot) { b.Metadata.Name = "" }),
+			assertError: isBadParam,
+		},
+		{
+			name:        "nil spec",
+			bot:         newBot(func(b *machineidv1pb.Bot) { b.Spec = nil }),
+			assertError: isBadParam,
+		},
+		{
+			name: "roles contains empty string",
+			bot: newBot(func(b *machineidv1pb.Bot) {
+				b.Spec.Roles = []string{"valid-role", ""}
+			}),
+			assertError: isBadParam,
+		},
+		{
+			name:        "valid unscoped bot",
+			bot:         newBot(nil),
+			assertError: require.NoError,
+		},
+		{
+			name: "valid unscoped bot with no roles",
+			bot: newBot(func(b *machineidv1pb.Bot) {
+				b.Spec.Roles = nil
+			}),
+			assertError: require.NoError,
+		},
+		{
+			name: "valid unscoped bot with traits and max_session_ttl",
+			bot: newBot(func(b *machineidv1pb.Bot) {
+				b.Spec.Traits = []*machineidv1pb.Trait{{Name: "foo", Values: []string{"bar"}}}
+				b.Spec.MaxSessionTtl = durationpb.New(time.Hour)
+			}),
+			assertError: require.NoError,
+		},
+		{
+			name:        "scoped bot with invalid scope",
+			bot:         newScopedBot(func(b *machineidv1pb.Bot) { b.Scope = "no-leading-slash" }),
+			assertError: isBadParam,
+		},
+		{
+			name: "scoped bot with roles set",
+			bot: newScopedBot(func(b *machineidv1pb.Bot) {
+				b.Spec.Roles = []string{"some-role"}
+			}),
+			assertError: isBadParam,
+		},
+		{
+			name: "scoped bot with traits set",
+			bot: newScopedBot(func(b *machineidv1pb.Bot) {
+				b.Spec.Traits = []*machineidv1pb.Trait{{Name: "foo", Values: []string{"bar"}}}
+			}),
+			assertError: isBadParam,
+		},
+		{
+			name: "scoped bot with max_session_ttl set",
+			bot: newScopedBot(func(b *machineidv1pb.Bot) {
+				b.Spec.MaxSessionTtl = durationpb.New(time.Hour)
+			}),
+			assertError: isBadParam,
+		},
+		{
+			name:        "valid scoped bot",
+			bot:         newScopedBot(nil),
+			assertError: require.NoError,
+		},
+		{
+			name:        "valid scoped bot at root scope",
+			bot:         newScopedBot(func(b *machineidv1pb.Bot) { b.Scope = "/" }),
+			assertError: require.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := machineidv1.StrongValidateBot(tt.bot)
+			tt.assertError(t, err)
+		})
+	}
+}
+
+// TestStrongValidateBotScopedFuzz fuzzes the spec fields of a scoped Bot. This
+// is designed to ensure that a new field that is added for unscoped Bots is
+// not accidentally valid for scoped Bots, which have a constrained set of
+// fields.
+//
+// All new spec fields which are permitted for scoped bots must be added to
+// the allowedScopedSpecFields map.
+func TestStrongValidateBotScopedFuzz(t *testing.T) {
+	allowedScopedSpecFields := map[protoreflect.Name]bool{
+		// No fields are currently allowed on scoped bots.
+	}
+
+	specDesc := (&machineidv1pb.BotSpec{}).ProtoReflect().Descriptor()
+	fields := specDesc.Fields()
+	for i := range fields.Len() {
+		fd := fields.Get(i)
+		t.Run(string(fd.Name()), func(t *testing.T) {
+			spec := &machineidv1pb.BotSpec{}
+			protoSetNonZeroField(spec.ProtoReflect(), fd)
+
+			bot := &machineidv1pb.Bot{
+				Metadata: &headerv1.Metadata{Name: "test-bot"},
+				Scope:    "/test/scope",
+				Spec:     spec,
+			}
+
+			err := machineidv1.StrongValidateBot(bot)
+			if allowedScopedSpecFields[fd.Name()] {
+				require.NoError(t, err,
+					"field %q is in allow-list but StrongValidateBot rejected it", fd.Name())
+			} else {
+				require.Error(t, err,
+					"field %q is not in allow-list but StrongValidateBot accepted a scoped bot "+
+						"with it set; either forbid it in StrongValidateBot or add it to allowedScopedSpecFields",
+					fd.Name())
+				require.True(t, trace.IsBadParameter(err),
+					"field %q: expected bad parameter, got: %v", fd.Name(), err)
+			}
+		})
+	}
+}
+
+// protoSetNonZeroField sets a non-zero value for fd in m.
+// For list fields it appends one non-zero element.
+// For message fields it recursively sets scalar sub-fields to non-zero values.
+func protoSetNonZeroField(m protoreflect.Message, fd protoreflect.FieldDescriptor) {
+	if fd.IsList() {
+		list := m.Mutable(fd).List()
+		if fd.Kind() == protoreflect.MessageKind {
+			elem := list.NewElement()
+			protoSetNonZeroMessageFields(elem.Message())
+			list.Append(elem)
+		} else {
+			list.Append(protoNonZeroScalarValue(fd))
+		}
+		return
+	}
+	if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind {
+		protoSetNonZeroMessageFields(m.Mutable(fd).Message())
+		return
+	}
+	m.Set(fd, protoNonZeroScalarValue(fd))
+}
+
+// protoSetNonZeroMessageFields sets scalar fields inside a message to non-zero
+// values (one level deep, to avoid infinite recursion on cyclic messages).
+func protoSetNonZeroMessageFields(m protoreflect.Message) {
+	fields := m.Descriptor().Fields()
+	for i := range fields.Len() {
+		fd := fields.Get(i)
+		if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind {
+			continue // skip nested messages to avoid recursion
+		}
+		if fd.IsList() {
+			m.Mutable(fd).List().Append(protoNonZeroScalarValue(fd))
+		} else {
+			m.Set(fd, protoNonZeroScalarValue(fd))
+		}
+	}
+}
+
+// protoNonZeroScalarValue returns a non-zero protoreflect.Value for a scalar field.
+func protoNonZeroScalarValue(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.Kind() {
+	case protoreflect.BoolKind:
+		return protoreflect.ValueOfBool(true)
+	case protoreflect.EnumKind:
+		return protoreflect.ValueOfEnum(1)
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return protoreflect.ValueOfInt32(1)
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return protoreflect.ValueOfUint32(1)
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return protoreflect.ValueOfInt64(1)
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return protoreflect.ValueOfUint64(1)
+	case protoreflect.FloatKind:
+		return protoreflect.ValueOfFloat32(1)
+	case protoreflect.DoubleKind:
+		return protoreflect.ValueOfFloat64(1)
+	case protoreflect.StringKind:
+		return protoreflect.ValueOfString("placeholder")
+	case protoreflect.BytesKind:
+		return protoreflect.ValueOfBytes([]byte("placeholder"))
+	default:
+		panic(fmt.Sprintf("unhandled proto field kind: %v", fd.Kind()))
+	}
+}
+
+func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*scopedaccessv1.CreateScopedRoleAssignmentResponse) {
+	t.Helper()
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, resp := range resps {
+			_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+				Name:    resp.GetAssignment().GetMetadata().GetName(),
+				SubKind: resp.GetAssignment().GetSubKind(),
+			})
+			require.NoError(t, err)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func newTestTLSServer(t testing.TB) (*authtest.TLSServer, *eventstest.MockRecorderEmitter) {

--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -30,6 +30,9 @@ func isAllowedScopedRule(kind string, verb string) bool {
 	case types.KindScopedToken:
 		// scoped tokens can be read/written, and contain secrets.
 		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
+	case types.KindBot:
+		// bots can be read/written, and do not currently contain a concept of a secret.
+		return isReadWriteNoSecrets(verb)
 	default:
 		return false
 	}

--- a/lib/scopes/feature_test.go
+++ b/lib/scopes/feature_test.go
@@ -29,5 +29,4 @@ func TestFeatureEnabled(t *testing.T) {
 	require.Error(t, AssertFeatureEnabled())
 	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	require.NoError(t, AssertFeatureEnabled())
-
 }

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -102,6 +102,10 @@ func (c *ScopedAccessCheckerContext) ScopePin() (*scopesv1.Pin, bool) {
 // yields a single checker wrapping the full unscoped context.
 //
 // This is the mechanism that *must* be used for getting checkers when checking access to a resource.
+//
+// Callers may pass an empty string ("") as scope to indicate an unscoped resource. This will not be treated as a
+// root scope resource - i.e. identities with privileges assigned in the root scope will not be able to access the
+// resource.
 func (c *ScopedAccessCheckerContext) CheckersForResourceScope(ctx context.Context, scope string) stream.Stream[*ScopedAccessChecker] {
 	if !c.isScoped() {
 		return stream.Once(NewScopedAccessCheckerFromUnscoped(c.unscopedChecker))

--- a/lib/tfgen/internal/reflect_modern_test.go
+++ b/lib/tfgen/internal/reflect_modern_test.go
@@ -103,6 +103,7 @@ func TestReflectModern(t *testing.T) {
 					attribute("role_name", stringVal("")),
 				),
 			),
+			attribute("scope", stringVal("")),
 		},
 	}
 


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/63195

Extends Bot resource to include `scope` field and modify the RPCs to correctly validate scoped Bots and support scoped RBAC for administrative CRUD.

This PR is the first of a stack that will fully implement MWI Scopes.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog will be held until the final PRs are in place.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] CRUD unscoped Bot with unscoped user identity
- [x] CRUD unscoped Bot with scoped user identity (expect failure)
- [x] CRD scoped Bot with unscoped user identity
- [x] CRD scoped Bot with scoped user identity
   - [x] In scope user has privileges in.
   - [x] In scope user does not have privileges in.
- [x] Scope Transition
  - [x] Upserting Bot from Scoped to Unscoped fails
  - [x] Upserting Bot from Unscoped to Scoped fails
  - [x] Upserting Bot from Scope /foo to Scope /bar fails
