### PR TITLE
loadtest: bump aws eks cluster version to 1.35

### DIFF
--- a/assets/loadtest/cluster/aws/cluster.yaml
+++ b/assets/loadtest/cluster/aws/cluster.yaml
@@ -3,7 +3,7 @@ kind: ClusterConfig
 metadata:
   name:
   region:
-  version: "1.29"
+  version: "1.35"
   tags:
     teleport.dev/creator:
 


### PR DESCRIPTION
The default version 1.29 has fallen out of support. This bumps the version to the latest standard support version.


## Manual Test Plan
### Test Environment
AWS EKS

### Test Cases
- [x] Deploy eks cluster for loadtesting
