### PR TITLE
Fix a "no roles configured" error in access requests UI for kube clusters

### DIFF
--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -2424,12 +2424,7 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 		return roles, nil
 	}
 
-	origRolesLength := len(roles)
 	roles, mappedRequestedRolesToAllowedKinds := m.pruneRequestedRolesNotMatchingKubernetesResourceKinds(requestedResourceAccessIDs, roles)
-	var kubeRelatedError error
-	if len(roles) < origRolesLength {
-		kubeRelatedError = getInvalidKubeKindAccessRequestsError(mappedRequestedRolesToAllowedKinds, false /* requestedRoles */)
-	}
 	if len(roles) == 0 { // all roles got pruned from not matching every kube requested kind.
 		return nil, getInvalidKubeKindAccessRequestsError(mappedRequestedRolesToAllowedKinds, false /* requestedRoles */)
 	}
@@ -2462,6 +2457,8 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 		return nil, trace.Wrap(err)
 	}
 
+	noRoleAllowingRequestedKubeResource := false
+	hasKubeResourceKindRestrictions := len(mappedRequestedRolesToAllowedKinds) > 0
 	necessaryRoles := make(map[string]struct{})
 	for _, resource := range underlyingResources {
 		var constraints *types.ResourceConstraints
@@ -2536,25 +2533,38 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 			// requested login and will include it.
 			rolesForResource = fewestLogins(rolesForResource)
 		}
+
+		if hasKubeResourceKindRestrictions && len(rolesForResource) == 0 {
+			kind := resource.GetKind()
+			if kind == types.KindKubernetesCluster ||
+				slices.Contains(types.KubernetesResourcesKinds, kind) {
+				noRoleAllowingRequestedKubeResource = true
+			}
+		}
 		for _, role := range rolesForResource {
 			necessaryRoles[role.GetName()] = struct{}{}
 		}
 	}
 
 	if len(necessaryRoles) == 0 {
+		// If a kube resource was requested but no role allows it, return a specific kube
+		// error rather than a generic "no access" error. The kube error may point to an
+		// easy fix (e.g. the request is missing a required namespace), so surfacing it
+		// first gives the user actionable guidance even when non-kube resources were also
+		// requested and similarly unmatched.
+		if noRoleAllowingRequestedKubeResource {
+			return nil, getInvalidKubeKindAccessRequestsError(mappedRequestedRolesToAllowedKinds, false /* requestedRoles */)
+		}
 		resourcesStr, err := types.ResourceIDsToString(requestedResourceIDs)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return nil, trace.NewAggregate(
-			trace.BadParameter(
-				`no roles configured in the "search_as_roles" for this user allow `+
-					`access to any requested resources. The user may already have `+
-					`access to all requested resources with their existing roles. `+
-					`resources: %s roles: %v login: %q`,
-				resourcesStr, roles, loginHint),
-			kubeRelatedError,
-		)
+		return nil, trace.BadParameter(
+			`no roles configured in the "search_as_roles" for this user allow `+
+				`access to any requested resources. The user may already have `+
+				`access to all requested resources with their existing roles. `+
+				`resources: %s roles: %v login: %q`,
+			resourcesStr, roles, loginHint)
 	}
 	prunedRoles := make([]string, 0, len(necessaryRoles))
 	for role := range necessaryRoles {

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -2424,9 +2424,9 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 		return roles, nil
 	}
 
-	roles, mappedRequestedRolesToAllowedKinds := m.pruneRequestedRolesNotMatchingKubernetesResourceKinds(requestedResourceAccessIDs, roles)
+	roles, mappedRequestedRolesToAllowedKubeKinds := m.pruneRequestedRolesNotMatchingKubernetesResourceKinds(requestedResourceAccessIDs, roles)
 	if len(roles) == 0 { // all roles got pruned from not matching every kube requested kind.
-		return nil, getInvalidKubeKindAccessRequestsError(mappedRequestedRolesToAllowedKinds, false /* requestedRoles */)
+		return nil, getInvalidKubeKindAccessRequestsError(mappedRequestedRolesToAllowedKubeKinds, false /* requestedRoles */)
 	}
 
 	clusterNameResource, err := m.getter.GetClusterName(ctx)
@@ -2458,7 +2458,7 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 	}
 
 	noRoleAllowingRequestedKubeResource := false
-	hasKubeResourceKindRestrictions := len(mappedRequestedRolesToAllowedKinds) > 0
+	hasKubeResourceKindRestrictions := len(mappedRequestedRolesToAllowedKubeKinds) > 0
 	necessaryRoles := make(map[string]struct{})
 	for _, resource := range underlyingResources {
 		var constraints *types.ResourceConstraints
@@ -2553,7 +2553,7 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 		// first gives the user actionable guidance even when non-kube resources were also
 		// requested and similarly unmatched.
 		if noRoleAllowingRequestedKubeResource {
-			return nil, getInvalidKubeKindAccessRequestsError(mappedRequestedRolesToAllowedKinds, false /* requestedRoles */)
+			return nil, getInvalidKubeKindAccessRequestsError(mappedRequestedRolesToAllowedKubeKinds, false /* requestedRoles */)
 		}
 		resourcesStr, err := types.ResourceIDsToString(requestedResourceIDs)
 		if err != nil {

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -2424,7 +2424,12 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 		return roles, nil
 	}
 
+	origRolesLength := len(roles)
 	roles, mappedRequestedRolesToAllowedKinds := m.pruneRequestedRolesNotMatchingKubernetesResourceKinds(requestedResourceAccessIDs, roles)
+	var kubeRelatedError error
+	if len(roles) < origRolesLength {
+		kubeRelatedError = getInvalidKubeKindAccessRequestsError(mappedRequestedRolesToAllowedKinds, false /* requestedRoles */)
+	}
 	if len(roles) == 0 { // all roles got pruned from not matching every kube requested kind.
 		return nil, getInvalidKubeKindAccessRequestsError(mappedRequestedRolesToAllowedKinds, false /* requestedRoles */)
 	}
@@ -2541,12 +2546,15 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return nil, trace.BadParameter(
-			`no roles configured in the "search_as_roles" for this user allow `+
-				`access to any requested resources. The user may already have `+
-				`access to all requested resources with their existing roles. `+
-				`resources: %s roles: %v login: %q`,
-			resourcesStr, roles, loginHint)
+		return nil, trace.NewAggregate(
+			trace.BadParameter(
+				`no roles configured in the "search_as_roles" for this user allow `+
+					`access to any requested resources. The user may already have `+
+					`access to all requested resources with their existing roles. `+
+					`resources: %s roles: %v login: %q`,
+				resourcesStr, roles, loginHint),
+			kubeRelatedError,
+		)
 	}
 	prunedRoles := make([]string, 0, len(necessaryRoles))
 	for role := range necessaryRoles {

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -3618,7 +3618,7 @@ func TestValidate_WithAllowRequestKubernetesResources_LegacyRequestFormat(t *tes
 			},
 			// db-access-wildcard and kube-no-access shouldn't be in the list, but a leaf is present
 			// which skips matcher tests.
-			expectedRequestRoles: []string{"v7-kube-access-namespace", "v7-kube-db-access-wildcard", "v7-kube-no-access"},
+			expectedRequestRoles: []string{"v7-kube-access-namespace", "v7-kube-db-access-wildcard", "v7-empty-access"},
 			requestResourceIDs: []types.ResourceID{
 				{Kind: types.KindKubeNamespace, ClusterName: myClusterName, Name: "kube", SubResourceName: "namespace"},
 				{Kind: types.KindKubeNamespace, ClusterName: myClusterName, Name: "kube", SubResourceName: "namespace2"},
@@ -3634,7 +3634,7 @@ func TestValidate_WithAllowRequestKubernetesResources_LegacyRequestFormat(t *tes
 			},
 			// db-access-wildcard and kube-no-access shouldn't be in the list, but a leaf is present
 			// which skips matcher tests.
-			expectedRequestRoles: []string{"v8-kube-access-namespace", "v8-kube-db-access-wildcard", "v8-kube-no-access"},
+			expectedRequestRoles: []string{"v8-kube-access-namespace", "v8-kube-db-access-wildcard", "v8-empty-access"},
 			requestResourceIDs: []types.ResourceID{
 				{Kind: types.KindKubeNamespace, ClusterName: myClusterName, Name: "kube", SubResourceName: "namespace"},
 				{Kind: types.KindKubeNamespace, ClusterName: myClusterName, Name: "kube", SubResourceName: "namespace2"},
@@ -4315,7 +4315,7 @@ func TestValidate_WithAllowRequestKubernetesResource(t *testing.T) {
 			},
 			// db-access-wildcard and kube-no-access shouldn't be in the list, but a leaf is present
 			// which skips matcher tests.
-			expectedRequestRoles: []string{"v7-kube-access-namespace", "v7-kube-db-access-wildcard", "v7-kube-no-access"},
+			expectedRequestRoles: []string{"v7-kube-access-namespace", "v7-kube-db-access-wildcard", "v7-empty-access"},
 			requestResourceIDs: []types.ResourceID{
 				{Kind: "kube:cw:namespaces", ClusterName: myClusterName, Name: "kube", SubResourceName: "namespace"},
 				{Kind: "kube:cw:namespaces", ClusterName: myClusterName, Name: "kube", SubResourceName: "namespace2"},
@@ -4331,7 +4331,7 @@ func TestValidate_WithAllowRequestKubernetesResource(t *testing.T) {
 			},
 			// db-access-wildcard and kube-no-access shouldn't be in the list, but a leaf is present
 			// which skips matcher tests.
-			expectedRequestRoles: []string{"v8-kube-access-namespace", "v8-kube-db-access-wildcard", "v8-kube-no-access"},
+			expectedRequestRoles: []string{"v8-kube-access-namespace", "v8-kube-db-access-wildcard", "v8-empty-access"},
 			requestResourceIDs: []types.ResourceID{
 				{Kind: "kube:cw:namespaces", ClusterName: myClusterName, Name: "kube", SubResourceName: "namespace"},
 				{Kind: "kube:cw:namespaces", ClusterName: myClusterName, Name: "kube", SubResourceName: "namespace2"},
@@ -4622,25 +4622,25 @@ func TestValidate_WithAllowRequestKubernetesResource(t *testing.T) {
 			desc: "v7 reject when requested role does not allow all requested kind and there is an unrelated requested role",
 			userStaticRoles: []string{
 				"v7-kube-request-namespace_search-namespace",
-				"v7-kube-request-no-access",
+				"v7-request-empty-access",
 			},
 			requestResourceIDs: []types.ResourceID{
 				{Kind: types.KindKubernetesCluster, ClusterName: myClusterName, Name: "kube"},
 			},
 			wantInvalidRequestKindErr: true,
-			wantNoRolesConfiguredErr:  true,
+			wantNoRolesConfiguredErr:  false,
 		},
 		{
 			desc: "v8 reject when requested role does not allow all requested kind and there is an unrelated requested role",
 			userStaticRoles: []string{
 				"v8-kube-request-namespace_search-namespace",
-				"v8-kube-request-no-access",
+				"v8-request-empty-access",
 			},
 			requestResourceIDs: []types.ResourceID{
 				{Kind: types.KindKubernetesCluster, ClusterName: myClusterName, Name: "kube"},
 			},
 			wantInvalidRequestKindErr: true,
-			wantNoRolesConfiguredErr:  true,
+			wantNoRolesConfiguredErr:  false,
 		},
 	}
 	for _, tc := range testCases {

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -4617,6 +4617,31 @@ func TestValidate_WithAllowRequestKubernetesResource(t *testing.T) {
 			},
 			wantInvalidRequestKindErr: true,
 		},
+
+		{
+			desc: "v7 reject when requested role does not allow all requested kind and there is an unrelated requested role",
+			userStaticRoles: []string{
+				"v7-kube-request-namespace_search-namespace",
+				"v7-kube-request-no-access",
+			},
+			requestResourceIDs: []types.ResourceID{
+				{Kind: types.KindKubernetesCluster, ClusterName: myClusterName, Name: "kube"},
+			},
+			wantInvalidRequestKindErr: true,
+			wantNoRolesConfiguredErr:  true,
+		},
+		{
+			desc: "v8 reject when requested role does not allow all requested kind and there is an unrelated requested role",
+			userStaticRoles: []string{
+				"v8-kube-request-namespace_search-namespace",
+				"v8-kube-request-no-access",
+			},
+			requestResourceIDs: []types.ResourceID{
+				{Kind: types.KindKubernetesCluster, ClusterName: myClusterName, Name: "kube"},
+			},
+			wantInvalidRequestKindErr: true,
+			wantNoRolesConfiguredErr:  true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -4635,15 +4660,21 @@ func TestValidate_WithAllowRequestKubernetesResource(t *testing.T) {
 
 			// Execute the validation.
 			err = validator.validate(t.Context(), req, tlsca.Identity{Expires: clock.Now().UTC().Add(8 * time.Hour)})
-			if tc.wantInvalidRequestKindErr {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), InvalidKubernetesKindAccessRequest)
-			} else if tc.wantNoRolesConfiguredErr {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), `no roles configured in the "search_as_roles"`)
-			} else {
+			if !tc.wantInvalidRequestKindErr && !tc.wantNoRolesConfiguredErr {
 				require.NoError(t, err)
 				require.ElementsMatch(t, tc.expectedRequestRoles, req.GetRoles())
+			} else {
+				require.Error(t, err)
+				if tc.wantInvalidRequestKindErr {
+					require.Contains(t, err.Error(), InvalidKubernetesKindAccessRequest)
+				} else {
+					require.NotContains(t, err.Error(), InvalidKubernetesKindAccessRequest)
+				}
+				if tc.wantNoRolesConfiguredErr {
+					require.Contains(t, err.Error(), `no roles configured in the "search_as_roles"`)
+				} else {
+					require.NotContains(t, err.Error(), `no roles configured in the "search_as_roles"`)
+				}
 			}
 		})
 	}

--- a/lib/services/testdata/roles/v7_kube_accessrequest_validate.yaml
+++ b/lib/services/testdata/roles/v7_kube_accessrequest_validate.yaml
@@ -20,7 +20,7 @@ spec:
 kind: role
 version: v7
 metadata:
-  name: v7-kube-no-access
+  name: v7-empty-access
 spec:
   allow: {}
   deny: {}
@@ -199,7 +199,7 @@ spec:
     request:
       search_as_roles:
       - v7-kube-db-access-wildcard
-      - v7-kube-no-access
+      - v7-empty-access
       kubernetes_resources:
       - kind: 'namespace'
   deny: {}
@@ -254,10 +254,10 @@ spec:
 kind: role
 version: v7
 metadata:
-  name: v7-kube-request-no-access
+  name: v7-request-empty-access
 spec:
   allow:
     request:
       search_as_roles:
-      - v7-kube-no-access
+      - v7-empty-access
   deny: {}

--- a/lib/services/testdata/roles/v7_kube_accessrequest_validate.yaml
+++ b/lib/services/testdata/roles/v7_kube_accessrequest_validate.yaml
@@ -250,3 +250,14 @@ spec:
     request:
       kubernetes_resources:
       - kind: '*'
+---
+kind: role
+version: v7
+metadata:
+  name: v7-kube-request-no-access
+spec:
+  allow:
+    request:
+      search_as_roles:
+      - v7-kube-no-access
+  deny: {}

--- a/lib/services/testdata/roles/v8_kube_accessrequest_validate.yaml
+++ b/lib/services/testdata/roles/v8_kube_accessrequest_validate.yaml
@@ -21,7 +21,7 @@ spec:
 kind: role
 version: v8
 metadata:
-  name: v8-kube-no-access
+  name: v8-empty-access
 spec:
   allow: {}
   deny: {}
@@ -217,7 +217,7 @@ spec:
     request:
       search_as_roles:
       - v8-kube-db-access-wildcard
-      - v8-kube-no-access
+      - v8-empty-access
       kubernetes_resources:
       - kind: 'namespaces'
         api_group: ''
@@ -279,10 +279,10 @@ spec:
 kind: role
 version: v8
 metadata:
-  name: v8-kube-request-no-access
+  name: v8-request-empty-access
 spec:
   allow:
     request:
       search_as_roles:
-      - v8-kube-no-access
+      - v8-empty-access
   deny: {}

--- a/lib/services/testdata/roles/v8_kube_accessrequest_validate.yaml
+++ b/lib/services/testdata/roles/v8_kube_accessrequest_validate.yaml
@@ -275,3 +275,14 @@ spec:
       kubernetes_resources:
       - kind: '*'
         api_group: '*'
+---
+kind: role
+version: v8
+metadata:
+  name: v8-kube-request-no-access
+spec:
+  allow:
+    request:
+      search_as_roles:
+      - v8-kube-no-access
+  deny: {}


### PR DESCRIPTION
Changelog: Fixed a misleading "no roles configured..." error message when requesting access to Kubernetes resources

~~This fix is not really one I'd like to see here, but it's a cheap way of addressing this problem immediately. A more robust fix would be to refrain from using errors altogether for this purpose and return structured response from the server. The current solution relies on increasingly brittle client-side parsing of English language.~~

Edit: An inaccurate "no roles configured" surfaced when user requested a kube cluster when their roles restrict request to a specific kube resource (e.g. `namespace`). So their role IS configured just the user needed to select a kube cluster `namespace`. This happens when user is assigned a role that restricts kube resource kinds, and another role without any configuration (which defaults to "allow all kube kinds") as demonstrated in this issue #57903

This PR determines if `no roles matched` is partly b/c of a kube kind restriction and surfaces this error first to give user a more accurate actionable step to fix (e.g. select `namespace`) before attempting request again.

This also fixes the issue outlined in issue #57903 where now the web UI will only render the kube related error if user clicks on `request` button without selecting required kube resource.

Fixes #57903

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

cloud staging

### Test Cases
With a user with same roles assigned as instructed #57903:

- [x] requesting access to something you already have access to renders a "no roles configured..." error
- [x] clicking request for a kubernetes cluster without a namespace selection renders a kube specific error telling user they need to select namespace. the web UI does not render this error on initial fetch, only when user clicks on `request access button`
- [x] success requesting kube resource after selecting a namespace