### PR TITLE
Support `WorkloadIdentity` resources in `--apply-on-startup` and `--bootstrap`

### DIFF
--- a/docs/pages/reference/cli/teleport.mdx
+++ b/docs/pages/reference/cli/teleport.mdx
@@ -826,7 +826,7 @@ Flags:
 |Flag|Default|Description|
 |---|---|---|
 |`--advertise-ip`|none|IP to advertise to clients if running behind NAT|
-|`--apply-on-startup`|none|Path to a non-empty YAML file containing resources to apply on startup. Works on initialized clusters, unlike --bootstrap. Only supports the following kinds: \[user token cluster_networking_config cluster_auth_preference bot role\].|
+|`--apply-on-startup`|none|Path to a non-empty YAML file containing resources to apply on startup. Works on initialized clusters, unlike --bootstrap. Only supports the following kinds: \[user token cluster_networking_config cluster_auth_preference bot role, workload_identity\].|
 |`--auth-server`|none|Address of the auth server \[127.0.0.1:3025\]|
 |`--bootstrap`|none|Path to a non-empty YAML file containing bootstrap resources (ignored if already initialized)|
 |`--ca-pin`|none|CA pin to validate the Auth Server (can be repeated for multiple pins)|

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -47,6 +47,7 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/clusterconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -1755,6 +1756,7 @@ var ResourceApplyPriority = map[string]int{
 	types.KindToken:                   3,
 	types.KindClusterNetworkingConfig: 3,
 	types.KindClusterAuthPreference:   3,
+	types.KindWorkloadIdentity:        3,
 	// Bots should be applied after users and roles as at the moment they are actually converted to users and roles.
 	// This will ensure that Bot Users/Roles are properly created regardless of the Teleport version from which the
 	// resources have been exported.
@@ -1804,6 +1806,8 @@ func applyResources(ctx context.Context, service *Services, resources []types.Re
 			_, err = autoupdatev1.UpsertAutoUpdateVersion(ctx, service, r.UnwrapT())
 		case types.Resource153UnwrapperT[*summarizerv1.InferenceModel]:
 			_, err = service.Summarizer.UpsertInferenceModel(ctx, r.UnwrapT())
+		case types.Resource153UnwrapperT[*workloadidentityv1.WorkloadIdentity]:
+			_, err = service.WorkloadIdentities.UpsertWorkloadIdentity(ctx, r.UnwrapT())
 		default:
 			return trace.NotImplemented("cannot apply resource of type %T", resource)
 		}

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -2621,7 +2621,7 @@ version: v1`
 func TestInitWithWorkloadIdentityResources(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	resources := []types.Resource{
 		resourceFromYAML(t, workloadIdentityYAML),
 	}

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -1953,6 +1953,14 @@ spec:
   type: local
 version: v2
 `
+	workloadIdentityYAML = `kind: workload_identity
+version: v1
+metadata:
+  name: example-workload-identity
+spec:
+  spiffe:
+    id: /svc/example
+`
 	botYAML = `kind: bot
 metadata:
   name: my-bot
@@ -1970,6 +1978,7 @@ func TestInit_ApplyOnStartup(t *testing.T) {
 	lock := resourceFromYAML(t, lockYAML).(types.Lock)
 	clusterNetworkingConfig := resourceFromYAML(t, clusterNetworkingConfYAML).(types.ClusterNetworkingConfig)
 	authPref := resourceFromYAML(t, authPrefYAML).(types.AuthPreference)
+	workloadIdentity := resourceFromYAML(t, workloadIdentityYAML)
 	bot := resourceFromYAML(t, botYAML)
 
 	tests := []struct {
@@ -2036,6 +2045,13 @@ func TestInit_ApplyOnStartup(t *testing.T) {
 			name: "Apply AuthPreference",
 			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, authPref)
+			},
+			assertError: require.NoError,
+		},
+		{
+			name: "Apply WorkloadIdentity",
+			modifyConfig: func(cfg *auth.InitConfig) {
+				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, workloadIdentity)
 			},
 			assertError: require.NoError,
 		},
@@ -2598,6 +2614,34 @@ version: v1`
 			version, err := auth.GetAutoUpdateVersion(ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, "1.2.3", version.GetSpec().GetTools().GetTargetVersion())
+		})
+	}
+}
+
+func TestInitWithWorkloadIdentityResources(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	resources := []types.Resource{
+		resourceFromYAML(t, workloadIdentityYAML),
+	}
+
+	for _, test := range []struct {
+		name string
+		fn   func(cfg *auth.InitConfig)
+	}{
+		{name: "bootstrap", fn: func(cfg *auth.InitConfig) { cfg.BootstrapResources = resources }},
+		{name: "apply", fn: func(cfg *auth.InitConfig) { cfg.ApplyOnStartupResources = resources }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := setupConfig(t)
+			test.fn(&cfg)
+			auth, err := auth.Init(ctx, cfg)
+			require.NoError(t, err)
+
+			workloadIdentity, err := auth.GetWorkloadIdentity(ctx, "example-workload-identity")
+			require.NoError(t, err)
+			require.Equal(t, "/svc/example", workloadIdentity.GetSpec().GetSpiffe().GetId())
 		})
 	}
 }

--- a/lib/services/local/resource.go
+++ b/lib/services/local/resource.go
@@ -26,6 +26,7 @@ import (
 
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
@@ -106,6 +107,8 @@ func itemsFromResource(resource types.Resource) ([]backend.Item, error) {
 		item, err = itemFromAutoUpdateVersion(r.UnwrapT())
 	case types.Resource153UnwrapperT[*healthcheckconfigv1.HealthCheckConfig]:
 		item, err = itemFromHealthCheckConfig(r.UnwrapT())
+	case types.Resource153UnwrapperT[*workloadidentityv1pb.WorkloadIdentity]:
+		item, err = itemFromWorkloadIdentity(r.UnwrapT())
 	default:
 		return nil, trace.NotImplemented("cannot itemFrom resource of type %T", resource)
 	}
@@ -154,6 +157,30 @@ func itemFromAuthPreference(ap types.AuthPreference) (*backend.Item, error) {
 		Revision: ap.GetRevision(),
 	}
 
+	return item, nil
+}
+
+// itemFromWorkloadIdentity attempts to encode the supplied workload identity as
+// an instance of `backend.Item` suitable for storage.
+func itemFromWorkloadIdentity(wi *workloadidentityv1pb.WorkloadIdentity) (*backend.Item, error) {
+	if err := services.ValidateWorkloadIdentity(wi); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	value, err := services.MarshalWorkloadIdentity(wi)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	expires, err := types.GetExpiry(wi)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item := &backend.Item{
+		Key:      backend.NewKey(workloadIdentityPrefix, wi.GetMetadata().GetName()),
+		Value:    value,
+		Expires:  expires,
+		Revision: wi.GetMetadata().GetRevision(),
+	}
 	return item, nil
 }
 

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -35,6 +35,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
@@ -808,6 +809,17 @@ func init() {
 			return nil, trace.Wrap(err)
 		}
 		return types.Resource153ToLegacy(cfg), nil
+	})
+	RegisterResourceUnmarshaler(types.KindWorkloadIdentity, func(bytes []byte, option ...MarshalOption) (types.Resource, error) {
+		cfg, err := CollectOptions(option)
+		if err != nil {
+			return nil, err
+		}
+		wid := &workloadidentityv1.WorkloadIdentity{}
+		if err := (protojson.UnmarshalOptions{DiscardUnknown: !cfg.DisallowUnknown}).Unmarshal(bytes, wid); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(wid), nil
 	})
 }
 

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -77,15 +77,37 @@ func TestTeleportMain(t *testing.T) {
 	require.NoError(t, os.WriteFile(configFile, []byte(configData), 0660))
 
 	// generate the fixture bootstrap file
-	bootstrapEntries := []struct{ fileName, kind, name string }{
-		{"role.yaml", types.KindRole, "role_name"},
-		{"github.yaml", types.KindGithubConnector, "github"},
-		{"user.yaml", types.KindRole, "user"},
+	bootstrapEntries := []struct {
+		fileName string
+		kind     string
+		name     string
+		content  string
+	}{
+		{fileName: "role.yaml", kind: types.KindRole, name: "role_name"},
+		{fileName: "github.yaml", kind: types.KindGithubConnector, name: "github"},
+		{fileName: "user.yaml", kind: types.KindRole, name: "user"},
+		{
+			fileName: "workload-identity.yaml",
+			kind:     types.KindWorkloadIdentity,
+			name:     "example-workload-identity",
+			content: `kind: workload_identity
+version: v1
+metadata:
+  name: example-workload-identity
+spec:
+  spiffe:
+    id: /svc/example
+`,
+		},
 	}
 	var bootstrapData []byte
 	for _, entry := range bootstrapEntries {
-		data, err := os.ReadFile(filepath.Join("..", "..", "..", "examples", "resources", entry.fileName))
-		require.NoError(t, err)
+		data := []byte(entry.content)
+		if entry.content == "" {
+			fileData, err := os.ReadFile(filepath.Join("..", "..", "..", "examples", "resources", entry.fileName))
+			require.NoError(t, err)
+			data = fileData
+		}
 		bootstrapData = append(bootstrapData, data...)
 		bootstrapData = append(bootstrapData, "\n---\n"...)
 	}


### PR DESCRIPTION
Changelog: Added support for `WorkloadIdentity` when using the `--apply-on-startup` and `--bootstrap` flags

## Manual Test Plan

### Test Environment

Local build of Teleport on my laptop.

**startup.yaml**

```yaml
kind: workload_identity
version: v1
metadata:
  name: startup-workload-identity
spec:
  spiffe:
    id: /startup
```

**bootstrap.yaml**

```yaml
kind: workload_identity
version: v1
metadata:
  name: bootstrap-workload-identity
spec:
  spiffe:
    id: /bootstrap
```

### Test Cases

- [x] Bootstrap and apply-on-startup resources get applied

```
$ teleport start -c teleport.yaml --bootstrap bootstrap.yaml --apply-on-startup startup.yaml
$ tctl -c teleport.yaml get workload_identity | grep -E 'bootstrap|startup'
```
