### PR TITLE
sessionsearch[1]: add RetrievalModel resource and CRUD RPCs to SummarizerService

### DIFF
--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
@@ -1569,6 +1569,193 @@ func (x *EnhancedSummary) GetNeedsFurtherReview() NeedsReviewReason {
 	return NeedsReviewReason_NEEDS_REVIEW_REASON_UNSPECIFIED
 }
 
+// RetrievalModel resource specifies the model configuration used to
+// generate embeddings for the session and perform search inference.
+// It tells Teleport how to generate embeddings for a specific session summary
+// and how to convert natural language queries into API requests.
+type RetrievalModel struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Kind is the resource kind. Should always be set to "retrieval_model".
+	Kind string `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	// SubKind is the resource sub-kind. Should be empty.
+	SubKind string `protobuf:"bytes,2,opt,name=sub_kind,json=subKind,proto3" json:"sub_kind,omitempty"`
+	// Version is the resource version. Should be set to "v1".
+	Version  string       `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
+	Metadata *v1.Metadata `protobuf:"bytes,4,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// spec contains the configuration for the retrieval model, including the
+	// embeddings provider and the search inference model.
+	// In the future it can be extended with re-rankers configuration and
+	// other settings.
+	Spec          *RetrievalModelSpec `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RetrievalModel) Reset() {
+	*x = RetrievalModel{}
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RetrievalModel) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RetrievalModel) ProtoMessage() {}
+
+func (x *RetrievalModel) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RetrievalModel.ProtoReflect.Descriptor instead.
+func (*RetrievalModel) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *RetrievalModel) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *RetrievalModel) GetSubKind() string {
+	if x != nil {
+		return x.SubKind
+	}
+	return ""
+}
+
+func (x *RetrievalModel) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *RetrievalModel) GetMetadata() *v1.Metadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *RetrievalModel) GetSpec() *RetrievalModelSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+// RetrievalModelSpec specifies the embeddings provider and search inference model.
+// In the future it can be extended with re-rankers configuration and
+// other settings.
+type RetrievalModelSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to EmbeddingsProvider:
+	//
+	//	*RetrievalModelSpec_Openai
+	//	*RetrievalModelSpec_Bedrock
+	EmbeddingsProvider isRetrievalModelSpec_EmbeddingsProvider `protobuf_oneof:"embeddings_provider"`
+	// inference_model_name is the name of the model used to convert natural
+	// language search queries into API requests and generate prose from a session
+	// summary.
+	InferenceModelName string `protobuf:"bytes,2,opt,name=inference_model_name,json=inferenceModelName,proto3" json:"inference_model_name,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *RetrievalModelSpec) Reset() {
+	*x = RetrievalModelSpec{}
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RetrievalModelSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RetrievalModelSpec) ProtoMessage() {}
+
+func (x *RetrievalModelSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RetrievalModelSpec.ProtoReflect.Descriptor instead.
+func (*RetrievalModelSpec) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *RetrievalModelSpec) GetEmbeddingsProvider() isRetrievalModelSpec_EmbeddingsProvider {
+	if x != nil {
+		return x.EmbeddingsProvider
+	}
+	return nil
+}
+
+func (x *RetrievalModelSpec) GetOpenai() *OpenAIProvider {
+	if x != nil {
+		if x, ok := x.EmbeddingsProvider.(*RetrievalModelSpec_Openai); ok {
+			return x.Openai
+		}
+	}
+	return nil
+}
+
+func (x *RetrievalModelSpec) GetBedrock() *BedrockProvider {
+	if x != nil {
+		if x, ok := x.EmbeddingsProvider.(*RetrievalModelSpec_Bedrock); ok {
+			return x.Bedrock
+		}
+	}
+	return nil
+}
+
+func (x *RetrievalModelSpec) GetInferenceModelName() string {
+	if x != nil {
+		return x.InferenceModelName
+	}
+	return ""
+}
+
+type isRetrievalModelSpec_EmbeddingsProvider interface {
+	isRetrievalModelSpec_EmbeddingsProvider()
+}
+
+type RetrievalModelSpec_Openai struct {
+	// Openai indicates that this model uses OpenAI as the embeddings provider
+	// and specifies OpenAI-specific parameters.
+	Openai *OpenAIProvider `protobuf:"bytes,1,opt,name=openai,proto3,oneof"`
+}
+
+type RetrievalModelSpec_Bedrock struct {
+	// Bedrock indicates that this model uses Amazon Bedrock as the embeddings
+	// provider and specifies Bedrock-specific parameters.
+	Bedrock *BedrockProvider `protobuf:"bytes,3,opt,name=bedrock,proto3,oneof"`
+}
+
+func (*RetrievalModelSpec_Openai) isRetrievalModelSpec_EmbeddingsProvider() {}
+
+func (*RetrievalModelSpec_Bedrock) isRetrievalModelSpec_EmbeddingsProvider() {}
+
 var File_teleport_summarizer_v1_summarizer_proto protoreflect.FileDescriptor
 
 const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
@@ -1668,7 +1855,18 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\x17notable_command_indexes\x18\x06 \x03(\x05R\x15notableCommandIndexes\x12C\n" +
 	"\bcommands\x18\a \x03(\v2'.teleport.summarizer.v1.CommandAnalysisR\bcommands\x12`\n" +
 	"\x14needs_further_review\x18\b \x01(\x0e2).teleport.summarizer.v1.NeedsReviewReasonH\x00R\x12needsFurtherReview\x88\x01\x01B\x17\n" +
-	"\x15_needs_further_review*|\n" +
+	"\x15_needs_further_review\"\xd3\x01\n" +
+	"\x0eRetrievalModel\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
+	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
+	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12>\n" +
+	"\x04spec\x18\x05 \x01(\v2*.teleport.summarizer.v1.RetrievalModelSpecR\x04spec\"\xe4\x01\n" +
+	"\x12RetrievalModelSpec\x12@\n" +
+	"\x06openai\x18\x01 \x01(\v2&.teleport.summarizer.v1.OpenAIProviderH\x00R\x06openai\x12C\n" +
+	"\abedrock\x18\x03 \x01(\v2'.teleport.summarizer.v1.BedrockProviderH\x00R\abedrock\x120\n" +
+	"\x14inference_model_name\x18\x02 \x01(\tR\x12inferenceModelNameB\x15\n" +
+	"\x13embeddings_provider*|\n" +
 	"\fSummaryState\x12\x1d\n" +
 	"\x19SUMMARY_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15SUMMARY_STATE_PENDING\x10\x01\x12\x19\n" +
@@ -1722,7 +1920,7 @@ func file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_summarizer_v1_summarizer_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_teleport_summarizer_v1_summarizer_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_teleport_summarizer_v1_summarizer_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_teleport_summarizer_v1_summarizer_proto_goTypes = []any{
 	(SummaryState)(0),              // 0: teleport.summarizer.v1.SummaryState
 	(CommandCategory)(0),           // 1: teleport.summarizer.v1.CommandCategory
@@ -1741,39 +1939,45 @@ var file_teleport_summarizer_v1_summarizer_proto_goTypes = []any{
 	(*CommandAnalysis)(nil),        // 14: teleport.summarizer.v1.CommandAnalysis
 	(*SecurityRecommendation)(nil), // 15: teleport.summarizer.v1.SecurityRecommendation
 	(*EnhancedSummary)(nil),        // 16: teleport.summarizer.v1.EnhancedSummary
-	(*v1.Metadata)(nil),            // 17: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 18: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),        // 19: google.protobuf.Struct
-	(*durationpb.Duration)(nil),    // 20: google.protobuf.Duration
+	(*RetrievalModel)(nil),         // 17: teleport.summarizer.v1.RetrievalModel
+	(*RetrievalModelSpec)(nil),     // 18: teleport.summarizer.v1.RetrievalModelSpec
+	(*v1.Metadata)(nil),            // 19: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 20: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),        // 21: google.protobuf.Struct
+	(*durationpb.Duration)(nil),    // 22: google.protobuf.Duration
 }
 var file_teleport_summarizer_v1_summarizer_proto_depIdxs = []int32{
-	17, // 0: teleport.summarizer.v1.InferenceModel.metadata:type_name -> teleport.header.v1.Metadata
+	19, // 0: teleport.summarizer.v1.InferenceModel.metadata:type_name -> teleport.header.v1.Metadata
 	6,  // 1: teleport.summarizer.v1.InferenceModel.spec:type_name -> teleport.summarizer.v1.InferenceModelSpec
 	7,  // 2: teleport.summarizer.v1.InferenceModelSpec.openai:type_name -> teleport.summarizer.v1.OpenAIProvider
 	8,  // 3: teleport.summarizer.v1.InferenceModelSpec.bedrock:type_name -> teleport.summarizer.v1.BedrockProvider
-	17, // 4: teleport.summarizer.v1.InferenceSecret.metadata:type_name -> teleport.header.v1.Metadata
+	19, // 4: teleport.summarizer.v1.InferenceSecret.metadata:type_name -> teleport.header.v1.Metadata
 	10, // 5: teleport.summarizer.v1.InferenceSecret.spec:type_name -> teleport.summarizer.v1.InferenceSecretSpec
-	17, // 6: teleport.summarizer.v1.InferencePolicy.metadata:type_name -> teleport.header.v1.Metadata
+	19, // 6: teleport.summarizer.v1.InferencePolicy.metadata:type_name -> teleport.header.v1.Metadata
 	12, // 7: teleport.summarizer.v1.InferencePolicy.spec:type_name -> teleport.summarizer.v1.InferencePolicySpec
 	0,  // 8: teleport.summarizer.v1.Summary.state:type_name -> teleport.summarizer.v1.SummaryState
-	18, // 9: teleport.summarizer.v1.Summary.inference_started_at:type_name -> google.protobuf.Timestamp
-	18, // 10: teleport.summarizer.v1.Summary.inference_finished_at:type_name -> google.protobuf.Timestamp
-	19, // 11: teleport.summarizer.v1.Summary.session_end_event:type_name -> google.protobuf.Struct
+	20, // 9: teleport.summarizer.v1.Summary.inference_started_at:type_name -> google.protobuf.Timestamp
+	20, // 10: teleport.summarizer.v1.Summary.inference_finished_at:type_name -> google.protobuf.Timestamp
+	21, // 11: teleport.summarizer.v1.Summary.session_end_event:type_name -> google.protobuf.Struct
 	16, // 12: teleport.summarizer.v1.Summary.enhanced_summary:type_name -> teleport.summarizer.v1.EnhancedSummary
 	1,  // 13: teleport.summarizer.v1.CommandAnalysis.category:type_name -> teleport.summarizer.v1.CommandCategory
 	2,  // 14: teleport.summarizer.v1.CommandAnalysis.risk_level:type_name -> teleport.summarizer.v1.RiskLevel
 	3,  // 15: teleport.summarizer.v1.CommandAnalysis.threat_category:type_name -> teleport.summarizer.v1.ThreatCategory
-	20, // 16: teleport.summarizer.v1.CommandAnalysis.start_offset:type_name -> google.protobuf.Duration
-	20, // 17: teleport.summarizer.v1.CommandAnalysis.end_offset:type_name -> google.protobuf.Duration
+	22, // 16: teleport.summarizer.v1.CommandAnalysis.start_offset:type_name -> google.protobuf.Duration
+	22, // 17: teleport.summarizer.v1.CommandAnalysis.end_offset:type_name -> google.protobuf.Duration
 	2,  // 18: teleport.summarizer.v1.SecurityRecommendation.severity:type_name -> teleport.summarizer.v1.RiskLevel
 	2,  // 19: teleport.summarizer.v1.EnhancedSummary.risk_level:type_name -> teleport.summarizer.v1.RiskLevel
 	14, // 20: teleport.summarizer.v1.EnhancedSummary.commands:type_name -> teleport.summarizer.v1.CommandAnalysis
 	4,  // 21: teleport.summarizer.v1.EnhancedSummary.needs_further_review:type_name -> teleport.summarizer.v1.NeedsReviewReason
-	22, // [22:22] is the sub-list for method output_type
-	22, // [22:22] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	19, // 22: teleport.summarizer.v1.RetrievalModel.metadata:type_name -> teleport.header.v1.Metadata
+	18, // 23: teleport.summarizer.v1.RetrievalModel.spec:type_name -> teleport.summarizer.v1.RetrievalModelSpec
+	7,  // 24: teleport.summarizer.v1.RetrievalModelSpec.openai:type_name -> teleport.summarizer.v1.OpenAIProvider
+	8,  // 25: teleport.summarizer.v1.RetrievalModelSpec.bedrock:type_name -> teleport.summarizer.v1.BedrockProvider
+	26, // [26:26] is the sub-list for method output_type
+	26, // [26:26] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_teleport_summarizer_v1_summarizer_proto_init() }
@@ -1786,13 +1990,17 @@ func file_teleport_summarizer_v1_summarizer_proto_init() {
 		(*InferenceModelSpec_Bedrock)(nil),
 	}
 	file_teleport_summarizer_v1_summarizer_proto_msgTypes[11].OneofWrappers = []any{}
+	file_teleport_summarizer_v1_summarizer_proto_msgTypes[13].OneofWrappers = []any{
+		(*RetrievalModelSpec_Openai)(nil),
+		(*RetrievalModelSpec_Bedrock)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_summarizer_v1_summarizer_proto_rawDesc), len(file_teleport_summarizer_v1_summarizer_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   12,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer_service.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer_service.pb.go
@@ -311,7 +311,7 @@ func (x *UpdateInferenceModelResponse) GetModel() *InferenceModel {
 	return nil
 }
 
-// UpsertInferenceModelRequest is a request for creating or updating a
+// UpsertInferenceModelRequest is a request for creating or updating an
 // InferenceModel.
 type UpsertInferenceModelRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2026,6 +2026,444 @@ func (x *TestInferenceModelResponse) GetMessage() string {
 	return ""
 }
 
+// CreateRetrievalModelRequest is a request for creating the RetrievalModel.
+// Only one RetrievalModel can exist per cluster.
+type CreateRetrievalModelRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Model is the RetrievalModel resource to create.
+	Model         *RetrievalModel `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateRetrievalModelRequest) Reset() {
+	*x = CreateRetrievalModelRequest{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateRetrievalModelRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateRetrievalModelRequest) ProtoMessage() {}
+
+func (x *CreateRetrievalModelRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateRetrievalModelRequest.ProtoReflect.Descriptor instead.
+func (*CreateRetrievalModelRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *CreateRetrievalModelRequest) GetModel() *RetrievalModel {
+	if x != nil {
+		return x.Model
+	}
+	return nil
+}
+
+// CreateRetrievalModelResponse is a response to creating the RetrievalModel.
+type CreateRetrievalModelResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Model is the RetrievalModel resource that was created.
+	Model         *RetrievalModel `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateRetrievalModelResponse) Reset() {
+	*x = CreateRetrievalModelResponse{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateRetrievalModelResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateRetrievalModelResponse) ProtoMessage() {}
+
+func (x *CreateRetrievalModelResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateRetrievalModelResponse.ProtoReflect.Descriptor instead.
+func (*CreateRetrievalModelResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *CreateRetrievalModelResponse) GetModel() *RetrievalModel {
+	if x != nil {
+		return x.Model
+	}
+	return nil
+}
+
+// GetRetrievalModelRequest is a request for retrieving the RetrievalModel.
+// Since only one RetrievalModel can exist per cluster, no name is required.
+type GetRetrievalModelRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRetrievalModelRequest) Reset() {
+	*x = GetRetrievalModelRequest{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRetrievalModelRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRetrievalModelRequest) ProtoMessage() {}
+
+func (x *GetRetrievalModelRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRetrievalModelRequest.ProtoReflect.Descriptor instead.
+func (*GetRetrievalModelRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{44}
+}
+
+// GetRetrievalModelResponse is a response to retrieving the RetrievalModel.
+type GetRetrievalModelResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Model is the RetrievalModel resource that was retrieved.
+	Model         *RetrievalModel `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRetrievalModelResponse) Reset() {
+	*x = GetRetrievalModelResponse{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRetrievalModelResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRetrievalModelResponse) ProtoMessage() {}
+
+func (x *GetRetrievalModelResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRetrievalModelResponse.ProtoReflect.Descriptor instead.
+func (*GetRetrievalModelResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *GetRetrievalModelResponse) GetModel() *RetrievalModel {
+	if x != nil {
+		return x.Model
+	}
+	return nil
+}
+
+// UpdateRetrievalModelRequest is a request for updating the RetrievalModel.
+type UpdateRetrievalModelRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Model is the RetrievalModel resource to update.
+	Model         *RetrievalModel `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateRetrievalModelRequest) Reset() {
+	*x = UpdateRetrievalModelRequest{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateRetrievalModelRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateRetrievalModelRequest) ProtoMessage() {}
+
+func (x *UpdateRetrievalModelRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateRetrievalModelRequest.ProtoReflect.Descriptor instead.
+func (*UpdateRetrievalModelRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *UpdateRetrievalModelRequest) GetModel() *RetrievalModel {
+	if x != nil {
+		return x.Model
+	}
+	return nil
+}
+
+// UpdateRetrievalModelResponse is a response to updating the RetrievalModel.
+type UpdateRetrievalModelResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Model is the RetrievalModel resource that was updated.
+	Model         *RetrievalModel `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateRetrievalModelResponse) Reset() {
+	*x = UpdateRetrievalModelResponse{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateRetrievalModelResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateRetrievalModelResponse) ProtoMessage() {}
+
+func (x *UpdateRetrievalModelResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateRetrievalModelResponse.ProtoReflect.Descriptor instead.
+func (*UpdateRetrievalModelResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *UpdateRetrievalModelResponse) GetModel() *RetrievalModel {
+	if x != nil {
+		return x.Model
+	}
+	return nil
+}
+
+// UpsertRetrievalModelRequest is a request for creating or updating the
+// RetrievalModel.
+type UpsertRetrievalModelRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Model is the RetrievalModel resource to create or update.
+	Model         *RetrievalModel `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertRetrievalModelRequest) Reset() {
+	*x = UpsertRetrievalModelRequest{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertRetrievalModelRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertRetrievalModelRequest) ProtoMessage() {}
+
+func (x *UpsertRetrievalModelRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpsertRetrievalModelRequest.ProtoReflect.Descriptor instead.
+func (*UpsertRetrievalModelRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *UpsertRetrievalModelRequest) GetModel() *RetrievalModel {
+	if x != nil {
+		return x.Model
+	}
+	return nil
+}
+
+// UpsertRetrievalModelResponse is a response to creating or updating the
+// RetrievalModel.
+type UpsertRetrievalModelResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Model is the RetrievalModel resource that was created or updated.
+	Model         *RetrievalModel `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertRetrievalModelResponse) Reset() {
+	*x = UpsertRetrievalModelResponse{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertRetrievalModelResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertRetrievalModelResponse) ProtoMessage() {}
+
+func (x *UpsertRetrievalModelResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpsertRetrievalModelResponse.ProtoReflect.Descriptor instead.
+func (*UpsertRetrievalModelResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *UpsertRetrievalModelResponse) GetModel() *RetrievalModel {
+	if x != nil {
+		return x.Model
+	}
+	return nil
+}
+
+// DeleteRetrievalModelRequest is a request for deleting the RetrievalModel.
+// Since only one RetrievalModel can exist per cluster, no name is required.
+type DeleteRetrievalModelRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteRetrievalModelRequest) Reset() {
+	*x = DeleteRetrievalModelRequest{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteRetrievalModelRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteRetrievalModelRequest) ProtoMessage() {}
+
+func (x *DeleteRetrievalModelRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteRetrievalModelRequest.ProtoReflect.Descriptor instead.
+func (*DeleteRetrievalModelRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{50}
+}
+
+// DeleteRetrievalModelResponse is a response to deleting the RetrievalModel.
+type DeleteRetrievalModelResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteRetrievalModelResponse) Reset() {
+	*x = DeleteRetrievalModelResponse{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteRetrievalModelResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteRetrievalModelResponse) ProtoMessage() {}
+
+func (x *DeleteRetrievalModelResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteRetrievalModelResponse.ProtoReflect.Descriptor instead.
+func (*DeleteRetrievalModelResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{51}
+}
+
 var File_teleport_summarizer_v1_summarizer_service_proto protoreflect.FileDescriptor
 
 const file_teleport_summarizer_v1_summarizer_service_proto_rawDesc = "" +
@@ -2122,7 +2560,24 @@ const file_teleport_summarizer_v1_summarizer_service_proto_rawDesc = "" +
 	"\x06secret\x18\x02 \x01(\v2+.teleport.summarizer.v1.InferenceSecretSpecR\x06secret\"P\n" +
 	"\x1aTestInferenceModelResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage2\x9e\x15\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"[\n" +
+	"\x1bCreateRetrievalModelRequest\x12<\n" +
+	"\x05model\x18\x01 \x01(\v2&.teleport.summarizer.v1.RetrievalModelR\x05model\"\\\n" +
+	"\x1cCreateRetrievalModelResponse\x12<\n" +
+	"\x05model\x18\x01 \x01(\v2&.teleport.summarizer.v1.RetrievalModelR\x05model\"\x1a\n" +
+	"\x18GetRetrievalModelRequest\"Y\n" +
+	"\x19GetRetrievalModelResponse\x12<\n" +
+	"\x05model\x18\x01 \x01(\v2&.teleport.summarizer.v1.RetrievalModelR\x05model\"[\n" +
+	"\x1bUpdateRetrievalModelRequest\x12<\n" +
+	"\x05model\x18\x01 \x01(\v2&.teleport.summarizer.v1.RetrievalModelR\x05model\"\\\n" +
+	"\x1cUpdateRetrievalModelResponse\x12<\n" +
+	"\x05model\x18\x01 \x01(\v2&.teleport.summarizer.v1.RetrievalModelR\x05model\"[\n" +
+	"\x1bUpsertRetrievalModelRequest\x12<\n" +
+	"\x05model\x18\x01 \x01(\v2&.teleport.summarizer.v1.RetrievalModelR\x05model\"\\\n" +
+	"\x1cUpsertRetrievalModelResponse\x12<\n" +
+	"\x05model\x18\x01 \x01(\v2&.teleport.summarizer.v1.RetrievalModelR\x05model\"\x1d\n" +
+	"\x1bDeleteRetrievalModelRequest\"\x1e\n" +
+	"\x1cDeleteRetrievalModelResponse2\xa8\x1a\n" +
 	"\x11SummarizerService\x12\x81\x01\n" +
 	"\x14CreateInferenceModel\x123.teleport.summarizer.v1.CreateInferenceModelRequest\x1a4.teleport.summarizer.v1.CreateInferenceModelResponse\x12x\n" +
 	"\x11GetInferenceModel\x120.teleport.summarizer.v1.GetInferenceModelRequest\x1a1.teleport.summarizer.v1.GetInferenceModelResponse\x12\x81\x01\n" +
@@ -2145,7 +2600,12 @@ const file_teleport_summarizer_v1_summarizer_service_proto_rawDesc = "" +
 	"\n" +
 	"GetSummary\x12).teleport.summarizer.v1.GetSummaryRequest\x1a*.teleport.summarizer.v1.GetSummaryResponse\x12`\n" +
 	"\tIsEnabled\x12(.teleport.summarizer.v1.IsEnabledRequest\x1a).teleport.summarizer.v1.IsEnabledResponse\x12{\n" +
-	"\x12TestInferenceModel\x121.teleport.summarizer.v1.TestInferenceModelRequest\x1a2.teleport.summarizer.v1.TestInferenceModelResponseBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
+	"\x12TestInferenceModel\x121.teleport.summarizer.v1.TestInferenceModelRequest\x1a2.teleport.summarizer.v1.TestInferenceModelResponse\x12\x81\x01\n" +
+	"\x14CreateRetrievalModel\x123.teleport.summarizer.v1.CreateRetrievalModelRequest\x1a4.teleport.summarizer.v1.CreateRetrievalModelResponse\x12x\n" +
+	"\x11GetRetrievalModel\x120.teleport.summarizer.v1.GetRetrievalModelRequest\x1a1.teleport.summarizer.v1.GetRetrievalModelResponse\x12\x81\x01\n" +
+	"\x14UpdateRetrievalModel\x123.teleport.summarizer.v1.UpdateRetrievalModelRequest\x1a4.teleport.summarizer.v1.UpdateRetrievalModelResponse\x12\x81\x01\n" +
+	"\x14UpsertRetrievalModel\x123.teleport.summarizer.v1.UpsertRetrievalModelRequest\x1a4.teleport.summarizer.v1.UpsertRetrievalModelResponse\x12\x81\x01\n" +
+	"\x14DeleteRetrievalModel\x123.teleport.summarizer.v1.DeleteRetrievalModelRequest\x1a4.teleport.summarizer.v1.DeleteRetrievalModelResponseBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
 
 var (
 	file_teleport_summarizer_v1_summarizer_service_proto_rawDescOnce sync.Once
@@ -2159,7 +2619,7 @@ func file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP() []byte {
 	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescData
 }
 
-var file_teleport_summarizer_v1_summarizer_service_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_teleport_summarizer_v1_summarizer_service_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
 var file_teleport_summarizer_v1_summarizer_service_proto_goTypes = []any{
 	(*CreateInferenceModelRequest)(nil),   // 0: teleport.summarizer.v1.CreateInferenceModelRequest
 	(*CreateInferenceModelResponse)(nil),  // 1: teleport.summarizer.v1.CreateInferenceModelResponse
@@ -2203,88 +2663,116 @@ var file_teleport_summarizer_v1_summarizer_service_proto_goTypes = []any{
 	(*IsEnabledResponse)(nil),             // 39: teleport.summarizer.v1.IsEnabledResponse
 	(*TestInferenceModelRequest)(nil),     // 40: teleport.summarizer.v1.TestInferenceModelRequest
 	(*TestInferenceModelResponse)(nil),    // 41: teleport.summarizer.v1.TestInferenceModelResponse
-	(*InferenceModel)(nil),                // 42: teleport.summarizer.v1.InferenceModel
-	(*InferenceSecret)(nil),               // 43: teleport.summarizer.v1.InferenceSecret
-	(*InferencePolicy)(nil),               // 44: teleport.summarizer.v1.InferencePolicy
-	(*Summary)(nil),                       // 45: teleport.summarizer.v1.Summary
-	(*InferenceModelSpec)(nil),            // 46: teleport.summarizer.v1.InferenceModelSpec
-	(*InferenceSecretSpec)(nil),           // 47: teleport.summarizer.v1.InferenceSecretSpec
+	(*CreateRetrievalModelRequest)(nil),   // 42: teleport.summarizer.v1.CreateRetrievalModelRequest
+	(*CreateRetrievalModelResponse)(nil),  // 43: teleport.summarizer.v1.CreateRetrievalModelResponse
+	(*GetRetrievalModelRequest)(nil),      // 44: teleport.summarizer.v1.GetRetrievalModelRequest
+	(*GetRetrievalModelResponse)(nil),     // 45: teleport.summarizer.v1.GetRetrievalModelResponse
+	(*UpdateRetrievalModelRequest)(nil),   // 46: teleport.summarizer.v1.UpdateRetrievalModelRequest
+	(*UpdateRetrievalModelResponse)(nil),  // 47: teleport.summarizer.v1.UpdateRetrievalModelResponse
+	(*UpsertRetrievalModelRequest)(nil),   // 48: teleport.summarizer.v1.UpsertRetrievalModelRequest
+	(*UpsertRetrievalModelResponse)(nil),  // 49: teleport.summarizer.v1.UpsertRetrievalModelResponse
+	(*DeleteRetrievalModelRequest)(nil),   // 50: teleport.summarizer.v1.DeleteRetrievalModelRequest
+	(*DeleteRetrievalModelResponse)(nil),  // 51: teleport.summarizer.v1.DeleteRetrievalModelResponse
+	(*InferenceModel)(nil),                // 52: teleport.summarizer.v1.InferenceModel
+	(*InferenceSecret)(nil),               // 53: teleport.summarizer.v1.InferenceSecret
+	(*InferencePolicy)(nil),               // 54: teleport.summarizer.v1.InferencePolicy
+	(*Summary)(nil),                       // 55: teleport.summarizer.v1.Summary
+	(*InferenceModelSpec)(nil),            // 56: teleport.summarizer.v1.InferenceModelSpec
+	(*InferenceSecretSpec)(nil),           // 57: teleport.summarizer.v1.InferenceSecretSpec
+	(*RetrievalModel)(nil),                // 58: teleport.summarizer.v1.RetrievalModel
 }
 var file_teleport_summarizer_v1_summarizer_service_proto_depIdxs = []int32{
-	42, // 0: teleport.summarizer.v1.CreateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
-	42, // 1: teleport.summarizer.v1.CreateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	42, // 2: teleport.summarizer.v1.GetInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	42, // 3: teleport.summarizer.v1.UpdateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
-	42, // 4: teleport.summarizer.v1.UpdateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	42, // 5: teleport.summarizer.v1.UpsertInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
-	42, // 6: teleport.summarizer.v1.UpsertInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	42, // 7: teleport.summarizer.v1.ListInferenceModelsResponse.models:type_name -> teleport.summarizer.v1.InferenceModel
-	43, // 8: teleport.summarizer.v1.CreateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	43, // 9: teleport.summarizer.v1.CreateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	43, // 10: teleport.summarizer.v1.GetInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	43, // 11: teleport.summarizer.v1.UpdateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	43, // 12: teleport.summarizer.v1.UpdateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	43, // 13: teleport.summarizer.v1.UpsertInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	43, // 14: teleport.summarizer.v1.UpsertInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	43, // 15: teleport.summarizer.v1.ListInferenceSecretsResponse.secrets:type_name -> teleport.summarizer.v1.InferenceSecret
-	44, // 16: teleport.summarizer.v1.CreateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	44, // 17: teleport.summarizer.v1.CreateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	44, // 18: teleport.summarizer.v1.GetInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	44, // 19: teleport.summarizer.v1.UpdateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	44, // 20: teleport.summarizer.v1.UpdateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	44, // 21: teleport.summarizer.v1.UpsertInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	44, // 22: teleport.summarizer.v1.UpsertInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	44, // 23: teleport.summarizer.v1.ListInferencePoliciesResponse.policies:type_name -> teleport.summarizer.v1.InferencePolicy
-	45, // 24: teleport.summarizer.v1.GetSummaryResponse.summary:type_name -> teleport.summarizer.v1.Summary
-	46, // 25: teleport.summarizer.v1.TestInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModelSpec
-	47, // 26: teleport.summarizer.v1.TestInferenceModelRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecretSpec
-	0,  // 27: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:input_type -> teleport.summarizer.v1.CreateInferenceModelRequest
-	2,  // 28: teleport.summarizer.v1.SummarizerService.GetInferenceModel:input_type -> teleport.summarizer.v1.GetInferenceModelRequest
-	4,  // 29: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:input_type -> teleport.summarizer.v1.UpdateInferenceModelRequest
-	6,  // 30: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:input_type -> teleport.summarizer.v1.UpsertInferenceModelRequest
-	8,  // 31: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:input_type -> teleport.summarizer.v1.DeleteInferenceModelRequest
-	10, // 32: teleport.summarizer.v1.SummarizerService.ListInferenceModels:input_type -> teleport.summarizer.v1.ListInferenceModelsRequest
-	12, // 33: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:input_type -> teleport.summarizer.v1.CreateInferenceSecretRequest
-	14, // 34: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:input_type -> teleport.summarizer.v1.GetInferenceSecretRequest
-	16, // 35: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:input_type -> teleport.summarizer.v1.UpdateInferenceSecretRequest
-	18, // 36: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:input_type -> teleport.summarizer.v1.UpsertInferenceSecretRequest
-	20, // 37: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:input_type -> teleport.summarizer.v1.DeleteInferenceSecretRequest
-	22, // 38: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:input_type -> teleport.summarizer.v1.ListInferenceSecretsRequest
-	24, // 39: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:input_type -> teleport.summarizer.v1.CreateInferencePolicyRequest
-	26, // 40: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:input_type -> teleport.summarizer.v1.GetInferencePolicyRequest
-	28, // 41: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:input_type -> teleport.summarizer.v1.UpdateInferencePolicyRequest
-	30, // 42: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:input_type -> teleport.summarizer.v1.UpsertInferencePolicyRequest
-	32, // 43: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:input_type -> teleport.summarizer.v1.DeleteInferencePolicyRequest
-	34, // 44: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:input_type -> teleport.summarizer.v1.ListInferencePoliciesRequest
-	36, // 45: teleport.summarizer.v1.SummarizerService.GetSummary:input_type -> teleport.summarizer.v1.GetSummaryRequest
-	38, // 46: teleport.summarizer.v1.SummarizerService.IsEnabled:input_type -> teleport.summarizer.v1.IsEnabledRequest
-	40, // 47: teleport.summarizer.v1.SummarizerService.TestInferenceModel:input_type -> teleport.summarizer.v1.TestInferenceModelRequest
-	1,  // 48: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:output_type -> teleport.summarizer.v1.CreateInferenceModelResponse
-	3,  // 49: teleport.summarizer.v1.SummarizerService.GetInferenceModel:output_type -> teleport.summarizer.v1.GetInferenceModelResponse
-	5,  // 50: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:output_type -> teleport.summarizer.v1.UpdateInferenceModelResponse
-	7,  // 51: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:output_type -> teleport.summarizer.v1.UpsertInferenceModelResponse
-	9,  // 52: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:output_type -> teleport.summarizer.v1.DeleteInferenceModelResponse
-	11, // 53: teleport.summarizer.v1.SummarizerService.ListInferenceModels:output_type -> teleport.summarizer.v1.ListInferenceModelsResponse
-	13, // 54: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:output_type -> teleport.summarizer.v1.CreateInferenceSecretResponse
-	15, // 55: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:output_type -> teleport.summarizer.v1.GetInferenceSecretResponse
-	17, // 56: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:output_type -> teleport.summarizer.v1.UpdateInferenceSecretResponse
-	19, // 57: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:output_type -> teleport.summarizer.v1.UpsertInferenceSecretResponse
-	21, // 58: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:output_type -> teleport.summarizer.v1.DeleteInferenceSecretResponse
-	23, // 59: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:output_type -> teleport.summarizer.v1.ListInferenceSecretsResponse
-	25, // 60: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:output_type -> teleport.summarizer.v1.CreateInferencePolicyResponse
-	27, // 61: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:output_type -> teleport.summarizer.v1.GetInferencePolicyResponse
-	29, // 62: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:output_type -> teleport.summarizer.v1.UpdateInferencePolicyResponse
-	31, // 63: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:output_type -> teleport.summarizer.v1.UpsertInferencePolicyResponse
-	33, // 64: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:output_type -> teleport.summarizer.v1.DeleteInferencePolicyResponse
-	35, // 65: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:output_type -> teleport.summarizer.v1.ListInferencePoliciesResponse
-	37, // 66: teleport.summarizer.v1.SummarizerService.GetSummary:output_type -> teleport.summarizer.v1.GetSummaryResponse
-	39, // 67: teleport.summarizer.v1.SummarizerService.IsEnabled:output_type -> teleport.summarizer.v1.IsEnabledResponse
-	41, // 68: teleport.summarizer.v1.SummarizerService.TestInferenceModel:output_type -> teleport.summarizer.v1.TestInferenceModelResponse
-	48, // [48:69] is the sub-list for method output_type
-	27, // [27:48] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	52, // 0: teleport.summarizer.v1.CreateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
+	52, // 1: teleport.summarizer.v1.CreateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	52, // 2: teleport.summarizer.v1.GetInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	52, // 3: teleport.summarizer.v1.UpdateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
+	52, // 4: teleport.summarizer.v1.UpdateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	52, // 5: teleport.summarizer.v1.UpsertInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
+	52, // 6: teleport.summarizer.v1.UpsertInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	52, // 7: teleport.summarizer.v1.ListInferenceModelsResponse.models:type_name -> teleport.summarizer.v1.InferenceModel
+	53, // 8: teleport.summarizer.v1.CreateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	53, // 9: teleport.summarizer.v1.CreateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	53, // 10: teleport.summarizer.v1.GetInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	53, // 11: teleport.summarizer.v1.UpdateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	53, // 12: teleport.summarizer.v1.UpdateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	53, // 13: teleport.summarizer.v1.UpsertInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	53, // 14: teleport.summarizer.v1.UpsertInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	53, // 15: teleport.summarizer.v1.ListInferenceSecretsResponse.secrets:type_name -> teleport.summarizer.v1.InferenceSecret
+	54, // 16: teleport.summarizer.v1.CreateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	54, // 17: teleport.summarizer.v1.CreateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	54, // 18: teleport.summarizer.v1.GetInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	54, // 19: teleport.summarizer.v1.UpdateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	54, // 20: teleport.summarizer.v1.UpdateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	54, // 21: teleport.summarizer.v1.UpsertInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	54, // 22: teleport.summarizer.v1.UpsertInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	54, // 23: teleport.summarizer.v1.ListInferencePoliciesResponse.policies:type_name -> teleport.summarizer.v1.InferencePolicy
+	55, // 24: teleport.summarizer.v1.GetSummaryResponse.summary:type_name -> teleport.summarizer.v1.Summary
+	56, // 25: teleport.summarizer.v1.TestInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModelSpec
+	57, // 26: teleport.summarizer.v1.TestInferenceModelRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecretSpec
+	58, // 27: teleport.summarizer.v1.CreateRetrievalModelRequest.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	58, // 28: teleport.summarizer.v1.CreateRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	58, // 29: teleport.summarizer.v1.GetRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	58, // 30: teleport.summarizer.v1.UpdateRetrievalModelRequest.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	58, // 31: teleport.summarizer.v1.UpdateRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	58, // 32: teleport.summarizer.v1.UpsertRetrievalModelRequest.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	58, // 33: teleport.summarizer.v1.UpsertRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	0,  // 34: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:input_type -> teleport.summarizer.v1.CreateInferenceModelRequest
+	2,  // 35: teleport.summarizer.v1.SummarizerService.GetInferenceModel:input_type -> teleport.summarizer.v1.GetInferenceModelRequest
+	4,  // 36: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:input_type -> teleport.summarizer.v1.UpdateInferenceModelRequest
+	6,  // 37: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:input_type -> teleport.summarizer.v1.UpsertInferenceModelRequest
+	8,  // 38: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:input_type -> teleport.summarizer.v1.DeleteInferenceModelRequest
+	10, // 39: teleport.summarizer.v1.SummarizerService.ListInferenceModels:input_type -> teleport.summarizer.v1.ListInferenceModelsRequest
+	12, // 40: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:input_type -> teleport.summarizer.v1.CreateInferenceSecretRequest
+	14, // 41: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:input_type -> teleport.summarizer.v1.GetInferenceSecretRequest
+	16, // 42: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:input_type -> teleport.summarizer.v1.UpdateInferenceSecretRequest
+	18, // 43: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:input_type -> teleport.summarizer.v1.UpsertInferenceSecretRequest
+	20, // 44: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:input_type -> teleport.summarizer.v1.DeleteInferenceSecretRequest
+	22, // 45: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:input_type -> teleport.summarizer.v1.ListInferenceSecretsRequest
+	24, // 46: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:input_type -> teleport.summarizer.v1.CreateInferencePolicyRequest
+	26, // 47: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:input_type -> teleport.summarizer.v1.GetInferencePolicyRequest
+	28, // 48: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:input_type -> teleport.summarizer.v1.UpdateInferencePolicyRequest
+	30, // 49: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:input_type -> teleport.summarizer.v1.UpsertInferencePolicyRequest
+	32, // 50: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:input_type -> teleport.summarizer.v1.DeleteInferencePolicyRequest
+	34, // 51: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:input_type -> teleport.summarizer.v1.ListInferencePoliciesRequest
+	36, // 52: teleport.summarizer.v1.SummarizerService.GetSummary:input_type -> teleport.summarizer.v1.GetSummaryRequest
+	38, // 53: teleport.summarizer.v1.SummarizerService.IsEnabled:input_type -> teleport.summarizer.v1.IsEnabledRequest
+	40, // 54: teleport.summarizer.v1.SummarizerService.TestInferenceModel:input_type -> teleport.summarizer.v1.TestInferenceModelRequest
+	42, // 55: teleport.summarizer.v1.SummarizerService.CreateRetrievalModel:input_type -> teleport.summarizer.v1.CreateRetrievalModelRequest
+	44, // 56: teleport.summarizer.v1.SummarizerService.GetRetrievalModel:input_type -> teleport.summarizer.v1.GetRetrievalModelRequest
+	46, // 57: teleport.summarizer.v1.SummarizerService.UpdateRetrievalModel:input_type -> teleport.summarizer.v1.UpdateRetrievalModelRequest
+	48, // 58: teleport.summarizer.v1.SummarizerService.UpsertRetrievalModel:input_type -> teleport.summarizer.v1.UpsertRetrievalModelRequest
+	50, // 59: teleport.summarizer.v1.SummarizerService.DeleteRetrievalModel:input_type -> teleport.summarizer.v1.DeleteRetrievalModelRequest
+	1,  // 60: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:output_type -> teleport.summarizer.v1.CreateInferenceModelResponse
+	3,  // 61: teleport.summarizer.v1.SummarizerService.GetInferenceModel:output_type -> teleport.summarizer.v1.GetInferenceModelResponse
+	5,  // 62: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:output_type -> teleport.summarizer.v1.UpdateInferenceModelResponse
+	7,  // 63: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:output_type -> teleport.summarizer.v1.UpsertInferenceModelResponse
+	9,  // 64: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:output_type -> teleport.summarizer.v1.DeleteInferenceModelResponse
+	11, // 65: teleport.summarizer.v1.SummarizerService.ListInferenceModels:output_type -> teleport.summarizer.v1.ListInferenceModelsResponse
+	13, // 66: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:output_type -> teleport.summarizer.v1.CreateInferenceSecretResponse
+	15, // 67: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:output_type -> teleport.summarizer.v1.GetInferenceSecretResponse
+	17, // 68: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:output_type -> teleport.summarizer.v1.UpdateInferenceSecretResponse
+	19, // 69: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:output_type -> teleport.summarizer.v1.UpsertInferenceSecretResponse
+	21, // 70: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:output_type -> teleport.summarizer.v1.DeleteInferenceSecretResponse
+	23, // 71: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:output_type -> teleport.summarizer.v1.ListInferenceSecretsResponse
+	25, // 72: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:output_type -> teleport.summarizer.v1.CreateInferencePolicyResponse
+	27, // 73: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:output_type -> teleport.summarizer.v1.GetInferencePolicyResponse
+	29, // 74: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:output_type -> teleport.summarizer.v1.UpdateInferencePolicyResponse
+	31, // 75: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:output_type -> teleport.summarizer.v1.UpsertInferencePolicyResponse
+	33, // 76: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:output_type -> teleport.summarizer.v1.DeleteInferencePolicyResponse
+	35, // 77: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:output_type -> teleport.summarizer.v1.ListInferencePoliciesResponse
+	37, // 78: teleport.summarizer.v1.SummarizerService.GetSummary:output_type -> teleport.summarizer.v1.GetSummaryResponse
+	39, // 79: teleport.summarizer.v1.SummarizerService.IsEnabled:output_type -> teleport.summarizer.v1.IsEnabledResponse
+	41, // 80: teleport.summarizer.v1.SummarizerService.TestInferenceModel:output_type -> teleport.summarizer.v1.TestInferenceModelResponse
+	43, // 81: teleport.summarizer.v1.SummarizerService.CreateRetrievalModel:output_type -> teleport.summarizer.v1.CreateRetrievalModelResponse
+	45, // 82: teleport.summarizer.v1.SummarizerService.GetRetrievalModel:output_type -> teleport.summarizer.v1.GetRetrievalModelResponse
+	47, // 83: teleport.summarizer.v1.SummarizerService.UpdateRetrievalModel:output_type -> teleport.summarizer.v1.UpdateRetrievalModelResponse
+	49, // 84: teleport.summarizer.v1.SummarizerService.UpsertRetrievalModel:output_type -> teleport.summarizer.v1.UpsertRetrievalModelResponse
+	51, // 85: teleport.summarizer.v1.SummarizerService.DeleteRetrievalModel:output_type -> teleport.summarizer.v1.DeleteRetrievalModelResponse
+	60, // [60:86] is the sub-list for method output_type
+	34, // [34:60] is the sub-list for method input_type
+	34, // [34:34] is the sub-list for extension type_name
+	34, // [34:34] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_teleport_summarizer_v1_summarizer_service_proto_init() }
@@ -2299,7 +2787,7 @@ func file_teleport_summarizer_v1_summarizer_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_summarizer_v1_summarizer_service_proto_rawDesc), len(file_teleport_summarizer_v1_summarizer_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   42,
+			NumMessages:   52,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer_service_grpc.pb.go
@@ -54,6 +54,11 @@ const (
 	SummarizerService_GetSummary_FullMethodName            = "/teleport.summarizer.v1.SummarizerService/GetSummary"
 	SummarizerService_IsEnabled_FullMethodName             = "/teleport.summarizer.v1.SummarizerService/IsEnabled"
 	SummarizerService_TestInferenceModel_FullMethodName    = "/teleport.summarizer.v1.SummarizerService/TestInferenceModel"
+	SummarizerService_CreateRetrievalModel_FullMethodName  = "/teleport.summarizer.v1.SummarizerService/CreateRetrievalModel"
+	SummarizerService_GetRetrievalModel_FullMethodName     = "/teleport.summarizer.v1.SummarizerService/GetRetrievalModel"
+	SummarizerService_UpdateRetrievalModel_FullMethodName  = "/teleport.summarizer.v1.SummarizerService/UpdateRetrievalModel"
+	SummarizerService_UpsertRetrievalModel_FullMethodName  = "/teleport.summarizer.v1.SummarizerService/UpsertRetrievalModel"
+	SummarizerService_DeleteRetrievalModel_FullMethodName  = "/teleport.summarizer.v1.SummarizerService/DeleteRetrievalModel"
 )
 
 // SummarizerServiceClient is the client API for SummarizerService service.
@@ -113,6 +118,17 @@ type SummarizerServiceClient interface {
 	// TestInferenceModel tests an InferenceModel configuration by making a test
 	// request to the configured provider (AWS Bedrock or OpenAI).
 	TestInferenceModel(ctx context.Context, in *TestInferenceModelRequest, opts ...grpc.CallOption) (*TestInferenceModelResponse, error)
+	// CreateRetrievalModel creates the RetrievalModel.
+	CreateRetrievalModel(ctx context.Context, in *CreateRetrievalModelRequest, opts ...grpc.CallOption) (*CreateRetrievalModelResponse, error)
+	// GetRetrievalModel retrieves the existing RetrievalModel.
+	GetRetrievalModel(ctx context.Context, in *GetRetrievalModelRequest, opts ...grpc.CallOption) (*GetRetrievalModelResponse, error)
+	// UpdateRetrievalModel updates the existing RetrievalModel.
+	UpdateRetrievalModel(ctx context.Context, in *UpdateRetrievalModelRequest, opts ...grpc.CallOption) (*UpdateRetrievalModelResponse, error)
+	// UpsertRetrievalModel creates a new RetrievalModel or updates the existing
+	// one.
+	UpsertRetrievalModel(ctx context.Context, in *UpsertRetrievalModelRequest, opts ...grpc.CallOption) (*UpsertRetrievalModelResponse, error)
+	// DeleteRetrievalModel deletes the existing RetrievalModel by name.
+	DeleteRetrievalModel(ctx context.Context, in *DeleteRetrievalModelRequest, opts ...grpc.CallOption) (*DeleteRetrievalModelResponse, error)
 }
 
 type summarizerServiceClient struct {
@@ -333,6 +349,56 @@ func (c *summarizerServiceClient) TestInferenceModel(ctx context.Context, in *Te
 	return out, nil
 }
 
+func (c *summarizerServiceClient) CreateRetrievalModel(ctx context.Context, in *CreateRetrievalModelRequest, opts ...grpc.CallOption) (*CreateRetrievalModelResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateRetrievalModelResponse)
+	err := c.cc.Invoke(ctx, SummarizerService_CreateRetrievalModel_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *summarizerServiceClient) GetRetrievalModel(ctx context.Context, in *GetRetrievalModelRequest, opts ...grpc.CallOption) (*GetRetrievalModelResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetRetrievalModelResponse)
+	err := c.cc.Invoke(ctx, SummarizerService_GetRetrievalModel_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *summarizerServiceClient) UpdateRetrievalModel(ctx context.Context, in *UpdateRetrievalModelRequest, opts ...grpc.CallOption) (*UpdateRetrievalModelResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpdateRetrievalModelResponse)
+	err := c.cc.Invoke(ctx, SummarizerService_UpdateRetrievalModel_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *summarizerServiceClient) UpsertRetrievalModel(ctx context.Context, in *UpsertRetrievalModelRequest, opts ...grpc.CallOption) (*UpsertRetrievalModelResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpsertRetrievalModelResponse)
+	err := c.cc.Invoke(ctx, SummarizerService_UpsertRetrievalModel_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *summarizerServiceClient) DeleteRetrievalModel(ctx context.Context, in *DeleteRetrievalModelRequest, opts ...grpc.CallOption) (*DeleteRetrievalModelResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteRetrievalModelResponse)
+	err := c.cc.Invoke(ctx, SummarizerService_DeleteRetrievalModel_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SummarizerServiceServer is the server API for SummarizerService service.
 // All implementations must embed UnimplementedSummarizerServiceServer
 // for forward compatibility.
@@ -390,6 +456,17 @@ type SummarizerServiceServer interface {
 	// TestInferenceModel tests an InferenceModel configuration by making a test
 	// request to the configured provider (AWS Bedrock or OpenAI).
 	TestInferenceModel(context.Context, *TestInferenceModelRequest) (*TestInferenceModelResponse, error)
+	// CreateRetrievalModel creates the RetrievalModel.
+	CreateRetrievalModel(context.Context, *CreateRetrievalModelRequest) (*CreateRetrievalModelResponse, error)
+	// GetRetrievalModel retrieves the existing RetrievalModel.
+	GetRetrievalModel(context.Context, *GetRetrievalModelRequest) (*GetRetrievalModelResponse, error)
+	// UpdateRetrievalModel updates the existing RetrievalModel.
+	UpdateRetrievalModel(context.Context, *UpdateRetrievalModelRequest) (*UpdateRetrievalModelResponse, error)
+	// UpsertRetrievalModel creates a new RetrievalModel or updates the existing
+	// one.
+	UpsertRetrievalModel(context.Context, *UpsertRetrievalModelRequest) (*UpsertRetrievalModelResponse, error)
+	// DeleteRetrievalModel deletes the existing RetrievalModel by name.
+	DeleteRetrievalModel(context.Context, *DeleteRetrievalModelRequest) (*DeleteRetrievalModelResponse, error)
 	mustEmbedUnimplementedSummarizerServiceServer()
 }
 
@@ -462,6 +539,21 @@ func (UnimplementedSummarizerServiceServer) IsEnabled(context.Context, *IsEnable
 }
 func (UnimplementedSummarizerServiceServer) TestInferenceModel(context.Context, *TestInferenceModelRequest) (*TestInferenceModelResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method TestInferenceModel not implemented")
+}
+func (UnimplementedSummarizerServiceServer) CreateRetrievalModel(context.Context, *CreateRetrievalModelRequest) (*CreateRetrievalModelResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateRetrievalModel not implemented")
+}
+func (UnimplementedSummarizerServiceServer) GetRetrievalModel(context.Context, *GetRetrievalModelRequest) (*GetRetrievalModelResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetRetrievalModel not implemented")
+}
+func (UnimplementedSummarizerServiceServer) UpdateRetrievalModel(context.Context, *UpdateRetrievalModelRequest) (*UpdateRetrievalModelResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateRetrievalModel not implemented")
+}
+func (UnimplementedSummarizerServiceServer) UpsertRetrievalModel(context.Context, *UpsertRetrievalModelRequest) (*UpsertRetrievalModelResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpsertRetrievalModel not implemented")
+}
+func (UnimplementedSummarizerServiceServer) DeleteRetrievalModel(context.Context, *DeleteRetrievalModelRequest) (*DeleteRetrievalModelResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteRetrievalModel not implemented")
 }
 func (UnimplementedSummarizerServiceServer) mustEmbedUnimplementedSummarizerServiceServer() {}
 func (UnimplementedSummarizerServiceServer) testEmbeddedByValue()                           {}
@@ -862,6 +954,96 @@ func _SummarizerService_TestInferenceModel_Handler(srv interface{}, ctx context.
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SummarizerService_CreateRetrievalModel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateRetrievalModelRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SummarizerServiceServer).CreateRetrievalModel(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SummarizerService_CreateRetrievalModel_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SummarizerServiceServer).CreateRetrievalModel(ctx, req.(*CreateRetrievalModelRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SummarizerService_GetRetrievalModel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetRetrievalModelRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SummarizerServiceServer).GetRetrievalModel(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SummarizerService_GetRetrievalModel_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SummarizerServiceServer).GetRetrievalModel(ctx, req.(*GetRetrievalModelRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SummarizerService_UpdateRetrievalModel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateRetrievalModelRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SummarizerServiceServer).UpdateRetrievalModel(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SummarizerService_UpdateRetrievalModel_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SummarizerServiceServer).UpdateRetrievalModel(ctx, req.(*UpdateRetrievalModelRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SummarizerService_UpsertRetrievalModel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpsertRetrievalModelRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SummarizerServiceServer).UpsertRetrievalModel(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SummarizerService_UpsertRetrievalModel_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SummarizerServiceServer).UpsertRetrievalModel(ctx, req.(*UpsertRetrievalModelRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SummarizerService_DeleteRetrievalModel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteRetrievalModelRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SummarizerServiceServer).DeleteRetrievalModel(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SummarizerService_DeleteRetrievalModel_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SummarizerServiceServer).DeleteRetrievalModel(ctx, req.(*DeleteRetrievalModelRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SummarizerService_ServiceDesc is the grpc.ServiceDesc for SummarizerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -952,6 +1134,26 @@ var SummarizerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "TestInferenceModel",
 			Handler:    _SummarizerService_TestInferenceModel_Handler,
+		},
+		{
+			MethodName: "CreateRetrievalModel",
+			Handler:    _SummarizerService_CreateRetrievalModel_Handler,
+		},
+		{
+			MethodName: "GetRetrievalModel",
+			Handler:    _SummarizerService_GetRetrievalModel_Handler,
+		},
+		{
+			MethodName: "UpdateRetrievalModel",
+			Handler:    _SummarizerService_UpdateRetrievalModel_Handler,
+		},
+		{
+			MethodName: "UpsertRetrievalModel",
+			Handler:    _SummarizerService_UpsertRetrievalModel_Handler,
+		},
+		{
+			MethodName: "DeleteRetrievalModel",
+			Handler:    _SummarizerService_DeleteRetrievalModel_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/proto/teleport/summarizer/v1/summarizer.proto
+++ b/api/proto/teleport/summarizer/v1/summarizer.proto
@@ -368,3 +368,40 @@ message EnhancedSummary {
   // NeedsFurtherReview indicates the reason why the session needs further review.
   optional NeedsReviewReason needs_further_review = 8;
 }
+
+// RetrievalModel resource specifies the model configuration used to
+// generate embeddings for the session and perform search inference.
+// It tells Teleport how to generate embeddings for a specific session summary
+// and how to convert natural language queries into API requests.
+message RetrievalModel {
+  // Kind is the resource kind. Should always be set to "retrieval_model".
+  string kind = 1;
+  // SubKind is the resource sub-kind. Should be empty.
+  string sub_kind = 2;
+  // Version is the resource version. Should be set to "v1".
+  string version = 3;
+  teleport.header.v1.Metadata metadata = 4;
+  // spec contains the configuration for the retrieval model, including the
+  // embeddings provider and the search inference model.
+  // In the future it can be extended with re-rankers configuration and
+  // other settings.
+  RetrievalModelSpec spec = 5;
+}
+
+// RetrievalModelSpec specifies the embeddings provider and search inference model.
+// In the future it can be extended with re-rankers configuration and
+// other settings.
+message RetrievalModelSpec {
+  oneof embeddings_provider {
+    // Openai indicates that this model uses OpenAI as the embeddings provider
+    // and specifies OpenAI-specific parameters.
+    OpenAIProvider openai = 1;
+    // Bedrock indicates that this model uses Amazon Bedrock as the embeddings
+    // provider and specifies Bedrock-specific parameters.
+    BedrockProvider bedrock = 3;
+  }
+  // inference_model_name is the name of the model used to convert natural
+  // language search queries into API requests and generate prose from a session
+  // summary.
+  string inference_model_name = 2;
+}

--- a/api/proto/teleport/summarizer/v1/summarizer_service.proto
+++ b/api/proto/teleport/summarizer/v1/summarizer_service.proto
@@ -78,6 +78,18 @@ service SummarizerService {
   // TestInferenceModel tests an InferenceModel configuration by making a test
   // request to the configured provider (AWS Bedrock or OpenAI).
   rpc TestInferenceModel(TestInferenceModelRequest) returns (TestInferenceModelResponse);
+
+  // CreateRetrievalModel creates the RetrievalModel.
+  rpc CreateRetrievalModel(CreateRetrievalModelRequest) returns (CreateRetrievalModelResponse);
+  // GetRetrievalModel retrieves the existing RetrievalModel.
+  rpc GetRetrievalModel(GetRetrievalModelRequest) returns (GetRetrievalModelResponse);
+  // UpdateRetrievalModel updates the existing RetrievalModel.
+  rpc UpdateRetrievalModel(UpdateRetrievalModelRequest) returns (UpdateRetrievalModelResponse);
+  // UpsertRetrievalModel creates a new RetrievalModel or updates the existing
+  // one.
+  rpc UpsertRetrievalModel(UpsertRetrievalModelRequest) returns (UpsertRetrievalModelResponse);
+  // DeleteRetrievalModel deletes the existing RetrievalModel by name.
+  rpc DeleteRetrievalModel(DeleteRetrievalModelRequest) returns (DeleteRetrievalModelResponse);
 }
 
 // Summarization inference models
@@ -118,7 +130,7 @@ message UpdateInferenceModelResponse {
   InferenceModel model = 1;
 }
 
-// UpsertInferenceModelRequest is a request for creating or updating a
+// UpsertInferenceModelRequest is a request for creating or updating an
 // InferenceModel.
 message UpsertInferenceModelRequest {
   // Model is the InferenceModel resource to create or update.
@@ -364,3 +376,59 @@ message TestInferenceModelResponse {
   // If success is false, this contains the error message.
   string message = 2;
 }
+
+// CreateRetrievalModelRequest is a request for creating the RetrievalModel.
+// Only one RetrievalModel can exist per cluster.
+message CreateRetrievalModelRequest {
+  // Model is the RetrievalModel resource to create.
+  RetrievalModel model = 1;
+}
+
+// CreateRetrievalModelResponse is a response to creating the RetrievalModel.
+message CreateRetrievalModelResponse {
+  // Model is the RetrievalModel resource that was created.
+  RetrievalModel model = 1;
+}
+
+// GetRetrievalModelRequest is a request for retrieving the RetrievalModel.
+// Since only one RetrievalModel can exist per cluster, no name is required.
+message GetRetrievalModelRequest {}
+
+// GetRetrievalModelResponse is a response to retrieving the RetrievalModel.
+message GetRetrievalModelResponse {
+  // Model is the RetrievalModel resource that was retrieved.
+  RetrievalModel model = 1;
+}
+
+// UpdateRetrievalModelRequest is a request for updating the RetrievalModel.
+message UpdateRetrievalModelRequest {
+  // Model is the RetrievalModel resource to update.
+  RetrievalModel model = 1;
+}
+
+// UpdateRetrievalModelResponse is a response to updating the RetrievalModel.
+message UpdateRetrievalModelResponse {
+  // Model is the RetrievalModel resource that was updated.
+  RetrievalModel model = 1;
+}
+
+// UpsertRetrievalModelRequest is a request for creating or updating the
+// RetrievalModel.
+message UpsertRetrievalModelRequest {
+  // Model is the RetrievalModel resource to create or update.
+  RetrievalModel model = 1;
+}
+
+// UpsertRetrievalModelResponse is a response to creating or updating the
+// RetrievalModel.
+message UpsertRetrievalModelResponse {
+  // Model is the RetrievalModel resource that was created or updated.
+  RetrievalModel model = 1;
+}
+
+// DeleteRetrievalModelRequest is a request for deleting the RetrievalModel.
+// Since only one RetrievalModel can exist per cluster, no name is required.
+message DeleteRetrievalModelRequest {}
+
+// DeleteRetrievalModelResponse is a response to deleting the RetrievalModel.
+message DeleteRetrievalModelResponse {}


### PR DESCRIPTION
Introduces the RetrievalModel proto resource, which configures the embeddings provider (OpenAI or Amazon Bedrock) and inference model used for session search. Adds Create/Get/Update/Upsert/Delete RPCs to SummarizerService.

Part of https://github.com/gravitational/teleport.e/pull/8046
