### PR TITLE
sessionsearch[6]: add TestRetrievalModel RPC to SummarizerService

### DIFF
--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer_service.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer_service.pb.go
@@ -2026,6 +2026,119 @@ func (x *TestInferenceModelResponse) GetMessage() string {
 	return ""
 }
 
+// TestRetrievalModelRequest is a request to test a RetrievalModel configuration.
+type TestRetrievalModelRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Model is the RetrievalModelSpec to test. The embeddings provider
+	// configuration will be used to generate a test embedding.
+	Model *RetrievalModelSpec `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	// Secret is the InferenceSecretSpec containing the API key or credentials.
+	// Required for OpenAI models. Optional for Bedrock models when using IAM.
+	Secret        *InferenceSecretSpec `protobuf:"bytes,2,opt,name=secret,proto3" json:"secret,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TestRetrievalModelRequest) Reset() {
+	*x = TestRetrievalModelRequest{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TestRetrievalModelRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TestRetrievalModelRequest) ProtoMessage() {}
+
+func (x *TestRetrievalModelRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TestRetrievalModelRequest.ProtoReflect.Descriptor instead.
+func (*TestRetrievalModelRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *TestRetrievalModelRequest) GetModel() *RetrievalModelSpec {
+	if x != nil {
+		return x.Model
+	}
+	return nil
+}
+
+func (x *TestRetrievalModelRequest) GetSecret() *InferenceSecretSpec {
+	if x != nil {
+		return x.Secret
+	}
+	return nil
+}
+
+// TestRetrievalModelResponse is a response from testing a RetrievalModel.
+type TestRetrievalModelResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Success indicates whether the test request was successful.
+	Success bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	// Message provides additional information about the test result.
+	// If success is false, this contains the error message.
+	Message       string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TestRetrievalModelResponse) Reset() {
+	*x = TestRetrievalModelResponse{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TestRetrievalModelResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TestRetrievalModelResponse) ProtoMessage() {}
+
+func (x *TestRetrievalModelResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TestRetrievalModelResponse.ProtoReflect.Descriptor instead.
+func (*TestRetrievalModelResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *TestRetrievalModelResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *TestRetrievalModelResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 // CreateRetrievalModelRequest is a request for creating the RetrievalModel.
 // Only one RetrievalModel can exist per cluster.
 type CreateRetrievalModelRequest struct {
@@ -2038,7 +2151,7 @@ type CreateRetrievalModelRequest struct {
 
 func (x *CreateRetrievalModelRequest) Reset() {
 	*x = CreateRetrievalModelRequest{}
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[42]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2050,7 +2163,7 @@ func (x *CreateRetrievalModelRequest) String() string {
 func (*CreateRetrievalModelRequest) ProtoMessage() {}
 
 func (x *CreateRetrievalModelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[42]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2063,7 +2176,7 @@ func (x *CreateRetrievalModelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateRetrievalModelRequest.ProtoReflect.Descriptor instead.
 func (*CreateRetrievalModelRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{42}
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *CreateRetrievalModelRequest) GetModel() *RetrievalModel {
@@ -2084,7 +2197,7 @@ type CreateRetrievalModelResponse struct {
 
 func (x *CreateRetrievalModelResponse) Reset() {
 	*x = CreateRetrievalModelResponse{}
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[43]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2096,7 +2209,7 @@ func (x *CreateRetrievalModelResponse) String() string {
 func (*CreateRetrievalModelResponse) ProtoMessage() {}
 
 func (x *CreateRetrievalModelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[43]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2109,7 +2222,7 @@ func (x *CreateRetrievalModelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateRetrievalModelResponse.ProtoReflect.Descriptor instead.
 func (*CreateRetrievalModelResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{43}
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *CreateRetrievalModelResponse) GetModel() *RetrievalModel {
@@ -2129,7 +2242,7 @@ type GetRetrievalModelRequest struct {
 
 func (x *GetRetrievalModelRequest) Reset() {
 	*x = GetRetrievalModelRequest{}
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[44]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2141,7 +2254,7 @@ func (x *GetRetrievalModelRequest) String() string {
 func (*GetRetrievalModelRequest) ProtoMessage() {}
 
 func (x *GetRetrievalModelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[44]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2154,7 +2267,7 @@ func (x *GetRetrievalModelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRetrievalModelRequest.ProtoReflect.Descriptor instead.
 func (*GetRetrievalModelRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{44}
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{46}
 }
 
 // GetRetrievalModelResponse is a response to retrieving the RetrievalModel.
@@ -2168,7 +2281,7 @@ type GetRetrievalModelResponse struct {
 
 func (x *GetRetrievalModelResponse) Reset() {
 	*x = GetRetrievalModelResponse{}
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[45]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2180,7 +2293,7 @@ func (x *GetRetrievalModelResponse) String() string {
 func (*GetRetrievalModelResponse) ProtoMessage() {}
 
 func (x *GetRetrievalModelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[45]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2193,7 +2306,7 @@ func (x *GetRetrievalModelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRetrievalModelResponse.ProtoReflect.Descriptor instead.
 func (*GetRetrievalModelResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{45}
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GetRetrievalModelResponse) GetModel() *RetrievalModel {
@@ -2214,7 +2327,7 @@ type UpdateRetrievalModelRequest struct {
 
 func (x *UpdateRetrievalModelRequest) Reset() {
 	*x = UpdateRetrievalModelRequest{}
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[46]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2226,7 +2339,7 @@ func (x *UpdateRetrievalModelRequest) String() string {
 func (*UpdateRetrievalModelRequest) ProtoMessage() {}
 
 func (x *UpdateRetrievalModelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[46]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2239,7 +2352,7 @@ func (x *UpdateRetrievalModelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateRetrievalModelRequest.ProtoReflect.Descriptor instead.
 func (*UpdateRetrievalModelRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{46}
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *UpdateRetrievalModelRequest) GetModel() *RetrievalModel {
@@ -2260,7 +2373,7 @@ type UpdateRetrievalModelResponse struct {
 
 func (x *UpdateRetrievalModelResponse) Reset() {
 	*x = UpdateRetrievalModelResponse{}
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[47]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2272,7 +2385,7 @@ func (x *UpdateRetrievalModelResponse) String() string {
 func (*UpdateRetrievalModelResponse) ProtoMessage() {}
 
 func (x *UpdateRetrievalModelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[47]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2285,7 +2398,7 @@ func (x *UpdateRetrievalModelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateRetrievalModelResponse.ProtoReflect.Descriptor instead.
 func (*UpdateRetrievalModelResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{47}
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *UpdateRetrievalModelResponse) GetModel() *RetrievalModel {
@@ -2307,7 +2420,7 @@ type UpsertRetrievalModelRequest struct {
 
 func (x *UpsertRetrievalModelRequest) Reset() {
 	*x = UpsertRetrievalModelRequest{}
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[48]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2319,7 +2432,7 @@ func (x *UpsertRetrievalModelRequest) String() string {
 func (*UpsertRetrievalModelRequest) ProtoMessage() {}
 
 func (x *UpsertRetrievalModelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[48]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2332,7 +2445,7 @@ func (x *UpsertRetrievalModelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertRetrievalModelRequest.ProtoReflect.Descriptor instead.
 func (*UpsertRetrievalModelRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{48}
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *UpsertRetrievalModelRequest) GetModel() *RetrievalModel {
@@ -2354,7 +2467,7 @@ type UpsertRetrievalModelResponse struct {
 
 func (x *UpsertRetrievalModelResponse) Reset() {
 	*x = UpsertRetrievalModelResponse{}
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[49]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2366,7 +2479,7 @@ func (x *UpsertRetrievalModelResponse) String() string {
 func (*UpsertRetrievalModelResponse) ProtoMessage() {}
 
 func (x *UpsertRetrievalModelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[49]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2379,7 +2492,7 @@ func (x *UpsertRetrievalModelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertRetrievalModelResponse.ProtoReflect.Descriptor instead.
 func (*UpsertRetrievalModelResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{49}
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *UpsertRetrievalModelResponse) GetModel() *RetrievalModel {
@@ -2399,7 +2512,7 @@ type DeleteRetrievalModelRequest struct {
 
 func (x *DeleteRetrievalModelRequest) Reset() {
 	*x = DeleteRetrievalModelRequest{}
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[50]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2411,7 +2524,7 @@ func (x *DeleteRetrievalModelRequest) String() string {
 func (*DeleteRetrievalModelRequest) ProtoMessage() {}
 
 func (x *DeleteRetrievalModelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[50]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2424,7 +2537,7 @@ func (x *DeleteRetrievalModelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRetrievalModelRequest.ProtoReflect.Descriptor instead.
 func (*DeleteRetrievalModelRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{50}
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{52}
 }
 
 // DeleteRetrievalModelResponse is a response to deleting the RetrievalModel.
@@ -2436,7 +2549,7 @@ type DeleteRetrievalModelResponse struct {
 
 func (x *DeleteRetrievalModelResponse) Reset() {
 	*x = DeleteRetrievalModelResponse{}
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[51]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2448,7 +2561,7 @@ func (x *DeleteRetrievalModelResponse) String() string {
 func (*DeleteRetrievalModelResponse) ProtoMessage() {}
 
 func (x *DeleteRetrievalModelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[51]
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2461,7 +2574,7 @@ func (x *DeleteRetrievalModelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRetrievalModelResponse.ProtoReflect.Descriptor instead.
 func (*DeleteRetrievalModelResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{51}
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{53}
 }
 
 var File_teleport_summarizer_v1_summarizer_service_proto protoreflect.FileDescriptor
@@ -2560,6 +2673,12 @@ const file_teleport_summarizer_v1_summarizer_service_proto_rawDesc = "" +
 	"\x06secret\x18\x02 \x01(\v2+.teleport.summarizer.v1.InferenceSecretSpecR\x06secret\"P\n" +
 	"\x1aTestInferenceModelResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\xa2\x01\n" +
+	"\x19TestRetrievalModelRequest\x12@\n" +
+	"\x05model\x18\x01 \x01(\v2*.teleport.summarizer.v1.RetrievalModelSpecR\x05model\x12C\n" +
+	"\x06secret\x18\x02 \x01(\v2+.teleport.summarizer.v1.InferenceSecretSpecR\x06secret\"P\n" +
+	"\x1aTestRetrievalModelResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"[\n" +
 	"\x1bCreateRetrievalModelRequest\x12<\n" +
 	"\x05model\x18\x01 \x01(\v2&.teleport.summarizer.v1.RetrievalModelR\x05model\"\\\n" +
@@ -2577,7 +2696,7 @@ const file_teleport_summarizer_v1_summarizer_service_proto_rawDesc = "" +
 	"\x1cUpsertRetrievalModelResponse\x12<\n" +
 	"\x05model\x18\x01 \x01(\v2&.teleport.summarizer.v1.RetrievalModelR\x05model\"\x1d\n" +
 	"\x1bDeleteRetrievalModelRequest\"\x1e\n" +
-	"\x1cDeleteRetrievalModelResponse2\xa8\x1a\n" +
+	"\x1cDeleteRetrievalModelResponse2\xa5\x1b\n" +
 	"\x11SummarizerService\x12\x81\x01\n" +
 	"\x14CreateInferenceModel\x123.teleport.summarizer.v1.CreateInferenceModelRequest\x1a4.teleport.summarizer.v1.CreateInferenceModelResponse\x12x\n" +
 	"\x11GetInferenceModel\x120.teleport.summarizer.v1.GetInferenceModelRequest\x1a1.teleport.summarizer.v1.GetInferenceModelResponse\x12\x81\x01\n" +
@@ -2605,7 +2724,8 @@ const file_teleport_summarizer_v1_summarizer_service_proto_rawDesc = "" +
 	"\x11GetRetrievalModel\x120.teleport.summarizer.v1.GetRetrievalModelRequest\x1a1.teleport.summarizer.v1.GetRetrievalModelResponse\x12\x81\x01\n" +
 	"\x14UpdateRetrievalModel\x123.teleport.summarizer.v1.UpdateRetrievalModelRequest\x1a4.teleport.summarizer.v1.UpdateRetrievalModelResponse\x12\x81\x01\n" +
 	"\x14UpsertRetrievalModel\x123.teleport.summarizer.v1.UpsertRetrievalModelRequest\x1a4.teleport.summarizer.v1.UpsertRetrievalModelResponse\x12\x81\x01\n" +
-	"\x14DeleteRetrievalModel\x123.teleport.summarizer.v1.DeleteRetrievalModelRequest\x1a4.teleport.summarizer.v1.DeleteRetrievalModelResponseBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
+	"\x14DeleteRetrievalModel\x123.teleport.summarizer.v1.DeleteRetrievalModelRequest\x1a4.teleport.summarizer.v1.DeleteRetrievalModelResponse\x12{\n" +
+	"\x12TestRetrievalModel\x121.teleport.summarizer.v1.TestRetrievalModelRequest\x1a2.teleport.summarizer.v1.TestRetrievalModelResponseBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
 
 var (
 	file_teleport_summarizer_v1_summarizer_service_proto_rawDescOnce sync.Once
@@ -2619,7 +2739,7 @@ func file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP() []byte {
 	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescData
 }
 
-var file_teleport_summarizer_v1_summarizer_service_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
+var file_teleport_summarizer_v1_summarizer_service_proto_msgTypes = make([]protoimpl.MessageInfo, 54)
 var file_teleport_summarizer_v1_summarizer_service_proto_goTypes = []any{
 	(*CreateInferenceModelRequest)(nil),   // 0: teleport.summarizer.v1.CreateInferenceModelRequest
 	(*CreateInferenceModelResponse)(nil),  // 1: teleport.summarizer.v1.CreateInferenceModelResponse
@@ -2663,116 +2783,123 @@ var file_teleport_summarizer_v1_summarizer_service_proto_goTypes = []any{
 	(*IsEnabledResponse)(nil),             // 39: teleport.summarizer.v1.IsEnabledResponse
 	(*TestInferenceModelRequest)(nil),     // 40: teleport.summarizer.v1.TestInferenceModelRequest
 	(*TestInferenceModelResponse)(nil),    // 41: teleport.summarizer.v1.TestInferenceModelResponse
-	(*CreateRetrievalModelRequest)(nil),   // 42: teleport.summarizer.v1.CreateRetrievalModelRequest
-	(*CreateRetrievalModelResponse)(nil),  // 43: teleport.summarizer.v1.CreateRetrievalModelResponse
-	(*GetRetrievalModelRequest)(nil),      // 44: teleport.summarizer.v1.GetRetrievalModelRequest
-	(*GetRetrievalModelResponse)(nil),     // 45: teleport.summarizer.v1.GetRetrievalModelResponse
-	(*UpdateRetrievalModelRequest)(nil),   // 46: teleport.summarizer.v1.UpdateRetrievalModelRequest
-	(*UpdateRetrievalModelResponse)(nil),  // 47: teleport.summarizer.v1.UpdateRetrievalModelResponse
-	(*UpsertRetrievalModelRequest)(nil),   // 48: teleport.summarizer.v1.UpsertRetrievalModelRequest
-	(*UpsertRetrievalModelResponse)(nil),  // 49: teleport.summarizer.v1.UpsertRetrievalModelResponse
-	(*DeleteRetrievalModelRequest)(nil),   // 50: teleport.summarizer.v1.DeleteRetrievalModelRequest
-	(*DeleteRetrievalModelResponse)(nil),  // 51: teleport.summarizer.v1.DeleteRetrievalModelResponse
-	(*InferenceModel)(nil),                // 52: teleport.summarizer.v1.InferenceModel
-	(*InferenceSecret)(nil),               // 53: teleport.summarizer.v1.InferenceSecret
-	(*InferencePolicy)(nil),               // 54: teleport.summarizer.v1.InferencePolicy
-	(*Summary)(nil),                       // 55: teleport.summarizer.v1.Summary
-	(*InferenceModelSpec)(nil),            // 56: teleport.summarizer.v1.InferenceModelSpec
-	(*InferenceSecretSpec)(nil),           // 57: teleport.summarizer.v1.InferenceSecretSpec
-	(*RetrievalModel)(nil),                // 58: teleport.summarizer.v1.RetrievalModel
+	(*TestRetrievalModelRequest)(nil),     // 42: teleport.summarizer.v1.TestRetrievalModelRequest
+	(*TestRetrievalModelResponse)(nil),    // 43: teleport.summarizer.v1.TestRetrievalModelResponse
+	(*CreateRetrievalModelRequest)(nil),   // 44: teleport.summarizer.v1.CreateRetrievalModelRequest
+	(*CreateRetrievalModelResponse)(nil),  // 45: teleport.summarizer.v1.CreateRetrievalModelResponse
+	(*GetRetrievalModelRequest)(nil),      // 46: teleport.summarizer.v1.GetRetrievalModelRequest
+	(*GetRetrievalModelResponse)(nil),     // 47: teleport.summarizer.v1.GetRetrievalModelResponse
+	(*UpdateRetrievalModelRequest)(nil),   // 48: teleport.summarizer.v1.UpdateRetrievalModelRequest
+	(*UpdateRetrievalModelResponse)(nil),  // 49: teleport.summarizer.v1.UpdateRetrievalModelResponse
+	(*UpsertRetrievalModelRequest)(nil),   // 50: teleport.summarizer.v1.UpsertRetrievalModelRequest
+	(*UpsertRetrievalModelResponse)(nil),  // 51: teleport.summarizer.v1.UpsertRetrievalModelResponse
+	(*DeleteRetrievalModelRequest)(nil),   // 52: teleport.summarizer.v1.DeleteRetrievalModelRequest
+	(*DeleteRetrievalModelResponse)(nil),  // 53: teleport.summarizer.v1.DeleteRetrievalModelResponse
+	(*InferenceModel)(nil),                // 54: teleport.summarizer.v1.InferenceModel
+	(*InferenceSecret)(nil),               // 55: teleport.summarizer.v1.InferenceSecret
+	(*InferencePolicy)(nil),               // 56: teleport.summarizer.v1.InferencePolicy
+	(*Summary)(nil),                       // 57: teleport.summarizer.v1.Summary
+	(*InferenceModelSpec)(nil),            // 58: teleport.summarizer.v1.InferenceModelSpec
+	(*InferenceSecretSpec)(nil),           // 59: teleport.summarizer.v1.InferenceSecretSpec
+	(*RetrievalModelSpec)(nil),            // 60: teleport.summarizer.v1.RetrievalModelSpec
+	(*RetrievalModel)(nil),                // 61: teleport.summarizer.v1.RetrievalModel
 }
 var file_teleport_summarizer_v1_summarizer_service_proto_depIdxs = []int32{
-	52, // 0: teleport.summarizer.v1.CreateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
-	52, // 1: teleport.summarizer.v1.CreateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	52, // 2: teleport.summarizer.v1.GetInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	52, // 3: teleport.summarizer.v1.UpdateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
-	52, // 4: teleport.summarizer.v1.UpdateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	52, // 5: teleport.summarizer.v1.UpsertInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
-	52, // 6: teleport.summarizer.v1.UpsertInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	52, // 7: teleport.summarizer.v1.ListInferenceModelsResponse.models:type_name -> teleport.summarizer.v1.InferenceModel
-	53, // 8: teleport.summarizer.v1.CreateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	53, // 9: teleport.summarizer.v1.CreateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	53, // 10: teleport.summarizer.v1.GetInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	53, // 11: teleport.summarizer.v1.UpdateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	53, // 12: teleport.summarizer.v1.UpdateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	53, // 13: teleport.summarizer.v1.UpsertInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	53, // 14: teleport.summarizer.v1.UpsertInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	53, // 15: teleport.summarizer.v1.ListInferenceSecretsResponse.secrets:type_name -> teleport.summarizer.v1.InferenceSecret
-	54, // 16: teleport.summarizer.v1.CreateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	54, // 17: teleport.summarizer.v1.CreateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	54, // 18: teleport.summarizer.v1.GetInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	54, // 19: teleport.summarizer.v1.UpdateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	54, // 20: teleport.summarizer.v1.UpdateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	54, // 21: teleport.summarizer.v1.UpsertInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	54, // 22: teleport.summarizer.v1.UpsertInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	54, // 23: teleport.summarizer.v1.ListInferencePoliciesResponse.policies:type_name -> teleport.summarizer.v1.InferencePolicy
-	55, // 24: teleport.summarizer.v1.GetSummaryResponse.summary:type_name -> teleport.summarizer.v1.Summary
-	56, // 25: teleport.summarizer.v1.TestInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModelSpec
-	57, // 26: teleport.summarizer.v1.TestInferenceModelRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecretSpec
-	58, // 27: teleport.summarizer.v1.CreateRetrievalModelRequest.model:type_name -> teleport.summarizer.v1.RetrievalModel
-	58, // 28: teleport.summarizer.v1.CreateRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
-	58, // 29: teleport.summarizer.v1.GetRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
-	58, // 30: teleport.summarizer.v1.UpdateRetrievalModelRequest.model:type_name -> teleport.summarizer.v1.RetrievalModel
-	58, // 31: teleport.summarizer.v1.UpdateRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
-	58, // 32: teleport.summarizer.v1.UpsertRetrievalModelRequest.model:type_name -> teleport.summarizer.v1.RetrievalModel
-	58, // 33: teleport.summarizer.v1.UpsertRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
-	0,  // 34: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:input_type -> teleport.summarizer.v1.CreateInferenceModelRequest
-	2,  // 35: teleport.summarizer.v1.SummarizerService.GetInferenceModel:input_type -> teleport.summarizer.v1.GetInferenceModelRequest
-	4,  // 36: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:input_type -> teleport.summarizer.v1.UpdateInferenceModelRequest
-	6,  // 37: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:input_type -> teleport.summarizer.v1.UpsertInferenceModelRequest
-	8,  // 38: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:input_type -> teleport.summarizer.v1.DeleteInferenceModelRequest
-	10, // 39: teleport.summarizer.v1.SummarizerService.ListInferenceModels:input_type -> teleport.summarizer.v1.ListInferenceModelsRequest
-	12, // 40: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:input_type -> teleport.summarizer.v1.CreateInferenceSecretRequest
-	14, // 41: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:input_type -> teleport.summarizer.v1.GetInferenceSecretRequest
-	16, // 42: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:input_type -> teleport.summarizer.v1.UpdateInferenceSecretRequest
-	18, // 43: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:input_type -> teleport.summarizer.v1.UpsertInferenceSecretRequest
-	20, // 44: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:input_type -> teleport.summarizer.v1.DeleteInferenceSecretRequest
-	22, // 45: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:input_type -> teleport.summarizer.v1.ListInferenceSecretsRequest
-	24, // 46: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:input_type -> teleport.summarizer.v1.CreateInferencePolicyRequest
-	26, // 47: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:input_type -> teleport.summarizer.v1.GetInferencePolicyRequest
-	28, // 48: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:input_type -> teleport.summarizer.v1.UpdateInferencePolicyRequest
-	30, // 49: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:input_type -> teleport.summarizer.v1.UpsertInferencePolicyRequest
-	32, // 50: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:input_type -> teleport.summarizer.v1.DeleteInferencePolicyRequest
-	34, // 51: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:input_type -> teleport.summarizer.v1.ListInferencePoliciesRequest
-	36, // 52: teleport.summarizer.v1.SummarizerService.GetSummary:input_type -> teleport.summarizer.v1.GetSummaryRequest
-	38, // 53: teleport.summarizer.v1.SummarizerService.IsEnabled:input_type -> teleport.summarizer.v1.IsEnabledRequest
-	40, // 54: teleport.summarizer.v1.SummarizerService.TestInferenceModel:input_type -> teleport.summarizer.v1.TestInferenceModelRequest
-	42, // 55: teleport.summarizer.v1.SummarizerService.CreateRetrievalModel:input_type -> teleport.summarizer.v1.CreateRetrievalModelRequest
-	44, // 56: teleport.summarizer.v1.SummarizerService.GetRetrievalModel:input_type -> teleport.summarizer.v1.GetRetrievalModelRequest
-	46, // 57: teleport.summarizer.v1.SummarizerService.UpdateRetrievalModel:input_type -> teleport.summarizer.v1.UpdateRetrievalModelRequest
-	48, // 58: teleport.summarizer.v1.SummarizerService.UpsertRetrievalModel:input_type -> teleport.summarizer.v1.UpsertRetrievalModelRequest
-	50, // 59: teleport.summarizer.v1.SummarizerService.DeleteRetrievalModel:input_type -> teleport.summarizer.v1.DeleteRetrievalModelRequest
-	1,  // 60: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:output_type -> teleport.summarizer.v1.CreateInferenceModelResponse
-	3,  // 61: teleport.summarizer.v1.SummarizerService.GetInferenceModel:output_type -> teleport.summarizer.v1.GetInferenceModelResponse
-	5,  // 62: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:output_type -> teleport.summarizer.v1.UpdateInferenceModelResponse
-	7,  // 63: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:output_type -> teleport.summarizer.v1.UpsertInferenceModelResponse
-	9,  // 64: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:output_type -> teleport.summarizer.v1.DeleteInferenceModelResponse
-	11, // 65: teleport.summarizer.v1.SummarizerService.ListInferenceModels:output_type -> teleport.summarizer.v1.ListInferenceModelsResponse
-	13, // 66: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:output_type -> teleport.summarizer.v1.CreateInferenceSecretResponse
-	15, // 67: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:output_type -> teleport.summarizer.v1.GetInferenceSecretResponse
-	17, // 68: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:output_type -> teleport.summarizer.v1.UpdateInferenceSecretResponse
-	19, // 69: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:output_type -> teleport.summarizer.v1.UpsertInferenceSecretResponse
-	21, // 70: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:output_type -> teleport.summarizer.v1.DeleteInferenceSecretResponse
-	23, // 71: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:output_type -> teleport.summarizer.v1.ListInferenceSecretsResponse
-	25, // 72: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:output_type -> teleport.summarizer.v1.CreateInferencePolicyResponse
-	27, // 73: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:output_type -> teleport.summarizer.v1.GetInferencePolicyResponse
-	29, // 74: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:output_type -> teleport.summarizer.v1.UpdateInferencePolicyResponse
-	31, // 75: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:output_type -> teleport.summarizer.v1.UpsertInferencePolicyResponse
-	33, // 76: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:output_type -> teleport.summarizer.v1.DeleteInferencePolicyResponse
-	35, // 77: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:output_type -> teleport.summarizer.v1.ListInferencePoliciesResponse
-	37, // 78: teleport.summarizer.v1.SummarizerService.GetSummary:output_type -> teleport.summarizer.v1.GetSummaryResponse
-	39, // 79: teleport.summarizer.v1.SummarizerService.IsEnabled:output_type -> teleport.summarizer.v1.IsEnabledResponse
-	41, // 80: teleport.summarizer.v1.SummarizerService.TestInferenceModel:output_type -> teleport.summarizer.v1.TestInferenceModelResponse
-	43, // 81: teleport.summarizer.v1.SummarizerService.CreateRetrievalModel:output_type -> teleport.summarizer.v1.CreateRetrievalModelResponse
-	45, // 82: teleport.summarizer.v1.SummarizerService.GetRetrievalModel:output_type -> teleport.summarizer.v1.GetRetrievalModelResponse
-	47, // 83: teleport.summarizer.v1.SummarizerService.UpdateRetrievalModel:output_type -> teleport.summarizer.v1.UpdateRetrievalModelResponse
-	49, // 84: teleport.summarizer.v1.SummarizerService.UpsertRetrievalModel:output_type -> teleport.summarizer.v1.UpsertRetrievalModelResponse
-	51, // 85: teleport.summarizer.v1.SummarizerService.DeleteRetrievalModel:output_type -> teleport.summarizer.v1.DeleteRetrievalModelResponse
-	60, // [60:86] is the sub-list for method output_type
-	34, // [34:60] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	54, // 0: teleport.summarizer.v1.CreateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
+	54, // 1: teleport.summarizer.v1.CreateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	54, // 2: teleport.summarizer.v1.GetInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	54, // 3: teleport.summarizer.v1.UpdateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
+	54, // 4: teleport.summarizer.v1.UpdateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	54, // 5: teleport.summarizer.v1.UpsertInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
+	54, // 6: teleport.summarizer.v1.UpsertInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	54, // 7: teleport.summarizer.v1.ListInferenceModelsResponse.models:type_name -> teleport.summarizer.v1.InferenceModel
+	55, // 8: teleport.summarizer.v1.CreateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	55, // 9: teleport.summarizer.v1.CreateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	55, // 10: teleport.summarizer.v1.GetInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	55, // 11: teleport.summarizer.v1.UpdateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	55, // 12: teleport.summarizer.v1.UpdateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	55, // 13: teleport.summarizer.v1.UpsertInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	55, // 14: teleport.summarizer.v1.UpsertInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	55, // 15: teleport.summarizer.v1.ListInferenceSecretsResponse.secrets:type_name -> teleport.summarizer.v1.InferenceSecret
+	56, // 16: teleport.summarizer.v1.CreateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	56, // 17: teleport.summarizer.v1.CreateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	56, // 18: teleport.summarizer.v1.GetInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	56, // 19: teleport.summarizer.v1.UpdateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	56, // 20: teleport.summarizer.v1.UpdateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	56, // 21: teleport.summarizer.v1.UpsertInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	56, // 22: teleport.summarizer.v1.UpsertInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	56, // 23: teleport.summarizer.v1.ListInferencePoliciesResponse.policies:type_name -> teleport.summarizer.v1.InferencePolicy
+	57, // 24: teleport.summarizer.v1.GetSummaryResponse.summary:type_name -> teleport.summarizer.v1.Summary
+	58, // 25: teleport.summarizer.v1.TestInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModelSpec
+	59, // 26: teleport.summarizer.v1.TestInferenceModelRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecretSpec
+	60, // 27: teleport.summarizer.v1.TestRetrievalModelRequest.model:type_name -> teleport.summarizer.v1.RetrievalModelSpec
+	59, // 28: teleport.summarizer.v1.TestRetrievalModelRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecretSpec
+	61, // 29: teleport.summarizer.v1.CreateRetrievalModelRequest.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	61, // 30: teleport.summarizer.v1.CreateRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	61, // 31: teleport.summarizer.v1.GetRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	61, // 32: teleport.summarizer.v1.UpdateRetrievalModelRequest.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	61, // 33: teleport.summarizer.v1.UpdateRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	61, // 34: teleport.summarizer.v1.UpsertRetrievalModelRequest.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	61, // 35: teleport.summarizer.v1.UpsertRetrievalModelResponse.model:type_name -> teleport.summarizer.v1.RetrievalModel
+	0,  // 36: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:input_type -> teleport.summarizer.v1.CreateInferenceModelRequest
+	2,  // 37: teleport.summarizer.v1.SummarizerService.GetInferenceModel:input_type -> teleport.summarizer.v1.GetInferenceModelRequest
+	4,  // 38: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:input_type -> teleport.summarizer.v1.UpdateInferenceModelRequest
+	6,  // 39: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:input_type -> teleport.summarizer.v1.UpsertInferenceModelRequest
+	8,  // 40: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:input_type -> teleport.summarizer.v1.DeleteInferenceModelRequest
+	10, // 41: teleport.summarizer.v1.SummarizerService.ListInferenceModels:input_type -> teleport.summarizer.v1.ListInferenceModelsRequest
+	12, // 42: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:input_type -> teleport.summarizer.v1.CreateInferenceSecretRequest
+	14, // 43: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:input_type -> teleport.summarizer.v1.GetInferenceSecretRequest
+	16, // 44: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:input_type -> teleport.summarizer.v1.UpdateInferenceSecretRequest
+	18, // 45: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:input_type -> teleport.summarizer.v1.UpsertInferenceSecretRequest
+	20, // 46: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:input_type -> teleport.summarizer.v1.DeleteInferenceSecretRequest
+	22, // 47: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:input_type -> teleport.summarizer.v1.ListInferenceSecretsRequest
+	24, // 48: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:input_type -> teleport.summarizer.v1.CreateInferencePolicyRequest
+	26, // 49: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:input_type -> teleport.summarizer.v1.GetInferencePolicyRequest
+	28, // 50: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:input_type -> teleport.summarizer.v1.UpdateInferencePolicyRequest
+	30, // 51: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:input_type -> teleport.summarizer.v1.UpsertInferencePolicyRequest
+	32, // 52: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:input_type -> teleport.summarizer.v1.DeleteInferencePolicyRequest
+	34, // 53: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:input_type -> teleport.summarizer.v1.ListInferencePoliciesRequest
+	36, // 54: teleport.summarizer.v1.SummarizerService.GetSummary:input_type -> teleport.summarizer.v1.GetSummaryRequest
+	38, // 55: teleport.summarizer.v1.SummarizerService.IsEnabled:input_type -> teleport.summarizer.v1.IsEnabledRequest
+	40, // 56: teleport.summarizer.v1.SummarizerService.TestInferenceModel:input_type -> teleport.summarizer.v1.TestInferenceModelRequest
+	44, // 57: teleport.summarizer.v1.SummarizerService.CreateRetrievalModel:input_type -> teleport.summarizer.v1.CreateRetrievalModelRequest
+	46, // 58: teleport.summarizer.v1.SummarizerService.GetRetrievalModel:input_type -> teleport.summarizer.v1.GetRetrievalModelRequest
+	48, // 59: teleport.summarizer.v1.SummarizerService.UpdateRetrievalModel:input_type -> teleport.summarizer.v1.UpdateRetrievalModelRequest
+	50, // 60: teleport.summarizer.v1.SummarizerService.UpsertRetrievalModel:input_type -> teleport.summarizer.v1.UpsertRetrievalModelRequest
+	52, // 61: teleport.summarizer.v1.SummarizerService.DeleteRetrievalModel:input_type -> teleport.summarizer.v1.DeleteRetrievalModelRequest
+	42, // 62: teleport.summarizer.v1.SummarizerService.TestRetrievalModel:input_type -> teleport.summarizer.v1.TestRetrievalModelRequest
+	1,  // 63: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:output_type -> teleport.summarizer.v1.CreateInferenceModelResponse
+	3,  // 64: teleport.summarizer.v1.SummarizerService.GetInferenceModel:output_type -> teleport.summarizer.v1.GetInferenceModelResponse
+	5,  // 65: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:output_type -> teleport.summarizer.v1.UpdateInferenceModelResponse
+	7,  // 66: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:output_type -> teleport.summarizer.v1.UpsertInferenceModelResponse
+	9,  // 67: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:output_type -> teleport.summarizer.v1.DeleteInferenceModelResponse
+	11, // 68: teleport.summarizer.v1.SummarizerService.ListInferenceModels:output_type -> teleport.summarizer.v1.ListInferenceModelsResponse
+	13, // 69: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:output_type -> teleport.summarizer.v1.CreateInferenceSecretResponse
+	15, // 70: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:output_type -> teleport.summarizer.v1.GetInferenceSecretResponse
+	17, // 71: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:output_type -> teleport.summarizer.v1.UpdateInferenceSecretResponse
+	19, // 72: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:output_type -> teleport.summarizer.v1.UpsertInferenceSecretResponse
+	21, // 73: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:output_type -> teleport.summarizer.v1.DeleteInferenceSecretResponse
+	23, // 74: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:output_type -> teleport.summarizer.v1.ListInferenceSecretsResponse
+	25, // 75: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:output_type -> teleport.summarizer.v1.CreateInferencePolicyResponse
+	27, // 76: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:output_type -> teleport.summarizer.v1.GetInferencePolicyResponse
+	29, // 77: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:output_type -> teleport.summarizer.v1.UpdateInferencePolicyResponse
+	31, // 78: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:output_type -> teleport.summarizer.v1.UpsertInferencePolicyResponse
+	33, // 79: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:output_type -> teleport.summarizer.v1.DeleteInferencePolicyResponse
+	35, // 80: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:output_type -> teleport.summarizer.v1.ListInferencePoliciesResponse
+	37, // 81: teleport.summarizer.v1.SummarizerService.GetSummary:output_type -> teleport.summarizer.v1.GetSummaryResponse
+	39, // 82: teleport.summarizer.v1.SummarizerService.IsEnabled:output_type -> teleport.summarizer.v1.IsEnabledResponse
+	41, // 83: teleport.summarizer.v1.SummarizerService.TestInferenceModel:output_type -> teleport.summarizer.v1.TestInferenceModelResponse
+	45, // 84: teleport.summarizer.v1.SummarizerService.CreateRetrievalModel:output_type -> teleport.summarizer.v1.CreateRetrievalModelResponse
+	47, // 85: teleport.summarizer.v1.SummarizerService.GetRetrievalModel:output_type -> teleport.summarizer.v1.GetRetrievalModelResponse
+	49, // 86: teleport.summarizer.v1.SummarizerService.UpdateRetrievalModel:output_type -> teleport.summarizer.v1.UpdateRetrievalModelResponse
+	51, // 87: teleport.summarizer.v1.SummarizerService.UpsertRetrievalModel:output_type -> teleport.summarizer.v1.UpsertRetrievalModelResponse
+	53, // 88: teleport.summarizer.v1.SummarizerService.DeleteRetrievalModel:output_type -> teleport.summarizer.v1.DeleteRetrievalModelResponse
+	43, // 89: teleport.summarizer.v1.SummarizerService.TestRetrievalModel:output_type -> teleport.summarizer.v1.TestRetrievalModelResponse
+	63, // [63:90] is the sub-list for method output_type
+	36, // [36:63] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_teleport_summarizer_v1_summarizer_service_proto_init() }
@@ -2787,7 +2914,7 @@ func file_teleport_summarizer_v1_summarizer_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_summarizer_v1_summarizer_service_proto_rawDesc), len(file_teleport_summarizer_v1_summarizer_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   52,
+			NumMessages:   54,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer_service_grpc.pb.go
@@ -59,6 +59,7 @@ const (
 	SummarizerService_UpdateRetrievalModel_FullMethodName  = "/teleport.summarizer.v1.SummarizerService/UpdateRetrievalModel"
 	SummarizerService_UpsertRetrievalModel_FullMethodName  = "/teleport.summarizer.v1.SummarizerService/UpsertRetrievalModel"
 	SummarizerService_DeleteRetrievalModel_FullMethodName  = "/teleport.summarizer.v1.SummarizerService/DeleteRetrievalModel"
+	SummarizerService_TestRetrievalModel_FullMethodName    = "/teleport.summarizer.v1.SummarizerService/TestRetrievalModel"
 )
 
 // SummarizerServiceClient is the client API for SummarizerService service.
@@ -129,6 +130,10 @@ type SummarizerServiceClient interface {
 	UpsertRetrievalModel(ctx context.Context, in *UpsertRetrievalModelRequest, opts ...grpc.CallOption) (*UpsertRetrievalModelResponse, error)
 	// DeleteRetrievalModel deletes the existing RetrievalModel by name.
 	DeleteRetrievalModel(ctx context.Context, in *DeleteRetrievalModelRequest, opts ...grpc.CallOption) (*DeleteRetrievalModelResponse, error)
+	// TestRetrievalModel tests a RetrievalModel configuration by generating a
+	// test embedding using the configured embeddings provider (AWS Bedrock or
+	// OpenAI).
+	TestRetrievalModel(ctx context.Context, in *TestRetrievalModelRequest, opts ...grpc.CallOption) (*TestRetrievalModelResponse, error)
 }
 
 type summarizerServiceClient struct {
@@ -399,6 +404,16 @@ func (c *summarizerServiceClient) DeleteRetrievalModel(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *summarizerServiceClient) TestRetrievalModel(ctx context.Context, in *TestRetrievalModelRequest, opts ...grpc.CallOption) (*TestRetrievalModelResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TestRetrievalModelResponse)
+	err := c.cc.Invoke(ctx, SummarizerService_TestRetrievalModel_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SummarizerServiceServer is the server API for SummarizerService service.
 // All implementations must embed UnimplementedSummarizerServiceServer
 // for forward compatibility.
@@ -467,6 +482,10 @@ type SummarizerServiceServer interface {
 	UpsertRetrievalModel(context.Context, *UpsertRetrievalModelRequest) (*UpsertRetrievalModelResponse, error)
 	// DeleteRetrievalModel deletes the existing RetrievalModel by name.
 	DeleteRetrievalModel(context.Context, *DeleteRetrievalModelRequest) (*DeleteRetrievalModelResponse, error)
+	// TestRetrievalModel tests a RetrievalModel configuration by generating a
+	// test embedding using the configured embeddings provider (AWS Bedrock or
+	// OpenAI).
+	TestRetrievalModel(context.Context, *TestRetrievalModelRequest) (*TestRetrievalModelResponse, error)
 	mustEmbedUnimplementedSummarizerServiceServer()
 }
 
@@ -554,6 +573,9 @@ func (UnimplementedSummarizerServiceServer) UpsertRetrievalModel(context.Context
 }
 func (UnimplementedSummarizerServiceServer) DeleteRetrievalModel(context.Context, *DeleteRetrievalModelRequest) (*DeleteRetrievalModelResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteRetrievalModel not implemented")
+}
+func (UnimplementedSummarizerServiceServer) TestRetrievalModel(context.Context, *TestRetrievalModelRequest) (*TestRetrievalModelResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method TestRetrievalModel not implemented")
 }
 func (UnimplementedSummarizerServiceServer) mustEmbedUnimplementedSummarizerServiceServer() {}
 func (UnimplementedSummarizerServiceServer) testEmbeddedByValue()                           {}
@@ -1044,6 +1066,24 @@ func _SummarizerService_DeleteRetrievalModel_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SummarizerService_TestRetrievalModel_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TestRetrievalModelRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SummarizerServiceServer).TestRetrievalModel(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SummarizerService_TestRetrievalModel_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SummarizerServiceServer).TestRetrievalModel(ctx, req.(*TestRetrievalModelRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SummarizerService_ServiceDesc is the grpc.ServiceDesc for SummarizerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1154,6 +1194,10 @@ var SummarizerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteRetrievalModel",
 			Handler:    _SummarizerService_DeleteRetrievalModel_Handler,
+		},
+		{
+			MethodName: "TestRetrievalModel",
+			Handler:    _SummarizerService_TestRetrievalModel_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/proto/teleport/summarizer/v1/summarizer_service.proto
+++ b/api/proto/teleport/summarizer/v1/summarizer_service.proto
@@ -90,6 +90,10 @@ service SummarizerService {
   rpc UpsertRetrievalModel(UpsertRetrievalModelRequest) returns (UpsertRetrievalModelResponse);
   // DeleteRetrievalModel deletes the existing RetrievalModel by name.
   rpc DeleteRetrievalModel(DeleteRetrievalModelRequest) returns (DeleteRetrievalModelResponse);
+  // TestRetrievalModel tests a RetrievalModel configuration by generating a
+  // test embedding using the configured embeddings provider (AWS Bedrock or
+  // OpenAI).
+  rpc TestRetrievalModel(TestRetrievalModelRequest) returns (TestRetrievalModelResponse);
 }
 
 // Summarization inference models
@@ -370,6 +374,25 @@ message TestInferenceModelRequest {
 
 // TestInferenceModelResponse is a response from testing an InferenceModel.
 message TestInferenceModelResponse {
+  // Success indicates whether the test request was successful.
+  bool success = 1;
+  // Message provides additional information about the test result.
+  // If success is false, this contains the error message.
+  string message = 2;
+}
+
+// TestRetrievalModelRequest is a request to test a RetrievalModel configuration.
+message TestRetrievalModelRequest {
+  // Model is the RetrievalModelSpec to test. The embeddings provider
+  // configuration will be used to generate a test embedding.
+  RetrievalModelSpec model = 1;
+  // Secret is the InferenceSecretSpec containing the API key or credentials.
+  // Required for OpenAI models. Optional for Bedrock models when using IAM.
+  InferenceSecretSpec secret = 2;
+}
+
+// TestRetrievalModelResponse is a response from testing a RetrievalModel.
+message TestRetrievalModelResponse {
   // Success indicates whether the test request was successful.
   bool success = 1;
   // Message provides additional information about the test result.


### PR DESCRIPTION
Adds a TestRetrievalModel RPC to SummarizerService, mirroring the existing TestInferenceModel

Part of https://github.com/gravitational/teleport.e/pull/8046

