### PR TITLE
Discovery Config Status: add sync and end time per resource type

### DIFF
--- a/api/types/discoveryconfig/convert/v1/discoveryconfig.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig.go
@@ -151,6 +151,9 @@ func StatusToProto(status discoveryconfig.Status) *discoveryconfigv1.DiscoveryCo
 
 	integrationDiscoveredResources := make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary, len(status.IntegrationDiscoveredResources))
 	for k, v := range status.IntegrationDiscoveredResources {
+		if v == nil {
+			v = &discoveryconfig.IntegrationDiscoveredSummary{}
+		}
 		integrationDiscoveredResources[k] = v.IntegrationDiscoveredSummary
 	}
 

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig.go
@@ -91,9 +91,9 @@ func StatusFromProto(msg *discoveryconfigv1.DiscoveryConfigStatus) discoveryconf
 	return discoveryconfig.Status{
 		State:                          discoveryconfigv1.DiscoveryConfigState_name[int32(msg.State)],
 		ErrorMessage:                   msg.ErrorMessage,
-		DiscoveredResources:            msg.DiscoveredResources,
+		DiscoveredResources:            msg.GetDiscoveredResources(),
 		LastSyncTime:                   lastSyncTime,
-		IntegrationDiscoveredResources: msg.IntegrationDiscoveredResources,
+		IntegrationDiscoveredResources: msg.GetIntegrationDiscoveredResources(),
 	}
 }
 

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig.go
@@ -88,12 +88,20 @@ func StatusFromProto(msg *discoveryconfigv1.DiscoveryConfigStatus) discoveryconf
 	if msg.LastSyncTime != nil {
 		lastSyncTime = msg.LastSyncTime.AsTime()
 	}
+
+	integrationDiscoveredResources := make(map[string]*discoveryconfig.IntegrationDiscoveredSummary, len(msg.IntegrationDiscoveredResources))
+	for k, v := range msg.IntegrationDiscoveredResources {
+		integrationDiscoveredResources[k] = &discoveryconfig.IntegrationDiscoveredSummary{
+			IntegrationDiscoveredSummary: v,
+		}
+	}
+
 	return discoveryconfig.Status{
 		State:                          discoveryconfigv1.DiscoveryConfigState_name[int32(msg.State)],
 		ErrorMessage:                   msg.ErrorMessage,
 		DiscoveredResources:            msg.GetDiscoveredResources(),
 		LastSyncTime:                   lastSyncTime,
-		IntegrationDiscoveredResources: msg.GetIntegrationDiscoveredResources(),
+		IntegrationDiscoveredResources: integrationDiscoveredResources,
 	}
 }
 
@@ -141,11 +149,16 @@ func StatusToProto(status discoveryconfig.Status) *discoveryconfigv1.DiscoveryCo
 		lastSyncTime = timestamppb.New(status.LastSyncTime)
 	}
 
+	integrationDiscoveredResources := make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary, len(status.IntegrationDiscoveredResources))
+	for k, v := range status.IntegrationDiscoveredResources {
+		integrationDiscoveredResources[k] = v.IntegrationDiscoveredSummary
+	}
+
 	return &discoveryconfigv1.DiscoveryConfigStatus{
 		State:                          discoveryconfigv1.DiscoveryConfigState(discoveryconfigv1.DiscoveryConfigState_value[status.State]),
 		ErrorMessage:                   status.ErrorMessage,
 		DiscoveredResources:            status.DiscoveredResources,
 		LastSyncTime:                   lastSyncTime,
-		IntegrationDiscoveredResources: status.IntegrationDiscoveredResources,
+		IntegrationDiscoveredResources: integrationDiscoveredResources,
 	}
 }

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig_test.go
@@ -76,12 +76,14 @@ func newDiscoveryConfig(t *testing.T, name string) *discoveryconfig.DiscoveryCon
 	discoveryConfig.Status.LastSyncTime = now
 	errMsg := "error message"
 	discoveryConfig.Status.ErrorMessage = &errMsg
-	discoveryConfig.Status.IntegrationDiscoveredResources = map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+	discoveryConfig.Status.IntegrationDiscoveredResources = map[string]*discoveryconfig.IntegrationDiscoveredSummary{
 		"my-integration": {
-			AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
-				Found:    3,
-				Enrolled: 2,
-				Failed:   1,
+			IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+				AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
+					Found:    3,
+					Enrolled: 2,
+					Failed:   1,
+				},
 			},
 		},
 	}

--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -84,7 +85,7 @@ type Status struct {
 	// LastSyncTime is the timestamp when the Discovery Config was last sync.
 	LastSyncTime time.Time `json:"last_sync_time,omitempty" yaml:"last_sync_time,omitempty"`
 	// IntegrationDiscoveredResources maps an integration to a summary of resources that were found using that integration.
-	IntegrationDiscoveredResources map[string]*discoveryconfigv1.IntegrationDiscoveredSummary `json:"integration_discovered_resources,omitempty" yaml:"integration_discovered_resources,omitempty"`
+	IntegrationDiscoveredResources map[string]*IntegrationDiscoveredSummary `json:"integration_discovered_resources,omitempty" yaml:"integration_discovered_resources,omitempty"`
 }
 
 // NewDiscoveryConfig will create a new discovery config.
@@ -99,6 +100,30 @@ func NewDiscoveryConfig(metadata header.Metadata, spec Spec) (*DiscoveryConfig, 
 	}
 
 	return discoveryConfig, nil
+}
+
+// IntegrationDiscoveredSummary holds the summary of resources discovered for a specific integration.
+type IntegrationDiscoveredSummary struct {
+	*discoveryconfigv1.IntegrationDiscoveredSummary
+}
+
+// MarshalJSON marshals the IntegrationDiscoveredSummary into JSON.
+func (s *IntegrationDiscoveredSummary) MarshalJSON() ([]byte, error) {
+	if s == nil {
+		s = &IntegrationDiscoveredSummary{}
+	}
+	return protojson.Marshal(s.IntegrationDiscoveredSummary)
+}
+
+// UnmarshalJSON unmarshals JSON data into the IntegrationDiscoveredSummary.
+func (s *IntegrationDiscoveredSummary) UnmarshalJSON(data []byte) error {
+	if s.IntegrationDiscoveredSummary == nil {
+		s.IntegrationDiscoveredSummary = &discoveryconfigv1.IntegrationDiscoveredSummary{}
+	}
+
+	return protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}.Unmarshal(data, s.IntegrationDiscoveredSummary)
 }
 
 // CheckAndSetDefaults validates fields and populates empty fields with default values.

--- a/lib/services/discoveryconfig_test.go
+++ b/lib/services/discoveryconfig_test.go
@@ -21,8 +21,11 @@ package services
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/header"
@@ -88,3 +91,85 @@ spec:
   - types: ["ec2"]
     regions: ["eu-west-2"]
 `
+
+func TestUnmarshalStatusCountersAsInt(t *testing.T) {
+	// We changed to protojson so that sync timers use a human readable format (instead of unix timestamps).
+	// However, using protojson also changed the way numeric fields are stored in the backend: from int64 to string.
+	// See: https://github.com/golang/protobuf/issues/1414
+	// This test simulates a scenario where the stored value for IntegrationDiscoveredSummary used int64 and ensures it doesn't cause any issues when loading the resource.
+
+	const legacyYAML = `---
+kind: discovery_group
+version: v1
+metadata:
+  name: test-discovery-config
+spec:
+  discovery_group: dg01
+  aws:
+  - types: ["ec2"]
+    regions: ["eu-west-2"]
+status:
+  integration_discovered_resources:
+    integration:
+      awsEc2:
+        failed: 5
+        found: 5
+`
+	dataLegacy, err := utils.ToJSON([]byte(legacyYAML))
+	require.NoError(t, err)
+
+	const newFormat = `---
+kind: discovery_group
+version: v1
+metadata:
+  name: test-discovery-config
+spec:
+  discovery_group: dg01
+  aws:
+  - types: ["ec2"]
+    regions: ["eu-west-2"]
+status:
+  integration_discovered_resources:
+    integration:
+      awsEc2:
+        failed: "5"
+        found: "5"
+`
+	dataNewFormat, err := utils.ToJSON([]byte(newFormat))
+	require.NoError(t, err)
+
+	expected, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{
+			Name: "test-discovery-config",
+		},
+		discoveryconfig.Spec{
+			DiscoveryGroup: "dg01",
+			AWS: []types.AWSMatcher{
+				{
+					Types:   []string{"ec2"},
+					Regions: []string{"eu-west-2"},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	expected.Status = discoveryconfig.Status{
+		IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+			"integration": {
+				IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+					AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
+						Found:  5,
+						Failed: 5,
+					},
+				},
+			},
+		},
+	}
+	actualLegacy, err := UnmarshalDiscoveryConfig(dataLegacy)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expected.Status, actualLegacy.Status, protocmp.Transform()))
+
+	actualNewFormat, err := UnmarshalDiscoveryConfig(dataNewFormat)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expected.Status, actualNewFormat.Status, protocmp.Transform()))
+}

--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
-	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
 )
@@ -62,7 +61,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						ErrorMessage:                   nil,
 						DiscoveredResources:            1,
 						LastSyncTime:                   clock.Now(),
-						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -86,7 +85,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						ErrorMessage:                   &testErr,
 						DiscoveredResources:            1,
 						LastSyncTime:                   clock.Now(),
-						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -109,7 +108,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						ErrorMessage:                   &testErr,
 						DiscoveredResources:            1,
 						LastSyncTime:                   clock.Now(),
-						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -142,7 +141,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						ErrorMessage:                   nil,
 						DiscoveredResources:            0,
 						LastSyncTime:                   clock.Now(),
-						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -172,7 +171,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						ErrorMessage:                   nil,
 						DiscoveredResources:            2,
 						LastSyncTime:                   clock.Now(),
-						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
 					},
 				},
 				"test2": {
@@ -181,7 +180,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						ErrorMessage:                   nil,
 						DiscoveredResources:            1,
 						LastSyncTime:                   clock.Now(),
-						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -206,7 +205,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						State:                          "DISCOVERY_CONFIG_STATE_ERROR",
 						ErrorMessage:                   stringPointer("error in fetcher 1\nerror in fetcher 2"),
 						LastSyncTime:                   clock.Now(),
-						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
 					},
 				},
 			},
@@ -232,7 +231,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						ErrorMessage:                   stringPointer("error in fetcher 1"),
 						DiscoveredResources:            2,
 						LastSyncTime:                   clock.Now(),
-						IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
+						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
 					},
 				},
 			},

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -66,6 +66,10 @@ type WatcherConfig struct {
 	Origin string
 	// PreFetchHookFn is called before starting a new fetch cycle.
 	PreFetchHookFn func()
+	// ProcessResourcesDiscoveredHookFn is called for each discovered resources during a fetch cycle.
+	ProcessResourcesDiscoveredHookFn func(types.ResourcesWithLabels)
+	// PostFetchHookFn is called after completing a fetch cycle.
+	PostFetchHookFn func()
 }
 
 // CheckAndSetDefaults validates the config.
@@ -88,6 +92,12 @@ func (c *WatcherConfig) CheckAndSetDefaults() error {
 	if c.Origin == "" {
 		return trace.BadParameter("origin is not set")
 	}
+	if c.PreFetchHookFn == nil {
+		c.PreFetchHookFn = func() {}
+	}
+	if c.PostFetchHookFn == nil {
+		c.PostFetchHookFn = func() {}
+	}
 	return nil
 }
 
@@ -107,10 +117,21 @@ func NewWatcher(ctx context.Context, config WatcherConfig) (*Watcher, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	resourcesC := make(chan types.ResourcesWithLabels)
+
+	if config.ProcessResourcesDiscoveredHookFn == nil {
+		config.ProcessResourcesDiscoveredHookFn = func(resources types.ResourcesWithLabels) {
+			select {
+			case resourcesC <- resources:
+			case <-ctx.Done():
+			}
+		}
+	}
+
 	return &Watcher{
 		cfg:        config,
 		ctx:        ctx,
-		resourcesC: make(chan types.ResourcesWithLabels),
+		resourcesC: resourcesC,
 	}, nil
 }
 
@@ -144,9 +165,8 @@ func (w *Watcher) Start() {
 
 // fetchAndSend fetches resources from all fetchers and sends them to the channel.
 func (w *Watcher) fetchAndSend() {
-	if w.cfg.PreFetchHookFn != nil {
-		w.cfg.PreFetchHookFn()
-	}
+	w.cfg.PreFetchHookFn()
+	defer w.cfg.PostFetchHookFn()
 
 	var (
 		newFetcherResources = make(types.ResourcesWithLabels, 0, 50)
@@ -227,10 +247,7 @@ func (w *Watcher) fetchAndSend() {
 	// error is discarded because we must run all fetchers until the end.
 	_ = group.Wait()
 
-	select {
-	case w.resourcesC <- newFetcherResources:
-	case <-w.ctx.Done():
-	}
+	w.cfg.ProcessResourcesDiscoveredHookFn(newFetcherResources)
 }
 
 // Resources returns a channel that receives fetched cloud resources.

--- a/lib/srv/discovery/common/watcher_test.go
+++ b/lib/srv/discovery/common/watcher_test.go
@@ -20,12 +20,14 @@ package common
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -61,14 +63,25 @@ func TestWatcher(t *testing.T) {
 	}
 
 	clock := clockwork.NewFakeClock()
-	fetchIterations := atomic.Uint32{}
+	fetchIterationsStart := atomic.Uint32{}
+	fetchIterationsEnd := atomic.Uint32{}
+	resourcesCollectorMU := sync.RWMutex{}
+	var resourcesCollector types.ResourcesWithLabels
 	watcher, err := NewWatcher(ctx, WatcherConfig{
 		FetchersFn: StaticFetchers([]Fetcher{appFetcher, noAuthFetcher, dbFetcher}),
 		Interval:   time.Hour,
 		Clock:      clock,
 		Origin:     types.OriginCloud,
 		PreFetchHookFn: func() {
-			fetchIterations.Add(1)
+			fetchIterationsStart.Add(1)
+		},
+		ProcessResourcesDiscoveredHookFn: func(rwl types.ResourcesWithLabels) {
+			resourcesCollectorMU.Lock()
+			defer resourcesCollectorMU.Unlock()
+			resourcesCollector = append(resourcesCollector, rwl...)
+		},
+		PostFetchHookFn: func() {
+			fetchIterationsEnd.Add(1)
 		},
 	})
 	require.NoError(t, err)
@@ -76,13 +89,33 @@ func TestWatcher(t *testing.T) {
 
 	// Watcher should fetch once right away at watcher.Start.
 	wantResources := types.ResourcesWithLabels{app1, app2, db}
-	assertFetchResources(t, watcher, wantResources)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		if !assert.Equal(collect, uint32(1), fetchIterationsEnd.Load()) {
+			return
+		}
+		assert.Equal(t, uint32(1), fetchIterationsStart.Load())
+
+		resourcesCollectorMU.RLock()
+		defer resourcesCollectorMU.RUnlock()
+		assert.ElementsMatch(collect, wantResources, resourcesCollector)
+	}, time.Second, 100*time.Millisecond, "timeout waiting for resources")
+
+	resourcesCollectorMU.Lock()
+	resourcesCollector = nil
+	resourcesCollectorMU.Unlock()
 
 	// Watcher should fetch again after interval.
 	clock.Advance(time.Hour + time.Minute)
-	assertFetchResources(t, watcher, wantResources)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		if !assert.Equal(collect, uint32(2), fetchIterationsEnd.Load()) {
+			return
+		}
+		assert.Equal(t, uint32(2), fetchIterationsStart.Load())
 
-	require.Equal(t, uint32(2), fetchIterations.Load())
+		resourcesCollectorMU.RLock()
+		defer resourcesCollectorMU.RUnlock()
+		assert.ElementsMatch(collect, wantResources, resourcesCollector)
+	}, time.Second, 100*time.Millisecond, "timeout waiting for resources")
 }
 
 func TestWatcherWithDynamicFetchers(t *testing.T) {

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -44,7 +44,7 @@ func (s *Server) startDatabaseWatchers() error {
 
 	var (
 		newDatabases []types.Database
-		mu           sync.Mutex
+		mu           sync.RWMutex
 	)
 
 	reconciler, err := services.NewReconciler(
@@ -52,8 +52,8 @@ func (s *Server) startDatabaseWatchers() error {
 			Matcher:             func(database types.Database) bool { return true },
 			GetCurrentResources: s.getCurrentDatabases,
 			GetNewResources: func() map[string]types.Database {
-				mu.Lock()
-				defer mu.Unlock()
+				mu.RLock()
+				defer mu.RUnlock()
 				return utils.FromSlice(newDatabases, types.Database.GetName)
 			},
 			Logger:   s.Log.With("kind", types.KindDatabase),
@@ -76,68 +76,64 @@ func (s *Server) startDatabaseWatchers() error {
 			Origin:         types.OriginCloud,
 			Clock:          s.clock,
 			PreFetchHookFn: s.databaseWatcherIterationStarted,
+			ProcessResourcesDiscoveredHookFn: func(rwl types.ResourcesWithLabels) {
+				s.handleDatabaseEnrollment(rwl, reconciler, &mu, &newDatabases)
+			},
+			PostFetchHookFn: s.databaseWatcherIterationEnded,
 		},
 	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	go watcher.Start()
-
-	go func() {
-		for {
-			resourcesFoundByGroup := make(map[awsResourceGroup]int)
-
-			select {
-			case newResources := <-watcher.ResourcesC():
-				dbs := make([]types.Database, 0, len(newResources))
-				for _, r := range newResources {
-					db, ok := r.(types.Database)
-					if !ok {
-						continue
-					}
-
-					resourceGroup := awsResourceGroupFromLabels(db.GetStaticLabels())
-					resourcesFoundByGroup[resourceGroup] += 1
-
-					dbs = append(dbs, db)
-
-					s.collectRDSIssuesAsUserTasks(db, resourceGroup.integration, resourceGroup.discoveryConfigName)
-				}
-				mu.Lock()
-				newDatabases = dbs
-				mu.Unlock()
-
-				for group, count := range resourcesFoundByGroup {
-					s.awsRDSResourcesStatus.incrementFound(group, count)
-				}
-
-				if err := reconciler.Reconcile(s.ctx); err != nil {
-					s.Log.WarnContext(s.ctx, "Unable to reconcile database resources", "error", err)
-
-					// When reconcile fails, it is assumed that everything failed.
-					for group, count := range resourcesFoundByGroup {
-						s.awsRDSResourcesStatus.incrementFailed(group, count)
-					}
-
-					break
-				}
-
-				for group, count := range resourcesFoundByGroup {
-					s.awsRDSResourcesStatus.incrementEnrolled(group, count)
-				}
-
-				if s.onDatabaseReconcile != nil {
-					s.onDatabaseReconcile()
-				}
-
-			case <-s.ctx.Done():
-				return
-			}
-
-			s.upsertTasksForAWSRDSFailedEnrollments()
-		}
-	}()
 	return nil
+}
+
+func (s *Server) handleDatabaseEnrollment(newResources types.ResourcesWithLabels, reconciler *services.Reconciler[types.Database], mu *sync.RWMutex, newDatabases *[]types.Database) {
+	resourcesFoundByGroup := make(map[awsResourceGroup]int)
+
+	dbs := make([]types.Database, 0, len(newResources))
+	for _, r := range newResources {
+		db, ok := r.(types.Database)
+		if !ok {
+			continue
+		}
+
+		resourceGroup := awsResourceGroupFromLabels(db.GetStaticLabels())
+		resourcesFoundByGroup[resourceGroup] += 1
+
+		dbs = append(dbs, db)
+
+		s.collectRDSIssuesAsUserTasks(db, resourceGroup.integration, resourceGroup.discoveryConfigName)
+	}
+	mu.Lock()
+	*newDatabases = dbs
+	mu.Unlock()
+
+	defer s.upsertTasksForAWSRDSFailedEnrollments()
+
+	for group, count := range resourcesFoundByGroup {
+		s.awsRDSResourcesStatus.incrementFound(group, count)
+	}
+
+	if err := reconciler.Reconcile(s.ctx); err != nil {
+		s.Log.WarnContext(s.ctx, "Unable to reconcile database resources", "error", err)
+
+		// When reconcile fails, it is assumed that everything failed.
+		for group, count := range resourcesFoundByGroup {
+			s.awsRDSResourcesStatus.incrementFailed(group, count)
+		}
+
+		return
+	}
+
+	for group, count := range resourcesFoundByGroup {
+		s.awsRDSResourcesStatus.incrementEnrolled(group, count)
+	}
+
+	if s.onDatabaseReconcile != nil {
+		s.onDatabaseReconcile()
+	}
 }
 
 // collectRDSIssuesAsUserTasks receives a discovered database converted into a Teleport Database resource and creates
@@ -180,11 +176,6 @@ func (s *Server) collectRDSIssuesAsUserTasks(db types.Database, integration, dis
 
 func (s *Server) databaseWatcherIterationStarted() {
 	allFetchers := s.getAllDatabaseFetchers()
-	if len(allFetchers) == 0 {
-		return
-	}
-
-	s.submitFetchersEvent(allFetchers)
 
 	awsResultGroups := slices.FilterMapUnique(
 		allFetchers,
@@ -198,16 +189,23 @@ func (s *Server) databaseWatcherIterationStarted() {
 		},
 	)
 
-	discoveryConfigs := slices.FilterMapUnique(awsResultGroups, func(g awsResourceGroup) (s string, include bool) {
-		return g.discoveryConfigName, true
-	})
+	s.awsRDSResourcesStatus.iterationStarted(awsResultGroups, s.clock.Now())
+	discoveryConfigs := s.awsRDSResourcesStatus.iterationDiscoveryConfigs()
 	s.updateDiscoveryConfigStatus(discoveryConfigs...)
-	s.awsRDSResourcesStatus.reset()
-	for _, g := range awsResultGroups {
-		s.awsRDSResourcesStatus.iterationStarted(g)
-	}
 
 	s.awsRDSTasks.reset()
+
+	if len(allFetchers) > 0 {
+		s.submitFetchersEvent(allFetchers)
+	}
+}
+
+func (s *Server) databaseWatcherIterationEnded() {
+	syncEnded := s.clock.Now()
+	s.awsRDSResourcesStatus.iterationEnded(syncEnded)
+
+	discoveryConfigs := s.awsRDSResourcesStatus.iterationDiscoveryConfigs()
+	s.updateDiscoveryConfigStatus(discoveryConfigs...)
 }
 
 func (s *Server) getAllDatabaseFetchers() []common.Fetcher {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -636,6 +636,19 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 		server.WithTriggerFetchC[*server.EC2Instances](s.newDiscoveryConfigChangedSub()),
 		server.WithPreFetchHookFn(s.ec2WatcherIterationStarted),
 		server.WithClock[*server.EC2Instances](s.clock),
+		server.WithPerInstanceHookFn(func(instanceGroups []*server.EC2Instances) {
+			for _, group := range instanceGroups {
+				s.awsEC2ResourcesStatus.incrementFound(awsResourceGroup{
+					discoveryConfigName: group.DiscoveryConfigName,
+					integration:         group.Integration,
+				}, len(group.Instances))
+
+				if err := s.handleEC2Instances(group); err != nil {
+					s.logHandleInstancesErr(err)
+				}
+			}
+		}),
+		server.WithPostFetchHookFn[*server.EC2Instances](s.ec2WatcherIterationEnded),
 	)
 	s.ec2Watcher.SetFetchers(noDiscoveryConfig, staticFetchers)
 
@@ -674,12 +687,6 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 }
 
 func (s *Server) ec2WatcherIterationStarted(fetchers []server.Fetcher[*server.EC2Instances]) {
-	if len(fetchers) == 0 {
-		return
-	}
-
-	s.submitFetchEvent(types.CloudAWS, types.AWSMatcherEC2)
-
 	awsResultGroups := libslices.FilterMapUnique(
 		fetchers,
 		func(f server.Fetcher[*server.EC2Instances]) (awsResourceGroup, bool) {
@@ -691,16 +698,26 @@ func (s *Server) ec2WatcherIterationStarted(fetchers []server.Fetcher[*server.EC
 			return resourceGroup, include
 		},
 	)
-	discoveryConfigs := libslices.FilterMapUnique(awsResultGroups, func(g awsResourceGroup) (s string, include bool) {
-		return g.discoveryConfigName, true
-	})
-	s.updateDiscoveryConfigStatus(discoveryConfigs...)
-	s.awsEC2ResourcesStatus.reset()
-	for _, g := range awsResultGroups {
-		s.awsEC2ResourcesStatus.iterationStarted(g)
-	}
+	syncStarted := s.clock.Now()
+	s.awsEC2ResourcesStatus.iterationStarted(awsResultGroups, syncStarted)
 
 	s.awsEC2Tasks.reset()
+
+	discoveryConfigs := s.awsEC2ResourcesStatus.iterationDiscoveryConfigs()
+	s.updateDiscoveryConfigStatus(discoveryConfigs...)
+
+	if len(fetchers) > 0 {
+		s.submitFetchEvent(types.CloudAWS, types.AWSMatcherEC2)
+	}
+}
+
+func (s *Server) ec2WatcherIterationEnded() {
+	syncEnded := s.clock.Now()
+	s.awsEC2ResourcesStatus.iterationEnded(syncEnded)
+
+	discoveryConfigs := s.awsEC2ResourcesStatus.iterationDiscoveryConfigs()
+	s.updateDiscoveryConfigStatus(discoveryConfigs...)
+	s.upsertTasksForAWSEC2FailedEnrollments()
 }
 
 func (s *Server) initKubeAppWatchers(matchers []types.KubernetesMatcher) error {
@@ -1403,7 +1420,7 @@ func (s *Server) findUnrotatedEC2Nodes(ctx context.Context) ([]types.Server, err
 	return found, nil
 }
 
-func (s *Server) handleEC2Discovery() {
+func (s *Server) startAWSServerDiscovery() {
 	if err := s.nodeWatcher.WaitInitialization(); err != nil {
 		s.Log.ErrorContext(s.ctx, "Failed to initialize nodeWatcher", "error", err)
 		return
@@ -1411,27 +1428,6 @@ func (s *Server) handleEC2Discovery() {
 
 	go s.ec2Watcher.Run()
 	go s.watchCARotation(s.ctx)
-
-	for {
-		select {
-		case instances := <-s.ec2Watcher.InstancesC:
-			s.Log.DebugContext(s.ctx, "EC2 instances discovered, starting installation", "account_id", instances.AccountID, "instances", genEC2InstancesLogStr(instances.Instances))
-
-			s.awsEC2ResourcesStatus.incrementFound(awsResourceGroup{
-				discoveryConfigName: instances.DiscoveryConfigName,
-				integration:         instances.Integration,
-			}, len(instances.Instances))
-
-			if err := s.handleEC2Instances(instances); err != nil {
-				s.logHandleInstancesErr(err)
-			}
-
-			s.upsertTasksForAWSEC2FailedEnrollments()
-		case <-s.ctx.Done():
-			s.ec2Watcher.Stop()
-			return
-		}
-	}
 }
 
 func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.AzureInstances) ([]server.AzureInstallFailure, error) {
@@ -1531,7 +1527,7 @@ func (s *Server) startAzureServerDiscovery() {
 			if len(fetchers) > 0 {
 				s.submitFetchEvent(types.CloudAzure, types.AzureMatcherVM)
 			}
-			sm = newStatusMap(types.AzureMatcherVM)
+			sm = newStatusMap(types.AzureMatcherVM, runStart)
 			vmTasks = &azureVMTasks{}
 
 			// Initialize the status map with an entry per fetcher (discoveryConfig + integration).
@@ -1547,6 +1543,7 @@ func (s *Server) startAzureServerDiscovery() {
 				}
 				sm.add(fgKey, make(map[statusType]int))
 			}
+			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
 		}),
 		server.WithPerInstanceHookFn(func(instanceGroups []*server.AzureInstances) {
 			s.Log.DebugContext(s.ctx, "Processing instances", "groups", len(instanceGroups))
@@ -1563,6 +1560,8 @@ func (s *Server) startAzureServerDiscovery() {
 		server.WithPostFetchHookFn[*server.AzureInstances](func() {
 			// refresh the fetchers after every iteration to avoid stale config
 			defer fullRefresh()
+
+			sm.syncEnded(s.clock.Now())
 			// update statuses of relevant discovery configs.
 			s.azureVMStatus.Store(sm)
 			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
@@ -1837,7 +1836,7 @@ func (s *Server) submitFetchEvent(cloudProvider, resourceType string) {
 // Start starts the discovery service.
 func (s *Server) Start() error {
 	if s.ec2Watcher != nil {
-		go s.handleEC2Discovery()
+		go s.startAWSServerDiscovery()
 		go s.reconciler.run(s.ctx)
 	}
 	go s.startAzureServerDiscovery()

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -936,7 +936,26 @@ func TestDiscoveryServer(t *testing.T) {
 					require.Equal(t, want.ErrorMessage, got.ErrorMessage)
 					for expectedKey, expectedValue := range want.IntegrationDiscoveredResources {
 						require.Contains(t, got.IntegrationDiscoveredResources, expectedKey)
-						require.Equal(t, expectedValue, got.IntegrationDiscoveredResources[expectedKey])
+						gotResourcesSummary := got.IntegrationDiscoveredResources[expectedKey]
+
+						cmpDiff := cmp.Diff(expectedValue, gotResourcesSummary,
+							protocmp.Transform(),
+							protocmp.IgnoreFields(&discoveryconfigv1.ResourcesDiscoveredSummary{}, "sync_end", "sync_start"),
+						)
+						require.Empty(t, cmpDiff, "expected discovery config status summary does not match actual summary, diff: %s", cmpDiff)
+
+						if expectedValue.AwsEc2 != nil {
+							requireSyncTimesSet(t, gotResourcesSummary.AwsEc2)
+						}
+						if expectedValue.AwsEks != nil {
+							requireSyncTimesSet(t, gotResourcesSummary.AwsEks)
+						}
+						if expectedValue.AwsRds != nil {
+							requireSyncTimesSet(t, gotResourcesSummary.AwsRds)
+						}
+						if expectedValue.AzureVms != nil {
+							requireSyncTimesSet(t, gotResourcesSummary.AzureVms)
+						}
 					}
 					return true
 				}, 1*time.Second, 50*time.Millisecond)
@@ -946,6 +965,12 @@ func TestDiscoveryServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func requireSyncTimesSet(t *testing.T, summary *discoveryconfigv1.ResourcesDiscoveredSummary) {
+	require.NotNil(t, summary)
+	require.True(t, summary.SyncStart.AsTime().After(time.Unix(0, 0)))
+	require.True(t, summary.SyncEnd.AsTime().After(time.Unix(0, 0)))
 }
 
 func fetchAllUserTasks(t *testing.T, userTasksClt services.UserTasks, minUserTasks, minUserTaskResources int) []*usertasksv1.UserTask {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -682,12 +682,14 @@ func TestDiscoveryServer(t *testing.T) {
 				ErrorMessage:        nil,
 				DiscoveredResources: 1,
 				LastSyncTime:        fakeClock.Now().UTC(),
-				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
 					"my-integration": {
-						AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
-							Found:    1,
-							Enrolled: 0,
-							Failed:   0,
+						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+							AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
+								Found:    1,
+								Enrolled: 0,
+								Failed:   0,
+							},
 						},
 					},
 				},
@@ -707,12 +709,14 @@ func TestDiscoveryServer(t *testing.T) {
 				ErrorMessage:        nil,
 				DiscoveredResources: 0,
 				LastSyncTime:        fakeClock.Now().UTC(),
-				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
 					"my-integration": {
-						AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
-							Found:    0,
-							Enrolled: 0,
-							Failed:   0,
+						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+							AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
+								Found:    0,
+								Enrolled: 0,
+								Failed:   0,
+							},
 						},
 					},
 				},

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -2874,12 +2874,12 @@ func TestDiscoveryDatabase(t *testing.T) {
 
 			if tc.discoveryConfigStatusCheck != nil {
 				require.EventuallyWithT(t, func(t *assert.CollectT) {
-					fakeClock.Advance(srv.PollInterval * 2)
 					dc, err := tlsServer.Auth().GetDiscoveryConfig(ctx, discoveryConfigName)
 					require.NoError(t, err)
 					require.Equal(t, tc.discoveryConfigStatusExpectedResources, int(dc.Status.DiscoveredResources))
 
 					tc.discoveryConfigStatusCheck(t, dc.Status)
+					fakeClock.Advance(srv.PollInterval * 2)
 				}, 10*time.Second, 100*time.Millisecond)
 
 			}

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -206,12 +206,14 @@ func (s *Server) startKubeIntegrationWatchers() error {
 }
 
 func (s *Server) kubernetesIntegrationWatcherIterationStarted() {
-	allFetchers := s.getKubeIntegrationFetchers()
-	if len(allFetchers) == 0 {
-		return
-	}
+	// TODO(marco): EKS discovery is highly async during enrollment part.
+	// now() does not represent the time when the cluster was discovered, but rather when starting a new iteration.
+	// This should be fixed, to ensure that we correctly track when discovered clusters are enrolled.
+	s.awsEKSResourcesStatus.iterationEnded(s.clock.Now())
+	discoveryConfigs := s.awsEKSResourcesStatus.iterationDiscoveryConfigs()
+	s.updateDiscoveryConfigStatus(discoveryConfigs...)
 
-	s.submitFetchersEvent(allFetchers)
+	allFetchers := s.getKubeIntegrationFetchers()
 
 	awsResultGroups := libslices.FilterMapUnique(
 		allFetchers,
@@ -225,16 +227,13 @@ func (s *Server) kubernetesIntegrationWatcherIterationStarted() {
 		},
 	)
 
-	discoveryConfigs := libslices.FilterMapUnique(awsResultGroups, func(g awsResourceGroup) (s string, include bool) {
-		return g.discoveryConfigName, true
-	})
-	s.updateDiscoveryConfigStatus(discoveryConfigs...)
-	s.awsEKSResourcesStatus.reset()
-	for _, g := range awsResultGroups {
-		s.awsEKSResourcesStatus.iterationStarted(g)
-	}
+	s.awsEKSResourcesStatus.iterationStarted(awsResultGroups, s.clock.Now())
 
 	s.awsEKSTasks.reset()
+
+	if len(allFetchers) > 0 {
+		s.submitFetchersEvent(allFetchers)
+	}
 }
 
 func (s *Server) enrollEKSClusters(region, integration, discoveryConfigName string, clusters []types.DiscoveredEKSCluster, agentVersion *semver.Version, mu *sync.Mutex, enrollingClusters map[string]bool) {

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -115,6 +115,7 @@ func (s *Server) startKubeIntegrationWatchers() error {
 		for {
 			resourcesFoundByGroup := make(map[awsResourceGroup]int)
 			resourcesEnrolledByGroup := make(map[awsResourceGroup]int)
+			iterationDiscoveryConfigs := make(map[string]struct{})
 
 			select {
 			case resources := <-watcher.ResourcesC():
@@ -164,6 +165,7 @@ func (s *Server) startKubeIntegrationWatchers() error {
 				mu.Unlock()
 
 				for group, count := range resourcesFoundByGroup {
+					iterationDiscoveryConfigs[group.discoveryConfigName] = struct{}{}
 					s.awsEKSResourcesStatus.incrementFound(group, count)
 				}
 
@@ -200,6 +202,8 @@ func (s *Server) startKubeIntegrationWatchers() error {
 			for group, count := range resourcesEnrolledByGroup {
 				s.awsEKSResourcesStatus.incrementEnrolled(group, count)
 			}
+
+			s.updateDiscoveryConfigStatus(slices.Collect(maps.Keys(iterationDiscoveryConfigs))...)
 		}
 	}()
 	return nil

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -234,10 +234,6 @@ func (s *Server) kubernetesIntegrationWatcherIterationStarted() {
 	s.awsEKSResourcesStatus.iterationStarted(awsResultGroups, s.clock.Now())
 
 	s.awsEKSTasks.reset()
-
-	if len(allFetchers) > 0 {
-		s.submitFetchersEvent(allFetchers)
-	}
 }
 
 func (s *Server) enrollEKSClusters(region, integration, discoveryConfigName string, clusters []types.DiscoveredEKSCluster, agentVersion *semver.Version, mu *sync.Mutex, enrollingClusters map[string]bool) {

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -152,11 +152,15 @@ func (s *Server) startKubeIntegrationWatchers() error {
 					resourceGroup := awsResourceGroupFromLabels(newCluster.GetStaticLabels())
 					resourcesFoundByGroup[resourceGroup] += 1
 
-					if enrollingClusters[newCluster.GetAWSConfig().Name] ||
-						slices.ContainsFunc(existingServers, func(c types.KubeServer) bool { return c.GetName() == newCluster.GetName() }) ||
-						slices.ContainsFunc(existingClusters, func(c types.KubeCluster) bool { return c.GetName() == newCluster.GetName() }) {
+					currentlyEnrolling := enrollingClusters[newCluster.GetAWSConfig().Name]
+					alreadyEnrolled := slices.ContainsFunc(existingServers, func(c types.KubeServer) bool { return c.GetName() == newCluster.GetName() }) ||
+						slices.ContainsFunc(existingClusters, func(c types.KubeCluster) bool { return c.GetName() == newCluster.GetName() })
 
+					if alreadyEnrolled {
 						resourcesEnrolledByGroup[resourceGroup] += 1
+					}
+
+					if currentlyEnrolling || alreadyEnrolled {
 						continue
 					}
 

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -70,7 +70,7 @@ func (s *Server) updateDiscoveryConfigStatus(discoveryConfigNames ...string) {
 		discoveryConfigStatus := discoveryconfig.Status{
 			State:                          discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_SYNCING.String(),
 			LastSyncTime:                   s.clock.Now(),
-			IntegrationDiscoveredResources: make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary),
+			IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
 		}
 
 		// Merge AWS or Azure Sync (TAG) status
@@ -294,7 +294,7 @@ func (ars *awsResourcesStatus) mergeIntoGlobalStatus(discoveryConfigName string,
 		// Update counters specific to AWS resources discovered.
 		existingIntegrationResources, ok := existingStatus.IntegrationDiscoveredResources[group.integration]
 		if !ok {
-			existingIntegrationResources = &discoveryconfigv1.IntegrationDiscoveredSummary{}
+			existingIntegrationResources = &discoveryconfig.IntegrationDiscoveredSummary{}
 		}
 
 		var syncEnd *timestamppb.Timestamp
@@ -425,8 +425,6 @@ func (s *Server) ReportEC2SSMInstallationResult(ctx context.Context, result *ser
 			Name:            result.InstanceName,
 		},
 	)
-
-	s.updateDiscoveryConfigStatus(result.DiscoveryConfigName)
 
 	return nil
 }
@@ -1145,14 +1143,12 @@ func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, ex
 
 		// Initialize map if needed.
 		if existingStatus.IntegrationDiscoveredResources == nil {
-			existingStatus.IntegrationDiscoveredResources = make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary)
+			existingStatus.IntegrationDiscoveredResources = make(map[string]*discoveryconfig.IntegrationDiscoveredSummary)
 		}
 
-		// Update counters specific to resources discovered.
-		var summary *discoveryconfigv1.IntegrationDiscoveredSummary
-		summary = existingStatus.IntegrationDiscoveredResources[key.integration]
+		summary := existingStatus.IntegrationDiscoveredResources[key.integration]
 		if summary == nil {
-			summary = &discoveryconfigv1.IntegrationDiscoveredSummary{}
+			summary = &discoveryconfig.IntegrationDiscoveredSummary{}
 		}
 
 		var syncStart *timestamppb.Timestamp
@@ -1193,7 +1189,11 @@ func (s *resourceStatusMap) discoveryConfigs() []string {
 	return slices.Collect(maps.Keys(names))
 }
 
-func integrationDiscoveredSummaryUpdate(summary *discoveryconfigv1.IntegrationDiscoveredSummary, resourceType string, resourcesSummary *discoveryconfigv1.ResourcesDiscoveredSummary) {
+func integrationDiscoveredSummaryUpdate(summary *discoveryconfig.IntegrationDiscoveredSummary, resourceType string, resourcesSummary *discoveryconfigv1.ResourcesDiscoveredSummary) {
+	if summary.IntegrationDiscoveredSummary == nil {
+		summary.IntegrationDiscoveredSummary = &discoveryconfigv1.IntegrationDiscoveredSummary{}
+	}
+
 	switch resourceType {
 	case types.AWSMatcherEC2:
 		summary.AwsEc2 = resourcesSummary

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -369,7 +369,7 @@ func (ars *awsResourcesStatus) incrementFound(g awsResourceGroup, count int) {
 }
 
 func (ars *awsResourcesStatus) incrementField(g awsResourceGroup, f func(groupStats *awsResourceGroupResult)) {
-	if g.discoveryConfigName == "" || g.integration == "" {
+	if g.discoveryConfigName == "" {
 		return
 	}
 

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -253,7 +253,7 @@ func newAWSResourceStatusCollector(resourceType string) awsResourcesStatus {
 type awsResourcesStatus struct {
 	mu sync.RWMutex
 	// awsResourcesResults maps the DiscoveryConfig name and integration to a summary of discovered/enrolled resources.
-	awsResourcesResults map[awsResourceGroup]awsResourceGroupResult
+	awsResourcesResults map[awsResourceGroup]*awsResourceGroupResult
 	resourceType        string
 }
 
@@ -272,16 +272,11 @@ func awsResourceGroupFromLabels(labels map[string]string) awsResourceGroup {
 
 // awsResourceGroupResult stores the result of the aws_sync Matchers for a given DiscoveryConfig.
 type awsResourceGroupResult struct {
-	found    int
-	enrolled int
-	failed   int
-}
-
-func (d *awsResourcesStatus) reset() {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	d.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
+	found     int
+	enrolled  int
+	failed    int
+	syncStart *time.Time
+	syncEnd   *time.Time
 }
 
 func (ars *awsResourcesStatus) mergeIntoGlobalStatus(discoveryConfigName string, existingStatus discoveryconfig.Status) discoveryconfig.Status {
@@ -302,10 +297,22 @@ func (ars *awsResourcesStatus) mergeIntoGlobalStatus(discoveryConfigName string,
 			existingIntegrationResources = &discoveryconfigv1.IntegrationDiscoveredSummary{}
 		}
 
+		var syncEnd *timestamppb.Timestamp
+		if groupResult.syncEnd != nil {
+			syncEnd = timestamppb.New(*groupResult.syncEnd)
+		}
+
+		var syncStart *timestamppb.Timestamp
+		if groupResult.syncStart != nil {
+			syncStart = timestamppb.New(*groupResult.syncStart)
+		}
+
 		resourcesSummary := &discoveryconfigv1.ResourcesDiscoveredSummary{
-			Found:    uint64(groupResult.found),
-			Enrolled: uint64(groupResult.enrolled),
-			Failed:   uint64(groupResult.failed),
+			Found:     uint64(groupResult.found),
+			Enrolled:  uint64(groupResult.enrolled),
+			Failed:    uint64(groupResult.failed),
+			SyncStart: syncStart,
+			SyncEnd:   syncEnd,
 		}
 
 		integrationDiscoveredSummaryUpdate(existingIntegrationResources, ars.resourceType, resourcesSummary)
@@ -317,45 +324,68 @@ func (ars *awsResourcesStatus) mergeIntoGlobalStatus(discoveryConfigName string,
 }
 
 func (ars *awsResourcesStatus) incrementFailed(g awsResourceGroup, count int) {
-	ars.mu.Lock()
-	defer ars.mu.Unlock()
-	if ars.awsResourcesResults == nil {
-		ars.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
-	}
-	groupStats := ars.awsResourcesResults[g]
-	groupStats.failed = groupStats.failed + count
-	ars.awsResourcesResults[g] = groupStats
+	ars.incrementField(g, func(groupStats *awsResourceGroupResult) {
+		groupStats.failed = groupStats.failed + count
+	})
 }
 
-func (ars *awsResourcesStatus) iterationStarted(g awsResourceGroup) {
+func (ars *awsResourcesStatus) iterationStarted(resourceGroups []awsResourceGroup, syncStartTime time.Time) {
 	ars.mu.Lock()
 	defer ars.mu.Unlock()
-	if ars.awsResourcesResults == nil {
-		ars.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
+
+	ars.awsResourcesResults = make(map[awsResourceGroup]*awsResourceGroupResult, len(resourceGroups))
+	for _, g := range resourceGroups {
+		ars.awsResourcesResults[g] = &awsResourceGroupResult{
+			syncStart: &syncStartTime,
+		}
 	}
-	ars.awsResourcesResults[g] = awsResourceGroupResult{}
+}
+
+func (ars *awsResourcesStatus) iterationEnded(syncEndTime time.Time) {
+	ars.mu.Lock()
+	defer ars.mu.Unlock()
+
+	for _, g := range ars.awsResourcesResults {
+		g.syncEnd = &syncEndTime
+	}
+}
+
+func (ars *awsResourcesStatus) iterationDiscoveryConfigs() []string {
+	ars.mu.RLock()
+	defer ars.mu.RUnlock()
+
+	uniqueDiscoveryConfigs := make(map[string]struct{})
+	for group := range ars.awsResourcesResults {
+		uniqueDiscoveryConfigs[group.discoveryConfigName] = struct{}{}
+	}
+
+	return slices.Collect(maps.Keys(uniqueDiscoveryConfigs))
 }
 
 func (ars *awsResourcesStatus) incrementFound(g awsResourceGroup, count int) {
+	ars.incrementField(g, func(groupStats *awsResourceGroupResult) {
+		groupStats.found = groupStats.found + count
+	})
+}
+
+func (ars *awsResourcesStatus) incrementField(g awsResourceGroup, f func(groupStats *awsResourceGroupResult)) {
+	if g.discoveryConfigName == "" || g.integration == "" {
+		return
+	}
+
 	ars.mu.Lock()
 	defer ars.mu.Unlock()
-	if ars.awsResourcesResults == nil {
-		ars.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
+	groupStats, ok := ars.awsResourcesResults[g]
+	if !ok {
+		return
 	}
-	groupStats := ars.awsResourcesResults[g]
-	groupStats.found = groupStats.found + count
-	ars.awsResourcesResults[g] = groupStats
+	f(groupStats)
 }
 
 func (ars *awsResourcesStatus) incrementEnrolled(g awsResourceGroup, count int) {
-	ars.mu.Lock()
-	defer ars.mu.Unlock()
-	if ars.awsResourcesResults == nil {
-		ars.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
-	}
-	groupStats := ars.awsResourcesResults[g]
-	groupStats.enrolled = groupStats.enrolled + count
-	ars.awsResourcesResults[g] = groupStats
+	ars.incrementField(g, func(groupStats *awsResourceGroupResult) {
+		groupStats.enrolled = groupStats.enrolled + count
+	})
 }
 
 // ReportEC2SSMInstallationResult is called when discovery gets the result of running the installation script in a EC2 instance.
@@ -395,6 +425,8 @@ func (s *Server) ReportEC2SSMInstallationResult(ctx context.Context, result *ser
 			Name:            result.InstanceName,
 		},
 	)
+
+	s.updateDiscoveryConfigStatus(result.DiscoveryConfigName)
 
 	return nil
 }
@@ -1068,13 +1100,20 @@ type fetcherGroupKey struct {
 type resourceStatusMap struct {
 	resourceType string
 	results      map[fetcherGroupKey]map[statusType]int
+	syncStart    *time.Time
+	syncEnd      *time.Time
 }
 
-func newStatusMap(resourceType string) *resourceStatusMap {
+func newStatusMap(resourceType string, syncStart time.Time) *resourceStatusMap {
 	return &resourceStatusMap{
 		resourceType: resourceType,
 		results:      make(map[fetcherGroupKey]map[statusType]int),
+		syncStart:    &syncStart,
 	}
+}
+
+func (s *resourceStatusMap) syncEnded(syncEnd time.Time) {
+	s.syncEnd = &syncEnd
 }
 
 func (s *resourceStatusMap) add(key fetcherGroupKey, results map[statusType]int) {
@@ -1102,7 +1141,7 @@ func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, ex
 		}
 
 		// Update global discovered resources count.
-		existingStatus.DiscoveredResources = existingStatus.DiscoveredResources + uint64(results[statusFailed])
+		existingStatus.DiscoveredResources = existingStatus.DiscoveredResources + uint64(results[statusFound])
 
 		// Initialize map if needed.
 		if existingStatus.IntegrationDiscoveredResources == nil {
@@ -1116,10 +1155,22 @@ func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, ex
 			summary = &discoveryconfigv1.IntegrationDiscoveredSummary{}
 		}
 
+		var syncStart *timestamppb.Timestamp
+		if s.syncStart != nil {
+			syncStart = timestamppb.New(*s.syncStart)
+		}
+
+		var syncEnd *timestamppb.Timestamp
+		if s.syncEnd != nil {
+			syncEnd = timestamppb.New(*s.syncEnd)
+		}
+
 		resourcesSummary := &discoveryconfigv1.ResourcesDiscoveredSummary{
-			Found:    uint64(results[statusFound]),
-			Enrolled: uint64(results[statusEnrolled]),
-			Failed:   uint64(results[statusFailed]),
+			Found:     uint64(results[statusFound]),
+			Enrolled:  uint64(results[statusEnrolled]),
+			Failed:    uint64(results[statusFailed]),
+			SyncStart: syncStart,
+			SyncEnd:   syncEnd,
 		}
 
 		integrationDiscoveredSummaryUpdate(summary, s.resourceType, resourcesSummary)

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -659,15 +659,20 @@ func (f *ec2InstanceFetcher) getInstancesInRegion(ctx context.Context, params ge
 			return nil, libcloudaws.ConvertRequestFailureError(err)
 		}
 
+		pageInstancesPerOwnerID := make(map[string][]ec2types.Instance)
+
 		for _, res := range page.Reservations {
-			for i := 0; i < len(res.Instances); i += awsEC2APIChunkSize {
-				end := min(i+awsEC2APIChunkSize, len(res.Instances))
-				ownerID := aws.ToString(res.OwnerId)
+			pageInstancesPerOwnerID[aws.ToString(res.OwnerId)] = append(pageInstancesPerOwnerID[aws.ToString(res.OwnerId)], res.Instances...)
+		}
+
+		for ownerID, pageInstances := range pageInstancesPerOwnerID {
+			for i := 0; i < len(pageInstances); i += awsEC2APIChunkSize {
+				end := min(i+awsEC2APIChunkSize, len(pageInstances))
 				inst := &EC2Instances{
 					AccountID:           ownerID,
 					Region:              params.region,
 					DocumentName:        f.Matcher.SSM.DocumentName,
-					Instances:           ToEC2Instances(res.Instances[i:end]),
+					Instances:           ToEC2Instances(pageInstances[i:end]),
 					Parameters:          params.ssmRunParams,
 					Rotation:            params.rotation,
 					Integration:         f.Matcher.Integration,
@@ -676,7 +681,7 @@ func (f *ec2InstanceFetcher) getInstancesInRegion(ctx context.Context, params ge
 					DiscoveryConfigName: f.DiscoveryConfigName,
 					EnrollMode:          f.Matcher.Params.EnrollMode,
 				}
-				for _, ec2inst := range res.Instances[i:end] {
+				for _, ec2inst := range pageInstances[i:end] {
 					f.cachedInstances.add(ownerID, aws.ToString(ec2inst.InstanceId))
 				}
 				instances = append(instances, inst)

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"testing/synctest"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/account"
@@ -57,6 +58,7 @@ func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.Descri
 		}
 		output.Reservations = append(output.Reservations, ec2types.Reservation{
 			Instances: instances,
+			OwnerId:   res.OwnerId,
 		})
 	}
 	return &output, nil
@@ -483,6 +485,150 @@ func TestEC2Watcher(t *testing.T) {
 		require.Fail(t, "unexpected instance: %v", inst)
 	default:
 	}
+}
+
+func TestEC2WatcherMergesReservationInstances(t *testing.T) {
+	matchers := []types.AWSMatcher{{
+		Params: &types.InstallerParams{
+			InstallTeleport: true,
+		},
+		Types:   []string{"ec2"},
+		Regions: []string{"us-west-2"},
+		Tags:    map[string]utils.Strings{"teleport": {"yes"}},
+		SSM:     &types.AWSSSM{},
+	}}
+
+	present := ec2types.Instance{
+		InstanceId: aws.String("instance-present"),
+		Tags: []ec2types.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String("Present"),
+			},
+			{
+				Key:   aws.String("teleport"),
+				Value: aws.String("yes"),
+			},
+		},
+		State: &ec2types.InstanceState{
+			Name: ec2types.InstanceStateNameRunning,
+		},
+	}
+	presentOther := ec2types.Instance{
+		InstanceId: aws.String("instance-present-2"),
+		Tags: []ec2types.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String("PresentOther"),
+			},
+			{
+				Key:   aws.String("teleport"),
+				Value: aws.String("yes"),
+			},
+		},
+		State: &ec2types.InstanceState{
+			Name: ec2types.InstanceStateNameRunning,
+		},
+	}
+
+	const noDiscoveryConfig = ""
+
+	t.Run("same account id in multiple reservations are merged", func(t *testing.T) {
+		ec2DescribeInstancesOneOwnerReservation := ec2.DescribeInstancesOutput{
+			Reservations: []ec2types.Reservation{
+				{Instances: []ec2types.Instance{present}, OwnerId: aws.String("123456789012")},
+				{Instances: []ec2types.Instance{presentOther}, OwnerId: aws.String("123456789012")},
+			},
+		}
+
+		ec2ClientGetter := func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+			return &mockEC2Client{
+				output: &ec2DescribeInstancesOneOwnerReservation,
+			}, nil
+		}
+
+		fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherToEC2FetcherParams{
+			Matchers: matchers,
+			PublicProxyAddrGetter: func(ctx context.Context) (string, error) {
+				return "proxy.example.com:3080", nil
+			},
+			EC2ClientGetter:     ec2ClientGetter,
+			DiscoveryConfigName: noDiscoveryConfig,
+		})
+		require.NoError(t, err)
+
+		watcher := NewWatcher[*EC2Instances](t.Context())
+		watcher.SetFetchers(noDiscoveryConfig, fetchers)
+
+		go watcher.Run()
+
+		expectedInstances := &EC2Instances{
+			Region:     "us-west-2",
+			Instances:  []EC2Instance{toEC2Instance(present), toEC2Instance(presentOther)},
+			Parameters: map[string]string{"token": "", "scriptName": ""},
+			AccountID:  "123456789012",
+		}
+
+		select {
+		case result := <-watcher.InstancesC:
+			require.Equal(t, expectedInstances, result)
+		case <-t.Context().Done():
+			require.Fail(t, "context canceled")
+		}
+	})
+
+	t.Run("if owner is not the same, they are not merged", func(t *testing.T) {
+		ec2DescribeInstancesOneInstancePerReservation := ec2.DescribeInstancesOutput{
+			Reservations: []ec2types.Reservation{
+				{Instances: []ec2types.Instance{present}, OwnerId: aws.String("123456789012")},
+				{Instances: []ec2types.Instance{presentOther}, OwnerId: aws.String("210987654321")},
+			},
+		}
+
+		ec2ClientGetter := func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+			return &mockEC2Client{
+				output: &ec2DescribeInstancesOneInstancePerReservation,
+			}, nil
+		}
+
+		fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherToEC2FetcherParams{
+			Matchers: matchers,
+			PublicProxyAddrGetter: func(ctx context.Context) (string, error) {
+				return "proxy.example.com:3080", nil
+			},
+			EC2ClientGetter:     ec2ClientGetter,
+			DiscoveryConfigName: noDiscoveryConfig,
+		})
+		require.NoError(t, err)
+
+		var gotInstances []*EC2Instances
+
+		synctest.Test(t, func(t *testing.T) {
+			watcher := NewWatcher(t.Context(), WithPerInstanceHookFn(func(groups []*EC2Instances) {
+				gotInstances = append(gotInstances, groups...)
+			}))
+			watcher.SetFetchers(noDiscoveryConfig, fetchers)
+			go watcher.Run()
+			synctest.Wait()
+		})
+
+		expectedInstances := []*EC2Instances{
+			{
+				Region:     "us-west-2",
+				Instances:  []EC2Instance{toEC2Instance(present)},
+				Parameters: map[string]string{"token": "", "scriptName": ""},
+				AccountID:  "123456789012",
+			},
+			{
+				Region:     "us-west-2",
+				Instances:  []EC2Instance{toEC2Instance(presentOther)},
+				Parameters: map[string]string{"token": "", "scriptName": ""},
+				AccountID:  "210987654321",
+			},
+		}
+
+		require.ElementsMatch(t, expectedInstances, gotInstances)
+	})
 }
 
 func TestEC2WatcherWithMultipleAccounts(t *testing.T) {

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -373,9 +373,11 @@ func TestCollectIntegrationStats(t *testing.T) {
 			Status: discoveryconfig.Status{
 				LastSyncTime:        syncTime,
 				DiscoveredResources: 2,
-				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
 					integrationName: {
-						AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+							AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+						},
 					},
 				},
 			},
@@ -389,9 +391,11 @@ func TestCollectIntegrationStats(t *testing.T) {
 			Status: discoveryconfig.Status{
 				LastSyncTime:        syncTime,
 				DiscoveredResources: 2,
-				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
 					integrationName: {
-						AwsRds: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+							AwsRds: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+						},
 					},
 				},
 			},
@@ -405,9 +409,11 @@ func TestCollectIntegrationStats(t *testing.T) {
 			Status: discoveryconfig.Status{
 				LastSyncTime:        syncTime,
 				DiscoveredResources: 2,
-				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
 					integrationName: {
-						AwsEks: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 4, Enrolled: 0, Failed: 0},
+						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+							AwsEks: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 4, Enrolled: 0, Failed: 0},
+						},
 					},
 				},
 			},
@@ -474,9 +480,11 @@ func TestCollectIntegrationStats(t *testing.T) {
 			Status: discoveryconfig.Status{
 				LastSyncTime:        syncTime,
 				DiscoveredResources: 2,
-				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
 					integrationName: {
-						AwsRds: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+							AwsRds: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+						},
 					},
 				},
 			},
@@ -1113,20 +1121,24 @@ func TestBuildBriefSummaries(t *testing.T) {
 
 	mockDC1 := &discoveryconfig.DiscoveryConfig{
 		Status: discoveryconfig.Status{
-			IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+			IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
 				mockAwsInt.GetName(): {
-					AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 0},
-					AwsEks: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 3, Enrolled: 0, Failed: 1},
-					AwsRds: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 5, Enrolled: 2, Failed: 2},
+					IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+						AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 0},
+						AwsEks: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 3, Enrolled: 0, Failed: 1},
+						AwsRds: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 5, Enrolled: 2, Failed: 2},
+					},
 				},
 			},
 		},
 	}
 	mockDC2 := &discoveryconfig.DiscoveryConfig{
 		Status: discoveryconfig.Status{
-			IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+			IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
 				mockAwsInt.GetName(): {
-					AzureVms: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 0},
+					IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+						AzureVms: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 0},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
When auto-discovering resources, Teleport can use static matchers (aka, matchers defined in `teleport.yaml/discovery_service.[aws|gcp|azure]`) or dynamic matchers, which are defined in DiscoveryConfig resources.

When using DiscoveryConfig, Teleport will report the number of discovered resources per resource type (eg, aws ec2, aws rds, aws eks and azure vm).

This PR adds the sync start and sync end time.
Even tho we have a last sync in the DiscoveryConfigStatus message, that does not correctly represent everything that the DiscoveryConfig has: multiple watchers which have different start and end times.

Along the way, we had to change some other things to ensure we correctly report the start and end sync times.

## Manual Test Plan
### Test Environment

- Local
- Cloud Tenant in staging

### Test Cases
- Local
  - [x] DiscoveryConfig with AWS EC2, RDS and EKS matchers
    - No resources found: shows the status as syncing and no resources discovered
    - Only EC2 instances found: shows the sync start and sync end timestamps
    - EC2, RDS and EKS: shows the sync start and sync end timestamps
  - [x] DiscoveryConfig with Azure (VMs only)
    - No resources found: shows the status as syncing
    - Only VMs found: shows the timestamps

- Cloud Tenant in staging
  - [x] DiscoveryConfig with AWS EC2

Demo

<img width="866" height="436" alt="image" src="https://github.com/user-attachments/assets/835810a2-0f62-4929-be01-2d104be8f877" />


<img width="713" height="296" alt="image" src="https://github.com/user-attachments/assets/b34729cf-b26d-4e98-8a50-21ad67d22f49" />
