### PR TITLE
[v18] Fix mouse move when using fixed screen size Windows desktop

### DIFF
--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -325,11 +325,6 @@ export function DesktopSession({
   }
 
   function handleMouseUp(e: React.MouseEvent<HTMLCanvasElement>) {
-    const scaled = scaleEvent(e);
-    if (!scaled.inBounds) {
-      return;
-    }
-
     inputHandler.current.handleInputEvent({
       cli: client,
       e: e.nativeEvent,

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -275,9 +275,23 @@ export function DesktopSession({
 
   function handleMouseMove(e: React.MouseEvent) {
     const rect = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-    client.sendMouseMove(x, y);
+    const canvas = e.currentTarget as HTMLCanvasElement
+
+    const scale = Math.min(1, rect.width / canvas.width, rect.height / canvas.height);
+
+    const renderedWidth = canvas.width * scale;
+    const renderedHeight = canvas.height * scale;
+
+    // calculate offset from center
+    const offsetX = (rect.width - renderedWidth) / 2;
+    const offsetY = (rect.height - renderedHeight) / 2;
+
+    const x = Math.round((e.clientX - rect.left - offsetX) / scale);
+    const y = Math.round((e.clientY - rect.top - offsetY) / scale);
+    
+    if (x >= 0 && y >= 0) {
+      client.sendMouseMove(Math.round(x), Math.round(y));
+    }
   }
 
   function handleMouseDown(e: React.MouseEvent) {

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -273,11 +273,15 @@ export function DesktopSession({
     inputHandler.current.onFocusOut();
   }
 
-  function handleMouseMove(e: React.MouseEvent) {
+  function scaleEvent(e: React.MouseEvent<HTMLCanvasElement>) {
     const rect = e.currentTarget.getBoundingClientRect();
-    const canvas = e.currentTarget as HTMLCanvasElement
+    const canvas = e.currentTarget;
 
-    const scale = Math.min(1, rect.width / canvas.width, rect.height / canvas.height);
+    const scale = Math.min(
+      1,
+      rect.width / canvas.width,
+      rect.height / canvas.height
+    );
 
     const renderedWidth = canvas.width * scale;
     const renderedHeight = canvas.height * scale;
@@ -288,13 +292,26 @@ export function DesktopSession({
 
     const x = Math.round((e.clientX - rect.left - offsetX) / scale);
     const y = Math.round((e.clientY - rect.top - offsetY) / scale);
-    
-    if (x >= 0 && y >= 0) {
-      client.sendMouseMove(Math.round(x), Math.round(y));
+
+    const inBounds = x >= 0 && y >= 0 && x < canvas.width && y < canvas.height;
+
+    return { x, y, inBounds };
+  }
+
+  function handleMouseMove(e: React.MouseEvent<HTMLCanvasElement>) {
+    const scaled = scaleEvent(e);
+
+    if (scaled.inBounds) {
+      client.sendMouseMove(scaled.x, scaled.y);
     }
   }
 
-  function handleMouseDown(e: React.MouseEvent) {
+  function handleMouseDown(e: React.MouseEvent<HTMLCanvasElement>) {
+    const scaled = scaleEvent(e);
+    if (!scaled.inBounds) {
+      return;
+    }
+
     inputHandler.current.handleInputEvent({
       cli: client,
       e: e.nativeEvent,
@@ -307,7 +324,12 @@ export function DesktopSession({
     sendLocalClipboardToRemote();
   }
 
-  function handleMouseUp(e: React.MouseEvent) {
+  function handleMouseUp(e: React.MouseEvent<HTMLCanvasElement>) {
+    const scaled = scaleEvent(e);
+    if (!scaled.inBounds) {
+      return;
+    }
+
     inputHandler.current.handleInputEvent({
       cli: client,
       e: e.nativeEvent,


### PR DESCRIPTION
Backport #64926 to branch/v18

changelog: Fix mouse move when using fixed screen size Windows desktop

## Manual Test Plan

### Test Environment
Local v18 cluster

### Test cases
- [x] Verify that mouse move is correctly registered by the desktop when `screen_size` is used and size is smaller than canvas
- [x] Verify that mouse move is correctly registered by the desktop when `screen_size` is used and size is bigger than canvas
- [x] Verify that mouse move is correctly registered by the desktop when `screen_size` is not used and screen fills the whole canvas
- [x] Verify that everything is still correct after browser resize with both `screen_size` used and ommited
