### PR TITLE
testplan: Fix moderated session instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1383,8 +1383,8 @@ For web, run each session in a different browser.
 
 Ensure the default `terminationPolicy` of `terminate` has not been changed.
 
-For each of the following cases, create a moderated session with the user using `tsh ssh` and join this session with the moderator using `tsh join --role moderator`:
- - [ ] Ensure that `Ctrl+C` in the user terminal disconnects the moderator as the session has ended.
+For each of the following cases, create a moderated session with the user using `tsh ssh` and join this session with the moderator using `tsh join --mode moderator`:
+ - [ ] Ensure that `Ctrl+D` in the user terminal disconnects the moderator as the session has ended.
  - [ ] Ensure that `Ctrl+C` in the moderator terminal disconnects the moderator and terminates the user's session as the session no longer has a moderator.
  - [ ] Ensure that `t` in the moderator terminal terminates the session for all participants.
  - [ ] Upload file (web only).


### PR DESCRIPTION
Fix moderated session section of the test plan template. The `tsh join` command
uses `--mode` (not `--role`) to specify the join mode. The first checkbox should
say `Ctrl+D` (EOF, which ends the shell session) instead of `Ctrl+C` (SIGINT,
which does not end the session). The second checkbox correctly uses `Ctrl+C` for
the moderator terminal since that terminates the moderator's participation.