### PR TITLE
[Browser MFA] Add Browser MFA UI

### DIFF
--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -128,6 +128,9 @@ type MFAChallengeResponse struct {
 	SSOResponse *SSOResponse `json:"sso_response"`
 	// TODO(Joerger): DELETE IN v20.0.0, WebauthnResponse used instead.
 	WebauthnAssertionResponse *wantypes.CredentialAssertionResponse `json:"webauthnAssertionResponse"`
+	// BrowserMFAResponse is a response the browser completing an MFA challenge
+	// as part of the Browser MFA flow.
+	BrowserMFAResponse *BrowserMFAResponse `json:"browser_response"`
 }
 
 // SSOResponse is a json compatible [proto.SSOResponse].

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1216,6 +1216,8 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/headless/:headless_authentication_id", h.WithAuth(h.getHeadless))
 	h.PUT("/webapi/headless/:headless_authentication_id", h.WithAuth(h.putHeadlessState))
 
+	h.PUT("/webapi/mfa/browser/:request_id", h.WithAuth(h.putBrowserMFA))
+
 	h.GET("/webapi/sites/:site/user-groups", h.WithClusterAuth(h.getUserGroups))
 
 	// Fetches the user's preferences

--- a/lib/web/browser_mfa.go
+++ b/lib/web/browser_mfa.go
@@ -1,0 +1,69 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package web
+
+import (
+	"net/http"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+
+	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/httplib"
+)
+
+// putBrowserMFA accepts a webauthn response from a Browser MFA attempt which is
+// sent to CompleteBrowserMFAChallenge for verification. Once verified a tsh
+// redirect URL with an encrypted webauthn response is returned.
+func (h *Handler) putBrowserMFA(_ http.ResponseWriter, r *http.Request, params httprouter.Params, sctx *SessionContext) (any, error) {
+	requestID := params.ByName("request_id")
+	if requestID == "" {
+		return "", trace.BadParameter("request is missing request ID")
+	}
+
+	var req client.MFAChallengeResponse
+	if err := httplib.ReadResourceJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	mfaResp, err := req.GetOptionalMFAResponseProtoReq()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if mfaResp == nil {
+		return nil, trace.Errorf("mfa response is nil")
+	}
+
+	clt, err := sctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := clt.MFAServiceClient().CompleteBrowserMFAChallenge(r.Context(), &mfav1.CompleteBrowserMFAChallengeRequest{
+		BrowserMfaResponse: &mfav1.BrowserMFAResponse{
+			RequestId:        requestID,
+			WebauthnResponse: mfaResp.GetWebauthn(),
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return resp.TshRedirectUrl, nil
+}

--- a/web/packages/design/src/CardError/CardError.jsx
+++ b/web/packages/design/src/CardError/CardError.jsx
@@ -121,3 +121,10 @@ export const LogoutFailed = ({ message, loginUrl }) => (
 const HyperLink = styled.a`
   color: ${({ theme }) => theme.colors.buttons.link.default};
 `;
+
+export const BadRequest = ({ message, ...rest }) => (
+  <CardError {...rest}>
+    <Header>400 Bad Request</Header>
+    <Content message={message} />
+  </CardError>
+);

--- a/web/packages/design/src/CardError/index.js
+++ b/web/packages/design/src/CardError/index.js
@@ -23,7 +23,16 @@ import CardError, {
   LogoutFailed,
   NotFound,
   Offline,
+  BadRequest,
 } from './CardError';
 
 export default CardError;
-export { Failed, LoginFailed, AccessDenied, NotFound, Offline, LogoutFailed };
+export {
+  Failed,
+  LoginFailed,
+  AccessDenied,
+  NotFound,
+  Offline,
+  LogoutFailed,
+  BadRequest,
+};

--- a/web/packages/shared/redirects/urlValidation.test.ts
+++ b/web/packages/shared/redirects/urlValidation.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { validateClientRedirect } from './urlValidation';
+
+describe('validateClientRedirect', () => {
+  test.each([
+    'http://localhost:12345?response=abc',
+    'https://localhost:12345?response=abc',
+    'http://127.0.0.1:12345?response=abc',
+    'http://[::1]:12345?response=abc',
+  ])('accepts loopback URL: %s', url => {
+    expect(() => validateClientRedirect(url)).not.toThrow();
+  });
+
+  test('rejects empty URL', () => {
+    expect(() => validateClientRedirect('')).toThrow(
+      'redirect URL must not be empty'
+    );
+  });
+
+  test('rejects non-local address', () => {
+    expect(() =>
+      validateClientRedirect('http://example.com:12345?response=abc')
+    ).toThrow('example.com is not a valid local address');
+  });
+
+  test('rejects unsupported protocol', () => {
+    expect(() =>
+      validateClientRedirect('ftp://localhost:12345?response=abc')
+    ).toThrow('ftp: is not a valid protocol');
+  });
+
+  test('rejects URL with credentials', () => {
+    expect(() =>
+      validateClientRedirect('http://user:pass@localhost:12345?response=abc')
+    ).toThrow('redirect URL must not contain credentials');
+  });
+});

--- a/web/packages/shared/redirects/urlValidation.ts
+++ b/web/packages/shared/redirects/urlValidation.ts
@@ -1,0 +1,63 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]'];
+
+/**
+ * Validates that a redirect URL points to a valid local address, uses an
+ * allowed protocol, and does not expose URL-based credentials.
+ *
+ * This function is intended for validating client-side redirect URLs used in
+ * flows such as browser MFA, where the redirect target must be a local address
+ * (e.g. tsh, tctl etc) rather than an arbitrary external URL.
+ *
+ * Throws an error if any of the following conditions are not met:
+ * - The URL must not be empty.
+ * - The hostname must be one of the allowed local hosts: localhost, 127.0.0.1, or [::1].
+ * - The protocol must be http: or https:.
+ * - The URL must not contain a username or password.
+ *
+ * @param url - The redirect URL string to validate.
+ * @throws {Error} If the URL is empty, has a disallowed host, uses an invalid protocol,
+ * or contains embedded credentials.
+ *
+ * @example
+ * validateClientRedirect('http://localhost:8080/callback') // valid, does not throw
+ * validateClientRedirect('http://evil.com/callback')       // throws: not a valid local address
+ * validateClientRedirect('ftp://localhost/callback')       // throws: not a valid protocol
+ * validateClientRedirect('http://user:pass@localhost/')    // throws: must not contain credentials
+ */
+export function validateClientRedirect(url: string) {
+  if (url === '') {
+    throw new Error('redirect URL must not be empty');
+  }
+
+  const parsedUrl = new URL(url);
+
+  if (!ALLOWED_HOSTS.includes(parsedUrl.hostname)) {
+    throw new Error(`${parsedUrl.hostname} is not a valid local address`);
+  }
+
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new Error(`${parsedUrl.protocol} is not a valid protocol`);
+  }
+
+  if (parsedUrl.username || parsedUrl.password) {
+    throw new Error('redirect URL must not contain credentials');
+  }
+}

--- a/web/packages/teleport/src/BrowserMFA/BrowserMFA.story.tsx
+++ b/web/packages/teleport/src/BrowserMFA/BrowserMFA.story.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024 Gravitational, Inc.
+ * Copyright (C) 2026 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { processRedirectUri } from './processRedirectUri';
-import { validateClientRedirect } from './urlValidation';
+import { BrowserMfaAccessDenied, BrowserMfaProcessing } from './BrowserMFA';
 
-export { processRedirectUri, validateClientRedirect };
+export default {
+  title: 'Teleport/BrowserMFA',
+};
+
+export function Processing() {
+  return <BrowserMfaProcessing />;
+}
+
+export function AccessDenied() {
+  return <BrowserMfaAccessDenied statusText="MFA validation failed" />;
+}
+
+export function AccessDeniedWithLongMessage() {
+  return (
+    <BrowserMfaAccessDenied statusText="Your browser could not complete this authentication request. Please retry and ensure your security key or passkey is available." />
+  );
+}

--- a/web/packages/teleport/src/BrowserMFA/BrowserMFA.test.tsx
+++ b/web/packages/teleport/src/BrowserMFA/BrowserMFA.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createMemoryRouter, RouterProvider } from 'react-router';
+
+import { render, screen, waitFor } from 'design/utils/testing';
+import { validateClientRedirect } from 'shared/redirects/urlValidation';
+
+import { BrowserMfa } from 'teleport/BrowserMFA/BrowserMFA';
+import cfg from 'teleport/config';
+import { useMfa, shouldShowMfaPrompt } from 'teleport/lib/useMfa';
+import auth from 'teleport/services/auth';
+
+const mockGetChallengeResponse = jest.fn();
+const mockSubmit = jest.fn();
+
+jest.mock('teleport/lib/useMfa', () => ({
+  useMfa: jest.fn(),
+  shouldShowMfaPrompt: jest.fn(),
+}));
+
+jest.mock('shared/redirects/urlValidation', () => ({
+  validateClientRedirect: jest.fn((url: string) => url),
+}));
+
+type SetupOptions = {
+  showMFAPrompt?: boolean;
+  path?: string;
+  onRedirect?: (url: string) => void;
+  browserMfaPutResponse?: Promise<string>;
+  validateRedirect?: (url: string) => string;
+};
+
+function setup({
+  showMFAPrompt = false,
+  path = '/web/mfa/browser/12345',
+  onRedirect = jest.fn(),
+  browserMfaPutResponse = Promise.resolve(
+    'http://localhost:12345?response=abc'
+  ),
+  validateRedirect = (url: string) => url,
+}: SetupOptions = {}) {
+  (shouldShowMfaPrompt as jest.Mock).mockReturnValue(showMFAPrompt);
+  (validateClientRedirect as jest.Mock).mockImplementation(validateRedirect);
+
+  mockGetChallengeResponse.mockResolvedValue({ webauthn_response: {} });
+
+  jest
+    .spyOn(auth, 'browserMfaPut')
+    .mockImplementation(() => browserMfaPutResponse);
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: cfg.routes.browserMfa,
+        element: <BrowserMfa onRedirect={onRedirect} />,
+      },
+    ],
+    {
+      initialEntries: [path],
+    }
+  );
+
+  render(<RouterProvider router={router} />);
+}
+
+describe('BrowserMFA', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useMfa as jest.Mock).mockReturnValue({
+      getChallengeResponse: mockGetChallengeResponse,
+      attempt: { status: '' },
+      challenge: null,
+      submit: mockSubmit,
+    });
+  });
+
+  test('shows MFA prompt', async () => {
+    setup({ showMFAPrompt: true });
+
+    expect(await screen.findByText('Verify Your Identity')).toBeInTheDocument();
+  });
+
+  test('calls auth.browserMfaPut with the request ID from the URL', async () => {
+    const onRedirect = jest.fn();
+    setup({ onRedirect });
+
+    await waitFor(() => expect(auth.browserMfaPut).toHaveBeenCalled());
+
+    expect(auth.browserMfaPut).toHaveBeenCalledWith(
+      expect.anything(),
+      '12345',
+      expect.any(AbortSignal)
+    );
+
+    expect(onRedirect).toHaveBeenCalledWith(
+      'http://localhost:12345?response=abc'
+    );
+  });
+
+  test('shows loading indicator while processing', async () => {
+    const onRedirect = jest.fn();
+    const neverResolves = new Promise<string>(() => {});
+
+    setup({ onRedirect, browserMfaPutResponse: neverResolves });
+
+    expect(await screen.findByTestId('indicator')).toBeInTheDocument();
+    expect(onRedirect).not.toHaveBeenCalled();
+  });
+
+  test('shows access denied when redirect URL is invalid', async () => {
+    const onRedirect = jest.fn();
+
+    setup({
+      onRedirect,
+      validateRedirect: () => {
+        throw new Error('Invalid redirect URL');
+      },
+    });
+
+    expect(await screen.findByText('Invalid redirect URL')).toBeInTheDocument();
+    expect(onRedirect).not.toHaveBeenCalled();
+  });
+
+  test('shows error when request ID not included', async () => {
+    setup({ path: '/web/mfa/browser' });
+
+    expect(await screen.findByText('Missing request ID')).toBeInTheDocument();
+    expect(auth.browserMfaPut).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/teleport/src/BrowserMFA/BrowserMFA.tsx
+++ b/web/packages/teleport/src/BrowserMFA/BrowserMFA.tsx
@@ -1,0 +1,118 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect } from 'react';
+import { useParams } from 'react-router';
+
+import { Flex, Indicator } from 'design';
+import { AccessDenied, BadRequest } from 'design/CardError';
+import useAttempt from 'shared/hooks/useAttemptNext';
+
+import AuthnDialog from 'teleport/components/AuthnDialog';
+import { useMfa, shouldShowMfaPrompt } from 'teleport/lib/useMfa';
+import auth from 'teleport/services/auth';
+
+import { validateClientRedirect } from '../../../shared/redirects/urlValidation';
+
+interface BrowserMfaProps {
+  // onRedirect is used for testing only.
+  onRedirect?: (url: string) => void;
+}
+
+export function BrowserMfa({ onRedirect = redirectTo }: BrowserMfaProps) {
+  const { requestId } = useParams<{ requestId: string }>();
+  const { attempt, setAttempt } = useAttempt('processing');
+
+  const mfa = useMfa({
+    isMfaRequired: true,
+    req: {
+      browserMfaRequestId: requestId,
+    },
+  });
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    async function promptWebauthnAndRedirect() {
+      try {
+        if (!requestId) {
+          setAttempt({
+            status: 'failed',
+            statusText: 'Missing request ID',
+            statusCode: 400,
+          });
+          return;
+        }
+
+        // Get the tsh redirect URL
+        const tshRedirectUrl = await auth.browserMfaPut(
+          mfa,
+          requestId,
+          abortController.signal
+        );
+
+        // Validate that it points to localhost
+        validateClientRedirect(tshRedirectUrl);
+
+        // Redirect to the validated URL
+        onRedirect(tshRedirectUrl);
+      } catch (err) {
+        setAttempt({
+          status: 'failed',
+          statusText: err.message,
+        });
+      }
+    }
+
+    promptWebauthnAndRedirect();
+    return () => abortController.abort();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- Only run the effect once on mount
+
+  if (attempt.status === 'failed') {
+    if (attempt.statusCode === 400) {
+      return <BadRequest message={attempt.statusText} />;
+    }
+    return <BrowserMfaAccessDenied statusText={attempt.statusText} />;
+  }
+
+  if (shouldShowMfaPrompt(mfa)) {
+    return <AuthnDialog mfaState={mfa} />;
+  }
+
+  return <BrowserMfaProcessing />;
+}
+
+export function BrowserMfaProcessing() {
+  return (
+    <Flex height="180px" justifyContent="center" alignItems="center" flex="1">
+      <Indicator />
+    </Flex>
+  );
+}
+
+interface BrowserMfaAccessDeniedProps {
+  statusText: string;
+}
+
+export function BrowserMfaAccessDenied(props: BrowserMfaAccessDeniedProps) {
+  return <AccessDenied message={props.statusText} />;
+}
+
+function redirectTo(url: string): void {
+  window.location.replace(url);
+}

--- a/web/packages/teleport/src/Login/useLogin.ts
+++ b/web/packages/teleport/src/Login/useLogin.ts
@@ -42,7 +42,10 @@ export default function useLogin() {
   const [showMotd, setShowMotd] = useState<boolean>(() => {
     const redirectUri = history.getRedirectParam();
 
-    if (redirectUri?.includes('headless')) {
+    if (
+      redirectUri?.includes('headless') ||
+      redirectUri?.includes('/mfa/browser')
+    ) {
       return false;
     }
     return !!cfg.getMotd();

--- a/web/packages/teleport/src/Teleport.tsx
+++ b/web/packages/teleport/src/Teleport.tsx
@@ -32,6 +32,7 @@ import { UserContextProvider } from 'teleport/User';
 import { NewCredentials } from 'teleport/Welcome/NewCredentials';
 
 import { AppLauncher } from './AppLauncher';
+import { BrowserMfa } from './BrowserMFA/BrowserMFA';
 import cfg from './config';
 import { ConsoleWithContext as Console } from './Console';
 import { DesktopSessionContainer as DesktopSession } from './DesktopSession';
@@ -222,6 +223,11 @@ export function getSharedPrivateRoutes() {
       key="headlessSSO"
       path={cfg.routes.headlessSso}
       element={<HeadlessRequest />}
+    />,
+    <Route
+      key="browserMFA"
+      path={cfg.routes.browserMfa}
+      element={<BrowserMfa />}
     />,
   ];
 }

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -168,6 +168,7 @@ export const ossRoutes = {
   userResetContinue: '/web/reset/:tokenId/continue',
   kubernetes: '/web/cluster/:clusterId/kubernetes',
   headlessSso: `/web/headless/:requestId`,
+  browserMfa: `/web/mfa/browser/:requestId?`,
   integrations: '/web/integrations',
   integrationOverview: '/web/integrations/overview/:type/:name',
   integrationStatus: '/web/integrations/status/:type/:name',
@@ -431,6 +432,8 @@ const cfg = {
     mfaLoginFinish: '/v1/webapi/mfa/login/finishsession', // creates a web session
 
     headlessSsoPath: `/v1/webapi/headless/:requestId`,
+
+    browserMfaPath: `/v1/webapi/mfa/browser/:requestId`,
 
     mfaCreateRegistrationChallengePath:
       '/v1/webapi/mfa/token/:tokenId/registerchallenge',
@@ -1147,6 +1150,10 @@ const cfg = {
 
   getHeadlessSsoPath(requestId: string) {
     return generatePath(cfg.api.headlessSsoPath, { requestId });
+  },
+
+  getBrowserMfaPath(requestId: string) {
+    return generatePath(cfg.api.browserMfaPath, { requestId });
   },
 
   getUserInviteTokenRoute(tokenId = '') {

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -264,6 +264,16 @@ const auth = {
     return api.put(cfg.getHeadlessSsoPath(transactionId), request);
   },
 
+  browserMfaPut(mfa: MfaState, requestId: string, abortSignal: AbortSignal) {
+    return mfa.getChallengeResponse().then((res: MfaChallengeResponse) => {
+      const request = {
+        ...res,
+      };
+
+      return api.put(cfg.getBrowserMfaPath(requestId), request, abortSignal);
+    });
+  },
+
   // getChallenge gets an MFA challenge for the provided parameters. If is_mfa_required_req
   // is provided and it is found that MFA is not required, returns undefined instead.
   async getMfaChallenge(
@@ -279,6 +289,7 @@ const auth = {
           challenge_allow_reuse: req.allowReuse,
           user_verification_requirement: req.userVerificationRequirement,
           proxy_address: cfg.baseUrl,
+          browser_mfa_request_id: req.browserMfaRequestId,
         },
         abortSignal
       )

--- a/web/packages/teleport/src/services/auth/types.ts
+++ b/web/packages/teleport/src/services/auth/types.ts
@@ -62,12 +62,24 @@ export type ResetPasswordWithWebauthnReqWithEvent = {
   eventMeta?: EventMeta;
 };
 
-export type CreateAuthenticateChallengeRequest = {
-  scope: MfaChallengeScope;
-  allowReuse?: boolean;
-  isMfaRequiredRequest?: IsMfaRequiredRequest;
-  userVerificationRequirement?: UserVerificationRequirement;
-};
+// CreateAuthenticateChallengeRequest is the request used when creating an MFA
+// challenge. If browserMfaRequestId is set, scope is optional because auth
+// will set the scope when creating the challenge.
+export type CreateAuthenticateChallengeRequest =
+  | {
+      browserMfaRequestId: string;
+      scope?: MfaChallengeScope;
+      allowReuse?: boolean;
+      isMfaRequiredRequest?: IsMfaRequiredRequest;
+      userVerificationRequirement?: UserVerificationRequirement;
+    }
+  | {
+      browserMfaRequestId?: never;
+      scope: MfaChallengeScope;
+      allowReuse?: boolean;
+      isMfaRequiredRequest?: IsMfaRequiredRequest;
+      userVerificationRequirement?: UserVerificationRequirement;
+    };
 
 export type ChangePasswordReq = {
   oldPassword: string;


### PR DESCRIPTION
This PR adds the UI for the Browser MFA feature. The RFD for this feature can be found [here](https://github.com/gravitational/teleport/blob/master/rfd/0233-tsh-browser-mfa.md). Tracking issue https://github.com/gravitational/teleport/issues/63987.

These changes address this part of the flow from the above RFD (with the Auth interactions cut out for brevity):

```mermaid
sequenceDiagram
    participant tsh
    participant browser as Browser
    participant proxy as Proxy

    tsh->>browser: Open browser to:<br/>https://teleport.example.com/web/mfa/browser/:request_id
    activate browser

    browser->>proxy: GET /web/mfa/browser/:request_id
    proxy->>browser: Render MFA page
    browser->>proxy: POST /webapi/mfa/authenticatechallenge<br/>w/ browser_mfa_request_id
    proxy->>browser: MFA Challenge
    browser-->>browser: Display WebAuthn prompt
    browser->>browser: User taps TouchID /<br/>Uses password manager passkey
    browser->>proxy: PUT /webapi/mfa/browser/:request_id
  
    proxy-->>browser: HTTP 200 with redirect URL

    browser->>tsh: Redirect to callback URL<br/>http://127.0.0.1:port/callback?response={encrypted_webauthn}
    deactivate browser
```

Quick demo: https://github.com/user-attachments/assets/eea50890-e4fb-4e65-9dd8-4151634bd252

## Manual Test Plan
### Test Environment
UI tested on a Teleport instance running this branch locally, with backend requests being sent to a Teleport instance that has Browser MFA server-side changes (`danielashare/tsh-browser-mfa-sso`). SSO supported by a local keycloak instance.
### Test Cases
- [x] Browser MFA login happy path
  - [x] tsh opens /web/mfa/browser/:requestId
  - [x] MFA prompt shows
  - [x] After completing MFA, user is redirected to tsh
  - [x] tsh is logged in
- [x] Missing request ID shows error
- [x] Using a fake request ID shows access denied
- [x] Injecting a redirect URL of `baddomain.com` is caught by local validation
- [x] SSO login and MFA is unaffected
