### PR TITLE
[v17] tctl recordings: print download path on sucessfull downloads

### DIFF
--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -178,7 +178,7 @@ loop:
 			return nil
 		}
 	}
-	fmt.Fprintf(c.stdout, "Session recording %q downloaded to %s\n", string(*sessionID), path)
+	fmt.Fprintf(os.Stdout, "Session recording %q downloaded to %s\n", string(*sessionID), path)
 	return nil
 }
 

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -140,12 +140,14 @@ func (c *RecordingsCommand) DownloadRecordings(ctx context.Context, tc *authclie
 	if err != nil {
 		return trace.Wrap(err, "creating file downloader")
 	}
+
+	path := filepath.Join(c.recordingsDownloadOutputDir, string(*sessionID)+".tar")
 	defer func() {
 		completeErr := e.Complete(ctx)
 		if err == nil && completeErr == nil {
 			return
 		}
-		localRemErr := os.Remove(filepath.Join(c.recordingsDownloadOutputDir, string(*sessionID)+".tar"))
+		localRemErr := os.Remove(path)
 		// ignore file not found errors
 		if os.IsNotExist(localRemErr) {
 			localRemErr = nil
@@ -176,6 +178,7 @@ loop:
 			return nil
 		}
 	}
+	fmt.Fprintf(c.stdout, "Session recording %q downloaded to %s\n", string(*sessionID), path)
 	return nil
 }
 


### PR DESCRIPTION
Backport #64713 to branch/v17

changelog: Print a message indicating that `tctl recordings download <session_id>` completed successfully. 

## Manual Test Plan
### Test Environment

### Test Cases
- [x] Tested locally  
