### PR TITLE
Add `tsh delegation create-session` command

### DIFF
--- a/api/gen/proto/go/teleport/delegation/v1/delegation_session_service.pb.go
+++ b/api/gen/proto/go/teleport/delegation/v1/delegation_session_service.pb.go
@@ -36,6 +36,61 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// CreateDelegationSessionRequest are the parameters to CreateDelegationSession.
+type CreateDelegationSessionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Spec of the delegation session that will be created.
+	Spec *DelegationSessionSpec `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
+	// TTL determines how long the session will last.
+	Ttl           *durationpb.Duration `protobuf:"bytes,2,opt,name=ttl,proto3" json:"ttl,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateDelegationSessionRequest) Reset() {
+	*x = CreateDelegationSessionRequest{}
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateDelegationSessionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateDelegationSessionRequest) ProtoMessage() {}
+
+func (x *CreateDelegationSessionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateDelegationSessionRequest.ProtoReflect.Descriptor instead.
+func (*CreateDelegationSessionRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *CreateDelegationSessionRequest) GetSpec() *DelegationSessionSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+func (x *CreateDelegationSessionRequest) GetTtl() *durationpb.Duration {
+	if x != nil {
+		return x.Ttl
+	}
+	return nil
+}
+
 // GenerateCertsRequest are the parameters to GenerateCerts.
 type GenerateCertsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -59,7 +114,7 @@ type GenerateCertsRequest struct {
 
 func (x *GenerateCertsRequest) Reset() {
 	*x = GenerateCertsRequest{}
-	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[0]
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71,7 +126,7 @@ func (x *GenerateCertsRequest) String() string {
 func (*GenerateCertsRequest) ProtoMessage() {}
 
 func (x *GenerateCertsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[0]
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -84,7 +139,7 @@ func (x *GenerateCertsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateCertsRequest.ProtoReflect.Descriptor instead.
 func (*GenerateCertsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{0}
+	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *GenerateCertsRequest) GetDelegationSessionId() string {
@@ -185,7 +240,7 @@ type RouteToKubernetes struct {
 
 func (x *RouteToKubernetes) Reset() {
 	*x = RouteToKubernetes{}
-	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[1]
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -197,7 +252,7 @@ func (x *RouteToKubernetes) String() string {
 func (*RouteToKubernetes) ProtoMessage() {}
 
 func (x *RouteToKubernetes) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[1]
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -210,7 +265,7 @@ func (x *RouteToKubernetes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteToKubernetes.ProtoReflect.Descriptor instead.
 func (*RouteToKubernetes) Descriptor() ([]byte, []int) {
-	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{1}
+	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *RouteToKubernetes) GetClusterName() string {
@@ -239,7 +294,7 @@ type RouteToDatabase struct {
 
 func (x *RouteToDatabase) Reset() {
 	*x = RouteToDatabase{}
-	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[2]
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -251,7 +306,7 @@ func (x *RouteToDatabase) String() string {
 func (*RouteToDatabase) ProtoMessage() {}
 
 func (x *RouteToDatabase) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[2]
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -264,7 +319,7 @@ func (x *RouteToDatabase) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteToDatabase.ProtoReflect.Descriptor instead.
 func (*RouteToDatabase) Descriptor() ([]byte, []int) {
-	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{2}
+	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *RouteToDatabase) GetServiceName() string {
@@ -327,7 +382,7 @@ type RouteToApp struct {
 
 func (x *RouteToApp) Reset() {
 	*x = RouteToApp{}
-	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[3]
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -339,7 +394,7 @@ func (x *RouteToApp) String() string {
 func (*RouteToApp) ProtoMessage() {}
 
 func (x *RouteToApp) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[3]
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -352,7 +407,7 @@ func (x *RouteToApp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteToApp.ProtoReflect.Descriptor instead.
 func (*RouteToApp) Descriptor() ([]byte, []int) {
-	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{3}
+	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *RouteToApp) GetName() string {
@@ -424,7 +479,7 @@ type GenerateCertsResponse struct {
 
 func (x *GenerateCertsResponse) Reset() {
 	*x = GenerateCertsResponse{}
-	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[4]
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -436,7 +491,7 @@ func (x *GenerateCertsResponse) String() string {
 func (*GenerateCertsResponse) ProtoMessage() {}
 
 func (x *GenerateCertsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[4]
+	mi := &file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -449,7 +504,7 @@ func (x *GenerateCertsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateCertsResponse.ProtoReflect.Descriptor instead.
 func (*GenerateCertsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{4}
+	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *GenerateCertsResponse) GetSsh() []byte {
@@ -470,7 +525,10 @@ var File_teleport_delegation_v1_delegation_session_service_proto protoreflect.Fi
 
 const file_teleport_delegation_v1_delegation_session_service_proto_rawDesc = "" +
 	"\n" +
-	"7teleport/delegation/v1/delegation_session_service.proto\x12\x16teleport.delegation.v1\x1a\x1egoogle/protobuf/duration.proto\"\xca\x03\n" +
+	"7teleport/delegation/v1/delegation_session_service.proto\x12\x16teleport.delegation.v1\x1a\x1egoogle/protobuf/duration.proto\x1a8teleport/delegation/v1/delegation_session_resource.proto\"\x90\x01\n" +
+	"\x1eCreateDelegationSessionRequest\x12A\n" +
+	"\x04spec\x18\x01 \x01(\v2-.teleport.delegation.v1.DelegationSessionSpecR\x04spec\x12+\n" +
+	"\x03ttl\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x03ttl\"\xca\x03\n" +
 	"\x14GenerateCertsRequest\x122\n" +
 	"\x15delegation_session_id\x18\x01 \x01(\tR\x13delegationSessionId\x12$\n" +
 	"\x0essh_public_key\x18\x02 \x01(\fR\fsshPublicKey\x12$\n" +
@@ -504,8 +562,9 @@ const file_teleport_delegation_v1_delegation_session_service_proto_rawDesc = "" 
 	"\x13gcp_service_account\x18\b \x01(\tR\x11gcpServiceAccount\";\n" +
 	"\x15GenerateCertsResponse\x12\x10\n" +
 	"\x03ssh\x18\x01 \x01(\fR\x03ssh\x12\x10\n" +
-	"\x03tls\x18\x02 \x01(\fR\x03tls2\x88\x01\n" +
-	"\x18DelegationSessionService\x12l\n" +
+	"\x03tls\x18\x02 \x01(\fR\x03tls2\x86\x02\n" +
+	"\x18DelegationSessionService\x12|\n" +
+	"\x17CreateDelegationSession\x126.teleport.delegation.v1.CreateDelegationSessionRequest\x1a).teleport.delegation.v1.DelegationSession\x12l\n" +
 	"\rGenerateCerts\x12,.teleport.delegation.v1.GenerateCertsRequest\x1a-.teleport.delegation.v1.GenerateCertsResponseBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1;delegationv1b\x06proto3"
 
 var (
@@ -520,27 +579,34 @@ func file_teleport_delegation_v1_delegation_session_service_proto_rawDescGZIP() 
 	return file_teleport_delegation_v1_delegation_session_service_proto_rawDescData
 }
 
-var file_teleport_delegation_v1_delegation_session_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_teleport_delegation_v1_delegation_session_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_teleport_delegation_v1_delegation_session_service_proto_goTypes = []any{
-	(*GenerateCertsRequest)(nil),  // 0: teleport.delegation.v1.GenerateCertsRequest
-	(*RouteToKubernetes)(nil),     // 1: teleport.delegation.v1.RouteToKubernetes
-	(*RouteToDatabase)(nil),       // 2: teleport.delegation.v1.RouteToDatabase
-	(*RouteToApp)(nil),            // 3: teleport.delegation.v1.RouteToApp
-	(*GenerateCertsResponse)(nil), // 4: teleport.delegation.v1.GenerateCertsResponse
-	(*durationpb.Duration)(nil),   // 5: google.protobuf.Duration
+	(*CreateDelegationSessionRequest)(nil), // 0: teleport.delegation.v1.CreateDelegationSessionRequest
+	(*GenerateCertsRequest)(nil),           // 1: teleport.delegation.v1.GenerateCertsRequest
+	(*RouteToKubernetes)(nil),              // 2: teleport.delegation.v1.RouteToKubernetes
+	(*RouteToDatabase)(nil),                // 3: teleport.delegation.v1.RouteToDatabase
+	(*RouteToApp)(nil),                     // 4: teleport.delegation.v1.RouteToApp
+	(*GenerateCertsResponse)(nil),          // 5: teleport.delegation.v1.GenerateCertsResponse
+	(*DelegationSessionSpec)(nil),          // 6: teleport.delegation.v1.DelegationSessionSpec
+	(*durationpb.Duration)(nil),            // 7: google.protobuf.Duration
+	(*DelegationSession)(nil),              // 8: teleport.delegation.v1.DelegationSession
 }
 var file_teleport_delegation_v1_delegation_session_service_proto_depIdxs = []int32{
-	5, // 0: teleport.delegation.v1.GenerateCertsRequest.ttl:type_name -> google.protobuf.Duration
-	1, // 1: teleport.delegation.v1.GenerateCertsRequest.route_to_kubernetes:type_name -> teleport.delegation.v1.RouteToKubernetes
-	2, // 2: teleport.delegation.v1.GenerateCertsRequest.route_to_database:type_name -> teleport.delegation.v1.RouteToDatabase
-	3, // 3: teleport.delegation.v1.GenerateCertsRequest.route_to_app:type_name -> teleport.delegation.v1.RouteToApp
-	0, // 4: teleport.delegation.v1.DelegationSessionService.GenerateCerts:input_type -> teleport.delegation.v1.GenerateCertsRequest
-	4, // 5: teleport.delegation.v1.DelegationSessionService.GenerateCerts:output_type -> teleport.delegation.v1.GenerateCertsResponse
-	5, // [5:6] is the sub-list for method output_type
-	4, // [4:5] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	6, // 0: teleport.delegation.v1.CreateDelegationSessionRequest.spec:type_name -> teleport.delegation.v1.DelegationSessionSpec
+	7, // 1: teleport.delegation.v1.CreateDelegationSessionRequest.ttl:type_name -> google.protobuf.Duration
+	7, // 2: teleport.delegation.v1.GenerateCertsRequest.ttl:type_name -> google.protobuf.Duration
+	2, // 3: teleport.delegation.v1.GenerateCertsRequest.route_to_kubernetes:type_name -> teleport.delegation.v1.RouteToKubernetes
+	3, // 4: teleport.delegation.v1.GenerateCertsRequest.route_to_database:type_name -> teleport.delegation.v1.RouteToDatabase
+	4, // 5: teleport.delegation.v1.GenerateCertsRequest.route_to_app:type_name -> teleport.delegation.v1.RouteToApp
+	0, // 6: teleport.delegation.v1.DelegationSessionService.CreateDelegationSession:input_type -> teleport.delegation.v1.CreateDelegationSessionRequest
+	1, // 7: teleport.delegation.v1.DelegationSessionService.GenerateCerts:input_type -> teleport.delegation.v1.GenerateCertsRequest
+	8, // 8: teleport.delegation.v1.DelegationSessionService.CreateDelegationSession:output_type -> teleport.delegation.v1.DelegationSession
+	5, // 9: teleport.delegation.v1.DelegationSessionService.GenerateCerts:output_type -> teleport.delegation.v1.GenerateCertsResponse
+	8, // [8:10] is the sub-list for method output_type
+	6, // [6:8] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_teleport_delegation_v1_delegation_session_service_proto_init() }
@@ -548,7 +614,8 @@ func file_teleport_delegation_v1_delegation_session_service_proto_init() {
 	if File_teleport_delegation_v1_delegation_session_service_proto != nil {
 		return
 	}
-	file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[0].OneofWrappers = []any{
+	file_teleport_delegation_v1_delegation_session_resource_proto_init()
+	file_teleport_delegation_v1_delegation_session_service_proto_msgTypes[1].OneofWrappers = []any{
 		(*GenerateCertsRequest_RouteToKubernetes)(nil),
 		(*GenerateCertsRequest_RouteToDatabase)(nil),
 		(*GenerateCertsRequest_RouteToApp)(nil),
@@ -559,7 +626,7 @@ func file_teleport_delegation_v1_delegation_session_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_delegation_v1_delegation_session_service_proto_rawDesc), len(file_teleport_delegation_v1_delegation_session_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/delegation/v1/delegation_session_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/delegation/v1/delegation_session_service_grpc.pb.go
@@ -33,7 +33,8 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	DelegationSessionService_GenerateCerts_FullMethodName = "/teleport.delegation.v1.DelegationSessionService/GenerateCerts"
+	DelegationSessionService_CreateDelegationSession_FullMethodName = "/teleport.delegation.v1.DelegationSessionService/CreateDelegationSession"
+	DelegationSessionService_GenerateCerts_FullMethodName           = "/teleport.delegation.v1.DelegationSessionService/GenerateCerts"
 )
 
 // DelegationSessionServiceClient is the client API for DelegationSessionService service.
@@ -43,6 +44,9 @@ const (
 // DelegationSessionService allows users to delegate a subset of their access to
 // a workload or bot.
 type DelegationSessionServiceClient interface {
+	// CreateDelegationSession creates a delegation session for the authenticated
+	// user.
+	CreateDelegationSession(ctx context.Context, in *CreateDelegationSessionRequest, opts ...grpc.CallOption) (*DelegationSession, error)
 	// GenerateCerts generates TLS and/or SSH certificates, scoped to a delegation
 	// session.
 	GenerateCerts(ctx context.Context, in *GenerateCertsRequest, opts ...grpc.CallOption) (*GenerateCertsResponse, error)
@@ -54,6 +58,16 @@ type delegationSessionServiceClient struct {
 
 func NewDelegationSessionServiceClient(cc grpc.ClientConnInterface) DelegationSessionServiceClient {
 	return &delegationSessionServiceClient{cc}
+}
+
+func (c *delegationSessionServiceClient) CreateDelegationSession(ctx context.Context, in *CreateDelegationSessionRequest, opts ...grpc.CallOption) (*DelegationSession, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DelegationSession)
+	err := c.cc.Invoke(ctx, DelegationSessionService_CreateDelegationSession_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *delegationSessionServiceClient) GenerateCerts(ctx context.Context, in *GenerateCertsRequest, opts ...grpc.CallOption) (*GenerateCertsResponse, error) {
@@ -73,6 +87,9 @@ func (c *delegationSessionServiceClient) GenerateCerts(ctx context.Context, in *
 // DelegationSessionService allows users to delegate a subset of their access to
 // a workload or bot.
 type DelegationSessionServiceServer interface {
+	// CreateDelegationSession creates a delegation session for the authenticated
+	// user.
+	CreateDelegationSession(context.Context, *CreateDelegationSessionRequest) (*DelegationSession, error)
 	// GenerateCerts generates TLS and/or SSH certificates, scoped to a delegation
 	// session.
 	GenerateCerts(context.Context, *GenerateCertsRequest) (*GenerateCertsResponse, error)
@@ -86,6 +103,9 @@ type DelegationSessionServiceServer interface {
 // pointer dereference when methods are called.
 type UnimplementedDelegationSessionServiceServer struct{}
 
+func (UnimplementedDelegationSessionServiceServer) CreateDelegationSession(context.Context, *CreateDelegationSessionRequest) (*DelegationSession, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateDelegationSession not implemented")
+}
 func (UnimplementedDelegationSessionServiceServer) GenerateCerts(context.Context, *GenerateCertsRequest) (*GenerateCertsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GenerateCerts not implemented")
 }
@@ -109,6 +129,24 @@ func RegisterDelegationSessionServiceServer(s grpc.ServiceRegistrar, srv Delegat
 		t.testEmbeddedByValue()
 	}
 	s.RegisterService(&DelegationSessionService_ServiceDesc, srv)
+}
+
+func _DelegationSessionService_CreateDelegationSession_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateDelegationSessionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DelegationSessionServiceServer).CreateDelegationSession(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DelegationSessionService_CreateDelegationSession_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DelegationSessionServiceServer).CreateDelegationSession(ctx, req.(*CreateDelegationSessionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _DelegationSessionService_GenerateCerts_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -136,6 +174,10 @@ var DelegationSessionService_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "teleport.delegation.v1.DelegationSessionService",
 	HandlerType: (*DelegationSessionServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "CreateDelegationSession",
+			Handler:    _DelegationSessionService_CreateDelegationSession_Handler,
+		},
 		{
 			MethodName: "GenerateCerts",
 			Handler:    _DelegationSessionService_GenerateCerts_Handler,

--- a/api/proto/teleport/delegation/v1/delegation_session_service.proto
+++ b/api/proto/teleport/delegation/v1/delegation_session_service.proto
@@ -17,15 +17,29 @@ syntax = "proto3";
 package teleport.delegation.v1;
 
 import "google/protobuf/duration.proto";
+import "teleport/delegation/v1/delegation_session_resource.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1;delegationv1";
 
 // DelegationSessionService allows users to delegate a subset of their access to
 // a workload or bot.
 service DelegationSessionService {
+  // CreateDelegationSession creates a delegation session for the authenticated
+  // user.
+  rpc CreateDelegationSession(CreateDelegationSessionRequest) returns (DelegationSession);
+
   // GenerateCerts generates TLS and/or SSH certificates, scoped to a delegation
   // session.
   rpc GenerateCerts(GenerateCertsRequest) returns (GenerateCertsResponse);
+}
+
+// CreateDelegationSessionRequest are the parameters to CreateDelegationSession.
+message CreateDelegationSessionRequest {
+  // Spec of the delegation session that will be created.
+  DelegationSessionSpec spec = 1;
+
+  // TTL determines how long the session will last.
+  google.protobuf.Duration ttl = 2;
 }
 
 // GenerateCertsRequest are the parameters to GenerateCerts.

--- a/lib/auth/delegation/delegationv1/create_delegation_session.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session.go
@@ -32,6 +32,11 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
+// sessionMaxTTL is the maximum length of delegation session you can create
+// using the CreateDelegationSession RPC. A week is chosen to allow for long-
+// running AI agents, etc.
+const sessionMaxTTL = 7 * 24 * time.Hour
+
 // CreateDelegationSession creates a delegation session.
 func (s *SessionService) CreateDelegationSession(
 	ctx context.Context,
@@ -53,8 +58,13 @@ func (s *SessionService) CreateDelegationSession(
 	if err := req.GetTtl().CheckValid(); err != nil {
 		return nil, trace.BadParameter("ttl: %v", err)
 	}
-	if req.GetTtl().AsDuration() <= 0 {
+
+	ttl := req.GetTtl().AsDuration()
+	if ttl <= 0 {
 		return nil, trace.BadParameter("ttl: is required")
+	}
+	if ttl > sessionMaxTTL {
+		return nil, trace.BadParameter("ttl: cannot be more than %d hours", sessionMaxTTL/time.Hour)
 	}
 
 	session := &delegationv1.DelegationSession{

--- a/lib/auth/delegation/delegationv1/create_delegation_session.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session.go
@@ -1,0 +1,96 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package delegationv1
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+	delegationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// CreateDelegationSession creates a delegation session.
+func (s *SessionService) CreateDelegationSession(
+	ctx context.Context,
+	req *delegationv1.CreateDelegationSessionRequest,
+) (*delegationv1.DelegationSession, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// This is a security-sensitive action, so require MFA.
+	if err := authCtx.AuthorizeAdminAction(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if req.GetTtl() == nil {
+		return nil, trace.BadParameter("ttl: is required")
+	}
+	if err := req.GetTtl().CheckValid(); err != nil {
+		return nil, trace.BadParameter("ttl: %v", err)
+	}
+	if req.GetTtl().AsDuration() <= 0 {
+		return nil, trace.BadParameter("ttl: is required")
+	}
+
+	session := &delegationv1.DelegationSession{
+		Kind:    types.KindDelegationSession,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name:    uuid.NewString(),
+			Expires: timestamppb.New(time.Now().Add(req.GetTtl().AsDuration())),
+		},
+		Spec: req.GetSpec(),
+	}
+	spec := session.GetSpec()
+	resources := spec.GetResources()
+
+	// Read user from the backend to get the current roles and traits.
+	user, err := s.userGetter.GetUser(ctx, authCtx.User.GetName(), false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if user.GetName() != spec.GetUser() {
+		return nil, trace.AccessDenied("cannot create a delegation session for a different user")
+	}
+
+	if !wildcardPermissions(resources) {
+		// Perform a best-effort check to see if the delegating user has access
+		// to the required resources, so we can surface problems early.
+		if err := s.bestEffortCheckResourceAccess(ctx, user, resources); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	// The session expiry, resource list, allowed users, etc. is checked by
+	// the backend service which calls ValidateDelegationSession.
+	session, err = s.sessionWriter.CreateDelegationSession(ctx, session)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return session, nil
+}

--- a/lib/auth/delegation/delegationv1/create_delegation_session.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session.go
@@ -24,11 +24,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-
 	"google.golang.org/protobuf/types/known/timestamppb"
+
 	delegationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // CreateDelegationSession creates a delegation session.
@@ -68,8 +69,10 @@ func (s *SessionService) CreateDelegationSession(
 	spec := session.GetSpec()
 	resources := spec.GetResources()
 
-	// Read user from the backend to get the current roles and traits.
-	user, err := s.userGetter.GetUser(ctx, authCtx.User.GetName(), false)
+	// Read user login state from the backend to get current roles, traits, and
+	// any enriched identity from external providers (e.g. GitHub). Falls back
+	// to the plain user if no login state exists.
+	user, err := services.GetUserOrLoginState(ctx, s.userGetter, authCtx.User.GetName())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/delegation/delegationv1/create_delegation_session.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session.go
@@ -58,6 +58,9 @@ func (s *SessionService) CreateDelegationSession(
 	if authCtx.Identity.GetIdentity().DelegationSessionID != "" {
 		return nil, trace.AccessDenied("cannot create a delegation session from within a delegation session")
 	}
+	if authCtx.Identity.GetIdentity().DisallowReissue {
+		return nil, trace.AccessDenied("cannot create a delegation session because certificate reissuance is prohibited")
+	}
 
 	if req.GetTtl() == nil {
 		return nil, trace.BadParameter("ttl: is required")

--- a/lib/auth/delegation/delegationv1/create_delegation_session.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session.go
@@ -52,6 +52,13 @@ func (s *SessionService) CreateDelegationSession(
 		return nil, trace.Wrap(err)
 	}
 
+	// TODO(boxofrad): Eventually, we'll need to support this to allow for agents
+	// that sub-delegate to other agents, but the authorization logic around that
+	// needs more thought, so we'll just disable it for now.
+	if authCtx.Identity.GetIdentity().DelegationSessionID != "" {
+		return nil, trace.AccessDenied("cannot create a delegation session from within a delegation session")
+	}
+
 	if req.GetTtl() == nil {
 		return nil, trace.BadParameter("ttl: is required")
 	}

--- a/lib/auth/delegation/delegationv1/create_delegation_session.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session.go
@@ -82,7 +82,7 @@ func (s *SessionService) CreateDelegationSession(
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:    uuid.NewString(),
-			Expires: timestamppb.New(time.Now().Add(req.GetTtl().AsDuration())),
+			Expires: timestamppb.New(time.Now().Add(ttl)),
 		},
 		Spec: req.GetSpec(),
 	}

--- a/lib/auth/delegation/delegationv1/create_delegation_session_test.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session_test.go
@@ -1,0 +1,253 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package delegationv1_test
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	delegationv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
+	"github.com/gravitational/teleport/api/mfa"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+)
+
+func TestSessionService_CreateSession(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			service, pack := sessionServiceTestPack(t)
+
+			pack.authenticateUser(t,
+				"bob",
+				authz.AdminActionAuthMFAVerified,
+				types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						AppLabels: types.Labels{
+							types.Wildcard: {types.Wildcard},
+						},
+					},
+				},
+			)
+
+			expectedExpires := time.Now().Add(5 * time.Minute)
+			expectedSpec := newDelegationSessionSpec("bob")
+
+			session, err := service.CreateDelegationSession(t.Context(), &delegationv1pb.CreateDelegationSessionRequest{
+				Spec: expectedSpec,
+				Ttl:  durationpb.New(5 * time.Minute),
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, types.KindDelegationSession, session.GetKind())
+			assert.Equal(t, types.V1, session.GetVersion())
+			assert.Equal(t, pack.user.GetName(), session.GetSpec().GetUser())
+			assert.NotEmpty(t, session.GetMetadata().GetName())
+			assert.Empty(t, cmp.Diff(
+				expectedSpec.GetResources(),
+				session.GetSpec().GetResources(),
+				protocmp.Transform(),
+			))
+			assert.Empty(t, cmp.Diff(
+				expectedSpec.GetAuthorizedUsers(),
+				session.GetSpec().GetAuthorizedUsers(),
+				protocmp.Transform(),
+			))
+			assert.True(t, expectedExpires.Equal(session.GetMetadata().GetExpires().AsTime()))
+		})
+	})
+
+	t.Run("success with wildcard resources", func(t *testing.T) {
+		service, pack := sessionServiceTestPack(t)
+
+		pack.authenticateUser(t,
+			"bob",
+			authz.AdminActionAuthMFAVerified,
+			types.RoleSpecV6{},
+		)
+
+		session, err := service.CreateDelegationSession(t.Context(), &delegationv1pb.CreateDelegationSessionRequest{
+			Spec: newDelegationSessionSpec(
+				"bob",
+				&delegationv1pb.DelegationResourceSpec{
+					Kind: types.Wildcard,
+					Name: types.Wildcard,
+				},
+			),
+			Ttl: durationpb.New(5 * time.Minute),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, types.Wildcard, session.GetSpec().GetResources()[0].GetKind())
+		assert.Equal(t, types.Wildcard, session.GetSpec().GetResources()[0].GetName())
+	})
+
+	t.Run("not allowed to use resources", func(t *testing.T) {
+		service, pack := sessionServiceTestPack(t)
+
+		pack.authenticateUser(t,
+			"bob",
+			authz.AdminActionAuthMFAVerified,
+			types.RoleSpecV6{},
+		)
+
+		_, err := service.CreateDelegationSession(t.Context(), &delegationv1pb.CreateDelegationSessionRequest{
+			Spec: newDelegationSessionSpec("bob"),
+			Ttl:  durationpb.New(5 * time.Minute),
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err))
+		require.ErrorContains(t, err, "User does not have permission to delegate access to all of the required resources")
+	})
+
+	t.Run("resource does not exist", func(t *testing.T) {
+		service, pack := sessionServiceTestPack(t)
+
+		pack.authenticateUser(t,
+			"bob",
+			authz.AdminActionAuthMFAVerified,
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					AppLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+				},
+			},
+		)
+
+		_, err := service.CreateDelegationSession(t.Context(), &delegationv1pb.CreateDelegationSessionRequest{
+			Spec: newDelegationSessionSpec(
+				"bob",
+				&delegationv1pb.DelegationResourceSpec{
+					Kind: types.KindApp,
+					Name: "unknown-app",
+				},
+			),
+			Ttl: durationpb.New(5 * time.Minute),
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err))
+		require.ErrorContains(t, err, "missing resources: [app/unknown-app]")
+	})
+
+	t.Run("cannot create a session for a different user", func(t *testing.T) {
+		service, pack := sessionServiceTestPack(t)
+
+		pack.authenticateUser(t,
+			"bob",
+			authz.AdminActionAuthMFAVerified,
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					AppLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+				},
+			},
+		)
+
+		_, err := service.CreateDelegationSession(t.Context(), &delegationv1pb.CreateDelegationSessionRequest{
+			Spec: newDelegationSessionSpec("alice"),
+			Ttl:  durationpb.New(5 * time.Minute),
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err))
+		require.ErrorContains(t, err, "cannot create a delegation session for a different user")
+	})
+
+	t.Run("requires MFA", func(t *testing.T) {
+		service, pack := sessionServiceTestPack(t)
+
+		pack.authenticateUser(t,
+			"bob",
+			authz.AdminActionAuthUnauthorized,
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					AppLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+				},
+			},
+		)
+
+		_, err := service.CreateDelegationSession(t.Context(), &delegationv1pb.CreateDelegationSessionRequest{
+			Spec: newDelegationSessionSpec("bob"),
+			Ttl:  durationpb.New(5 * time.Minute),
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired)
+	})
+
+	t.Run("missing ttl", func(t *testing.T) {
+		service, pack := sessionServiceTestPack(t)
+
+		pack.authenticateUser(t,
+			"bob",
+			authz.AdminActionAuthMFAVerified,
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					AppLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+				},
+			},
+		)
+
+		_, err := service.CreateDelegationSession(t.Context(), &delegationv1pb.CreateDelegationSessionRequest{
+			Spec: newDelegationSessionSpec("bob"),
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+		require.ErrorContains(t, err, "ttl: is required")
+	})
+}
+
+func newDelegationSessionSpec(
+	user string,
+	resources ...*delegationv1pb.DelegationResourceSpec,
+) *delegationv1pb.DelegationSessionSpec {
+	if len(resources) == 0 {
+		resources = []*delegationv1pb.DelegationResourceSpec{
+			{
+				Kind: types.KindApp,
+				Name: "hr-system",
+			},
+		}
+	}
+
+	return &delegationv1pb.DelegationSessionSpec{
+		User:      user,
+		Resources: resources,
+		AuthorizedUsers: []*delegationv1pb.DelegationUserSpec{
+			{
+				Kind: types.KindBot,
+				Matcher: &delegationv1pb.DelegationUserSpec_BotName{
+					BotName: "payroll-agent",
+				},
+			},
+		},
+	}
+}

--- a/lib/auth/delegation/delegationv1/create_delegation_session_test.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session_test.go
@@ -223,6 +223,30 @@ func TestSessionService_CreateSession(t *testing.T) {
 		require.True(t, trace.IsBadParameter(err))
 		require.ErrorContains(t, err, "ttl: is required")
 	})
+
+	t.Run("ttl too large", func(t *testing.T) {
+		service, pack := sessionServiceTestPack(t)
+
+		pack.authenticateUser(t,
+			"bob",
+			authz.AdminActionAuthMFAVerified,
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					AppLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+				},
+			},
+		)
+
+		_, err := service.CreateDelegationSession(t.Context(), &delegationv1pb.CreateDelegationSessionRequest{
+			Spec: newDelegationSessionSpec("bob"),
+			Ttl:  durationpb.New(14 * 24 * time.Hour),
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+		require.ErrorContains(t, err, "ttl: cannot be more than 168 hours")
+	})
 }
 
 func newDelegationSessionSpec(

--- a/lib/auth/delegation/delegationv1/create_delegation_session_test.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session_test.go
@@ -121,7 +121,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
-		require.ErrorContains(t, err, "User does not have permission to delegate access to all of the required resources")
+		require.ErrorContains(t, err, "user does not have permission to delegate access to all of the required resources")
 	})
 
 	t.Run("resource does not exist", func(t *testing.T) {

--- a/lib/auth/delegation/delegationv1/create_delegation_session_test.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session_test.go
@@ -201,6 +201,32 @@ func TestSessionService_CreateSession(t *testing.T) {
 		require.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired)
 	})
 
+	t.Run("cannot create a session from within a delegation session", func(t *testing.T) {
+		service, pack := sessionServiceTestPack(t)
+
+		pack.authenticateUserInDelegationSession(
+			t,
+			"bob",
+			"source-session",
+			authz.AdminActionAuthMFAVerified,
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					AppLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+				},
+			},
+		)
+
+		_, err := service.CreateDelegationSession(t.Context(), &delegationv1pb.CreateDelegationSessionRequest{
+			Spec: newDelegationSessionSpec("bob"),
+			Ttl:  durationpb.New(5 * time.Minute),
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err))
+		require.ErrorContains(t, err, "cannot create a delegation session from within a delegation session")
+	})
+
 	t.Run("missing ttl", func(t *testing.T) {
 		service, pack := sessionServiceTestPack(t)
 

--- a/lib/auth/delegation/delegationv1/create_delegation_session_test.go
+++ b/lib/auth/delegation/delegationv1/create_delegation_session_test.go
@@ -227,6 +227,31 @@ func TestSessionService_CreateSession(t *testing.T) {
 		require.ErrorContains(t, err, "cannot create a delegation session from within a delegation session")
 	})
 
+	t.Run("cannot create a session with a non-reissuable certificate", func(t *testing.T) {
+		service, pack := sessionServiceTestPack(t)
+
+		pack.authenticateUserWithDisallowReissue(
+			t,
+			"bob",
+			authz.AdminActionAuthMFAVerified,
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					AppLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+				},
+			},
+		)
+
+		_, err := service.CreateDelegationSession(t.Context(), &delegationv1pb.CreateDelegationSessionRequest{
+			Spec: newDelegationSessionSpec("bob"),
+			Ttl:  durationpb.New(5 * time.Minute),
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err))
+		require.ErrorContains(t, err, "cannot create a delegation session because certificate reissuance is prohibited")
+	})
+
 	t.Run("missing ttl", func(t *testing.T) {
 		service, pack := sessionServiceTestPack(t)
 

--- a/lib/auth/delegation/delegationv1/session_service_test.go
+++ b/lib/auth/delegation/delegationv1/session_service_test.go
@@ -114,6 +114,7 @@ func sessionServiceTestPack(t *testing.T) (*delegationv1.SessionService, *sessio
 						Username:            pack.user.GetName(),
 						Groups:              pack.user.GetRoles(),
 						DelegationSessionID: pack.delegationSessionID,
+						DisallowReissue:     pack.disallowReissue,
 					},
 				}
 
@@ -169,6 +170,7 @@ type sessionTestPack struct {
 	adminActionAuthState authz.AdminActionAuthState
 	botName              string
 	delegationSessionID  string
+	disallowReissue      bool
 
 	onCreateAppSession func(context.Context, sessionreq.NewAppSessionRequest) (types.WebSession, error)
 	onGenerateCert     func(context.Context, cert.Request) (*proto.Certs, error)
@@ -198,6 +200,18 @@ func (p *sessionTestPack) authenticateUserInDelegationSession(
 
 	p.authenticateUser(t, name, mfaState, roleSpec)
 	p.delegationSessionID = delegationSessionID
+}
+
+func (p *sessionTestPack) authenticateUserWithDisallowReissue(
+	t *testing.T,
+	name string,
+	mfaState authz.AdminActionAuthState,
+	roleSpec types.RoleSpecV6,
+) {
+	t.Helper()
+
+	p.authenticateUser(t, name, mfaState, roleSpec)
+	p.disallowReissue = true
 }
 
 func (p *sessionTestPack) createUser(

--- a/lib/auth/delegation/delegationv1/session_service_test.go
+++ b/lib/auth/delegation/delegationv1/session_service_test.go
@@ -109,10 +109,20 @@ func sessionServiceTestPack(t *testing.T) (*delegationv1.SessionService, *sessio
 				)
 				require.NoError(t, err)
 
+				identity := authz.LocalUser{
+					Identity: tlsca.Identity{
+						Username:            pack.user.GetName(),
+						Groups:              pack.user.GetRoles(),
+						DelegationSessionID: pack.delegationSessionID,
+					},
+				}
+
 				return &authz.Context{
 					User:                 pack.user,
 					AdminActionAuthState: pack.adminActionAuthState,
 					Checker:              checker,
+					Identity:             identity,
+					UnmappedIdentity:     identity,
 				}, nil
 			}
 
@@ -174,6 +184,20 @@ func (p *sessionTestPack) authenticateUser(
 
 	p.user = p.createUser(t, name, roleSpec)
 	p.adminActionAuthState = mfaState
+	p.delegationSessionID = ""
+}
+
+func (p *sessionTestPack) authenticateUserInDelegationSession(
+	t *testing.T,
+	name string,
+	delegationSessionID string,
+	mfaState authz.AdminActionAuthState,
+	roleSpec types.RoleSpecV6,
+) {
+	t.Helper()
+
+	p.authenticateUser(t, name, mfaState, roleSpec)
+	p.delegationSessionID = delegationSessionID
 }
 
 func (p *sessionTestPack) createUser(

--- a/lib/auth/delegation/delegationv1/session_service_test.go
+++ b/lib/auth/delegation/delegationv1/session_service_test.go
@@ -164,6 +164,18 @@ type sessionTestPack struct {
 	onGenerateCert     func(context.Context, cert.Request) (*proto.Certs, error)
 }
 
+func (p *sessionTestPack) authenticateUser(
+	t *testing.T,
+	name string,
+	mfaState authz.AdminActionAuthState,
+	roleSpec types.RoleSpecV6,
+) {
+	t.Helper()
+
+	p.user = p.createUser(t, name, roleSpec)
+	p.adminActionAuthState = mfaState
+}
+
 func (p *sessionTestPack) createUser(
 	t *testing.T,
 	name string,

--- a/tool/tsh/common/delegation.go
+++ b/tool/tsh/common/delegation.go
@@ -1,0 +1,188 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	delegationv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
+	"github.com/gravitational/teleport/api/mfa"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+func onDelegationCreateSession(cf *CLIConf) error {
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if cf.Username == "" {
+		cf.Username = tc.Username
+	}
+
+	req, err := buildCreateDelegationSessionRequest(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var session *delegationv1pb.DelegationSession
+	err = client.RetryWithRelogin(cf.Context, tc, func() error {
+		return tc.WithRootClusterClient(cf.Context, func(clt authclient.ClientI) error {
+			ctx := cf.Context
+
+			mfaResp, err := mfa.PerformAdminActionMFACeremony(ctx, clt.PerformMFACeremony, true)
+			if err == nil {
+				ctx = mfa.ContextWithMFAResponse(ctx, mfaResp)
+			} else if !errors.Is(err, &mfa.ErrMFANotRequired) && !errors.Is(err, &mfa.ErrMFANotSupported) {
+				return trace.Wrap(err)
+			}
+
+			session, err = clt.DelegationSessionServiceClient().CreateDelegationSession(ctx, req)
+			return trace.Wrap(err)
+		})
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = fmt.Fprintf(cf.Stdout(), "Delegation session created: %s\n", session.GetMetadata().GetName())
+	return trace.Wrap(err)
+}
+
+func buildCreateDelegationSessionRequest(cf *CLIConf) (*delegationv1pb.CreateDelegationSessionRequest, error) {
+	if cf.SessionTTL <= 0 {
+		return nil, trace.BadParameter("--session-ttl must be greater than zero")
+	}
+
+	resources, err := buildDelegationResources(cf)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if len(cf.DelegationBots) == 0 {
+		return nil, trace.BadParameter("at least one --bot must be provided")
+	}
+
+	authorizedUsers := make([]*delegationv1pb.DelegationUserSpec, 0, len(cf.DelegationBots))
+	for _, botName := range cf.DelegationBots {
+		if botName == "" {
+			return nil, trace.BadParameter("--bot must not be empty")
+		}
+
+		authorizedUsers = append(authorizedUsers, &delegationv1pb.DelegationUserSpec{
+			Kind: types.KindBot,
+			Matcher: &delegationv1pb.DelegationUserSpec_BotName{
+				BotName: botName,
+			},
+		})
+	}
+
+	return &delegationv1pb.CreateDelegationSessionRequest{
+		Spec: &delegationv1pb.DelegationSessionSpec{
+			User:            cf.Username,
+			Resources:       resources,
+			AuthorizedUsers: authorizedUsers,
+		},
+		Ttl: durationpb.New(cf.SessionTTL),
+	}, nil
+}
+
+func buildDelegationResources(cf *CLIConf) ([]*delegationv1pb.DelegationResourceSpec, error) {
+	explicitResources := len(cf.DelegationAllowNodes) +
+		len(cf.DelegationAllowDatabases) +
+		len(cf.DelegationAllowApps) +
+		len(cf.DelegationAllowKubeClusters) +
+		len(cf.DelegationAllowWindowsDesktops) +
+		len(cf.DelegationAllowGitServers)
+
+	switch {
+	case cf.DelegationAllowAll && explicitResources != 0:
+		return nil, trace.BadParameter("--allow-all is mutually exclusive with the other --allow-* flags")
+	case cf.DelegationAllowAll:
+		return []*delegationv1pb.DelegationResourceSpec{{
+			Kind: types.Wildcard,
+			Name: types.Wildcard,
+		}}, nil
+	case explicitResources == 0:
+		return nil, trace.BadParameter("at least one resource must be provided via --allow-all or an --allow-* flag")
+	}
+
+	resources := make([]*delegationv1pb.DelegationResourceSpec, 0, explicitResources)
+	for _, name := range cf.DelegationAllowNodes {
+		if name == "" {
+			return nil, trace.BadParameter("--allow-node must not be empty")
+		}
+		resources = append(resources, &delegationv1pb.DelegationResourceSpec{
+			Kind: types.KindNode,
+			Name: name,
+		})
+	}
+	for _, name := range cf.DelegationAllowDatabases {
+		if name == "" {
+			return nil, trace.BadParameter("--allow-db must not be empty")
+		}
+		resources = append(resources, &delegationv1pb.DelegationResourceSpec{
+			Kind: types.KindDatabase,
+			Name: name,
+		})
+	}
+	for _, name := range cf.DelegationAllowApps {
+		if name == "" {
+			return nil, trace.BadParameter("--allow-app must not be empty")
+		}
+		resources = append(resources, &delegationv1pb.DelegationResourceSpec{
+			Kind: types.KindApp,
+			Name: name,
+		})
+	}
+	for _, name := range cf.DelegationAllowKubeClusters {
+		if name == "" {
+			return nil, trace.BadParameter("--allow-kube-cluster must not be empty")
+		}
+		resources = append(resources, &delegationv1pb.DelegationResourceSpec{
+			Kind: types.KindKubernetesCluster,
+			Name: name,
+		})
+	}
+	for _, name := range cf.DelegationAllowWindowsDesktops {
+		if name == "" {
+			return nil, trace.BadParameter("--allow-windows-desktop must not be empty")
+		}
+		resources = append(resources, &delegationv1pb.DelegationResourceSpec{
+			Kind: types.KindWindowsDesktop,
+			Name: name,
+		})
+	}
+	for _, name := range cf.DelegationAllowGitServers {
+		if name == "" {
+			return nil, trace.BadParameter("--allow-git-server must not be empty")
+		}
+		resources = append(resources, &delegationv1pb.DelegationResourceSpec{
+			Kind: types.KindGitServer,
+			Name: name,
+		})
+	}
+
+	return resources, nil
+}

--- a/tool/tsh/common/delegation.go
+++ b/tool/tsh/common/delegation.go
@@ -51,7 +51,7 @@ func onDelegationCreateSession(cf *CLIConf) error {
 		return tc.WithRootClusterClient(cf.Context, func(clt authclient.ClientI) error {
 			ctx := cf.Context
 
-			mfaResp, err := mfa.PerformAdminActionMFACeremony(ctx, clt.PerformMFACeremony, true)
+			mfaResp, err := mfa.PerformAdminActionMFACeremony(ctx, clt.PerformMFACeremony, false)
 			if err == nil {
 				ctx = mfa.ContextWithMFAResponse(ctx, mfaResp)
 			} else if !errors.Is(err, &mfa.ErrMFANotRequired) && !errors.Is(err, &mfa.ErrMFANotSupported) {

--- a/tool/tsh/common/delegation_test.go
+++ b/tool/tsh/common/delegation_test.go
@@ -1,0 +1,138 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	delegationv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestBuildCreateDelegationSessionRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("explicit resources", func(t *testing.T) {
+		req, err := buildCreateDelegationSessionRequest(&CLIConf{
+			Username:                       "bob",
+			SessionTTL:                     10 * time.Minute,
+			DelegationAllowNodes:           []string{"node1"},
+			DelegationAllowDatabases:       []string{"database1"},
+			DelegationAllowApps:            []string{"app1"},
+			DelegationAllowKubeClusters:    []string{"cluster1"},
+			DelegationAllowWindowsDesktops: []string{"desktop1"},
+			DelegationAllowGitServers:      []string{"git1"},
+			DelegationBots:                 []string{"bot1", "bot2"},
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, "bob", req.GetSpec().GetUser())
+		require.Equal(t, 10*time.Minute, req.GetTtl().AsDuration())
+
+		require.Empty(t, cmp.Diff([]*delegationv1pb.DelegationResourceSpec{
+			{Kind: types.KindNode, Name: "node1"},
+			{Kind: types.KindDatabase, Name: "database1"},
+			{Kind: types.KindApp, Name: "app1"},
+			{Kind: types.KindKubernetesCluster, Name: "cluster1"},
+			{Kind: types.KindWindowsDesktop, Name: "desktop1"},
+			{Kind: types.KindGitServer, Name: "git1"},
+		}, req.GetSpec().GetResources(), protocmp.Transform()))
+
+		require.Empty(t, cmp.Diff([]*delegationv1pb.DelegationUserSpec{
+			{
+				Kind: types.KindBot,
+				Matcher: &delegationv1pb.DelegationUserSpec_BotName{
+					BotName: "bot1",
+				},
+			},
+			{
+				Kind: types.KindBot,
+				Matcher: &delegationv1pb.DelegationUserSpec_BotName{
+					BotName: "bot2",
+				},
+			},
+		}, req.GetSpec().GetAuthorizedUsers(), protocmp.Transform()))
+	})
+
+	t.Run("wildcard resources", func(t *testing.T) {
+		req, err := buildCreateDelegationSessionRequest(&CLIConf{
+			Username:           "bob",
+			SessionTTL:         5 * time.Minute,
+			DelegationAllowAll: true,
+			DelegationBots:     []string{"bot1"},
+		})
+		require.NoError(t, err)
+
+		require.Empty(t, cmp.Diff([]*delegationv1pb.DelegationResourceSpec{
+			{Kind: types.Wildcard, Name: types.Wildcard},
+		}, req.GetSpec().GetResources(), protocmp.Transform()))
+	})
+
+	t.Run("allow all is mutually exclusive", func(t *testing.T) {
+		_, err := buildCreateDelegationSessionRequest(&CLIConf{
+			Username:             "bob",
+			SessionTTL:           5 * time.Minute,
+			DelegationAllowAll:   true,
+			DelegationAllowNodes: []string{"node1"},
+			DelegationBots:       []string{"bot1"},
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+		require.ErrorContains(t, err, "--allow-all is mutually exclusive")
+	})
+
+	t.Run("requires resource selection", func(t *testing.T) {
+		_, err := buildCreateDelegationSessionRequest(&CLIConf{
+			Username:       "bob",
+			SessionTTL:     5 * time.Minute,
+			DelegationBots: []string{"bot1"},
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+		require.ErrorContains(t, err, "at least one resource must be provided")
+	})
+
+	t.Run("requires bot", func(t *testing.T) {
+		_, err := buildCreateDelegationSessionRequest(&CLIConf{
+			Username:             "bob",
+			SessionTTL:           5 * time.Minute,
+			DelegationAllowNodes: []string{"node1"},
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+		require.ErrorContains(t, err, "at least one --bot must be provided")
+	})
+
+	t.Run("requires ttl", func(t *testing.T) {
+		_, err := buildCreateDelegationSessionRequest(&CLIConf{
+			Username:             "bob",
+			DelegationAllowNodes: []string{"node1"},
+			DelegationBots:       []string{"bot1"},
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsBadParameter(err))
+		require.ErrorContains(t, err, "--session-ttl must be greater than zero")
+	})
+}

--- a/tool/tsh/common/delegation_test.go
+++ b/tool/tsh/common/delegation_test.go
@@ -34,105 +34,130 @@ import (
 func TestBuildCreateDelegationSessionRequest(t *testing.T) {
 	t.Parallel()
 
-	t.Run("explicit resources", func(t *testing.T) {
-		req, err := buildCreateDelegationSessionRequest(&CLIConf{
-			Username:                       "bob",
-			SessionTTL:                     10 * time.Minute,
-			DelegationAllowNodes:           []string{"node1"},
-			DelegationAllowDatabases:       []string{"database1"},
-			DelegationAllowApps:            []string{"app1"},
-			DelegationAllowKubeClusters:    []string{"cluster1"},
-			DelegationAllowWindowsDesktops: []string{"desktop1"},
-			DelegationAllowGitServers:      []string{"git1"},
-			DelegationBots:                 []string{"bot1", "bot2"},
-		})
-		require.NoError(t, err)
-
-		require.Equal(t, "bob", req.GetSpec().GetUser())
-		require.Equal(t, 10*time.Minute, req.GetTtl().AsDuration())
-
-		require.Empty(t, cmp.Diff([]*delegationv1pb.DelegationResourceSpec{
-			{Kind: types.KindNode, Name: "node1"},
-			{Kind: types.KindDatabase, Name: "database1"},
-			{Kind: types.KindApp, Name: "app1"},
-			{Kind: types.KindKubernetesCluster, Name: "cluster1"},
-			{Kind: types.KindWindowsDesktop, Name: "desktop1"},
-			{Kind: types.KindGitServer, Name: "git1"},
-		}, req.GetSpec().GetResources(), protocmp.Transform()))
-
-		require.Empty(t, cmp.Diff([]*delegationv1pb.DelegationUserSpec{
-			{
-				Kind: types.KindBot,
-				Matcher: &delegationv1pb.DelegationUserSpec_BotName{
-					BotName: "bot1",
+	tests := []struct {
+		name               string
+		conf               *CLIConf
+		wantUser           string
+		wantTTL            time.Duration
+		wantResources      []*delegationv1pb.DelegationResourceSpec
+		wantAuthorizedUser []*delegationv1pb.DelegationUserSpec
+		wantErr            string
+	}{
+		{
+			name: "explicit resources",
+			conf: &CLIConf{
+				Username:                       "bob",
+				SessionTTL:                     10 * time.Minute,
+				DelegationAllowNodes:           []string{"node1"},
+				DelegationAllowDatabases:       []string{"database1"},
+				DelegationAllowApps:            []string{"app1"},
+				DelegationAllowKubeClusters:    []string{"cluster1"},
+				DelegationAllowWindowsDesktops: []string{"desktop1"},
+				DelegationAllowGitServers:      []string{"git1"},
+				DelegationBots:                 []string{"bot1", "bot2"},
+			},
+			wantUser: "bob",
+			wantTTL:  10 * time.Minute,
+			wantResources: []*delegationv1pb.DelegationResourceSpec{
+				{Kind: types.KindNode, Name: "node1"},
+				{Kind: types.KindDatabase, Name: "database1"},
+				{Kind: types.KindApp, Name: "app1"},
+				{Kind: types.KindKubernetesCluster, Name: "cluster1"},
+				{Kind: types.KindWindowsDesktop, Name: "desktop1"},
+				{Kind: types.KindGitServer, Name: "git1"},
+			},
+			wantAuthorizedUser: []*delegationv1pb.DelegationUserSpec{
+				{
+					Kind: types.KindBot,
+					Matcher: &delegationv1pb.DelegationUserSpec_BotName{
+						BotName: "bot1",
+					},
+				},
+				{
+					Kind: types.KindBot,
+					Matcher: &delegationv1pb.DelegationUserSpec_BotName{
+						BotName: "bot2",
+					},
 				},
 			},
-			{
-				Kind: types.KindBot,
-				Matcher: &delegationv1pb.DelegationUserSpec_BotName{
-					BotName: "bot2",
+		},
+		{
+			name: "wildcard resources",
+			conf: &CLIConf{
+				Username:           "bob",
+				SessionTTL:         5 * time.Minute,
+				DelegationAllowAll: true,
+				DelegationBots:     []string{"bot1"},
+			},
+			wantUser: "bob",
+			wantTTL:  5 * time.Minute,
+			wantResources: []*delegationv1pb.DelegationResourceSpec{
+				{Kind: types.Wildcard, Name: types.Wildcard},
+			},
+			wantAuthorizedUser: []*delegationv1pb.DelegationUserSpec{
+				{
+					Kind: types.KindBot,
+					Matcher: &delegationv1pb.DelegationUserSpec_BotName{
+						BotName: "bot1",
+					},
 				},
 			},
-		}, req.GetSpec().GetAuthorizedUsers(), protocmp.Transform()))
-	})
+		},
+		{
+			name: "allow all is mutually exclusive",
+			conf: &CLIConf{
+				Username:             "bob",
+				SessionTTL:           5 * time.Minute,
+				DelegationAllowAll:   true,
+				DelegationAllowNodes: []string{"node1"},
+				DelegationBots:       []string{"bot1"},
+			},
+			wantErr: "--allow-all is mutually exclusive",
+		},
+		{
+			name: "requires resource selection",
+			conf: &CLIConf{
+				Username:       "bob",
+				SessionTTL:     5 * time.Minute,
+				DelegationBots: []string{"bot1"},
+			},
+			wantErr: "at least one resource must be provided",
+		},
+		{
+			name: "requires bot",
+			conf: &CLIConf{
+				Username:             "bob",
+				SessionTTL:           5 * time.Minute,
+				DelegationAllowNodes: []string{"node1"},
+			},
+			wantErr: "at least one --bot must be provided",
+		},
+		{
+			name: "requires ttl",
+			conf: &CLIConf{
+				Username:             "bob",
+				DelegationAllowNodes: []string{"node1"},
+				DelegationBots:       []string{"bot1"},
+			},
+			wantErr: "--session-ttl must be greater than zero",
+		},
+	}
 
-	t.Run("wildcard resources", func(t *testing.T) {
-		req, err := buildCreateDelegationSessionRequest(&CLIConf{
-			Username:           "bob",
-			SessionTTL:         5 * time.Minute,
-			DelegationAllowAll: true,
-			DelegationBots:     []string{"bot1"},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := buildCreateDelegationSessionRequest(tt.conf)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err))
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantUser, req.GetSpec().GetUser())
+			require.Equal(t, tt.wantTTL, req.GetTtl().AsDuration())
+			require.Empty(t, cmp.Diff(tt.wantResources, req.GetSpec().GetResources(), protocmp.Transform()))
+			require.Empty(t, cmp.Diff(tt.wantAuthorizedUser, req.GetSpec().GetAuthorizedUsers(), protocmp.Transform()))
 		})
-		require.NoError(t, err)
-
-		require.Empty(t, cmp.Diff([]*delegationv1pb.DelegationResourceSpec{
-			{Kind: types.Wildcard, Name: types.Wildcard},
-		}, req.GetSpec().GetResources(), protocmp.Transform()))
-	})
-
-	t.Run("allow all is mutually exclusive", func(t *testing.T) {
-		_, err := buildCreateDelegationSessionRequest(&CLIConf{
-			Username:             "bob",
-			SessionTTL:           5 * time.Minute,
-			DelegationAllowAll:   true,
-			DelegationAllowNodes: []string{"node1"},
-			DelegationBots:       []string{"bot1"},
-		})
-		require.Error(t, err)
-		require.True(t, trace.IsBadParameter(err))
-		require.ErrorContains(t, err, "--allow-all is mutually exclusive")
-	})
-
-	t.Run("requires resource selection", func(t *testing.T) {
-		_, err := buildCreateDelegationSessionRequest(&CLIConf{
-			Username:       "bob",
-			SessionTTL:     5 * time.Minute,
-			DelegationBots: []string{"bot1"},
-		})
-		require.Error(t, err)
-		require.True(t, trace.IsBadParameter(err))
-		require.ErrorContains(t, err, "at least one resource must be provided")
-	})
-
-	t.Run("requires bot", func(t *testing.T) {
-		_, err := buildCreateDelegationSessionRequest(&CLIConf{
-			Username:             "bob",
-			SessionTTL:           5 * time.Minute,
-			DelegationAllowNodes: []string{"node1"},
-		})
-		require.Error(t, err)
-		require.True(t, trace.IsBadParameter(err))
-		require.ErrorContains(t, err, "at least one --bot must be provided")
-	})
-
-	t.Run("requires ttl", func(t *testing.T) {
-		_, err := buildCreateDelegationSessionRequest(&CLIConf{
-			Username:             "bob",
-			DelegationAllowNodes: []string{"node1"},
-			DelegationBots:       []string{"bot1"},
-		})
-		require.Error(t, err)
-		require.True(t, trace.IsBadParameter(err))
-		require.ErrorContains(t, err, "--session-ttl must be greater than zero")
-	})
+	}
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -433,6 +433,23 @@ type CLIConf struct {
 	// MaxDuration specifies how long the access will be granted for.
 	MaxDuration time.Duration
 
+	// DelegationAllowNodes is the list of SSH nodes to include in a delegation session.
+	DelegationAllowNodes []string
+	// DelegationAllowDatabases is the list of databases to include in a delegation session.
+	DelegationAllowDatabases []string
+	// DelegationAllowApps is the list of applications to include in a delegation session.
+	DelegationAllowApps []string
+	// DelegationAllowKubeClusters is the list of Kubernetes clusters to include in a delegation session.
+	DelegationAllowKubeClusters []string
+	// DelegationAllowWindowsDesktops is the list of Windows desktops to include in a delegation session.
+	DelegationAllowWindowsDesktops []string
+	// DelegationAllowGitServers is the list of Git servers to include in a delegation session.
+	DelegationAllowGitServers []string
+	// DelegationAllowAll requests wildcard resource access in a delegation session.
+	DelegationAllowAll bool
+	// DelegationBots is the list of bots allowed to use a delegation session.
+	DelegationBots []string
+
 	// executablePath is the absolute path to the current executable.
 	executablePath string
 
@@ -1371,6 +1388,18 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	environment.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
 	environment.Flag("unset", "Print commands to clear Teleport session environment variables.").BoolVar(&cf.unsetEnvironment)
 
+	delegation := app.Command("delegation", "Manage delegation sessions.")
+	delegationCreateSession := delegation.Command("create-session", "Create a delegation session, allowing a bot or workload to temporarily act on your behalf.")
+	delegationCreateSession.Flag("allow-node", "Allow access to an SSH node.").StringsVar(&cf.DelegationAllowNodes)
+	delegationCreateSession.Flag("allow-db", "Allow access to a database.").StringsVar(&cf.DelegationAllowDatabases)
+	delegationCreateSession.Flag("allow-app", "Allow access to an application.").StringsVar(&cf.DelegationAllowApps)
+	delegationCreateSession.Flag("allow-kube-cluster", "Allow access to a Kubernetes cluster.").StringsVar(&cf.DelegationAllowKubeClusters)
+	delegationCreateSession.Flag("allow-windows-desktop", "Allow access to a Windows desktop.").StringsVar(&cf.DelegationAllowWindowsDesktops)
+	delegationCreateSession.Flag("allow-git-server", "Allow access to a Git server.").StringsVar(&cf.DelegationAllowGitServers)
+	delegationCreateSession.Flag("allow-all", "Allow access to all resources, including destructive administrative actions. Mutually exclusive with the other --allow-* flags.").BoolVar(&cf.DelegationAllowAll)
+	delegationCreateSession.Flag("bot", "Name of a bot allowed to use the delegation session. Repeat to allow multiple bots.").StringsVar(&cf.DelegationBots)
+	delegationCreateSession.Flag("session-ttl", "How long the delegation session should remain valid.").DurationVar(&cf.SessionTTL)
+
 	req := app.Command("request", "Manage Access Requests.").Alias("requests")
 
 	reqList := req.Command("ls", "List Access Requests.").Alias("list")
@@ -1896,6 +1925,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = onDatabaseExec(&cf)
 	case environment.FullCommand():
 		err = onEnvironment(&cf)
+	case delegationCreateSession.FullCommand():
+		err = onDelegationCreateSession(&cf)
 	case mfa.ls.FullCommand():
 		err = mfa.ls.run(&cf)
 	case mfa.add.FullCommand():


### PR DESCRIPTION
Introduces the `CreateDelegationSession` RPC and adds a matching `tsh` command.

Note: this won't actually be used when creating a beam's delegation session, but it provides a way to manually use (and for our purposes, test) the delegation feature.

Changelog: Added `tsh delegation create-session` command for temporarily lending your access to a bot

## Manual Test Plan

This is the test plan for the full stack of delegation PRs (including #64900).

Full report including evidence here: https://gist.github.com/boxofrad/ddcc00b232b7d3caf560e2f89770c427

### Test Environment

Tested against a GCP instance running a local build of `teleport`. Driven by Codex using local builds of `tsh`, `tctl`, and `tbot`.

Pre-registered resources:

- Nodes: `ssh-node-1`, `ssh-node-2`
- Databases: `postgres-db-1`, `postgres-db-2`
- Applications: `nginx-1`, `nginx-2`.

### Test Cases
- [x] Delegated identities can be issued successfully for `--allow-all`, `--allow-node`, `--allow-db`, and `--allow-app`
- [x] `tsh status` shows the delegated human identity, delegation session ID, and allowed resources for restricted sessions
- [x] Delegation sessions can only be used by the bot explicitly named on the session
- [x] `--allow-all` sessions inherit all standing permissions
- [x] `--allow-node` sessions restrict `tsh ls` to the allowed node
- [x] `--allow-node` sessions allow `tsh ssh` to the allowed node and deny the other node
- [x] `--allow-node` sessions allow OpenSSH via delegated `identity` output to the allowed node and deny the other node
- [x] `ssh-multiplexer` starts successfully for the authorized bot and is denied for the wrong bot
- [x] `ssh-multiplexer` writes usable client artifacts for the authorized bot
- [x] `--allow-db` sessions restrict `tsh db ls` to the allowed database
- [x] `--allow-db` sessions allow access to the allowed database and deny the other database
- [x] `database-tunnel` works for the allowed database and is denied for the other database
- [x] `--allow-app` sessions restrict `tsh apps ls` to the allowed application
- [x] `--allow-app` sessions allow access to the allowed application and deny the other application
- [x] `application-tunnel` works for the allowed application and is denied for the other application
- [x] Restricted delegated sessions cannot perform representative administrative actions
