### PR TITLE
docs: update matcher in server advanced setting auto discovery

### DIFF
--- a/docs/pages/includes/auto-discovery/server-advanced-config.mdx
+++ b/docs/pages/includes/auto-discovery/server-advanced-config.mdx
@@ -9,7 +9,7 @@ When using blue-green deployments or other multiple clusters setups, you might w
 Teleport supports installing and running multiple agents on the same instance, using a suffixed installation which allows you to isolate each installation.
 <Tabs>
 <TabItem label="Dynamic configuration (recommended)">
-To configure the Discovery Service to use a suffixed installation, edit the Discovery Config and set the `spec.aws.install.suffix` key:
+To configure the Discovery Service to use a suffixed installation, edit the Discovery Config and set the `spec.{{ matcher }}.install.suffix` key:
 
 ```yaml
 kind: discovery_config
@@ -44,7 +44,7 @@ If you are using Teleport [Agent managed updates](../../upgrading/agent-managed-
 
 <Tabs>
 <TabItem label="Dynamic configuration (recommended)">
-To set the update group, edit the Discovery Config and set the `spec.aws.install.update_group` key:
+To set the update group, edit the Discovery Config and set the `spec.{{ matcher }}.install.update_group` key:
 
 ```yaml
 kind: discovery_config
@@ -79,7 +79,7 @@ For instances which require a proxy to access the installation files, you can co
 
 <Tabs>
 <TabItem label="Dynamic configuration (recommended)">
-To set the HTTP proxy settings, edit the Discovery Config and set the `spec.aws.install.http_proxy_settings` key:
+To set the HTTP proxy settings, edit the Discovery Config and set the `spec.{{ matcher }}.install.http_proxy_settings` key:
 
 ```yaml
 kind: discovery_config


### PR DESCRIPTION

Currently this is showing `aws` tags instead of `azure` for the context. See https://goteleport.com/docs/enroll-resources/auto-discovery/servers/azure-discovery/#install-multiple-teleport-agents-on-the-same-instance


<img width="1245" height="374" alt="image" src="https://github.com/user-attachments/assets/31fd73d6-06f4-4cf1-8e83-25b324d58a7d" />
