### PR TITLE
Set "events" for dynamo_* event metrics

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -328,7 +328,7 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 			},
 		}),
 		awsconfig.WithAPIOptions(awsmetrics.MetricsMiddleware()),
-		awsconfig.WithAPIOptions(dynamometrics.MetricsMiddleware(dynamometrics.Backend)),
+		awsconfig.WithAPIOptions(dynamometrics.MetricsMiddleware(dynamometrics.Events)),
 	}
 
 	if cfg.CredentialsProvider != nil {

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -42,6 +42,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -890,6 +892,73 @@ func TestEndpoints(t *testing.T) {
 			assert.Nil(t, b, "backend not nil")
 		})
 	}
+}
+
+func TestNew_UsesEventsMetricsLabel(t *testing.T) {
+	// Don't t.Parallel(), this test reads global Prometheus counters.
+	ctx := context.Background()
+
+	before, err := getDynamoRequestsByTypeLabel("events")
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	b, err := New(ctx, Config{
+		Region:       "us-west-1",
+		Tablename:    "teleport-test",
+		UIDGenerator: utils.NewFakeUID(),
+		// Intentionally pass endpoint without scheme to exercise normalization.
+		Endpoint: strings.TrimPrefix(server.URL, "http://"),
+		Insecure: true,
+		CredentialsProvider: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+			return aws.Credentials{}, nil
+		}),
+	})
+	assert.ErrorContains(t, err, fmt.Sprintf("StatusCode: %d", http.StatusTeapot))
+	assert.Nil(t, b, "backend not nil")
+
+	after, err := getDynamoRequestsByTypeLabel("events")
+	require.NoError(t, err)
+	require.Greater(t, after, before, "expected dynamo metrics type=events to increase")
+}
+
+func getDynamoRequestsByTypeLabel(typeLabel string) (float64, error) {
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	var count float64
+	for _, family := range families {
+		if family.GetName() != "dynamo_requests_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if getMetricLabelValue(metric, "type") != typeLabel {
+				continue
+			}
+			if counter := metric.GetCounter(); counter != nil {
+				count += counter.GetValue()
+			}
+		}
+	}
+
+	return count, nil
+}
+
+func getMetricLabelValue(metric *dto.Metric, name string) string {
+	for _, label := range metric.GetLabel() {
+		if label.GetName() == name {
+			return label.GetValue()
+		}
+	}
+	return ""
 }
 
 func TestStartKeyBackCompat(t *testing.T) {


### PR DESCRIPTION
Fix the `type` label for DynamoDB Prometheus metrics for the audit event table.

It looks like we always set "backend" as the type, so the operations across both tables are added together. For example, if an auth server should show the following:

```
dynamo_requests{operation="PutItem",result="error",type="backend"} 2
dynamo_requests{operation="PutItem",result="success",type="backend"} 110
dynamo_requests{operation="PutItem",result="error",type="events"} 3
dynamo_requests{operation="PutItem",result="success",type="events"} 1122
```

It currently combines them like this:

```
dynamo_requests{operation="PutItem",result="error",type="backend"} 5
dynamo_requests{operation="PutItem",result="success",type="backend"} 1232
```



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fix a bug that incorrectly labeled Prometheus metrics when using the DynamoDB audit event backend.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

A Teleport auth server configured to use DynamoDB for backend and event storage.

### Test Cases
- [x] Confirm that Teleport is writing to both the backend and event table.
- [x] Ensure that `dynamo_*` metrics have both `type=events` and `type=backend` labels present.
- [x] Intentionally perform actions that generate audit events and/or backend operations. Verify that each `type` label reflects the type of activities you do.
