### PR TITLE
Fix newline rendering in access request comments

### DIFF
--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -535,7 +535,7 @@ function Comment({
         <Text typography="body3">{createdDuration}</Text>
       </Flex>
       {comment && (
-        <Box p={3} bg="levels.elevated">
+        <Box p={3} bg="levels.elevated" css="white-space: pre-wrap;">
           {comment}
         </Box>
       )}

--- a/web/packages/shared/components/AccessRequests/fixtures/index.ts
+++ b/web/packages/shared/components/AccessRequests/fixtures/index.ts
@@ -65,9 +65,9 @@ export const requestSearchPending: AccessRequest = {
   sessionTTLDuration: '',
   roles: ['test'],
   requestReason:
-    'Testing long message format. I am requesting access for the developer role that i will be using to \
-        commit fixes for our production application. I will need access for the \
-        rest of the day to complete my changes.',
+    'Testing long message format with multi-line text.\n\nI am requesting access for the developer role that i will be using to \
+commit fixes for our production application.\n\nI will need access for the \
+rest of the day to complete my changes.',
   resolveReason: '',
   reviews: [],
   reviewers: [
@@ -175,9 +175,9 @@ export const requestRolePending: AccessRequest = {
   sessionTTLDuration: '',
   roles: ['admin'],
   requestReason:
-    'Testing long message format. I am requesting access for the developer role that i will be using to \
-        commit fixes for our production application. I will need access for the \
-        rest of the day to complete my changes.',
+    'Testing long message format with multi-line text.\n\nI am requesting access for the developer role that i will be using to \
+commit fixes for our production application.\n\nI will need access for the \
+rest of the day to complete my changes.',
   resolveReason: '',
   reviews: [],
   reviewers: [


### PR DESCRIPTION




<!-- Provide a descriptive entry for the changelog of the next release. -->


Changelog: Fixed access request comments and review reasons not preserving newlines when rendered.




Before:
<img width="1192" height="910" alt="screenshot-before-fix" src="https://github.com/user-attachments/assets/2bcb21e1-5045-4818-99c8-aa7ef351876d" />

After:
<img width="1192" height="1198" alt="screenshot-after-fix" src="https://github.com/user-attachments/assets/8aca3860-81d2-4844-992f-a53582bf4cf0" />




<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Storybook (local)
- Story: Shared/AccessRequests/RequestView/LoadedRolePending

### Test Cases
- [x] Multi-line request reason renders with preserved newlines, paragraph breaks, and numbered lists
- [x] Multi-line review comment renders with preserved newlines, bullet points, and paragraph breaks
- [x] Long single-line text still wraps normally (no horizontal overflow)
- [x] Existing unit tests pass (RequestView.test.tsx — 2/2)
