### PR TITLE
app: Fix ARN encoding in web launcher URL

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -29,8 +29,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -663,11 +663,20 @@ func makeAppRedirectURL(r *http.Request, proxyPublicAddr, addr string, req launc
 			urlPath = append(urlPath, req.clusterName, req.publicAddr)
 
 			if req.arn != "" {
-				urlPath = append(urlPath, req.arn)
+				urlPath = append(urlPath, url.PathEscape(req.arn))
 			}
 		}
 
-		u.Path = path.Join(urlPath...)
+		// Use strings.Join instead of path.Join to preserve
+		// percent-encoded segments like %2F in ARNs.
+		u.RawPath = "/" + strings.Join(urlPath, "/")
+		// Fall back to RawPath if PathUnescape fails, which can
+		// only happen if a non-ARN segment contains a bare percent.
+		var err error
+		u.Path, err = url.PathUnescape(u.RawPath)
+		if err != nil {
+			u.Path = u.RawPath
+		}
 
 	} else {
 		// Hitting this case means the user has hit an endpoint directly

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -663,20 +663,21 @@ func makeAppRedirectURL(r *http.Request, proxyPublicAddr, addr string, req launc
 			urlPath = append(urlPath, req.clusterName, req.publicAddr)
 
 			if req.arn != "" {
-				urlPath = append(urlPath, url.PathEscape(req.arn))
+				urlPath = append(urlPath, req.arn)
 			}
 		}
 
-		// Use strings.Join instead of path.Join to preserve
-		// percent-encoded segments like %2F in ARNs.
-		u.RawPath = "/" + strings.Join(urlPath, "/")
-		// Fall back to RawPath if PathUnescape fails, which can
-		// only happen if a non-ARN segment contains a bare percent.
-		var err error
-		u.Path, err = url.PathUnescape(u.RawPath)
-		if err != nil {
-			u.Path = u.RawPath
+		// Percent-encode every segment so that slashes in ARNs
+		// are not interpreted as path separators during URL
+		// serialization. Use strings.Join instead of path.Join
+		// to preserve the percent-encoded segments.
+		for i, s := range urlPath {
+			urlPath[i] = url.PathEscape(s)
 		}
+		u.RawPath = "/" + strings.Join(urlPath, "/")
+		// Error is unreachable: RawPath was built from
+		// PathEscape output above.
+		u.Path, _ = url.PathUnescape(u.RawPath)
 
 	} else {
 		// Hitting this case means the user has hit an endpoint directly

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -736,14 +736,16 @@ func TestMakeAppRedirectURL(t *testing.T) {
 			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost?path=&required-apps=&state=abc123",
 		},
 		{
+			// ARN inputs are decoded (matching the real flow through q.Get("arn")
+			// which URL-decodes query parameters).
 			name: "OK - with clusterId, publicAddr, and arn",
 			launderURLParams: launcherURLParams{
 				stateToken:  "abc123",
 				clusterName: "im-a-cluster-name",
 				publicAddr:  "grafana.localhost",
-				arn:         "arn:aws:iam::123456789012:role%2Frole-name",
+				arn:         "arn:aws:iam::123456789012:role/role-name",
 			},
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost/arn:aws:iam::123456789012:role%252Frole-name?path=&required-apps=&state=abc123",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost/arn:aws:iam::123456789012:role%2Frole-name?path=&required-apps=&state=abc123",
 		},
 		{
 			name: "OK - with clusterId, publicAddr, arn and path",
@@ -751,10 +753,10 @@ func TestMakeAppRedirectURL(t *testing.T) {
 				stateToken:  "abc123",
 				clusterName: "im-a-cluster-name",
 				publicAddr:  "grafana.localhost",
-				arn:         "arn:aws:iam::123456789012:role%2Frole-name",
+				arn:         "arn:aws:iam::123456789012:role/role-name",
 				path:        "/foo/bar?qux=qex",
 			},
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost/arn:aws:iam::123456789012:role%252Frole-name?path=%2Ffoo%2Fbar%3Fqux%3Dqex&required-apps=&state=abc123",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost/arn:aws:iam::123456789012:role%2Frole-name?path=%2Ffoo%2Fbar%3Fqux%3Dqex&required-apps=&state=abc123",
 		},
 		{
 			name: "OK - with clusterId, publicAddr, arn, path, and required-apps",
@@ -762,11 +764,31 @@ func TestMakeAppRedirectURL(t *testing.T) {
 				stateToken:       "abc123",
 				clusterName:      "im-a-cluster-name",
 				publicAddr:       "grafana.localhost",
-				arn:              "arn:aws:iam::123456789012:role%2Frole-name",
+				arn:              "arn:aws:iam::123456789012:role/role-name",
 				path:             "/foo/bar?qux=qex",
 				requiredAppFQDNs: "api.example.com,grafana.localhost",
 			},
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost/arn:aws:iam::123456789012:role%252Frole-name?path=%2Ffoo%2Fbar%3Fqux%3Dqex&required-apps=api.example.com%2Cgrafana.localhost&state=abc123",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost/arn:aws:iam::123456789012:role%2Frole-name?path=%2Ffoo%2Fbar%3Fqux%3Dqex&required-apps=api.example.com%2Cgrafana.localhost&state=abc123",
+		},
+		{
+			name: "OK - with ARN containing multi-level path",
+			launderURLParams: launcherURLParams{
+				stateToken:  "abc123",
+				clusterName: "im-a-cluster-name",
+				publicAddr:  "grafana.localhost",
+				arn:         "arn:aws:iam::123456789012:role/path/to/role-name",
+			},
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost/arn:aws:iam::123456789012:role%2Fpath%2Fto%2Frole-name?path=&required-apps=&state=abc123",
+		},
+		{
+			name: "OK - with ARN containing special characters",
+			launderURLParams: launcherURLParams{
+				stateToken:  "abc123",
+				clusterName: "im-a-cluster-name",
+				publicAddr:  "grafana.localhost",
+				arn:         "arn:aws:iam::123456789012:role/path+with=chars",
+			},
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost/im-a-cluster-name/grafana.localhost/arn:aws:iam::123456789012:role%2Fpath+with=chars?path=&required-apps=&state=abc123",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -16,11 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router';
 
 import { render, screen, waitFor } from 'design/utils/testing';
 
 import cfg from 'teleport/config';
+import { UrlLauncherParams } from 'teleport/config';
 import api from 'teleport/services/api';
 import service from 'teleport/services/apps';
 
@@ -44,16 +45,18 @@ const launcherPathTestCases: {
     expectedPath: 'x-teleport-auth?path=%2Ffoo%2Fbar',
   },
   {
-    name: 'no state with other path params (clusterId, publicAddr, publicArn',
-    path: '/some-cluster-id/some-public-addr/arn::123/name',
+    // The ARN is percent-encoded in the URL path so that the slash in
+    // "arn::123/name" does not split it into two path segments.
+    name: 'no state with other path params (clusterId, publicAddr, arn)',
+    path: '/some-cluster-id/some-public-addr/arn%3A%3A123%2Fname',
     expectedPath:
-      'x-teleport-auth?cluster=some-cluster-id&addr=some-public-addr&arn=arn%3A%3A123',
+      'x-teleport-auth?cluster=some-cluster-id&addr=some-public-addr&arn=arn%3A%3A123%2Fname',
   },
   {
     name: 'no state with path and with other path params',
-    path: '/some-cluster-id/some-public-addr/arn::123/name?path=%2Ffoo%2Fbar',
+    path: '/some-cluster-id/some-public-addr/arn%3A%3A123%2Fname?path=%2Ffoo%2Fbar',
     expectedPath:
-      'x-teleport-auth?path=%2Ffoo%2Fbar&cluster=some-cluster-id&addr=some-public-addr&arn=arn%3A%3A123',
+      'x-teleport-auth?path=%2Ffoo%2Fbar&cluster=some-cluster-id&addr=some-public-addr&arn=arn%3A%3A123%2Fname',
   },
   {
     name: 'with state',
@@ -129,12 +132,23 @@ const appSessionTestCases: {
   expectedArn: string;
 }[] = [
   {
+    // The ARN is percent-encoded in the URL path. React Router's
+    // useParams() auto-decodes the %2F back to /, so the ARN arrives
+    // fully decoded for createAppSession.
     name: 'ARN URL',
-    path: 'test-app.test.teleport/test.teleport/test-app.test.teleport/arn:aws:iam::joe123:role%2FEC2FullAccess?state=ABC',
+    path: 'test-app.test.teleport/test.teleport/test-app.test.teleport/arn%3Aaws%3Aiam%3A%3Ajoe123%3Arole%2FEC2FullAccess?state=ABC',
     returnedFqdn: 'test-app.test.teleport',
     expectedFqdn: 'test-app.test.teleport',
     expectedPublicAddr: 'test-app.test.teleport',
     expectedArn: 'arn:aws:iam::joe123:role/EC2FullAccess',
+  },
+  {
+    name: 'ARN URL with multi-level path',
+    path: 'test-app.test.teleport/test.teleport/test-app.test.teleport/arn%3Aaws%3Aiam%3A%3Ajoe123%3Arole%2Fpath%2Fto%2FEC2FullAccess?state=ABC',
+    returnedFqdn: 'test-app.test.teleport',
+    expectedFqdn: 'test-app.test.teleport',
+    expectedPublicAddr: 'test-app.test.teleport',
+    expectedArn: 'arn:aws:iam::joe123:role/path/to/EC2FullAccess',
   },
   {
     name: 'uppercase resolved FQDN',
@@ -356,5 +370,47 @@ describe('fqdn is matched', () => {
     await screen.findByText(/access denied/i);
     expect(screen.getByText(/Failed to parse URL:/i)).toBeInTheDocument();
     expect(windowLocation.replace).not.toHaveBeenCalled();
+  });
+});
+
+// Round-trip test: verifies that an ARN with slashes survives the full
+// cycle from URL generation through React Router matching and param
+// decoding.
+describe('ARN round-trips through URL generation and routing', () => {
+  function ArnCapture({ onArn }: { onArn: (arn: string) => void }) {
+    const params = useParams<UrlLauncherParams>();
+    const arn = params.arn ? decodeURIComponent(params.arn) : undefined;
+    if (arn) {
+      onArn(arn);
+    }
+    return <div>captured</div>;
+  }
+
+  test.each([
+    'arn:aws:iam::123456789012:role/my-role',
+    'arn:aws:iam::123456789012:role/path/to/my-role',
+    'arn:aws:iam::123456789012:role/path+with=chars',
+  ])('round-trips ARN: %s', async rawArn => {
+    const url = cfg.getAppLauncherRoute({
+      fqdn: 'app.example.com',
+      clusterId: 'cluster1',
+      publicAddr: 'app.example.com',
+      arn: rawArn,
+    });
+
+    let capturedArn: string | undefined;
+    render(
+      <MemoryRouter initialEntries={[url]}>
+        <Routes>
+          <Route
+            path={`${cfg.routes.appLauncher}/*`}
+            element={<ArnCapture onArn={arn => (capturedArn = arn)} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText('captured');
+    expect(capturedArn).toBe(rawArn);
   });
 });

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -20,8 +20,7 @@ import { MemoryRouter, Route, Routes, useParams } from 'react-router';
 
 import { render, screen, waitFor } from 'design/utils/testing';
 
-import cfg from 'teleport/config';
-import { UrlLauncherParams } from 'teleport/config';
+import cfg, { UrlLauncherParams } from 'teleport/config';
 import api from 'teleport/services/api';
 import service from 'teleport/services/apps';
 

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -131,6 +131,10 @@ export function AppLauncher({
         }
 
         // Continue the auth exchange.
+        // decodeURIComponent is redundant here: React Router's useParams()
+        // already decodes percent-encoded path segments (e.g. %2F → /),
+        // so params.arn contains the decoded ARN. Retained as defensive
+        // code in case a caller constructs the URL without encoding.
         if (params.arn) {
           params.arn = decodeURIComponent(params.arn);
         }

--- a/web/packages/teleport/src/config.test.ts
+++ b/web/packages/teleport/src/config.test.ts
@@ -135,6 +135,36 @@ test('getClusterEventsUrl does not corrupt startKey when start is set', () => {
   expect(url).not.toContain('00.000ZKey?');
 });
 
+test('getAppLauncherRoute encodes slash in AWS role ARN', () => {
+  const url = cfg.getAppLauncherRoute({
+    fqdn: 'app.example.com',
+    clusterId: 'cluster1',
+    publicAddr: 'app.example.com',
+    arn: 'arn:aws:iam::123456789012:role/my-role',
+  });
+  expect(url).toContain('role%2Fmy-role');
+  expect(url).not.toContain('role/my-role');
+});
+
+test('getAppLauncherRoute encodes multi-level ARN path', () => {
+  const url = cfg.getAppLauncherRoute({
+    fqdn: 'app.example.com',
+    clusterId: 'cluster1',
+    publicAddr: 'app.example.com',
+    arn: 'arn:aws:iam::123456789012:role/path/to/my-role',
+  });
+  expect(url).toContain('role%2Fpath%2Fto%2Fmy-role');
+});
+
+test('getAppLauncherRoute without ARN leaves route unchanged', () => {
+  const url = cfg.getAppLauncherRoute({
+    fqdn: 'app.example.com',
+    clusterId: 'cluster1',
+    publicAddr: 'app.example.com',
+  });
+  expect(url).toBe('/web/launch/app.example.com/cluster1/app.example.com');
+});
+
 test('getRoleUrl listv2 encodes query params', () => {
   expect(
     cfg.getRoleUrl({


### PR DESCRIPTION
When an AWS console app role ARN contains a `/` in the path component (e.g.
`arn:aws:iam::123:role/my-role`), the web launcher redirect truncates the ARN
at the slash.

The configured IAM role ARN must appear exactly in the session cert for the
access check to pass. When the cert carries a truncated value
(`arn:aws:iam::123:role` instead of `arn:aws:iam::123:role/my-role`), the app
service rejects the mismatch and the user gets "Not Found".

This is a regression from the react-router v7 upgrade
([PR gravitational/teleport#63496](https://github.com/gravitational/teleport/pull/63496)).

The app launcher route is `/web/launch/:fqdn/:clusterId?/:publicAddr?/:arn?`.
Both v5 and v7 encode `/` as `%2F` in `generatePath`. The difference is
`useParams()`: v5 (via path-to-regexp 1.9.0) returned the raw percent-encoded
value, while v7 (which dropped path-to-regexp) auto-decodes it. This changes
how the ARN travels through the auth exchange.

Confirmed by bisecting between the commit before the v7 upgrade (c75ea42d362)
and the upgrade commit itself (6298fe25b47). The `cert.create` audit event shows
the difference:

```
Before (v5): route_to_app:map[aws_role_arn:arn:aws:iam::123456789012:role/my-role ...]
After (v7):  route_to_app:map[aws_role_arn:arn:aws:iam::123456789012:role ...]
```
Percent-encode the ARN with `url.PathEscape` before appending it to the URL
path, and replace `path.Join` with `strings.Join` plus explicit `RawPath`/`Path`
setting so that `%2F` survives URL serialization.

<details><summary>react-router v5 vs v7 vs v7 with this fix</summary>

**v5 (react-router 5.3.4, path-to-regexp 1.9.0):**

1. **(JS)** `generatePath` encodes `/` → `%2F`. URL: `.../arn%3Aaws%3Aiam%3A%3A123%3Arole%2Fmy-role`
2. **(JS)** `useParams()` does NOT decode → `params.arn` = `arn%3Aaws%3Aiam%3A%3A123%3Arole%2Fmy-role` 🔑
3. **(JS)** `searchParams.set('arn', params.arn)` double-encodes → `arn=arn%253A...%252Fmy-role`
4. **(Go)** `q.Get("arn")` decodes one layer → `arn%3Aaws%3Aiam%3A%3A123%3Arole%2Fmy-role`
5. **(Go)** `path.Join` sees `%2F` as literal characters, not a slash → ARN stays as one segment ✅
6. **(Go)** Redirect URL path has `%2F` intact
7. **(JS)** Second trip: `:arn?` matches the whole thing because `%2F` is not a `/` ✅
8. **(JS)** `decodeURIComponent(params.arn)` → `arn:aws:iam::123:role/my-role`
9. **(JS)** `createAppSession` POSTs `arn: "arn:aws:iam::123:role/my-role"`
10. **(Go)** Auth server issues X.509 cert with `aws_role_arn = arn:aws:iam::123:role/my-role`
11. **(Go)** App service compares cert ARN against configured role → exact match, access granted ✅

**v7 broken (react-router 7.13.0, no path-to-regexp):**

1. **(JS)** `generatePath` encodes `/` → `%2F`. URL: same as v5
2. **(JS)** `useParams()` auto-decodes `%2F` → `params.arn` = `arn:aws:iam::123:role/my-role` (literal `/`) 💥
3. **(JS)** `searchParams.set('arn', params.arn)` single-encodes → `arn=arn%3A...role%2Fmy-role`
4. **(Go)** `q.Get("arn")` decodes → `arn:aws:iam::123:role/my-role` (literal `/`)
5. **(Go)** `path.Join` outputs path with literal `/` inside the ARN, indistinguishable from structural slashes
6. **(Go)** Redirect URL: `.../arn:aws:iam::123:role/my-role?state=TOKEN`
7. **(JS)** Second trip: `:arn?` matches `[^/]+`, captures only `arn:aws:iam::123:role`. `my-role` becomes a stray segment, discarded 💥
8. **(JS)** `decodeURIComponent` is a no-op on the already-truncated value
9. **(JS)** `createAppSession` POSTs `arn: "arn:aws:iam::123:role"`
10. **(Go)** Auth server issues X.509 cert with `aws_role_arn = arn:aws:iam::123:role`
11. **(Go)** App service compares cert ARN against configured role → mismatch, "Not Found" ❌

**v7 with this fix:**

1. **(JS)** `generatePath` encodes `/` → `%2F`. URL: same as above
2. **(JS)** `useParams()` auto-decodes `%2F` → `params.arn` = `arn:aws:iam::123:role/my-role` (literal `/`)
3. **(JS)** `searchParams.set('arn', params.arn)` single-encodes → `arn=arn%3A...role%2Fmy-role`
4. **(Go)** `q.Get("arn")` decodes → `arn:aws:iam::123:role/my-role` (literal `/`)
5. **(Go)** `url.PathEscape(req.arn)` re-encodes `/` → `%2F` 🔧
6. **(Go)** `strings.Join` preserves `%2F` as literal characters (replaces `path.Join`) 🔧
7. **(Go)** `u.RawPath` set with encoded value. `url.URL.String()` uses `RawPath` → `%2F` intact 🔧
8. **(JS)** Second trip: URL has `%2F` in path. `:arn?` matches the whole encoded segment. `useParams()` auto-decodes → full ARN ✅
9. **(JS)** `decodeURIComponent(params.arn)` is a no-op (already decoded)
10. **(JS)** `createAppSession` POSTs `arn: "arn:aws:iam::123:role/my-role"`
11. **(Go)** Auth server issues X.509 cert with `aws_role_arn = arn:aws:iam::123:role/my-role`
12. **(Go)** App service compares cert ARN against configured role → exact match, access granted ✅

</details>

Issue: https://github.com/gravitational/teleport/issues/64823

## Manual Test Plan

### Test Environment

Local Teleport instance with an AWS console app configured with an IAM
role whose ARN contains a path component
(`arn:aws:iam::<ACCOUNT>:role/<ROLE_NAME>`).

### Test Cases

- [x] Open the web UI, click the `awsconsole` app, select the role from
      the picker. The AWS console opens instead of "Not Found".
- [x] Same test in an incognito window (exercises the full auth exchange
      round-trip through `makeAppRedirectURL`).
- [x] CLI access: `tsh apps login awsconsole --aws-role <ARN>` followed
      by `tsh aws sts get-caller-identity` returns the assumed role.
- [x] Launch a non-AWS app from the web UI. No regression.