### PR TITLE
Fix flaky TestTerminalRouting

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2420,7 +2420,7 @@ func TestTerminal(t *testing.T) {
 
 func TestTerminalRouting(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+	s := newWebSuiteWithConfig(t, webSuiteConfig{disableDiskBasedRecording: true})
 
 	// add nodes with conflicting hostnames
 	llama := s.addNode(t, uuid.NewString(), "llama", "127.0.0.1:0")
@@ -2453,7 +2453,6 @@ func TestTerminalRouting(t *testing.T) {
 	}
 
 	for i, tt := range cases {
-		i, tt := i, tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Resolves an unlink error cleaning up the session recordings directory. Observed at https://github.com/gravitational/teleport/actions/runs/23497277680/job/68381855749