### PR TITLE
[web] Update Button/IconButton styles, IconTooltip impl

### DIFF
--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -455,12 +455,14 @@ const StyledButton = styled.button.withConfig({
   // it). This could be especially visible when animating horizontal padding and
   // border width together. It would cause table borders on the storybook page
   // to shake.
-  transition:
-    background-color 0.1s,
-    border-color 0.1s,
-    outline-color 0.1s,
-    box-shadow 0.1s;
+  transition-property: background-color, color, border-color, outline-color, box-shadow;
+  transition-duration: ${({ theme }) => theme.transitions.interactive.duration};
+  transition-timing-function: ${({ theme }) => theme.transitions.interactive.timingFunction};
   -webkit-font-smoothing: antialiased;
+
+  svg {
+    transition: color ${({ theme }) => theme.transitions.interactive.duration} ${({ theme }) => theme.transitions.interactive.timingFunction};
+  }
 
   ${themedStyles}
 `;

--- a/web/packages/design/src/ButtonIcon/ButtonIcon.tsx
+++ b/web/packages/design/src/ButtonIcon/ButtonIcon.tsx
@@ -73,8 +73,14 @@ const StyledButtonIcon = styled.button<{ size: Size }>`
   flex: 0 0 auto;
   background: transparent;
   color: inherit;
-  transition: all 0.3s;
+  transition-property: background-color, color, border-color, outline-color, box-shadow;
+  transition-duration: ${({ theme }) => theme.transitions.interactive.duration};
+  transition-timing-function: ${({ theme }) => theme.transitions.interactive.timingFunction};
   -webkit-font-smoothing: antialiased;
+
+  svg {
+    transition: color ${({ theme }) => theme.transitions.interactive.duration} ${({ theme }) => theme.transitions.interactive.timingFunction};
+  }
 
   &:disabled {
     color: ${({ theme }) => theme.colors.text.disabled};

--- a/web/packages/design/src/Tooltip/HoverTooltip.tsx
+++ b/web/packages/design/src/Tooltip/HoverTooltip.tsx
@@ -23,7 +23,10 @@ import {
   FloatingArrow,
   FloatingPortal,
   offset,
+  type Placement,
+  safePolygon,
   shift,
+  useClick,
   useDismiss,
   useFloating,
   useFocus,
@@ -31,7 +34,6 @@ import {
   useInteractions,
   useRole,
   useTransitionStyles,
-  type Placement,
 } from '@floating-ui/react';
 import React, {
   Children,
@@ -90,6 +92,19 @@ type HoverTooltipProps = {
    */
   children: ReactElement<{ ref: Ref<HTMLElement> }>;
   /**
+   * How the tooltip is triggered. Defaults to `'hover'`.
+   */
+  trigger?: 'hover' | 'click';
+  /**
+   * When true, the tooltip stays open while the user hovers over it,
+   * allowing interaction with its content.
+   */
+  sticky?: boolean;
+  /**
+   * Maximum width of the tooltip in pixels. Defaults to `350`.
+   */
+  maxWidth?: number;
+  /**
    * Optional HTMLElement to render the portal into.
    * Defaults to `document.body`.
    */
@@ -114,6 +129,9 @@ export const HoverTooltip = ({
   delay = 0,
   disableFlip = false,
   disableTransitions = false,
+  trigger = 'hover',
+  sticky = false,
+  maxWidth = 350,
   portalRoot,
 }: HoverTooltipProps) => {
   const theme = useTheme();
@@ -137,7 +155,7 @@ export const HoverTooltip = ({
       return;
     }
 
-    if (disabled) {
+    if (disabled || !tipContent) {
       return;
     }
 
@@ -196,14 +214,21 @@ export const HoverTooltip = ({
   const openDelay = typeof delay === 'object' ? delay.open : delay;
   const closeDelay = typeof delay === 'object' ? delay.close : delay;
 
-  const { getFloatingProps } = useInteractions([
+  const isClickTrigger = trigger === 'click';
+  const isInteractive = isClickTrigger || sticky;
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([
     useHover(context, {
+      enabled: !isClickTrigger,
       delay: { open: openDelay, close: closeDelay },
-      handleClose: null,
+      handleClose: sticky
+        ? safePolygon({ buffer: 12, blockPointerEvents: true })
+        : null,
     }),
-    useFocus(context),
+    useClick(context, { enabled: isClickTrigger }),
+    useFocus(context, { enabled: !isClickTrigger }),
     useDismiss(context),
-    useRole(context, { role: 'tooltip' }),
+    useRole(context, { role: isClickTrigger ? 'dialog' : 'tooltip' }),
   ]);
 
   // `children` is a single valid React element, as enforced by the ReactElement type.
@@ -214,6 +239,7 @@ export const HoverTooltip = ({
   );
   const childWithRef = cloneElement(child, {
     ref: mergedRef,
+    ...getReferenceProps(),
   });
 
   return (
@@ -222,6 +248,8 @@ export const HoverTooltip = ({
       {isMounted && tipContent && (
         <FloatingPortal root={portalRoot}>
           <StyledTooltip
+            $interactive={isInteractive}
+            $maxWidth={maxWidth}
             data-testid="tooltip"
             ref={refs.setFloating}
             style={{
@@ -253,12 +281,15 @@ export const HoverTooltip = ({
   );
 };
 
-const StyledTooltip = styled.div`
-  max-width: 350px;
+const StyledTooltip = styled.div<{
+  $interactive?: boolean;
+  $maxWidth: number;
+}>`
+  max-width: ${p => p.$maxWidth}px;
   word-wrap: break-word;
   z-index: 1500;
   border-radius: 4px;
-  pointer-events: none;
+  pointer-events: ${p => (p.$interactive ? 'auto' : 'none')};
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.15));
   backdrop-filter: blur(2px);
   a {
@@ -267,6 +298,5 @@ const StyledTooltip = styled.div`
 `;
 
 const StyledContent = styled(Text)`
-  max-width: 350px;
   word-wrap: break-word;
 `;

--- a/web/packages/design/src/Tooltip/IconTooltip.tsx
+++ b/web/packages/design/src/Tooltip/IconTooltip.tsx
@@ -16,95 +16,33 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { PropsWithChildren, useState } from 'react';
-import styled, { useTheme } from 'styled-components';
+import React, { PropsWithChildren } from 'react';
+import styled from 'styled-components';
 
 import * as Icons from 'design/Icon';
-import Popover from 'design/Popover';
-import { Position } from 'design/Popover/Popover';
-import Text from 'design/Text';
-
-import { anchorOriginForPosition, transformOriginForPosition } from './shared';
+import { HoverTooltip } from 'design/Tooltip/HoverTooltip';
 
 type ToolTipKind = 'info' | 'warning' | 'error';
 
 export const IconTooltip: React.FC<
-  PropsWithChildren<{
-    trigger?: 'click' | 'hover';
-    position?: Position;
-    muteIconColor?: boolean;
-    sticky?: boolean;
-    maxWidth?: number;
-    kind?: ToolTipKind;
-  }>
+  PropsWithChildren<
+    {
+      muteIconColor?: boolean;
+      kind?: ToolTipKind;
+    } & Omit<React.ComponentProps<typeof HoverTooltip>, 'children'>
+  >
 > = ({
   children,
-  trigger = 'hover',
-  position = 'bottom',
   muteIconColor = false,
-  sticky = false,
-  maxWidth = 350,
   kind = 'info',
+  ...hoverTooltipProps
 }) => {
-  const theme = useTheme();
-  const [anchorEl, setAnchorEl] = useState<Element>();
-  const open = Boolean(anchorEl);
-
-  function handlePopoverOpen(event: React.MouseEvent) {
-    setAnchorEl(event.currentTarget);
-  }
-
-  function handlePopoverClose() {
-    setAnchorEl(undefined);
-  }
-
-  const triggerOnHoverProps = {
-    onMouseEnter: handlePopoverOpen,
-    onMouseLeave: sticky ? undefined : handlePopoverClose,
-  };
-  const triggerOnClickProps = {
-    onClick: handlePopoverOpen,
-  };
-
   return (
-    <>
-      <span
-        role="icon"
-        aria-owns={open ? 'mouse-over-popover' : undefined}
-        {...(trigger === 'hover' && triggerOnHoverProps)}
-        {...(trigger === 'click' && triggerOnClickProps)}
-        css={`
-          &:hover {
-            cursor: pointer;
-          }
-          vertical-align: middle;
-          display: inline-block;
-          height: 18px;
-        `}
-      >
+    <HoverTooltip {...hoverTooltipProps} tipContent={children}>
+      <IconWrapper>
         <ToolTipIcon kind={kind} muteIconColor={muteIconColor} />
-      </span>
-      <Popover
-        modalCss={() =>
-          trigger === 'hover' && `pointer-events: ${sticky ? 'auto' : 'none'}`
-        }
-        popoverCss={() => ({
-          background: theme.colors.tooltip.background,
-          backdropFilter: 'blur(2px)',
-        })}
-        onClose={handlePopoverClose}
-        open={open}
-        anchorEl={anchorEl}
-        anchorOrigin={anchorOriginForPosition(position)}
-        transformOrigin={transformOriginForPosition(position)}
-        arrow
-        popoverMargin={4}
-      >
-        <StyledOnHover px={3} py={2} $maxWidth={maxWidth}>
-          {children}
-        </StyledOnHover>
-      </Popover>
-    </>
+      </IconWrapper>
+    </HoverTooltip>
   );
 };
 
@@ -125,12 +63,11 @@ const ToolTipIcon = ({
   }
 };
 
-const StyledOnHover = styled(Text)<{ $maxWidth: number }>`
-  color: ${props => props.theme.colors.text.primaryInverse};
-  max-width: ${p => p.$maxWidth}px;
-  a {
-    color: ${props => props.theme.colors.tooltip.inverseLinkDefault};
-  }
+const IconWrapper = styled.span`
+  display: inline-flex;
+  vertical-align: middle;
+  cursor: pointer;
+  height: 18px;
 `;
 
 const InfoIcon = styled(Icons.Info)<{ $muteIconColor?: boolean }>`

--- a/web/packages/design/src/theme/themes/sharedStyles.ts
+++ b/web/packages/design/src/theme/themes/sharedStyles.ts
@@ -88,6 +88,16 @@ export const sharedStyles: SharedStyles = {
   radii: [0, 2, 4, 8, 16, 9999, '100%', 24],
   regular: fontWeights.regular,
   bold: fontWeights.bold,
+  transitions: {
+    interactive: {
+      duration: '150ms',
+      timingFunction: 'ease',
+    },
+    layout: {
+      duration: '200ms',
+      timingFunction: 'ease',
+    },
+  },
 };
 
 // Colors that are shared between all themes, these should be added to the theme.colors object.

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -398,6 +398,17 @@ export type SharedStyles = {
   radii: (number | string)[];
   regular: number;
   bold: number;
+  transitions: {
+    /** For interactive state changes: hover, focus, active. */
+    interactive: TransitionTokens;
+    /** For layout/content animations: expand, slide, fade. */
+    layout: TransitionTokens;
+  };
+};
+
+type TransitionTokens = {
+  duration: string;
+  timingFunction: string;
 };
 
 export type Theme = {


### PR DESCRIPTION
## Context
Update Button/IconButton styles to use consistent transition props from theme. Reuse HoverTooltip within IconTooltip for consistent styles/animations and `safePolygon` to make interactive/sticky tooltips less finicky.
