### PR TITLE
stabilize new join gRPC API

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -92,8 +92,6 @@ breaking:
   ignore:
     # TODO(codingllama): Remove ignore once the PDP API is stable.
     - api/proto/teleport/decision/v1alpha1
-    # TODO(nklaassen): Remove ignore once the new join API is stable.
-    - api/proto/teleport/join/v1
     # TODO(eriktate): Remove ignore once the new scopes API is stable.
     - api/proto/teleport/scopes
 


### PR DESCRIPTION
This commit removes the linter exception that allowed breaking changes to the gRPC joining API while it was in development.