### PR TITLE
[v18] scoped client idle timeout

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -130,13 +130,22 @@ func (x *ScopedRole) GetSpec() *ScopedRoleSpec {
 	return nil
 }
 
-// ScopedRoleSpec is the specification of a scoped role.
+// ScopedRoleSpec is the specification of a scoped role. Note that this type and all of its
+// members (e.g. [ScopedRoleOptions]) are required to have presence enabled for all non-sequence
+// fields (enforced by unit tests in lib/scopes/access). In practice, this means that scalar values
+// should be declared as optional. This policy exists because fields that default to a value that
+// looks potentially meaningful (e.g. false for bools) can cause difficulties when trying to determine
+// if a field was intentionally set to that value or just left unset. For scoped roles we generally
+// want to defer to global configuration for any policy not explicitly set in the role, so its important
+// to always be able to distinguish presence.
 type ScopedRoleSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// AssignableScopes is a list of scopes to which this role can be assigned.
 	AssignableScopes []string `protobuf:"bytes,1,rep,name=assignable_scopes,json=assignableScopes,proto3" json:"assignable_scopes,omitempty"`
 	// Allow specifies the permissions granted by this role.
-	Allow         *ScopedRoleConditions `protobuf:"bytes,2,opt,name=allow,proto3" json:"allow,omitempty"`
+	Allow *ScopedRoleConditions `protobuf:"bytes,2,opt,name=allow,proto3" json:"allow,omitempty"`
+	// Options contains fine tuning options for various protocols/controls.
+	Options       *ScopedRoleOptions `protobuf:"bytes,3,opt,name=options,proto3" json:"options,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -181,6 +190,13 @@ func (x *ScopedRoleSpec) GetAssignableScopes() []string {
 func (x *ScopedRoleSpec) GetAllow() *ScopedRoleConditions {
 	if x != nil {
 		return x.Allow
+	}
+	return nil
+}
+
+func (x *ScopedRoleSpec) GetOptions() *ScopedRoleOptions {
+	if x != nil {
+		return x.Options
 	}
 	return nil
 }
@@ -306,6 +322,55 @@ func (x *ScopedRule) GetVerbs() []string {
 	return nil
 }
 
+// ScopedRoleOptions contains fine tuning options for various protocols/controls.
+type ScopedRoleOptions struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ClientIdleTimeout sets the idle timeout for access sessions. If set to 0 or
+	// an empty string, the appropriate globally defined value is used. The value
+	// must be a valid Go duration string (e.g. "30m", "1h", "90s"). Values that
+	// exceed globally defined limits have no effect.
+	ClientIdleTimeout string `protobuf:"bytes,1,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ScopedRoleOptions) Reset() {
+	*x = ScopedRoleOptions{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRoleOptions) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRoleOptions) ProtoMessage() {}
+
+func (x *ScopedRoleOptions) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedRoleOptions.ProtoReflect.Descriptor instead.
+func (*ScopedRoleOptions) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ScopedRoleOptions) GetClientIdleTimeout() string {
+	if x != nil {
+		return x.ClientIdleTimeout
+	}
+	return ""
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -318,10 +383,11 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12=\n" +
-	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\x84\x01\n" +
+	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\xcc\x01\n" +
 	"\x0eScopedRoleSpec\x12+\n" +
 	"\x11assignable_scopes\x18\x01 \x03(\tR\x10assignableScopes\x12E\n" +
-	"\x05allow\x18\x02 \x01(\v2/.teleport.scopes.access.v1.ScopedRoleConditionsR\x05allow\"\xa6\x01\n" +
+	"\x05allow\x18\x02 \x01(\v2/.teleport.scopes.access.v1.ScopedRoleConditionsR\x05allow\x12F\n" +
+	"\aoptions\x18\x03 \x01(\v2,.teleport.scopes.access.v1.ScopedRoleOptionsR\aoptions\"\xa6\x01\n" +
 	"\x14ScopedRoleConditions\x12;\n" +
 	"\x05rules\x18\x01 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12\x16\n" +
 	"\x06logins\x18\x02 \x03(\tR\x06logins\x129\n" +
@@ -330,7 +396,9 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
-	"\x05verbs\x18\x02 \x03(\tR\x05verbsBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x05verbs\x18\x02 \x03(\tR\x05verbs\"C\n" +
+	"\x11ScopedRoleOptions\x12.\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeoutBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
 var (
 	file_teleport_scopes_access_v1_role_proto_rawDescOnce sync.Once
@@ -344,26 +412,28 @@ func file_teleport_scopes_access_v1_role_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_role_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),           // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),       // 1: teleport.scopes.access.v1.ScopedRoleSpec
 	(*ScopedRoleConditions)(nil), // 2: teleport.scopes.access.v1.ScopedRoleConditions
 	(*ScopedRule)(nil),           // 3: teleport.scopes.access.v1.ScopedRule
-	(*v1.Metadata)(nil),          // 4: teleport.header.v1.Metadata
-	(*v11.Label)(nil),            // 5: teleport.label.v1.Label
+	(*ScopedRoleOptions)(nil),    // 4: teleport.scopes.access.v1.ScopedRoleOptions
+	(*v1.Metadata)(nil),          // 5: teleport.header.v1.Metadata
+	(*v11.Label)(nil),            // 6: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	4, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	5, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2, // 2: teleport.scopes.access.v1.ScopedRoleSpec.allow:type_name -> teleport.scopes.access.v1.ScopedRoleConditions
-	3, // 3: teleport.scopes.access.v1.ScopedRoleConditions.rules:type_name -> teleport.scopes.access.v1.ScopedRule
-	5, // 4: teleport.scopes.access.v1.ScopedRoleConditions.node_labels:type_name -> teleport.label.v1.Label
-	5, // [5:5] is the sub-list for method output_type
-	5, // [5:5] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	4, // 3: teleport.scopes.access.v1.ScopedRoleSpec.options:type_name -> teleport.scopes.access.v1.ScopedRoleOptions
+	3, // 4: teleport.scopes.access.v1.ScopedRoleConditions.rules:type_name -> teleport.scopes.access.v1.ScopedRule
+	6, // 5: teleport.scopes.access.v1.ScopedRoleConditions.node_labels:type_name -> teleport.label.v1.Label
+	6, // [6:6] is the sub-list for method output_type
+	6, // [6:6] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -377,7 +447,7 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -44,13 +44,23 @@ message ScopedRole {
   ScopedRoleSpec spec = 6;
 }
 
-// ScopedRoleSpec is the specification of a scoped role.
+// ScopedRoleSpec is the specification of a scoped role. Note that this type and all of its
+// members (e.g. [ScopedRoleOptions]) are required to have presence enabled for all non-sequence
+// fields (enforced by unit tests in lib/scopes/access). In practice, this means that scalar values
+// should be declared as optional. This policy exists because fields that default to a value that
+// looks potentially meaningful (e.g. false for bools) can cause difficulties when trying to determine
+// if a field was intentionally set to that value or just left unset. For scoped roles we generally
+// want to defer to global configuration for any policy not explicitly set in the role, so its important
+// to always be able to distinguish presence.
 message ScopedRoleSpec {
   // AssignableScopes is a list of scopes to which this role can be assigned.
   repeated string assignable_scopes = 1;
 
   // Allow specifies the permissions granted by this role.
   ScopedRoleConditions allow = 2;
+
+  // Options contains fine tuning options for various protocols/controls.
+  ScopedRoleOptions options = 3;
 }
 
 // ScopedRoleConditions describes a role's allow block.
@@ -73,4 +83,13 @@ message ScopedRule {
   repeated string resources = 1;
   // Verbs is the list of action verbs (e.g. 'read') that apply to the above resources.
   repeated string verbs = 2;
+}
+
+// ScopedRoleOptions contains fine tuning options for various protocols/controls.
+message ScopedRoleOptions {
+  // ClientIdleTimeout sets the idle timeout for access sessions. If set to 0 or
+  // an empty string, the appropriate globally defined value is used. The value
+  // must be a valid Go duration string (e.g. "30m", "1h", "90s"). Values that
+  // exceed globally defined limits have no effect.
+  string client_idle_timeout = 1;
 }

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
@@ -793,4 +795,46 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 			require.Equal(t, tt.expect, result)
 		})
 	}
+}
+
+// requireAllFieldsHavePresence recursively verifies that all non-sequence fileds in a proto message have
+// presence enabled (for proto3 this typically means that scalar fields are marked optional).
+func requireAllFieldsHavePresence(t *testing.T, msg proto.Message) {
+	requireAllFieldsHavePresenceRecursive(t, msg.ProtoReflect().Descriptor())
+}
+
+func requireAllFieldsHavePresenceRecursive(t *testing.T, descriptor protoreflect.MessageDescriptor) {
+	fields := descriptor.Fields()
+	for i := range fields.Len() {
+		field := fields.Get(i)
+
+		// recursively check nested fields.
+		if field.Kind() == protoreflect.MessageKind {
+			// note: MessageKind fields covers both singular and repeated messages
+			requireAllFieldsHavePresenceRecursive(t, field.Message())
+		}
+		if field.IsMap() && field.MapValue().Kind() == protoreflect.MessageKind {
+			requireAllFieldsHavePresenceRecursive(t, field.MapValue().Message())
+		}
+
+		// skip lists/strings/bytes since empty sequences aren't as concerning as false/0 when it comes to distinguishing
+		// unset vs set to zero value.
+		if field.IsList() || field.Kind() == protoreflect.StringKind || field.Kind() == protoreflect.BytesKind {
+			continue
+		}
+
+		// require that presence is enabled. if you are adding a new field to scoped roles and run into this check failing,
+		// you likely need to make the field optional.
+		require.True(t, field.HasPresence(),
+			"field %s.%s must have presence enabled (use optional for scalar fields)",
+			descriptor.FullName(), field.Name())
+	}
+}
+
+// TestScopedRoleSpecFieldsHavePresence verifies that the scoped role spec and its members
+// have presence enabled for all non-sequence fields.
+// See proto comments for the ScopedRoleSpec type for discussion of this policy.
+func TestScopedRoleSpecFieldsHavePresence(t *testing.T) {
+	t.Parallel()
+	requireAllFieldsHavePresence(t, (*scopedaccessv1.ScopedRoleSpec)(nil))
 }

--- a/lib/scopes/access/compat.go
+++ b/lib/scopes/access/compat.go
@@ -85,10 +85,19 @@ func scopedRoleConditionsToRoleConditions(src *scopedaccessv1.ScopedRoleConditio
 // format converted role names as "<role-name>@<assigned-scope>" to help ensure reasonable error messages from
 // role evaluation logic.
 func ScopedRoleToRole(sr *scopedaccessv1.ScopedRole, assignedScope string) (types.Role, error) {
+	// Parse the client_idle_timeout if specified
+	var clientIdleTimeout time.Duration
+	if timeoutStr := sr.GetSpec().GetOptions().GetClientIdleTimeout(); timeoutStr != "" {
+		var err error
+		clientIdleTimeout, err = time.ParseDuration(timeoutStr)
+		if err != nil {
+			return nil, trace.Errorf("failed to parse client_idle_timeout %q for scoped role %q: %w", timeoutStr, sr.GetMetadata().GetName(), err)
+		}
+	}
 	role, err := types.NewRoleWithVersion(sr.GetMetadata().GetName()+"@"+assignedScope, types.V8, types.RoleSpecV6{
 		// scoped roles support allow blocks, but not deny blocks.
 		Allow: scopedRoleConditionsToRoleConditions(sr.GetSpec().GetAllow()),
-		// no scoped role options have been implemented yet. all options blocks are default/placeholder values.
+		// many scoped role options have not been implemented yet. some of options have been deliberately seeded with conservative defaults.
 		Options: types.RoleOptions{
 			// CertificateFormat is always set to "standard" for scoped roles. We don't anticipate needing to change
 			// this in the future, but if we did alternative options for controlling the parameter via some other
@@ -137,14 +146,10 @@ func ScopedRoleToRole(sr *scopedaccessv1.ScopedRole, assignedScope string) (type
 			// per-access lock evaluation specialization possible, but its likely that cert-creation locking behavior will
 			// need special handling of some kind.
 			Lock: "",
-			// ClientIdleTimeout is disabled until we can decide how to handle the cases where client idle timeout is
-			// being used independently of an access check (and therefore independent of a known target scope). It is possible
-			// that the correct way to handle this will be to break compatibility with classic roles and introduce separate
-			// per-protocol idle timeouts, with the global timeout always applying for operations that are not tied to a
-			// specific access check. By setting this value to zero we effectively make the default behavior one where we
-			// are always deferring to the global setting for scoped identities, which aught to be forwards compatible with
-			// whatever solution we eventually land on.
-			ClientIdleTimeout: types.NewDuration(0),
+			// ClientIdleTimeout is set from the role's client_idle_timeout field. If not specified (zero value),
+			// the global cluster networking config timeout will be used as the default. This allows scoped roles
+			// to specify custom idle timeouts that are enforced during post-access-check operations like SSH sessions.
+			ClientIdleTimeout: types.NewDuration(clientIdleTimeout),
 
 			// DisconnectExpiredCert is disabled until we can decide how to handle the cases where disconnect on expired cert is
 			// being used independently of an access check (and therefore independent of a known target scope). It is possible

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -553,17 +553,13 @@ func (c *ScopedAccessChecker) SSHPortForwardMode() decisionpb.SSHPortForwardMode
 	return c.checker.SSHPortForwardMode()
 }
 
-// AdjustClientIdleTimeout adjusts requested idle timeout
-// to the lowest max allowed timeout, the most restrictive
-// option will be picked, negative values will be assumed as 0
+// AdjustClientIdleTimeout determines the client idle timeout to apply. The supplied argument must be the globally
+// defined most-permissive value. If the underlying scoped role specifies a more restrictive value, that value will
+// be returned, otherwise the globally defined value is returned unchanged.
 func (c *ScopedAccessChecker) AdjustClientIdleTimeout(timeout time.Duration) time.Duration {
-	// scoped roles do not currently support client idle timeouts, but we don't currently foresee
-	// issues with mirroring the classic role interface here and this method is not used to
-	// derive certificate parameters.  *however*, there are some usages of this method that
-	// are not pre-access-check. This method can be used now for post-access-check adjustments,
-	// but further work will need to be done to determine how we want to handle client idle
-	// timeouts in the context of scoped roles. See ../scopes/access/compat.go for more
-	// discussion.
+	// scoped client idle timeout calculation differs from classic roles, but only insofar as
+	// we don't support multi-role evaluation. since scope access checkers are always built from
+	// a single role anyway, we can defer to the classic implementation.
 	return c.checker.AdjustClientIdleTimeout(timeout)
 }
 

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -24,10 +24,12 @@ import (
 	"crypto/rand"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
@@ -39,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -47,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshca"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 type mockCAandAuthPrefGetter struct {
@@ -305,9 +309,6 @@ func TestRBAC(t *testing.T) {
 
 // TestScopedRBAC verifies that scoped RBAC checks are performed correctly.
 func TestScopedRBAC(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
 	node, err := types.NewNode("testnode", types.SubKindTeleportNode, types.ServerSpecV2{
 		Addr:     "1.2.3.4:22",
 		Hostname: "testnode",
@@ -318,42 +319,6 @@ func TestScopedRBAC(t *testing.T) {
 
 	serverV2 := node.(*types.ServerV2)
 	serverV2.Scope = "/staging/west"
-
-	// create User CA
-	userCAPriv, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.ECDSAP256)
-	require.NoError(t, err)
-	userCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
-		Type:        types.UserCA,
-		ClusterName: "localhost",
-		ActiveKeys: types.CAKeySet{
-			SSH: []*types.SSHKeyPair{
-				{
-					PublicKey:      userCAPriv.MarshalSSHPublicKey(),
-					PrivateKey:     userCAPriv.PrivateKeyPEM(),
-					PrivateKeyType: types.PrivateKeyType_RAW,
-				},
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	// create mock SSH server and add a cluster name
-	server := newMockServer(t)
-
-	// set the mock SSH server's view of itself when performing RBAC
-	// checks in `ComponentNode` mode.
-	server.setInfo(node)
-
-	clusterName, err := types.NewClusterName(types.ClusterNameSpecV2{
-		ClusterName: "localhost",
-		ClusterID:   "cluster_id",
-	})
-	require.NoError(t, err)
-	err = server.auth.SetClusterName(clusterName)
-	require.NoError(t, err)
-
-	_, err = server.auth.CreateClusterNetworkingConfig(ctx, types.DefaultClusterNetworkingConfig())
-	require.NoError(t, err)
 
 	scopedRoles := []*scopedaccessv1.ScopedRole{
 		{
@@ -472,16 +437,7 @@ func TestScopedRBAC(t *testing.T) {
 		},
 	}
 
-	accessPoint := mockScopedRoleReaderGetter{
-		AccessPoint: mockCAandAuthPrefGetter{
-			AccessPoint: server.auth,
-			authPref:    types.DefaultAuthPreference(),
-			cas: map[types.CertAuthType][]types.CertAuthority{
-				types.UserCA: {userCA},
-			},
-		},
-		scopedRoles: scopedRoles,
-	}
+	pack := newScopedAccessAuthzPack(t, serverV2, scopedRoles, types.DefaultClusterNetworkingConfig())
 
 	tts := []struct {
 		name    string
@@ -562,40 +518,11 @@ func TestScopedRBAC(t *testing.T) {
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			config := &AuthHandlerConfig{
-				Server:       server,
-				Component:    teleport.ComponentNode,
-				Emitter:      &eventstest.MockRecorderEmitter{},
-				AccessPoint:  accessPoint,
-				TargetServer: node,
-			}
-			ah, err := NewAuthHandlers(config)
-			require.NoError(t, err)
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
 
-			// create SSH certificate
-			caSigner, err := ssh.NewSignerFromKey(userCAPriv)
-			require.NoError(t, err)
-			privateKey, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.ECDSAP256)
-			require.NoError(t, err)
-
-			c, err := testauthority.GenerateUserCert(sshca.UserCertificateRequest{
-				CASigner:      caSigner,
-				PublicUserKey: ssh.MarshalAuthorizedKey(privateKey.SSHPublicKey()),
-				Identity: sshca.Identity{
-					Username:   "testuser",
-					Principals: []string{"testuser"},
-					ScopePin:   tt.pin,
-				},
-			})
-			require.NoError(t, err)
-
-			cert, err := sshutils.ParseCertificate(c)
-			require.NoError(t, err)
-
-			// preform public key authentication
-			_, err = ah.UserKeyAuth(&mockConnMetadata{}, cert)
 			if tt.allowed {
 				require.NoError(t, err)
+				require.NotNil(t, permit)
 			} else {
 				require.Error(t, err)
 				require.True(t, trace.IsAccessDenied(err))
@@ -1158,4 +1085,459 @@ func TestAuthAttemptAuditEvent(t *testing.T) {
 	authEvent := emitter.LastEvent().(*apievents.AuthAttempt)
 	require.Equal(t, node.GetName(), authEvent.ServerID)
 	require.Equal(t, node.GetHostname(), authEvent.ServerHostname)
+}
+
+// scopedAccessAuthzPack is a helper intended to simplify testing scoped authz logic.
+type scopedAccessAuthzPack struct {
+	node       *types.ServerV2
+	userCAPriv *keys.PrivateKey
+	authConfig *AuthHandlerConfig
+}
+
+// newScopedAccessAuthzPack creates a new scopedAccessAuthPack set up with the provided node as the target of the authz decision,
+// and the provided scoped roles available in the access point. Subsequent calls to scopedAccessAuthzPack.UserKeyAuthFromPin
+// with various pins assigning the supplied roles can then be used to test decision logic.
+func newScopedAccessAuthzPack(t *testing.T, node *types.ServerV2, roles []*scopedaccessv1.ScopedRole, netConfig types.ClusterNetworkingConfig) *scopedAccessAuthzPack {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	// create User CA
+	userCAPriv, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	userCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.UserCA,
+		ClusterName: "localhost",
+		ActiveKeys: types.CAKeySet{
+			SSH: []*types.SSHKeyPair{
+				{
+					PublicKey:      userCAPriv.MarshalSSHPublicKey(),
+					PrivateKey:     userCAPriv.PrivateKeyPEM(),
+					PrivateKeyType: types.PrivateKeyType_RAW,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// create mock SSH server and add a cluster name
+	server := newMockServer(t)
+
+	// set the mock SSH server's view of itself when performing RBAC
+	// checks in `ComponentNode` mode
+	server.setInfo(node)
+
+	clusterName, err := types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: "localhost",
+		ClusterID:   "cluster_id",
+	})
+	require.NoError(t, err)
+	err = server.auth.SetClusterName(clusterName)
+	require.NoError(t, err)
+
+	// use caller-provided cluster networking config (cnc affects various access parameters
+	// and is relevant for some test scenarios)
+	_, err = server.auth.CreateClusterNetworkingConfig(ctx, netConfig)
+	require.NoError(t, err)
+
+	accessPoint := mockScopedRoleReaderGetter{
+		AccessPoint: mockCAandAuthPrefGetter{
+			AccessPoint: server.auth,
+			authPref:    types.DefaultAuthPreference(),
+			cas: map[types.CertAuthType][]types.CertAuthority{
+				types.UserCA: {userCA},
+			},
+		},
+		scopedRoles: roles,
+	}
+
+	config := &AuthHandlerConfig{
+		Server:       server,
+		Component:    teleport.ComponentNode,
+		Emitter:      &eventstest.MockRecorderEmitter{},
+		AccessPoint:  accessPoint,
+		TargetServer: node,
+	}
+
+	return &scopedAccessAuthzPack{
+		node:       node,
+		userCAPriv: userCAPriv,
+		authConfig: config,
+	}
+}
+
+// UserKeyAuthFromPin wraps the AuthHandlers.UserKeyAuth method to allow for easily testing calls with various scope pins
+// and examining the resulting permits. Helpful for table driven tests that want to validate that authz decisions for scoped
+// identities. If an error is returned, it is the error from UserKeyAuth specifically.
+func (h *scopedAccessAuthzPack) UserKeyAuthFromPin(t *testing.T, pin *scopesv1.Pin) (*decisionpb.SSHAccessPermit, error) {
+	ah, err := NewAuthHandlers(h.authConfig)
+	require.NoError(t, err)
+
+	// create SSH certificate
+	caSigner, err := ssh.NewSignerFromKey(h.userCAPriv)
+	require.NoError(t, err)
+	privateKey, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+
+	c, err := testauthority.GenerateUserCert(sshca.UserCertificateRequest{
+		CASigner:      caSigner,
+		PublicUserKey: ssh.MarshalAuthorizedKey(privateKey.SSHPublicKey()),
+		Identity: sshca.Identity{
+			Username:   "testuser",
+			Principals: []string{"testuser"},
+			ScopePin:   pin,
+		},
+	})
+	require.NoError(t, err)
+
+	cert, err := sshutils.ParseCertificate(c)
+	require.NoError(t, err)
+
+	// perform public key authentication
+	perms, err := ah.UserKeyAuth(&mockConnMetadata{}, cert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// extract and return the AccessPermit (always present when authhandlers are in ComponentNode mode)
+	permitJSON, ok := perms.Extensions[utils.ExtIntSSHAccessPermit]
+	require.True(t, ok, "expected AccessPermit in permissions extensions")
+
+	var permit decisionpb.SSHAccessPermit
+	require.NoError(t, (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(permitJSON), &permit))
+
+	return &permit, nil
+}
+
+// TestScopedClientIdleTimeout tests various scenarios/combinations of scoped roles with different client idle
+// timeout values.
+func TestScopedClientIdleTimeout(t *testing.T) {
+	// set up a fake node with scoping and labels to act as the subject of access
+	node, err := types.NewNode("testnode", types.SubKindTeleportNode, types.ServerSpecV2{
+		Addr:     "1.2.3.4:22",
+		Hostname: "testnode",
+	}, map[string]string{
+		"env": "test",
+	})
+	require.NoError(t, err)
+
+	serverV2 := node.(*types.ServerV2)
+	serverV2.Scope = "/staging/west"
+
+	// set up networking config with a specific timeout.
+	netConfig := types.DefaultClusterNetworkingConfig()
+	netConfig.SetClientIdleTimeout(30 * time.Minute)
+
+	// set up various scoped roles with different scoping, labels, and logins. Note that this test relies on
+	// the each role, and the above cnc, using unique timeout values so that we can tell which policy "won".
+	scopedRoles := []*scopedaccessv1.ScopedRole{
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "no-timeout",
+			},
+			Scope: "/staging/west",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/west"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Logins: []string{"testuser"},
+					NodeLabels: []*labelv1.Label{
+						{
+							Name:   "env",
+							Values: []string{"test"},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "10m-timeout",
+			},
+			Scope: "/staging/west",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/west"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Logins: []string{"testuser"},
+					NodeLabels: []*labelv1.Label{
+						{
+							Name:   "env",
+							Values: []string{"test"},
+						},
+					},
+				},
+				Options: &scopedaccessv1.ScopedRoleOptions{
+					ClientIdleTimeout: "10m",
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "1h-timeout",
+			},
+			Scope: "/staging/west",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/west"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Logins: []string{"testuser"},
+					NodeLabels: []*labelv1.Label{
+						{
+							Name:   "env",
+							Values: []string{"test"},
+						},
+					},
+				},
+				Options: &scopedaccessv1.ScopedRoleOptions{
+					ClientIdleTimeout: "1h",
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "25m-timeout",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/west"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Logins: []string{"testuser"},
+					NodeLabels: []*labelv1.Label{
+						{
+							Name:   "env",
+							Values: []string{"test"},
+						},
+					},
+				},
+				Options: &scopedaccessv1.ScopedRoleOptions{
+					ClientIdleTimeout: "25m",
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "22m-timeout-general",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Logins: []string{"testuser"},
+					NodeLabels: []*labelv1.Label{
+						{
+							Name:   "env",
+							Values: []string{"test"},
+						},
+					},
+				},
+				Options: &scopedaccessv1.ScopedRoleOptions{
+					ClientIdleTimeout: "22m",
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "15m-timeout-specific",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/west"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Logins: []string{"testuser"},
+					NodeLabels: []*labelv1.Label{
+						{
+							Name:   "env",
+							Values: []string{"test"},
+						},
+					},
+				},
+				Options: &scopedaccessv1.ScopedRoleOptions{
+					ClientIdleTimeout: "15m",
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "12m-timeout-team-blue",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/west"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Logins: []string{"testuser"},
+					NodeLabels: []*labelv1.Label{
+						{
+							Name:   "team",
+							Values: []string{"blue"},
+						},
+					},
+				},
+				Options: &scopedaccessv1.ScopedRoleOptions{
+					ClientIdleTimeout: "12m",
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "16m-timeout",
+			},
+			Scope: "/staging/west",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/west"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Logins: []string{"testuser"},
+					NodeLabels: []*labelv1.Label{
+						{
+							Name:   "env",
+							Values: []string{"test"},
+						},
+					},
+				},
+				Options: &scopedaccessv1.ScopedRoleOptions{
+					ClientIdleTimeout: "16m",
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "18m-timeout-wrong-login",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/west"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Logins: []string{"wronguser"},
+					NodeLabels: []*labelv1.Label{
+						{
+							Name:   "env",
+							Values: []string{"test"},
+						},
+					},
+				},
+				Options: &scopedaccessv1.ScopedRoleOptions{
+					ClientIdleTimeout: "18m",
+				},
+			},
+			Version: types.V1,
+		},
+	}
+
+	pack := newScopedAccessAuthzPack(t, serverV2, scopedRoles, netConfig)
+
+	tts := []struct {
+		name            string
+		pin             *scopesv1.Pin
+		expectTimeout   time.Duration
+		expectAccessErr bool
+	}{
+		{
+			name: "no role timeout uses global default",
+			pin: &scopesv1.Pin{
+				Scope: "/staging",
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					"/staging/west": {"/staging/west": {"no-timeout"}},
+				}),
+			},
+			expectTimeout: 30 * time.Minute, // global default from cnc
+		},
+		{
+			name: "role timeout more restrictive than global",
+			pin: &scopesv1.Pin{
+				Scope: "/staging",
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					"/staging/west": {"/staging/west": {"10m-timeout"}},
+				}),
+			},
+			expectTimeout: 10 * time.Minute, // role timeout from the only applicable role
+		},
+		{
+			name: "role timeout less restrictive than global",
+			pin: &scopesv1.Pin{
+				Scope: "/staging",
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					"/staging/west": {"/staging/west": {"1h-timeout"}},
+				}),
+			},
+			expectTimeout: 30 * time.Minute, // global default due to being more restrictive than role timeout
+		},
+		{
+			name: "winning role determines timeout (single-role evaluation)",
+			pin: &scopesv1.Pin{
+				Scope: "/staging",
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					"/staging":      {"/staging/west": {"25m-timeout"}},
+					"/staging/west": {"/staging/west": {"10m-timeout"}},
+				}),
+			},
+			expectTimeout: 25 * time.Minute, // role assigned *from* a more ancestral/authoritative scope of origin wins
+		},
+		{
+			name: "more specific scope of effect wins (same origin)",
+			pin: &scopesv1.Pin{
+				Scope: "/staging",
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					"/staging": {
+						"/staging":      {"22m-timeout-general"},
+						"/staging/west": {"15m-timeout-specific"},
+					},
+				}),
+			},
+			expectTimeout: 15 * time.Minute, // role assigned *to* a more specific scope of effect wins
+		},
+		{
+			name: "label selector mismatch causes fallback to next role",
+			pin: &scopesv1.Pin{
+				Scope: "/staging",
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					"/staging":      {"/staging/west": {"12m-timeout-team-blue"}},
+					"/staging/west": {"/staging/west": {"16m-timeout"}},
+				}),
+			},
+			expectTimeout: 16 * time.Minute, // role with child scope of origin wins due to label selector mismatch
+		},
+		{
+			name: "login mismatch causes fallback to next role",
+			pin: &scopesv1.Pin{
+				Scope: "/staging",
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					"/staging":      {"/staging/west": {"18m-timeout-wrong-login"}},
+					"/staging/west": {"/staging/west": {"10m-timeout"}},
+				}),
+			},
+			expectTimeout: 10 * time.Minute, // role with child scope of origin wins due to login mismatch
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+
+			if tt.expectAccessErr {
+				require.Error(t, err)
+				require.True(t, trace.IsAccessDenied(err))
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, permit)
+
+			actualTimeout := permit.ClientIdleTimeout.AsDuration()
+			require.Equal(t, tt.expectTimeout, actualTimeout,
+				"ClientIdleTimeout should be %v but got %v", tt.expectTimeout, actualTimeout)
+		})
+	}
 }


### PR DESCRIPTION
Backport #63750 to branch/v18.

## Manual Test Plan

### Test Environment

Local env, enterprise build.

### Test Cases

- [x] Teleport understands (and emits) the expected "pretty" duration strings in yaml, and `tctl` get/create/edit generally handle the field as expected.
- [x] When a `client_idle_timeout` is specified, it is enforced by the agent as expected.
- [x] When multiple scoped roles specify a `client_idle_timeout`, the "winning" role (per role evaluation rules) determines the timeout value that is enforced.
- [x] When some scoped roles specify a `client_idle_timeout` and some do not, the winning role determines what (and if) timeout is enforced.
- [x] Adding a field without presence inside of the scoped role spec or one of its children causes the presence unit test to fail.