### PR TITLE
Update tbot, tctl and tsh command descs

### DIFF
--- a/lib/tbot/cli/wait.go
+++ b/lib/tbot/cli/wait.go
@@ -51,7 +51,7 @@ func NewWaitCommand(app KingpinClause, action func(*WaitCommand) error) *WaitCom
 	).StringVar(&c.Service)
 	cmd.Flag(
 		"timeout",
-		"An optional timeout. If set, returns an error if all specified "+
+		"An optional timeout. If set, returns an error if not all specified "+
 			"services have reported healthy by the timeout.",
 	).DurationVar(&c.Timeout)
 

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -80,7 +80,7 @@ func Run(args []string, stdout io.Writer) error {
 	startCmd := app.Command("start", "Starts an instance of tbot.")
 
 	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).")
-	configureCmd.Flag("output", "Path to write the generated configuration file to rather. If unspecified, the generated configuration is written to stdout.").Short('o').StringVar(&configureOutPath)
+	configureCmd.Flag("output", "Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.").Short('o').StringVar(&configureOutPath)
 
 	keypairCmd := app.Command("keypair", "Manage keypairs for bound-keypair joining")
 

--- a/tool/tctl/common/terraform_command.go
+++ b/tool/tctl/common/terraform_command.go
@@ -92,7 +92,7 @@ type TerraformCommand struct {
 func (c *TerraformCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, cfg *servicecfg.Config) {
 	tfCmd := app.Command("terraform", "Helpers to run the Teleport Terraform Provider.")
 
-	c.envCmd = tfCmd.Command("env", "Obtain certificates and load them into environments variables. This creates a temporary MachineID bot.")
+	c.envCmd = tfCmd.Command("env", "Obtain certificates and load them into environment variables. This creates a temporary MachineID bot.")
 	c.envCmd.Flag(
 		"resource-prefix",
 		fmt.Sprintf("Resource prefix to use when creating the Terraform role and bots. Defaults to [%s]", terraformHelperDefaultResourcePrefix),

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -192,7 +192,7 @@ func (c *TokensCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCL
 	c.tokenKubeOIDC.Flag("bot", "Name of the bot that this token will grant access to. When set, creates a bot token. Overrides --type").StringVar(&c.botName)
 	c.tokenKubeOIDC.Flag("type", "Type(s) of token to add, e.g. --type=kube,app,db,discovery,proxy,etc").Default("kube,app,discovery").StringVar(&c.tokenType)
 	c.tokenKubeOIDC.Flag("service-account", "Name of the Kubernetes Service Account using the token. For 'teleport-kube-agent' and 'tbot' Helm charts, this is the release name.").Short('s').Required().StringVar(&c.serviceAccountName)
-	c.tokenKubeOIDC.Flag("namespace", "Namespace of the Kubernetes Service Account using the token. For 'teleport-kube-agent' and 'tbot' Helm charts, this is release namespace.").Short('n').Default("teleport").StringVar(&c.namespace)
+	c.tokenKubeOIDC.Flag("namespace", "Namespace of the Kubernetes Service Account using the token. For 'teleport-kube-agent' and 'tbot' Helm charts, this is the release namespace.").Short('n').Default("teleport").StringVar(&c.namespace)
 	c.tokenKubeOIDC.Flag("update-group", "Optional update group used for version detection and agent updater configuration").StringVar(&c.updateGroup)
 	c.tokenKubeOIDC.Flag("force", "Force the token creation, even if the token already exists").Default("false").Short('f').BoolVar(&c.force)
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1469,7 +1469,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	headlessApprove.Arg("request id", "Headless authentication request ID.").StringVar(&cf.HeadlessAuthenticationID)
 	headlessApprove.Flag("skip-confirm", "Skip confirmation and prompt for MFA immediately.").Envar(headlessSkipConfirmEnvVar).BoolVar(&cf.headlessSkipConfirm)
 
-	reqDrop := req.Command("drop", "Drop one more Access Requests from current identity.")
+	reqDrop := req.Command("drop", "Drop one or more Access Requests from current identity.")
 	reqDrop.Arg("request-id", "IDs of requests to drop (default drops all requests).").Default("*").StringsVar(&cf.RequestIDs)
 	kubectl := app.Command("kubectl", "Runs a kubectl command on a Kubernetes cluster.").Interspersed(false)
 	// This hack is required in order to accept any args for tsh kubectl.

--- a/tool/tsh/common/workload_identity.go
+++ b/tool/tsh/common/workload_identity.go
@@ -71,7 +71,7 @@ type issueX509Command struct {
 
 func newIssueX509Command(parent *kingpin.CmdClause) *issueX509Command {
 	cmd := &issueX509Command{
-		CmdClause: parent.Command("issue-x509", "Use Teleport Workload Identity to issue an X509 credential write it to a local directory."),
+		CmdClause: parent.Command("issue-x509", "Use Teleport Workload Identity to issue an X509 credential and write it to a local directory."),
 	}
 
 	cmd.Flag(


### PR DESCRIPTION
Correct some verbiage and grammar in `tbot`, `tsh` and `tctl` command descriptions.