### PR TITLE
Improve specificity of MySQL version check test case in test plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1520,7 +1520,8 @@ manualy testing.
   - [ ] Self-hosted Postgres.
     - [ ] verify that cancelling a Postgres request works. (`select pg_sleep(10)` followed by ctrl-c is a good query to test.)
   - [ ] Self-hosted MySQL.
-    - [ ] MySQL server version reported by Teleport is correct.
+    - [ ] MySQL server version reported by Teleport is correct. You can find this in the connection information that is printed when you connect via `tsh db connect`.
+    - [ ] MySQL server version reported by `SELECT VERSION();` is correct and approximately matches the one printed in the connection information above.
   - [ ] Self-hosted MariaDB.
   - [ ] Self-hosted MongoDB.
   - [ ] Self-hosted CockroachDB.


### PR DESCRIPTION
I had a moment of confusion when doing this test. This PR makes the test case more descriptive as to where the MySQL version reported by teleport can be found. It also adds a check for the version reported by `SELECT VERSION();`, which I added due to a conversation with @greedy52.

## Manual Test Plan
### Test Environment

N/A

### Test Cases
- [x] N/A
