### PR TITLE
Storybook vite config: Add wasm files to `assetsInclude`

### DIFF
--- a/web/.storybook/vite.config.mts
+++ b/web/.storybook/vite.config.mts
@@ -7,4 +7,5 @@ export default defineConfig(({ mode }) => ({
     tsconfigPaths: true,
   },
   plugins: [reactPlugin(mode)],
+  assetsInclude: ['**/shared/libs/ironrdp/**/*.wasm'],
 }));


### PR DESCRIPTION
Similar to #63997, Storybook has its own Vite config we forgot about. :~) This meant that stories that used components which import the wasm file (like https://localhost:9002/?path=/story/teleterm-tabhost--story which renders the desktop tab from Connect) would crash with an error:

```
■  Vite Internal server error: Failed to parse source for import analysis because
│  the content contains invalid JS syntax. You may need to install appropriate
│  plugins to handle the .wasm?inline file format, or if it's an asset, add
│  "**/*.wasm?inline" to `assetsInclude` in your configuration.
│  Plugin: vite:import-analysis
│  File: ./web/packages/shared/libs/ironrdp/pkg/ironrdp_bg.wasm?inline
``` 

## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] The https://localhost:9002/?path=/story/teleterm-tabhost--story story works now.
