### PR TITLE
docs: machine-id updates

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -416,7 +416,6 @@
     "cloudkms",
     "cloudspanner",
     "cloudsql",
-    "clusers",
     "cluster-6uysmebmutd",
     "clusteradmin",
     "clustercfg",

--- a/docs/pages/includes/machine-id/daemon-or-oneshot.mdx
+++ b/docs/pages/includes/machine-id/daemon-or-oneshot.mdx
@@ -22,7 +22,7 @@ To use `tbot` in one-shot mode, modify `/etc/tbot.yaml` to add `oneshot: true`:
 ```yaml
 version: v2
 oneshot: true
-auth_server: ...
+proxy_server: ...
 ```
 
 Now, you should test your `tbot` configuration. When started, several log

--- a/docs/pages/machine-workload-identity/access-guides/ansible-awx.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/ansible-awx.mdx
@@ -49,7 +49,7 @@ through the Teleport Proxy Service.
 ## Step 1/5. Configure Teleport resources
 
 To begin, we'll need to create three new Teleport resources:
-1. A Teleport role to that will grant the `tbot` sidecar access to your desired
+1. A Teleport role that will grant the `tbot` sidecar access to your desired
    SSH nodes
 1. A bot resource to name the bot and specify its list of allowed roles
 2. A join token to allow the bot to authenticate to Teleport
@@ -478,7 +478,7 @@ would like to configure the token and other Teleport resources manually, you can
 follow these steps to do so.
 
 To begin, we'll need to create three new Teleport resources:
-1. A Teleport role to that will grant the `tbot` sidecar access to your desired
+1. A Teleport role that will grant the `tbot` sidecar access to your desired
    SSH nodes
 1. A bot resource to name the bot and specify its list of allowed roles
 2. A join token to allow the bot to authenticate to Teleport

--- a/docs/pages/machine-workload-identity/access-guides/argocd.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/argocd.mdx
@@ -28,7 +28,7 @@ cluster credentials. When configured to use the Argo CD output service, `tbot`
 writes Teleport-signed Kubernetes cluster credentials into secrets that Argo CD
 can then use to access Teleport-protected Kubernetes clusters.
 
-## Prerequisite
+## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 

--- a/docs/pages/machine-workload-identity/access-guides/databases.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/databases.mdx
@@ -83,7 +83,7 @@ $ tctl bots update example --add-roles example-role
 
 This rule will allow the bot to do two things:
 
-- Access the database `example` on any database server (due to the `'*': '*'`
+- Access the database `example-db` on any database server (due to the `'*': '*'`
   label selector) as the user `alice`.
 - Discover information about database resources in Teleport.
 
@@ -141,7 +141,7 @@ services:
     path: /opt/machine-id
   # Specify the details of the database you wish to connect to.
   service: example-server
-  database: example
+  database: example-db
   username: alice
   # Specify a format to use for the output credentials. For most databases,
   # this configuration field can be omitted.

--- a/docs/pages/machine-workload-identity/access-guides/tctl.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/tctl.mdx
@@ -99,8 +99,7 @@ services:
 ```
 
 If operating `tbot` as a background service, restart it. If running `tbot` in
-one-shot mode, it must be executed before you attempt to execute the Terraform
-plan later.
+one-shot mode, it must be executed before you attempt to execute `tctl` later.
 
 You should now see an `identity` file under `/opt/machine-id`. This contains
 the private key and signed certificates needed by `tctl` to

--- a/docs/pages/machine-workload-identity/deployment/aws.mdx
+++ b/docs/pages/machine-workload-identity/deployment/aws.mdx
@@ -121,7 +121,7 @@ Replace:
 
 - `example.teleport.sh:443` with the address of your Teleport Proxy Service or
   Auth Service. Prefer using the address of a Teleport Proxy Service instance.
-- `example-bot` with the name of the token you created in the second step.
+- `example-bot` with the name of the token you created in the third step.
 
 (!docs/pages/includes/machine-id/daemon-or-oneshot.mdx!)
 

--- a/docs/pages/machine-workload-identity/deployment/azure-devops.mdx
+++ b/docs/pages/machine-workload-identity/deployment/azure-devops.mdx
@@ -147,7 +147,7 @@ Replace:
 
 - <Var name="example.teleport.sh" /> with the address of your Teleport Proxy Service or
 Auth Service. Prefer using the address of the Teleport Proxy Service.
-- `example-bot` with the name of the token you created in the second step
+- `example-bot` with the name of the token you created in the third step.
 
 Now you'll modify your Azure DevOps pipeline to install `tbot` and run it with
 the configuration you just created.

--- a/docs/pages/machine-workload-identity/deployment/bitbucket.mdx
+++ b/docs/pages/machine-workload-identity/deployment/bitbucket.mdx
@@ -127,7 +127,7 @@ pipelines:
             - curl "https://<Var name="example.teleport.sh"/>:443/scripts/install.sh" | bash
 
             # Run `tbot` in identity mode for SSH access
-            - tbot start identity --destination=./tbot-user --join-method=bitbucket --proxy-server=<Var name="example.teleport.sh"/>:443 --token=bot-bitbucket --oneshot
+            - tbot start identity --destination=./tbot-user --join-method=bitbucket --proxy-server=<Var name="example.teleport.sh"/>:443 --token=example-bot --oneshot
 
             # Make use of the generated SSH credentials
             - ssh -F ./tbot-user/ssh_config user@node.example.teleport.sh echo "hello world"

--- a/docs/pages/machine-workload-identity/deployment/circleci.mdx
+++ b/docs/pages/machine-workload-identity/deployment/circleci.mdx
@@ -105,8 +105,6 @@ Let's go over the token resource's fields in more detail:
 
 - `metadata.name` defines the name of the token. Note that this value will need
 to be used in other parts of the configuration later.
-- `metadata.expires` defines the date that the join token will expire. This
-example is set to the year `2100`.
 - `spec.bot_name` is the name of the Machine ID bot that this token will grant
 access to. Note that this value will need to be used in other parts of the
 configuration later.
@@ -152,7 +150,7 @@ Replace:
 
 - <Var name="example.teleport.sh"/> with the address of your Teleport Proxy or
   Auth Service. Prefer using the address of a Teleport Proxy.
-- `example-bot` with the name of the token you created in the second step.
+- `example-bot` with the name of the token you created in the third step.
 
 Now, the CircleCI pipeline can be defined. Before the pipeline can use `tbot`,
 it must be available within the environment. For this example, we'll show

--- a/docs/pages/machine-workload-identity/deployment/gcp.mdx
+++ b/docs/pages/machine-workload-identity/deployment/gcp.mdx
@@ -156,7 +156,7 @@ On the host where you have deployed `tbot`, run the following, replacing
 path to the `identity` file within your configured directory:
 
 ```code
-$ tsh --proxy example.teleport.sh:443 -i /opt/machine-id/identity status                                                                                                                                                                                                                                         127 ↵
+$ tsh --proxy example.teleport.sh:443 -i /opt/machine-id/identity status
 > Profile URL:        https://example.teleport.sh:443
 Logged in as:       bot-example
 Cluster:            example.teleport.sh

--- a/docs/pages/machine-workload-identity/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/deployment/github-actions.mdx
@@ -198,7 +198,7 @@ spec:
       '*': '*'
 ```
 
-With that privileges granted, you can now create the GitHub Actions workflow.
+With those privileges granted, you can now create the GitHub Actions workflow.
 Create `.github/workflows/example.yaml`:
 
 ```yaml
@@ -331,7 +331,7 @@ in `kubernetes_resources`. Otherwise the example `kubectl get pods -A` execution
 will be denied.
 </Admonition>
 
-With that privileges granted, you can now create the GitHub Actions workflow.
+With those privileges granted, you can now create the GitHub Actions workflow.
 Create `.github/workflows/example.yaml`:
 
 ```yaml
@@ -733,7 +733,7 @@ services: []
 Replace:
 
 - `example.teleport.sh:443` with the address of your Teleport Proxy Service.
-- `example-bot` with the name of the token you created in the first step.
+- `example-bot` with the name of the token you created in the second step.
 
 Now you can define a GitHub Actions workflow that will start `tbot` with this
 configuration.

--- a/docs/pages/machine-workload-identity/deployment/linux-tpm.mdx
+++ b/docs/pages/machine-workload-identity/deployment/linux-tpm.mdx
@@ -111,7 +111,7 @@ spec:
 
   # bot_name specifies the name of the bot that this token will grant access to
   # when it is used.
-  bot_name: my-bot
+  bot_name: example
 
   # tpm specifies the TPM join method specific configuration for this token.
   tpm:


### PR DESCRIPTION

Machine-id doc updates for reference and grammar fixes.
for one-shot example updated to `proxy_server` that is the best practice recommendation and works with cloud tenants.

Removed `clusers` as a allowed misspell as it was fixed in a k8s doc already.


