### PR TITLE
Bump unit test timeout from 20 to 30 minutes

### DIFF
--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -70,7 +70,7 @@ jobs:
         run: mount -t debugfs none /sys/kernel/debug/
 
       - name: Run tests
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: make -j"$(nproc)" test-go test-sh test-api
 
       - name: Upload test metrics


### PR DESCRIPTION
The CI is currently failing because of go unit test timeouts after 20 minutes. This is a band-aid solution to unclog the merge queue.
We might want to look into this later.
