### PR TITLE
Remove repeated words in cli command descriptions

### DIFF
--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -189,7 +189,7 @@ func (c *TokensCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCL
 	c.tokenKubeOIDC.Flag("context", "Kubernetes context to use. When not set, defaults to the active context.").StringVar(&c.kubeContext)
 	c.tokenKubeOIDC.Flag("cluster-name", "Name of the Kubernetes cluster. When not set, defaults to the context name.").StringVar(&c.kubeName)
 	c.tokenKubeOIDC.Flag("token-name", "Optional name of the created join token. When not set, default to '<CLUSTER_NAME>(-<BOT_NAME>)'").StringVar(&c.tokenName)
-	c.tokenKubeOIDC.Flag("bot", "Name of the the bot that this token will grant access to. When set, creates a bot token. Overrides --type").StringVar(&c.botName)
+	c.tokenKubeOIDC.Flag("bot", "Name of the bot that this token will grant access to. When set, creates a bot token. Overrides --type").StringVar(&c.botName)
 	c.tokenKubeOIDC.Flag("type", "Type(s) of token to add, e.g. --type=kube,app,db,discovery,proxy,etc").Default("kube,app,discovery").StringVar(&c.tokenType)
 	c.tokenKubeOIDC.Flag("service-account", "Name of the Kubernetes Service Account using the token. For 'teleport-kube-agent' and 'tbot' Helm charts, this is the release name.").Short('s').Required().StringVar(&c.serviceAccountName)
 	c.tokenKubeOIDC.Flag("namespace", "Namespace of the Kubernetes Service Account using the token. For 'teleport-kube-agent' and 'tbot' Helm charts, this is release namespace.").Short('n').Default("teleport").StringVar(&c.namespace)

--- a/tool/tctl/sso/configure/saml.go
+++ b/tool/tctl/sso/configure/saml.go
@@ -106,7 +106,7 @@ func addSAMLCommand(cmd *SSOConfigureCommand) *AuthKindCommand {
 	// alternatives to --entity-descriptor:
 	sub.Flag("issuer", "Issuer is the identity provider issuer.").StringVar(&spec.Issuer)
 	sub.Flag("sso", "SSO is the URL of the identity provider's SSO service.").StringVar(&spec.SSO)
-	sub.Flag("cert", "Cert file with with the IdP certificate PEM. IdP signs <Response> responses using this certificate.").SetValue(flags.NewFileReader(&spec.Cert))
+	sub.Flag("cert", "Cert file with the IdP certificate PEM. IdP signs <Response> responses using this certificate.").SetValue(flags.NewFileReader(&spec.Cert))
 
 	// provided for completeness, but typically omitted.
 	sub.Flag("acs", "AssertionConsumerService is a URL for assertion consumer service on the service provider (Teleport's side).").StringVar(&spec.AssertionConsumerService)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1119,12 +1119,12 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	proxyApp := proxy.Command("app", "Start local TLS proxy for app connection when using Teleport in single-port mode.")
 	proxyApp.Arg("app", "The name of the application to start local proxy for.").Required().StringVar(&cf.AppName)
-	proxyApp.Flag("port", "Specifies the listening port used by by the proxy app listener. Accepts an optional target port of a multi-port TCP app after a colon, e.g. \"1234:5678\".").Short('p').StringVar(&cf.LocalProxyPortMapping)
+	proxyApp.Flag("port", "Specifies the listening port used by the proxy app listener. Accepts an optional target port of a multi-port TCP app after a colon, e.g. \"1234:5678\".").Short('p').StringVar(&cf.LocalProxyPortMapping)
 	proxyApp.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
 
 	proxyMCP := proxy.Command("mcp", "Start local proxy for MCP access.")
 	proxyMCP.Arg("app", "The name of the MCP application to start local proxy for.").Required().StringVar(&cf.AppName)
-	proxyMCP.Flag("port", "Specifies the listening port used by by the proxy app listener.").Short('p').StringVar(&cf.LocalProxyPortMapping)
+	proxyMCP.Flag("port", "Specifies the listening port used by the proxy app listener.").Short('p').StringVar(&cf.LocalProxyPortMapping)
 	proxyMCP.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
 
 	proxyAWS := proxy.Command("aws", "Start local proxy for AWS access.")


### PR DESCRIPTION


Removes repeated words in command descriptions for `tsh` and `tctl`. Will correct in docs for cli in sep pr.
