### PR TITLE
Fix resource leaks in bpf program loading

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -115,9 +115,7 @@ func New(config *servicecfg.BPFConfig) (bpf BPF, err error) {
 	}
 	defer func() {
 		if err != nil {
-			if err := s.cgroup.Close(true); err != nil {
-				logger.WarnContext(closeContext, "Failed to close cgroup", "error", err)
-			}
+			_ = s.Close(true)
 		}
 	}()
 
@@ -165,6 +163,10 @@ func New(config *servicecfg.BPFConfig) (bpf BPF, err error) {
 // shutdown, from the man page for BPF: "Generally, eBPF programs are loaded by
 // the user process and automatically unloaded when the process exits".
 func (s *Service) Close(restarting bool) error {
+	if s == nil {
+		return nil
+	}
+
 	// Unload the BPF programs.
 	s.exec.close()
 	s.open.close()
@@ -173,12 +175,16 @@ func (s *Service) Close(restarting bool) error {
 	// Close cgroup service. We should not unmount the cgroup filesystem if
 	// we're restarting.
 	skipCgroupUnmount := restarting
-	if err := s.cgroup.Close(skipCgroupUnmount); err != nil {
-		logger.WarnContext(s.closeContext, "Failed to close cgroup", "error", err)
+	if s.cgroup != nil {
+		if err := s.cgroup.Close(skipCgroupUnmount); err != nil {
+			logger.WarnContext(s.closeContext, "Failed to close cgroup", "error", err)
+		}
 	}
 
 	// Signal to the processAccessEvents pulling events off the perf buffer to shutdown.
-	s.closeFunc()
+	if s.closeFunc != nil {
+		s.closeFunc()
+	}
 
 	return nil
 }

--- a/lib/bpf/command.go
+++ b/lib/bpf/command.go
@@ -60,8 +60,8 @@ type exec struct {
 
 // startExec will load, start, and pull events off the ring buffer
 // for the BPF program.
-func startExec(bufferSize int) (*exec, error) {
-	err := metrics.RegisterPrometheusCollectors(lostCommandEvents)
+func startExec(bufferSize int) (e *exec, err error) {
+	err = metrics.RegisterPrometheusCollectors(lostCommandEvents)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -76,12 +76,22 @@ func startExec(bufferSize int) (*exec, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	lostCtr, err := NewCounter(objs.LostCounter, objs.LostDoorbell, lostCommandEvents)
+	e = &exec{
+		objs: objs,
+		lost: objs.LostCounter,
+	}
+
+	// clean up in case of partial initialization
+	defer func() {
+		if err != nil {
+			e.close()
+		}
+	}()
+
+	e.lostCounter, err = NewCounter(e.objs.LostCounter, e.objs.LostDoorbell, lostCommandEvents)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	toClose := make([]io.Closer, 0)
 
 	tracePoints := []struct {
 		name       string
@@ -89,47 +99,41 @@ func startExec(bufferSize int) (*exec, error) {
 	}{
 		{
 			name:       "sys_enter_execve",
-			tracepoint: objs.TracepointSyscallsSysEnterExecve,
+			tracepoint: e.objs.TracepointSyscallsSysEnterExecve,
 		},
 		{
 			name:       "sys_exit_execve",
-			tracepoint: objs.TracepointSyscallsSysExitExecve,
+			tracepoint: e.objs.TracepointSyscallsSysExitExecve,
 		},
 		{
 			name:       "sys_enter_execveat",
-			tracepoint: objs.TracepointSyscallsSysEnterExecveat,
+			tracepoint: e.objs.TracepointSyscallsSysEnterExecveat,
 		},
 		{
 			name:       "sys_exit_execveat",
-			tracepoint: objs.TracepointSyscallsSysExitExecveat,
+			tracepoint: e.objs.TracepointSyscallsSysExitExecveat,
 		},
 	}
 
+	e.toClose = make([]io.Closer, 0)
 	for _, tp := range tracePoints {
 		tp, err := link.Tracepoint("syscalls", tp.name, tp.tracepoint, nil)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		toClose = append(toClose, tp)
+		e.toClose = append(e.toClose, tp)
 	}
 
-	eventBuf, err := ringbuf.NewReader(objs.ExecveEvents)
+	e.eventBuf, err = ringbuf.NewReader(e.objs.ExecveEvents)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	bpfEvents := make(chan []byte, bufferSize)
-	go sendEvents(bpfEvents, eventBuf)
+	e.bpfEvents = make(chan []byte, bufferSize)
+	go sendEvents(e.bpfEvents, e.eventBuf)
 
-	return &exec{
-		objs:        objs,
-		eventBuf:    eventBuf,
-		lost:        objs.LostCounter,
-		toClose:     toClose,
-		bpfEvents:   bpfEvents,
-		lostCounter: lostCtr,
-	}, nil
+	return e, nil
 }
 
 func (e *exec) startSession(auditSessionID uint32) error {
@@ -165,27 +169,41 @@ func (e *exec) endSession(auditSessionID uint32) error {
 // close will stop reading events off the ring buffer and unload the BPF
 // program. The ring buffer is closed as part of the module being closed.
 func (e *exec) close() {
+	if e == nil {
+		return
+	}
+
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
 
 	if e.closed {
 		return
 	}
-
 	e.closed = true
 
 	for _, link := range e.toClose {
+		if link == nil {
+			continue
+		}
 		if err := link.Close(); err != nil {
 			logger.WarnContext(context.Background(), "failed to close link", "error", err)
 		}
 	}
 
-	if err := e.objs.Close(); err != nil {
-		logger.WarnContext(context.Background(), "failed to close command objects", "error", err)
+	if e.eventBuf != nil {
+		if err := e.eventBuf.Close(); err != nil {
+			logger.WarnContext(context.Background(), "failed to close command ring buffer reader", "error", err)
+		}
 	}
 
-	if err := e.lostCounter.Close(); err != nil {
-		logger.WarnContext(context.Background(), "failed to close command lost counter", "error", err)
+	if e.lostCounter != nil {
+		if err := e.lostCounter.Close(); err != nil {
+			logger.WarnContext(context.Background(), "failed to close command lost counter", "error", err)
+		}
+	}
+
+	if err := e.objs.Close(); err != nil {
+		logger.WarnContext(context.Background(), "failed to close command objects", "error", err)
 	}
 
 	logger.DebugContext(context.Background(), "Closed command BPF module")

--- a/lib/bpf/command.go
+++ b/lib/bpf/command.go
@@ -80,8 +80,6 @@ func startExec(bufferSize int) (e *exec, err error) {
 		objs: objs,
 		lost: objs.LostCounter,
 	}
-
-	// clean up in case of partial initialization
 	defer func() {
 		if err != nil {
 			e.close()

--- a/lib/bpf/disk.go
+++ b/lib/bpf/disk.go
@@ -47,19 +47,20 @@ var lostDiskEvents = prometheus.NewCounter(
 type open struct {
 	objs diskObjects
 
-	eventBuf chan []byte
+	eventBuf *ringbuf.Reader
 	toClose  []io.Closer
 
 	closed bool
 	mtx    sync.Mutex
 
+	bpfEvents   chan []byte
 	lostCounter *Counter
 }
 
 // startOpen will compile, load, start, and pull events off the perf buffer
 // for the BPF program.
-func startOpen(bufferSize int) (*open, error) {
-	err := metrics.RegisterPrometheusCollectors(lostDiskEvents)
+func startOpen(bufferSize int) (o *open, err error) {
+	err = metrics.RegisterPrometheusCollectors(lostDiskEvents)
 	if err != nil {
 		return nil, trace.Wrap(err, "registering prometheus collectors: %v", err)
 	}
@@ -75,7 +76,16 @@ func startOpen(bufferSize int) (*open, error) {
 		return nil, trace.Wrap(err, "loading disk objects: %v", err)
 	}
 
-	lostCtr, err := NewCounter(objs.LostCounter, objs.LostDoorbell, lostDiskEvents)
+	o = &open{
+		objs: objs,
+	}
+	defer func() {
+		if err != nil {
+			o.close()
+		}
+	}()
+
+	o.lostCounter, err = NewCounter(o.objs.LostCounter, o.objs.LostDoorbell, lostDiskEvents)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -86,19 +96,19 @@ func startOpen(bufferSize int) (*open, error) {
 	}{
 		{
 			name: "sys_enter_openat",
-			prog: objs.TracepointSyscallsSysEnterOpenat,
+			prog: o.objs.TracepointSyscallsSysEnterOpenat,
 		},
 		{
 			name: "sys_exit_openat",
-			prog: objs.TracepointSyscallsSysExitOpenat,
+			prog: o.objs.TracepointSyscallsSysExitOpenat,
 		},
 		{
 			name: "sys_enter_openat2",
-			prog: objs.TracepointSyscallsSysEnterOpenat2,
+			prog: o.objs.TracepointSyscallsSysEnterOpenat2,
 		},
 		{
 			name: "sys_exit_openat2",
-			prog: objs.TracepointSyscallsSysExitOpenat2,
+			prog: o.objs.TracepointSyscallsSysExitOpenat2,
 		},
 	}
 
@@ -110,47 +120,42 @@ func startOpen(bufferSize int) (*open, error) {
 		}{
 			{
 				name: "sys_enter_creat",
-				prog: objs.TracepointSyscallsSysEnterCreat,
+				prog: o.objs.TracepointSyscallsSysEnterCreat,
 			},
 			{
 				name: "sys_exit_creat",
-				prog: objs.TracepointSyscallsSysExitCreat,
+				prog: o.objs.TracepointSyscallsSysExitCreat,
 			},
 			{
 				name: "sys_enter_open",
-				prog: objs.TracepointSyscallsSysEnterOpen,
+				prog: o.objs.TracepointSyscallsSysEnterOpen,
 			},
 			{
 				name: "sys_exit_open",
-				prog: objs.TracepointSyscallsSysExitOpen,
+				prog: o.objs.TracepointSyscallsSysExitOpen,
 			},
 		}...)
 	}
 
-	toClose := make([]io.Closer, 0, len(trs))
+	o.toClose = make([]io.Closer, 0, len(trs))
 	for _, tr := range trs {
 		tp, err := link.Tracepoint("syscalls", tr.name, tr.prog, nil)
 		if err != nil {
 			return nil, trace.Wrap(err, "linking %q tracepoint: %v", tr.name, err)
 		}
 
-		toClose = append(toClose, tp)
+		o.toClose = append(o.toClose, tp)
 	}
 
-	eventBuf, err := ringbuf.NewReader(objs.OpenEvents)
+	o.eventBuf, err = ringbuf.NewReader(o.objs.OpenEvents)
 	if err != nil {
 		return nil, trace.Wrap(err, "creating ring buffer reader: %v", err)
 	}
 
-	bpfEvents := make(chan []byte, bufferSize)
-	go sendEvents(bpfEvents, eventBuf)
+	o.bpfEvents = make(chan []byte, bufferSize)
+	go sendEvents(o.bpfEvents, o.eventBuf)
 
-	return &open{
-		objs:        objs,
-		eventBuf:    bpfEvents,
-		toClose:     toClose,
-		lostCounter: lostCtr,
-	}, nil
+	return o, nil
 }
 
 func (o *open) startSession(auditSessionID uint32) error {
@@ -186,6 +191,10 @@ func (o *open) endSession(auditSessionID uint32) error {
 // close will stop reading events off the ring buffer and unload the BPF
 // program. The ring buffer is closed as part of the module being closed.
 func (o *open) close() {
+	if o == nil {
+		return
+	}
+
 	o.mtx.Lock()
 	defer o.mtx.Unlock()
 
@@ -195,9 +204,24 @@ func (o *open) close() {
 
 	o.closed = true
 
-	for _, toClose := range o.toClose {
-		if err := toClose.Close(); err != nil {
+	for _, link := range o.toClose {
+		if link == nil {
+			continue
+		}
+		if err := link.Close(); err != nil {
 			logger.WarnContext(context.Background(), "failed to close link", "error", err)
+		}
+	}
+
+	if o.lostCounter != nil {
+		if err := o.lostCounter.Close(); err != nil {
+			logger.WarnContext(context.Background(), "failed to close disk lost counter", "error", err)
+		}
+	}
+
+	if o.eventBuf != nil {
+		if err := o.eventBuf.Close(); err != nil {
+			logger.WarnContext(context.Background(), "failed to close ring buffer reader", "error", err)
 		}
 	}
 
@@ -205,14 +229,10 @@ func (o *open) close() {
 		logger.WarnContext(context.Background(), "failed to close disk objects", "error", err)
 	}
 
-	if err := o.lostCounter.Close(); err != nil {
-		logger.WarnContext(context.Background(), "failed to close disk lost counter", "error", err)
-	}
-
 	logger.DebugContext(context.Background(), "Closed disk BPF module")
 }
 
 // events contains raw events off the perf buffer.
 func (o *open) events() <-chan []byte {
-	return o.eventBuf
+	return o.bpfEvents
 }

--- a/lib/bpf/network.go
+++ b/lib/bpf/network.go
@@ -46,6 +46,9 @@ var lostNetworkEvents = prometheus.NewCounter(
 type conn struct {
 	objs *networkObjects
 
+	event4Buf *ringbuf.Reader
+	event6Buf *ringbuf.Reader
+
 	event4Chan chan []byte
 	event6Chan chan []byte
 	toClose    []io.Closer
@@ -56,8 +59,8 @@ type conn struct {
 	lostCounter *Counter
 }
 
-func startConn(bufferSize int) (*conn, error) {
-	err := metrics.RegisterPrometheusCollectors(lostNetworkEvents)
+func startConn(bufferSize int) (c *conn, err error) {
+	err = metrics.RegisterPrometheusCollectors(lostNetworkEvents)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -72,7 +75,16 @@ func startConn(bufferSize int) (*conn, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	lostCtr, err := NewCounter(objs.LostCounter, objs.LostDoorbell, lostNetworkEvents)
+	c = &conn{
+		objs: &objs,
+	}
+	defer func() {
+		if err != nil {
+			c.close()
+		}
+	}()
+
+	c.lostCounter, err = NewCounter(c.objs.LostCounter, c.objs.LostDoorbell, lostNetworkEvents)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -83,11 +95,11 @@ func startConn(bufferSize int) (*conn, error) {
 	}{
 		{
 			symbol: "tcp_v4_connect",
-			prog:   objs.KprobeTcpV4Connect,
+			prog:   c.objs.KprobeTcpV4Connect,
 		},
 		{
 			symbol: "tcp_v6_connect",
-			prog:   objs.KprobeTcpV6Connect,
+			prog:   c.objs.KprobeTcpV6Connect,
 		},
 	}
 
@@ -97,22 +109,22 @@ func startConn(bufferSize int) (*conn, error) {
 	}{
 		{
 			symbol: "tcp_v4_connect",
-			prog:   objs.KretprobeTcpV4Connect,
+			prog:   c.objs.KretprobeTcpV4Connect,
 		},
 		{
 			symbol: "tcp_v6_connect",
-			prog:   objs.KretprobeTcpV6Connect,
+			prog:   c.objs.KretprobeTcpV6Connect,
 		},
 	}
 
-	toClose := make([]io.Closer, 0)
+	c.toClose = make([]io.Closer, 0)
 	for _, kprobe := range kprobes {
 		kp, err := link.Kprobe(kprobe.symbol, kprobe.prog, nil)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		toClose = append(toClose, kp)
+		c.toClose = append(c.toClose, kp)
 	}
 
 	for _, kretprobe := range kretProbes {
@@ -121,31 +133,25 @@ func startConn(bufferSize int) (*conn, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		toClose = append(toClose, kret)
+		c.toClose = append(c.toClose, kret)
 	}
 
-	eventBufV4, err := ringbuf.NewReader(objs.Ipv4Events)
+	c.event4Buf, err = ringbuf.NewReader(c.objs.Ipv4Events)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	eventBufV6, err := ringbuf.NewReader(objs.Ipv6Events)
+	c.event6Buf, err = ringbuf.NewReader(c.objs.Ipv6Events)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	bpfv4Events := make(chan []byte, bufferSize)
-	go sendEvents(bpfv4Events, eventBufV4)
+	c.event4Chan = make(chan []byte, bufferSize)
+	go sendEvents(c.event4Chan, c.event4Buf)
 
-	bpfv6Events := make(chan []byte, bufferSize)
-	go sendEvents(bpfv6Events, eventBufV6)
+	c.event6Chan = make(chan []byte, bufferSize)
+	go sendEvents(c.event6Chan, c.event6Buf)
 
-	return &conn{
-		objs:        &objs,
-		event4Chan:  bpfv4Events,
-		event6Chan:  bpfv6Events,
-		toClose:     toClose,
-		lostCounter: lostCtr,
-	}, nil
+	return c, nil
 }
 
 func (c *conn) startSession(auditSessionID uint32) error {
@@ -181,7 +187,10 @@ func (c *conn) endSession(auditSessionID uint32) error {
 // close will stop reading events off the ring buffer and unload the BPF
 // program. The ring buffer is closed as part of the module being closed.
 func (c *conn) close() {
-	// c.lost.Close()
+	if c == nil {
+		return
+	}
+
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
@@ -192,17 +201,34 @@ func (c *conn) close() {
 	c.closed = true
 
 	for _, link := range c.toClose {
+		if link == nil {
+			continue
+		}
 		if err := link.Close(); err != nil {
 			logger.WarnContext(context.Background(), "failed to close link", "error", err)
 		}
 	}
 
-	if err := c.objs.Close(); err != nil {
-		logger.WarnContext(context.Background(), "failed to close network objects", "error", err)
+	if c.lostCounter != nil {
+		if err := c.lostCounter.Close(); err != nil {
+			logger.WarnContext(context.Background(), "failed to close network lost counter", "error", err)
+		}
 	}
 
-	if err := c.lostCounter.Close(); err != nil {
-		logger.WarnContext(context.Background(), "failed to close network lost counter", "error", err)
+	if c.event4Buf != nil {
+		if err := c.event4Buf.Close(); err != nil {
+			logger.WarnContext(context.Background(), "failed to close v4 event buffer", "error", err)
+		}
+	}
+
+	if c.event6Buf != nil {
+		if err := c.event6Buf.Close(); err != nil {
+			logger.WarnContext(context.Background(), "failed to close v6 event buffer", "error", err)
+		}
+	}
+
+	if err := c.objs.Close(); err != nil {
+		logger.WarnContext(context.Background(), "failed to close network objects", "error", err)
 	}
 
 	logger.DebugContext(context.Background(), "Closed network BPF module")


### PR DESCRIPTION
There were a handful of potential resource leaks in the process of loading bpf programs.

Update the New service method to defer Close on the service.

Update the service Close method to guard against nil values.

Update startExec to clean up partial initialization with a nil-safe close method.

Update startOpen to save the ring buf reader on the struct so it can be closed, clean up partial init with a nil-safe close method.

Update startConn to save the v4 and v6 ring buf reader, clean up partial init with a nil-safe close method.

## Manual Test Plan
### Test Environment

- Linux VM wtih kernel >= 5.8 and BTF support
- Teleport built from this branch with BPF build tag
- Role with `options.bpf: ["command", "disk", "network"]
- Enhanced session recording enabled

### Test Cases
#### All three event types work

1. SSH into node
2. Run `ls /tmp`
3. Run `cat /etc/hostname`
4. Run `curl http://example.com
5. Exit session
6. Query the audit log with `tctl events ls`

- [ ] `session.command` events appear for `ls`, `cat`, `curl`
- [ ] `session.disk` events appear showing file opens
- [ ] `session.network` events appear showing TCP connections
- [ ] Events contain correct metadata
- [ ] Check for any panics or "use after close" errors in logs

#### Multiple concurrent sessions

1. Open two SSH sessions simultaneously to the node
2. In session A: `whoami && sleep 2 && echo done_A`
3. In session B: `whoami && sleep 2 && echo done_B`
4. Close both sessions
5. Query the audit log

- [ ] Events from each session have different session IDs
- [ ] No cross-contamination of events between sessions
- [ ] No missing events

#### No resource leaks on shutdown

1. SSH into node, run a few commands
2. Exit the session
3. Stop Teleport gracefully
4. Check Teleport logs for warnings

- [ ] No "failed to close" warnings
- [ ] Logs show "Closed" messages for all three BPF modules
- [ ] Process exists cleanly

#### Service restart

1. SSH in, verify commands are captured
2. Trigger a graceful restart of Teleport
3. SSH in again, verify events are captured

- [ ] BPF programs successfully reload
- [ ] Enhanced recording works normally after restart

