### PR TITLE
sessionsearch[3]: wire summarizer resources into the cache layer

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -33,6 +33,7 @@ import (
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	summaryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
@@ -183,6 +184,22 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 	case types.Resource153UnwrapperT[*workloadclusterv1.WorkloadCluster]:
 		out.Resource = &proto.Event_WorkloadCluster{
 			WorkloadCluster: r.UnwrapT(),
+		}
+	case types.Resource153UnwrapperT[*summaryv1.InferenceModel]:
+		out.Resource = &proto.Event_InferenceModel{
+			InferenceModel: r.UnwrapT(),
+		}
+	case types.Resource153UnwrapperT[*summaryv1.InferenceSecret]:
+		out.Resource = &proto.Event_InferenceSecret{
+			InferenceSecret: r.UnwrapT(),
+		}
+	case types.Resource153UnwrapperT[*summaryv1.InferencePolicy]:
+		out.Resource = &proto.Event_InferencePolicy{
+			InferencePolicy: r.UnwrapT(),
+		}
+	case types.Resource153UnwrapperT[*summaryv1.RetrievalModel]:
+		out.Resource = &proto.Event_RetrievalModel{
+			RetrievalModel: r.UnwrapT(),
 		}
 	case *types.ResourceHeader:
 		out.Resource = &proto.Event_ResourceHeader{
@@ -697,6 +714,18 @@ func EventFromGRPC(in *proto.Event) (*types.Event, error) {
 		out.Resource = types.ProtoResource153ToLegacy(r)
 		return &out, nil
 	} else if r := in.GetWorkloadCluster(); r != nil {
+		out.Resource = types.Resource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetInferenceModel(); r != nil {
+		out.Resource = types.ProtoResource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetInferenceSecret(); r != nil {
+		out.Resource = types.ProtoResource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetInferencePolicy(); r != nil {
+		out.Resource = types.ProtoResource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetRetrievalModel(); r != nil {
 		out.Resource = types.Resource153ToLegacy(r)
 		return &out, nil
 	} else {

--- a/api/client/proto/event.pb.go
+++ b/api/client/proto/event.pb.go
@@ -42,6 +42,7 @@ import (
 	v117 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	v13 "github.com/gravitational/teleport/api/gen/proto/go/teleport/secreports/v1"
 	v124 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	v125 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
 	v2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	v112 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
@@ -210,6 +211,10 @@ type Event struct {
 	//	*Event_WorkloadCluster
 	//	*Event_ValidatedMFAChallenge
 	//	*Event_CertAuthorityOverride
+	//	*Event_InferenceModel
+	//	*Event_InferenceSecret
+	//	*Event_InferencePolicy
+	//	*Event_RetrievalModel
 	Resource      isEvent_Resource `protobuf_oneof:"Resource"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1024,6 +1029,42 @@ func (x *Event) GetCertAuthorityOverride() *v124.CertAuthorityOverride {
 	return nil
 }
 
+func (x *Event) GetInferenceModel() *v125.InferenceModel {
+	if x != nil {
+		if x, ok := x.Resource.(*Event_InferenceModel); ok {
+			return x.InferenceModel
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetInferenceSecret() *v125.InferenceSecret {
+	if x != nil {
+		if x, ok := x.Resource.(*Event_InferenceSecret); ok {
+			return x.InferenceSecret
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetInferencePolicy() *v125.InferencePolicy {
+	if x != nil {
+		if x, ok := x.Resource.(*Event_InferencePolicy); ok {
+			return x.InferencePolicy
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRetrievalModel() *v125.RetrievalModel {
+	if x != nil {
+		if x, ok := x.Resource.(*Event_RetrievalModel); ok {
+			return x.RetrievalModel
+		}
+	}
+	return nil
+}
+
 type isEvent_Resource interface {
 	isEvent_Resource()
 }
@@ -1458,6 +1499,26 @@ type Event_CertAuthorityOverride struct {
 	CertAuthorityOverride *v124.CertAuthorityOverride `protobuf:"bytes,90,opt,name=CertAuthorityOverride,proto3,oneof"`
 }
 
+type Event_InferenceModel struct {
+	// InferenceModel is a resource for defining inference models.
+	InferenceModel *v125.InferenceModel `protobuf:"bytes,91,opt,name=InferenceModel,proto3,oneof"`
+}
+
+type Event_InferenceSecret struct {
+	// InferenceSecret is a resource for defining inference secrets.
+	InferenceSecret *v125.InferenceSecret `protobuf:"bytes,92,opt,name=InferenceSecret,proto3,oneof"`
+}
+
+type Event_InferencePolicy struct {
+	// InferencePolicy is a resource for defining inference policies.
+	InferencePolicy *v125.InferencePolicy `protobuf:"bytes,93,opt,name=InferencePolicy,proto3,oneof"`
+}
+
+type Event_RetrievalModel struct {
+	// RetrievalModel is a resource for defining retrieval models.
+	RetrievalModel *v125.RetrievalModel `protobuf:"bytes,94,opt,name=RetrievalModel,proto3,oneof"`
+}
+
 func (*Event_ResourceHeader) isEvent_Resource() {}
 
 func (*Event_CertAuthority) isEvent_Resource() {}
@@ -1628,11 +1689,19 @@ func (*Event_ValidatedMFAChallenge) isEvent_Resource() {}
 
 func (*Event_CertAuthorityOverride) isEvent_Resource() {}
 
+func (*Event_InferenceModel) isEvent_Resource() {}
+
+func (*Event_InferenceSecret) isEvent_Resource() {}
+
+func (*Event_InferencePolicy) isEvent_Resource() {}
+
+func (*Event_RetrievalModel) isEvent_Resource() {}
+
 var File_teleport_legacy_client_proto_event_proto protoreflect.FileDescriptor
 
 const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"\n" +
-	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a-teleport/appauthconfig/v1/appauthconfig.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a,teleport/linuxdesktop/v1/linux_desktop.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a)teleport/mfa/v1/validated_challenge.proto\x1a-teleport/notifications/v1/notifications.proto\x1a'teleport/presence/v1/relay_server.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a:teleport/recordingencryption/v1/recording_encryption.proto\x1a*teleport/scopes/access/v1/assignment.proto\x1a$teleport/scopes/access/v1/role.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/subca/v1/cert_authority_override.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a1teleport/workloadcluster/v1/workloadcluster.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\x9f4\n" +
+	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a-teleport/appauthconfig/v1/appauthconfig.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a,teleport/linuxdesktop/v1/linux_desktop.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a)teleport/mfa/v1/validated_challenge.proto\x1a-teleport/notifications/v1/notifications.proto\x1a'teleport/presence/v1/relay_server.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a:teleport/recordingencryption/v1/recording_encryption.proto\x1a*teleport/scopes/access/v1/assignment.proto\x1a$teleport/scopes/access/v1/role.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/subca/v1/cert_authority_override.proto\x1a'teleport/summarizer/v1/summarizer.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a1teleport/workloadcluster/v1/workloadcluster.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\xed6\n" +
 	"\x05Event\x12$\n" +
 	"\x04Type\x18\x01 \x01(\x0e2\x10.proto.OperationR\x04Type\x12?\n" +
 	"\x0eResourceHeader\x18\x02 \x01(\v2\x15.types.ResourceHeaderH\x00R\x0eResourceHeader\x12>\n" +
@@ -1732,7 +1801,11 @@ const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"\fLinuxDesktop\x18W \x01(\v2&.teleport.linuxdesktop.v1.LinuxDesktopH\x00R\fLinuxDesktop\x12X\n" +
 	"\x0fWorkloadCluster\x18X \x01(\v2,.teleport.workloadcluster.v1.WorkloadClusterH\x00R\x0fWorkloadCluster\x12^\n" +
 	"\x15ValidatedMFAChallenge\x18Y \x01(\v2&.teleport.mfa.v1.ValidatedMFAChallengeH\x00R\x15ValidatedMFAChallenge\x12`\n" +
-	"\x15CertAuthorityOverride\x18Z \x01(\v2(.teleport.subca.v1.CertAuthorityOverrideH\x00R\x15CertAuthorityOverrideB\n" +
+	"\x15CertAuthorityOverride\x18Z \x01(\v2(.teleport.subca.v1.CertAuthorityOverrideH\x00R\x15CertAuthorityOverride\x12P\n" +
+	"\x0eInferenceModel\x18[ \x01(\v2&.teleport.summarizer.v1.InferenceModelH\x00R\x0eInferenceModel\x12S\n" +
+	"\x0fInferenceSecret\x18\\ \x01(\v2'.teleport.summarizer.v1.InferenceSecretH\x00R\x0fInferenceSecret\x12S\n" +
+	"\x0fInferencePolicy\x18] \x01(\v2'.teleport.summarizer.v1.InferencePolicyH\x00R\x0fInferencePolicy\x12P\n" +
+	"\x0eRetrievalModel\x18^ \x01(\v2&.teleport.summarizer.v1.RetrievalModelH\x00R\x0eRetrievalModelB\n" +
 	"\n" +
 	"\bResourceJ\x04\b\a\x10\bJ\x04\b1\x102J\x04\b?\x10@J\x04\bD\x10ER\x12ExternalCloudAuditR\x0eStaticHostUserR\x13AutoUpdateAgentPlan**\n" +
 	"\tOperation\x12\b\n" +
@@ -1840,6 +1913,10 @@ var file_teleport_legacy_client_proto_event_proto_goTypes = []any{
 	(*v122.WorkloadCluster)(nil),                // 81: teleport.workloadcluster.v1.WorkloadCluster
 	(*v123.ValidatedMFAChallenge)(nil),          // 82: teleport.mfa.v1.ValidatedMFAChallenge
 	(*v124.CertAuthorityOverride)(nil),          // 83: teleport.subca.v1.CertAuthorityOverride
+	(*v125.InferenceModel)(nil),                 // 84: teleport.summarizer.v1.InferenceModel
+	(*v125.InferenceSecret)(nil),                // 85: teleport.summarizer.v1.InferenceSecret
+	(*v125.InferencePolicy)(nil),                // 86: teleport.summarizer.v1.InferencePolicy
+	(*v125.RetrievalModel)(nil),                 // 87: teleport.summarizer.v1.RetrievalModel
 }
 var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	0,  // 0: proto.Event.Type:type_name -> proto.Operation
@@ -1928,11 +2005,15 @@ var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	81, // 83: proto.Event.WorkloadCluster:type_name -> teleport.workloadcluster.v1.WorkloadCluster
 	82, // 84: proto.Event.ValidatedMFAChallenge:type_name -> teleport.mfa.v1.ValidatedMFAChallenge
 	83, // 85: proto.Event.CertAuthorityOverride:type_name -> teleport.subca.v1.CertAuthorityOverride
-	86, // [86:86] is the sub-list for method output_type
-	86, // [86:86] is the sub-list for method input_type
-	86, // [86:86] is the sub-list for extension type_name
-	86, // [86:86] is the sub-list for extension extendee
-	0,  // [0:86] is the sub-list for field type_name
+	84, // 86: proto.Event.InferenceModel:type_name -> teleport.summarizer.v1.InferenceModel
+	85, // 87: proto.Event.InferenceSecret:type_name -> teleport.summarizer.v1.InferenceSecret
+	86, // 88: proto.Event.InferencePolicy:type_name -> teleport.summarizer.v1.InferencePolicy
+	87, // 89: proto.Event.RetrievalModel:type_name -> teleport.summarizer.v1.RetrievalModel
+	90, // [90:90] is the sub-list for method output_type
+	90, // [90:90] is the sub-list for method input_type
+	90, // [90:90] is the sub-list for extension type_name
+	90, // [90:90] is the sub-list for extension extendee
+	0,  // [0:90] is the sub-list for field type_name
 }
 
 func init() { file_teleport_legacy_client_proto_event_proto_init() }
@@ -2026,6 +2107,10 @@ func file_teleport_legacy_client_proto_event_proto_init() {
 		(*Event_WorkloadCluster)(nil),
 		(*Event_ValidatedMFAChallenge)(nil),
 		(*Event_CertAuthorityOverride)(nil),
+		(*Event_InferenceModel)(nil),
+		(*Event_InferenceSecret)(nil),
+		(*Event_InferencePolicy)(nil),
+		(*Event_RetrievalModel)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api/proto/teleport/legacy/client/proto/event.proto
+++ b/api/proto/teleport/legacy/client/proto/event.proto
@@ -40,6 +40,7 @@ import "teleport/scopes/access/v1/assignment.proto";
 import "teleport/scopes/access/v1/role.proto";
 import "teleport/secreports/v1/secreports.proto";
 import "teleport/subca/v1/cert_authority_override.proto";
+import "teleport/summarizer/v1/summarizer.proto";
 import "teleport/userloginstate/v1/userloginstate.proto";
 import "teleport/userprovisioning/v2/statichostuser.proto";
 import "teleport/usertasks/v1/user_tasks.proto";
@@ -249,5 +250,13 @@ message Event {
     teleport.mfa.v1.ValidatedMFAChallenge ValidatedMFAChallenge = 89;
     // CertAuthorityOverride allows admins to override Teleport CA certificates.
     teleport.subca.v1.CertAuthorityOverride CertAuthorityOverride = 90;
+    // InferenceModel is a resource for defining inference models.
+    teleport.summarizer.v1.InferenceModel InferenceModel = 91;
+    // InferenceSecret is a resource for defining inference secrets.
+    teleport.summarizer.v1.InferenceSecret InferenceSecret = 92;
+    // InferencePolicy is a resource for defining inference policies.
+    teleport.summarizer.v1.InferencePolicy InferencePolicy = 93;
+    // RetrievalModel is a resource for defining retrieval models.
+    teleport.summarizer.v1.RetrievalModel RetrievalModel = 94;
   }
 }

--- a/gen/preset-roles.json
+++ b/gen/preset-roles.json
@@ -1179,6 +1179,18 @@
           },
           {
             "resources": [
+              "retrieval_model"
+            ],
+            "verbs": [
+              "list",
+              "create",
+              "read",
+              "update",
+              "delete"
+            ]
+          },
+          {
+            "resources": [
               "client_ip_restriction"
             ],
             "verbs": [

--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -117,6 +117,7 @@ type Config struct {
 	Plugin                  services.Plugins
 	AppAuthConfig           services.AppAuthConfigReader
 	WorkloadClusterService  services.WorkloadClusterService
+	Summarizer              services.Summarizer
 }
 
 func (c *Config) CheckAndSetDefaults() error {
@@ -206,6 +207,7 @@ func NewCache(cfg Config) (*cache.Cache, error) {
 		Plugin:                  cfg.Plugin,
 		AppAuthConfig:           cfg.AppAuthConfig,
 		WorkloadClusterService:  cfg.WorkloadClusterService,
+		Summarizer:              cfg.Summarizer,
 	}
 
 	return cache.New(cfg.Setup(cacheCfg))

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1490,6 +1490,8 @@ type Cache interface {
 
 	// WorkloadClusterServiceGetter defines methods for fetching workload clusters.
 	services.WorkloadClusterServiceGetter
+	// SummarizerServiceGetter defines methods for fetching summarizer resources.
+	services.SummarizerServiceGetter
 }
 
 type NodeWrapper struct {

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -647,6 +647,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		AppAuthConfig:           p.AuthServer.Services.AppAuthConfig,
 		StaticScopedToken:       p.AuthServer.Services.ClusterConfigurationInternal,
 		WorkloadClusterService:  p.AuthServer.Services.WorkloadClusterService,
+		Summarizer:              p.AuthServer.Services.Summarizer,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -219,6 +219,10 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindRecordingEncryption},
 		{Kind: types.KindAppAuthConfig},
 		{Kind: types.KindWorkloadCluster},
+		{Kind: types.KindInferenceModel},
+		{Kind: types.KindInferencePolicy},
+		{Kind: types.KindInferenceSecret},
+		{Kind: types.KindRetrievalModel},
 	}
 	cfg.QueueSize = defaults.AuthQueueSize
 	// We don't want to enable partial health for auth cache because auth uses an event stream
@@ -797,6 +801,8 @@ type Config struct {
 	AppAuthConfig services.AppAuthConfigReader
 	// WorkloadClusterService is a workload cluster service
 	WorkloadClusterService services.WorkloadClusterService
+	// Summarizer is a summarizer service.
+	Summarizer services.Summarizer
 }
 
 // CheckAndSetDefaults checks parameters and sets default values

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -59,6 +59,7 @@ import (
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	summaryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
@@ -173,6 +174,7 @@ type testPack struct {
 	plugin                  *local.PluginsService
 	appAuthConfigs          *local.AppAuthConfigService
 	workloadClusters        *local.WorkloadClusterService
+	summarizer              *local.SummarizerService
 }
 
 // resourceOps contains helpers to modify the state of either types.Resource or types.Resource153  which
@@ -539,6 +541,13 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	}
 	p.workloadClusters = workloadClusterSvc
 
+	p.summarizer, err = local.NewSummarizerService(local.SummarizerServiceConfig{
+		Backend: p.backend,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return p, nil
 }
 
@@ -604,6 +613,7 @@ func newPack(t testing.TB, setupConfig func(c Config) Config, opts ...packOption
 		AppAuthConfig:           p.appAuthConfigs,
 		StaticScopedToken:       p.clusterConfigS,
 		WorkloadClusterService:  p.workloadClusters,
+		Summarizer:              p.summarizer,
 	}))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -876,6 +886,7 @@ func TestCompletenessInit(t *testing.T) {
 			AppAuthConfig:           p.appAuthConfigs,
 			StaticScopedToken:       p.clusterConfigS,
 			WorkloadClusterService:  p.workloadClusters,
+			Summarizer:              p.summarizer,
 		}))
 		require.NoError(t, err)
 
@@ -967,6 +978,7 @@ func TestCompletenessReset(t *testing.T) {
 		AppAuthConfig:           p.appAuthConfigs,
 		StaticScopedToken:       p.clusterConfigS,
 		WorkloadClusterService:  p.workloadClusters,
+		Summarizer:              p.summarizer,
 	}))
 	require.NoError(t, err)
 
@@ -1134,6 +1146,7 @@ func TestListResources_NodesTTLVariant(t *testing.T) {
 		AppAuthConfig:           p.appAuthConfigs,
 		StaticScopedToken:       p.clusterConfigS,
 		WorkloadClusterService:  p.workloadClusters,
+		Summarizer:              p.summarizer,
 	}))
 	require.NoError(t, err)
 
@@ -1236,6 +1249,7 @@ func initStrategy(t *testing.T) {
 		AppAuthConfig:           p.appAuthConfigs,
 		StaticScopedToken:       p.clusterConfigS,
 		WorkloadClusterService:  p.workloadClusters,
+		Summarizer:              p.summarizer,
 	}))
 	require.NoError(t, err)
 
@@ -1983,6 +1997,10 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindBotInstance:                       types.ProtoResource153ToLegacy(new(machineidv1.BotInstance)),
 		types.KindAppAuthConfig:                     types.Resource153ToLegacy(new(appauthconfigv1.AppAuthConfig)),
 		types.KindWorkloadCluster:                   types.Resource153ToLegacy(newWorkloadCluster(t, "test")),
+		types.KindInferenceModel:                    types.Resource153ToLegacy(new(summaryv1.InferenceModel)),
+		types.KindInferenceSecret:                   types.Resource153ToLegacy(new(summaryv1.InferenceSecret)),
+		types.KindInferencePolicy:                   types.Resource153ToLegacy(new(summaryv1.InferencePolicy)),
+		types.KindRetrievalModel:                    types.Resource153ToLegacy(new(summaryv1.RetrievalModel)),
 	}
 
 	for name, cfg := range cases {
@@ -2058,6 +2076,15 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*appauthconfigv1.AppAuthConfig]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				case types.Resource153UnwrapperT[*workloadclusterv1.WorkloadCluster]:
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*workloadclusterv1.WorkloadCluster]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+				case types.Resource153UnwrapperT[*summaryv1.InferenceModel]:
+					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*summaryv1.InferenceModel]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+				case types.Resource153UnwrapperT[*summaryv1.InferenceSecret]:
+					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*summaryv1.InferenceSecret]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+				case types.Resource153UnwrapperT[*summaryv1.InferencePolicy]:
+					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*summaryv1.InferencePolicy]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+				case types.Resource153UnwrapperT[*summaryv1.RetrievalModel]:
+					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*summaryv1.RetrievalModel]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+
 				default:
 					require.Empty(t, cmp.Diff(resource, event.Resource))
 				}

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -37,6 +37,7 @@ import (
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	userprovisioningv2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
@@ -150,6 +151,10 @@ type collections struct {
 	plugins                            *collection[types.Plugin, pluginIndex]
 	appAuthConfig                      *collection[*appauthconfigv1.AppAuthConfig, appAuthConfigIndex]
 	workloadClusters                   *collection[*workloadclusterv1.WorkloadCluster, workloadClusterIndex]
+	inferenceModels                    *collection[*summarizerv1.InferenceModel, inferenceModelIndex]
+	inferenceSecrets                   *collection[*summarizerv1.InferenceSecret, inferenceSecretIndex]
+	inferencePolicies                  *collection[*summarizerv1.InferencePolicy, inferencePolicyIndex]
+	retrievalModels                    *collection[*summarizerv1.RetrievalModel, retrievalModelIndex]
 }
 
 // isKnownUncollectedKind is true if a resource kind is not stored in
@@ -797,6 +802,38 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.workloadClusters = collect
 			out.byKind[resourceKind] = out.workloadClusters
+		case types.KindInferenceModel:
+			collect, err := newInferenceModelCollection(c.Summarizer, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.inferenceModels = collect
+			out.byKind[resourceKind] = out.inferenceModels
+		case types.KindInferenceSecret:
+			collect, err := newInferenceSecretCollection(c.Summarizer, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.inferenceSecrets = collect
+			out.byKind[resourceKind] = out.inferenceSecrets
+		case types.KindInferencePolicy:
+			collect, err := newInferencePolicyCollection(c.Summarizer, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.inferencePolicies = collect
+			out.byKind[resourceKind] = out.inferencePolicies
+		case types.KindRetrievalModel:
+			collect, err := newRetrievalModelCollection(c.Summarizer, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.retrievalModels = collect
+			out.byKind[resourceKind] = out.retrievalModels
 		default:
 			if _, ok := out.byKind[resourceKind]; !ok {
 				return nil, trace.BadParameter("resource %q is not supported", watch.Kind)

--- a/lib/cache/inventory/inventory_cache_test.go
+++ b/lib/cache/inventory/inventory_cache_test.go
@@ -216,6 +216,11 @@ func setupTestCache(t *testing.T, setupConfig cache.SetupConfigFn) (*testCache, 
 	workloadClusters, err := local.NewWorkloadClusterService(bkWrapper)
 	require.NoError(t, err)
 
+	summaries, err := local.NewSummarizerService(local.SummarizerServiceConfig{
+		Backend: bkWrapper,
+	})
+	require.NoError(t, err)
+
 	c, err := cache.New(setupConfig(cache.Config{
 		Context:                 ctx,
 		Events:                  eventsS,
@@ -268,6 +273,7 @@ func setupTestCache(t *testing.T, setupConfig cache.SetupConfigFn) (*testCache, 
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 eventsC,
 		WorkloadClusterService:  workloadClusters,
+		Summarizer:              summaries,
 	}))
 	require.NoError(t, err)
 

--- a/lib/cache/summarizer.go
+++ b/lib/cache/summarizer.go
@@ -1,0 +1,313 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"iter"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type inferenceModelIndex struct{}
+
+var inferenceModelNameIndex = inferenceModelIndex{}
+
+func newInferenceModelCollection(upstream services.Summarizer, w types.WatchKind) (*collection[*summarizerv1.InferenceModel, inferenceModelIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter Summarizer")
+	}
+
+	return &collection[*summarizerv1.InferenceModel, inferenceModelIndex]{
+		store: newStore(
+			types.KindInferenceModel,
+			proto.CloneOf[*summarizerv1.InferenceModel],
+			map[inferenceModelIndex]func(*summarizerv1.InferenceModel) string{
+				inferenceModelNameIndex: func(r *summarizerv1.InferenceModel) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*summarizerv1.InferenceModel, error) {
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListInferenceModels))
+			return out, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *summarizerv1.InferenceModel {
+			return &summarizerv1.InferenceModel{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+func (c *Cache) GetInferenceModel(ctx context.Context, name string) (*summarizerv1.InferenceModel, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetInferenceModel")
+	defer span.End()
+
+	getter := genericGetter[*summarizerv1.InferenceModel, inferenceModelIndex]{
+		cache:       c,
+		collection:  c.collections.inferenceModels,
+		index:       inferenceModelNameIndex,
+		upstreamGet: c.Config.Summarizer.GetInferenceModel,
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}
+
+func (c *Cache) ListInferenceModels(ctx context.Context, pageSize int, pageToken string) ([]*summarizerv1.InferenceModel, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListInferenceModels")
+	defer span.End()
+
+	lister := genericLister[*summarizerv1.InferenceModel, inferenceModelIndex]{
+		cache:        c,
+		collection:   c.collections.inferenceModels,
+		index:        inferenceModelNameIndex,
+		upstreamList: c.Config.Summarizer.ListInferenceModels,
+		nextToken: func(t *summarizerv1.InferenceModel) string {
+			return t.GetMetadata().GetName()
+		},
+	}
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+type inferenceSecretIndex struct{}
+
+var inferenceSecretNameIndex = inferenceSecretIndex{}
+
+func newInferenceSecretCollection(upstream services.Summarizer, w types.WatchKind) (*collection[*summarizerv1.InferenceSecret, inferenceSecretIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter Summarizer")
+	}
+
+	return &collection[*summarizerv1.InferenceSecret, inferenceSecretIndex]{
+		store: newStore(
+			types.KindInferenceSecret,
+			proto.CloneOf[*summarizerv1.InferenceSecret],
+			map[inferenceSecretIndex]func(*summarizerv1.InferenceSecret) string{
+				inferenceSecretNameIndex: func(r *summarizerv1.InferenceSecret) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*summarizerv1.InferenceSecret, error) {
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListInferenceSecrets))
+			return out, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *summarizerv1.InferenceSecret {
+			return &summarizerv1.InferenceSecret{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+func (c *Cache) GetInferenceSecret(ctx context.Context, name string) (*summarizerv1.InferenceSecret, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetInferenceSecret")
+	defer span.End()
+
+	getter := genericGetter[*summarizerv1.InferenceSecret, inferenceSecretIndex]{
+		cache:       c,
+		collection:  c.collections.inferenceSecrets,
+		index:       inferenceSecretNameIndex,
+		upstreamGet: c.Config.Summarizer.GetInferenceSecret,
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}
+
+func (c *Cache) ListInferenceSecrets(ctx context.Context, pageSize int, pageToken string) ([]*summarizerv1.InferenceSecret, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListInferenceSecrets")
+	defer span.End()
+
+	lister := genericLister[*summarizerv1.InferenceSecret, inferenceSecretIndex]{
+		cache:        c,
+		collection:   c.collections.inferenceSecrets,
+		index:        inferenceSecretNameIndex,
+		upstreamList: c.Config.Summarizer.ListInferenceSecrets,
+		nextToken: func(t *summarizerv1.InferenceSecret) string {
+			return t.GetMetadata().GetName()
+		},
+	}
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+type inferencePolicyIndex struct{}
+
+var inferencePolicyNameIndex = inferencePolicyIndex{}
+
+func newInferencePolicyCollection(upstream services.Summarizer, w types.WatchKind) (*collection[*summarizerv1.InferencePolicy, inferencePolicyIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter Summarizer")
+	}
+
+	return &collection[*summarizerv1.InferencePolicy, inferencePolicyIndex]{
+		store: newStore(
+			types.KindInferencePolicy,
+			proto.CloneOf[*summarizerv1.InferencePolicy],
+			map[inferencePolicyIndex]func(*summarizerv1.InferencePolicy) string{
+				inferencePolicyNameIndex: func(r *summarizerv1.InferencePolicy) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*summarizerv1.InferencePolicy, error) {
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListInferencePolicies))
+			return out, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *summarizerv1.InferencePolicy {
+			return &summarizerv1.InferencePolicy{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+func (c *Cache) GetInferencePolicy(ctx context.Context, name string) (*summarizerv1.InferencePolicy, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetInferencePolicy")
+	defer span.End()
+
+	getter := genericGetter[*summarizerv1.InferencePolicy, inferencePolicyIndex]{
+		cache:       c,
+		collection:  c.collections.inferencePolicies,
+		index:       inferencePolicyNameIndex,
+		upstreamGet: c.Config.Summarizer.GetInferencePolicy,
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}
+
+func (c *Cache) ListInferencePolicies(ctx context.Context, pageSize int, pageToken string) ([]*summarizerv1.InferencePolicy, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListInferencePolicies")
+	defer span.End()
+
+	lister := genericLister[*summarizerv1.InferencePolicy, inferencePolicyIndex]{
+		cache:        c,
+		collection:   c.collections.inferencePolicies,
+		index:        inferencePolicyNameIndex,
+		upstreamList: c.Config.Summarizer.ListInferencePolicies,
+		nextToken: func(t *summarizerv1.InferencePolicy) string {
+			return t.GetMetadata().GetName()
+		},
+	}
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+func (c *Cache) AllInferencePolicies(ctx context.Context) iter.Seq2[*summarizerv1.InferencePolicy, error] {
+	return func(yield func(*summarizerv1.InferencePolicy, error) bool) {
+		rg, err := acquireReadGuard(c, c.collections.inferencePolicies)
+		if err != nil {
+			yield(nil, trace.Wrap(err))
+			return
+		}
+		defer rg.Release()
+
+		if !rg.ReadCache() {
+			for policy, err := range c.Config.Summarizer.AllInferencePolicies(ctx) {
+				if !yield(policy, err) {
+					return
+				}
+			}
+			return
+		}
+
+		for policy := range rg.store.resources(inferencePolicyNameIndex, "", "") {
+			if !yield(proto.CloneOf(policy), nil) {
+				return
+			}
+		}
+	}
+}
+
+type retrievalModelIndex struct{}
+
+var retrievalModelNameIndex = retrievalModelIndex{}
+
+func newRetrievalModelCollection(upstream services.Summarizer, w types.WatchKind) (*collection[*summarizerv1.RetrievalModel, retrievalModelIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter Summarizer")
+	}
+
+	return &collection[*summarizerv1.RetrievalModel, retrievalModelIndex]{
+		store: newStore(
+			types.KindRetrievalModel,
+			proto.CloneOf[*summarizerv1.RetrievalModel],
+			map[retrievalModelIndex]func(*summarizerv1.RetrievalModel) string{
+				retrievalModelNameIndex: func(r *summarizerv1.RetrievalModel) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*summarizerv1.RetrievalModel, error) {
+			model, err := upstream.GetRetrievalModel(ctx)
+			if err != nil {
+				if trace.IsNotFound(err) {
+					return nil, nil
+				}
+				return nil, trace.Wrap(err)
+			}
+			return []*summarizerv1.RetrievalModel{model}, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *summarizerv1.RetrievalModel {
+			return &summarizerv1.RetrievalModel{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+func (c *Cache) GetRetrievalModel(ctx context.Context) (*summarizerv1.RetrievalModel, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetRetrievalModel")
+	defer span.End()
+
+	getter := genericGetter[*summarizerv1.RetrievalModel, retrievalModelIndex]{
+		cache:      c,
+		collection: c.collections.retrievalModels,
+		index:      retrievalModelNameIndex,
+		upstreamGet: func(ctx context.Context, _ string) (*summarizerv1.RetrievalModel, error) {
+			return c.Config.Summarizer.GetRetrievalModel(ctx)
+		},
+	}
+	out, err := getter.get(ctx, types.MetaNameRetrievalModel)
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/summarizer_test.go
+++ b/lib/cache/summarizer_test.go
@@ -1,0 +1,131 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/summarizer"
+)
+
+func TestInferenceModelCache(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs[*summarizerv1.InferenceModel]{
+		newResource: func(name string) (*summarizerv1.InferenceModel, error) {
+			return summarizer.NewInferenceModel(name, &summarizerv1.InferenceModelSpec{
+				Provider: &summarizerv1.InferenceModelSpec_Openai{
+					Openai: &summarizerv1.OpenAIProvider{
+						OpenaiModelId: "gpt-4o",
+					},
+				},
+			}), nil
+		},
+		create: func(ctx context.Context, item *summarizerv1.InferenceModel) error {
+			_, err := p.summarizer.CreateInferenceModel(ctx, item)
+			return err
+		},
+		list:      p.summarizer.ListInferenceModels,
+		cacheList: p.cache.ListInferenceModels,
+		deleteAll: p.summarizer.DeleteAllInferenceModels,
+	})
+}
+
+func TestInferenceSecretCache(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs[*summarizerv1.InferenceSecret]{
+		newResource: func(name string) (*summarizerv1.InferenceSecret, error) {
+			return summarizer.NewInferenceSecret(name, &summarizerv1.InferenceSecretSpec{
+				Value: "super-secret-value",
+			}), nil
+		},
+		create: func(ctx context.Context, item *summarizerv1.InferenceSecret) error {
+			_, err := p.summarizer.CreateInferenceSecret(ctx, item)
+			return err
+		},
+		list:      p.summarizer.ListInferenceSecrets,
+		cacheList: p.cache.ListInferenceSecrets,
+		deleteAll: p.summarizer.DeleteAllInferenceSecrets,
+	})
+}
+
+func TestInferencePolicyCache(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs[*summarizerv1.InferencePolicy]{
+		newResource: func(name string) (*summarizerv1.InferencePolicy, error) {
+			return summarizer.NewInferencePolicy(name, &summarizerv1.InferencePolicySpec{
+				Kinds: []string{string(types.SSHSessionKind)},
+				Model: "test-model",
+			}), nil
+		},
+		create: func(ctx context.Context, item *summarizerv1.InferencePolicy) error {
+			_, err := p.summarizer.CreateInferencePolicy(ctx, item)
+			return err
+		},
+		list:      p.summarizer.ListInferencePolicies,
+		cacheList: p.cache.ListInferencePolicies,
+		deleteAll: p.summarizer.DeleteAllInferencePolicies,
+	})
+}
+
+func TestRetrievalModelCache(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs[*summarizerv1.RetrievalModel]{
+		newResource: func(name string) (*summarizerv1.RetrievalModel, error) {
+			return summarizer.NewRetrievalModel(&summarizerv1.RetrievalModelSpec{
+				EmbeddingsProvider: &summarizerv1.RetrievalModelSpec_Openai{
+					Openai: &summarizerv1.OpenAIProvider{
+						OpenaiModelId:   "text-embedding-3-small",
+						ApiKeySecretRef: "some",
+					},
+				},
+				InferenceModelName: "some",
+			}), nil
+		},
+		create: func(ctx context.Context, item *summarizerv1.RetrievalModel) error {
+			_, err := p.summarizer.CreateRetrievalModel(ctx, item)
+			return err
+		},
+		update: func(ctx context.Context, item *summarizerv1.RetrievalModel) error {
+			_, err := p.summarizer.UpdateRetrievalModel(ctx, item)
+			return trace.Wrap(err)
+		},
+		list:      singletonListAdapter(p.summarizer.GetRetrievalModel),
+		cacheList: singletonListAdapter(p.cache.GetRetrievalModel),
+		deleteAll: p.summarizer.DeleteRetrievalModel,
+	}, withSkipPaginationTest()) // skip pagination test because NetworkRestrictions is a singleton resource
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3136,6 +3136,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.Plugin = services.Plugins
 	cfg.AppAuthConfig = services.AppAuthConfig
 	cfg.WorkloadClusterService = services.WorkloadClusterService
+	cfg.Summarizer = services.Summarizer
 
 	return accesspoint.NewCache(cfg)
 }

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -283,6 +283,14 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newAppAuthConfigParser()
 		case types.KindWorkloadCluster:
 			parser = newWorkloadClusterParser()
+		case types.KindInferenceModel:
+			parser = newInferenceModelParser()
+		case types.KindInferencePolicy:
+			parser = newInferencePolicyParser()
+		case types.KindInferenceSecret:
+			parser = newInferenceSecretParser()
+		case types.KindRetrievalModel:
+			parser = newRetrievalModelParser()
 		default:
 			if watch.AllowPartialSuccess {
 				continue

--- a/lib/services/local/summarizer.go
+++ b/lib/services/local/summarizer.go
@@ -382,3 +382,164 @@ func NewSummarizerService(cfg SummarizerServiceConfig) (*SummarizerService, erro
 		retrievalModelService: retrievalModelService,
 	}, nil
 }
+
+// Parser implementations for event watching
+func newInferenceModelParser() *inferenceModelParser {
+	return &inferenceModelParser{
+		baseParser: newBaseParser(backend.NewKey(inferenceModelPrefix)),
+	}
+}
+
+type inferenceModelParser struct {
+	baseParser
+}
+
+func (p *inferenceModelParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		components := event.Item.Key.Components()
+		if len(components) != 2 {
+			return nil, trace.NotFound("failed parsing %v: expected 2 components, got %d", event.Item.Key.String(), len(components))
+		}
+		name := components[1]
+		return &types.ResourceHeader{
+			Kind:    types.KindInferenceModel,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name: name,
+			},
+		}, nil
+	case types.OpPut:
+		model, err := services.UnmarshalProtoResource[*summarizerv1.InferenceModel](
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(model), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+func newInferencePolicyParser() *inferencePolicyParser {
+	return &inferencePolicyParser{
+		baseParser: newBaseParser(backend.NewKey(inferencePolicyPrefix)),
+	}
+}
+
+type inferencePolicyParser struct {
+	baseParser
+}
+
+func (p *inferencePolicyParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		components := event.Item.Key.Components()
+		if len(components) != 2 {
+			return nil, trace.NotFound("failed parsing %v: expected 2 components, got %d", event.Item.Key.String(), len(components))
+		}
+		name := components[1]
+		return &types.ResourceHeader{
+			Kind:    types.KindInferencePolicy,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name: name,
+			},
+		}, nil
+	case types.OpPut:
+		policy, err := services.UnmarshalProtoResource[*summarizerv1.InferencePolicy](
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(policy), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+func newInferenceSecretParser() *inferenceSecretParser {
+	return &inferenceSecretParser{
+		baseParser: newBaseParser(backend.NewKey(inferenceSecretPrefix)),
+	}
+}
+
+type inferenceSecretParser struct {
+	baseParser
+}
+
+func (p *inferenceSecretParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		components := event.Item.Key.Components()
+		if len(components) != 2 {
+			return nil, trace.NotFound("failed parsing %v: expected 2 components, got %d", event.Item.Key.String(), len(components))
+		}
+		name := components[1]
+		return &types.ResourceHeader{
+			Kind:    types.KindInferenceSecret,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name: name,
+			},
+		}, nil
+	case types.OpPut:
+		secret, err := services.UnmarshalProtoResource[*summarizerv1.InferenceSecret](
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(secret), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+func newRetrievalModelParser() *retrievalModelParser {
+	return &retrievalModelParser{
+		baseParser: newBaseParser(backend.NewKey(retrievalModelPrefix)),
+	}
+}
+
+type retrievalModelParser struct {
+	baseParser
+}
+
+func (p *retrievalModelParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		components := event.Item.Key.Components()
+		if len(components) != 2 {
+			return nil, trace.NotFound("failed parsing %v: expected 2 components, got %d", event.Item.Key.String(), len(components))
+		}
+		name := components[1]
+		return &types.ResourceHeader{
+			Kind:    types.KindRetrievalModel,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name: name,
+			},
+		}, nil
+	case types.OpPut:
+		model, err := services.UnmarshalProtoResource[*summarizerv1.RetrievalModel](
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(model), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -223,6 +223,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindInferenceModel, RW()),
 					types.NewRule(types.KindInferenceSecret, RW()),
 					types.NewRule(types.KindInferencePolicy, RW()),
+					types.NewRule(types.KindRetrievalModel, RW()),
 					types.NewRule(types.KindClientIPRestriction, RW()),
 					types.NewRule(scopedaccess.KindScopedRole, RW()),
 					types.NewRule(scopedaccess.KindScopedRoleAssignment, RW()),
@@ -1333,12 +1334,12 @@ func updateAllowLabels(role types.Role, kind string, defaultLabels types.Labels)
 
 func defaultGitHubOrgs() map[string][]string {
 	return map[string][]string{
-		teleport.PresetAccessRoleName: []string{teleport.TraitInternalGitHubOrgs},
+		teleport.PresetAccessRoleName: {teleport.TraitInternalGitHubOrgs},
 	}
 }
 
 func defaultMCPTools() map[string][]string {
 	return map[string][]string{
-		teleport.PresetAccessRoleName: []string{teleport.TraitInternalMCPTools},
+		teleport.PresetAccessRoleName: {teleport.TraitInternalMCPTools},
 	}
 }

--- a/lib/services/summarizer.go
+++ b/lib/services/summarizer.go
@@ -34,12 +34,10 @@ import (
 // Summarizer is a service that provides methods to manage summary inference
 // configuration resources in the backend.
 type Summarizer interface {
+	SummarizerServiceGetter
 	// CreateInferenceModel creates a new session summary inference model in the
 	// backend.
 	CreateInferenceModel(ctx context.Context, model *summarizerv1.InferenceModel) (*summarizerv1.InferenceModel, error)
-	// GetInferenceModel retrieves a session summary inference model from the
-	// backend by name.
-	GetInferenceModel(ctx context.Context, name string) (*summarizerv1.InferenceModel, error)
 	// UpdateInferenceModel updates an existing session summary inference model
 	// in the backend.
 	UpdateInferenceModel(ctx context.Context, model *summarizerv1.InferenceModel) (*summarizerv1.InferenceModel, error)
@@ -49,18 +47,11 @@ type Summarizer interface {
 	// DeleteInferenceModel deletes a session summary inference model from the
 	// backend by name.
 	DeleteInferenceModel(ctx context.Context, name string) error
-	// ListInferenceModels lists session summary inference models in the backend
-	// with pagination support. Returns a slice of models and a next page token.
-	ListInferenceModels(ctx context.Context, size int, pageToken string) ([]*summarizerv1.InferenceModel, string, error)
 
 	// CreateInferenceSecret creates a new session summary inference secret in
 	// the backend. The returned object contains the secret value and should be
 	// handled with care.
 	CreateInferenceSecret(ctx context.Context, secret *summarizerv1.InferenceSecret) (*summarizerv1.InferenceSecret, error)
-	// GetInferenceSecret retrieves a session summary inference secret from the
-	// backend by name. The returned object contains the secret value and should
-	// be handled with care.
-	GetInferenceSecret(ctx context.Context, name string) (*summarizerv1.InferenceSecret, error)
 	// UpdateInferenceSecret updates an existing session summary inference secret
 	// in the backend. The returned object contains the secret value and should
 	// be handled with care.
@@ -73,18 +64,10 @@ type Summarizer interface {
 	// DeleteInferenceSecret deletes a session summary inference secret from the
 	// backend by name.
 	DeleteInferenceSecret(ctx context.Context, name string) error
-	// ListInferenceSecrets lists session summary inference secrets in the
-	// backend with pagination support. Returns a slice of secrets and a next
-	// page token. The returned objects contain the secret values and should be
-	// handled with care.
-	ListInferenceSecrets(ctx context.Context, size int, pageToken string) ([]*summarizerv1.InferenceSecret, string, error)
 
 	// CreateInferencePolicy creates a new session summary inference policy in
 	// the backend.
 	CreateInferencePolicy(ctx context.Context, policy *summarizerv1.InferencePolicy) (*summarizerv1.InferencePolicy, error)
-	// GetInferencePolicy retrieves a session summary inference policy from the
-	// backend by name.
-	GetInferencePolicy(ctx context.Context, name string) (*summarizerv1.InferencePolicy, error)
 	// UpdateInferencePolicy updates an existing session summary inference policy
 	// in the backend.
 	UpdateInferencePolicy(ctx context.Context, policy *summarizerv1.InferencePolicy) (*summarizerv1.InferencePolicy, error)
@@ -94,20 +77,10 @@ type Summarizer interface {
 	// DeleteInferencePolicy deletes a session summary inference policy from the
 	// backend by name.
 	DeleteInferencePolicy(ctx context.Context, name string) error
-	// ListInferencePolicies lists session summary inference policies in the
-	// backend with pagination support. Returns a slice of policies and a next
-	// page token.
-	ListInferencePolicies(ctx context.Context, size int, pageToken string) ([]*summarizerv1.InferencePolicy, string, error)
-	// AllInferencePolicies returns an iterator that retrieves all session
-	// summary inference policies from the backend, without pagination.
-	AllInferencePolicies(ctx context.Context) iter.Seq2[*summarizerv1.InferencePolicy, error]
 
 	// CreateRetrievalModel creates the search model in the backend.
 	// Only one RetrievalModel can exist per cluster.
 	CreateRetrievalModel(ctx context.Context, model *summarizerv1.RetrievalModel) (*summarizerv1.RetrievalModel, error)
-	// GetRetrievalModel retrieves the search model from the backend.
-	// Since only one RetrievalModel can exist per cluster, no name is required.
-	GetRetrievalModel(ctx context.Context) (*summarizerv1.RetrievalModel, error)
 	// UpdateRetrievalModel updates the existing search model in the backend.
 	UpdateRetrievalModel(ctx context.Context, model *summarizerv1.RetrievalModel) (*summarizerv1.RetrievalModel, error)
 	// UpsertRetrievalModel creates or updates the search model in the backend.
@@ -116,6 +89,42 @@ type Summarizer interface {
 	// DeleteRetrievalModel deletes the search model from the backend.
 	// Since only one RetrievalModel can exist per cluster, no name is required.
 	DeleteRetrievalModel(ctx context.Context) error
+}
+
+// SummarizerServiceGetter is the interface that defines the methods required for
+// retrieving objects from the cache.
+type SummarizerServiceGetter interface {
+	// GetInferenceModel retrieves a session summary inference model from the
+	// backend by name.
+	GetInferenceModel(ctx context.Context, name string) (*summarizerv1.InferenceModel, error)
+	// ListInferenceModels lists session summary inference models in the backend
+	// with pagination support. Returns a slice of models and a next page token.
+	ListInferenceModels(ctx context.Context, size int, pageToken string) ([]*summarizerv1.InferenceModel, string, error)
+
+	// GetInferenceSecret retrieves a session summary inference secret from the
+	// backend by name. The returned object contains the secret value and should
+	// be handled with care.
+	GetInferenceSecret(ctx context.Context, name string) (*summarizerv1.InferenceSecret, error)
+	// ListInferenceSecrets lists session summary inference secrets in the
+	// backend with pagination support. Returns a slice of secrets and a next
+	// page token. The returned objects contain the secret values and should be
+	// handled with care.
+	ListInferenceSecrets(ctx context.Context, size int, pageToken string) ([]*summarizerv1.InferenceSecret, string, error)
+
+	// GetInferencePolicy retrieves a session summary inference policy from the
+	// backend by name.
+	GetInferencePolicy(ctx context.Context, name string) (*summarizerv1.InferencePolicy, error)
+	// ListInferencePolicies lists session summary inference policies in the
+	// backend with pagination support. Returns a slice of policies and a next
+	// page token.
+	ListInferencePolicies(ctx context.Context, size int, pageToken string) ([]*summarizerv1.InferencePolicy, string, error)
+	// AllInferencePolicies returns an iterator that retrieves all session
+	// summary inference policies from the backend, without pagination.
+	AllInferencePolicies(ctx context.Context) iter.Seq2[*summarizerv1.InferencePolicy, error]
+
+	// GetRetrievalModel retrieves the search model from the backend.
+	// Since only one RetrievalModel can exist per cluster, no name is required.
+	GetRetrievalModel(ctx context.Context) (*summarizerv1.RetrievalModel, error)
 }
 
 // InferencePolicyMatchingContext is a special kind of [RuleContext] that is


### PR DESCRIPTION
Adds cache support for all summarizer resources (InferenceModel, InferenceSecret, InferencePolicy, and RetrievalModel) by implementing event parsers, cache collections, and read-through methods.

Part of https://github.com/gravitational/teleport.e/pull/8046
