### PR TITLE
Prepare e2e runner for access request tests in Connect

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -7,12 +7,7 @@ runner/e2e
 runner/runner
 certs/
 data/
-config/teleport.yaml
-config/*-teleport.yaml
-config/state.yaml
-node/node.yaml
-node/*-node.yaml
-teleport.log
-teleport-*.log
-docker-node-*.log
+config/*.yaml
+node/*.yaml
+*.log
 .auth/

--- a/e2e/config/leaf.yaml.tmpl
+++ b/e2e/config/leaf.yaml.tmpl
@@ -1,0 +1,40 @@
+{{- /*gotype: github.com/gravitational/teleport/e2e/runner.TeleportConfig */ -}}
+version: v3
+teleport:
+  nodename: teleport-e2e-leaf
+  auth_token: foo
+  data_dir: {{ .DataDir }}
+  log:
+    output: stderr
+    severity: {{ .LogLevel }}
+    format:
+      output: text
+  auth_server: localhost:{{ .AuthServerPort }}
+
+auth_service:
+  enabled: "yes"
+  listen_addr: 0.0.0.0:{{ .AuthServerPort }}
+  proxy_listener_mode: multiplex
+  cluster_name: teleport-e2e-leaf
+  tokens:
+    - "node:foo"
+{{- if .LicenseFile }}
+  license_file: {{ .LicenseFile }}
+{{- end }}
+  authentication:
+    type: local
+    second_factors: ["webauthn"]
+    webauthn:
+      rp_id: "localhost"
+
+ssh_service:
+  enabled: "no"
+
+proxy_service:
+  enabled: "yes"
+  public_addr: localhost:{{ .ProxyPort }}
+  acme: {}
+  web_listen_addr: 0.0.0.0:{{ .ProxyPort }}
+  https_keypairs:
+    - key_file: {{ .KeyFilePath }}
+      cert_file: {{ .CertFilePath }}

--- a/e2e/config/state.yaml.tmpl
+++ b/e2e/config/state.yaml.tmpl
@@ -48,3 +48,54 @@ spec:
       - root
     windows_logins: null
 version: v2
+---
+kind: user
+metadata:
+  id: 1689831509413322786
+  name: alice
+spec:
+  created_by:
+    time: "2023-07-20T05:38:29.4127778Z"
+    user:
+      name: a0fc0c8b-adaa-4a58-b604-10388415fa0b.teleport-e2e
+  expires: "0001-01-01T00:00:00Z"
+  local_auth:
+    mfa:
+      - addedAt: "2024-11-26T13:50:42.504120787Z"
+        id: 2b3c4d5e-6f78-90ab-cdef-234567890abc
+        kind: mfa_device
+        lastUsed: "2024-11-26T13:50:42.506405156Z"
+        metadata:
+          Name: webauthn-device
+          Namespace: default
+        webauthn:
+          credentialId: {{ .CredentialIDBase64 }}
+          publicKeyCbor: {{ .PublicKeyCBORBase64 }}
+          attestationType: none
+          aaguid: AAAAAAAAAAAAAAAAAAAAAA==
+          signatureCounter: 0
+          residentKey: false
+          credentialRpId: localhost
+        version: v1
+    password_hash: {{ .PasswordHashBase64 }}
+  roles:
+    - access
+    - editor
+  status:
+    is_locked: false
+    lock_expires: "0001-01-01T00:00:00Z"
+    locked_time: "0001-01-01T00:00:00Z"
+    recovery_attempt_lock_expires: "0001-01-01T00:00:00Z"
+  traits:
+    aws_role_arns: null
+    azure_identities: null
+    db_names: null
+    db_roles: null
+    db_users: null
+    gcp_service_accounts: null
+    kubernetes_groups: null
+    kubernetes_users: null
+    logins:
+      - root
+    windows_logins: null
+version: v2

--- a/e2e/helpers/connect.ts
+++ b/e2e/helpers/connect.ts
@@ -65,7 +65,7 @@ export async function launchApp(homeDir: string) {
   }
 }
 
-export async function login(page: Page): Promise<void> {
+export async function login(page: Page, username = 'bob'): Promise<void> {
   await page.getByRole('button', { name: 'Connect', exact: true }).click();
   const clusterInput = page.getByPlaceholder('teleport.example.com');
   await expect(clusterInput).toBeVisible();
@@ -74,7 +74,7 @@ export async function login(page: Page): Promise<void> {
   await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
   await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-  await page.getByPlaceholder('Username').fill('bob');
+  await page.getByPlaceholder('Username').fill(username);
   await page.getByPlaceholder('Password').fill(password);
   await page.getByRole('button', { name: 'Sign In' }).click();
   await expect(page.getByPlaceholder('Search or jump to')).toBeVisible();

--- a/e2e/helpers/env.ts
+++ b/e2e/helpers/env.ts
@@ -37,3 +37,4 @@ export const startUrl = required('START_URL');
 export const connectTshBin = required('E2E_CONNECT_TSH_BIN');
 export const connectAppDir = required('E2E_CONNECT_APP_DIR');
 export const leafProxyUrl = process.env.E2E_LEAF_PROXY_URL || '';
+export const leafTeleportConfig = process.env.E2E_LEAF_TELEPORT_CONFIG || '';

--- a/e2e/helpers/env.ts
+++ b/e2e/helpers/env.ts
@@ -36,3 +36,4 @@ export const teleportConfig = required('E2E_TELEPORT_CONFIG');
 export const startUrl = required('START_URL');
 export const connectTshBin = required('E2E_CONNECT_TSH_BIN');
 export const connectAppDir = required('E2E_CONNECT_APP_DIR');
+export const leafProxyUrl = process.env.E2E_LEAF_PROXY_URL || '';

--- a/e2e/helpers/tctl.ts
+++ b/e2e/helpers/tctl.ts
@@ -51,8 +51,9 @@ export function deleteUser(username: string) {
   tctl('users', 'rm', username);
 }
 
-export function tctlCreate(yaml: string) {
-  execFileSync(tctlBin, ['create', '-f', '/dev/stdin', '-c', teleportConfig], {
+export function tctlCreate(yaml: string, opts: { config?: string } = {}) {
+  const config = opts.config ?? teleportConfig;
+  execFileSync(tctlBin, ['create', '-f', '/dev/stdin', '-c', config], {
     input: yaml,
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'ignore'],

--- a/e2e/helpers/tctl.ts
+++ b/e2e/helpers/tctl.ts
@@ -51,7 +51,19 @@ export function deleteUser(username: string) {
   tctl('users', 'rm', username);
 }
 
-function tctl(...args: string[]) {
+export function tctlCreate(yaml: string) {
+  execFileSync(tctlBin, ['create', '-f', '/dev/stdin', '-c', teleportConfig], {
+    input: yaml,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'ignore'],
+  });
+}
+
+export function tctlRemove(kind: string, name: string) {
+  tctl('rm', `${kind}/${name}`);
+}
+
+export function tctl(...args: string[]) {
   return execFileSync(tctlBin, [...args, '-c', teleportConfig], {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'ignore'],

--- a/e2e/node/node.yaml.tmpl
+++ b/e2e/node/node.yaml.tmpl
@@ -1,7 +1,7 @@
 {{- /*gotype: github.com/gravitational/teleport/e2e/runner.TeleportNodeConfig */ -}}
 version: v3
 teleport:
-  nodename: docker-node
+  nodename: {{ .NodeName }}
   auth_token: foo
   data_dir: /var/lib/teleport
   log:
@@ -19,7 +19,9 @@ ssh_service:
   listen_addr: 0.0.0.0:{{ .SSHServerPort }}
   public_addr: localhost:{{ .SSHServerPort }}
   labels:
-    env: example
+{{- range $k, $v := .Labels }}
+    {{ $k }}: {{ $v }}
+{{- end }}
 
 proxy_service:
   enabled: "no"

--- a/e2e/runner/flags.go
+++ b/e2e/runner/flags.go
@@ -30,6 +30,7 @@ import (
 )
 
 var sshNode = registerFixture("ssh-node", "start and connect a Teleport SSH node, runs in Docker")
+var leafCluster = registerFixture("leaf-cluster", "start a leaf Teleport cluster connected via trusted cluster")
 var connect = registerFixture("connect", "build Teleport Connect")
 
 var validBrowsers = []string{"chromium", "firefox", "webkit"}

--- a/e2e/runner/instance.go
+++ b/e2e/runner/instance.go
@@ -34,6 +34,15 @@ type browserInstance struct {
 	teleportConfigPath string
 	teleport           *teleportInstance
 	node               *dockerNode
+
+	// Leaf cluster fields, populated when --with-leaf-cluster is enabled.
+	leafProxyPort          int
+	leafAuthPort           int
+	leafSSHPort            int
+	leafDataDir            string
+	leafTeleportConfigPath string
+	leafTeleport           *teleportInstance
+	leafNode               *dockerNode
 }
 
 var browserColors = map[string]string{

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -354,6 +354,8 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 					AuthServerHost: dockerHost,
 					AuthServerPort: inst.authPort,
 					SSHServerPort:  inst.sshPort,
+					NodeName:       "docker-node",
+					Labels:         map[string]string{"env": "example"},
 				})
 				if err != nil {
 					return fmt.Errorf("failed to generate node config for %s: %w", inst.browser, err)
@@ -366,6 +368,7 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 					tctlBin:            config.tctlBin,
 					teleportConfigPath: inst.teleportConfigPath,
 					logFilePath:        filepath.Join(config.e2eDir, "docker-node-"+inst.browser+".log"),
+					nodeName:           "docker-node",
 					imageName:          nodeImage,
 					containerName:      "teleport-e2e-node-" + inst.browser,
 					configPath:         nodeConfigPath,

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -469,7 +469,7 @@ spec:
 						AuthServerHost: dockerHost,
 						AuthServerPort: inst.authPort,
 						SSHServerPort:  inst.sshPort,
-						NodeName:       "docker-node",
+						NodeName:       "docker-root-node",
 						Labels:         map[string]string{"env": "example"},
 					})
 					if err != nil {
@@ -483,7 +483,7 @@ spec:
 						tctlBin:            config.tctlBin,
 						teleportConfigPath: inst.teleportConfigPath,
 						logFilePath:        filepath.Join(config.e2eDir, "docker-node-"+inst.browser+".log"),
-						nodeName:           "docker-node",
+						nodeName:           "docker-root-node",
 						imageName:          nodeImage,
 						containerName:      "teleport-e2e-node-" + inst.browser,
 						configPath:         nodeConfigPath,
@@ -498,7 +498,7 @@ spec:
 							AuthServerHost: dockerHost,
 							AuthServerPort: inst.leafAuthPort,
 							SSHServerPort:  inst.leafSSHPort,
-							NodeName:       "leaf-node",
+							NodeName:       "docker-leaf-node",
 							Labels:         map[string]string{"cluster": "leaf"},
 						})
 						if err != nil {
@@ -512,7 +512,7 @@ spec:
 							tctlBin:            config.tctlBin,
 							teleportConfigPath: inst.leafTeleportConfigPath,
 							logFilePath:        filepath.Join(config.e2eDir, "leaf-node-"+inst.browser+".log"),
-							nodeName:           "leaf-node",
+							nodeName:           "docker-leaf-node",
 							imageName:          nodeImage,
 							containerName:      "teleport-e2e-leaf-node-" + inst.browser,
 							configPath:         nodeConfigPath,

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -27,6 +27,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -122,6 +123,7 @@ type e2eConfig struct {
 
 	nodeConfigTemplate     string
 	teleportConfigTemplate string
+	leafConfigTemplate     string
 	stateTemplate          string
 
 	// teleportBuildDir is the directory in which to run `make build/teleport`.
@@ -151,6 +153,7 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 		certsDir:               filepath.Join(e2eDir, "certs"),
 		stateTemplate:          filepath.Join(e2eDir, "config", "state.yaml.tmpl"),
 		teleportConfigTemplate: filepath.Join(e2eDir, "config", "teleport.yaml.tmpl"),
+		leafConfigTemplate:     filepath.Join(e2eDir, "config", "leaf.yaml.tmpl"),
 		nodeConfigTemplate:     filepath.Join(e2eDir, "node", "node.yaml.tmpl"),
 		connectAppDir:          filepath.Join(filepath.Dir(e2eDir), "web", "packages", "teleterm"),
 		connectTshBinPath:      filepath.Join(filepath.Dir(e2eDir), "build", "tsh-e2e-webauthnmock"),
@@ -208,9 +211,24 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 		if sshNode.enabled {
 			portTargets = append(portTargets, &inst.sshPort)
 		}
+		if leafCluster.enabled {
+			portTargets = append(portTargets, &inst.leafProxyPort, &inst.leafAuthPort)
+			if sshNode.enabled {
+				portTargets = append(portTargets, &inst.leafSSHPort)
+			}
+		}
 	}
 	if ci := config.connectInstance; ci != nil {
 		portTargets = append(portTargets, &ci.proxyPort, &ci.authPort)
+		if sshNode.enabled {
+			portTargets = append(portTargets, &ci.sshPort)
+		}
+		if leafCluster.enabled {
+			portTargets = append(portTargets, &ci.leafProxyPort, &ci.leafAuthPort)
+			if sshNode.enabled {
+				portTargets = append(portTargets, &ci.leafSSHPort)
+			}
+		}
 	}
 
 	if err := allocatePorts(portTargets...); err != nil {
@@ -320,68 +338,199 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 
 		defer func() {
 			for _, inst := range allInstances {
+				if inst.leafNode != nil {
+					inst.leafNode.stop(context.Background())
+				}
 				if inst.node != nil {
 					inst.node.stop(context.Background())
 				}
 			}
 			for _, inst := range allInstances {
+				if inst.leafTeleport != nil {
+					inst.leafTeleport.stop()
+				}
 				if inst.teleport != nil {
 					inst.teleport.stop()
 				}
 			}
 		}()
 
-		if sshNode.enabled {
-			slog.Info("running with SSH node fixture enabled")
+		if leafCluster.enabled {
+			slog.Info("running with leaf cluster fixture enabled")
 
-			nodeBin := config.teleportBin
-			if runtime.GOOS != "linux" {
-				buildDir := config.teleportBuildDir
-				if buildDir == "" {
-					buildDir = config.repoRoot
+			for _, inst := range allInstances {
+				inst.leafDataDir = filepath.Join(e2eDir, "data", inst.browser+"-leaf")
+
+				inst.log.Debug("cleaning leaf data directory", "path", inst.leafDataDir)
+				if err := os.RemoveAll(inst.leafDataDir); err != nil {
+					return fmt.Errorf("failed to clean leaf data directory for %s: %w", inst.browser, err)
 				}
-				nodeBin = filepath.Join(buildDir, "build", "teleport-node")
-			}
 
-			dockerHost, err := resolveDockerHost()
-			if err != nil {
-				return fmt.Errorf("resolving docker host: %w", err)
-			}
-
-			for _, inst := range config.instances {
-				outPath := filepath.Join(e2eDir, "node", inst.browser+"-node.yaml")
-				nodeConfigPath, err := generateTeleportNodeConfig(config.nodeConfigTemplate, outPath, &TeleportNodeConfig{
-					AuthServerHost: dockerHost,
-					AuthServerPort: inst.authPort,
-					SSHServerPort:  inst.sshPort,
-					NodeName:       "docker-node",
-					Labels:         map[string]string{"env": "example"},
+				outPath := filepath.Join(e2eDir, "config", inst.browser+"-leaf.yaml")
+				lcfg, err := generateTeleportConfig(config.leafConfigTemplate, outPath, &TeleportConfig{
+					DataDir:        inst.leafDataDir,
+					AuthServerPort: inst.leafAuthPort,
+					ProxyPort:      inst.leafProxyPort,
+					KeyFilePath:    filepath.Join(config.certsDir, keyFileName),
+					CertFilePath:   filepath.Join(config.certsDir, certFileName),
+					LicenseFile:    config.licenseFile,
+					LogLevel:       config.teleportLogLevel,
 				})
 				if err != nil {
-					return fmt.Errorf("failed to generate node config for %s: %w", inst.browser, err)
+					return fmt.Errorf("failed to generate leaf Teleport config for %s: %w", inst.browser, err)
 				}
-				inst.log.Debug("generated Teleport node config", "path", nodeConfigPath)
-
-				inst.node = &dockerNode{
-					log:                inst.log,
-					sshPort:            inst.sshPort,
-					tctlBin:            config.tctlBin,
-					teleportConfigPath: inst.teleportConfigPath,
-					logFilePath:        filepath.Join(config.e2eDir, "docker-node-"+inst.browser+".log"),
-					nodeName:           "docker-node",
-					imageName:          nodeImage,
-					containerName:      "teleport-e2e-node-" + inst.browser,
-					configPath:         nodeConfigPath,
-					teleportBin:        nodeBin,
-				}
-			}
-
-			if err := pullImage(ctx, nodeImage); err != nil {
-				return fmt.Errorf("pulling docker image: %w", err)
+				inst.leafTeleportConfigPath = lcfg
+				inst.log.Debug("generated leaf Teleport config", "path", lcfg)
 			}
 
 			g, gctx := errgroup.WithContext(ctx)
-			for _, inst := range config.instances {
+			for _, inst := range allInstances {
+				leaf := &teleportInstance{
+					log:         inst.log,
+					teleportBin: config.teleportBin,
+					proxyPort:   inst.leafProxyPort,
+					configPath:  inst.leafTeleportConfigPath,
+					insecure:    true,
+				}
+				if config.isCI || config.quiet {
+					leaf.logFile = filepath.Join(config.e2eDir, "teleport-"+inst.browser+"-leaf.log")
+					inst.log.Debug("redirecting leaf Teleport logs to file", "path", leaf.logFile)
+				}
+				inst.leafTeleport = leaf
+
+				g.Go(func() error {
+					if err := leaf.start(ctx); err != nil {
+						return fmt.Errorf("failed to start leaf Teleport for %s: %w", inst.browser, err)
+					}
+					if err := leaf.waitReady(gctx, 30*time.Second); err != nil {
+						return fmt.Errorf("leaf Teleport for %s failed to become ready: %w", inst.browser, err)
+					}
+					return nil
+				})
+			}
+			if err := g.Wait(); err != nil {
+				return err
+			}
+
+			// Create the trusted cluster resource on each leaf, pointing to the root.
+			for _, inst := range allInstances {
+				trustedClusterYAML := fmt.Sprintf(`kind: trusted_cluster
+version: v2
+metadata:
+  name: teleport-e2e
+spec:
+  enabled: true
+  token: foo
+  web_proxy_addr: localhost:%d
+  role_map:
+    - remote: access
+      local: [access]
+    - remote: editor
+      local: [editor]
+`, inst.proxyPort)
+
+				inst.log.Debug("creating trusted cluster resource on leaf")
+				cmd := exec.CommandContext(ctx, config.tctlBin, "create", "-f", "/dev/stdin",
+					"-c", inst.leafTeleportConfigPath)
+				cmd.Stdin = strings.NewReader(trustedClusterYAML)
+				if out, err := cmd.CombinedOutput(); err != nil {
+					return fmt.Errorf("failed to create trusted cluster for %s: %w\n%s", inst.browser, err, out)
+				}
+			}
+
+		}
+
+		// Start SSH nodes and wait for leaf cluster tunnels in parallel.
+		if sshNode.enabled || leafCluster.enabled {
+			var nodeBin string
+			var dockerHost string
+
+			if sshNode.enabled {
+				slog.Info("running with SSH node fixture enabled")
+
+				nodeBin = config.teleportBin
+				if runtime.GOOS != "linux" {
+					buildDir := config.teleportBuildDir
+					if buildDir == "" {
+						buildDir = config.repoRoot
+					}
+					nodeBin = filepath.Join(buildDir, "build", "teleport-node")
+				}
+
+				var err error
+				dockerHost, err = resolveDockerHost()
+				if err != nil {
+					return fmt.Errorf("resolving docker host: %w", err)
+				}
+
+				for _, inst := range allInstances {
+					outPath := filepath.Join(e2eDir, "node", inst.browser+"-node.yaml")
+					nodeConfigPath, err := generateTeleportNodeConfig(config.nodeConfigTemplate, outPath, &TeleportNodeConfig{
+						AuthServerHost: dockerHost,
+						AuthServerPort: inst.authPort,
+						SSHServerPort:  inst.sshPort,
+						NodeName:       "docker-node",
+						Labels:         map[string]string{"env": "example"},
+					})
+					if err != nil {
+						return fmt.Errorf("failed to generate node config for %s: %w", inst.browser, err)
+					}
+					inst.log.Debug("generated Teleport node config", "path", nodeConfigPath)
+
+					inst.node = &dockerNode{
+						log:                inst.log,
+						sshPort:            inst.sshPort,
+						tctlBin:            config.tctlBin,
+						teleportConfigPath: inst.teleportConfigPath,
+						logFilePath:        filepath.Join(config.e2eDir, "docker-node-"+inst.browser+".log"),
+						nodeName:           "docker-node",
+						imageName:          nodeImage,
+						containerName:      "teleport-e2e-node-" + inst.browser,
+						configPath:         nodeConfigPath,
+						teleportBin:        nodeBin,
+					}
+				}
+
+				if leafCluster.enabled {
+					for _, inst := range allInstances {
+						outPath := filepath.Join(e2eDir, "node", inst.browser+"-leaf-node.yaml")
+						nodeConfigPath, err := generateTeleportNodeConfig(config.nodeConfigTemplate, outPath, &TeleportNodeConfig{
+							AuthServerHost: dockerHost,
+							AuthServerPort: inst.leafAuthPort,
+							SSHServerPort:  inst.leafSSHPort,
+							NodeName:       "leaf-node",
+							Labels:         map[string]string{"cluster": "leaf"},
+						})
+						if err != nil {
+							return fmt.Errorf("failed to generate leaf node config for %s: %w", inst.browser, err)
+						}
+						inst.log.Debug("generated leaf node config", "path", nodeConfigPath)
+
+						inst.leafNode = &dockerNode{
+							log:                inst.log,
+							sshPort:            inst.leafSSHPort,
+							tctlBin:            config.tctlBin,
+							teleportConfigPath: inst.leafTeleportConfigPath,
+							logFilePath:        filepath.Join(config.e2eDir, "leaf-node-"+inst.browser+".log"),
+							nodeName:           "leaf-node",
+							imageName:          nodeImage,
+							containerName:      "teleport-e2e-leaf-node-" + inst.browser,
+							configPath:         nodeConfigPath,
+							teleportBin:        nodeBin,
+						}
+					}
+				}
+
+				if err := pullImage(ctx, nodeImage); err != nil {
+					return fmt.Errorf("pulling docker image: %w", err)
+				}
+			}
+
+			g, gctx := errgroup.WithContext(ctx)
+			for _, inst := range allInstances {
+				if inst.node == nil {
+					continue
+				}
 				g.Go(func() error {
 					if err := inst.node.start(gctx); err != nil {
 						return fmt.Errorf("failed to start docker node for %s: %w", inst.browser, err)
@@ -391,6 +540,42 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 					}
 					return nil
 				})
+			}
+			for _, inst := range allInstances {
+				if inst.leafNode != nil {
+					g.Go(func() error {
+						if err := inst.leafNode.start(gctx); err != nil {
+							return fmt.Errorf("failed to start leaf docker node for %s: %w", inst.browser, err)
+						}
+						if err := inst.leafNode.waitJoined(gctx, 30*time.Second); err != nil {
+							return fmt.Errorf("leaf docker node for %s failed to join cluster: %w", inst.browser, err)
+						}
+						return nil
+					})
+				}
+				if leafCluster.enabled {
+					g.Go(func() error {
+						tunnelStart := time.Now()
+						inst.log.Info("waiting for leaf cluster tunnel to come online")
+						// The auth service refreshes the list of remote clusters every 40s, so this is going to
+						// take a while.
+						// https://github.com/gravitational/teleport/blob/71850948ec686c9c178544f98caf53a912842250/lib/auth/auth.go#L1948-L1965
+						isLeafClusterOnline := func(ctx context.Context) (bool, error) {
+							cmd := exec.CommandContext(ctx, config.tctlBin, "get", "rc/teleport-e2e-leaf",
+								"-c", inst.teleportConfigPath)
+							out, err := cmd.Output()
+							if err != nil {
+								return false, nil
+							}
+							return strings.Contains(string(out), "connection: online"), nil
+						}
+						if err := pollUntil(gctx, 90*time.Second, 2*time.Second, isLeafClusterOnline); err != nil {
+							return fmt.Errorf("leaf cluster tunnel failed to come online for %s: %w", inst.browser, err)
+						}
+						inst.log.Info("leaf cluster tunnel is online", "elapsed", time.Since(tunnelStart).Round(time.Second))
+						return nil
+					})
+				}
 			}
 			if err := g.Wait(); err != nil {
 				return err

--- a/e2e/runner/node.go
+++ b/e2e/runner/node.go
@@ -42,6 +42,7 @@ type dockerNode struct {
 	tctlBin            string
 	teleportConfigPath string
 	logFilePath        string
+	nodeName           string
 
 	imageName     string
 	containerName string
@@ -66,7 +67,7 @@ func (d *dockerNode) removeStale(ctx context.Context) {
 }
 
 func (d *dockerNode) runContainer(ctx context.Context) error {
-	d.log.Info("starting docker SSH node")
+	d.log.Info("starting docker SSH node", "name", d.nodeName)
 
 	d.removeStale(ctx)
 
@@ -124,14 +125,14 @@ func (d *dockerNode) waitJoined(ctx context.Context, timeout time.Duration) erro
 			return false, nil
 		}
 
-		return strings.Contains(string(out), "docker-node"), nil
+		return strings.Contains(string(out), d.nodeName), nil
 	}
 
 	if err := pollUntil(ctx, timeout, 1*time.Second, probe); err != nil {
 		return fmt.Errorf("docker node failed to join cluster: %w", err)
 	}
 
-	d.log.Info("docker SSH node is ready")
+	d.log.Info("docker SSH node is ready", "name", d.nodeName)
 
 	return nil
 }

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -272,6 +272,9 @@ func (p *playwrightRunner) startEnv(inst *browserInstance) ([]string, error) {
 	if inst.leafProxyPort != 0 {
 		env = append(env, fmt.Sprintf("E2E_LEAF_PROXY_URL=https://localhost:%d/web", inst.leafProxyPort))
 	}
+	if inst.leafTeleportConfigPath != "" {
+		env = append(env, "E2E_LEAF_TELEPORT_CONFIG="+inst.leafTeleportConfigPath)
+	}
 
 	if leafCluster.enabled && sshNode.enabled && p.config.licenseFile != "" {
 		env = append(env, "E2E_ACCESS_REQUESTS=true")

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -273,6 +273,10 @@ func (p *playwrightRunner) startEnv(inst *browserInstance) ([]string, error) {
 		env = append(env, fmt.Sprintf("E2E_LEAF_PROXY_URL=https://localhost:%d/web", inst.leafProxyPort))
 	}
 
+	if leafCluster.enabled && sshNode.enabled && p.config.licenseFile != "" {
+		env = append(env, "E2E_ACCESS_REQUESTS=true")
+	}
+
 	return env, nil
 }
 

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -269,6 +269,10 @@ func (p *playwrightRunner) startEnv(inst *browserInstance) ([]string, error) {
 	env = append(env, "E2E_CONNECT_TSH_BIN="+p.config.connectTshBinPath)
 	env = append(env, "E2E_CONNECT_APP_DIR="+p.config.connectAppDir)
 
+	if inst.leafProxyPort != 0 {
+		env = append(env, fmt.Sprintf("E2E_LEAF_PROXY_URL=https://localhost:%d/web", inst.leafProxyPort))
+	}
+
 	return env, nil
 }
 

--- a/e2e/runner/teleport.go
+++ b/e2e/runner/teleport.go
@@ -164,6 +164,8 @@ type TeleportNodeConfig struct {
 	AuthServerHost string
 	AuthServerPort int
 	SSHServerPort  int
+	NodeName       string
+	Labels         map[string]string
 }
 
 func generateTeleportNodeConfig(templatePath, outPath string, data *TeleportNodeConfig) (string, error) {

--- a/e2e/runner/teleport.go
+++ b/e2e/runner/teleport.go
@@ -41,6 +41,7 @@ type teleportInstance struct {
 	proxyPort   int
 	configPath  string
 	stateFile   string
+	insecure    bool
 	logFile     string // empty means stdout/stderr
 
 	cmd      *exec.Cmd
@@ -50,7 +51,14 @@ type teleportInstance struct {
 }
 
 func (t *teleportInstance) start(ctx context.Context) error {
-	t.cmd = exec.CommandContext(ctx, t.teleportBin, "start", "-c", t.configPath, "--bootstrap", t.stateFile)
+	args := []string{"start", "-c", t.configPath}
+	if t.stateFile != "" {
+		args = append(args, "--bootstrap", t.stateFile)
+	}
+	if t.insecure {
+		args = append(args, "--insecure")
+	}
+	t.cmd = exec.CommandContext(ctx, t.teleportBin, args...)
 
 	if t.logFile != "" {
 		f, err := os.Create(t.logFile)

--- a/e2e/tests/connect/accessRequests.spec.ts
+++ b/e2e/tests/connect/accessRequests.spec.ts
@@ -1,0 +1,245 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  expect,
+  initializeDataDir,
+  launchApp,
+  login,
+  test,
+  withDefaultAppConfig,
+} from '@gravitational/e2e/helpers/connect';
+import { leafTeleportConfig, startUrl } from '@gravitational/e2e/helpers/env';
+import { tctl, tctlCreate } from '@gravitational/e2e/helpers/tctl';
+
+const roleDefinitions = [
+  `kind: role
+metadata:
+  name: allow-roles-and-nodes
+spec:
+  allow:
+    logins: [root]
+    node_labels:
+      '*': '*'
+    rules:
+      - resources: [role]
+        verbs: [list, read]
+  options:
+    max_session_ttl: 8h0m0s
+version: v5`,
+  `kind: role
+metadata:
+  name: allow-users-with-short-ttl
+spec:
+  allow:
+    rules:
+      - resources: [user]
+        verbs: [list, read]
+  deny:
+    node_labels:
+      '*': '*'
+  options:
+    max_session_ttl: 4m0s
+version: v5`,
+  `kind: role
+metadata:
+  name: test-role-based-requests
+spec:
+  allow:
+    request:
+      roles:
+        - allow-roles-and-nodes
+        - allow-users-with-short-ttl
+      suggested_reviewers:
+        - bob
+version: v5`,
+  `kind: role
+metadata:
+  name: reviewer
+spec:
+  allow:
+    review_requests:
+      roles: ['*']
+version: v3`,
+  `kind: role
+metadata:
+  name: searcheable-resources
+spec:
+  allow:
+    logins: [root]
+    node_labels:
+      '*': '*'
+version: v5`,
+  `kind: role
+metadata:
+  name: test-search-based-requests
+spec:
+  allow:
+    request:
+      search_as_roles:
+        - searcheable-resources
+      suggested_reviewers:
+        - bob
+version: v5`,
+];
+
+const trustedClusterWithTestRoles = `kind: trusted_cluster
+version: v2
+metadata:
+  name: teleport-e2e
+spec:
+  enabled: true
+  token: foo
+  web_proxy_addr: ${new URL(startUrl).host}
+  role_map:
+    - remote: access
+      local: [access]
+    - remote: editor
+      local: [editor]
+    - remote: test-role-based-requests
+      local: [test-role-based-requests]
+    - remote: test-search-based-requests
+      local: [test-search-based-requests]
+    - remote: searcheable-resources
+      local: [searcheable-resources]
+    - remote: reviewer
+      local: [reviewer]`;
+
+function getUserRoles(username: string): string[] {
+  const output = tctl('get', `user/${username}`, '--format=json');
+  const users = JSON.parse(output);
+  return users[0]?.spec?.roles ?? [];
+}
+
+function deleteAllAccessRequests() {
+  const output = tctl('requests', 'ls', '--format=json').trim();
+  const requests = JSON.parse(output);
+  for (const req of requests) {
+    tctl('requests', 'rm', req.metadata.name, '--force');
+  }
+}
+
+test.describe('access requests', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.skip(
+    !process.env.E2E_ACCESS_REQUESTS,
+    'requires enterprise cluster with leaf cluster'
+  );
+
+  let requesterSnapshot: string;
+  let reviewerSnapshot: string;
+  let originalAliceRoles: string[];
+  let originalBobRoles: string[];
+
+  test.beforeAll(async () => {
+    // Create roles on both root and leaf clusters.
+    for (const role of roleDefinitions) {
+      tctlCreate(role);
+      tctlCreate(role, { config: leafTeleportConfig });
+    }
+
+    // Update the trusted cluster role mapping to include the new roles.
+    tctlCreate(trustedClusterWithTestRoles, { config: leafTeleportConfig });
+
+    originalAliceRoles = getUserRoles('alice');
+    originalBobRoles = getUserRoles('bob');
+
+    tctl(
+      'users',
+      'update',
+      'alice',
+      '--set-roles=test-role-based-requests,test-search-based-requests'
+    );
+    tctl('users', 'update', 'bob', '--set-roles=access,editor,reviewer');
+
+    requesterSnapshot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'connect-e2e-requester-')
+    );
+    await initializeDataDir(requesterSnapshot, withDefaultAppConfig({}));
+    {
+      await using app = await launchApp(requesterSnapshot);
+      await login(app.page, 'alice');
+    }
+
+    reviewerSnapshot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'connect-e2e-reviewer-')
+    );
+    await initializeDataDir(reviewerSnapshot, withDefaultAppConfig({}));
+    {
+      await using app = await launchApp(reviewerSnapshot);
+      await login(app.page, 'bob');
+    }
+  });
+
+  test.afterEach(() => {
+    deleteAllAccessRequests();
+  });
+
+  test.afterAll(async () => {
+    tctl(
+      'users',
+      'update',
+      'alice',
+      `--set-roles=${originalAliceRoles.join(',')}`
+    );
+    tctl('users', 'update', 'bob', `--set-roles=${originalBobRoles.join(',')}`);
+
+    await fs.rm(requesterSnapshot, { recursive: true, force: true });
+    await fs.rm(reviewerSnapshot, { recursive: true, force: true });
+  });
+
+  async function launchFromSnapshot(snapshot: string) {
+    await using stack = new AsyncDisposableStack();
+    const temp = stack.use(
+      await fs.mkdtempDisposable(path.join(os.tmpdir(), 'connect-e2e-ar-'))
+    );
+    await fs.cp(snapshot, temp.path, { recursive: true });
+    const launched = stack.use(await launchApp(temp.path));
+    const disposables = stack.move();
+    return {
+      ...launched,
+      [Symbol.asyncDispose]: () => disposables.disposeAsync(),
+    };
+  }
+
+  async function launchAsRequester() {
+    return launchFromSnapshot(requesterSnapshot);
+  }
+
+  // oxlint-disable-next-line eslint/no-unused-vars
+  async function launchAsReviewer() {
+    return launchFromSnapshot(reviewerSnapshot);
+  }
+
+  test('leaf cluster is visible with resources', async () => {
+    await using app = await launchAsRequester();
+    const { page } = app;
+
+    const clusterSelector = page.locator('[title*="Open Clusters"]');
+    await expect(clusterSelector).toBeVisible();
+
+    await clusterSelector.click();
+    await page.getByText('teleport-e2e-leaf').click();
+
+    await expect(page.getByText('docker-leaf-node')).toBeVisible();
+  });
+});

--- a/e2e/tests/connect/stateRestoration.spec.ts
+++ b/e2e/tests/connect/stateRestoration.spec.ts
@@ -32,25 +32,51 @@ import {
 // These tests manage the app lifecycle manually (multiple launches/closes), so they do not use the
 // `app` fixture.
 test.describe('state restoration from disk', () => {
-  let tempPath: string;
+  // Run all tests in this block sequentially in a single worker so that beforeAll runs exactly
+  // once, not once per test (which fullyParallel would otherwise cause).
+  test.describe.configure({ mode: 'serial' });
 
-  test.beforeEach(async () => {
-    tempPath = await fs.mkdtemp(path.join(os.tmpdir(), 'connect-e2e-state-'));
-    await initializeDataDir(tempPath, withDefaultAppConfig({}));
+  // A snapshot of a data dir with a logged-in session, created once in beforeAll. Tests that need
+  // logged-in state copy this snapshot instead of calling login again, keeping total login calls to
+  // a minimum (important to avoid rate-limiting when running full Connect suite).
+  let loggedInSnapshotPath: string;
+
+  test.beforeAll(async () => {
+    loggedInSnapshotPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'connect-e2e-state-snapshot-')
+    );
+    await initializeDataDir(loggedInSnapshotPath, withDefaultAppConfig({}));
+
+    // Login once to populate the data dir with session state.
+    {
+      await using app = await launchApp(loggedInSnapshotPath);
+      await login(app.page);
+    }
   });
 
-  test.afterEach(async () => {
-    await fs.rm(tempPath, { recursive: true, force: true });
+  test.afterAll(async () => {
+    await fs.rm(loggedInSnapshotPath, { recursive: true, force: true });
   });
+
+  /**
+   * Creates a fresh disposable temp dir pre-populated with the logged-in snapshot.
+   */
+  async function loggedInDataDir() {
+    const temp = await fs.mkdtempDisposable(
+      path.join(os.tmpdir(), 'connect-e2e-state-')
+    );
+    await fs.cp(loggedInSnapshotPath, temp.path, { recursive: true });
+    return temp;
+  }
 
   test('relaunch restores tabs', async () => {
-    // Login and create extra tabs.
-    {
-      await using app = await launchApp(tempPath);
-      const { page } = app;
-      await login(page);
+    await using temp = await loggedInDataDir();
 
-      // Open a terminal tab so there are 2 tabs (cluster + terminal).
+    // Open a terminal tab so there are 2 tabs (cluster + terminal).
+    {
+      await using app = await launchApp(temp.path);
+      const { page } = app;
+
       await page.getByTitle('Additional Actions').click();
       await page.getByText('Open new terminal').click();
       await expect(
@@ -60,7 +86,7 @@ test.describe('state restoration from disk', () => {
 
     // Relaunch – the app should offer to restore the terminal tab.
     {
-      await using app = await launchApp(tempPath);
+      await using app = await launchApp(temp.path);
       const { page } = app;
       await expect(page.getByText('Reopen previous session')).toBeVisible();
       await page.getByRole('button', { name: 'Reopen' }).click();
@@ -77,18 +103,14 @@ test.describe('state restoration from disk', () => {
   });
 
   test('missing app_state.json does not crash the app', async () => {
-    // Login to create state files on disk.
-    {
-      await using app = await launchApp(tempPath);
-      await login(app.page);
-    }
+    await using temp = await loggedInDataDir();
 
     // Remove app_state.json (keep tsh dir) – the app should not crash.
-    const appStatePath = path.join(tempPath, 'userData', 'app_state.json');
+    const appStatePath = path.join(temp.path, 'userData', 'app_state.json');
     await fs.rm(appStatePath);
 
     {
-      await using app = await launchApp(tempPath);
+      await using app = await launchApp(temp.path);
 
       // Without app_state.json, the app has no saved rootClusterUri, so no workspace is activated
       // and the cluster connect panel prompts the user to pick one.
@@ -99,18 +121,14 @@ test.describe('state restoration from disk', () => {
   });
 
   test('missing tsh home directory does not crash the app', async () => {
-    // Login to create state files on disk.
-    {
-      await using app = await launchApp(tempPath);
-      await login(app.page);
-    }
+    await using temp = await loggedInDataDir();
 
     // Remove the tsh home directory (keep app_state.json) – the app should not crash.
-    const tshHomePath = path.join(tempPath, 'home', '.tsh');
+    const tshHomePath = path.join(temp.path, 'home', '.tsh');
     await fs.rm(tshHomePath, { recursive: true });
 
     {
-      await using app = await launchApp(tempPath);
+      await using app = await launchApp(temp.path);
       const { page } = app;
 
       // With no tsh dir, no cluster can be connected.
@@ -123,9 +141,9 @@ test.describe('state restoration from disk', () => {
   });
 
   test('logout clears previous tabs', async () => {
-    await using app = await launchApp(tempPath);
+    await using temp = await loggedInDataDir();
+    await using app = await launchApp(temp.path);
     const { page } = app;
-    await login(page);
 
     // Open a terminal tab.
     await page.getByTitle('Additional Actions').click();
@@ -159,11 +177,12 @@ test.describe('state restoration from disk', () => {
   });
 
   test('identical workspace shape does not trigger restore dialog', async () => {
-    // Login, then replace the default cluster tab with a new one (same shape).
+    await using temp = await loggedInDataDir();
+
+    // Replace the default cluster tab with a new one (same shape).
     {
-      await using app = await launchApp(tempPath);
+      await using app = await launchApp(temp.path);
       const { page } = app;
-      await login(page);
 
       const clusterTab = page.locator(
         '[role="tab"][data-doc-kind="doc.cluster"]'
@@ -179,7 +198,7 @@ test.describe('state restoration from disk', () => {
 
     // Relaunch – no restore dialog since the workspace has the same shape.
     {
-      await using app = await launchApp(tempPath);
+      await using app = await launchApp(temp.path);
       const { page } = app;
 
       const clusterTab = page.locator(
@@ -191,10 +210,20 @@ test.describe('state restoration from disk', () => {
   });
 
   test('window remembers size and position after restart', async () => {
+    await using temp = await fs.mkdtempDisposable(
+      path.join(os.tmpdir(), 'connect-e2e-state-')
+    );
+    await initializeDataDir(temp.path, withDefaultAppConfig({}));
+
     // Launch the app and resize the window.
-    let targetBounds: { x: number; y: number; width: number; height: number };
+    let targetBounds: {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+    };
     {
-      await using app = await launchApp(tempPath);
+      await using app = await launchApp(temp.path);
       const { page } = app;
       await expect(page.getByText('Connect a Cluster')).toBeVisible();
 
@@ -240,7 +269,7 @@ test.describe('state restoration from disk', () => {
 
     // Relaunch – the window should restore to the same size & position.
     {
-      await using app = await launchApp(tempPath);
+      await using app = await launchApp(temp.path);
 
       // Wait for the app to fully initialize before reading bounds and closing, otherwise the
       // app may close before the renderer acks the initial cluster store message, causing a

--- a/e2e/tests/web/with-ssh-node/ssh.spec.ts
+++ b/e2e/tests/web/with-ssh-node/ssh.spec.ts
@@ -23,7 +23,10 @@ test('verify that a user can SSH into a node', async ({
 }) => {
   await unifiedResourcesPage.goto();
 
-  const terminal = await unifiedResourcesPage.connect('docker-node', 'root');
+  const terminal = await unifiedResourcesPage.connect(
+    'docker-root-node',
+    'root'
+  );
 
   await terminal.waitForReady();
   await terminal.exec('ls /');


### PR DESCRIPTION
For those access request tests, we need a leaf cluster and an SSH node in each cluster. The bulk of this work is in "Add leaf cluster fixture to Go runner" which adds a new Teleport node, new Docker node and then establishes a trusted cluster relationship between the root and the leaf.

