### PR TITLE
Fix teleport reload corner case

### DIFF
--- a/examples/systemd/fips/teleport.service
+++ b/examples/systemd/fips/teleport.service
@@ -9,7 +9,7 @@ RestartSec=5
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --fips --pid-file=/run/teleport.pid
 # systemd before 239 needs an absolute path
-ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
+ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/production/auth/teleport.service
+++ b/examples/systemd/production/auth/teleport.service
@@ -13,7 +13,7 @@ RestartSec=5
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=auth --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport.pid
 # systemd before 239 needs an absolute path
-ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
+ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/production/node/teleport.service
+++ b/examples/systemd/production/node/teleport.service
@@ -13,7 +13,7 @@ RestartSec=5
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=node --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
 # systemd before 239 needs an absolute path
-ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
+ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/production/proxy/teleport.service
+++ b/examples/systemd/production/proxy/teleport.service
@@ -13,7 +13,7 @@ RestartSec=5
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=proxy --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
 # systemd before 239 needs an absolute path
-ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
+ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 

--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -9,7 +9,7 @@ RestartSec=5
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --config /etc/teleport.yaml --pid-file=/run/teleport.pid
 # systemd before 239 needs an absolute path
-ExecReload=/bin/sh -c "exec pkill -HUP -L -F /run/teleport.pid"
+ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport.pid
 LimitNOFILE=524288
 


### PR DESCRIPTION
I've noticed that if we start and reload teleport soon after, the file doesn't exist yet.

Changelog: fix systemd example unit for reload corner case.

## Manual Test Plan

Take the systemd example service and try this test case.

### Test Cases
- [x] `sudo systemctl start teleport; sudo systemctl reload teleport`

```
Mar 12 15:58:19 foo systemd[1]: Started teleport.service - Teleport Service.
Mar 12 15:58:20 foo systemd[1]: Reloading teleport.service - Teleport Service...
Mar 12 15:58:20 foo sh[148837]: pkill: pidfile not valid
Mar 12 15:58:20 foo sh[148837]: Try `pkill --help' for more information.
Mar 12 15:58:20 foo systemd[1]: teleport.service: Control process exited, code=exited, status=1/FAILURE
Mar 12 15:58:20 foo systemd[1]: Reload failed for teleport.service - Teleport Service.
```