### PR TITLE
Add event stream support for SAML connector

### DIFF
--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -190,6 +190,8 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newCrownJewelParser()
 		case types.KindPlugin:
 			parser = newPluginParser(kind.LoadSecrets)
+		case types.KindSAMLConnector:
+			parser = newSAMLConnectorParser(kind.LoadSecrets)
 		case types.KindSAMLIdPServiceProvider:
 			parser = newSAMLIDPServiceProviderParser()
 		case types.KindUserGroup:

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -2538,7 +2538,7 @@ skiploop:
 		var deleteResource types.Resource
 		switch r := resource.(type) {
 		case *types.SAMLConnectorV2:
-			meta := resource.GetMetadata()
+			meta := r.GetMetadata()
 			deleteResource = &types.SAMLConnectorV2{
 				Kind:    r.GetKind(),
 				Version: r.GetVersion(),
@@ -2548,11 +2548,11 @@ skiploop:
 				},
 			}
 		default:
-			meta := resource.GetMetadata()
+			meta := r.GetMetadata()
 			deleteResource = &types.ResourceHeader{
-				Kind:    resource.GetKind(),
-				SubKind: resource.GetSubKind(),
-				Version: resource.GetVersion(),
+				Kind:    r.GetKind(),
+				SubKind: r.GetSubKind(),
+				Version: r.GetVersion(),
 				Metadata: types.Metadata{
 					Name:      meta.Name,
 					Namespace: meta.Namespace,

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -2294,6 +2294,42 @@ func (s *ServicesTestSuite) Events(t *testing.T) {
 				return out[0]
 			},
 		},
+		{
+			name: "SAMLConnector",
+			kind: types.WatchKind{
+				Kind: types.KindSAMLConnector,
+			},
+			crud: func(ctx context.Context) types.Resource {
+				connector, err := types.NewSAMLConnector("test-saml-connector", types.SAMLConnectorSpecV2{
+					Display:                  "SAML",
+					Issuer:                   "http://example.com",
+					SSO:                      "https://example.com/saml/sso",
+					AssertionConsumerService: "https://localhost/acs",
+					Audience:                 "https://localhost/aud",
+					ServiceProviderIssuer:    "https://localhost/iss",
+					AttributesToRoles: []types.AttributeMapping{
+						{Name: "groups", Value: "admin", Roles: []string{"admin"}},
+					},
+					Cert: fixtures.TLSCACertPEM,
+					SigningKeyPair: &types.AsymmetricKeyPair{
+						PrivateKey: fixtures.TLSCAKeyPEM,
+						Cert:       fixtures.TLSCACertPEM,
+					},
+				})
+				require.NoError(t, err)
+
+				_, err = s.WebS.CreateSAMLConnector(ctx, connector)
+				require.NoError(t, err)
+
+				out, err := s.WebS.GetSAMLConnector(ctx, connector.GetName(), false)
+				require.NoError(t, err)
+
+				err = s.WebS.DeleteSAMLConnector(ctx, connector.GetName())
+				require.NoError(t, err)
+
+				return out
+			},
+		},
 	}
 	// this also tests the partial success mode by requesting an unknown kind
 	s.runEventsTests(t, testCases, types.Watch{
@@ -2497,17 +2533,33 @@ skiploop:
 
 		ExpectResource(t, w, 3*time.Second, resource)
 
-		meta := resource.GetMetadata()
-		header := &types.ResourceHeader{
-			Kind:    resource.GetKind(),
-			SubKind: resource.GetSubKind(),
-			Version: resource.GetVersion(),
-			Metadata: types.Metadata{
-				Name:      meta.Name,
-				Namespace: meta.Namespace,
-			},
+		// Explicitly handle watchers that emit a concrete type on delete, rather than
+		// a ResourceHeader.
+		var deleteResource types.Resource
+		switch r := resource.(type) {
+		case *types.SAMLConnectorV2:
+			meta := resource.GetMetadata()
+			deleteResource = &types.SAMLConnectorV2{
+				Kind:    r.GetKind(),
+				Version: r.GetVersion(),
+				Metadata: types.Metadata{
+					Name:      meta.Name,
+					Namespace: meta.Namespace,
+				},
+			}
+		default:
+			meta := resource.GetMetadata()
+			deleteResource = &types.ResourceHeader{
+				Kind:    resource.GetKind(),
+				SubKind: resource.GetSubKind(),
+				Version: resource.GetVersion(),
+				Metadata: types.Metadata{
+					Name:      meta.Name,
+					Namespace: meta.Namespace,
+				},
+			}
 		}
-		ExpectDeleteResource(t, w, 3*time.Second, header)
+		ExpectDeleteResource(t, w, 3*time.Second, deleteResource)
 	}
 }
 

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -2288,6 +2288,53 @@ func keyAttestationDataFingerprint(pubDER []byte) string {
 	return encodedSHA
 }
 
+func newSAMLConnectorParser(loadSecrets bool) *samlConnectorParser {
+	return &samlConnectorParser{
+		baseParser:  newBaseParser(backend.ExactKey(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix)),
+		loadSecrets: loadSecrets,
+	}
+}
+
+type samlConnectorParser struct {
+	baseParser
+	loadSecrets bool
+}
+
+func (p *samlConnectorParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		name := event.Item.Key.TrimPrefix(backend.ExactKey(webPrefix, connectorsPrefix, samlPrefix, connectorsPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.SAMLConnectorV2{
+			Kind:    types.KindSAMLConnector,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      name,
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
+	case types.OpPut:
+		connector, err := services.UnmarshalSAMLConnectorWithValidationOptions(
+			event.Item.Value,
+			[]types.SAMLConnectorValidationOption{types.SAMLConnectorValidationFollowURLs(false)},
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !p.loadSecrets {
+			return connector.WithoutSecrets(), nil
+		}
+		return connector, nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
 const (
 	webPrefix                 = "web"
 	usersPrefix               = "users"


### PR DESCRIPTION
This change adds event stream support and local watch parsing for SAML connectors. 

To be tested via integration in https://github.com/gravitational/teleport/pull/64504
