### PR TITLE
update test plan with perf node configs

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1397,6 +1397,11 @@ For all performance tests
  1) Verify that there are no memory/goroutine/file descriptor leaks
  2) Compare the baseline metrics with the previous release to determine if resource usage has increased
 
+
+Where applicable nodes used should be configured as follows:
+
+ 1) Transparent hugepages disabled.
+
 ### Ansible-like Test
 
 Run the [ansible-like](https://github.com/gravitational/teleport/tree/4fd411add0c6fa7d4d0d19b1cf0c5c13c541498e/assets/loadtest/ansible-like)

--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1400,7 +1400,7 @@ For all performance tests
 
 Where applicable nodes used should be configured as follows:
 
- 1) Transparent hugepages disabled.
+ 1) [Transparent hugepages](https://docs.kernel.org/admin-guide/mm/transhuge.html#global-thp-controls) disabled.
 
 ### Ansible-like Test
 


### PR DESCRIPTION
The usage of THP together with go's GC has historically resulted in performance issues. There has been active efforts to improve this as outlined in https://go.googlesource.com/proposal/+/master/design/59960-heap-hugepage-util.md

And as such the recommended configuration is at most `madvise`, to keep results consistent across releases we recommend disabling (`never`) THP when testing Teleport to remove this as a potential variable between tests.