### PR TITLE
[v18] Disable http_proxy for IMDS/metadata services

### DIFF
--- a/lib/cloud/gcp/vm.go
+++ b/lib/cloud/gcp/vm.go
@@ -589,14 +589,15 @@ https://cloud.google.com/solutions/connecting-securely#storing_host_keys_by_enab
 			return nil
 		}
 
+		loggerWithVMMetadata.ErrorContext(ctx, "Installing teleport in GCP VM failed",
+			"ip", ip,
+			"error", err,
+			"stdout", string(stdout),
+			"stderr", string(stderr),
+		)
+
 		// An exit error means the connection was successful, so don't try another address.
 		if errors.Is(err, &ssh.ExitError{}) {
-			loggerWithVMMetadata.ErrorContext(ctx, "Installing teleport in GCP VM failed after connecting",
-				"ip", ip,
-				"error", err,
-				"stdout", string(stdout),
-				"stderr", string(stderr),
-			)
 			return trace.Wrap(err)
 		}
 		errs = append(errs, err)

--- a/lib/cloud/imds/azure/imds.go
+++ b/lib/cloud/imds/azure/imds.go
@@ -104,7 +104,12 @@ func (client *InstanceMetadataClient) selectVersion(ctx context.Context) error {
 
 // getRawMetadata gets the raw metadata from a specified path.
 func (client *InstanceMetadataClient) getRawMetadata(ctx context.Context, route string, queryParams url.Values) ([]byte, error) {
-	httpClient, err := defaults.HTTPClient()
+	// From Azure Docs at https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=windows#proxies
+	//
+	// > IMDS is not intended to be used behind a proxy and doing so is unsupported.
+	// > Most HTTP clients provide an option for you to disable proxies on your requests, and this functionality must be utilized when communicating with IMDS.
+	// > Consult your client's documentation for details.
+	httpClient, err := defaults.HTTPClient(defaults.DisableProxyFromEnvironment())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/cloud/imds/azure/imds_test.go
+++ b/lib/cloud/imds/azure/imds_test.go
@@ -20,9 +20,11 @@ package azure
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -86,6 +88,31 @@ func TestAzureIsInstanceMetadataAvailable(t *testing.T) {
 			tc.assertion(t, clt.IsAvailable(t.Context()))
 		})
 	}
+}
+
+func TestAzureIsInstanceMetadataAvailableWithHTTPProxyEnv(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/versions" {
+			w.WriteHeader(http.StatusOK)
+			versions := struct {
+				APIVersions []string `json:"apiVersions"`
+			}{
+				APIVersions: []string{"2026-03-11"},
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(versions))
+			return
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:0")
+
+	// We need to use a hostname that is not localhost or net/IP.IsLoopback, because Go's default HTTP proxy implementation ignores calls to those hosts even if HTTP_PROXY is set.
+	// httptest can only provide an http server at localhost, so we have to use a workaround to get a non-localhost host that still resolves to the HTTP Server above.
+	serverURL := strings.Replace(server.URL, "127.0.0.1", "127.0.0.1.nip.io", 1)
+
+	clt := NewInstanceMetadataClient(WithBaseURL(serverURL))
+	require.True(t, clt.IsAvailable(t.Context()), "instance metadata should be available even with HTTP_PROXY set")
 }
 
 func TestSelectVersion(t *testing.T) {

--- a/lib/cloud/imds/gcp/imds.go
+++ b/lib/cloud/imds/gcp/imds.go
@@ -278,6 +278,13 @@ func getMetadataClient(ctx context.Context) (*metadata.Client, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// Per GCP docs at https://docs.cloud.google.com/compute/docs/troubleshooting/troubleshoot-metadata-server#failed-proxy
+	//
+	// > If the VM is behind a proxy, you must set the NO_PROXY configuration for both the IP address and Hostname.
+	//
+	// This specific HTTP Client is only used to fetch instance metadata, so removing the usage of Proxy settings is safe.
+	transport.Proxy = nil
 	return metadata.NewClient(&http.Client{
 		Transport: contextRoundTripper{
 			ctx:       ctx,

--- a/lib/cloud/imds/gcp/imds_test.go
+++ b/lib/cloud/imds/gcp/imds_test.go
@@ -20,7 +20,10 @@ package gcp
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -209,4 +212,25 @@ func TestGetTags(t *testing.T) {
 			require.Equal(t, tc.expectedTags, tags)
 		})
 	}
+}
+
+func TestGCPIsInstanceMetadataAvailableWithHTTPProxyEnv(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/computeMetadata/v1/instance/id" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("12345678"))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:0")
+
+	// We need to use a hostname that is not localhost or net/IP.IsLoopback, because Go's default HTTP proxy implementation ignores calls to those hosts even if HTTP_PROXY is set.
+	// httptest can only provide an http server at localhost, so we have to use a workaround to get a non-localhost host that still resolves to the HTTP Server above.
+	serverHost := strings.Replace(strings.TrimPrefix(server.URL, "http://"), "127.0.0.1", "127.0.0.1.nip.io", 1)
+	t.Setenv("GCE_METADATA_HOST", serverHost)
+
+	client, err := NewInstanceMetadataClient(nil)
+	require.NoError(t, err)
+	require.True(t, client.IsAvailable(t.Context()), "instance metadata should be available even with HTTP_PROXY set")
 }

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -827,14 +827,25 @@ var (
 type HTTPClientOption func(*httpClientOptions) *httpClientOptions
 
 type httpClientOptions struct {
-	useProxyFromEnvironment bool
+	useProxyFromEnvironment *bool
 }
 
 // UseProxyFromEnvironment configures the HTTP client to use proxy
 // settings from the environment variables HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.
 func UseProxyFromEnvironment() HTTPClientOption {
 	return func(opts *httpClientOptions) *httpClientOptions {
-		opts.useProxyFromEnvironment = true
+		var enable = true
+		opts.useProxyFromEnvironment = &enable
+		return opts
+	}
+}
+
+// DisableProxyFromEnvironment configures the HTTP client to ignore proxy
+// settings from the environment variables HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.
+func DisableProxyFromEnvironment() HTTPClientOption {
+	return func(opts *httpClientOptions) *httpClientOptions {
+		var enable = false
+		opts.useProxyFromEnvironment = &enable
 		return opts
 	}
 }
@@ -851,8 +862,12 @@ func HTTPClient(opts ...HTTPClientOption) (*http.Client, error) {
 		httpOpts = o(httpOpts)
 	}
 
-	if httpOpts.useProxyFromEnvironment {
+	switch {
+	case httpOpts.useProxyFromEnvironment == nil:
+	case *httpOpts.useProxyFromEnvironment == true:
 		transport.Proxy = http.ProxyFromEnvironment
+	case *httpOpts.useProxyFromEnvironment == false:
+		transport.Proxy = nil
 	}
 
 	return &http.Client{


### PR DESCRIPTION
Backport #64158 to branch/v18

changelog: Fixed Azure and GCP server auto-discovery installation when the target VM had a system-wide HTTP proxy configured.


## Manual Test Plan

### Test Environment

local cluster

### Test Cases
- [x] Server discovery in GCP, in a VM that requires HTTP_PROXY to reach internet
