### PR TITLE
docs: add :443 port to Okta SSO ACS URL examples

### DIFF
--- a/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
@@ -108,13 +108,13 @@ Okta Integration Network support is still in beta. If unsure please proceed with
      - Single sign on URL:
 
        ```
-       https://<Var name="example.teleport.sh" />/v1/webapi/saml/acs/okta
+       https://<Var name="example.teleport.sh" />:443/v1/webapi/saml/acs/okta
        ```
 
      - Audience URI (SP Entity ID):
 
        ```
-       https://<Var name="example.teleport.sh" />/v1/webapi/saml/acs/okta
+       https://<Var name="example.teleport.sh" />:443/v1/webapi/saml/acs/okta
        ```
 
      - Name ID format `EmailAddress`


### PR DESCRIPTION
## Description

The Okta SSO setup guide instructs users to configure the ACS URL and Audience URI
without the `:443` port. However, `tctl sso configure saml --preset=okta` generates
a connector spec with `:443` included (via `proxy.GetPublicAddr()`). This mismatch
causes SAML validation to fail:

```
Unrecognized Destination value,
Expected: https://example.cloud.gravitational.io:443/v1/webapi/saml/acs/okta,
Actual: https://example.cloud.gravitational.io/v1/webapi/saml/acs/okta
```

## Changes

Added `:443` to both the **Single sign on URL** and **Audience URI** examples in the
Custom SAML 2.0 app (legacy) instructions, matching the `tctl`-generated output
shown later on the same page.

Fixes #64835