### PR TITLE
Ensure canvas dimensions are integers

### DIFF
--- a/web/packages/shared/components/CanvasRenderer.tsx
+++ b/web/packages/shared/components/CanvasRenderer.tsx
@@ -103,7 +103,13 @@ export const CanvasRenderer = forwardRef<
         canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
       },
       focus: () => canvasRef.current.focus(),
-      getSize: () => canvasRef.current.getBoundingClientRect(),
+      getSize: () => {
+        const rect = canvasRef.current.getBoundingClientRect();
+        return {
+          height: Math.round(rect.height),
+          width: Math.round(rect.width),
+        };
+      },
     };
   }, []);
 
@@ -120,8 +126,8 @@ export const CanvasRenderer = forwardRef<
     const observer = new ResizeObserver(([entry]) => {
       if (entry && entry.contentRect.height !== 0) {
         debouncedOnResize({
-          height: entry.contentRect.height,
-          width: entry.contentRect.width,
+          height: Math.round(entry.contentRect.height),
+          width: Math.round(entry.contentRect.width),
         });
       }
     });


### PR DESCRIPTION
Before TDPB, screen dimensions were encoded using `setUint32()`, which truncates any fractional values:
>All integer arrays (except Uint8ClampedArray) use [fixed-width number conversion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#fixed-width_number_conversion), which first truncates the decimal part of the number and then takes the lowest bits.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#value_encoding_and_normalization

https://github.com/gravitational/teleport/blob/ea7d11fd73b126c3f2de9662c22c2451dc9cb79a/web/packages/shared/libs/tdp/codec.ts#L1255-L1256

With TPDB, we pass values directly, which leads to errors when writing floating-point values to the proto format.
This happens only in Firefox, it seems that other browsers round dimensions returned from `getBoundingClientRect()`.

<img width="481" height="392" alt="image" src="https://github.com/user-attachments/assets/1feb09c8-5605-4a92-ab96-849bd0edc015" />

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
A windows desktop resource.

### Test Cases
- [x] Verified the desktop session starts and can be resized in Firefox, Safari, and Chrome. 
