### PR TITLE
Support username in role templates and expressions

### DIFF
--- a/docs/pages/reference/access-controls/predicate-language.mdx
+++ b/docs/pages/reference/access-controls/predicate-language.mdx
@@ -89,10 +89,11 @@ for an overview of label expressions and where they can be used.
 Label expressions support a predicate language with the following fields
 available:
 
-| Field              | Type                    | Description |
-|--------------------|-------------------------|-------------|
-| `labels`           | `map[string]string`     | Combined static and dynamic labels of the resource (server, application, etc.) being accessed. |
-| `user.spec.traits` | `map[string][]string`   | All traits of the user accessing the resource (referred to as `external` or `internal` in role template expressions). |
+| Field                | Type                    | Description |
+|----------------------|-------------------------|-------------|
+| `labels`             | `map[string]string`     | Combined static and dynamic labels of the resource (server, application, etc.) being accessed. |
+| `user.spec.traits`   | `map[string][]string`   | All traits of the user accessing the resource (referred to as `external` or `internal` in role template expressions). |
+| `user.metadata.name` | `string`                | The user's Teleport username. |
 
 The language supports the following operators:
 

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -920,6 +920,15 @@ supported data type.
 Refer to your identity provider's documentation for the complete list of
 available claims and attributes.
 
+#### Other template variables
+
+In addition to user traits, you can also use the following variables in role
+templates:
+
+| Variable | Description |
+| - | - |
+| `{{user.metadata.name}}` | The user's Teleport username. Useful for matching resources the user "owns" or is responsible for. |
+
 ### Access Request template functions
 
 The following variables and functions allow more fine-grained control over a

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2885,7 +2885,10 @@ func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCert
 	roles := make([]types.Role, len(req.Roles))
 	for i := range req.Roles {
 		var err error
-		roles[i], err = services.ApplyTraits(req.Roles[i], req.User.GetTraits())
+		roles[i], err = services.ApplyTraitsWithContext(req.Roles[i], services.RoleTemplateContext{
+			Username: req.User.GetName(),
+			Traits:   req.User.GetTraits(),
+		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -5130,7 +5133,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req authclient.WebSession
 		allowedResourceAccessIDs = nil
 
 		// Calculate expiry time.
-		roleSet, err := services.FetchRoles(userState.GetRoles(), a, userState.GetTraits())
+		roleSet, err := services.FetchRolesForUser(userState, a)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -2710,6 +2710,42 @@ func TestGenerateOpenSSHCert(t *testing.T) {
 	// verify that user's logins are present in cert
 	logins = append(logins, teleport.SSHSessionJoinPrincipal)
 	require.Equal(t, logins, signedCert.ValidPrincipals)
+
+	t.Run("user name login template", func(t *testing.T) {
+		u, r, err := authtest.CreateUserAndRole(
+			p.a,
+			"templated-user",
+			nil,
+			nil,
+			authtest.WithRoleMutator(func(role types.Role) {
+				role.SetLogins(types.Allow, []string{"{{user.metadata.name}}"})
+			}),
+		)
+		require.NoError(t, err)
+
+		user, ok := u.(*types.UserV2)
+		require.True(t, ok)
+
+		role, ok := r.(*types.RoleV6)
+		require.True(t, ok)
+
+		priv, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.Ed25519)
+		require.NoError(t, err)
+
+		reply, err := p.a.GenerateOpenSSHCert(ctx, &proto.OpenSSHCertRequest{
+			User:      user,
+			Roles:     []*types.RoleV6{role},
+			PublicKey: priv.MarshalSSHPublicKey(),
+			TTL:       proto.Duration(time.Hour),
+			Cluster:   p.clusterName.GetClusterName(),
+		})
+		require.NoError(t, err)
+
+		signedCert, err := sshutils.ParseCertificate(reply.Cert)
+		require.NoError(t, err)
+		require.Contains(t, signedCert.ValidPrincipals, user.GetName())
+		require.Contains(t, signedCert.ValidPrincipals, teleport.SSHSessionJoinPrincipal)
+	})
 }
 
 func TestGenerateUserCertWithLocks(t *testing.T) {
@@ -3183,6 +3219,28 @@ func TestNewWebSession(t *testing.T) {
 	require.NotEmpty(t, ws.GetTLSPriv())
 	require.NotEmpty(t, ws.GetPub())
 	require.NotEmpty(t, ws.GetTLSCert())
+
+	t.Run("expands user metadata name in logins", func(t *testing.T) {
+		user, _, err := authtest.CreateUserAndRole(p.a, "templated-web-user", nil, nil, authtest.WithRoleMutator(func(role types.Role) {
+			role.SetLogins(types.Allow, []string{"{{user.metadata.name}}"})
+		}))
+		require.NoError(t, err)
+
+		req := auth.NewWebSessionRequest{
+			User:       user.GetName(),
+			Roles:      user.GetRoles(),
+			Traits:     user.GetTraits(),
+			LoginTime:  p.a.GetClock().Now().UTC(),
+			SessionTTL: apidefaults.CertDuration,
+		}
+
+		_, checker, err := p.a.NewWebSession(ctx, req, nil /* opts */)
+		require.NoError(t, err)
+
+		logins, err := checker.CheckLoginDuration(0)
+		require.NoError(t, err)
+		require.Contains(t, logins, user.GetName())
+	})
 }
 
 func TestDeleteMFADeviceSync(t *testing.T) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -49,7 +49,6 @@ import (
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
-	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
@@ -488,7 +487,7 @@ func (a *ServerWithRoles) GetSessionTracker(ctx context.Context, sessionID strin
 	}
 
 	user := a.context.User
-	joinerRoles, err := services.FetchRoles(user.GetRoles(), a.authServer, user.GetTraits())
+	joinerRoles, err := services.FetchRolesForUser(user, a.authServer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -514,7 +513,7 @@ func (a *ServerWithRoles) GetActiveSessionTrackers(ctx context.Context) ([]types
 
 	var filteredSessions []types.SessionTracker
 	user := a.context.User
-	joinerRoles, err := services.FetchRoles(user.GetRoles(), a.authServer, user.GetTraits())
+	joinerRoles, err := services.FetchRolesForUser(user, a.authServer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -542,7 +541,7 @@ func (a *ServerWithRoles) GetActiveSessionTrackersWithFilter(ctx context.Context
 
 	var filteredSessions []types.SessionTracker
 	user := a.context.User
-	joinerRoles, err := services.FetchRoles(user.GetRoles(), a.authServer, user.GetTraits())
+	joinerRoles, err := services.FetchRolesForUser(user, a.authServer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3377,7 +3376,7 @@ func (a *ServerWithRoles) desiredAccessInfo(ctx context.Context, req *proto.User
 			a.authServer.logger.WarnContext(ctx, "User tried to issue a cert with both role and access requests", "user", a.context.User.GetName())
 			return nil, trace.AccessDenied("User %v tried to issue a cert with both role and access requests. This is not supported.", a.context.User.GetName())
 		}
-		return a.desiredAccessInfoForRoleRequest(req, user.GetTraits())
+		return a.desiredAccessInfoForRoleRequest(req, user)
 	}
 	return a.desiredAccessInfoForUser(ctx, req, user)
 }
@@ -3386,13 +3385,14 @@ func (a *ServerWithRoles) desiredAccessInfo(ctx context.Context, req *proto.User
 // impersonation request.
 func (a *ServerWithRoles) desiredAccessInfoForImpersonation(user services.UserState) (*services.AccessInfo, error) {
 	return &services.AccessInfo{
-		Roles:  user.GetRoles(),
-		Traits: user.GetTraits(),
+		Username: user.GetName(),
+		Roles:    user.GetRoles(),
+		Traits:   user.GetTraits(),
 	}, nil
 }
 
 // desiredAccessInfoForRoleRequest returns the desired roles for a role request.
-func (a *ServerWithRoles) desiredAccessInfoForRoleRequest(req *proto.UserCertsRequest, traits wrappers.Traits) (*services.AccessInfo, error) {
+func (a *ServerWithRoles) desiredAccessInfoForRoleRequest(req *proto.UserCertsRequest, user services.UserState) (*services.AccessInfo, error) {
 	// If UseRoleRequests is set, make sure we don't return unusable certs: an
 	// identity without roles can't be parsed.
 	if len(req.RoleRequests) == 0 {
@@ -3408,8 +3408,9 @@ func (a *ServerWithRoles) desiredAccessInfoForRoleRequest(req *proto.UserCertsRe
 	// Traits are copied across from the impersonating user so that role
 	// variables within the impersonated role behave as expected.
 	return &services.AccessInfo{
-		Roles:  req.RoleRequests,
-		Traits: traits,
+		Username: user.GetName(),
+		Roles:    req.RoleRequests,
+		Traits:   user.GetTraits(),
 	}, nil
 }
 
@@ -3655,7 +3656,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 			// it is limited by max session ttl or mfa_verification_interval or req.Expires.
 
 			// Calculate the expiration time.
-			roleSet, err := services.FetchRoles(user.GetRoles(), a, user.GetTraits())
+			roleSet, err := services.FetchRolesForUser(user, a)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -3698,7 +3699,10 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		return nil, trace.Wrap(err)
 	}
 
-	parsedRoles, err := services.FetchRoleList(accessInfo.Roles, a.authServer, accessInfo.Traits)
+	parsedRoles, err := services.FetchRoleListWithContext(accessInfo.Roles, a.authServer, services.RoleTemplateContext{
+		Username: accessInfo.Username,
+		Traits:   accessInfo.Traits,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1356,6 +1356,13 @@ func TestGenerateUserCertsWithRoleRequest(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	userNameRole, err := authtest.CreateRole(ctx, srv.Auth(), "test-access-username", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins: []string{"{{user.metadata.name}}"},
+		},
+	})
+	require.NoError(t, err)
+
 	impersonatorRole, err := authtest.CreateRole(ctx, srv.Auth(), "test-impersonator", types.RoleSpecV6{
 		Allow: types.RoleConditions{
 			Impersonate: &types.ImpersonateConditions{
@@ -1363,6 +1370,7 @@ func TestGenerateUserCertsWithRoleRequest(t *testing.T) {
 					accessFooRole.GetName(),
 					accessBarRole.GetName(),
 					loginsTraitsRole.GetName(),
+					userNameRole.GetName(),
 				},
 			},
 		},
@@ -1440,6 +1448,14 @@ func TestGenerateUserCertsWithRoleRequest(t *testing.T) {
 			roleRequests:     []string{loginsTraitsRole.GetName()},
 			useRoleRequests:  true,
 			expectPrincipals: []string{"trait-login"},
+		},
+		{
+			desc:             "requesting a role preserves the teleport username",
+			username:         "ivy",
+			roles:            []string{emptyRole.GetName(), impersonatorRole.GetName()},
+			roleRequests:     []string{userNameRole.GetName()},
+			useRoleRequests:  true,
+			expectPrincipals: []string{"ivy"},
 		},
 		{
 			// Users not using role requests should keep their own roles

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -275,7 +275,10 @@ func (a *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 	}
 
 	// Extract user roles from the identity.
-	roles, err := services.FetchRoles(id.Groups, a, id.Traits)
+	roles, err := services.FetchRolesWithContext(id.Groups, a, services.RoleTemplateContext{
+		Username: id.Username,
+		Traits:   id.Traits,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -939,7 +939,10 @@ func (a *Server) calculateGithubUser(ctx context.Context, diagCtx *SSODiagContex
 	p.KubeUsers = p.Traits[constants.TraitKubeUsers]
 
 	// Pick smaller for role: session TTL from role or requested TTL.
-	roles, err := services.FetchRoles(p.Roles, a, p.Traits)
+	roles, err := services.FetchRolesWithContext(p.Roles, a, services.RoleTemplateContext{
+		Username: p.Username,
+		Traits:   p.Traits,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -240,6 +240,7 @@ func (a *Server) newWebSession(
 	}
 
 	checker, err := services.NewAccessChecker(&services.AccessInfo{
+		Username:                 userState.GetName(),
 		Roles:                    req.Roles,
 		Traits:                   req.Traits,
 		AllowedResourceAccessIDs: req.RequestedResourceAccessIDs,

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -347,6 +347,7 @@ func (c *Context) WithExtraRoles(access services.RoleGetter, clusterName string,
 	}
 
 	accessInfo := &services.AccessInfo{
+		Username:                 c.User.GetName(),
 		Roles:                    newRoleNames,
 		Traits:                   c.User.GetTraits(),
 		AllowedResourceAccessIDs: c.Checker.GetAllowedResourceAccessIDs(),

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -941,6 +941,41 @@ func TestContext_GetAccessState(t *testing.T) {
 	}
 }
 
+type roleGetterFunc func(context.Context, string) (types.Role, error)
+
+func (f roleGetterFunc) GetRole(ctx context.Context, name string) (types.Role, error) {
+	return f(ctx, name)
+}
+
+func TestContext_WithExtraRoles_ExpandsUserMetadataName(t *testing.T) {
+	t.Parallel()
+
+	user, err := types.NewUser("llama")
+	require.NoError(t, err)
+
+	extraRole, err := types.NewRole("extra", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins: []string{"{{user.metadata.name}}"},
+		},
+	})
+	require.NoError(t, err)
+
+	ctx := authz.Context{
+		User:    user,
+		Checker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{}, clusterName, nil),
+	}
+
+	newCtx, err := ctx.WithExtraRoles(roleGetterFunc(func(ctx context.Context, name string) (types.Role, error) {
+		require.Equal(t, "extra", name)
+		return extraRole, nil
+	}), clusterName, []string{"extra"})
+	require.NoError(t, err)
+
+	logins, err := newCtx.Checker.CheckLoginDuration(0)
+	require.NoError(t, err)
+	require.Contains(t, logins, user.GetName())
+}
+
 func TestCheckIPPinning(t *testing.T) {
 	testCases := []struct {
 		desc       string

--- a/lib/healthcheck/manager.go
+++ b/lib/healthcheck/manager.go
@@ -336,6 +336,7 @@ func (m *manager) getConfigLocked(ctx context.Context, r types.ResourceWithLabel
 		matched, _, err := services.CheckLabelsMatch(
 			types.Allow,
 			cfg.getLabelMatchers(r.GetKind()),
+			"",  // username
 			nil, // userTraits
 			r,
 			false, // debug

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1011,7 +1011,7 @@ func (f *Forwarder) getKubeAccessDetails(
 		// Creates a matcher that matches the cluster labels against `kubernetes_labels`
 		// defined for each user's role.
 		matchers = append(matchers,
-			services.NewKubernetesClusterLabelMatcher(labels, accessChecker.Traits()),
+			services.NewKubernetesClusterLabelMatcher(labels, accessChecker.AccessInfo().Username, accessChecker.Traits()),
 		)
 
 		// If the kubeResource is available, append an extra matcher that validates

--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -343,6 +343,7 @@ func deleteResources[T kubeObjectInterface](
 			false,
 			services.NewKubernetesClusterLabelMatcher(
 				params.authCtx.kubeClusterLabels,
+				params.authCtx.Checker.AccessInfo().Username,
 				params.authCtx.Checker.Traits(),
 			),
 			services.NewKubernetesResourceMatcher(

--- a/lib/kube/proxy/response_rewriter.go
+++ b/lib/kube/proxy/response_rewriter.go
@@ -135,7 +135,7 @@ func collectSystemMastersTeleportRoles(s *clusterSession) []string {
 	// defined for each user's role.
 	matchers = append(
 		matchers,
-		services.NewKubernetesClusterLabelMatcher(s.kubeClusterLabels, accessChecker.Traits()),
+		services.NewKubernetesClusterLabelMatcher(s.kubeClusterLabels, accessChecker.AccessInfo().Username, accessChecker.Traits()),
 	)
 
 	// If the kubeResource is available, append an extra matcher that validates

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -351,7 +351,10 @@ func NewAccessChecker(info *AccessInfo, localCluster string, access RoleGetter) 
 	if info.ScopePin != nil {
 		return nil, trace.Errorf("cannot create standard access checker: %w", ErrScopedIdentity)
 	}
-	roleSet, err := FetchRoles(info.Roles, access, info.Traits)
+	roleSet, err := FetchRolesWithContext(info.Roles, access, RoleTemplateContext{
+		Username: info.Username,
+		Traits:   info.Traits,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -364,7 +367,10 @@ func NewAccessChecker(info *AccessInfo, localCluster string, access RoleGetter) 
 // a user session role lookup error (which should prompt the user to re-login) vs. other role lookup
 // failures.
 func NewAccessCheckerForUserSession(info *AccessInfo, localCluster string, access RoleGetter) (AccessChecker, error) {
-	roleSet, err := FetchRoles(info.Roles, access, info.Traits)
+	roleSet, err := FetchRolesWithContext(info.Roles, access, RoleTemplateContext{
+		Username: info.Username,
+		Traits:   info.Traits,
+	})
 	if err != nil {
 		if trace.IsNotFound(err) {
 			// Add the UserSessionRoleNotFoundErrorMsg message to indicate this role not found error was encountered fetching
@@ -437,7 +443,10 @@ func NewAccessCheckerForRemoteCluster(ctx context.Context, localAccessInfo *Acce
 	}
 
 	for i := range remoteRoles {
-		remoteRoles[i], err = ApplyTraits(remoteRoles[i], remoteAccessInfo.Traits)
+		remoteRoles[i], err = ApplyTraitsWithContext(remoteRoles[i], RoleTemplateContext{
+			Username: remoteAccessInfo.Username,
+			Traits:   remoteAccessInfo.Traits,
+		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -578,7 +587,7 @@ func (a *accessChecker) validateAccessConditions(r AccessCheckable, state Access
 		}
 	}
 
-	preconds, err := a.checkAccess(r, a.info.Traits, state, matchers...)
+	preconds, err := a.checkAccess(r, a.info.Username, a.info.Traits, state, matchers...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -595,17 +604,17 @@ func (a *accessChecker) CheckAccessToSAMLIdP(r AccessCheckable, authPref readonl
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(a.RoleSet.CheckAccessToSAMLIdP(r, a.info.Traits, authPref, state, matchers...))
+	return trace.Wrap(a.RoleSet.CheckAccessToSAMLIdP(r, a.info.Username, a.info.Traits, authPref, state, matchers...))
 }
 
 // GetKubeResources returns the allowed and denied Kubernetes Resources configured
 // for a user.
 func (a *accessChecker) GetKubeResources(cluster types.KubeCluster) (allowed, denied []types.KubernetesResource) {
 	if len(a.info.AllowedResourceAccessIDs) == 0 {
-		return a.RoleSet.GetKubeResources(cluster, a.info.Traits)
+		return a.RoleSet.GetKubeResources(cluster, a.info.Username, a.info.Traits)
 	}
 	var err error
-	rolesAllowed, rolesDenied := a.RoleSet.GetKubeResources(cluster, a.info.Traits)
+	rolesAllowed, rolesDenied := a.RoleSet.GetKubeResources(cluster, a.info.Username, a.info.Traits)
 
 	// If we have a legacy 'namespace' in the allowedResourceIDs, we need to add the new 'namespaces' one.
 	// The old one will get mapped to wildcard later.
@@ -823,7 +832,7 @@ func (a *accessChecker) checkDatabaseRoles(database types.Database) (*checkDatab
 	// assigned.
 	var allowedRoleSet RoleSet
 	for _, role := range autoCreateRoles {
-		match, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Traits, database, false)
+		match, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Username, a.info.Traits, database, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -835,7 +844,7 @@ func (a *accessChecker) checkDatabaseRoles(database types.Database) (*checkDatab
 	}
 	var deniedRoleSet RoleSet
 	for _, role := range autoCreateRoles {
-		match, _, err := checkRoleLabelsMatch(types.Deny, role, a.info.Traits, database, false)
+		match, _, err := checkRoleLabelsMatch(types.Deny, role, a.info.Username, a.info.Traits, database, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -961,7 +970,7 @@ func (a *accessChecker) EnumerateEntities(resource AccessCheckable, listFn roleE
 		// if the role allows the resource without any matcher confirms
 		// namespace and label matching has passed.
 		var resourceAllowedByRole bool
-		if _, err := NewRoleSet(role).checkAccess(resource, a.info.Traits, AccessState{MFAVerified: true}); err == nil {
+		if _, err := NewRoleSet(role).checkAccess(resource, a.info.Username, a.info.Traits, AccessState{MFAVerified: true}); err == nil {
 			resourceAllowedByRole = true
 		}
 
@@ -1127,7 +1136,7 @@ func (a *accessChecker) CheckAccessToRemoteCluster(rc types.RemoteCluster) error
 	// the deny role set prohibits access.
 	var errs []error
 	for _, role := range a.RoleSet {
-		matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Deny, role, a.info.Traits, rc, isLoggingEnabled)
+		matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Deny, role, a.info.Username, a.info.Traits, rc, isLoggingEnabled)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1144,7 +1153,7 @@ func (a *accessChecker) CheckAccessToRemoteCluster(rc types.RemoteCluster) error
 
 	// Check allow rules: label has to match in any role in the role set to be granted access.
 	for _, role := range a.RoleSet {
-		matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Allow, role, a.info.Traits, rc, isLoggingEnabled)
+		matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Allow, role, a.info.Username, a.info.Traits, rc, isLoggingEnabled)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1183,7 +1192,7 @@ func (a *accessChecker) CheckAccessToRemoteCluster(rc types.RemoteCluster) error
 func (a *accessChecker) DesktopGroups(s types.WindowsDesktop) ([]string, error) {
 	groups := set.New[string]()
 	for _, role := range a.RoleSet {
-		result, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Traits, s, false)
+		result, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Username, a.info.Traits, s, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1202,7 +1211,7 @@ func (a *accessChecker) DesktopGroups(s types.WindowsDesktop) ([]string, error) 
 		}
 	}
 	for _, role := range a.RoleSet {
-		result, _, err := checkRoleLabelsMatch(types.Deny, role, a.info.Traits, s, false)
+		result, _, err := checkRoleLabelsMatch(types.Deny, role, a.info.Username, a.info.Traits, s, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1240,7 +1249,7 @@ func (a *accessChecker) HostUsers(s types.Server) (*decisionpb.HostUsersInfo, er
 	var mode types.CreateHostUserMode
 
 	for _, role := range a.RoleSet {
-		result, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Traits, s, false)
+		result, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Username, a.info.Traits, s, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1298,7 +1307,7 @@ func (a *accessChecker) HostUsers(s types.Server) (*decisionpb.HostUsersInfo, er
 	}
 
 	for _, role := range a.RoleSet {
-		result, _, err := checkRoleLabelsMatch(types.Deny, role, a.info.Traits, s, false)
+		result, _, err := checkRoleLabelsMatch(types.Deny, role, a.info.Username, a.info.Traits, s, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1342,7 +1351,7 @@ func (a *accessChecker) HostSudoers(s types.Server) ([]string, error) {
 
 	seenSudoers := make(map[string]struct{})
 	for _, role := range roleSet {
-		result, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Traits, s, false)
+		result, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Username, a.info.Traits, s, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1362,7 +1371,7 @@ func (a *accessChecker) HostSudoers(s types.Server) ([]string, error) {
 
 	var finalSudoers []string
 	for _, role := range roleSet {
-		result, _, err := checkRoleLabelsMatch(types.Deny, role, a.info.Traits, s, false)
+		result, _, err := checkRoleLabelsMatch(types.Deny, role, a.info.Username, a.info.Traits, s, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1208,6 +1208,13 @@ func NewRequestValidatorForUser(ctx context.Context, clock clockwork.Clock, gett
 	return m, nil
 }
 
+func (m *RequestValidator) roleTemplateContext() RoleTemplateContext {
+	return RoleTemplateContext{
+		Username: m.userState.GetName(),
+		Traits:   m.userState.GetTraits(),
+	}
+}
+
 // validate validates an access request and potentially modifies it depending on what the validator
 // options were configured in the requestValidator.
 //
@@ -2222,7 +2229,7 @@ func (m *RequestValidator) insertAllowedAnnotations(ctx context.Context, conditi
 		// iterate through all new values and expand any
 		// variable interpolation syntax they contain.
 		for _, template := range annotationValueTemplates {
-			expandedValues, err := ApplyValueTraits(template, m.userState.GetTraits())
+			expandedValues, err := ApplyValueTraitsWithContext(template, m.roleTemplateContext())
 			if err != nil {
 				// skip values that failed variable expansion
 				m.logger.WarnContext(ctx, "Failed to expand trait template in access request annotation",
@@ -2247,7 +2254,7 @@ func (m *RequestValidator) insertDeniedAnnotations(ctx context.Context, conditio
 		// iterate through all new values and expand any
 		// variable interpolation syntax they contain.
 		for _, template := range annotationValueTemplates {
-			expandedValues, err := ApplyValueTraits(template, m.userState.GetTraits())
+			expandedValues, err := ApplyValueTraitsWithContext(template, m.roleTemplateContext())
 			if err != nil {
 				// skip values that failed variable expansion
 				m.logger.WarnContext(ctx, "Failed to expand trait template in access request annotation",
@@ -2445,7 +2452,7 @@ func (m *RequestValidator) pruneResourceRequestRoles(
 		}
 	}
 
-	allRoles, err := FetchRoles(roles, m.getter, m.userState.GetTraits())
+	allRoles, err := FetchRolesWithContext(roles, m.getter, m.roleTemplateContext())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2589,7 +2596,7 @@ func (m *RequestValidator) roleAllowsResource(
 		matchers = append(matchers, NewLoginMatcher(loginHint))
 	}
 	matchers = append(matchers, extraMatchers...)
-	_, err := roleSet.checkAccess(resource, m.userState.GetTraits(), AccessState{MFAVerified: true}, matchers...)
+	_, err := roleSet.checkAccess(resource, m.userState.GetName(), m.userState.GetTraits(), AccessState{MFAVerified: true}, matchers...)
 	if trace.IsAccessDenied(err) {
 		// Access denied, this role does not allow access to this resource, no
 		// unexpected error to report.

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -3138,6 +3138,62 @@ func TestValidate_RequestedMaxDuration(t *testing.T) {
 	}
 }
 
+func TestValidateAccessRequest_ExpandsUserNameAnnotations(t *testing.T) {
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	g := &mockGetter{
+		roles:       make(map[string]types.Role),
+		userStates:  make(map[string]*userloginstate.UserLoginState),
+		users:       make(map[string]types.User),
+		nodes:       make(map[string]types.Server),
+		kubeServers: make(map[string]types.KubeServer),
+		dbServers:   make(map[string]types.DatabaseServer),
+		appServers:  make(map[string]types.AppServer),
+		desktops:    make(map[string]types.WindowsDesktop),
+		clusterName: "root",
+	}
+
+	requesterRole, err := types.NewRole("requester", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				Roles: []string{"target"},
+				Annotations: map[string][]string{
+					"owner": {"{{user.metadata.name}}"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	g.roles[requesterRole.GetName()] = requesterRole
+
+	targetRole, err := types.NewRole("target", types.RoleSpecV6{})
+	require.NoError(t, err)
+	g.roles[targetRole.GetName()] = targetRole
+
+	uls, err := userloginstate.New(header.Metadata{
+		Name: "alice",
+	}, userloginstate.Spec{
+		Roles: []string{requesterRole.GetName()},
+		Traits: trait.Traits{
+			"logins": []string{"alice"},
+		},
+	})
+	require.NoError(t, err)
+	g.userStates[uls.GetName()] = uls
+
+	req, err := types.NewAccessRequest("some-id", uls.GetName(), targetRole.GetName())
+	require.NoError(t, err)
+
+	err = ValidateAccessRequestForUser(ctx, clock, g, req, tlsca.Identity{
+		Expires: clock.Now().UTC().Add(time.Hour),
+	}, WithExpandVars(true))
+	require.NoError(t, err)
+	require.Equal(t, map[string][]string{
+		"owner": {"alice"},
+	}, req.GetSystemAnnotations())
+}
+
 // TestValidate_RequestedPendingTTLAndMaxDuration tests that both requested
 // max duration and pending TTL is respected (given within limits).
 func TestValidate_RequestedPendingTTLAndMaxDuration(t *testing.T) {

--- a/lib/services/label_expressions.go
+++ b/lib/services/label_expressions.go
@@ -34,6 +34,7 @@ type labelExpression typical.Expression[labelExpressionEnv, bool]
 
 type labelExpressionEnv struct {
 	resourceLabelGetter LabelGetter
+	username            string
 	userTraits          map[string][]string
 }
 
@@ -59,6 +60,13 @@ func mustNewLabelExpressionParser() *typical.CachedParser[labelExpressionEnv, bo
 func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool], error) {
 	parser, err := typical.NewCachedParser[labelExpressionEnv, bool](typical.ParserSpec[labelExpressionEnv]{
 		Variables: map[string]typical.Variable{
+			"user.metadata.name": typical.DynamicVariable(
+				func(env labelExpressionEnv) (string, error) {
+					if env.username == "" {
+						return "", trace.NotFound("user.metadata.name is not available in this context")
+					}
+					return env.username, nil
+				}),
 			"user.spec.traits": typical.DynamicVariable(
 				func(env labelExpressionEnv) (map[string][]string, error) {
 					return env.userTraits, nil

--- a/lib/services/label_expressions_test.go
+++ b/lib/services/label_expressions_test.go
@@ -55,6 +55,11 @@ func TestLabelExpressions(t *testing.T) {
 			expectMatch: false,
 		},
 		{
+			desc:        "username match",
+			expr:        `user.metadata.name == "alice"`,
+			expectMatch: true,
+		},
+		{
 			desc: "wrong type",
 			expr: `user.spec.traits["allow-env"] == "staging"`,
 			expectParseError: []string{
@@ -319,6 +324,7 @@ func TestLabelExpressions(t *testing.T) {
 
 			env := labelExpressionEnv{
 				resourceLabelGetter: mapLabelGetter(tc.resourceLabels),
+				username:            "alice",
 				userTraits:          tc.userTraits,
 			}
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -478,62 +478,75 @@ func MatchValidAzureIdentity(identity string) bool {
 	return azureIdentityPattern.MatchString(identity)
 }
 
+// RoleTemplateContext is the runtime context used to evaluate role template
+// expressions.
+type RoleTemplateContext struct {
+	Username string
+	Traits   map[string][]string
+}
+
 // ApplyTraits applies the passed in traits to any variables within the role
 // and returns itself.
 func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
+	return ApplyTraitsWithContext(r, RoleTemplateContext{Traits: traits})
+}
+
+// ApplyTraitsWithContext applies the passed in role template context to any
+// variables within the role and returns itself.
+func ApplyTraitsWithContext(r types.Role, ctx RoleTemplateContext) (types.Role, error) {
 	for _, condition := range []types.RoleConditionType{types.Allow, types.Deny} {
 
 		inLogins := r.GetLogins(condition)
-		outLogins := applyValueTraitsSlice(inLogins, traits, "login")
+		outLogins := applyValueTraitsSlice(inLogins, ctx, "login")
 		outLogins = filterInvalidUnixLogins(outLogins)
 		r.SetLogins(condition, apiutils.Deduplicate(outLogins))
 
 		inWindowsLogins := r.GetWindowsLogins(condition)
-		outWindowsLogins := applyValueTraitsSlice(inWindowsLogins, traits, "windows_login")
+		outWindowsLogins := applyValueTraitsSlice(inWindowsLogins, ctx, "windows_login")
 		outWindowsLogins = filterInvalidWindowsLogins(outWindowsLogins)
 		r.SetWindowsLogins(condition, apiutils.Deduplicate(outWindowsLogins))
 
 		inRoleARNs := r.GetAWSRoleARNs(condition)
-		outRoleARNs := applyValueTraitsSlice(inRoleARNs, traits, "AWS role ARN")
+		outRoleARNs := applyValueTraitsSlice(inRoleARNs, ctx, "AWS role ARN")
 		r.SetAWSRoleARNs(condition, apiutils.Deduplicate(outRoleARNs))
 
 		inAzureIdentities := r.GetAzureIdentities(condition)
-		outAzureIdentities := applyValueTraitsSlice(inAzureIdentities, traits, "Azure identity")
+		outAzureIdentities := applyValueTraitsSlice(inAzureIdentities, ctx, "Azure identity")
 		warnInvalidAzureIdentities(outAzureIdentities)
 		r.SetAzureIdentities(condition, apiutils.Deduplicate(outAzureIdentities))
 
 		inGCPAccounts := r.GetGCPServiceAccounts(condition)
-		outGCPAccounts := applyValueTraitsSlice(inGCPAccounts, traits, "GCP service account")
+		outGCPAccounts := applyValueTraitsSlice(inGCPAccounts, ctx, "GCP service account")
 		r.SetGCPServiceAccounts(condition, apiutils.Deduplicate(outGCPAccounts))
 
 		// apply templates to kubernetes groups
 		inKubeGroups := r.GetKubeGroups(condition)
-		outKubeGroups := applyValueTraitsSlice(inKubeGroups, traits, "kube group")
+		outKubeGroups := applyValueTraitsSlice(inKubeGroups, ctx, "kube group")
 		r.SetKubeGroups(condition, apiutils.Deduplicate(outKubeGroups))
 
 		// apply templates to kubernetes users
 		inKubeUsers := r.GetKubeUsers(condition)
-		outKubeUsers := applyValueTraitsSlice(inKubeUsers, traits, "kube user")
+		outKubeUsers := applyValueTraitsSlice(inKubeUsers, ctx, "kube user")
 		r.SetKubeUsers(condition, apiutils.Deduplicate(outKubeUsers))
 
 		// apply templates to database names
 		inDbNames := r.GetDatabaseNames(condition)
-		outDbNames := applyValueTraitsSlice(inDbNames, traits, "database name")
+		outDbNames := applyValueTraitsSlice(inDbNames, ctx, "database name")
 		r.SetDatabaseNames(condition, apiutils.Deduplicate(outDbNames))
 
 		// apply templates to database users
 		inDbUsers := r.GetDatabaseUsers(condition)
-		outDbUsers := applyValueTraitsSlice(inDbUsers, traits, "database user")
+		outDbUsers := applyValueTraitsSlice(inDbUsers, ctx, "database user")
 		r.SetDatabaseUsers(condition, apiutils.Deduplicate(outDbUsers))
 
 		// apply templates to database roles
 		inDbRoles := r.GetDatabaseRoles(condition)
-		outDbRoles := applyValueTraitsSlice(inDbRoles, traits, "database role")
+		outDbRoles := applyValueTraitsSlice(inDbRoles, ctx, "database role")
 		r.SetDatabaseRoles(condition, apiutils.Deduplicate(outDbRoles))
 
 		githubPermissions := r.GetGitHubPermissions(condition)
 		for i, perm := range githubPermissions {
-			githubPermissions[i].Organizations = applyValueTraitsSlice(perm.Organizations, traits, "github organizations")
+			githubPermissions[i].Organizations = applyValueTraitsSlice(perm.Organizations, ctx, "github organizations")
 		}
 		r.SetGitHubPermissions(condition, githubPermissions)
 
@@ -542,15 +555,15 @@ func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
 		// to avoid receiving the compatibility resources added in GetKubernetesResources
 		// for roles <v7
 		for _, rec := range r.GetRoleConditions(condition).KubernetesResources {
-			namespaces := applyValueTraitsSlice([]string{rec.Namespace}, traits, "kubernetes resource namespace")
+			namespaces := applyValueTraitsSlice([]string{rec.Namespace}, ctx, "kubernetes resource namespace")
 			if rec.Namespace == "" {
 				namespaces = []string{""}
 			}
-			names := applyValueTraitsSlice([]string{rec.Name}, traits, "kubernetes resource name")
+			names := applyValueTraitsSlice([]string{rec.Name}, ctx, "kubernetes resource name")
 			if rec.Name == "" {
 				names = []string{""}
 			}
-			verbs := applyValueTraitsSlice(rec.Verbs, traits, "kubernetes resource verb")
+			verbs := applyValueTraitsSlice(rec.Verbs, ctx, "kubernetes resource verb")
 			for _, namespace := range namespaces {
 				for _, name := range names {
 					out = append(out, types.KubernetesResource{
@@ -588,24 +601,24 @@ func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
 			if len(labelMatchers.Labels) == 0 {
 				continue
 			}
-			labelMatchers.Labels = applyLabelsTraits(labelMatchers.Labels, traits)
+			labelMatchers.Labels = applyLabelsTraits(labelMatchers.Labels, ctx)
 			if err := r.SetLabelMatchers(condition, kind, labelMatchers); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		}
 
 		r.SetHostGroups(condition,
-			applyValueTraitsSlice(r.GetHostGroups(condition), traits, "host_groups"))
+			applyValueTraitsSlice(r.GetHostGroups(condition), ctx, "host_groups"))
 
 		r.SetHostSudoers(condition,
-			applyValueTraitsSlice(r.GetHostSudoers(condition), traits, "host_sudoers"))
+			applyValueTraitsSlice(r.GetHostSudoers(condition), ctx, "host_sudoers"))
 
 		r.SetDesktopGroups(condition,
-			applyValueTraitsSlice(r.GetDesktopGroups(condition), traits, "desktop_groups"))
+			applyValueTraitsSlice(r.GetDesktopGroups(condition), ctx, "desktop_groups"))
 
 		options := r.GetOptions()
 		for i, ext := range options.CertExtensions {
-			vals, err := ApplyValueTraits(ext.Value, traits)
+			vals, err := ApplyValueTraitsWithContext(ext.Value, ctx)
 			if err != nil && !trace.IsNotFound(err) {
 				slog.WarnContext(context.Background(), "Failed to apply trait to cert_extensions.value", "error", err)
 				continue
@@ -618,15 +631,15 @@ func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
 		// apply templates to impersonation conditions
 		inCond := r.GetImpersonateConditions(condition)
 		var outCond types.ImpersonateConditions
-		outCond.Users = applyValueTraitsSlice(inCond.Users, traits, "impersonate user")
-		outCond.Roles = applyValueTraitsSlice(inCond.Roles, traits, "impersonate role")
+		outCond.Users = applyValueTraitsSlice(inCond.Users, ctx, "impersonate user")
+		outCond.Roles = applyValueTraitsSlice(inCond.Roles, ctx, "impersonate role")
 		outCond.Users = apiutils.Deduplicate(outCond.Users)
 		outCond.Roles = apiutils.Deduplicate(outCond.Roles)
 		outCond.Where = inCond.Where
 		r.SetImpersonateConditions(condition, outCond)
 
 		if mcp := r.GetMCPPermissions(condition); mcp != nil {
-			mcp.Tools = applyValueTraitsSlice(mcp.Tools, traits, "mcp.tools")
+			mcp.Tools = applyValueTraitsSlice(mcp.Tools, ctx, "mcp.tools")
 			r.SetMCPPermissions(condition, mcp)
 		}
 	}
@@ -635,11 +648,11 @@ func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
 }
 
 // applyValueTraitsSlice iterates over a slice of input strings, calling
-// ApplyValueTraits on each.
-func applyValueTraitsSlice(inputs []string, traits map[string][]string, fieldName string) []string {
+// ApplyValueTraitsWithContext on each.
+func applyValueTraitsSlice(inputs []string, ctx RoleTemplateContext, fieldName string) []string {
 	var output []string
 	for _, value := range inputs {
-		outputs, err := ApplyValueTraits(value, traits)
+		outputs, err := ApplyValueTraitsWithContext(value, ctx)
 		if err != nil {
 			if !trace.IsNotFound(err) {
 				slog.DebugContext(context.Background(), "Skipping trait value.", "field", fieldName, "value", value, "error", err)
@@ -665,11 +678,11 @@ func applyValueTraitsSlice(inputs []string, traits map[string][]string, fieldNam
 // cluster_labels:
 //
 //	env: ['admins', 'devs']
-func applyLabelsTraits(inLabels types.Labels, traits map[string][]string) types.Labels {
+func applyLabelsTraits(inLabels types.Labels, ctx RoleTemplateContext) types.Labels {
 	outLabels := make(types.Labels, len(inLabels))
 	// every key will be mapped to the first value
 	for key, vals := range inLabels {
-		keyVars, err := ApplyValueTraits(key, traits)
+		keyVars, err := ApplyValueTraitsWithContext(key, ctx)
 		if err != nil {
 			// empty key will not match anything
 			slog.DebugContext(context.Background(), "Setting empty node label pair", "key", key, "values", vals, "error", err)
@@ -678,7 +691,7 @@ func applyLabelsTraits(inLabels types.Labels, traits map[string][]string) types.
 
 		var values []string
 		for _, val := range vals {
-			valVars, err := ApplyValueTraits(val, traits)
+			valVars, err := ApplyValueTraitsWithContext(val, ctx)
 			if err != nil {
 				slog.DebugContext(context.Background(), "Setting empty node label value", "key", key, "value", val, "error", err)
 				// empty value will not match anything
@@ -697,6 +710,12 @@ func applyLabelsTraits(inLabels types.Labels, traits map[string][]string) types.
 // mapped list of values otherwise, the function guarantees to return
 // at least one value in case if return value is nil
 func ApplyValueTraits(val string, traits map[string][]string) ([]string, error) {
+	return ApplyValueTraitsWithContext(val, RoleTemplateContext{Traits: traits})
+}
+
+// ApplyValueTraitsWithContext applies the passed in role template context to
+// the variable.
+func ApplyValueTraitsWithContext(val string, ctx RoleTemplateContext) ([]string, error) {
 	// Extract the variable from the role variable.
 	expr, err := parse.NewTraitsTemplateExpression(val)
 	if err != nil {
@@ -733,7 +752,7 @@ func ApplyValueTraits(val string, traits map[string][]string) ([]string, error) 
 		//   traits in the "external" namespace.
 		return nil
 	}
-	interpolated, err := expr.Interpolate(varValidation, traits)
+	interpolated, err := expr.InterpolateWithUser(varValidation, ctx.Username, ctx.Traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -962,6 +981,12 @@ func ExtractFromIdentity(ctx context.Context, access UserGetter, identity tlsca.
 // FetchRoleList fetches roles by their names, applies the traits to role
 // variables, and returns the list
 func FetchRoleList(roleNames []string, access RoleGetter, traits map[string][]string) (RoleSet, error) {
+	return FetchRoleListWithContext(roleNames, access, RoleTemplateContext{Traits: traits})
+}
+
+// FetchRoleListWithContext fetches roles by their names, applies the role
+// template context to role variables, and returns the list.
+func FetchRoleListWithContext(roleNames []string, access RoleGetter, ctx RoleTemplateContext) (RoleSet, error) {
 	var roles []types.Role
 
 	for _, roleName := range roleNames {
@@ -969,7 +994,7 @@ func FetchRoleList(roleNames []string, access RoleGetter, traits map[string][]st
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		role, err = ApplyTraits(role, traits)
+		role, err = ApplyTraitsWithContext(role, ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -983,11 +1008,27 @@ func FetchRoleList(roleNames []string, access RoleGetter, traits map[string][]st
 // variables, and returns the RoleSet. Adds runtime roles like the default
 // implicit role to RoleSet.
 func FetchRoles(roleNames []string, access RoleGetter, traits map[string][]string) (RoleSet, error) {
-	roles, err := FetchRoleList(roleNames, access, traits)
+	return FetchRolesWithContext(roleNames, access, RoleTemplateContext{Traits: traits})
+}
+
+// FetchRolesWithContext fetches roles by their names, applies the role
+// template context to role variables, and returns the RoleSet. Adds runtime
+// roles like the default implicit role to RoleSet.
+func FetchRolesWithContext(roleNames []string, access RoleGetter, ctx RoleTemplateContext) (RoleSet, error) {
+	roles, err := FetchRoleListWithContext(roleNames, access, ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return NewRoleSet(roles...), nil
+}
+
+// FetchRolesForUser fetches a user's roles using their username and traits as
+// role template context.
+func FetchRolesForUser(user UserAccessState, access RoleGetter) (RoleSet, error) {
+	return FetchRolesWithContext(user.GetRoles(), access, RoleTemplateContext{
+		Username: user.GetName(),
+		Traits:   user.GetTraits(),
+	})
 }
 
 // NewRoleSet returns new RoleSet based on the roles
@@ -1666,7 +1707,7 @@ func checkAccessToSAMLIdPLegacy(state AccessState, role types.Role) error {
 // For Teleport role version v8 and above (non-legacy SAML IdP RBAC),
 // labels, MFA and Device Trust is checked.
 // IDP option in the auth preference is checked in both the cases.
-func (set RoleSet) CheckAccessToSAMLIdP(r AccessCheckable, traits wrappers.Traits, authPref readonly.AuthPreference, state AccessState, matchers ...RoleMatcher) error {
+func (set RoleSet) CheckAccessToSAMLIdP(r AccessCheckable, username string, traits wrappers.Traits, authPref readonly.AuthPreference, state AccessState, matchers ...RoleMatcher) error {
 	if authPref != nil {
 		if !authPref.IsSAMLIdPEnabled() {
 			return trace.AccessDenied("SAML IdP is disabled at the cluster level")
@@ -1697,7 +1738,7 @@ func (set RoleSet) CheckAccessToSAMLIdP(r AccessCheckable, traits wrappers.Trait
 		return nil
 	}
 
-	if _, err := v8RoleSet.checkAccess(r, traits, state, matchers...); err != nil {
+	if _, err := v8RoleSet.checkAccess(r, username, traits, state, matchers...); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -2466,6 +2507,7 @@ func (l *awsAppLoginMatcher) Match(role types.Role, typ types.RoleConditionType)
 
 type kubernetesClusterLabelMatcher struct {
 	clusterLabels map[string]string
+	username      string
 	userTraits    wrappers.Traits
 }
 
@@ -2568,8 +2610,8 @@ func (m *KubernetesResourceMatcher) String() string {
 
 // NewKubernetesClusterLabelMatcher creates a RoleMatcher that checks whether a role's
 // Kubernetes service labels match.
-func NewKubernetesClusterLabelMatcher(clustersLabels map[string]string, userTraits wrappers.Traits) RoleMatcher {
-	return &kubernetesClusterLabelMatcher{clusterLabels: clustersLabels, userTraits: userTraits}
+func NewKubernetesClusterLabelMatcher(clustersLabels map[string]string, username string, userTraits wrappers.Traits) RoleMatcher {
+	return &kubernetesClusterLabelMatcher{clusterLabels: clustersLabels, username: username, userTraits: userTraits}
 }
 
 // Match matches a Kubernetes cluster labels against a role.
@@ -2578,7 +2620,7 @@ func (l *kubernetesClusterLabelMatcher) Match(role types.Role, typ types.RoleCon
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	ok, _, err := CheckLabelsMatch(typ, labelMatchers, l.userTraits, mapLabelGetter(l.clusterLabels), false)
+	ok, _, err := CheckLabelsMatch(typ, labelMatchers, l.username, l.userTraits, mapLabelGetter(l.clusterLabels), false)
 	return ok, trace.Wrap(err)
 }
 
@@ -2636,6 +2678,7 @@ func resourceRequiresLabelMatching(r AccessCheckable) bool {
 // state.ReturnPreconditions is false, it returns an error immediately if access is denied.
 func (set RoleSet) checkAccess(
 	r AccessCheckable,
+	username string,
 	traits wrappers.Traits,
 	state AccessState,
 	matchers ...RoleMatcher,
@@ -2697,7 +2740,7 @@ func (set RoleSet) checkAccess(
 			continue
 		}
 		if requiresLabelMatching {
-			matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Deny, role, traits, r, isLoggingEnabled)
+			matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Deny, role, username, traits, r, isLoggingEnabled)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -2757,7 +2800,7 @@ func (set RoleSet) checkAccess(
 		}
 
 		if requiresLabelMatching {
-			matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Allow, role, traits, r, isLoggingEnabled)
+			matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Allow, role, username, traits, r, isLoggingEnabled)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -2889,6 +2932,7 @@ func deduplicateAndSortPreconditions(preconds []*decisionpb.Precondition) []*dec
 func checkRoleLabelsMatch(
 	condition types.RoleConditionType,
 	role types.Role,
+	username string,
 	userTraits wrappers.Traits,
 	resource AccessCheckable,
 	debug bool,
@@ -2897,7 +2941,7 @@ func checkRoleLabelsMatch(
 	if err != nil {
 		return false, "", trace.Wrap(err)
 	}
-	return CheckLabelsMatch(condition, labelMatchers, userTraits, resource, debug)
+	return CheckLabelsMatch(condition, labelMatchers, username, userTraits, resource, debug)
 }
 
 // CheckLabelsMatch checks if the [labelMatchers] match the labels of [resource]
@@ -2916,6 +2960,7 @@ func checkRoleLabelsMatch(
 func CheckLabelsMatch(
 	condition types.RoleConditionType,
 	labelMatchers types.LabelMatchers,
+	username string,
 	userTraits wrappers.Traits,
 	resource LabelGetter,
 	debug bool,
@@ -2943,7 +2988,7 @@ func CheckLabelsMatch(
 	}
 
 	if len(labelMatchers.Expression) > 0 {
-		match, msg, err := matchLabelExpression(labelMatchers.Expression, resource, userTraits)
+		match, msg, err := matchLabelExpression(labelMatchers.Expression, resource, username, userTraits)
 		if err != nil {
 			return false, "", trace.Wrap(err)
 		}
@@ -2966,13 +3011,14 @@ func CheckLabelsMatch(
 	return labelsUnsetOrMatch && expressionUnsetOrMatch, message, nil
 }
 
-func matchLabelExpression(labelExpression string, resource LabelGetter, userTraits wrappers.Traits) (bool, string, error) {
+func matchLabelExpression(labelExpression string, resource LabelGetter, username string, userTraits wrappers.Traits) (bool, string, error) {
 	parsedExpr, err := parseLabelExpression(labelExpression)
 	if err != nil {
 		return false, "", trace.Wrap(err)
 	}
 	match, err := parsedExpr.Evaluate(labelExpressionEnv{
 		resourceLabelGetter: resource,
+		username:            username,
 		userTraits:          userTraits,
 	})
 	if err != nil {
@@ -3277,9 +3323,9 @@ func (set RoleSet) CheckAccessToRule(ctx RuleContext, namespace string, resource
 }
 
 // GetKubeResources returns allowed and denied list of Kubernetes Resources configured in the RoleSet.
-func (set RoleSet) GetKubeResources(cluster types.KubeCluster, userTraits wrappers.Traits) (allowed, denied []types.KubernetesResource) {
+func (set RoleSet) GetKubeResources(cluster types.KubeCluster, username string, userTraits wrappers.Traits) (allowed, denied []types.KubernetesResource) {
 	for _, role := range set {
-		matchLabels, _, err := checkRoleLabelsMatch(types.Allow, role, userTraits, cluster, false)
+		matchLabels, _, err := checkRoleLabelsMatch(types.Allow, role, username, userTraits, cluster, false)
 		if err != nil || !matchLabels {
 			continue
 		}

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -3920,6 +3920,23 @@ func TestApplyTraits(t *testing.T) {
 	}
 }
 
+func TestFetchRolesForUser_ExpandsUserMetadataName(t *testing.T) {
+	role := newRole(func(r *types.RoleV6) {
+		r.Metadata.Name = "dev"
+		r.Spec.Allow.Logins = []string{"{{user.metadata.name}}"}
+	})
+
+	roleSet, err := FetchRolesForUser(mockCurrentUser{
+		roles: []string{"dev"},
+	}, mockCurrentUserRoleGetter{
+		nameToRole: map[string]types.Role{
+			"dev": role,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"mockCurrentUser"}, roleSet[0].GetLogins(types.Allow))
+}
+
 // TestExtractFrom makes sure roles and traits are extracted from SSH and TLS
 // certificates not services.User.
 func TestExtractFrom(t *testing.T) {
@@ -4320,7 +4337,7 @@ func TestCheckAccessToDatabase(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, access := range tc.access {
-				_, err := tc.roles.checkAccess(access.server, wrappers.Traits{}, tc.state,
+				_, err := tc.roles.checkAccess(access.server, "", wrappers.Traits{}, tc.state,
 					NewDatabaseUserMatcher(access.server, access.dbUser),
 					&DatabaseNameMatcher{Name: access.dbName})
 				if access.access {
@@ -4533,7 +4550,7 @@ func TestCheckAccessToDatabaseUser(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, access := range tc.access {
-				_, err := tc.roles.checkAccess(access.server, wrappers.Traits{}, AccessState{}, NewDatabaseUserMatcher(access.server, access.dbUser))
+				_, err := tc.roles.checkAccess(access.server, "", wrappers.Traits{}, AccessState{}, NewDatabaseUserMatcher(access.server, access.dbUser))
 				if access.access {
 					require.NoError(t, err, "access check shouldn't have failed for username %q", access.dbUser)
 				} else {
@@ -5653,7 +5670,7 @@ func TestCheckAccessToDatabaseService(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, access := range tc.access {
-				_, err := tc.roles.checkAccess(access.server, userTraits, AccessState{})
+				_, err := tc.roles.checkAccess(access.server, "", userTraits, AccessState{})
 				if access.access {
 					require.NoError(t, err)
 				} else {
@@ -5761,6 +5778,7 @@ func TestCheckAccessToAWSConsole(t *testing.T) {
 			for _, access := range test.access {
 				_, err := test.roles.checkAccess(
 					app,
+					"",
 					wrappers.Traits{},
 					AccessState{},
 					&AWSRoleARNMatcher{RoleARN: access.roleARN})
@@ -5861,7 +5879,7 @@ func TestCheckAccessToAzureCloud(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for identity, hasAccess := range test.access {
-				_, err := test.roles.checkAccess(app, wrappers.Traits{}, AccessState{}, &AzureIdentityMatcher{Identity: identity})
+				_, err := test.roles.checkAccess(app, "", wrappers.Traits{}, AccessState{}, &AzureIdentityMatcher{Identity: identity})
 				if hasAccess {
 					require.NoError(t, err)
 				} else {
@@ -5959,7 +5977,7 @@ func TestCheckAccessToGCP(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for account, hasAccess := range test.access {
-				_, err := test.roles.checkAccess(app, wrappers.Traits{}, AccessState{}, &GCPServiceAccountMatcher{ServiceAccount: account})
+				_, err := test.roles.checkAccess(app, "", wrappers.Traits{}, AccessState{}, &GCPServiceAccountMatcher{ServiceAccount: account})
 				if hasAccess {
 					require.NoError(t, err)
 				} else {
@@ -7296,7 +7314,7 @@ func TestCheckAccessToWindowsDesktop(t *testing.T) {
 			for i, check := range test.checks {
 				msg := fmt.Sprintf("check=%d, user=%v, server=%v, should_have_access=%v",
 					i, check.login, check.desktop.GetName(), check.hasAccess)
-				_, err := test.roleSet.checkAccess(check.desktop, wrappers.Traits{}, AccessState{}, NewWindowsLoginMatcher(check.login))
+				_, err := test.roleSet.checkAccess(check.desktop, "", wrappers.Traits{}, AccessState{}, NewWindowsLoginMatcher(check.login))
 				if check.hasAccess {
 					require.NoError(t, err, msg)
 				} else {
@@ -7403,7 +7421,7 @@ func TestCheckAccessToUserGroups(t *testing.T) {
 			for i, check := range test.checks {
 				msg := fmt.Sprintf("check=%d, userGroup=%v, should_have_access=%v",
 					i, check.userGroup.GetName(), check.hasAccess)
-				_, err := test.roleSet.checkAccess(check.userGroup, wrappers.Traits{}, AccessState{})
+				_, err := test.roleSet.checkAccess(check.userGroup, "", wrappers.Traits{}, AccessState{})
 				if check.hasAccess {
 					require.NoError(t, err, msg)
 				} else {
@@ -7495,6 +7513,7 @@ func BenchmarkCheckConditionalAccessToServer(b *testing.B) {
 				// is testing the performance of failed RBAC checks
 				_, _ = set.checkAccess(
 					servers[i],
+					"",
 					userTraits,
 					AccessState{},
 					NewLoginMatcher(login),
@@ -7975,7 +7994,7 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			matcher := NewKubernetesClusterLabelMatcher(tc.kubeResLabels, userTraits)
+			matcher := NewKubernetesClusterLabelMatcher(tc.kubeResLabels, "alice", userTraits)
 			gotGroups, gotUsers, err := tc.roles.CheckKubeGroupsAndUsers(time.Hour, true, matcher)
 			if tc.errorFunc == nil {
 				require.NoError(t, err)
@@ -8127,6 +8146,17 @@ func TestGetKubeResources(t *testing.T) {
 				}),
 			},
 			clusterLabels: map[string]string{"env": "prod"},
+			expectAllowed: []types.KubernetesResource{podA, podB},
+		},
+		{
+			desc: "labels expression matches username",
+			roles: []types.Role{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.KubernetesLabelsExpression = `labels["owner"] == user.metadata.name`
+					r.Spec.Allow.KubernetesResources = []types.KubernetesResource{podA, podB}
+				}),
+			},
+			clusterLabels: map[string]string{"owner": "alice"},
 			expectAllowed: []types.KubernetesResource{podA, podB},
 		},
 		{
@@ -9769,6 +9799,21 @@ func TestCheckAccessWithLabelExpressions(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestCheckAccess_WithLabelExpressionUsername(t *testing.T) {
+	t.Parallel()
+
+	role := newRole(func(r *types.RoleV6) {
+		r.Spec.Allow.NodeLabelsExpression = `labels["owner"] == user.metadata.name`
+	})
+
+	server := &types.ServerV2{Kind: types.KindNode}
+	server.SetStaticLabels(map[string]string{"owner": "alice"})
+
+	accessChecker := makeAccessCheckerWithRoleSet(NewRoleSet(role))
+	err := accessChecker.CheckAccess(server, AccessState{})
+	require.NoError(t, err)
 }
 
 func TestCheckSPIFFESVID(t *testing.T) {

--- a/lib/srv/statichostusers.go
+++ b/lib/srv/statichostusers.go
@@ -224,6 +224,7 @@ func (s *StaticHostUserHandler) handleNewHostUser(ctx context.Context, hostUser 
 				Labels:     nodeLabels,
 				Expression: matcher.NodeLabelsExpression,
 			},
+			"",  // username
 			nil, // userTraits
 			server,
 			false, // debug

--- a/lib/utils/parse/parse.go
+++ b/lib/utils/parse/parse.go
@@ -72,7 +72,8 @@ type TraitsTemplateExpression struct {
 	expr traitsTemplateExpression
 }
 
-// NewTraitsTemplateExpression parses expressions like {{external.foo}} or {{internal.bar}},
+// NewTraitsTemplateExpression parses expressions like {{external.foo}}, {{internal.bar}},
+// or {{user.metadata.name}},
 // or a literal value like "prod". Call Interpolate on the returned Expression
 // to get the final value based on user traits.
 func NewTraitsTemplateExpression(value string) (*TraitsTemplateExpression, error) {
@@ -109,7 +110,14 @@ func NewTraitsTemplateExpression(value string) (*TraitsTemplateExpression, error
 // and this variable is not found on any trait, nil in case of success,
 // and BadParameter otherwise.
 func (e *TraitsTemplateExpression) Interpolate(varValidation func(namespace, name string) error, traits map[string][]string) ([]string, error) {
+	return e.InterpolateWithUser(varValidation, "", traits)
+}
+
+// InterpolateWithUser interpolates the variable adding prefix and suffix if
+// present, with optional Teleport username.
+func (e *TraitsTemplateExpression) InterpolateWithUser(varValidation func(namespace, name string) error, username string, traits map[string][]string) ([]string, error) {
 	result, err := e.expr.Evaluate(traitsTemplateEnv{
+		username:       username,
 		traits:         traits,
 		traitValidator: varValidation,
 	})
@@ -128,6 +136,7 @@ func (e *TraitsTemplateExpression) Interpolate(varValidation func(namespace, nam
 }
 
 type traitsTemplateEnv struct {
+	username       string
 	traits         map[string][]string
 	traitValidator func(namespace, name string) error
 }
@@ -167,6 +176,12 @@ func newTraitsTemplateParser() (*typical.CachedParser[traitsTemplateEnv, []strin
 		Variables: map[string]typical.Variable{
 			"external": traitsVariable("external"),
 			"internal": traitsVariable("internal"),
+			"user.metadata.name": typical.DynamicVariable(func(e traitsTemplateEnv) ([]string, error) {
+				if e.username == "" {
+					return nil, trace.NotFound("user.metadata.name is not available in this context")
+				}
+				return []string{e.username}, nil
+			}),
 		},
 		Functions: map[string]typical.Function{
 			EmailLocalFnName:    typical.UnaryFunction[traitsTemplateEnv](EmailLocal),

--- a/lib/utils/parse/parse_test.go
+++ b/lib/utils/parse/parse_test.go
@@ -246,6 +246,12 @@ func TestInterpolate(t *testing.T) {
 			res:    result{errCheck: errCheckIsNotFound, values: []string{}},
 		},
 		{
+			title:  "legacy user.name trait alias",
+			in:     "{{user.name}}",
+			traits: map[string][]string{"name": {"alice-from-trait"}},
+			res:    result{values: []string{"alice-from-trait"}},
+		},
+		{
 			title:  "traits with prefix and suffix",
 			in:     "IAM#{{external.foo}};",
 			traits: map[string][]string{"foo": {"a", "b"}, "bar": {"c"}},
@@ -306,6 +312,41 @@ func TestInterpolate(t *testing.T) {
 			require.Equal(t, tt.res.values, values)
 		})
 	}
+}
+
+func TestInterpolateWithUser(t *testing.T) {
+	t.Parallel()
+
+	expr, err := NewTraitsTemplateExpression("hello-{{user.metadata.name}}")
+	require.NoError(t, err)
+
+	noVarValidation := func(string, string) error {
+		return nil
+	}
+
+	values, err := expr.InterpolateWithUser(noVarValidation, "alice", nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"hello-alice"}, values)
+
+	_, err = expr.InterpolateWithUser(noVarValidation, "", nil)
+	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+}
+
+func TestInterpolateWithUserPreservesLegacyUserNameTrait(t *testing.T) {
+	t.Parallel()
+
+	expr, err := NewTraitsTemplateExpression("hello-{{user.name}}")
+	require.NoError(t, err)
+
+	noVarValidation := func(string, string) error {
+		return nil
+	}
+
+	values, err := expr.InterpolateWithUser(noVarValidation, "alice", map[string][]string{
+		"name": {"alice-from-trait"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"hello-alice-from-trait"}, values)
 }
 
 // TestVarValidation tests that vars are validated during interpolation.

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -236,7 +236,7 @@ func MakeKubeResources(resources []*types.KubernetesResourceV1, cluster string) 
 // each Role, and focuses only on listing all users and groups that the user may
 // have access to.
 func getAllowedKubeUsersAndGroupsForCluster(accessChecker services.AccessChecker, kube types.KubeCluster) (kubeUsers []string, kubeGroups []string) {
-	matcher := services.NewKubernetesClusterLabelMatcher(kube.GetAllLabels(), accessChecker.Traits())
+	matcher := services.NewKubernetesClusterLabelMatcher(kube.GetAllLabels(), accessChecker.AccessInfo().Username, accessChecker.Traits())
 	// We ignore the TTL verification because we want to include every possibility.
 	// Later, if the user certificate expiration is longer than the maximum allowed TTL
 	// for the role that defines the `kubernetes_*` principals the request will be


### PR DESCRIPTION
## Description

Adds a new variable `user.metadata.name` that can be used in role templates:

```yaml
allow:
  node_labels:
    owner: '{{user.metadata.name}}'
```

Or in expressions:

```yaml
allow:
  node_labels_expression: |
    labels["owner"] == user.metadata.name
```

So you can create roles that allow access to user-owned resources such as "Connect My Computer" nodes, or the upcoming Beams feature.

### Alternatives considered

#### Calling the variable `{{user.name}}`

Unfortunately, older versions of the template parser accidentally allowed `<anything>.trait` as an alias for `external.trait`. Because some users wrote typos, we have to maintain this behavior for backward-compatability, which means that `user.name` would technically conflict with the `external.name` trait 😭 

Variable names with three or more parts do not have this issue, hence `user.metadata.name` for symmetry with `user.spec.traits`.

#### Synthetic `{{internal.username}}` trait

Many SSO users already have the `{{external.username}}` trait, so an obvious alternative is to match this for local users by injecting a "synthetic" username trait at evaluation-time.

This approach was abandoned because:

1. There are a lot of places we read the traits in different ways (e.g. directly from the user record, from SSH/TLS certificate extensions, etc.) and it'd be very easy to miss one.
2. What should we do if the user already _has_ a username trait? It feels dangerous to mix user traits with "facts" like this.

#### Real `{{internal.username}}` trait

A possible solution to one of the issues with the synthetic trait approach would be to set the username trait at write-time, so for all intents and purposes it is a "real" trait, and we wouldn't need to worry about missing a callsite.

However, the other issue remains, and it feels wrong to mutate user-given fields in this way (e.g. we'd need to mark the field as "computed" in the Terraform provider).

## Manual Test Plan

### Test Environment

Staging cloud tenant + app service running in a local Docker container.

**App service config:**

```yaml
app_service:
  enabled: yes
  apps:
  - name: "test-app"
    uri: "http://localhost:3000"
    public_addr: test-app.dupton.cloud.gravitational.io
    labels:
      owner: 'daniel.upton@goteleport.com'
      teleport.internal/resource-id: 7e6f2c74-e1c0-4fc4-b8bb-606d2bd79922
```

**Role 1:**

```yaml
kind: role
version: v8
metadata:
  name: owner-app-access-1
spec:
  allow:
    app_labels: |
      owner: '{{user.metadata.name}}'
```

**Role 2:**

```yaml
kind: role
version: v8
metadata:
  name: owner-app-access-2
spec:
  allow:
    app_labels_expression: |
      labels["owner"] == user.metadata.name
```

### Test Cases
- [x] User with Role 1 can access the application
- [x] User with Role 2 can access the application
- [x] Removing the label from the application removes the user's access

changelog: Added `user.metadata.name` variable to RBAC role templates and expressions