### PR TITLE
Fix URL path segments not decoded for handleGetUserOrResetToken endpoint

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1366,7 +1366,7 @@ func (h *Handler) handleGetUserOrResetToken(w http.ResponseWriter, r *http.Reque
 	if len(pathFields) == 1 {
 		params = httprouter.Params{httprouter.Param{
 			Key:   "username",
-			Value: pathFields[0],
+			Value: decodeURLPathParamField(pathFields[0]),
 		}}
 
 		handleFunc = h.WithAuth(h.getUserHandle)
@@ -1376,13 +1376,25 @@ func (h *Handler) handleGetUserOrResetToken(w http.ResponseWriter, r *http.Reque
 	if len(pathFields) == 3 && pathFields[0] == "password" && pathFields[1] == "token" && pathFields[2] != "" {
 		params = httprouter.Params{httprouter.Param{
 			Key:   "token",
-			Value: pathFields[2],
+			Value: decodeURLPathParamField(pathFields[2]),
 		}}
 
 		handleFunc = httplib.MakeHandler(h.getResetPasswordTokenHandle)
 	}
 
 	handleFunc(w, r, params)
+}
+
+// decodeURLPathParamField URL-decodes a manually extracted path segment.
+// Use this when path params are set manually, since httprouter.Params.ByName()
+// only auto-decodes params captured by the router itself.
+func decodeURLPathParamField(value string) string {
+	decoded, err := url.PathUnescape(value)
+	if err != nil {
+		decoded = value
+	}
+
+	return decoded
 }
 
 // getUserContext returns user context

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1364,9 +1364,14 @@ func (h *Handler) handleGetUserOrResetToken(w http.ResponseWriter, r *http.Reque
 
 	// having one means we have an username
 	if len(pathFields) == 1 {
+		username, err := decodeURLPathParamField(pathFields[0])
+		if err != nil {
+			trace.WriteError(w, err)
+			return
+		}
 		params = httprouter.Params{httprouter.Param{
 			Key:   "username",
-			Value: decodeURLPathParamField(pathFields[0]),
+			Value: username,
 		}}
 
 		handleFunc = h.WithAuth(h.getUserHandle)
@@ -1374,9 +1379,14 @@ func (h *Handler) handleGetUserOrResetToken(w http.ResponseWriter, r *http.Reque
 
 	// if we have exactly 3 and they look like /password/token/:token
 	if len(pathFields) == 3 && pathFields[0] == "password" && pathFields[1] == "token" && pathFields[2] != "" {
+		token, err := decodeURLPathParamField(pathFields[2])
+		if err != nil {
+			trace.WriteError(w, err)
+			return
+		}
 		params = httprouter.Params{httprouter.Param{
 			Key:   "token",
-			Value: decodeURLPathParamField(pathFields[2]),
+			Value: token,
 		}}
 
 		handleFunc = httplib.MakeHandler(h.getResetPasswordTokenHandle)
@@ -1388,13 +1398,13 @@ func (h *Handler) handleGetUserOrResetToken(w http.ResponseWriter, r *http.Reque
 // decodeURLPathParamField URL-decodes a manually extracted path segment.
 // Use this when path params are set manually, since httprouter.Params.ByName()
 // only auto-decodes params captured by the router itself.
-func decodeURLPathParamField(value string) string {
+func decodeURLPathParamField(value string) (string, error) {
 	decoded, err := url.PathUnescape(value)
 	if err != nil {
-		decoded = value
+		return "", trace.BadParameter("failed to decode URL path segment: %v", err)
 	}
 
-	return decoded
+	return decoded, nil
 }
 
 // getUserContext returns user context

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -6651,10 +6651,45 @@ func TestDesktopActive(t *testing.T) {
 	check("\"active\":true")
 }
 
+func TestDecodeURLPathParamField(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "string with special characters encoded",
+			input:    "foo-bar.baz_qux%2B10%40testing.com",
+			expected: "foo-bar.baz_qux+10@testing.com",
+		},
+		{
+			name:     "string with special characters NOT encoded",
+			input:    "foo-bar.baz_qux+10@testing.com",
+			expected: "foo-bar.baz_qux+10@testing.com",
+		},
+		{
+			name:     "string with special characters double encoded",
+			input:    "foo-bar.baz_qux%252B10%2540testing.com",
+			expected: "foo-bar.baz_qux%2B10%40testing.com",
+		},
+		{
+			name:     "plain string",
+			input:    "llama",
+			expected: "llama",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, decodeURLPathParamField(tt.input))
+		})
+	}
+}
+
 func TestGetUserOrResetToken(t *testing.T) {
 	env := newWebPack(t, 1)
 	ctx := context.Background()
-	username := "someuser"
+	username := "foo-bar.baz_qux+10@testing.com"
 
 	// Create a username.
 	teleUser, err := types.NewUser(username)
@@ -6681,7 +6716,8 @@ func TestGetUserOrResetToken(t *testing.T) {
 	_, err = env.server.Auth().UpsertRole(ctx, fooRole)
 	require.NoError(t, err)
 
-	resp, err := pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "users", username), url.Values{})
+	encodedUsername := "foo-bar.baz_qux%2B10%40testing.com"
+	resp, err := pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "users", encodedUsername), url.Values{})
 	require.NoError(t, err)
 	require.Contains(t, string(resp.Bytes()), "login1")
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -6653,35 +6653,48 @@ func TestDesktopActive(t *testing.T) {
 
 func TestDecodeURLPathParamField(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name        string
+		input       string
+		expected    string
+		assertError require.ErrorAssertionFunc
 	}{
 		{
-			name:     "string with special characters encoded",
-			input:    "foo-bar.baz_qux%2B10%40testing.com",
-			expected: "foo-bar.baz_qux+10@testing.com",
+			name:        "string with special characters encoded",
+			input:       "foo-bar.baz_qux%2B10%40testing.com",
+			expected:    "foo-bar.baz_qux+10@testing.com",
+			assertError: require.NoError,
 		},
 		{
-			name:     "string with special characters NOT encoded",
-			input:    "foo-bar.baz_qux+10@testing.com",
-			expected: "foo-bar.baz_qux+10@testing.com",
+			name:        "string with special characters NOT encoded",
+			input:       "foo-bar.baz_qux+10@testing.com",
+			expected:    "foo-bar.baz_qux+10@testing.com",
+			assertError: require.NoError,
 		},
 		{
-			name:     "string with special characters double encoded",
-			input:    "foo-bar.baz_qux%252B10%2540testing.com",
-			expected: "foo-bar.baz_qux%2B10%40testing.com",
+			name:        "string with special characters double encoded",
+			input:       "foo-bar.baz_qux%252B10%2540testing.com",
+			expected:    "foo-bar.baz_qux%2B10%40testing.com",
+			assertError: require.NoError,
 		},
 		{
-			name:     "plain string",
-			input:    "llama",
-			expected: "llama",
+			name:        "plain string",
+			input:       "llama",
+			expected:    "llama",
+			assertError: require.NoError,
+		},
+		{
+			name:        "invalid percent encoding",
+			input:       "bad%2Zvalue",
+			expected:    "",
+			assertError: require.Error,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, decodeURLPathParamField(tt.input))
+			got, err := decodeURLPathParamField(tt.input)
+			tt.assertError(t, err)
+			require.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
+++ b/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
@@ -218,11 +218,11 @@ export const InfoGuide = ({ isGitHub = false }) => (
         isGitHub
           ? {
               title: 'Configure GitHub connector',
-              href: 'https://goteleport.com/docs/admin-guides/access-controls/sso/github-sso/',
+              href: 'https://goteleport.com/docs/zero-trust-access/sso/integrate-idp/github-sso/',
             }
           : {
               title: 'Samples of different connectors',
-              href: 'https://goteleport.com/docs/admin-guides/access-controls/sso/',
+              href: 'https://goteleport.com/docs/zero-trust-access/sso/integrate-idp/#integrating-your-provider',
             },
       ]}
     />

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/SetupAccess/SetupAccess.story.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/SetupAccess/SetupAccess.story.tsx
@@ -18,7 +18,6 @@
 
 import { http, HttpResponse } from 'msw';
 import React from 'react';
-import { MemoryRouter } from 'react-router';
 
 import { AwsRole } from 'shared/services/apps';
 
@@ -69,11 +68,9 @@ const defaultUserGet = http.get(cfg.api.userWithUsernamePath, () =>
 );
 
 export const NoTraits = () => (
-  <MemoryRouter>
     <Provider awsRoles={[]}>
       <SetupAccess />
     </Provider>
-  </MemoryRouter>
 );
 NoTraits.parameters = {
   msw: {
@@ -82,11 +79,9 @@ NoTraits.parameters = {
 };
 
 export const WithTraits = () => (
-  <MemoryRouter>
     <Provider awsRoles={awsRoles}>
       <SetupAccess />
     </Provider>
-  </MemoryRouter>
 );
 WithTraits.parameters = {
   msw: {
@@ -108,11 +103,9 @@ WithTraits.parameters = {
 };
 
 export const NoAccess = () => (
-  <MemoryRouter>
     <Provider awsRoles={awsRoles} noAccess={true}>
       <SetupAccess />
     </Provider>
-  </MemoryRouter>
 );
 NoAccess.parameters = {
   msw: {
@@ -121,11 +114,9 @@ NoAccess.parameters = {
 };
 
 export const SsoUser = () => (
-  <MemoryRouter>
     <Provider awsRoles={awsRoles} isSso={true}>
       <SetupAccess />
     </Provider>
-  </MemoryRouter>
 );
 SsoUser.parameters = {
   msw: {

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/SetupAccess/SetupAccess.story.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/SetupAccess/SetupAccess.story.tsx
@@ -68,9 +68,9 @@ const defaultUserGet = http.get(cfg.api.userWithUsernamePath, () =>
 );
 
 export const NoTraits = () => (
-    <Provider awsRoles={[]}>
-      <SetupAccess />
-    </Provider>
+  <Provider awsRoles={[]}>
+    <SetupAccess />
+  </Provider>
 );
 NoTraits.parameters = {
   msw: {
@@ -79,9 +79,9 @@ NoTraits.parameters = {
 };
 
 export const WithTraits = () => (
-    <Provider awsRoles={awsRoles}>
-      <SetupAccess />
-    </Provider>
+  <Provider awsRoles={awsRoles}>
+    <SetupAccess />
+  </Provider>
 );
 WithTraits.parameters = {
   msw: {
@@ -103,9 +103,9 @@ WithTraits.parameters = {
 };
 
 export const NoAccess = () => (
-    <Provider awsRoles={awsRoles} noAccess={true}>
-      <SetupAccess />
-    </Provider>
+  <Provider awsRoles={awsRoles} noAccess={true}>
+    <SetupAccess />
+  </Provider>
 );
 NoAccess.parameters = {
   msw: {
@@ -114,9 +114,9 @@ NoAccess.parameters = {
 };
 
 export const SsoUser = () => (
-    <Provider awsRoles={awsRoles} isSso={true}>
-      <SetupAccess />
-    </Provider>
+  <Provider awsRoles={awsRoles} isSso={true}>
+    <SetupAccess />
+  </Provider>
 );
 SsoUser.parameters = {
   msw: {

--- a/web/packages/teleport/src/Users/Users.tsx
+++ b/web/packages/teleport/src/Users/Users.tsx
@@ -285,6 +285,7 @@ export function Users(props: State) {
           </ExternalLink>{' '}
           and{' '}
           <ExternalLink
+            target="_blank"
             href="https://goteleport.com/docs/reference/user-types/"
             className="external-link"
           >

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -1207,7 +1207,7 @@ const cfg = {
   // This is a temporary patch that does not encode segments (same behavior pre-React Router v7)
   // to provide backwards compatibility.
   getUserWithUsernameTemporaryPatchedUrl(username: string) {
-     return cfg.api.userWithUsernamePath.replace(':username', username)
+    return cfg.api.userWithUsernamePath.replace(':username', username);
   },
 
   getActiveAndPendingSessionsUrl({ clusterId }: UrlParams) {

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -1200,7 +1200,7 @@ const cfg = {
   },
 
   // TODO(kimlisa): DELETE IN v21 and replace with getUserWithUsernameUrl.
-  // React Router v7 auto encodes dynamic segments in path (v6 version did not).
+  // React Router v7 auto encodes dynamic segments in path (v5 version did not).
   // The upgrade surfaced a backend bug where path params were not getting auto decoded which
   // is the default behavior of go's httprouter.Params.ByName() b/c path params for this
   // particular endpoint are being manually set.

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -1199,6 +1199,17 @@ const cfg = {
     return generatePath(cfg.api.userWithUsernamePath, { username });
   },
 
+  // TODO(kimlisa): DELETE IN v21 and replace with getUserWithUsernameUrl.
+  // React Router v7 auto encodes dynamic segments in path (v6 version did not).
+  // The upgrade surfaced a backend bug where path params were not getting auto decoded which
+  // is the default behavior of go's httprouter.Params.ByName() b/c path params for this
+  // particular endpoint are being manually set.
+  // This is a temporary patch that does not encode segments (same behavior pre-React Router v7)
+  // to provide backwards compatibility.
+  getUserWithUsernameTemporaryPatchedUrl(username: string) {
+     return cfg.api.userWithUsernamePath.replace(':username', username)
+  },
+
   getActiveAndPendingSessionsUrl({ clusterId }: UrlParams) {
     return generatePath(cfg.api.activeAndPendingSessionsPath, { clusterId });
   },

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -61,7 +61,9 @@ const service = {
   },
 
   fetchUser(username: string) {
-    return api.get(cfg.getUserWithUsernameTemporaryPatchedUrl(username)).then(makeUser);
+    return api
+      .get(cfg.getUserWithUsernameTemporaryPatchedUrl(username))
+      .then(makeUser);
   },
 
   // TODO(rudream): DELETE IN v21.0

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -61,7 +61,7 @@ const service = {
   },
 
   fetchUser(username: string) {
-    return api.get(cfg.getUserWithUsernameUrl(username)).then(makeUser);
+    return api.get(cfg.getUserWithUsernameTemporaryPatchedUrl(username)).then(makeUser);
   },
 
   // TODO(rudream): DELETE IN v21.0


### PR DESCRIPTION
Fixes a bug when fetching a user by their name fails with `user "lisa%40goteleport.com" not found`.

This is because of the react router v7 upgrade where dynamic path segments now get auto encoded which surfaced a backend bug that didn't decode this segment. Normally go's `httprouter.Params.ByName()` auto decodes, but because this particular [endpoint](https://github.com/gravitational/teleport/blob/863a154e75d3bd8e2d4459e13d069c8fcf366fee/lib/web/apiserver.go#L869) manually sets the params, the auto decode didn't get applied.

This PR now adds decoding path segments for that endpoint, and it also adds a temporary patch that removes auto encoding in the frontend before request goes to the backend (how it was pre router upgrade). This is to provide backwards compatibility when requests goes to an older proxy that does not have the decoding fix.

I didn't add any backwards compat patches for the GET token path since we use CryptoRandomHex to generate token which are just alphanumerics that doesn't need encoding

I also snuck in updating some outdated links.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

local master build

### Test Cases
- [x] test GET user with special characters encoded
- [x] test GET user with special characters unencoded (testing old behavior still works as expected)
- [x] test GET reset token by resetting a user authentication

https://github.com/gravitational/teleport/issues/64627