### PR TITLE
[v18] docs: Webauthn Default 2FA for Cloud

### DIFF
--- a/docs/pages/reference/access-controls/authentication.mdx
+++ b/docs/pages/reference/access-controls/authentication.mdx
@@ -18,9 +18,9 @@ users`](../cli/tctl.mdx) command. Teleport also supports
 multi-factor authentication (MFA) for the local connector. There are several
 possible values (types) of MFA:
 
-- `otp` is the default. It implements the [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
+- `otp` is the default for Self-Hosted. It implements the [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
   standard. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator), [Authy](https://www.authy.com/) or any other TOTP client.
-- `webauthn` implements the [Web Authentication standard](https://webauthn.guide) for utilizing
+- `webauthn` is the default for Cloud-Hosted. It implements the [Web Authentication standard](https://webauthn.guide) for utilizing
   multi-factor authenticators and hardware devices.
   You can use [YubiKeys](https://www.yubico.com/), [SoloKeys](https://solokeys.com/) or any other authenticator that
   implements FIDO2 or FIDO U2F standards.
@@ -51,7 +51,7 @@ Add the following to your Teleport configuration file, which is stored in
   auth_service:
     authentication:
       type: local
-      second_factors: ["webauthn"]
+      second_factors: ["webauthn"] # Possible values: "otp", "webauthn", and "sso".
       webauthn:
         rp_id: example.teleport.sh
   ```
@@ -106,7 +106,7 @@ metadata:
   name: cluster-auth-preference
 spec:
   type: local
-  second_factors: ["webauthn"]
+  second_factors: ["webauthn"] # Possible values: "otp", "webauthn", and "sso".
   webauthn:
     rp_id: example.teleport.sh
 version: v2
@@ -276,7 +276,7 @@ See [GitHub OAuth 2.0](../../zero-trust-access/sso/integrate-idp/github-sso.mdx)
 ## Require displaying a message of the day
 
 Teleport can display a custom message of the day (MOTD) for users prior to authenticating
-in the Teleport Web UI and CLI. 
+in the Teleport Web UI and CLI.
 
 ### Self-Hosted
 

--- a/docs/pages/reference/access-controls/authentication.mdx
+++ b/docs/pages/reference/access-controls/authentication.mdx
@@ -18,9 +18,9 @@ users`](../cli/tctl.mdx) command. Teleport also supports
 multi-factor authentication (MFA) for the local connector. There are several
 possible values (types) of MFA:
 
-- `otp` is the default for Self-Hosted. It implements the [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
+- `otp` is the default for self-hosted Teleport deployments. It implements the [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
   standard. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator), [Authy](https://www.authy.com/) or any other TOTP client.
-- `webauthn` is the default for Cloud-Hosted. It implements the [Web Authentication standard](https://webauthn.guide) for utilizing
+- `webauthn` is the default for cloud-hosted Teleport Enterprise accounts. It implements the [Web Authentication standard](https://webauthn.guide) for utilizing
   multi-factor authenticators and hardware devices.
   You can use [YubiKeys](https://www.yubico.com/), [SoloKeys](https://solokeys.com/) or any other authenticator that
   implements FIDO2 or FIDO U2F standards.

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/cluster-auth-preferences.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/cluster-auth-preferences.mdx
@@ -13,7 +13,7 @@ metadata:
 spec:
   # Sets the list of allowed second factors for the cluster.
   # Possible values: "otp", "webauthn", and "sso".
-  # Defaults to ["otp"].
+  # Defaults to ["otp"] for self-hosted and ["webauthn"] for cloud-hosted.
   second_factors: ["webauthn", "otp"]
 
   # second_factors is the list of allowed second factors for the cluster.

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/cluster-auth-preferences.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/cluster-auth-preferences.mdx
@@ -13,7 +13,7 @@ metadata:
 spec:
   # Sets the list of allowed second factors for the cluster.
   # Possible values: "otp", "webauthn", and "sso".
-  # Defaults to ["otp"] for self-hosted and ["webauthn"] for cloud-hosted.
+  # Defaults to ["otp"] for self-hosted Teleport deployments and ["webauthn"] for cloud-hosted Teleport Enterprise accounts.
   second_factors: ["webauthn", "otp"]
 
   # second_factors is the list of allowed second factors for the cluster.

--- a/docs/pages/zero-trust-access/management/security/idp-compromise.mdx
+++ b/docs/pages/zero-trust-access/management/security/idp-compromise.mdx
@@ -49,8 +49,9 @@ It's compatible with hardware keys (e.g., YubiKeys, SoloKeys) and biometric auth
 
 ### Step 1/3. Enable WebAuthn support
 
-WebAuthn is disabled by default. To enable WebAuthn support, update your
-Teleport configuration as below:
+WebAuthn is disabled by default for Self-Hosted clusters and enabled by default
+for Cloud-Hosted clusters. To enable WebAuthn support, update your Teleport
+configuration as below:
 
   Edit the `cluster_auth_preference` resource:
 

--- a/docs/pages/zero-trust-access/management/security/idp-compromise.mdx
+++ b/docs/pages/zero-trust-access/management/security/idp-compromise.mdx
@@ -49,9 +49,7 @@ It's compatible with hardware keys (e.g., YubiKeys, SoloKeys) and biometric auth
 
 ### Step 1/3. Enable WebAuthn support
 
-WebAuthn is disabled by default for Self-Hosted clusters and enabled by default
-for Cloud-Hosted clusters. To enable WebAuthn support, update your Teleport
-configuration as below:
+To enable WebAuthn support, update your Teleport configuration as below:
 
   Edit the `cluster_auth_preference` resource:
 


### PR DESCRIPTION
Backport #64186 to branch/v18