### PR TITLE
[vnet] Support diag checks on Linux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -472,6 +472,7 @@ require (
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d // indirect
+	github.com/jsimonetti/rtnetlink v1.4.2 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -176,6 +176,7 @@ require (
 	github.com/johannesboyne/gofakes3 v0.0.0-20250916175020-ebf3e50324d3
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531
+	github.com/jsimonetti/rtnetlink/v2 v2.0.1
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0 // replaced
 	github.com/keys-pub/go-libfido2 v1.5.3-0.20220306005615-8ab03fb1ec27 // replaced
@@ -472,7 +473,6 @@ require (
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d // indirect
-	github.com/jsimonetti/rtnetlink v1.4.2 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1718,8 +1718,6 @@ github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531 h1:hgVxRoDDPtQE68PT4
 github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531/go.mod h1:fqTUQpVYBvhCNIsMXGl2GE9q6z94DIP6NtFKXCSTVbg=
 github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d h1:J8tJzRyiddAFF65YVgxli+TyWBi0f79Sld6rJP6CBcY=
 github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d/go.mod h1:b+Q3v8Yrg5o15d71PSUraUzYb+jWl6wQMSBXSGS/hv0=
-github.com/jsimonetti/rtnetlink v1.4.2 h1:Df9w9TZ3npHTyDn0Ev9e1uzmN2odmXd0QX+J5GTEn90=
-github.com/jsimonetti/rtnetlink v1.4.2/go.mod h1:92s6LJdE+1iOrw+F2/RO7LYI2Qd8pPpFNNUYW06gcoM=
 github.com/jsimonetti/rtnetlink/v2 v2.0.1 h1:xda7qaHDSVOsADNouv7ukSuicKZO7GgVUCXxpaIEIlM=
 github.com/jsimonetti/rtnetlink/v2 v2.0.1/go.mod h1:7MoNYNbb3UaDHtF8udiJo/RH6VsTKP1pqKLUTVCvToE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/go.sum
+++ b/go.sum
@@ -1718,6 +1718,8 @@ github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531 h1:hgVxRoDDPtQE68PT4
 github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531/go.mod h1:fqTUQpVYBvhCNIsMXGl2GE9q6z94DIP6NtFKXCSTVbg=
 github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d h1:J8tJzRyiddAFF65YVgxli+TyWBi0f79Sld6rJP6CBcY=
 github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d/go.mod h1:b+Q3v8Yrg5o15d71PSUraUzYb+jWl6wQMSBXSGS/hv0=
+github.com/jsimonetti/rtnetlink v1.4.2 h1:Df9w9TZ3npHTyDn0Ev9e1uzmN2odmXd0QX+J5GTEn90=
+github.com/jsimonetti/rtnetlink v1.4.2/go.mod h1:92s6LJdE+1iOrw+F2/RO7LYI2Qd8pPpFNNUYW06gcoM=
 github.com/jsimonetti/rtnetlink/v2 v2.0.1 h1:xda7qaHDSVOsADNouv7ukSuicKZO7GgVUCXxpaIEIlM=
 github.com/jsimonetti/rtnetlink/v2 v2.0.1/go.mod h1:7MoNYNbb3UaDHtF8udiJo/RH6VsTKP1pqKLUTVCvToE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/lib/teleterm/vnet/service_linux.go
+++ b/lib/teleterm/vnet/service_linux.go
@@ -1,5 +1,5 @@
 // Teleport
-// Copyright (C) 2025 Gravitational, Inc.
+// Copyright (C) 2026 Gravitational, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -14,16 +14,35 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !darwin && !windows && !linux
-
 package vnet
 
 import (
 	"context"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/lib/vnet/diag"
 )
 
 func (s *Service) platformDiagChecks(ctx context.Context) ([]diag.DiagCheck, error) {
-	return nil, nil
+	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
+		VnetIfaceName: s.networkStackInfo.InterfaceName,
+		Routing:       &diag.LinuxRouting{},
+		Interfaces:    &diag.NetInterfaces{},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	sshDiag, err := diag.NewSSHDiag(&diag.SSHConfig{
+		ProfilePath: s.cfg.profilePath,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return []diag.DiagCheck{
+		routeConflictDiag,
+		sshDiag,
+	}, nil
 }

--- a/lib/vnet/diag/routeconflict_linux.go
+++ b/lib/vnet/diag/routeconflict_linux.go
@@ -1,0 +1,106 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package diag
+
+import (
+	"context"
+	"net/netip"
+	"os/exec"
+
+	"github.com/gravitational/trace"
+	"github.com/jsimonetti/rtnetlink"
+	"golang.org/x/sys/unix"
+)
+
+// LinuxRouting provides Linux-specific [Routing] implementation used by [RouteConflictDiag].
+type LinuxRouting struct{}
+
+// GetRouteDestinations gets routes from the OS and then extracts the only information needed from
+// them: the route destination and the index of the network interface. It operates solely on IPv4
+// routes.
+//
+// It might be called by [RouteConflictDiag] multiple times in case an interface was removed after
+// the routes were fetched.
+func (lr *LinuxRouting) GetRouteDestinations() ([]RouteDest, error) {
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer conn.Close()
+
+	routes, err := conn.Route.List()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rds := make([]RouteDest, 0, len(routes))
+	for _, route := range routes {
+		if route.Family != unix.AF_INET {
+			continue
+		}
+
+		dst := route.Attributes.Dst
+		ifaceIndex := int(route.Attributes.OutIface)
+
+		// A nil destination means the default route (0.0.0.0/0).
+		if dst == nil {
+			addr := netip.IPv4Unspecified()
+			rds = append(rds, &RouteDestPrefix{
+				Prefix:     netip.PrefixFrom(addr, 0),
+				ifaceIndex: ifaceIndex,
+			})
+			continue
+		}
+
+		addr, ok := netip.AddrFromSlice(dst)
+		if !ok {
+			continue
+		}
+
+		if addr.IsLinkLocalMulticast() {
+			continue
+		}
+
+		prefixLen := int(route.DstLength)
+		if prefixLen == 32 {
+			rds = append(rds, &RouteDestIP{
+				Addr:       addr,
+				ifaceIndex: ifaceIndex,
+			})
+		} else {
+			rds = append(rds, &RouteDestPrefix{
+				Prefix:     netip.PrefixFrom(addr, prefixLen),
+				ifaceIndex: ifaceIndex,
+			})
+		}
+	}
+
+	return rds, nil
+}
+
+func (n *NetInterfaces) interfaceApp(ctx context.Context, ifaceName string) (string, error) {
+	// Linux TUN interfaces don't carry app metadata like macOS NetworkExtension.
+	// Return the interface name, similar to the Windows approach.
+	return ifaceName, nil
+}
+
+func (c *RouteConflictDiag) commands(ctx context.Context) []*exec.Cmd {
+	return []*exec.Cmd{
+		exec.CommandContext(ctx, "ip", "route", "show"),
+		exec.CommandContext(ctx, "resolvectl", "status"),
+	}
+}

--- a/lib/vnet/diag/routeconflict_linux.go
+++ b/lib/vnet/diag/routeconflict_linux.go
@@ -56,6 +56,12 @@ func (lr *LinuxRouting) GetRouteDestinations() ([]RouteDest, error) {
 		dst := route.Attributes.Dst
 		ifaceIndex := int(route.Attributes.OutIface)
 
+		// Routes with no output interface (OutIface == 0) don't forward traffic to a network interface
+		// This includes blackhole, unreachable, prohibit, throw routes and ECMP/multipath. Skip them.
+		if ifaceIndex == 0 {
+			continue
+		}
+
 		// A nil destination means the default route (0.0.0.0/0).
 		if dst == nil {
 			addr := netip.IPv4Unspecified()

--- a/lib/vnet/diag/routeconflict_linux.go
+++ b/lib/vnet/diag/routeconflict_linux.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 
 	"github.com/gravitational/trace"
-	"github.com/jsimonetti/rtnetlink"
+	"github.com/jsimonetti/rtnetlink/v2"
 	"golang.org/x/sys/unix"
 )
 

--- a/lib/vnet/diag/routeconflict_linux_test.go
+++ b/lib/vnet/diag/routeconflict_linux_test.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package diag
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLinuxRouting is just a smoke test to verify that LinuxRouting does not blow up when ran on
+// an actual Linux machine.
+func TestLinuxRouting(t *testing.T) {
+	lr := LinuxRouting{}
+
+	rds, err := lr.GetRouteDestinations()
+	require.NoError(t, err)
+	require.NotEmpty(t, rds)
+
+	hasNonDefaultRoute := slices.ContainsFunc(rds, func(rd RouteDest) bool {
+		return !rd.IsDefault()
+	})
+	// Check that the code that converts rtnetlink routes to RouteDest isn't bugged and doesn't just
+	// cast everything to 0.0.0.0.
+	require.True(t, hasNonDefaultRoute, "Expected routes to include at least one route with a non-default destination, got: %+v", rds)
+}

--- a/lib/vnet/diag/routeconflict_other.go
+++ b/lib/vnet/diag/routeconflict_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !windows
+//go:build !darwin && !windows && !linux
 
 // Teleport
 // Copyright (C) 2025 Gravitational, Inc.

--- a/tool/tsh/common/vnet_linux.go
+++ b/tool/tsh/common/vnet_linux.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
@@ -25,6 +26,7 @@ import (
 	"github.com/gravitational/teleport"
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 	"github.com/gravitational/teleport/lib/vnet"
+	"github.com/gravitational/teleport/lib/vnet/diag"
 )
 
 // vnetAdminSetupCommand is the fallback command ran as root when there is no
@@ -63,5 +65,22 @@ func newPlatformVnetUninstallServiceCommand(app *kingpin.Application) vnetComman
 }
 
 func runVnetDiagnostics(ctx context.Context, nsi *vnetv1.NetworkStackInfo) error {
-	return trace.NotImplemented("diagnostics not implemented")
+	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
+		VnetIfaceName: nsi.InterfaceName,
+		Routing:       &diag.LinuxRouting{},
+		Interfaces:    &diag.NetInterfaces{},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	rcs, err := routeConflictDiag.Run(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for _, rc := range rcs.GetRouteConflictReport().RouteConflicts {
+		fmt.Printf("Found a conflicting route: %+v\n", rc)
+	}
+
+	return nil
 }

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
@@ -114,7 +114,6 @@ const VnetConnectionItemBase = forwardRef<
     diagnosticsAttempt,
     getDisabledDiagnosticsReason,
     showDiagWarningIndicator,
-    isDiagSupported,
     installTimeRequirementsCheck,
   } = useVnetContext();
   const { close: closeConnectionsPanel } = useConnectionsContext();
@@ -269,18 +268,16 @@ const VnetConnectionItemBase = forwardRef<
                 </ButtonIcon>
               )}
 
-              {isDiagSupported && (
-                <ButtonIcon
-                  title={disabledDiagnosticsReason || 'Run diagnostics'}
-                  disabled={!!disabledDiagnosticsReason}
-                  onClick={e => {
-                    e.stopPropagation();
-                    props.runDiagnosticsFromVnetPanel();
-                  }}
-                >
-                  <icons.ListMagnifyingGlass size={18} />
-                </ButtonIcon>
-              )}
+              <ButtonIcon
+                title={disabledDiagnosticsReason || 'Run diagnostics'}
+                disabled={!!disabledDiagnosticsReason}
+                onClick={e => {
+                  e.stopPropagation();
+                  props.runDiagnosticsFromVnetPanel();
+                }}
+              >
+                <icons.ListMagnifyingGlass size={18} />
+              </ButtonIcon>
             </>
           )}
 

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
@@ -37,7 +37,6 @@ import { useVnetContext, VnetContextProvider } from './vnetContext';
 import { VnetSliderStep as Component } from './VnetSliderStep';
 
 type StoryProps = {
-  platform: 'darwin' | 'win32' | 'linux';
   startVnet: 'success' | 'error' | 'processing';
   autoStart: boolean;
   appDnsZones: string[];
@@ -56,7 +55,6 @@ type StoryProps = {
 };
 
 const defaultArgs: StoryProps = {
-  platform: 'darwin',
   startVnet: 'success',
   autoStart: true,
   appDnsZones: ['teleport.example.com', 'company.test'],
@@ -83,10 +81,6 @@ const meta: Meta<StoryProps> = {
     },
   ],
   argTypes: {
-    platform: {
-      control: { type: 'inline-radio' },
-      options: ['darwin', 'win32', 'linux'],
-    },
     startVnet: {
       control: { type: 'inline-radio' },
       options: ['success', 'error', 'processing'],
@@ -128,7 +122,7 @@ const meta: Meta<StoryProps> = {
 export default meta;
 
 function VnetSliderStep(props: StoryProps) {
-  const appContext = new MockAppContext({ platform: props.platform });
+  const appContext = new MockAppContext();
 
   if (props.windowsVNetServiceNotFound) {
     appContext.vnet.checkInstallTimeRequirements = () =>

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -58,10 +58,6 @@ export type VnetContext = {
    * Describes whether the given OS can run VNet.
    */
   isSupported: boolean;
-  /**
-   * Describes whether the given OS can run VNet diagnostics.
-   */
-  isDiagSupported: boolean;
   status: VnetStatus;
   start: () => Promise<[void, Error]>;
   startAttempt: Attempt<void>;
@@ -181,7 +177,6 @@ export const VnetContextProvider: FC<
   );
   const isSupported =
     platform === 'darwin' || platform === 'win32' || platform === 'linux';
-  const isDiagSupported = platform === 'darwin' || platform === 'win32';
 
   const [checkInstallTimeRequirementsAttempt, checkInstallTimeRequirements] =
     useAsync(
@@ -490,10 +485,6 @@ export const VnetContextProvider: FC<
 
   useEffect(
     function periodicallyRunDiagnostics() {
-      if (!isDiagSupported) {
-        return;
-      }
-
       if (status.value !== 'running') {
         return;
       }
@@ -515,7 +506,6 @@ export const VnetContextProvider: FC<
       };
     },
     [
-      isDiagSupported,
       diagnosticsIntervalMs,
       runDiagnosticsAndShowNotification,
       status.value,
@@ -551,7 +541,6 @@ export const VnetContextProvider: FC<
     <VnetContext.Provider
       value={{
         isSupported,
-        isDiagSupported,
         status,
         start,
         startAttempt,


### PR DESCRIPTION
## What
Add VNet route conflict and SSH diagnostics on Linux

changelog: Add VNet diagnostics on Linux

## Manual Test Plan

### Test Environment

Any Linux distro with systemd, D-Bus, and polkit.

A dummy interface that conflicts with the VNet IP range:
```bash
sudo ip link add dummy0 type dummy
sudo ip link set dummy0 up
sudo ip addr add 192.168.99.1/24 dev dummy0
sudo ip route add 100.64.1.0/24 dev dummy0
```

To clean up:
```bash
sudo ip route del 100.64.1.0/24 dev dummy0
sudo ip link del dummy0
```

### Test Cases

- [x] Build `tsh` and `teleport-connect`
- [x] Verify that `tsh vnet --diag` reports the conflicting route
- [x] Verify that Teleport Connect shows the conflicting route in the diagnostics panel
- [x] Verify that removing the conflicting route clears the diagnostic warning
- [x] Verify that `tsh vnet --diag` produces no conflict output when no conflicting routes exist
