### PR TITLE
Desktop Access: Support Multiple LDAPS CA Certificates

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2328,7 +2328,7 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if fc.WindowsDesktop.LDAP.DEREncodedCAFile != "" && fc.WindowsDesktop.LDAP.PEMEncodedCACert != "" {
+	if fc.WindowsDesktop.LDAP.DEREncodedCAFile != "" && fc.WindowsDesktop.LDAP.PEMEncodedCACerts != "" {
 		return trace.BadParameter("WindowsDesktopService can not use both der_ca_file and ldap_ca_cert")
 	}
 
@@ -2346,8 +2346,8 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		certs = append(certs, derCert)
 	}
 
-	if fc.WindowsDesktop.LDAP.PEMEncodedCACert != "" {
-		pemCerts, err := tlsca.ParseCertificatePEMs([]byte(fc.WindowsDesktop.LDAP.PEMEncodedCACert))
+	if fc.WindowsDesktop.LDAP.PEMEncodedCACerts != "" {
+		pemCerts, err := tlsca.ParseCertificatePEMs([]byte(fc.WindowsDesktop.LDAP.PEMEncodedCACerts))
 		if err != nil {
 			return trace.WrapWithMessage(err, "parsing the LDAP root CA PEM cert")
 		}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2343,7 +2343,7 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		if err != nil {
 			return trace.WrapWithMessage(err, "parsing the LDAP root CA file %v", fc.WindowsDesktop.LDAP.DEREncodedCAFile)
 		}
-		certs = append(certs, derCert)
+		certs = []*x509.Certificate{derCert}
 	}
 
 	if fc.WindowsDesktop.LDAP.PEMEncodedCACerts != "" {
@@ -2351,7 +2351,7 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		if err != nil {
 			return trace.WrapWithMessage(err, "parsing the LDAP root CA PEM cert")
 		}
-		certs = append(certs, pemCerts...)
+		certs = pemCerts
 	}
 
 	locateServer := servicecfg.LocateServer{

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2349,7 +2349,10 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	if fc.WindowsDesktop.LDAP.PEMEncodedCACerts != "" {
 		pemCerts, err := tlsca.ParseCertificatePEMs([]byte(fc.WindowsDesktop.LDAP.PEMEncodedCACerts))
 		if err != nil {
-			return trace.WrapWithMessage(err, "parsing the LDAP root CA PEM cert")
+			return trace.WrapWithMessage(err, "parsing the LDAP root CA PEM cert(s)")
+		}
+		if len(pemCerts) == 0 {
+			return trace.Errorf("ldap_ca_cert is set, but no certificates were parsed")
 		}
 		certs = pemCerts
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2352,7 +2352,7 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			return trace.WrapWithMessage(err, "parsing the LDAP root CA PEM cert(s)")
 		}
 		if len(pemCerts) == 0 {
-			return trace.Errorf("ldap_ca_cert is set, but no certificates were parsed")
+			return trace.BadParameter("ldap_ca_cert is set, but no certificates were parsed")
 		}
 		certs = pemCerts
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2332,24 +2332,26 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		return trace.BadParameter("WindowsDesktopService can not use both der_ca_file and ldap_ca_cert")
 	}
 
-	var cert *x509.Certificate
+	var certs []*x509.Certificate
 	if fc.WindowsDesktop.LDAP.DEREncodedCAFile != "" {
 		rawCert, err := os.ReadFile(fc.WindowsDesktop.LDAP.DEREncodedCAFile)
 		if err != nil {
 			return trace.WrapWithMessage(err, "loading the LDAP CA from file %v", fc.WindowsDesktop.LDAP.DEREncodedCAFile)
 		}
 
-		cert, err = x509.ParseCertificate(rawCert)
+		derCert, err := x509.ParseCertificate(rawCert)
 		if err != nil {
 			return trace.WrapWithMessage(err, "parsing the LDAP root CA file %v", fc.WindowsDesktop.LDAP.DEREncodedCAFile)
 		}
+		certs = append(certs, derCert)
 	}
 
 	if fc.WindowsDesktop.LDAP.PEMEncodedCACert != "" {
-		cert, err = tlsca.ParseCertificatePEM([]byte(fc.WindowsDesktop.LDAP.PEMEncodedCACert))
+		pemCerts, err := tlsca.ParseCertificatePEMs([]byte(fc.WindowsDesktop.LDAP.PEMEncodedCACert))
 		if err != nil {
 			return trace.WrapWithMessage(err, "parsing the LDAP root CA PEM cert")
 		}
+		certs = append(certs, pemCerts...)
 	}
 
 	locateServer := servicecfg.LocateServer{
@@ -2364,7 +2366,7 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		Domain:             fc.WindowsDesktop.LDAP.Domain,
 		InsecureSkipVerify: fc.WindowsDesktop.LDAP.InsecureSkipVerify,
 		ServerName:         fc.WindowsDesktop.LDAP.ServerName,
-		CA:                 cert,
+		CAs:                certs,
 		LocateServer:       locateServer,
 	}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2480,7 +2480,7 @@ uQM=
 				fc.WindowsDesktop.LDAP = LDAPConfig{
 					Addr: "something",
 				}
-				fc.WindowsDesktop.LDAP.PEMEncodedCACert = testCA
+				fc.WindowsDesktop.LDAP.PEMEncodedCACerts = testCA
 			},
 			assertions: []func(t *testing.T, cfg *servicecfg.Config){
 				func(t *testing.T, cfg *servicecfg.Config) {
@@ -2498,7 +2498,7 @@ uQM=
 				fc.WindowsDesktop.HostLabels = []WindowsHostLabelRule{
 					{Match: ".*", Labels: map[string]string{"key": "value"}},
 				}
-				fc.WindowsDesktop.LDAP.PEMEncodedCACert = strings.ReplaceAll("pem\npem\npem", "pem", testCA)
+				fc.WindowsDesktop.LDAP.PEMEncodedCACerts = strings.ReplaceAll("pem\npem\npem", "pem", testCA)
 			},
 			assertions: []func(t *testing.T, cfg *servicecfg.Config){
 				func(t *testing.T, cfg *servicecfg.Config) {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2474,6 +2474,16 @@ uQM=
 			},
 		},
 		{
+			desc:        "NOK - invalid ldaps ca",
+			expectError: require.Error,
+			mutate: func(fc *FileConfig) {
+				fc.WindowsDesktop.LDAP = LDAPConfig{
+					Addr: "something",
+				}
+				fc.WindowsDesktop.LDAP.PEMEncodedCACerts = "invalid string"
+			},
+		},
+		{
 			desc:        "OK - single ldaps ca",
 			expectError: require.NoError,
 			mutate: func(fc *FileConfig) {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2274,10 +2274,23 @@ func TestProxyConfigurationVersion(t *testing.T) {
 func TestWindowsDesktopService(t *testing.T) {
 	t.Parallel()
 
+	const testCA = `-----BEGIN CERTIFICATE-----
+MIIBfjCCASOgAwIBAgIUcgtowC2aiqtoaaqg8Wz9IQsUV5cwCgYIKoZIzj0EAwIw
+FDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDIyNjE5MzAzOVoXDTI3MDIyNjE5
+MzAzOVowFDESMBAGA1UEAwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAExP70cLQNy03OwKKr5DadftNYQyLEe6POP0ncvRxOV4PwlTSjPzetJJvV
+cvD8osxLRHxoUIO6XHP15NjcMo3gpKNTMFEwHQYDVR0OBBYEFL9zTzq0IkOOQysJ
+4oHUm5wv7cSdMB8GA1UdIwQYMBaAFL9zTzq0IkOOQysJ4oHUm5wv7cSdMA8GA1Ud
+EwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSQAwRgIhAPiuMeGa9LOZzAb1QzRvS3hW
+1CnGa5we8zUbh+L7g8/kAiEAt4OjLC0bXoq0pLYoMcPhFP3QOBSA3LPd+vH939ym
+uQM=
+-----END CERTIFICATE-----`
+
 	for _, test := range []struct {
 		desc        string
 		mutate      func(fc *FileConfig)
 		expectError require.ErrorAssertionFunc
+		assertions  []func(*testing.T, *servicecfg.Config)
 	}{
 		{
 			desc:        "NOK - invalid static host addr",
@@ -2460,6 +2473,39 @@ func TestWindowsDesktopService(t *testing.T) {
 				}
 			},
 		},
+		{
+			desc:        "OK - single ldaps ca",
+			expectError: require.NoError,
+			mutate: func(fc *FileConfig) {
+				fc.WindowsDesktop.LDAP = LDAPConfig{
+					Addr: "something",
+				}
+				fc.WindowsDesktop.LDAP.PEMEncodedCACert = testCA
+			},
+			assertions: []func(t *testing.T, cfg *servicecfg.Config){
+				func(t *testing.T, cfg *servicecfg.Config) {
+					assert.Len(t, cfg.WindowsDesktop.LDAP.CAs, 1)
+				},
+			},
+		},
+		{
+			desc:        "OK - multiple ldaps ca",
+			expectError: require.NoError,
+			mutate: func(fc *FileConfig) {
+				fc.WindowsDesktop.LDAP = LDAPConfig{
+					Addr: "something",
+				}
+				fc.WindowsDesktop.HostLabels = []WindowsHostLabelRule{
+					{Match: ".*", Labels: map[string]string{"key": "value"}},
+				}
+				fc.WindowsDesktop.LDAP.PEMEncodedCACert = strings.ReplaceAll("pem\npem\npem", "pem", testCA)
+			},
+			assertions: []func(t *testing.T, cfg *servicecfg.Config){
+				func(t *testing.T, cfg *servicecfg.Config) {
+					assert.Len(t, cfg.WindowsDesktop.LDAP.CAs, 3)
+				},
+			},
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			fc := &FileConfig{}
@@ -2467,6 +2513,9 @@ func TestWindowsDesktopService(t *testing.T) {
 			cfg := &servicecfg.Config{}
 			err := applyWindowsDesktopConfig(fc, cfg)
 			test.expectError(t, err)
+			for _, assertion := range test.assertions {
+				assertion(t, cfg)
+			}
 		})
 	}
 }

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2925,8 +2925,8 @@ type LDAPConfig struct {
 	ServerName string `yaml:"server_name,omitempty"`
 	// DEREncodedCAFile is the filepath to an optional DER encoded CA cert to be used for verification (if InsecureSkipVerify is set to false).
 	DEREncodedCAFile string `yaml:"der_ca_file,omitempty"`
-	// PEMEncodedCACert is an optional PEM encoded CA cert to be used for verification (if InsecureSkipVerify is set to false).
-	PEMEncodedCACert string `yaml:"ldap_ca_cert,omitempty"`
+	// PEMEncodedCACerts are optional PEM encoded CA certs to be used for verification (if InsecureSkipVerify is set to false).
+	PEMEncodedCACerts string `yaml:"ldap_ca_cert,omitempty"`
 	// LocateServer is the config that enables LDAP server location using DNS SRV records.
 	LocateServer `yaml:"locate_server"`
 }

--- a/lib/service/servicecfg/windows.go
+++ b/lib/service/servicecfg/windows.go
@@ -179,8 +179,8 @@ type LDAPConfig struct {
 	InsecureSkipVerify bool
 	// ServerName is the name of the LDAP server for TLS.
 	ServerName string
-	// CA is an optional CA cert to be used for verification if InsecureSkipVerify is set to false.
-	CA *x509.Certificate
+	// CAs are an optional CA certs to be used for verification if InsecureSkipVerify is set to false.
+	CAs []*x509.Certificate
 }
 
 // CheckAndSetDefaults verifies this LDAPConfig

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -351,7 +351,7 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 	// (You may need this configuration in order to use certificates to
 	// authenticate with LDAP when the LDAP server name is not correct
 	// in the certificate).
-	if cfg.LDAPConfig.CA != nil && cfg.LDAPConfig.InsecureSkipVerify {
+	if len(cfg.LDAPConfig.CAs) > 0 && cfg.LDAPConfig.InsecureSkipVerify {
 		cfg.Logger.WarnContext(context.Background(), insecureSkipVerifyWarning)
 	}
 
@@ -518,9 +518,11 @@ func (s *WindowsService) issueNewTLSConfigForLDAP() (*tls.Config, error) {
 		ServerName:         s.cfg.ServerName,
 	}
 
-	if s.cfg.CA != nil {
+	if len(s.cfg.CAs) > 0 {
 		pool := x509.NewCertPool()
-		pool.AddCert(s.cfg.CA)
+		for _, ca := range s.cfg.CAs {
+			pool.AddCert(ca)
+		}
 		tc.RootCAs = pool
 	}
 

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
+	"github.com/gravitational/teleport/lib/subca/testenv"
 	"github.com/gravitational/teleport/lib/tlsca"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -481,7 +482,16 @@ func TestLoadTLSConfigForLDAP(t *testing.T) {
 		require.NoError(t, client.Close())
 	})
 
+	mustSelfSignedCA := func() *x509.Certificate {
+		ca, err := testenv.NewSelfSignedCA(&testenv.CAParams{})
+		if err != nil {
+			panic(err)
+		}
+		return ca.Cert
+	}
+
 	newWindowsService := func(clock clockwork.Clock, client *authclient.Client) *WindowsService {
+
 		return &WindowsService{
 			cfg: WindowsServiceConfig{
 				Clock:      clock,
@@ -491,11 +501,23 @@ func TestLoadTLSConfigForLDAP(t *testing.T) {
 					Domain:   "test.example.com",
 					Username: "test-user",
 					Addr:     "ldap.example.com:389",
+					CAs:      []*x509.Certificate{mustSelfSignedCA(), mustSelfSignedCA()},
 				},
 			},
 			closeCtx: context.Background(),
 		}
 	}
+
+	t.Run("issued cert supports multiple CAs", func(t *testing.T) {
+		s := newWindowsService(clockwork.NewFakeClock(), client)
+
+		config, err := s.issueNewTLSConfigForLDAP()
+		require.NoError(t, err)
+		// Validate that both configured CAs made it into
+		// the TLS config's cert pool.
+		assertCertInPool(t, config.RootCAs, *s.cfg.CAs[0])
+		assertCertInPool(t, config.RootCAs, *s.cfg.CAs[1])
+	})
 
 	t.Run("returns cached config when not expired", func(t *testing.T) {
 		clock := clockwork.NewFakeClock()
@@ -827,5 +849,12 @@ func (c *mockCertificateStoreClient) WaitForUpdate(t *testing.T, wantCalls int) 
 		case <-ch:
 			continue
 		}
+	}
+}
+
+func assertCertInPool(t *testing.T, pool *x509.CertPool, cert x509.Certificate) {
+	t.Helper()
+	if _, err := cert.Verify(x509.VerifyOptions{Roots: pool}); err != nil {
+		t.Fatalf("cert not found/trusted in pool: %v", err)
 	}
 }


### PR DESCRIPTION
With cross-domain sign in coming soon, it may be necessary for Windows Desktop Service to support multiple configured LDAP CAs in order to authenticate with domain controllers from external forests. This PR allows users to simply concatenate multiple PEM encoded certificates in the `ldap.ldap_ca_cert` field. 



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added support for multiple trusted CA certificates to Windows Desktop Service's LDAP configuration.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local and CI

### Test Cases
- [x] Unit tests that validate correct parsing of concatenated PEM encoded certificates in WDS's LDAP configuration block.
- [x] Unit tests that validate that all configured CA certificates are added to the trusted CA cert pool on TLS config used by WDS for LDAPS.
