### PR TITLE
[v17] Improve error reporting in `tsh ssh` if the MFA API is unavailable

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2067,10 +2067,10 @@ func (tc *TeleportClient) ConnectToNode(ctx context.Context, clt *ClusterClient,
 	case !errors.Is(mfaErr, io.EOF) && // Ignore any errors from MFA due to locks being enforced, the direct error will be friendlier
 		!errors.As(mfaErr, new(*MFARequiredUnknownError)) && // Ignore any failures that occurred before determining if MFA was required
 		!errors.Is(mfaErr, services.ErrSessionMFANotRequired): // Ignore any errors caused by attempting the MFA ceremony when MFA will not grant access
-		log.DebugContext(ctx, "Failed to connect to node, returning MFA ceremony error and ignoring direct connection error", "direct_error", directErr)
+		log.WithError(directErr).Debug("Failed to connect to node, returning MFA ceremony error and ignoring direct connection error")
 		return nil, trace.Wrap(mfaErr)
 	default:
-		log.DebugContext(ctx, "Failed to connect to node, returning direct connection error and ignoring MFA ceremony error", "mfa_error", mfaErr)
+		log.WithError(mfaErr).Debug(ctx, "Failed to connect to node, returning direct connection error and ignoring MFA ceremony error")
 		return nil, trace.Wrap(directErr)
 	}
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2065,7 +2065,7 @@ func (tc *TeleportClient) ConnectToNode(ctx context.Context, clt *ClusterClient,
 	case !trace.IsAccessDenied(directErr) && errors.Is(mfaErr, authclient.ErrNoMFADevices):
 		return nil, trace.Wrap(directErr)
 	case !errors.Is(mfaErr, io.EOF) && // Ignore any errors from MFA due to locks being enforced, the direct error will be friendlier
-		!errors.Is(mfaErr, MFARequiredUnknownErr{}) && // Ignore any failures that occurred before determining if MFA was required
+		!errors.As(mfaErr, new(*MFARequiredUnknownError)) && // Ignore any failures that occurred before determining if MFA was required
 		!errors.Is(mfaErr, services.ErrSessionMFANotRequired): // Ignore any errors caused by attempting the MFA ceremony when MFA will not grant access
 		return nil, trace.Wrap(mfaErr)
 	default:
@@ -2073,43 +2073,32 @@ func (tc *TeleportClient) ConnectToNode(ctx context.Context, clt *ClusterClient,
 	}
 }
 
-// MFARequiredUnknownErr indicates that connections to an instance failed
-// due to being unable to determine if mfa is required
-type MFARequiredUnknownErr struct {
+// MFARequiredUnknownError indicates that connections to an instance failed due
+// to being unable to determine if MFA is required.
+type MFARequiredUnknownError struct {
 	err error
 }
 
-// MFARequiredUnknown creates a new MFARequiredUnknownErr that wraps the
-// error encountered attempting to determine if the mfa ceremony should proceed.
+// MFARequiredUnknown creates a new MFARequiredUnknownError that wraps the error
+// encountered attempting to determine if the MFA ceremony should proceed.
 func MFARequiredUnknown(err error) error {
-	return MFARequiredUnknownErr{err: err}
+	return &MFARequiredUnknownError{err: err}
 }
 
 // Error returns the error string of the wrapped error if one exists.
-func (m MFARequiredUnknownErr) Error() string {
+func (m *MFARequiredUnknownError) Error() string {
+	const msg = "unable to determine if a MFA ceremony is required"
 	if m.err == nil {
-		return ""
+		return msg
 	}
 
-	return m.err.Error()
+	return msg + ": " + m.err.Error()
 }
 
-// Unwrap returns the underlying error from checking if an mfa
-// ceremony should have been performed.
-func (m MFARequiredUnknownErr) Unwrap() error {
+// Unwrap returns the underlying error from checking if an MFA ceremony should
+// have been performed.
+func (m *MFARequiredUnknownError) Unwrap() error {
 	return m.err
-}
-
-// Is determines if the provided error is an MFARequiredUnknownErr.
-func (m MFARequiredUnknownErr) Is(err error) bool {
-	switch err.(type) {
-	case MFARequiredUnknownErr:
-		return true
-	case *MFARequiredUnknownErr:
-		return true
-	default:
-		return false
-	}
 }
 
 // connectToNodeWithMFA checks if per session mfa is required to connect to the target host, and

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2067,8 +2067,10 @@ func (tc *TeleportClient) ConnectToNode(ctx context.Context, clt *ClusterClient,
 	case !errors.Is(mfaErr, io.EOF) && // Ignore any errors from MFA due to locks being enforced, the direct error will be friendlier
 		!errors.As(mfaErr, new(*MFARequiredUnknownError)) && // Ignore any failures that occurred before determining if MFA was required
 		!errors.Is(mfaErr, services.ErrSessionMFANotRequired): // Ignore any errors caused by attempting the MFA ceremony when MFA will not grant access
+		log.DebugContext(ctx, "Failed to connect to node, returning MFA ceremony error and ignoring direct connection error", "direct_error", directErr)
 		return nil, trace.Wrap(mfaErr)
 	default:
+		log.DebugContext(ctx, "Failed to connect to node, returning direct connection error and ignoring MFA ceremony error", "mfa_error", mfaErr)
 		return nil, trace.Wrap(directErr)
 	}
 }

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -767,16 +767,18 @@ func PerformSessionMFACeremony(ctx context.Context, params PerformSessionMFACere
 	// If connecting to a host in a leaf cluster and MFA failed check to see
 	// if the leaf cluster requires MFA. If it doesn't return an error indicating
 	// that MFA was not required instead of the error received from the root cluster.
+	var mfaKnownToBeRequired bool
 	if mfaRequiredReq != nil && !params.MFAAgainstRoot {
 		mfaRequiredResp, err := currentClient.IsMFARequired(ctx, mfaRequiredReq)
 		log.Debugf("MFA requirement acquired from leaf, MFARequired=%s", mfaRequiredResp.GetMFARequired())
 		switch {
 		case err != nil:
-			return nil, trace.Wrap(MFARequiredUnknown(err))
+			return nil, trace.Wrap(MFARequiredUnknown(trace.Unwrap(err)))
 		case !mfaRequiredResp.Required:
 			return nil, trace.Wrap(services.ErrSessionMFANotRequired)
 		}
 		mfaRequiredReq = nil // Already checked, don't check again at root.
+		mfaKnownToBeRequired = true
 	}
 
 	allowReuse := mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO
@@ -784,7 +786,20 @@ func PerformSessionMFACeremony(ctx context.Context, params PerformSessionMFACere
 		allowReuse = mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES
 	}
 
-	params.MFACeremony.CreateAuthenticateChallenge = rootClient.CreateAuthenticateChallenge
+	params.MFACeremony.CreateAuthenticateChallenge = func(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error) {
+		chal, err := rootClient.CreateAuthenticateChallenge(ctx, req)
+		if err != nil {
+			// not an exhaustive list, but connection problem and limit exceeded are
+			// almost surely caused by network conditions or general problems rather
+			// than being from the actual handling of the request
+			if !mfaKnownToBeRequired && (trace.IsConnectionProblem(err) || trace.IsLimitExceeded(err)) {
+				return nil, trace.Wrap(MFARequiredUnknown(trace.Unwrap(err)))
+			}
+			return nil, trace.Wrap(err)
+		}
+		return chal, nil
+	}
+
 	mfaResp, err := params.MFACeremony.Run(ctx, &proto.CreateAuthenticateChallengeRequest{
 		Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
 			ContextUser: &proto.ContextUser{},
@@ -795,22 +810,10 @@ func PerformSessionMFACeremony(ctx context.Context, params PerformSessionMFACere
 			AllowReuse: allowReuse,
 		},
 	}, promptOpts...)
-	if err != nil {
-		switch {
-		case errors.Is(err, &mfa.ErrMFANotRequired):
-			return nil, trace.Wrap(services.ErrSessionMFANotRequired)
-		// this is not a completely exhaustive list for errors that are
-		// definitely not errors coming from the MFA ceremony itself, but we
-		// (and gRPC in general) don't seem to have a great way of
-		// distinguishing errors that are definitely coming from the upper
-		// layers of the connection from errors deep in the server handler;
-		// connection problem and limit exceeded are errors that are
-		// overwhelmingly more likely to happen in the former, tho
-		case trace.IsConnectionProblem(err), trace.IsLimitExceeded(err):
-			return nil, trace.Wrap(MFARequiredUnknown(trace.Unwrap(err)))
-		default:
-			return nil, trace.Wrap(err)
-		}
+	if errors.Is(err, &mfa.ErrMFANotRequired) {
+		return nil, trace.Wrap(services.ErrSessionMFANotRequired)
+	} else if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// If mfaResp.GetResponse() is nil, the ceremony was a no-op (no devices

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -795,10 +795,22 @@ func PerformSessionMFACeremony(ctx context.Context, params PerformSessionMFACere
 			AllowReuse: allowReuse,
 		},
 	}, promptOpts...)
-	if errors.Is(err, &mfa.ErrMFANotRequired) {
-		return nil, trace.Wrap(services.ErrSessionMFANotRequired)
-	} else if err != nil {
-		return nil, trace.Wrap(err)
+	if err != nil {
+		switch {
+		case errors.Is(err, &mfa.ErrMFANotRequired):
+			return nil, trace.Wrap(services.ErrSessionMFANotRequired)
+		// this is not a completely exhaustive list for errors that are
+		// definitely not errors coming from the MFA ceremony itself, but we
+		// (and gRPC in general) don't seem to have a great way of
+		// distinguishing errors that are definitely coming from the upper
+		// layers of the connection from errors deep in the server handler;
+		// connection problem and limit exceeded are errors that are
+		// overwhelmingly more likely to happen in the former, tho
+		case trace.IsConnectionProblem(err), trace.IsLimitExceeded(err):
+			return nil, trace.Wrap(MFARequiredUnknown(trace.Unwrap(err)))
+		default:
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// If mfaResp.GetResponse() is nil, the ceremony was a no-op (no devices

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -767,7 +767,7 @@ func (t *sshBaseHandler) connectToHost(ctx context.Context, ws terminal.WSConn, 
 	case !trace.IsAccessDenied(directErr) && errors.Is(mfaErr, authclient.ErrNoMFADevices):
 		return nil, trace.Wrap(directErr)
 	case !errors.Is(mfaErr, io.EOF) && // Ignore any errors from MFA due to locks being enforced, the direct error will be friendlier
-		!errors.Is(mfaErr, client.MFARequiredUnknownErr{}) && // Ignore any failures that occurred before determining if MFA was required
+		!errors.As(mfaErr, new(*client.MFARequiredUnknownError)) && // Ignore any failures that occurred before determining if MFA was required
 		!errors.Is(mfaErr, services.ErrSessionMFANotRequired): // Ignore any errors caused by attempting the MFA ceremony when MFA will not grant access
 		return nil, trace.Wrap(mfaErr)
 	default:


### PR DESCRIPTION
Backport #63984 and #64765 to branch/v17

## Manual Test Plan

### Test Environment

Control plane running 18.7.3 release (Teleport Cloud staging), `tsh` running on darwin arm64 (custom build from this branch).

### Test Cases
- [x] The normal error display when `tsh ssh` hits a connection error while the auth API is rate limited (due to mass `tsh ssh`, for example) shows the error from the connection error rather than just "rate limit exceeded"
- [x] Debug logging shows the deprioritized MFA error
- [x] Per-session MFA errors are still shown when the MFA ceremony fails