### PR TITLE
Remove Teleport 18 mention in account settings UI

### DIFF
--- a/web/packages/teleport/src/Account/Preferences.tsx
+++ b/web/packages/teleport/src/Account/Preferences.tsx
@@ -313,15 +313,7 @@ export function Preferences({ setErrorMessage }: PreferencesProps) {
         <SingleRowBox>
           <Header
             title="Windows Desktop Session Keyboard Layout"
-            description={
-              <>
-                Choose keyboard layout for Windows Desktop sessions.
-                <br />
-                <br />
-                Note: To maintain keyboard layout settings your agents need to
-                be upgraded to Teleport 18.0.0 or later.
-              </>
-            }
+            description="Choose keyboard layout for Windows Desktop sessions."
             icon={<Icon.Keyboard />}
             actions={
               <Box minWidth="210px">


### PR DESCRIPTION
This will go out in Teleport 19, by which time all agents will be on 18 at a minimum.

<img width="1110" height="476" alt="Screenshot 2026-03-17 at 4 30 04 PM" src="https://github.com/user-attachments/assets/ff11fa51-30e8-4795-a997-a6d1b9dd2829" />
