### PR TITLE
Add role and label guidance to Get Started

### DIFF
--- a/docs/pages/get-started/access.mdx
+++ b/docs/pages/get-started/access.mdx
@@ -101,6 +101,14 @@ explanations of the essential fields. Each role provides access to
 Teleport-protected servers, databases, and Kubernetes clusters, but with access
 tailored to each team and level of access.
 
+<Admonition type="warning">
+
+These roles are only examples. You must define your own roles to suit your
+organization's needs. See the [additional considerations
+below](#additional-role-considerations).
+
+</Admonition>
+
 Note how these examples use the `env`, `service`, and `team` labels we mentioned
 in [Step 2](connect.mdx):
 
@@ -347,15 +355,47 @@ $ tctl create platform-rw-prod.yaml
 </TabItem>
 </Tabs>
 
-Role fields such as `db_users`, `logins`, and `kubernetes_groups` indicate the
-principals that a user is allowed to assume on the target infrastructure. A
-principal must already exist before a user can connect to a resource.
+### Additional role considerations
 
-For example, if there is no user called `manager` on a Linux host, a user
-allowed to assume that principal with the `spec.allow.logins` field will still
-not be able to gain access. A role that allows a user to access the Ubuntu
-server we enrolled in [Step 2](connect.mdx) would need to include `ubuntu` in
-the list of permitted logins.
+When considering these example roles, you should note the following caveats:
+
+1. **Named principals must exist on the target resource.** Role fields such as
+   `db_users`, `logins`, and `kubernetes_groups` indicate the principals that a
+   user is allowed to assume on the target infrastructure. A principal must
+   already exist before a user can connect to a resource.
+
+   For example, if there is no user called `manager` on a Linux host, a user
+   allowed to assume that principal with the `spec.allow.logins` field will
+   still not be able to gain access. A role that allows a user to access the
+   Ubuntu server we enrolled in [Step 2](connect.mdx) would need to include
+   `ubuntu` in the list of permitted logins.
+
+2. **The examples do not include Teleport resource permissions.** The preset
+   `editor` role allows users to manage most Teleport resources, including users
+   and roles, with the `spec.allow.rules` field:
+
+   ```yaml
+   spec:
+     allow:
+       rules:
+       - resources:
+         - user
+         verbs:
+         - list
+         - create
+         - read
+         - update
+         - delete
+   ```
+
+   The roles we illustrated above do not include permissions to manage Teleport
+   resources.
+
+   While setting up your initial cluster configuration, you can continue using
+   your admin user. For a production cluster, we recommend managing Teleport
+   resources with infrastructure as code tools with minimal permissions to
+   manage Teleport resources. See [Infrastructure as
+   Code](../zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx).
 
 For instructions on creating custom roles and assigning roles to users, read the
 [Getting Started with Teleport Access

--- a/docs/pages/get-started/access.mdx
+++ b/docs/pages/get-started/access.mdx
@@ -54,11 +54,266 @@ You can view all available roles by navigating to **Zero Trust Access** > **Role
 
 ## Custom roles
 
-Organizations often require custom roles to enforce least-privilege access and follow internal security policies. By creating custom roles, you can align Teleport's access controls with your company's structure and security policies.
+While the preset roles are useful for administrative identities that your
+organization reserves as a fallback, you should use custom roles to ensure that
+no identity in your organization has unnecessary privileges.
 
-For instructions on creating custom roles and assigning roles to users, follow along with our [Getting Started with Teleport Access Controls](../zero-trust-access/rbac-get-started/role-demo.mdx) demo guide. 
+### Name the roles you need
 
-For mapping SSO users to roles, refer to our guide on [Configuring Single Sign-On](../zero-trust-access/sso/sso.mdx#how-teleport-uses-sso) for more information.
+To determine the custom roles you need, we recommend that you:
+
+1. List the teams in your organization that you want to define roles for. For
+   example, you may want to start with roles for the Core Team, which owns the
+   main product, and the Platform Team, which owns the infrastructure other
+   teams use to deploy and manage services.
+
+1. Determine the levels of access you want to enforce, such as read-only access,
+   read-write access to non-production resources, and read-write access to
+   production resources.
+
+1. Plan to define a role for each combination of team and access level.
+
+   Continuing our example, if you have the access levels `read-only`,
+   `rw-staging`, and `rw-prod`, and the teams `core` and `platform`, you would
+   want to define the following roles:
+   
+   - `core-read-only`
+   - `core-rw-staging`
+   - `core-rw-prod`
+   - `platform-read-only`
+   - `platform-rw-staging`
+   - `platform-rw-prod`
+
+### Configure each role
+
+For each role you need to define, consider the access patterns of team members
+with the given level of access:
+
+- **Which resources should they have access to?** You can configure a role to
+  allow and deny access to resources with certain labels, which you configured
+  in [Step 2](connect.mdx).
+- **Which actions should they be allowed to perform?** You can configure a role
+  to allow or deny certain principals, such as user accounts on a target server,
+  Kubernetes cluster, or database.
+
+To illustrate this, consider the examples of Teleport roles below, with
+explanations of the essential fields. Each role provides access to
+Teleport-protected servers, databases, and Kubernetes clusters, but with access
+tailored to each team and level of access.
+
+Note how these examples use the `env`, `service`, and `team` labels we mentioned
+in [Step 2](connect.mdx):
+
+<Tabs>
+<TabItem label="core-read-only">
+
+The `core-read-only` role has read-only access to any server, database, and
+Kubernetes cluster owned by the Core Team in the main product (`service:core`)
+across all environments. This role can only assume the `readonly` login on
+servers and the `readonly` user on databases:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: core-read-only
+spec:
+  allow:
+    logins: ['readonly']
+    node_labels:
+      team: core
+      service: core
+    db_labels:
+      team: core
+      service: core
+    db_users: ['readonly']
+    # Allow access to any database on the target database server
+    db_names: ['*']
+    kubernetes_labels:
+      team: core
+      service: core
+    kubernetes_groups: ['viewers']
+```
+
+</TabItem>
+<TabItem label="core-rw-staging">
+
+The `core-rw-staging` role has access to any server, database, and Kubernetes
+cluster owned by the Core Team within the main product (`service:core`) in the
+staging environment. On staging servers, this role can assume the `manager` user
+and, on databases, the privileged `dbuser` role:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: core-rw-staging
+spec:
+  allow:
+    logins: ['manager']
+    node_labels:
+      team: core
+      service: core
+      env: staging
+    db_labels:
+      team: core
+      service: core
+      env: staging
+    db_users: ['dbuser']
+    # Allow access to any database on the target database server
+    db_names: ['*']
+    kubernetes_labels:
+      team: core
+      service: core
+      env: staging
+    kubernetes_groups: ['developers']
+```
+
+Note that this role is identical to `core-rw-prod` except for the `env` label of
+the resources we allow access to.
+
+</TabItem>
+<TabItem label="core-rw-prod">
+
+The `core-rw-prod` role has access to any server, database, and Kubernetes
+cluster owned by the Core Team within the main product (`service:core`) in the
+production environment. On production servers, this role can assume the
+`manager` user and, on databases, the privileged `dbuser` role:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: core-rw-prod
+spec:
+  allow:
+    logins: ['manager']
+    node_labels:
+      team: core
+      service: core
+      env: prod
+    db_labels:
+      team: core
+      service: core
+      env: prod
+    db_users: ['dbuser']
+    # Allow access to any database on the target database server
+    db_names: ['*']
+    kubernetes_labels:
+      team: core
+      service: core
+      env: prod
+    kubernetes_groups: ['developers']
+```
+
+Note that this role is identical to `core-rw-staging` except for the `env` label
+of the resources we allow access to.
+
+</TabItem>
+<TabItem label="platform-read-only">
+
+The `platform-read-only` role has read-only access to any server, database, and
+Kubernetes cluster owned by the Platform Team within the `data-lake` service
+across all environments. This role can only assume the `readonly` login on
+servers and the `readonly` user on databases:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: platform-read-only
+spec:
+  allow:
+    logins: ['readonly']
+    node_labels:
+      team: platform
+      service: data-lake
+    db_labels:
+      team: platform
+      service: data-lake
+    db_users: ['readonly']
+    # Allow access to any database on the target database server
+    db_names: ['*']
+    kubernetes_labels:
+      team: platform
+      service: data-lake
+    kubernetes_groups: ['viewers']
+```
+
+</TabItem>
+<TabItem label="platform-rw-staging">
+
+The `platform-rw-staging` role has access to any server, database, and
+Kubernetes cluster owned by the Platform Team in the staging environment, as
+long as it is part of the `data-lake` service. On staging servers, this role can
+assume the `manager` user and, on databases, the privileged `dbuser` role:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: platform-rw-staging
+spec:
+  allow:
+    logins: ['manager']
+    node_labels:
+      team: platform
+      service: data-lake
+      env: staging
+    db_labels:
+      team: platform
+      service: data-lake
+      env: staging
+    db_users: ['dbuser']
+    # Allow access to any database on the target database server
+    db_names: ['*']
+    kubernetes_labels:
+      team: platform
+      service: data-lake
+      env: staging
+    kubernetes_groups: ['developers']
+```
+
+</TabItem>
+<TabItem label="platform-rw-prod">
+
+The `platform-rw-prod` role has access to any server, database, and Kubernetes
+cluster owned by the Platform Team within the `data-lake` service in the
+production environment. On production servers, this role can assume the
+`manager` user and, on databases, the privileged `dbuser` role:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: platform-rw-prod
+spec:
+  allow:
+    logins: ['manager']
+    node_labels:
+      team: platform
+      service: data-lake
+      env: prod
+    db_labels:
+      team: platform
+      service: data-lake
+      env: prod
+    db_users: ['dbuser']
+    # Allow access to any database on the target database server
+    db_names: ['*']
+    kubernetes_labels:
+      team: platform
+      service: data-lake
+      env: prod
+    kubernetes_groups: ['developers']
+```
+
+</TabItem>
+</Tabs>
+
+For instructions on creating custom roles and assigning roles to users, read the
+[Getting Started with Teleport Access
+Controls](../zero-trust-access/rbac-get-started/role-demo.mdx) demo guide.
 
 ## Next steps
 
@@ -67,3 +322,4 @@ In the final step of the Getting Started guide, we'll cover how to monitor activ
 <div style={{ marginTop: 'var(--m-4)' }}>
   <Button style={{ padding: '0 var(--m-2)' }} as="link" href="../audit/" variant="primary" shape="lg">Step 4 - Monitor Audit Logs <Icon name="arrowRight" inline size="sm"/> </Button>
 </div>
+

--- a/docs/pages/get-started/access.mdx
+++ b/docs/pages/get-started/access.mdx
@@ -135,6 +135,12 @@ spec:
     kubernetes_groups: ['viewers']
 ```
 
+Save this role as `core-read-only.yaml`, then create it:
+
+```code
+$ tctl create core-read-only.yaml
+```
+
 </TabItem>
 <TabItem label="core-rw-staging">
 
@@ -167,6 +173,12 @@ spec:
       service: core
       env: staging
     kubernetes_groups: ['developers']
+```
+
+Save this role as `core-rw-staging.yaml`, then create it:
+
+```code
+$ tctl create core-rw-staging.yaml
 ```
 
 Note that this role is identical to `core-rw-prod` except for the `env` label of
@@ -206,6 +218,12 @@ spec:
     kubernetes_groups: ['developers']
 ```
 
+Save this role as `core-rw-prod.yaml`, then create it:
+
+```code
+$ tctl create core-rw-prod.yaml
+```
+
 Note that this role is identical to `core-rw-staging` except for the `env` label
 of the resources we allow access to.
 
@@ -238,6 +256,12 @@ spec:
       team: platform
       service: data-lake
     kubernetes_groups: ['viewers']
+```
+
+Save this role as `platform-read-only.yaml`, then create it:
+
+```code
+$ tctl create platform-read-only.yaml
 ```
 
 </TabItem>
@@ -274,6 +298,12 @@ spec:
     kubernetes_groups: ['developers']
 ```
 
+Save this role as `platform-rw-staging.yaml`, then create it:
+
+```code
+$ tctl create platform-rw-staging.yaml
+```
+
 </TabItem>
 <TabItem label="platform-rw-prod">
 
@@ -308,12 +338,30 @@ spec:
     kubernetes_groups: ['developers']
 ```
 
+Save this role as `platform-rw-prod.yaml`, then create it:
+
+```code
+$ tctl create platform-rw-prod.yaml
+```
+
 </TabItem>
 </Tabs>
 
+Role fields such as `db_users`, `logins`, and `kubernetes_groups` indicate the
+principals that a user is allowed to assume on the target infrastructure. A
+principal must already exist before a user can connect to a resource.
+
+For example, if there is no user called `manager` on a Linux host, a user
+allowed to assume that principal with the `spec.allow.logins` field will still
+not be able to gain access. A role that allows a user to access the Ubuntu
+server we enrolled in [Step 2](connect.mdx) would need to include `ubuntu` in
+the list of permitted logins.
+
 For instructions on creating custom roles and assigning roles to users, read the
 [Getting Started with Teleport Access
-Controls](../zero-trust-access/rbac-get-started/role-demo.mdx) demo guide.
+Controls](../zero-trust-access/rbac-get-started/role-demo.mdx) demo guide. For a
+full description of Teleport role fields, see the [Teleport Role
+Reference](../reference/access-controls/roles.mdx). 
 
 ## Next steps
 

--- a/docs/pages/get-started/connect.mdx
+++ b/docs/pages/get-started/connect.mdx
@@ -97,7 +97,8 @@ Follow these steps to enroll your Ubuntu Linux server:
 
 1. In the Teleport Web UI, click **Enroll New Resource**, or navigate to **Add New** > **Resource** in the left sidebar.
 2. Select **Ubuntu** from the list of resource types.
-3. (Optional) Add labels like `env: staging` or `cloud: aws` for filtering or restricting access later.
+3. Add labels for filtering or restricting access later. Recall the
+   label scheme you designed [earlier in the guide](#define-a-label-scheme).
 4. Run the install script that Teleport provides on your Ubuntu server (or in your Docker container) to install the Teleport SSH Service. 
 5. Wait for the installation to complete. You should see a notification in the Teleport Web UI confirming the agent was successfully detected.
 6. Add `ubuntu` as an OS user you will use to connect to the server and test your connection to verify that the server is accessible before you finish the guided setup.

--- a/docs/pages/get-started/connect.mdx
+++ b/docs/pages/get-started/connect.mdx
@@ -13,6 +13,34 @@ After deploying your Teleport cluster, the next step is to enroll the infrastruc
 
 Teleport supports a wide range of resource types, including Linux servers, MCP servers, Kubernetes clusters, databases, internal web apps, and cloud provider APIs. You can enroll these through the Teleport Web UI's guided setup workflows.
 
+## Define a label scheme
+
+**Labels** are the backbone of Teleport role-based access control for
+infrastructure resources. Each infrastructure resource you enroll in your
+Teleport cluster has one or more labels, which are arbitrary key-value pairs
+such as `env:dev` and `team:analytics`.
+
+In Step 3, you can determine which users can connect to which resources by
+restricting the labels you allow access to in their Teleport roles. Together,
+roles and resource labels define the different access patterns you expect for
+identities in your organization.
+
+Before following the rest of this guide, design a starting label scheme. We
+recommend the following keys to begin:
+
+|Label key|Description|
+|---|---|
+| `env`| Infrastructure environment, such as `dev`, `staging`, or `prod`.|
+| `team`| Team within your organization that owns the infrastructure resource.|
+| `app` or `service`| Service the infrastructure resource belongs to (e.g., a load balancer, web server pool, cache layer, and backend layer could belong to a single service).|
+
+To get started, take a moment to think of three or so values for each key. For
+example, you could use:
+
+- `env:dev`, `env:staging`, `env:prod`
+- `team:platform`, `team:core`, `team:ai`
+- `service:core`, `service:data-lake`
+
 ## Demo: Enroll an Ubuntu server
 
 To help you understand the enrollment process, let's walk through enrolling an Ubuntu Linux server as a hands-on example.


### PR DESCRIPTION
See #63019

Two key parts of the Get Started flow are defining roles and connecting resources - which requires adding labels - but users who are new with Teleport have no guidance for who to start thinking about labels and roles.

This change incorporates internal recommendations for setting up a label scheme and defining roles into the Get Started flow.