### PR TITLE
Refactor subca validation to lib/subca

### DIFF
--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -17,14 +17,7 @@
 package local
 
 import (
-	"cmp"
 	"context"
-	"crypto/x509"
-	"errors"
-	"fmt"
-	"regexp"
-	"slices"
-	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -47,17 +40,6 @@ import (
 func newCAOverridesPrefix() backend.Key {
 	return backend.NewKey("cert_authority_overrides", "cluster")
 }
-
-var (
-	allowedCAOverrideSubKinds = []string{
-		string(types.DatabaseClientCA),
-		string(types.WindowsCA),
-	}
-
-	// Public keys are printed as HEX(SHA256(...)), therefore it's a hex string
-	// with exactly 64 characters. See subca.PublicKeyHash.
-	certificateOverridePublicKeyRE = regexp.MustCompile(`^[0-9A-Fa-f]{64}$`)
-)
 
 // CertAuthorityOverrideID uniquely identifies a CertAuthorityOverride resource.
 type CertAuthorityOverrideID struct {
@@ -96,7 +78,10 @@ func NewSubCAService(p SubCAServiceParams) (*SubCAService, error) {
 		BackendPrefix: newCAOverridesPrefix(),
 		MarshalFunc:   services.MarshalCertAuthorityOverride,
 		UnmarshalFunc: services.UnmarshalCertAuthorityOverride,
-		ValidateFunc:  validateCAOverride,
+		ValidateFunc: func(resource *subcav1.CertAuthorityOverride) error {
+			_, err := subca.ValidateAndParseCAOverride(resource)
+			return trace.Wrap(err)
+		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -163,148 +148,4 @@ func (s *SubCAService) serviceForClusterAndType(
 	return s.service.WithNameKeyFunc(func() backend.Key {
 		return backend.NewKey(clusterName, caType)
 	}), nil
-}
-
-func validateCAOverride(resource *subcav1.CertAuthorityOverride) error {
-	switch {
-	case resource == nil:
-		return trace.BadParameter("resource required")
-	case resource.Kind != types.KindCertAuthorityOverride:
-		return trace.BadParameter("invalid kind: %q", resource.Kind)
-	case !slices.Contains(allowedCAOverrideSubKinds, resource.SubKind):
-		return trace.BadParameter("invalid or unsupported sub_kind/caType: %q", resource.SubKind)
-	case resource.Version != types.V1:
-		return trace.BadParameter("invalid or unsupported version: %q", resource.Version)
-	case resource.Metadata == nil:
-		return trace.BadParameter("metadata required")
-	case resource.Metadata.Name == "":
-		return trace.BadParameter("metadata.name/clusterName required")
-	case resource.Spec == nil:
-		return trace.BadParameter("spec required")
-	}
-
-	overrides := resource.Spec.CertificateOverrides
-	seenPublicKeys := make(map[string]struct{})
-	for i, co := range overrides {
-		parsedCO, fieldName, err := validateCertificateOverride(co)
-		if err != nil {
-			if fieldName != "" {
-				fieldName = "." + fieldName
-			}
-			return trace.BadParameter("spec.certificate_overrides[%d]%s: %v", i, fieldName, err)
-		}
-
-		if _, ok := seenPublicKeys[parsedCO.publicKey]; ok {
-			return trace.BadParameter(
-				"spec.certificate_overrides[%d]: found duplicate override for public key %q",
-				i, parsedCO.publicKey,
-			)
-		}
-		seenPublicKeys[parsedCO.publicKey] = struct{}{}
-	}
-	return nil
-}
-
-type parsedCertificateOverride struct {
-	certificateOverride *subcav1.CertificateOverride
-	publicKey           string
-}
-
-func validateCertificateOverride(
-	co *subcav1.CertificateOverride,
-) (_ *parsedCertificateOverride, fieldName string, _ error) {
-	// Trace not used on purpose. Errors are trace-wrapped up in the chain.
-	if co == nil {
-		return nil, "", errors.New("nil certificate override")
-	}
-
-	// Certificate.
-	var cert *x509.Certificate
-	var wantPublicKey string
-	if co.Certificate != "" {
-		var err error
-		cert, err = subca.ParseCertificateOverrideCertificate(co.Certificate)
-		if err != nil {
-			return nil, "certificate", err
-		}
-		wantPublicKey = subca.HashCertificatePublicKey(cert)
-	}
-
-	// PublicKey.
-	if co.PublicKey != "" {
-		if !certificateOverridePublicKeyRE.MatchString(co.PublicKey) {
-			return nil, "", errors.New("invalid public key")
-		}
-		if wantPublicKey != "" && !strings.EqualFold(co.PublicKey, wantPublicKey) {
-			return nil, "public_key", fmt.Errorf("certificate public key mismatch (want %q)", wantPublicKey)
-		}
-	}
-
-	// Validate "required" fields now that we know both Certificate and PublicKey
-	// are valid.
-	switch {
-	case co.Disabled && co.PublicKey == "" && co.Certificate == "":
-		return nil, "", errors.New("certificate or public key required")
-	case co.Disabled:
-		// OK, determined above to have either PublicKey or Certificate.
-	case co.Certificate == "":
-		return nil, "", errors.New("certificate required")
-	}
-
-	// Chain.
-	if len(co.Chain) > 0 {
-		if cert == nil {
-			return nil, "", errors.New("chain not allowed with an empty certificate")
-		}
-
-		// The exact number is arbitrary, the fact that a cap exists isn't.
-		const maxChainLength = 10
-		if len(co.Chain) > maxChainLength {
-			return nil, "chain", fmt.Errorf(
-				"certificate chain has too many entries (%d > %d)", len(co.Chain), maxChainLength)
-		}
-
-		prev := cert
-		for i, chainPEM := range co.Chain {
-			chainCert, err := subca.ParseCertificateOverrideCertificate(chainPEM)
-			if err != nil {
-				return nil, fmt.Sprintf("chain[%d]", i), err
-			}
-			chainSub := chainCert.Subject.String()
-
-			// Certificate not in chain.
-			if i == 0 && cert.Subject.String() == chainSub {
-				return nil, fmt.Sprintf("chain[%d]", i),
-					errors.New("override certificate should not be included in chain")
-			}
-
-			// Issuer/Subject relationship.
-			if issuer := prev.Issuer.String(); issuer != chainSub {
-				return nil, fmt.Sprintf("chain[%d]", i),
-					fmt.Errorf("chain out of order, subject=%q (want %q)", chainSub, issuer)
-			}
-
-			// Verify signature.
-			if err := prev.CheckSignatureFrom(chainCert); err != nil {
-				return nil,
-					fmt.Sprintf("chain[%d]", i),
-					fmt.Errorf("chain signature check failed, previous certificate not signed by current: %w", err)
-			}
-
-			// Note: we purposefully avoid time-based chain validation at this layer,
-			// as that could make an override that was once valid impossible to
-			// bootstrap or update without destructive action.
-
-			prev = chainCert
-		}
-	}
-
-	// Normalize public key to lowercase so it matches subca.HashPublicKey.
-	publicKey := cmp.Or(wantPublicKey, co.PublicKey)
-	publicKey = strings.ToLower(publicKey)
-
-	return &parsedCertificateOverride{
-		certificateOverride: co,
-		publicKey:           publicKey,
-	}, "", nil
 }

--- a/lib/services/local/subca_service_test.go
+++ b/lib/services/local/subca_service_test.go
@@ -17,8 +17,6 @@
 package local_test
 
 import (
-	"crypto/x509"
-	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -38,57 +36,36 @@ import (
 func TestSubCAService_Create(t *testing.T) {
 	t.Parallel()
 
-	const caType = types.WindowsCA
+	const caType1 = types.DatabaseClientCA // for test table
+	const caType2 = types.WindowsCA        // for "storage key" test
 
-	// sharedEnv is shared by failure tests, since they aren't expected to change
-	// the underlying resource.
-	sharedEnv := subcaenv.New(t, subcaenv.EnvParams{
-		CATypesToCreate:  []types.CertAuthType{caType},
-		SkipExternalRoot: true,
-	})
-
-	// External CA chain.
-	const chainLength = 3
-	caChain := sharedEnv.MakeCAChain(t, chainLength)
-	leafToRootChain := caChain.LeafToRootPEMs()
-	// Create overrides from the tip of the external chain.
-	sharedEnv.ExternalRoot = caChain[len(caChain)-1]
-
-	cloneEnv := func(t *testing.T) *subcaenv.Env {
-		env := subcaenv.New(t, subcaenv.EnvParams{
-			CATypesToCreate:  []types.CertAuthType{caType},
-			SkipExternalRoot: true,
-		})
-		env.ExternalRoot = sharedEnv.ExternalRoot
-		return env
-	}
-
-	// Cloned by failure tests.
-	sharedCAOverride := sharedEnv.NewOverrideForCAType(t, caType)
-
-	// Used to test various public key mismatch scenarios. "Random".
-	const unrelatedPublicKey = `9852b3bbc867cc047e6d894333488da322df27fa96aa20ebb29c0bf44ff6327f`
-
-	// Forge a CA that has the correct Subject to match the override certificate,
-	// but has a different set of keys.
-	forgedExternalRoot, err := subcaenv.NewSelfSignedCA(&subcaenv.CAParams{
-		Clock: sharedEnv.Clock,
-		Template: &x509.Certificate{
-			Subject: sharedEnv.ExternalRoot.Cert.Subject,
+	env := subcaenv.New(t, subcaenv.EnvParams{
+		CATypesToCreate: []types.CertAuthType{
+			caType1,
+			caType2,
 		},
 	})
-	require.NoError(t, err)
+	service := env.SubCA
+
+	// Cloned before every test.
+	sharedCAOverride := env.NewOverrideForCAType(t, caType1)
+
+	t.Run("nil resource", func(t *testing.T) {
+		t.Parallel()
+		_, err := service.CreateCertAuthorityOverride(t.Context(), nil)
+		assert.ErrorContains(t, err, "name/clusterName required", "Create error mismatch")
+	})
 
 	// Verify that resources are written under the correct customized key.
 	t.Run("storage key", func(t *testing.T) {
 		t.Parallel()
 
-		env := cloneEnv(t)
 		be := env.Backend
 		ctx := t.Context()
 
-		// Create resource.
-		caOverride := env.NewOverrideForCAType(t, caType)
+		// Create resource. Uses a different caType from sharedCAOverride to not
+		// interfere in the test table.
+		caOverride := env.NewOverrideForCAType(t, caType2)
 		_, err := env.SubCA.CreateCertAuthorityOverride(ctx, caOverride)
 		require.NoError(t, err, "CreateCertAuthorityOverride errored")
 
@@ -117,7 +94,6 @@ func TestSubCAService_Create(t *testing.T) {
 	tests := []struct {
 		name    string
 		modify  func(ca *subcav1.CertAuthorityOverride)
-		success bool // mutually exclusive with wantErr
 		wantErr string
 	}{
 		{
@@ -125,260 +101,30 @@ func TestSubCAService_Create(t *testing.T) {
 			modify: func(ca *subcav1.CertAuthorityOverride) {
 				// Don't modify anything, take the default testenv override.
 			},
-			success: true,
 		},
 		{
-			name: "OK: Minimal CA override",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Spec = &subcav1.CertAuthorityOverrideSpec{}
-			},
-			success: true,
-		},
-
-		{
-			name: "empty kind",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Kind = ""
-			},
-			wantErr: "kind",
-		},
-		{
-			name: "invalid kind",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Kind = types.KindCertAuthority // wrong type
-			},
-			wantErr: "kind",
-		},
-		{
-			name: "empty sub_kind",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.SubKind = ""
-			},
-			wantErr: "sub_kind",
-		},
-		{
-			name: "invalid sub_kind",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.SubKind = string(types.DatabaseCA) // not allowed
-			},
-			wantErr: "sub_kind",
-		},
-		{
-			name: "empty version",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Version = ""
-			},
-			wantErr: "version",
-		},
-		{
-			name: "invalid version",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Version = types.V2
-			},
-			wantErr: "version",
-		},
-		{
-			name: "nil metadata",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Metadata = nil
-			},
-			wantErr: "name/clusterName required",
-		},
-		{
-			name: "empty name",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Metadata.Name = ""
-			},
-			wantErr: "name/clusterName required",
-		},
-		{
-			name: "nil spec",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Spec = nil
-			},
-			wantErr: "spec required",
-		},
-		{
-			name: "nil certificate_override",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Spec.CertificateOverrides = append(ca.Spec.CertificateOverrides, nil)
-			},
-			wantErr: "nil certificate override",
-		},
-		{
-			name: "certificate_override: empty certificate and public key (enabled)",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Spec.CertificateOverrides[0].Certificate = ""
-				ca.Spec.CertificateOverrides[0].PublicKey = ""
-				ca.Spec.CertificateOverrides[0].Disabled = false
-			},
-			wantErr: "certificate required",
-		},
-		{
-			name: "certificate_override: empty certificate and public key (disabled)",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Spec.CertificateOverrides[0].Certificate = ""
-				ca.Spec.CertificateOverrides[0].PublicKey = ""
-				ca.Spec.CertificateOverrides[0].Disabled = true
-			},
-			wantErr: "certificate or public key required",
-		},
-		{
-			name: "certificate_override: invalid certificate",
+			name: "CAOverride is validated",
 			modify: func(ca *subcav1.CertAuthorityOverride) {
 				ca.Spec.CertificateOverrides[0].Certificate = "ceci n'est pas a certificate"
 			},
 			wantErr: "expected PEM",
-		},
-		{
-			name: "certificate_override: invalid public key",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				ca.Spec.CertificateOverrides[0].PublicKey = "not a valid key"
-			},
-			wantErr: "invalid public key",
-		},
-		{
-			name: "certificate_override: certificate and public key mismatch",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				// Doesn't match the Certificate field.
-				ca.Spec.CertificateOverrides[0].PublicKey = unrelatedPublicKey
-			},
-			wantErr: "public key mismatch",
-		},
-		{
-			name: "certificate_override: chain without certificate",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				co.Chain = leafToRootChain
-				co.Certificate = ""
-				co.Disabled = true
-			},
-			wantErr: "chain not allowed with an empty certificate",
-		},
-		{
-			name: "certificate_override: chain certificate invalid",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				co.PublicKey = ""
-				co.Chain = []string{
-					leafToRootChain[0],
-					"ceci n'est pas a certificate",
-					leafToRootChain[1],
-					leafToRootChain[2],
-				}
-			},
-			wantErr: "chain[1]: expected PEM",
-		},
-		{
-			name: "certificate_override: certificate included in chain",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				co.PublicKey = ""
-				co.Chain = append([]string{co.Certificate}, leafToRootChain...)
-			},
-			wantErr: "override certificate should not be included",
-		},
-		{
-			name: "certificate_override: chain out of order",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				co.PublicKey = ""
-				co.Chain = caChain.RootToLeafPEMs() // reverse order
-			},
-			wantErr: "chain out of order",
-		},
-		{
-			name: "certificate_override: chain signature invalid (forged CA)",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				co.Chain = append(
-					[]string{string(forgedExternalRoot.CertPEM)},
-					leafToRootChain[1:]...,
-				)
-			},
-			wantErr: "chain signature check failed",
-		},
-		{
-			name: "certificate_override: chain has too many entries",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				co.PublicKey = ""
-				co.Chain = slices.Repeat([]string{leafToRootChain[0]}, 20)
-			},
-			wantErr: "chain has too many entries",
-		},
-		{
-			name: "certificate_override: duplicate public key",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				ca.Spec.CertificateOverrides = append(
-					ca.Spec.CertificateOverrides,
-					&subcav1.CertificateOverride{PublicKey: co.PublicKey, Disabled: true},
-				)
-			},
-			wantErr: "duplicate override",
-		},
-
-		{
-			name: "OK: Enabled override",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				co.Disabled = false
-			},
-			success: true,
-		},
-		{
-			name: "OK: Override without public key",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				co.PublicKey = ""
-			},
-			success: true,
-		},
-		{
-			name: "OK: Disabled override with only public key",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				co.Certificate = ""
-			},
-			success: true,
-		},
-		{
-			name: "OK: Override with chain",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
-				co := ca.Spec.CertificateOverrides[0]
-				co.Chain = leafToRootChain
-			},
-			success: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Create a distinct env for success tests, but otherwise use shared
-			// resources.
-			env := sharedEnv
-			var caOverride *subcav1.CertAuthorityOverride
-			if test.success {
-				env = cloneEnv(t)
-				caOverride = env.NewOverrideForCAType(t, caType)
-			} else {
-				caOverride = proto.Clone(sharedCAOverride).(*subcav1.CertAuthorityOverride)
-			}
-			service := env.SubCA
-
+			caOverride := proto.Clone(sharedCAOverride).(*subcav1.CertAuthorityOverride)
 			test.modify(caOverride)
 
 			// Take a copy. generic.Service modifies its inputs.
 			want := proto.Clone(caOverride).(*subcav1.CertAuthorityOverride)
 
 			got, err := service.CreateCertAuthorityOverride(t.Context(), caOverride)
-			if !test.success {
+			if test.wantErr != "" {
 				// Assert failures.
-				if assert.ErrorContains(t, err, test.wantErr, "Create error mismatch") {
-					assert.ErrorAs(t, err, new(*trace.BadParameterError), "Create error type mismatch")
-				}
+				require.ErrorContains(t, err, test.wantErr, "Create error mismatch")
+				assert.ErrorAs(t, err, new(*trace.BadParameterError), "Create error type mismatch")
 				return
 			}
 			// Assert success.

--- a/lib/subca/parsed.go
+++ b/lib/subca/parsed.go
@@ -1,0 +1,188 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca
+
+import (
+	"cmp"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/subca"
+)
+
+var (
+	allowedCAOverrideSubKinds = []string{
+		string(types.DatabaseClientCA),
+		string(types.WindowsCA),
+	}
+
+	// Public keys are printed as HEX(SHA256(...)), therefore it's a hex string
+	// with exactly 64 characters. See PublicKeyHash.
+	certificateOverridePublicKeyRE = regexp.MustCompile(`^[0-9A-Fa-f]{64}$`)
+)
+
+func validateCAOverride(resource *subcav1.CertAuthorityOverride) error {
+	switch {
+	case resource == nil:
+		return trace.BadParameter("resource required")
+	case resource.Kind != types.KindCertAuthorityOverride:
+		return trace.BadParameter("invalid kind: %q", resource.Kind)
+	case !slices.Contains(allowedCAOverrideSubKinds, resource.SubKind):
+		return trace.BadParameter("invalid or unsupported sub_kind/caType: %q", resource.SubKind)
+	case resource.Version != types.V1:
+		return trace.BadParameter("invalid or unsupported version: %q", resource.Version)
+	case resource.Metadata == nil:
+		return trace.BadParameter("metadata required")
+	case resource.Metadata.Name == "":
+		return trace.BadParameter("metadata.name/clusterName required")
+	case resource.Spec == nil:
+		return trace.BadParameter("spec required")
+	}
+
+	overrides := resource.Spec.CertificateOverrides
+	seenPublicKeys := make(map[string]struct{})
+	for i, co := range overrides {
+		parsedCO, fieldName, err := validateCertificateOverride(co)
+		if err != nil {
+			if fieldName != "" {
+				fieldName = "." + fieldName
+			}
+			return trace.BadParameter("spec.certificate_overrides[%d]%s: %v", i, fieldName, err)
+		}
+
+		if _, ok := seenPublicKeys[parsedCO.publicKey]; ok {
+			return trace.BadParameter(
+				"spec.certificate_overrides[%d]: found duplicate override for public key %q",
+				i, parsedCO.publicKey,
+			)
+		}
+		seenPublicKeys[parsedCO.publicKey] = struct{}{}
+	}
+	return nil
+}
+
+type parsedCertificateOverride struct {
+	certificateOverride *subcav1.CertificateOverride
+	publicKey           string
+}
+
+func validateCertificateOverride(
+	co *subcav1.CertificateOverride,
+) (_ *parsedCertificateOverride, fieldName string, _ error) {
+	// Trace not used on purpose. Errors are trace-wrapped up in the chain.
+	if co == nil {
+		return nil, "", errors.New("nil certificate override")
+	}
+
+	// Certificate.
+	var cert *x509.Certificate
+	var wantPublicKey string
+	if co.Certificate != "" {
+		var err error
+		cert, err = subca.ParseCertificateOverrideCertificate(co.Certificate)
+		if err != nil {
+			return nil, "certificate", err
+		}
+		wantPublicKey = subca.HashCertificatePublicKey(cert)
+	}
+
+	// PublicKey.
+	if co.PublicKey != "" {
+		if !certificateOverridePublicKeyRE.MatchString(co.PublicKey) {
+			return nil, "", errors.New("invalid public key")
+		}
+		if wantPublicKey != "" && !strings.EqualFold(co.PublicKey, wantPublicKey) {
+			return nil, "public_key", fmt.Errorf("certificate public key mismatch (want %q)", wantPublicKey)
+		}
+	}
+
+	// Validate "required" fields now that we know both Certificate and PublicKey
+	// are valid.
+	switch {
+	case co.Disabled && co.PublicKey == "" && co.Certificate == "":
+		return nil, "", errors.New("certificate or public key required")
+	case co.Disabled:
+		// OK, determined above to have either PublicKey or Certificate.
+	case co.Certificate == "":
+		return nil, "", errors.New("certificate required")
+	}
+
+	// Chain.
+	if len(co.Chain) > 0 {
+		if cert == nil {
+			return nil, "", errors.New("chain not allowed with an empty certificate")
+		}
+
+		// The exact number is arbitrary, the fact that a cap exists isn't.
+		const maxChainLength = 10
+		if len(co.Chain) > maxChainLength {
+			return nil, "chain", fmt.Errorf(
+				"certificate chain has too many entries (%d > %d)", len(co.Chain), maxChainLength)
+		}
+
+		prev := cert
+		for i, chainPEM := range co.Chain {
+			chainCert, err := subca.ParseCertificateOverrideCertificate(chainPEM)
+			if err != nil {
+				return nil, fmt.Sprintf("chain[%d]", i), err
+			}
+			chainSub := chainCert.Subject.String()
+
+			// Certificate not in chain.
+			if i == 0 && cert.Subject.String() == chainSub {
+				return nil, fmt.Sprintf("chain[%d]", i),
+					errors.New("override certificate should not be included in chain")
+			}
+
+			// Issuer/Subject relationship.
+			if issuer := prev.Issuer.String(); issuer != chainSub {
+				return nil, fmt.Sprintf("chain[%d]", i),
+					fmt.Errorf("chain out of order, subject=%q (want %q)", chainSub, issuer)
+			}
+
+			// Verify signature.
+			if err := prev.CheckSignatureFrom(chainCert); err != nil {
+				return nil,
+					fmt.Sprintf("chain[%d]", i),
+					fmt.Errorf("chain signature check failed, previous certificate not signed by current: %w", err)
+			}
+
+			// Note: we purposefully avoid time-based chain validation at this layer,
+			// as that could make an override that was once valid impossible to
+			// bootstrap or update without destructive action.
+
+			prev = chainCert
+		}
+	}
+
+	// Normalize public key to lowercase so it matches subca.HashPublicKey.
+	publicKey := cmp.Or(wantPublicKey, co.PublicKey)
+	publicKey = strings.ToLower(publicKey)
+
+	return &parsedCertificateOverride{
+		certificateOverride: co,
+		publicKey:           publicKey,
+	}, "", nil
+}

--- a/lib/subca/parsed.go
+++ b/lib/subca/parsed.go
@@ -78,7 +78,7 @@ type ParsedCertificateOverride struct {
 func ValidateAndParseCAOverride(resource *subcav1.CertAuthorityOverride) (*ParsedCertAuthorityOverride, error) {
 	switch {
 	case resource == nil:
-		return nil, trace.BadParameter("resource required")
+		return nil, trace.BadParameter("ca override required")
 	case resource.Kind != types.KindCertAuthorityOverride:
 		return nil, trace.BadParameter("invalid kind: %q", resource.Kind)
 	case !slices.Contains(allowedCAOverrideSubKinds, resource.SubKind):

--- a/lib/subca/parsed.go
+++ b/lib/subca/parsed.go
@@ -29,7 +29,6 @@ import (
 
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/subca"
 )
 
 var (
@@ -43,25 +42,59 @@ var (
 	certificateOverridePublicKeyRE = regexp.MustCompile(`^[0-9A-Fa-f]{64}$`)
 )
 
-func validateCAOverride(resource *subcav1.CertAuthorityOverride) error {
+// ParsedCertAuthorityOverride is a CertAuthorityOverride with a
+// ParsedCertificateOverride list.
+type ParsedCertAuthorityOverride struct {
+	// CAOverride is the original resource.
+	CAOverride *subcav1.CertAuthorityOverride
+	// CertificateOverrides is a ParsedCertAuthorityOverride list, parallel to
+	// CAOverride.Spec.CertificateOverrides.
+	CertificateOverrides []*ParsedCertificateOverride
+}
+
+// ParsedCertificateOverride is a CertificateOverride with its certificates
+// parsed and a normalized PublicKeyHash field.
+type ParsedCertificateOverride struct {
+	// CertificateOverride is the original resource.
+	CertificateOverride *subcav1.CertificateOverride
+	// PublicKey is a normalized public key from CertificateOverride.
+	// If CertificateOverride.Certificate is present it's calculated from it,
+	// otherwise it's normalized from CertificateOverride.PublicKey.
+	PublicKey string
+	// Certificate is the parsed certificate.
+	Certificate *x509.Certificate
+	// Chain is the parsed certificate chain.
+	Chain []*x509.Certificate
+}
+
+// ValidateAndParseCAOverride validates a CertAuthorityOverride resource and
+// returns it in parsed form.
+//
+// Used by storage to validate resources in write paths.
+//
+// It should not be used by any layers in read paths. Stored resources are
+// considered valid and must not be subject to validation (lest they fail new
+// validation rules, making reading impossible).
+func ValidateAndParseCAOverride(resource *subcav1.CertAuthorityOverride) (*ParsedCertAuthorityOverride, error) {
 	switch {
 	case resource == nil:
-		return trace.BadParameter("resource required")
+		return nil, trace.BadParameter("resource required")
 	case resource.Kind != types.KindCertAuthorityOverride:
-		return trace.BadParameter("invalid kind: %q", resource.Kind)
+		return nil, trace.BadParameter("invalid kind: %q", resource.Kind)
 	case !slices.Contains(allowedCAOverrideSubKinds, resource.SubKind):
-		return trace.BadParameter("invalid or unsupported sub_kind/caType: %q", resource.SubKind)
+		return nil, trace.BadParameter("invalid or unsupported sub_kind/caType: %q", resource.SubKind)
 	case resource.Version != types.V1:
-		return trace.BadParameter("invalid or unsupported version: %q", resource.Version)
+		return nil, trace.BadParameter("invalid or unsupported version: %q", resource.Version)
 	case resource.Metadata == nil:
-		return trace.BadParameter("metadata required")
+		return nil, trace.BadParameter("metadata required")
 	case resource.Metadata.Name == "":
-		return trace.BadParameter("metadata.name/clusterName required")
+		return nil, trace.BadParameter("metadata.name/clusterName required")
 	case resource.Spec == nil:
-		return trace.BadParameter("spec required")
+		return nil, trace.BadParameter("spec required")
 	}
 
 	overrides := resource.Spec.CertificateOverrides
+	parsedOverrides := make([]*ParsedCertificateOverride, len(overrides))
 	seenPublicKeys := make(map[string]struct{})
 	for i, co := range overrides {
 		parsedCO, fieldName, err := validateCertificateOverride(co)
@@ -69,28 +102,29 @@ func validateCAOverride(resource *subcav1.CertAuthorityOverride) error {
 			if fieldName != "" {
 				fieldName = "." + fieldName
 			}
-			return trace.BadParameter("spec.certificate_overrides[%d]%s: %v", i, fieldName, err)
+			return nil, trace.BadParameter("spec.certificate_overrides[%d]%s: %v", i, fieldName, err)
 		}
 
-		if _, ok := seenPublicKeys[parsedCO.publicKey]; ok {
-			return trace.BadParameter(
+		if _, ok := seenPublicKeys[parsedCO.PublicKey]; ok {
+			return nil, trace.BadParameter(
 				"spec.certificate_overrides[%d]: found duplicate override for public key %q",
-				i, parsedCO.publicKey,
+				i, parsedCO.PublicKey,
 			)
 		}
-		seenPublicKeys[parsedCO.publicKey] = struct{}{}
-	}
-	return nil
-}
+		seenPublicKeys[parsedCO.PublicKey] = struct{}{}
 
-type parsedCertificateOverride struct {
-	certificateOverride *subcav1.CertificateOverride
-	publicKey           string
+		parsedOverrides[i] = parsedCO
+	}
+
+	return &ParsedCertAuthorityOverride{
+		CAOverride:           resource,
+		CertificateOverrides: parsedOverrides,
+	}, nil
 }
 
 func validateCertificateOverride(
 	co *subcav1.CertificateOverride,
-) (_ *parsedCertificateOverride, fieldName string, _ error) {
+) (_ *ParsedCertificateOverride, fieldName string, _ error) {
 	// Trace not used on purpose. Errors are trace-wrapped up in the chain.
 	if co == nil {
 		return nil, "", errors.New("nil certificate override")
@@ -101,11 +135,11 @@ func validateCertificateOverride(
 	var wantPublicKey string
 	if co.Certificate != "" {
 		var err error
-		cert, err = subca.ParseCertificateOverrideCertificate(co.Certificate)
+		cert, err = ParseCertificateOverrideCertificate(co.Certificate)
 		if err != nil {
 			return nil, "certificate", err
 		}
-		wantPublicKey = subca.HashCertificatePublicKey(cert)
+		wantPublicKey = HashCertificatePublicKey(cert)
 	}
 
 	// PublicKey.
@@ -130,6 +164,8 @@ func validateCertificateOverride(
 	}
 
 	// Chain.
+
+	var chain []*x509.Certificate
 	if len(co.Chain) > 0 {
 		if cert == nil {
 			return nil, "", errors.New("chain not allowed with an empty certificate")
@@ -142,9 +178,10 @@ func validateCertificateOverride(
 				"certificate chain has too many entries (%d > %d)", len(co.Chain), maxChainLength)
 		}
 
+		chain = make([]*x509.Certificate, len(co.Chain))
 		prev := cert
 		for i, chainPEM := range co.Chain {
-			chainCert, err := subca.ParseCertificateOverrideCertificate(chainPEM)
+			chainCert, err := ParseCertificateOverrideCertificate(chainPEM)
 			if err != nil {
 				return nil, fmt.Sprintf("chain[%d]", i), err
 			}
@@ -173,16 +210,19 @@ func validateCertificateOverride(
 			// as that could make an override that was once valid impossible to
 			// bootstrap or update without destructive action.
 
+			chain[i] = chainCert
 			prev = chainCert
 		}
 	}
 
-	// Normalize public key to lowercase so it matches subca.HashPublicKey.
+	// Normalize public key to lowercase so it matches HashPublicKey.
 	publicKey := cmp.Or(wantPublicKey, co.PublicKey)
 	publicKey = strings.ToLower(publicKey)
 
-	return &parsedCertificateOverride{
-		certificateOverride: co,
-		publicKey:           publicKey,
+	return &ParsedCertificateOverride{
+		CertificateOverride: co,
+		PublicKey:           publicKey,
+		Certificate:         cert,
+		Chain:               chain,
 	}, "", nil
 }

--- a/lib/subca/parsed_test.go
+++ b/lib/subca/parsed_test.go
@@ -21,50 +21,38 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/testing/protocmp"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/subca"
 	subcaenv "github.com/gravitational/teleport/lib/subca/testenv"
 )
 
-func TestSubCAService_Create(t *testing.T) {
+func TestValidateAndParseCAOverride(t *testing.T) {
 	t.Parallel()
 
 	const caType = types.WindowsCA
 
-	// sharedEnv is shared by failure tests, since they aren't expected to change
-	// the underlying resource.
-	sharedEnv := subcaenv.New(t, subcaenv.EnvParams{
+	// A testenv is the simplest way to get a valid-looking CAOverride.
+	env := subcaenv.New(t, subcaenv.EnvParams{
 		CATypesToCreate:  []types.CertAuthType{caType},
 		SkipExternalRoot: true,
 	})
 
 	// External CA chain.
 	const chainLength = 3
-	caChain := sharedEnv.MakeCAChain(t, chainLength)
+	caChain := env.MakeCAChain(t, chainLength)
 	leafToRootChain := caChain.LeafToRootPEMs()
 	// Create overrides from the tip of the external chain.
-	sharedEnv.ExternalRoot = caChain[len(caChain)-1]
+	env.ExternalRoot = caChain[len(caChain)-1]
 
-	cloneEnv := func(t *testing.T) *subcaenv.Env {
-		env := subcaenv.New(t, subcaenv.EnvParams{
-			CATypesToCreate:  []types.CertAuthType{caType},
-			SkipExternalRoot: true,
-		})
-		env.ExternalRoot = sharedEnv.ExternalRoot
-		return env
-	}
-
-	// Cloned by failure tests.
-	sharedCAOverride := sharedEnv.NewOverrideForCAType(t, caType)
+	// Cloned before every test.
+	sharedCAOverride := env.NewOverrideForCAType(t, caType)
 
 	// Used to test various public key mismatch scenarios. "Random".
 	const unrelatedPublicKey = `9852b3bbc867cc047e6d894333488da322df27fa96aa20ebb29c0bf44ff6327f`
@@ -72,52 +60,22 @@ func TestSubCAService_Create(t *testing.T) {
 	// Forge a CA that has the correct Subject to match the override certificate,
 	// but has a different set of keys.
 	forgedExternalRoot, err := subcaenv.NewSelfSignedCA(&subcaenv.CAParams{
-		Clock: sharedEnv.Clock,
+		Clock: env.Clock,
 		Template: &x509.Certificate{
-			Subject: sharedEnv.ExternalRoot.Cert.Subject,
+			Subject: env.ExternalRoot.Cert.Subject,
 		},
 	})
 	require.NoError(t, err)
 
-	// Verify that resources are written under the correct customized key.
-	t.Run("storage key", func(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
 		t.Parallel()
-
-		env := cloneEnv(t)
-		be := env.Backend
-		ctx := t.Context()
-
-		// Create resource.
-		caOverride := env.NewOverrideForCAType(t, caType)
-		_, err := env.SubCA.CreateCertAuthorityOverride(ctx, caOverride)
-		require.NoError(t, err, "CreateCertAuthorityOverride errored")
-
-		// Form our customized key.
-		wantKey := backend.NewKey(
-			"cert_authority_overrides",
-			"cluster",
-			caOverride.Metadata.Name,
-			caOverride.SubKind,
-		)
-
-		// Get resource from customized key.
-		_, err = be.Get(ctx, wantKey)
-		require.NoError(t, err, "Read resource by customized key")
-
-		// Verify that the "normal" generic.Service key doesn't exist.
-		notWantKey := backend.NewKey(
-			"cert_authority_overrides",
-			"cluster",
-			caOverride.Metadata.Name,
-		)
-		_, err = be.Get(ctx, notWantKey)
-		assert.ErrorAs(t, err, new(*trace.NotFoundError), "Read resource by notWantKey")
+		_, err := subca.ValidateAndParseCAOverride(nil)
+		assert.ErrorContains(t, err, "ca override required")
 	})
 
 	tests := []struct {
 		name    string
 		modify  func(ca *subcav1.CertAuthorityOverride)
-		success bool // mutually exclusive with wantErr
 		wantErr string
 	}{
 		{
@@ -125,14 +83,12 @@ func TestSubCAService_Create(t *testing.T) {
 			modify: func(ca *subcav1.CertAuthorityOverride) {
 				// Don't modify anything, take the default testenv override.
 			},
-			success: true,
 		},
 		{
 			name: "OK: Minimal CA override",
 			modify: func(ca *subcav1.CertAuthorityOverride) {
 				ca.Spec = &subcav1.CertAuthorityOverrideSpec{}
 			},
-			success: true,
 		},
 
 		{
@@ -182,7 +138,7 @@ func TestSubCAService_Create(t *testing.T) {
 			modify: func(ca *subcav1.CertAuthorityOverride) {
 				ca.Metadata = nil
 			},
-			wantErr: "name/clusterName required",
+			wantErr: "metadata required",
 		},
 		{
 			name: "empty name",
@@ -325,7 +281,6 @@ func TestSubCAService_Create(t *testing.T) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.Disabled = false
 			},
-			success: true,
 		},
 		{
 			name: "OK: Override without public key",
@@ -333,7 +288,6 @@ func TestSubCAService_Create(t *testing.T) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.PublicKey = ""
 			},
-			success: true,
 		},
 		{
 			name: "OK: Disabled override with only public key",
@@ -341,7 +295,6 @@ func TestSubCAService_Create(t *testing.T) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.Certificate = ""
 			},
-			success: true,
 		},
 		{
 			name: "OK: Override with chain",
@@ -349,51 +302,89 @@ func TestSubCAService_Create(t *testing.T) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.Chain = leafToRootChain
 			},
-			success: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Create a distinct env for success tests, but otherwise use shared
-			// resources.
-			env := sharedEnv
-			var caOverride *subcav1.CertAuthorityOverride
-			if test.success {
-				env = cloneEnv(t)
-				caOverride = env.NewOverrideForCAType(t, caType)
-			} else {
-				caOverride = proto.Clone(sharedCAOverride).(*subcav1.CertAuthorityOverride)
-			}
-			service := env.SubCA
-
+			caOverride := proto.Clone(sharedCAOverride).(*subcav1.CertAuthorityOverride)
 			test.modify(caOverride)
 
-			// Take a copy. generic.Service modifies its inputs.
-			want := proto.Clone(caOverride).(*subcav1.CertAuthorityOverride)
-
-			got, err := service.CreateCertAuthorityOverride(t.Context(), caOverride)
-			if !test.success {
-				// Assert failures.
-				if assert.ErrorContains(t, err, test.wantErr, "Create error mismatch") {
-					assert.ErrorAs(t, err, new(*trace.BadParameterError), "Create error type mismatch")
-				}
+			_, err := subca.ValidateAndParseCAOverride(caOverride)
+			if test.wantErr == "" {
+				assert.NoError(t, err, "ValidateAndParseCAOverride errored")
 				return
 			}
-			// Assert success.
-			require.NoError(t, err, "CreateCertAuthorityOverride errored")
-			want.Metadata.Revision = got.Metadata.Revision
-			if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
-				t.Errorf("Create mismatch (-want +got)\n%s", diff)
-			}
 
-			// Assert stored resource.
-			stored, err := service.GetCertAuthorityOverride(t.Context(), local.CertAuthorityOverrideIDFromResource(got))
-			require.NoError(t, err, "GetCertAuthorityOverride errored")
-			if diff := cmp.Diff(got, stored, protocmp.Transform()); diff != "" {
-				t.Errorf("Get mismatch (-want +got)\n%s", diff)
-			}
+			require.ErrorContains(t, err, test.wantErr, "ValidateAndParseCAOverride error mismatch")
+			assert.ErrorAs(t, err, new(*trace.BadParameterError), "ValidateAndParseCAOverride error type mismatch")
 		})
 	}
+}
+
+func TestValidateAndParseCAOverride_ParsedResource(t *testing.T) {
+	t.Parallel()
+
+	// Use a pre-made caOverride so we have predicatable certificates/public keys.
+	caOverride := &subcav1.CertAuthorityOverride{
+		Kind:    "cert_authority_override",
+		SubKind: "windows",
+		Version: "v1",
+		Metadata: &headerv1.Metadata{
+			Name: "zarquon",
+		},
+		Spec: &subcav1.CertAuthorityOverrideSpec{
+			CertificateOverrides: []*subcav1.CertificateOverride{
+				{
+					//PublicKey:   "b05b24e7c4b141d8a081f49242ad859218d95ab826f23cf823c4e07138c95a9f",
+					Certificate: "-----BEGIN CERTIFICATE-----\nMIIBtDCCAVqgAwIBAgIBBDAKBggqhkjOPQQDAjAxMSMwIQYDVQQDExpFWFRFUk5B\nTCBJTlRFUk1FRElBVEUgQ0EgMzEKMAgGA1UEBRMBMzAeFw0yNjAzMTIxMzA4MTZa\nFw0yNjAzMTIxNDA5MTZaMDExIzAhBgNVBAMTGkVYVEVSTkFMIElOVEVSTUVESUFU\nRSBDQSA0MQowCAYDVQQFEwE0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+quy\nog1ZSEDzXc3rGhRqQG98tbn2rnrf8ynmRCejQRCmfWA8fHQB1ObedzRGbnkyUvYa\nfKCJxhhHS6vhgM0xM6NjMGEwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMB\nAf8wHQYDVR0OBBYEFJFkotRmGwBC0gKTDIGqDcAKtdeJMB8GA1UdIwQYMBaAFNuI\nI2v0B+R00TyVP+uJ5wzUhrQoMAoGCCqGSM49BAMCA0gAMEUCIQCnugqmqxDg1JnJ\nwjT8MpDMPrwPO5+IVth5E67QAq9ZIAIgcvkIy0V+k3Q180AziL7ZrLtLY2h0FRqv\nyWt+1Lnx+EY=\n-----END CERTIFICATE-----\n",
+					Chain: []string{
+						"-----BEGIN CERTIFICATE-----\nMIIBtTCCAVqgAwIBAgIBAzAKBggqhkjOPQQDAjAxMSMwIQYDVQQDExpFWFRFUk5B\nTCBJTlRFUk1FRElBVEUgQ0EgMjEKMAgGA1UEBRMBMjAeFw0yNjAzMTIxMzA4MTZa\nFw0yNjAzMTIxNDA5MTZaMDExIzAhBgNVBAMTGkVYVEVSTkFMIElOVEVSTUVESUFU\nRSBDQSAzMQowCAYDVQQFEwEzMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPBu0\nRewncuGV9LP2CUEW5U5JHRMbgcL4RUNkl+gYo3WYAxFYRdjqFGRD0d7wzo2t4I+s\niT/CwF1EfNO1AAtePKNjMGEwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMB\nAf8wHQYDVR0OBBYEFNuII2v0B+R00TyVP+uJ5wzUhrQoMB8GA1UdIwQYMBaAFKWp\nG0/k4iUwHJf1hjDBbOGgJIicMAoGCCqGSM49BAMCA0kAMEYCIQC/yLDWxElbkYJJ\nD7B7HnMNWabsJu0EDA408s+M0JcS9gIhAI1Cs+smAkb5f+UXQdBv7lqOlHFfR/3c\ni/ONL+HCRA1P\n-----END CERTIFICATE-----\n",
+						"-----BEGIN CERTIFICATE-----\nMIIBrzCCAVWgAwIBAgIBAjAKBggqhkjOPQQDAjApMRswGQYDVQQDExJFWFRFUk5B\nTCBST09UIENBIDExCjAIBgNVBAUTATEwHhcNMjYwMzEyMTMwODE2WhcNMjYwMzEy\nMTQwOTE2WjAxMSMwIQYDVQQDExpFWFRFUk5BTCBJTlRFUk1FRElBVEUgQ0EgMjEK\nMAgGA1UEBRMBMjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABHX5Lb4OjZG21k/7\nqAdDRPCNXn1G4XndwMoBL53Ni3xd+ovx4zIFajLq+8i6jg/rihxI74QBnR38j/D7\nlaPp48WjZjBkMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgEBMB0G\nA1UdDgQWBBSlqRtP5OIlMByX9YYwwWzhoCSInDAfBgNVHSMEGDAWgBSgEnGXl1ci\nDYWoRhm8uNXB5T3t8zAKBggqhkjOPQQDAgNIADBFAiBc1KqvASkx1PYuVjZEQr7b\nWCizRoOn3J/yLbi5DVo/TgIhAPHPm8ErDxl/AoZybbdT8QVwQYPeB1jsK+h9Kcm1\nAkDR\n-----END CERTIFICATE-----\n",
+						"-----BEGIN CERTIFICATE-----\nMIIBhjCCASygAwIBAgIBATAKBggqhkjOPQQDAjApMRswGQYDVQQDExJFWFRFUk5B\nTCBST09UIENBIDExCjAIBgNVBAUTATEwHhcNMjYwMzEyMTMwODE2WhcNMjYwMzEy\nMTQwOTE2WjApMRswGQYDVQQDExJFWFRFUk5BTCBST09UIENBIDExCjAIBgNVBAUT\nATEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASP68oeRXs8P10r2KMP0yx1zkTk\nyUDdy9PCMMQgdDl85jMwOLcEKeOR+rwqp4FvHJVkDebQdtU4mqIweyOW1u8to0Uw\nQzAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBAjAdBgNVHQ4EFgQU\noBJxl5dXIg2FqEYZvLjVweU97fMwCgYIKoZIzj0EAwIDSAAwRQIgWXfQuNOSTrY2\nEHG41FDbIY3kB5730M7NNLm09ZuecRICIQCXwm9EH13zx462z+6eahLAoYeUdtP6\nhBW0accYgMXnmQ==\n-----END CERTIFICATE-----\n",
+					},
+					Disabled: true,
+				},
+				{
+					PublicKey: "89B32EF334D6FA94E2A7D9B3CC122115A3A9ED19907A7F25D3FE71BBC734619D",
+					Disabled:  true,
+				},
+			},
+		},
+	}
+
+	// Verify ParsedCAOverride.
+	parsed, err := subca.ValidateAndParseCAOverride(caOverride)
+	require.NoError(t, err)
+	assert.Same(t, caOverride, parsed.CAOverride, "CAOverride")
+	require.Len(t, parsed.CertificateOverrides, 2, "CertificateOverrides mismatch")
+
+	// Verify CertificateOverride #0.
+	const publicKey0 = "b05b24e7c4b141d8a081f49242ad859218d95ab826f23cf823c4e07138c95a9f"
+	co0 := parsed.CertificateOverrides[0]
+	assert.Same(t, caOverride.Spec.CertificateOverrides[0], co0.CertificateOverride, "CertificateOverride changed")
+	assert.Equal(t, publicKey0, co0.PublicKey, "PublicKey mismatch")
+	assert.NotNil(t, co0.Certificate, "Certificate expected")
+	assert.Equal(t, publicKey0, subca.HashCertificatePublicKey(co0.Certificate), "Certificate public key mismatch")
+	assert.Len(t, co0.Chain, 3, "Chain mismatch")
+
+	chainPublicKeys := []string{
+		"6fe333ee9900316999fecc7b026b833fa97f301ed08ec545728a21c2ef04a7ba",
+		"76e4355c0493658b869450c097f233ed4017ccb8eb1f7f6d251e8745b33f4336",
+		"b14d63ec97168d52dee4de8f80be040441964e2b06443ce50786b60f0028ec42",
+	}
+	for i, chain := range co0.Chain {
+		assert.NotNil(t, chain, "Chain[%d] certificate expected", i)
+		assert.Equal(t, chainPublicKeys[i], subca.HashCertificatePublicKey(chain),
+			"Chain[%d] certificate public key mismatch", i)
+	}
+
+	// Verify CertificateOverride #1.
+	const publicKey1 = "89b32ef334d6fa94e2a7d9b3cc122115a3a9ed19907a7f25d3fe71bbc734619d" // lowercase!
+	co1 := parsed.CertificateOverrides[1]
+	assert.Same(t, caOverride.Spec.CertificateOverrides[1], co1.CertificateOverride, "CertificateOverride changed")
+	assert.Equal(t, publicKey1, co1.PublicKey, "PublicKey mismatch")
+	assert.Nil(t, co1.Certificate)
+	assert.Empty(t, co1.Chain)
 }

--- a/lib/subca/parsed_test.go
+++ b/lib/subca/parsed_test.go
@@ -1,0 +1,399 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca_test
+
+import (
+	"crypto/x509"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services/local"
+	subcaenv "github.com/gravitational/teleport/lib/subca/testenv"
+)
+
+func TestSubCAService_Create(t *testing.T) {
+	t.Parallel()
+
+	const caType = types.WindowsCA
+
+	// sharedEnv is shared by failure tests, since they aren't expected to change
+	// the underlying resource.
+	sharedEnv := subcaenv.New(t, subcaenv.EnvParams{
+		CATypesToCreate:  []types.CertAuthType{caType},
+		SkipExternalRoot: true,
+	})
+
+	// External CA chain.
+	const chainLength = 3
+	caChain := sharedEnv.MakeCAChain(t, chainLength)
+	leafToRootChain := caChain.LeafToRootPEMs()
+	// Create overrides from the tip of the external chain.
+	sharedEnv.ExternalRoot = caChain[len(caChain)-1]
+
+	cloneEnv := func(t *testing.T) *subcaenv.Env {
+		env := subcaenv.New(t, subcaenv.EnvParams{
+			CATypesToCreate:  []types.CertAuthType{caType},
+			SkipExternalRoot: true,
+		})
+		env.ExternalRoot = sharedEnv.ExternalRoot
+		return env
+	}
+
+	// Cloned by failure tests.
+	sharedCAOverride := sharedEnv.NewOverrideForCAType(t, caType)
+
+	// Used to test various public key mismatch scenarios. "Random".
+	const unrelatedPublicKey = `9852b3bbc867cc047e6d894333488da322df27fa96aa20ebb29c0bf44ff6327f`
+
+	// Forge a CA that has the correct Subject to match the override certificate,
+	// but has a different set of keys.
+	forgedExternalRoot, err := subcaenv.NewSelfSignedCA(&subcaenv.CAParams{
+		Clock: sharedEnv.Clock,
+		Template: &x509.Certificate{
+			Subject: sharedEnv.ExternalRoot.Cert.Subject,
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify that resources are written under the correct customized key.
+	t.Run("storage key", func(t *testing.T) {
+		t.Parallel()
+
+		env := cloneEnv(t)
+		be := env.Backend
+		ctx := t.Context()
+
+		// Create resource.
+		caOverride := env.NewOverrideForCAType(t, caType)
+		_, err := env.SubCA.CreateCertAuthorityOverride(ctx, caOverride)
+		require.NoError(t, err, "CreateCertAuthorityOverride errored")
+
+		// Form our customized key.
+		wantKey := backend.NewKey(
+			"cert_authority_overrides",
+			"cluster",
+			caOverride.Metadata.Name,
+			caOverride.SubKind,
+		)
+
+		// Get resource from customized key.
+		_, err = be.Get(ctx, wantKey)
+		require.NoError(t, err, "Read resource by customized key")
+
+		// Verify that the "normal" generic.Service key doesn't exist.
+		notWantKey := backend.NewKey(
+			"cert_authority_overrides",
+			"cluster",
+			caOverride.Metadata.Name,
+		)
+		_, err = be.Get(ctx, notWantKey)
+		assert.ErrorAs(t, err, new(*trace.NotFoundError), "Read resource by notWantKey")
+	})
+
+	tests := []struct {
+		name    string
+		modify  func(ca *subcav1.CertAuthorityOverride)
+		success bool // mutually exclusive with wantErr
+		wantErr string
+	}{
+		{
+			name: "OK: Valid CA override",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				// Don't modify anything, take the default testenv override.
+			},
+			success: true,
+		},
+		{
+			name: "OK: Minimal CA override",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Spec = &subcav1.CertAuthorityOverrideSpec{}
+			},
+			success: true,
+		},
+
+		{
+			name: "empty kind",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Kind = ""
+			},
+			wantErr: "kind",
+		},
+		{
+			name: "invalid kind",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Kind = types.KindCertAuthority // wrong type
+			},
+			wantErr: "kind",
+		},
+		{
+			name: "empty sub_kind",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.SubKind = ""
+			},
+			wantErr: "sub_kind",
+		},
+		{
+			name: "invalid sub_kind",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.SubKind = string(types.DatabaseCA) // not allowed
+			},
+			wantErr: "sub_kind",
+		},
+		{
+			name: "empty version",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Version = ""
+			},
+			wantErr: "version",
+		},
+		{
+			name: "invalid version",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Version = types.V2
+			},
+			wantErr: "version",
+		},
+		{
+			name: "nil metadata",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Metadata = nil
+			},
+			wantErr: "name/clusterName required",
+		},
+		{
+			name: "empty name",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Metadata.Name = ""
+			},
+			wantErr: "name/clusterName required",
+		},
+		{
+			name: "nil spec",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Spec = nil
+			},
+			wantErr: "spec required",
+		},
+		{
+			name: "nil certificate_override",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Spec.CertificateOverrides = append(ca.Spec.CertificateOverrides, nil)
+			},
+			wantErr: "nil certificate override",
+		},
+		{
+			name: "certificate_override: empty certificate and public key (enabled)",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Spec.CertificateOverrides[0].Certificate = ""
+				ca.Spec.CertificateOverrides[0].PublicKey = ""
+				ca.Spec.CertificateOverrides[0].Disabled = false
+			},
+			wantErr: "certificate required",
+		},
+		{
+			name: "certificate_override: empty certificate and public key (disabled)",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Spec.CertificateOverrides[0].Certificate = ""
+				ca.Spec.CertificateOverrides[0].PublicKey = ""
+				ca.Spec.CertificateOverrides[0].Disabled = true
+			},
+			wantErr: "certificate or public key required",
+		},
+		{
+			name: "certificate_override: invalid certificate",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Spec.CertificateOverrides[0].Certificate = "ceci n'est pas a certificate"
+			},
+			wantErr: "expected PEM",
+		},
+		{
+			name: "certificate_override: invalid public key",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				ca.Spec.CertificateOverrides[0].PublicKey = "not a valid key"
+			},
+			wantErr: "invalid public key",
+		},
+		{
+			name: "certificate_override: certificate and public key mismatch",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				// Doesn't match the Certificate field.
+				ca.Spec.CertificateOverrides[0].PublicKey = unrelatedPublicKey
+			},
+			wantErr: "public key mismatch",
+		},
+		{
+			name: "certificate_override: chain without certificate",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				co.Chain = leafToRootChain
+				co.Certificate = ""
+				co.Disabled = true
+			},
+			wantErr: "chain not allowed with an empty certificate",
+		},
+		{
+			name: "certificate_override: chain certificate invalid",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				co.PublicKey = ""
+				co.Chain = []string{
+					leafToRootChain[0],
+					"ceci n'est pas a certificate",
+					leafToRootChain[1],
+					leafToRootChain[2],
+				}
+			},
+			wantErr: "chain[1]: expected PEM",
+		},
+		{
+			name: "certificate_override: certificate included in chain",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				co.PublicKey = ""
+				co.Chain = append([]string{co.Certificate}, leafToRootChain...)
+			},
+			wantErr: "override certificate should not be included",
+		},
+		{
+			name: "certificate_override: chain out of order",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				co.PublicKey = ""
+				co.Chain = caChain.RootToLeafPEMs() // reverse order
+			},
+			wantErr: "chain out of order",
+		},
+		{
+			name: "certificate_override: chain signature invalid (forged CA)",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				co.Chain = append(
+					[]string{string(forgedExternalRoot.CertPEM)},
+					leafToRootChain[1:]...,
+				)
+			},
+			wantErr: "chain signature check failed",
+		},
+		{
+			name: "certificate_override: chain has too many entries",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				co.PublicKey = ""
+				co.Chain = slices.Repeat([]string{leafToRootChain[0]}, 20)
+			},
+			wantErr: "chain has too many entries",
+		},
+		{
+			name: "certificate_override: duplicate public key",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				ca.Spec.CertificateOverrides = append(
+					ca.Spec.CertificateOverrides,
+					&subcav1.CertificateOverride{PublicKey: co.PublicKey, Disabled: true},
+				)
+			},
+			wantErr: "duplicate override",
+		},
+
+		{
+			name: "OK: Enabled override",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				co.Disabled = false
+			},
+			success: true,
+		},
+		{
+			name: "OK: Override without public key",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				co.PublicKey = ""
+			},
+			success: true,
+		},
+		{
+			name: "OK: Disabled override with only public key",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				co.Certificate = ""
+			},
+			success: true,
+		},
+		{
+			name: "OK: Override with chain",
+			modify: func(ca *subcav1.CertAuthorityOverride) {
+				co := ca.Spec.CertificateOverrides[0]
+				co.Chain = leafToRootChain
+			},
+			success: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a distinct env for success tests, but otherwise use shared
+			// resources.
+			env := sharedEnv
+			var caOverride *subcav1.CertAuthorityOverride
+			if test.success {
+				env = cloneEnv(t)
+				caOverride = env.NewOverrideForCAType(t, caType)
+			} else {
+				caOverride = proto.Clone(sharedCAOverride).(*subcav1.CertAuthorityOverride)
+			}
+			service := env.SubCA
+
+			test.modify(caOverride)
+
+			// Take a copy. generic.Service modifies its inputs.
+			want := proto.Clone(caOverride).(*subcav1.CertAuthorityOverride)
+
+			got, err := service.CreateCertAuthorityOverride(t.Context(), caOverride)
+			if !test.success {
+				// Assert failures.
+				if assert.ErrorContains(t, err, test.wantErr, "Create error mismatch") {
+					assert.ErrorAs(t, err, new(*trace.BadParameterError), "Create error type mismatch")
+				}
+				return
+			}
+			// Assert success.
+			require.NoError(t, err, "CreateCertAuthorityOverride errored")
+			want.Metadata.Revision = got.Metadata.Revision
+			if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("Create mismatch (-want +got)\n%s", diff)
+			}
+
+			// Assert stored resource.
+			stored, err := service.GetCertAuthorityOverride(t.Context(), local.CertAuthorityOverrideIDFromResource(got))
+			require.NoError(t, err, "GetCertAuthorityOverride errored")
+			if diff := cmp.Diff(got, stored, protocmp.Transform()); diff != "" {
+				t.Errorf("Get mismatch (-want +got)\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refactor subca validation to lib/subca and return the parsed forms.

This is to be used by the service layer, in addition to storage, as it needs the parsed form to do various cross checks.

Validation logic is unchanged, it's simply moved/adapted from storage (lib/services/local). I've added coverage to check the correctness of the parsed form.

https://github.com/gravitational/teleport.e/issues/7675