### PR TITLE
[v18] Update Rust to 1.94.0

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -368,5 +368,7 @@ COPY --chown=ci fips-files/boringtest.nogo /tmp/boringtest.go
 RUN echo "Ensure Go is using BoringCrypto" && \
     go run /tmp/boringtest.go
 
+RUN rm /tmp/boringtest.go
+
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -969,7 +969,7 @@ impl Client {
 
     fn x224_lock(
         x224_processor: &Arc<Mutex<x224::Processor>>,
-    ) -> Result<MutexGuard<x224::Processor>, SessionError> {
+    ) -> Result<MutexGuard<'_, x224::Processor>, SessionError> {
         x224_processor
             .lock()
             .map_err(|err| reason_err!(function!(), "PoisonError: {:?}", err))
@@ -977,7 +977,7 @@ impl Client {
 
     fn resize_manager_lock(
         pending_resize: &Arc<Mutex<PendingResize>>,
-    ) -> Result<MutexGuard<PendingResize>, SessionError> {
+    ) -> Result<MutexGuard<'_, PendingResize>, SessionError> {
         pending_resize
             .lock()
             .map_err(|err| reason_err!(function!(), "PoisonError: {:?}", err))

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/path.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/path.rs
@@ -75,7 +75,7 @@ impl UnixPath {
     }
 
     pub fn last(&self) -> Option<&str> {
-        self.path.split('/').last()
+        self.path.split('/').next_back()
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.94.0"
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Updates Rust to 1.94.0.

- [x] Wait for https://github.com/gravitational/teleport.e/pull/8334 

## Manual Test Plan

### Test Environment

- Run a tag build

### Test Cases
- [x] Successful tag build: https://github.com/gravitational/teleport.e/actions/runs/23621213049
- [x] Desktop Access connections work (AD)
- [x] Desktop Access connections work (non-AD)
- [x] fdpass-teleport works
