### PR TITLE
fix: instance rejoin against legacy join server

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -66,6 +66,9 @@ type APIConfig struct {
 	// OracleHTTPClient (optional) overrides the HTTP client used to make
 	// requests to the Oracle API for the Oracle join method.
 	OracleHTTPClient utils.HTTPDoClient
+	// DisableJoinV1 disables registration of the new join gRPC service.
+	// Intended for tests that need to exercise legacy join fallback paths.
+	DisableJoinV1 bool
 }
 
 // CheckAndSetDefaults checks and sets default values

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -919,6 +919,13 @@ func WithBufconnListener() TestTLSServerOption {
 	}
 }
 
+// WithoutJoinV1 disables the new join gRPC service while keeping legacy join registered.
+func WithoutJoinV1() TestTLSServerOption {
+	return func(cfg *TLSServerConfig) {
+		cfg.APIConfig.DisableJoinV1 = true
+	}
+}
+
 // NewRemoteClient creates new client to the remote server using identity
 // generated for this certificate authority
 func (a *AuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, pool *x509.CertPool) (*authclient.Client, error) {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6279,13 +6279,15 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	legacyJoinServiceServer := legacyjoin.NewJoinServiceGRPCServer(cfg.AuthServer)
 	authpb.RegisterJoinServiceServer(server, legacyJoinServiceServer)
 
-	joinv1.RegisterJoinServiceServer(server, join.NewServer(&join.ServerConfig{
-		Authorizer:         cfg.Authorizer,
-		AuthService:        cfg.AuthServer,
-		FIPS:               cfg.AuthServer.fips,
-		ScopedTokenService: cfg.AuthServer.Services,
-		OracleHTTPClient:   cfg.OracleHTTPClient,
-	}))
+	if !cfg.DisableJoinV1 {
+		joinv1.RegisterJoinServiceServer(server, join.NewServer(&join.ServerConfig{
+			Authorizer:         cfg.Authorizer,
+			AuthService:        cfg.AuthServer,
+			FIPS:               cfg.AuthServer.fips,
+			ScopedTokenService: cfg.AuthServer.Services,
+			OracleHTTPClient:   cfg.OracleHTTPClient,
+		}))
+	}
 
 	integrationServiceServer, err := integrationv1.NewService(&integrationv1.ServiceConfig{
 		Authorizer:      cfg.Authorizer,

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -829,7 +829,7 @@ type joinServiceClient interface {
 func registerUsingTokenRequestForParams(token string, hostKeys *newHostKeys, params RegisterParams) *types.RegisterUsingTokenRequest {
 	return &types.RegisterUsingTokenRequest{
 		Token:                token,
-		HostID:               params.ID.HostUUID,
+		HostID:               params.ID.HostID(),
 		NodeName:             params.ID.NodeName,
 		Role:                 params.ID.Role,
 		AdditionalPrincipals: params.AdditionalPrincipals,

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -991,13 +991,66 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	wg.Wait()
 }
 
-// TestInstanceSelfRepair tests a node that first starts up with only the Proxy
-// service and joins the cluster with a token valid only for role Proxy, and
-// then restarts with the SSH service now enabled and a token valid only for
-// role Node. The instance identity should self-repair on the second startup to
-// get a certificate with both the Proxy and Node system roles.
+// TestInstanceSelfRepair exercises instance self-repair across both the new
+// join service and legacy fallback, with a second token that either contains
+// only the newly required role or all required roles.
 func TestInstanceSelfRepair(t *testing.T) {
-	// Setup: create an auth server with two tokens, one proxy proxies and one for nodes.
+	for _, tc := range []struct {
+		name   string
+		params instanceSelfRepairParams
+	}{
+		{
+			name: "new join service/second token only has newly required role",
+			params: instanceSelfRepairParams{
+				rejoinTokenRoles:      []types.SystemRole{types.RoleNode},
+				expectedRejoinedRoles: []string{types.RoleProxy.String(), types.RoleNode.String()},
+			},
+		},
+		{
+			name: "new join service/second token has all required roles",
+			params: instanceSelfRepairParams{
+				rejoinTokenRoles:      []types.SystemRole{types.RoleProxy, types.RoleNode},
+				expectedRejoinedRoles: []string{types.RoleProxy.String(), types.RoleNode.String()},
+			},
+		},
+		{
+			name: "legacy fallback/second token only has newly required role",
+			params: instanceSelfRepairParams{
+				// Disable the new join service to force a fallback to the
+				// legacy join method.
+				tlsServerOpts: []authtest.TestTLSServerOption{authtest.WithoutJoinV1()},
+				// Despite the instance identity being unable to gain the
+				// Node role not available in the new token, the process
+				// should still be able to get a working node identity.
+				rejoinTokenRoles:      []types.SystemRole{types.RoleNode},
+				expectedRejoinedRoles: []string{types.RoleProxy.String()},
+			},
+		},
+		{
+			name: "legacy fallback/second token has all required roles",
+			params: instanceSelfRepairParams{
+				tlsServerOpts: []authtest.TestTLSServerOption{authtest.WithoutJoinV1()},
+				// With both roles available in the token, the Instance
+				// identity will end up with both roles.
+				rejoinTokenRoles:      []types.SystemRole{types.RoleProxy, types.RoleNode},
+				expectedRejoinedRoles: []string{types.RoleProxy.String(), types.RoleNode.String()},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testInstanceSelfRepair(t, tc.params)
+		})
+	}
+}
+
+type instanceSelfRepairParams struct {
+	tlsServerOpts         []authtest.TestTLSServerOption
+	rejoinTokenRoles      []types.SystemRole
+	expectedRejoinedRoles []string
+}
+
+func testInstanceSelfRepair(t *testing.T, params instanceSelfRepairParams) {
+	// Setup: create an auth server with two tokens, one for proxies and one for nodes.
 	const clusterName = "testcluster"
 	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:         makeTempDir(t),
@@ -1006,7 +1059,7 @@ func TestInstanceSelfRepair(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
 
-	tlsServer, err := testAuthServer.NewTestTLSServer()
+	tlsServer, err := testAuthServer.NewTestTLSServer(params.tlsServerOpts...)
 	require.NoError(t, err)
 	defer tlsServer.Close()
 
@@ -1015,11 +1068,11 @@ func TestInstanceSelfRepair(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, testAuthServer.AuthServer.UpsertToken(t.Context(), proxyToken))
-	sshToken, err := types.NewProvisionTokenFromSpec("sshToken", time.Now().Add(time.Minute), types.ProvisionTokenSpecV2{
-		Roles: []types.SystemRole{types.RoleNode},
+	rejoinToken, err := types.NewProvisionTokenFromSpec("rejoinToken", time.Now().Add(time.Minute), types.ProvisionTokenSpecV2{
+		Roles: params.rejoinTokenRoles,
 	})
 	require.NoError(t, err)
-	require.NoError(t, testAuthServer.AuthServer.UpsertToken(t.Context(), sshToken))
+	require.NoError(t, testAuthServer.AuthServer.UpsertToken(t.Context(), rejoinToken))
 
 	logger := logtest.NewLogger()
 	dataDir := makeTempDir(t)
@@ -1056,8 +1109,8 @@ func TestInstanceSelfRepair(t *testing.T) {
 	require.NotNil(t, connector)
 	id := connector.clientState.Load().identity
 	require.Equal(t, types.RoleInstance, id.ID.Role)
-	require.Equal(t, []string{types.RoleProxy.String()}, id.SystemRoles)
-	originalHostID := id.ID.HostID()
+	require.ElementsMatch(t, []string{types.RoleProxy.String()}, id.SystemRoles)
+	originalHostID := id.ID.HostUUID
 
 	// Close the original process.
 	require.NoError(t, process.Close())
@@ -1066,7 +1119,7 @@ func TestInstanceSelfRepair(t *testing.T) {
 	// Start up a new process using the same data dir so that it has access to
 	// the previous Instance and Proxy certs, but enable the SSH service and
 	// provide the token that allows only role Node.
-	process = newStartedProcess(sshToken.GetName(), true)
+	process = newStartedProcess(rejoinToken.GetName(), true)
 
 	// Get the new Instance identity and make sure it includes both the Proxy
 	// and Node system roles.
@@ -1075,21 +1128,21 @@ func TestInstanceSelfRepair(t *testing.T) {
 	require.NotNil(t, instanceConnector)
 	instanceID := instanceConnector.clientState.Load().identity
 	require.Equal(t, types.RoleInstance, instanceID.ID.Role)
-	assert.ElementsMatch(t, []string{types.RoleProxy.String(), types.RoleNode.String()}, instanceID.SystemRoles)
+	require.ElementsMatch(t, params.expectedRejoinedRoles, instanceID.SystemRoles)
 	// Make sure the host ID has not changed.
-	assert.Equal(t, instanceID.ID.HostID(), originalHostID)
+	require.Equal(t, originalHostID, instanceID.ID.HostUUID)
 
 	// Make sure the SSH identity becomes available.
 	sshConnector, err := process.WaitForConnector(SSHIdentityEvent, logger)
 	require.NoError(t, err)
 	require.NotNil(t, sshConnector)
 	sshID := sshConnector.clientState.Load().identity
-	require.Equal(t, types.RoleNode, sshID.ID.Role)
+	assert.Equal(t, types.RoleNode, sshID.ID.Role)
 	// Make sure the host ID matches the original instance host ID.
-	assert.Equal(t, sshID.ID.HostID(), originalHostID)
+	assert.Equal(t, originalHostID, sshID.ID.HostUUID)
 	// Make sure the SSH cert has all expected principals.
 	expectSSHPrincipals := expectedSSHPrincipals(sshID.ID.HostID(), hostName, clusterName)
-	require.ElementsMatch(t, expectSSHPrincipals, sshID.Cert.ValidPrincipals)
+	assert.ElementsMatch(t, expectSSHPrincipals, sshID.Cert.ValidPrincipals)
 
 	// Close the process to clean up.
 	require.NoError(t, process.Close())


### PR DESCRIPTION
Fixes #64598

This commit fixes an issue with Instance identity "self-healing". When starting up with additional enabled services which have no corresponding role in the current Instance identity, the node attempts a new cluster join request with the currently configured join token to get an Instance identity with all required roles.

There's currently a bug if:
- the node is new enough to attempt joining via the new join service and fall back to the legacy join service
- the Auth is old enough it doesn't support the new join service
- the token used for the rejoin includes all of the original instance cert roles and the newly required roles

The bug exists because `state.IdentityID.HostUUID` is overloaded. When originally joining, it is expected to be populated with a plain UUID. When it is parsed from an existing certificate, it includes a suffix of `.<clustername>`. So when the rejoin attempt passes in the current `IdentityID` from the existing identity, it includes the clustername suffix, and then when rejoining auth adds the suffix again, and you end up with a double suffix.

This doesn't affect joining via the new join service because the node doesn't explicitly pass its desired HostUUID at all, Auth extracts it from the authenticated identity used for the rejoin request.

The fix is to call `state.IdentityID.HostID()` which strips the clustername suffix. This will fix new 18.7.x+ nodes rejoining to older 18.2.10- auth servers.

Added test coverage for four cases:
1. rejoing with new join service with token including all required roles
2. rejoing with new join service with token including only the newly required role
3. rejoing with legacy join service with token including all required roles
4. rejoing with legacy join service with token including only the newly required role

The bug currently effects case 3, all others still work.

changelog: fixed a bug affecting nodes on v18.3.0+ rejoining with new system roles to clusters with Auth services on v18.2.10-

## Manual Test Plan
### Test Environment

Cluster with Auth server running v18.2.10 or older.
Node with this fix that has already joined with the Node (ssh) role only.

### Test Cases
- [x] Add the App role to the join token. Enable the app service in the node config. Restart the node. It should rejoin and work.
- [x] Upgrade the Auth server to this branch and retest the above.
