### PR TITLE
[v18] Storybook vite config: Add wasm files to `assetsInclude`

### DIFF
--- a/web/.storybook/vite.config.mts
+++ b/web/.storybook/vite.config.mts
@@ -5,4 +5,5 @@ import { tsconfigPathsPlugin } from '@gravitational/build/vite/tsconfigPaths.mjs
 
 export default defineConfig(({ mode }) => ({
   plugins: [tsconfigPathsPlugin(), reactPlugin(mode)],
+  assetsInclude: ['**/shared/libs/ironrdp/**/*.wasm'],
 }));


### PR DESCRIPTION
Backport #64898.

## Manual Test Plan
### Test Environment

My laptop.

### Test Cases
- [x] The https://localhost:9002/?path=/story/teleterm-tabhost--story story works now.