### PR TITLE
[v18] Add Documentation for the `tsh aws-profile` Command

### DIFF
--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/using-aws-cli.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/using-aws-cli.mdx
@@ -3,10 +3,10 @@ title: Using the AWS CLI tools with Teleport and AWS IAM Identity Center
 sidebar_label: AWS CLI Access
 description: Explains how to use the AWS IAM Identity Center integration to protect AWS CLI tools with Teleport.
 tags:
- - how-to
- - identity-governance
- - privileged-access
- - aws
+  - how-to
+  - identity-governance
+  - privileged-access
+  - aws
 enterprise: Identity Governance
 ---
 
@@ -16,11 +16,11 @@ access granted via Teleport and AWS Identity Center.
 ## How it works
 
 For a deep dive into how Teleport manages AWS Identity Center access works you can
-read the main [AWS IAM Identity Center guide](./aws-iam-identity-center.mdx). For the 
+read the main [AWS IAM Identity Center guide](./aws-iam-identity-center.mdx). For the
 purposes of this guide, it's enough to understand that Teleport manages the creation
 and deletion of AWS Account Assignments based on a users's Account Assignment grants,
 either from their standing Teleport Roles, Access List membership or approved
-Access Requests. 
+Access Requests.
 
 You can access these Teleport-managed Accounts and Permission Set assignments
 with the AWS CLI tools by using `sso` login and AWS profiles.
@@ -29,27 +29,69 @@ with the AWS CLI tools by using `sso` login and AWS profiles.
 
 Before you begin, you will need:
 
- * A Teleport-managed AWS Identity Center organization. See our [getting started guide](./guide.mdx)
-   for setting up an Identity Center integration.
- * The AWS CLI tools, installed as per the AWS [installation guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
- * The SSO Start URL and AWS Region for your Identity Center organization. Ask your AWS administrator for the appropriate values.
+- A Teleport-managed AWS Identity Center organization. See our [getting started guide](./guide.mdx)
+  for setting up an Identity Center integration.
+- The AWS CLI tools, installed as per the AWS [installation guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- The SSO Start URL and AWS Region for your Identity Center organization. Ask your AWS administrator for the appropriate values.
 
-## Step 1/2. Configure the AWS SSO Session
+## Configuration
 
-This step configures the AWS CLI tools to use SSO for authentication. You can
-either configure this manually, or via the `aws configure sso-session` wizard.
+Choose one of the following setup flows. The `tsh` flow is the recommended
+option when using Teleport `tsh` client version 18.8.x or later.
 
 <Tabs>
-<TabItem label="Wizard">
-Invoke the AWS SSO configuration wizard by running the following command and
-answering the questions asked by the wizard.  
+<TabItem label="tsh">
+The `tsh aws-profile` command automatically generates native AWS SSO profiles in
+`~/.aws/config` from your AWS Identity Center integration data.
+It preserves existing non-Teleport entries, updates Teleport-managed AWS Identity Center 
+sections, and removes stale Teleport-managed profiles and SSO sessions that are no longer available from the cluster you are currently logged into.
+
+<Admonition type="tip">
+  Use `tsh aws-profile --dry-run` to preview the changes before they are written
+  to your AWS config file.
+</Admonition>
+
+1. Run the following command to generate the profiles:
 
 ```shell
-$ aws configure sso-session
+$ tsh aws-profile
+AWS configuration updated at: /Users/alice/.aws/config
+
+Profile                    Account Account ID   Role   SSO Session
+-------------------------- ------- ------------ ------ ----------------
+teleport-awsic-dev-admin   dev     123456789012 Admin  teleport-d-12345
+teleport-awsic-prod-reader prod    098765432109 Reader teleport-d-12345
 ```
 
-You will need to pick a name for the SSO session; this is just a local name for
-this particular SSO configuration. For this example we are using `my-identity-center`. 
+2. Select a profile and export it to the `AWS_PROFILE` environment variable. For example:
+
+```shell
+$ export AWS_PROFILE=teleport-awsic-prod-reader
+```
+
+3. Authenticate with AWS SSO:
+
+```shell
+$ aws sso login
+```
+
+This opens a browser window to complete the authentication process via Teleport.
+
+4. Switch to another profile by exporting a different `AWS_PROFILE` value:
+
+```shell
+$ export AWS_PROFILE=teleport-awsic-dev-admin
+```
+
+If the profiles use the same SSO session, you do not need to run `aws sso login`
+again.
+
+</TabItem>
+<TabItem label="Wizard">
+Use the AWS CLI wizards if you prefer guided setup.
+
+1. Create an SSO session by running the following command and answering the prompts.
+   For this example we use `my-identity-center` as the SSO session name.
 
 ```shell
 $ aws configure sso-session
@@ -58,58 +100,32 @@ SSO start URL [None]: https://d-12234567890.awsapps.com/start
 SSO region [None]: us-east-1
 SSO registration scopes [sso:account:access]:
 ```
-</TabItem>
-<TabItem label="Manual Configuration">
-You can configure SSO authentication manually by editing your `.aws/config` file. The above example would look like this:
 
-```ini
-[sso-session my-identity-center]
-sso_start_url = https://d-12234567890.awsapps.com/start
-sso_region = us-east-1
-sso_registration_scopes = sso:account:access
-```
-</TabItem>
-</Tabs>
-
-### Testing the SSO Session
-
-To test the SSO configuration, try logging into AWS via SSO.
+2. Log in to AWS via SSO:
 
 ```shell
 $ aws sso login --sso-session my-identity-center
 ```
 
-This will launch a browser-based flow that will log you into AWS via Teleport
-and ask you confirm the AWS CLI tool's access to AWS using your account.
+This launches a browser-based flow that logs you into AWS via Teleport.
 
-## Step 2/2. Creating AWS Profiles
-
-You will need to create a separate AWS CLI profile for each AWS Account and Permission Set
-you want to access. These profiles will reference the SSO Session created above,
-which tells the AWS tools to use SSO authentication when the profile is active.
-
-Again you can do this either via an `aws configure` wizard, or editing your `/.aws/config` file directly.
+3. Create a profile that uses the SSO session by running:
 
 <Admonition type="tip">
-You can create as many profiles as you like, so repeat this step for as many AWS
-Account / Permission Set pairs that you need.
+  You can create as many profiles as you like, so repeat this step for as many
+  AWS Account / Permission Set pairs that you need.
 </Admonition>
-
-<Tabs>
-<TabItem label="Wizard">
-To create a profile that uses given SSO session, invoke the SSO configuration 
-wizard with the following commands, and answering the questions it asks:
 
 ```shell
 $ aws configure sso
 ```
 
 The wizard asks several questions about the profile to create, but for our
-purposes, only selecting the AWS Account and Role are important. 
+purposes, selecting the AWS account and role are the important steps.
 
-Firstly, select the AWS account this profile will use. The wizard will offer you
-a list of available AWS accounts based on your current Account Assignments, if
-you are only permitted to use a single AWS account, the wizard automatically
+First, select the AWS account this profile will use. The wizard offers a list
+of available AWS accounts based on your current Account Assignments. If you
+are only permitted to use a single AWS account, the wizard automatically
 picks that and skips the question.
 
 ```shell
@@ -118,9 +134,9 @@ There are 2 AWS accounts available to you.
   Production, my.login@example.com (637423191929)
 ```
 
-Next, select the AWS Role to assume when this profile is active. Identity Center
-Permission Sets are provisioned onto AWS accounts as Roles, so select the role
-with the same name as the Permission Set you want to use.
+Next, select the AWS role to assume when this profile is active. Identity
+Center Permission Sets are provisioned onto AWS accounts as roles, so select
+the role with the same name as the Permission Set you want to use.
 
 ```shell
 There are 3 roles available to you.
@@ -129,21 +145,43 @@ There are 3 roles available to you.
   PowerUserAccess
 ```
 
-Again, if only one option is available the wizard will automatically select that
-and skip the question.
+If only one option is available, the wizard automatically selects it and
+skips the question.
 
-After several generic AWS profile questions (e.g. default AWS region, default
-output format, etc), the wizard will ask for the profile name. For this example,
-given that the profile will use the `AdminAccess` role on the `Staging` account
-we will call it `admin-on-staging`.
+After several generic AWS profile questions, the wizard asks for the profile
+name. For this example, given that the profile will use the
+`AdministratorAccess` role on the `Staging` account, we call it
+`admin-on-staging`.
+
 </TabItem>
-<TabItem label="Manual Configuration">
-While helpful, the `aws configure sso` wizard requires currently-assigned Accounts
-and Permission Sets to work with. You can pre-configure an AWS profile to use
-Account Assignments that you currently do not have access to by editing your 
-`~/.aws/config` file and adding the profile directly.
+<TabItem label="Manual">
+Configure the SSO session and profile directly in `~/.aws/config` if you need
+full manual control.
 
-For example, the `admin-on-staging` profile we created above looks like this:
+1. Add the SSO session configuration:
+
+```ini
+[sso-session my-identity-center]
+sso_start_url = https://d-12234567890.awsapps.com/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+```
+
+2. Log in to AWS via SSO:
+
+```shell
+$ aws sso login --sso-session my-identity-center
+```
+
+This launches a browser-based flow that logs you into AWS via Teleport.
+
+3. Add a profile that references the SSO session. For example, the
+   `admin-on-staging` profile looks like this:
+
+<Admonition type="tip">
+  You can create as many profiles as you like, so repeat this step for as many
+  AWS Account / Permission Set pairs that you need.
+</Admonition>
 
 ```ini
 [profile admin-on-staging]
@@ -152,13 +190,23 @@ sso_account_id = 058264527036
 sso_role_name = AdministratorAccess
 region = us-east-1
 ```
+
 </TabItem>
 </Tabs>
 
 ### Testing the profile
 
-You can test the profile by running `aws sts get-caller-identity` and verifying
-the returned user ID and assumed Role. For example:
+After completing one of the configuration flows above, test the profile by
+running `aws sts get-caller-identity` and verifying the returned user ID and
+assumed role.
+
+If you have already exported `AWS_PROFILE`, run:
+
+```shell
+$ aws sts get-caller-identity
+```
+
+Or pass the profile explicitly. For example:
 
 ```shell
 $ aws sts get-caller-identity --profile admin-on-staging
@@ -169,31 +217,31 @@ $ aws sts get-caller-identity --profile admin-on-staging
 }
 ```
 
-Once you have validate that the profile is configured correctly, you can use the
-`--profile` argument in any `aws` subcommand select it and use the corresponding
-Identity Center Account assignment in that operation.
+Once you have validated that the profile is configured correctly, you can use
+the `--profile` argument in any `aws` subcommand to select it and use the
+corresponding Identity Center Account assignment in that operation.
 
 <Admonition type="info">
 You can also use this profile with other tools that support the standard AWS client
 environment variables. Set the profile by setting the `AWS_PROFILE` environment
 variable. For example:
 
-
 ```shell
 $ AWS_PROFILE=admin-on-staging ./some-aws-tool
 ```
+
 </Admonition>
 
-## Troubleshooting 
+## Troubleshooting
 
 ### "Invalid Callback" error
 
-If AWS presents you with an "invalid Callback URL" error message, the most likely 
-problem is an incorrect AWS region in your `sso-session` configuration. 
+If AWS presents you with an "invalid Callback URL" error message, the most likely
+problem is an incorrect AWS region in your `sso-session` configuration.
 
 ### "Error loading SSO Token" error
 
-The AWS cache directory has probably been deleted. Log in again with `aws sso login --sso-session ${SSO_SESSION_NAME}`, 
+The AWS cache directory has probably been deleted. Log in again with `aws sso login --sso-session ${SSO_SESSION_NAME}`,
 where `${SSO_SESSION_NAME}` is the name of your configured SSO session.
 
 ## Next Steps

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -179,6 +179,24 @@ Arguments:
 |---|---|---|
 |command|none (optional)|AWS command and subcommands arguments that are going to be forwarded to AWS CLI.|
 
+## tsh aws-profile
+
+Generate AWS config profiles by syncing with your integrated AWS IAM Identity
+Center account(s). Other profiles in the config file are left untouched.
+
+Usage:
+
+```code
+$ tsh aws-profile [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--aws-sso-region`|none|AWS region for SSO. Auto-detected from cluster if not specified.|
+|`--[no-]dry-run`|`false`|Print the configuration that will be applied without modifying the AWS config file.|
+
 ## tsh az
 
 Access Azure API.

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1031,7 +1031,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	aws.Flag("aws-role", "(For AWS CLI access only) Amazon IAM role ARN or role name.").StringVar(&cf.AWSRole)
 
 	// Generate AWS profiles via AWS Identity Center integration.
-	awsProfile := app.Command("aws-profile", "Write AWS profiles retrieved from the AWS IAM Identity Center integration to the AWS config file.")
+	awsProfile := app.Command("aws-profile", "Generate AWS config profiles by syncing with your integrated AWS IAM Identity Center account(s). Other profiles in the config file are left untouched.")
 	awsProfile.Flag("aws-sso-region", "AWS region for SSO. Auto-detected from cluster if not specified.").StringVar(&cf.AWSSSORegion)
 	awsProfile.Flag("dry-run", "Print the configuration that will be applied without modifying the AWS config file.").BoolVar(&cf.DryRun)
 


### PR DESCRIPTION
Backport of the following PR to branch/v18:
- #64450

## Manual Test Plan

### Test Environment
1. Git clone [docs-website](https://github.com/gravitational/docs-website) as a sibling repo to your Teleport repo.
2. In the `docs-website` repo, execute:
```bash
./run-docker.sh 18.x
```

3. Check out this PR branch in your Teleport repo.

### Test Cases
- [x] **CLI reference doc update**: Visit the [tsh CLI reference page](http://localhost:3000/ver/18.x/reference/cli/tsh/). In the right-side navigation listing all `tsh` commands, verify that a "tsh aws-profile" link is present. Click the link and verify that the usage instructions for the command are displayed.
- [x] **AWS Identity Center integration doc update**: Visit the [Using AWS CLI page](http://localhost:3000/ver/18.x/identity-governance/integrations/aws-iam-identity-center/using-aws-cli/). Verify that immediately after the **Prerequisites** section, there is an **Configuration** section and an additional "tsh" tab where it details how to use `tsh aws-profile` to quickly set up AWS access.

changelog: Add documentation for the `tsh aws-profile` command