### PR TITLE
docs: Fix minor typos and simplify JWKS key fetch command

### DIFF
--- a/docs/pages/machine-workload-identity/deployment/kubernetes.mdx
+++ b/docs/pages/machine-workload-identity/deployment/kubernetes.mdx
@@ -23,7 +23,7 @@ due to the limited support Kubernetes has for sidecars.
 
 In this guide, we demonstrate the `kubernetes` join method, in which `tbot`
 proves its identity to the Teleport Auth Service by presenting a JSON web token
-(JWT) signed by the Kubernetes API server. This JWT contains identifies the
+(JWT) signed by the Kubernetes API server. This JWT contains the
 service account, the pod and the namespace in which `tbot` is running. The
 Teleport Auth Service checks the signature of the JWT against the Kubernetes
 cluster's public signing key.
@@ -93,8 +93,7 @@ presented by `tbot` is signed legitimately by the Kubernetes cluster.
 Run the following commands to determine the JWKS formatted public key:
 
 ```code
-$ kubectl proxy -p 8080
-$ curl http://localhost:8080/openid/v1/jwks
+$ kubectl get --raw /openid/v1/jwks
 {"keys":[--snip--]}%
 ```
 

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -787,7 +787,7 @@ Principals a user can assume on infrastructure resources:
 - `windows_desktop_logins`
 
 Teleport principals that a user can impersonate:
-- `impersonate.rules`
+- `impersonate.roles`
 - `impersonate.users`
 
 #### Functions

--- a/docs/pages/reference/access-controls/user-types.mdx
+++ b/docs/pages/reference/access-controls/user-types.mdx
@@ -49,7 +49,7 @@ representation of a user of a remote system.
 Remote users don't perform their login challenge in Teleport. They are redirected
 to their identity provider (IdP) to enter their password, MFA, or any
 authentication method required by the upstream SSO provider. Teleport is not
-aware of the authentication method not the user credentials, it trusts the IdP
+aware of the authentication method nor the user credentials; it trusts the IdP
 response.
 
 If `teleport.auth_service.authentication.second_factors` is `["webauthn"]`, Teleport

--- a/docs/pages/reference/architecture/authentication.mdx
+++ b/docs/pages/reference/architecture/authentication.mdx
@@ -115,9 +115,9 @@ within a cluster. To join services to the cluster and receive certificates, admi
 
 Unlike users and services, internal services receive long-lived certificates.
 
-To renew these certificates, admins should use certificate authority rotation, the process of invalidating all
-previously-issued certificates for nodes or users regardless of expiry and issuing a new ones,
-using a new certificate authority.
+To renew these certificates, admins should use certificate authority rotation.
+This is the process of invalidating all previously-issued certificates for nodes
+or users regardless of expiry, and issuing new ones using a new certificate authority.
 
 Take a look at the [Certificate Rotation Guide](../../zero-trust-access/management/security/ca-rotation.mdx) to
 learn how to do certificate rotation in practice.

--- a/docs/pages/reference/deployment/join-methods.mdx
+++ b/docs/pages/reference/deployment/join-methods.mdx
@@ -461,7 +461,7 @@ The Kubernetes join methods exists in three variants:
 #### Kubernetes In-cluster
 
 Kubernetes in-cluster joining is available for any Teleport process running
-in the same Kubernetes cluster than the Auth Service. It uses the Kubernetes
+in the same Kubernetes cluster as the Auth Service. It uses the Kubernetes
 ServiceAccount tokens to validate the pod identity. The method relies on the
 [Kubernetes TokenReview API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/)
 which is typically only reachable from within the Kubernetes cluster. Because of

--- a/docs/pages/zero-trust-access/rbac-get-started/labels.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/labels.mdx
@@ -382,6 +382,5 @@ After you have labeled your resources, you can use the labels when running
 For more information, see [Resource filtering](../../reference/access-controls/predicate-language.mdx).
 
 You can also use labels to limit the access that users in different roles have to
-
 specific classes of resources. For more information, see
 [Teleport Role Templates](role-templates.mdx).


### PR DESCRIPTION
Fixed some minor typos in docs and simplified some wording.

For the `tbot` kubernetes static JWKS method, modified the JWKS key fetch command to use a simpler one that doesn't require opening a local port. Both commands yield the same JSON result.