### PR TITLE
kube: add precompiled per-request fast matcher for RBAC list filtering

### DIFF
--- a/lib/kube/proxy/fast_matcher.go
+++ b/lib/kube/proxy/fast_matcher.go
@@ -1,0 +1,236 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// fastMatcher is a precompiled per-request RBAC matcher that reduces per-item matching overhead.
+// Instead of calling matchKubernetesResource per item (which does cache lookups, rule iteration, per-field matching),
+// the fast matcher resolves constant fields at compile time and only checks per-item fields during matching.
+//
+// Of the five rule fields:
+//   - Kind: exact-match or wildcard only, constant per request, resolved at compile time.
+//   - Verb: exact-match or wildcard only, constant per request, resolved at compile time.
+//   - APIGroup: supports regex/glob, constant per request, resolved at compile time.
+//   - Namespace: supports regex/glob, varies per item, checked per item.
+//   - Name: supports regex/glob, varies per item, checked per item.
+//
+// The fast matcher handles the common "default" case in KubeResourceMatchesRegex.
+// It cannot handle namespace special cases (when the requested kind is "namespaces").
+type fastMatcher struct {
+	allowRules []compiledMatchRule
+	denyRules  []compiledMatchRule
+}
+
+// compiledMatchRule is a single RBAC rule with pre-compiled name and namespace matchers.
+// Kind, verb, and apiGroup have already been resolved during rule filtering.
+type compiledMatchRule struct {
+	name      fieldMatcher
+	namespace fieldMatcher
+	// requiresNamespace is true when the original rule had a non-empty, non-wildcard namespace pattern.
+	// When true, resources with an empty namespace cannot match this rule.
+	requiresNamespace bool
+}
+
+// fieldMatcher matches a string either by exact literal comparison or by compiled regex.
+type fieldMatcher struct {
+	literal string         // set for exact match
+	re      *regexp.Regexp // set for pattern match
+}
+
+func (f fieldMatcher) match(s string) bool {
+	if f.re == nil {
+		return f.literal == s
+	}
+	return f.re.MatchString(s)
+}
+
+// newFastMatcher filters rules by request parameters and compiles a fast matcher.
+func newFastMatcher(mr metaResource, allowed, denied []types.KubernetesResource) (*fastMatcher, error) {
+	// Local cache for this compilation pass.
+	// Many rules share the same patterns, so this avoids compiling the same expression multiple times.
+	cache := make(map[string]*regexp.Regexp)
+
+	filteredAllowed, err := filterRules(mr, allowed, cache)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	filteredDenied, err := filterRules(mr, denied, cache)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	allowRules, err := compileMatchRules(filteredAllowed, cache)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	denyRules, err := compileMatchRules(filteredDenied, cache)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &fastMatcher{
+		allowRules: allowRules,
+		denyRules:  denyRules,
+	}, nil
+}
+
+// filterRules returns the subset of rules that match the given request parameters.
+func filterRules(mr metaResource, rules []types.KubernetesResource, cache map[string]*regexp.Regexp) ([]types.KubernetesResource, error) {
+	filtered := make([]types.KubernetesResource, 0, len(rules))
+	for _, r := range rules {
+		if !kindAllowed(r.Kind, mr.requestedResource.resourceKind) {
+			continue
+		}
+		if !verbAllowed(r.Verbs, mr.verb) {
+			continue
+		}
+		if !namespaceAllowed(r.Namespace, mr.requestedResource.namespace) {
+			continue
+		}
+		match, err := apiGroupMatches(r.APIGroup, mr.requestedResource.apiGroup, cache)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !match {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	return filtered, nil
+}
+
+func kindAllowed(ruleKind, requestedKind string) bool {
+	return ruleKind == types.Wildcard || ruleKind == requestedKind
+}
+
+func verbAllowed(allowedVerbs []string, verb string) bool {
+	return utils.IsVerbAllowed(allowedVerbs, verb)
+}
+
+func namespaceAllowed(ruleNamespace, requestedNamespace string) bool {
+	if requestedNamespace == "" {
+		// Cluster-wide request: all rules pass since items may come from any namespace.
+		return true
+	}
+	// Empty rule namespace targets cluster-wide resources.
+	// Keep it during pre-filtering; the compiled matcher only matches items with empty namespace.
+	if ruleNamespace == "" {
+		return true
+	}
+	// Pattern namespaces are kept since they need compilation.
+	if isGlobOrRegexp(ruleNamespace) {
+		return true
+	}
+	return ruleNamespace == requestedNamespace
+}
+
+func apiGroupMatches(ruleAPIGroup, requestedAPIGroup string, cache map[string]*regexp.Regexp) (bool, error) {
+	if !isGlobOrRegexp(ruleAPIGroup) {
+		return ruleAPIGroup == requestedAPIGroup, nil
+	}
+	if re, ok := cache[ruleAPIGroup]; ok {
+		return re.MatchString(requestedAPIGroup), nil
+	}
+	re, err := utils.CompileExpression(ruleAPIGroup)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	cache[ruleAPIGroup] = re
+	return re.MatchString(requestedAPIGroup), nil
+}
+
+func isGlobOrRegexp(expr string) bool {
+	return strings.Contains(expr, "*") || utils.IsRegexp(expr)
+}
+
+func compileMatchRules(resources []types.KubernetesResource, cache map[string]*regexp.Regexp) ([]compiledMatchRule, error) {
+	rules := make([]compiledMatchRule, 0, len(resources))
+	for _, r := range resources {
+		nameM, err := compileFieldMatcher(r.Name, cache)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		nsM, err := compileFieldMatcher(r.Namespace, cache)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		rules = append(rules, compiledMatchRule{
+			name:              nameM,
+			namespace:         nsM,
+			requiresNamespace: r.Namespace != "" && r.Namespace != types.Wildcard,
+		})
+	}
+	return rules, nil
+}
+
+// compileFieldMatcher returns a fieldMatcher for the given expression.
+// Literal expressions (no wildcards or regex) use direct string comparison.
+// Patterns are compiled to regex, with results cached across rules.
+func compileFieldMatcher(expression string, cache map[string]*regexp.Regexp) (fieldMatcher, error) {
+	if !isGlobOrRegexp(expression) {
+		return fieldMatcher{literal: expression}, nil
+	}
+	if re, ok := cache[expression]; ok {
+		return fieldMatcher{re: re}, nil
+	}
+	re, err := utils.CompileExpression(expression)
+	if err != nil {
+		return fieldMatcher{}, trace.Wrap(err)
+	}
+	cache[expression] = re
+	return fieldMatcher{re: re}, nil
+}
+
+// match checks if a resource with the given name and namespace is allowed by the precompiled RBAC rules.
+func (m *fastMatcher) match(name, namespace string) (bool, error) {
+	for i := range m.denyRules {
+		if m.denyRules[i].matches(name, namespace) {
+			return false, nil
+		}
+	}
+	for i := range m.allowRules {
+		if m.allowRules[i].matches(name, namespace) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// matches checks whether a single compiled rule matches the given fields.
+// This mirrors the "default" case in KubeResourceMatchesRegex.
+// Kind, verb, and apiGroup are already resolved during rule filtering.
+func (r *compiledMatchRule) matches(name, namespace string) bool {
+	if !r.name.match(name) {
+		return false
+	}
+	if r.requiresNamespace && namespace == "" {
+		return false
+	}
+	return r.namespace.match(namespace)
+}

--- a/lib/kube/proxy/fast_matcher_test.go
+++ b/lib/kube/proxy/fast_matcher_test.go
@@ -1,0 +1,879 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
+)
+
+func TestNewMatcher(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		kind           string
+		verb           string
+		apiGroup       string
+		namespace      string
+		allowed        []types.KubernetesResource
+		wantDefault    bool
+		wantAllowCount int
+		wantDenyCount  int
+	}{
+		{
+			name:        "returns defaultMatcher for namespace kind",
+			kind:        "namespaces",
+			verb:        types.KubeVerbList,
+			wantDefault: true,
+		},
+		{
+			name: "compiles successfully for pod kind",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name: "filters out rules with non-matching kind",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+				{Kind: types.KindKubeConfigmap, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name: "includes wildcard kind rules",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.Wildcard, Namespace: "*", Name: "*", Verbs: []string{types.Wildcard}, APIGroup: "*"},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name: "filters out rules with non-matching verb",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbCreate}, APIGroup: "*"},
+			},
+			wantAllowCount: 0,
+		},
+		{
+			name: "wildcard verb only recognized as first element",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbGet, types.Wildcard}, APIGroup: "*"},
+			},
+			wantAllowCount: 0,
+		},
+		{
+			name: "wildcard verb as first element matches any verb",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.Wildcard}, APIGroup: "*"},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name: "empty verbs matches nothing",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{}, APIGroup: "*"},
+			},
+			wantAllowCount: 0,
+		},
+		{
+			name: "returns defaultMatcher for invalid regex",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "^[invalid$", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			wantDefault: true,
+		},
+		{
+			name:     "filters out rules with non-matching literal API group",
+			kind:     types.KindKubePod,
+			verb:     types.KubeVerbList,
+			apiGroup: "",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "apps"},
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name:     "keeps rules with wildcard API group",
+			kind:     types.KindKubePod,
+			verb:     types.KubeVerbList,
+			apiGroup: "",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name:     "keeps rules with regex API group",
+			kind:     types.KindKubePod,
+			verb:     types.KubeVerbList,
+			apiGroup: "apps",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "^apps|extensions$"},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name:      "filters out rules with non-matching literal namespace",
+			kind:      types.KindKubePod,
+			verb:      types.KubeVerbList,
+			namespace: "default",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "staging", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "default", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			wantAllowCount: 1,
+		},
+		{
+			name:      "keeps all rules when request is cluster-wide",
+			kind:      types.KindKubePod,
+			verb:      types.KubeVerbList,
+			namespace: "",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "staging", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "default", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			wantAllowCount: 2,
+		},
+		{
+			name:      "keeps rules with wildcard namespace when targeting specific namespace",
+			kind:      types.KindKubePod,
+			verb:      types.KubeVerbList,
+			namespace: "default",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			wantAllowCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mr := metaResource{
+				requestedResource: apiResource{resourceKind: tt.kind, apiGroup: tt.apiGroup, namespace: tt.namespace},
+				verb:              tt.verb,
+			}
+			log := slog.New(slog.DiscardHandler)
+			m := newMatcher(mr, tt.allowed, nil, log)
+			if tt.wantDefault {
+				require.IsType(t, &defaultMatcher{}, m)
+				return
+			}
+			fm, ok := m.(*fastMatcher)
+			require.True(t, ok, "expected *fastMatcher, got %T", m)
+			require.Len(t, fm.allowRules, tt.wantAllowCount)
+			require.Len(t, fm.denyRules, tt.wantDenyCount)
+		})
+	}
+}
+
+// TestNamespaceKindFallback verifies that namespace kind requests go through defaultMatcher
+// and produce correct results for all the special cases in KubeResourceMatchesRegex:
+// - pod rule in namespace "foo" → user can list namespace "foo"
+// - explicit namespace rule → matched by name
+// - wildcard kind with namespace swapping
+// If someone removes the namespace guard from newMatcher, these will fail.
+func TestNamespaceKindFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		verb    string
+		allowed []types.KubernetesResource
+		denied  []types.KubernetesResource
+		input   types.KubernetesResource
+	}{
+		{
+			name: "pod rule grants read-only namespace visibility",
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "production", Name: "*", Verbs: []string{types.Wildcard}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "production", Verbs: []string{types.KubeVerbList}},
+		},
+		{
+			name: "pod rule does not grant visibility to other namespaces",
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "production", Name: "*", Verbs: []string{types.Wildcard}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "staging", Verbs: []string{types.KubeVerbList}},
+		},
+		{
+			name: "explicit namespace rule matched by name",
+			verb: types.KubeVerbGet,
+			allowed: []types.KubernetesResource{
+				{Kind: "namespaces", Name: "default", Verbs: []string{types.KubeVerbGet}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "default", Verbs: []string{types.KubeVerbGet}},
+		},
+		{
+			name: "explicit namespace rule does not match different name",
+			verb: types.KubeVerbGet,
+			allowed: []types.KubernetesResource{
+				{Kind: "namespaces", Name: "default", Verbs: []string{types.KubeVerbGet}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "staging", Verbs: []string{types.KubeVerbGet}},
+		},
+		{
+			name: "wildcard kind with wildcard namespace uses name as target",
+			verb: types.KubeVerbGet,
+			allowed: []types.KubernetesResource{
+				{Kind: types.Wildcard, APIGroup: types.Wildcard, Namespace: types.Wildcard, Name: types.Wildcard, Verbs: []string{types.Wildcard}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "anything", Verbs: []string{types.KubeVerbGet}},
+		},
+		{
+			name: "deny rule blocks namespace visibility",
+			verb: types.KubeVerbGet,
+			allowed: []types.KubernetesResource{
+				{Kind: types.Wildcard, APIGroup: types.Wildcard, Namespace: types.Wildcard, Name: types.Wildcard, Verbs: []string{types.Wildcard}},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.Wildcard, APIGroup: types.Wildcard, Namespace: types.Wildcard, Name: types.Wildcard, Verbs: []string{types.Wildcard}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "default", Verbs: []string{types.KubeVerbGet}},
+		},
+		{
+			name: "pod rule does not grant write access to namespace",
+			verb: types.KubeVerbUpdate,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "production", Name: "*", Verbs: []string{types.Wildcard}},
+			},
+			input: types.KubernetesResource{Kind: "namespaces", Name: "production", Verbs: []string{types.KubeVerbUpdate}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mr := metaResource{
+				requestedResource: apiResource{resourceKind: "namespaces"},
+				verb:              tt.verb,
+			}
+			log := slog.New(slog.DiscardHandler)
+			m := newMatcher(mr, tt.allowed, tt.denied, log)
+			require.IsType(t, &defaultMatcher{}, m)
+
+			expected, err := matchKubernetesResource(tt.input, true, tt.allowed, tt.denied)
+			require.NoError(t, err)
+
+			got, err := m.match(tt.input.Name, tt.input.Namespace)
+			require.NoError(t, err)
+			require.Equal(t, expected, got)
+		})
+	}
+}
+
+// TestMatcherEquivalence verifies that fastMatcher and defaultMatcher produce the same results.
+// The original function is the source of truth, no hardcoded expected values.
+func TestMatcherEquivalence(t *testing.T) {
+	t.Parallel()
+
+	type input struct {
+		resource              types.KubernetesResource
+		isClusterWideResource bool
+	}
+	pod := func(ns, name string) input {
+		return input{resource: types.KubernetesResource{Kind: types.KindKubePod, Namespace: ns, Name: name, Verbs: []string{types.KubeVerbList}, APIGroup: ""}}
+	}
+	deploy := func(ns, name, apiGroup string) input {
+		return input{resource: types.KubernetesResource{Kind: types.KindKubeDeployment, Namespace: ns, Name: name, Verbs: []string{types.KubeVerbList}, APIGroup: apiGroup}}
+	}
+
+	tests := []struct {
+		name     string
+		kind     string
+		verb     string
+		apiGroup string
+		allowed  []types.KubernetesResource
+		denied   []types.KubernetesResource
+		inputs   []input
+	}{
+		// -- allow rule patterns --
+		{
+			name: "wildcard allows everything",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			inputs: []input{
+				pod("default", "nginx"),
+				pod("kube-system", "coredns"),
+				pod("", "orphan"),
+			},
+		},
+		{
+			name: "exact namespace and name matching",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "nginx", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx"),
+				pod("default", "redis"),
+				pod("kube-system", "nginx"),
+			},
+		},
+		{
+			name: "glob name pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "nginx-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx-deployment-abc123"),
+				pod("default", "redis"),
+			},
+		},
+		{
+			name: "regex name pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "^nginx-[a-z]+$", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx-deployment"),
+				pod("default", "nginx-123"),
+				pod("default", "redis"),
+			},
+		},
+		{
+			name: "multiple allow rules",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "staging", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx"),
+				pod("staging", "nginx"),
+				pod("production", "nginx"),
+			},
+		},
+		{
+			name:    "no allow rules means no access",
+			kind:    types.KindKubePod,
+			verb:    types.KubeVerbList,
+			allowed: []types.KubernetesResource{},
+			inputs: []input{
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name: "empty namespace input with specific and wildcard rules",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("", "nginx"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name:     "apigroup match",
+			kind:     types.KindKubeDeployment,
+			verb:     types.KubeVerbList,
+			apiGroup: "apps",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubeDeployment, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "apps"},
+			},
+			inputs: []input{
+				deploy("default", "nginx", "apps"),
+			},
+		},
+		{
+			name:     "apigroup mismatch",
+			kind:     types.KindKubeDeployment,
+			verb:     types.KubeVerbList,
+			apiGroup: "extensions",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubeDeployment, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "apps"},
+			},
+			inputs: []input{
+				deploy("default", "nginx", "extensions"),
+			},
+		},
+		// -- glob and exact patterns with deny --
+		{
+			name: "glob and exact patterns with deny",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "nginx-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "staging", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.Wildcard, Namespace: "monitoring", Name: "*", Verbs: []string{types.Wildcard}, APIGroup: "*"},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "staging", Name: "secret-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx-abc"),
+				pod("default", "redis"),
+				pod("staging", "app"),
+				pod("staging", "secret-data"),
+				pod("monitoring", "prometheus"),
+				pod("production", "app"),
+				pod("", "orphan"),
+				{resource: types.KubernetesResource{Kind: types.KindKubePod, Namespace: "", Name: "cluster-wide-pod", Verbs: []string{types.KubeVerbList}, APIGroup: ""}, isClusterWideResource: true},
+			},
+		},
+		// -- deny rule patterns --
+		{
+			name: "deny with exact namespace",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "kube-system", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			inputs: []input{
+				pod("kube-system", "coredns"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name: "deny with regex namespace pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "^kube-.*$", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("kube-system", "coredns"),
+				pod("kube-public", "info"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name: "deny with regex name pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "^(secret|internal)-.*$", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "secret-data"),
+				pod("default", "internal-api"),
+				pod("default", "nginx"),
+				pod("default", "secret"),
+			},
+		},
+		{
+			name: "deny with glob name pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "secret-*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			inputs: []input{
+				pod("default", "secret-data"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name: "deny with exact name",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "secret-data", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			inputs: []input{
+				pod("default", "secret-data"),
+				pod("default", "secret-other"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name: "multiple deny rules with mixed patterns",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "kube-system", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+				{Kind: types.KindKubePod, Namespace: "*", Name: "secret-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("kube-system", "coredns"),
+				pod("default", "secret-data"),
+				pod("default", "nginx"),
+				pod("kube-system", "secret-data"),
+			},
+		},
+		{
+			name: "deny with glob namespace pattern",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "kube-*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("kube-system", "coredns"),
+				pod("kube-public", "info"),
+				pod("default", "nginx"),
+			},
+		},
+		{
+			name:     "deny with regex apigroup",
+			kind:     types.KindKubeDeployment,
+			verb:     types.KubeVerbList,
+			apiGroup: "apps",
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubeDeployment, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "*"},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubeDeployment, Namespace: "*", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: "^apps|extensions$"},
+			},
+			inputs: []input{
+				deploy("default", "nginx", "apps"),
+				deploy("staging", "redis", "apps"),
+			},
+		},
+		{
+			name: "narrow allow with overlapping deny",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "default", Name: "nginx-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			denied: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "*", Name: "nginx-secret", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx-web"),
+				pod("default", "nginx-secret"),
+				pod("default", "redis"),
+				pod("staging", "nginx-web"),
+			},
+		},
+		// -- namespace edge cases --
+		{
+			name: "allow with empty namespace rule",
+			kind: types.KindKubePod,
+			verb: types.KubeVerbList,
+			allowed: []types.KubernetesResource{
+				{Kind: types.KindKubePod, Namespace: "", Name: "*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+			},
+			inputs: []input{
+				pod("default", "nginx"),
+				pod("", "orphan"),
+				{resource: types.KubernetesResource{Kind: types.KindKubePod, Namespace: "", Name: "orphan", Verbs: []string{types.KubeVerbList}, APIGroup: ""}, isClusterWideResource: true},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mr := metaResource{
+				requestedResource: apiResource{resourceKind: tc.kind, apiGroup: tc.apiGroup},
+				verb:              tc.verb,
+			}
+
+			log := slog.New(slog.DiscardHandler)
+			fm := newMatcher(mr, tc.allowed, tc.denied, log)
+			require.IsType(t, &fastMatcher{}, fm)
+
+			dm := &defaultMatcher{
+				kind:             tc.kind,
+				verb:             tc.verb,
+				apiGroup:         tc.apiGroup,
+				allowedResources: tc.allowed,
+				deniedResources:  tc.denied,
+			}
+
+			for _, tt := range tc.inputs {
+				t.Run(fmt.Sprintf("%s/%s", tt.resource.Namespace, tt.resource.Name), func(t *testing.T) {
+					t.Parallel()
+
+					// Use the original matchKubernetesResource as source of truth.
+					expected, err := matchKubernetesResource(tt.resource, tt.isClusterWideResource, tc.allowed, tc.denied)
+					require.NoError(t, err)
+
+					fastResult, err := fm.match(tt.resource.Name, tt.resource.Namespace)
+					require.NoError(t, err)
+					require.Equal(t, expected, fastResult, "fastMatcher mismatch for %s/%s", tt.resource.Namespace, tt.resource.Name)
+
+					defaultResult, err := dm.match(tt.resource.Name, tt.resource.Namespace)
+					require.NoError(t, err)
+					require.Equal(t, expected, defaultResult, "defaultMatcher mismatch for %s/%s", tt.resource.Namespace, tt.resource.Name)
+				})
+			}
+		})
+	}
+}
+
+// TestMatcherEquivalenceMatrix generates a cross product of rule patterns and resource inputs.
+// Then verifies fastMatcher, defaultMatcher and the original matchKubernetesResource all agree.
+// This catches regressions that hand-picked cases might miss.
+func TestMatcherEquivalenceMatrix(t *testing.T) {
+	t.Parallel()
+
+	// Rule patterns covering literals, globs, regexes, wildcards, and empty strings.
+	namePatterns := []string{"nginx", "nginx-*", "^nginx-[a-z]+$", "*", ""}
+	nsPatterns := []string{"default", "kube-*", "^staging-.*$", "*", ""}
+	apiGroupPatterns := []string{"", "apps", "*"}
+
+	// Resources to match against each rule set.
+	names := []string{"nginx", "nginx-web", "nginx-123", "redis", ""}
+	namespaces := []string{"default", "kube-system", "staging-prod", "other", ""}
+	apiGroups := []string{"", "apps"}
+
+	kind := types.KindKubePod
+	verb := types.KubeVerbList
+
+	for _, nameP := range namePatterns {
+		for _, nsP := range nsPatterns {
+			for _, agP := range apiGroupPatterns {
+				allowed := []types.KubernetesResource{
+					{Kind: kind, Namespace: nsP, Name: nameP, Verbs: []string{verb}, APIGroup: agP},
+				}
+
+				for _, inputName := range names {
+					for _, inputNS := range namespaces {
+						for _, inputAG := range apiGroups {
+							mr := metaResource{
+								requestedResource: apiResource{resourceKind: kind, apiGroup: inputAG},
+								verb:              verb,
+							}
+							log := slog.New(slog.DiscardHandler)
+							m := newMatcher(mr, allowed, nil, log)
+							fm, ok := m.(*fastMatcher)
+							if !ok {
+								// Invalid regex — fell back to defaultMatcher. Skip.
+								continue
+							}
+
+							resource := types.KubernetesResource{
+								Kind: kind, Namespace: inputNS, Name: inputName,
+								Verbs: []string{verb}, APIGroup: inputAG,
+							}
+
+							expected, err := matchKubernetesResource(resource, false, allowed, nil)
+							if err != nil {
+								continue
+							}
+
+							fastResult, err := fm.match(inputName, inputNS)
+							if err != nil {
+								continue
+							}
+
+							dm := &defaultMatcher{
+								kind: kind, verb: verb, apiGroup: inputAG,
+								allowedResources: allowed,
+							}
+							defaultResult, err := dm.match(inputName, inputNS)
+							if err != nil {
+								continue
+							}
+
+							label := fmt.Sprintf("allow[ns=%q,name=%q,ag=%q]/input[ns=%q,name=%q,ag=%q]",
+								nsP, nameP, agP, inputNS, inputName, inputAG)
+
+							if fastResult != expected {
+								t.Errorf("fastMatcher mismatch: %s: got %v, want %v", label, fastResult, expected)
+							}
+							if defaultResult != expected {
+								t.Errorf("defaultMatcher mismatch: %s: got %v, want %v", label, defaultResult, expected)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// buildUnstructuredList creates an unstructured list with the given items for benchmarks.
+func buildUnstructuredList(listKind, apiVersion string, items []map[string]any) *unstructured.Unstructured {
+	anyItems := make([]any, len(items))
+	for i, item := range items {
+		anyItems[i] = item
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": apiVersion,
+			"kind":       listKind,
+			"metadata":   map[string]any{"resourceVersion": ""},
+			"items":      anyItems,
+		},
+	}
+}
+
+// BenchmarkFilterObj benchmarks the full FilterObj path through newResourceFilterer,
+// comparing fast matcher vs fallback at different item and rule counts.
+func BenchmarkFilterObj(b *testing.B) {
+	log := slog.New(slog.DiscardHandler)
+
+	mr := metaResource{
+		requestedResource: apiResource{
+			resourceKind: types.KindKubePod,
+			apiGroup:     "",
+		},
+		resourceDefinition: &metav1.APIResource{Namespaced: true},
+		verb:               types.KubeVerbList,
+	}
+
+	namespaces := []string{"default", "staging", "monitoring", "kube-system", "production"}
+
+	buildRules := func(ruleCount int) (allowed, denied []types.KubernetesResource) {
+		for i := range ruleCount {
+			allowed = append(allowed, types.KubernetesResource{
+				Kind:      types.KindKubePod,
+				Namespace: namespaces[i%len(namespaces)],
+				Name:      fmt.Sprintf("app-%d-*", i),
+				Verbs:     []string{types.KubeVerbList},
+				APIGroup:  "",
+			})
+		}
+		denied = []types.KubernetesResource{
+			{Kind: types.KindKubePod, Namespace: "default", Name: "secret-*", Verbs: []string{types.KubeVerbList}, APIGroup: ""},
+		}
+		return allowed, denied
+	}
+
+	buildItems := func(count int) ([]map[string]any, []any) {
+		items := make([]map[string]any, count)
+		for i := range items {
+			items[i] = map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]any{
+					"name":      fmt.Sprintf("pod-%d", i),
+					"namespace": namespaces[i%len(namespaces)],
+				},
+			}
+		}
+		saved := make([]any, len(items))
+		for i, item := range items {
+			saved[i] = item
+		}
+		return items, saved
+	}
+
+	newFilterer := func(b *testing.B, items []map[string]any, allowed, denied []types.KubernetesResource, useFastMatcher bool) (*resourceFilterer, *unstructured.Unstructured) {
+		b.Helper()
+		wrapper := newResourceFilterer(mr, &globalKubeCodecs, allowed, denied, log)
+		filter, err := wrapper(responsewriters.DefaultContentType, 200)
+		require.NoError(b, err)
+		rf := filter.(*resourceFilterer)
+		if useFastMatcher {
+			require.IsType(b, &fastMatcher{}, rf.matcher)
+		} else {
+			rf.matcher = &defaultMatcher{
+				kind:             mr.requestedResource.resourceKind,
+				verb:             mr.verb,
+				apiGroup:         mr.requestedResource.apiGroup,
+				isClusterWide:    mr.isClusterWideResource(),
+				allowedResources: allowed,
+				deniedResources:  denied,
+			}
+		}
+		obj := buildUnstructuredList("PodList", "v1", items)
+		return rf, obj
+	}
+
+	for _, ruleCount := range []int{4, 50, 150, 4000} {
+		allowed, denied := buildRules(ruleCount)
+
+		for _, itemCount := range []int{500, 5000} {
+			items, savedItems := buildItems(itemCount)
+			prefix := fmt.Sprintf("%d_rules/%d_items", ruleCount, itemCount)
+
+			b.Run(prefix+"/fast_matcher", func(b *testing.B) {
+				rf, obj := newFilterer(b, items, allowed, denied, true)
+				require.IsType(b, &fastMatcher{}, rf.matcher)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					obj.Object["items"] = savedItems
+					rf.FilterObj(obj)
+				}
+			})
+
+			b.Run(prefix+"/default_matcher", func(b *testing.B) {
+				rf, obj := newFilterer(b, items, allowed, denied, false)
+				require.IsType(b, &defaultMatcher{}, rf.matcher)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					obj.Object["items"] = savedItems
+					rf.FilterObj(obj)
+				}
+			})
+		}
+	}
+}

--- a/lib/kube/proxy/resource_filters.go
+++ b/lib/kube/proxy/resource_filters.go
@@ -56,15 +56,14 @@ func newResourceFilterer(mr metaResource, codecs *serializer.CodecFactory, allow
 			return nil, trace.Wrap(err)
 		}
 		return &resourceFilterer{
-			encoder:          encoder,
-			decoder:          decoder,
-			contentType:      contentType,
-			responseCode:     responseCode,
-			negotiator:       negotiator,
-			allowedResources: allowedResources,
-			deniedResources:  deniedResources,
-			log:              log,
-			metaResource:     mr,
+			encoder:      encoder,
+			decoder:      decoder,
+			contentType:  contentType,
+			responseCode: responseCode,
+			negotiator:   negotiator,
+			log:          log,
+			metaResource: mr,
+			matcher:      newMatcher(mr, allowedResources, deniedResources, log),
 		}, nil
 	}
 }
@@ -104,16 +103,45 @@ type resourceFilterer struct {
 	// negotiator is an instance of a client negotiator.
 	negotiator runtime.ClientNegotiator
 
-	// allowedResources is the list of kubernetes resources the user has access to.
-	allowedResources []types.KubernetesResource
-	// deniedResources is the list of kubernetes resources the user must not access.
-	deniedResources []types.KubernetesResource
-
 	// log is the logger.
 	log *slog.Logger
 
 	// metaResource contains the information about the resource being filtered.
 	metaResource metaResource
+
+	// matcher is the per-item RBAC matcher (either fast precompiled or fallback per-item).
+	matcher resourceMatcher
+}
+
+// resourceMatcher matches a Kubernetes resource by name and namespace.
+//
+// A Teleport RBAC rule has five fields: kind, verb, apiGroup, namespace, and name.
+// Only name and namespace vary per item in a list response.
+// The rest are constant for the entire request (determined by the URL and HTTP method),
+// so can be resolved once when the matcher is constructed.
+type resourceMatcher interface {
+	match(name, namespace string) (bool, error)
+}
+
+func newMatcher(mr metaResource, allowed, denied []types.KubernetesResource, log *slog.Logger) resourceMatcher {
+	// The fast matcher cannot handle namespace special cases in KubeResourceMatchesRegex
+	// (read-only namespace visibility, namespace kind matching with different target selection).
+	if mr.requestedResource.resourceKind != "namespaces" {
+		fm, err := newFastMatcher(mr, allowed, denied)
+		if err != nil {
+			log.DebugContext(context.Background(), "Failed to compile fast matcher, falling back to per-item matching", "error", err)
+		} else {
+			return fm
+		}
+	}
+	return &defaultMatcher{
+		kind:             mr.requestedResource.resourceKind,
+		verb:             mr.verb,
+		apiGroup:         mr.requestedResource.apiGroup,
+		isClusterWide:    mr.isClusterWideResource(),
+		allowedResources: allowed,
+		deniedResources:  denied,
+	}
 }
 
 // FilterBuffer receives a byte array, decodes the response into the appropriate
@@ -166,11 +194,7 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 			return hasElemts, true, nil
 		}
 
-		r := getKubeResource(d.metaResource.requestedResource.resourceKind, d.metaResource.requestedResource.apiGroup, d.metaResource.verb, o)
-		result, err := matchKubernetesResource(
-			r, d.metaResource.isClusterWideResource(),
-			d.allowedResources, d.deniedResources,
-		)
+		result, err := d.matcher.match(o.GetName(), o.GetNamespace())
 		if err != nil {
 			d.log.WarnContext(ctx, "Unable to compile regex expressions within kubernetes_resources", "error", err)
 		}
@@ -178,7 +202,7 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return result, false, nil
 
 	case *metav1.Table:
-		_, err := d.filterMetaV1Table(o, d.allowedResources, d.deniedResources)
+		_, err := d.filterMetaV1Table(o)
 		if err != nil {
 			return false, false, trace.Wrap(err)
 		}
@@ -278,12 +302,7 @@ type kubeObjectInterface interface {
 
 // filterResource validates if the user should access the current resource.
 func (d *resourceFilterer) filterResource(resource kubeObjectInterface) (bool, error) {
-	result, err := matchKubernetesResource(
-		getKubeResource(d.metaResource.requestedResource.resourceKind, d.metaResource.requestedResource.apiGroup, d.metaResource.verb, resource),
-		d.metaResource.isClusterWideResource(),
-		d.allowedResources, d.deniedResources,
-	)
-	return result, trace.Wrap(err)
+	return d.matcher.match(resource.GetName(), resource.GetNamespace())
 }
 
 func getKubeResource(kind, group, verb string, obj kubeObjectInterface) types.KubernetesResource {
@@ -298,7 +317,7 @@ func getKubeResource(kind, group, verb string, obj kubeObjectInterface) types.Ku
 
 // filterMetaV1Table filters the serverside printed table to exclude resources
 // that the user must not have access to.
-func (d *resourceFilterer) filterMetaV1Table(table *metav1.Table, allowedResources, deniedResources []types.KubernetesResource) (*metav1.Table, error) {
+func (d *resourceFilterer) filterMetaV1Table(table *metav1.Table) (*metav1.Table, error) {
 	resources := make([]metav1.TableRow, 0, len(table.Rows))
 	for i := range table.Rows {
 		row := &(table.Rows[i])
@@ -309,10 +328,10 @@ func (d *resourceFilterer) filterMetaV1Table(table *metav1.Table, allowedResourc
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if result, err := matchKubernetesResource(resource, d.metaResource.isClusterWideResource(), allowedResources, deniedResources); err == nil && result {
-			resources = append(resources, *row)
-		} else if err != nil {
+		if result, err := d.matcher.match(resource.Name, resource.Namespace); err != nil {
 			d.log.WarnContext(context.Background(), "Unable to compile regex expression", "error", err)
+		} else if result {
+			resources = append(resources, *row)
 		}
 	}
 	table.Rows = resources
@@ -441,17 +460,33 @@ func (d *resourceFilterer) filterUnstructuredList(obj *unstructured.Unstructured
 
 	filteredList := make([]any, 0, len(objList.Items))
 	for _, resource := range objList.Items {
-		gvk := resource.GroupVersionKind()
-		r := getKubeResource(d.metaResource.requestedResource.resourceKind, gvk.Group, d.metaResource.verb, &resource)
-		if result, err := matchKubernetesResource(
-			r, d.metaResource.isClusterWideResource(),
-			d.allowedResources, d.deniedResources,
-		); result {
-			filteredList = append(filteredList, resource.Object)
-		} else if err != nil {
+		if result, err := d.matcher.match(resource.GetName(), resource.GetNamespace()); err != nil {
 			slog.WarnContext(context.Background(), "Unable to compile regex expressions within kubernetes_resources", "error", err)
+		} else if result {
+			filteredList = append(filteredList, resource.Object)
 		}
 	}
 	obj.Object[itemsKey] = filteredList
 	return len(filteredList) > 0
+}
+
+// defaultMatcher uses the existing matchKubernetesResource path for per-item matching.
+type defaultMatcher struct {
+	kind             string
+	verb             string
+	apiGroup         string
+	isClusterWide    bool
+	allowedResources []types.KubernetesResource
+	deniedResources  []types.KubernetesResource
+}
+
+func (m *defaultMatcher) match(name, namespace string) (bool, error) {
+	resource := types.KubernetesResource{
+		Kind:      m.kind,
+		Namespace: namespace,
+		Name:      name,
+		Verbs:     []string{m.verb},
+		APIGroup:  m.apiGroup,
+	}
+	return matchKubernetesResource(resource, m.isClusterWide, m.allowedResources, m.deniedResources)
 }

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -77,12 +77,7 @@ func replaceRegexCached(expression string, config RegexpConfig) (*regexp.Regexp,
 		return expr, nil
 	}
 
-	if !strings.HasPrefix(expression, "^") || !strings.HasSuffix(expression, "$") {
-		// replace glob-style wildcards with regexp wildcards
-		// for plain strings, and quote all characters that could
-		// be interpreted in regular expression
-		expression = "^" + GlobToRegexp(expression) + "$"
-	}
+	expression = expressionToRegexp(expression)
 	if config.IgnoreCase {
 		expression = "(?i)" + expression
 	}
@@ -197,7 +192,7 @@ func KubeResourceMatchesRegex(input types.KubernetesResource, isClusterWideResou
 		// it doesn't match.
 		// When the resource has a wildcard verb, we only allow one verb in the
 		// resource input.
-		if !isVerbAllowed(resource.Verbs, verb) {
+		if !IsVerbAllowed(resource.Verbs, verb) {
 			continue
 		}
 		switch {
@@ -293,7 +288,7 @@ func KubeResourceCouldMatchRules(input types.KubernetesResource, isClusterWideRe
 		// it doesn't match.
 		// When the resource has a wildcard verb, we only allow one verb in the
 		// resource input.
-		if !isVerbAllowed(resource.Verbs, verb) {
+		if !IsVerbAllowed(resource.Verbs, verb) {
 			continue
 		}
 		switch {
@@ -362,10 +357,9 @@ func KubeResourceCouldMatchRules(input types.KubernetesResource, isClusterWideRe
 	return false, nil
 }
 
-// isVerbAllowed returns true if the verb is allowed in the resource.
-// If the resource has a wildcard verb, it matches all verbs, otherwise
-// the resource must have the verb we're looking for.
-func isVerbAllowed(allowedVerbs []string, verb string) bool {
+// IsVerbAllowed returns true if the verb is allowed in the resource.
+// It short-circuits on a wildcard in position 0, otherwise checks whether the verb appears in the list.
+func IsVerbAllowed(allowedVerbs []string, verb string) bool {
 	return len(allowedVerbs) != 0 && (allowedVerbs[0] == types.Wildcard || slices.Contains(allowedVerbs, verb))
 }
 
@@ -420,16 +414,26 @@ func MatchString(input, expression string) (bool, error) {
 	return expr.MatchString(input), nil
 }
 
+// IsRegexp returns true if the expression is a raw regex pattern (starts with ^ and ends with $).
+func IsRegexp(expression string) bool {
+	return strings.HasPrefix(expression, "^") && strings.HasSuffix(expression, "$")
+}
+
+// expressionToRegexp converts a Teleport expression to a regexp string.
+func expressionToRegexp(expression string) string {
+	if IsRegexp(expression) {
+		return expression
+	}
+	// replace glob-style wildcards with regexp wildcards
+	// for plain strings, and quote all characters that could
+	// be interpreted in regular expression
+	return "^" + GlobToRegexp(expression) + "$"
+}
+
 // CompileExpression compiles the given regex expression with Teleport's custom globbing
 // and quoting logic.
 func CompileExpression(expression string) (*regexp.Regexp, error) {
-	if !strings.HasPrefix(expression, "^") || !strings.HasSuffix(expression, "$") {
-		// replace glob-style wildcards with regexp wildcards
-		// for plain strings, and quote all characters that could
-		// be interpreted in regular expression
-		expression = "^" + GlobToRegexp(expression) + "$"
-	}
-
+	expression = expressionToRegexp(expression)
 	expr, err := regexp.Compile(expression)
 	if err != nil {
 		return nil, trace.BadParameter("%s", err)


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/63204

## Summary

Adds a precompiled per-request fast matcher for RBAC filtering of Kubernetes resource lists, reducing matching latency and eliminating per-item allocations.

## Background

When a user runs `kubectl get pods`, k8s apiserver returns all pods, and Teleport filters the response based on the user's RBAC rules before sending it back.
For each item in the list, `matchKubernetesResource` is called for checking the item against every allow and deny rule.

Each rule check goes through `KubeResourceMatchesRegex` in `lib/utils/replace.go`, which matches the item's name, namespace, and API group against the rule's patterns.
The patterns support exact strings, glob wildcards (`*`), and explicit regexes (`^...$`).

### The existing optimization: cached regex compilation

Regex compilation is expensive, so Teleport already caches compiled regexes in a global LRU cache.

This is effective, regex compilation cost is essentially zero after the first request.
But the per-item overhead that remains is not regex compilation. It's everything around it.

### How the numbers add up

The standard Kubernetes page size is 500 items.
This is universal across kubectl, client-go, ArgoCD and virtually every k8s client. So 500 items is the realistic per-response size.

Consider a user with 3 allow rules and 1 deny rule listing 500 pods (one page). For each pod, the current code:

1. Checks deny rules: calls `KubeResourceMatchesRegex` which iterates the 1 deny rule:
   - `isVerbAllowed(["list"], "list")` - slice scan
   - `input.Kind != resource.Kind` - string comparison
   - `MatchString(apiGroup, rule.APIGroup)` - hash key -> LRU map lookup -> LRU move-to-front -> `regexp.MatchString`
   - `MatchString(name, rule.Name)` - same LRU overhead
   - If those pass: `MatchString(namespace, rule.Namespace)` - same again

2. Checks allow rules: same process for 3 allow rules, stopping at first match.

For a single pod against these rules, that's 8 LRU cache lookups, 3 verb checks, 3 kind comparisons.
Each LRU lookup hashes a struct key, probes a map, and updates a linked list (move to front on hit).

Multiply by 500 pods:

- ~3,000–4,000 LRU cache lookups (depends on early exit patterns)
- 500 x 4 verb checks and kind comparisons

Benchmarked at 0.33ms per 500 pod page through `FilterObj`, with 1,514 allocations and 34KB allocated.

## This optimization

The key finding: for a given list request, the kind, verb, and API group are the same for every item. There's no reason to check them 500 times.

`tryCompileFastMatcher` runs once when the filter is created (once per HTTP request).

It does two things:

1. **Pre-filters rules** by kind and verb, only rules that could match this request survive. A user might have 20 rules across different resource types, but only 3 are for pods with the `list` verb. The other 17 are discarded at compile time, not checked per item.

2. **Pre-compiles regex patterns** - calls `regexp.Compile` for each surviving rule's name, namespace, and API group patterns. The compiled `*regexp.Regexp` is stored directly on a struct field.

Then for each item, `fastResourceMatcher.match(name, namespace, apiGroup)` does direct `regexp.MatchString` calls on the pre-compiled regexes. No struct allocation, no verb check, no kind check, no LRU cache lookup.

### What we avoid per item

| Per-item work | Before | After |
|---|---|---|
| `[]string{"list"}` allocation | every item | eliminated |
| Verb check (`slices.Contains`) | per item x per rule | done once at compile |
| Kind comparison | per item x per rule | done once at compile |
| LRU cache lookup per regex | hash + map probe + linked list update | direct `regexp.MatchString` on struct field |
| Rule iteration scope | all rules | only kind/verb-matching rules |

### Fallback

The fast matcher falls back to `matchKubernetesResource` in only one case:

1. **Namespace-kind requests** - `kubectl get namespaces` has special matching logic in `KubeResourceMatchesRegex` that the fast matcher can't replicate. These requests are rare compared to pod/deployment/configmap lists.

### Benchmark results

Full `FilterObj` pipeline, varying rule count and item count. 500 items is the standard Kubernetes page size; 5000 is included for comparison with unpaginated clients.

```
                                              ns/op         B/op    allocs/op
4_rules/500_items/fast_matcher-12            136,000       25,611      1,014
4_rules/500_items/fallback-12                332,000       33,613      1,514
4_rules/5000_items/fast_matcher-12         1,370,000      316,779     10,020
4_rules/5000_items/fallback-12             3,346,000      396,789     15,020

50_rules/500_items/fast_matcher-12           970,000       25,612      1,014
50_rules/500_items/fallback-12             2,302,000       33,615      1,514
50_rules/5000_items/fast_matcher-12       10,257,000      316,782     10,020
50_rules/5000_items/fallback-12           23,668,000      396,825     15,020

150_rules/500_items/fast_matcher-12        2,412,000       25,611      1,014
150_rules/500_items/fallback-12            6,342,000       33,618      1,514
150_rules/5000_items/fast_matcher-12      28,833,000      316,790     10,020
150_rules/5000_items/fallback-12          69,152,000      396,863     15,020
```

Summary at the standard 500-item page size:

| Rules | fast_matcher | fallback | Speedup |
|---|---|---|---|
| 4 | 0.14ms | 0.33ms | 59% |
| 50 | 0.97ms | 2.30ms | 58% |
| 150 | 2.41ms | 6.34ms | 62% |

The fast matcher wins consistently across all combinations.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment

Kind cluster running a custom Teleport build from this branch. Test scenarios from the [Kubernetes RBAC section](https://github.com/gravitational/teleport/blob/master/.github/ISSUE_TEMPLATE/testplan.md#kubernetes-rbac) of the manual test plan.

### Test Cases

  - [x] Verify role v7 with multiple resources. Examples are given for `pod`, but should also be tested with `deployment` and `clusterrole`:
    - [x] Verify the following scenarios for `kubernetes_resources`:
      - [x] `{"kind":"pod","name":"*","namespace":"*"}` - must allow access to every pod
      - [x] `{"kind":"pod","name":"somename","namespace":"*"}` - must allow access to pod `somename` in every namespace
      - [x] `{"kind":"pod","name":"*","namespace":"<somenamespace>"}` - must allow access to any pod in `<somenamespace>` namespace
      - [x] Verify support for `*` wildcards - `myapp-*` and regex for `name` and `namespace` fields
      - [x] Verify support for delete pods collection (`kubectl delete --raw=/api/v1/namespaces/<namespace name>/pods`)
    - [x] Verify scenarios with multiple roles defining `kubernetes_resources`:
      - [x] Validate that the returned list of pods is the union of every role
      - [x] Validate that access to other pods is denied by RBAC
      - [x] Validate that the Kubernetes Groups/Users are correctly selected depending on the role that applies to the pod
        - [x] Test with a `kubernetes_groups` that denies exec into a pod
    - [x] Verify kind wildcard `{"kind":"*","name":"*","namespace":"foo"}`:
      - [x] Verify access to namespaced resources like `pods`, `deployments` in the `foo` namespace
      - [x] Verify access to global resources like `clusterroles`, `nodes`
      - [x] Verify access to namespaced CRD `crontabs` and cluster-wide CRD `globals`
    - [x] Verify special `namespace` kind `{"kind":"namespace","name":"foo"}` (different behavior than rolev8)
      - [x] Verify access to namespaced resources `pods`, `deployments` in the `foo` namespace
      - [x] Verify access to the namespaced CRD `crontabs` in the `foo` namespace
      - [x] Verify access denied to global resources like `clusterroles` and `nodes`
  - [x] Upgrade role v7 to v8:
    - [x] Attempt to upgrade without looking at the docs, the errors should be descriptive enough (using the CLI and using the Web editor)
    - [x] Attempt to use a rolev7 value in kind with wildcard or matching api group, the following should yield a descriptive error:
      - [x] kind: pod, no api_group
      - [x] kind: deployment, api_group apps
      - [x] kind: jobs, api_group '*'
  - [x] Verify role v8
    - [x] Namespaced CRD
      - [x] Restart kuberbetes_service after creating the CRDs above
      - [x] Verify you don't have access to the namespaced CRD `crontabs` in any namespace
      - [x] Grant access to it with `{"kind":"crontabs","api_group":"stable.example.com","namespace":"foo",...}`
      - [x] Verify you have access to the custom resources in the `foo` namespace and no acess in `dev` and `prod` namespaces.
      - [x] Verify wildcard api_group `{"kind":"crontabs","api_group":"*.example.com","namespace":"dev",...}`
      - [x] Verify you have access to the custom resources in the `dev` namespace
    - [x] Cluster-wide CRD
      - [x] Restart kuberbetes_service after creating the CRDs above
      - [x] Verify you don't have access to the cluster-wide CRD `globals`
      - [x] Grant access to a wrong api_group with:  `{"kind":"globals","namespace":"",...}` (missing api_group)
      - [x] Verify you still don't have access
      - [x] Grant access to it with `{"kind":"globals","api_group":"*","namespace":"",...}`
      - [x] Verify you have access to the `globals` cluster-wide resource
    - [x] Verify namespace kind
      - [x] Grant access to a namespace with `{"kind":"namespaces","namespace":"foo",...}`
      - [x] Verify you can access the namespace itself
      - [x] Verify you don't have access to any resource within the namespace nor cluster-wide resources
    - [x] Verify kind wildcard - global
      - [x] Grant a wildcard kind access with wildcard ns `{"kind":"*","name":"*","namespace":"*","api_group":"*","verbs":["*"]}`
      - [x] Verify access to namespaced resources like `pods`, `deployments`, including namespaced CRD `crontabs`
      - [x] Verify access to cluster-wide resources `clusterroles`, `nodes`, including cluster-wide CRD `globals`
    - [x] Verify kind wildcard - cluster-wide
      - [x] Grant a wildcard kind acess without namespace `{"kind":"*","name":"*","namespace":"","api_group":"*","verbs":["*"]}`
      - [x] Verify access to cluster-wide resources `clusterroles`, `nodes`, including cluster-wide CRDs `globals`
      - [x] Verify access denied to namespaced resources `pods`, `deployments`, `services`, including namespaced CRDs `globals`
    - [x] Verify deny access to CRDs
      - [x] Grant full access to everything in the allow section: `{"kind":"*","name":"*","namespace":"*","api_group":"*","verbs":["*"]}`
      - [x] Add a deny rule to a specific namespaced CRD `{"kind":"crontabs","name":"*","namespace":"*","api_group":"*","verbs":["*"]}`
      - [x] Verify access denied
      - [x] Add a deny rule to a specific cluster-wide CRD `{"kind":"crontabs","name":"*","namespace":"","api_group":"stable.example.com","verbs":["*"]}`
      - [x] Verify access denied

## End-to-End Test Results

The precompiled fast matcher was A/B tested on a live EKS cluster.
Two Teleport installations: one from the base commit (no fast matcher) and one from the PR branch, served the same Kubernetes resources with identical RBAC rules. 
End-to-end `kubectl get configmaps` latency was measured in-cluster across rule counts from 10 to 2,000.

At low rule counts (10–100), the improvement is in the noise. At 500+ rules, the fast matcher shows measurable gains. At 2,000 rules, the fast matcher is **15.8x faster**, reducing a 23-second request to 1.5 seconds.

5,000 ConfigMaps, default kubectl pagination (500 items/page), 10 runs + 2 warmup, [hyperfine](https://github.com/sharkdp/hyperfine):

| Rules | Base (no optimization) | Fast Matcher | Improvement |
|------:|----------------------:|-------------:|------------:|
| 10 | 831ms | 858ms | — |
| 100 | 952ms | 1,006ms | — |
| 500 | 1,029ms | 973ms | **5%** |
| 1,000 | 1,977ms | 1,144ms | **42%** |
| 2,000 | 23,305ms | 1,477ms | **15.8x** |

**Infrastructure**

- **EKS cluster:** `dev-cenk`, us-west-2, t3.xlarge node
- **Base build:** fork point commit `b9082bd09ef`, deployed to `perf-base` namespace
- **Fast matcher build:** PR branch HEAD `d540eb2f37`, deployed to `perf-fast-matcher` namespace
- Both deployed via `teleport-cluster` Helm chart with custom Docker images (cross-compiled linux/amd64 with `go build -tags webassets_embed`, layered on `teleport-distroless:18.7.1`, pushed to private ECR)
- Both installations serve the same EKS cluster's Kubernetes API
- **Test data:** 5,000 ConfigMaps in `perf-test-data` namespace (3,500 `cm-*`, 1500 `other-*`)
- **RBAC:** Single role with N allow rules (all `kind: configmaps`, `namespace: perf-test-*`, glob pattern `cm-{i}*`)

**Benchmark Execution**

An Ubuntu pod ran inside the EKS cluster with kubectl, hyperfine, and tbot.

The benchmark command:

```bash
hyperfine --warmup 2 --runs 10 \
  'kubectl get configmaps -n perf-test-data --chunk-size=500'
```

**Analysis**

1. **The fast matcher is algorithmically faster, not just cache-friendly.** Even with a 10x larger LRU cache (zero thrashing), the default matcher is 3–17x slower. The improvement comes from eliminating per-item rule iteration, LRU cache lookups, and allocations.

2. **Below 500 rules, the end-to-end improvement is negligible.** Matching is a small fraction of total time (K8s API call + TLS + decode + encode). At 10–100 rules, matching takes <2ms out of ~800ms.

3. **At 1,000+ rules, the improvement is significant.** The default matcher iterates all rules for every item, performing up to 3 LRU cache lookups per rule (apiGroup, name, namespace) plus verb and kind checks. The fast matcher pre-compiles and pre-filters rules once, then does direct regex matches with no cache lookups.

4. **At 2,000 rules, the default matcher degrades severely.** The per-item cost grows linearly with rule count, and the cumulative overhead across ~7 paginated requests pushes total latency to 23 seconds. The fast matcher's one-time compilation cost is amortized across all items, keeping total time under 1.5 seconds.

5. **The fast matcher's time stays roughly constant** (~0.9–1.5s) across all rule counts, while the base build degrades from 0.8s to 23s.
