### PR TITLE
[docs] Note hsm-v1 in HSM migration guides

### DIFF
--- a/docs/pages/zero-trust-access/deploy-a-cluster/private-keys/aws-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/private-keys/aws-kms.mdx
@@ -235,6 +235,11 @@ certificates can be signed without error.
 
 ## Migrating an existing cluster
 
+Before proceeding, ensure you have configured the cluster to use the
+`hsm-v1` or `fips-v1` signature algorithm. See
+[Signature Algorithm Suites](../../../reference/deployment/signature-algorithms.mdx)
+for more details.
+
 If you have an existing Teleport cluster it will have already created software
 CA keys during its first start.
 Those existing CA keys will have been used to sign all existing user and host

--- a/docs/pages/zero-trust-access/deploy-a-cluster/private-keys/gcp-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/private-keys/gcp-kms.mdx
@@ -247,6 +247,11 @@ Certificate Authority keys.
 
 ## Migrating an existing cluster
 
+Before proceeding, ensure you have configured the cluster to use the
+`hsm-v1` or `fips-v1` signature algorithm. See
+[Signature Algorithm Suites](../../../reference/deployment/signature-algorithms.mdx)
+for more details.
+
 If you have an existing Teleport cluster it will have already created software
 CA keys during its first start.
 Those existing CA keys will have been used to sign all existing user and host

--- a/docs/pages/zero-trust-access/deploy-a-cluster/private-keys/hsm.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/private-keys/hsm.mdx
@@ -338,6 +338,11 @@ auth_service:
 
 ## Step 3/5. (Re)start Teleport Auth
 
+Before proceeding, ensure you have configured the cluster to use the
+`hsm-v1` or `fips-v1` signature algorithm. See
+[Signature Algorithm Suites](../../../reference/deployment/signature-algorithms.mdx)
+for more details.
+
 If this is a new Teleport Auth Service which has not been started yet, starting
 a brand new cluster with an empty backend, HSM keys will be automatically
 generated at startup and no further action is required, skip to step 5.
@@ -362,7 +367,7 @@ Any users allowed the `update` verb for `cert_authority` resources in any of
 their Teleport roles will also see a cluster alert reminding them to rotate the
 CAs.
 
-CA rotation can be performed manually or semi-automatically, see our admin guide
+CA rotation can be performed manually or semi-automatically. See our admin guide
 on [Certificate rotation](../../management/security/ca-rotation.mdx).
 All CAs listed in the output of `tctl status` must be rotated.
 


### PR DESCRIPTION
Add a note to HSM guides that the signature_algorithm_suite in the cluster_auth_preference must be set to hsm-v1 before rotating CAs during the migration. Without doing this users can get confusing errors about unsupported key algorithms for Ed25519.