### PR TITLE
[v18]  Add `tsh aws-profile` to Generate AWS Profiles from AWS Identity Center Integration

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -834,6 +834,8 @@ const (
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
 	AWSAccountIDLabel = TeleportNamespace + "/account-id"
+	// AWSAccountNameLabel is the human-readable AWS account name label.
+	AWSAccountNameLabel = TeleportNamespace + "/account-name"
 	// AWSInstanceIDLabel is used to identify nodes by EC2 instance ID
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
@@ -841,6 +843,8 @@ const (
 	// AWSInstanceRegion is used to identify the region an EC2
 	// instance is running in
 	AWSInstanceRegion = TeleportNamespace + "/aws-region"
+	// AWSSSORegionLabel is the AWS Identity Center SSO region label.
+	AWSSSORegionLabel = TeleportNamespace + "/sso-region"
 	// SubscriptionIDLabel is used to identify virtual machines by Azure
 	// subscription ID found via automatic discovery, to avoid re-running
 	// installation commands on the node.

--- a/lib/aws/awsconfigfile/awsconfigfile.go
+++ b/lib/aws/awsconfigfile/awsconfigfile.go
@@ -17,6 +17,7 @@
 package awsconfigfile
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,7 +27,8 @@ import (
 )
 
 const (
-	ownershipComment = "Do not edit. Section managed by Teleport."
+	ownershipComment    = "Do not edit. Section managed by Teleport."
+	ssoOwnershipComment = "Do not edit. Section managed by Teleport (AWS Identity Center integration)."
 )
 
 // AWSConfigFilePath returns the path to the AWS configuration file.
@@ -42,6 +44,152 @@ func AWSConfigFilePath() (string, error) {
 	}
 
 	return filepath.Join(homedir, ".aws", "config"), nil
+}
+
+// SSOSession represents an AWS SSO session configuration.
+type SSOSession struct {
+	// Name is the session name.
+	Name string
+	// StartURL is the SSO start URL.
+	StartURL string
+	// Region is the SSO region.
+	Region string
+}
+
+// SSOProfile represents an AWS Identity Center profile configuration.
+type SSOProfile struct {
+	// Name is the profile name.
+	Name string
+	// Session is the name of the SSO session.
+	Session string
+	// AccountID is the AWS account ID.
+	AccountID string
+	// RoleName is the name of the IAM role.
+	RoleName string
+	// Account is the AWS account name or alias.
+	Account string
+}
+
+// WriteSSOConfig writes multiple SSO profiles and sessions to the AWS configuration file in a single pass,
+// and prunes any stale Teleport-managed SSO sections.
+func WriteSSOConfig(configFilePath string, profiles []SSOProfile, sessions []SSOSession) error {
+	return writeSSOConfig(configFilePath, profiles, sessions, nil)
+}
+
+// PrintSSOConfig simulates writing multiple SSO profiles and sessions by printing the result to the provided writer,
+// without modifying the AWS configuration file on disk.
+func PrintSSOConfig(configFilePath string, profiles []SSOProfile, sessions []SSOSession, out io.Writer) error {
+	return writeSSOConfig(configFilePath, profiles, sessions, out)
+}
+
+func writeSSOConfig(configFilePath string, profiles []SSOProfile, sessions []SSOSession, out io.Writer) error {
+	iniFile, err := ini.LoadSources(ini.LoadOptions{
+		AllowNestedValues: true,
+		Loose:             true,
+	}, configFilePath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	keepProfiles := make(map[string]struct{})
+	keepSessions := make(map[string]struct{})
+
+	// Add/Update sessions.
+	for _, s := range sessions {
+		sectionName := "sso-session " + s.Name
+		keepSessions[sectionName] = struct{}{}
+
+		section, err := getOrCreateManagedSection(iniFile, sectionName, ssoOwnershipComment)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		section.Comment = ssoOwnershipComment
+		if _, err := section.NewKey("sso_start_url", s.StartURL); err != nil {
+			return trace.Wrap(err)
+		}
+		if _, err := section.NewKey("sso_region", s.Region); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	// Add/Update profiles.
+	for _, p := range profiles {
+		sectionName := "profile " + p.Name
+		keepProfiles[sectionName] = struct{}{}
+
+		section, err := getOrCreateManagedSection(iniFile, sectionName, ssoOwnershipComment)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if section.HasKey("credential_process") {
+			return trace.BadParameter("%s: section %q contains 'credential_process' and cannot be converted to an SSO profile, remove the section and try again", configFilePath, section.Name())
+		}
+
+		section.Comment = ssoOwnershipComment
+		if _, err := section.NewKey("sso_session", p.Session); err != nil {
+			return trace.Wrap(err)
+		}
+		if _, err := section.NewKey("sso_account_id", p.AccountID); err != nil {
+			return trace.Wrap(err)
+		}
+		if _, err := section.NewKey("sso_role_name", p.RoleName); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	// Prune stale sections.
+	for _, section := range iniFile.Sections() {
+		if !strings.Contains(section.Comment, ssoOwnershipComment) {
+			continue
+		}
+
+		name := section.Name()
+		shouldDelete := false
+		switch {
+		case strings.HasPrefix(name, "profile "):
+			if _, ok := keepProfiles[name]; !ok {
+				shouldDelete = true
+			}
+		case strings.HasPrefix(name, "sso-session "):
+			if _, ok := keepSessions[name]; !ok {
+				shouldDelete = true
+			}
+		}
+
+		if shouldDelete {
+			iniFile.DeleteSection(name)
+		}
+	}
+
+	if out != nil {
+		_, err := iniFile.WriteTo(out)
+		return trace.Wrap(err)
+	}
+
+	// Create the directory if it does not exist.
+	if err := os.MkdirAll(filepath.Dir(configFilePath), 0o700); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(iniFile.SaveTo(configFilePath))
+}
+
+func getOrCreateManagedSection(iniFile *ini.File, sectionName, expectedComment string) (*ini.Section, error) {
+	if iniFile.HasSection(sectionName) {
+		section := iniFile.Section(sectionName)
+		if !strings.Contains(section.Comment, expectedComment) {
+			return nil, trace.BadParameter("section %q is not managed by Teleport, remove the section and try again", sectionName)
+		}
+		return section, nil
+	}
+
+	section, err := iniFile.NewSection(sectionName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return section, nil
 }
 
 // SetDefaultProfileCredentialProcess sets the credential_process for the default profile.
@@ -95,7 +243,7 @@ func addCredentialProcessToSection(configFilePath, sectionName, credentialProces
 	}
 
 	// Create the directory if it does not exist, otherwise ini.SaveTo will fail.
-	if err := os.MkdirAll(filepath.Dir(configFilePath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configFilePath), 0o700); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/aws/awsconfigfile/awsconfigfile_test.go
+++ b/lib/aws/awsconfigfile/awsconfigfile_test.go
@@ -244,7 +244,12 @@ credential_process = credential_process
 		err := SetDefaultProfileCredentialProcess(configFilePath, "credential_process")
 		require.NoError(t, err)
 
-		require.DirExists(t, filepath.Join(tmpDir, "dir"))
+		dir := filepath.Join(tmpDir, "dir")
+		require.DirExists(t, dir)
+		info, err := os.Stat(dir)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0700), info.Mode().Perm())
+
 		bs, err := os.ReadFile(configFilePath)
 		require.NoError(t, err)
 		require.Equal(t, `; Do not edit. Section managed by Teleport.
@@ -436,6 +441,42 @@ credential_process = process
 	}
 }
 
+func TestSSORemovalGuard(t *testing.T) {
+	configFilePath := filepath.Join(t.TempDir(), "config")
+
+	// 1. Create a transient profile (managed by old comment)
+	err := UpsertProfileCredentialProcess(configFilePath, "transient", "tsh apps config --format aws-credential-process app")
+	require.NoError(t, err)
+
+	// 2. Create an SSO session and profile (managed by new SSO comment)
+	err = WriteSSOConfig(configFilePath,
+		[]SSOProfile{{Name: "sso-profile", Session: "sso-session", AccountID: "123", RoleName: "Admin"}},
+		[]SSOSession{{Name: "sso-session", StartURL: "https://start.url", Region: "us-east-1"}},
+	)
+	require.NoError(t, err)
+
+	// 3. Verify they all exist
+	content, err := os.ReadFile(configFilePath)
+	require.NoError(t, err)
+	s := string(content)
+	require.Contains(t, s, "[profile transient]")
+	require.Contains(t, s, "[sso-session sso-session]")
+	require.Contains(t, s, "[profile sso-profile]")
+
+	// 4. Run RemoveAllTeleportManagedProfiles (simulating 'tsh apps logout')
+	err = RemoveAllTeleportManagedProfiles(configFilePath)
+	require.NoError(t, err)
+
+	// 5. Verify transient is gone, but SSO sections remain
+	content, err = os.ReadFile(configFilePath)
+	require.NoError(t, err)
+	s = string(content)
+
+	require.NotContains(t, s, "[profile transient]", "Transient profile should be removed on logout")
+	require.Contains(t, s, "[sso-session sso-session]", "SSO session should persist after logout")
+	require.Contains(t, s, "[profile sso-profile]", "SSO profile should persist after logout")
+}
+
 func TestUpdateRemoveCycle(t *testing.T) {
 	initialContents := "[profile baz]\nregion = us-east-1\n\n[default]\nregion = us-west-2\n"
 	configFilePath := filepath.Join(t.TempDir(), "config")
@@ -460,4 +501,149 @@ func TestUpdateRemoveCycle(t *testing.T) {
 	bs, err := os.ReadFile(configFilePath)
 	require.NoError(t, err)
 	require.Equal(t, initialContents, string(bs))
+}
+func TestSSOConfig(t *testing.T) {
+	t.Run("WriteSSOConfig creates directory and writes session", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configFilePath := filepath.Join(tmpDir, "dir", "config")
+
+		err := WriteSSOConfig(configFilePath,
+			nil,
+			[]SSOSession{{Name: "my-session", StartURL: "https://start.url", Region: "us-east-1"}},
+		)
+		require.NoError(t, err)
+
+		dir := filepath.Join(tmpDir, "dir")
+		require.DirExists(t, dir)
+		info, err := os.Stat(dir)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0700), info.Mode().Perm())
+
+		bs, err := os.ReadFile(configFilePath)
+		require.NoError(t, err)
+		require.Equal(t, `; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[sso-session my-session]
+sso_start_url = https://start.url
+sso_region    = us-east-1
+`, string(bs))
+	})
+
+	t.Run("WriteSSOConfig writes profile", func(t *testing.T) {
+		configFilePath := filepath.Join(t.TempDir(), "config")
+
+		err := WriteSSOConfig(configFilePath,
+			[]SSOProfile{{Name: "my-profile", Session: "my-session", AccountID: "123456789012", RoleName: "Admin"}},
+			[]SSOSession{{Name: "my-session", StartURL: "https://start.url", Region: "us-east-1"}},
+		)
+		require.NoError(t, err)
+
+		bs, err := os.ReadFile(configFilePath)
+		require.NoError(t, err)
+		require.Equal(t, `; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[sso-session my-session]
+sso_start_url = https://start.url
+sso_region    = us-east-1
+
+; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[profile my-profile]
+sso_session    = my-session
+sso_account_id = 123456789012
+sso_role_name  = Admin
+`, string(bs))
+	})
+
+	t.Run("WriteSSOConfig errors on credential_process", func(t *testing.T) {
+		configFilePath := filepath.Join(t.TempDir(), "config")
+		initial := `; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[profile my-profile]
+credential_process = some-command
+`
+		err := os.WriteFile(configFilePath, []byte(initial), 0600)
+		require.NoError(t, err)
+
+		err = WriteSSOConfig(configFilePath,
+			[]SSOProfile{{Name: "my-profile", Session: "my-session", AccountID: "123456789012", RoleName: "Admin"}},
+			nil,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "contains 'credential_process' and cannot be converted to an SSO profile")
+	})
+
+	t.Run("WriteSSOConfig handles updates", func(t *testing.T) {
+		configFilePath := filepath.Join(t.TempDir(), "config")
+
+		err := WriteSSOConfig(configFilePath,
+			nil,
+			[]SSOSession{{Name: "my-session", StartURL: "https://start.url", Region: "us-east-1"}},
+		)
+		require.NoError(t, err)
+
+		err = WriteSSOConfig(configFilePath,
+			nil,
+			[]SSOSession{{Name: "my-session", StartURL: "https://new.url", Region: "us-west-2"}},
+		)
+		require.NoError(t, err)
+
+		bs, err := os.ReadFile(configFilePath)
+		require.NoError(t, err)
+		require.Equal(t, `; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[sso-session my-session]
+sso_start_url = https://new.url
+sso_region    = us-west-2
+`, string(bs))
+	})
+}
+
+func TestWriteSSOConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config")
+
+	initialContent := `[profile external]
+region = us-west-2
+
+; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[sso-session teleport-stale]
+sso_start_url = https://stale.url
+sso_region = us-east-1
+
+; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[profile teleport-stale-profile]
+sso_session = teleport-stale
+`
+	err := os.WriteFile(configPath, []byte(initialContent), 0600)
+	require.NoError(t, err)
+
+	profiles := []SSOProfile{
+		{
+			Name:      "new-profile",
+			Session:   "new-session",
+			AccountID: "123",
+			RoleName:  "Admin",
+		},
+	}
+	sessions := []SSOSession{
+		{
+			Name:     "new-session",
+			StartURL: "https://new.url",
+			Region:   "us-east-1",
+		},
+	}
+
+	err = WriteSSOConfig(configPath, profiles, sessions)
+	require.NoError(t, err)
+
+	bs, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	content := string(bs)
+
+	// External preserved
+	require.Contains(t, content, "[profile external]")
+
+	// New sections added
+	require.Contains(t, content, "[sso-session new-session]")
+	require.Contains(t, content, "[profile new-profile]")
+	require.Contains(t, content, "sso_start_url = https://new.url")
+
+	// Stale sections pruned
+	require.NotContains(t, content, "[sso-session teleport-stale]")
+	require.NotContains(t, content, "[profile teleport-stale-profile]")
 }

--- a/tool/tsh/common/aws_profile.go
+++ b/tool/tsh/common/aws_profile.go
@@ -1,0 +1,233 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/aws/awsconfigfile"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+// onAWSProfile generates AWS configuration for AWS Identity Center integration.
+// It's a noop if there are no AWS Identity Center integrations.
+func onAWSProfile(cf *CLIConf) error {
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var resources types.EnrichedResources
+	err = client.RetryWithRelogin(cf.Context, tc, func() error {
+		clt, err := tc.ConnectToCluster(cf.Context)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clt.Close()
+
+		// Fetch all app resources from the cluster.
+		resources, err = apiclient.GetAllUnifiedResources(cf.Context, clt.AuthClient, &proto.ListUnifiedResourcesRequest{
+			Kinds:         []string{types.KindApp},
+			IncludeLogins: true, // This enables permission set filtering for AWS IC apps
+		})
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	icApps := filterAWSIdentityCenterApps(resources)
+
+	configPath, err := awsconfigfile.AWSConfigFilePath()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Write into AWS config file.
+	writtenProfiles, err := writeAWSConfig(configPath, cf.AWSSSORegion, icApps, cf.DryRun, cf.Stdout())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Output summary to user if not in dry-run mode.
+	if !cf.DryRun {
+		writeAWSProfileSummary(cf.Stdout(), configPath, writtenProfiles)
+	}
+
+	return nil
+}
+
+func filterAWSIdentityCenterApps(resources types.EnrichedResources) []types.Application {
+	var apps []types.Application
+	for _, resource := range resources {
+		app, ok := resource.ResourceWithLabels.(types.AppServer)
+		if !ok {
+			continue
+		}
+		if app.GetApp().GetIdentityCenter() == nil {
+			continue
+		}
+		apps = append(apps, app.GetApp())
+	}
+	return apps
+}
+
+func writeAWSConfig(configPath, ssoRegionOverride string, identityCenterApps []types.Application, dryRun bool, out io.Writer) ([]awsconfigfile.SSOProfile, error) {
+	sessionMap := make(map[string]awsconfigfile.SSOSession)
+	var profiles []awsconfigfile.SSOProfile
+
+	for _, app := range identityCenterApps {
+		startURL := extractAWSStartURL(app.GetURI())
+		sessionName := extractAWSSessionName(startURL)
+
+		if _, ok := sessionMap[sessionName]; !ok {
+			// Use the explicit flag if provided, otherwise read from the label
+			// set by the Identity Center sync.
+			region := ssoRegionOverride
+			if region == "" {
+				region, _ = app.GetLabel("teleport.dev/aws-sso-region")
+			}
+			if region == "" {
+				return nil, trace.BadParameter("could not determine SSO region for app %q; use --aws-sso-region to specify it", app.GetName())
+			}
+			sessionMap[sessionName] = awsconfigfile.SSOSession{
+				Name:     sessionName,
+				StartURL: startURL,
+				Region:   region,
+			}
+		}
+
+		awsIC := app.GetIdentityCenter()
+
+		accountName, _ := app.GetLabel("teleport.dev/account-name")
+		if accountName == "" {
+			accountName = awsIC.AccountID
+		}
+
+		// Prepare AWS profile for the combination of each permission set and account.
+		for _, ps := range awsIC.PermissionSets {
+			profileName := formatAWSProfileName(accountName, ps.Name)
+			profiles = append(profiles, awsconfigfile.SSOProfile{
+				Name:      profileName,
+				Session:   sessionName,
+				AccountID: awsIC.AccountID,
+				RoleName:  ps.Name,
+				Account:   accountName,
+			})
+		}
+	}
+
+	sessions := make([]awsconfigfile.SSOSession, 0, len(sessionMap))
+	for _, s := range sessionMap {
+		sessions = append(sessions, s)
+	}
+
+	if dryRun {
+		if err := awsconfigfile.PrintSSOConfig(configPath, profiles, sessions, out); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		if err := awsconfigfile.WriteSSOConfig(configPath, profiles, sessions); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return profiles, nil
+}
+
+func writeAWSProfileSummary(w io.Writer, configPath string, profiles []awsconfigfile.SSOProfile) {
+	if len(profiles) > 0 {
+		fmt.Fprintf(w, "AWS configuration updated at: %s\n", configPath)
+		fmt.Fprintln(w)
+
+		table := asciitable.MakeTable([]string{"Profile", "Account", "Account ID", "Role", "SSO Session"})
+		for _, p := range profiles {
+			table.AddRow([]string{p.Name, p.Account, p.AccountID, p.RoleName, p.Session})
+		}
+		table.WriteTo(w)
+		fmt.Fprintln(w)
+
+		fmt.Fprintf(w, "To use these profiles, set the AWS_PROFILE environment variable and authenticate with AWS. Example:\n")
+		fmt.Fprintf(w, "  export AWS_PROFILE=%s\n", profiles[0].Name)
+		fmt.Fprintf(w, "  aws sso login\n")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "You can now run AWS commands. Example:\n")
+		fmt.Fprintf(w, "  aws s3 ls\n")
+		fmt.Fprintln(w)
+	} else {
+		fmt.Fprintln(w, "No AWS Identity Center accounts or roles available for the current user.")
+	}
+}
+
+// awsProfileNameRegex is used to sanitize AWS profile names. The AWS CLI supports relatively
+// arbitrary characters in profile names, but since these are derived from AWS IAM roles and Account
+// names remotely, we restrict them heavily to prevent INI injection in configuration blocks.
+var awsProfileNameRegex = regexp.MustCompile(`[^a-zA-Z0-9_\-]`)
+
+func formatAWSProfileName(accountName, roleName string) string {
+	accName := strings.ReplaceAll(accountName, " ", "-")
+	rName := strings.ReplaceAll(roleName, " ", "-")
+	combined := fmt.Sprintf("teleport-awsic-%s-%s", accName, rName)
+	return strings.ToLower(awsProfileNameRegex.ReplaceAllString(combined, ""))
+}
+
+func extractAWSStartURL(rawURL string) string {
+	// Identity Center Start URLs use '#' to separate the portal base URL from the specific console path.
+	// Standard: https://<subdomain>.awsapps.com/start/#/console...
+	// GovCloud: https://start.us-gov-home.awsapps.com/directory/<idSource>#/console...
+	if index := strings.Index(rawURL, "#"); index != -1 {
+		return strings.TrimSuffix(rawURL[:index], "/")
+	}
+
+	// Fallback to legacy behavior if anchor is missing but /start/ is present.
+	if index := strings.Index(rawURL, "/start/"); index != -1 {
+		return rawURL[:index+len("/start")]
+	}
+
+	return rawURL
+}
+
+func extractAWSSessionName(startURL string) string {
+	// For GovCloud, the unique identifier is at the end of the directory path.
+	// Pattern: https://start.us-gov-home.awsapps.com/directory/<idSource>
+	if index := strings.LastIndex(startURL, "/directory/"); index != -1 {
+		id := startURL[index+len("/directory/"):]
+		if id != "" {
+			return "teleport-" + id
+		}
+	}
+	// For standard partition, the unique identifier is the subdomain.
+	// Pattern: https://<idSource>.awsapps.com/start
+	raw := strings.TrimPrefix(startURL, "https://")
+	if dotIndex := strings.Index(raw, "."); dotIndex != -1 {
+		return "teleport-" + raw[:dotIndex]
+	}
+	// Rare: fallback to a hash of the URL if we can't find a subdomain to ensure uniqueness
+	return fmt.Sprintf("teleport-%x", sha256.Sum256([]byte(startURL)))[:16]
+}

--- a/tool/tsh/common/aws_profile.go
+++ b/tool/tsh/common/aws_profile.go
@@ -185,16 +185,27 @@ func writeAWSProfileSummary(w io.Writer, configPath string, profiles []awsconfig
 	}
 }
 
-// awsProfileNameRegex is used to sanitize AWS profile names. The AWS CLI supports relatively
+// invalidAWSProfileCharRegex is used to sanitize AWS profile names. The AWS CLI supports relatively
 // arbitrary characters in profile names, but since these are derived from AWS IAM roles and Account
 // names remotely, we restrict them heavily to prevent INI injection in configuration blocks.
-var awsProfileNameRegex = regexp.MustCompile(`[^a-zA-Z0-9_\-]`)
+var invalidAWSProfileCharRegex = regexp.MustCompile(`[^a-zA-Z0-9_\-]`)
 
 func formatAWSProfileName(accountName, roleName string) string {
 	accName := strings.ReplaceAll(accountName, " ", "-")
 	rName := strings.ReplaceAll(roleName, " ", "-")
 	combined := fmt.Sprintf("teleport-awsic-%s-%s", accName, rName)
-	return strings.ToLower(awsProfileNameRegex.ReplaceAllString(combined, ""))
+	
+	// Replace invalid characters with their hex equivalent (e.g., "@" -> "_x40")
+	// to maintain uniqueness while strictly using safe characters.
+	sanitized := invalidAWSProfileCharRegex.ReplaceAllStringFunc(combined, func(match string) string {
+		var sb strings.Builder
+		for _, r := range match {
+			fmt.Fprintf(&sb, "_x%x", r)
+		}
+		return sb.String()
+	})
+	
+	return strings.ToLower(sanitized)
 }
 
 func extractAWSStartURL(rawURL string) string {

--- a/tool/tsh/common/aws_profile.go
+++ b/tool/tsh/common/aws_profile.go
@@ -194,7 +194,7 @@ func formatAWSProfileName(accountName, roleName string) string {
 	accName := strings.ReplaceAll(accountName, " ", "-")
 	rName := strings.ReplaceAll(roleName, " ", "-")
 	combined := fmt.Sprintf("teleport-awsic-%s-%s", accName, rName)
-	
+
 	// Replace invalid characters with their hex equivalent (e.g., "@" -> "_x40")
 	// to maintain uniqueness while strictly using safe characters.
 	sanitized := invalidAWSProfileCharRegex.ReplaceAllStringFunc(combined, func(match string) string {
@@ -204,7 +204,7 @@ func formatAWSProfileName(accountName, roleName string) string {
 		}
 		return sb.String()
 	})
-	
+
 	return strings.ToLower(sanitized)
 }
 

--- a/tool/tsh/common/aws_profile.go
+++ b/tool/tsh/common/aws_profile.go
@@ -111,7 +111,7 @@ func writeAWSConfig(configPath, ssoRegionOverride string, identityCenterApps []t
 			// set by the Identity Center sync.
 			region := ssoRegionOverride
 			if region == "" {
-				region, _ = app.GetLabel("teleport.dev/aws-sso-region")
+				region, _ = app.GetLabel(types.AWSSSORegionLabel)
 			}
 			if region == "" {
 				return nil, trace.BadParameter("could not determine SSO region for app %q; use --aws-sso-region to specify it", app.GetName())
@@ -125,7 +125,7 @@ func writeAWSConfig(configPath, ssoRegionOverride string, identityCenterApps []t
 
 		awsIC := app.GetIdentityCenter()
 
-		accountName, _ := app.GetLabel("teleport.dev/account-name")
+		accountName, _ := app.GetLabel(types.AWSAccountNameLabel)
 		if accountName == "" {
 			accountName = awsIC.AccountID
 		}

--- a/tool/tsh/common/aws_profile_test.go
+++ b/tool/tsh/common/aws_profile_test.go
@@ -241,7 +241,7 @@ func TestWriteAWSConfig(t *testing.T) {
 	app1, err := types.NewAppV3(types.Metadata{
 		Name: "app1",
 		Labels: map[string]string{
-			"teleport.dev/account-name": "dev",
+			types.AWSAccountNameLabel: "dev",
 		},
 	}, types.AppSpecV3{
 		URI: "https://d-123.awsapps.com/start/#/",
@@ -322,8 +322,8 @@ func TestWriteAWSConfig_RegionFromLabel(t *testing.T) {
 	app1, err := types.NewAppV3(types.Metadata{
 		Name: "app1",
 		Labels: map[string]string{
-			"teleport.dev/account-name":   "dev",
-			"teleport.dev/aws-sso-region": "eu-west-1",
+			types.AWSAccountNameLabel: "dev",
+			types.AWSSSORegionLabel:   "eu-west-1",
 		},
 	}, types.AppSpecV3{
 		URI: "https://d-123.awsapps.com/start/#/",
@@ -352,8 +352,8 @@ func TestWriteAWSConfig_RegionFlagOverridesLabel(t *testing.T) {
 	app1, err := types.NewAppV3(types.Metadata{
 		Name: "app1",
 		Labels: map[string]string{
-			"teleport.dev/account-name":   "dev",
-			"teleport.dev/aws-sso-region": "eu-west-1",
+			types.AWSAccountNameLabel: "dev",
+			types.AWSSSORegionLabel:   "eu-west-1",
 		},
 	}, types.AppSpecV3{
 		URI: "https://d-123.awsapps.com/start/#/",
@@ -402,7 +402,7 @@ region = us-east-1
 	// Now write config for a set of apps that doesn't include the stale one.
 	app1, err := types.NewAppV3(types.Metadata{
 		Name:   "aws-ic-new",
-		Labels: map[string]string{"teleport.dev/account-name": "production"},
+		Labels: map[string]string{types.AWSAccountNameLabel: "production"},
 	}, types.AppSpecV3{
 		URI: "https://production.awsapps.com/start/#/console",
 		IdentityCenter: &types.AppIdentityCenter{

--- a/tool/tsh/common/aws_profile_test.go
+++ b/tool/tsh/common/aws_profile_test.go
@@ -149,10 +149,16 @@ func TestFormatAWSProfileName(t *testing.T) {
 			expected:    "teleport-awsic-123456789012-readonly",
 		},
 		{
+			desc:        "Account and Role with special characters",
+			accountName: "Finance#Dept",
+			roleName:    "Admin@Work",
+			expected:    "teleport-awsic-finance_x23dept-admin_x40work",
+		},
+		{
 			desc:        "Malicious INI injection characters",
 			accountName: "malicious \n[profile default]\n",
 			roleName:    "admin [!]",
-			expected:    "teleport-awsic-malicious-profile-default-admin-",
+			expected:    "teleport-awsic-malicious-_xa_x5bprofile-default_x5d_xa-admin-_x5b_x21_x5d",
 		},
 	}
 

--- a/tool/tsh/common/aws_profile_test.go
+++ b/tool/tsh/common/aws_profile_test.go
@@ -1,0 +1,437 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/aws/awsconfigfile"
+	"github.com/gravitational/teleport/lib/utils/testutils/golden"
+)
+
+func TestExtractAWSStartURL(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{
+			desc:     "URL with anchor",
+			input:    "https://d-92670253d5.awsapps.com/start/#/console?param=value",
+			expected: "https://d-92670253d5.awsapps.com/start",
+		},
+		{
+			desc:     "URL with subpath but no anchor",
+			input:    "https://d-92670253d5.awsapps.com/start/console",
+			expected: "https://d-92670253d5.awsapps.com/start",
+		},
+		{
+			desc:     "GovCloud URL",
+			input:    "https://start.us-gov-home.awsapps.com/directory/d-92671f2def#/console?account_id=987654321098",
+			expected: "https://start.us-gov-home.awsapps.com/directory/d-92671f2def",
+		},
+		{
+			desc:     "URL without anchor",
+			input:    "https://test.awsapps.com/start",
+			expected: "https://test.awsapps.com/start",
+		},
+		{
+			desc:     "Random URL",
+			input:    "https://aws.amazon.com",
+			expected: "https://aws.amazon.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expected, extractAWSStartURL(tc.input))
+		})
+	}
+}
+
+func TestExtractAWSSessionName(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{
+			desc:     "Standard AWS Identify Center URL",
+			input:    "https://d-92670253d5.awsapps.com/start",
+			expected: "teleport-d-92670253d5",
+		},
+		{
+			desc:     "URL with single subdomain",
+			input:    "https://mycompany.awsapps.com/start",
+			expected: "teleport-mycompany",
+		},
+		{
+			desc:     "GovCloud URL",
+			input:    "https://start.us-gov-home.awsapps.com/directory/d-92671f2def",
+			expected: "teleport-d-92671f2def",
+		},
+		{
+			desc:     "URL without subdomain subdomain (rare)",
+			input:    "https://awsapps.com/start",
+			expected: "teleport-awsapps",
+		},
+		{
+			desc:     "Fallback to hash for non-standard URL",
+			input:    "https://unknown-format",
+			expected: "teleport-95924c5", // SHA256 prefix of "https://unknown-format"
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expected, extractAWSSessionName(tc.input))
+		})
+	}
+}
+
+func TestFormatAWSProfileName(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		accountName string
+		roleName    string
+		expected    string
+	}{
+		{
+			desc:        "Standard lowercase",
+			accountName: "teleport-dev",
+			roleName:    "Admin",
+			expected:    "teleport-awsic-teleport-dev-admin",
+		},
+		{
+			desc:        "Case sensitivity check",
+			accountName: "Production-Account",
+			roleName:    "PowerUser",
+			expected:    "teleport-awsic-production-account-poweruser",
+		},
+		{
+			desc:        "Account with space",
+			accountName: "Production Account",
+			roleName:    "ReadOnly",
+			expected:    "teleport-awsic-production-account-readonly",
+		},
+		{
+			desc:        "Role with space",
+			accountName: "QA",
+			roleName:    "System Administrator",
+			expected:    "teleport-awsic-qa-system-administrator",
+		},
+		{
+			desc:        "Account ID fallback",
+			accountName: "123456789012",
+			roleName:    "ReadOnly",
+			expected:    "teleport-awsic-123456789012-readonly",
+		},
+		{
+			desc:        "Malicious INI injection characters",
+			accountName: "malicious \n[profile default]\n",
+			roleName:    "admin [!]",
+			expected:    "teleport-awsic-malicious-profile-default-admin-",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expected, formatAWSProfileName(tc.accountName, tc.roleName))
+		})
+	}
+}
+
+func TestWriteAWSProfileSummary(t *testing.T) {
+	configPath := "/home/user/.aws/config"
+	profiles := []awsconfigfile.SSOProfile{
+		{
+			Name:      "teleport-awsic-dev-admin",
+			AccountID: "123456789012",
+			RoleName:  "Admin",
+			Session:   "teleport-d-12345",
+			Account:   "dev",
+		},
+		{
+			Name:      "teleport-awsic-prod-reader",
+			AccountID: "098765432109",
+			RoleName:  "Reader",
+			Session:   "teleport-d-12345",
+			Account:   "prod",
+		},
+	}
+
+	t.Run("with profiles", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		writeAWSProfileSummary(buf, configPath, profiles)
+		output := buf.Bytes()
+
+		if golden.ShouldSet() {
+			golden.Set(t, output)
+		}
+		require.Equal(t, string(golden.Get(t)), string(output))
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		writeAWSProfileSummary(buf, configPath, nil)
+		output := buf.Bytes()
+
+		if golden.ShouldSet() {
+			golden.Set(t, output)
+		}
+		require.Equal(t, string(golden.Get(t)), string(output))
+	})
+}
+
+func TestFilterAWSIdentityCenterApps(t *testing.T) {
+	appWithIC, err := types.NewAppV3(types.Metadata{Name: "aws-ic"}, types.AppSpecV3{
+		URI: "https://d-123.awsapps.com/start",
+		IdentityCenter: &types.AppIdentityCenter{
+			AccountID:      "123456789012",
+			PermissionSets: []*types.IdentityCenterPermissionSet{{Name: "Admin"}},
+		},
+	})
+	require.NoError(t, err)
+
+	appWithoutIC, err := types.NewAppV3(types.Metadata{Name: "no-ic"}, types.AppSpecV3{
+		URI: "https://example.com",
+	})
+	require.NoError(t, err)
+
+	resources := types.EnrichedResources{
+		{
+			ResourceWithLabels: &types.AppServerV3{Spec: types.AppServerSpecV3{App: appWithIC}},
+		},
+		{
+			ResourceWithLabels: &types.AppServerV3{Spec: types.AppServerSpecV3{App: appWithoutIC}},
+		},
+	}
+
+	filtered := filterAWSIdentityCenterApps(resources)
+	require.Len(t, filtered, 1)
+	require.Equal(t, "aws-ic", filtered[0].GetName())
+}
+
+func TestWriteAWSConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+
+	app1, err := types.NewAppV3(types.Metadata{
+		Name: "app1",
+		Labels: map[string]string{
+			"teleport.dev/account-name": "dev",
+		},
+	}, types.AppSpecV3{
+		URI: "https://d-123.awsapps.com/start/#/",
+		IdentityCenter: &types.AppIdentityCenter{
+			AccountID: "111111111111",
+			PermissionSets: []*types.IdentityCenterPermissionSet{
+				{Name: "Admin"},
+				{Name: "Reader"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	app2, err := types.NewAppV3(types.Metadata{
+		Name: "app2",
+	}, types.AppSpecV3{
+		URI: "https://d-123.awsapps.com/start",
+		IdentityCenter: &types.AppIdentityCenter{
+			AccountID: "222222222222",
+			PermissionSets: []*types.IdentityCenterPermissionSet{
+				{Name: "Admin"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	apps := []types.Application{app1, app2}
+
+	// Pre-write some non-Teleport managed content.
+	nonTeleportContent := `[default]
+region = us-west-2
+output = json
+
+[profile external]
+role_arn = arn:aws:iam::123456789012:role/external-role
+source_profile = default
+`
+	err = os.WriteFile(configPath, []byte(nonTeleportContent), 0600)
+	require.NoError(t, err)
+
+	written, err := writeAWSConfig(configPath, "us-east-1", apps, false, nil)
+	require.NoError(t, err)
+	require.Len(t, written, 3)
+
+	// Verify the returned slice items
+	require.Equal(t, "teleport-awsic-dev-admin", written[0].Name)
+	require.Equal(t, "111111111111", written[0].AccountID)
+	require.Equal(t, "Admin", written[0].RoleName)
+	require.Equal(t, "teleport-d-123", written[0].Session)
+
+	require.Equal(t, "teleport-awsic-dev-reader", written[1].Name)
+	require.Equal(t, "111111111111", written[1].AccountID)
+	require.Equal(t, "Reader", written[1].RoleName)
+	require.Equal(t, "teleport-d-123", written[1].Session)
+
+	require.Equal(t, "teleport-awsic-222222222222-admin", written[2].Name)
+	require.Equal(t, "222222222222", written[2].AccountID)
+	require.Equal(t, "Admin", written[2].RoleName)
+	require.Equal(t, "teleport-d-123", written[2].Session)
+
+	// Verify file content
+	content, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	// Verify that non-Teleport content is preserved.
+	require.Contains(t, string(content), "[default]")
+	require.Contains(t, string(content), "[profile external]")
+
+	if golden.ShouldSet() {
+		golden.Set(t, content)
+	}
+	require.Equal(t, string(golden.Get(t)), string(content))
+}
+
+func TestWriteAWSConfig_RegionFromLabel(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config")
+
+	app1, err := types.NewAppV3(types.Metadata{
+		Name: "app1",
+		Labels: map[string]string{
+			"teleport.dev/account-name":   "dev",
+			"teleport.dev/aws-sso-region": "eu-west-1",
+		},
+	}, types.AppSpecV3{
+		URI: "https://d-123.awsapps.com/start/#/",
+		IdentityCenter: &types.AppIdentityCenter{
+			AccountID: "111111111111",
+			PermissionSets: []*types.IdentityCenterPermissionSet{
+				{Name: "Admin"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Pass empty ssoRegion to test auto-detection from label.
+	written, err := writeAWSConfig(configPath, "", []types.Application{app1}, false, nil)
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	content, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "sso_region=eu-west-1")
+}
+
+func TestWriteAWSConfig_RegionFlagOverridesLabel(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config")
+
+	app1, err := types.NewAppV3(types.Metadata{
+		Name: "app1",
+		Labels: map[string]string{
+			"teleport.dev/account-name":   "dev",
+			"teleport.dev/aws-sso-region": "eu-west-1",
+		},
+	}, types.AppSpecV3{
+		URI: "https://d-123.awsapps.com/start/#/",
+		IdentityCenter: &types.AppIdentityCenter{
+			AccountID: "111111111111",
+			PermissionSets: []*types.IdentityCenterPermissionSet{
+				{Name: "Admin"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Explicit flag should override label.
+	written, err := writeAWSConfig(configPath, "us-west-2", []types.Application{app1}, false, nil)
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	content, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "sso_region=us-west-2")
+	require.NotContains(t, string(content), "eu-west-1")
+}
+
+func TestWriteAWSConfig_Pruning(t *testing.T) {
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "config")
+
+	// Set up initial config with a stale Teleport profile.
+	initialContent := `; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[sso-session teleport-stale]
+sso_start_url = https://stale.awsapps.com/start
+sso_region = us-east-1
+
+; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[profile teleport-awsic-stale-admin]
+sso_session = teleport-stale
+sso_account_id = 111111111111
+sso_role_name = Admin
+
+[profile external]
+region = us-east-1
+`
+	err := os.WriteFile(configPath, []byte(initialContent), 0600)
+	require.NoError(t, err)
+
+	// Now write config for a set of apps that doesn't include the stale one.
+	app1, err := types.NewAppV3(types.Metadata{
+		Name:   "aws-ic-new",
+		Labels: map[string]string{"teleport.dev/account-name": "production"},
+	}, types.AppSpecV3{
+		URI: "https://production.awsapps.com/start/#/console",
+		IdentityCenter: &types.AppIdentityCenter{
+			AccountID: "222222222222",
+			PermissionSets: []*types.IdentityCenterPermissionSet{
+				{Name: "Admin"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	apps := []types.Application{app1}
+
+	written, err := writeAWSConfig(configPath, "us-east-1", apps, false, nil)
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	content, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	contentStr := string(content)
+
+	// Verify new profile is there
+	require.Contains(t, contentStr, "[profile teleport-awsic-production-admin]")
+	require.Contains(t, contentStr, "[sso-session teleport-production]")
+
+	// Verify external profile is preserved
+	require.Contains(t, contentStr, "[profile external]")
+
+	// Verify stale profile is gone
+	require.NotContains(t, contentStr, "[profile teleport-awsic-stale-admin]")
+	require.NotContains(t, contentStr, "[sso-session teleport-stale]")
+}

--- a/tool/tsh/common/testdata/TestWriteAWSConfig.golden
+++ b/tool/tsh/common/testdata/TestWriteAWSConfig.golden
@@ -1,0 +1,30 @@
+[default]
+region=us-west-2
+output=json
+
+[profile external]
+role_arn=arn:aws:iam::123456789012:role/external-role
+source_profile=default
+
+; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[sso-session teleport-d-123]
+sso_start_url=https://d-123.awsapps.com/start
+sso_region=us-east-1
+
+; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[profile teleport-awsic-dev-admin]
+sso_session=teleport-d-123
+sso_account_id=111111111111
+sso_role_name=Admin
+
+; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[profile teleport-awsic-dev-reader]
+sso_session=teleport-d-123
+sso_account_id=111111111111
+sso_role_name=Reader
+
+; Do not edit. Section managed by Teleport (AWS Identity Center integration).
+[profile teleport-awsic-222222222222-admin]
+sso_session=teleport-d-123
+sso_account_id=222222222222
+sso_role_name=Admin

--- a/tool/tsh/common/testdata/TestWriteAWSProfileSummary/empty.golden
+++ b/tool/tsh/common/testdata/TestWriteAWSProfileSummary/empty.golden
@@ -1,0 +1,1 @@
+No AWS Identity Center accounts or roles available for the current user.

--- a/tool/tsh/common/testdata/TestWriteAWSProfileSummary/with_profiles.golden
+++ b/tool/tsh/common/testdata/TestWriteAWSProfileSummary/with_profiles.golden
@@ -1,0 +1,14 @@
+AWS configuration updated at: /home/user/.aws/config
+
+Profile                    Account Account ID   Role   SSO Session      
+-------------------------- ------- ------------ ------ ---------------- 
+teleport-awsic-dev-admin   dev     123456789012 Admin  teleport-d-12345 
+teleport-awsic-prod-reader prod    098765432109 Reader teleport-d-12345 
+
+To use these profiles, set the AWS_PROFILE environment variable and authenticate with AWS. Example:
+  export AWS_PROFILE=teleport-awsic-dev-admin
+  aws sso login
+
+You can now run AWS commands. Example:
+  aws s3 ls
+

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -212,6 +212,8 @@ type CLIConf struct {
 	NodePort int32
 	// Login on a remote SSH host
 	NodeLogin string
+	// DryRun prints the configuration without applying it
+	DryRun bool
 	// InsecureSkipVerify bypasses verification of HTTPS certificate when talking to web proxy
 	InsecureSkipVerify bool
 	// SessionID identifies the session tsh is operating on.
@@ -489,6 +491,8 @@ type CLIConf struct {
 	// proxy instead of an HTTPS proxy.
 	// TODO(gabrielcorado): DELETE IN 19.0.0
 	AWSEndpointURLMode bool
+	// AWSSSORegion is the AWS region used for SSO.
+	AWSSSORegion string
 
 	// AzureIdentity is Azure identity that will be used for Azure CLI access.
 	AzureIdentity string
@@ -1023,6 +1027,11 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		Short('e').Hidden().BoolVar(&cf.AWSEndpointURLMode)
 	aws.Flag("exec", "Execute different commands (e.g. terraform) under Teleport credentials").StringVar(&cf.Exec)
 	aws.Flag("aws-role", "(For AWS CLI access only) Amazon IAM role ARN or role name.").StringVar(&cf.AWSRole)
+
+	// Generate AWS profiles via AWS Identity Center integration.
+	awsProfile := app.Command("aws-profile", "Write AWS profiles retrieved from the AWS IAM Identity Center integration to the AWS config file.")
+	awsProfile.Flag("aws-sso-region", "AWS region for SSO. Auto-detected from cluster if not specified.").StringVar(&cf.AWSSSORegion)
+	awsProfile.Flag("dry-run", "Print the configuration that will be applied without modifying the AWS config file.").BoolVar(&cf.DryRun)
 
 	azure := app.Command("az", "Access Azure API.").Interspersed(false)
 	azure.Arg("command", "`az` command and subcommands arguments that are going to be forwarded to Azure CLI.").StringsVar(&cf.AzureCommandArgs)
@@ -1890,6 +1899,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = onPuttyConfig(&cf)
 	case aws.FullCommand():
 		err = onAWS(&cf)
+	case awsProfile.FullCommand():
+		err = onAWSProfile(&cf)
 	case azure.FullCommand():
 		err = onAzure(&cf)
 	case gcloud.FullCommand():


### PR DESCRIPTION
Backport of the following PRs to branch/v18:
- #63032
- #64397


**Example Usage**
```
% tsh aws-profile 

AWS configuration updated at: /Users/dev1/.aws/config

Profile                                  Account              Account ID      Role            SSO Session         
------------------------------------------------------------------------------------------------------------------
teleport-awsic-cloudest-dev01-reader     cloudest-dev01       581094247987    Reader          cloudest-test1
teleport-awsic-cloudest-dev01-admin      cloudest-dev01       581094247987    Admin           cloudest-test1
teleport-awsic-cloudest-dev02-reader     cloudest-dev02       839274615032    Reader          cloudest-test1
teleport-awsic-cloudest-dev02-admin      cloudest-dev02       839274615032    Admin           cloudest-test1

To use these profiles, set the AWS_PROFILE environment variable and authenticate with AWS. Example:
  export AWS_PROFILE=teleport-awsic-cloudest-dev01-reader 
  aws sso login

You can now run AWS commands. Example:
  aws s3 ls
  
```

## Manual Test Plan

### Test Environment
- A Teleport cluster with an existing AWS Identity Center integration
- A Teleport cluster **without** an AWS Identity Center integration
- Both this PR branch and the [corresponding branch in e](https://github.com/gravitational/teleport.e/pull/8250) checked out locally

### Test Cases
- [x] Log in to a cluster **with** an AWS Identity Center integration using `tsh login`. Run `TELEPORT_TOOLS_VERSION=off go run ./tool/tsh aws-profile` and verify the output matches the format shown in the **Example Usage** section above.
- [x] Log in to a cluster **without** an AWS Identity Center integration using `tsh login`. Run `TELEPORT_TOOLS_VERSION=off go run ./tool/tsh aws-profile` and verify it displays a message indicating no AWS Identity Center integration is installed on the cluster.


changelog: Added a new tsh aws-profile command that detects your AWS Identity Center integration (if configured) and writes corresponding AWS profiles into your local AWS config file for later use
