### PR TITLE
[v18] Fix newline rendering in access request comments

### DIFF
--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -470,7 +470,7 @@ function Comment({
         <Text typography="body3">{createdDuration}</Text>
       </Flex>
       {comment && (
-        <Box p={3} bg="levels.elevated">
+        <Box p={3} bg="levels.elevated" css="white-space: pre-wrap;">
           {comment}
         </Box>
       )}

--- a/web/packages/shared/components/AccessRequests/fixtures/index.ts
+++ b/web/packages/shared/components/AccessRequests/fixtures/index.ts
@@ -64,9 +64,9 @@ export const requestSearchPending: AccessRequest = {
   sessionTTLDuration: '',
   roles: ['test'],
   requestReason:
-    'Testing long message format. I am requesting access for the developer role that i will be using to \
-        commit fixes for our production application. I will need access for the \
-        rest of the day to complete my changes.',
+    'Testing long message format with multi-line text.\n\nI am requesting access for the developer role that i will be using to \
+commit fixes for our production application.\n\nI will need access for the \
+rest of the day to complete my changes.',
   resolveReason: '',
   reviews: [],
   reviewers: [
@@ -174,9 +174,9 @@ export const requestRolePending: AccessRequest = {
   sessionTTLDuration: '',
   roles: ['admin'],
   requestReason:
-    'Testing long message format. I am requesting access for the developer role that i will be using to \
-        commit fixes for our production application. I will need access for the \
-        rest of the day to complete my changes.',
+    'Testing long message format with multi-line text.\n\nI am requesting access for the developer role that i will be using to \
+commit fixes for our production application.\n\nI will need access for the \
+rest of the day to complete my changes.',
   resolveReason: '',
   reviews: [],
   reviewers: [


### PR DESCRIPTION
Backport of #64753.

Cherry-pick was clean, no conflicts.

Changelog: Fixed access request comments and review reasons not preserving newlines when rendered.

## Manual Test Plan
### Test Environment
- Storybook (local)
- Story: Shared/AccessRequests/RequestView/LoadedRolePending

### Test Cases
- [x] Multi-line request reason renders with preserved newlines, paragraph breaks, and numbered lists
- [x] Multi-line review comment renders with preserved newlines, bullet points, and paragraph breaks
- [x] Long single-line text still wraps normally (no horizontal overflow)
- [x] Existing unit tests pass (RequestView.test.tsx — 2/2)
