### PR TITLE
Fix cleanup in session setup failure path

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -420,6 +420,7 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 
 	approved, err := s.isApprovedFileTransfer(scx)
 	if err != nil {
+		sess.Close()
 		return trace.Wrap(err)
 	}
 
@@ -427,12 +428,14 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 	canStart, _, err := sess.checkIfStartUnderLock()
 	sess.mu.Unlock()
 	if err != nil {
+		sess.Close()
 		return trace.Wrap(err)
 	}
 
 	// canStart will be true for non-moderated sessions. If canStart is false, check to
 	// see if the request has been approved through a moderated session next.
 	if !canStart && !approved {
+		sess.Close()
 		return errCannotStartUnattendedSession
 	}
 
@@ -822,7 +825,6 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		return nil, nil, trace.BadParameter("session creation only supported in context of ssh access or proxying permit")
 	}
 
-	serverSessions.Inc()
 	startTime := time.Now().UTC()
 	rsess := rsession.Session{
 		Kind: types.SSHSessionKind,
@@ -856,6 +858,7 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		policySets = scx.Identity.UnstableSessionJoiningAccessChecker.SessionPolicySets()
 	}
 
+	serverSessions.Inc()
 	access := moderation.NewSessionAccessEvaluator(policySets, types.SSHSessionKind, scx.Identity.TeleportUser)
 	sess := &session{
 		logger: slog.With(
@@ -900,13 +903,12 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		}
 	}()
 
-	// create a new "party" (connected client) and launch/join the session.
+	// create a new "party" (connected client).
 	p := newParty(sess, types.SessionPeerMode, ch, scx)
-	sess.parties[p.id] = p
-	sess.participants[p.id] = p
 
 	var err error
 	if err = sess.trackSession(ctx, scx.Identity.TeleportUser, policySets, p, sessType); err != nil {
+		sess.Close()
 		if trace.IsNotImplemented(err) {
 			return nil, nil, trace.NotImplemented("Attempted to use Moderated Sessions with an Auth Server below the minimum version of 9.0.0.")
 		}
@@ -915,6 +917,7 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 
 	sess.recorder, err = newRecorder(sess, scx, sessType)
 	if err != nil {
+		sess.Close()
 		return nil, nil, trace.Wrap(err)
 	}
 
@@ -977,8 +980,10 @@ func (s *session) Stop() {
 	s.haltTerminal()
 
 	// Close session tracker and mark it as terminated
-	if err := s.tracker.Close(s.serverCtx); err != nil {
-		s.logger.DebugContext(s.serverCtx, "Failed to close session tracker.", "error", err)
+	if s.tracker != nil {
+		if err := s.tracker.Close(s.serverCtx); err != nil {
+			s.logger.DebugContext(s.serverCtx, "Failed to close session tracker.", "error", err)
+		}
 	}
 }
 

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -412,7 +412,7 @@ func (s *SessionRegistry) JoinSession(ctx context.Context, ch ssh.Channel, scx *
 func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
 	// This logic allows concurrent request to create a new session
 	// to fail, what is ok because we should never have this condition.
-	sess, _, err := newSession(ctx, s, scx, channel, sessionTypeNonInteractive)
+	sess, p, err := newSession(ctx, s, scx, channel, sessionTypeNonInteractive)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -443,7 +443,7 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 	// occurs, otherwise it will be closed by the callee.
 	scx.setSession(ctx, sess)
 
-	err = sess.startExec(ctx, channel, scx)
+	err = sess.startExec(ctx, channel, scx, p)
 	if err != nil {
 		sess.Close()
 		return trace.Wrap(err)
@@ -1633,7 +1633,7 @@ func newRecorder(s *session, ctx *ServerContext, sessType sessionType) (events.S
 	return rec, nil
 }
 
-func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
+func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *ServerContext, p *party) error {
 	// Emit a session.start event for the exec session.
 	s.emitSessionStartEvent(scx)
 
@@ -1645,6 +1645,12 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 	if err := execRequest.Start(ctx, channel); err != nil {
 		return trace.Wrap(err)
 	}
+
+	// Add the party to the session once it is running.
+	s.mu.Lock()
+	s.parties[p.id] = p
+	s.participants[p.id] = p
+	s.mu.Unlock()
 
 	bpfEnabled := scx.srv.GetBPF().Enabled()
 	var eventsMap map[string]struct{}

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -409,7 +409,7 @@ func (s *SessionRegistry) JoinSession(ctx context.Context, ch ssh.Channel, scx *
 }
 
 // OpenExecSession opens a non-interactive exec session.
-func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
+func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Channel, scx *ServerContext) (err error) {
 	// This logic allows concurrent request to create a new session
 	// to fail, what is ok because we should never have this condition.
 	sess, p, err := newSession(ctx, s, scx, channel, sessionTypeNonInteractive)
@@ -418,9 +418,15 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 	}
 	scx.Logger.InfoContext(ctx, "Creating exec session", "session_id", sess.id)
 
+	// Make sure to close the session when returning an error
+	defer func() {
+		if err != nil {
+			sess.Close()
+		}
+	}()
+
 	approved, err := s.isApprovedFileTransfer(scx)
 	if err != nil {
-		sess.Close()
 		return trace.Wrap(err)
 	}
 
@@ -428,14 +434,12 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 	canStart, _, err := sess.checkIfStartUnderLock()
 	sess.mu.Unlock()
 	if err != nil {
-		sess.Close()
 		return trace.Wrap(err)
 	}
 
 	// canStart will be true for non-moderated sessions. If canStart is false, check to
 	// see if the request has been approved through a moderated session next.
 	if !canStart && !approved {
-		sess.Close()
 		return errCannotStartUnattendedSession
 	}
 
@@ -445,7 +449,6 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 
 	err = sess.startExec(ctx, channel, scx, p)
 	if err != nil {
-		sess.Close()
 		return trace.Wrap(err)
 	}
 
@@ -814,7 +817,7 @@ const (
 )
 
 // newSession creates a new session with a given ID within a given context.
-func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch ssh.Channel, sessType sessionType) (*session, *party, error) {
+func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch ssh.Channel, sessType sessionType) (s *session, p *party, err error) {
 	var sessionRecordingMode constants.SessionRecordingMode
 	switch {
 	case scx.Identity.AccessPermit != nil:
@@ -887,6 +890,13 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		serverMeta:                     scx.srv.EventMetadata(),
 	}
 
+	// Make sure to close the session when returning an error
+	defer func() {
+		if err != nil {
+			sess.Close()
+		}
+	}()
+
 	sess.io.OnWriteError = sess.onWriteErrorCallback(sessionRecordingMode)
 
 	// Nodes discard events in cases when proxies are already recording them.
@@ -904,11 +914,9 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 	}()
 
 	// create a new "party" (connected client).
-	p := newParty(sess, types.SessionPeerMode, ch, scx)
+	p = newParty(sess, types.SessionPeerMode, ch, scx)
 
-	var err error
 	if err = sess.trackSession(ctx, scx.Identity.TeleportUser, policySets, p, sessType); err != nil {
-		sess.Close()
 		if trace.IsNotImplemented(err) {
 			return nil, nil, trace.NotImplemented("Attempted to use Moderated Sessions with an Auth Server below the minimum version of 9.0.0.")
 		}
@@ -917,7 +925,6 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 
 	sess.recorder, err = newRecorder(sess, scx, sessType)
 	if err != nil {
-		sess.Close()
 		return nil, nil, trace.Wrap(err)
 	}
 

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -352,8 +352,6 @@ func TestSession_newRecorder(t *testing.T) {
 }
 
 func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
-	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
-
 	moderatedRole, err := types.NewRole("access", types.RoleSpecV6{
 		Allow: types.RoleConditions{
 			RequireSessionJoin: []*types.SessionRequirePolicy{{

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -476,7 +476,8 @@ func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
 				tt.errAssertion(t, err)
 			}
 
-			require.Equal(t, countBefore, testutil.ToFloat64(serverSessions))
+			// +1 because InEpsilon doesn't allow expected=0
+			require.InEpsilon(t, countBefore+1, testutil.ToFloat64(serverSessions)+1, 0)
 
 			// If we created a tracker before the failure, the tracker should be updated to terminated.
 			if trackingService.CreatedCount() != 0 {

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -346,6 +347,143 @@ func TestSession_newRecorder(t *testing.T) {
 			rec, err := newRecorder(sess, tt.sctx, sessType)
 			tt.errAssertion(t, err)
 			tt.recAssertion(t, rec)
+		})
+	}
+}
+
+func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
+
+	moderatedRole, err := types.NewRole("access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			RequireSessionJoin: []*types.SessionRequirePolicy{{
+				Name:   "foo",
+				Filter: "contains(user.roles, 'auditor')",
+				Kinds:  []string{string(types.SSHSessionKind)},
+				Modes:  []string{string(types.SessionModeratorMode)},
+				Count:  1,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	recordAtNodeSync := func() *types.SessionRecordingConfigV2 {
+		return &types.SessionRecordingConfigV2{
+			Kind:    types.KindSessionRecordingConfig,
+			Version: types.V2,
+			Spec: types.SessionRecordingConfigSpecV2{
+				Mode: types.RecordAtNodeSync,
+			},
+		}
+	}
+
+	type testCase struct {
+		name         string
+		openSession  func(context.Context, *SessionRegistry, ssh.Channel, *ServerContext) error
+		sessionRoles services.RoleSet
+		configure    func(*testing.T, *mockServer, *ServerContext, *trackerService)
+		errAssertion require.ErrorAssertionFunc
+	}
+
+	cases := []testCase{
+		{
+			name: "interactive track session failure",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenSession(ctx, ch, scx)
+			},
+			sessionRoles: services.NewRoleSet(moderatedRole),
+			configure: func(t *testing.T, srv *mockServer, scx *ServerContext, trackingService *trackerService) {
+				scx.SessionRecordingConfig = recordAtNodeSync()
+				trackingService.createError = trace.ConnectionProblem(context.DeadlineExceeded, "")
+			},
+		},
+		{
+			name: "interactive recorder failure",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenSession(ctx, ch, scx)
+			},
+			configure: func(t *testing.T, srv *mockServer, scx *ServerContext, _ *trackerService) {
+				srv.datadir = ""
+				scx.SessionRecordingConfig = recordAtNodeSync()
+			},
+		},
+		{
+			name: "exec unapproved moderated session",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenExecSession(ctx, ch, scx)
+			},
+			sessionRoles: services.NewRoleSet(moderatedRole),
+			configure: func(t *testing.T, _ *mockServer, scx *ServerContext, _ *trackerService) {
+				scx.SessionRecordingConfig = recordAtNodeSync()
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorIs(t, err, errCannotStartUnattendedSession)
+			},
+		},
+		{
+			name: "exec unapproved moderated file transfer",
+			openSession: func(ctx context.Context, reg *SessionRegistry, ch ssh.Channel, scx *ServerContext) error {
+				return reg.OpenExecSession(ctx, ch, scx)
+			},
+			configure: func(t *testing.T, _ *mockServer, scx *ServerContext, _ *trackerService) {
+				scx.SetEnv(sftp.EnvModeratedSessionID, string(rsession.NewID()))
+			},
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsNotFound(err))
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newMockServer(t)
+
+			mockTrackerService := &mockSessiontrackerService{
+				trackers: make(map[string]types.SessionTracker),
+			}
+			trackingService := &trackerService{
+				SessionTrackerService: mockTrackerService,
+			}
+
+			reg, err := NewSessionRegistry(SessionRegistryConfig{
+				Srv:                   srv,
+				SessionTrackerService: trackingService,
+				clock:                 clockwork.NewFakeClock(),
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { reg.Close() })
+
+			// Use strict recording mode so that recorder errors aren't ignored.
+			accessPermit := &decisionpb.SSHAccessPermit{
+				SessionRecordingMode: string(constants.SessionRecordingModeStrict),
+			}
+
+			scx := newTestServerContext(t, reg.Srv, tt.sessionRoles, accessPermit)
+			t.Cleanup(func() { require.NoError(t, scx.Close()) })
+
+			tt.configure(t, srv, scx, trackingService)
+
+			channel := newMockSSHChannel()
+			t.Cleanup(func() { require.NoError(t, channel.Close()) })
+
+			countBefore := testutil.ToFloat64(serverSessions)
+
+			err = tt.openSession(t.Context(), reg, channel, scx)
+			require.Error(t, err)
+			require.Nil(t, scx.session)
+
+			if tt.errAssertion != nil {
+				tt.errAssertion(t, err)
+			}
+
+			require.Equal(t, countBefore, testutil.ToFloat64(serverSessions))
+
+			// If we created a tracker before the failure, the tracker should be updated to terminated.
+			if trackingService.CreatedCount() != 0 {
+				for _, tracker := range mockTrackerService.trackers {
+					require.Equal(t, types.SessionState_SessionStateTerminated, tracker.GetState())
+				}
+			}
 		})
 	}
 }

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -474,8 +474,7 @@ func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
 				tt.errAssertion(t, err)
 			}
 
-			// +1 because InEpsilon doesn't allow expected=0
-			require.InEpsilon(t, countBefore+1, testutil.ToFloat64(serverSessions)+1, 0)
+			require.InDelta(t, countBefore, testutil.ToFloat64(serverSessions), 0)
 
 			// If we created a tracker before the failure, the tracker should be updated to terminated.
 			if trackingService.CreatedCount() != 0 {


### PR DESCRIPTION
Ensure cleanup operations are carried out if we fail to start a session during setup.

Fixes:
- prometheus `interactive_sessions` counter not getting decremented when the session fails.
- session tracker getting created in Pending state, but never updated to Terminated and leaking this [goroutine](https://github.com/gravitational/teleport/blob/d5460a0b99a4675ed540edb43226df516e628b68/lib/srv/sess.go#L2381).
- session recorder is initialized but not cleaned up, leading to a [goroutine leak](https://github.com/gravitational/teleport/blob/f72348ac71fbe5352d8ec7e32e061f986870a539/lib/events/session_writer.go#L61), 

This is primarily relevant in the `exec` setup path, which may fail due to routine actions rather than system failures. For example, before this PR, attempting an exec session when moderated sessions is required for the user soulc fail without cleaning up the session. However, since exec requests don't create session trackers or recorders (except in bpf mode) the prometheus metric is the only issue likely to occur today. This is largely a future proofing fix.

Note: There is one structural change worth noting. Session parties are not added to the session during session setup (newSession). Instead the party is added once the shell is started. This avoids a range of issues/complexities that would be introduced if the, now consistent, calls to `sess.Close` trigger the party to close before the session is running.

## Manual Test Plan

### Test Cases
- [x] interactive session
  - [x] emits start/leave/end events
  - [x] creates session recording
- [x] non-interactive session
  - [x] emits start/leave/end events