### PR TITLE
Add idp-initiated partial to Entra ID SSO guide

### DIFF
--- a/docs/pages/zero-trust-access/sso/integrate-idp/entra-id.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/entra-id.mdx
@@ -199,6 +199,8 @@ version: v2
 
 ```
 
+(!docs/pages/includes/sso/idp-initiated.mdx!)
+
 ### Test the connector
 
 With the connector in place on the cluster, you can test it with `tctl`:


### PR DESCRIPTION
Closes #64217

Add the `idp-initiated.mdx` partial to the Entra ID guide in the same location as it is in the Okta SAML guide.
