### PR TITLE
[v18] Supporting kube role when using scoped tokens

### DIFF
--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -34,6 +34,9 @@ import (
 
 var rolesSupportingScopes = types.SystemRoles{
 	types.RoleNode,
+	types.RoleKube,
+	types.RoleApp,
+	types.RoleDiscovery,
 }
 
 // TokenUsageMode represents the possible usage modes of a scoped token.
@@ -47,7 +50,6 @@ const (
 )
 
 func validateJoinMethod(token *joiningv1.ScopedToken) error {
-
 	switch types.JoinMethod(token.GetSpec().GetJoinMethod()) {
 	case types.JoinMethodToken:
 		if token.GetStatus().GetSecret() == "" {

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -291,6 +291,9 @@ func TestValidateScopedToken(t *testing.T) {
 		},
 		{
 			name: "valid scoped token",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.Roles = types.SystemRoles{types.RoleNode, types.RoleKube, types.RoleApp, types.RoleDiscovery}.StringSlice()
+			},
 		},
 		{
 			name: "valid ec2 scoped token with TTL",


### PR DESCRIPTION
Backport #64385 to branch/v18

# Manual Test Plan
- [x] Create a scoped token with type `kube` (`tctl scoped tokens add --type=kube --scope=/test --assign-scope=/test`)
- [x] Join a Teleport Kubernetes Service using the scoped token
- [x] Confirm joining was successful
- [x] Confirm the instance's scope is applied (`tctl get kube_server/<k8s_cluster_name>`)