### PR TITLE
docs: iac doc updates

### DIFF
--- a/docs/pages/includes/management/dynamic-resources/terraform-role.mdx
+++ b/docs/pages/includes/management/dynamic-resources/terraform-role.mdx
@@ -2,7 +2,7 @@ Starting with 16.2, Teleport comes with a built-in role for the Terraform provid
 
 <details>
 <summary>RBAC for versions before v16.2</summary>
-    On older version you will need to create the Terraform role yourself.
+    On older versions you will need to create the Terraform role yourself.
     Write the following `role.yaml` manifest:
 
     ```yaml

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/access-list.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/access-list.mdx
@@ -1,6 +1,6 @@
 ---
 title: Creating Access Lists with IaC
-sidebar_label: Infrastructure as Code
+sidebar_label: Access Lists
 description: Use Infrastructure-as-Code tooling to create Access Lists.
 tags:
  - infrastructure-as-code
@@ -23,7 +23,7 @@ Access Lists are registered with the Teleport Auth Service as resources stored
 on the Auth Service backend. The Teleport Auth Service exposes a gRPC API that
 enables clients to create, delete, or modify backend resources, including Access
 Lists. The Teleport Kubernetes Operator and Terraform provider, along with the
-`tctl` command-line tool, can manage agentless SSH services by authenticating to
+`tctl` command-line tool, can manage Access Lists by authenticating to
 the Teleport Auth Service and interacting with its gRPC API.
 
 By default, Access Lists can be managed via IaC but Access List memberships

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-operator.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-operator.mdx
@@ -21,7 +21,7 @@ This guide is applicable if you self-host Teleport in Kubernetes using the
 Login Rules are registered with the Teleport Auth Service as resources stored on
 the Auth Service backend. The Teleport Auth Service exposes a gRPC API that
 enables clients to create, delete, or modify backend resources, including Login
-Rules. The Teleport Kubernetes Operator can manage agentless SSH services by
+Rules. The Teleport Kubernetes Operator can manage Login Rules by
 authenticating to the Teleport Auth Service and interacting with its gRPC API.
 
 ## Prerequisites
@@ -260,5 +260,5 @@ logins:
 
 - Read the [Teleport Operator Guide](../teleport-operator/teleport-operator.mdx) to
   learn more about the Teleport Operator.
-- Read the [Login Rules reference](../../../reference/access-controls/login-rules.mdx) to learn mode about the
+- Read the [Login Rules reference](../../../reference/access-controls/login-rules.mdx) to learn more about the
   Login Rule expression syntax.

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-terraform.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-terraform.mdx
@@ -19,7 +19,7 @@ This guide will explain how to:
 Login Rules are registered with the Teleport Auth Service as resources stored on
 the Auth Service backend. The Teleport Auth Service exposes a gRPC API that
 enables clients to create, delete, or modify backend resources, including Login
-Rules. The Teleport Terraform Provider can manage agentless SSH services by
+Rules. The Teleport Terraform Provider can manage Login Rules by
 authenticating to the Teleport Auth Service and interacting with its gRPC API.
 
 ## Prerequisites
@@ -168,5 +168,5 @@ logins:
 
 - Read the [Terraform Guide](../terraform-provider/terraform-provider.mdx) to
   learn more about configuring the Terraform provider.
-- Read the [Login Rules reference](../../../reference/access-controls/login-rules.mdx) to learn mode about the
+- Read the [Login Rules reference](../../../reference/access-controls/login-rules.mdx) to learn more about the
   Login Rule expression syntax.

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/secret-lookup.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/secret-lookup.mdx
@@ -107,7 +107,7 @@ The operator indicates if the reconciliation worked on the CR `status` field.
 Run the following command to know if it worked:
 
 ```code
-$ kubectl get -n -n <Var name="teleport-iac" /> teleportgithubconnector github -o yaml
+$ kubectl get -n <Var name="teleport-iac" /> teleportgithubconnector github -o yaml
 
 apiVersion: resources.teleport.dev/v3
 kind: TeleportGithubConnector
@@ -126,7 +126,7 @@ status:
     type: SuccessfullyReconciled
 ```
 
-If everything worked, all condition statuses should be `True`. Of some status is `False`, the message and the reason
+If everything worked, all condition statuses should be `True`. If some status is `False`, the message and the reason
 will give you more information about what failed.
 
 Finally, validate the resource has been properly created in Teleport:

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator.mdx
@@ -31,7 +31,7 @@ could cause instability and non-deterministic behaviour.
 
 Supported Teleport resources are listed in [the Operator Reference Page](../../../reference/infrastructure-as-code/operator-resources/operator-resources.mdx).
 
-### Setting up the operator
+## Setting up the operator
 
 If you are self-hosting Teleport using the `teleport-cluster` Helm chart,
 follow [the guide for Helm-deployed clusters](teleport-operator-helm.mdx).
@@ -39,11 +39,11 @@ follow [the guide for Helm-deployed clusters](teleport-operator-helm.mdx).
 If you are hosting Teleport out of Kubernetes (Teleport Cloud, Terraform, ...),
 follow [the standalone operator guide](teleport-operator-standalone.mdx).
 
-### Control reconciliation with annotations
+## Control reconciliation with annotations
 
 The operator supports two annotations on CRs:
 
-#### `teleport.dev/keep`
+### `teleport.dev/keep`
 
 This annotation instructs the operator to keep the Teleport resource if the CR is deleted.
 This is useful if you want to migrate between two resource versions.
@@ -55,7 +55,7 @@ For example, to migrate from `TeleportRoleV6` to `TeleportRoleV7`:
 
 Possible values are `"true"` or `"false"` (those are strings, as Booleans are not valid label values in Kubernetes).
 
-#### `teleport.dev/ignore`
+### `teleport.dev/ignore`
 
 This annotation instructs the operator to ignore the CR when reconciling.
 This means the resource will not be created, updated, or deleted in Teleport.
@@ -66,7 +66,7 @@ finalizer or remove the ignore annotation.
 
 Possible values are `"true"` or `"false"` (those are strings, as Booleans are not valid label values in Kubernetes).
 
-### Look up values from secrets
+## Look up values from secrets
 
 Some Teleport resources might contain sensitive values. Select CR fields can reference an existing
 Kubernetes secret and the operator will retrieve the value from the secret when reconciling.
@@ -77,7 +77,7 @@ Teleport administrator and retrieve the sensitive values from Teleport.
 
 See [the dedicated guide](secret-lookup.mdx) for more details.
 
-### Troubleshooting
+## Troubleshooting
 
 (!docs/pages/includes/diagnostics/kubernetes-operator-troubleshooting.mdx!)
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
@@ -9,7 +9,7 @@ tags:
  - zero-trust
 ---
 
-This guides covers how to run the Teleport Terraform Provider from:
+This guide covers how to run the Teleport Terraform Provider from:
 
 - your CI/CD pipelines on:
   - GitHub Actions (we'll use the `github` join method)
@@ -21,7 +21,7 @@ This guides covers how to run the Teleport Terraform Provider from:
 
 <Admonition type="note">
 Running the Terraform provider with native Machine & Workload Identity is supported on Azure, inside a Kubernetes pod,
-and on servers with Trusted Platform Module (TPM). While those setups are not described in details in this guide,
+and on servers with Trusted Platform Module (TPM). While those setups are not described in detail in this guide,
 you can follow their regular Machine & Workload Identity guides and replace the "Configure `tbot`" step by passing the
 join method and token to the provider.
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/import-existing-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/import-existing-resources.mdx
@@ -99,4 +99,4 @@ reference](../../../reference/infrastructure-as-code/terraform-provider/resource
 - Explore the full list of supported [Terraform provider
   resources](../../../reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx).
 - See [the list of supported Teleport Terraform
-  setups](../terraform-provider/terraform-provider.mdx):
+  setups](../terraform-provider/terraform-provider.mdx).

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
@@ -8,8 +8,8 @@ tags:
  - zero-trust
 ---
 
-This guide explains you how to create a Terraform user and have the Teleport Auth Service sign long-lived credentials
-for it. The Teleport Terraform Provider can then user those credentials to interact with Teleport.
+This guide explains how to create a Terraform user and have the Teleport Auth Service sign long-lived credentials
+for it. The Teleport Terraform Provider can then use those credentials to interact with Teleport.
 
 ## How it works
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
@@ -209,7 +209,7 @@ These parameters must be set:
 - `addr` should match the public hostname and port of your Teleport cluster
 - `join_method` should be `terraform_cloud`. Note that Terraform Enterprise also
   uses the same join method, with a hostname as configured in Step 1.
-- `join_token` should match the name of the `token` resource created in Step #2
+- `join_token` should match the name of the `token` resource created in Step #1
 - `audience_tag` should match the suffix on the key of the variable created in
   the Terraform Cloud dashboard. For example, given the variable key
   `TFC_WORKLOAD_IDENTITY_AUDIENCE_TELEPORT`, the audience tag should be

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-getting-started.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-getting-started.mdx
@@ -629,8 +629,8 @@ module "prod_role" {
 |`db_roles`|Roles the user can access on a database when they authenticate to a database server.|
 |`db_users`|Users the user can access on a database when they authenticate to a database server.|
 |`gcp_service_accounts`|Google Cloud service accounts the user can access when authenticating to a Google Cloud API.|
-|`kubernetes_groups`|Kubernetes groups the Teleport Database Service can impersonate when proxying requests from the user.|
-|`kubernetes_users`|Kubernetes users the Teleport Database Service can impersonate when proxying requests from the user.|
+|`kubernetes_groups`|Kubernetes groups the Teleport Kubernetes Service can impersonate when proxying requests from the user.|
+|`kubernetes_users`|Kubernetes users the Teleport Kubernetes Service can impersonate when proxying requests from the user.|
 |`logins`|Operating system logins the user can access when authenticating to a Linux server.|
 |`windows_desktop_logins`|Operating system logins the user can access when authenticating to a Windows desktop.|
 
@@ -689,7 +689,7 @@ If you plan to skip this step, make sure to remove the `module "saml"` or
    `https://example.teleport.sh:443/v1/webapi/oidc/callback`, replacing
    `example.teleport.sh` with the domain name of your Teleport cluster. 
 
-   Ensure that `oidc_redirect_url` matches match the URL you configured with
+   Ensure that `oidc_redirect_url` matches the URL you configured with
    your IdP when registering your Teleport cluster as a relying party.
 
    </TabItem>
@@ -849,7 +849,7 @@ ip-10-1-1-24.ec2.internal  ⟵ Tunnel   role=agent-pool
    <Admonition type="tip">
 
    If you receive errors logging in using your authentication connector, log in
-   as a local user with permissions to view the Teleport audit log. These is
+   as a local user with permissions to view the Teleport audit log. This is
    available in the preset `auditor` role. Check for error messages in events
    related with the "SSO Login" type.
 

--- a/examples/resources/terraform/terraform-login-rules.tf
+++ b/examples/resources/terraform/terraform-login-rules.tf
@@ -30,7 +30,7 @@ resource "teleport_login_rule" "terraform-test-map-rule" {
   # The rule with the lowest priority will be evaluated first.
   priority = 0
 
-  # traits_map holds a map of all desired trait keys to list ofexpressions to
+  # traits_map holds a map of all desired trait keys to list of expressions to
   # determine the trait values.
   traits_map = {
 


### PR DESCRIPTION

Updates:
- access-list: fix sidebar label and intro paragraph. The sidebar showed as Infrastructure as Code instead of Access Lists.
- login rules: fix intro paragraph and verbiage
- login rules terraform: fix comment words
- terraform-role include: fix verbiage
- secret-lookup: fix command parameter and verbiage
- teleport-operator: fix heading level
- ci-or-cloud: verbiage fixes
- import-existing-resources: fix period
- long-lived-credential: verbiage fixes
- terraform-cloud: verbiage fix
- terraform-getting-started: verbiage fixes