### PR TITLE
sessionsearch[2]: implement RetrievalModel CRUD backend service

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -672,6 +672,9 @@ const (
 	// stable UNIX users.
 	KindStableUNIXUser = "stable_unix_user"
 
+	// KindRetrievalModel is the kind of teleport.summarizer.v1.RetrievalModel.
+	KindRetrievalModel = "retrieval_model"
+
 	// KindInferenceModel is the kind of teleport.summarizer.v1.InferenceModel.
 	KindInferenceModel = "inference_model"
 
@@ -687,6 +690,10 @@ const (
 
 	// MetaNameVnetConfig is the exact name of the singleton resource holding VNet config.
 	MetaNameVnetConfig = "vnet-config"
+
+	// MetaNameRetrievalModel is the name of the singleton resource holding
+	// the default retrieval model configuration.
+	MetaNameRetrievalModel = "retrieval-model"
 
 	// KindRelayServer is the resource kind for a Relay service heartbeat.
 	KindRelayServer = "relay_server"

--- a/api/types/summarizer/summarizer.go
+++ b/api/types/summarizer/summarizer.go
@@ -226,3 +226,78 @@ func ValidateInferencePolicy(p *summarizerv1.InferencePolicy) error {
 
 	return nil
 }
+
+// NewRetrievalModel creates a new RetrievalModel resource with the given spec.
+// Since only one RetrievalModel can exist per cluster, a fixed name is used.
+func NewRetrievalModel(spec *summarizerv1.RetrievalModelSpec) *summarizerv1.RetrievalModel {
+	return &summarizerv1.RetrievalModel{
+		Kind:    types.KindRetrievalModel,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: types.MetaNameRetrievalModel,
+		},
+		Spec: spec,
+	}
+}
+
+// ValidateRetrievalModel validates a RetrievalModel.
+func ValidateRetrievalModel(m *summarizerv1.RetrievalModel) error {
+	switch {
+	case m == nil:
+		return trace.BadParameter("retrieval model is nil")
+	case m.GetKind() != types.KindRetrievalModel:
+		return trace.BadParameter("kind must be %s, got %s", types.KindRetrievalModel, m.GetKind())
+	case m.GetSubKind() != "":
+		return trace.BadParameter("subkind must be empty")
+	case m.GetVersion() == "":
+		return trace.BadParameter("version is required")
+	case m.GetVersion() != types.V1:
+		return trace.BadParameter("unsupported version %s, supported: %s", m.GetVersion(), types.V1)
+
+	case m.GetMetadata() == nil:
+		return trace.BadParameter("metadata is required")
+	case m.GetMetadata().GetName() != types.MetaNameRetrievalModel:
+		return trace.BadParameter("metadata.name must be %q, got %q", types.MetaNameRetrievalModel, m.GetMetadata().GetName())
+
+	case m.GetSpec() == nil:
+		return trace.BadParameter("spec is required")
+	}
+
+	provider := m.GetSpec().GetEmbeddingsProvider()
+	switch p := provider.(type) {
+	case *summarizerv1.RetrievalModelSpec_Openai:
+		if p.Openai.GetOpenaiModelId() == "" {
+			return trace.BadParameter("spec.embeddings_provider.openai.openai_model_id is required")
+		}
+		if p.Openai.GetApiKeySecretRef() == "" {
+			return trace.BadParameter("spec.embeddings_provider.openai.api_key_secret_ref is required")
+		}
+	case *summarizerv1.RetrievalModelSpec_Bedrock:
+		if p.Bedrock.GetBedrockModelId() == "" {
+			return trace.BadParameter("spec.embeddings_provider.bedrock.bedrock_model_id is required")
+		}
+		if containsPlaceholderInstruction(p.Bedrock.GetBedrockModelId()) {
+			return trace.BadParameter("spec.embeddings_provider.bedrock.bedrock_model_id does not support model expansion")
+		}
+
+		if p.Bedrock.GetRegion() == "" {
+			return trace.BadParameter("spec.embeddings_provider.bedrock.region is required")
+		}
+		switch {
+		case containsPlaceholderInstruction(p.Bedrock.GetRegion()):
+			if strings.ReplaceAll(p.Bedrock.GetRegion(), " ", "") != BedrockRegionExpansionPlaceholder {
+				return trace.BadParameter("spec.embeddings_provider.bedrock.region contains invalid placeholder instructions. Valid placeholder: %s; got %s", BedrockRegionExpansionPlaceholder, p.Bedrock.GetRegion())
+			}
+		case aws.IsValidRegion(p.Bedrock.GetRegion()) != nil:
+			return trace.BadParameter("invalid spec.embeddings_provider.bedrock.region: %q", p.Bedrock.GetRegion())
+		}
+	default:
+		return trace.BadParameter("invalid embeddings_provider specified")
+	}
+
+	if m.GetSpec().GetInferenceModelName() == "" {
+		return trace.BadParameter("spec.inference_model_name is required")
+	}
+
+	return nil
+}

--- a/lib/services/local/summarizer.go
+++ b/lib/services/local/summarizer.go
@@ -33,9 +33,10 @@ import (
 // SummarizerService implements the [services.Summarizer]
 // interface and manages summarization configuration resources in the backend.
 type SummarizerService struct {
-	modelService  *generic.ServiceWrapper[*summarizerv1.InferenceModel]
-	secretService *generic.ServiceWrapper[*summarizerv1.InferenceSecret]
-	policyService *generic.ServiceWrapper[*summarizerv1.InferencePolicy]
+	modelService          *generic.ServiceWrapper[*summarizerv1.InferenceModel]
+	secretService         *generic.ServiceWrapper[*summarizerv1.InferenceSecret]
+	policyService         *generic.ServiceWrapper[*summarizerv1.InferencePolicy]
+	retrievalModelService *generic.ServiceWrapper[*summarizerv1.RetrievalModel]
 }
 
 var _ services.Summarizer = (*SummarizerService)(nil)
@@ -75,6 +76,12 @@ func (s *SummarizerService) ListInferenceModels(
 	return res, nextToken, trace.Wrap(err)
 }
 
+// DeleteAllInferenceModels deletes all session summary inference models from
+// the backend. This should only be used by the cache.
+func (s *SummarizerService) DeleteAllInferenceModels(ctx context.Context) error {
+	return trace.Wrap(s.modelService.DeleteAllResources(ctx))
+}
+
 // UpdateInferenceModel updates an existing session summary inference model in
 // the backend.
 func (s *SummarizerService) UpdateInferenceModel(
@@ -106,7 +113,8 @@ func (s *SummarizerService) CreateInferenceSecret(
 // DeleteInferenceSecret deletes a session summary inference secret from the
 // backend by name.
 func (s *SummarizerService) DeleteInferenceSecret(
-	ctx context.Context, name string) error {
+	ctx context.Context, name string,
+) error {
 	return trace.Wrap(s.secretService.DeleteResource(ctx, name))
 }
 
@@ -129,6 +137,12 @@ func (s *SummarizerService) ListInferenceSecrets(
 ) ([]*summarizerv1.InferenceSecret, string, error) {
 	res, nextToken, err := s.secretService.ListResources(ctx, size, pageToken)
 	return res, nextToken, trace.Wrap(err)
+}
+
+// DeleteAllInferenceSecrets deletes all session summary inference secrets from
+// the backend. This should only be used by the cache.
+func (s *SummarizerService) DeleteAllInferenceSecrets(ctx context.Context) error {
+	return trace.Wrap(s.secretService.DeleteAllResources(ctx))
 }
 
 // UpdateInferenceSecret updates an existing session summary inference secret
@@ -187,6 +201,12 @@ func (s *SummarizerService) ListInferencePolicies(
 	return res, nextToken, trace.Wrap(err)
 }
 
+// DeleteAllInferencePolicies deletes all session summary inference policies
+// from the backend. This should only be used by the cache.
+func (s *SummarizerService) DeleteAllInferencePolicies(ctx context.Context) error {
+	return trace.Wrap(s.policyService.DeleteAllResources(ctx))
+}
+
 // UpdateInferencePolicy updates an existing session summary inference policy
 // in the backend.
 func (s *SummarizerService) UpdateInferencePolicy(
@@ -213,10 +233,52 @@ func (s *SummarizerService) AllInferencePolicies(
 	return s.policyService.Resources(ctx, "", "")
 }
 
+// CreateRetrievalModel creates the search model in the backend.
+// Only one RetrievalModel can exist per cluster.
+func (s *SummarizerService) CreateRetrievalModel(
+	ctx context.Context, model *summarizerv1.RetrievalModel,
+) (*summarizerv1.RetrievalModel, error) {
+	res, err := s.retrievalModelService.CreateResource(ctx, model)
+	return res, trace.Wrap(err)
+}
+
+// GetRetrievalModel retrieves the search model from the backend.
+// Since only one RetrievalModel can exist per cluster, no name is required.
+func (s *SummarizerService) GetRetrievalModel(
+	ctx context.Context,
+) (*summarizerv1.RetrievalModel, error) {
+	res, err := s.retrievalModelService.GetResource(ctx, types.MetaNameRetrievalModel)
+	return res, trace.Wrap(err)
+}
+
+// UpdateRetrievalModel updates the existing search model in the backend.
+func (s *SummarizerService) UpdateRetrievalModel(
+	ctx context.Context, model *summarizerv1.RetrievalModel,
+) (*summarizerv1.RetrievalModel, error) {
+	res, err := s.retrievalModelService.ConditionalUpdateResource(ctx, model)
+	return res, trace.Wrap(err)
+}
+
+// UpsertRetrievalModel creates or updates the search model in the backend.
+// If the model already exists, it will be updated.
+func (s *SummarizerService) UpsertRetrievalModel(
+	ctx context.Context, model *summarizerv1.RetrievalModel,
+) (*summarizerv1.RetrievalModel, error) {
+	res, err := s.retrievalModelService.UpsertResource(ctx, model)
+	return res, trace.Wrap(err)
+}
+
+// DeleteRetrievalModel deletes the search model from the backend.
+// Since only one RetrievalModel can exist per cluster, no name is required.
+func (s *SummarizerService) DeleteRetrievalModel(ctx context.Context) error {
+	return trace.Wrap(s.retrievalModelService.DeleteResource(ctx, types.MetaNameRetrievalModel))
+}
+
 const (
 	inferenceModelPrefix  = "inference_models"
 	inferenceSecretPrefix = "inference_secrets"
 	inferencePolicyPrefix = "inference_policies"
+	retrievalModelPrefix  = "retrieval_model"
 )
 
 // SummarizerServiceConfig provides data necessary to initialize a
@@ -291,9 +353,32 @@ func NewSummarizerService(cfg SummarizerServiceConfig) (*SummarizerService, erro
 		return nil, trace.Wrap(err)
 	}
 
+	validateRetrievalModel := func(m *summarizerv1.RetrievalModel) error {
+		err := summarizer.ValidateRetrievalModel(m)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		return nil
+	}
+
+	retrievalModelService, err := generic.NewServiceWrapper(
+		generic.ServiceConfig[*summarizerv1.RetrievalModel]{
+			Backend:       cfg.Backend,
+			ResourceKind:  types.KindRetrievalModel,
+			BackendPrefix: backend.NewKey(retrievalModelPrefix),
+			MarshalFunc:   services.MarshalProtoResource[*summarizerv1.RetrievalModel],
+			UnmarshalFunc: services.UnmarshalProtoResource[*summarizerv1.RetrievalModel],
+			ValidateFunc:  validateRetrievalModel,
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &SummarizerService{
-		modelService:  modelService,
-		secretService: secretService,
-		policyService: policyService,
+		modelService:          modelService,
+		secretService:         secretService,
+		policyService:         policyService,
+		retrievalModelService: retrievalModelService,
 	}, nil
 }

--- a/lib/services/local/summarizer_test.go
+++ b/lib/services/local/summarizer_test.go
@@ -842,3 +842,232 @@ func TestSummarizerService_AllInferencePolicies(t *testing.T) {
 		}))
 	}
 }
+
+func newRetrievalModel() *summarizerv1.RetrievalModel {
+	return summarizer.NewRetrievalModel(&summarizerv1.RetrievalModelSpec{
+		EmbeddingsProvider: &summarizerv1.RetrievalModelSpec_Openai{
+			Openai: &summarizerv1.OpenAIProvider{
+				OpenaiModelId:   "text-embedding-3-small",
+				ApiKeySecretRef: "something",
+			},
+		},
+		InferenceModelName: "gpt-4o",
+	})
+}
+
+func TestSummarizerService_CreateRetrievalModel(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		ctx, service := setupSummarizerTest(t)
+		want := newRetrievalModel()
+		got, err := service.CreateRetrievalModel(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.CloneOf(want),
+		)
+		require.NoError(t, err)
+		assert.NotEmpty(t, got.Metadata.Revision)
+		assert.Empty(t, cmp.Diff(
+			want,
+			got,
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		))
+	})
+	t.Run("invalid", func(t *testing.T) {
+		ctx, service := setupSummarizerTest(t)
+		m := newRetrievalModel()
+		m.Spec.GetOpenai().OpenaiModelId = ""
+		_, err := service.CreateRetrievalModel(
+			ctx,
+			proto.CloneOf(m),
+		)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, trace.BadParameter("spec.embeddings_provider.openai.openai_model_id is required"))
+	})
+	t.Run("no upsert", func(t *testing.T) {
+		ctx, service := setupSummarizerTest(t)
+		res := newRetrievalModel()
+		_, err := service.CreateRetrievalModel(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.CloneOf(res),
+		)
+		require.NoError(t, err)
+		_, err = service.CreateRetrievalModel(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.CloneOf(res),
+		)
+		require.Error(t, err)
+		assert.True(t, trace.IsAlreadyExists(err))
+	})
+}
+
+func TestSummarizerService_CreateRetrievalModel_BedrockAllowed(t *testing.T) {
+	// Perform a similar setup procedure, but enable Bedrock.
+	t.Parallel()
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+	service, err := NewSummarizerService(SummarizerServiceConfig{
+		Backend:                          backend.NewSanitizer(mem),
+		EnableBedrockWithoutRestrictions: true,
+	})
+	require.NoError(t, err)
+
+	want := summarizer.NewRetrievalModel(&summarizerv1.RetrievalModelSpec{
+		EmbeddingsProvider: &summarizerv1.RetrievalModelSpec_Bedrock{
+			Bedrock: &summarizerv1.BedrockProvider{
+				Region:         "us-east-1",
+				BedrockModelId: "amazon.titan-embed-text-v2:0",
+			},
+		},
+		InferenceModelName: "gpt-4o",
+	})
+
+	got, err := service.CreateRetrievalModel(
+		ctx,
+		// Clone to avoid Marshaling modifying want
+		proto.CloneOf(want),
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, got.Metadata.Revision)
+	assert.Empty(t, cmp.Diff(
+		want,
+		got,
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+	))
+}
+
+func TestSummarizerService_UpsertRetrievalModel(t *testing.T) {
+	ctx, service := setupSummarizerTest(t)
+
+	want := newRetrievalModel()
+	got, err := service.UpsertRetrievalModel(
+		ctx,
+		// Clone to avoid Marshaling modifying want
+		proto.CloneOf(want),
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, got.Metadata.Revision)
+	assert.Empty(t, cmp.Diff(
+		want,
+		got,
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+	))
+
+	// Ensure we can upsert over an existing resource
+	_, err = service.UpsertRetrievalModel(
+		ctx,
+		// Clone to avoid Marshaling modifying want
+		proto.CloneOf(want),
+	)
+	require.NoError(t, err)
+}
+
+func TestSummarizerService_GetRetrievalModel(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		ctx, service := setupSummarizerTest(t)
+		want := newRetrievalModel()
+		_, err := service.CreateRetrievalModel(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.CloneOf(want),
+		)
+		require.NoError(t, err)
+		got, err := service.GetRetrievalModel(ctx)
+		require.NoError(t, err)
+		assert.NotEmpty(t, got.Metadata.Revision)
+		assert.Empty(t, cmp.Diff(
+			want,
+			got,
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		))
+	})
+	t.Run("not found", func(t *testing.T) {
+		ctx, service := setupSummarizerTest(t)
+		_, err := service.GetRetrievalModel(ctx)
+		require.Error(t, err)
+		assert.True(t, trace.IsNotFound(err))
+	})
+}
+
+func TestSummarizerService_DeleteRetrievalModel(t *testing.T) {
+	ctx, service := setupSummarizerTest(t)
+
+	t.Run("ok", func(t *testing.T) {
+		_, err := service.CreateRetrievalModel(
+			ctx,
+			newRetrievalModel(),
+		)
+		require.NoError(t, err)
+
+		_, err = service.GetRetrievalModel(ctx)
+		require.NoError(t, err)
+
+		err = service.DeleteRetrievalModel(ctx)
+		require.NoError(t, err)
+
+		_, err = service.GetRetrievalModel(ctx)
+		require.Error(t, err)
+		assert.True(t, trace.IsNotFound(err))
+	})
+	t.Run("not found", func(t *testing.T) {
+		err := service.DeleteRetrievalModel(ctx)
+		require.Error(t, err)
+		assert.True(t, trace.IsNotFound(err))
+	})
+}
+
+func TestSummarizerService_UpdateRetrievalModel(t *testing.T) {
+	ctx, service := setupSummarizerTest(t)
+
+	t.Run("ok", func(t *testing.T) {
+		// Create resource for us to Update since we can't update a non-existent resource.
+		created, err := service.CreateRetrievalModel(
+			ctx,
+			newRetrievalModel(),
+		)
+		require.NoError(t, err)
+		want := proto.CloneOf(created)
+		want.Spec.GetOpenai().BaseUrl = "https://localhost:4000"
+
+		updated, err := service.UpdateRetrievalModel(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.CloneOf(want),
+		)
+		require.NoError(t, err)
+		assert.NotEqual(t, created.Metadata.Revision, updated.Metadata.Revision)
+		assert.Empty(t, cmp.Diff(
+			want,
+			updated,
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		))
+
+		got, err := service.GetRetrievalModel(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, cmp.Diff(
+			want,
+			got,
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		))
+		assert.Equal(t, updated.Metadata.Revision, got.Metadata.Revision)
+	})
+	t.Run("no create", func(t *testing.T) {
+		_, err := service.UpdateRetrievalModel(
+			ctx,
+			newRetrievalModel(),
+		)
+		require.Error(t, err)
+	})
+}

--- a/lib/services/summarizer.go
+++ b/lib/services/summarizer.go
@@ -101,6 +101,21 @@ type Summarizer interface {
 	// AllInferencePolicies returns an iterator that retrieves all session
 	// summary inference policies from the backend, without pagination.
 	AllInferencePolicies(ctx context.Context) iter.Seq2[*summarizerv1.InferencePolicy, error]
+
+	// CreateRetrievalModel creates the search model in the backend.
+	// Only one RetrievalModel can exist per cluster.
+	CreateRetrievalModel(ctx context.Context, model *summarizerv1.RetrievalModel) (*summarizerv1.RetrievalModel, error)
+	// GetRetrievalModel retrieves the search model from the backend.
+	// Since only one RetrievalModel can exist per cluster, no name is required.
+	GetRetrievalModel(ctx context.Context) (*summarizerv1.RetrievalModel, error)
+	// UpdateRetrievalModel updates the existing search model in the backend.
+	UpdateRetrievalModel(ctx context.Context, model *summarizerv1.RetrievalModel) (*summarizerv1.RetrievalModel, error)
+	// UpsertRetrievalModel creates or updates the search model in the backend.
+	// If the model already exists, it will be updated.
+	UpsertRetrievalModel(ctx context.Context, model *summarizerv1.RetrievalModel) (*summarizerv1.RetrievalModel, error)
+	// DeleteRetrievalModel deletes the search model from the backend.
+	// Since only one RetrievalModel can exist per cluster, no name is required.
+	DeleteRetrievalModel(ctx context.Context) error
 }
 
 // InferencePolicyMatchingContext is a special kind of [RuleContext] that is


### PR DESCRIPTION
Adds the RetrievalModel singleton resource, which configures the embeddings provider and inference model used for session search.

Part of https://github.com/gravitational/teleport.e/pull/8046
