### PR TITLE
Add `GOWORK=off` to `e2e/run.sh`

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 export E2E_CALLER_DIR="$PWD"
-cd "$(dirname "$0")/runner" && go build -o e2e . && exec ./e2e "$@"
+cd "$(dirname "$0")/runner" && GOWORK=off go build -o e2e . && exec ./e2e "$@"


### PR DESCRIPTION
This way devs using Go workspaces won't have to remember to add `GOWORK=off` by hand before executing the e2e runner. It should have no effect on devs who do not use workspaces. We use `GOWORK=off` already in multiple places in our Makefile.