### PR TITLE
Update Rust to 1.94.0

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -970,7 +970,7 @@ impl Client {
 
     fn x224_lock(
         x224_processor: &Arc<Mutex<x224::Processor>>,
-    ) -> Result<MutexGuard<x224::Processor>, SessionError> {
+    ) -> Result<MutexGuard<'_, x224::Processor>, SessionError> {
         x224_processor
             .lock()
             .map_err(|err| reason_err!(function!(), "PoisonError: {:?}", err))
@@ -978,7 +978,7 @@ impl Client {
 
     fn resize_manager_lock(
         pending_resize: &Arc<Mutex<PendingResize>>,
-    ) -> Result<MutexGuard<PendingResize>, SessionError> {
+    ) -> Result<MutexGuard<'_, PendingResize>, SessionError> {
         pending_resize
             .lock()
             .map_err(|err| reason_err!(function!(), "PoisonError: {:?}", err))

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.94.0"
 targets = [ "wasm32-unknown-unknown", "x86_64-pc-windows-gnu" ]


### PR DESCRIPTION
Requires #64591

TODO:

- [x] wait for #64591 to merge
- [x] merge Rust update in teleport.e first: https://github.com/gravitational/teleport.e/pull/8276
- [x] Include submodule update in this PR

## Manual Test Plan

### Test Environment

- Tag build: https://github.com/gravitational/teleport.e/actions/runs/23071787976

### Test Cases
- [x] Successful tag build: https://github.com/gravitational/teleport.e/actions/runs/23071787976
- [x] Desktop Access connections work (AD)
- [x] Desktop Access connections work (non-AD)
- [x] fdpass-teleport works (see comment below)
