### PR TITLE
fix indentation in testplan MCP section

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1689,13 +1689,13 @@ manualy testing.
   - [ ] Redshift
   - [ ] CockroachDB
   - [ ] Verify Teleport MCP servers can be configured and function correctly across various clients
-   - [ ]`tsh mcp db config`
-    - [ ] Claude Desktop
-    - [ ] VSCode
-    - [ ] Cursor
-    - [ ] `claude`
-    - [ ] `codex`
-   - [ ] Dev testing via MCP inspector
+    - [ ] `tsh mcp db config`
+      - [ ] Claude Desktop
+      - [ ] VSCode
+      - [ ] Cursor
+      - [ ] `claude`
+      - [ ] `codex`
+    - [ ] Dev testing via MCP inspector
 
 ## Git Proxy
 - [ ] [GitHub proxy](https://goteleport.com/docs/admin-guides/management/guides/github-integration/)
@@ -2306,35 +2306,35 @@ The following should work with SSO MFA, automatically opening the SSO MFA redire
 
 ## MCP Access
 - [ ] Verify Teleport supports MCP servers in various transports
- - [ ] Teleport demo server (special in-memory MCP)
- - [ ] stdio
-  - [ ] Verify Teleport/tsh can automatically reconnect if client connection is disrupted
-  - [ ] Verify the MCP process (node, python, etc.) is stopped after session is done
-  - [ ] Verify docker containers are removed after session is done for docker-based MCPs.
-  - [ ] Verify `run_as_host_user` with a different user than caller.
- - [ ] streamable-HTTP
-  - [ ] Verify custom headers can be set via `app.rewrite.headers`
-  - [ ] Verify Teleport can passthrough custom headers from client side (e.g. github PAT via `tsh db connect --header`)
-  - [ ] Verify Teleport can passthrough 3rd party OAuth flow (e.g. Cloudflare OAuth)
-  - [ ] Verify egress auth with JWT token (e.g. Grafana that trust's Teleport JWT)
-  - [ ] Verify egress auth with OpenID token (e.g. AWS AgentCore MCP Gateway)
- - [ ] SSE (deprecated but still in-use)
+  - [ ] Teleport demo server (special in-memory MCP)
+  - [ ] stdio
+    - [ ] Verify Teleport/tsh can automatically reconnect if client connection is disrupted
+    - [ ] Verify the MCP process (node, python, etc.) is stopped after session is done
+    - [ ] Verify docker containers are removed after session is done for docker-based MCPs.
+    - [ ] Verify `run_as_host_user` with a different user than caller.
+  - [ ] streamable-HTTP
+    - [ ] Verify custom headers can be set via `app.rewrite.headers`
+    - [ ] Verify Teleport can passthrough custom headers from client side (e.g. github PAT via `tsh db connect --header`)
+    - [ ] Verify Teleport can passthrough 3rd party OAuth flow (e.g. Cloudflare OAuth)
+    - [ ] Verify egress auth with JWT token (e.g. Grafana that trust's Teleport JWT)
+    - [ ] Verify egress auth with OpenID token (e.g. AWS AgentCore MCP Gateway)
+  - [ ] SSE (deprecated but still in-use)
 - [ ] Verify Teleport MCP servers can be configured and function correctly across various clients
- - [ ] `tsh mcp config`
-  - [ ] Claude Desktop
-  - [ ] VSCode
-  - [ ] Cursor
-  - [ ] `claude`
-  - [ ] `codex`
- - [ ] Web UI deep links
-  - [ ] VSCode
-  - [ ] Cursor
- - [ ] Dev testing via MCP inspector
+  - [ ] `tsh mcp config`
+    - [ ] Claude Desktop
+    - [ ] VSCode
+    - [ ] Cursor
+    - [ ] `claude`
+    - [ ] `codex`
+  - [ ] Web UI deep links
+    - [ ] VSCode
+    - [ ] Cursor
+  - [ ] Dev testing via MCP inspector
 - [ ] Verify Teleport MCP servers hint on "tsh login" when tsh session is expired (via chat/prompt)
 - [ ] RBAC
- - [ ] Verify users can only see MCP servers allowed by `allow.app_labels`
- - [ ] Verify MCP client can only see allowed tools
- - [ ] Verify `deny.mcp.tools` is greedy (deny overrides allow)
+  - [ ] Verify users can only see MCP servers allowed by `allow.app_labels`
+  - [ ] Verify MCP client can only see allowed tools
+  - [ ] Verify `deny.mcp.tools` is greedy (deny overrides allow)
 
 ## Resources
 


### PR DESCRIPTION

<img width="300"  alt="Screenshot 2026-03-12 at 9 30 09 AM" src="https://github.com/user-attachments/assets/de8fddf2-adeb-405c-b6d3-2bea2f8528e0" />

related:
- https://github.com/gravitational/teleport/pull/64378

The above PR use single space as indentation causing Github couldn't render the nested list properly 😭

This shows that even changes that appear trivial may still require a manual test plan.

## Manual Test Plan
### Test Environment
Github

### Test Cases
- [x] https://github.com/gravitational/teleport/blob/STeve/fix_mcp_testplan/.github/ISSUE_TEMPLATE/testplan.md

<img width="150" alt="Screenshot 2026-03-12 at 9 51 53 AM" src="https://github.com/user-attachments/assets/6ed26f06-715b-4770-a9fc-09d2716f1341" />

<img width="300" alt="Screenshot 2026-03-12 at 9 52 16 AM" src="https://github.com/user-attachments/assets/d0298424-801d-419c-8c33-f7694312e195" />
