### PR TITLE
[tsh] fix bench web sessions

### DIFF
--- a/lib/benchmark/benchmark.go
+++ b/lib/benchmark/benchmark.go
@@ -201,11 +201,10 @@ func (c *Config) Benchmark(ctx context.Context, tc *client.TeleportClient, suite
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	requestsC := make(chan benchMeasure)
 	resultC := make(chan benchMeasure)
 
 	var wg sync.WaitGroup
-	go func() {
+	wg.Go(func() {
 		interval := time.Duration(1 / float64(c.Rate) * float64(time.Second))
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -221,17 +220,12 @@ func (c *Config) Benchmark(ctx context.Context, tc *client.TeleportClient, suite
 					ResponseStart: t,
 				}
 
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					work(ctx, measure, resultC, workload)
-				}()
+				wg.Go(func() { work(ctx, measure, resultC, workload) })
 			case <-ctx.Done():
-				close(requestsC)
 				return
 			}
 		}
-	}()
+	})
 
 	defer wg.Wait()
 
@@ -244,22 +238,24 @@ func (c *Config) Benchmark(ctx context.Context, tc *client.TeleportClient, suite
 		if c.MinimumWindow <= time.Since(start) {
 			timeElapsed = true
 		}
+
 		select {
+		case <-ctx.Done():
+			result.Duration = time.Since(start)
+			return result, nil
 		case measure := <-resultC:
 			result.Histogram.RecordValue(int64(measure.End.Sub(measure.ResponseStart) / time.Millisecond))
 			result.RequestsOriginated++
-			if timeElapsed && result.RequestsOriginated >= c.MinimumMeasurements {
-				cancel()
-			}
 			if measure.Error != nil {
 				result.RequestsFailed++
 				result.LastError = measure.Error
 			}
-		case <-ctx.Done():
-			result.Duration = time.Since(start)
-			return result, nil
 		case <-statusTicker.C:
 			slog.InfoContext(ctx, "working...", "current_observation_count", result.RequestsOriginated)
+		}
+
+		if timeElapsed && result.RequestsOriginated >= c.MinimumMeasurements {
+			cancel()
 		}
 	}
 }

--- a/lib/benchmark/web.go
+++ b/lib/benchmark/web.go
@@ -33,12 +33,12 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web/terminal"
@@ -189,6 +189,50 @@ type TerminalRequest struct {
 	Term session.TerminalParams `json:"term"`
 }
 
+// tokenExchange sends the token over a newly created websocket and waits for server to validate and respond.
+func tokenExchange(ws *websocket.Conn, token string) error {
+	type wsBearerToken struct {
+		Token string `json:"token"`
+	}
+
+	type wsStatus struct {
+		Type    string `json:"type"`
+		Status  string `json:"status"`
+		Message string `json:"message,omitempty"`
+	}
+
+	req, err := json.Marshal(wsBearerToken{Token: token})
+	if err != nil {
+		return trace.Wrap(err, "marshaling token")
+	}
+
+	if err := ws.WriteMessage(websocket.TextMessage, req); err != nil {
+		return trace.Wrap(err, "writing to websocket")
+	}
+
+	ty, resp, err := ws.ReadMessage()
+	if err != nil {
+		return trace.Wrap(err, "reading from websocket")
+	}
+
+	var status wsStatus
+	if err := json.Unmarshal(resp, &status); err != nil {
+		return trace.Wrap(err, "unmarshalling response")
+	}
+
+	if ty != websocket.TextMessage {
+		return trace.AccessDenied("unexpected message type: %d", ty)
+	}
+
+	if status.Status != "ok" {
+		return trace.AccessDenied("unexpected response: %q", status.Message)
+	}
+
+	// At this point the socket is ready.
+	return nil
+
+}
+
 // connectToHost opens an SSH session to the target host via the Proxy web api.
 func connectToHost(ctx context.Context, tc *client.TeleportClient, webSession *webSession, host string) (io.ReadWriteCloser, error) {
 	req := TerminalRequest{
@@ -206,13 +250,10 @@ func connectToHost(ctx context.Context, tc *client.TeleportClient, webSession *w
 	}
 
 	u := url.URL{
-		Host:   tc.WebProxyAddr,
-		Scheme: client.WSS,
-		Path:   fmt.Sprintf("/v1/webapi/sites/%v/connect/ws", tc.SiteName),
-		RawQuery: url.Values{
-			"params":                        []string{string(data)},
-			roundtrip.AccessTokenQueryParam: []string{webSession.getToken()},
-		}.Encode(),
+		Host:     tc.WebProxyAddr,
+		Scheme:   client.WSS,
+		Path:     fmt.Sprintf("/v1/webapi/sites/%v/connect/ws", tc.SiteName),
+		RawQuery: url.Values{"params": []string{string(data)}}.Encode(),
 	}
 
 	dialer := websocket.Dialer{
@@ -223,22 +264,43 @@ func connectToHost(ctx context.Context, tc *client.TeleportClient, webSession *w
 	ws, resp, err := dialer.DialContext(ctx, u.String(), http.Header{
 		"Origin": []string{"http://localhost"},
 	})
+
+	if resp != nil && resp.Body != nil {
+		// the library can return a valid iocloser even on error
+		defer resp.Body.Close()
+	}
+
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer resp.Body.Close()
+		fields := map[string]any{"url": u.String()}
+		if resp != nil {
+			fields["status"] = resp.Status
+			fields["headers"] = resp.Header
+			if resp.Body != nil {
+				if b, readErr := io.ReadAll(resp.Body); readErr != nil {
+					fields["body_error"] = readErr.Error()
+				} else {
+					fields["body"] = string(b)
+				}
+			}
+		}
 
-	ty, _, err := ws.ReadMessage()
-	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.WithFields(trace.Wrap(err, "dialing websocket"), fields)
 	}
 
-	if ty != websocket.BinaryMessage {
-		return nil, trace.BadParameter("unexpected websocket message received %d", ty)
+	if err := tokenExchange(ws, webSession.getToken()); err != nil {
+		ws.Close() // clean up the websocket since we do not pass it to a Stream.
+		return nil, trace.Wrap(err, "performing token exchange")
 	}
 
-	stream := terminal.NewStream(ctx, terminal.StreamConfig{WS: ws})
-	return stream, trace.Wrap(err)
+	return terminal.NewStream(ctx,
+		terminal.StreamConfig{
+			WS: ws,
+			Handlers: map[string]terminal.WSHandlerFunc{
+				// Unhandled currently, set to avoid nosiy logs during benchmarks:
+				defaults.WebsocketLatency:         func(ctx context.Context, e terminal.Envelope) {},
+				defaults.WebsocketSessionMetadata: func(ctx context.Context, e terminal.Envelope) {},
+			},
+		}), nil
 }
 
 func (s *webSession) expires() time.Time {
@@ -302,6 +364,9 @@ func (s *WebSessionBenchmark) ConfigOverride(ctx context.Context, tc *client.Tel
 
 // BenchBuilder returns a WorkloadFunc for the given benchmark suite.
 func (s *WebSessionBenchmark) BenchBuilder(ctx context.Context, tc *client.TeleportClient) (WorkloadFunc, error) {
+	if s.Max < 0 {
+		return nil, trace.BadParameter("max number of sessions cannot be negative, got: %d", s.Max)
+	}
 	// The benchmark runner may override stderr to be [io.Discard] which
 	// results in the login prompt being sent into the void and the user
 	// staring at a blank terminal. Temporarily override stderr to allow
@@ -329,34 +394,32 @@ func (s *WebSessionBenchmark) BenchBuilder(ctx context.Context, tc *client.Telep
 	}
 
 	var (
-		mu     sync.Mutex
-		active int
-		next   int
+		mu   sync.Mutex
+		next int
 	)
+
+	sem := make(chan struct{}, s.Max)
 
 	// Open a ssh session to the next host if the maximum
 	// number of connections has not already been reached.
 	return func(ctx context.Context) error {
-		mu.Lock()
-		if active >= s.Max {
-			mu.Unlock()
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
 			return nil
 		}
-		active++
 
+		defer func() { <-sem }()
+
+		mu.Lock()
 		current := next
 		next = (next + 1) % len(s.servers)
 		mu.Unlock()
 
-		defer func() {
-			mu.Lock()
-			active--
-			mu.Unlock()
-		}()
-
-		stream, err := connectToHost(ctx, tc, webSess, s.servers[current].GetName()+":0")
+		host := s.servers[current].GetName() + ":0"
+		stream, err := connectToHost(ctx, tc, webSess, host)
 		if err != nil {
-			return trace.Wrap(err)
+			return trace.Wrap(err, "connecting to host %q as %q", host, tc.HostLogin)
 		}
 
 		return trace.Wrap(utils.ProxyConn(ctx,


### PR DESCRIPTION
The web session benchmark connect has fallen out of sync with the rest of the codebase, the server now expects the token to be sent over the web socket instead of using request params.

This change also improves error handling of the `gorilla/websocket` lib which uses the response body to pass contextual information to the caller. These are encoded in the error if needed but only the brief error is printed on the status line:

For example:
```
* Last error: connecting to host "94a9c68c-a693-436e-ba20-b1cb698b94d5:0" as "root"
	dialing websocket
		websocket: bad handshake
```

This should make diagnosing the issue easier.

This change also adds additional message type handlers to prevent noisy logs, for now these are stubs but could be used in the future to add additional measurements.

The session benchmark now makes use of a counting semaphore, this will prevent the latency metric from being skewed by immediately returning. This also changes the way the elapsed minimum measurement time is checked to ensure that work items cannot block forever. 

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

Fixes #64851 

## Manual Test Plan
### Test Environment
Local `tsh` client and a v19 staging cluster. 

### Test Cases
- [x] `TELEPORT_TOOLS_VERSION=off ./build/tsh bench web sessions -d --max=5  root@all /busybox/ls`
  - [x] All sessions are created.
  - [x] Benchmark runs for at least a minute with all sessions in place. 
- [x] `TELEPORT_TOOLS_VERSION=off ./build/tsh bench web ssh -d ---duration=1m  root@all /busybox/ls`
  - [x] All commands run successfully
- [x] Verify `tsh bench ssh` still works as expected. 
