### PR TITLE
Helm: Add metadata.namespace to event-handler chart templates

### DIFF
--- a/examples/chart/event-handler/templates/configmap.yaml
+++ b/examples/chart/event-handler/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "event-handler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.annotations.config }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/examples/chart/event-handler/templates/deployment.yaml
+++ b/examples/chart/event-handler/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "event-handler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.annotations.deployment }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/examples/chart/event-handler/templates/pvc.yaml
+++ b/examples/chart/event-handler/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "event-handler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "event-handler.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
## Summary

- Add `namespace: {{ .Release.Namespace }}` to `metadata` in `templates/deployment.yaml`, `templates/configmap.yaml`, and `templates/pvc.yaml` in the `teleport-plugin-event-handler` chart
- Aligns these three templates with the existing pattern used by the `tbot` subchart and the `certificate.yaml`/`issuer.yaml` templates, which already include explicit namespace metadata

## Why

GitOps controllers like GKE ConfigSync, Flux, and ArgoCD render Helm charts via `helm template` and apply the output declaratively. Without explicit `metadata.namespace` in the templates, these resources get deployed to the `default` namespace instead of the intended release namespace.

The `--namespace` flag only sets `{{ .Release.Namespace }}` during rendering — it doesn't inject `metadata.namespace` into the output. GitOps tools that apply rendered manifests (rather than running `helm install`) need the namespace to be explicit in the resource metadata.

## Test plan

- [x] Verify with `helm template teleport-event-handler teleport/teleport-plugin-event-handler --namespace teleport` that all three resources now include `namespace: teleport` in metadata
- [ ] Confirm no regression with standard `helm install --namespace teleport` workflow

Fixes #64738