### PR TITLE
[v18] scope pin pruning

### DIFF
--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -410,7 +410,7 @@ func (c *Cache) fetch(ctx context.Context) (state, error) {
 		}
 	}
 
-	assignmentCache := assignments.NewAssignmentCache()
+	assignmentCache := assignments.NewAssignmentCache(assignments.AssignmentCacheConfig{})
 
 	for assignment, err := range scopedutils.RangeScopedRoleAssignments(ctx, c.cfg.Reader, &scopedaccessv1.ListScopedRoleAssignmentsRequest{}) {
 		if err != nil {

--- a/lib/scopes/cache/assignments/assignment_cache.go
+++ b/lib/scopes/cache/assignments/assignment_cache.go
@@ -20,7 +20,9 @@ package assignments
 
 import (
 	"context"
+	"os"
 	"slices"
+	"strconv"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
@@ -33,17 +35,38 @@ import (
 )
 
 const (
-	defaultPageSize = 256
-	maxPageSize     = 1024
+	defaultPageSize               = 256
+	maxPageSize                   = 1024
+	defaultMaxAssignmentTreeBytes = 2048
 )
+
+// AssignmentCacheConfig is the configuration for the assignment cache.
+type AssignmentCacheConfig struct {
+	// MaxAssignmentTreeBytes is the maximum encoded size for assignment trees, which make up
+	// the bulk of the size of a scope pin when encoded on a certificate. See [pinning.PruneAssignmentTree]
+	// for details on how pruning of oversized assignment trees works. Defaults to 2kb.
+	MaxAssignmentTreeBytes int
+}
 
 // AssignmentCache is a cache for scoped role assignments.
 type AssignmentCache struct {
 	cache *cache.Cache[*scopedaccessv1.ScopedRoleAssignment, string]
+	cfg   AssignmentCacheConfig
 }
 
-// NewAssignmentCache creates a new assignment cache instance.
-func NewAssignmentCache() *AssignmentCache {
+// NewAssignmentCache creates a new assignment cache instance with the given configuration.
+func NewAssignmentCache(cfg AssignmentCacheConfig) *AssignmentCache {
+	if cfg.MaxAssignmentTreeBytes == 0 {
+		cfg.MaxAssignmentTreeBytes = defaultMaxAssignmentTreeBytes
+	}
+
+	if matb := os.Getenv("TELEPORT_UNSTABLE_MAX_ASSIGNMENT_TREE_BYTES"); matb != "" {
+		parsed, err := strconv.Atoi(matb)
+		if err == nil && parsed > 0 {
+			cfg.MaxAssignmentTreeBytes = parsed
+		}
+	}
+
 	return &AssignmentCache{
 		cache: cache.Must(cache.Config[*scopedaccessv1.ScopedRoleAssignment, string]{
 			Scope: func(assignment *scopedaccessv1.ScopedRoleAssignment) string {
@@ -54,6 +77,7 @@ func NewAssignmentCache() *AssignmentCache {
 			},
 			Clone: proto.CloneOf[*scopedaccessv1.ScopedRoleAssignment],
 		}),
+		cfg: cfg,
 	}
 }
 

--- a/lib/scopes/cache/assignments/assignment_cache_test.go
+++ b/lib/scopes/cache/assignments/assignment_cache_test.go
@@ -186,7 +186,7 @@ func TestListScopedRoleAssignmentsScenarios(t *testing.T) {
 		},
 	}
 
-	cache := NewAssignmentCache()
+	cache := NewAssignmentCache(AssignmentCacheConfig{})
 	for _, assignment := range assignments {
 		_, err := cache.GetScopedRoleAssignment(t.Context(), &scopedaccessv1.GetScopedRoleAssignmentRequest{
 			Name: assignment.GetMetadata().GetName(),
@@ -595,7 +595,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 	}
 
-	cache := NewAssignmentCache()
+	cache := NewAssignmentCache(AssignmentCacheConfig{})
 	for _, assignment := range assignments {
 		_, err := cache.GetScopedRoleAssignment(t.Context(), &scopedaccessv1.GetScopedRoleAssignmentRequest{
 			Name: assignment.GetMetadata().GetName(),

--- a/lib/scopes/cache/assignments/pinning.go
+++ b/lib/scopes/cache/assignments/pinning.go
@@ -120,6 +120,16 @@ func (c *AssignmentCache) PopulatePinnedAssignmentsForUser(ctx context.Context, 
 		return trace.NotFound("no scoped role assignments found for user %q applicable to pinned scope %q", user, pin.GetScope())
 	}
 
+	// Prune the assignment tree if it exceeds the maximum encoded size. See [pinning.PruneAssignmentTree] for a detailed
+	// discussion of the rationale for pruning and the justification for the specific pruning strategy employed.
+	if prunedCount := pinning.PruneAssignmentTree(ctx, pin, c.cfg.MaxAssignmentTreeBytes); prunedCount > 0 {
+		slog.WarnContext(ctx, "pruned assignment tree to limit certificate size, user may experience degraded privileges until assignments are reduced",
+			"user", user,
+			"pin_scope", pin.GetScope(),
+			"total_pruned", prunedCount,
+			"max_bytes", c.cfg.MaxAssignmentTreeBytes)
+	}
+
 	// perform a final weak validation of the pin to ensure that it is well-formed. this should be redundant since auth performs strong
 	// validation of all pins prior to encoding them on certs, but its worth being defensive due to how critical scope pins are.
 	if err := pinning.WeakValidate(pin); err != nil {

--- a/lib/scopes/cache/assignments/pinning_test.go
+++ b/lib/scopes/cache/assignments/pinning_test.go
@@ -189,7 +189,7 @@ func TestPopulatePinnedAssignmentsForUser(t *testing.T) {
 		},
 	}
 
-	cache := NewAssignmentCache()
+	cache := NewAssignmentCache(AssignmentCacheConfig{})
 	for _, assignment := range assignments {
 		_, err := cache.GetScopedRoleAssignment(t.Context(), &scopedaccessv1.GetScopedRoleAssignmentRequest{
 			Name: assignment.GetMetadata().GetName(),
@@ -268,4 +268,91 @@ func TestPopulatePinnedAssignmentsForUser(t *testing.T) {
 			require.Empty(t, cmp.Diff(pin, tt.expect, protocmp.Transform()))
 		})
 	}
+}
+
+// TestAssignmentTreePruning verifies that the assignment cache actually prunes oversized assignment trees
+// as expected. See [pinning.PruneAssignmentTree] for detailed discussion of assignment tree pruning.
+func TestAssignmentTreePruning(t *testing.T) {
+	t.Parallel()
+
+	// set up a cache with a very small max tree size in order to verify pruning behavior
+	cache := NewAssignmentCache(AssignmentCacheConfig{
+		MaxAssignmentTreeBytes: 50,
+	})
+
+	// set up some initial assignments. pruning operates at the scope of origin level, so assignments
+	// must have a mix of resource scopes to provide a natural pruning boundary.
+	assignments := []*scopedaccessv1.ScopedRoleAssignment{
+		{
+			Kind: scopedaccess.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "alice-root",
+			},
+			Scope: "/",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: "root-role", Scope: "/staging"},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "alice-staging",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: "staging-role", Scope: "/staging"},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "alice-staging-west",
+			},
+			Scope: "/staging/west",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: "west-role", Scope: "/staging/west"},
+				},
+			},
+			Version: types.V1,
+		},
+	}
+
+	for _, assignment := range assignments {
+		err := cache.Put(assignment)
+		require.NoError(t, err)
+	}
+
+	pin := &scopesv1.Pin{
+		Scope: "/staging/west",
+	}
+	err := cache.PopulatePinnedAssignmentsForUser(t.Context(), "alice", pin)
+	require.NoError(t, err)
+
+	// verify the tree was populated
+	require.NotNil(t, pin.AssignmentTree)
+
+	// verify the tree fits within the size limit
+	treeSize := proto.Size(pin.AssignmentTree)
+	require.LessOrEqual(t, treeSize, cache.cfg.MaxAssignmentTreeBytes,
+		"assignment tree should be pruned to fit within configured limit")
+
+	// verify that the pruned tree retained the most important assignment
+	expectedTree := map[string]map[string][]string{
+		"/": {
+			"/staging": {"root-role"},
+		},
+	}
+	actualTree := pinning.AssignmentTreeIntoMap(pin.AssignmentTree)
+	require.Equal(t, expectedTree, actualTree,
+		"pruning should preserve highest authority assignments (root level)")
 }

--- a/lib/scopes/pinning/pinning.go
+++ b/lib/scopes/pinning/pinning.go
@@ -19,10 +19,13 @@
 package pinning
 
 import (
+	"context"
 	"iter"
+	"log/slog"
 	"slices"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -473,4 +476,160 @@ func enumerateRoleNode(node *scopesv1.RoleNode, scopeOfOrigin string, effectSegm
 	}
 
 	return true
+}
+
+// PruneAssignmentTree prunes the assignment tree s.t. its encoded size is less than or equal to the specified
+// maximum. This is necessary in order to prevent excessively large assignment trees from causing certificate
+// size issues. The *strategy* of pruning has been devised to allow for "graceful degradation", consistent
+// with the rules and philosophy of scoping. When an assignment tree is too large, the assignments with the
+// deepest Scope of Origin (i.e. those assignments theoretically authored/owned by the admins of least authority)
+// are preferentially pruned.
+//
+// It is important to understand that this is a rough approximation of the ideal pruning strategy. And admin in
+// `/staging/west` always outranks an admin in `/staging/west/testing`, however it isn't necessarily true that
+// an admin in `/staging/west` actually outranks an admin at `/prod/west/testing`. What we have selected is the
+// most *straightforward* pruning strategy that meaningfully respects scope hierarchy, but relative ranking of
+// orthogonal scopes is ambiguous. We think what we have here is an acceptable approximation, espectially because,
+// thanks to scope pinning, scenarios where this pruning strategy fails are likely easily addressable by simply pinning
+// to a more specific scope (e.g. pinning to `/prod` to avoid having assignments in `/staging` count toward the size of
+// the pin).
+//
+// Note that the pruning strategy prunes entire Scope of Origin depth levels as a unit. For example, if a pin contains
+// assignments originating from `/prod`, `/staging`, `/prod/west`, and `/staging/west`, and exceeds the maximum size,
+// all 2-depth assignments (i.e. those originating from `/prod/west` and `/staging/west`) will be pruned, even if only
+// pruning a subset would have brought the pin within the size constraint. This was done because we judged picking and
+// choosing individual assignments to be pruned to be a potentially surprising and hazardous. One alternative that was
+// considered but not implemented was to do a weighted pruning within each depth level, prioritizing pruning specific
+// origin scopes within a given depth based on their size. In the above example, this would mean that we might prune
+// all assignments from `/staging/west` and retain all assignments from `/prod/west` if the former contained more
+// assignments than the latter. This approach was not taken because it added significant complexity without wholly
+// solving the orthogonal ranking problem, but may be something to revisit if the scenarios where it performs better
+// end up being more common in practice than we anticipate.
+func PruneAssignmentTree(ctx context.Context, pin *scopesv1.Pin, maxBytes int) (prunedCount int) {
+	if pin == nil || pin.AssignmentTree == nil {
+		return 0
+	}
+
+	// check if pruning is actually needed
+	initialSize := proto.Size(pin.AssignmentTree)
+	if initialSize <= maxBytes {
+		return 0
+	}
+
+	// get count of assignments before pruning
+	initialCount := countAssignments(pin.AssignmentTree)
+
+	currentSize := initialSize
+
+	// iteratively prune the deepest depth level until we fit within the size limit
+	for {
+		// find the deepest Scope of Origin depth currently contained in the tree
+		maxDepth := maxAssignmentDepth(pin.AssignmentTree)
+		if maxDepth == 0 {
+			slog.WarnContext(ctx, "assignment tree exceeds prescribed size limit but will not be pruned further due to all remaining assignments originating from root scope",
+				"pin_scope", pin.GetScope(),
+				"initial_size", initialSize,
+				"current_size", currentSize,
+				"max_size", maxBytes,
+				"initial_count", initialCount,
+				"current_count", countAssignments(pin.AssignmentTree),
+			)
+			// note that the pin may still contain root level assignments. we opt not to prune
+			// those as they would render the pin (and therefore the resulting certificate)
+			// effectively useless.
+			break
+		}
+
+		// prune the tree in-place
+		pruneTreeToDepth(pin.AssignmentTree, maxDepth-1)
+
+		currentSize = proto.Size(pin.AssignmentTree)
+		if currentSize <= maxBytes {
+			// we've pruned enough to fit within the size limit
+			break
+		}
+	}
+
+	// return total number of assignments pruned
+	return initialCount - countAssignments(pin.AssignmentTree)
+}
+
+// maxAssignmentDepth returns the maximum Scope of Origin depth present in the assignment tree.
+// Depth is the number of segments in the Scope of Origin (e.g., "/" = 0, "/staging" = 1).
+// Returns 0 for an empty tree or a tree containing only root-level assignments.
+func maxAssignmentDepth(tree *scopesv1.AssignmentNode) int {
+	if tree == nil {
+		return 0
+	}
+	return maxDepthOfAssignmentNode(tree, 0)
+}
+
+// maxDepthOfAssignmentNode recursively traverses the assignment tree to find the maximum depth
+// at which any assignments exist.
+func maxDepthOfAssignmentNode(node *scopesv1.AssignmentNode, depth int) int {
+	// maxDepth tracks the maximum depth found among child nodes
+	maxDepth := depth
+	for _, child := range node.Children {
+		maxDepth = max(maxDepth, maxDepthOfAssignmentNode(child, depth+1))
+	}
+
+	return maxDepth
+}
+
+// countAssignments counts the total number of role assignments encoded in the assignment tree.
+func countAssignments(tree *scopesv1.AssignmentNode) int {
+	if tree == nil {
+		return 0
+	}
+	return countAssignmentsInTree(tree)
+}
+
+// countAssignmentsInTree recursively counts role assignments in the assignment tree.
+func countAssignmentsInTree(node *scopesv1.AssignmentNode) int {
+	count := 0
+
+	// count roles in this node's role tree
+	if node.RoleTree != nil {
+		count += countRolesInTree(node.RoleTree)
+	}
+
+	// recursively count in children
+	for _, child := range node.Children {
+		count += countAssignmentsInTree(child)
+	}
+
+	return count
+}
+
+// countRolesInTree recursively counts roles in a role tree node.
+func countRolesInTree(node *scopesv1.RoleNode) int {
+	count := len(node.Roles)
+
+	// recursively count in children
+	for _, child := range node.Children {
+		count += countRolesInTree(child)
+	}
+
+	return count
+}
+
+// pruneTreeToDepth prunes the assignment tree in-place to remove all assignment nodes
+// deeper than the specified maxDepth. Assignment nodes at depth <= maxDepth are preserved.
+func pruneTreeToDepth(tree *scopesv1.AssignmentNode, maxDepth int) {
+	pruneAssignmentNodeToDepth(tree, maxDepth, 0)
+}
+
+// pruneAssignmentNodeToDepth recursively prunes assignment nodes, removing children
+// that exceed the maximum allowed depth.
+func pruneAssignmentNodeToDepth(node *scopesv1.AssignmentNode, maxDepth, currentDepth int) {
+	if currentDepth == maxDepth {
+		// This is the last level we want to keep, remove all children
+		node.Children = nil
+		return
+	}
+
+	// currentDepth < maxDepth, so recursively prune children
+	for _, child := range node.Children {
+		pruneAssignmentNodeToDepth(child, maxDepth, currentDepth+1)
+	}
 }

--- a/lib/scopes/pinning/pinning_test.go
+++ b/lib/scopes/pinning/pinning_test.go
@@ -19,10 +19,12 @@
 package pinning
 
 import (
+	"context"
 	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -883,6 +885,230 @@ func TestAssignmentTreeMapConversions(t *testing.T) {
 			}
 
 			require.Equal(t, tt.input, got, "round-trip conversion should preserve all assignments")
+		})
+	}
+}
+
+// TestPruneAssignmentTree verifies that assignment tree pruning correctly removes
+// entire depth levels (by Scope of Origin) to fit within size constraints, preserving
+// higher authority assignments.
+func TestPruneAssignmentTree(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		before          map[string]map[string][]string
+		after           map[string]map[string][]string
+		maxBytes        int
+		expectPruned    int
+		expectOversized bool
+	}{
+		{
+			name: "no pruning needed",
+			before: map[string]map[string][]string{
+				"/": {
+					"/staging": {"role1"},
+				},
+			},
+			after: map[string]map[string][]string{
+				"/": {
+					"/staging": {"role1"},
+				},
+			},
+			maxBytes:     10000,
+			expectPruned: 0,
+		},
+		{
+			name: "prune deepest level only",
+			before: map[string]map[string][]string{
+				"/": {
+					"/staging":      {"root-staging"},
+					"/staging/west": {"root-west"},
+				},
+				"/staging": {
+					"/staging/west": {"staging-west"},
+				},
+				"/staging/west": {
+					"/staging/west": {"west-local"},
+				},
+			},
+			after: map[string]map[string][]string{
+				"/": {
+					"/staging":      {"root-staging"},
+					"/staging/west": {"root-west"},
+				},
+				"/staging": {
+					"/staging/west": {"staging-west"},
+				},
+			},
+			maxBytes:     110,
+			expectPruned: 1,
+		},
+		{
+			name: "prune two deepest levels",
+			before: map[string]map[string][]string{
+				"/": {
+					"/":                  {"global"},
+					"/staging":           {"root-staging"},
+					"/staging/west":      {"root-west"},
+					"/staging/west/rack": {"root-rack"},
+				},
+				"/staging": {
+					"/staging/west":      {"staging-west"},
+					"/staging/west/rack": {"staging-rack"},
+				},
+				"/staging/west": {
+					"/staging/west/rack": {"west-rack"},
+				},
+				"/staging/west/rack": {
+					"/staging/west/rack": {"rack-local"},
+				},
+			},
+			after: map[string]map[string][]string{
+				"/": {
+					"/":                  {"global"},
+					"/staging":           {"root-staging"},
+					"/staging/west":      {"root-west"},
+					"/staging/west/rack": {"root-rack"},
+				},
+				"/staging": {
+					"/staging/west":      {"staging-west"},
+					"/staging/west/rack": {"staging-rack"},
+				},
+			},
+			maxBytes:     160,
+			expectPruned: 2,
+		},
+		{
+			name: "uniform pruning across branches",
+			before: map[string]map[string][]string{
+				"/": {
+					"/staging": {"root-staging"},
+					"/prod":    {"root-prod"},
+				},
+				"/staging": {
+					"/staging/west": {"west-admin"},
+					"/staging/east": {"east-admin"},
+				},
+				"/prod": {
+					"/prod/us": {"us-admin"},
+					"/prod/eu": {"eu-admin"},
+				},
+			},
+			after: map[string]map[string][]string{
+				"/": {
+					"/staging": {"root-staging"},
+					"/prod":    {"root-prod"},
+				},
+			},
+			maxBytes:     150,
+			expectPruned: 4,
+		},
+		{
+			name: "prune everything except root",
+			before: map[string]map[string][]string{
+				"/": {
+					"/":        {"global"},
+					"/staging": {"root-staging"},
+				},
+				"/staging": {
+					"/staging": {"staging-admin"},
+				},
+			},
+			after: map[string]map[string][]string{
+				"/": {
+					"/":        {"global"},
+					"/staging": {"root-staging"},
+				},
+			},
+			maxBytes:     40,
+			expectPruned: 1,
+		},
+		{
+			name:         "empty tree",
+			before:       nil,
+			after:        nil,
+			maxBytes:     100,
+			expectPruned: 0,
+		},
+		{
+			// verify that an oversized assignment tree consisting solely of root-origin assignments
+			// is left unmodified (root assignments are never pruned).
+			name: "only root assignments, oversized",
+			before: map[string]map[string][]string{
+				"/": {
+					"/a": {"role1"},
+					"/b": {"role2"},
+					"/c": {"role3"},
+				},
+			},
+			after: map[string]map[string][]string{
+				"/": {
+					"/a": {"role1"},
+					"/b": {"role2"},
+					"/c": {"role3"},
+				},
+			},
+			maxBytes:        1,
+			expectPruned:    0,
+			expectOversized: true,
+		},
+		{
+			// verify that an oversized assignment tree is pruned down to root-origin assignments
+			// even when the root-origin assignments alone still exceed the size limit.
+			name: "still oversized after pruning to root",
+			before: map[string]map[string][]string{
+				"/": {
+					"/a": {"role1"},
+					"/b": {"role2"},
+					"/c": {"role3"},
+				},
+				"/a": {
+					"/a": {"a-role1"},
+					"/b": {"a-role2"},
+				},
+			},
+			after: map[string]map[string][]string{
+				"/": {
+					"/a": {"role1"},
+					"/b": {"role2"},
+					"/c": {"role3"},
+				},
+			},
+			maxBytes:        1,
+			expectPruned:    2,
+			expectOversized: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// set up pin with assignment tree
+			pin := &scopesv1.Pin{
+				Scope:          "/staging/west",
+				AssignmentTree: AssignmentTreeFromMap(tt.before),
+			}
+
+			// perform pruning
+			prunedCount := PruneAssignmentTree(context.Background(), pin, tt.maxBytes)
+
+			// verify resulting tree matches expected
+			afterMap := AssignmentTreeIntoMap(pin.AssignmentTree)
+			require.Equal(t, tt.after, afterMap, "tree after pruning should match expected")
+
+			// verify pruned count (this is more about making sure the function returns the expected
+			// count, the assertion above is the more important check for correctness of pruning)
+			require.Equal(t, tt.expectPruned, prunedCount, "pruned count should match expected")
+
+			// verify final size is on the expected side of the limit
+			if pin.AssignmentTree != nil {
+				finalSize := proto.Size(pin.AssignmentTree)
+				if tt.expectOversized {
+					require.Greater(t, finalSize, tt.maxBytes, "pruned tree should still exceed size limit")
+				} else {
+					require.LessOrEqual(t, finalSize, tt.maxBytes, "pruned tree should fit within size limit")
+				}
+			}
 		})
 	}
 }

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -275,6 +275,24 @@ func Split(scope string) []string {
 	return strings.Split(trimForSplit(scope), separator)
 }
 
+// Depth returns the depth of a scope (i.e., the number of segments) e.g. `Depth("/a/b/c")` returns 3,
+// `Depth("/")` returns 0, etc. This is equivalent to `len(Split(scope))` but avoids allocation.
+//
+// Note that this function does not perform validation and is deliberately more relaxed about
+// its inputs than our validation functions allow.
+func Depth(scope string) int {
+	if scope == "" || scope == separator {
+		return 0
+	}
+
+	trimmed := trimForSplit(scope)
+	if trimmed == "" {
+		return 0
+	}
+
+	return strings.Count(trimmed, separator) + 1
+}
+
 func trimForSplit(scope string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(scope, separator), separator)
 }

--- a/lib/scopes/scopes_test.go
+++ b/lib/scopes/scopes_test.go
@@ -1269,3 +1269,67 @@ func TestEnforcementPointsForResourceScope(t *testing.T) {
 		})
 	}
 }
+
+// TestDepth verifies that Depth returns the correct number of segments for various scopes
+// and matches the behavior of len(Split(scope)).
+func TestDepth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		scope         string
+		expectedDepth int
+	}{
+		{
+			name:          "root scope",
+			scope:         "/",
+			expectedDepth: 0,
+		},
+		{
+			name:          "empty scope",
+			scope:         "",
+			expectedDepth: 0,
+		},
+		{
+			name:          "single segment",
+			scope:         "/staging",
+			expectedDepth: 1,
+		},
+		{
+			name:          "two segments",
+			scope:         "/staging/west",
+			expectedDepth: 2,
+		},
+		{
+			name:          "three segments",
+			scope:         "/staging/west/rack",
+			expectedDepth: 3,
+		},
+		{
+			name:          "deep hierarchy",
+			scope:         "/a/b/c/d/e/f",
+			expectedDepth: 6,
+		},
+		{
+			name:          "scope with trailing slash (invalid but handled gracefully)",
+			scope:         "/staging/",
+			expectedDepth: 1,
+		},
+		{
+			name:          "scope without leading slash (invalid but handled gracefully)",
+			scope:         "staging/west",
+			expectedDepth: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Depth(tt.scope)
+			require.Equal(t, tt.expectedDepth, got, "depth should match expected value")
+
+			// as a sanity-check, verify that Depth matches the behavior of len(Split(scope))
+			splitLen := len(Split(tt.scope))
+			require.Equal(t, splitLen, got, "Depth should match len(Split(scope))")
+		})
+	}
+}

--- a/lib/scopes/utils/range_test.go
+++ b/lib/scopes/utils/range_test.go
@@ -83,7 +83,7 @@ func TestRangeScopedRoleAssignments(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	upstream := assignments.NewAssignmentCache()
+	upstream := assignments.NewAssignmentCache(assignments.AssignmentCacheConfig{})
 
 	expectedAssignmentNames := make([]string, 0, assignmentCount)
 


### PR DESCRIPTION
Backport #63944 to branch/v18.

### Manual Testing

- [x] Manually verify that pruning is applied as appropriate in real teleport clusters.
- [x] Manually verify that preserved privileges function as expected (i.e. that a pruned cert remains usable).

note: manual testing was performed with the final version of this logic in place, but with a smaller than standard size limit supplied via unstable env var.