### PR TITLE
Connect: Add e2e tests for local terminal, enable screen reader mode in Xterm

### DIFF
--- a/e2e/helpers/connect.ts
+++ b/e2e/helpers/connect.ts
@@ -20,6 +20,7 @@ import fs from 'node:fs/promises';
 import module from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   _electron as electron,
@@ -95,6 +96,7 @@ export const test = base.extend<{
     await using temp = await fs.mkdtempDisposable(
       path.join(os.tmpdir(), 'connect-e2e-test-')
     );
+    await setupConnectConfig(temp.path);
     await using app = await launchApp(temp.path);
     if (autoLogin) {
       await login(app.page);
@@ -106,6 +108,26 @@ export const test = base.extend<{
     }
   },
 });
+
+// setupConnectConfig writes the Connect app config to the data directory,
+// configuring the terminal to use a wrapper shell that disables history
+// and rc files so that tests don't pollute the user's shell history.
+async function setupConnectConfig(dataDir: string) {
+  const shellWrapper = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../scripts/connect-e2e-shell.sh'
+  );
+
+  const userDataDir = path.join(dataDir, 'userData');
+  await fs.mkdir(userDataDir, { recursive: true });
+  await fs.writeFile(
+    path.join(userDataDir, 'app_config.json'),
+    JSON.stringify({
+      'terminal.shell': 'custom',
+      'terminal.customShell': shellWrapper,
+    })
+  );
+}
 
 const logFiles = ['main.log', 'renderer.log', 'shared.log', 'tshd.log'];
 async function attachLogs(dataDir: string, testInfo: TestInfo) {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -82,6 +82,7 @@ export default defineConfig({
     {
       name: 'connect',
       testDir: './tests/connect',
+      workers: 1,
     },
   ],
 });

--- a/e2e/scripts/connect-e2e-shell.sh
+++ b/e2e/scripts/connect-e2e-shell.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Shell wrapper for Connect's e2e tests. Disables history so that tests don't pollute the user's
+# shell history, and skips profile so they don't depend on the user's shell config.
+exec bash --noprofile --rcfile <(echo 'unset HISTFILE')

--- a/e2e/tests/connect/shell.spec.ts
+++ b/e2e/tests/connect/shell.spec.ts
@@ -44,14 +44,20 @@ test('shell session', async ({ app }) => {
   await expect(terminalInput).toBeVisible({ timeout: 10_000 });
 
   await terminalInput.pressSequentially(
-    `echo $TELEPORT_PROXY $TELEPORT_CLUSTER $TELEPORT_AUTH_SERVER\n`
+    `echo $TELEPORT_PROXY $TELEPORT_CLUSTER $TELEPORT_AUTH_SERVER $TELEPORT_TOOLS_VERSION\n`
   );
   await expect(terminal).toContainText(
-    `${proxyHost} ${clusterName} ${proxyHost}`,
+    `${proxyHost} ${clusterName} ${proxyHost} off`,
     {
       timeout: 10_000,
     }
   );
+
+  // Verify that TELEPORT_HOME points to the tsh home directory managed by Connect.
+  await terminalInput.pressSequentially('echo $TELEPORT_HOME\n');
+  await expect(terminal).toContainText('/home/.tsh', {
+    timeout: 10_000,
+  });
 
   // Verify that changing directory updates the tab title.
   await using tmpDir = await fs.mkdtempDisposable(

--- a/e2e/tests/connect/shell.spec.ts
+++ b/e2e/tests/connect/shell.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { test, expect } from '@gravitational/e2e/helpers/connect';
+import { startUrl } from '@gravitational/e2e/helpers/env';
+
+test.use({ autoLogin: true });
+
+test('shell session', async ({ app }) => {
+  const { page } = app;
+
+  const proxyHost = new URL(startUrl).host;
+  // Read the cluster name from the default DocumentCluster tab.
+  const clusterTab = page.locator('[role="tab"][data-doc-kind="doc.cluster"]');
+  const clusterName = await clusterTab.getAttribute('title');
+  if (!clusterName) {
+    throw new Error('Cluster tab is missing a title');
+  }
+
+  await page.getByTitle('Additional Actions').click();
+  await page.getByText('Open new terminal').click();
+
+  const terminal = page.locator('.xterm');
+  const terminalInput = page.getByRole('textbox', { name: 'Terminal input' });
+  await expect(terminalInput).toBeVisible({ timeout: 10_000 });
+
+  await terminalInput.pressSequentially(
+    `echo $TELEPORT_PROXY $TELEPORT_CLUSTER $TELEPORT_AUTH_SERVER\n`
+  );
+  await expect(terminal).toContainText(
+    `${proxyHost} ${clusterName} ${proxyHost}`,
+    {
+      timeout: 10_000,
+    }
+  );
+
+  // Verify that changing directory updates the tab title.
+  await using tmpDir = await fs.mkdtempDisposable(
+    path.join(os.tmpdir(), 'connect-e2e-shell-')
+  );
+  // Resolve symlinks (e.g., on macOS /tmp -> /private/tmp) to match what the shell reports.
+  const realTmpDir = await fs.realpath(tmpDir.path);
+  await terminalInput.pressSequentially(`cd ${realTmpDir}\n`);
+  const terminalTab = page.locator(
+    '[role="tab"][data-doc-kind="doc.terminal_shell"]'
+  );
+  await expect(terminalTab).toHaveAccessibleName(
+    new RegExp(`${realTmpDir} · ${clusterName}$`),
+    { timeout: 10_000 }
+  );
+
+  // Verify that `exit` (code 0) closes the tab.
+  await terminalInput.pressSequentially('exit\n');
+  await expect(terminalTab).toHaveCount(0, { timeout: 10_000 });
+
+  // Open a new terminal to test `exit 1`.
+  await page.getByTitle('Additional Actions').click();
+  await page.getByText('Open new terminal').click();
+  await expect(terminalInput).toBeVisible({ timeout: 10_000 });
+
+  // Verify that `exit 1` does not close the tab but the shell exits
+  // (the tab title loses the cwd, leaving just the cluster name or shell name + cluster name).
+  await terminalInput.pressSequentially('exit 1\n');
+  await expect(terminalTab).toHaveAccessibleName(
+    new RegExp(`${clusterName}$`),
+    { timeout: 10_000 }
+  );
+});

--- a/e2e/tests/connect/shell.spec.ts
+++ b/e2e/tests/connect/shell.spec.ts
@@ -41,23 +41,18 @@ test('shell session', async ({ app }) => {
 
   const terminal = page.locator('.xterm');
   const terminalInput = page.getByRole('textbox', { name: 'Terminal input' });
-  await expect(terminalInput).toBeVisible({ timeout: 10_000 });
+  await expect(terminalInput).toBeVisible();
 
   await terminalInput.pressSequentially(
     `echo $TELEPORT_PROXY $TELEPORT_CLUSTER $TELEPORT_AUTH_SERVER $TELEPORT_TOOLS_VERSION\n`
   );
   await expect(terminal).toContainText(
-    `${proxyHost} ${clusterName} ${proxyHost} off`,
-    {
-      timeout: 10_000,
-    }
+    `${proxyHost} ${clusterName} ${proxyHost} off`
   );
 
   // Verify that TELEPORT_HOME points to the tsh home directory managed by Connect.
   await terminalInput.pressSequentially('echo $TELEPORT_HOME\n');
-  await expect(terminal).toContainText('/home/.tsh', {
-    timeout: 10_000,
-  });
+  await expect(terminal).toContainText('/home/.tsh');
 
   // Verify that changing directory updates the tab title.
   await using tmpDir = await fs.mkdtempDisposable(
@@ -70,24 +65,20 @@ test('shell session', async ({ app }) => {
     '[role="tab"][data-doc-kind="doc.terminal_shell"]'
   );
   await expect(terminalTab).toHaveAccessibleName(
-    new RegExp(`${realTmpDir} · ${clusterName}$`),
-    { timeout: 10_000 }
+    new RegExp(`${realTmpDir} · ${clusterName}$`)
   );
 
   // Verify that `exit` (code 0) closes the tab.
   await terminalInput.pressSequentially('exit\n');
-  await expect(terminalTab).toHaveCount(0, { timeout: 10_000 });
+  await expect(terminalTab).toHaveCount(0);
 
   // Open a new terminal to test `exit 1`.
   await page.getByTitle('Additional Actions').click();
   await page.getByText('Open new terminal').click();
-  await expect(terminalInput).toBeVisible({ timeout: 10_000 });
+  await expect(terminalInput).toBeVisible();
 
   // Verify that `exit 1` does not close the tab but the shell exits
   // (the tab title loses the cwd, leaving just the cluster name or shell name + cluster name).
   await terminalInput.pressSequentially('exit 1\n');
-  await expect(terminalTab).toHaveAccessibleName(
-    new RegExp(`${clusterName}$`),
-    { timeout: 10_000 }
-  );
+  await expect(terminalTab).toHaveAccessibleName(new RegExp(`${clusterName}$`));
 });

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.ts
@@ -94,6 +94,7 @@ export default class TtyTerminal implements TerminalSearcher {
       fontSize: this.options.fontSize,
       scrollback: 5000,
       minimumContrastRatio: 4.5, // minimum for WCAG AA compliance
+      screenReaderMode: true,
       rightClickSelectsWord: this.config['terminal.rightClick'] === 'menu',
       theme: this.options.theme,
       windowsPty: this.options.windowsPty && {

--- a/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
@@ -24,6 +24,7 @@ import * as Icons from 'design/Icon';
 import { IconProps } from 'design/Icon/Icon';
 
 import { LinearProgress } from 'teleterm/ui/components/LinearProgress';
+import { Kind } from 'teleterm/ui/services/workspacesService/documentsService';
 
 import { useTabDnD } from './useTabDnD';
 
@@ -35,6 +36,7 @@ type TabItemProps = {
   nextActive?: boolean;
   closeTabTooltip?: string;
   isLoading?: boolean;
+  docKind?: Kind;
   onClick?(): void;
   onClose?(): void;
   onMoved?(oldIndex: number, newIndex: number): void;
@@ -53,6 +55,7 @@ export function TabItem(props: TabItemProps) {
     isLoading,
     onContextMenu,
     closeTabTooltip,
+    docKind,
   } = props;
   const ref = useRef<HTMLDivElement>(null);
   const canDrag = !!onMoved;
@@ -77,7 +80,15 @@ export function TabItem(props: TabItemProps) {
         min-width: 0;
       `}
     >
-      <TabContent ref={ref} active={active} dragging={isDragging} title={name}>
+      <TabContent
+        ref={ref}
+        active={active}
+        dragging={isDragging}
+        title={name}
+        role="tab"
+        aria-selected={active}
+        data-doc-kind={docKind}
+      >
         {props.Icon && <props.Icon size="small" pr={1} />}
         <Title color="inherit" fontWeight={500} fontSize="12px">
           {name}

--- a/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
@@ -53,6 +53,7 @@ export function Tabs(props: Props) {
           key={item.uri}
           index={index}
           name={item.title}
+          docKind={item.kind}
           active={active}
           Icon={getStaticNameAndIcon(item)?.Icon}
           nextActive={nextActive}
@@ -70,7 +71,7 @@ export function Tabs(props: Props) {
   );
 
   return (
-    <StyledTabs as="nav" {...styledProps}>
+    <StyledTabs role="tablist" {...styledProps}>
       {$items}
       <NewTabItem tooltip={newTabTooltip} onClick={onNew} />
     </StyledTabs>


### PR DESCRIPTION
This PR adds an e2e test which covers some of the points from the Shell section of Connect's test plan:

https://github.com/gravitational/teleport/blob/da0503c4d8ae31247f00adb66b0919f0ddd199cb/.github/ISSUE_TEMPLATE/webtestplan.md#L901-L916

* Similar to #64568, it enables screen reader mode in Xterm so that it's easier to verify terminal output in tests. Otherwise we'd pretty much have to dump output to text files and read them from disk.
* It also adds a custom shell for Connect e2e tests. Otherwise all commands executed during tests would run in user's default shell, polluting its history.
* I also made it so that it's easier to read tab titles in tests, as well as which doc kind each tab represents.
* Connect tests now run in just 1 worker.
  * This is because the app doesn't allow for more than one instance to be active at a time. I think we should be able to support running multiple instances if need be, but do you think it's necessary at the moment?

## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] The new tests are working.
- [x] Xterm works properly on all four platforms with screen reader mode enabled.
