### PR TITLE
enforce region validation on all AWS config loading

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,7 @@ linters:
             - '**/lib/cloud/imds/**'
           allow:
             - github.com/gravitational/teleport/lib/cloud/imds
+            - github.com/gravitational/teleport/lib/cloud/aws/config
           deny:
             - pkg: github.com/gravitational/teleport/lib/auth$
               desc: lib/auth should not be imported to prevent increasing binary size, prefer lib/auth/authclient instead
@@ -346,6 +347,9 @@ linters:
         - pattern: ^semver\.New$
           pkg: ^github.com/coreos/go-semver/semver$
           msg: construct a semver.Version manually or use semver.NewVersion
+        - pattern: ^[^\.]+\.LoadDefaultConfig$
+          pkg: ^github.com/aws/aws-sdk-go-v2/config$
+          msg: use github.com/gravitational/teleport/lib/cloud/aws/config.LoadDefaultConfig to ensure region validation
       analyze-types: true
     misspell:
       locale: US
@@ -472,6 +476,18 @@ linters:
           - forbidigo
         path: lib/utils/aws/stsutils/stscreds_v1.go
         text: stscreds.NewCredentials
+      - linters:
+          - forbidigo
+        path: lib/cloud/aws/config/config.go
+        text: LoadDefaultConfig
+      - linters:
+          - forbidigo
+        path: examples/dynamoathenamigration/migration.go
+        text: LoadDefaultConfig'
+      - linters:
+          - forbidigo
+        path: e/scripts/loadtest-login/main.go
+        text: LoadDefaultConfig
     paths:
       - (^|/)node_modules/
       - ^api/gen/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -483,7 +483,7 @@ linters:
       - linters:
           - forbidigo
         path: examples/dynamoathenamigration/migration.go
-        text: LoadDefaultConfig'
+        text: LoadDefaultConfig
       - linters:
           - forbidigo
         path: e/scripts/loadtest-login/main.go

--- a/api/utils/aws/identifiers.go
+++ b/api/utils/aws/identifiers.go
@@ -209,7 +209,7 @@ var (
 	// convention (e.g. users that have AWS compatible services). This prevents
 	// invalid input (special characters, whitespace, injection
 	// attempts).
-	weakRegionValidation = regexp.MustCompile(`^[a-z0-9-]+$`)
+	weakRegionValidation = regexp.MustCompile(`^[a-zA-Z0-9-_]+$`)
 
 	// https://docs.aws.amazon.com/athena/latest/APIReference/API_CreateWorkGroup.html
 	matchAthenaWorkgroupName = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,128}$`).MatchString

--- a/api/utils/aws/identifiers.go
+++ b/api/utils/aws/identifiers.go
@@ -109,6 +109,17 @@ func IsValidRegion(region string) error {
 	return trace.BadParameter("region %q is invalid", region)
 }
 
+// IsValidRegionWithWeakCheck validates a region accepting any string of
+// lowercase letters, digits, and hyphens. Use this instead of IsValidRegion
+// when customers can be interacting with their own AWS like API implementation
+// like S3 where regions do not follow strict naming convention.
+func IsValidRegionWithWeakCheck(region string) error {
+	if weakRegionValidation.MatchString(region) {
+		return nil
+	}
+	return trace.BadParameter("region %q is invalid", region)
+}
+
 // IsValidPartition checks if partition is a valid AWS partition
 func IsValidPartition(partition string) error {
 	if slices.Contains(validPartitions, partition) {
@@ -190,6 +201,15 @@ var (
 	// Reference:
 	// https://github.com/aws/aws-sdk-go-v2/blob/main/codegen/smithy-aws-go-codegen/src/main/resources/software/amazon/smithy/aws/go/codegen/endpoints.json
 	matchRegion = regexp.MustCompile(`^(eusc-)?[a-z]{2}(-gov|-iso|-isob|-isoe|-isof)?-\w+-\d+$`)
+
+	// weakRegionValidation is a permissive regex used as a fallback when a
+	// region does not match the stricter matchRegion pattern. It accepts any
+	// string composed solely of lowercase letters, digits, and hyphens, which
+	// covers regions that may not yet conform to the known naming
+	// convention (e.g. users that have AWS compatible services). This prevents
+	// invalid input (special characters, whitespace, injection
+	// attempts).
+	weakRegionValidation = regexp.MustCompile(`^[a-z0-9-]+$`)
 
 	// https://docs.aws.amazon.com/athena/latest/APIReference/API_CreateWorkGroup.html
 	matchAthenaWorkgroupName = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,128}$`).MatchString

--- a/api/utils/aws/identifiers_test.go
+++ b/api/utils/aws/identifiers_test.go
@@ -269,7 +269,12 @@ func TestIsValidRegionWithWeakCheck(t *testing.T) {
 		{
 			name:     "uppercase letters",
 			region:   "US-EAST-1",
-			errCheck: isBadParamErrFn,
+			errCheck: require.NoError,
+		},
+		{
+			name:     "underscores",
+			region:   "US_EAST_1",
+			errCheck: require.NoError,
 		},
 		{
 			name:     "special symbols",

--- a/api/utils/aws/identifiers_test.go
+++ b/api/utils/aws/identifiers_test.go
@@ -225,6 +225,84 @@ func TestIsValidRegion(t *testing.T) {
 	}
 }
 
+func TestIsValidRegionWithWeakCheck(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		region   string
+		errCheck require.ErrorAssertionFunc
+	}{
+		{
+			name:     "standard us region",
+			region:   "us-east-1",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "aws global sentinel value",
+			region:   "aws-global",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "eu region",
+			region:   "eu-west-1",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "us gov",
+			region:   "us-gov-east-1",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "unknown region with valid chars accepted by weak check",
+			region:   "xx-newpartition-99",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "digits only accepted by weak check",
+			region:   "123",
+			errCheck: require.NoError,
+		},
+		{
+			name:     "empty",
+			region:   "",
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "uppercase letters",
+			region:   "US-EAST-1",
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "special symbols",
+			region:   "us@east-1",
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "spaces",
+			region:   "us east-1",
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "unicode digit",
+			region:   "us-east-৩",
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "/ char",
+			region:   "us-east/",
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "? char",
+			region:   "us-east?",
+			errCheck: isBadParamErrFn,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.errCheck(t, IsValidRegionWithWeakCheck(tt.region))
+		})
+	}
+}
+
 func TestCheckRoleARN(t *testing.T) {
 	for _, tt := range []struct {
 		name     string

--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -32,7 +32,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	mysqlclient "github.com/go-mysql-org/go-mysql/client"
 	"github.com/gravitational/trace"
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
@@ -369,7 +370,7 @@ func getMasterUserPassword(t *testing.T, ctx context.Context, secretID string) s
 func getSecretValue(t *testing.T, ctx context.Context, secretID string) secretsmanager.GetSecretValueOutput {
 	t.Helper()
 	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(mustGetEnv(t, awsRegionEnv)),
+		awsconfig.WithRegion(mustGetEnv(t, awsRegionEnv)),
 	)
 	require.NoError(t, err)
 

--- a/e2e/aws/rds_test.go
+++ b/e2e/aws/rds_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	mysqlclient "github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -37,6 +37,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -575,7 +576,7 @@ func connectAsRDSMySQLAdmin(t *testing.T, ctx context.Context, instanceID string
 func getRDSAdminInfo(t *testing.T, ctx context.Context, instanceID string) dbUserLogin {
 	t.Helper()
 	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(mustGetEnv(t, awsRegionEnv)),
+		awsconfig.WithRegion(mustGetEnv(t, awsRegionEnv)),
 	)
 	require.NoError(t, err)
 

--- a/e2e/aws/redshift_test.go
+++ b/e2e/aws/redshift_test.go
@@ -24,12 +24,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -215,7 +216,7 @@ func connectAsRedshiftClusterAdmin(t *testing.T, ctx context.Context, clusterID 
 func getRedshiftAdminInfo(t *testing.T, ctx context.Context, clusterID string) dbUserLogin {
 	t.Helper()
 	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(mustGetEnv(t, awsRegionEnv)),
+		awsconfig.WithRegion(mustGetEnv(t, awsRegionEnv)),
 	)
 	require.NoError(t, err)
 	clt := redshift.NewFromConfig(cfg)

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -242,7 +242,6 @@ func (p *playwrightRunner) openConnectAuthenticated(ctx context.Context) error {
 	return p.pnpm(ctx, []string{"exec", "tsx", "scripts/open-connect.ts"}, env)
 }
 
-
 // startEnv builds the environment variables that Playwright tests need,
 // including START_URL, credentials, and tctl paths for invite URL generation.
 func (p *playwrightRunner) startEnv(inst *browserInstance) ([]string, error) {

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
@@ -43,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
+	"github.com/gravitational/teleport/lib/cloud/aws/config"
 	cloudimds "github.com/gravitational/teleport/lib/cloud/imds"
 	cloudaws "github.com/gravitational/teleport/lib/cloud/imds/aws"
 	"github.com/gravitational/teleport/lib/defaults"

--- a/lib/auth/join/iam/iam.go
+++ b/lib/auth/join/iam/iam.go
@@ -26,13 +26,13 @@ import (
 	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	smithyendpoints "github.com/aws/smithy-go/endpoints"
 	"github.com/aws/smithy-go/tracing/smithyoteltracing"
 	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel"
 
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	cloudaws "github.com/gravitational/teleport/lib/cloud/imds/aws"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )

--- a/lib/auth/keystore/aws_kms.go
+++ b/lib/auth/keystore/aws_kms.go
@@ -34,7 +34,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
@@ -48,6 +48,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
@@ -90,8 +91,8 @@ func newAWSKMSKeystore(ctx context.Context, cfg *servicecfg.AWSKMSConfig, opts *
 			useFIPSEndpoint = aws.FIPSEndpointStateEnabled
 		}
 		awsCfg, err := config.LoadDefaultConfig(ctx,
-			config.WithRegion(cfg.AWSRegion),
-			config.WithUseFIPSEndpoint(useFIPSEndpoint),
+			awsconfig.WithRegion(cfg.AWSRegion),
+			awsconfig.WithUseFIPSEndpoint(useFIPSEndpoint),
 		)
 		if err != nil {
 			return nil, trace.Wrap(err, "loading default AWS config")

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	awsmetrics "github.com/gravitational/teleport/lib/observability/metrics/aws"
 	dynamometrics "github.com/gravitational/teleport/lib/observability/metrics/dynamo"
@@ -250,21 +251,21 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 
 	l.InfoContext(ctx, "Initializing backend", "table", cfg.TableName, "poll_stream_period", cfg.PollStreamPeriod)
 
-	opts := []func(*config.LoadOptions) error{
-		config.WithRegion(cfg.Region),
-		config.WithHTTPClient(&http.Client{
+	opts := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRegion(cfg.Region),
+		awsconfig.WithHTTPClient(&http.Client{
 			Transport: &http.Transport{
 				Proxy:               http.ProxyFromEnvironment,
 				MaxIdleConns:        defaults.HTTPMaxIdleConns,
 				MaxIdleConnsPerHost: defaults.HTTPMaxIdleConnsPerHost,
 			},
 		}),
-		config.WithAPIOptions(awsmetrics.MetricsMiddleware()),
-		config.WithAPIOptions(dynamometrics.MetricsMiddleware(dynamometrics.Backend)),
+		awsconfig.WithAPIOptions(awsmetrics.MetricsMiddleware()),
+		awsconfig.WithAPIOptions(dynamometrics.MetricsMiddleware(dynamometrics.Backend)),
 	}
 
 	if cfg.AccessKey != "" || cfg.SecretKey != "" {
-		opts = append(opts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(cfg.AccessKey, cfg.SecretKey, "")))
+		opts = append(opts, awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(cfg.AccessKey, cfg.SecretKey, "")))
 	}
 
 	awsConfig, err := config.LoadDefaultConfig(ctx, opts...)

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
 	autoscalingtypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -45,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
+	"github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/utils/clocki"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )

--- a/lib/cloud/aws/config/config.go
+++ b/lib/cloud/aws/config/config.go
@@ -1,0 +1,52 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/gravitational/trace"
+
+	apiutilsaws "github.com/gravitational/teleport/api/utils/aws"
+)
+
+// LoadDefaultConfig loads an AWS config using the SDK defaults, validating any
+// explicitly requested region before use.
+func LoadDefaultConfig(ctx context.Context, optFns ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+	var loadOptions awsconfig.LoadOptions
+
+	for _, optFn := range optFns {
+		if err := optFn(&loadOptions); err != nil {
+			return aws.Config{}, trace.Wrap(err)
+		}
+	}
+
+	if loadOptions.Region != "" {
+		// Use the weak check here rather than the strict one because the region
+		// may come from customer-supplied configuration targeting an AWS compatible
+		// service that uses different region naming schema.
+		// To avoid breaking them, we introduced the weak check that allows any
+		// string containing hiphens, numbers and lowercase letters.
+		if err := apiutilsaws.IsValidRegionWithWeakCheck(loadOptions.Region); err != nil {
+			return aws.Config{}, trace.Wrap(err)
+		}
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, optFns...)
+	return cfg, trace.Wrap(err)
+}

--- a/lib/cloud/aws/config/config.go
+++ b/lib/cloud/aws/config/config.go
@@ -50,3 +50,16 @@ func LoadDefaultConfig(ctx context.Context, optFns ...func(*awsconfig.LoadOption
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, optFns...)
 	return cfg, trace.Wrap(err)
 }
+
+// ConfigureRegion sets the region on cfg after validating it. An empty region
+// is accepted and clears the existing value. Use this instead of assigning
+// cfg.Region directly so that invalid region strings are rejected before use.
+func ConfigureRegion(cfg *aws.Config, region string) error {
+	if region != "" {
+		if err := apiutilsaws.IsValidRegionWithWeakCheck(region); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	cfg.Region = region
+	return nil
+}

--- a/lib/cloud/awsconfig/awsconfig.go
+++ b/lib/cloud/awsconfig/awsconfig.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
@@ -36,6 +36,7 @@ import (
 
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/integrations/awsra"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
@@ -385,26 +386,26 @@ func loadDefaultConfig(ctx context.Context, region string, cred aws.CredentialsP
 	return cfg, nil
 }
 
-func buildConfigOptions(region string, cred aws.CredentialsProvider, opts *options) []func(*config.LoadOptions) error {
-	configOpts := []func(*config.LoadOptions) error{
-		config.WithRegion(region),
-		config.WithCredentialsProvider(cred),
-		config.WithCredentialsCacheOptions(awsCredentialsCacheOptions),
+func buildConfigOptions(region string, cred aws.CredentialsProvider, opts *options) []func(*awsconfig.LoadOptions) error {
+	configOpts := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRegion(region),
+		awsconfig.WithCredentialsProvider(cred),
+		awsconfig.WithCredentialsCacheOptions(awsCredentialsCacheOptions),
 	}
 	if modules.GetModules().IsBoringBinary() {
-		configOpts = append(configOpts, config.WithUseFIPSEndpoint(aws.FIPSEndpointStateEnabled))
+		configOpts = append(configOpts, awsconfig.WithUseFIPSEndpoint(aws.FIPSEndpointStateEnabled))
 	}
 	if opts.customRetryer != nil {
-		configOpts = append(configOpts, config.WithRetryer(opts.customRetryer))
+		configOpts = append(configOpts, awsconfig.WithRetryer(opts.customRetryer))
 	}
 	if opts.maxRetries != nil {
-		configOpts = append(configOpts, config.WithRetryMaxAttempts(*opts.maxRetries))
+		configOpts = append(configOpts, awsconfig.WithRetryMaxAttempts(*opts.maxRetries))
 	}
 	if opts.withFallbackRegionResolver == nil {
 		// if we pass WithDefaultRegion, then we will never get back an empty
 		// region, so we have to skip passing it here if we want to make use of
 		// a custom fallback resolver.
-		configOpts = append(configOpts, config.WithDefaultRegion(defaultRegion))
+		configOpts = append(configOpts, awsconfig.WithDefaultRegion(defaultRegion))
 	}
 	return configOpts
 }

--- a/lib/cloud/imds/aws/imds.go
+++ b/lib/cloud/imds/aws/imds.go
@@ -25,12 +25,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -52,7 +53,7 @@ func WithIMDSClient(client *imds.Client) InstanceMetadataClientOption {
 
 // convertLoadConfigError converts common AWS config loading errors to trace errors.
 func convertLoadConfigError(configErr error) error {
-	var sharedConfigProfileNotExistError config.SharedConfigProfileNotExistError
+	var sharedConfigProfileNotExistError awsconfig.SharedConfigProfileNotExistError
 	switch {
 	case errors.As(configErr, &sharedConfigProfileNotExistError):
 		return trace.NotFound("%s", configErr)

--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awssdkconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/backend"
+	awsconfig "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage"
 	"github.com/gravitational/teleport/lib/observability/metrics"
@@ -445,8 +446,8 @@ func (cfg *Config) UpdateForExternalAuditStorage(ctx context.Context, externalAu
 	cfg.Region = spec.Region
 
 	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
-		awsconfig.WithRegion(cfg.Region),
-		awsconfig.WithCredentialsProvider(externalAuditStorage.CredentialsProvider()),
+		awssdkconfig.WithRegion(cfg.Region),
+		awssdkconfig.WithCredentialsProvider(externalAuditStorage.CredentialsProvider()),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/events/athena/integration_test.go
+++ b/lib/events/athena/integration_test.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 	athenaTypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/aws/aws-sdk-go-v2/service/glue"
@@ -54,6 +53,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	awsconfig "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
 	"github.com/gravitational/teleport/lib/observability/tracing"

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -34,7 +34,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
 	autoscalingtypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	awsmetrics "github.com/gravitational/teleport/lib/observability/metrics/aws"
@@ -317,21 +318,21 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	opts := []func(*config.LoadOptions) error{
-		config.WithRegion(cfg.Region),
-		config.WithHTTPClient(&http.Client{
+	opts := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRegion(cfg.Region),
+		awsconfig.WithHTTPClient(&http.Client{
 			Transport: &http.Transport{
 				Proxy:               http.ProxyFromEnvironment,
 				MaxIdleConns:        defaults.HTTPMaxIdleConns,
 				MaxIdleConnsPerHost: defaults.HTTPMaxIdleConnsPerHost,
 			},
 		}),
-		config.WithAPIOptions(awsmetrics.MetricsMiddleware()),
-		config.WithAPIOptions(dynamometrics.MetricsMiddleware(dynamometrics.Backend)),
+		awsconfig.WithAPIOptions(awsmetrics.MetricsMiddleware()),
+		awsconfig.WithAPIOptions(dynamometrics.MetricsMiddleware(dynamometrics.Backend)),
 	}
 
 	if cfg.CredentialsProvider != nil {
-		opts = append(opts, config.WithCredentialsProvider(cfg.CredentialsProvider))
+		opts = append(opts, awsconfig.WithCredentialsProvider(cfg.CredentialsProvider))
 	}
 
 	resolver, err := endpoint.NewLoggingResolver(
@@ -359,7 +360,7 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 			return nil, trace.BadParameter("configured DynamoDB events endpoint is invalid: %s", err.Error())
 		}
 
-		opts = append(opts, config.WithBaseEndpoint(cfg.Endpoint))
+		opts = append(opts, awsconfig.WithBaseEndpoint(cfg.Endpoint))
 	}
 
 	// FIPS settings are applied on the individual service instead of the aws config,

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -33,7 +33,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
@@ -201,12 +202,12 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 	}
 	logger := slog.With(teleport.ComponentKey, teleport.SchemeS3)
 
-	opts := []func(*config.LoadOptions) error{
-		config.WithRegion(cfg.Region),
+	opts := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRegion(cfg.Region),
 	}
 
 	if cfg.Insecure {
-		opts = append(opts, config.WithHTTPClient(&http.Client{
+		opts = append(opts, awsconfig.WithHTTPClient(&http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
@@ -217,16 +218,16 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		opts = append(opts, config.WithHTTPClient(hc))
+		opts = append(opts, awsconfig.WithHTTPClient(hc))
 	}
 
 	if cfg.CredentialsProvider != nil {
-		opts = append(opts, config.WithCredentialsProvider(cfg.CredentialsProvider))
+		opts = append(opts, awsconfig.WithCredentialsProvider(cfg.CredentialsProvider))
 	}
 
 	opts = append(opts,
-		config.WithAPIOptions(awsmetrics.MetricsMiddleware()),
-		config.WithAPIOptions(s3metrics.MetricsMiddleware()),
+		awsconfig.WithAPIOptions(awsmetrics.MetricsMiddleware()),
+		awsconfig.WithAPIOptions(s3metrics.MetricsMiddleware()),
 	)
 
 	resolver, err := endpoint.NewLoggingResolver(
@@ -252,7 +253,7 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 			return nil, trace.BadParameter("configured S3 endpoint is invalid: %s", err.Error())
 		}
 
-		opts = append(opts, config.WithBaseEndpoint(cfg.Endpoint))
+		opts = append(opts, awsconfig.WithBaseEndpoint(cfg.Endpoint))
 
 		s3Opts = append(s3Opts, func(options *s3.Options) {
 			options.UsePathStyle = !cfg.UseVirtualStyleAddressing

--- a/lib/integrations/awsoidc/accessgraph_sync.go
+++ b/lib/integrations/awsoidc/accessgraph_sync.go
@@ -24,12 +24,13 @@ import (
 	"regexp"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gravitational/trace"
 
 	awsutils "github.com/gravitational/teleport/api/utils/aws"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
 	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
@@ -127,7 +128,7 @@ type defaultTAGIAMConfigureClient struct {
 
 // NewAccessGraphIAMConfigureClient creates a new TAGIAMConfigureClient.
 func NewAccessGraphIAMConfigureClient(ctx context.Context) (AccessGraphIAMConfigureClient, error) {
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("" /* region */))
+	cfg, err := config.LoadDefaultConfig(ctx, awsconfig.WithRegion("" /* region */))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsoidc/aws_app_access_iam_config.go
+++ b/lib/integrations/awsoidc/aws_app_access_iam_config.go
@@ -23,11 +23,12 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
 	"github.com/gravitational/teleport/lib/modules"
@@ -91,10 +92,10 @@ type defaultAWSAppAccessConfigureClient struct {
 
 // NewAWSAppAccessConfigureClient creates a new AWSAppAccessConfigureClient.
 func NewAWSAppAccessConfigureClient(ctx context.Context) (AWSAppAccessConfigureClient, error) {
-	var configOptions []func(*config.LoadOptions) error
+	var configOptions []func(*awsconfig.LoadOptions) error
 
 	if modules.GetModules().IsBoringBinary() {
-		configOptions = append(configOptions, config.WithUseFIPSEndpoint(aws.FIPSEndpointStateEnabled))
+		configOptions = append(configOptions, awsconfig.WithUseFIPSEndpoint(aws.FIPSEndpointStateEnabled))
 	}
 
 	cfg, err := config.LoadDefaultConfig(ctx, configOptions...)

--- a/lib/integrations/awsoidc/bedrock_session_summaries_iam_config.go
+++ b/lib/integrations/awsoidc/bedrock_session_summaries_iam_config.go
@@ -22,12 +22,13 @@ import (
 	"context"
 	"io"
 
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
 	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
@@ -103,7 +104,7 @@ func (c *defaultBedrockSessionSummariesIAMConfigureClient) GetCallerIdentity(ctx
 
 // NewBedrockSessionSummariesIAMConfigureClient creates a new BedrockSessionSummariesIAMConfigureClient.
 func NewBedrockSessionSummariesIAMConfigureClient(ctx context.Context) (BedrockSessionSummariesIAMConfigureClient, error) {
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("" /* region */))
+	cfg, err := config.LoadDefaultConfig(ctx, awsconfig.WithRegion("" /* region */))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsoidc/clients.go
+++ b/lib/integrations/awsoidc/clients.go
@@ -22,7 +22,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect"
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/trace"
 
 	awsutils "github.com/gravitational/teleport/api/utils/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
@@ -76,7 +77,7 @@ func newAWSConfig(ctx context.Context, req *AWSClientRequest) (*aws.Config, erro
 		return nil, trace.Wrap(err)
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(req.Region))
+	cfg, err := config.LoadDefaultConfig(ctx, awsconfig.WithRegion(req.Region))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsoidc/credprovider/integration_config_provider.go
+++ b/lib/integrations/awsoidc/credprovider/integration_config_provider.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	awssdkconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	awsConfig "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
@@ -61,7 +62,7 @@ func CreateAWSConfigForIntegration(ctx context.Context, config Config, option ..
 	}
 	go credCache.Run(ctx)
 
-	awsCfg, err := newAWSConfig(ctx, config.Region, awsConfig.WithCredentialsProvider(credCache))
+	awsCfg, err := newAWSConfig(ctx, config.Region, awssdkconfig.WithCredentialsProvider(credCache))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -147,15 +148,15 @@ func newAWSCredCache(ctx context.Context, cfg Config, stsClient stscreds.AssumeR
 	return credCache, nil
 }
 
-func newAWSConfig(ctx context.Context, awsRegion string, options ...func(*awsConfig.LoadOptions) error) (*aws.Config, error) {
+func newAWSConfig(ctx context.Context, awsRegion string, options ...func(*awssdkconfig.LoadOptions) error) (*aws.Config, error) {
 	var useFIPS aws.FIPSEndpointState
 	if modules.GetModules().IsBoringBinary() {
 		useFIPS = aws.FIPSEndpointStateEnabled
 	}
 	options = append(options,
-		awsConfig.WithRegion(awsRegion),
-		awsConfig.WithUseFIPSEndpoint(useFIPS),
-		awsConfig.WithRetryMaxAttempts(10),
+		awssdkconfig.WithRegion(awsRegion),
+		awssdkconfig.WithUseFIPSEndpoint(useFIPS),
+		awssdkconfig.WithRetryMaxAttempts(10),
 	)
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, options...)
 	if err != nil {

--- a/lib/integrations/awsoidc/credprovider/integration_config_provider_test.go
+++ b/lib/integrations/awsoidc/credprovider/integration_config_provider_test.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	integrationName = "test-integration1"
-	awsRegion       = " eu-central-1"
+	awsRegion       = "eu-central-1"
 	testUser        = "test-user"
 )
 

--- a/lib/integrations/awsoidc/deployservice_iam_config.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config.go
@@ -23,12 +23,13 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gravitational/trace"
 
 	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
@@ -141,7 +142,7 @@ func NewDeployServiceIAMConfigureClient(ctx context.Context, region string) (Dep
 		return nil, trace.BadParameter("region is required")
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	cfg, err := config.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsoidc/ec2_ssm_iam_config.go
+++ b/lib/integrations/awsoidc/ec2_ssm_iam_config.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
 	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
@@ -135,7 +136,7 @@ func NewEC2SSMConfigureClient(ctx context.Context, region string) (EC2SSMConfigu
 		return nil, trace.BadParameter("region is required")
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	cfg, err := config.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsoidc/eks_iam_config.go
+++ b/lib/integrations/awsoidc/eks_iam_config.go
@@ -22,11 +22,12 @@ import (
 	"context"
 	"io"
 
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
 	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
@@ -95,7 +96,7 @@ func NewEKSIAMConfigureClient(ctx context.Context, region string) (EKSIAMConfigu
 		return nil, trace.BadParameter("region is required")
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	cfg, err := config.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -25,13 +25,13 @@ import (
 	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/common"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"

--- a/lib/integrations/awsoidc/listdatabases_iam_config.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config.go
@@ -22,11 +22,12 @@ import (
 	"context"
 	"io"
 
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
 	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
@@ -87,7 +88,7 @@ func NewListDatabasesIAMConfigureClient(ctx context.Context, region string) (Lis
 		return nil, trace.BadParameter("region is required")
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	cfg, err := config.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsra/client.go
+++ b/lib/integrations/awsra/client.go
@@ -22,11 +22,12 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/gravitational/trace"
 
 	awsutils "github.com/gravitational/teleport/api/utils/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 )
 
 // AWSClientConfig contains the required fields to set up an AWS SDK Clients.
@@ -64,8 +65,8 @@ func newAWSConfig(ctx context.Context, req *AWSClientConfig) (aws.Config, error)
 
 	awsConfig, err := config.LoadDefaultConfig(
 		ctx,
-		config.WithRegion(req.Region),
-		config.WithCredentialsProvider(
+		awsconfig.WithRegion(req.Region),
+		awsconfig.WithCredentialsProvider(
 			credentials.NewStaticCredentialsProvider(
 				req.Credentials.AccessKeyID,
 				req.Credentials.SecretAccessKey,

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
 	"github.com/google/uuid"
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -386,8 +387,8 @@ func buildAWSRolesAnywhereClientForIntegration(ctx context.Context, params AWSRo
 
 	awsConfig, err := config.LoadDefaultConfig(
 		ctx,
-		config.WithRegion(region),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(resp.AccessKeyID, resp.SecretAccessKey, resp.SessionToken)),
+		awsconfig.WithRegion(region),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(resp.AccessKeyID, resp.SecretAccessKey, resp.SessionToken)),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/integrations/awsra/trustanchor_config.go
+++ b/lib/integrations/awsra/trustanchor_config.go
@@ -26,13 +26,13 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"

--- a/lib/integrations/externalauditstorage/configurator.go
+++ b/lib/integrations/externalauditstorage/configurator.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/entitlements"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc/credprovider"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
@@ -103,8 +104,8 @@ func (o *Options) setDefaults(ctx context.Context, region string) error {
 		}
 		cfg, err := config.LoadDefaultConfig(
 			ctx,
-			config.WithRegion(region),
-			config.WithUseFIPSEndpoint(useFips),
+			awsconfig.WithRegion(region),
+			awsconfig.WithUseFIPSEndpoint(useFips),
 		)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/join/ec2join/ec2.go
+++ b/lib/join/ec2join/ec2.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -42,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/services"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"

--- a/lib/srv/discovery/fetchers/eks_test.go
+++ b/lib/srv/discovery/fetchers/eks_test.go
@@ -51,7 +51,7 @@ func TestEKSFetcher(t *testing.T) {
 		{
 			name: "list everything",
 			args: args{
-				region: types.Wildcard,
+				region: "eu-west-1",
 				filterLabels: types.Labels{
 					types.Wildcard: []string{types.Wildcard},
 				},
@@ -61,7 +61,7 @@ func TestEKSFetcher(t *testing.T) {
 		{
 			name: "list everything with assumed role",
 			args: args{
-				region: types.Wildcard,
+				region: "eu-west-1",
 				filterLabels: types.Labels{
 					types.Wildcard: []string{types.Wildcard},
 				},
@@ -72,7 +72,7 @@ func TestEKSFetcher(t *testing.T) {
 		{
 			name: "list prod clusters",
 			args: args{
-				region: types.Wildcard,
+				region: "eu-west-1",
 				filterLabels: types.Labels{
 					"env": []string{"prod"},
 				},

--- a/lib/utils/aws/ec2.go
+++ b/lib/utils/aws/ec2.go
@@ -21,11 +21,11 @@ package aws
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	config "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/utils"
 )
 

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	awssdkconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/trace"
 
 	ecatypes "github.com/gravitational/teleport/api/types/externalauditstorage"
+	awsConfig "github.com/gravitational/teleport/lib/cloud/aws/config"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/integrations/awsra"
@@ -165,7 +166,7 @@ func onIntegrationConfListDatabasesIAM(ctx context.Context, params config.Integr
 }
 
 func onIntegrationConfExternalAuditCmd(ctx context.Context, params easconfig.ExternalAuditStorageConfiguration) error {
-	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(params.Region))
+	cfg, err := awsConfig.LoadDefaultConfig(ctx, awssdkconfig.WithRegion(params.Region))
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Replace direct uses of `github.com/aws/aws-sdk-go-v2/config.LoadDefaultConfig` with the internal `lib/cloud/aws/config.LoadDefaultConfig` wrapper, which validates any explicitly requested AWS region before use. Enforces this via a new forbidigo linter rule.
