### PR TITLE
Introducing Release PR Linting

### DIFF
--- a/.github/workflows/lint-release.yaml
+++ b/.github/workflows/lint-release.yaml
@@ -1,0 +1,32 @@
+# This workflow runs some checks on release branches to ensure
+# that the release is ready to be published.
+name: Lint Release
+
+on:
+  push:
+    branches:
+      - release/*
+  pull_request:
+    branches:
+      - release/*
+
+jobs:
+  ensure-changelog-entry:
+    name: Ensure Changelog Entry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Ensure Changelog Entry
+        run: make ensure-changelog-entry
+
+      - name: Fetch base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch origin ${{ github.base_ref }}
+
+      - name: Ensure Version Changed
+        if: github.event_name == 'pull_request'
+        run: make ensure-version-changed BASE_REF=origin/${{ github.base_ref }}

--- a/.github/workflows/lint-release.yaml
+++ b/.github/workflows/lint-release.yaml
@@ -11,8 +11,8 @@ on:
       - release/*
 
 jobs:
-  ensure-changelog-entry:
-    name: Ensure Changelog Entry
+  lint-release:
+    name: Check Release Correctness
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lint-release.yaml
+++ b/.github/workflows/lint-release.yaml
@@ -1,5 +1,5 @@
-# This workflow runs some checks on release branches to ensure
-# that the release is ready to be published.
+# This workflow runs some checks on release branches to ensure correctness
+# for the release.
 name: Lint Release
 
 on:
@@ -23,6 +23,7 @@ jobs:
       - name: Ensure Changelog Entry
         run: make ensure-changelog-entry
 
+      # Base branch is only available for Pull Requests
       - name: Fetch base branch
         if: github.event_name == 'pull_request'
         run: git fetch origin ${{ github.base_ref }}

--- a/.github/workflows/lint-release.yaml
+++ b/.github/workflows/lint-release.yaml
@@ -3,31 +3,75 @@
 name: Lint Release
 
 on:
-  push:
-    branches:
-      - release/*
   pull_request:
-    branches:
-      - release/*
 
 jobs:
   lint-release:
     name: Check Release Correctness
+    if: startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from Makefile
+        id: extract_version
+        run: |
+          VERSION=$(sed -nE 's/^VERSION[[:space:]]*[?:]?=[[:space:]]*([^[:space:]#]+).*/\1/p' Makefile)
+          if [ -z "$VERSION" ]; then
+            echo "VERSION not found in Makefile"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+          case "$VERSION" in
+            *-*) IS_PRERELEASE=true ;;
+            *)   IS_PRERELEASE=false ;;
+          esac
+          echo "IS_PRERELEASE=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Determine merge base
+        id: merge_base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF"
+          MERGE_BASE=$(git merge-base "origin/${BASE_REF}" HEAD)
+          echo "MERGE_BASE=$MERGE_BASE" >> "$GITHUB_OUTPUT"
 
       - name: Ensure Changelog Entry
-        run: make ensure-changelog-entry
+        if: steps.extract_version.outputs.IS_PRERELEASE == 'false'
+        env:
+          VERSION: ${{ steps.extract_version.outputs.VERSION }}
+        run: |
+          if ! grep -qF -- "$VERSION" CHANGELOG.md; then
+            echo "Missing changelog entry for $VERSION"
+            exit 1
+          fi
 
-      # Base branch is only available for Pull Requests
-      - name: Fetch base branch
-        if: github.event_name == 'pull_request'
-        run: git fetch origin ${{ github.base_ref }}
+      - name: Ensure Changelog Untouched (pre-release)
+        if: steps.extract_version.outputs.IS_PRERELEASE == 'true'
+        env:
+          VERSION: ${{ steps.extract_version.outputs.VERSION }}
+          MERGE_BASE: ${{ steps.merge_base.outputs.MERGE_BASE }}
+        run: |
+          if ! git diff --quiet "$MERGE_BASE" -- CHANGELOG.md; then
+            echo "Pre-release version $VERSION must not modify CHANGELOG.md"
+            exit 1
+          fi
 
       - name: Ensure Version Changed
-        if: github.event_name == 'pull_request'
-        run: make ensure-version-changed BASE_REF=origin/${{ github.base_ref }}
+        env:
+          VERSION: ${{ steps.extract_version.outputs.VERSION }}
+          MERGE_BASE: ${{ steps.merge_base.outputs.MERGE_BASE }}
+        run: |
+          BASE_VER=$(git show "${MERGE_BASE}:Makefile" \
+            | sed -nE 's/^VERSION[[:space:]]*[?:]?=[[:space:]]*([^[:space:]#]+).*/\1/p')
+          if [ "$VERSION" = "$BASE_VER" ]; then
+            echo "VERSION $VERSION has not changed from merge-base"
+            exit 1
+          fi

--- a/.github/workflows/lint-release.yaml
+++ b/.github/workflows/lint-release.yaml
@@ -48,8 +48,9 @@ jobs:
         env:
           VERSION: ${{ steps.extract_version.outputs.VERSION }}
         run: |
-          if ! grep -qF -- "$VERSION" CHANGELOG.md; then
-            echo "Missing changelog entry for $VERSION"
+          ESCAPED=${VERSION//./\\.}
+          if ! grep -qE "^## ${ESCAPED}\$" CHANGELOG.md; then
+            echo "Missing changelog entry for $VERSION (expected header: ## $VERSION)"
             exit 1
           fi
 

--- a/.github/workflows/lint-release.yaml
+++ b/.github/workflows/lint-release.yaml
@@ -49,8 +49,8 @@ jobs:
           VERSION: ${{ steps.extract_version.outputs.VERSION }}
         run: |
           ESCAPED=${VERSION//./\\.}
-          if ! grep -qE "^## ${ESCAPED}\$" CHANGELOG.md; then
-            echo "Missing changelog entry for $VERSION (expected header: ## $VERSION)"
+          if ! grep -qE "^## ${ESCAPED}( |\$)" CHANGELOG.md; then
+            echo "Missing changelog entry for $VERSION (expected header starting with: ## $VERSION)"
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -2104,3 +2104,11 @@ ifndef BENCH_FILES
 	$(error "Please provide BENCH_FILES=<file1> <file2> ...")
 endif
 	@$(BENCHSTAT) $(BENCH_FILES) | tee test-logs/benchstat.txt
+
+# ensure-changelog-entry will check that the VERSION is present as a changelog entry
+.PHONY: ensure-changelog-entry
+ensure-changelog-entry:
+	@if ! grep -q "$(VERSION)" CHANGELOG.md; then \
+		echo Missing changelog entry for $(VERSION); \
+		exit 1; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -2112,3 +2112,19 @@ ensure-changelog-entry:
 		echo Missing changelog entry for $(VERSION); \
 		exit 1; \
 	fi
+
+# ensure-version-changed checks that the version has been updated between current ref and base ref
+# Usage:
+#   git fetch origin <branch>
+#   make ensure-version-changed BASE_REF=origin/<branch>
+.PHONY: ensure-version-changed
+ensure-version-changed:
+	@if [ -z "$(BASE_REF)" ]; then \
+		echo "BASE_REF is not set"; \
+		exit 1; \
+	fi
+	@BASE_VER=$$(git show $(BASE_REF):Makefile | grep "^VERSION=" | cut -d= -f2); \
+	if [ "$(VERSION)" \= "$$BASE_VER" ]; then \
+		echo "VERSION $(VERSION) has not changed from $(BASE_REF)"; \
+		exit 1; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -2104,27 +2104,3 @@ ifndef BENCH_FILES
 	$(error "Please provide BENCH_FILES=<file1> <file2> ...")
 endif
 	@$(BENCHSTAT) $(BENCH_FILES) | tee test-logs/benchstat.txt
-
-# ensure-changelog-entry will check that the VERSION is present as a changelog entry
-.PHONY: ensure-changelog-entry
-ensure-changelog-entry:
-	@if ! grep -q "$(VERSION)" CHANGELOG.md; then \
-		echo Missing changelog entry for $(VERSION); \
-		exit 1; \
-	fi
-
-# ensure-version-changed checks that the version has been updated between current ref and base ref
-# Usage:
-#   git fetch origin <branch>
-#   make ensure-version-changed BASE_REF=origin/<branch>
-.PHONY: ensure-version-changed
-ensure-version-changed:
-	@if [ -z "$(BASE_REF)" ]; then \
-		echo "BASE_REF is not set"; \
-		exit 1; \
-	fi
-	@BASE_VER=$$(git show $(BASE_REF):Makefile | grep "^VERSION=" | cut -d= -f2); \
-	if [ "$(VERSION)" \= "$$BASE_VER" ]; then \
-		echo "VERSION $(VERSION) has not changed from $(BASE_REF)"; \
-		exit 1; \
-	fi


### PR DESCRIPTION
This introduced linting for release PRs to add some automation to help us avoid making mistakes during our release process. Our release process has many manual steps which can sometimes be missed. While we are working towards full automation of releases, it would be helpful to have some simple automation in place in the meantime to minimize potential mistakes in the current process.
