### PR TITLE
docs: update api docs

### DIFF
--- a/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
+++ b/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
@@ -68,7 +68,7 @@ Download the source code for our minimal API client:
 
 ```code
 $ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
-$ cd examples/service-discovery-api-client
+$ cd teleport/examples/service-discovery-api-client
 ```
 
 For the rest of this guide, we will show you how to set up this API client and
@@ -517,7 +517,7 @@ to join the resource to the cluster dynamically using a method similar to
 <summary>Registering applications dynamically</summary>
 
 To register applications dynamically, rather than start a new Application
-Service instance to proxy an application, use the `*clientClient.CreateApp`
+Service instance to proxy an application, use the `*client.Client.CreateApp`
 method:
 
 ```go

--- a/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
+++ b/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
@@ -517,7 +517,7 @@ to join the resource to the cluster dynamically using a method similar to
 <summary>Registering applications dynamically</summary>
 
 To register applications dynamically, rather than start a new Application
-Service instance to proxy an application, use the `*client.Client.CreateApp`
+Service instance to proxy an application, use the `(*client.Client).CreateApp`
 method:
 
 ```go

--- a/docs/pages/zero-trust-access/api/rbac.mdx
+++ b/docs/pages/zero-trust-access/api/rbac.mdx
@@ -814,7 +814,7 @@ servers registered with Teleport (`teleport.GetKubernetesServers`) and checks if
 there is a registered Kubernetes cluster that matches the one you specified.
 
 If a matching Kubernetes cluster exists, the code calls the
-`createTeleportRolesForKubeClusters` function we defined earlier. If not, the
+`createTeleportRolesForKubeCluster` function we defined earlier. If not, the
 program prints an error message and a stack trace by calling Go's built-in
 `panic` function.
 


### PR DESCRIPTION

Fixes to api docs:
- `cd` wouldn't work in if copying and pasting in automatically-register-agents doc
- fix to function reference `CreateApp` in automatically-register-agents doc
- fix to function name ``createTeleportRolesForKubeCluster` reference in rbac doc
