### PR TITLE
Update v18 version variables

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -67,17 +67,17 @@
     },
     "teleport": {
       "major_version": "18",
-      "version": "18.7.2",
+      "version": "18.7.3",
       "url": "teleport.example.com",
       "golang": "1.25.8",
       "plugin": {
-        "version": "18.7.2"
+        "version": "18.7.3"
       },
       "helm_repo_url": "https://charts.releases.teleport.dev",
-      "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport-distroless:18.7.2",
-      "latest_oss_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:18.7.2",
-      "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless:18.7.2",
-      "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless-debug:18.7.2",
+      "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport-distroless:18.7.3",
+      "latest_oss_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:18.7.3",
+      "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless:18.7.3",
+      "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless-debug:18.7.3",
       "teleport_install_script_url": "https://cdn.teleport.dev/install.sh"
     },
     "terraform": {


### PR DESCRIPTION
Reflect the 18.7.3 private security release. Ensure users installing Teleport via the docs receive the latest security updates.
