### PR TITLE
[v18] connect: fix modtimes for desktop directory sharing

### DIFF
--- a/lib/teleterm/services/desktop/directorysharing.go
+++ b/lib/teleterm/services/desktop/directorysharing.go
@@ -278,7 +278,7 @@ func (d *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) 
 
 	info = &FileOrDirInfo{
 		Size:         f.Size(),
-		LastModified: f.ModTime().Unix(),
+		LastModified: f.ModTime().UnixMilli(),
 		Path:         relativePath,
 		IsEmpty:      false,
 	}

--- a/lib/teleterm/services/desktop/directorysharing_test.go
+++ b/lib/teleterm/services/desktop/directorysharing_test.go
@@ -93,7 +93,7 @@ func TestDirectoryAccessSuccessOperations(t *testing.T) {
 
 		require.Equal(t, &FileOrDirInfo{
 			Size:         4096,
-			LastModified: osStat.ModTime().Unix(),
+			LastModified: osStat.ModTime().UnixMilli(),
 			FileType:     FileTypeDir,
 			IsEmpty:      false,
 			Path:         "",
@@ -110,7 +110,7 @@ func TestDirectoryAccessSuccessOperations(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, dir, &FileOrDirInfo{
 			Size:         4096,
-			LastModified: osStat.ModTime().Unix(),
+			LastModified: osStat.ModTime().UnixMilli(),
 			FileType:     FileTypeDir,
 			IsEmpty:      true,
 			Path:         testDirname,
@@ -119,7 +119,7 @@ func TestDirectoryAccessSuccessOperations(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, dir, &FileOrDirInfo{
 			Size:         osStat.Size(),
-			LastModified: osStat.ModTime().Unix(),
+			LastModified: osStat.ModTime().UnixMilli(),
 			FileType:     FileTypeFile,
 			IsEmpty:      false,
 			Path:         testFilename,


### PR DESCRIPTION
Backport #64872 to branch/v18

changelog: Fixed an issue with desktop directory sharing in Teleport Connect that caused file modification times not to be displayed.

## Manual Test Plan

### Test Environment

Local cluster, connecting to a Windows Server 2019 host.

### Test Cases

- [x] File modification times show up when sharing a directory.
