### PR TITLE
Add configurable kube token path to tbot and the TF provider

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
@@ -187,6 +187,7 @@ This auth method has the following limitations:
 - `join_token` (String) Name of the token used for the native MachineID joining. This value is not sensitive for [delegated join methods](../../deployment/join-methods.mdx#secret-vs-delegated). This can also be set with the environment variable `TF_TELEPORT_JOIN_TOKEN`.
 - `key_base64` (String, Sensitive) Base64 encoded TLS auth key. This can also be set with the environment variable `TF_TELEPORT_KEY_BASE64`.
 - `key_path` (String) Path to Teleport auth key file. This can also be set with the environment variable `TF_TELEPORT_KEY`.
+- `kubernetes_token_path` (String) KubernetesTokenPath configures the Kubernetes token location when joining using MachineID and the `kubernetes` join method. When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location: `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 - `profile_dir` (String) Teleport profile path. This can also be set with the environment variable `TF_TELEPORT_PROFILE_PATH`.
 - `profile_name` (String) Teleport profile name. This can also be set with the environment variable `TF_TELEPORT_PROFILE_NAME`.
 - `retry_base_duration` (String) Retry algorithm when the API returns 'not found': base duration between retries (https://pkg.go.dev/time#ParseDuration). This can also be set with the environment variable `TF_TELEPORT_RETRY_BASE_DURATION`.

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -140,6 +140,14 @@ onboarding:
     # key.
     static_key_path: ./path/to/secret
 
+  # kubernetes holds parameters specific to the "kubernetes" join methods.
+  kubernetes:
+    # token_path is the optional path that used to lookup the Kubernetes service account token for joining.
+    # When unset, tbot will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
+    # "/var/run/secrets/kubernetes.io/serviceaccount/token".
+    #
+    # token_path: "./path/to/token"
+
 # storage specifies the destination that `tbot` should use to store its
 # internal state. This state is sensitive, and you should ensure that the
 # destination you specify here can only be accessed by `tbot`.

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -528,6 +528,9 @@ See https://goteleport.com/docs/reference/join-methods for more details.`)
 			Gitlab: onboarding.GitlabOnboardingConfig{
 				TokenEnvVarName: gitlabIDTokenEnvVar,
 			},
+			Kubernetes: onboarding.KubernetesOnboardingConfig{
+				TokenPath: config.KubernetesTokenPath.Value,
+			},
 		},
 		CredentialLifetime: bot.CredentialLifetime{
 			TTL:             time.Hour,

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -95,6 +95,10 @@ const (
 	// attributeTerraformGitlabIDTokenEnvVar is the attribute configuring the environment variable used to fetch the ID
 	// token issued by GitLab for the `gitlab` join method. If unset, this defaults to `TBOT_GITLAB_JWT`.
 	attributeTerraformGitlabIDTokenEnvVar = "gitlab_id_token_env_var"
+	// attributeKubernetesTokenPath configures the Kubernetes token location when joining using MachineID and the `kubernetes` join method.
+	// When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
+	// "/var/run/secrets/kubernetes.io/serviceaccount/token".
+	attributeKubernetesTokenPath = "kubernetes_token_path"
 )
 
 type RetryConfig struct {
@@ -158,6 +162,10 @@ type providerData struct {
 	// defaults to `TBOT_GITLAB_JWT`. Useful in cases where multiple Teleport
 	// clusters are managed by the same GitLab job.
 	GitlabIDTokenEnvVar types.String `tfsdk:"gitlab_id_token_env_var"`
+	// KubernetesTokenPath configures the Kubernetes token location when joining using MachineID and the `kubernetes` join method.
+	// When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
+	// "/var/run/secrets/kubernetes.io/serviceaccount/token".
+	KubernetesTokenPath types.String `tfsdk:"kubernetes_token_path"`
 }
 
 // New returns an empty provider struct
@@ -284,6 +292,12 @@ func (p *Provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				Sensitive:   false,
 				Optional:    true,
 				Description: fmt.Sprintf("Environment variable used to fetch the ID token issued by GitLab for the `gitlab` join method. If unset, this defaults to `TBOT_GITLAB_JWT`. This can also be set with the environment variable `%s`.", constants.EnvVarGitlabIDTokenEnvVar),
+			},
+			attributeKubernetesTokenPath: {
+				Type:        types.StringType,
+				Sensitive:   false,
+				Optional:    true,
+				Description: "KubernetesTokenPath configures the Kubernetes token location when joining using MachineID and the `kubernetes` join method. When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location: `/var/run/secrets/kubernetes.io/serviceaccount/token`.",
 			},
 		},
 	}, nil

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -35,7 +35,6 @@ import (
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
-	kubetoken "github.com/gravitational/teleport/lib/kube/token"
 	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
@@ -119,7 +118,6 @@ func TestTerraformJoin(t *testing.T) {
 	tempDir := t.TempDir()
 	jwtPath := filepath.Join(tempDir, "token")
 	require.NoError(t, os.WriteFile(jwtPath, []byte(jwt), 0600))
-	require.NoError(t, os.Setenv(kubetoken.EnvVarCustomKubernetesTokenPath, jwtPath))
 
 	// Test setup: craft a Terraform provider configuration
 	terraformConfig := fmt.Sprintf(`
@@ -130,8 +128,9 @@ func TestTerraformJoin(t *testing.T) {
 			retry_base_duration = "900ms"
 			retry_cap_duration = "4s"
 			retry_max_tries = "12"
+			kubernetes_token_path = %q
 		}
-	`, authHelper.ServerAddr(), testTokenName, types.JoinMethodKubernetes)
+	`, authHelper.ServerAddr(), testTokenName, types.JoinMethodKubernetes, jwtPath)
 
 	terraformProvider := provider.New()
 	terraformProviders := make(map[string]func() (tfprotov6.ProviderServer, error))
@@ -247,7 +246,6 @@ func TestTerraformJoinViaProxy(t *testing.T) {
 	tempDir := t.TempDir()
 	jwtPath := filepath.Join(tempDir, "token")
 	require.NoError(t, os.WriteFile(jwtPath, []byte(jwt), 0600))
-	require.NoError(t, os.Setenv(kubetoken.EnvVarCustomKubernetesTokenPath, jwtPath))
 
 	// Test setup: craft a Terraform provider configuration
 	proxyAddr, err := process.ProxyTunnelAddr()
@@ -262,8 +260,9 @@ func TestTerraformJoinViaProxy(t *testing.T) {
 			retry_base_duration = "900ms"
 			retry_cap_duration = "4s"
 			retry_max_tries = "12"
+			kubernetes_token_path = %q
 		}
-	`, proxyAddr, testTokenName, types.JoinMethodKubernetes)
+	`, proxyAddr, testTokenName, types.JoinMethodKubernetes, jwtPath)
 
 	terraformProvider := provider.New()
 	terraformProviders := make(map[string]func() (tfprotov6.ProviderServer, error))

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -166,6 +166,10 @@ type RegisterParams struct {
 	// Register method will not attempt to dial, and many other parameters
 	// may be ignored.
 	AuthClient AuthJoinClient
+	// KubernetesTokenPath is the optional path that used to lookup the Kubernetes service account token for joining.
+	// When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
+	// "/var/run/secrets/kubernetes.io/serviceaccount/token".
+	KubernetesTokenPath string
 	// KubernetesReadFileFunc is a function used to read the Kubernetes token
 	// from disk. Used in tests, and set to `os.ReadFile` if unset.
 	KubernetesReadFileFunc func(name string) ([]byte, error)
@@ -354,7 +358,7 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 		}
 	case types.JoinMethodKubernetes:
 		if params.IDToken == "" {
-			params.IDToken, err = kubetoken.GetIDToken(os.Getenv, params.KubernetesReadFileFunc)
+			params.IDToken, err = kubetoken.GetIDToken(params.KubernetesTokenPath, os.Getenv, params.KubernetesReadFileFunc)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -361,7 +361,7 @@ func joinWithMethod(
 		return oidcJoin(stream, joinParams, clientParams)
 	case types.JoinMethodKubernetes:
 		if joinParams.IDToken == "" {
-			joinParams.IDToken, err = kubetoken.GetIDToken(os.Getenv, joinParams.KubernetesReadFileFunc)
+			joinParams.IDToken, err = kubetoken.GetIDToken(joinParams.KubernetesTokenPath, os.Getenv, joinParams.KubernetesReadFileFunc)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/kube/token/source.go
+++ b/lib/kube/token/source.go
@@ -32,12 +32,12 @@ const (
 type getEnvFunc func(key string) string
 type readFileFunc func(name string) ([]byte, error)
 
-func GetIDToken(getEnv getEnvFunc, readFile readFileFunc) (string, error) {
-	// We check if we should use a custom location instead of the default one. This env var is not standard.
-	// This is useful when the operator wants to use a custom projected token, or another service account.
+func GetIDToken(customPath string, getEnv getEnvFunc, readFile readFileFunc) (string, error) {
 	path := kubernetesDefaultTokenPath
-	if customPath := getEnv(EnvVarCustomKubernetesTokenPath); customPath != "" {
+	if customPath != "" {
 		path = customPath
+	} else if envPath := getEnv(EnvVarCustomKubernetesTokenPath); envPath != "" {
+		path = envPath
 	}
 
 	token, err := readFile(path)

--- a/lib/kube/token/source_test.go
+++ b/lib/kube/token/source_test.go
@@ -58,6 +58,7 @@ func TestGetIDToken(t *testing.T) {
 		name        string
 		getEnv      getEnvFunc
 		readFile    readFileFunc
+		customPath  string
 		wantString  string
 		assertError require.ErrorAssertionFunc
 	}{
@@ -91,11 +92,19 @@ func TestGetIDToken(t *testing.T) {
 				require.ErrorContains(t, err, "/custom: no such file")
 			},
 		},
+		{
+			name:        "custom-token-via-path",
+			getEnv:      nil, // should not be called
+			readFile:    fakeReadFile("foobarbizz", "/custom"),
+			customPath:  "/custom",
+			wantString:  "foobarbizz",
+			assertError: require.NoError,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(t.Name(), func(t *testing.T) {
-			str, err := GetIDToken(tt.getEnv, tt.readFile)
+			str, err := GetIDToken(tt.customPath, tt.getEnv, tt.readFile)
 			require.Equal(t, tt.wantString, str)
 			tt.assertError(t, err)
 		})

--- a/lib/tbot/bot/onboarding/config.go
+++ b/lib/tbot/bot/onboarding/config.go
@@ -189,6 +189,14 @@ func (c *BoundKeypairOnboardingConfig) StaticPrivateKeyBytes() ([]byte, error) {
 	return nil, nil
 }
 
+// KubernetesOnboardingConfig holds configuration relevant to the `kubernetes` join method.
+type KubernetesOnboardingConfig struct {
+	// TokenPath is the optional path that tbot uses to lookup the Kubernetes service account token used to join.
+	// When unset, the join client will try the `KUBERNETES_TOKEN_PATH` env var, else it will use the standard location:
+	// "/var/run/secrets/kubernetes.io/serviceaccount/token".
+	TokenPath string `yaml:"token_path,omitempty"`
+}
+
 // Config contains values relevant to how the bot authenticates with
 // and joins the Teleport cluster.
 type Config struct {
@@ -219,8 +227,11 @@ type Config struct {
 	// Gitlab holds configuration relevant to the `gitlab` join method.
 	Gitlab GitlabOnboardingConfig `yaml:"gitlab,omitempty"`
 
-	// BoundKeypair holds configuration relevant to the `bound_keypair` join method
+	// BoundKeypair holds configuration relevant to the `bound_keypair` join method.
 	BoundKeypair BoundKeypairOnboardingConfig `yaml:"bound_keypair,omitempty"`
+
+	// Kubernetes holds the configuration relevant to the `kubernetes` join method.
+	Kubernetes KubernetesOnboardingConfig `yaml:"kubernetes,omitempty"`
 }
 
 // HasToken gives the ability to check if there has been a token value stored

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -788,6 +788,8 @@ func botIdentityFromToken(
 		if err != nil {
 			return nil, trace.Wrap(err, "initializing bound keypair client state")
 		}
+	case types.JoinMethodKubernetes:
+		params.KubernetesTokenPath = cfg.Onboarding.Kubernetes.TokenPath
 	}
 
 	result, err := joinclient.Join(ctx, params)


### PR DESCRIPTION
Changelog: Added the ability for tbot and the Terraform provider to receive a custom Kubernetes token path via the configuration.


## Manual Test Plan
### Test Environment

Personal Cloud Tenant using a token from my local k3s cluster.

### Test Cases
- [x] tbot chart still works
- [x] tbot can use the config instead of the env var
- [x] TF provider works when pointed to a token extracted from a cluster
