### PR TITLE
Add database and windows desktop resources for load/performance testing

### DIFF
--- a/assets/loadtest/Makefile
+++ b/assets/loadtest/Makefile
@@ -163,6 +163,7 @@ deploy-app-service:
 	--set proxyAddr=${PROXY_SERVER} \
 	--set authToken=${TOKEN} \
 	--set "appResources[0].labels.*=*" \
+	--set image=${TELEPORT_IMAGE_REPO} \
 	--set teleportVersionOverride="${TELEPORT_VERSION}" \
 	--values ./helm/values/app-service-agent.yaml
 
@@ -180,8 +181,130 @@ create-app-resources:
 	--set proxy=${PROXY_SERVER} \
 	--set clusterName=${CLUSTER_NAME} \
 	--set resources.count=${COUNT} \
-	--set resources.parallelism=${PARALLELISM}
+	--set resources.parallelism=${PARALLELISM} \
+	--set resources.template=resources/apps.yaml
 
-.PHONY: delete-app-resources
-delete-app-resources:
+.PHONY: delete-resources
+delete-resources:
 	helm delete -n resources resources
+
+.PHONY: deploy-windows-desktop-service
+deploy-windows-desktop-service:
+	helm upgrade --install teleport-windows-desktop-agent ./helm/windows-desktop-agent \
+	--create-namespace \
+	--namespace teleport \
+	--set proxyServer=${PROXY_SERVER} \
+	--set joinParams.token_name=${TOKEN} \
+	--set "windowsDesktopResources[0].labels.*=*" \
+	--set image.repository=${TELEPORT_IMAGE_REPO} \
+	--set image.tag="${TELEPORT_VERSION}"
+
+.PHONY: delete-windows-desktop-service
+delete-windows-desktop-service:
+	helm delete -n teleport teleport-windows-desktop-agent
+
+.PHONY: create-windows-desktop-resources
+create-windows-desktop-resources: COUNT ?= 100
+create-windows-desktop-resources: PARALLELISM ?= 10
+create-windows-desktop-resources:
+	helm upgrade --install resources \
+	-n resources --create-namespace \
+	./helm/resources \
+	--set proxy=${PROXY_SERVER} \
+	--set clusterName=${CLUSTER_NAME} \
+	--set resources.count=${COUNT} \
+	--set resources.parallelism=${PARALLELISM} \
+	--set resources.template=resources/windows-desktops.yaml
+
+define REAL_WINDOWS_DESKTOP_YAML
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  name: real-windows-desktop
+  labels:
+    env: loadtest
+spec:
+  addr: $(REAL_WINDOWS_DESKTOP_ADDR)
+  non_ad: true
+endef
+export REAL_WINDOWS_DESKTOP_YAML
+
+.PHONY: create-real-windows-desktop-resource
+create-real-windows-desktop-resource:
+	@echo "$$REAL_WINDOWS_DESKTOP_YAML"
+	echo "$$REAL_WINDOWS_DESKTOP_YAML" | tctl create -f -
+
+.PHONY: deploy-database-service
+deploy-database-service:
+	helm upgrade --install teleport-database-agent ../../examples/chart/teleport-kube-agent \
+	--create-namespace \
+	--namespace teleport \
+	--set roles=db \
+	--set proxyAddr=${PROXY_SERVER} \
+	--set authToken=${TOKEN} \
+	--set teleportClusterName=${CLUSTER_NAME} \
+	--set "databaseResources[0].labels.*=*" \
+	--set image=${TELEPORT_IMAGE_REPO} \
+	--set teleportVersionOverride="${TELEPORT_VERSION}" \
+	--values ./helm/values/database-agent.yaml
+
+.PHONY: delete-database-service
+delete-database-service:
+	helm delete -n teleport teleport-database-agent
+
+.PHONY: create-database-resources
+create-database-resources: COUNT ?= 100
+create-database-resources: PARALLELISM ?= 10
+create-database-resources:
+	helm upgrade --install resources \
+	-n resources --create-namespace \
+	./helm/resources \
+	--set proxy=${PROXY_SERVER} \
+	--set clusterName=${CLUSTER_NAME} \
+	--set resources.count=${COUNT} \
+	--set resources.parallelism=${PARALLELISM} \
+	--set resources.template=resources/databases.yaml
+
+define REAL_DATABASE_YAML
+kind: db
+version: v3
+metadata:
+  name: real-postgres
+  labels:
+    env: loadtest
+    real: "true"
+spec:
+  protocol: postgres
+  uri: postgres-postgresql.teleport.svc.cluster.local:5432
+endef
+export REAL_DATABASE_YAML
+
+.PHONY: create-real-database-resource
+create-real-database-resource:
+	@echo "$$REAL_DATABASE_YAML"
+	echo "$$REAL_DATABASE_YAML" | tctl create -f -
+
+# Deploys a real PostgreSQL instance and registers it with Teleport.
+# Requires tctl to be authenticated. The server cert is signed by Teleport's
+# DB CA and valid for 90 days (2160h).
+.PHONY: deploy-postgres
+deploy-postgres:
+	tctl auth sign --format=db \
+		--host=postgres-postgresql.teleport.svc.cluster.local \
+		--out=/tmp/postgres-server \
+		--ttl=2160h
+	kubectl create secret generic postgres-tls -n teleport \
+		--from-file=tls.crt=/tmp/postgres-server.crt \
+		--from-file=tls.key=/tmp/postgres-server.key \
+		--from-file=ca.crt=/tmp/postgres-server.cas \
+		--dry-run=client -o yaml | kubectl apply -f -
+	helm upgrade --install postgres bitnami/postgresql \
+		-n teleport --create-namespace \
+		--values ./helm/values/postgres.yaml
+	$(MAKE) create-real-database-resource
+
+.PHONY: delete-postgres
+delete-postgres:
+	helm delete -n teleport postgres
+	kubectl delete secret postgres-tls -n teleport --ignore-not-found
+	tctl rm db/real-postgres

--- a/assets/loadtest/helm/fixtures/tbot.yaml
+++ b/assets/loadtest/helm/fixtures/tbot.yaml
@@ -28,13 +28,58 @@ spec:
       - resources: [app]
         verbs: ['list', 'read', 'create', 'update', 'delete']
 ---
+kind: role
+version: v8
+metadata:
+  name: db-admin
+spec:
+  allow:
+    db_labels:
+      "*": "*"
+    rules:
+      - resources: [db]
+        verbs: ['list', 'read', 'create', 'update', 'delete']
+---
+kind: role
+version: v8
+metadata:
+  name: db-access
+spec:
+  allow:
+    db_labels:
+      "*": "*"
+    db_users: ["admin"]
+    db_names: ["postgres"]
+---
+kind: role
+version: v8
+metadata:
+  name: windows-desktop-admin
+spec:
+  allow:
+    windows_desktop_labels:
+      "*": "*"
+    rules:
+      - resources: [dynamic_windows_desktop]
+        verbs: ['list', 'read', 'create', 'update', 'delete']
+---
+kind: role
+version: v8
+metadata:
+  name: windows-access
+spec:
+  allow:
+    windows_desktop_labels:
+      "*": "*"
+    windows_desktop_logins: ["Administrator"]
+---
 kind: bot
 version: v1
 metadata:
   # name is a unique identifier for the Bot in the cluster.
   name: k8s-tbot
 spec:
-  roles: [k8s-editor, appsmith]
+  roles: [k8s-editor, appsmith, db-admin, windows-desktop-admin]
 ---
 kind: token
 version: v2

--- a/assets/loadtest/helm/resources/Chart.yaml
+++ b/assets/loadtest/helm/resources/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 0.1.0
 
-appVersion: "18.1.8"
+appVersion: "18.7.3"

--- a/assets/loadtest/helm/resources/resources/databases.yaml
+++ b/assets/loadtest/helm/resources/resources/databases.yaml
@@ -1,0 +1,120 @@
+kind: db
+version: v3
+metadata:
+  description: 'Dummy database'
+  labels:
+    owner: test
+    real: "false"
+  name: db0-@@JOB_INDEX@@
+spec:
+  protocol: postgres
+  uri: localhost:5432
+---
+kind: db
+version: v3
+metadata:
+  description: 'Dummy database'
+  labels:
+    owner: test
+    real: "false"
+  name: db1-@@JOB_INDEX@@
+spec:
+  protocol: postgres
+  uri: localhost:5432
+---
+kind: db
+version: v3
+metadata:
+  description: 'Dummy database'
+  labels:
+    owner: test
+    real: "false"
+  name: db2-@@JOB_INDEX@@
+spec:
+  protocol: postgres
+  uri: localhost:5432
+---
+kind: db
+version: v3
+metadata:
+  description: 'Dummy database'
+  labels:
+    owner: test
+    real: "false"
+  name: db3-@@JOB_INDEX@@
+spec:
+  protocol: postgres
+  uri: localhost:5432
+---
+kind: db
+version: v3
+metadata:
+  description: 'Dummy database'
+  labels:
+    owner: test
+    real: "false"
+  name: db4-@@JOB_INDEX@@
+spec:
+  protocol: postgres
+  uri: localhost:5432
+---
+kind: db
+version: v3
+metadata:
+  description: 'Dummy database'
+  labels:
+    owner: test
+    real: "false"
+  name: db5-@@JOB_INDEX@@
+spec:
+  protocol: postgres
+  uri: localhost:5432
+---
+kind: db
+version: v3
+metadata:
+  description: 'Dummy database'
+  labels:
+    owner: test
+    real: "false"
+  name: db6-@@JOB_INDEX@@
+spec:
+  protocol: postgres
+  uri: localhost:5432
+---
+kind: db
+version: v3
+metadata:
+  description: 'Dummy database'
+  labels:
+    owner: test
+    real: "false"
+  name: db7-@@JOB_INDEX@@
+spec:
+  protocol: postgres
+  uri: localhost:5432
+---
+kind: db
+version: v3
+metadata:
+  description: 'Dummy database'
+  labels:
+    owner: test
+    real: "false"
+  name: db8-@@JOB_INDEX@@
+spec:
+  protocol: postgres
+  uri: localhost:5432
+---
+kind: db
+version: v3
+metadata:
+  description: 'Dummy database'
+  labels:
+    owner: test
+    real: "false"
+  name: db9-@@JOB_INDEX@@
+spec:
+  protocol: postgres
+  uri: localhost:5432
+---

--- a/assets/loadtest/helm/resources/resources/windows-desktops.yaml
+++ b/assets/loadtest/helm/resources/resources/windows-desktops.yaml
@@ -1,0 +1,119 @@
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  description: 'Dummy windows desktop'
+  labels:
+    owner: test
+    real: "false"
+  name: windowsdesktop0-@@JOB_INDEX@@
+spec:
+  addr: localhost:3389
+  non_ad: true
+---
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  description: 'Dummy windows desktop'
+  labels:
+    owner: test
+    real: "false"
+  name: windowsdesktop1-@@JOB_INDEX@@
+spec:
+  addr: localhost:3389
+  non_ad: true
+---
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  description: 'Dummy windows desktop'
+  labels:
+    owner: test
+    real: "false"
+  name: windowsdesktop2-@@JOB_INDEX@@
+spec:
+  addr: localhost:3389
+  non_ad: true
+---
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  description: 'Dummy windows desktop'
+  labels:
+    owner: test
+    real: "false"
+  name: windowsdesktop3-@@JOB_INDEX@@
+spec:
+  addr: localhost:3389
+  non_ad: true
+---
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  description: 'Dummy windows desktop'
+  labels:
+    owner: test
+    real: "false"
+  name: windowsdesktop4-@@JOB_INDEX@@
+spec:
+  addr: localhost:3389
+  non_ad: true
+---
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  description: 'Dummy windows desktop'
+  labels:
+    owner: test
+    real: "false"
+  name: windowsdesktop5-@@JOB_INDEX@@
+spec:
+  addr: localhost:3389
+  non_ad: true
+---
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  description: 'Dummy windows desktop'
+  labels:
+    owner: test
+    real: "false"
+  name: windowsdesktop6-@@JOB_INDEX@@
+spec:
+  addr: localhost:3389
+  non_ad: true
+---
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  description: 'Dummy windows desktop'
+  labels:
+    owner: test
+    real: "false"
+  name: windowsdesktop7-@@JOB_INDEX@@
+spec:
+  addr: localhost:3389
+  non_ad: true
+---
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  description: 'Dummy windows desktop'
+  labels:
+    owner: test
+    real: "false"
+  name: windowsdesktop8-@@JOB_INDEX@@
+spec:
+  addr: localhost:3389
+  non_ad: true
+---
+kind: dynamic_windows_desktop
+version: v1
+metadata:
+  description: 'Dummy windows desktop'
+  labels:
+    owner: test
+    real: "false"
+  name: windowsdesktop9-@@JOB_INDEX@@
+spec:
+  addr: localhost:3389
+  non_ad: true

--- a/assets/loadtest/helm/resources/templates/job.yaml
+++ b/assets/loadtest/helm/resources/templates/job.yaml
@@ -3,11 +3,15 @@ kind: Job
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   completions: {{ .Values.resources.count }}
   parallelism: {{ .Values.resources.parallelism }}
   completionMode: Indexed
   backoffLimit: 2
+  ttlSecondsAfterFinished: 1800
   template:
     metadata:
       labels:

--- a/assets/loadtest/helm/values/database-agent.yaml
+++ b/assets/loadtest/helm/values/database-agent.yaml
@@ -1,0 +1,6 @@
+teleportConfig:
+  db_service:
+    enabled: true
+    resources:
+    - labels:
+        '*': '*'

--- a/assets/loadtest/helm/values/postgres.yaml
+++ b/assets/loadtest/helm/values/postgres.yaml
@@ -1,0 +1,54 @@
+auth:
+  username: admin
+  password: teleport
+  database: postgres
+
+tls:
+  enabled: true
+  # Secret must contain: tls.crt (server cert), tls.key (server key),
+  # ca.crt (Teleport DB CA from `tctl auth export --type=db-client-ca`)
+  certificatesSecret: postgres-tls
+  certFilename: tls.crt
+  certKeyFilename: tls.key
+  certCAFilename: ca.crt
+
+primary:
+  persistence:
+    enabled: false
+  extendedConfiguration: |
+    max_connections = 200
+  pgHbaConfiguration: |
+    host    all all 127.0.0.1/32      trust
+    host    all all ::1/128           trust
+    hostssl all all 0.0.0.0/0         cert
+    local   all all                   trust
+  # Override probes to avoid presenting the server cert as a client cert.
+  # By default bitnami passes sslcert/sslkey which PostgreSQL rejects
+  # because the server cert isn't signed by the db-client CA in ssl_ca_file.
+  customLivenessProbe:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - exec pg_isready -U "admin" -h 127.0.0.1 -p 5432
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+  customReadinessProbe:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - exec pg_isready -U "admin" -h 127.0.0.1 -p 5432
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+commonLabels:
+  env: loadtest

--- a/assets/loadtest/helm/windows-desktop-agent/.helmignore
+++ b/assets/loadtest/helm/windows-desktop-agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/assets/loadtest/helm/windows-desktop-agent/Chart.yaml
+++ b/assets/loadtest/helm/windows-desktop-agent/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: windows-desktop-agent
+description: Deploys windows_desktop_service in gateway mode for load testing desktop access.
+
+type: application
+
+version: 1.0.0
+
+appVersion: "18.7.3"

--- a/assets/loadtest/helm/windows-desktop-agent/templates/config.yaml
+++ b/assets/loadtest/helm/windows-desktop-agent/templates/config.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  teleport.yaml: |2
+    version: v3
+    teleport:
+      log:
+        severity: DEBUG
+        format:
+          output: json
+      join_params: {{- toYaml .Values.joinParams | nindent 8 }}
+      {{- if .Values.proxyServer }}
+      proxy_server: {{ .Values.proxyServer }}
+      {{- end }}
+    windows_desktop_service:
+      enabled: true
+      resources:
+        {{- toYaml .Values.windowsDesktopResources | nindent 10 }}
+          
+    auth_service:
+      enabled: false
+    proxy_service:
+      enabled: false
+    ssh_service:
+      enabled: false
+
+  entrypoint.sh: |2
+    #!/busybox/sh
+    set -euxo pipefail
+    sed -i 's!/sbin/nologin!/busybox/sh!' /etc/passwd
+    cp /etc/teleport-config/teleport.yaml /etc/teleport.yaml
+    nodename="$( hostname )"
+    cat /etc/teleport.yaml
+    exec dumb-init --rewrite 15:3 -- teleport start --nodename "${nodename}"

--- a/assets/loadtest/helm/windows-desktop-agent/templates/deployment.yaml
+++ b/assets/loadtest/helm/windows-desktop-agent/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}
+spec:
+  replicas: 1
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      containers:
+        - image: "{{ $.Values.image.repository }}:{{ default $.Chart.AppVersion $.Values.image.tag }}"
+          name: desktop-access-gateway
+          command: ["/busybox/sh", "/etc/teleport-config/entrypoint.sh"]
+          env:
+            {{- if $.Values.tls.existingCASecretName }}
+            - name: SSL_CERT_FILE
+              value: /etc/teleport-tls-ca/ca.pem
+            {{- end }}
+            {{- if $.Values.extraEnv }}{{ toYaml $.Values.extraEnv | nindent 12 }}{{ end }}
+          volumeMounts:
+            - mountPath: /etc/teleport-config
+              name: config
+              readOnly: true
+            {{- if $.Values.tls.existingCASecretName }}
+            - mountPath: /etc/teleport-tls-ca
+              name: "teleport-tls-ca"
+              readOnly: true
+            {{- end }}
+          resources: {{- toYaml $.Values.resources | nindent 12 }}
+      volumes:
+        - configMap:
+            name: {{ .Release.Name }}
+            defaultMode: 0766
+          name: config
+        {{- if .Values.tls.existingCASecretName }}
+        - name: teleport-tls-ca
+          secret:
+            secretName: {{ .Values.tls.existingCASecretName }}
+        {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{ toYaml .Values.tolerations | nindent 8}}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8}}
+      {{- end }}

--- a/assets/loadtest/helm/windows-desktop-agent/templates/serviceaccount.yaml
+++ b/assets/loadtest/helm/windows-desktop-agent/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/assets/loadtest/helm/windows-desktop-agent/values.yaml
+++ b/assets/loadtest/helm/windows-desktop-agent/values.yaml
@@ -1,0 +1,44 @@
+proxyServer: ""
+authServer: ""
+
+minReadySeconds: 0
+
+image:
+  repository: public.ecr.aws/gravitational/teleport-ent-distroless-debug
+  pullPolicy: IfNotPresent
+  tag: ""
+
+serviceAccount:
+  create: true
+
+joinParams:
+  # the kubernetes join method is not currently suited for joining a large amount of nodes in a short time
+  method: token
+  # DO NOT USE THIS IN PRODUCTION
+  token_name: ""
+
+# pod tolerations
+# array of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#toleration-v1-core
+tolerations: []
+
+# pod affinity rules
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#affinity-v1-core
+affinity: {}
+
+tls:
+  existingCASecretName: ""
+
+# envvars set in each container
+# array of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#envvar-v1-core
+extraEnv: []
+
+# resource requirements for each container
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#resourcerequirements-v1-core
+resources: {}
+
+# Teleport labels
+labels: {}
+
+windowsDesktopResources:
+  - labels:
+      "*": "*"


### PR DESCRIPTION
This change supports the effort to expand our performance testing to additional services.

- Add new helm chart for windows desktop agent
- Add make targets for deploying and deleting windows desktop and database resources
- Add postgres make targets for managing a real postgres database and registering it with teleport