### PR TITLE
[firestore] add database_id for test cfg

### DIFF
--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -81,6 +81,7 @@ func firestoreParams() backend.Params {
 	collection := "tp-cluster-data-test"
 	projectID := "tp-testproj"
 	endpoint := ""
+	databaseId := ""
 
 	if c := os.Getenv("TELEPORT_FIRESTORE_TEST_COLLECTION"); c != "" {
 		collection = c
@@ -94,10 +95,15 @@ func firestoreParams() backend.Params {
 		endpoint = e
 	}
 
+	if d := os.Getenv("TELEPORT_FIRESTORE_TEST_DATABASE"); d != "" {
+		databaseId = d
+	}
+
 	return map[string]any{
 		"collection_name":                       collection,
 		"project_id":                            projectID,
 		"endpoint":                              endpoint,
+		"database_id":                           databaseId,
 		"purge_expired_documents_poll_interval": 300 * time.Millisecond,
 	}
 }


### PR DESCRIPTION
Added a new env var `TELEPORT_FIRESTORE_TEST_DATABASE` used to configure the database ID to use in the tests. This is useful as when unspecified this defaults to `(default)` which may not be in the ideal region. This is a test change only.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
gcp
### Test Cases
- [x] run `TELEPORT_FIRESTORE_TEST=y go test -timeout 1h -v ./lib/backend/firestore` without setting `TELEPORT_FIRESTORE_TEST_DATABASE` 
  - [x] verify default db is used. 
- [x] run `TELEPORT_FIRESTORE_TEST=y TELEPORT_FIRESTORE_TEST_DATABASE=example go test -timeout 1h -v ./lib/backend/firestore`
  - [x] verify correct db is created and used by tests

