### PR TITLE
[v17] Moved Device Trust from Identity Governance to Zero Trust Access in Docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -670,7 +670,7 @@ tsh ssh node-that-requires-device-trust
 
     Linux users need read/write permissions to /dev/tpmrm0. The simplest way is
     to assign yourself to the `tss` group. See
-    https://goteleport.com/docs/access-controls/device-trust/device-management/#troubleshooting.
+    https://goteleport.com/docs/zero-trust-access/device-trust/device-management/#troubleshooting.
 
   - [ ] Verify device extensions on TLS certificate
 
@@ -708,7 +708,7 @@ tsh ssh node-that-requires-device-trust
 
     Confirm that it works by failing first. Most protocols can be tested using
     device_trust.mode="required". App Access and Desktop Access require a custom
-    role (see [enforcing device trust](https://goteleport.com/docs/access-controls/device-trust/enforcing-device-trust/#app-access-support)).
+    role (see [enforcing device trust](https://goteleport.com/docs/zero-trust-access/device-trust/enforcing-device-trust/#web-application-support)).
 
     For SSO users confirm that device web authentication happens successfully.
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -332,7 +332,12 @@
     },
     {
       "source": "/access-controls/device-trust/guide/",
-      "destination": "/identity-governance/device-trust/guide/",
+      "destination": "/zero-trust-access/device-trust/guide/",
+      "permanent": true
+    },
+    {
+      "source": "/identity-governance/device-trust/guide/",
+      "destination": "/zero-trust-access/device-trust/guide/",
       "permanent": true
     },
     {
@@ -562,27 +567,47 @@
     },
     {
       "source": "/admin-guides/access-controls/device-trust/device-management/",
-      "destination": "/identity-governance/device-trust/device-management/",
+      "destination": "/zero-trust-access/device-trust/device-management/",
+      "permanent": true
+    },
+    {
+      "source": "/identity-governance/device-trust/device-management/",
+      "destination": "/zero-trust-access/device-trust/device-management/",
       "permanent": true
     },
     {
       "source": "/admin-guides/access-controls/device-trust/",
-      "destination": "/identity-governance/device-trust/",
+      "destination": "/zero-trust-access/device-trust/",
+      "permanent": true
+    },
+    {
+      "source": "/identity-governance/device-trust/",
+      "destination": "/zero-trust-access/device-trust/",
       "permanent": true
     },
     {
       "source": "/admin-guides/access-controls/device-trust/enforcing-device-trust/",
-      "destination": "/identity-governance/device-trust/enforcing-device-trust/",
+      "destination": "/zero-trust-access/device-trust/enforcing-device-trust/",
+      "permanent": true
+    },
+    {
+      "source": "/identity-governance/device-trust/enforcing-device-trust/",
+      "destination": "/zero-trust-access/device-trust/enforcing-device-trust/",
       "permanent": true
     },
     {
       "source": "/admin-guides/access-controls/device-trust/guide/",
-      "destination": "/identity-governance/device-trust/guide/",
+      "destination": "/zero-trust-access/device-trust/guide/",
       "permanent": true
     },
     {
       "source": "/admin-guides/access-controls/device-trust/jamf-integration/",
-      "destination": "/identity-governance/device-trust/jamf-integration/",
+      "destination": "/zero-trust-access/device-trust/jamf-integration/",
+      "permanent": true
+    },
+    {
+      "source": "/identity-governance/device-trust/jamf-integration/",
+      "destination": "/zero-trust-access/device-trust/jamf-integration/",
       "permanent": true
     },
     {

--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -115,7 +115,7 @@ The Jamf Service integrates with Jamf to enrolls trusted devices for macOS endpo
 Before a user is granted access, Teleport checks the device's compliance status with Jamf. 
 This service is ideal for organizations that need to verify macOS device posture as part of 
 their access control strategy, ensuring only trusted devices are allowed to connect. 
-[Read more about the Jamf Service](./identity-governance/device-trust/jamf-integration.mdx).
+[Read more about the Jamf Service](./zero-trust-access/device-trust/jamf-integration.mdx).
 
 ### Teleport Debug Service
 

--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -18,12 +18,12 @@ HTML tag until we can support these requirements some other way.*/}
     to update this list whenever we change the organization of the tables.
   */
   table:nth-of-type(1) tbody tr:nth-of-type(1),
-  table:nth-of-type(1) tbody tr:nth-of-type(5),
   table:nth-of-type(1) tbody tr:nth-of-type(7),
-  table:nth-of-type(1) tbody tr:nth-of-type(14),
-  table:nth-of-type(1) tbody tr:nth-of-type(17),
-  table:nth-of-type(1) tbody tr:nth-of-type(25),
-  table:nth-of-type(1) tbody tr:nth-of-type(28),
+  table:nth-of-type(1) tbody tr:nth-of-type(9),
+  table:nth-of-type(1) tbody tr:nth-of-type(16),
+  table:nth-of-type(1) tbody tr:nth-of-type(19),
+  table:nth-of-type(1) tbody tr:nth-of-type(27),
+  table:nth-of-type(1) tbody tr:nth-of-type(30),
   table:nth-of-type(5) tbody tr:nth-of-type(1),
   table:nth-of-type(5) tbody tr:nth-of-type(9),
   table:nth-of-type(5) tbody tr:nth-of-type(19)
@@ -71,6 +71,7 @@ across distributed infrastructures.
 | [Single Sign-On](zero-trust-access/sso/sso.mdx)| GitHub, Google Workspace, Microsoft Entra ID, Okta, OIDC, SAML, Teleport | GitHub, Google Workspace, Microsoft Entra ID, Okta, OIDC, SAML, Teleport | GitHub |
 | User & Group Provisioning & Deprovisioning (SCIM & Custom Protocols), including Okta and Entra | Available In Teleport Identity Governance | Available In Teleport Identity Governance | ✖ |
 | [Hardware Private Key Support](zero-trust-access/access-controls/guides/hardware-key-support.mdx) (e.g., via YubiKey) | ✔ (External-connected HSM/KMS coming soon) | ✔ | ✖ |
+| [Device Trust](zero-trust-access/device-trust/guide.mdx): Require an up-to-date, registered device for each authentication. Teleport uses TPMs and secure enclaves to give every device a cryptographic identity. Restrict further by resource or MDM-authorization. | ✔ | ✔ | ✖ |
 | [Per-Session MFA](zero-trust-access/access-controls/guides/per-session-mfa.mdx)| ✔ | ✔ | ✔ |
 |**Resource identity.** Assign a cryptographic identity to every Teleport Protected Resource:||||
 | Protecting: [Applications](./enroll-resources/application-access/getting-started.mdx), [Databases](./enroll-resources/database-access/getting-started.mdx), [Kubernetes Clusters](./enroll-resources/kubernetes-access/getting-started.mdx), [Linux Servers](./enroll-resources/server-access/getting-started.mdx), [Windows Servers](./enroll-resources/desktop-access/introduction.mdx), [Windows Desktops](./enroll-resources/desktop-access/introduction.mdx), Cloud Consoles & Resources (AWS, Azure, GCP), [GitHub](zero-trust-access/management/guides/github-integration.mdx) | ✔ | ✔ | ✔ (does not include Oracle support) |
@@ -130,7 +131,6 @@ and non-human identities.
 | Automatic Access Requests & Approvals: Automate pre-defined workflows based on RBAC, ABAC, or context-based authorization. | ✔ | ✔ | ✖ |
 | [Access Lists & Access Reviews](identity-governance/access-lists/access-lists.mdx): Review access requests using Slack, PagerDuty, Microsoft Teams, Jira and ServiceNow. Assign managers, automate mandatory reviews, and implement custom review logic using our API and Go SDK. Integrates with AWS Identity Center. | ✔ | ✔ | ✖ |
 | [Session & Identity Locks](identity-governance/locking.mdx): Lock suspicious or compromised identities and stop all their activity across all protocols and services. | ✔ | ✔ | ✖ |
-| [Device Trust](identity-governance/device-trust/guide.mdx): Require an up-to-date, registered device for each authentication. Teleport uses TPMs and secure enclaves to give every device a cryptographic identity. Restrict further by resource or MDM-authorization. | ✔ | ✔ | ✖ |
 | User & Group Provisioning & Deprovisioning (SCIM & Custom Protocols), including Okta and Entra | ✔ | ✔ | ✖ |
 | [Access Monitoring & Response](identity-governance/access-monitoring.mdx): Detect overly broad privileges and inspect sessions that are not using strong protection, such as multi-factor authentication or device trust. Alert on access violations and purge unused permissions with automated access rules. | ✔ | ✔ | ✖ |
 | [Okta integration](identity-governance/okta/okta.mdx): Configure Teleport to import and grant access to Okta applications and user groups. | ✔ | ✔ | ✖ |

--- a/docs/pages/identity-governance/identity-gov-use-cases.mdx
+++ b/docs/pages/identity-governance/identity-gov-use-cases.mdx
@@ -45,11 +45,6 @@ You can receive Access Request notifications where your team already works, such
 Define membership-based access with owners, eligibility rules, and time-boxed enrollment. 
 Access Lists map groups to Teleport roles, require periodic reviews, and provide a clear record of who had access and why.
 
-## Device Trust
-
-[Enforce trusted registered device access](./device-trust/device-trust.mdx).
-Device identity can help block access from unknown or non-compliant workstations by policy.
-
 ## Session and Identity Locking
 
 [Lock compromised users and resources](./locking.mdx).

--- a/docs/pages/identity-governance/identity-governance.mdx
+++ b/docs/pages/identity-governance/identity-governance.mdx
@@ -46,12 +46,7 @@ import jamfProSvg from "@site/src/components/Icon/teleport-svg/jamf-pro.svg";
       title: "Manage standing access for teams",
       description: "Use Access Lists for group-based access",
       href: "./access-lists/",
-    },
-    {
-      title: "Require managed devices for access",
-      description: "Ensure users are using trusted devices",
-      href: "./device-trust/",
-    },  
+    }, 
     {
       title: "Monitor for risky access",
       description: "Identify risky access patterns and behaviors",
@@ -97,13 +92,6 @@ import jamfProSvg from "@site/src/components/Icon/teleport-svg/jamf-pro.svg";
       href: "./access-request-plugins/ssh-approval-jira/",
       iconColor: "#0078D41A",
       iconComponent: jiraSvg,
-    },
-    {
-      title: "Jamf Pro",
-      description: "Automatically sync your Jamf inventory with Teleport's trusted devices",
-      href: "./device-trust/jamf-integration/",
-      iconColor: "#788EB11A",
-      iconComponent: jamfProSvg,
     },
     {
       title: "PagerDuty",

--- a/docs/pages/identity-governance/locking.mdx
+++ b/docs/pages/identity-governance/locking.mdx
@@ -18,7 +18,7 @@ A lock can target the following objects or attributes:
 
 - a Teleport user by the user's name
 - a Teleport [RBAC](../reference/access-controls/roles.mdx) role by the role's name
-- a Teleport [trusted device](device-trust/enforcing-device-trust.mdx#locking-a-device) by the device ID
+- a Teleport [trusted device](../zero-trust-access/device-trust/enforcing-device-trust.mdx#locking-a-device) by the device ID
 - an MFA device by the device's UUID
 - an OS/UNIX login
 - a Teleport Agent by the Agent's server UUID (effectively unregistering it from the

--- a/docs/pages/identity-security/integrations/ssh-keys-scan.mdx
+++ b/docs/pages/identity-security/integrations/ssh-keys-scan.mdx
@@ -45,7 +45,7 @@ Teleport's `tsh` CLI tool can scan users' laptops for SSH private keys.
 It goes through the specified directories, defaulting to `/Users` on macOS, `/home` on Linux, and `C:\Users` on Windows,
 by peeking into files to identify SSH private keys.
 
-The `tsh` tool authenticates with the Teleport cluster through the [Device Trust](../../identity-governance/device-trust/device-trust.mdx) feature,
+The `tsh` tool authenticates with the Teleport cluster through the [Device Trust](../../zero-trust-access/device-trust/device-trust.mdx) feature,
 which guarantees that only enrolled devices can submit private keys to the cluster. By utilizing the device's Secure
 Enclave or TPM private key, it confirms that the device is the same one that was enrolled, enabling Teleport to trust
 and accept the private key reports without requiring further authentication or credentials thus allowing scanning operations
@@ -71,7 +71,7 @@ It also never sends the private key path or any other sensitive information.
 - A running Teleport Enterprise cluster v15.4.16/v16.2.0 or later.
 - Identity Security enabled for your account.
 - A Linux/macOS server running the Teleport SSH Service.
-- Devices enrolled in the [Teleport Device Trust feature](../../identity-governance/device-trust/device-trust.mdx).
+- Devices enrolled in the [Teleport Device Trust feature](../../zero-trust-access/device-trust/device-trust.mdx).
 - For Jamf Pro integration, devices must be enrolled in Jamf Pro and have the signed `tsh` binary installed.
 - For self-hosted clusters:
   - Ensure that an up-to-date `license.pem` is used in the Auth Service configuration.
@@ -109,7 +109,7 @@ and local users.
 
 ## Step 2/3. Scan for SSH private keys
 
-On devices enrolled in the Teleport, you can use the `tsh` CLI tool to scan for SSH private keys. Check [Device Trust](../../identity-governance/device-trust/device-trust.mdx)
+On devices enrolled in the Teleport, you can use the `tsh` CLI tool to scan for SSH private keys. Check [Device Trust](../../zero-trust-access/device-trust/device-trust.mdx)
 for details on how to enroll devices in Teleport, specially if you are using Jamf Pro.
 
 To scan for SSH private keys, run the following command from any enrolled device:
@@ -177,7 +177,7 @@ Below are a few example queries demonstrating how the `ssh_keys` view can be use
 ## Jamf Pro Integration
 
 If you are using Jamf Pro to manage your devices, you can integrate it with Teleport to automate the device enrollment
-process and periodically scan for SSH private keys. Check the [Jamf Pro Integration](../../identity-governance/device-trust/jamf-integration.mdx)
+process and periodically scan for SSH private keys. Check the [Jamf Pro Integration](../../zero-trust-access/device-trust/jamf-integration.mdx)
 page for details on how to set up the device enrollment and scanning process.
 
 On your Jamf Pro page navigate to Settings > Scripts and create a new script command that runs the `tsh scan keys` command
@@ -207,7 +207,7 @@ Cluster. The keys will be imported and displayed in the Access Graph.
 ### `"device not enrolled"` error
 
 If you see the `device not enrolled` error when running the `tsh scan keys` command, it means that the device is not enrolled
-in the Teleport Device Trust feature. Check the [Device Trust](../../identity-governance/device-trust/device-trust.mdx) page for details on how to enroll devices
+in the Teleport Device Trust feature. Check the [Device Trust](../../zero-trust-access/device-trust/device-trust.mdx) page for details on how to enroll devices
 in Teleport.
 
 ### `"binary missing signature or entitlements"` error

--- a/docs/pages/includes/access-control-guides.mdx
+++ b/docs/pages/includes/access-control-guides.mdx
@@ -8,6 +8,6 @@
 - [Locking](../identity-governance/locking.mdx): Lock access to active user sessions or hosts.
 - [Joining Sessions](../zero-trust-access/access-controls/guides/joining-sessions.mdx): Configure access to existing sessions.
 - [Hardware Key Support](../zero-trust-access/access-controls/guides/hardware-key-support.mdx): Enforce the use of hardware-based private keys.
-- [Device Trust](../identity-governance/device-trust/guide.mdx): Register and enforce trusted devices.
+- [Device Trust](../zero-trust-access/device-trust/guide.mdx): Register and enforce trusted devices.
 - [Headless WebAuthn](../zero-trust-access/access-controls/guides/headless.mdx): Login with Webauthn from a remote device.
 - [IP Pinning](../zero-trust-access/access-controls/guides/ip-pinning.mdx): Pin a user's certificates to a login IP address.

--- a/docs/pages/includes/device-trust/troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/troubleshooting.mdx
@@ -7,8 +7,8 @@ the problem.
 ### "unauthorized device" errors using a trusted device
 
 A trusted device needs to be registered and enrolled before it is recognized by
-Teleport as such. Follow the [registration](../../identity-governance/device-trust/device-management.mdx#register-a-trusted-device) and
-[enrollment](../../identity-governance/device-trust/device-management.mdx#enroll-a-trusted-device) steps
+Teleport as such. Follow the [registration](../../zero-trust-access/device-trust/device-management.mdx#register-a-trusted-device) and
+[enrollment](../../zero-trust-access/device-trust/device-management.mdx#enroll-a-trusted-device) steps
 and make sure to `tsh logout` and `tsh login` after enrollment is done.
 
 ### "Failed to open the TPM device" on Linux
@@ -49,7 +49,7 @@ Follow the instructions in the [Web UI troubleshooting section](
 #web-ui-fails-to-authenticate-trusted-device) below (Teleport v16 or later).
 
 Alternatively, you may use one of the tsh commands described by
-[App Access support](../../identity-governance/device-trust/enforcing-device-trust.mdx).
+[App Access support](../../zero-trust-access/device-trust/enforcing-device-trust.mdx).
 For example, for an app called `myapp`, run `tsh proxy app myapp -p 8888`, then
 open http://localhost:8888 in your browser.
 
@@ -69,7 +69,7 @@ The Web UI attempts to authenticate your device using Teleport Connect during
 login. If you are not asked to authenticate your device immediately after login,
 follow the steps below:
 
-1. Make sure your device is [registered and enrolled](../../identity-governance/device-trust/device-management.mdx#register-a-trusted-device)
+1. Make sure your device is [registered and enrolled](../../zero-trust-access/device-trust/device-management.mdx#register-a-trusted-device)
 2. Install [Teleport Connect](
    ../../connect-your-client/teleport-connect.mdx#installation--upgrade).
    Use the DEB or RPM packages on Linux (the tarball doesn't register the custom

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -144,6 +144,11 @@ import listBulletsSvg from "@site/src/components/Icon/teleport-svg/list-bullets.
           href: './zero-trust-access/access-controls/guides/passwordless/'
         },
         {
+          title: 'Require Managed Devices for Access',
+          description: 'Guarantee access only from trusted devices',
+          href: './zero-trust-access/device-trust/'
+        },
+        {
           title: 'Integrate with SSO Providers',
           description: 'Connect Okta, Entra ID, Google, and more',
           href: './zero-trust-access/sso/'
@@ -232,11 +237,6 @@ import listBulletsSvg from "@site/src/components/Icon/teleport-svg/list-bullets.
           title: 'Manage Standing Access for Teams',
           description: 'Sync IdP groups to roles w/ automated reviews',
           href: './identity-governance/okta/app-and-group-sync/'
-        },
-        {
-          title: 'Require Managed Devices for Access',
-          description: 'Guarantee access only from trusted devices',
-          href: './zero-trust-access/device-trust/'
         },
         {
           title: 'Instantly Lock Identities & Sessions',

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -236,7 +236,7 @@ import listBulletsSvg from "@site/src/components/Icon/teleport-svg/list-bullets.
         {
           title: 'Require Managed Devices for Access',
           description: 'Guarantee access only from trusted devices',
-          href: './identity-governance/device-trust/'
+          href: './zero-trust-access/device-trust/'
         },
         {
           title: 'Instantly Lock Identities & Sessions',
@@ -385,7 +385,7 @@ import listBulletsSvg from "@site/src/components/Icon/teleport-svg/list-bullets.
     },
     {
       title: 'Jamf Pro',
-      href: './identity-governance/device-trust/jamf-integration/',
+      href: './zero-trust-access/device-trust/jamf-integration/',
       iconColor: '#788EB11A',
       iconComponent: jamfProSvg,
     },

--- a/docs/pages/reference/architecture/device-trust.mdx
+++ b/docs/pages/reference/architecture/device-trust.mdx
@@ -3,7 +3,8 @@ title: Device Trust
 description: How Teleport Device Trust works.
 tags:
  - conceptual
- - identity-governance
+ - zero-trust
+ - resiliency
 ---
 
 Device Trust leverages the macOS Secure Enclave, or TPM 2.0 on Linux and Windows
@@ -50,8 +51,8 @@ web][blog-post] blog post describes the implementation challenges in detail.
 
 For practical use see the [Device Trust section][section].
 
-[auto-enrollment]: ../../identity-governance/device-trust/device-management.mdx#auto-enrollment
-[device enrollment tokens]: ../../identity-governance/device-trust/device-management.mdx#create-a-device-enrollment-token
-[device enforcement]: ../../identity-governance/device-trust/enforcing-device-trust.mdx
+[auto-enrollment]: ../../zero-trust-access/device-trust/device-management.mdx#auto-enrollment
+[device enrollment tokens]: ../../zero-trust-access/device-trust/device-management.mdx#create-a-device-enrollment-token
+[device enforcement]: ../../zero-trust-access/device-trust/enforcing-device-trust.mdx
 [blog-post]: https://goteleport.com/blog/device-trust-for-web-challenges-and-solutions/
-[section]: ../../identity-governance/device-trust/device-trust.mdx
+[section]: ../../zero-trust-access/device-trust/device-trust.mdx

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -147,7 +147,7 @@ Further reading:
   so you can configure Teleport to use a specific SSO authentication connector.
 - [Locking](../identity-governance/locking.mdx): Configuring the
   `locking_mode` option.
-- [Device Trust](../identity-governance/device-trust/device-trust.mdx): Configuring
+- [Device Trust](../zero-trust-access/device-trust/device-trust.mdx): Configuring
   the `device_trust` section.
 - [Recording Proxy Mode](architecture/session-recording.mdx): If you configure
   Recording Proxy Mode, consider enabling `proxy_checks_host_keys`.

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -29,7 +29,7 @@ The `teleport-kube-agent` chart can run any or all of three Teleport services:
 | [`application_service`](../../enroll-resources/application-access/guides/guides.mdx)              | `app`                                  | Uses Teleport to handle authentication<br/> with and proxy access to web-based applications  |
 | [`database_service`](../../enroll-resources/database-access/guides/guides.mdx)                    | `db`                                   | Uses Teleport to handle authentication<br/> with and proxy access to databases               |
 | [`discovery_service`](../../enroll-resources/auto-discovery/auto-discovery.mdx)              | `discovery`                            | Uses Teleport to discover new resources<br/> and dynamically add them to the cluster         |
-| [`jamf_service`](../../identity-governance/device-trust/jamf-integration.mdx) | `jamf`                                 | Uses Teleport to integrate with Jamf Pro<br/> and sync devices with Device Trust inventory   |
+| [`jamf_service`](../../zero-trust-access/device-trust/jamf-integration.mdx) | `jamf`                                 | Uses Teleport to integrate with Jamf Pro<br/> and sync devices with Device Trust inventory   |
 
 ### Kubernetes resources
 

--- a/docs/pages/reference/resources.mdx
+++ b/docs/pages/reference/resources.mdx
@@ -58,7 +58,7 @@ Here's the list of resources currently exposed via [`tctl`](./cli/tctl.mdx):
 | windows_desktop | A registered Windows desktop. |
 | cluster | A trusted cluster. See [here](../zero-trust-access/management/admin/trustedclusters.mdx) for more details on connecting clusters together. |
 | [login_rule](#login-rules) | A Login Rule, see the [Login Rules guide](../zero-trust-access/access-controls/login-rules/login-rules.mdx) for more info. |
-| [device](#device) | A Teleport Trusted Device, see the [Device Trust guide](../identity-governance/device-trust/guide.mdx) for more info. |
+| [device](#device) | A Teleport Trusted Device, see the [Device Trust guide](../zero-trust-access/device-trust/guide.mdx) for more info. |
 | [ui_config](#ui-config) | Configuration for the Web UI served by the Proxy Service. |
 | [vnet_config](#vnet-config) | Configuration for the cluster's VNet options. |
 | [cluster_auth_preference](#cluster-auth-preferences) | Configuration for the cluster's auth preferences. |

--- a/docs/pages/zero-trust-access/access-controls/access-controls.mdx
+++ b/docs/pages/zero-trust-access/access-controls/access-controls.mdx
@@ -11,7 +11,7 @@ policies for who can perform certain actions against specific resources. For
 example, you can allow analytics team members to SSH into a MongoDB read
 replica, but not the main database. You can also allow SREs to access a
 production server only when using a [trusted hardware
-device](../../identity-governance/device-trust/guide.mdx), or if approved by someone else from the same
+device](../device-trust/guide.mdx), or if approved by someone else from the same
 team.
 
 <DocCardList />

--- a/docs/pages/zero-trust-access/access-controls/guides/webauthn.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/webauthn.mdx
@@ -365,7 +365,7 @@ enrolls the user's device in their next Teleport (`tsh`) login.
 
 For auto-enrollment to work, the following conditions must be met:
 - A device must be registered. Registration may be [manual](#implement-cluster-wide-device-trust) or performed using an
-integration, like the [Jamf Pro integration](../../../identity-governance/device-trust/jamf-integration.mdx).
+integration, like the [Jamf Pro integration](../../../zero-trust-access/device-trust/jamf-integration.mdx).
 - Auto-enrollment must be enabled in the cluster setting.
 
 ### Step 1/2. Enable auto-enrollment in your cluster settings

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Self-Hosting Teleport
 sidebar_label: Self-Hosting
-sidebar_position: 5
+sidebar_position: 6
 description: "Guides to running a self-hosted Teleport cluster in production."
 tags:
  - platform-wide

--- a/docs/pages/zero-trust-access/device-trust/device-management.mdx
+++ b/docs/pages/zero-trust-access/device-trust/device-management.mdx
@@ -3,7 +3,9 @@ title: Manage Trusted Devices
 description: Learn how to manage Trusted Devices
 tags:
  - conceptual
- - identity-governance
+ - zero-trust
+ - resiliency
+enterprise: Device Trust
 ---
 
 This guide provides instructions for performing Device Trust management

--- a/docs/pages/zero-trust-access/device-trust/device-trust.mdx
+++ b/docs/pages/zero-trust-access/device-trust/device-trust.mdx
@@ -3,10 +3,12 @@ title: Device Trust
 description: Teleport Device Trust Concepts
 template: "no-toc"
 videoBanner: gBQyj_X1LVw
-sidebar_position: 5
+sidebar_position: 4
 tags:
  - conceptual
- - identity-governance
+ - zero-trust
+ - resiliency
+enterprise: Device Trust
 ---
 
 Device Trust allows Teleport admins to enforce the use of trusted devices.

--- a/docs/pages/zero-trust-access/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/zero-trust-access/device-trust/enforcing-device-trust.mdx
@@ -4,7 +4,9 @@ description: Learn how to enforce trusted devices with Teleport
 videoBanner: gBQyj_X1LVw
 tags:
  - conceptual
- - identity-governance
+ - zero-trust
+ - resiliency
+enterprise: Device Trust
 ---
 
 <Admonition type="note" title="Supported Resources">
@@ -51,8 +53,7 @@ instructions.
 Role-based configuration enforces trusted device access at the role level. It
 can be configured with the `spec.options.device_trust_mode` option and
 applies to the resources in its `allow` rules. It
-works similarly to [`require_session_mfa`](../../zero-trust-access/access-controls/guides/per-session-mfa.mdx).
-
+works similarly to [`require_session_mfa`](../access-controls/guides/per-session-mfa.mdx).
 To enforce authenticated device checks for a specific role when a user accesses
 databases, Kubernetes clusters, and servers with Teleport, update the role with
 the `device_trust_mode` field assigned to `"required"` or `"required-for-humans"`.
@@ -138,7 +139,7 @@ ERROR: ssh: rejected: administratively prohibited (unauthorized device)
 
 <Admonition type="tip" title="Trusted Clusters">
 It is possible to use [trusted
-clusters](../../zero-trust-access/management/admin/trustedclusters.mdx) to limit the impact of
+clusters](../management/admin/trustedclusters.mdx) to limit the impact of
 device mode `required`. A leaf cluster in mode `required` will enforce access to
 all of its resources, without imposing the same restrictions to the root
 cluster. Likewise, a root cluster will not enforce Device Trust on resources in
@@ -250,7 +251,7 @@ device.
 
 ## Locking a device
 
-Similar to [session and identity locking](../locking.mdx), a device can
+Similar to [session and identity locking](../../identity-governance/locking.mdx), a device can
 be locked using `tctl lock`.
 
 Locking blocks certificate issuance and ongoing or future accesses originating

--- a/docs/pages/zero-trust-access/device-trust/guide.mdx
+++ b/docs/pages/zero-trust-access/device-trust/guide.mdx
@@ -4,7 +4,9 @@ description: Get started with Teleport Device Trust
 videoBanner: gBQyj_X1LVw
 tags:
  - get-started
- - identity-governance
+ - zero-trust
+ - resiliency
+enterprise: Device Trust
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/zero-trust-access/device-trust/jamf-integration.mdx
+++ b/docs/pages/zero-trust-access/device-trust/jamf-integration.mdx
@@ -3,7 +3,9 @@ title: Jamf Pro Integration
 description: Sync your Jamf Pro inventory into Teleport
 tags:
  - how-to
- - identity-governance
+ - zero-trust
+ - resiliency
+enterprise: Device Trust
 ---
 
 Device Trust Jamf Pro integration lets you automatically sync your Jamf Pro computer

--- a/docs/pages/zero-trust-access/zero-trust-access.mdx
+++ b/docs/pages/zero-trust-access/zero-trust-access.mdx
@@ -186,6 +186,11 @@ import mcpAndAiSvg from "@site/src/components/Icon/teleport-svg/mcp-and-ai.svg";
       href: "./access-controls/guides/passwordless/",
     },
     {
+      title: "Device Trust",
+      description: "Enforce access only from trusted, registered devices",
+      href: "./device-trust/guide/",
+    },
+    {
       title: "Integrate with SSO providers",
       description: "Connect Okta, Entra ID, Google, and more",
       href: "./sso/",

--- a/web/packages/teleport/src/DeviceTrust/EmptyList.tsx
+++ b/web/packages/teleport/src/DeviceTrust/EmptyList.tsx
@@ -207,7 +207,7 @@ export const EmptyList = ({
               </ButtonPrimary>
               <ButtonSecondary
                 as="a"
-                href="https://goteleport.com/docs/admin-guides/access-controls/device-trust/jamf-integration/"
+                href="https://goteleport.com/docs/zero-trust-access/device-trust/jamf-integration/"
                 target="_blank"
                 width="280px"
                 size="large"

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -151,7 +151,7 @@ function DeviceTrustMessage(props: { status: DeviceTrustStatus }) {
           <P3>
             Full access requires a trusted device. Learn how to{' '}
             <Link
-              href="https://goteleport.com/docs/identity-governance/device-trust/device-management/#create-a-device-enrollment-token"
+              href="https://goteleport.com/docs/zero-trust-access/device-trust/device-management/#create-a-device-enrollment-token"
               target="_blank"
             >
               enroll your device


### PR DESCRIPTION
Moving device trust docs from Identity Governance to Zero Trust Access to reflect Teleport's current offerings.

Backports #63961 

## Manual Test Plan
### Test Environment
~~Copy changes over to `docs-website` repo and deploy local dev server.~~ To test web UI features, make sure the path is valid on the local dev server.

Edit: `docs-website` seems a little messy after I pulled from it recently. I tested this with the amplify deployment instead.

### Test Cases
- [x] Links under Device Trust point to valid pages (including `../`)
- [x] Links referring Device Trust sections work
- [x] Link paths to docs in the Teleport Web UI is valid