### PR TITLE
docs: update joining services

### DIFF
--- a/docs/pages/enroll-resources/agents/add-service-to-agent.mdx
+++ b/docs/pages/enroll-resources/agents/add-service-to-agent.mdx
@@ -285,7 +285,7 @@ If your Teleport Agent runs on a Linux server:
 1. Restart the agent:
 
    ```code
-   $ sudo systemctl reload teleport
+   $ sudo systemctl restart teleport
    ```
 
 ### Helm chart
@@ -293,7 +293,7 @@ If your Teleport Agent runs on a Linux server:
 Upgrade your Helm release:
 
 ```code
-$ helm upgrade teleport-agent teleport-kube-agent
+$ helm upgrade teleport-agent teleport/teleport-kube-agent -f values.yaml
 ```
 
 ## Further reading: manage tokens as code

--- a/docs/pages/enroll-resources/agents/join-token.mdx
+++ b/docs/pages/enroll-resources/agents/join-token.mdx
@@ -315,7 +315,7 @@ Run the following command on your local machine to create a token for a new
 Proxy Service:
 
 ```code
-$ tctl tokens add --ttl=5m --roles=proxy
+$ tctl tokens add --ttl=5m --type=proxy
 # The invite token: (=presets.tokens.first=).
 # This token will expire in 5 minutes.
 #

--- a/docs/pages/enroll-resources/agents/join-token.mdx
+++ b/docs/pages/enroll-resources/agents/join-token.mdx
@@ -231,12 +231,12 @@ process into communicating with a malicious service.
 
 ### Obtain a CA pin
 
-On you local machine, retrieve the CA pin of the Auth Service:
+On your local machine, retrieve the CA pin of the Auth Service:
 
 ```code
 $ tctl status
 Cluster      teleport.example.com
-Version      12.1.1
+Version      (=teleport.version=)
 host CA      never updated
 user CA      never updated
 db CA        never updated
@@ -315,7 +315,7 @@ Run the following command on your local machine to create a token for a new
 Proxy Service:
 
 ```code
-$ tctl nodes add --ttl=5m --roles=proxy
+$ tctl tokens add --ttl=5m --roles=proxy
 # The invite token: (=presets.tokens.first=).
 # This token will expire in 5 minutes.
 #

--- a/docs/pages/enroll-resources/agents/kubernetes.mdx
+++ b/docs/pages/enroll-resources/agents/kubernetes.mdx
@@ -112,7 +112,7 @@ indicated:
 
 Add the following Kubernetes resource manifest, replacing values as indicated:
 
-(!docs/pages/includes/provision-token/kubernetes-in-cluster-spec-kube.mdx!)
+(!docs/pages/includes/provision-token/iam-spec-hcl.mdx!)
 
 </TabItem>
 </Tabs>

--- a/docs/pages/enroll-resources/agents/kubernetes.mdx
+++ b/docs/pages/enroll-resources/agents/kubernetes.mdx
@@ -112,7 +112,7 @@ indicated:
 
 Add the following Kubernetes resource manifest, replacing values as indicated:
 
-(!docs/pages/includes/provision-token/iam-spec-hcl.mdx!)
+(!docs/pages/includes/provision-token/kubernetes-in-cluster-spec-kube.mdx!)
 
 </TabItem>
 </Tabs>

--- a/docs/pages/includes/iac-clients.mdx
+++ b/docs/pages/includes/iac-clients.mdx
@@ -2,4 +2,4 @@ One of the following client tools for managing Teleport resources:
 
 - The `tctl` CLI, which you can install along with Teleport on your workstation ([documentation](../installation/installation.mdx)) on your workstation.
 - [Teleport Terraform provider](../zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx)
-- [Teleport Kubernetes operator](../zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx)
+- [Teleport Kubernetes operator](../zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator.mdx)


### PR DESCRIPTION
docs/pages/includes/iac-clients.mdx:
- Correct Kubernetes operator link

docs/pages/enroll-resources/agents/add-service-to-agent.mdx:
- A agent should be restarted over reloaded when the data dir is removed
- helm upgrade was incomplete

docs/pages/enroll-resources/agents/join-token.mdx:
- show variable version instead of hardcoded v12
- use `tctl tokens add` instead of `tctl nodes add`





