### PR TITLE
ui: update user types link to open new page

### DIFF
--- a/web/packages/teleport/src/Users/Users.tsx
+++ b/web/packages/teleport/src/Users/Users.tsx
@@ -285,6 +285,7 @@ export function Users(props: State) {
           </ExternalLink>{' '}
           and{' '}
           <ExternalLink
+            target="_blank"
             href="https://goteleport.com/docs/reference/user-types/"
             className="external-link"
           >


### PR DESCRIPTION
Updates so user types link will open a new page. Currently this replaces the current page in the browser navigation.

This matches the `https://goteleport.com/docs/usage-billing/#monthly-active-users` link this will target `_blank` so a new page is opened. 


## Manual Test Plan
### Test Environment

   Developer environment

### Test Cases
- [X] Confirm user types links opens to a new page.
