### PR TITLE
e2e: Install JS deps before building Teleport & Connect

### DIFF
--- a/e2e/runner/build.go
+++ b/e2e/runner/build.go
@@ -36,22 +36,14 @@ func build(ctx context.Context, config *e2eConfig) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	if !config.noBuild {
-		switch config.teleportBin {
-		case filepath.Join(config.repoRoot, "build", "teleport"):
+		if config.teleportBuildDir != "" {
+			buildDir := config.teleportBuildDir
 			g.Go(func() error {
-				slog.Info("building teleport")
+				slog.Info("building teleport", "dir", buildDir)
 
-				return runMake(ctx, config.repoRoot, "build/teleport")
+				return runMake(ctx, buildDir, "build/teleport")
 			})
-
-		case filepath.Join(config.repoRoot, "e", "build", "teleport"):
-			g.Go(func() error {
-				slog.Info("building teleport (enterprise)")
-
-				return runMake(ctx, filepath.Join(config.repoRoot, "e"), "build/teleport")
-			})
-
-		default:
+		} else {
 			slog.Info("teleport binary overridden, skipping build", "path", config.teleportBin)
 		}
 
@@ -68,11 +60,7 @@ func build(ctx context.Context, config *e2eConfig) error {
 
 	if sshNode.enabled && !config.noBuild && runtime.GOOS != "linux" {
 		g.Go(func() error {
-			buildDir := config.repoRoot
-			if config.teleportBin == filepath.Join(config.repoRoot, "e", "build", "teleport") {
-				buildDir = filepath.Join(config.repoRoot, "e")
-			}
-
+			buildDir := config.teleportBuildDir
 			slog.Info("cross-compiling teleport for linux (docker node)", "dir", buildDir)
 
 			output := filepath.Join(buildDir, "build", "teleport-node")

--- a/e2e/runner/build.go
+++ b/e2e/runner/build.go
@@ -70,7 +70,12 @@ func build(ctx context.Context, config *e2eConfig) error {
 
 	if sshNode.enabled && !config.noBuild && runtime.GOOS != "linux" {
 		g.Go(func() error {
+			// Fall back to repoRoot when the teleport binary is overridden; the docker node
+			// always needs a Linux binary built from source.
 			buildDir := config.teleportBuildDir
+			if buildDir == "" {
+				buildDir = config.repoRoot
+			}
 			slog.Info("cross-compiling teleport for linux (docker node)", "dir", buildDir)
 
 			output := filepath.Join(buildDir, "build", "teleport-node")

--- a/e2e/runner/build.go
+++ b/e2e/runner/build.go
@@ -33,6 +33,16 @@ import (
 
 // build compiles teleport binaries and installs playwright dependencies in parallel.
 func build(ctx context.Context, config *e2eConfig) error {
+	// Both the teleport build (through make build/teleport -> build-ui) and the Connect build need JS
+	// deps installed. Running pnpm install concurrently from multiple goroutines would cause a race,
+	// so we ensure JS deps are installed up front before starting concurrent work.
+	if !config.noBuild && (config.teleportBuildDir != "" || connect.enabled) {
+		slog.Info("ensuring JS dependencies are installed")
+		if err := runMake(ctx, config.repoRoot, "ensure-js-deps"); err != nil {
+			return err
+		}
+	}
+
 	g, ctx := errgroup.WithContext(ctx)
 
 	if !config.noBuild {

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -124,6 +124,10 @@ type e2eConfig struct {
 	teleportConfigTemplate string
 	stateTemplate          string
 
+	// teleportBuildDir is the directory in which to run `make build/teleport`.
+	// Empty when the teleport binary is overridden and no build is needed.
+	teleportBuildDir string
+
 	connectAppDir     string
 	connectTshBinPath string
 
@@ -150,6 +154,13 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 		nodeConfigTemplate:     filepath.Join(e2eDir, "node", "node.yaml.tmpl"),
 		connectAppDir:          filepath.Join(filepath.Dir(e2eDir), "web", "packages", "teleterm"),
 		connectTshBinPath:      filepath.Join(filepath.Dir(e2eDir), "build", "tsh-e2e-webauthnmock"),
+	}
+
+	switch config.teleportBin {
+	case filepath.Join(config.repoRoot, "build", "teleport"):
+		config.teleportBuildDir = config.repoRoot
+	case filepath.Join(config.repoRoot, "e", "build", "teleport"):
+		config.teleportBuildDir = filepath.Join(config.repoRoot, "e")
 	}
 
 	if flags.browsers == nil {
@@ -325,11 +336,7 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 
 			nodeBin := config.teleportBin
 			if runtime.GOOS != "linux" {
-				buildDir := config.repoRoot
-				if config.teleportBin == filepath.Join(config.repoRoot, "e", "build", "teleport") {
-					buildDir = filepath.Join(config.repoRoot, "e")
-				}
-				nodeBin = filepath.Join(buildDir, "build", "teleport-node")
+				nodeBin = filepath.Join(config.teleportBuildDir, "build", "teleport-node")
 			}
 
 			dockerHost, err := resolveDockerHost()

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -133,8 +133,8 @@ type e2eConfig struct {
 
 	creds *credentials
 
-	instances        []*browserInstance
-	connectInstance  *browserInstance
+	instances       []*browserInstance
+	connectInstance *browserInstance
 }
 
 // run sets up the test environment (ports, certs, credentials, teleport instance)
@@ -336,7 +336,11 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 
 			nodeBin := config.teleportBin
 			if runtime.GOOS != "linux" {
-				nodeBin = filepath.Join(config.teleportBuildDir, "build", "teleport-node")
+				buildDir := config.teleportBuildDir
+				if buildDir == "" {
+					buildDir = config.repoRoot
+				}
+				nodeBin = filepath.Join(buildDir, "build", "teleport-node")
 			}
 
 			dockerHost, err := resolveDockerHost()


### PR DESCRIPTION
When there are changes in JS deps, `make build/teleport` and `pnpm --filter=@gravitational/teleterm build` run concurrently. This can result in an error where the Connect build fails simply because the proper deps are not yet installed.

## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] `./e2e/run.sh --full` works.
  - Well, it actually fails on `e2e/tests/web/authenticated/authconnectors.spec.ts`, but it fails on master for me too.

<details><summary>auth connector failure</summary>
<p>

```
  1) [chromium:authenticated] › e2e/tests/web/authenticated/authconnectors.spec.ts:22:1 › verify that a user can create and delete an auth connector

    Error: expect(locator).not.toBeVisible() failed

    Locator: getByText('testconnector')
    Expected: not visible
    Error: strict mode violation: getByText('testconnector') resolved to 2 elements:
        1) <h2 title="testconnector" class="sc-kAycey eqUhJG">testconnector</h2> aka getByRole('heading', { name: 'testconnector' })
        2) <span color="text.main" class="sc-kAycey iOGuDu">testconnector</span> aka getByTestId('dialogbox').getByText('testconnector')

    Call log:
      - Expect "not toBeVisible" with timeout 5000ms
      - waiting for getByText('testconnector')


      55 |   await page.waitForTimeout(500);
      56 |
    > 57 |   await expect(page.getByText('testconnector')).not.toBeVisible();
         |                                                     ^
      58 | });
      59 |
        at /Users/rav/src/teleport-jj/e2e/tests/web/authenticated/authconnectors.spec.ts:57:53

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    e2e/blob-reports/resources/385369310d36eff8582b0fd89e445ca104c567d5.png

    attachment #2: error-context (text/markdown) ───────────────────────────────────────────────────
    e2e/blob-reports/resources/4907ed8ae864e1405375a4fbd7d45a42ee9aa3ff.markdown
    ────────────────────────────────────────────────────────────────────────────────────────────────

  1 failed
    [chromium:authenticated] › e2e/tests/web/authenticated/authconnectors.spec.ts:22:1 › verify that a user can create and delete an auth connector
```

</p>
</details>  
