### PR TITLE
Explain tracking best_effort recording failures

### DIFF
--- a/docs/pages/reference/deployment/monitoring/audit.mdx
+++ b/docs/pages/reference/deployment/monitoring/audit.mdx
@@ -245,6 +245,37 @@ spec:
       ssh: strict
 ```
 
+<details>
+<summary>Tracking best-effort recording failures</summary>
+
+In `best_effort` mode, you can track failed session recordings by examining the
+logs for the Teleport SSH Service instance recording the session.
+
+When a session recording failure takes place in `best_effort` mode, the service
+will emit one of the following log messages. If the Teleport service could not
+initialize the recording, e.g., because of an issue with the configured data
+directory, you will see the following message:
+
+```
+Failed to initialize session recording, disabling it for this session.
+```
+
+The Teleport service emits the initialization failure log with an `error` field
+that indicates the underlying cause.
+
+On a failure to write the session recording to disk, the Teleport service emits
+the following log:
+
+```
+Failed to write to session recorder, disabling session recording.
+```
+
+If you are concerned about failed session recordings, you can use a log
+management platform to aggregate the counts of these messages across Teleport
+services.
+
+</details>
+
 ### Enable Recording Proxy Mode
 
 Edit the Auth Service configuration file as follows:


### PR DESCRIPTION
The docs on the best_effort recording mode explain that Teleport silently drops a recording while continuing a session in this mode. A user may wonder how they can track recording failures while enabling best_effort mode. This change addresses this gap in the documentation.