### PR TITLE
[v17] Bump unit test timeout from 20 to 30 minutes

### DIFF
--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -71,7 +71,7 @@ jobs:
         run: mount -t debugfs none /sys/kernel/debug/
 
       - name: Run tests
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: make -j"$(nproc)" test-go test-sh test-api
 
       - name: Upload test metrics


### PR DESCRIPTION
Backport #64780 to branch/v17