### PR TITLE
Move `auth.certRequest` into internal package so it can be used in sub-packages

### DIFF
--- a/lib/auth/app_access_aws_credentials.go
+++ b/lib/auth/app_access_aws_credentials.go
@@ -27,7 +27,7 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/internal"
+	"github.com/gravitational/teleport/lib/auth/internal/cert"
 	"github.com/gravitational/teleport/lib/integrations/awsra"
 )
 
@@ -42,7 +42,7 @@ var errAppWithoutAWSClientSideCredentials = errors.New("target resource is not a
 func generateAWSClientSideCredentials(
 	ctx context.Context,
 	a *Server,
-	req internal.CertRequest,
+	req cert.Request,
 	notAfter time.Time,
 ) (string, error) {
 	if req.AppName == "" || req.AWSRoleARN == "" {
@@ -96,7 +96,7 @@ func getAppServerByName(ctx context.Context, a *Server, appServerName string) (t
 func generateAWSRolesAnywhereCredentials(
 	ctx context.Context,
 	a *Server,
-	req internal.CertRequest,
+	req cert.Request,
 	appInfo types.Application,
 	integration types.Integration,
 	notAfter time.Time,

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -90,7 +90,7 @@ import (
 	"github.com/gravitational/teleport/entitlements"
 	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/auth/internal"
+	"github.com/gravitational/teleport/lib/auth/internal/cert"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/auth/machineid/workloadidentityv1"
@@ -2677,18 +2677,18 @@ func (a *Server) GetKeyStore() *keystore.Manager {
 	return a.keyStore
 }
 
-type certRequestOption func(*internal.CertRequest)
+type certRequestOption func(*cert.Request)
 
 func certRequestPreviousIdentityExpires(previousIdentityExpires time.Time) certRequestOption {
-	return func(r *internal.CertRequest) { r.PreviousIdentityExpires = previousIdentityExpires }
+	return func(r *cert.Request) { r.PreviousIdentityExpires = previousIdentityExpires }
 }
 
 func certRequestLoginIP(ip string) certRequestOption {
-	return func(r *internal.CertRequest) { r.LoginIP = ip }
+	return func(r *cert.Request) { r.LoginIP = ip }
 }
 
 func certRequestDeviceExtensions(ext tlsca.DeviceExtensions) certRequestOption {
-	return func(r *internal.CertRequest) {
+	return func(r *cert.Request) {
 		r.DeviceExtensions = ext
 	}
 }
@@ -2763,7 +2763,7 @@ func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCert
 		return nil, trace.Wrap(err)
 	}
 
-	certs, err := a.generateOpenSSHCert(ctx, internal.CertRequest{
+	certs, err := a.generateOpenSSHCert(ctx, cert.Request{
 		User:            req.User,
 		SSHPublicKey:    req.PublicKey,
 		Compatibility:   constants.CertificateFormatStandard,
@@ -2828,7 +2828,7 @@ func (a *Server) GenerateUserTestCertsWithContext(ctx context.Context, req Gener
 		return nil, nil, trace.Wrap(err)
 	}
 
-	certReq := internal.CertRequest{
+	certReq := cert.Request{
 		User:                             userState,
 		TTL:                              req.TTL,
 		Compatibility:                    req.Compatibility,
@@ -2919,7 +2919,7 @@ func (a *Server) GenerateUserAppTestCert(req AppTestCertRequest) ([]byte, error)
 		login = uuid.New().String()
 	}
 
-	certs, err := a.generateUserCert(ctx, internal.CertRequest{
+	certs, err := a.generateUserCert(ctx, cert.Request{
 		User:           userState,
 		TLSPublicKey:   req.PublicKey,
 		CheckerContext: services.NewUnscopedSplitAccessCheckerContext(checker),
@@ -2981,7 +2981,7 @@ func (a *Server) GenerateDatabaseTestCert(req DatabaseTestCertRequest) ([]byte, 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	certs, err := a.generateUserCert(ctx, internal.CertRequest{
+	certs, err := a.generateUserCert(ctx, cert.Request{
 		User:           userState,
 		TLSPublicKey:   req.PublicKey,
 		LoginIP:        req.PinnedIP,
@@ -3386,7 +3386,7 @@ func (a *Server) augmentUserCertificates(
 
 // submitCertificateIssuedEvent submits a certificate issued usage event to the
 // usage reporting service.
-func (a *Server) submitCertificateIssuedEvent(req *internal.CertRequest, attestedKeyPolicy keys.PrivateKeyPolicy) {
+func (a *Server) submitCertificateIssuedEvent(req *cert.Request, attestedKeyPolicy keys.PrivateKeyPolicy) {
 	var database, app, kubernetes, desktop bool
 
 	if req.DBService != "" {
@@ -3435,16 +3435,16 @@ func (a *Server) submitCertificateIssuedEvent(req *internal.CertRequest, atteste
 }
 
 // generateUserCert generates certificates signed with User CA
-func (a *Server) generateUserCert(ctx context.Context, req internal.CertRequest) (*proto.Certs, error) {
+func (a *Server) generateUserCert(ctx context.Context, req cert.Request) (*proto.Certs, error) {
 	return generateCert(ctx, a, req, types.UserCA)
 }
 
 // generateOpenSSHCert generates certificates signed with OpenSSH CA
-func (a *Server) generateOpenSSHCert(ctx context.Context, req internal.CertRequest) (*proto.Certs, error) {
+func (a *Server) generateOpenSSHCert(ctx context.Context, req cert.Request) (*proto.Certs, error) {
 	return generateCert(ctx, a, req, types.OpenSSHCA)
 }
 
-func generateCert(ctx context.Context, a *Server, req internal.CertRequest, caType types.CertAuthType) (*proto.Certs, error) {
+func generateCert(ctx context.Context, a *Server, req cert.Request, caType types.CertAuthType) (*proto.Certs, error) {
 	err := req.Check()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -74,7 +74,6 @@ import (
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
-	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/metadata"
 	mfa "github.com/gravitational/teleport/api/mfa"
@@ -91,6 +90,7 @@ import (
 	"github.com/gravitational/teleport/entitlements"
 	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/internal"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/auth/machineid/workloadidentityv1"
@@ -2677,175 +2677,19 @@ func (a *Server) GetKeyStore() *keystore.Manager {
 	return a.keyStore
 }
 
-type certRequest struct {
-	// sshPublicKey is a public key in SSH authorized_keys format. If set it
-	// will be used as the subject public key for the returned SSH certificate.
-	sshPublicKey []byte
-	// tlsPublicKey is a PEM-encoded public key in PKCS#1 or PKIX ASN.1 DER
-	// form. If set it will be used as the subject public key for the returned
-	// TLS certificate.
-	tlsPublicKey []byte
-	// sshPublicKeyAttestationStatement is an attestation statement associated with sshPublicKey.
-	sshPublicKeyAttestationStatement *hardwarekey.AttestationStatement
-	// tlsPublicKeyAttestationStatement is an attestation statement associated with tlsPublicKey.
-	tlsPublicKeyAttestationStatement *hardwarekey.AttestationStatement
-
-	// user is a user to generate certificate for
-	user services.UserState
-	// impersonator is a user who generates the certificate,
-	// is set when different from the user in the certificate
-	impersonator string
-
-	// checkerContext is an access checker context that may either be scoped or unscoped. For unscoped
-	// identities, this wraps a classic access checker and cert parameters are determined by role policies.
-	// For scoped identities, this wraps a scoped access checker context and cert parameters must be
-	// determined by configuration/defaults since we cannot know which role will apply without knowing
-	// the target resource.
-	checkerContext *services.SplitAccessCheckerContext
-
-	// ttl is Duration of the certificate
-	ttl time.Duration
-	// compatibility is compatibility mode
-	compatibility string
-	// overrideRoleTTL is used for requests when the requested TTL should not be
-	// adjusted based off the role of the user. This is used by tctl to allow
-	// creating long lived user certs.
-	overrideRoleTTL bool
-	// usage is a list of acceptable usages to be encoded in X509 certificate,
-	// is used to limit ways the certificate can be used, for example
-	// the cert can be only used against kubernetes endpoint, and not auth endpoint,
-	// no usage means unrestricted (to keep backwards compatibility)
-	usage []string
-	// routeToCluster is an optional teleport cluster name to route the
-	// certificate requests to, this teleport cluster name will be used to
-	// route the requests to in case of kubernetes
-	routeToCluster string
-	// kubernetesCluster specifies the target kubernetes cluster for TLS
-	// identities. This can be empty on older Teleport clients.
-	kubernetesCluster string
-	// traits hold claim data used to populate a role at runtime.
-	traits wrappers.Traits
-	// activeRequests tracks privilege escalation requests applied
-	// during the construction of the certificate.
-	activeRequests []string
-	// appSessionID is the session ID of the application session.
-	appSessionID string
-	// appPublicAddr is the public address of the application.
-	appPublicAddr string
-	// appClusterName is the name of the cluster this application is in.
-	appClusterName string
-	// appName is the name of the application to generate cert for.
-	appName string
-	// appURI is the URI of the app. This is the internal endpoint where the application is running and isn't user-facing.
-	appURI string
-	// appTargetPort signifies that the cert should grant access to a specific port in a multi-port
-	// TCP app, as long as the port is defined in the app spec. Used only for routing, should not be
-	// used in other contexts (e.g., access requests).
-	appTargetPort int
-	// awsRoleARN is the role ARN to generate certificate for.
-	awsRoleARN string
-	// azureIdentity is the Azure identity to generate certificate for.
-	azureIdentity string
-	// gcpServiceAccount is the GCP service account to generate certificate for.
-	gcpServiceAccount string
-	// dbService identifies the name of the database service requests will
-	// be routed to.
-	dbService string
-	// dbProtocol specifies the protocol of the database a certificate will
-	// be issued for.
-	dbProtocol string
-	// dbUser is the optional database user which, if provided, will be used
-	// as a default username.
-	dbUser string
-	// dbName is the optional database name which, if provided, will be used
-	// as a default database.
-	dbName string
-	// dbRoles is the optional list of database roles which, if provided, will
-	// be used instead of all database roles granted for the target database.
-	dbRoles []string
-	// mfaVerified is the UUID of an MFA device when this certRequest was
-	// created immediately after an MFA check.
-	mfaVerified string
-	// previousIdentityExpires is the expiry time of the identity/cert that this
-	// identity/cert was derived from. It is used to determine a session's hard
-	// deadline in cases where both require_session_mfa and disconnect_expired_cert
-	// are enabled. See https://github.com/gravitational/teleport/issues/18544.
-	previousIdentityExpires time.Time
-	// loginIP is an IP of the client requesting the certificate.
-	loginIP string
-	// pinIP flags that client's login IP should be pinned in the certificate
-	pinIP bool
-	// disallowReissue flags that a cert should not be allowed to issue future
-	// certificates.
-	disallowReissue bool
-	// renewable indicates that the certificate can be renewed,
-	// having its TTL increased
-	renewable bool
-	// includeHostCA indicates that host CA certs should be included in the
-	// returned certs
-	includeHostCA bool
-	// generation indicates the number of times this certificate has been
-	// renewed.
-	generation uint64
-	// connectionDiagnosticID contains the ID of the ConnectionDiagnostic.
-	// The Node/Agent will append connection traces to this instance.
-	connectionDiagnosticID string
-	// deviceExtensions holds device-aware user certificate extensions.
-	deviceExtensions DeviceExtensions
-	// botName is the name of the bot requesting this cert, if any
-	botName string
-	// botInstanceID is the unique identifier of the bot instance associated
-	// with this cert, if any
-	botInstanceID string
-	// joinToken is the name of the join token used to join, set only for bot
-	// identities. It is unset for token-joined bots, whose token names are
-	// secret values.
-	joinToken string
-	// joinAttributes holds attributes derived from attested metadata from the
-	// join process, should any exist.
-	joinAttributes *workloadidentityv1pb.JoinAttrs
-	// requesterName is the name of the service that sent the request.
-	requesterName proto.UserCertsRequest_Requester
-}
-
-// check verifies the cert request is valid.
-func (r *certRequest) check() error {
-	if r.user == nil {
-		return trace.BadParameter("missing parameter user")
-	}
-	if r.checkerContext == nil {
-		return trace.BadParameter("missing parameter checkerContext")
-	}
-
-	// When generating certificate for MongoDB access, database username must
-	// be encoded into it. This is required to be able to tell which database
-	// user to authenticate the connection as.
-	if r.dbProtocol == defaults.ProtocolMongoDB {
-		if r.dbUser == "" {
-			return trace.BadParameter("must provide database user name to generate certificate for database %q", r.dbService)
-		}
-	}
-
-	if r.sshPublicKey == nil && r.tlsPublicKey == nil {
-		return trace.BadParameter("must provide a public key")
-	}
-
-	return nil
-}
-
-type certRequestOption func(*certRequest)
+type certRequestOption func(*internal.CertRequest)
 
 func certRequestPreviousIdentityExpires(previousIdentityExpires time.Time) certRequestOption {
-	return func(r *certRequest) { r.previousIdentityExpires = previousIdentityExpires }
+	return func(r *internal.CertRequest) { r.PreviousIdentityExpires = previousIdentityExpires }
 }
 
 func certRequestLoginIP(ip string) certRequestOption {
-	return func(r *certRequest) { r.loginIP = ip }
+	return func(r *internal.CertRequest) { r.LoginIP = ip }
 }
 
 func certRequestDeviceExtensions(ext tlsca.DeviceExtensions) certRequestOption {
-	return func(r *certRequest) {
-		r.deviceExtensions = DeviceExtensions(ext)
+	return func(r *internal.CertRequest) {
+		r.DeviceExtensions = ext
 	}
 }
 
@@ -2919,15 +2763,15 @@ func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCert
 		return nil, trace.Wrap(err)
 	}
 
-	certs, err := a.generateOpenSSHCert(ctx, certRequest{
-		user:            req.User,
-		sshPublicKey:    req.PublicKey,
-		compatibility:   constants.CertificateFormatStandard,
-		checkerContext:  services.NewUnscopedSplitAccessCheckerContext(checker), // TODO(fspmarshall/scopes): add scoping support to OpenSSH certs.
-		ttl:             sessionTTL,
-		traits:          req.User.GetTraits(),
-		routeToCluster:  req.Cluster,
-		disallowReissue: true,
+	certs, err := a.generateOpenSSHCert(ctx, internal.CertRequest{
+		User:            req.User,
+		SSHPublicKey:    req.PublicKey,
+		Compatibility:   constants.CertificateFormatStandard,
+		CheckerContext:  services.NewUnscopedSplitAccessCheckerContext(checker), // TODO(fspmarshall/scopes): add scoping support to OpenSSH certs.
+		TTL:             sessionTTL,
+		Traits:          req.User.GetTraits(),
+		RouteToCluster:  req.Cluster,
+		DisallowReissue: true,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2984,33 +2828,33 @@ func (a *Server) GenerateUserTestCertsWithContext(ctx context.Context, req Gener
 		return nil, nil, trace.Wrap(err)
 	}
 
-	certReq := certRequest{
-		user:                             userState,
-		ttl:                              req.TTL,
-		compatibility:                    req.Compatibility,
-		sshPublicKey:                     req.SSHPubKey,
-		tlsPublicKey:                     req.TLSPubKey,
-		routeToCluster:                   req.RouteToCluster,
-		checkerContext:                   services.NewUnscopedSplitAccessCheckerContext(checker),
-		traits:                           userState.GetTraits(),
-		loginIP:                          req.PinnedIP,
-		pinIP:                            req.PinnedIP != "",
-		mfaVerified:                      req.MFAVerified,
-		sshPublicKeyAttestationStatement: req.SSHAttestationStatement,
-		tlsPublicKeyAttestationStatement: req.TLSAttestationStatement,
-		appName:                          req.AppName,
-		appSessionID:                     req.AppSessionID,
-		deviceExtensions:                 req.DeviceExtensions,
-		generation:                       req.Generation,
-		renewable:                        req.Renewable,
-		activeRequests:                   req.ActiveRequests,
-		kubernetesCluster:                req.KubernetesCluster,
-		usage:                            req.Usage,
+	certReq := internal.CertRequest{
+		User:                             userState,
+		TTL:                              req.TTL,
+		Compatibility:                    req.Compatibility,
+		SSHPublicKey:                     req.SSHPubKey,
+		TLSPublicKey:                     req.TLSPubKey,
+		RouteToCluster:                   req.RouteToCluster,
+		CheckerContext:                   services.NewUnscopedSplitAccessCheckerContext(checker),
+		Traits:                           userState.GetTraits(),
+		LoginIP:                          req.PinnedIP,
+		PinIP:                            req.PinnedIP != "",
+		MFAVerified:                      req.MFAVerified,
+		SSHPublicKeyAttestationStatement: req.SSHAttestationStatement,
+		TLSPublicKeyAttestationStatement: req.TLSAttestationStatement,
+		AppName:                          req.AppName,
+		AppSessionID:                     req.AppSessionID,
+		DeviceExtensions:                 tlsca.DeviceExtensions(req.DeviceExtensions),
+		Generation:                       req.Generation,
+		Renewable:                        req.Renewable,
+		ActiveRequests:                   req.ActiveRequests,
+		KubernetesCluster:                req.KubernetesCluster,
+		Usage:                            req.Usage,
 	}
 
 	if botName, isBot := userState.GetLabel(types.BotLabel); isBot {
-		certReq.botName = botName
-		certReq.botInstanceID = uuid.NewString()
+		certReq.BotName = botName
+		certReq.BotInstanceID = uuid.NewString()
 	}
 
 	certs, err := a.generateUserCert(ctx, certReq)
@@ -3075,29 +2919,29 @@ func (a *Server) GenerateUserAppTestCert(req AppTestCertRequest) ([]byte, error)
 		login = uuid.New().String()
 	}
 
-	certs, err := a.generateUserCert(ctx, certRequest{
-		user:           userState,
-		tlsPublicKey:   req.PublicKey,
-		checkerContext: services.NewUnscopedSplitAccessCheckerContext(checker),
-		ttl:            req.TTL,
+	certs, err := a.generateUserCert(ctx, internal.CertRequest{
+		User:           userState,
+		TLSPublicKey:   req.PublicKey,
+		CheckerContext: services.NewUnscopedSplitAccessCheckerContext(checker),
+		TTL:            req.TTL,
 		// Set the login to be a random string. Application certificates are never
 		// used to log into servers but SSH certificate generation code requires a
 		// principal be in the certificate.
-		traits: wrappers.Traits(map[string][]string{
+		Traits: wrappers.Traits(map[string][]string{
 			constants.TraitLogins: {login},
 		}),
 		// Only allow this certificate to be used for applications.
-		usage: []string{teleport.UsageAppsOnly},
+		Usage: []string{teleport.UsageAppsOnly},
 		// Add in the application routing information.
-		appSessionID:      sessionID,
-		appPublicAddr:     req.PublicAddr,
-		appTargetPort:     req.TargetPort,
-		appClusterName:    req.ClusterName,
-		awsRoleARN:        req.AWSRoleARN,
-		azureIdentity:     req.AzureIdentity,
-		gcpServiceAccount: req.GCPServiceAccount,
-		pinIP:             req.PinnedIP != "",
-		loginIP:           req.PinnedIP,
+		AppSessionID:      sessionID,
+		AppPublicAddr:     req.PublicAddr,
+		AppTargetPort:     req.TargetPort,
+		AppClusterName:    req.ClusterName,
+		AWSRoleARN:        req.AWSRoleARN,
+		AzureIdentity:     req.AzureIdentity,
+		GCPServiceAccount: req.GCPServiceAccount,
+		PinIP:             req.PinnedIP != "",
+		LoginIP:           req.PinnedIP,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -3137,22 +2981,22 @@ func (a *Server) GenerateDatabaseTestCert(req DatabaseTestCertRequest) ([]byte, 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	certs, err := a.generateUserCert(ctx, certRequest{
-		user:           userState,
-		tlsPublicKey:   req.PublicKey,
-		loginIP:        req.PinnedIP,
-		pinIP:          req.PinnedIP != "",
-		checkerContext: services.NewUnscopedSplitAccessCheckerContext(checker),
-		ttl:            time.Hour,
-		traits: map[string][]string{
+	certs, err := a.generateUserCert(ctx, internal.CertRequest{
+		User:           userState,
+		TLSPublicKey:   req.PublicKey,
+		LoginIP:        req.PinnedIP,
+		PinIP:          req.PinnedIP != "",
+		CheckerContext: services.NewUnscopedSplitAccessCheckerContext(checker),
+		TTL:            time.Hour,
+		Traits: map[string][]string{
 			constants.TraitLogins: {req.Username},
 		},
-		routeToCluster: req.Cluster,
-		dbService:      req.RouteToDatabase.ServiceName,
-		dbProtocol:     req.RouteToDatabase.Protocol,
-		dbUser:         req.RouteToDatabase.Username,
-		dbName:         req.RouteToDatabase.Database,
-		dbRoles:        req.RouteToDatabase.Roles,
+		RouteToCluster: req.Cluster,
+		DBService:      req.RouteToDatabase.ServiceName,
+		DBProtocol:     req.RouteToDatabase.Protocol,
+		DBUser:         req.RouteToDatabase.Username,
+		DBName:         req.RouteToDatabase.Database,
+		DBRoles:        req.RouteToDatabase.Roles,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -3542,28 +3386,28 @@ func (a *Server) augmentUserCertificates(
 
 // submitCertificateIssuedEvent submits a certificate issued usage event to the
 // usage reporting service.
-func (a *Server) submitCertificateIssuedEvent(req *certRequest, attestedKeyPolicy keys.PrivateKeyPolicy) {
+func (a *Server) submitCertificateIssuedEvent(req *internal.CertRequest, attestedKeyPolicy keys.PrivateKeyPolicy) {
 	var database, app, kubernetes, desktop bool
 
-	if req.dbService != "" {
+	if req.DBService != "" {
 		database = true
 	}
 
-	if req.appName != "" {
+	if req.AppName != "" {
 		app = true
 	}
 
-	if req.kubernetesCluster != "" {
+	if req.KubernetesCluster != "" {
 		kubernetes = true
 	}
 
 	// Bot users are regular Teleport users, but have a special internal label.
-	bot := req.user.IsBot()
+	bot := req.User.IsBot()
 
 	// Unfortunately the only clue we have about Windows certs is the usage
 	// restriction: `RouteToWindowsDesktop` isn't actually passed along to the
 	// certRequest.
-	for _, usage := range req.usage {
+	for _, usage := range req.Usage {
 		switch usage {
 		case teleport.UsageWindowsDesktopOnly:
 			desktop = true
@@ -3572,41 +3416,41 @@ func (a *Server) submitCertificateIssuedEvent(req *certRequest, attestedKeyPolic
 
 	// For usage reporting, we care about the impersonator rather than the user
 	// being impersonated (if any).
-	user := req.user.GetName()
-	if req.impersonator != "" {
-		user = req.impersonator
+	user := req.User.GetName()
+	if req.Impersonator != "" {
+		user = req.Impersonator
 	}
 
 	a.AnonymizeAndSubmit(&usagereporter.UserCertificateIssuedEvent{
 		UserName:         user,
-		Ttl:              durationpb.New(req.ttl),
+		Ttl:              durationpb.New(req.TTL),
 		IsBot:            bot,
 		UsageDatabase:    database,
 		UsageApp:         app,
 		UsageKubernetes:  kubernetes,
 		UsageDesktop:     desktop,
 		PrivateKeyPolicy: string(attestedKeyPolicy),
-		BotInstanceId:    req.botInstanceID,
+		BotInstanceId:    req.BotInstanceID,
 	})
 }
 
 // generateUserCert generates certificates signed with User CA
-func (a *Server) generateUserCert(ctx context.Context, req certRequest) (*proto.Certs, error) {
+func (a *Server) generateUserCert(ctx context.Context, req internal.CertRequest) (*proto.Certs, error) {
 	return generateCert(ctx, a, req, types.UserCA)
 }
 
 // generateOpenSSHCert generates certificates signed with OpenSSH CA
-func (a *Server) generateOpenSSHCert(ctx context.Context, req certRequest) (*proto.Certs, error) {
+func (a *Server) generateOpenSSHCert(ctx context.Context, req internal.CertRequest) (*proto.Certs, error) {
 	return generateCert(ctx, a, req, types.OpenSSHCA)
 }
 
-func generateCert(ctx context.Context, a *Server, req certRequest, caType types.CertAuthType) (*proto.Certs, error) {
-	err := req.check()
+func generateCert(ctx context.Context, a *Server, req internal.CertRequest, caType types.CertAuthType) (*proto.Certs, error) {
+	err := req.Check()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if _, ok := req.checkerContext.ScopePin(); ok {
+	if _, ok := req.CheckerContext.ScopePin(); ok {
 		// require that the scope feature is enabled for scoped certificate creation
 		if err := scopes.AssertFeatureEnabled(); err != nil {
 			return nil, trace.Wrap(err)
@@ -3620,7 +3464,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		}
 	}
 
-	if unscoped := req.checkerContext.CertParams().UnscopedCertParams(); unscoped != nil {
+	if unscoped := req.CheckerContext.CertParams().UnscopedCertParams(); unscoped != nil {
 		if len(unscoped.GetAllowedResourceAccessIDs()) > 0 && modules.GetModules().BuildType() != modules.BuildEnterprise {
 			return nil, trace.Errorf("resource access requests: %w", ErrRequiresEnterprise)
 		}
@@ -3632,27 +3476,27 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		return nil, trace.Wrap(err)
 	}
 	if err := a.verifyLocksForUserCerts(verifyLocksForUserCertsReq{
-		checkerContext:       req.checkerContext,
+		checkerContext:       req.CheckerContext,
 		defaultMode:          readOnlyAuthPref.GetLockingMode(),
-		username:             req.user.GetName(),
-		mfaVerified:          req.mfaVerified,
-		activeAccessRequests: req.activeRequests,
-		deviceID:             req.deviceExtensions.DeviceID,
-		botInstanceID:        req.botInstanceID,
-		joinToken:            req.joinToken,
+		username:             req.User.GetName(),
+		mfaVerified:          req.MFAVerified,
+		activeAccessRequests: req.ActiveRequests,
+		deviceID:             req.DeviceExtensions.DeviceID,
+		botInstanceID:        req.BotInstanceID,
+		joinToken:            req.JoinToken,
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// extract the passed in certificate format. if nothing was passed in, fetch
 	// the certificate format from the role.
-	certificateFormat, err := utils.CheckCertificateFormatFlag(req.compatibility)
+	certificateFormat, err := utils.CheckCertificateFormatFlag(req.Compatibility)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Certificate parameters namespace - makes it clear these are for cert generation
-	certParams := req.checkerContext.CertParams()
+	certParams := req.CheckerContext.CertParams()
 
 	// scoped identities must use the standard certificate format, unscoped identities may have their
 	// certificate format customized by request parameters and/or role settings.
@@ -3673,18 +3517,18 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	var sessionTTL time.Duration
 	var allowedLogins []string
 
-	if req.ttl == 0 {
-		req.ttl = time.Duration(readOnlyAuthPref.GetDefaultSessionTTL())
+	if req.TTL == 0 {
+		req.TTL = time.Duration(readOnlyAuthPref.GetDefaultSessionTTL())
 	}
 
 	// If the role TTL is ignored, do not restrict session TTL and allowed logins.
 	// The only caller setting this parameter should be "tctl auth sign".
 	// Otherwise, set the session TTL to the smallest of all roles and
 	// then only grant access to allowed logins based on that.
-	if req.overrideRoleTTL {
+	if req.OverrideRoleTTL {
 		// Take whatever was passed in. Pass in 0 to GetSSHLoginsForTTL so all
 		// logins are returned for the role set.
-		sessionTTL = req.ttl
+		sessionTTL = req.TTL
 		allowedLogins, err = certParams.GetSSHLoginsForTTL(ctx, 0)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -3693,7 +3537,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		// Adjust session TTL to the smaller of two values: the session TTL requested
 		// in tsh (possibly using default_session_ttl) or the session TTL for the
 		// role. For scoped identities, this returns the requested TTL unchanged.
-		sessionTTL = certParams.AdjustSessionTTL(req.ttl)
+		sessionTTL = certParams.AdjustSessionTTL(req.TTL)
 		// Return a list of logins that meet the session TTL limit. For scoped identities,
 		// this enumerates all possible logins across all roles in the pin.
 		allowedLogins, err = certParams.GetSSHLoginsForTTL(ctx, sessionTTL)
@@ -3714,43 +3558,43 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 			sshAttestedKeyPolicy keys.PrivateKeyPolicy
 			tlsAttestedKeyPolicy keys.PrivateKeyPolicy
 		)
-		if req.sshPublicKey != nil {
-			sshCryptoPubKey, err := sshutils.CryptoPublicKey(req.sshPublicKey)
+		if req.SSHPublicKey != nil {
+			sshCryptoPubKey, err := sshutils.CryptoPublicKey(req.SSHPublicKey)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			sshAttestedKeyPolicy, err = a.attestHardwareKey(ctx, &attestHardwareKeyParams{
 				requiredKeyPolicy:    requiredKeyPolicy,
 				pubKey:               sshCryptoPubKey,
-				attestationStatement: req.sshPublicKeyAttestationStatement,
+				attestationStatement: req.SSHPublicKeyAttestationStatement,
 				sessionTTL:           sessionTTL,
 				readOnlyAuthPref:     readOnlyAuthPref,
-				userName:             req.user.GetName(),
-				userTraits:           req.checkerContext.Traits(),
+				userName:             req.User.GetName(),
+				userTraits:           req.CheckerContext.Traits(),
 			})
 			if err != nil {
 				return nil, trace.Wrap(err, "attesting SSH key")
 			}
 		}
-		if req.tlsPublicKey != nil {
-			tlsCryptoPubKey, err := keys.ParsePublicKey(req.tlsPublicKey)
+		if req.TLSPublicKey != nil {
+			tlsCryptoPubKey, err := keys.ParsePublicKey(req.TLSPublicKey)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			tlsAttestedKeyPolicy, err = a.attestHardwareKey(ctx, &attestHardwareKeyParams{
 				requiredKeyPolicy:    requiredKeyPolicy,
 				pubKey:               tlsCryptoPubKey,
-				attestationStatement: req.tlsPublicKeyAttestationStatement,
+				attestationStatement: req.TLSPublicKeyAttestationStatement,
 				sessionTTL:           sessionTTL,
 				readOnlyAuthPref:     readOnlyAuthPref,
-				userName:             req.user.GetName(),
-				userTraits:           req.checkerContext.Traits(),
+				userName:             req.User.GetName(),
+				userTraits:           req.CheckerContext.Traits(),
 			})
 			if err != nil {
 				return nil, trace.Wrap(err, "attesting TLS key")
 			}
 		}
-		if req.sshPublicKey != nil && req.tlsPublicKey != nil && sshAttestedKeyPolicy != tlsAttestedKeyPolicy {
+		if req.SSHPublicKey != nil && req.TLSPublicKey != nil && sshAttestedKeyPolicy != tlsAttestedKeyPolicy {
 			return nil, trace.BadParameter("SSH attested key policy %q does not match TLS attested key policy %q, this not supported",
 				sshAttestedKeyPolicy, tlsAttestedKeyPolicy)
 		}
@@ -3761,23 +3605,23 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if req.routeToCluster == "" {
-		req.routeToCluster = clusterName
+	if req.RouteToCluster == "" {
+		req.RouteToCluster = clusterName
 	}
-	if req.routeToCluster != clusterName {
+	if req.RouteToCluster != clusterName {
 		unscoped := certParams.UnscopedCertParams()
 		if unscoped == nil {
-			return nil, trace.BadParameter("cannot generate certs for remote cluster %q, remote cluster access is only supported for unscoped certs", req.routeToCluster)
+			return nil, trace.BadParameter("cannot generate certs for remote cluster %q, remote cluster access is only supported for unscoped certs", req.RouteToCluster)
 		}
 
 		// Authorize access to a remote cluster.
-		rc, err := a.GetRemoteCluster(ctx, req.routeToCluster)
+		rc, err := a.GetRemoteCluster(ctx, req.RouteToCluster)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		if err := unscoped.CheckAccessToRemoteCluster(rc); err != nil {
 			if trace.IsAccessDenied(err) {
-				return nil, trace.NotFound("remote cluster %q not found", req.routeToCluster)
+				return nil, trace.NotFound("remote cluster %q not found", req.RouteToCluster)
 			}
 			return nil, trace.Wrap(err)
 		}
@@ -3788,12 +3632,12 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	allowedLogins = append(allowedLogins, teleport.SSHSessionJoinPrincipal)
 
 	pinnedIP := ""
-	if caType == types.UserCA && (certParams.PinSourceIP() || req.pinIP) {
-		if req.loginIP == "" {
-			return nil, trace.BadParameter("IP pinning is enabled for user %q but there is no client IP information", req.user.GetName())
+	if caType == types.UserCA && (certParams.PinSourceIP() || req.PinIP) {
+		if req.LoginIP == "" {
+			return nil, trace.BadParameter("IP pinning is enabled for user %q but there is no client IP information", req.User.GetName())
 		}
 
-		pinnedIP = req.loginIP
+		pinnedIP = req.LoginIP
 	}
 
 	ca, err := a.GetCertAuthority(ctx, types.CertAuthID{
@@ -3806,7 +3650,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 
 	// At most one GitHub identity expected.
 	var githubUserID, githubUsername string
-	if githubIdentities := req.user.GetGithubIdentities(); len(githubIdentities) > 0 {
+	if githubIdentities := req.User.GetGithubIdentities(); len(githubIdentities) > 0 {
 		githubUserID = githubIdentities[0].UserID
 		githubUsername = githubIdentities[0].Username
 	}
@@ -3818,7 +3662,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		allowedResourceAccessIDs []types.ResourceAccessID
 	)
 
-	if pin, ok := req.checkerContext.ScopePin(); ok {
+	if pin, ok := req.CheckerContext.ScopePin(); ok {
 		scopePin = pin
 	}
 
@@ -3828,7 +3672,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	}
 
 	var signedSSHCert []byte
-	if req.sshPublicKey != nil {
+	if req.SSHPublicKey != nil {
 		sshSigner, err := a.keyStore.GetSSHSigner(ctx, ca)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -3842,38 +3686,38 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 
 		params := sshca.UserCertificateRequest{
 			CASigner:          sshSigner,
-			PublicUserKey:     req.sshPublicKey,
+			PublicUserKey:     req.SSHPublicKey,
 			TTL:               sessionTTL,
 			CertificateFormat: certificateFormat,
 			Identity: sshca.Identity{
-				Username:                 req.user.GetName(),
-				Impersonator:             req.impersonator,
+				Username:                 req.User.GetName(),
+				Impersonator:             req.Impersonator,
 				Principals:               allowedLogins,
 				ScopePin:                 scopePin,
 				Roles:                    roleNames,
 				PermitPortForwarding:     certParams.CanPortForward(),
 				PermitAgentForwarding:    certParams.CanForwardAgents(),
 				PermitX11Forwarding:      certParams.PermitX11Forwarding(),
-				RouteToCluster:           req.routeToCluster,
-				Traits:                   req.traits,
-				ActiveRequests:           req.activeRequests,
-				MFAVerified:              req.mfaVerified,
-				PreviousIdentityExpires:  req.previousIdentityExpires,
-				LoginIP:                  req.loginIP,
+				RouteToCluster:           req.RouteToCluster,
+				Traits:                   req.Traits,
+				ActiveRequests:           req.ActiveRequests,
+				MFAVerified:              req.MFAVerified,
+				PreviousIdentityExpires:  req.PreviousIdentityExpires,
+				LoginIP:                  req.LoginIP,
 				PinnedIP:                 pinnedIP,
-				DisallowReissue:          req.disallowReissue,
-				Renewable:                req.renewable,
-				Generation:               req.generation,
-				BotName:                  req.botName,
-				BotInstanceID:            req.botInstanceID,
-				JoinToken:                req.joinToken,
+				DisallowReissue:          req.DisallowReissue,
+				Renewable:                req.Renewable,
+				Generation:               req.Generation,
+				BotName:                  req.BotName,
+				BotInstanceID:            req.BotInstanceID,
+				JoinToken:                req.JoinToken,
 				CertificateExtensions:    certificateExtensions,
 				AllowedResourceAccessIDs: allowedResourceAccessIDs,
-				ConnectionDiagnosticID:   req.connectionDiagnosticID,
+				ConnectionDiagnosticID:   req.ConnectionDiagnosticID,
 				PrivateKeyPolicy:         attestedKeyPolicy,
-				DeviceID:                 req.deviceExtensions.DeviceID,
-				DeviceAssetTag:           req.deviceExtensions.AssetTag,
-				DeviceCredentialID:       req.deviceExtensions.CredentialID,
+				DeviceID:                 req.DeviceExtensions.DeviceID,
+				DeviceAssetTag:           req.DeviceExtensions.AssetTag,
+				DeviceCredentialID:       req.DeviceExtensions.CredentialID,
 				GitHubUserID:             githubUserID,
 				GitHubUsername:           githubUsername,
 			},
@@ -3888,20 +3732,20 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	// when the certificate is intended for a local Kubernetes cluster.
 	// If the certificate is targeting a trusted Teleport cluster, it is the
 	// responsibility of the cluster to ensure its existence.
-	if req.routeToCluster == clusterName && req.kubernetesCluster != "" {
+	if req.RouteToCluster == clusterName && req.KubernetesCluster != "" {
 		var found bool
 		for ks, err := range a.UnifiedResourceCache.KubernetesServers(a.closeCtx, services.UnifiedResourcesIterateParams{}) {
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 
-			if ks.GetCluster().GetName() == req.kubernetesCluster {
+			if ks.GetCluster().GetName() == req.KubernetesCluster {
 				found = true
 				break
 			}
 		}
 		if !found {
-			return nil, trace.BadParameter("Kubernetes cluster %q is not registered in this Teleport cluster; you can list registered Kubernetes clusters using 'tsh kube ls'", req.kubernetesCluster)
+			return nil, trace.BadParameter("Kubernetes cluster %q is not registered in this Teleport cluster; you can list registered Kubernetes clusters using 'tsh kube ls'", req.KubernetesCluster)
 		}
 	}
 
@@ -3915,7 +3759,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 
 	// only unscoped identities currently support kube groups/users.
 	if unscoped := certParams.UnscopedCertParams(); unscoped != nil {
-		kubeGroups, kubeUsers, err = unscoped.CheckKubeGroupsAndUsers(sessionTTL, req.overrideRoleTTL)
+		kubeGroups, kubeUsers, err = unscoped.CheckKubeGroupsAndUsers(sessionTTL, req.OverrideRoleTTL)
 		// NotFound errors are acceptable - this user may have no k8s access
 		// granted and that shouldn't prevent us from issuing a TLS cert.
 		if err != nil && !trace.IsNotFound(err) {
@@ -3923,25 +3767,25 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		}
 
 		// See which database names and users this user is allowed to use.
-		dbNames, dbUsers, err = unscoped.CheckDatabaseNamesAndUsers(sessionTTL, req.overrideRoleTTL)
+		dbNames, dbUsers, err = unscoped.CheckDatabaseNamesAndUsers(sessionTTL, req.OverrideRoleTTL)
 		if err != nil && !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 
 		// See which AWS role ARNs this user is allowed to assume.
-		roleARNs, err = unscoped.CheckAWSRoleARNs(sessionTTL, req.overrideRoleTTL)
+		roleARNs, err = unscoped.CheckAWSRoleARNs(sessionTTL, req.OverrideRoleTTL)
 		if err != nil && !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 
 		// See which Azure identities this user is allowed to assume.
-		azureIdentities, err = unscoped.CheckAzureIdentities(sessionTTL, req.overrideRoleTTL)
+		azureIdentities, err = unscoped.CheckAzureIdentities(sessionTTL, req.OverrideRoleTTL)
 		if err != nil && !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
 
 		// Enumerate allowed GCP service accounts.
-		gcpAccounts, err = unscoped.CheckGCPServiceAccounts(sessionTTL, req.overrideRoleTTL)
+		gcpAccounts, err = unscoped.CheckGCPServiceAccounts(sessionTTL, req.OverrideRoleTTL)
 		if err != nil && !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
@@ -3952,7 +3796,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	switch {
 	case errors.Is(err, errAppWithoutAWSClientSideCredentials):
 		// Requesting AWS credential_process credentials for Apps without AWS client side credentials is a client error.
-		if req.requesterName == proto.UserCertsRequest_TSH_APP_AWS_CREDENTIALPROCESS {
+		if req.RequesterName == proto.UserCertsRequest_TSH_APP_AWS_CREDENTIALPROCESS {
 			return nil, trace.BadParameter("client requested aws credentials for an invalid resource")
 		}
 
@@ -3961,70 +3805,70 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	}
 
 	identity := tlsca.Identity{
-		Username:          req.user.GetName(),
-		Impersonator:      req.impersonator,
+		Username:          req.User.GetName(),
+		Impersonator:      req.Impersonator,
 		ScopePin:          scopePin,
 		Groups:            roleNames,
 		Principals:        allowedLogins,
-		Usage:             req.usage,
-		RouteToCluster:    req.routeToCluster,
-		KubernetesCluster: req.kubernetesCluster,
-		Traits:            req.traits,
+		Usage:             req.Usage,
+		RouteToCluster:    req.RouteToCluster,
+		KubernetesCluster: req.KubernetesCluster,
+		Traits:            req.Traits,
 		KubernetesGroups:  kubeGroups,
 		KubernetesUsers:   kubeUsers,
 		RouteToApp: tlsca.RouteToApp{
-			SessionID:                       req.appSessionID,
-			URI:                             req.appURI,
-			TargetPort:                      req.appTargetPort,
-			PublicAddr:                      req.appPublicAddr,
-			ClusterName:                     req.appClusterName,
-			Name:                            req.appName,
-			AWSRoleARN:                      req.awsRoleARN,
+			SessionID:                       req.AppSessionID,
+			URI:                             req.AppURI,
+			TargetPort:                      req.AppTargetPort,
+			PublicAddr:                      req.AppPublicAddr,
+			ClusterName:                     req.AppClusterName,
+			Name:                            req.AppName,
+			AWSRoleARN:                      req.AWSRoleARN,
 			AWSCredentialProcessCredentials: awsCredentialProcessCredentials,
-			AzureIdentity:                   req.azureIdentity,
-			GCPServiceAccount:               req.gcpServiceAccount,
+			AzureIdentity:                   req.AzureIdentity,
+			GCPServiceAccount:               req.GCPServiceAccount,
 		},
 		TeleportCluster:   clusterName,
 		OriginClusterName: clusterName,
 		RouteToDatabase: tlsca.RouteToDatabase{
-			ServiceName: req.dbService,
-			Protocol:    req.dbProtocol,
-			Username:    req.dbUser,
-			Database:    req.dbName,
-			Roles:       req.dbRoles,
+			ServiceName: req.DBService,
+			Protocol:    req.DBProtocol,
+			Username:    req.DBUser,
+			Database:    req.DBName,
+			Roles:       req.DBRoles,
 		},
 		DatabaseNames:            dbNames,
 		DatabaseUsers:            dbUsers,
-		MFAVerified:              req.mfaVerified,
-		PreviousIdentityExpires:  req.previousIdentityExpires,
-		LoginIP:                  req.loginIP,
+		MFAVerified:              req.MFAVerified,
+		PreviousIdentityExpires:  req.PreviousIdentityExpires,
+		LoginIP:                  req.LoginIP,
 		PinnedIP:                 pinnedIP,
 		AWSRoleARNs:              roleARNs,
 		AzureIdentities:          azureIdentities,
 		GCPServiceAccounts:       gcpAccounts,
-		ActiveRequests:           req.activeRequests,
-		DisallowReissue:          req.disallowReissue,
-		Renewable:                req.renewable,
-		Generation:               req.generation,
-		BotName:                  req.botName,
-		BotInstanceID:            req.botInstanceID,
-		JoinToken:                req.joinToken,
+		ActiveRequests:           req.ActiveRequests,
+		DisallowReissue:          req.DisallowReissue,
+		Renewable:                req.Renewable,
+		Generation:               req.Generation,
+		BotName:                  req.BotName,
+		BotInstanceID:            req.BotInstanceID,
+		JoinToken:                req.JoinToken,
 		AllowedResourceAccessIDs: allowedResourceAccessIDs,
 		PrivateKeyPolicy:         attestedKeyPolicy,
-		ConnectionDiagnosticID:   req.connectionDiagnosticID,
+		ConnectionDiagnosticID:   req.ConnectionDiagnosticID,
 		DeviceExtensions: tlsca.DeviceExtensions{
-			DeviceID:     req.deviceExtensions.DeviceID,
-			AssetTag:     req.deviceExtensions.AssetTag,
-			CredentialID: req.deviceExtensions.CredentialID,
+			DeviceID:     req.DeviceExtensions.DeviceID,
+			AssetTag:     req.DeviceExtensions.AssetTag,
+			CredentialID: req.DeviceExtensions.CredentialID,
 		},
-		UserType:       req.user.GetUserType(),
-		JoinAttributes: req.joinAttributes,
+		UserType:       req.User.GetUserType(),
+		JoinAttributes: req.JoinAttributes,
 	}
 
 	var signedTLSCert []byte
 	var tlsIssuer *tlsca.CertAuthority
-	if req.tlsPublicKey != nil {
-		tlsCryptoPubKey, err := keys.ParsePublicKey(req.tlsPublicKey)
+	if req.TLSPublicKey != nil {
+		tlsCryptoPubKey, err := keys.ParsePublicKey(req.TLSPublicKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -4065,7 +3909,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	cas := []types.CertAuthority{ca}
 
 	// also include host CA certs if requested
-	if req.includeHostCA {
+	if req.IncludeHostCA {
 		hostCA, err := a.GetCertAuthority(ctx, types.CertAuthID{
 			Type:       types.HostCA,
 			DomainName: clusterName,

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -56,6 +56,7 @@ import (
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
+	"github.com/gravitational/teleport/lib/auth/internal"
 	"github.com/gravitational/teleport/lib/auth/join/oracle"
 	"github.com/gravitational/teleport/lib/auth/moderation"
 	"github.com/gravitational/teleport/lib/auth/okta"
@@ -3822,58 +3823,58 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 
 	// Generate certificate, note that the roles TTL will be ignored because
 	// the request is coming from "tctl auth sign" itself.
-	certReq := certRequest{
-		mfaVerified:                      verifiedMFADeviceID,
-		user:                             user,
-		ttl:                              req.Expires.Sub(a.authServer.GetClock().Now()),
-		compatibility:                    req.Format,
-		sshPublicKey:                     req.SSHPublicKey,
-		tlsPublicKey:                     req.TLSPublicKey,
-		sshPublicKeyAttestationStatement: hardwarekey.AttestationStatementFromProto(req.SSHPublicKeyAttestationStatement),
-		tlsPublicKeyAttestationStatement: hardwarekey.AttestationStatementFromProto(req.TLSPublicKeyAttestationStatement),
-		overrideRoleTTL:                  a.hasBuiltinRole(types.RoleAdmin),
-		routeToCluster:                   req.RouteToCluster,
-		requesterName:                    req.RequesterName,
-		kubernetesCluster:                req.KubernetesCluster,
-		dbService:                        req.RouteToDatabase.ServiceName,
-		dbProtocol:                       req.RouteToDatabase.Protocol,
-		dbUser:                           req.RouteToDatabase.Username,
-		dbName:                           req.RouteToDatabase.Database,
-		dbRoles:                          req.RouteToDatabase.Roles,
-		appSessionID:                     appSessionID,
-		appName:                          req.RouteToApp.Name,
-		appPublicAddr:                    req.RouteToApp.PublicAddr,
-		appURI:                           req.RouteToApp.URI,
-		appTargetPort:                    int(req.RouteToApp.TargetPort),
-		appClusterName:                   req.RouteToApp.ClusterName,
-		awsRoleARN:                       req.RouteToApp.AWSRoleARN,
-		azureIdentity:                    req.RouteToApp.AzureIdentity,
-		gcpServiceAccount:                req.RouteToApp.GCPServiceAccount,
-		checkerContext:                   services.NewUnscopedSplitAccessCheckerContext(checker), // TODO(fspmarshall/scopes): add scoping support to generateUserCerts.
+	certReq := internal.CertRequest{
+		MFAVerified:                      verifiedMFADeviceID,
+		User:                             user,
+		TTL:                              req.Expires.Sub(a.authServer.GetClock().Now()),
+		Compatibility:                    req.Format,
+		SSHPublicKey:                     req.SSHPublicKey,
+		TLSPublicKey:                     req.TLSPublicKey,
+		SSHPublicKeyAttestationStatement: hardwarekey.AttestationStatementFromProto(req.SSHPublicKeyAttestationStatement),
+		TLSPublicKeyAttestationStatement: hardwarekey.AttestationStatementFromProto(req.TLSPublicKeyAttestationStatement),
+		OverrideRoleTTL:                  a.hasBuiltinRole(types.RoleAdmin),
+		RouteToCluster:                   req.RouteToCluster,
+		RequesterName:                    req.RequesterName,
+		KubernetesCluster:                req.KubernetesCluster,
+		DBService:                        req.RouteToDatabase.ServiceName,
+		DBProtocol:                       req.RouteToDatabase.Protocol,
+		DBUser:                           req.RouteToDatabase.Username,
+		DBName:                           req.RouteToDatabase.Database,
+		DBRoles:                          req.RouteToDatabase.Roles,
+		AppSessionID:                     appSessionID,
+		AppName:                          req.RouteToApp.Name,
+		AppPublicAddr:                    req.RouteToApp.PublicAddr,
+		AppURI:                           req.RouteToApp.URI,
+		AppTargetPort:                    int(req.RouteToApp.TargetPort),
+		AppClusterName:                   req.RouteToApp.ClusterName,
+		AWSRoleARN:                       req.RouteToApp.AWSRoleARN,
+		AzureIdentity:                    req.RouteToApp.AzureIdentity,
+		GCPServiceAccount:                req.RouteToApp.GCPServiceAccount,
+		CheckerContext:                   services.NewUnscopedSplitAccessCheckerContext(checker), // TODO(fspmarshall/scopes): add scoping support to generateUserCerts.
 		// Copy IP from current identity to the generated certificate, if present,
 		// to avoid generateUserCerts() being used to drop IP pinning in the new certificates.
-		loginIP:                a.context.Identity.GetIdentity().LoginIP,
-		traits:                 accessInfo.Traits,
-		activeRequests:         req.AccessRequests,
-		connectionDiagnosticID: req.ConnectionDiagnosticID,
-		botName:                getBotName(user),
+		LoginIP:                a.context.Identity.GetIdentity().LoginIP,
+		Traits:                 accessInfo.Traits,
+		ActiveRequests:         req.AccessRequests,
+		ConnectionDiagnosticID: req.ConnectionDiagnosticID,
+		BotName:                getBotName(user),
 
 		// Always pass through a bot instance ID if available. Legacy bots
 		// joining without an instance ID may have one generated when
 		// `updateBotInstance()` is called below, and this (empty) value will be
 		// overridden.
-		botInstanceID: a.context.Identity.GetIdentity().BotInstanceID,
-		joinToken:     a.context.Identity.GetIdentity().JoinToken,
+		BotInstanceID: a.context.Identity.GetIdentity().BotInstanceID,
+		JoinToken:     a.context.Identity.GetIdentity().JoinToken,
 		// Propagate any join attributes from the current identity to the new
 		// identity.
-		joinAttributes: a.context.Identity.GetIdentity().JoinAttributes,
+		JoinAttributes: a.context.Identity.GetIdentity().JoinAttributes,
 	}
 
 	if user.GetName() != a.context.User.GetName() {
-		certReq.impersonator = a.context.User.GetName()
+		certReq.Impersonator = a.context.User.GetName()
 	} else if isRoleImpersonation(req) {
 		// Role impersonation uses the user's own name as the impersonator value.
-		certReq.impersonator = a.context.User.GetName()
+		certReq.Impersonator = a.context.User.GetName()
 
 		// By default, deny reissuing certs to prevent privilege re-escalation.
 		// (E.g a cert generated intended for use for Kubernetes Access against
@@ -3881,21 +3882,21 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		// This can be overridden by the user if they acknowledge the risk and
 		// require a certificate which can be reissued (e.g dynamic app access
 		// use-case).
-		certReq.disallowReissue = true
+		certReq.DisallowReissue = true
 		if req.ReissuableRoleImpersonation {
-			certReq.disallowReissue = false
+			certReq.DisallowReissue = false
 		}
 	} else if a.context.Identity != nil && a.context.Identity.GetIdentity().Impersonator != "" {
 		// impersonating users can receive new certs
-		certReq.impersonator = a.context.Identity.GetIdentity().Impersonator
+		certReq.Impersonator = a.context.Identity.GetIdentity().Impersonator
 	}
 	switch req.Usage {
 	case proto.UserCertsRequest_Database:
-		certReq.usage = []string{teleport.UsageDatabaseOnly}
+		certReq.Usage = []string{teleport.UsageDatabaseOnly}
 	case proto.UserCertsRequest_App:
-		certReq.usage = []string{teleport.UsageAppsOnly}
+		certReq.Usage = []string{teleport.UsageAppsOnly}
 	case proto.UserCertsRequest_Kubernetes:
-		certReq.usage = []string{teleport.UsageKubeOnly}
+		certReq.Usage = []string{teleport.UsageKubeOnly}
 	case proto.UserCertsRequest_SSH:
 		// SSH certs are ssh-only by definition, certReq.usage only applies to
 		// TLS certs.
@@ -3903,7 +3904,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		// Unrestricted usage.
 	case proto.UserCertsRequest_WindowsDesktop:
 		// Desktop certs.
-		certReq.usage = []string{teleport.UsageWindowsDesktopOnly}
+		certReq.Usage = []string{teleport.UsageWindowsDesktopOnly}
 	default:
 		return nil, trace.BadParameter("unsupported cert usage %q", req.Usage)
 	}
@@ -3918,27 +3919,27 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	if a.context.Identity.GetIdentity().Renewable &&
 		req.Username == a.context.User.GetName() &&
 		!isRoleImpersonation(req) &&
-		!certReq.disallowReissue {
-		certReq.renewable = true
+		!certReq.DisallowReissue {
+		certReq.Renewable = true
 	}
 
 	// If the cert is renewable, process any bot instance updates (generation
 	// counter, auth records, etc). `updateBotInstance()` may modify certain
 	// `certReq` attributes (generation, botInstanceID).
-	if certReq.renewable {
+	if certReq.Renewable {
 		currentIdentityGeneration := a.context.Identity.GetIdentity().Generation
 
 		// If we're handling a renewal for a bot, we want to return the
 		// Host CAs as well as the User CAs.
-		if certReq.botName != "" {
-			certReq.includeHostCA = true
+		if certReq.BotName != "" {
+			certReq.IncludeHostCA = true
 		}
 
 		// Update the bot instance based on this authentication. This may create
 		// a new bot instance record if the identity is missing an instance ID.
 		if err := a.authServer.updateBotInstance(
-			ctx, &certReq, user.GetName(), certReq.botName,
-			certReq.botInstanceID, nil, int32(currentIdentityGeneration),
+			ctx, &certReq, user.GetName(), certReq.BotName,
+			certReq.BotInstanceID, nil, int32(currentIdentityGeneration),
 		); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -56,7 +56,7 @@ import (
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
-	"github.com/gravitational/teleport/lib/auth/internal"
+	"github.com/gravitational/teleport/lib/auth/internal/cert"
 	"github.com/gravitational/teleport/lib/auth/join/oracle"
 	"github.com/gravitational/teleport/lib/auth/moderation"
 	"github.com/gravitational/teleport/lib/auth/okta"
@@ -3823,7 +3823,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 
 	// Generate certificate, note that the roles TTL will be ignored because
 	// the request is coming from "tctl auth sign" itself.
-	certReq := internal.CertRequest{
+	certReq := cert.Request{
 		MFAVerified:                      verifiedMFADeviceID,
 		User:                             user,
 		TTL:                              req.Expires.Sub(a.authServer.GetClock().Now()),

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -36,6 +36,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/internal"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -51,7 +52,7 @@ import (
 // TODO(timothyb89): In v18, we should explicitly remove generation counters
 // labels from the bot user.
 // REMOVE IN V18: Use bot instance generation counters instead.
-func (a *Server) legacyValidateGenerationLabel(ctx context.Context, username string, certReq *certRequest, currentIdentityGeneration uint64) error {
+func (a *Server) legacyValidateGenerationLabel(ctx context.Context, username string, certReq *internal.CertRequest, currentIdentityGeneration uint64) error {
 	// Fetch the user, bypassing the cache. We might otherwise fetch a stale
 	// value in case of a rapid certificate renewal.
 	user, err := a.Services.GetUser(ctx, username, false)
@@ -70,19 +71,19 @@ func (a *Server) legacyValidateGenerationLabel(ctx context.Context, username str
 
 	// If there is no existing generation on any of the user, identity, or
 	// cert request, we have nothing to do here.
-	if currentUserGeneration == 0 && currentIdentityGeneration == 0 && certReq.generation == 0 {
+	if currentUserGeneration == 0 && currentIdentityGeneration == 0 && certReq.Generation == 0 {
 		return nil
 	}
 
 	// By now, we know a generation counter is in play _somewhere_ and this is a
 	// bot certs. Bot certs should include the host CA so that they can make
 	// Teleport API calls.
-	certReq.includeHostCA = true
+	certReq.IncludeHostCA = true
 
 	// If the certReq already has generation set, it was explicitly requested
 	// (presumably this is the initial set of renewable certs). We'll want to
 	// commit that value to the User object.
-	if certReq.generation > 0 {
+	if certReq.Generation > 0 {
 		// ...however, if the user already has a stored generation, bail.
 		// (bots should be deleted and recreated if their certs expire)
 		if currentUserGeneration > 0 {
@@ -93,8 +94,8 @@ func (a *Server) legacyValidateGenerationLabel(ctx context.Context, username str
 		}
 
 		// Sanity check that the requested generation is 1.
-		if certReq.generation != 1 {
-			return trace.BadParameter("explicitly requested generation %d is not equal to 1, this is a logic error", certReq.generation)
+		if certReq.Generation != 1 {
+			return trace.BadParameter("explicitly requested generation %d is not equal to 1, this is a logic error", certReq.Generation)
 		}
 
 		userV2, ok := user.(*types.UserV2)
@@ -103,7 +104,7 @@ func (a *Server) legacyValidateGenerationLabel(ctx context.Context, username str
 		}
 		newUser := apiutils.CloneProtoMsg(userV2)
 		metadata := newUser.GetMetadata()
-		generation := fmt.Sprint(certReq.generation)
+		generation := fmt.Sprint(certReq.Generation)
 		metadata.Labels[types.BotGenerationLabel] = generation
 		newUser.SetMetadata(metadata)
 
@@ -123,10 +124,10 @@ func (a *Server) legacyValidateGenerationLabel(ctx context.Context, username str
 	if currentIdentityGeneration != currentUserGeneration {
 		if err := a.tryLockBotDueToGenerationMismatch(
 			ctx,
-			certReq.botName,
-			certReq.botInstanceID,
-			certReq.joinToken,
-			certReq.renewable,
+			certReq.BotName,
+			certReq.BotInstanceID,
+			certReq.JoinToken,
+			certReq.Renewable,
 		); err != nil {
 			a.logger.WarnContext(ctx, "Failed to lock bot when a generation mismatch was detected",
 				"error", err,
@@ -160,7 +161,7 @@ func (a *Server) legacyValidateGenerationLabel(ctx context.Context, username str
 	}
 
 	// And lastly, set the generation on the cert request.
-	certReq.generation = newGeneration
+	certReq.Generation = newGeneration
 
 	return nil
 }
@@ -313,7 +314,7 @@ func shouldEnforceGenerationCounter(renewable bool, joinMethod string) bool {
 // identity, if any. If the optional `templateAuthRecord` is provided, various
 // metadata fields will be copied into the newly generated auth record.
 func (a *Server) updateBotInstance(
-	ctx context.Context, req *certRequest,
+	ctx context.Context, req *internal.CertRequest,
 	username, botName, botInstanceID string,
 	templateAuthRecord *machineidv1pb.BotInstanceStatusAuthentication,
 	currentIdentityGeneration int32,
@@ -344,12 +345,12 @@ func (a *Server) updateBotInstance(
 	}
 
 	var publicKeyPEM []byte
-	if req.tlsPublicKey != nil {
-		publicKeyPEM = req.tlsPublicKey
+	if req.TLSPublicKey != nil {
+		publicKeyPEM = req.TLSPublicKey
 	} else {
 		// At least one of tlsPublicKey or sshPublicKey will be set, this is validated by [req.check].
 		var err error
-		publicKeyPEM, err = sshPublicKeyToPKIXPEM(req.sshPublicKey)
+		publicKeyPEM, err = sshPublicKeyToPKIXPEM(req.SSHPublicKey)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -401,10 +402,10 @@ func (a *Server) updateBotInstance(
 			}
 
 			// Copy the value from the request into the auth record.
-			authRecord.Generation = int32(req.generation)
+			authRecord.Generation = int32(req.Generation)
 		} else {
 			// Otherwise, just set it to 1.
-			req.generation = 1
+			req.Generation = 1
 			authRecord.Generation = 1
 		}
 
@@ -414,7 +415,7 @@ func (a *Server) updateBotInstance(
 			"new_instance_id", logutils.StringerAttr(instanceID),
 		)
 
-		expires := a.GetClock().Now().Add(req.ttl + machineidv1.ExpiryMargin)
+		expires := a.GetClock().Now().Add(req.TTL + machineidv1.ExpiryMargin)
 
 		bi := newBotInstance(&machineidv1pb.BotInstanceSpec{
 			BotName:    botName,
@@ -426,7 +427,7 @@ func (a *Server) updateBotInstance(
 		}
 
 		// Add the new ID to the cert request
-		req.botInstanceID = instanceID.String()
+		req.BotInstanceID = instanceID.String()
 
 		return nil
 	}
@@ -444,8 +445,8 @@ func (a *Server) updateBotInstance(
 	} else if currentIdentityGeneration > 0 && currentIdentityGeneration != instanceGeneration {
 		// Generation counter enforcement depends on the type of cert and join
 		// method (if any - token renewals technically have no join method.)
-		if shouldEnforceGenerationCounter(req.renewable, authRecord.JoinMethod) {
-			if err := a.tryLockBotDueToGenerationMismatch(ctx, botName, botInstanceID, req.joinToken, req.renewable); err != nil {
+		if shouldEnforceGenerationCounter(req.Renewable, authRecord.JoinMethod) {
+			if err := a.tryLockBotDueToGenerationMismatch(ctx, botName, botInstanceID, req.JoinToken, req.Renewable); err != nil {
 				log.WarnContext(ctx, "Failed to lock bot when a generation mismatch was detected", "error", err)
 			}
 
@@ -472,7 +473,7 @@ func (a *Server) updateBotInstance(
 	// should be incremented and stored even if it is not validated above.
 	newGeneration := instanceGeneration + 1
 	authRecord.Generation = newGeneration
-	req.generation = uint64(newGeneration)
+	req.Generation = uint64(newGeneration)
 
 	// Commit the generation counter to the bot user for downgrade
 	// compatibility, but only if this is a renewable identity. Previous
@@ -480,7 +481,7 @@ func (a *Server) updateBotInstance(
 	// setting this for other methods will break compatibility.
 	// Note: new join methods that enforce generation counter checks will not
 	// write a generation counter to user labels (e.g. bound keypair).
-	if req.renewable {
+	if req.Renewable {
 		if err := a.commitLegacyGenerationCounterToBotUser(ctx, username, uint64(newGeneration)); err != nil {
 			log.WarnContext(ctx, "unable to commit legacy generation counter to bot user", "error", err)
 		}
@@ -493,7 +494,7 @@ func (a *Server) updateBotInstance(
 
 		// Update the record's expiration timestamp based on the request TTL
 		// plus an expiry margin.
-		bi.Metadata.Expires = timestamppb.New(a.GetClock().Now().Add(req.ttl + machineidv1.ExpiryMargin))
+		bi.Metadata.Expires = timestamppb.New(a.GetClock().Now().Add(req.TTL + machineidv1.ExpiryMargin))
 
 		// If we're at or above the limit, remove enough of the front elements
 		// to make room for the new one at the end.
@@ -594,18 +595,18 @@ func (a *Server) generateInitialBotCerts(
 	}
 
 	// Generate certificate
-	certReq := certRequest{
-		user:           userState,
-		ttl:            expires.Sub(a.GetClock().Now()),
-		sshPublicKey:   sshPubKey,
-		tlsPublicKey:   tlsPubKey,
-		checkerContext: services.NewUnscopedSplitAccessCheckerContext(checker), // TODO(fspmarshall/scopes): add scoping support to generateInitialBotCerts (likely not necessary until bot scoping work begins).
-		traits:         accessInfo.Traits,
-		renewable:      renewable,
-		includeHostCA:  true,
-		loginIP:        loginIP,
-		botName:        botName,
-		joinAttributes: joinAttrs,
+	certReq := internal.CertRequest{
+		User:           userState,
+		TTL:            expires.Sub(a.GetClock().Now()),
+		SSHPublicKey:   sshPubKey,
+		TLSPublicKey:   tlsPubKey,
+		CheckerContext: services.NewUnscopedSplitAccessCheckerContext(checker), // TODO(fspmarshall/scopes): add scoping support to generateInitialBotCerts (likely not necessary until bot scoping work begins).
+		Traits:         accessInfo.Traits,
+		Renewable:      renewable,
+		IncludeHostCA:  true,
+		LoginIP:        loginIP,
+		BotName:        botName,
+		JoinAttributes: joinAttrs,
 	}
 
 	// Set the join token cert field for non-renewable identities. This is used
@@ -613,7 +614,7 @@ func (a *Server) generateInitialBotCerts(
 	// token-joined bots and it's a secret value, so we don't bother setting it.
 	// (The renewable flag implies token joining.)
 	if !renewable {
-		certReq.joinToken = initialAuth.JoinToken
+		certReq.JoinToken = initialAuth.JoinToken
 	}
 
 	if existingInstanceID == "" {
@@ -636,8 +637,8 @@ func (a *Server) generateInitialBotCerts(
 			return nil, "", trace.Wrap(err)
 		}
 
-		certReq.botInstanceID = uuid.String()
-		certReq.generation = 1
+		certReq.BotInstanceID = uuid.String()
+		certReq.Generation = 1
 	} else {
 		// Otherwise, reuse the existing instance ID, and pass the
 		// initialAuth along.
@@ -653,8 +654,8 @@ func (a *Server) generateInitialBotCerts(
 
 		// Only set the bot instance ID if it's empty; `updateBotInstance()`
 		// may set it if a new instance is created.
-		if certReq.botInstanceID == "" {
-			certReq.botInstanceID = existingInstanceID
+		if certReq.BotInstanceID == "" {
+			certReq.BotInstanceID = existingInstanceID
 		}
 	}
 
@@ -663,5 +664,5 @@ func (a *Server) generateInitialBotCerts(
 		return nil, "", trace.Wrap(err)
 	}
 
-	return certs, certReq.botInstanceID, nil
+	return certs, certReq.BotInstanceID, nil
 }

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -36,7 +36,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/auth/internal"
+	"github.com/gravitational/teleport/lib/auth/internal/cert"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -52,7 +52,7 @@ import (
 // TODO(timothyb89): In v18, we should explicitly remove generation counters
 // labels from the bot user.
 // REMOVE IN V18: Use bot instance generation counters instead.
-func (a *Server) legacyValidateGenerationLabel(ctx context.Context, username string, certReq *internal.CertRequest, currentIdentityGeneration uint64) error {
+func (a *Server) legacyValidateGenerationLabel(ctx context.Context, username string, certReq *cert.Request, currentIdentityGeneration uint64) error {
 	// Fetch the user, bypassing the cache. We might otherwise fetch a stale
 	// value in case of a rapid certificate renewal.
 	user, err := a.Services.GetUser(ctx, username, false)
@@ -314,7 +314,7 @@ func shouldEnforceGenerationCounter(renewable bool, joinMethod string) bool {
 // identity, if any. If the optional `templateAuthRecord` is provided, various
 // metadata fields will be copied into the newly generated auth record.
 func (a *Server) updateBotInstance(
-	ctx context.Context, req *internal.CertRequest,
+	ctx context.Context, req *cert.Request,
 	username, botName, botInstanceID string,
 	templateAuthRecord *machineidv1pb.BotInstanceStatusAuthentication,
 	currentIdentityGeneration int32,
@@ -595,7 +595,7 @@ func (a *Server) generateInitialBotCerts(
 	}
 
 	// Generate certificate
-	certReq := internal.CertRequest{
+	certReq := cert.Request{
 		User:           userState,
 		TTL:            expires.Sub(a.GetClock().Now()),
 		SSHPublicKey:   sshPubKey,

--- a/lib/auth/internal/cert/request.go
+++ b/lib/auth/internal/cert/request.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package internal
+package cert
 
 import (
 	"time"
@@ -32,8 +32,8 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
-// CertRequest contains the parameters used to issue user and OpenSSH certificates.
-type CertRequest struct {
+// Request contains the parameters used to issue user and OpenSSH certificates.
+type Request struct {
 	// SSHPublicKey is a public key in SSH authorized_keys format. If set it
 	// will be used as the subject public key for the returned SSH certificate.
 	SSHPublicKey []byte
@@ -120,7 +120,7 @@ type CertRequest struct {
 	// DBRoles is the optional list of database roles which, if provided, will
 	// be used instead of all database roles granted for the target database.
 	DBRoles []string
-	// MFAVerified is the UUID of an MFA device when this CertRequest was
+	// MFAVerified is the UUID of an MFA device when this Request was
 	// created immediately after an MFA check.
 	MFAVerified string
 	// PreviousIdentityExpires is the expiry time of the identity/cert that this
@@ -166,7 +166,7 @@ type CertRequest struct {
 }
 
 // Check verifies the cert request is valid.
-func (r *CertRequest) Check() error {
+func (r *Request) Check() error {
 	if r.User == nil {
 		return trace.BadParameter("missing parameter user")
 	}

--- a/lib/auth/internal/cert_request.go
+++ b/lib/auth/internal/cert_request.go
@@ -1,0 +1,191 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package internal
+
+import (
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+// CertRequest contains the parameters used to issue user and OpenSSH certificates.
+type CertRequest struct {
+	// SSHPublicKey is a public key in SSH authorized_keys format. If set it
+	// will be used as the subject public key for the returned SSH certificate.
+	SSHPublicKey []byte
+	// TLSPublicKey is a PEM-encoded public key in PKCS#1 or PKIX ASN.1 DER
+	// form. If set it will be used as the subject public key for the returned
+	// TLS certificate.
+	TLSPublicKey []byte
+	// SSHPublicKeyAttestationStatement is an attestation statement associated with SSHPublicKey.
+	SSHPublicKeyAttestationStatement *hardwarekey.AttestationStatement
+	// TLSPublicKeyAttestationStatement is an attestation statement associated with TLSPublicKey.
+	TLSPublicKeyAttestationStatement *hardwarekey.AttestationStatement
+
+	// User is a user to generate certificate for.
+	User services.UserState
+	// Impersonator is a user who generates the certificate,
+	// is set when different from the user in the certificate.
+	Impersonator string
+
+	// CheckerContext is an access checker context that may either be scoped or
+	// unscoped. For unscoped identities, this wraps a classic access checker and
+	// cert parameters are determined by role policies. For scoped identities,
+	// this wraps a scoped access checker context and cert parameters must be
+	// determined by configuration/defaults since we cannot know which role will
+	// apply without knowing the target resource.
+	CheckerContext *services.SplitAccessCheckerContext
+
+	// TTL is duration of the certificate.
+	TTL time.Duration
+	// Compatibility is compatibility mode.
+	Compatibility string
+	// OverrideRoleTTL is used for requests when the requested TTL should not be
+	// adjusted based off the role of the user. This is used by tctl to allow
+	// creating long lived user certs.
+	OverrideRoleTTL bool
+	// Usage is a list of acceptable usages to be encoded in X509 certificate,
+	// is used to limit ways the certificate can be used, for example
+	// the cert can be only used against kubernetes endpoint, and not auth endpoint,
+	// no Usage means unrestricted (to keep backwards compatibility).
+	Usage []string
+	// RouteToCluster is an optional teleport cluster name to route the
+	// certificate requests to, this teleport cluster name will be used to
+	// route the requests to in case of kubernetes.
+	RouteToCluster string
+	// KubernetesCluster specifies the target kubernetes cluster for TLS
+	// identities. This can be empty on older Teleport clients.
+	KubernetesCluster string
+	// Traits hold claim data used to populate a role at runtime.
+	Traits wrappers.Traits
+	// ActiveRequests tracks privilege escalation requests applied
+	// during the construction of the certificate.
+	ActiveRequests []string
+	// AppSessionID is the session ID of the application session.
+	AppSessionID string
+	// AppPublicAddr is the public address of the application.
+	AppPublicAddr string
+	// AppClusterName is the name of the cluster this application is in.
+	AppClusterName string
+	// AppName is the name of the application to generate cert for.
+	AppName string
+	// AppURI is the URI of the app. This is the internal endpoint where the application is running and isn't user-facing.
+	AppURI string
+	// AppTargetPort signifies that the cert should grant access to a specific port in a multi-port
+	// TCP app, as long as the port is defined in the app spec. Used only for routing, should not be
+	// used in other contexts (e.g., access requests).
+	AppTargetPort int
+	// AWSRoleARN is the role ARN to generate certificate for.
+	AWSRoleARN string
+	// AzureIdentity is the Azure identity to generate certificate for.
+	AzureIdentity string
+	// GCPServiceAccount is the GCP service account to generate certificate for.
+	GCPServiceAccount string
+	// DBService identifies the name of the database service requests will
+	// be routed to.
+	DBService string
+	// DBProtocol specifies the protocol of the database a certificate will
+	// be issued for.
+	DBProtocol string
+	// DBUser is the optional database user which, if provided, will be used
+	// as a default username.
+	DBUser string
+	// DBName is the optional database name which, if provided, will be used
+	// as a default database.
+	DBName string
+	// DBRoles is the optional list of database roles which, if provided, will
+	// be used instead of all database roles granted for the target database.
+	DBRoles []string
+	// MFAVerified is the UUID of an MFA device when this CertRequest was
+	// created immediately after an MFA check.
+	MFAVerified string
+	// PreviousIdentityExpires is the expiry time of the identity/cert that this
+	// identity/cert was derived from. It is used to determine a session's hard
+	// deadline in cases where both require_session_mfa and disconnect_expired_cert
+	// are enabled. See https://github.com/gravitational/teleport/issues/18544.
+	PreviousIdentityExpires time.Time
+	// LoginIP is an IP of the client requesting the certificate.
+	LoginIP string
+	// PinIP flags that client's login IP should be pinned in the certificate.
+	PinIP bool
+	// DisallowReissue flags that a cert should not be allowed to issue future
+	// certificates.
+	DisallowReissue bool
+	// Renewable indicates that the certificate can be renewed,
+	// having its TTL increased.
+	Renewable bool
+	// IncludeHostCA indicates that host CA certs should be included in the
+	// returned certs.
+	IncludeHostCA bool
+	// Generation indicates the number of times this certificate has been
+	// renewed.
+	Generation uint64
+	// ConnectionDiagnosticID contains the ID of the ConnectionDiagnostic.
+	// The Node/Agent will append connection traces to this instance.
+	ConnectionDiagnosticID string
+	// DeviceExtensions holds device-aware user certificate extensions.
+	DeviceExtensions tlsca.DeviceExtensions
+	// BotName is the name of the bot requesting this cert, if any.
+	BotName string
+	// BotInstanceID is the unique identifier of the bot instance associated
+	// with this cert, if any.
+	BotInstanceID string
+	// JoinToken is the name of the join token used to join, set only for bot
+	// identities. It is unset for token-joined bots, whose token names are
+	// secret values.
+	JoinToken string
+	// JoinAttributes holds attributes derived from attested metadata from the
+	// join process, should any exist.
+	JoinAttributes *workloadidentityv1pb.JoinAttrs
+	// RequesterName is the name of the service that sent the request.
+	RequesterName proto.UserCertsRequest_Requester
+}
+
+// Check verifies the cert request is valid.
+func (r *CertRequest) Check() error {
+	if r.User == nil {
+		return trace.BadParameter("missing parameter user")
+	}
+	if r.CheckerContext == nil {
+		return trace.BadParameter("missing parameter checkerContext")
+	}
+
+	// When generating certificate for MongoDB access, database username must
+	// be encoded into it. This is required to be able to tell which database
+	// user to authenticate the connection as.
+	if r.DBProtocol == defaults.ProtocolMongoDB {
+		if r.DBUser == "" {
+			return trace.BadParameter("must provide database user name to generate certificate for database %q", r.DBService)
+		}
+	}
+
+	if r.SSHPublicKey == nil && r.TLSPublicKey == nil {
+		return trace.BadParameter("must provide a public key")
+	}
+
+	return nil
+}

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/auth/internal"
+	"github.com/gravitational/teleport/lib/auth/internal/cert"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -795,7 +795,7 @@ func (a *Server) AuthenticateSSHUser(ctx context.Context, req authclient.Authent
 		return nil, trace.BadParameter("source IP pinning is enabled but client IP is unknown")
 	}
 
-	certReq := internal.CertRequest{
+	certReq := cert.Request{
 		User:                             user,
 		TTL:                              req.TTL,
 		SSHPublicKey:                     req.SSHPublicKey,

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/internal"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -794,19 +795,19 @@ func (a *Server) AuthenticateSSHUser(ctx context.Context, req authclient.Authent
 		return nil, trace.BadParameter("source IP pinning is enabled but client IP is unknown")
 	}
 
-	certReq := certRequest{
-		user:                             user,
-		ttl:                              req.TTL,
-		sshPublicKey:                     req.SSHPublicKey,
-		tlsPublicKey:                     req.TLSPublicKey,
-		compatibility:                    req.CompatibilityMode,
-		checkerContext:                   checker,
-		traits:                           user.GetTraits(),
-		routeToCluster:                   req.RouteToCluster,
-		kubernetesCluster:                req.KubernetesCluster,
-		loginIP:                          clientIP,
-		sshPublicKeyAttestationStatement: req.SSHAttestationStatement,
-		tlsPublicKeyAttestationStatement: req.TLSAttestationStatement,
+	certReq := internal.CertRequest{
+		User:                             user,
+		TTL:                              req.TTL,
+		SSHPublicKey:                     req.SSHPublicKey,
+		TLSPublicKey:                     req.TLSPublicKey,
+		Compatibility:                    req.CompatibilityMode,
+		CheckerContext:                   checker,
+		Traits:                           user.GetTraits(),
+		RouteToCluster:                   req.RouteToCluster,
+		KubernetesCluster:                req.KubernetesCluster,
+		LoginIP:                          clientIP,
+		SSHPublicKeyAttestationStatement: req.SSHAttestationStatement,
+		TLSPublicKeyAttestationStatement: req.TLSAttestationStatement,
 	}
 
 	// For headless authentication, a short-lived mfa-verified cert should be generated.
@@ -821,8 +822,8 @@ func (a *Server) AuthenticateSSHUser(ctx context.Context, req authclient.Authent
 		if !bytes.Equal(req.TLSPublicKey, ha.TlsPublicKey) {
 			return nil, trace.AccessDenied("headless authentication TLS public key mismatch")
 		}
-		certReq.mfaVerified = ha.MfaDevice.Metadata.Name
-		certReq.ttl = time.Minute
+		certReq.MFAVerified = ha.MfaDevice.Metadata.Name
+		certReq.TTL = time.Minute
 	}
 
 	certs, err := a.generateUserCert(ctx, certReq)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -318,7 +318,7 @@ func (a *Server) newWebSession(
 	var hasDeviceExtensions bool
 	if opts != nil && opts.deviceExtensions != nil {
 		// Apply extensions to request.
-		certReq.DeviceExtensions = tlsca.DeviceExtensions(*opts.deviceExtensions)
+		certReq.DeviceExtensions = *opts.deviceExtensions
 		hasDeviceExtensions = true
 	}
 

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -39,7 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/appauthconfig/appauthconfigv1"
-	"github.com/gravitational/teleport/lib/auth/internal"
+	"github.com/gravitational/teleport/lib/auth/internal/cert"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
@@ -305,7 +305,7 @@ func (a *Server) newWebSession(
 		return nil, nil, trace.Wrap(err)
 	}
 
-	certReq := internal.CertRequest{
+	certReq := cert.Request{
 		User:           userState,
 		LoginIP:        req.LoginIP,
 		TTL:            sessionTTL,
@@ -594,7 +594,7 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		return nil, trace.Wrap(err)
 	}
 
-	certs, err := a.generateUserCert(ctx, internal.CertRequest{
+	certs, err := a.generateUserCert(ctx, cert.Request{
 		User:           user,
 		LoginIP:        req.LoginIP,
 		TLSPublicKey:   tlsPublicKey,
@@ -797,7 +797,7 @@ func (a *Server) CreateSessionCerts(ctx context.Context, req *SessionCertsReques
 		return nil, nil, trace.Wrap(err)
 	}
 
-	certs, err := a.generateUserCert(ctx, internal.CertRequest{
+	certs, err := a.generateUserCert(ctx, cert.Request{
 		User:                             req.UserState,
 		TTL:                              req.SessionTTL,
 		SSHPublicKey:                     req.SSHPubKey,

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/appauthconfig/appauthconfigv1"
+	"github.com/gravitational/teleport/lib/auth/internal"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
@@ -304,20 +305,20 @@ func (a *Server) newWebSession(
 		return nil, nil, trace.Wrap(err)
 	}
 
-	certReq := certRequest{
-		user:           userState,
-		loginIP:        req.LoginIP,
-		ttl:            sessionTTL,
-		sshPublicKey:   sshAuthorizedKey,
-		tlsPublicKey:   tlsPublicKeyPEM,
-		checkerContext: services.NewUnscopedSplitAccessCheckerContext(checker), // TODO(fspmarshall/scopes): add scoping support to newWebSession.
-		traits:         req.Traits,
-		activeRequests: req.AccessRequests,
+	certReq := internal.CertRequest{
+		User:           userState,
+		LoginIP:        req.LoginIP,
+		TTL:            sessionTTL,
+		SSHPublicKey:   sshAuthorizedKey,
+		TLSPublicKey:   tlsPublicKeyPEM,
+		CheckerContext: services.NewUnscopedSplitAccessCheckerContext(checker), // TODO(fspmarshall/scopes): add scoping support to newWebSession.
+		Traits:         req.Traits,
+		ActiveRequests: req.AccessRequests,
 	}
 	var hasDeviceExtensions bool
 	if opts != nil && opts.deviceExtensions != nil {
 		// Apply extensions to request.
-		certReq.deviceExtensions = DeviceExtensions(*opts.deviceExtensions)
+		certReq.DeviceExtensions = tlsca.DeviceExtensions(*opts.deviceExtensions)
 		hasDeviceExtensions = true
 	}
 
@@ -593,30 +594,30 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		return nil, trace.Wrap(err)
 	}
 
-	certs, err := a.generateUserCert(ctx, certRequest{
-		user:           user,
-		loginIP:        req.LoginIP,
-		tlsPublicKey:   tlsPublicKey,
-		checkerContext: services.NewUnscopedSplitAccessCheckerContext(checker), // TODO(fspmarshall/scopes): add scoping support to newAppSession.
-		ttl:            req.SessionTTL,
-		traits:         req.Traits,
-		activeRequests: req.AccessRequests,
+	certs, err := a.generateUserCert(ctx, internal.CertRequest{
+		User:           user,
+		LoginIP:        req.LoginIP,
+		TLSPublicKey:   tlsPublicKey,
+		CheckerContext: services.NewUnscopedSplitAccessCheckerContext(checker), // TODO(fspmarshall/scopes): add scoping support to newAppSession.
+		TTL:            req.SessionTTL,
+		Traits:         req.Traits,
+		ActiveRequests: req.AccessRequests,
 		// Set the app session ID in the certificate - used in auditing from the App Service.
-		appSessionID: sessionID,
+		AppSessionID: sessionID,
 		// Only allow this certificate to be used for applications.
-		usage:             []string{teleport.UsageAppsOnly},
-		appPublicAddr:     req.PublicAddr,
-		appClusterName:    req.ClusterName,
-		appTargetPort:     req.AppTargetPort,
-		awsRoleARN:        req.AWSRoleARN,
-		azureIdentity:     req.AzureIdentity,
-		gcpServiceAccount: req.GCPServiceAccount,
+		Usage:             []string{teleport.UsageAppsOnly},
+		AppPublicAddr:     req.PublicAddr,
+		AppClusterName:    req.ClusterName,
+		AppTargetPort:     req.AppTargetPort,
+		AWSRoleARN:        req.AWSRoleARN,
+		AzureIdentity:     req.AzureIdentity,
+		GCPServiceAccount: req.GCPServiceAccount,
 		// Pass along device extensions from the user.
-		deviceExtensions: req.DeviceExtensions,
-		mfaVerified:      req.MFAVerified,
+		DeviceExtensions: tlsca.DeviceExtensions(req.DeviceExtensions),
+		MFAVerified:      req.MFAVerified,
 		// Pass along bot details to ensure audit logs are correct.
-		botName:       req.BotName,
-		botInstanceID: req.BotInstanceID,
+		BotName:       req.BotName,
+		BotInstanceID: req.BotInstanceID,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -796,19 +797,19 @@ func (a *Server) CreateSessionCerts(ctx context.Context, req *SessionCertsReques
 		return nil, nil, trace.Wrap(err)
 	}
 
-	certs, err := a.generateUserCert(ctx, certRequest{
-		user:                             req.UserState,
-		ttl:                              req.SessionTTL,
-		sshPublicKey:                     req.SSHPubKey,
-		tlsPublicKey:                     req.TLSPubKey,
-		sshPublicKeyAttestationStatement: req.SSHAttestationStatement,
-		tlsPublicKeyAttestationStatement: req.TLSAttestationStatement,
-		compatibility:                    req.Compatibility,
-		checkerContext:                   checker,
-		traits:                           req.UserState.GetTraits(),
-		routeToCluster:                   req.RouteToCluster,
-		kubernetesCluster:                req.KubernetesCluster,
-		loginIP:                          req.LoginIP,
+	certs, err := a.generateUserCert(ctx, internal.CertRequest{
+		User:                             req.UserState,
+		TTL:                              req.SessionTTL,
+		SSHPublicKey:                     req.SSHPubKey,
+		TLSPublicKey:                     req.TLSPubKey,
+		SSHPublicKeyAttestationStatement: req.SSHAttestationStatement,
+		TLSPublicKeyAttestationStatement: req.TLSAttestationStatement,
+		Compatibility:                    req.Compatibility,
+		CheckerContext:                   checker,
+		Traits:                           req.UserState.GetTraits(),
+		RouteToCluster:                   req.RouteToCluster,
+		KubernetesCluster:                req.KubernetesCluster,
+		LoginIP:                          req.LoginIP,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)


### PR DESCRIPTION
In a coming PR, we're going to be adding a `lib/auth/delegation` package which implements the `DelegationSessionService` (see: [RFD 0238 - Delegating Access to AI Workloads](https://github.com/gravitational/teleport/blob/master/rfd/0238-delegating-access-to-ai-workloads.md)). This service will call the `generateUserCert` method (wrapped in a closure) to generate user certificates, which currently accepts the unexported `certRequest` struct.

This PR moves `certRequest` into an internal package so that it can be used by descendants of `lib/auth`.
