### PR TITLE
Show AWS Identity Center-Specific Guidance for Unauthorized Status

### DIFF
--- a/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
@@ -24,6 +24,7 @@ import { IntegrationList } from 'teleport/Integrations/IntegrationList';
 import {
   IntegrationKind,
   IntegrationStatusCode,
+  type Plugin,
 } from 'teleport/services/integrations';
 
 test('integration list does not display action menu for aws-oidc, row click navigates', async () => {
@@ -58,4 +59,28 @@ test('integration list does not display action menu for aws-oidc, row click navi
   expect(screen.getByTestId('current-path')).toHaveTextContent(
     '/web/integrations/status/aws-oidc/aws-integration'
   );
+});
+
+test('integration list details prefer plugin status error message over details', () => {
+  const plugin: Plugin = {
+    resourceType: 'plugin',
+    name: 'okta-plugin',
+    kind: 'okta',
+    details: 'fallback details',
+    statusCode: IntegrationStatusCode.OtherError,
+    status: {
+      code: IntegrationStatusCode.OtherError,
+      lastRun: new Date('2026-03-31T00:00:00Z'),
+      errorMessage: 'sync failed',
+    },
+  };
+
+  render(
+    <MemoryRouter>
+      <IntegrationList list={[plugin]} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText('sync failed')).toBeInTheDocument();
+  expect(screen.queryByText('fallback details')).not.toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -489,7 +489,9 @@ export function percent(n: number, d: number): string {
 }
 
 const DetailsCell = ({ integration }: { integration: IntegrationLike }) => {
-  let content = <Text>{integration.details}</Text>;
+  let content = (
+    <Text>{integration.status?.errorMessage || integration.details}</Text>
+  );
   switch (integration.kind) {
     case IntegrationKind.AwsOidc:
     case IntegrationKind.AzureOidc:


### PR DESCRIPTION
This PR supports https://github.com/gravitational/teleport.e/pull/8330 and addresses the 2nd ask of [#62286](https://github.com/gravitational/teleport/issues/62286) by showing a targeted failure message when the AWS IAM Identity Center integration encounters an unauthorized error (e.g., expired or rotated SCIM token), instead of the generic "revoked authorization" message. This gives operators clear, actionable guidance to rotate the SCIM API token.

The following change was made:

- **Integration List(`IntegrationList.tsx`):** Updated the Details cell to prioritize displaying the backend error message (`status.errorMessage`) over the generic plugin details.

## Manual Test Plan

### Test Environment
- Follow the setup laid out in https://github.com/gravitational/teleport.e/pull/8330

### Test Cases

- [x] Follow the steps laid out in https://github.com/gravitational/teleport.e/pull/8330

changelog: AWS Identity Center-specific guidance is now given when the integration encounters an unauthorized error, suggesting SCIM API token rotation
