### PR TITLE
lib/cloud/awsconfig: validate AWS region before fetching config

### DIFF
--- a/lib/cloud/awsconfig/awsconfig_test.go
+++ b/lib/cloud/awsconfig/awsconfig_test.go
@@ -114,8 +114,7 @@ func testGetConfigIntegration(t *testing.T, provider Provider) {
 	}
 
 	t.Run("with an invalid region must return bad parameter error", func(t *testing.T) {
-		ctx := context.Background()
-		_, err := provider.GetConfig(ctx, "test-region-1", WithCredentialsMaybeIntegration(IntegrationMetadata{Name: dummyIntegration}))
+		_, err := provider.GetConfig(t.Context(), "test-region-1", WithCredentialsMaybeIntegration(IntegrationMetadata{Name: dummyIntegration}))
 		require.True(t, trace.IsBadParameter(err), "unexpected error: %v", err)
 		require.ErrorContains(t, err, "region \"test-region-1\" is invalid")
 	})

--- a/lib/cloud/awsconfig/awsconfig_test.go
+++ b/lib/cloud/awsconfig/awsconfig_test.go
@@ -91,7 +91,7 @@ func TestGetConfigIntegration(t *testing.T) {
 
 func testGetConfigIntegration(t *testing.T, provider Provider) {
 	dummyIntegration := "integration-test"
-	dummyRegion := "test-region-123"
+	dummyRegion := "us-region-1"
 
 	awsOIDCIntegration, err := types.NewIntegrationAWSOIDC(
 		types.Metadata{Name: "integration-test"},
@@ -112,6 +112,13 @@ func testGetConfigIntegration(t *testing.T, provider Provider) {
 	stsClt := func(cfg aws.Config) STSClient {
 		return &mockAssumeRoleAPIClient{}
 	}
+
+	t.Run("with an invalid region must return bad parameter error", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := provider.GetConfig(ctx, "test-region-1", WithCredentialsMaybeIntegration(IntegrationMetadata{Name: dummyIntegration}))
+		require.True(t, trace.IsBadParameter(err), "unexpected error: %v", err)
+		require.ErrorContains(t, err, "region \"test-region-1\" is invalid")
+	})
 
 	t.Run("without an integration client, must return missing integration getter error", func(t *testing.T) {
 		ctx := context.Background()

--- a/lib/cloud/awsconfig/cache.go
+++ b/lib/cloud/awsconfig/cache.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gravitational/trace"
 
+	apiutilsaws "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -80,6 +81,11 @@ func (c *Cache) withDefaultOptions(optFns []OptionsFn) []OptionsFn {
 
 // GetConfig returns an [aws.Config] for the given region and options.
 func (c *Cache) GetConfig(ctx context.Context, region string, optFns ...OptionsFn) (aws.Config, error) {
+	if region != "" {
+		if err := apiutilsaws.IsValidRegion(region); err != nil {
+			return aws.Config{}, trace.Wrap(err)
+		}
+	}
 	opts, err := buildOptions(c.withDefaultOptions(optFns)...)
 	if err != nil {
 		return aws.Config{}, trace.Wrap(err)

--- a/lib/cloud/awsconfig/provider.go
+++ b/lib/cloud/awsconfig/provider.go
@@ -20,6 +20,9 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/gravitational/trace"
+
+	apiutilsaws "github.com/gravitational/teleport/api/utils/aws"
 )
 
 // Provider provides an [aws.Config].
@@ -33,5 +36,10 @@ type ProviderFunc func(ctx context.Context, region string, optFns ...OptionsFn) 
 
 // GetConfig returns an [aws.Config] for the given region and options.
 func (fn ProviderFunc) GetConfig(ctx context.Context, region string, optFns ...OptionsFn) (aws.Config, error) {
+	if region != "" {
+		if err := apiutilsaws.IsValidRegion(region); err != nil {
+			return aws.Config{}, trace.Wrap(err)
+		}
+	}
 	return fn(ctx, region, optFns...)
 }

--- a/lib/srv/db/cloud/iam_test.go
+++ b/lib/srv/db/cloud/iam_test.go
@@ -75,7 +75,7 @@ func TestAWSIAM(t *testing.T) {
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
 		URI:      "localhost",
-		AWS:      types.AWS{Region: "localhost", AccountID: "123456789012", RDS: types.RDS{InstanceID: "postgres-rds", ResourceID: "postgres-rds-resource-id"}},
+		AWS:      types.AWS{Region: "us-east-1", AccountID: "123456789012", RDS: types.RDS{InstanceID: "postgres-rds", ResourceID: "postgres-rds-resource-id"}},
 	})
 	require.NoError(t, err)
 
@@ -84,7 +84,7 @@ func TestAWSIAM(t *testing.T) {
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
 		URI:      "localhost",
-		AWS:      types.AWS{Region: "localhost", AccountID: "123456789012", RDS: types.RDS{ClusterID: "postgres-aurora", ResourceID: "postgres-aurora-resource-id"}},
+		AWS:      types.AWS{Region: "us-east-1", AccountID: "123456789012", RDS: types.RDS{ClusterID: "postgres-aurora", ResourceID: "postgres-aurora-resource-id"}},
 	})
 	require.NoError(t, err)
 
@@ -93,7 +93,7 @@ func TestAWSIAM(t *testing.T) {
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
 		URI:      "localhost",
-		AWS:      types.AWS{Region: "localhost", AccountID: "123456789012", RDSProxy: types.RDSProxy{Name: "rds-proxy", ResourceID: "rds-proxy-resource-id"}},
+		AWS:      types.AWS{Region: "us-east-1", AccountID: "123456789012", RDSProxy: types.RDSProxy{Name: "rds-proxy", ResourceID: "rds-proxy-resource-id"}},
 	})
 	require.NoError(t, err)
 
@@ -102,7 +102,7 @@ func TestAWSIAM(t *testing.T) {
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
 		URI:      "localhost",
-		AWS:      types.AWS{Region: "localhost", AccountID: "123456789012", Redshift: types.Redshift{ClusterID: "redshift-cluster-1"}},
+		AWS:      types.AWS{Region: "us-east-1", AccountID: "123456789012", Redshift: types.Redshift{ClusterID: "redshift-cluster-1"}},
 	})
 	require.NoError(t, err)
 
@@ -319,7 +319,7 @@ func TestAWSIAMNoPermissions(t *testing.T) {
 	}{
 		{
 			name: "RDS database",
-			meta: types.AWS{Region: "localhost", AccountID: "123456789012", RDS: types.RDS{InstanceID: "postgres-rds", ResourceID: "postgres-rds-resource-id"}},
+			meta: types.AWS{Region: "us-east-1", AccountID: "123456789012", RDS: types.RDS{InstanceID: "postgres-rds", ResourceID: "postgres-rds-resource-id"}},
 			awsClients: fakeAWSClients{
 				iamClient: &mocks.IAMMock{Unauth: true},
 				rdsClient: &mocks.RDSClient{Unauth: true},
@@ -328,7 +328,7 @@ func TestAWSIAMNoPermissions(t *testing.T) {
 		},
 		{
 			name: "Aurora cluster",
-			meta: types.AWS{Region: "localhost", AccountID: "123456789012", RDS: types.RDS{ClusterID: "postgres-aurora", ResourceID: "postgres-aurora-resource-id"}},
+			meta: types.AWS{Region: "us-east-1", AccountID: "123456789012", RDS: types.RDS{ClusterID: "postgres-aurora", ResourceID: "postgres-aurora-resource-id"}},
 			awsClients: fakeAWSClients{
 				iamClient: &mocks.IAMMock{Unauth: true},
 				rdsClient: &mocks.RDSClient{Unauth: true},
@@ -337,7 +337,7 @@ func TestAWSIAMNoPermissions(t *testing.T) {
 		},
 		{
 			name: "RDS database missing metadata",
-			meta: types.AWS{Region: "localhost", RDS: types.RDS{ClusterID: "postgres-aurora"}},
+			meta: types.AWS{Region: "us-east-1", RDS: types.RDS{ClusterID: "postgres-aurora"}},
 			awsClients: fakeAWSClients{
 				iamClient: &mocks.IAMMock{Unauth: true},
 				rdsClient: &mocks.RDSClient{Unauth: true},
@@ -346,7 +346,7 @@ func TestAWSIAMNoPermissions(t *testing.T) {
 		},
 		{
 			name: "Redshift cluster",
-			meta: types.AWS{Region: "localhost", AccountID: "123456789012", Redshift: types.Redshift{ClusterID: "redshift-cluster-1"}},
+			meta: types.AWS{Region: "us-east-1", AccountID: "123456789012", Redshift: types.Redshift{ClusterID: "redshift-cluster-1"}},
 			awsClients: fakeAWSClients{
 				iamClient: &mocks.IAMMock{Unauth: true},
 				stsClient: stsClient,
@@ -354,7 +354,7 @@ func TestAWSIAMNoPermissions(t *testing.T) {
 		},
 		{
 			name: "ElastiCache",
-			meta: types.AWS{Region: "localhost", AccountID: "123456789012", ElastiCache: types.ElastiCache{ReplicationGroupID: "some-group"}},
+			meta: types.AWS{Region: "us-east-1", AccountID: "123456789012", ElastiCache: types.ElastiCache{ReplicationGroupID: "some-group"}},
 			awsClients: fakeAWSClients{
 				iamClient: &mocks.IAMMock{Unauth: true},
 				stsClient: stsClient,
@@ -362,7 +362,7 @@ func TestAWSIAMNoPermissions(t *testing.T) {
 		},
 		{
 			name: "IAM UnmodifiableEntityException",
-			meta: types.AWS{Region: "localhost", AccountID: "123456789012", Redshift: types.Redshift{ClusterID: "redshift-cluster-1"}},
+			meta: types.AWS{Region: "us-east-1", AccountID: "123456789012", Redshift: types.Redshift{ClusterID: "redshift-cluster-1"}},
 			awsClients: fakeAWSClients{
 				iamClient: &mocks.IAMMock{
 					Error: &iamtypes.UnmodifiableEntityException{


### PR DESCRIPTION
Add region validation to both `Cache.GetConfig` and `ProviderFunc.GetConfig` using the existing `apiutilsaws.IsValidRegion` helper. Returns a bad parameter error early if a non-empty region is invalid, preventing unnecessary downstream calls with a bad region and upstream validations.

