### PR TITLE
doc: add READMEs for athena and pgevents integration tests

### DIFF
--- a/lib/events/athena/README.md
+++ b/lib/events/athena/README.md
@@ -19,7 +19,7 @@ The tests create and clean up per-run resources automatically (SNS topic, SQS qu
 
 ```bash
 AWS_PROFILE=teleport-dev AWS_REGION=eu-central-1 TEST_AWS=true \
-  go test ./lib/events/athena/ -run TestIntegrationAthena -v -timeout 10m
+  go test ./lib/events/athena/ -run TestIntegrationAthena -v
 ```
 
 `AWS_REGION` must be `eu-central-1` — the S3 buckets live in that region and the AWS SDK will return `301 PermanentRedirect` if a different region is used.

--- a/lib/events/athena/README.md
+++ b/lib/events/athena/README.md
@@ -1,0 +1,25 @@
+# Athena audit log backend
+
+## Running integration tests
+
+The integration tests run against real AWS resources in the **teleport-dev** account, region **`eu-central-1`**.
+
+### Prerequisites
+
+- Access to the `teleport-dev` AWS account
+- The following resources already exist in `eu-central-1`:
+  - S3 bucket `auditlogs-integrationtests-locking` (object locking enabled, 1-day governance retention)
+  - S3 bucket `auditlogs-integrationtests` (1-day lifecycle expiration)
+  - Glue database `auditlogs_integrationtests`
+  - Athena workgroup `primary`
+
+The tests create and clean up per-run resources automatically (SNS topic, SQS queue, Athena table). The S3 buckets and Glue database are shared and long-lived.
+
+### Run
+
+```bash
+AWS_PROFILE=teleport-dev AWS_REGION=eu-central-1 TEST_AWS=true \
+  go test ./lib/events/athena/ -run TestIntegrationAthena -v -timeout 10m
+```
+
+`AWS_REGION` must be `eu-central-1` — the S3 buckets live in that region and the AWS SDK will return `301 PermanentRedirect` if a different region is used.

--- a/lib/events/pgevents/pgevents_test.go
+++ b/lib/events/pgevents/pgevents_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/testing/protocmp"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
@@ -142,8 +141,10 @@ func TestLog_nonStandardSessionID(t *testing.T) {
 		"", // startKey
 	)
 	require.NoError(t, err, "search session events")
-	want := []apievents.AuditEvent{appStartEvent}
-	if diff := cmp.Diff(want, appEvents, protocmp.Transform()); diff != "" {
+	wantFields, err := events.ToEventFields(appStartEvent)
+	require.NoError(t, err, "convert event to fields")
+	want := []events.EventFields{wantFields}
+	if diff := cmp.Diff(want, appEvents); diff != "" {
 		t.Errorf("searchEvents mismatch (-want +got)\n%s", diff)
 	}
 }


### PR DESCRIPTION
Add a README for the Athena integration tests documenting the required AWS account (teleport-dev), region (eu-central-1), pre-existing resources, and the exact command to run the tests.

Also fix a type mismatch in the pgevents test: searchEvents returns []EventFields, not []apievents.AuditEvent, so compare using EventFields after converting with events.ToEventFields.



Fixes #64730
Documents #64731