### PR TITLE
docs: update workload identity

### DIFF
--- a/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
@@ -301,7 +301,7 @@ resource "aws_iam_role_policy_attachment" "example" {
   1. Select `example.teleport.sh:sub` for the key
   1. Select "StringEquals" for the condition
   1. Enter the SPIFFE ID of your workload for the value. In our example, this 
-    will be `spiffe://example.teleport.sh/svc/example-service
+    will be `spiffe://example.teleport.sh/svc/example-service`
 1. Click "Next"
 1. Select the IAM policy you created earlier, and click "Next"
 1. Enter a unique and meaningful name for this role, in our example, this will

--- a/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
@@ -35,7 +35,7 @@ AWS APIs in a few ways:
 
 Whilst this guide is primarily aimed at allowing a machine to access AWS,
 the `tsh svid issue` command can be used in place of `tbot` to allow a human
-user to authenticate with using AWS Roles Anywhere.
+user to authenticate using AWS Roles Anywhere.
 
 ## OIDC Federation vs Roles Anywhere
 
@@ -283,10 +283,10 @@ services:
 ```
 Replace:
 
-- /opt/roles-anywhere-svid with the directory where you want the X509 to be
+- `/opt/roles-anywhere-svid` with the directory where you want the X509 to be
   written.
-- example-workload-identity with the name of the Workload Identity you have
-  created
+- `example-workload-identity` with the name of the Workload Identity you have
+  created.
 
 Restart your `tbot` service to apply the new configuration.
 

--- a/docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx
@@ -62,7 +62,7 @@ If you have already deployed Teleport Workload Identity, then you will already
 have a SPIFFE ID structure in place. If you have not, then you will need to
 decide on a structure for your SPIFFE IDs.
 
-If you are only using Teleport Workload Identity with AWS OIDC Federation, you
+If you are only using Teleport Workload Identity with Azure Federated Credentials, you
 may structure your SPIFFE IDs so that they explicitly specify the Azure
 user-managed identity they are allowed to assume. However, it often makes more
 sense to name the workload or person that will use the SPIFFE ID. See the
@@ -307,7 +307,7 @@ $ az storage blob upload \
   --container-name examplecontainer \
   --name test.txt \
   --file ./test.txt
-# Check that the file has been uploaded. Replace the name of teh account and
+# Check that the file has been uploaded. Replace the name of the account and
 # container with those you selected earlier.
 $ az storage blob list \
   --auth login \

--- a/docs/pages/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt.mdx
@@ -60,7 +60,7 @@ your Teleport cluster. The structure of the path of this URI is up to you.
 For the purposes of this guide, we will be granting access to GCP to the
 `spiffe://example.teleport.sh/svc/example-service` SPIFFE ID.
 
-If you have already deployed Teleport Workload Identity, then you will already
+If you have already deployed Teleport Workload Identity, then you will 
 have a SPIFFE ID structure in place. If you have not, then you will need to
 decide on a structure for your SPIFFE IDs.
 
@@ -142,15 +142,15 @@ Use the `gcloud` CLI to create a workload identity provider:
 ```code
 # Replace "workload-id-pool" with the name of the pool you just created and
 # "workload-id-oidc" with a meaningful, unique name.
+# Replace example.teleport.sh with the hostname of your Proxy Service's 
+# public address for issuer-uri. 
+# The `attribute-mapping` maps the `sub` claim within the JWT to the `google.subject` attribute.
+# This will allow it to be used to make Authz decisions in GCP.
+
 $ gcloud iam workload-identity-pools providers create-oidc workload-id-oidc \
     --location="global" \
-    # This should match the name of the pool you just created.
     --workload-identity-pool="workload-id-pool" \
-    # Replace example.teleport.sh with the hostname of your Proxy Service's
-    # public address.
     --issuer-uri="https://example.teleport.sh/workload-identity" \
-    # Maps the `sub` claim within the JWT to the `google.subject` attribute.
-    # This will allow it to be used to make Authz decisions in GCP.
     --attribute-mapping="google.subject=assertion.sub"
 ```
 

--- a/docs/pages/machine-workload-identity/workload-identity/spiffe.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/spiffe.mdx
@@ -46,7 +46,7 @@ e.g. `example.teleport.sh`.
 The workload identifier is encoded in the URI as the path. This should be a
 string that identifies your workload within the trust domain. What you include
 within this path is up to you and your application's requirements. Typically,
-the hierarchical nature of the path is leveraged. For example, you had the
+the hierarchical nature of the path is leveraged. For example, if you had the
 service `foo` operating in the `europe` region, you may wish to represent this
 as: `/region/europe/svc/foo`.
 
@@ -58,8 +58,8 @@ spiffe://example.teleport.sh/region/europe/svc/foo
 
 ## SPIFFE Verifiable Identity Documents (SVIDs)
 
-The SPIFFE ID may be a unique identifier for a workload, but provides no way
-for a workload to verifiably prove its identity. This is where the Secure
+The SPIFFE ID may be a unique identifier for a workload, but it provides no way
+for a workload to verifiably prove its identity. This is where the SPIFFE
 Verifiable Identity Documents (SVIDs) come in.
 
 The SVID is a document that encodes the SPIFFE ID and a cryptographic proof


### PR DESCRIPTION

docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx: fix code formatting
docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx: grammar and code formatting fix
docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx: fix Azure reference and grammar
docs/pages/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt.mdx:
  - grammar fix
  - script would not copy and execute from this example
 
 docs/pages/machine-workload-identity/workload-identity/spiffe.mdx: acronym name and grammar fix



