### PR TITLE
[ci] prevent PRs from changing both e and OSS

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -17,10 +17,9 @@ jobs:
         with:
           filters: |
             submodule:
-              - 'e'        # The submodule pointer itself
+              - 'e'
             other:
-              - '**'
-              - '!e'      # Anything except the submodule pointer
+              - '!e'
 
       - name: Validate PR
         run: |

--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -1,0 +1,37 @@
+name: Submodule Update Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  submodule-validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            submodule:
+              - 'e'        # The submodule pointer itself
+            other:
+              - '**'
+              - '!e'      # Anything except the submodule pointer
+
+      - name: Validate PR
+        run: |
+          echo "Submodule changed: ${{ steps.filter.outputs.submodule }}"
+          echo "Other changes: ${{ steps.filter.outputs.other }}"
+
+          if [[ "${{ steps.filter.outputs.submodule }}" == "true" && "${{ steps.filter.outputs.other }}" == "true" ]]; then
+            echo "ERROR: PR contains both submodule and other changes!"
+            exit 1
+          fi

--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
       - name: Filter paths
         id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2


### PR DESCRIPTION
This workflow prevents accidental merges of e/ changes in larger PRs. Updating e should be a standalone PR.


## Manual Test Plan
### Test Environment
GHA
### Test Cases
- [x] Open a PR on a second branch and test the permutations of changes.
