### PR TITLE
[loadtest] update gcp docs and examples

### DIFF
--- a/assets/loadtest/cluster/gcp/README.md
+++ b/assets/loadtest/cluster/gcp/README.md
@@ -18,7 +18,7 @@ To create/resize the cluster, edit [`terraform.tfvars`](./terraform.tfvars)
 as needed, then run:
 
 ```bash
-$ make apply
+$ make create-cluster
 ```
 
 *NOTE*: The node pool is spread across three regions, so the `nodes_per_zone` variable

--- a/assets/loadtest/cluster/gcp/main.tf
+++ b/assets/loadtest/cluster/gcp/main.tf
@@ -24,6 +24,9 @@ resource "google_container_cluster" "loadtest" {
   # immediately delete it.
   remove_default_node_pool = true
   initial_node_count       = 1
+
+  # The cluster is a short term resource, disable deletion protection to avoid issues with cleanup.
+  deletion_protection = false
 }
 
 #trivy:ignore:AVD-GCP-0048

--- a/assets/loadtest/control-plane/example-vars.env
+++ b/assets/loadtest/control-plane/example-vars.env
@@ -30,3 +30,12 @@ TELEPORT_VERSION="15.0.0"
 
 # aws region to use for resources
 REGION="$(aws configure get region)"
+
+# path to gcp credentials
+GCP_CREDENTIALS="${HOME}/.config/gcloud/application_default_credentials.json"
+
+# When testing on GCP, set the backend to firestore and set the project to use
+GCP_PROJECT="foobar"
+
+# session recording bucket name for firestore backend
+FIRESTORE_SESSION_BUCKET="${CLUSTER_NAME}-sess-deadbeefdeadbeef"

--- a/assets/loadtest/control-plane/init.sh
+++ b/assets/loadtest/control-plane/init.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 # initialize dependencies
 
-helm repo add teleport https://charts.releases.teleport.dev
+# helm repo add teleport https://charts.releases.teleport.dev
+helm repo add teleport https://charts.releases.development.teleport.dev
 helm repo add jetstack https://charts.jetstack.io
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update


### PR DESCRIPTION
Add examples of the required env vars when testing against gcp. 
Updates docs to match the makefile
Switch to devel chart repo by default.
Disables delete protection on the cluster since this is a short term deployment for testing only.




