### PR TITLE
VNet: Reconfigure DNS if VNet registry key under group policy was removed

### DIFF
--- a/lib/vnet/osconfig_windows.go
+++ b/lib/vnet/osconfig_windows.go
@@ -129,13 +129,21 @@ func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSCo
 	// Configure DNS only if the DNS zones or addresses have changed. This typically happens when the
 	// user logs in or out of a cluster. Otherwise configureDNS would refresh all computer policies
 	// every 10 seconds when platformConfigureOS is called.
+	//
+	// Also reconfigure DNS if VNet's own NRPT key under the group policy path has been removed by an
+	// external group policy refresh, or if the group policy parent key has been created or removed.
 	doesGroupPolicyKeyExist, err := doesKeyPathExist(registry.LOCAL_MACHINE, groupPolicyNRPTParentKey)
 	if err != nil {
 		return trace.Wrap(err, "checking existence of group policy NRPT registry key %s", groupPolicyNRPTParentKey)
 	}
+	vnetGroupPolicyNRPTKeyExists, err := doesKeyPathExist(registry.LOCAL_MACHINE, groupPolicyNRPTParentKey+`\`+vnetNRPTKeyID)
+	if err != nil {
+		return trace.Wrap(err, "checking existence of VNet NRPT registry key under group policy path")
+	}
 	if !slices.Equal(cfg.dnsZones, state.configuredDNSZones) ||
 		!slices.Equal(cfg.dnsAddrs, state.configuredDNSAddrs) ||
-		doesGroupPolicyKeyExist != state.configuredGroupPolicyKey {
+		doesGroupPolicyKeyExist != state.configuredGroupPolicyKey ||
+		(doesGroupPolicyKeyExist && !vnetGroupPolicyNRPTKeyExists && len(cfg.dnsZones) > 0) {
 		if err := configureDNS(ctx, cfg.dnsZones, cfg.dnsAddrs, doesGroupPolicyKeyExist); err != nil {
 			return trace.Wrap(err, "configuring DNS")
 		}


### PR DESCRIPTION
Changelog: Fixed intermittent issues with VNet on Windows with NRPT rules being wiped after Group Policy refresh

(For broader context see #56729. If a Windows device is in Active Directory and has NRPT rules set through Group Policy, we have to set them under another relevant registry key too.)

The customer for whom we originally worked on #61881 came back saying that while the custom build worked, the fix we shipped did not fully help and that they still had intermittent problems with VNet (see [the Zendesk ticket](https://gravitational.zendesk.com/agent/tickets/16828)). VNet would sometimes work, sometimes not; sometimes after waking up from sleep it would just not work.

The custom build we gave them had 8e028ee8b808fad65e521ba03ed154211c630fd9. Compared to #61881, it always reconfigured DNS every 10 seconds. This seemed wasteful, so #61881 includes an optimization where DNS is reconfigured only if we discover that VNet's DNS zones or addresses have changed:

https://github.com/gravitational/teleport/blob/8e2f75a63cc75bf150e8b97223f6549edbdbf108/lib/vnet/osconfig_windows.go#L129-L145

However, compared to the algorithm described in https://github.com/tailscale/tailscale/issues/4607#issuecomment-1130586168, this does not check if the VNet registry key still exists. According to Claude Code, this can happen during [Group Policy refresh](https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/group-policy/group-policy-processing). I could not find conclusive evidence that the GP engine deletes sub-keys it didn't create. Best I could do is find that the GP refresh works by [removing and then setting against registry keys](https://hinchley.net/articles/group-policy-refresh-behaviour). We could probably confirm this scenario with the customer by asking them to inspect the registry when VNet doesn't work.

However, I think in this scenario it's going to be easier to just send them another tag build to verify if it helps. We don't interact directly with the person running into those problems here, so this will cut on back-and-forth. It also seems plausible that VNet's key gets removed since it's set manually by us and not by a group policy. This is what I believe Taiscale's team was referring to by saying "writing NRPT rules to the LGPO instead of directly to the registry" (https://github.com/tailscale/tailscale/issues/4607#issuecomment-3558593563).

## Manual Test Plan
### Test Environment

Windows VM.

### Test Cases
- [x] Create a registry key `HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\DnsPolicyConfig\Foo`. Turn on VNet. Wait for VNet to create its own key under `DnsPolicyConfig`. Delete the key. Wait up to 10 seconds. Verify that after this time VNet re-created its key under `DnsPolicyConfig`.
