### PR TITLE
[v18] Add generated note to CLI reference docs

### DIFF
--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -6,6 +6,8 @@ tags:
   - reference
   - mwi
 ---
+{/*GENERATED FILE. DO NOT EDIT.*/}
+{/*To generate, run: make cli-docs-tbot*/}
 {/*vale messaging = NO*/}
 
 This guide provides a comprehensive list of commands, arguments, and flags for
@@ -24,9 +26,9 @@ Global flags:
 |Flag|Default|Description|
 |---|---|---|
 |`-c`, `--config`|none|Path to a configuration file.|
-|`-d`, `--[no-]debug`|`false`|Verbose logging to stdout.|
+|`-d`, `--[no-]debug`|`false`|Enables verbose logging to stdout.|
 |`--log-format`|`text`|Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.|
-|`--[no-]fips`|`false`|Runs tbot in FIPS compliance mode. This requires the FIPS binary is in use.|
+|`--[no-]fips`|`false`|Enables FIPS compliance mode. This requires the FIPS binary is in use.|
 |`--[no-]insecure`|`false`|Insecure configures the bot to trust the certificates from the Auth Server or Proxy on first connect without verification. Do not use in production.|
 
 Global environment variables:
@@ -34,7 +36,7 @@ Global environment variables:
 |Variable|Default|Description|
 |---|---|---|
 |`TBOT_CONFIG_PATH`|none|Path to a configuration file.|
-|`TBOT_DEBUG`|`false`|Verbose logging to stdout.|
+|`TBOT_DEBUG`|`false`|Enables verbose logging to stdout.|
 
 ## tbot configure application
 
@@ -67,7 +69,7 @@ Flags:
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
-|`--[no-]specific-tls-extensions`|`false`|If set, include additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions|
+|`--[no-]specific-tls-extensions`|`false`|If set, includes additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -81,7 +83,7 @@ Flags:
 
 ## tbot configure application-proxy
 
-Configures tbot with an application proxy.
+Configures tbot with a HTTP application proxy.
 
 Usage:
 
@@ -107,7 +109,7 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--listen`|none|A socket URI, such as tcp://0.0.0.0:8080|
+|`--listen`|none|The socket URI on which the local proxy should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -147,7 +149,7 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--listen`|none|A socket URI, such as tcp://0.0.0.0:8080|
+|`--listen`|none|The socket URI on which the tunnel should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -183,10 +185,10 @@ Flags:
 |`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
 |`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|none|TTL of short-lived machine certificates.|
-|`--database`|none|The name of the database available in the requested database service|
+|`--database`|none|The name of the database available in the requested database service.|
 |`--destination`|none|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--format`|``|The database output format if necessary|
+|`--format`|``|The format of the credentials to generate. If specified, must be `tls`, `mongo` or `cockroach`.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -197,11 +199,11 @@ Flags:
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
 |`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
 |`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
-|`--service`|none|The database service name|
+|`--service`|none|The database service name.|
 |`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
 |`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
 |`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
-|`--username`|none|The database user name|
+|`--username`|none|The database user name.|
 
 ## tbot configure database-tunnel
 
@@ -228,22 +230,22 @@ Flags:
 |`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
 |`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|none|TTL of short-lived machine certificates.|
-|`--database`|none|The name of the database available in the requested database service|
+|`--database`|none|The name of the database available in the requested database service.|
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--listen`|none|A socket URI to listen on, such as tcp://0.0.0.0:3306|
+|`--listen`|none|A socket URI to listen on, such as `tcp://0.0.0.0:3306`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
 |`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
 |`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
-|`--service`|none|The database service name|
+|`--service`|none|The database service name.|
 |`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
 |`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
 |`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
-|`--username`|none|The database user name|
+|`--username`|none|The database user name.|
 
 ## tbot configure identity
 
@@ -270,7 +272,7 @@ Flags:
 |`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
 |`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|none|TTL of short-lived machine certificates.|
-|`--cluster`|none|The name of a specific cluster for which to issue an identity if using a leaf cluster|
+|`--cluster`|none|The name of a specific cluster for which to issue an identity if using a leaf cluster.|
 |`--destination`|none|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
@@ -317,7 +319,7 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--kubernetes-cluster`|none|The name of the Kubernetes cluster in Teleport for which to fetch credentials|
+|`--kubernetes-cluster`|none|The name of the Kubernetes cluster in Teleport for which to fetch credentials.|
 |`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
@@ -410,6 +412,44 @@ Flags:
 |`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
 |`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
 
+## tbot configure noop
+
+Configures tbot with no configured services to test onboarding config.
+
+Usage:
+
+```code
+$ tbot configure noop [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
 ## tbot configure ssh-multiplexer
 
 Configures tbot with an SSH Multiplexer service.
@@ -483,9 +523,9 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--listen`|none|The address on which the workload identity API should listen. This should either be prefixed with 'unix://' or 'tcp://'.|
-|`--name-selector`|none|The name of the workload identity to issue|
+|`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -526,8 +566,8 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
-|`--name-selector`|none|The name of the workload identity to issue|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
+|`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--profile-arn`|none|The ARN of the Roles Anywhere profile to use.|
@@ -576,8 +616,8 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
-|`--name-selector`|none|The name of the workload identity to issue|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
+|`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -619,9 +659,9 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
-|`--name-selector`|none|The name of the workload identity to issue|
-|`--[no-]include-federated-trust-bundles`|`false`|If set, include federated trust bundles in the output|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
+|`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
+|`--[no-]include-federated-trust-bundles`|`false`|If set, include federated trust bundles in the output.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -636,7 +676,7 @@ Flags:
 
 ## tbot copy-binaries
 
-Copies this tbot binary to a given destination
+Copies this tbot binary to a given destination.
 
 Usage:
 
@@ -654,11 +694,11 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|destination-dir|none (required)|The destination path to write the copy of the tbot binary|
+|destination-dir|none (required)|The destination path to write the copy of the tbot binary.|
 
 ## tbot db
 
-Execute database commands through tsh.
+Executes database commands through tsh.
 
 Usage:
 
@@ -671,8 +711,8 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--cluster`|none|The cluster name. Extracted from the certificate if unset.|
-|`--destination-dir`|none|The destination directory with which to authenticate tsh|
-|`--proxy-server`|none|The Teleport proxy server to use, in host:port form.|
+|`--destination-dir`|none|The destination directory to provide tsh for authentication.|
+|`--proxy-server`|none|The address of the Teleport proxy server to use, in host:port form.|
 
 Arguments:
 
@@ -698,8 +738,7 @@ Arguments:
 
 ## tbot init
 
-Initialize a certificate destination directory for writes from a separate bot
-user.
+Initializes a destination directory for writes from a separate bot user.
 
 Usage:
 
@@ -722,7 +761,7 @@ Flags:
 |`--bot-user`|none|Enables POSIX ACLs and defines Linux user that can read/write short-lived certificates to "--destination-dir".|
 |`--destination-dir`|none|Directory to write short-lived machine certificates.|
 |`--init-dir`|none|If using a config file and multiple destinations are configured, controls which destination dir to configure.|
-|`--[no-]clean`|`false`|If set, remove unexpected files and directories from the destination.|
+|`--[no-]clean`|`false`|If set, removes unexpected files and directories from the destination.|
 |`--owner`|none|Defines Linux "user:group" owner of "--destination-dir". Defaults to the Linux user running tbot if unspecified.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-user`|none|Enables POSIX ACLs and defines Linux user that will read short-lived certificates from "--destination-dir".|
@@ -747,13 +786,35 @@ Flags:
 |`--[no-]anonymous-telemetry`|`false`|Enable anonymous telemetry.|
 |`--[no-]force`|`false`|Overwrite existing systemd unit file if present.|
 |`--[no-]write`|`false`|Write the systemd unit file. If not specified, this command runs in a dry-run mode that outputs the generated content to stdout.|
+|`--pid-file`|none|Overrides the PID file path that should be set in the systemd unit files.|
 |`--systemd-directory`|`/etc/systemd/system`|Path to the directory that the systemd unit file should be written. Defaults to '/etc/systemd/system'.|
 |`--user`|`teleport`|The user that the service should run as. Defaults to 'teleport'.|
 
+## tbot keypair create
+
+Creates a keypair to preregister for bound-keypair joining.
+
+Usage:
+
+```code
+$ tbot keypair create --proxy-server=PROXY-SERVER [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--format`|`text`|Output format, one of: text, json|
+|`--[no-]overwrite`|`false`|If set, overwrite any existing keypair. If unset and a keypair already exists, its key will be printed for use.|
+|`--[no-]static`|`false`|If set, creates a static private key instead of writing a mutable key into bot storage. If --static-key-path is unset, the key will be printed to the terminal.|
+|`--proxy-server`|none|The proxy server, which will be pinged to determine the current cryptographic suite in use.|
+|`--static-key-path`|none|If set, writes the static private key to a file.|
+|`--storage`|none|The internal storage URI to write the keypair to, such as `file:///var/lib/teleport/bot`.|
+
 ## tbot migrate
 
-Migrates a config file from an older version to the newest version. Outputs to
-stdout by default.
+Migrates a configuration file from an older version to the newest version.
+Outputs to stdout by default.
 
 Usage:
 
@@ -765,11 +826,11 @@ Flags:
 
 |Flag|Default|Description|
 |---|---|---|
-|`-o`, `--output`|none|Path to write the generated configuration file to rather than write to stdout.|
+|`-o`, `--output`|none|The path to write the generated configuration file to. If unset, it will be written to stdout.|
 
 ## tbot proxy
 
-Start a local TLS proxy via tsh to connect to Teleport in single-port mode.
+Starts a local TLS proxy via tsh to connect to Teleport in single-port mode.
 
 Usage:
 
@@ -777,19 +838,13 @@ Usage:
 $ tbot proxy [<flags>] [<args>...]
 ```
 
-Environment variables:
-
-|Variable|Default|Description|
-|---|---|---|
-|`TELEPORT_PROXY`|none|The Teleport proxy server to use, in host:port form.|
-
 Flags:
 
 |Flag|Default|Description|
 |---|---|---|
 |`--cluster`|none|The cluster name. Extracted from the certificate if unset.|
-|`--destination-dir`|none|The destination directory with which to authenticate tsh|
-|`--proxy-server`|none|The Teleport proxy server to use, in host:port form.|
+|`--destination-dir`|none|The destination directory to provide tsh for authentication.|
+|`--proxy-server`|none|The address of the Teleport proxy server to use, in host:port form.|
 
 Arguments:
 
@@ -844,7 +899,7 @@ Flags:
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
-|`--[no-]specific-tls-extensions`|`false`|If set, include additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions|
+|`--[no-]specific-tls-extensions`|`false`|If set, includes additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
@@ -858,7 +913,7 @@ Flags:
 
 ## tbot start application-proxy
 
-Starts tbot with an application proxy.
+Starts tbot with a HTTP application proxy.
 
 Usage:
 
@@ -884,7 +939,7 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--listen`|none|A socket URI, such as tcp://0.0.0.0:8080|
+|`--listen`|none|The socket URI on which the local proxy should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -924,7 +979,7 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--listen`|none|A socket URI, such as tcp://0.0.0.0:8080|
+|`--listen`|none|The socket URI on which the tunnel should listen, such as `tcp://0.0.0.0:8080`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -960,10 +1015,10 @@ Flags:
 |`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
 |`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|none|TTL of short-lived machine certificates.|
-|`--database`|none|The name of the database available in the requested database service|
+|`--database`|none|The name of the database available in the requested database service.|
 |`--destination`|none|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
-|`--format`|``|The database output format if necessary|
+|`--format`|``|The format of the credentials to generate. If specified, must be `tls`, `mongo` or `cockroach`.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
@@ -974,11 +1029,11 @@ Flags:
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
 |`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
 |`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
-|`--service`|none|The database service name|
+|`--service`|none|The database service name.|
 |`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
 |`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
 |`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
-|`--username`|none|The database user name|
+|`--username`|none|The database user name.|
 
 ## tbot start database-tunnel
 
@@ -1005,22 +1060,22 @@ Flags:
 |`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
 |`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|none|TTL of short-lived machine certificates.|
-|`--database`|none|The name of the database available in the requested database service|
+|`--database`|none|The name of the database available in the requested database service.|
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--listen`|none|A socket URI to listen on, such as tcp://0.0.0.0:3306|
+|`--listen`|none|A socket URI to listen on, such as `tcp://0.0.0.0:3306`.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
 |`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
 |`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
 |`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
-|`--service`|none|The database service name|
+|`--service`|none|The database service name.|
 |`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
 |`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
 |`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
-|`--username`|none|The database user name|
+|`--username`|none|The database user name.|
 
 ## tbot start identity
 
@@ -1047,7 +1102,7 @@ Flags:
 |`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
 |`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
 |`--certificate-ttl`|none|TTL of short-lived machine certificates.|
-|`--cluster`|none|The name of a specific cluster for which to issue an identity if using a leaf cluster|
+|`--cluster`|none|The name of a specific cluster for which to issue an identity if using a leaf cluster.|
 |`--destination`|none|A destination URI, such as file:///foo/bar|
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
@@ -1094,7 +1149,7 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--kubernetes-cluster`|none|The name of the Kubernetes cluster in Teleport for which to fetch credentials|
+|`--kubernetes-cluster`|none|The name of the Kubernetes cluster in Teleport for which to fetch credentials.|
 |`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
@@ -1187,6 +1242,44 @@ Flags:
 |`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
 |`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
 
+## tbot start noop
+
+Starts tbot with no configured services to test onboarding config.
+
+Usage:
+
+```code
+$ tbot start noop [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
 ## tbot start ssh-multiplexer
 
 Starts tbot with an SSH Multiplexer service.
@@ -1260,9 +1353,9 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
 |`--listen`|none|The address on which the workload identity API should listen. This should either be prefixed with 'unix://' or 'tcp://'.|
-|`--name-selector`|none|The name of the workload identity to issue|
+|`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -1303,8 +1396,8 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
-|`--name-selector`|none|The name of the workload identity to issue|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
+|`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--profile-arn`|none|The ARN of the Roles Anywhere profile to use.|
@@ -1353,8 +1446,8 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
-|`--name-selector`|none|The name of the workload identity to issue|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
+|`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -1396,9 +1489,9 @@ Flags:
 |`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
 |`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
 |`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
-|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
-|`--name-selector`|none|The name of the workload identity to issue|
-|`--[no-]include-federated-trust-bundles`|`false`|If set, include federated trust bundles in the output|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.|
+|`--name-selector`|none|The name of the workload identity to issue. Mutually exclusive with --label-selector.|
+|`--[no-]include-federated-trust-bundles`|`false`|If set, include federated trust bundles in the output.|
 |`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
 |`--proxy-server`|none|Address of the Teleport Proxy Server.|
@@ -1413,7 +1506,7 @@ Flags:
 
 ## tbot tpm identify
 
-Output identifying information related to the TPM detected on the system.
+Outputs identifying information related to the TPM detected on the system.
 
 Usage:
 
@@ -1423,7 +1516,7 @@ $ tbot tpm identify
 
 ## tbot version
 
-Print the version of your tbot binary.
+Prints the version of this tbot binary.
 
 Usage:
 

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -6,6 +6,8 @@ tags:
   - reference
   - platform-wide
 ---
+{/*GENERATED FILE. DO NOT EDIT.*/}
+{/*To generate, run: make cli-docs-tctl*/}
 {/*vale messaging = NO*/}
 
 This guide provides a comprehensive list of commands, arguments, and flags for
@@ -78,6 +80,52 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--format`|`yaml`|Output format, 'yaml', 'json', or 'text'|
+|`--[no-]review-only`|`false`|List only access lists that are due for review within the next 2 weeks or past due|
+
+## tctl acl reviews create
+
+Submit a new review for a given access list.
+
+Usage:
+
+```code
+$ tctl acl reviews create [<flags>] <access-list-name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--notes`|none|Optional review notes.|
+|`--remove-members`|none|Comma-separated list of members to remove as part of this review.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|access-list-name|none (required)|The access list name to submit review for.|
+
+## tctl acl reviews ls
+
+List past audit history for a given access list.
+
+Usage:
+
+```code
+$ tctl acl reviews ls [<flags>] <access-list-name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--format`|`text`|Output format 'yaml', 'json', or 'text'|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|access-list-name|none (required)|The access list name to fetch review history for.|
 
 ## tctl acl users add
 
@@ -483,7 +531,7 @@ Flags:
 |`--[no-]interactive`|`false`|Enable interactive mode|
 |`--[no-]manual`|`false`|Activate manual rotation, set rotation phases manually|
 |`--phase`|none|Target rotation phase to set, used in manual rotation, one of: init, standby, update_clients, update_servers, rollback|
-|`--type`|none|Certificate authority to rotate, one of: host, user, db, db_client, openssh, jwt, saml_idp, oidc_idp, spiffe, okta, awsra, bound_keypair|
+|`--type`|none|Certificate authority to rotate, one of: host, windows, user, db, db_client, openssh, jwt, saml_idp, oidc_idp, spiffe, okta, awsra, bound_keypair|
 
 ## tctl auth sign
 
@@ -1538,16 +1586,25 @@ Flags:
 
 ## tctl recordings download
 
-Download session recordings from the cluster's recording storage to a local file.
-If you omit an output directory, recordings are saved to the current working directory.
+Download session recordings.
 
-If session recording encryption is enabled in the cluster, recordings are decrypted during download.
-
-### Example
+Usage:
 
 ```code
-$ tctl recordings download [--output-dir <output-dir>] <session_id>
+$ tctl recordings download [<flags>] <session-id>
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-o`, `--output-dir`|`<current working directory>`|Directory to download session recordings to.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|session-id|none (required)|ID of the session to download recordings for.|
 
 ## tctl recordings encryption complete-rotation
 
@@ -1809,7 +1866,7 @@ Arguments:
 
 ## tctl scoped status
 
-Show the status of scoped resources
+Show the status of scoped resources.
 
 Usage:
 
@@ -1833,8 +1890,11 @@ Flags:
 |---|---|---|
 |`--assign-scope`|none|Scope that should be applied to resources provisioned by this token|
 |`--format`|none|Output format, 'text', 'json', or 'yaml'|
+|`--labels`|none|Set token labels, e.g. env=prod,region=us-west|
+|`--mode`|none|Usage mode of a token (default: unlimited, single_use)|
 |`--name`|none|Override the default, randomly generated token name with a specified name|
 |`--scope`|none|Scope assigned to the token itself|
+|`--ssh-labels`|none|Set immutable ssh labels the token should assign to provisioned resources, e.g. env=prod,region=us-west|
 |`--ttl`|`30m0s`|Set expiration time for token, default is 30 minutes|
 |`--type`|none|Type(s) of token to add, e.g. --type=node|
 

--- a/docs/pages/reference/cli/teleport.mdx
+++ b/docs/pages/reference/cli/teleport.mdx
@@ -6,6 +6,8 @@ tags:
   - reference
   - platform-wide
 ---
+{/*GENERATED FILE. DO NOT EDIT.*/}
+{/*To generate, run: make cli-docs-teleport*/}
 {/*vale messaging = NO*/}
 
 This guide provides a comprehensive list of commands, arguments, and flags for
@@ -381,7 +383,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|PROFILES|none (optional)|Comma-separated profile names to be exported. Supported profiles: threadcreate,cmdline,goroutine,mutex,trace,allocs,block,heap,profile. Default: goroutine,heap,profile|
+|PROFILES|none (optional)|Comma-separated profile names to be exported. Supported profiles: block,cmdline,goroutine,heap,trace,allocs,mutex,profile,threadcreate. Default: goroutine,heap,profile|
 
 ## teleport debug readyz
 
@@ -731,6 +733,26 @@ Flags:
 |`--pool-name`|none|Name for the new workforce identity pool.|
 |`--pool-provider-name`|none|Name for the new workforce identity pool provider.|
 
+## teleport integration configure session-summaries bedrock
+
+Adds required IAM permissions for Session Summaries feature using Amazon
+Bedrock.
+
+Usage:
+
+```code
+$ teleport integration configure session-summaries bedrock --role=ROLE [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--aws-account-id`|none|The AWS account ID.|
+|`--[no-]confirm`|`false`|Apply changes without confirmation prompt.|
+|`--resource`|`*`|The Amazon Bedrock resource to grant access to. Can be a full ARN or a model ID (e.g., 'anthropic.claude-v2' or '*' for all models).|
+|`--role`|none|The AWS Role name used by the AWS OIDC Integration.|
+
 ## teleport join openssh
 
 Join an SSH server to a Teleport cluster.
@@ -753,10 +775,11 @@ Flags:
 |`--labels`|none|Comma-separated list of labels for this OpenSSH node, for example env=dev,app=web.|
 |`--[no-]insecure`|`false`|Insecure mode disables certificate validation.|
 |`--[no-]restart-sshd`|`true`|Restart OpenSSH.|
+|`--[no-]skip-version-check`|`false`|Skip version checking between server and client.|
 |`--openssh-config`|`/etc/ssh/sshd_config`|Path to the OpenSSH config file \[/etc/ssh/sshd_config\].|
 |`--proxy-server`|none|Address of the proxy server.|
 |`--sshd-check-command`|`sshd -t -f`|Command to use when checking OpenSSH config for validity. (sshd -t -f \<sshd_config\>)|
-|`--sshd-restart-command`|`systemctl restart sshd`|Command to use when restarting openssh.|
+|`--sshd-restart-command`|none|Command to use when restarting openssh.|
 |`--token`|none|Invitation token or path to file with token value to register with an auth server.|
 
 ## teleport node configure
@@ -822,6 +845,7 @@ Flags:
 |`--pid-file`|none|Full path to the PID file. By default no PID file will be created|
 |`-r`, `--roles`|none|Comma-separated list of roles to start with \[proxy,node,auth,app,db\]|
 |`--token`|none|Invitation token or path to file with token value. Used to register with an auth server \[none\]|
+|`--token-secret`|none|Invitation token secret or path to file with secret value. Used to register with an auth server \[none\]|
 
 ## teleport status
 

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -6,6 +6,8 @@ tags:
   - reference
   - platform-wide
 ---
+{/*GENERATED FILE. DO NOT EDIT.*/}
+{/*To generate, run: make cli-docs-tsh*/}
 {/*vale messaging = NO*/}
 
 This guide provides a comprehensive list of commands, arguments, and flags for
@@ -859,7 +861,7 @@ Flags:
 |`--request-reason`|none|Reason for requesting additional roles|
 |`--request-reviewers`|none|Suggested reviewers for role request|
 |`--request-roles`|none|Request one or more extra roles|
-|`--scope`|none|Scope pins credentials to a given scope.|
+|`--scope`|none|Scope pins credentials to a given scope. Use "" to explicitly remove scoping.|
 |`-v`, `--[no-]verbose`|`false`|Show extra status information|
 
 Arguments:
@@ -1214,6 +1216,8 @@ Flags:
 |`--as`|none|Configure custom Kubernetes user impersonation.|
 |`--as-groups`|none|Configure custom Kubernetes group impersonation.|
 |`-c`, `--cluster`|none|Specify the Teleport cluster to connect|
+|`--exec-arg`|none|Arguments to pass to the executed command (can be specified multiple times).|
+|`--exec-cmd`|none|Command to execute when --exec is enabled. If not specified, defaults to $SHELL or /bin/bash. Implicitly enables exec mode.|
 |`-f`, `--format`|`unix`|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix.|
 |`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)|
 |`-n`, `--namespace`|none|Configure the default Kubernetes namespace.|
@@ -1631,7 +1635,8 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`-f`, `--format`|`text`|Format output (text, json, yaml)|
-|`-v`, `--[no-]verbose`|`false`|Show extra status information after successful login|
+|`--[no-]client`|`false`|Show client information only (no server required).|
+|`-v`, `--[no-]verbose`|`false`|Show extra status information after successful login.|
 
 ## tsh svid issue
 

--- a/lib/utils/docs-usage.md.tmpl
+++ b/lib/utils/docs-usage.md.tmpl
@@ -59,6 +59,8 @@ tags:
   - reference
   - {{if eq .App.Name "tbot"}}mwi{{else}}platform-wide{{end}}
 ---
+{/*GENERATED FILE. DO NOT EDIT.*/}
+{/*To generate, run: make cli-docs-{{.App.Name}}*/}
 {/*vale messaging = NO*/}
 
 This guide provides a comprehensive list of commands, arguments, and flags for

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -536,9 +536,9 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfEKSCmd.Flag("confirm", "Apply changes without confirmation prompt.").BoolVar(&ccf.IntegrationConfEKSIAMArguments.AutoConfirm)
 
 	integrationConfSessionSummariesCmd := integrationConfigureCmd.Command("session-summaries", "Adds required IAM permissions for Session Summaries feature.")
-	integrationBedrockSessionSummariesCmd := integrationConfSessionSummariesCmd.Command("bedrock", "Adds required IAM permissions for Session Summaries feature using AWS Bedrock.")
+	integrationBedrockSessionSummariesCmd := integrationConfSessionSummariesCmd.Command("bedrock", "Adds required IAM permissions for Session Summaries feature using Amazon Bedrock.")
 	integrationBedrockSessionSummariesCmd.Flag("role", "The AWS Role name used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.Role)
-	integrationBedrockSessionSummariesCmd.Flag("resource", "The AWS Bedrock resource to grant access to. Can be a full ARN or a model ID (e.g., 'anthropic.claude-v2' or '*' for all models).").Default("*").StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.Resource)
+	integrationBedrockSessionSummariesCmd.Flag("resource", "The Amazon Bedrock resource to grant access to. Can be a full ARN or a model ID (e.g., 'anthropic.claude-v2' or '*' for all models).").Default("*").StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.Resource)
 	integrationBedrockSessionSummariesCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.AccountID)
 	integrationBedrockSessionSummariesCmd.Flag("confirm", "Apply changes without confirmation prompt.").BoolVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.AutoConfirm)
 


### PR DESCRIPTION
Backports #64466

Make it clear in generated CLI reference docs that they were generated so authors do not attempt to edit them directly. Edit the template for generated CLI docs to add a message.

Regenerate CLI references to include the message. This also updates the references.

Note that the CLI reference doc generation is not yet fully idempotent, so we cannot enforce generation.

To pass linting, edit the `teleport` CLI to use "Amazon Bedrock" (the correct product name) in an error message instead of "AWS Bedrock".