### PR TITLE
[v17] Replace the endpoint-specific rate limit for `CreateAuthenticateChallenge` with a custom rate limiter for unauthenticated requests

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -33,6 +33,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	gocmp "github.com/google/go-cmp/cmp"
@@ -4627,6 +4628,10 @@ func TestCleanupNotifications(t *testing.T) {
 }
 
 func TestCreateAccessListReminderNotifications(t *testing.T) {
+	synctest.Test(t, testCreateAccessListReminderNotifications)
+}
+
+func testCreateAccessListReminderNotifications(t *testing.T) {
 	ctx := context.Background()
 
 	modulestest.SetTestModules(t, modulestest.Modules{
@@ -4639,8 +4644,9 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 	})
 
 	// Setup test auth server
-	testServer := newTestTLSServer(t)
+	testServer := newTestTLSServer(t, withBufconnListener())
 	authServer := testServer.Auth()
+	defer testServer.Close()
 
 	testRole, err := types.NewRole("test", types.RoleSpecV6{
 		Allow: types.RoleConditions{
@@ -4661,6 +4667,7 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 
 	client, err := testServer.NewClient(authtest.TestUser(testUsername))
 	require.NoError(t, err)
+	defer client.Close()
 
 	// Helper to create access lists with specific next audit dates
 	createAccessList := func(t *testing.T, name string, nextAuditDate time.Time) {
@@ -4729,26 +4736,20 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 	}
 
 	// Check notifications
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		resp, err := client.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{})
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.ElementsMatch(t, expectedSubKinds, slices.Map(resp.Notifications, reminderNotificationSubKind))
-	}, 5*time.Minute, 500*time.Millisecond)
+	synctest.Wait()
+	resp, err := client.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, expectedSubKinds, slices.Map(resp.Notifications, reminderNotificationSubKind))
 
 	// Run CreateAccessListReminderNotifications() again to verify no duplicates are created
 	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond))
 
 	// Check notifications again, counts should remain the same.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		resp, err := client.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{})
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.ElementsMatch(t, expectedSubKinds, slices.Map(resp.Notifications, reminderNotificationSubKind),
-			"notifications should not have changed after second reconciliation")
-	}, 5*time.Minute, 500*time.Millisecond)
+	synctest.Wait()
+	resp, err = client.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, expectedSubKinds, slices.Map(resp.Notifications, reminderNotificationSubKind),
+		"notifications should not have changed after second reconciliation")
 }
 
 type createAccessListOptions struct {

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -35,6 +35,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
@@ -836,6 +837,20 @@ func WithAccessGraphConfig(config auth.AccessGraphConfig) TestTLSServerOption {
 	}
 }
 
+// WithBufconnListener configures the auth test server to use a gRPC bufconn
+// listener and dialer instead of loopback TCP. This is useful with synctest
+// where real TCP listeners are not durably blocking.
+func WithBufconnListener() TestTLSServerOption {
+	const testBufconnSize = 1024
+	return func(cfg *TLSServerConfig) {
+		listener := bufconn.Listen(testBufconnSize)
+		cfg.Listener = listener
+		cfg.AuthDialer = client.ContextDialerFunc(func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		})
+	}
+}
+
 // NewRemoteClient creates new client to the remote server using identity
 // generated for this certificate authority
 func (a *AuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, pool *x509.CertPool) (*authclient.Client, error) {
@@ -868,6 +883,8 @@ type TLSServerConfig struct {
 	Limiter *limiter.Config
 	// Listener is a listener to serve requests on
 	Listener net.Listener
+	// AuthDialer is a dialer to use when making auth clients.
+	AuthDialer client.ContextDialer
 	// AcceptedUsage is a list of accepted usage restrictions
 	AcceptedUsage []string
 }
@@ -937,9 +954,11 @@ func NewTestTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	tlsConfig.Time = cfg.AuthServer.Clock().Now
 	tlsCert := tlsConfig.Certificates[0]
 
-	srv.Listener, err = net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if srv.Listener == nil {
+		srv.Listener, err = net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	srv.TLSServer, err = auth.NewTLSServer(context.Background(), auth.TLSServerConfig{
@@ -1074,7 +1093,8 @@ func (t *TLSServer) NewClientFromWebSession(sess types.WebSession) (*authclient.
 	tlsConfig.Time = t.AuthServer.AuthServer.GetClock().Now
 
 	return authclient.NewClient(client.Config{
-		Addrs: []string{t.Addr().String()},
+		Addrs:  []string{t.Addr().String()},
+		Dialer: t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
@@ -1129,7 +1149,8 @@ func (t *TLSServer) CloneClient(tt *testing.T, clt *authclient.Client) *authclie
 	}
 
 	newClient, err := authclient.NewClient(client.Config{
-		Addrs: []string{t.Addr().String()},
+		Addrs:  []string{t.Addr().String()},
+		Dialer: t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
@@ -1152,7 +1173,8 @@ func (t *TLSServer) NewClientWithCert(clientCert tls.Certificate) (*authclient.C
 	tlsConfig.Time = t.AuthServer.AuthServer.GetClock().Now
 	tlsConfig.Certificates = []tls.Certificate{clientCert}
 	newClient, err := authclient.NewClient(client.Config{
-		Addrs: []string{t.Addr().String()},
+		Addrs:  []string{t.Addr().String()},
+		Dialer: t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
@@ -1174,6 +1196,7 @@ func (t *TLSServer) NewClient(identity TestIdentity) (*authclient.Client, error)
 	newClient, err := authclient.NewClient(client.Config{
 		DialInBackground: true,
 		Addrs:            []string{t.Addr().String()},
+		Dialer:           t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -116,6 +116,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/joinserver"
+	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
@@ -192,6 +193,13 @@ type GRPCServer struct {
 	// in-flight CreateAuditStream RPCs, by sending a value in at the beginning
 	// of the RPC and pulling one out before returning.
 	createAuditStreamSemaphore chan struct{}
+
+	// createAuthenticateChallengeLimiter is a rate limiter for invocations of
+	// /proto.AuthService/CreateAuthenticateChallenge that don't rely on a user
+	// context and thus warrant additional rate limiting since they are
+	// unauthenticated (either through direct API connections or coming from the
+	// proxy on behalf of a remote unauthenticated user).
+	createAuthenticateChallengeLimiter *limiter.RateLimiter
 }
 
 // Export forwards OTLP traces to the upstream collector configured in the tracing service. This allows for
@@ -4483,6 +4491,22 @@ func (g *GRPCServer) CreateAuthenticateChallenge(ctx context.Context, req *authp
 		return nil, trace.Wrap(err)
 	}
 
+	if req.GetContextUser() == nil && req.GetRequest() != nil {
+		// requests with a user context (or with an empty request, which is
+		// considered to be the same) will be checked for legitimacy by
+		// ServerWithRoles later, so we only need to care about adding an
+		// additional rate limit for the non-user-context requests here
+
+		peerInfo, ok := peer.FromContext(ctx)
+		if !ok {
+			return nil, trace.BadParameter("unable to find peer")
+		}
+
+		if err := g.createAuthenticateChallengeLimiter.RegisterRequestFromAddr(peerInfo.Addr, nil); err != nil {
+			return nil, trace.LimitExceeded("rate limit exceeded")
+		}
+	}
+
 	res, err := actx.ServerWithRoles.CreateAuthenticateChallenge(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -5724,12 +5748,25 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		stableUNIXUsersServiceServer,
 	)
 
+	createAuthenticateChallengeLimiter, err := limiter.NewRateLimiter(limiter.Config{
+		Rates: []limiter.Rate{{
+			Period:  defaults.LimiterPeriod,
+			Average: defaults.LimiterAverage,
+			Burst:   defaults.LimiterBurst,
+		}},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	authServer := &GRPCServer{
 		APIConfig: cfg.APIConfig,
 		Entry: logrus.WithFields(logrus.Fields{
 			teleport.ComponentKey: teleport.Component(teleport.ComponentAuth, teleport.ComponentGRPC),
 		}),
 		server: server,
+
+		createAuthenticateChallengeLimiter: createAuthenticateChallengeLimiter,
 	}
 
 	if en := os.Getenv("TELEPORT_UNSTABLE_CREATEAUDITSTREAM_INFLIGHT_LIMIT"); en != "" {

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -31,6 +31,7 @@ import (
 	"net/http/httptest"
 	"sort"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -4394,62 +4395,50 @@ func TestListResources(t *testing.T) {
 }
 
 func TestCustomRateLimiting(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
 	tests := []struct {
 		name  string
 		burst int
-		fn    func(*authclient.Client) error
+		fn    func(context.Context, *authclient.Client) error
 	}{
 		{
 			name: "RPC ChangeUserAuthentication",
-			fn: func(clt *authclient.Client) error {
+			fn: func(ctx context.Context, clt *authclient.Client) error {
 				_, err := clt.ChangeUserAuthentication(ctx, &proto.ChangeUserAuthenticationRequest{})
 				return err
 			},
 		},
 		{
-			name:  "RPC CreateAuthenticateChallenge",
-			burst: defaults.LimiterBurst,
-			fn: func(clt *authclient.Client) error {
-				_, err := clt.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{})
-				return err
-			},
-		},
-		{
 			name: "RPC GetAccountRecoveryToken",
-			fn: func(clt *authclient.Client) error {
+			fn: func(ctx context.Context, clt *authclient.Client) error {
 				_, err := clt.GetAccountRecoveryToken(ctx, &proto.GetAccountRecoveryTokenRequest{})
 				return err
 			},
 		},
 		{
 			name: "RPC StartAccountRecovery",
-			fn: func(clt *authclient.Client) error {
+			fn: func(ctx context.Context, clt *authclient.Client) error {
 				_, err := clt.StartAccountRecovery(ctx, &proto.StartAccountRecoveryRequest{})
 				return err
 			},
 		},
 		{
 			name: "RPC VerifyAccountRecovery",
-			fn: func(clt *authclient.Client) error {
+			fn: func(ctx context.Context, clt *authclient.Client) error {
 				_, err := clt.VerifyAccountRecovery(ctx, &proto.VerifyAccountRecoveryRequest{})
 				return err
 			},
 		},
 	}
 	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
+		synctestCase := func(t *testing.T) {
 			// Create new instance per test case, to troubleshoot which test case
 			// specifically failed, otherwise multiple cases can fail from running
 			// cases in parallel.
-			srv := newTestTLSServer(t)
+			srv := newTestTLSServer(t, withBufconnListener())
+			defer srv.Close()
 			clt, err := srv.NewClient(authtest.TestNop())
 			require.NoError(t, err)
+			defer clt.Close()
 
 			var attempts int
 			if test.burst == 0 {
@@ -4458,14 +4447,84 @@ func TestCustomRateLimiting(t *testing.T) {
 				attempts = test.burst
 			}
 
-			for i := 0; i < attempts; i++ {
-				err = test.fn(clt)
-				require.False(t, trace.IsLimitExceeded(err), "got err = %v, want non-IsLimitExceeded", err)
+			for range attempts {
+				err = test.fn(t.Context(), clt)
+				require.NotErrorAs(t, err, new(*trace.LimitExceededError))
 			}
 
-			err = test.fn(clt)
-			require.True(t, trace.IsLimitExceeded(err), "got err = %v, want LimitExceeded", err)
+			err = test.fn(t.Context(), clt)
+			require.ErrorAs(t, err, new(*trace.LimitExceededError))
+		}
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, synctestCase)
 		})
+	}
+
+	t.Run("unauthenticated CreateAuthenticateChallenge", func(t *testing.T) {
+		synctest.Test(t, synctestCustomRateLimitingUnauthenticatedCreateAuthenticateChallenge)
+	})
+}
+
+func synctestCustomRateLimitingUnauthenticatedCreateAuthenticateChallenge(t *testing.T) {
+	ctx := t.Context()
+
+	srv := newTestTLSServer(t, withBufconnListener())
+	defer srv.Close()
+	clt, err := srv.NewClient(authtest.TestNop())
+	require.NoError(t, err)
+	defer clt.Close()
+
+	nonContextUserRequest := &proto.CreateAuthenticateChallengeRequest{
+		Request: &proto.CreateAuthenticateChallengeRequest_UserCredentials{
+			UserCredentials: new(proto.UserCredentials),
+		},
+	}
+	contextUserRequest := &proto.CreateAuthenticateChallengeRequest{
+		Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
+			ContextUser: new(proto.ContextUser),
+		},
+	}
+
+	for range defaults.LimiterBurst {
+		_, err := clt.CreateAuthenticateChallenge(ctx, nonContextUserRequest)
+		require.NotErrorAs(t, err, new(*trace.LimitExceededError))
+	}
+	_, err = clt.CreateAuthenticateChallenge(ctx, nonContextUserRequest)
+	require.ErrorAs(t, err, new(*trace.LimitExceededError))
+	_, err = clt.CreateAuthenticateChallenge(ctx, nonContextUserRequest)
+	require.ErrorAs(t, err, new(*trace.LimitExceededError))
+
+	time.Sleep(defaults.LimiterPeriod)
+
+	for range defaults.LimiterBurst - defaults.LimiterAverage {
+		_, err := clt.CreateAuthenticateChallenge(ctx, nonContextUserRequest)
+		require.NotErrorAs(t, err, new(*trace.LimitExceededError))
+	}
+	_, err = clt.CreateAuthenticateChallenge(ctx, nonContextUserRequest)
+	require.ErrorAs(t, err, new(*trace.LimitExceededError))
+	_, err = clt.CreateAuthenticateChallenge(ctx, nonContextUserRequest)
+	require.ErrorAs(t, err, new(*trace.LimitExceededError))
+
+	require.Greater(t, 1000*defaults.LimiterAverage, defaults.LimiterBurst,
+		"Waiting 1000 periods should bring us to LimiterBurst but no higher")
+	time.Sleep(1000 * defaults.LimiterPeriod)
+
+	for range defaults.LimiterBurst {
+		_, err := clt.CreateAuthenticateChallenge(ctx, nonContextUserRequest)
+		require.NotErrorAs(t, err, new(*trace.LimitExceededError))
+	}
+	_, err = clt.CreateAuthenticateChallenge(ctx, nonContextUserRequest)
+	require.ErrorAs(t, err, new(*trace.LimitExceededError))
+	_, err = clt.CreateAuthenticateChallenge(ctx, nonContextUserRequest)
+	require.ErrorAs(t, err, new(*trace.LimitExceededError))
+
+	// no time has passed, but we can do a full burst and more if we pretend to
+	// have a user context (the request will fail, but not due to the rate
+	// limiter)
+
+	for range defaults.LimiterBurst + 1 {
+		_, err := clt.CreateAuthenticateChallenge(ctx, contextUserRequest)
+		require.NotErrorAs(t, err, new(*trace.LimitExceededError))
 	}
 }
 

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -397,17 +397,6 @@ func getCustomRate(endpoint string) *limiter.RateSet {
 			return nil
 		}
 		return rates
-	// Passwordless RPCs (potential unauthenticated challenge generation).
-	case "/proto.AuthService/CreateAuthenticateChallenge":
-		const period = defaults.LimiterPeriod
-		const average = defaults.LimiterAverage
-		const burst = defaults.LimiterBurst
-		rates := limiter.NewRateSet()
-		if err := rates.Add(period, average, burst); err != nil {
-			log.WithError(err).Debugf("Failed to define a custom rate for rpc method %q, using default rate", endpoint)
-			return nil
-		}
-		return rates
 	}
 	return nil
 }

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -5707,9 +5707,10 @@ func verifyJWTAWSOIDC(clock clockwork.Clock, clusterName string, pairs []*types.
 }
 
 type testTLSServerOptions struct {
-	cacheEnabled bool
-	accessGraph  *auth.AccessGraphConfig
-	clock        clockwork.Clock
+	cacheEnabled    bool
+	accessGraph     *auth.AccessGraphConfig
+	clock           clockwork.Clock
+	bufconnListener bool
 }
 
 type testTLSServerOption func(*testTLSServerOptions)
@@ -5729,6 +5730,11 @@ func withAccessGraphConfig(cfg auth.AccessGraphConfig) testTLSServerOption {
 func withClock(clock clockwork.Clock) testTLSServerOption {
 	return func(options *testTLSServerOptions) {
 		options.clock = clock
+	}
+}
+func withBufconnListener() testTLSServerOption {
+	return func(options *testTLSServerOptions) {
+		options.bufconnListener = true
 	}
 }
 
@@ -5756,6 +5762,9 @@ func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *authtest.TLSSe
 	var tlsServerOpts []authtest.TestTLSServerOption
 	if options.accessGraph != nil {
 		tlsServerOpts = append(tlsServerOpts, authtest.WithAccessGraphConfig(*options.accessGraph))
+	}
+	if options.bufconnListener {
+		tlsServerOpts = append(tlsServerOpts, authtest.WithBufconnListener())
 	}
 	srv, err := as.NewTestTLSServer(tlsServerOpts...)
 	require.NoError(t, err)

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -138,7 +138,7 @@ func (l *Limiter) UnaryServerInterceptorWithCustomRate(customRate CustomRateFunc
 			return nil, trace.AccessDenied("missing peer info")
 		}
 		// Limit requests per second and simultaneous connection by client IP.
-		clientIP, _, err := net.SplitHostPort(peerInfo.Addr.String())
+		clientIP, err := clientIPFromAddr(peerInfo.Addr)
 		if err != nil {
 			return nil, trace.BadParameter("missing client IP")
 		}
@@ -161,7 +161,7 @@ func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.Ser
 		return trace.AccessDenied("missing peer info")
 	}
 	// Limit requests per second and simultaneous connection by client IP.
-	clientIP, _, err := net.SplitHostPort(peerInfo.Addr.String())
+	clientIP, err := clientIPFromAddr(peerInfo.Addr)
 	if err != nil {
 		return trace.BadParameter("missing client IP")
 	}
@@ -173,6 +173,27 @@ func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.Ser
 	}
 	defer l.connectionLimiter.ReleaseConnection(clientIP)
 	return handler(srv, serverStream)
+}
+
+func clientIPFromAddr(addr net.Addr) (string, error) {
+	if addr == nil {
+		return "", trace.BadParameter("missing client IP")
+	}
+
+	s := addr.String()
+
+	// bufconn peers don't include host:port, so use a stable synthetic key
+	// for request/connection limiting in tests.
+	if s == "bufconn" && addr.Network() == "bufconn" {
+		return "bufconn", nil
+	}
+
+	clientIP, _, err := net.SplitHostPort(s)
+	if err == nil {
+		return clientIP, nil
+	}
+
+	return "", trace.BadParameter("missing client IP")
 }
 
 // WrapListener returns a [Listener] that wraps the provided listener

--- a/lib/limiter/ratelimiter.go
+++ b/lib/limiter/ratelimiter.go
@@ -21,6 +21,7 @@ package limiter
 import (
 	"cmp"
 	"context"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -131,6 +132,17 @@ func (l *RateLimiter) RegisterRequest(token string, customRate *ratelimit.RateSe
 		return trace.LimitExceeded("rate limit exceeded, try again in %v", delay)
 	}
 	return nil
+}
+
+// RegisterRequestFromAddr increases the number of requests coming for the given
+// remote address, returning an error if the address is invalid or if there have
+// been too many requests from that address recently.
+func (l *RateLimiter) RegisterRequestFromAddr(addr net.Addr, customRate *ratelimit.RateSet) error {
+	token, err := clientIPFromAddr(addr)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return l.RegisterRequest(token, customRate)
 }
 
 // Add rate limiter to the handle


### PR DESCRIPTION
Backport to branch/v17 of
- #63942
- #64559

<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: API rate limiting for authenticated per-session MFA requests now follows the regular API rate limits, making the limit unlikely to be hit during parallel SSH operations 

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Control plane on cloud staging (custom build with this PR, linux amd64), `tsh` 17.7.21 (release, darwin arm64), custom scripts using the API module (code from this PR, darwin arm64).

### Test Cases
- [x] A burst of SSH requests won't result in "rate limit exceeded" errors from the MFA attempt
- [x] Logins are still rate limited at 20 per minute with a burst of 40