### PR TITLE
Refactor teleport/discovery/aws module to support eks

### DIFF
--- a/api/types/matchers_aws.go
+++ b/api/types/matchers_aws.go
@@ -198,6 +198,16 @@ func (m *AWSMatcher) CheckAndSetDefaults() error {
 		m.Tags = map[string]apiutils.Strings{Wildcard: {Wildcard}}
 	}
 
+	if slices.Contains(m.Types, AWSMatcherEC2) {
+		if err := m.checkAndSetDefaultsEC2(); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+func (m *AWSMatcher) checkAndSetDefaultsEC2() error {
 	if m.Params == nil {
 		m.Params = &InstallerParams{
 			InstallTeleport: true,
@@ -222,7 +232,7 @@ func (m *AWSMatcher) CheckAndSetDefaults() error {
 		return trace.BadParameter("invalid enroll mode %s", m.Params.EnrollMode.String())
 	}
 
-	if slices.Contains(m.Types, AWSMatcherEC2) && m.Params.EnrollMode == InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_EICE {
+	if m.Params.EnrollMode == InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_EICE {
 		if eiceEnabled, _ := strconv.ParseBool(os.Getenv(constants.UnstableEnableEICEEnvVar)); !eiceEnabled {
 			return trace.BadParameter(constants.EICEDisabledMessage)
 		}
@@ -276,6 +286,7 @@ func (m *AWSMatcher) CheckAndSetDefaults() error {
 			m.SSM.DocumentName = AWSInstallerDocument
 		}
 	}
+
 	return nil
 }
 

--- a/api/types/matchers_aws_test.go
+++ b/api/types/matchers_aws_test.go
@@ -240,18 +240,9 @@ func TestAWSMatcherCheckAndSetDefaults(t *testing.T) {
 				Tags: Labels{
 					"*": []string{"*"},
 				},
-				Params: &InstallerParams{
-					JoinMethod:      "iam",
-					JoinToken:       "aws-discovery-iam-token",
-					InstallTeleport: true,
-					ScriptName:      "default-installer",
-					SSHDConfig:      "/etc/ssh/sshd_config",
-					EnrollMode:      InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
-				},
 				AssumeRole: &AssumeRole{
 					ExternalID: "id123",
 				},
-				SSM: &AWSSSM{DocumentName: "TeleportDiscoveryInstaller"},
 			},
 		},
 		{
@@ -445,6 +436,88 @@ func TestAWSMatcherCheckAndSetDefaults(t *testing.T) {
 				},
 			},
 			errCheck: isBadParameterErr,
+		},
+		{
+			name: "eks matcher with integration does not trigger EICE logic",
+			in: &AWSMatcher{
+				Types:       []string{"eks"},
+				Regions:     []string{"us-east-1"},
+				Integration: "my-integration",
+			},
+			errCheck: require.NoError,
+			expected: &AWSMatcher{
+				Types:       []string{"eks"},
+				Regions:     []string{"us-east-1"},
+				Integration: "my-integration",
+				Tags: Labels{
+					"*": []string{"*"},
+				},
+			},
+		},
+		{
+			name: "eks matcher with valid setup_access_for_arn",
+			in: &AWSMatcher{
+				Types:             []string{"eks"},
+				Regions:           []string{"us-east-1"},
+				SetupAccessForARN: "arn:aws:iam::123456789012:role/my-role",
+			},
+			errCheck: require.NoError,
+			expected: &AWSMatcher{
+				Types:             []string{"eks"},
+				Regions:           []string{"us-east-1"},
+				SetupAccessForARN: "arn:aws:iam::123456789012:role/my-role",
+				Tags: Labels{
+					"*": []string{"*"},
+				},
+			},
+		},
+		{
+			name: "ec2 matcher with setup_access_for_arn fails",
+			in: &AWSMatcher{
+				Types:             []string{"ec2"},
+				Regions:           []string{"us-east-1"},
+				SetupAccessForARN: "arn:aws:iam::123456789012:role/my-role",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name: "eks matcher does not get install params or ssm defaults",
+			in: &AWSMatcher{
+				Types:   []string{"eks"},
+				Regions: []string{"us-east-1"},
+			},
+			errCheck: require.NoError,
+			expected: &AWSMatcher{
+				Types:   []string{"eks"},
+				Regions: []string{"us-east-1"},
+				Tags: Labels{
+					"*": []string{"*"},
+				},
+			},
+		},
+		{
+			name: "mixed ec2 and eks matcher gets install params and ssm defaults",
+			in: &AWSMatcher{
+				Types:   []string{"ec2", "eks"},
+				Regions: []string{"us-east-1"},
+			},
+			errCheck: require.NoError,
+			expected: &AWSMatcher{
+				Types:   []string{"ec2", "eks"},
+				Regions: []string{"us-east-1"},
+				Tags: Labels{
+					"*": []string{"*"},
+				},
+				Params: &InstallerParams{
+					JoinMethod:      "iam",
+					JoinToken:       "aws-discovery-iam-token",
+					InstallTeleport: true,
+					ScriptName:      "default-installer",
+					SSHDConfig:      "/etc/ssh/sshd_config",
+					EnrollMode:      InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+				},
+				SSM: &AWSSSM{DocumentName: "TeleportDiscoveryInstaller"},
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account-legacy.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account-legacy.mdx
@@ -1,0 +1,58 @@
+---
+title: Example for discovering AWS resources in a single account
+sidebar_label: single-account-legacy
+description: Configure Teleport to discover resources in a AWS account.
+---
+
+{/*
+    Auto-generated file.
+    Do not edit this directly in the docs/pages tree.
+    Instead, edit teleport/discovery/aws/examples/single-account-legacy/README.md
+    Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
+*/}
+
+Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy)
+## Teleport AWS Account Discovery Example
+
+Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover resources in a single AWS account.
+
+In addition, the example uses a custom AWS IAM policy to narrow the scope of permissions for Teleport Discovery Service instances.
+
+{/* BEGIN_TF_DOCS */}
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0 |
+| aws | >= 5.0 |
+| teleport | >= 18.5.1 |
+| tls | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 5.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| aws\_discovery | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy_document.teleport_discovery_service_single_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| aws\_discovery | n/a |
+{/* END_TF_DOCS */}

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account.mdx
@@ -14,9 +14,7 @@ description: Configure Teleport to discover resources in a AWS account.
 Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/single-account](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/single-account)
 ## Teleport AWS Account Discovery Example
 
-Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover resources in a single AWS account.
-
-In addition, the example uses a custom AWS IAM policy to narrow the scope of permissions for Teleport Discovery Service instances.
+Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover EC2 and EKS resources in a single AWS account.
 
 {/* BEGIN_TF_DOCS */}
 ## Requirements
@@ -30,9 +28,7 @@ In addition, the example uses a custom AWS IAM policy to narrow the scope of per
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| aws | >= 5.0 |
+No providers.
 
 ## Modules
 
@@ -42,9 +38,7 @@ In addition, the example uses a custom AWS IAM policy to narrow the scope of per
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_iam_policy_document.teleport_discovery_service_single_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+No resources.
 
 ## Inputs
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -14,7 +14,7 @@ description: This page describes the Terraform module for discovering resources 
 Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws)
 ## AWS Discovery Terraform module
 
-This Terraform module creates the AWS and Teleport cluster resources necessary for a Teleport cluster to discover resources in AWS.
+This Terraform module creates the AWS and Teleport cluster resources necessary for a Teleport cluster to discover AWS resources.
 
 - AWS IAM role for Teleport Discovery Service to assume.
 - AWS IAM policy attached to the IAM role that grants the AWS permissions necessary for Teleport to discover resources in AWS.
@@ -48,11 +48,26 @@ module "aws_discovery" {
     Terraform = "true"
     Env       = "dev"
   }
-  # Match EC2 instances that have the AWS tag "origin=example"
-  match_aws_resource_types = ["ec2"]
-  match_aws_tags = {
-    origin = ["example"]
-  }
+
+  # Configure matchers to discover EC2 instances and EKS clusters.
+  aws_matchers = [
+    {
+      types   = ["ec2"]
+      # EC2 discovery supports wildcard to find instances in all regions.
+      regions = ["*"]
+      tags = {
+        origin = ["example"]
+      }
+    },
+    {
+      types   = ["eks"]
+      # EKS requires region selection.
+      regions = ["us-east-1"]
+      tags = {
+        team = ["platform"]
+      }
+    }
+  ]
 }
 ```
 
@@ -115,12 +130,13 @@ No modules.
 | aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
+| aws\_matchers | AWS resource discovery matchers. | ```list(object({ types = list(string) regions = list(string) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") }))``` | `null` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
 | discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |
-| match\_aws\_regions | AWS regions to discover. The default matches all AWS regions. | `list(string)` | ```[ "*" ]``` | no |
-| match\_aws\_resource\_types | AWS resource types to match when discovering resources with Teleport. Valid values are: `ec2`. | `list(string)` | n/a | yes |
-| match\_aws\_tags | AWS resource tags to match when discovering resources with Teleport. The default matches all discovered AWS resources. | `map(list(string))` | ```{ "*": [ "*" ] }``` | no |
+| match\_aws\_regions | Deprecated legacy input. Use aws\_matchers instead. AWS regions to discover. The default matches all AWS regions. | `list(string)` | `null` | no |
+| match\_aws\_resource\_types | Deprecated legacy input. Use aws\_matchers instead. AWS resource types to match when discovering resources with Teleport. | `list(string)` | `null` | no |
+| match\_aws\_tags | Deprecated legacy input. Use aws\_matchers instead. AWS resource tags to match when discovering resources with Teleport. The default matches all discovered AWS resources. | `map(list(string))` | `null` | no |
 | teleport\_discovery\_config\_name | Name for the `teleport_discovery_config` resource. | `string` | `"discovery"` | no |
 | teleport\_discovery\_config\_use\_name\_prefix | Determines whether the name of the Teleport discovery config (`teleport_discovery_config_name`) is used as a prefix. | `bool` | `true` | no |
 | teleport\_discovery\_group\_name | Teleport discovery group to use. For discovery configuration to apply, this name must match at least one Teleport Discovery Service instance's configured `discovery_group`. For Teleport Cloud clusters, use "cloud-discovery-group". | `string` | n/a | yes |

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -1,6 +1,6 @@
 ## AWS Discovery Terraform module
 
-This Terraform module creates the AWS and Teleport cluster resources necessary for a Teleport cluster to discover resources in AWS.
+This Terraform module creates the AWS and Teleport cluster resources necessary for a Teleport cluster to discover AWS resources.
 
 - AWS IAM role for Teleport Discovery Service to assume.
 - AWS IAM policy attached to the IAM role that grants the AWS permissions necessary for Teleport to discover resources in AWS.
@@ -34,11 +34,26 @@ module "aws_discovery" {
     Terraform = "true"
     Env       = "dev"
   }
-  # Match EC2 instances that have the AWS tag "origin=example"
-  match_aws_resource_types = ["ec2"]
-  match_aws_tags = {
-    origin = ["example"]
-  }
+
+  # Configure matchers to discover EC2 instances and EKS clusters.
+  aws_matchers = [
+    {
+      types   = ["ec2"]
+      # EC2 discovery supports wildcard to find instances in all regions.
+      regions = ["*"]
+      tags = {
+        origin = ["example"]
+      }
+    },
+    {
+      types   = ["eks"]
+      # EKS requires region selection.
+      regions = ["us-east-1"]
+      tags = {
+        team = ["platform"]
+      }
+    }
+  ]
 }
 ```
 
@@ -101,12 +116,13 @@ No modules.
 | aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
+| aws\_matchers | AWS resource discovery matchers. | ```list(object({ types = list(string) regions = list(string) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") }))``` | `null` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
 | discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |
-| match\_aws\_regions | AWS regions to discover. The default matches all AWS regions. | `list(string)` | ```[ "*" ]``` | no |
-| match\_aws\_resource\_types | AWS resource types to match when discovering resources with Teleport. Valid values are: `ec2`. | `list(string)` | n/a | yes |
-| match\_aws\_tags | AWS resource tags to match when discovering resources with Teleport. The default matches all discovered AWS resources. | `map(list(string))` | ```{ "*": [ "*" ] }``` | no |
+| match\_aws\_regions | Deprecated legacy input. Use aws\_matchers instead. AWS regions to discover. The default matches all AWS regions. | `list(string)` | `null` | no |
+| match\_aws\_resource\_types | Deprecated legacy input. Use aws\_matchers instead. AWS resource types to match when discovering resources with Teleport. | `list(string)` | `null` | no |
+| match\_aws\_tags | Deprecated legacy input. Use aws\_matchers instead. AWS resource tags to match when discovering resources with Teleport. The default matches all discovered AWS resources. | `map(list(string))` | `null` | no |
 | teleport\_discovery\_config\_name | Name for the `teleport_discovery_config` resource. | `string` | `"discovery"` | no |
 | teleport\_discovery\_config\_use\_name\_prefix | Determines whether the name of the Teleport discovery config (`teleport_discovery_config_name`) is used as a prefix. | `bool` | `true` | no |
 | teleport\_discovery\_group\_name | Teleport discovery group to use. For discovery configuration to apply, this name must match at least one Teleport Discovery Service instance's configured `discovery_group`. For Teleport Cloud clusters, use "cloud-discovery-group". | `string` | n/a | yes |

--- a/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
@@ -13,23 +13,46 @@ locals {
     ? null
     : var.aws_iam_policy_name
   )
-}
 
-data "aws_iam_policy_document" "teleport_discovery_service_single_account" {
-  count = local.create ? 1 : 0
+  uses_ec2 = contains(local.aws_matcher_types, "ec2")
+  uses_eks = contains(local.aws_matcher_types, "eks")
 
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "account:ListRegions",
+  ec2_actions = concat(
+    contains(local.aws_matcher_regions, "*") ? ["account:ListRegions"] : [],
+    [
       "ec2:DescribeInstances",
       "ssm:DescribeInstanceInformation",
       "ssm:GetCommandInvocation",
       "ssm:ListCommandInvocations",
       "ssm:SendCommand",
     ]
+  )
 
+  # TODO(charles): add account:ListRegions when EKS supports wildcard region
+  eks_actions = [
+    "eks:ListClusters",
+    "eks:DescribeCluster",
+    "eks:ListAccessEntries",
+    "eks:DescribeAccessEntry",
+    "eks:CreateAccessEntry",
+    "eks:DeleteAccessEntry",
+    "eks:AssociateAccessPolicy",
+    "eks:TagResource",
+    "eks:UpdateAccessEntry",
+  ]
+
+  policy_actions = concat(
+    local.uses_ec2 ? local.ec2_actions : [],
+    local.uses_eks ? local.eks_actions : [],
+  )
+}
+
+data "aws_iam_policy_document" "teleport_discovery_service_single_account" {
+  count = local.create ? 1 : 0
+
+  statement {
+    effect    = "Allow"
+    actions   = local.policy_actions
     resources = ["*"]
   }
 }

--- a/integrations/terraform-modules/teleport/discovery/aws/aws_iam_role.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/aws_iam_role.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "teleport_discovery_service_iam_role_trust" {
 
       condition {
         test     = "StringEquals"
-        variable = "${local.teleport_cluster_name}:aud"
+        variable = "${local.aws_iam_oidc_provider_name}:aud"
         values   = [local.aws_iam_oidc_provider_aud]
       }
     }
@@ -52,13 +52,17 @@ data "aws_iam_policy_document" "teleport_discovery_service_iam_role_trust" {
 
       principals {
         type        = "AWS"
-        identifiers = trust.value.role_arn
+        identifiers = [trust.value.role_arn]
       }
 
-      condition {
-        test     = "StringEquals"
-        variable = "sts:ExternalId"
-        values   = [trust.value.external_id]
+      dynamic "condition" {
+        for_each = trust.value.external_id != "" ? [trust.value.external_id] : []
+
+        content {
+          test     = "StringEquals"
+          variable = "sts:ExternalId"
+          values   = [condition.value]
+        }
       }
     }
   }

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy/README.md
@@ -1,0 +1,44 @@
+## Teleport AWS Account Discovery Example
+
+Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover resources in a single AWS account.
+
+In addition, the example uses a custom AWS IAM policy to narrow the scope of permissions for Teleport Discovery Service instances.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0 |
+| aws | >= 5.0 |
+| teleport | >= 18.5.1 |
+| tls | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 5.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| aws\_discovery | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy_document.teleport_discovery_service_single_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| aws\_discovery | n/a |
+<!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy/main.tf
@@ -1,0 +1,65 @@
+module "aws_discovery" {
+  source = "../.."
+
+  teleport_proxy_public_addr    = "example.teleport.sh:443"
+  teleport_discovery_group_name = "cloud-discovery-group"
+
+  # Discover EC2 AWS resources 
+  match_aws_resource_types = ["ec2"]
+  # Apply the additional AWS tag "origin=example" to all AWS resources created by this module
+  apply_aws_tags = { origin = "example" }
+  # Apply the additional Teleport label "origin=example" to all Teleport resources created by this module
+  apply_teleport_resource_labels = { origin = "example" }
+
+  # Examples of existing AWS resource reuse:
+  # AWS IAM OIDC provider for this Teleport cluster's public proxy address must already exist
+  create_aws_iam_openid_connect_provider = false
+
+  # Use a custom IAM policy with permission conditions
+  aws_iam_policy_document = data.aws_iam_policy_document.teleport_discovery_service_single_account.json
+}
+
+data "aws_iam_policy_document" "teleport_discovery_service_single_account" {
+  # read-only discovery
+  statement {
+    effect = "Allow"
+    actions = [
+      "account:ListRegions",
+      "ec2:DescribeInstances",
+      "ssm:DescribeInstanceInformation",
+      "ssm:GetCommandInvocation",
+      "ssm:ListCommandInvocations",
+    ]
+    resources = ["*"]
+  }
+
+  # SSM command execution document access
+  # (Allows using any document, or restrict to specific documents here)
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:SendCommand",
+    ]
+    resources = [
+      "arn:aws:ssm:*:*:document/AWS-RunShellScript"
+    ]
+  }
+
+  # SSM command execution instance access
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:SendCommand",
+    ]
+    resources = [
+      "arn:aws:ec2:*:*:instance/*"
+    ]
+
+    # restrict command execution on instances based on resource tags
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/TeleportManaged"
+      values   = ["true"]
+    }
+  }
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy/outputs.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy/outputs.tf
@@ -1,0 +1,3 @@
+output "aws_discovery" {
+  value = module.aws_discovery
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy/versions.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account-legacy/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
+    teleport = {
+      source  = "terraform.releases.teleport.dev/gravitational/teleport"
+      version = ">= 18.5.1"
+    }
+  }
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/README.md
@@ -1,8 +1,6 @@
 ## Teleport AWS Account Discovery Example
 
-Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover resources in a single AWS account.
-
-In addition, the example uses a custom AWS IAM policy to narrow the scope of permissions for Teleport Discovery Service instances.
+Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover EC2 and EKS resources in a single AWS account.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -16,9 +14,7 @@ In addition, the example uses a custom AWS IAM policy to narrow the scope of per
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| aws | >= 5.0 |
+No providers.
 
 ## Modules
 
@@ -28,9 +24,7 @@ In addition, the example uses a custom AWS IAM policy to narrow the scope of per
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_iam_policy_document.teleport_discovery_service_single_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+No resources.
 
 ## Inputs
 

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/main.tf
@@ -4,62 +4,28 @@ module "aws_discovery" {
   teleport_proxy_public_addr    = "example.teleport.sh:443"
   teleport_discovery_group_name = "cloud-discovery-group"
 
-  # Discover EC2 AWS resources 
-  match_aws_resource_types = ["ec2"]
-  # Apply the additional AWS tag "origin=example" to all AWS resources created by this module
-  apply_aws_tags = { origin = "example" }
+  # Discover EC2 instances and EKS clusters with separate matching rules
+  aws_matchers = [
+    {
+      types = ["ec2"]
+      # EC2 discovery supports a wildcard to find instances in all regions.
+      regions = ["*"]
+      tags = {
+        env = ["prod"]
+      }
+    },
+    {
+      types = ["eks"]
+      # EKS requires region selection.
+      regions = ["us-east-1"]
+      tags = {
+        team = ["platform"]
+      }
+    }
+  ]
+
   # Apply the additional Teleport label "origin=example" to all Teleport resources created by this module
   apply_teleport_resource_labels = { origin = "example" }
-
-  # Examples of existing AWS resource reuse:
-  # AWS IAM OIDC provider for this Teleport cluster's public proxy address must already exist
-  create_aws_iam_openid_connect_provider = false
-
-  # Use a custom IAM policy with permission conditions
-  aws_iam_policy_document = data.aws_iam_policy_document.teleport_discovery_service_single_account.json
-}
-
-data "aws_iam_policy_document" "teleport_discovery_service_single_account" {
-  # read-only discovery
-  statement {
-    effect = "Allow"
-    actions = [
-      "account:ListRegions",
-      "ec2:DescribeInstances",
-      "ssm:DescribeInstanceInformation",
-      "ssm:GetCommandInvocation",
-      "ssm:ListCommandInvocations",
-    ]
-    resources = ["*"]
-  }
-
-  # SSM command execution document access
-  # (Allows using any document, or restrict to specific documents here)
-  statement {
-    effect = "Allow"
-    actions = [
-      "ssm:SendCommand",
-    ]
-    resources = [
-      "arn:aws:ssm:*:*:document/AWS-RunShellScript"
-    ]
-  }
-
-  # SSM command execution instance access
-  statement {
-    effect = "Allow"
-    actions = [
-      "ssm:SendCommand",
-    ]
-    resources = [
-      "arn:aws:ec2:*:*:instance/*"
-    ]
-
-    # restrict command execution on instances based on resource tags
-    condition {
-      test     = "StringEquals"
-      variable = "aws:ResourceTag/TeleportManaged"
-      values   = ["true"]
-    }
-  }
+  # Apply the additional AWS tag "origin=example" to all AWS resources created by this module
+  apply_aws_tags = { origin = "example" }
 }

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
@@ -12,10 +12,98 @@ locals {
     role_arn    = var.discovery_service_iam_credential_source.trust_role.role_arn,
     external_id = var.discovery_service_iam_credential_source.trust_role.external_id,
   }, null)
+
+  legacy_aws_matchers = var.match_aws_resource_types == null ? [] : [
+    {
+      types                = var.match_aws_resource_types
+      regions              = coalesce(var.match_aws_regions, ["*"])
+      tags                 = coalesce(var.match_aws_tags, { "*" : ["*"] })
+      setup_access_for_arn = ""
+    }
+  ]
+
+  effective_aws_matchers = (
+    var.aws_matchers != null && length(var.aws_matchers) > 0
+    ? var.aws_matchers
+    : local.legacy_aws_matchers
+  )
+
+  aws_matchers = [
+    for matcher in local.effective_aws_matchers : merge(
+      {
+        types       = matcher.types
+        regions     = matcher.regions
+        tags        = try(matcher.tags, { "*" : ["*"] })
+        assume_role = local.trust_role
+        integration = (
+          local.use_oidc_integration
+          ? try(teleport_integration.aws_oidc[0].metadata.name, local.teleport_integration_name)
+          : ""
+        )
+      },
+      contains(matcher.types, "ec2") ? {
+        install = {
+          enroll_mode      = 1 # INSTALL_PARAM_ENROLL_MODE_SCRIPT
+          install_teleport = true
+          join_method      = "iam"
+          join_token       = local.teleport_provision_token_name
+          script_name      = "default-installer"
+          sshd_config      = "/etc/ssh/sshd_config"
+        }
+        ssm = {
+          document_name = "AWS-RunShellScript"
+        }
+      } : {},
+      contains(matcher.types, "eks") && matcher.setup_access_for_arn != "" ? {
+        setup_access_for_arn = matcher.setup_access_for_arn
+      } : {}
+    )
+  ]
+
+  aws_matcher_types = distinct(flatten([
+    for matcher in local.aws_matchers : matcher.types
+  ]))
+  aws_matcher_regions = distinct(flatten([
+    for matcher in local.aws_matchers : matcher.regions
+  ]))
 }
 
 resource "teleport_discovery_config" "aws" {
   count = local.create ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition = (
+        (var.aws_matchers != null && length(var.aws_matchers) > 0) ||
+        (var.match_aws_resource_types != null && length(var.match_aws_resource_types) > 0)
+      )
+      error_message = "aws_matchers must be set to discover your resources."
+    }
+    precondition {
+      condition = !(
+        var.aws_matchers != null &&
+        length(var.aws_matchers) > 0 &&
+        var.match_aws_resource_types != null &&
+        length(var.match_aws_resource_types) > 0
+      )
+      error_message = "aws_matchers and the legacy match_aws_* variables cannot be used together. Merge the legacy match variables into aws_matchers."
+    }
+    precondition {
+      condition = !(
+        var.match_aws_resource_types != null &&
+        contains(var.match_aws_resource_types, "eks") &&
+        (var.match_aws_regions == null || contains(var.match_aws_regions, "*"))
+      )
+      error_message = "EKS discovery does not support wildcard regions. Set match_aws_regions to explicit regions when discovering EKS, or use aws_matchers instead."
+    }
+    precondition {
+      condition = !anytrue([
+        for matcher in local.effective_aws_matchers :
+        matcher.setup_access_for_arn != "" && var.discovery_service_iam_credential_source.use_oidc_integration
+      ])
+      error_message = "setup_access_for_arn requires discovery_service_iam_credential_source.use_oidc_integration to be false. OIDC integration bypasses EKS access entry setup."
+    }
+  }
 
   header = {
     version = "v1"
@@ -28,27 +116,6 @@ resource "teleport_discovery_config" "aws" {
 
   spec = {
     discovery_group = var.teleport_discovery_group_name
-    aws = [{
-      assume_role = local.trust_role
-      install = {
-        enroll_mode      = 1 # INSTALL_PARAM_ENROLL_MODE_SCRIPT
-        install_teleport = true
-        join_method      = "iam"
-        join_token       = local.teleport_provision_token_name
-        script_name      = "default-installer"
-        sshd_config      = "/etc/ssh/sshd_config"
-      }
-      integration = (
-        local.use_oidc_integration
-        ? try(teleport_integration.aws_oidc[0].metadata.name, local.teleport_integration_name)
-        : ""
-      )
-      regions = var.match_aws_regions
-      ssm = {
-        document_name = "AWS-RunShellScript"
-      }
-      tags  = var.match_aws_tags
-      types = var.match_aws_resource_types
-    }]
+    aws             = local.aws_matchers
   }
 }

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_integration.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_integration.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 resource "teleport_integration" "aws_oidc" {
-  count = local.create ? 1 : 0
+  count = local.create && local.use_oidc_integration ? 1 : 0
 
   metadata = {
     name        = local.teleport_integration_name

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_provision_token.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_provision_token.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 resource "teleport_provision_token" "aws_iam" {
-  count = local.create ? 1 : 0
+  count = local.create && local.uses_ec2 ? 1 : 0
 
   metadata = {
     name        = local.teleport_provision_token_name

--- a/integrations/terraform-modules/teleport/discovery/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/variables.tf
@@ -25,34 +25,66 @@ variable "teleport_discovery_group_name" {
 }
 
 variable "match_aws_resource_types" {
-  description = "AWS resource types to match when discovering resources with Teleport. Valid values are: `ec2`."
+  description = "Deprecated legacy input. Use aws_matchers instead. AWS resource types to match when discovering resources with Teleport."
   type        = list(string)
-  nullable    = false
+  default     = null
+  nullable    = true
 
   validation {
-    condition = alltrue([
+    condition = var.match_aws_resource_types == null || alltrue([
       for rt in var.match_aws_resource_types :
       contains([
-        # TODO(gavin): add module support for all resource types
-        # "docdb",
         "ec2",
-        # "eks",
-        # "elasticache-serverless",
-        # "elasticache",
-        # "memorydb",
-        # "opensearch",
-        # "rds",
-        # "rdsproxy",
-        # "redshift-serverless",
-        # "redshift"
+        "eks",
       ], rt)
     ])
-    error_message = format(
-      "Allowed values for match_aws_resource_types are: %s.",
-      join(", ", [
-        "ec2",
-      ])
-    )
+    error_message = "Allowed values for match_aws_resource_types are: ec2, eks."
+  }
+}
+
+variable "aws_matchers" {
+  description = "AWS resource discovery matchers."
+  type = list(object({
+    types                = list(string)
+    regions              = list(string)
+    tags                 = optional(map(list(string)), { "*" : ["*"] })
+    setup_access_for_arn = optional(string, "")
+  }))
+  default  = null
+  nullable = true
+
+  validation {
+    condition = var.aws_matchers == null || alltrue([
+      for matcher in var.aws_matchers :
+      length(matcher.types) > 0 && length(matcher.regions) > 0
+    ])
+    error_message = "Each aws_matcher must have types and regions set."
+  }
+
+  validation {
+    condition = var.aws_matchers == null || alltrue(flatten([
+      for matcher in var.aws_matchers : [
+        for rt in matcher.types :
+        contains(["ec2", "eks"], rt)
+      ]
+    ]))
+    error_message = "Allowed values for aws_matchers.types are: ec2, eks."
+  }
+
+  validation {
+    condition = var.aws_matchers == null || !anytrue([
+      for matcher in var.aws_matchers :
+      contains(matcher.types, "eks") && contains(matcher.regions, "*")
+    ])
+    error_message = "EKS discovery does not support wildcard regions. Specify explicit regions for EKS matchers."
+  }
+
+  validation {
+    condition = var.aws_matchers == null || !anytrue([
+      for matcher in var.aws_matchers :
+      matcher.setup_access_for_arn != "" && !contains(matcher.types, "eks")
+    ])
+    error_message = "setup_access_for_arn is only supported for EKS matchers."
   }
 }
 
@@ -96,17 +128,17 @@ variable "aws_iam_policy_document" {
 }
 
 variable "match_aws_regions" {
-  description = "AWS regions to discover. The default matches all AWS regions."
+  description = "Deprecated legacy input. Use aws_matchers instead. AWS regions to discover. The default matches all AWS regions."
   type        = list(string)
-  default     = ["*"]
-  nullable    = false
+  default     = null
+  nullable    = true
 }
 
 variable "match_aws_tags" {
-  description = "AWS resource tags to match when discovering resources with Teleport. The default matches all discovered AWS resources."
+  description = "Deprecated legacy input. Use aws_matchers instead. AWS resource tags to match when discovering resources with Teleport. The default matches all discovered AWS resources."
   type        = map(list(string))
-  default     = { "*" : ["*"] }
-  nullable    = false
+  default     = null
+  nullable    = true
 }
 
 variable "aws_iam_policy_name" {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1631,13 +1631,18 @@ func applyDiscoveryConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			}
 		}
 
+		var ssm *types.AWSSSM
+		if matcher.SSM.DocumentName != "" {
+			ssm = &types.AWSSSM{DocumentName: matcher.SSM.DocumentName}
+		}
+
 		serviceMatcher := types.AWSMatcher{
 			Types:             matcher.Types,
 			Regions:           matcher.Regions,
 			AssumeRole:        assumeRole,
 			Tags:              matcher.Tags,
 			Params:            installParams,
-			SSM:               &types.AWSSSM{DocumentName: matcher.SSM.DocumentName},
+			SSM:               ssm,
 			Integration:       matcher.Integration,
 			KubeAppDiscovery:  matcher.KubeAppDiscovery,
 			SetupAccessForARN: matcher.SetupAccessForARN,

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -5089,15 +5089,6 @@ func TestDiscoveryConfig(t *testing.T) {
 				Tags: map[string]apiutils.Strings{
 					"discover_teleport": []string{"yes"},
 				},
-				Params: &types.InstallerParams{
-					JoinMethod:      types.JoinMethodIAM,
-					JoinToken:       "aws-discovery-iam-token",
-					SSHDConfig:      "/etc/ssh/sshd_config",
-					ScriptName:      "default-installer",
-					InstallTeleport: true,
-					EnrollMode:      types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
-				},
-				SSM: &types.AWSSSM{DocumentName: "TeleportDiscoveryInstaller"},
 				AssumeRole: &types.AssumeRole{
 					RoleARN:    "",
 					ExternalID: "externalid123",


### PR DESCRIPTION
Adds support for EKS matchers in the discovery aws terraform module.

I did some refactoring around allowing more than a single EC2 matcher.
* deprecated the singular `match_aws_*` variables.
* added `aws_matchers` variable to allow defining multiple matchers.
* switched the existing example to "legacy" and added a new example for multiple matchers.
* made IAM permissions conditional on the types of matchers.

The singular matcher is a nice simple path when a user only wants EC2, but may not work well with multiple resource types. I'm assuming users are commonly going to have different conditions for the different types. I also want the terraform options to more closely match the discovery_config options when using the cli/api. 


Changelog: Adds EKS support when using AWS discovery with Terraform.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Cloud staging environment with a local 19.0.0-prealpha.2 build deployed.
EC2 instance that can be discovered.
EKS cluster that can be discovered.
### Test Cases
- [x] Test module with EC2 legacy matchers
- [x] Test module with EKS matcher
- [x] Test module with EKS + EC2 matchers
- [x] Discovery works with EKS + EC2 matchers.
- [x] Upgrade from 18.7.3 (legacy integration) => 18.7.4-dev.disceks.3 (end-to-end dev build). 
