### PR TITLE
Fix goroutine leak in Connect MFA prompt

### DIFF
--- a/api/mfa/ceremony_test.go
+++ b/api/mfa/ceremony_test.go
@@ -160,11 +160,11 @@ func TestMFACeremony_SSO(t *testing.T) {
 			}
 
 			return mfa.PromptFunc(func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
-				if cfg.MFACeremony == nil {
+				if cfg.CallbackCeremony == nil {
 					return nil, trace.BadParameter("expected mfa ceremony")
 				}
 
-				return cfg.MFACeremony.Run(ctx, chal)
+				return cfg.CallbackCeremony.Run(ctx, chal)
 			})
 		},
 		MFACeremonyConstructor: func(ctx context.Context) (mfa.CallbackCeremony, error) {
@@ -218,11 +218,11 @@ func TestMFACeremony_BrowserMFA(t *testing.T) {
 			}
 
 			return mfa.PromptFunc(func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
-				if cfg.MFACeremony == nil {
+				if cfg.CallbackCeremony == nil {
 					return nil, trace.BadParameter("expected mfa ceremony")
 				}
 
-				return cfg.MFACeremony.Run(ctx, chal)
+				return cfg.CallbackCeremony.Run(ctx, chal)
 			})
 		},
 		MFACeremonyConstructor: func(ctx context.Context) (mfa.CallbackCeremony, error) {

--- a/api/mfa/prompt.go
+++ b/api/mfa/prompt.go
@@ -54,8 +54,8 @@ type PromptConfig struct {
 	// Extensions are the challenge extensions used to create the prompt's challenge.
 	// Used to enrich certain prompts.
 	Extensions *mfav1.ChallengeExtensions
-	// MFACeremony is an SSO or Browser MFA ceremony.
-	MFACeremony CallbackCeremony
+	// CallbackCeremony is an SSO or Browser MFA ceremony.
+	CallbackCeremony CallbackCeremony
 }
 
 // DeviceDescriptor is a descriptor for a device, such as "registered".
@@ -123,6 +123,6 @@ func WithPromptChallengeExtensions(exts *mfav1.ChallengeExtensions) PromptOpt {
 // withSSOMFACeremony sets the SSO MFA ceremony for the MFA prompt.
 func withSSOMFACeremony(ssoMFACeremony CallbackCeremony) PromptOpt {
 	return func(cfg *PromptConfig) {
-		cfg.MFACeremony = ssoMFACeremony
+		cfg.CallbackCeremony = ssoMFACeremony
 	}
 }

--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -235,18 +235,18 @@ func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 		slog.DebugContext(ctx, "Disabling WebAuthn: hardware device MFA not supported by your platform")
 	}
 
-	if state.promptSSO && c.cfg.MFACeremony == nil {
+	if state.promptSSO && c.cfg.CallbackCeremony == nil {
 		state.promptSSO = false
 		slog.DebugContext(ctx, "Disabling SSO MFA: SSO MFA ceremony not available (this is likely a bug)")
 	}
 
-	if state.promptBrowser && (chal.WebauthnChallenge == nil || c.cfg.MFACeremony == nil) {
+	if state.promptBrowser && (chal.WebauthnChallenge == nil || c.cfg.CallbackCeremony == nil) {
 		state.promptBrowser = false
 		slog.DebugContext(
 			ctx,
 			"Disabling Browser MFA: user needs at least one webauthn device and client needs to support SSO MFA Ceremony",
 			"webauthn_available", chal.WebauthnChallenge != nil,
-			"mfa_ceremony_available (if false, this is a bug)", c.cfg.MFACeremony != nil,
+			"mfa_ceremony_available (if false, this is a bug)", c.cfg.CallbackCeremony != nil,
 		)
 	}
 
@@ -419,63 +419,57 @@ func (c *CLIPrompt) promptDevicePrefix() string {
 }
 
 func (c *CLIPrompt) promptWebauthnAndOTP(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
-	spawnGoroutines := func(ctx context.Context, wg *sync.WaitGroup, respC chan<- MFAGoroutineResponse) {
-		var message string
-		if c.getOS() == constants.WindowsOS {
-			message = "Follow the OS dialogs for platform authentication, or enter an OTP code here:"
-			webauthnwin.SetPromptPlatformMessage("")
-		} else {
-			message = fmt.Sprintf("Tap any %ssecurity key or enter a code from a %sOTP device", c.promptDevicePrefix(), c.promptDevicePrefix())
-		}
-		fmt.Fprintln(c.writer(), message)
+	var message string
+	if c.getOS() == constants.WindowsOS {
+		message = "Follow the OS dialogs for platform authentication, or enter an OTP code here:"
+		webauthnwin.SetPromptPlatformMessage("")
+	} else {
+		message = fmt.Sprintf("Tap any %ssecurity key or enter a code from a %sOTP device", c.promptDevicePrefix(), c.promptDevicePrefix())
+	}
+	fmt.Fprintln(c.writer(), message)
 
-		// Fire OTP goroutine.
-		var otpCancelAndWait func()
-		otpCtx, otpCancel := context.WithCancel(ctx)
-		otpDone := make(chan struct{})
-		otpCancelAndWait = func() {
-			otpCancel()
-			<-otpDone
-		}
+	// Prepare to fire OTP goroutine.
+	otpCtx, otpCancel := context.WithCancel(ctx)
+	defer otpCancel()
 
-		wg.Add(1)
-		go func() {
-			defer func() {
-				wg.Done()
-				otpCancel()
-				close(otpDone)
-			}()
-
-			resp, err := c.promptOTP(otpCtx, true /*quiet*/)
-			respC <- MFAGoroutineResponse{Resp: resp, Err: trace.Wrap(err, "TOTP authentication failed")}
-		}()
-
-		// Fire Webauthn goroutine.
-		wg.Add(1)
-		go func() {
-			defer func() {
-				wg.Done()
-				// Important for dual-prompt.
-				webauthnwin.ResetPromptPlatformMessage()
-			}()
-
-			// Skip FirstTouchMessage when both OTP and WebAuthn are possible,
-			// as the prompt happens externally.
-			defaultPrompt := c.getWebauthnPrompt(ctx)
-			defaultPrompt.FirstTouchMessage = ""
-
-			// Wrap the prompt with otp context handler.
-			prompt := &webauthnPromptWithOTP{
-				LoginPrompt:      defaultPrompt,
-				otpCancelAndWait: otpCancelAndWait,
-			}
-
-			resp, err := c.promptWebauthn(ctx, chal, prompt)
-			respC <- MFAGoroutineResponse{Resp: resp, Err: trace.Wrap(err, "Webauthn authentication failed")}
-		}()
+	otpDone := make(chan struct{})
+	otpCancelAndWait := func() {
+		otpCancel()
+		<-otpDone
 	}
 
-	return HandleMFAPromptGoroutines(ctx, spawnGoroutines)
+	promptOTP := func(ctx context.Context, _ *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+		defer func() {
+			otpCancel()
+			close(otpDone)
+		}()
+
+		resp, err := c.promptOTP(otpCtx, true /*quiet*/)
+		return resp, trace.Wrap(err, "TOTP authentication failed")
+	}
+
+	promptWebauthn := func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+		defer func() {
+			// Important for dual-prompt.
+			webauthnwin.ResetPromptPlatformMessage()
+		}()
+
+		// Skip FirstTouchMessage when both OTP and WebAuthn are possible,
+		// as the prompt happens externally.
+		defaultPrompt := c.getWebauthnPrompt(ctx)
+		defaultPrompt.FirstTouchMessage = ""
+
+		// Wrap the prompt with otp context handler.
+		prompt := &webauthnPromptWithOTP{
+			LoginPrompt:      defaultPrompt,
+			otpCancelAndWait: otpCancelAndWait,
+		}
+
+		resp, err := c.promptWebauthn(ctx, chal, prompt)
+		return resp, trace.Wrap(err, "Webauthn authentication failed")
+	}
+
+	return HandleConcurrentMFAPrompts(ctx, chal, promptOTP, promptWebauthn)
 }
 
 // webauthnPromptWithOTP implements wancli.LoginPrompt for MFA logins.
@@ -525,7 +519,7 @@ func (c *CLIPrompt) promptSSO(ctx context.Context, chal *proto.MFAAuthenticateCh
 	// but to be safe, copy and remove the Browser MFA challenge here.
 	ssoChal := *chal
 	ssoChal.BrowserMFAChallenge = nil
-	resp, err := c.cfg.MFACeremony.Run(ctx, &ssoChal)
+	resp, err := c.cfg.CallbackCeremony.Run(ctx, &ssoChal)
 	return resp, trace.Wrap(err)
 }
 
@@ -534,6 +528,6 @@ func (c *CLIPrompt) promptBrowser(ctx context.Context, chal *proto.MFAAuthentica
 	// so remove copy and remove the SSO challenge so Browser MFA is used.
 	browserChal := *chal
 	browserChal.SSOChallenge = nil
-	resp, err := c.cfg.MFACeremony.Run(ctx, &browserChal)
+	resp, err := c.cfg.CallbackCeremony.Run(ctx, &browserChal)
 	return resp, trace.Wrap(err)
 }

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -167,7 +167,7 @@ func TestCLIPrompt(t *testing.T) {
 			},
 			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
 				cfg.PreferBrowser = true
-				cfg.MFACeremony = &mockSSOMFACeremony{
+				cfg.CallbackCeremony = &mockSSOMFACeremony{
 					runFunc: func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
 						return &proto.MFAAuthenticateResponse{
 							Response: &proto.MFAAuthenticateResponse_Browser{
@@ -439,7 +439,7 @@ Enter your security key PIN:
 			},
 			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
 				cfg.WebauthnSupported = false
-				cfg.MFACeremony = nil
+				cfg.CallbackCeremony = nil
 			},
 			expectErr: trace.BadParameter("client does not support any available MFA methods [WEBAUTHN, SSO], see debug logs for details"),
 		},
@@ -549,7 +549,7 @@ Enter your security key PIN:
 			},
 			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
 				cfg.RuntimeOS = constants.WindowsOS
-				cfg.MFACeremony = &mockSSOMFACeremony{
+				cfg.CallbackCeremony = &mockSSOMFACeremony{
 					runFunc: func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
 						return &proto.MFAAuthenticateResponse{
 							Response: &proto.MFAAuthenticateResponse_Browser{
@@ -582,7 +582,7 @@ Enter your security key PIN:
 				}
 			},
 			modifyPromptConfig: func(cfg *mfa.CLIPromptConfig) {
-				cfg.MFACeremony = &mockSSOMFACeremony{
+				cfg.CallbackCeremony = &mockSSOMFACeremony{
 					runFunc: func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
 						return &proto.MFAAuthenticateResponse{
 							Response: &proto.MFAAuthenticateResponse_Browser{
@@ -631,7 +631,7 @@ Enter your security key PIN:
 				}
 			}
 
-			cfg.MFACeremony = &mockSSOMFACeremony{
+			cfg.CallbackCeremony = &mockSSOMFACeremony{
 				mfaResp: tc.expectResp,
 			}
 

--- a/lib/client/mfa/prompt.go
+++ b/lib/client/mfa/prompt.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
-	"sync"
 
 	"github.com/gravitational/trace"
 
@@ -79,41 +78,38 @@ func (c PromptConfig) GetWebauthnOrigin() string {
 	return c.ProxyAddress
 }
 
-// MFAGoroutineResponse is an MFA goroutine response.
-type MFAGoroutineResponse struct {
-	Resp *proto.MFAAuthenticateResponse
-	Err  error
-}
-
-// HandleMFAPromptGoroutines spawns MFA prompt goroutines and returns the first successful response,
+// HandleConcurrentMFAPrompts handles concurrently prompting for MFA with all
+// of the given promptFuncs and returning the the first successful response,
 // terminating error, or an aggregated error if they all fail.
-func HandleMFAPromptGoroutines(ctx context.Context, startGoroutines func(context.Context, *sync.WaitGroup, chan<- MFAGoroutineResponse)) (*proto.MFAAuthenticateResponse, error) {
-	respC := make(chan MFAGoroutineResponse, 3)
-	var wg sync.WaitGroup
-
+func HandleConcurrentMFAPrompts(ctx context.Context, chal *proto.MFAAuthenticateChallenge, promptFuncs ...mfa.PromptFunc) (*proto.MFAAuthenticateResponse, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	defer func() {
-		cancel()
-		// wait for all goroutines to complete to ensure there are no leaks.
-		wg.Wait()
-	}()
+	defer cancel()
 
-	startGoroutines(ctx, &wg, respC)
+	type promptResponse struct {
+		resp *proto.MFAAuthenticateResponse
+		err  error
+	}
 
-	// Wait for spawned goroutines above to complete, then close respC.
-	go func() {
-		wg.Wait()
-		close(respC)
-	}()
+	respC := make(chan promptResponse, len(promptFuncs))
+	for _, prompt := range promptFuncs {
+		go func() {
+			resp, err := prompt(ctx, chal)
+			respC <- promptResponse{
+				resp: resp,
+				err:  err,
+			}
+		}()
+	}
 
 	// Wait for a successful response, or terminating error, from the spawned goroutines.
-	// The goroutine above will ensure the response channel is closed once all goroutines are done.
 	var errs []error
-	for resp := range respC {
-		switch err := resp.Err; {
+	for range len(promptFuncs) {
+		resp := <-respC
+
+		switch err := resp.err; {
 		case errors.Is(err, wancli.ErrUsingNonRegisteredDevice):
 			// Surface error immediately.
-			return nil, trace.Wrap(resp.Err)
+			return nil, trace.Wrap(resp.err)
 		case err != nil:
 			slog.DebugContext(ctx, "MFA goroutine failed, continuing so other goroutines have a chance to succeed", "error", err)
 			errs = append(errs, err)
@@ -122,10 +118,15 @@ func HandleMFAPromptGoroutines(ctx context.Context, startGoroutines func(context
 			continue
 		}
 
+		if resp.resp == nil {
+			continue
+		}
+
 		// Return successful response.
-		return resp.Resp, nil
+		return resp.resp, nil
 	}
 
+	// If the prompts result in no response or error, it's a no-op.
 	if len(errs) == 0 {
 		return &proto.MFAAuthenticateResponse{}, nil
 	}

--- a/lib/teleterm/daemon/mfaprompt.go
+++ b/lib/teleterm/daemon/mfaprompt.go
@@ -21,7 +21,6 @@ package daemon
 import (
 	"context"
 	"io"
-	"sync"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc/codes"
@@ -74,13 +73,39 @@ func (s *Service) promptAppMFA(ctx context.Context, in *api.PromptMFARequest) (*
 func (p *mfaPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
 	promptOTP := chal.TOTP != nil
 	promptWebauthn := chal.WebauthnChallenge != nil && p.cfg.WebauthnSupported
-	promptSSO := chal.SSOChallenge != nil && p.cfg.MFACeremony != nil
-	promptBrowserMfa := chal.BrowserMFAChallenge != nil && p.cfg.MFACeremony != nil
-	scope := p.cfg.Extensions.GetScope()
+	promptSSO := chal.SSOChallenge != nil && p.cfg.CallbackCeremony != nil
+	promptBrowserMfa := chal.BrowserMFAChallenge != nil && p.cfg.CallbackCeremony != nil
+
 	// No prompt to run, no-op.
 	if !promptOTP && !promptWebauthn && !promptSSO && !promptBrowserMfa {
 		return &proto.MFAAuthenticateResponse{}, nil
 	}
+
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	appPrompt := func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+		resp, err := p.promptApp(ctx, chal)
+
+		// If the user closes the modal in the Electron app, we need to be able to cancel the other
+		// goroutine as well so that we stop waiting for the hardware key tap.
+		if err != nil && status.Code(err) == codes.Aborted {
+			cancel(err)
+		}
+
+		return resp, trace.Wrap(err)
+	}
+
+	return libmfa.HandleConcurrentMFAPrompts(ctx, chal, appPrompt, p.maybePromptWebauthn, p.maybePromptBrowserOrSSO)
+}
+
+// promptApp handles the client modal, cancellation, and TOTP.
+func (p *mfaPrompt) promptApp(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+	promptOTP := chal.TOTP != nil
+	promptWebauthn := chal.WebauthnChallenge != nil && p.cfg.WebauthnSupported
+	promptSSO := chal.SSOChallenge != nil && p.cfg.CallbackCeremony != nil
+	promptBrowserMfa := chal.BrowserMFAChallenge != nil && p.cfg.CallbackCeremony != nil
+	scope := p.cfg.Extensions.GetScope()
 
 	var ssoChallenge *api.SSOChallenge
 	if promptSSO {
@@ -99,60 +124,15 @@ func (p *mfaPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 		}
 	}
 
-	spawnGoroutines := func(ctx context.Context, wg *sync.WaitGroup, respC chan<- libmfa.MFAGoroutineResponse) {
-		ctx, cancel := context.WithCancelCause(ctx)
-
-		// Fire app Prompt goroutine. Handles client cancellation and TOTP.
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			resp, err := p.promptMFA(ctx, &api.PromptMFARequest{
-				ClusterUri:    p.resourceURI.GetClusterURI().String(),
-				Reason:        p.cfg.PromptReason,
-				Totp:          promptOTP,
-				Webauthn:      promptWebauthn,
-				Sso:           ssoChallenge,
-				Browser:       browserMfaChallenge,
-				PerSessionMfa: scope == mfav1.ChallengeScope_CHALLENGE_SCOPE_USER_SESSION,
-			})
-			respC <- libmfa.MFAGoroutineResponse{Resp: resp, Err: err}
-
-			// If the user closes the modal in the Electron app, we need to be able to cancel the other
-			// goroutine as well so that we stop waiting for the hardware key tap.
-			if err != nil && status.Code(err) == codes.Aborted {
-				cancel(err)
-			}
-		}()
-
-		// Fire Webauthn goroutine.
-		if promptWebauthn {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
-				resp, err := p.promptWebauthn(ctx, chal)
-				respC <- libmfa.MFAGoroutineResponse{Resp: resp, Err: trace.Wrap(err, "Webauthn authentication failed")}
-			}()
-		}
-
-		// Fire SSO/Browser MFA goroutine. They both share the same callback handler.
-		if promptSSO || promptBrowserMfa {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
-				resp, err := p.promptBrowserOrSSO(ctx, chal)
-				respC <- libmfa.MFAGoroutineResponse{Resp: resp, Err: trace.Wrap(err, "SSO/Browser MFA authentication failed")}
-			}()
-		}
-	}
-
-	return libmfa.HandleMFAPromptGoroutines(ctx, spawnGoroutines)
-}
-
-func (p *mfaPrompt) promptMFA(ctx context.Context, req *api.PromptMFARequest) (*proto.MFAAuthenticateResponse, error) {
-	resp, err := p.promptAppMFA(ctx, req)
+	resp, err := p.promptAppMFA(ctx, &api.PromptMFARequest{
+		ClusterUri:    p.resourceURI.GetClusterURI().String(),
+		Reason:        p.cfg.PromptReason,
+		Totp:          promptOTP,
+		Webauthn:      promptWebauthn,
+		Sso:           ssoChallenge,
+		Browser:       browserMfaChallenge,
+		PerSessionMfa: scope == mfav1.ChallengeScope_CHALLENGE_SCOPE_USER_SESSION,
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -163,18 +143,27 @@ func (p *mfaPrompt) promptMFA(ctx context.Context, req *api.PromptMFARequest) (*
 	}, nil
 }
 
-func (p *mfaPrompt) promptWebauthn(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+// Prompt Webauthn if it's a supported method.
+func (p *mfaPrompt) maybePromptWebauthn(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+	if chal.WebauthnChallenge == nil || !p.cfg.WebauthnSupported {
+		return nil, nil
+	}
+
 	prompt := wancli.NewDefaultPrompt(ctx, io.Discard)
 	opts := &wancli.LoginOpts{AuthenticatorAttachment: p.cfg.AuthenticatorAttachment}
 	resp, _, err := p.cfg.WebauthnLoginFunc(ctx, p.cfg.GetWebauthnOrigin(), wantypes.CredentialAssertionFromProto(chal.WebauthnChallenge), prompt, opts)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "Webauthn authentication failed")
 	}
-
 	return resp, nil
 }
 
-func (c *mfaPrompt) promptBrowserOrSSO(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
-	resp, err := c.cfg.MFACeremony.Run(ctx, chal)
+// Prompt Browser/SSO if it's a supported method.
+func (p *mfaPrompt) maybePromptBrowserOrSSO(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+	if (chal.SSOChallenge == nil && chal.BrowserMFAChallenge == nil) || p.cfg.CallbackCeremony == nil {
+		return nil, nil
+	}
+
+	resp, err := p.cfg.CallbackCeremony.Run(ctx, chal)
 	return resp, trace.Wrap(err)
 }


### PR DESCRIPTION
Changelog: Fix a goroutine leak in the Teleport Connect MFA prompt when both SSO MFA and Webauthn are available second factors.

[Codex spotted](https://github.com/gravitational/teleport/pull/64887/changes#r2986610380) a potential deadlock in the Connect MFA prompting goroutines caused by insufficient buffering. In practice, I'm not sure there is a way to force 2 of the goroutines to fail, which would cause the 3rd to block on `respC <- ...` and deadlock. For that reason, I've diagnosed this a goroutine leak instead, as the last goroutine will always block on sending.

This PR fixes it by refactoring the concurrent prompt handling with a much more sensible separation of concerns between `HandleConcurrentMFAPrompts`. Namely, the caller does have any responsibility for the concurrency logic with this change.

## Manual Test Plan

### Test Cases
- [x] tsh MFA prompt with SSO MFA
- [x] tsh MFA prompt with Webauthn
- [x] Teleport Connect MFA prompt with SSO MFA
- [x] Teleport Connect MFA prompt with Webauthn

