### PR TITLE
Remove use of `github.com/lib/pq` as direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -180,7 +180,6 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0 // replaced
 	github.com/keys-pub/go-libfido2 v1.5.3-0.20220306005615-8ab03fb1ec27 // replaced
-	github.com/lib/pq v1.10.9
 	github.com/mailgun/mailgun-go/v4 v4.23.0
 	github.com/mark3labs/mcp-go v0.43.0
 	github.com/mattn/go-shellwords v1.0.12
@@ -481,6 +480,7 @@ require (
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/letsencrypt/boulder v0.20251110.0 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect

--- a/lib/srv/db/postgres/users.go
+++ b/lib/srv/db/postgres/users.go
@@ -32,7 +32,6 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v4"
-	"github.com/lib/pq"
 
 	"github.com/gravitational/teleport/api/types"
 	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
@@ -254,7 +253,7 @@ func (e *Engine) applyPermissions(ctx context.Context, sessionCtx *common.Sessio
 		return trace.Wrap(err)
 	})
 	if err != nil {
-		var pgErr *pq.Error
+		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			if pgErr.Code == common.SQLStatePermissionsChanged {
 				logger.ErrorContext(ctx, "User permissions have changed, rejecting connection",


### PR DESCRIPTION
As @rosstimothy noticed, we use `github.com/lib/pq` in only one place. This PR replaces that use with a type from `github.com/jackc/pgconn`.

Changelog: Remove direct dependency on github.com/lib/pq.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [x] Error is still printed by CLI OR reported in DB service logs when we:
  - [x] Start a session as a user via a role with `db_permissions` set, and keep that session alive.
  - [x] Modify `db_permissions` on the role so that the set of permissions granted to the user is different.
  - [x] Attempt to start a second simultaneous session with the same user.
- [x] No error is printed when we:
  - [x] Start a session as a user via a role with `db_permissions` set, and keep that session alive.
  - [x] Without modifying that `db_permissions`, attempt to start a second simultaneous session with the same user.