### PR TITLE
Support wildcard Azure subscription VM discovery

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -459,6 +459,11 @@ type Server struct {
 
 	// azureClientCache caches instances of integration-specific Azure clients.
 	azureClientCache *utils.FnCache
+
+	// azureSubscriptionCache caches integration-to-subscription-list mapping.
+	// This cache avoids repeated API calls when multiple discovery matchers for
+	// the same integration use a wildcard subscription.
+	azureSubscriptionCache *utils.FnCache
 }
 
 // New initializes a discovery Server
@@ -757,7 +762,56 @@ func (s *Server) azureServerFetchersFromMatchers(matchers []types.AzureMatcher, 
 		return matcherType == types.AzureMatcherVM
 	})
 
-	return server.MatchersToAzureInstanceFetchers(s.Log, serverMatchers, s.getAzureClients, discoveryConfigName)
+	return server.MatchersToAzureInstanceFetchers(s.ctx, s.Log, serverMatchers, s.getAzureClients, discoveryConfigName, s.getAzureSubscriptionList)
+}
+
+func (s *Server) getAzureSubscriptionListNoCache(ctx context.Context, integration string) ([]string, error) {
+	azureClients, err := s.getAzureClients(ctx, integration)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	subsClient, err := azureClients.GetSubscriptionClient(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	subscriptions, err := subsClient.ListSubscriptionIDs(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return subscriptions, nil
+}
+
+func (s *Server) getAzureSubscriptionList(ctx context.Context, integration string) ([]string, error) {
+	err := func() error {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.azureSubscriptionCache == nil {
+			azureSubscriptionCache, err := utils.NewFnCache(utils.FnCacheConfig{
+				// Making an API call to list subscriptions at most once per
+				// minute is fine and limits the delay before changes to Azure
+				// permissions or subscriptions are seen by discovery services.
+				TTL:   time.Minute,
+				Clock: s.clock,
+			})
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			s.azureSubscriptionCache = azureSubscriptionCache
+		}
+		return nil
+	}()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	out, err := utils.FnCacheGet(ctx, s.azureSubscriptionCache, integration, func(ctx context.Context) ([]string, error) {
+		return s.getAzureSubscriptionListNoCache(ctx, integration)
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return out, nil
 }
 
 // gcpServerFetchersFromMatchers converts Matchers into a set of GCP Servers Fetchers.
@@ -1442,20 +1496,25 @@ func (s *Server) startAzureServerDiscovery() {
 
 	var azureWatcher *server.Watcher[*server.AzureInstances]
 
-	// static fetchers; can be cached, any changes require service restart.
-	staticFetchers := s.azureServerFetchersFromMatchers(s.Matchers.Azure, noDiscoveryConfig)
-
 	// a full refresh is somewhat wasteful, however not overly so due to inexpensive operations involved.
 	// a more selective approach would necessitate deeper refactoring.
 	fullRefresh := func() {
+		s.Log.DebugContext(s.ctx, "Refreshing Azure server fetchers")
 		replaceMap := make(map[string][]server.Fetcher[*server.AzureInstances])
-		replaceMap[noDiscoveryConfig] = staticFetchers
+		replaceMap[noDiscoveryConfig] = s.azureServerFetchersFromMatchers(s.Matchers.Azure, noDiscoveryConfig)
 
 		s.dynamicDiscoveryConfigMu.RLock()
+		// avoid holding the read lock while converting matchers to fetchers,
+		// in case of API calls, e.g., to expand subscription wildcard.
+		dynamicConfigs := make(map[string][]types.AzureMatcher, len(s.dynamicDiscoveryConfig))
 		for _, config := range s.dynamicDiscoveryConfig {
-			replaceMap[config.GetName()] = s.azureServerFetchersFromMatchers(config.Spec.Azure, config.GetName())
+			dynamicConfigs[config.GetName()] = config.Spec.Azure
 		}
 		s.dynamicDiscoveryConfigMu.RUnlock()
+
+		for configName, matchers := range dynamicConfigs {
+			replaceMap[configName] = s.azureServerFetchersFromMatchers(matchers, configName)
+		}
 		azureWatcher.ReplaceFetchers(replaceMap)
 	}
 
@@ -1502,6 +1561,8 @@ func (s *Server) startAzureServerDiscovery() {
 			}
 		}),
 		server.WithPostFetchHookFn[*server.AzureInstances](func() {
+			// refresh the fetchers after every iteration to avoid stale config
+			defer fullRefresh()
 			// update statuses of relevant discovery configs.
 			s.azureVMStatus.Store(sm)
 			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
@@ -2097,6 +2158,9 @@ func (s *Server) Wait() error {
 func (s *Server) getAzureSubscriptions(ctx context.Context, integration string, subs []string) ([]string, error) {
 	subscriptionIds := subs
 	if slices.Contains(subs, types.Wildcard) {
+		// TODO(gavin): instead of listing subscriptions during init, do it
+		// on every fetch to prevent stale discovery configuration when
+		// subscriptions are added or removed
 		azureClients, err := s.getAzureClients(ctx, integration)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -30,6 +30,7 @@ import (
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/installers"
+	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -113,10 +114,20 @@ func (instances *AzureInstances) FilterExistingNodes(existingNodes []types.Serve
 
 type azureClientGetter func(ctx context.Context, integration string) (azure.Clients, error)
 
+type listSubscriptionsFunc func(ctx context.Context, integration string) (subscriptions []string, err error)
+
 // MatchersToAzureInstanceFetchers converts a list of Azure VM Matchers into a list of Azure VM Fetchers.
-func MatchersToAzureInstanceFetchers(logger *slog.Logger, matchers []types.AzureMatcher, getClient azureClientGetter, discoveryConfigName string) []Fetcher[*AzureInstances] {
+func MatchersToAzureInstanceFetchers(
+	ctx context.Context,
+	logger *slog.Logger,
+	matchers []types.AzureMatcher,
+	getClient azureClientGetter,
+	discoveryConfigName string,
+	listSubs listSubscriptionsFunc,
+) []Fetcher[*AzureInstances] {
 	ret := make([]Fetcher[*AzureInstances], 0)
 	for _, matcher := range matchers {
+		matcher.Subscriptions = expandAzureMatcherSubscriptions(ctx, logger, matcher.Subscriptions, matcher.Integration, listSubs)
 		for _, subscription := range matcher.Subscriptions {
 			for _, resourceGroup := range matcher.ResourceGroups {
 				fetcher := newAzureInstanceFetcher(azureFetcherConfig{
@@ -132,6 +143,35 @@ func MatchersToAzureInstanceFetchers(logger *slog.Logger, matchers []types.Azure
 		}
 	}
 	return ret
+}
+
+// expandAzureMatcherSubscriptions fetches the subscriptions for any wildcard
+// subscriptions and replaces the wildcard with the subscriptions list.
+func expandAzureMatcherSubscriptions(
+	ctx context.Context,
+	logger *slog.Logger,
+	subscriptions []string,
+	integration string,
+	listSubs listSubscriptionsFunc,
+) []string {
+	var out []string
+	for _, sub := range subscriptions {
+		if sub != types.Wildcard {
+			out = append(out, sub)
+			continue
+		}
+		subs, err := listSubs(ctx, integration)
+		if err != nil {
+			// TODO(gavin): make a user task
+			logger.WarnContext(ctx, "Failed to fetch Azure subscription list for wildcard in discovery configuration",
+				"integration", integration,
+				"error", err,
+			)
+			continue
+		}
+		out = append(out, subs...)
+	}
+	return utils.Deduplicate(out)
 }
 
 type azureFetcherConfig struct {

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -20,12 +20,14 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -36,55 +38,103 @@ import (
 type mockClients struct {
 	azure.Clients
 
-	vmClient azure.VirtualMachinesClient
+	vmClients map[string]azure.VirtualMachinesClient
 }
 
 func (c *mockClients) GetVirtualMachinesClient(ctx context.Context, subscription string) (azure.VirtualMachinesClient, error) {
-	return c.vmClient, nil
+	vmClient, ok := c.vmClients[subscription]
+	if !ok {
+		return nil, trace.NotFound("subscription %s not found", subscription)
+	}
+	return vmClient, nil
 }
 
 func TestAzureWatcher(t *testing.T) {
 	t.Parallel()
 
+	const (
+		sub1 = "00000000-0000-0000-0000-000000000000"
+		sub2 = "11111111-1111-1111-1111-111111111111"
+	)
 	clients := mockClients{
-		vmClient: azure.NewVirtualMachinesClientByAPI(&azure.ARMComputeMock{
-			VirtualMachines: map[string][]*armcompute.VirtualMachine{
-				"rg1": {
-					{
-						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"),
-						Location: to.Ptr("location1"),
-					},
-					{
-						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2"),
-						Location: to.Ptr("location1"),
-						Tags: map[string]*string{
-							"teleport": to.Ptr("yes"),
+		vmClients: map[string]azure.VirtualMachinesClient{
+			sub1: azure.NewVirtualMachinesClientByAPI(&azure.ARMComputeMock{
+				VirtualMachines: map[string][]*armcompute.VirtualMachine{
+					"rg1": {
+						{
+							ID:       to.Ptr(makeAzureVMID(sub1, "rg1", "vm1")),
+							Location: to.Ptr("location1"),
+						},
+						{
+							ID:       to.Ptr(makeAzureVMID(sub1, "rg1", "vm2")),
+							Location: to.Ptr("location1"),
+							Tags: map[string]*string{
+								"teleport": to.Ptr("yes"),
+							},
+						},
+						{
+							ID:       to.Ptr(makeAzureVMID(sub1, "rg1", "vm5")),
+							Location: to.Ptr("location2"),
 						},
 					},
-					{
-						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm5"),
-						Location: to.Ptr("location2"),
-					},
-				},
-				"rg2": {
-					{
-						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm3"),
-						Location: to.Ptr("location1"),
-					},
-					{
-						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm4"),
-						Location: to.Ptr("location1"),
-						Tags: map[string]*string{
-							"teleport": to.Ptr("yes"),
+					"rg2": {
+						{
+							ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm3")),
+							Location: to.Ptr("location1"),
+						},
+						{
+							ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm4")),
+							Location: to.Ptr("location1"),
+							Tags: map[string]*string{
+								"teleport": to.Ptr("yes"),
+							},
+						},
+						{
+							ID:       to.Ptr(makeAzureVMID(sub1, "rg2", "vm6")),
+							Location: to.Ptr("location2"),
 						},
 					},
-					{
-						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm6"),
-						Location: to.Ptr("location2"),
+				},
+			}, nil /* scaleSetAPI */),
+			sub2: azure.NewVirtualMachinesClientByAPI(&azure.ARMComputeMock{
+				VirtualMachines: map[string][]*armcompute.VirtualMachine{
+					"rg3": {
+						{
+							ID:       to.Ptr(makeAzureVMID(sub2, "rg3", "vm7")),
+							Location: to.Ptr("location1"),
+						},
+						{
+							ID:       to.Ptr(makeAzureVMID(sub2, "rg3", "vm8")),
+							Location: to.Ptr("location1"),
+							Tags: map[string]*string{
+								"teleport": to.Ptr("yes"),
+							},
+						},
+						{
+							ID:       to.Ptr(makeAzureVMID(sub2, "rg3", "vm9")),
+							Location: to.Ptr("location2"),
+						},
+					},
+					"rg4": {
+						{
+							ID:       to.Ptr(makeAzureVMID(sub2, "rg4", "vm10")),
+							Location: to.Ptr("location1"),
+						},
+						{
+							ID:       to.Ptr(makeAzureVMID(sub2, "rg4", "vm11")),
+							Location: to.Ptr("location1"),
+							Tags: map[string]*string{
+								"teleport": to.Ptr("yes"),
+							},
+						},
+						{
+							ID:       to.Ptr(makeAzureVMID(sub2, "rg4", "vm12")),
+							Location: to.Ptr("location2"),
+						},
 					},
 				},
-			},
-		}, nil /* scaleSetAPI */),
+			}, nil /* scaleSetAPI */),
+		},
 	}
 
 	tests := []struct {
@@ -93,11 +143,12 @@ func TestAzureWatcher(t *testing.T) {
 		wantVMs []string
 	}{
 		{
-			name: "all vms",
+			name: "all vms in a subscription",
 			matcher: types.AzureMatcher{
 				ResourceGroups: []string{"rg1", "rg2"},
 				Regions:        []string{"location1", "location2"},
 				ResourceTags:   types.Labels{"*": []string{"*"}},
+				Subscriptions:  []string{sub1},
 			},
 			wantVMs: []string{"vm1", "vm2", "vm3", "vm4", "vm5", "vm6"},
 		},
@@ -107,6 +158,7 @@ func TestAzureWatcher(t *testing.T) {
 				ResourceGroups: []string{"rg1"},
 				Regions:        []string{"location1", "location2"},
 				ResourceTags:   types.Labels{"*": []string{"*"}},
+				Subscriptions:  []string{sub1},
 			},
 			wantVMs: []string{"vm1", "vm2", "vm5"},
 		},
@@ -116,6 +168,7 @@ func TestAzureWatcher(t *testing.T) {
 				ResourceGroups: []string{"rg1", "rg2"},
 				Regions:        []string{"location2"},
 				ResourceTags:   types.Labels{"*": []string{"*"}},
+				Subscriptions:  []string{sub1},
 			},
 			wantVMs: []string{"vm5", "vm6"},
 		},
@@ -125,6 +178,7 @@ func TestAzureWatcher(t *testing.T) {
 				ResourceGroups: []string{"rg1", "rg2"},
 				Regions:        []string{"location1", "location2"},
 				ResourceTags:   types.Labels{"teleport": []string{"yes"}},
+				Subscriptions:  []string{sub1},
 			},
 			wantVMs: []string{"vm2", "vm4"},
 		},
@@ -134,6 +188,7 @@ func TestAzureWatcher(t *testing.T) {
 				ResourceGroups: []string{"rg1", "rg2"},
 				Regions:        []string{types.Wildcard},
 				ResourceTags:   types.Labels{"*": []string{"*"}},
+				Subscriptions:  []string{sub1},
 			},
 			wantVMs: []string{"vm1", "vm2", "vm3", "vm4", "vm5", "vm6"},
 		},
@@ -143,15 +198,35 @@ func TestAzureWatcher(t *testing.T) {
 				ResourceGroups: []string{"*"},
 				Regions:        []string{types.Wildcard},
 				ResourceTags:   types.Labels{"*": []string{"*"}},
+				Subscriptions:  []string{sub1},
 			},
 			wantVMs: []string{"vm1", "vm2", "vm3", "vm4", "vm5", "vm6"},
+		},
+		{
+			name: "subscription wildcard",
+			matcher: types.AzureMatcher{
+				ResourceGroups: []string{"rg1", "rg4"},
+				Regions:        []string{types.Wildcard},
+				ResourceTags:   types.Labels{"*": []string{"*"}},
+				Subscriptions:  []string{"*"},
+			},
+			wantVMs: []string{"vm1", "vm2", "vm5", "vm10", "vm11", "vm12"},
+		},
+		{
+			name: "subscription wildcard with resource group wildcard",
+			matcher: types.AzureMatcher{
+				ResourceGroups: []string{"*"},
+				Regions:        []string{types.Wildcard},
+				ResourceTags:   types.Labels{"*": []string{"*"}},
+				Subscriptions:  []string{"*"},
+			},
+			wantVMs: []string{"vm1", "vm2", "vm3", "vm4", "vm5", "vm6", "vm7", "vm8", "vm9", "vm10", "vm11", "vm12"},
 		},
 	}
 
 	logger := logtest.NewLogger()
 	for _, tc := range tests {
 		tc.matcher.Types = []string{"vm"}
-		tc.matcher.Subscriptions = []string{"sub1"}
 
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -160,10 +235,18 @@ func TestAzureWatcher(t *testing.T) {
 
 			const noDiscoveryConfig = ""
 			watcher.SetFetchers(noDiscoveryConfig,
-				MatchersToAzureInstanceFetchers(logger, []types.AzureMatcher{tc.matcher},
+				MatchersToAzureInstanceFetchers(
+					t.Context(),
+					logger,
+					[]types.AzureMatcher{tc.matcher},
 					func(ctx context.Context, integration string) (azure.Clients, error) {
 						return &clients, nil
-					}, noDiscoveryConfig),
+					},
+					noDiscoveryConfig,
+					func(ctx context.Context, integration string) (subscriptions []string, err error) {
+						return []string{sub1, sub2}, nil
+					},
+				),
 			)
 
 			go watcher.Run()
@@ -180,9 +263,10 @@ func TestAzureWatcher(t *testing.T) {
 						vmID := parsedResource.Name
 						vmIDs = append(vmIDs, vmID)
 					}
-					require.NotEqual(t, "*", results.ResourceGroup)
+					require.NotEqual(t, "*", results.ResourceGroup, "Discovered VM's ResourceGroup should never be the wildcard")
+					require.NotEqual(t, "*", results.SubscriptionID, "Discovered VM's SubscriptionID should never be the wildcard")
 				case <-ctx.Done():
-					require.Fail(t, "Expected %v VMs, got %v", tc.wantVMs, len(vmIDs))
+					require.ElementsMatch(t, tc.wantVMs, vmIDs, "timed out while waiting for expected VMs")
 				}
 			}
 
@@ -356,4 +440,10 @@ func makeAzureNode(t *testing.T, name, subscriptionID, vmID string) types.Server
 	node, err := types.NewServerWithLabels(name, types.KindNode, types.ServerSpecV2{}, labels)
 	require.NoError(t, err)
 	return node
+}
+
+func makeAzureVMID(subscription, resourceGroup, name string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s",
+		subscription, resourceGroup, name,
+	)
 }


### PR DESCRIPTION
The wildcard "*" can now be used for VM discovery across all subscriptions. The subscriptions discovered will depend on the scope(s) that discovery service identity has Microsoft.Resources/subscriptions/read permission.

TODO in separate PRs:
- Update docs for discovery config and for Azure discovery permissions. Docs reference for static discovery also needs to show the "integration" setting.
- Add support for Azure wildcard subscription join token rule

Changelog: Azure VM discovery configuration now supports specifying a wildcard ("*") subscription to discover all VMs in all subscriptions where the Discovery service has Microsoft.Resources/subscriptions/read permission.

## Manual Test Plan
### Test Environment

- [x] Create multiple Azure subscriptions
- [x] Create VMs in each subscription
- [x] Create an Azure join token that allows joining from each subscription ID (wildcard Azure subscription join token is not implemented in this PR)
- [x] Create an Azure role for discovery and assign it to the discovery service at a high enough scope to discover each subscription. (I made an assignment for each subscription, but an Azure management group assignment could be used instead)

### Test Cases
- [x] Start a discovery service with static config that uses wildcard Azure subscription
  - [x] Verify that all expected VMs are discovered and join the cluster
- [x] Stop discovery service, remove all static configuration except for discovery_group, and disenroll all discovered VMs
- [x] Create a dynamic discovery_config that uses wildcard Azure subscription
  - [x] Verify that all expected VMs are discovered and join the cluster
