### PR TITLE
Add support for nested lists and tables in the markdown component

### DIFF
--- a/web/packages/shared/components/Markdown/Markdown.test.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.test.tsx
@@ -811,6 +811,24 @@ code here
       expect(items[0]).toHaveTextContent('Step');
       expect(items[1]).toHaveTextContent('Note');
     });
+
+    it('preserves explicit start number on ordered lists', () => {
+      const text = `3. Third
+4. Fourth
+5. Fifth`;
+
+      renderMarkdown(text);
+
+      const list = screen.getByRole('list');
+
+      expect(list.tagName).toBe('OL');
+      expect(list).toHaveAttribute('start', '3');
+
+      const items = screen.getAllByRole('listitem');
+
+      expect(items).toHaveLength(3);
+      expect(items[0]).toHaveTextContent('Third');
+    });
   });
 
   describe('edge cases', () => {

--- a/web/packages/shared/components/Markdown/Markdown.test.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.test.tsx
@@ -792,6 +792,25 @@ code here
       expect(screen.getByText('Some paragraph')).toBeInTheDocument();
       expect(screen.getByRole('listitem')).toHaveTextContent('First item');
     });
+
+    it('stops consuming items when marker type changes', () => {
+      const text = `1. Step
+- Note`;
+
+      renderMarkdown(text);
+
+      const lists = screen.getAllByRole('list');
+
+      expect(lists).toHaveLength(2);
+      expect(lists[0].tagName).toBe('OL');
+      expect(lists[1].tagName).toBe('UL');
+
+      const items = screen.getAllByRole('listitem');
+
+      expect(items).toHaveLength(2);
+      expect(items[0]).toHaveTextContent('Step');
+      expect(items[1]).toHaveTextContent('Note');
+    });
   });
 
   describe('edge cases', () => {

--- a/web/packages/shared/components/Markdown/Markdown.test.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.test.tsx
@@ -508,6 +508,111 @@ code here
     });
   });
 
+  describe('tables', () => {
+    it('renders a table with header', () => {
+      const text = `| Name | Age |
+| --- | --- |
+| Alice | 30 |
+| Bob | 25 |`;
+
+      renderMarkdown(text);
+
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+
+      const headers = screen.getAllByRole('columnheader');
+      expect(headers).toHaveLength(2);
+      expect(headers[0]).toHaveTextContent('Name');
+      expect(headers[1]).toHaveTextContent('Age');
+
+      const cells = screen.getAllByRole('cell');
+      expect(cells).toHaveLength(4);
+      expect(cells[0]).toHaveTextContent('Alice');
+      expect(cells[1]).toHaveTextContent('30');
+      expect(cells[2]).toHaveTextContent('Bob');
+      expect(cells[3]).toHaveTextContent('25');
+    });
+
+    it('renders a table without header separator as all data rows', () => {
+      const text = `| Alice | 30 |
+| Bob | 25 |`;
+
+      renderMarkdown(text);
+
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+
+      expect(screen.queryByRole('columnheader')).not.toBeInTheDocument();
+
+      const cells = screen.getAllByRole('cell');
+      expect(cells).toHaveLength(4);
+    });
+
+    it('renders inline formatting inside table cells', () => {
+      const text = `| Feature | Status |
+| --- | --- |
+| **Auth** | \`enabled\` |`;
+
+      renderMarkdown(text);
+
+      expect(screen.getByText('Auth').tagName).toBe('STRONG');
+      expect(screen.getByText('enabled').tagName).toBe('CODE');
+    });
+
+    it('handles paragraph ending at table', () => {
+      const text = `Some paragraph text
+| Col1 | Col2 |
+| --- | --- |
+| A | B |`;
+
+      renderMarkdown(text);
+
+      expect(screen.getByText('Some paragraph text')).toBeInTheDocument();
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    it('treats single pipe line as paragraph', () => {
+      renderMarkdown(`| just one line |`);
+
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+
+    it('applies column alignment from separator row', () => {
+      const text = `| Left | Center | Right |
+| :--- | :---: | ---: |
+| A | B | C |`;
+
+      renderMarkdown(text);
+
+      const headers = screen.getAllByRole('columnheader');
+      expect(headers[0]).not.toHaveStyle({ textAlign: 'center' });
+      expect(headers[1]).toHaveStyle({ textAlign: 'center' });
+      expect(headers[2]).toHaveStyle({ textAlign: 'right' });
+
+      const cells = screen.getAllByRole('cell');
+      expect(cells[1]).toHaveStyle({ textAlign: 'center' });
+      expect(cells[2]).toHaveStyle({ textAlign: 'right' });
+    });
+
+    it('handles escaped pipes in cells', () => {
+      const text = `| Name | Value |
+| --- | --- |
+| A\\|B | C |`;
+
+      renderMarkdown(text);
+
+      const cells = screen.getAllByRole('cell');
+      expect(cells[0]).toHaveTextContent('A|B');
+      expect(cells[1]).toHaveTextContent('C');
+    });
+
+    it('requires at least two cells to detect a table', () => {
+      renderMarkdown(`| single cell |`);
+
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
+
   describe('nested lists', () => {
     it('renders a nested list', () => {
       const text = `- Item 1

--- a/web/packages/shared/components/Markdown/Markdown.test.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.test.tsx
@@ -732,6 +732,45 @@ code here
 
       expect(nestedItem).toHaveTextContent('Nested child');
     });
+
+    it('keeps blank-line-separated children in the same nested list', () => {
+      const text = `- Parent
+  - A
+
+  - B`;
+
+      renderMarkdown(text);
+
+      const outerList = screen.getAllByRole('list')[0];
+      const outerItems = within(outerList).getAllByRole('listitem');
+
+      expect(outerItems[0]).toHaveTextContent('Parent');
+
+      const nestedList = within(outerItems[0]).getByRole('list');
+      const nestedItems = within(nestedList).getAllByRole('listitem');
+
+      expect(nestedItems).toHaveLength(2);
+      expect(nestedItems[0]).toHaveTextContent('A');
+      expect(nestedItems[1]).toHaveTextContent('B');
+    });
+
+    it('preserves fenced code blocks under a list item', () => {
+      const text = `- Run this
+  \`\`\`bash
+  tsh login
+  \`\`\``;
+
+      renderMarkdown(text);
+
+      expect(screen.getByRole('listitem')).toHaveTextContent('Run this');
+
+      const code = screen.getByText(
+        (_content, element) =>
+          element!.tagName === 'CODE' &&
+          element!.textContent!.includes('tsh login')
+      );
+      expect(code).toBeInTheDocument();
+    });
   });
 
   describe('ordered lists', () => {

--- a/web/packages/shared/components/Markdown/Markdown.test.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.test.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 
 import { render, userEvent } from 'design/utils/testing';
 
@@ -505,6 +505,187 @@ code here
           element.tagName === 'CODE' && element.textContent === 'code here'
       );
       expect(code).toBeInTheDocument();
+    });
+  });
+
+  describe('nested lists', () => {
+    it('renders a nested list', () => {
+      const text = `- Item 1
+  - Nested 1
+  - Nested 2
+- Item 2`;
+
+      renderMarkdown(text);
+
+      const outerList = screen.getAllByRole('list')[0];
+      const outerItems = within(outerList).getAllByRole('listitem');
+
+      expect(outerItems[0]).toHaveTextContent('Item 1');
+
+      const nestedList = within(outerItems[0]).getByRole('list');
+      const nestedItems = within(nestedList).getAllByRole('listitem');
+
+      expect(nestedItems).toHaveLength(2);
+      expect(nestedItems[0]).toHaveTextContent('Nested 1');
+      expect(nestedItems[1]).toHaveTextContent('Nested 2');
+
+      expect(outerItems[3]).toHaveTextContent('Item 2');
+      expect(within(outerItems[3]).queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    it('renders deeply nested lists', () => {
+      const text = `- Level 1
+  - Level 2
+    - Level 3`;
+
+      renderMarkdown(text);
+
+      const outerList = screen.getAllByRole('list')[0];
+      const level1Item = within(outerList).getAllByRole('listitem')[0];
+
+      expect(level1Item).toHaveTextContent('Level 1');
+
+      const midList = within(level1Item).getAllByRole('list')[0];
+      const level2Item = within(midList).getAllByRole('listitem')[0];
+
+      expect(level2Item).toHaveTextContent('Level 2');
+
+      const innerList = within(level2Item).getAllByRole('list')[0];
+      const level3Item = within(innerList).getAllByRole('listitem')[0];
+
+      expect(level3Item).toHaveTextContent('Level 3');
+    });
+
+    it('renders nested list with inline formatting', () => {
+      const text = `- **Bold item**
+  - \`code item\``;
+
+      renderMarkdown(text);
+
+      const outerItem = screen.getAllByRole('listitem')[0];
+      const nestedList = within(outerItem).getByRole('list');
+
+      expect(screen.getByText('Bold item').tagName).toBe('STRONG');
+      expect(within(nestedList).getByText('code item').tagName).toBe('CODE');
+    });
+
+    it('handles multiple nested groups', () => {
+      const text = `- A
+  - A1
+  - A2
+- B
+  - B1`;
+
+      renderMarkdown(text);
+
+      const outerList = screen.getAllByRole('list')[0];
+      const outerItems = within(outerList).getAllByRole('listitem');
+
+      const aNestedList = within(outerItems[0]).getByRole('list');
+      const aNestedItems = within(aNestedList).getAllByRole('listitem');
+
+      expect(aNestedItems).toHaveLength(2);
+      expect(aNestedItems[0]).toHaveTextContent('A1');
+      expect(aNestedItems[1]).toHaveTextContent('A2');
+
+      const bNestedList = within(outerItems[3]).getByRole('list');
+      const bNestedItems = within(bNestedList).getAllByRole('listitem');
+
+      expect(bNestedItems).toHaveLength(1);
+      expect(bNestedItems[0]).toHaveTextContent('B1');
+    });
+
+    it('collects multi-line list items', () => {
+      const text = `- First item that
+  continues on next line
+- Second item`;
+
+      renderMarkdown(text);
+
+      const items = screen.getAllByRole('listitem');
+
+      expect(items).toHaveLength(2);
+      expect(items[0]).toHaveTextContent(
+        'First item that continues on next line'
+      );
+      expect(items[1]).toHaveTextContent('Second item');
+    });
+
+    it('handles blank lines between parent and nested children', () => {
+      const text = `- Parent
+
+  - Nested child`;
+
+      renderMarkdown(text);
+
+      const outerItem = screen.getAllByRole('listitem')[0];
+
+      expect(outerItem).toHaveTextContent('Parent');
+
+      const nestedList = within(outerItem).getByRole('list');
+      const nestedItem = within(nestedList).getByRole('listitem');
+
+      expect(nestedItem).toHaveTextContent('Nested child');
+    });
+  });
+
+  describe('ordered lists', () => {
+    it('renders an ordered list', () => {
+      const text = `1. First
+2. Second
+3. Third`;
+
+      renderMarkdown(text);
+
+      const list = screen.getByRole('list');
+
+      expect(list.tagName).toBe('OL');
+
+      const items = screen.getAllByRole('listitem');
+
+      expect(items).toHaveLength(3);
+      expect(items[0]).toHaveTextContent('First');
+      expect(items[1]).toHaveTextContent('Second');
+      expect(items[2]).toHaveTextContent('Third');
+    });
+
+    it('renders ordered list with inline formatting', () => {
+      const text = `1. **Bold** item
+2. Item with \`code\``;
+
+      renderMarkdown(text);
+
+      expect(screen.getByText('Bold').tagName).toBe('STRONG');
+      expect(screen.getByText('code').tagName).toBe('CODE');
+    });
+
+    it('renders nested ordered list inside unordered', () => {
+      const text = `- Item
+  1. Sub one
+  2. Sub two`;
+
+      renderMarkdown(text);
+
+      const outerItem = screen.getAllByRole('listitem')[0];
+      const nestedList = within(outerItem).getByRole('list');
+
+      expect(nestedList.tagName).toBe('OL');
+
+      const nestedItems = within(nestedList).getAllByRole('listitem');
+
+      expect(nestedItems).toHaveLength(2);
+      expect(nestedItems[0]).toHaveTextContent('Sub one');
+      expect(nestedItems[1]).toHaveTextContent('Sub two');
+    });
+
+    it('handles paragraph ending at ordered list', () => {
+      const text = `Some paragraph
+1. First item`;
+
+      renderMarkdown(text);
+
+      expect(screen.getByText('Some paragraph')).toBeInTheDocument();
+      expect(screen.getByRole('listitem')).toHaveTextContent('First item');
     });
   });
 

--- a/web/packages/shared/components/Markdown/Markdown.test.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.test.tsx
@@ -784,6 +784,7 @@ code here
       const list = screen.getByRole('list');
 
       expect(list.tagName).toBe('OL');
+      expect(list).toHaveAttribute('start', '1');
 
       const items = screen.getAllByRole('listitem');
 

--- a/web/packages/shared/components/Markdown/Markdown.test.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.test.tsx
@@ -611,6 +611,27 @@ code here
 
       expect(screen.queryByRole('table')).not.toBeInTheDocument();
     });
+
+    it('caps the number of columns', () => {
+      const headerRow = `|${' h |'.repeat(500)}`;
+      const separatorRow = `|${' --- |'.repeat(500)}`;
+      const dataRow = `|${' c |'.repeat(500)}`;
+      renderMarkdown(`${headerRow}\n${separatorRow}\n${dataRow}`);
+
+      expect(screen.getAllByRole('columnheader')).toHaveLength(100);
+      expect(screen.getAllByRole('cell')).toHaveLength(100);
+    });
+
+    it('caps the number of rows', () => {
+      const header = `| h1 | h2 |\n| --- | --- |`;
+      const dataRow = `| a | b |`;
+      const text = `${header}\n${Array(5000).fill(dataRow).join('\n')}`;
+
+      renderMarkdown(text);
+
+      // MAX_TABLE_ROWS caps total collected lines (header + separator + data).
+      expect(screen.getAllByRole('row')).toHaveLength(999);
+    });
   });
 
   describe('nested lists', () => {

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -231,14 +231,21 @@ function parseRow(row: string) {
     .map(cell => cell.trim().replace(/\\\|/g, '|'));
 }
 
+const MAX_LIST_DEPTH = 10;
+
 function parseListItems(
   activeParsers: MarkdownParser[],
   lines: string[],
   startIndex: number,
   baseIndent: number,
   listType: ListType,
-  isRoot = false
+  isRoot = false,
+  depth = 0
 ): { node: ReactNode; endIndex: number } {
+  if (depth >= MAX_LIST_DEPTH) {
+    return { node: null, endIndex: startIndex };
+  }
+
   const listItems: ReactNode[] = [];
   let i = startIndex;
 
@@ -306,7 +313,9 @@ function parseListItems(
           lines,
           i,
           nextIndent,
-          nextType
+          nextType,
+          false,
+          depth + 1
         );
 
         nestedList = nested.node;

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -345,7 +345,13 @@ function processMarkdown(text: string, options: MarkdownOptions): ReactNode[] {
         const [, hashes, content] = headerMatch;
         const level = hashes.length;
 
-        items.push(createElement(`h${level}`, { key: i }, content.trim()));
+        items.push(
+          createElement(
+            `h${level}`,
+            { key: i },
+            ...parseLine(activeParsers, content.trim())
+          )
+        );
 
         i += 1;
 

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -252,6 +252,15 @@ function parseListItems(
   let i = startIndex;
 
   while (i < lines.length) {
+    // Skip blank lines between sibling list items so that
+    // blank-line-separated children stay in the same nested list.
+    while (i < lines.length && lines[i].trim() === '') {
+      i += 1;
+    }
+    if (i >= lines.length) {
+      break;
+    }
+
     const raw = lines[i];
     const trimmed = raw.trimStart();
 
@@ -287,6 +296,7 @@ function parseListItems(
       if (
         nextTrimmed === '' ||
         isListItem(nextTrimmed) ||
+        fencedCodeRegex.test(nextTrimmed) ||
         nextIndent <= baseIndent
       ) {
         // If the next line is blank, a new list item, or less indented than the base,

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -227,9 +227,12 @@ function parseRow(row: string) {
   return row
     .replace(/^\|/, '')
     .replace(/\|$/, '')
-    .split(/(?<!\\)\|/)
+    .split(/(?<!\\)\|/, MAX_TABLE_COLUMNS)
     .map(cell => cell.trim().replace(/\\\|/g, '|'));
 }
+
+const MAX_TABLE_COLUMNS = 100;
+const MAX_TABLE_ROWS = 1000;
 
 const MAX_LIST_DEPTH = 10;
 
@@ -282,6 +285,7 @@ function parseListItems(
     i += 1;
 
     const contentParts = [content];
+    const contentStartI = i;
     while (i < lines.length) {
       const next = lines[i];
       const nextTrimmed = next.trimStart();
@@ -300,6 +304,10 @@ function parseListItems(
 
       contentParts.push(nextTrimmed);
       i += 1;
+
+      if (i - contentStartI > MAX_ITERATIONS) {
+        break;
+      }
     }
 
     const fullContent = contentParts.join(' ');
@@ -308,7 +316,11 @@ function parseListItems(
     let nestedList: ReactNode = null;
     let blankSkip = 0;
 
-    while (i + blankSkip < lines.length && lines[i + blankSkip].trim() === '') {
+    while (
+      i + blankSkip < lines.length &&
+      lines[i + blankSkip].trim() === '' &&
+      blankSkip <= MAX_ITERATIONS
+    ) {
       blankSkip += 1;
     }
 
@@ -547,7 +559,9 @@ function processMarkdown(text: string, options: MarkdownOptions): ReactNode[] {
       const startI = i;
 
       while (i < lines.length && tableRowRegex.test(lines[i].trim())) {
-        tableLines.push(lines[i].trim());
+        if (tableLines.length < MAX_TABLE_ROWS) {
+          tableLines.push(lines[i].trim());
+        }
         i += 1;
 
         if (i - startI > MAX_ITERATIONS) {

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -253,7 +253,8 @@ function parseListItems(
     const raw = lines[i];
     const trimmed = raw.trimStart();
 
-    if (!isListItem(trimmed)) {
+    const itemType = isListItem(trimmed);
+    if (!itemType || itemType !== listType) {
       break;
     }
 

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -239,7 +239,6 @@ function parseListItems(
   startIndex: number,
   baseIndent: number,
   listType: ListType,
-  isRoot = false,
   depth = 0
 ): { node: ReactNode; endIndex: number } {
   if (depth >= MAX_LIST_DEPTH) {
@@ -252,16 +251,13 @@ function parseListItems(
   let i = startIndex;
 
   while (i < lines.length) {
-    // Skip blank lines between sibling list items so that
-    // blank-line-separated children stay in the same nested list.
-    while (i < lines.length && lines[i].trim() === '') {
+    const raw = lines[i];
+
+    if (raw.trim() === '') {
       i += 1;
-    }
-    if (i >= lines.length) {
-      break;
+      continue;
     }
 
-    const raw = lines[i];
     const trimmed = raw.trimStart();
 
     const itemType = isListItem(trimmed);
@@ -277,9 +273,7 @@ function parseListItems(
     // Capture the start number from the first ordered list item.
     if (listType === 'ol' && startNumber === undefined) {
       const num = parseInt(trimmed, 10);
-      if (num !== 1) {
-        startNumber = num;
-      }
+      startNumber = num;
     }
 
     const content = getItemContent(trimmed);
@@ -335,7 +329,6 @@ function parseListItems(
           i,
           nextIndent,
           nextType,
-          false,
           depth + 1
         );
 
@@ -359,11 +352,11 @@ function parseListItems(
   const key = `list-${startIndex}`;
   const node =
     listType === 'ol' ? (
-      <StyledOl key={key} root={isRoot} start={startNumber}>
+      <StyledOl key={key} root={depth === 0} start={startNumber}>
         {listItems}
       </StyledOl>
     ) : (
-      <StyledUl key={key} root={isRoot}>
+      <StyledUl key={key} root={depth === 0}>
         {listItems}
       </StyledUl>
     );
@@ -450,8 +443,7 @@ function processMarkdown(text: string, options: MarkdownOptions): ReactNode[] {
         lines,
         i,
         baseIndent,
-        listType,
-        true
+        listType
       );
 
       items.push(result.node);
@@ -568,11 +560,7 @@ function processMarkdown(text: string, options: MarkdownOptions): ReactNode[] {
         const hasHeader = tableSeparatorRegex.test(tableLines[1]);
         const headerCells = hasHeader ? parseRow(tableLines[0]) : [];
         const alignments = hasHeader
-          ? tableLines[1]
-              .replace(/^\|/, '')
-              .replace(/\|$/, '')
-              .split(/(?<!\\)\|/)
-              .map(getAlignment)
+          ? parseRow(tableLines[1]).map(getAlignment)
           : [];
         const dataRows = tableLines
           .slice(hasHeader ? 2 : 0)

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -254,6 +254,10 @@ function parseListItems(
   let i = startIndex;
 
   while (i < lines.length) {
+    if (i - startIndex > MAX_ITERATIONS) {
+      break;
+    }
+
     const raw = lines[i];
 
     if (raw.trim() === '') {
@@ -355,10 +359,6 @@ function parseListItems(
         {nestedList}
       </li>
     );
-
-    if (i - startIndex > MAX_ITERATIONS) {
-      break;
-    }
   }
 
   const key = `list-${startIndex}`;

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -247,6 +247,8 @@ function parseListItems(
   }
 
   const listItems: ReactNode[] = [];
+
+  let startNumber: number | undefined;
   let i = startIndex;
 
   while (i < lines.length) {
@@ -261,6 +263,14 @@ function parseListItems(
     const indent = raw.length - trimmed.length;
     if (indent < baseIndent) {
       break;
+    }
+
+    // Capture the start number from the first ordered list item.
+    if (listType === 'ol' && startNumber === undefined) {
+      const num = parseInt(trimmed, 10);
+      if (num !== 1) {
+        startNumber = num;
+      }
     }
 
     const content = getItemContent(trimmed);
@@ -339,7 +349,7 @@ function parseListItems(
   const key = `list-${startIndex}`;
   const node =
     listType === 'ol' ? (
-      <StyledOl key={key} root={isRoot}>
+      <StyledOl key={key} root={isRoot} start={startNumber}>
         {listItems}
       </StyledOl>
     ) : (

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -64,6 +64,16 @@ const StyledLink = styled.a`
   text-transform: none;
 `;
 
+const StyledUl = styled.ul<{ root?: boolean }>`
+  padding-left: ${p => p.theme.space[3]}px;
+  margin-bottom: ${p => (p.root ? `${p.theme.space[3]}px` : '0')};
+`;
+
+const StyledOl = styled.ol<{ root?: boolean }>`
+  padding-left: ${p => p.theme.space[3]}px;
+  margin-bottom: ${p => (p.root ? `${p.theme.space[3]}px` : '0')};
+`;
+
 const parsers: MarkdownParser[] = [
   {
     pattern: /\*\*(?<content>[^*]+?)\*\*/,
@@ -143,8 +153,146 @@ function parseLine(activeParsers: MarkdownParser[], line: string): ReactNode[] {
   return items;
 }
 
+type ListType = 'ul' | 'ol';
+
+function isListItem(trimmed: string): ListType | null {
+  if (trimmed.startsWith('- ')) {
+    return 'ul';
+  }
+
+  if (orderedItemRegex.test(trimmed)) {
+    return 'ol';
+  }
+
+  return null;
+}
+
+function getItemContent(trimmed: string) {
+  if (trimmed.startsWith('- ')) {
+    return trimmed.substring(2);
+  }
+
+  const match = trimmed.match(orderedItemRegex);
+  if (match) {
+    return trimmed.substring(match[0].length);
+  }
+
+  return trimmed;
+}
+
+function parseListItems(
+  activeParsers: MarkdownParser[],
+  lines: string[],
+  startIndex: number,
+  baseIndent: number,
+  listType: ListType,
+  isRoot = false
+): { node: ReactNode; endIndex: number } {
+  const listItems: ReactNode[] = [];
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const raw = lines[i];
+    const trimmed = raw.trimStart();
+
+    if (!isListItem(trimmed)) {
+      break;
+    }
+
+    const indent = raw.length - trimmed.length;
+    if (indent < baseIndent) {
+      break;
+    }
+
+    const content = getItemContent(trimmed);
+    const itemKey = i;
+
+    i += 1;
+
+    const contentParts = [content];
+    while (i < lines.length) {
+      const next = lines[i];
+      const nextTrimmed = next.trimStart();
+      const nextIndent = next.length - nextTrimmed.length;
+
+      if (
+        nextTrimmed === '' ||
+        isListItem(nextTrimmed) ||
+        nextIndent <= baseIndent
+      ) {
+        // If the next line is blank, a new list item, or less indented than the base,
+        // it's not part of the current item's content.
+        break;
+      }
+
+      contentParts.push(nextTrimmed);
+      i += 1;
+    }
+
+    const fullContent = contentParts.join(' ');
+
+    // Skip blank lines before checking for nested items.
+    let nestedList: ReactNode = null;
+    let blankSkip = 0;
+
+    while (i + blankSkip < lines.length && lines[i + blankSkip].trim() === '') {
+      blankSkip += 1;
+    }
+
+    // Check for nested list items after the current item, allowing for blank lines in between.
+    if (i + blankSkip < lines.length) {
+      const nextRaw = lines[i + blankSkip];
+      const nextTrimmed = nextRaw.trimStart();
+      const nextIndent = nextRaw.length - nextTrimmed.length;
+      const nextType = isListItem(nextTrimmed);
+
+      if (nextType && nextIndent > baseIndent) {
+        // If we find a nested list item, parse it and attach it to the current item.
+        i += blankSkip;
+
+        const nested = parseListItems(
+          activeParsers,
+          lines,
+          i,
+          nextIndent,
+          nextType
+        );
+
+        nestedList = nested.node;
+        i = nested.endIndex;
+      }
+    }
+
+    listItems.push(
+      <li key={itemKey}>
+        {parseLine(activeParsers, fullContent)}
+        {nestedList}
+      </li>
+    );
+
+    if (i - startIndex > MAX_ITERATIONS) {
+      break;
+    }
+  }
+
+  const key = `list-${startIndex}`;
+  const node =
+    listType === 'ol' ? (
+      <StyledOl key={key} root={isRoot}>
+        {listItems}
+      </StyledOl>
+    ) : (
+      <StyledUl key={key} root={isRoot}>
+        {listItems}
+      </StyledUl>
+    );
+
+  return { node, endIndex: i };
+}
+
 const headerRegex = /^(?<hashes>#{1,6})\s*(?<content>.*)$/;
 const fencedCodeRegex = /^```(\w*)\s*$/;
+const orderedItemRegex = /^\d+\.\s/;
 
 const MAX_ITERATIONS = 10000;
 const MAX_DEPTH = 16;
@@ -205,30 +353,20 @@ function processMarkdown(text: string, options: MarkdownOptions): ReactNode[] {
       }
     }
 
-    if (line.trimStart().startsWith('- ')) {
-      const listItems: ReactNode[] = [];
-      const startI = i;
+    const listType = isListItem(line);
+    if (listType) {
+      const baseIndent = lines[i].length - lines[i].trimStart().length;
+      const result = parseListItems(
+        activeParsers,
+        lines,
+        i,
+        baseIndent,
+        listType,
+        true
+      );
 
-      while (i < lines.length && lines[i].trimStart().startsWith('- ')) {
-        const firstDashIndex = lines[i].indexOf('- ');
-
-        listItems.push(
-          <li key={i}>
-            {parseLine(
-              activeParsers,
-              lines[i].substring(firstDashIndex + 2).trim()
-            )}
-          </li>
-        );
-
-        i += 1;
-
-        if (i - startI > MAX_ITERATIONS) {
-          break;
-        }
-      }
-
-      items.push(<ul key={i}>{listItems}</ul>);
+      items.push(result.node);
+      i = result.endIndex;
 
       continue;
     }
@@ -328,11 +466,14 @@ function processMarkdown(text: string, options: MarkdownOptions): ReactNode[] {
     while (i < lines.length && lines[i].trim() !== '') {
       const currentLine = lines[i];
 
+      const trimmedLine = currentLine.trim();
+
       if (
-        headerRegex.test(currentLine.trim()) ||
-        currentLine.trim().startsWith('- ') ||
-        fencedCodeRegex.test(currentLine.trim()) ||
-        currentLine.trim().startsWith('<details')
+        headerRegex.test(trimmedLine) ||
+        isListItem(trimmedLine) ||
+        fencedCodeRegex.test(trimmedLine) ||
+        tableRowRegex.test(trimmedLine) ||
+        trimmedLine.startsWith('<details')
       ) {
         break;
       }

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -64,6 +64,36 @@ const StyledLink = styled.a`
   text-transform: none;
 `;
 
+const StyledTable = styled.table`
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid ${p => p.theme.colors.spotBackground[2]};
+  border-radius: ${p => p.theme.radii[2]}px;
+  margin: ${p => p.theme.space[2]}px 0;
+  overflow: hidden;
+
+  th,
+  td {
+    border-bottom: 1px solid ${p => p.theme.colors.spotBackground[2]};
+    border-right: 1px solid ${p => p.theme.colors.spotBackground[2]};
+    padding: ${p => p.theme.space[1]}px ${p => p.theme.space[2]}px;
+    text-align: left;
+  }
+
+  th:last-child,
+  td:last-child {
+    border-right: none;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+
+  th {
+    background: ${p => p.theme.colors.spotBackground[1]};
+  }
+`;
+
 const StyledUl = styled.ul<{ root?: boolean }>`
   padding-left: ${p => p.theme.space[3]}px;
   margin-bottom: ${p => (p.root ? `${p.theme.space[3]}px` : '0')};
@@ -180,6 +210,27 @@ function getItemContent(trimmed: string) {
   return trimmed;
 }
 
+function getAlignment(sep: string): 'left' | 'center' | 'right' {
+  const t = sep.trim();
+  if (t.startsWith(':') && t.endsWith(':')) {
+    return 'center';
+  }
+
+  if (t.endsWith(':')) {
+    return 'right';
+  }
+
+  return 'left';
+}
+
+function parseRow(row: string) {
+  return row
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split(/(?<!\\)\|/)
+    .map(cell => cell.trim().replace(/\\\|/g, '|'));
+}
+
 function parseListItems(
   activeParsers: MarkdownParser[],
   lines: string[],
@@ -293,6 +344,8 @@ function parseListItems(
 const headerRegex = /^(?<hashes>#{1,6})\s*(?<content>.*)$/;
 const fencedCodeRegex = /^```(\w*)\s*$/;
 const orderedItemRegex = /^\d+\.\s/;
+const tableRowRegex = /^\|([^|]*\|){2,}$/;
+const tableSeparatorRegex = /^\|([\s:]*-+[\s:]*\|)+$/;
 
 const MAX_ITERATIONS = 10000;
 const MAX_DEPTH = 16;
@@ -462,6 +515,85 @@ function processMarkdown(text: string, options: MarkdownOptions): ReactNode[] {
           <Markdown text={content.join('\n')} {...options} />
         </Section>
       );
+
+      continue;
+    }
+
+    // Tables: | col1 | col2 |
+    if (tableRowRegex.test(line)) {
+      const tableLines: string[] = [];
+      const startI = i;
+
+      while (i < lines.length && tableRowRegex.test(lines[i].trim())) {
+        tableLines.push(lines[i].trim());
+        i += 1;
+
+        if (i - startI > MAX_ITERATIONS) {
+          break;
+        }
+      }
+
+      // We need at least 2 lines for a valid table (header + separator)
+      if (tableLines.length >= 2) {
+        const hasHeader = tableSeparatorRegex.test(tableLines[1]);
+        const headerCells = hasHeader ? parseRow(tableLines[0]) : [];
+        const alignments = hasHeader
+          ? tableLines[1]
+              .replace(/^\|/, '')
+              .replace(/\|$/, '')
+              .split(/(?<!\\)\|/)
+              .map(getAlignment)
+          : [];
+        const dataRows = tableLines
+          .slice(hasHeader ? 2 : 0)
+          .map(row => parseRow(row));
+
+        items.push(
+          <StyledTable key={`table-${startI}`}>
+            {hasHeader && (
+              <thead>
+                <tr>
+                  {headerCells.map((cell, ci) => (
+                    <th
+                      key={ci}
+                      style={
+                        alignments[ci] && alignments[ci] !== 'left'
+                          ? { textAlign: alignments[ci] }
+                          : undefined
+                      }
+                    >
+                      {parseLine(activeParsers, cell)}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+            )}
+            <tbody>
+              {dataRows.map((row, ri) => (
+                <tr key={ri}>
+                  {row.map((cell, ci) => (
+                    <td
+                      key={ci}
+                      style={
+                        alignments[ci] && alignments[ci] !== 'left'
+                          ? { textAlign: alignments[ci] }
+                          : undefined
+                      }
+                    >
+                      {parseLine(activeParsers, cell)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </StyledTable>
+        );
+      } else {
+        // Single line starting with |, treat as paragraph.
+        items.push(
+          <p key={`p-${startI}`}>{parseLine(activeParsers, tableLines[0])}</p>
+        );
+      }
 
       continue;
     }


### PR DESCRIPTION
This adds nested list and table support to the markdown component, and fixes an issue with header contents not parsing the markdown inside them

Before
<img width="954" height="588" alt="image" src="https://github.com/user-attachments/assets/a0716497-7b50-4666-a0c8-65c31750356a" />

<img width="938" height="678" alt="image" src="https://github.com/user-attachments/assets/296084d7-1543-4c54-bf98-a52170f5420d" />

After

<img width="339" height="328" alt="image" src="https://github.com/user-attachments/assets/99f3ba9a-2ad9-4fb4-98df-f0e125e3f607" />

<img width="346" height="796" alt="image" src="https://github.com/user-attachments/assets/6b4062f6-76aa-498f-89da-6c4a18c6402d" />

Changelog: Rendered markdown content now supports nested lists and tables

## Manual Test Plan
### Test Environment

Local, UI changes only

### Test Cases
- [x] Verified nested lists show correctly
- [x] Verified tables show correctly
