### PR TITLE
Add support for OpenSSH CA to tbot's `ssh_host` service

### DIFF
--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -569,7 +569,7 @@ connect to it.
 The output service generates the following artifacts:
 - `ssh_host-cert.pub`: an SSH certificate signed by the Teleport host certificate authority.
 - `ssh_host`: the private key associated with the SSH host certificate.
-- `ssh_host-user-ca.pub`: an export of the Teleport user certificate authority in an OpenSSH compatible format.
+- `ssh_host-user-ca.pub`: an export of the configured Teleport certificate authorities in an OpenSSH-compatible format.
 
 ```yaml
 # type specifies the type of the output. For the ssh host output, this will
@@ -579,6 +579,12 @@ type: ssh_host
 # These names should match the names that clients use to connect to the host.
 principals:
   - host.example.com
+# ca_types controls which CA types are exported to `ssh_host-user-ca.pub`.
+# Supported values are `user` and `openssh`. If unspecified, this defaults to
+# `user`.
+ca_types:
+  - user
+  - openssh
 
 (!docs/pages/includes/machine-id/common-output-config.yaml!)
 ```

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -579,12 +579,10 @@ type: ssh_host
 # These names should match the names that clients use to connect to the host.
 principals:
   - host.example.com
-# ca_types controls which CA types are exported to `ssh_host-user-ca.pub`.
+# ca_type selects which CA type is exported to `ssh_host-user-ca.pub`.
 # Supported values are `user` and `openssh`. If unspecified, this defaults to
 # `user`.
-ca_types:
-  - user
-  - openssh
+ca_type: user
 
 (!docs/pages/includes/machine-id/common-output-config.yaml!)
 ```

--- a/lib/tbot/services/ssh/host_output.go
+++ b/lib/tbot/services/ssh/host_output.go
@@ -186,21 +186,17 @@ func (s *HostOutputService) generate(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	var exportedCAs strings.Builder
-	for _, caType := range s.cfg.CATypes {
-		userCAs, err := s.botAuthClient.GetCertAuthorities(ctx, caType, false)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		caBlock, err := exportSSHUserCAs(userCAs, clusterName)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		exportedCAs.WriteString(caBlock)
+	userCAs, err := s.botAuthClient.GetCertAuthorities(ctx, s.cfg.CAType, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	exportedCAs, err := exportSSHUserCAs(userCAs, clusterName)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
 	userCAPath := SSHHostCertPath + SSHHostUserCASuffix
-	if err := s.cfg.Destination.Write(ctx, userCAPath, []byte(exportedCAs.String())); err != nil {
+	if err := s.cfg.Destination.Write(ctx, userCAPath, []byte(exportedCAs)); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/tbot/services/ssh/host_output.go
+++ b/lib/tbot/services/ssh/host_output.go
@@ -186,19 +186,21 @@ func (s *HostOutputService) generate(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	userCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.UserCA, false)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	exportedCAs, err := exportSSHUserCAs(userCAs, clusterName)
-	if err != nil {
-		return trace.Wrap(err)
+	var exportedCAs strings.Builder
+	for _, caType := range s.cfg.CATypes {
+		userCAs, err := s.botAuthClient.GetCertAuthorities(ctx, caType, false)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		caBlock, err := exportSSHUserCAs(userCAs, clusterName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		exportedCAs.WriteString(caBlock)
 	}
 
 	userCAPath := SSHHostCertPath + SSHHostUserCASuffix
-	if err := s.cfg.Destination.Write(ctx, userCAPath, []byte(exportedCAs)); err != nil {
+	if err := s.cfg.Destination.Write(ctx, userCAPath, []byte(exportedCAs.String())); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/tbot/services/ssh/host_output_config.go
+++ b/lib/tbot/services/ssh/host_output_config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/internal"
@@ -58,6 +59,10 @@ type HostOutputConfig struct {
 	// Principals is a list of principals to request for the host cert.
 	Principals []string `yaml:"principals"`
 
+	// CATypes lists the CA types to export for TrustedUserCAKeys.
+	// Supported values: "user", "openssh". Defaults to ["user"].
+	CATypes []types.CertAuthType `yaml:"ca_types,omitempty"`
+
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime bot.CredentialLifetime `yaml:",inline"`
@@ -90,6 +95,20 @@ func (o *HostOutputConfig) CheckAndSetDefaults() error {
 	}
 	if len(o.Principals) == 0 {
 		return trace.BadParameter("at least one principal must be specified")
+	}
+
+	if len(o.CATypes) == 0 {
+		o.CATypes = []types.CertAuthType{types.UserCA}
+	}
+
+	for idx, caType := range o.CATypes {
+		switch caType {
+		case types.UserCA, types.OpenSSHCA:
+		case "":
+			return trace.BadParameter("ca_types[%d] must not be empty", idx)
+		default:
+			return trace.BadParameter("ca_types[%d] (%q) is unsupported", idx, caType)
+		}
 	}
 
 	return nil

--- a/lib/tbot/services/ssh/host_output_config.go
+++ b/lib/tbot/services/ssh/host_output_config.go
@@ -59,9 +59,9 @@ type HostOutputConfig struct {
 	// Principals is a list of principals to request for the host cert.
 	Principals []string `yaml:"principals"`
 
-	// CATypes lists the CA types to export for TrustedUserCAKeys.
-	// Supported values: "user", "openssh". Defaults to ["user"].
-	CATypes []types.CertAuthType `yaml:"ca_types,omitempty"`
+	// CAType selects the CA type to export for TrustedUserCAKeys.
+	// Supported values: "user", "openssh". Defaults to "user".
+	CAType types.CertAuthType `yaml:"ca_type,omitempty"`
 
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
@@ -97,18 +97,12 @@ func (o *HostOutputConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("at least one principal must be specified")
 	}
 
-	if len(o.CATypes) == 0 {
-		o.CATypes = []types.CertAuthType{types.UserCA}
-	}
-
-	for idx, caType := range o.CATypes {
-		switch caType {
-		case types.UserCA, types.OpenSSHCA:
-		case "":
-			return trace.BadParameter("ca_types[%d] must not be empty", idx)
-		default:
-			return trace.BadParameter("ca_types[%d] (%q) is unsupported", idx, caType)
-		}
+	switch o.CAType {
+	case "":
+		o.CAType = types.UserCA
+	case types.UserCA, types.OpenSSHCA:
+	default:
+		return trace.BadParameter("ca_type (%q) is unsupported", o.CAType)
 	}
 
 	return nil

--- a/lib/tbot/services/ssh/host_output_config_test.go
+++ b/lib/tbot/services/ssh/host_output_config_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 )
@@ -35,6 +36,7 @@ func TestSSHHostOutput_YAML(t *testing.T) {
 				Destination: dest,
 				Roles:       []string{"access"},
 				Principals:  []string{"host.example.com"},
+				CATypes:     []types.CertAuthType{types.UserCA},
 				CredentialLifetime: bot.CredentialLifetime{
 					TTL:             1 * time.Minute,
 					RenewalInterval: 30 * time.Second,
@@ -61,6 +63,7 @@ func TestSSHHostOutput_CheckAndSetDefaults(t *testing.T) {
 					Destination: destination.NewMemory(),
 					Roles:       []string{"access"},
 					Principals:  []string{"host.example.com"},
+					CATypes:     []types.CertAuthType{types.UserCA, types.OpenSSHCA},
 				}
 			},
 		},
@@ -82,6 +85,28 @@ func TestSSHHostOutput_CheckAndSetDefaults(t *testing.T) {
 				}
 			},
 			wantErr: "at least one principal must be specified",
+		},
+		{
+			name: "invalid ca_types",
+			in: func() *HostOutputConfig {
+				return &HostOutputConfig{
+					Destination: destination.NewMemory(),
+					Principals:  []string{"host.example.com"},
+					CATypes:     []types.CertAuthType{"invalid"},
+				}
+			},
+			wantErr: `ca_types[0] ("invalid") is unsupported`,
+		},
+		{
+			name: "empty ca_types entry",
+			in: func() *HostOutputConfig {
+				return &HostOutputConfig{
+					Destination: destination.NewMemory(),
+					Principals:  []string{"host.example.com"},
+					CATypes:     []types.CertAuthType{""},
+				}
+			},
+			wantErr: `ca_types[0] must not be empty`,
 		},
 	}
 	testCheckAndSetDefaults(t, tests)

--- a/lib/tbot/services/ssh/host_output_config_test.go
+++ b/lib/tbot/services/ssh/host_output_config_test.go
@@ -36,7 +36,7 @@ func TestSSHHostOutput_YAML(t *testing.T) {
 				Destination: dest,
 				Roles:       []string{"access"},
 				Principals:  []string{"host.example.com"},
-				CATypes:     []types.CertAuthType{types.UserCA},
+				CAType:      types.UserCA,
 				CredentialLifetime: bot.CredentialLifetime{
 					TTL:             1 * time.Minute,
 					RenewalInterval: 30 * time.Second,
@@ -63,8 +63,22 @@ func TestSSHHostOutput_CheckAndSetDefaults(t *testing.T) {
 					Destination: destination.NewMemory(),
 					Roles:       []string{"access"},
 					Principals:  []string{"host.example.com"},
-					CATypes:     []types.CertAuthType{types.UserCA, types.OpenSSHCA},
+					CAType:      types.OpenSSHCA,
 				}
+			},
+		},
+		{
+			name: "default ca_type",
+			in: func() *HostOutputConfig {
+				return &HostOutputConfig{
+					Destination: destination.NewMemory(),
+					Principals:  []string{"host.example.com"},
+				}
+			},
+			want: &HostOutputConfig{
+				Destination: destination.NewMemory(),
+				Principals:  []string{"host.example.com"},
+				CAType:      types.UserCA,
 			},
 		},
 		{
@@ -87,26 +101,15 @@ func TestSSHHostOutput_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "at least one principal must be specified",
 		},
 		{
-			name: "invalid ca_types",
+			name: "invalid ca_type",
 			in: func() *HostOutputConfig {
 				return &HostOutputConfig{
 					Destination: destination.NewMemory(),
 					Principals:  []string{"host.example.com"},
-					CATypes:     []types.CertAuthType{"invalid"},
+					CAType:      types.CertAuthType("invalid"),
 				}
 			},
-			wantErr: `ca_types[0] ("invalid") is unsupported`,
-		},
-		{
-			name: "empty ca_types entry",
-			in: func() *HostOutputConfig {
-				return &HostOutputConfig{
-					Destination: destination.NewMemory(),
-					Principals:  []string{"host.example.com"},
-					CATypes:     []types.CertAuthType{""},
-				}
-			},
-			wantErr: `ca_types[0] must not be empty`,
+			wantErr: `ca_type ("invalid") is unsupported`,
 		},
 	}
 	testCheckAndSetDefaults(t, tests)

--- a/lib/tbot/services/ssh/testdata/TestSSHHostOutput_YAML/full.golden
+++ b/lib/tbot/services/ssh/testdata/TestSSHHostOutput_YAML/full.golden
@@ -5,7 +5,6 @@ roles:
   - access
 principals:
   - host.example.com
-ca_types:
-  - user
+ca_type: user
 credential_ttl: 1m0s
 renewal_interval: 30s

--- a/lib/tbot/services/ssh/testdata/TestSSHHostOutput_YAML/full.golden
+++ b/lib/tbot/services/ssh/testdata/TestSSHHostOutput_YAML/full.golden
@@ -5,5 +5,7 @@ roles:
   - access
 principals:
   - host.example.com
+ca_types:
+  - user
 credential_ttl: 1m0s
 renewal_interval: 30s


### PR DESCRIPTION
Adds support for exporting the OpenSSH CA certificate in tbot's `ssh_host` output service, so that it can be used to configure "agentless" nodes.

changelog: Added support for configuring agentless OpenSSH servers using `tbot`

## Manual Test Plan

We've been testing this extensively in the Beams project, as it's the way the Teleport proxy authenticates with each beam's `sshd`.

### Test Environment

Kubernetes pod running in EKS (cloud dev-red environment) with:

1. Debian container running `sshd`
2. tbot sidecar container, writing its output to a shared volume

tbot configuration:

```yaml
services:
  - type: ssh_host
    destination:
      type: directory
      path: /var/run/tbot/ssh-host
    ca_types: ["openssh"]
    principals: ["<beam-id>"]
```

sshd configuration:

```
HostKey /var/run/tbot/ssh-host/ssh_host
HostCertificate /var/run/tbot/ssh-host/ssh_host-cert.pub
TrustedUserCAKeys /var/run/tbot/ssh-host/ssh_host-user-ca.pub
```

### Test Cases

- [x] User can `tsh ssh` into the OpenSSH node
- [x] Default (`ca_types: ["user"]`) configuration doesn't change contents of `ssh_host-user-ca.pub`
