### PR TITLE
Connect: add e2e tests for app configuration

### DIFF
--- a/e2e/helpers/connect.ts
+++ b/e2e/helpers/connect.ts
@@ -54,14 +54,6 @@ export async function launchApp(homeDir: string) {
     const page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
 
-    const usageData = page.getByText('Anonymous usage data');
-    await usageData.isVisible();
-    const declineUsageData = page.getByRole('button', {
-      name: 'Decline',
-      exact: true,
-    });
-    await declineUsageData.click();
-
     return { app, page, [Symbol.asyncDispose]: async () => app.close() };
   } catch (err) {
     await app.close();
@@ -87,20 +79,35 @@ export async function login(page: Page): Promise<void> {
 export interface App {
   electronApp: ElectronApplication;
   page: Page;
+  appConfigPath: string;
 }
 
 export const test = base.extend<{
   autoLogin: boolean;
+  /**
+   * Sets app config before launching the app.
+   *
+   * Use `withDefaultAppConfig` for normal config overrides.
+   */
+  appConfig: AppConfigSetup;
   app: App;
 }>({
   autoLogin: [false, { option: true }],
-  // Playwright fixture callbacks receive `use` to provide the fixture value:
-  // https://playwright.dev/docs/test-fixtures
-  app: async ({ autoLogin }, use, testInfo) => {
+  appConfig: [withDefaultAppConfig({}), { option: true }],
+  app: async ({ autoLogin, appConfig }, use, testInfo) => {
     await using temp = await fs.mkdtempDisposable(
       path.join(os.tmpdir(), 'connect-e2e-test-')
     );
-    await setupConnectConfig(temp.path);
+
+    const userDataDir = path.join(temp.path, 'userData');
+    await fs.mkdir(userDataDir, { recursive: true });
+
+    const appConfigPath = path.join(userDataDir, 'app_config.json');
+    await applyAppConfig({
+      appConfigPath,
+      action: appConfig,
+    });
+
     await using launchedApp = await launchApp(temp.path);
     if (autoLogin) {
       await login(launchedApp.page);
@@ -108,6 +115,7 @@ export const test = base.extend<{
     await use({
       electronApp: launchedApp.app,
       page: launchedApp.page,
+      appConfigPath,
     });
 
     if (testInfo.status !== testInfo.expectedStatus) {
@@ -116,24 +124,65 @@ export const test = base.extend<{
   },
 });
 
-// setupConnectConfig writes the Connect app config to the data directory,
-// configuring the terminal to use a wrapper shell that disables history
-// and rc files so that tests don't pollute the user's shell history.
-async function setupConnectConfig(dataDir: string) {
+export type AppConfigSetup =
+  | {
+      kind: 'appConfigPatch';
+      patch: Record<string, unknown>;
+    }
+  | {
+      kind: 'appConfigRaw';
+      rawConfig: string;
+    };
+
+/**
+ * Writes the Connect app config to the data directory,
+ * configuring the terminal to use a wrapper shell that disables history
+ * and rc files so that tests don't pollute the user's shell history.
+ */
+export function withDefaultAppConfig(
+  patch: Record<string, unknown>
+): AppConfigSetup {
+  return {
+    kind: 'appConfigPatch',
+    patch,
+  };
+}
+
+export function withRawAppConfig(rawConfig: string): AppConfigSetup {
+  return {
+    kind: 'appConfigRaw',
+    rawConfig,
+  };
+}
+
+async function applyAppConfig({
+  appConfigPath,
+  action,
+}: {
+  appConfigPath: string;
+  action: AppConfigSetup;
+}) {
   const shellWrapper = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     '../scripts/connect-e2e-shell.sh'
   );
+  const defaultAppConfig: Record<string, unknown> = {
+    'usageReporting.enabled': false,
+    'terminal.shell': 'custom',
+    'terminal.customShell': shellWrapper,
+  };
 
-  const userDataDir = path.join(dataDir, 'userData');
-  await fs.mkdir(userDataDir, { recursive: true });
-  await fs.writeFile(
-    path.join(userDataDir, 'app_config.json'),
-    JSON.stringify({
-      'terminal.shell': 'custom',
-      'terminal.customShell': shellWrapper,
-    })
-  );
+  switch (action.kind) {
+    case 'appConfigPatch':
+      await fs.writeFile(
+        appConfigPath,
+        JSON.stringify({ ...defaultAppConfig, ...action.patch }),
+        'utf8'
+      );
+      break;
+    case 'appConfigRaw':
+      await fs.writeFile(appConfigPath, action.rawConfig, 'utf8');
+  }
 }
 
 const logFiles = ['main.log', 'renderer.log', 'shared.log', 'tshd.log'];

--- a/e2e/helpers/connect.ts
+++ b/e2e/helpers/connect.ts
@@ -28,6 +28,7 @@ import {
   test as base,
   type Page,
   TestInfo,
+  ElectronApplication,
 } from '@playwright/test';
 
 import { connectTshBin, connectAppDir, password, startUrl } from './env';
@@ -83,7 +84,10 @@ export async function login(page: Page): Promise<void> {
   await expect(page.getByPlaceholder('Search or jump to')).toBeVisible();
 }
 
-type App = Awaited<ReturnType<typeof launchApp>>;
+export interface App {
+  electronApp: ElectronApplication;
+  page: Page;
+}
 
 export const test = base.extend<{
   autoLogin: boolean;
@@ -97,11 +101,14 @@ export const test = base.extend<{
       path.join(os.tmpdir(), 'connect-e2e-test-')
     );
     await setupConnectConfig(temp.path);
-    await using app = await launchApp(temp.path);
+    await using launchedApp = await launchApp(temp.path);
     if (autoLogin) {
-      await login(app.page);
+      await login(launchedApp.page);
     }
-    await use(app);
+    await use({
+      electronApp: launchedApp.app,
+      page: launchedApp.page,
+    });
 
     if (testInfo.status !== testInfo.expectedStatus) {
       await attachLogs(temp.path, testInfo);

--- a/e2e/helpers/connect.ts
+++ b/e2e/helpers/connect.ts
@@ -98,16 +98,7 @@ export const test = base.extend<{
     await using temp = await fs.mkdtempDisposable(
       path.join(os.tmpdir(), 'connect-e2e-test-')
     );
-
-    const userDataDir = path.join(temp.path, 'userData');
-    await fs.mkdir(userDataDir, { recursive: true });
-
-    const appConfigPath = path.join(userDataDir, 'app_config.json');
-    await applyAppConfig({
-      appConfigPath,
-      action: appConfig,
-    });
-
+    const { appConfigPath } = await initializeDataDir(temp.path, appConfig);
     await using launchedApp = await launchApp(temp.path);
     if (autoLogin) {
       await login(launchedApp.page);
@@ -153,6 +144,22 @@ export function withRawAppConfig(rawConfig: string): AppConfigSetup {
     kind: 'appConfigRaw',
     rawConfig,
   };
+}
+
+export async function initializeDataDir(
+  dataDir: string,
+  appConfig: AppConfigSetup
+): Promise<{ appConfigPath: string }> {
+  const userDataDir = path.join(dataDir, 'userData');
+  await fs.mkdir(userDataDir, { recursive: true });
+  const appConfigPath = path.join(userDataDir, 'app_config.json');
+
+  await applyAppConfig({
+    appConfigPath,
+    action: appConfig,
+  });
+
+  return { appConfigPath };
 }
 
 async function applyAppConfig({

--- a/e2e/scripts/open-connect.ts
+++ b/e2e/scripts/open-connect.ts
@@ -20,7 +20,12 @@ import { mkdtempDisposable } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { launchApp, login } from '../helpers/connect';
+import {
+  launchApp,
+  login,
+  withDefaultAppConfig,
+  initializeDataDir,
+} from '../helpers/connect';
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[22m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[39m`;
@@ -33,6 +38,7 @@ await using dataDir = await mkdtempDisposable(
   join(tmpdir(), 'connect-e2e-browse-')
 );
 info(`created temporary CONNECT_DATA_DIR: ${bold(dataDir.path)}`);
+await initializeDataDir(dataDir.path, withDefaultAppConfig({}));
 
 const launched = await launchApp(dataDir.path);
 await login(launched.page);

--- a/e2e/tests/connect/config.spec.ts
+++ b/e2e/tests/connect/config.spec.ts
@@ -1,0 +1,121 @@
+/*
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import fs from 'node:fs/promises';
+
+import {
+  expect,
+  test,
+  withDefaultAppConfig,
+  withRawAppConfig,
+} from '@gravitational/e2e/helpers/connect';
+
+test.describe('config applies valid values', () => {
+  test.use({
+    autoLogin: true,
+    appConfig: withDefaultAppConfig({
+      'terminal.fontFamily': 'Courier New',
+    }),
+  });
+
+  test('terminal font change', async ({ app }) => {
+    const { page } = app;
+    await page.getByTitle('Additional Actions').click();
+    await page.getByRole('button', { name: 'Open new terminal' }).click();
+
+    const fontFamily = await page
+      .getByTestId('terminal-container')
+      .last()
+      .evaluate(el => el.style.fontFamily);
+    expect(fontFamily).toBe('"Courier New"');
+  });
+});
+
+test.describe('config duplicate shortcuts', () => {
+  const duplicateShortcut =
+    process.platform === 'darwin' ? 'Command+1' : 'Ctrl+1';
+
+  test.use({
+    appConfig: withDefaultAppConfig({
+      'keymap.tab1': duplicateShortcut,
+      'keymap.tab2': duplicateShortcut,
+    }),
+  });
+
+  test('duplicate keyboard shortcuts show a conflict notification', async ({
+    app,
+  }) => {
+    const { page } = app;
+    const duplicateShortcut =
+      process.platform === 'darwin' ? 'Command+1' : 'Ctrl+1';
+    await expect(
+      page.getByText('Shortcuts conflicts', { exact: true })
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        `${duplicateShortcut} is used for actions: tab1, tab2. Only one of them will work.`,
+        { exact: true }
+      )
+    ).toBeVisible();
+  });
+});
+
+test.describe('config invalid value', () => {
+  test.use({
+    appConfig: withDefaultAppConfig({
+      'keymap.tab1': 'ABC',
+    }),
+  });
+
+  test('invalid config value shows validation notification', async ({
+    app,
+  }) => {
+    const { page } = app;
+    await expect(
+      page.getByText('Encountered errors in config file', {
+        exact: true,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByText('keymap.tab1: "ABC" cannot be used as a key code')
+    ).toBeVisible();
+  });
+});
+
+test.describe('config malformed JSON', () => {
+  const malformedConfig = 'not-a-json';
+
+  test.use({
+    appConfig: withRawAppConfig(malformedConfig),
+  });
+
+  test('syntax error shows an error notification, the config file contents is not overridden', async ({
+    app,
+  }) => {
+    const { page, electronApp, appConfigPath } = app;
+    await expect(
+      page.getByText('Failed to load config file', { exact: true })
+    ).toBeVisible();
+
+    // Close the app and verify the config on disk has not been overridden.
+    await electronApp.close();
+
+    const contentAfterClose = await fs.readFile(appConfigPath, 'utf8');
+    expect(contentAfterClose).toBe(malformedConfig);
+  });
+});


### PR DESCRIPTION
Adds tests for the Configuration section of the test plan:
https://github.com/gravitational/teleport/blob/e9bcb1a6eca2fd5982dd7a4912300d30881db5b1/.github/ISSUE_TEMPLATE/webtestplan.md?plain=1#L1154-L1169

I renamed `app` to `electronApp` to avoid names like `app.app` (now it's `app.electronApp`).
I also enabled customizing the config file in tests.

## Manual Test Plan
My laptop.

### Test Cases
- [x] The new tests are passing.
