### PR TITLE
Web: Fix bot integration routes

### DIFF
--- a/web/packages/teleport/src/Bots/Add/AddBots.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBots.tsx
@@ -17,7 +17,7 @@
  */
 
 import { FeatureBox } from 'teleport/components/Layout';
-import { Redirect, Route, Switch } from 'teleport/components/Router';
+import { Redirect, useParams } from 'teleport/components/Router';
 import cfg from 'teleport/config';
 
 import { BotFlowType } from '../types';
@@ -25,24 +25,23 @@ import { GitHubActionsK8s } from './GitHubActionsK8s/GitHubActionsK8s';
 import GitHubActionsSshFlow from './GitHubActionsSsh';
 
 export function AddBots() {
-  return (
-    <FeatureBox>
-      <Switch>
-        <Route
-          path={cfg.getBotsNewRoute(BotFlowType.GitHubActionsSsh)}
-          element={<GitHubActionsSshFlow />}
-        />
-        <Route
-          path={cfg.getBotsNewRoute(BotFlowType.GitHubActionsK8s)}
-          element={<GitHubActionsK8s />}
-        />
-        <Route
-          path={cfg.getBotsNewRoute()}
-          element={
-            <Redirect to={`${cfg.getIntegrationEnrollRoute()}?tags=bot`} />
-          }
-        />
-      </Switch>
-    </FeatureBox>
-  );
+  const { type } = useParams<{ type?: string }>();
+
+  if (type === BotFlowType.GitHubActionsSsh) {
+    return (
+      <FeatureBox>
+        <GitHubActionsSshFlow />
+      </FeatureBox>
+    );
+  }
+
+  if (type === BotFlowType.GitHubActionsK8s) {
+    return (
+      <FeatureBox>
+        <GitHubActionsK8s />
+      </FeatureBox>
+    );
+  }
+
+  return <Redirect to={`${cfg.getIntegrationEnrollRoute()}?tags=bot`} />;
 }

--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -57,17 +57,6 @@ export const integrations: BotIntegration[] = [
     guided: true,
     tags: ['bot', 'cicd'],
   },
-  // Hiding the new guide for now.
-  // {
-  //   title: 'GitHub Actions + Kubernetes',
-  //   description: 'Use Machine & Workload Identity to grant GitHub Actions CI/CD access to Teleport resources.',
-  //   link: cfg.getBotsNewRoute(BotFlowType.GitHubActionsK8s),
-  //   icon: 'github',
-  //   kind: IntegrationEnrollKind.MachineIDGitHubActionsK8s,
-  //   type: 'bot',
-  //   guided: true,
-  //   tags: ['bot', 'cicd'],
-  // },
   {
     title: 'GitHub Actions + Kubernetes',
     description:


### PR DESCRIPTION
There was a route bug where routing to `github + k8` (or redirecting to bots page) routed to `github + ssh`. I'm not entirely sure why the switch route doesn't work anymore after the router update (i tried replacing the optional route param done similarly elsewhere and using `exact` and none worked)

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
ran locally on current master both enterprise and oss


### Test Cases
- [x] successfully route to github + k8
- [x] successfully route to github + ssh
- [x] successfully route to "add new bots" from the left panel nav (it tests the "redirection" with `?tags=bott` in the URL)

https://github.com/gravitational/teleport/issues/64627