### PR TITLE
Provide reexec process child error in exec audit events

### DIFF
--- a/lib/srv/bpf_test.go
+++ b/lib/srv/bpf_test.go
@@ -931,7 +931,7 @@ func runCommand(t *testing.T, srv Server, bpfSrv bpf.BPF, command string, expect
 
 	t.Logf("running %q", command)
 
-	_, err := scx.execRequest.Start(ctx, channel)
+	err := scx.execRequest.Start(ctx, channel)
 	require.NoError(t, err)
 
 	t.Log("reading audit session ID")

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -134,6 +134,9 @@ type localExec struct {
 	// reexec and shell processes. This is necessary due to the use of custom pipes,
 	// which exec.Cmd does not wait for closure of in cmd.Wait().
 	waitForOutputStreams sync.WaitGroup
+	// childStderr is stderr read from the child process which may be populated once
+	// waitForOutputStreams completes.
+	childStderr string
 
 	pid int
 }
@@ -210,6 +213,7 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) error {
 			return
 		}
 
+		e.childStderr = childErr
 		if _, err := crlfReplacer.WriteString(channel, childErr); err != nil {
 			logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to client", "error", err)
 		}
@@ -269,24 +273,28 @@ func (e *localExec) Wait() ExecResult {
 	}
 
 	// Block until the command is finished executing.
-	err := e.Cmd.Wait()
+	exitErr := e.Cmd.Wait()
 	e.waitForOutputStreams.Wait()
-	if err != nil {
-		e.Ctx.Logger.DebugContext(e.Ctx.CancelContext(), "Local command failed", "error", err)
+	if exitErr != nil {
+		e.Ctx.Logger.DebugContext(e.Ctx.CancelContext(), "Local command failed", "error", exitErr)
 	} else {
 		e.Ctx.Logger.DebugContext(e.Ctx.CancelContext(), "Local command successfully executed")
 	}
 
-	execResult := ExecResult{
+	result := ExecResult{
 		Command: e.GetCommand(),
-		Code:    exitCode(err),
-		Error:   err,
+		Code:    exitCode(exitErr),
+		Error:   exitErr,
+	}
+
+	if e.childStderr != "" {
+		result.Error = errors.New(strings.TrimRight(e.childStderr, "\r\n"))
 	}
 
 	// Emit the result of execution to the Audit Log.
-	emitExecAuditEvent(e.Ctx, execResult)
+	emitExecAuditEvent(e.Ctx, result)
 
-	return execResult
+	return result
 }
 
 // ReadAuditSessionID reads the unique audit session ID of the process

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -56,6 +56,9 @@ type ExecResult struct {
 
 	// Code is return code that execution of the command resulted in.
 	Code int
+
+	// Error is a launch error or exit error from the child process.
+	Error error
 }
 
 // Exec executes an "exec" request.
@@ -70,7 +73,7 @@ type Exec interface {
 	Start(ctx context.Context, channel ssh.Channel) (*ExecResult, error)
 
 	// Wait will block while the command executes.
-	Wait() *ExecResult
+	Wait() ExecResult
 
 	// ReadAuditSessionID reads the unique audit session ID of the process
 	// that will be used to correlate audit events to the SSH session for
@@ -218,13 +221,16 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 	if err != nil {
 		logger.WarnContext(ctx, "Local command failed to start", "error", err)
 
-		// Emit the result of execution to the audit log
-		emitExecAuditEvent(e.Ctx, e.GetCommand(), err)
-
-		return &ExecResult{
+		execResult := ExecResult{
 			Command: e.GetCommand(),
-			Code:    exitCode(err),
-		}, trace.ConvertSystemError(err)
+			Code:    reexecconstants.RemoteCommandFailure,
+			Error:   err,
+		}
+
+		// Emit the result of execution to the audit log
+		emitExecAuditEvent(e.Ctx, execResult)
+
+		return &execResult, trace.ConvertSystemError(err)
 	}
 	// Close our half of the write pipe since it is only to be used by the child process.
 	// Not closing prevents being signaled when the child closes its half.
@@ -260,7 +266,7 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 }
 
 // Wait will block while the command executes.
-func (e *localExec) Wait() *ExecResult {
+func (e *localExec) Wait() ExecResult {
 	if e.Cmd.Process == nil {
 		e.Ctx.Logger.ErrorContext(e.Ctx.CancelContext(), "No process")
 	}
@@ -274,13 +280,14 @@ func (e *localExec) Wait() *ExecResult {
 		e.Ctx.Logger.DebugContext(e.Ctx.CancelContext(), "Local command successfully executed")
 	}
 
-	// Emit the result of execution to the Audit Log.
-	emitExecAuditEvent(e.Ctx, e.GetCommand(), err)
-
-	execResult := &ExecResult{
+	execResult := ExecResult{
 		Command: e.GetCommand(),
 		Code:    exitCode(err),
+		Error:   err,
 	}
+
+	// Emit the result of execution to the Audit Log.
+	emitExecAuditEvent(e.Ctx, execResult)
 
 	return execResult
 }
@@ -462,7 +469,7 @@ func (e *remoteExec) Start(ctx context.Context, ch ssh.Channel) (*ExecResult, er
 }
 
 // Wait will block while the command executes.
-func (e *remoteExec) Wait() *ExecResult {
+func (e *remoteExec) Wait() ExecResult {
 	// Block until the command is finished executing.
 	err := e.session.Wait()
 	if err != nil {
@@ -471,13 +478,16 @@ func (e *remoteExec) Wait() *ExecResult {
 		e.ctx.Logger.DebugContext(e.ctx.CancelContext(), "Remote command successfully executed")
 	}
 
-	// Emit the result of execution to the Audit Log.
-	emitExecAuditEvent(e.ctx, e.command, err)
-
-	return &ExecResult{
-		Command: e.GetCommand(),
+	result := ExecResult{
+		Command: e.command,
 		Code:    exitCode(err),
+		Error:   err,
 	}
+
+	// Emit the result of execution to the Audit Log.
+	emitExecAuditEvent(e.ctx, result)
+
+	return result
 }
 
 func (e *remoteExec) ReadAuditSessionID() (uint32, error) { return 0, nil }
@@ -495,7 +505,7 @@ func (e *remoteExec) PID() int {
 //
 // Note: to ensure that the event is recorded ctx.session must be used
 // instead of ctx.srv.
-func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
+func emitExecAuditEvent(ctx *ServerContext, result ExecResult) {
 	// Create common fields for event.
 	serverMeta := ctx.GetServer().EventMetadata()
 	sessionMeta := ctx.GetSessionMetadata()
@@ -507,22 +517,22 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 	}
 
 	commandMeta := apievents.CommandMetadata{
-		Command: cmd,
+		Command: result.Command,
 		// Due to scp being inherently vulnerable to command injection, always
 		// make sure the full command and exit code is recorded for accountability.
 		// For more details, see the following.
 		//
 		// https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=327019
 		// https://bugzilla.mindrot.org/show_bug.cgi?id=1998
-		ExitCode: strconv.Itoa(exitCode(execErr)),
+		ExitCode: strconv.Itoa(result.Code),
 	}
 
-	if execErr != nil {
-		commandMeta.Error = execErr.Error()
+	if result.Error != nil {
+		commandMeta.Error = result.Error.Error()
 	}
 
 	// Parse the exec command to find out if it was SCP or not.
-	path, action, isSCP, err := parseSecureCopy(cmd)
+	path, action, isSCP, err := parseSecureCopy(result.Command)
 	if err != nil {
 		ctx.Logger.WarnContext(ctx.srv.Context(), "Unable to parse scp command", "error", err)
 		return
@@ -546,13 +556,13 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 
 		switch action {
 		case events.SCPActionUpload:
-			if execErr != nil {
+			if result.Error != nil {
 				scpEvent.Code = events.SCPUploadFailureCode
 			} else {
 				scpEvent.Code = events.SCPUploadCode
 			}
 		case events.SCPActionDownload:
-			if execErr != nil {
+			if result.Error != nil {
 				scpEvent.Code = events.SCPDownloadFailureCode
 			} else {
 				scpEvent.Code = events.SCPDownloadCode
@@ -573,7 +583,7 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 			ConnectionMetadata: connectionMeta,
 			CommandMetadata:    commandMeta,
 		}
-		if execErr != nil {
+		if result.Error != nil {
 			execEvent.Code = events.ExecFailureCode
 		} else {
 			execEvent.Code = events.ExecCode

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -496,8 +496,9 @@ func (e *remoteExec) Wait() ExecResult {
 	var sshExitErr *ssh.ExitError
 	if errors.As(err, &sshExitErr) {
 		result.Code = sshExitErr.ExitStatus()
+		// Error omitted on purpose, we don't want trivial errors to be logged to audit.
 	} else if err != nil {
-		result.Code = teleport.RemoteCommandFailure
+		result.Code = reexecconstants.RemoteCommandFailure
 		result.Error = err
 	}
 

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -284,10 +284,18 @@ func (e *localExec) Wait() ExecResult {
 	result := ExecResult{
 		Command: e.GetCommand(),
 		Code:    exitCode(exitErr),
+		// Error omitted on purpose, we don't want trivial errors to be logged to audit.
 	}
 
 	if e.childStderr != "" {
 		result.Error = errors.New(strings.TrimRight(e.childStderr, "\r\n"))
+	} else if exitErr != nil {
+		// If we get a non exec.ExitError and no launch error, preserve the
+		// error from Wait as it may indicate some other genuine error.
+		var execExitErr *exec.ExitError
+		if !errors.As(exitErr, &execExitErr) {
+			result.Error = exitErr
+		}
 	}
 
 	// Emit the result of execution to the Audit Log.
@@ -565,13 +573,13 @@ func emitExecAuditEvent(ctx *ServerContext, result ExecResult) {
 
 		switch action {
 		case events.SCPActionUpload:
-			if result.Error != nil {
+			if result.Code != 0 {
 				scpEvent.Code = events.SCPUploadFailureCode
 			} else {
 				scpEvent.Code = events.SCPUploadCode
 			}
 		case events.SCPActionDownload:
-			if result.Error != nil {
+			if result.Code != 0 {
 				scpEvent.Code = events.SCPDownloadFailureCode
 			} else {
 				scpEvent.Code = events.SCPDownloadCode
@@ -592,7 +600,7 @@ func emitExecAuditEvent(ctx *ServerContext, result ExecResult) {
 			ConnectionMetadata: connectionMeta,
 			CommandMetadata:    commandMeta,
 		}
-		if result.Error != nil {
+		if result.Code != 0 {
 			execEvent.Code = events.ExecFailureCode
 		} else {
 			execEvent.Code = events.ExecCode

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -70,7 +70,7 @@ type Exec interface {
 	SetCommand(string)
 
 	// Start will start the execution of the command.
-	Start(ctx context.Context, channel ssh.Channel) (*ExecResult, error)
+	Start(ctx context.Context, channel ssh.Channel) error
 
 	// Wait will block while the command executes.
 	Wait() ExecResult
@@ -148,36 +148,35 @@ func (e *localExec) SetCommand(command string) {
 	e.Command = command
 }
 
-// Start launches the given command returns (nil, nil) if successful.
-// ExecResult is only used to communicate an error while launching.
-func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult, error) {
+// Start launches the given command.
+func (e *localExec) Start(ctx context.Context, channel ssh.Channel) error {
 	logger := e.Ctx.Logger.With("command", e.GetCommand())
 
 	// Parse the command to see if it is scp.
 	err := e.transformSecureCopy()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	// Create pipes to capture stdio of the shell (grandchild) process, closing our
 	// side of each pipe after starting the command.
 	shellStdinR, shellStdinW, err := os.Pipe()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 	defer shellStdinR.Close()
 	e.Ctx.AddCloser(shellStdinW)
 
 	shellStdoutR, shellStdoutW, err := os.Pipe()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 	defer shellStdoutW.Close()
 	e.Ctx.AddCloser(shellStdoutR)
 
 	shellStderrR, shellStderrW, err := os.Pipe()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 	defer shellStderrW.Close()
 	e.Ctx.AddCloser(shellStderrR)
@@ -185,13 +184,13 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 	// Create the command that will actually execute.
 	e.Cmd, err = ConfigureCommand(e.Ctx, shellStdinR, shellStdoutW, shellStderrW)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	// Capture stderr.
 	stderrR, stderrW, err := os.Pipe()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 	defer stderrW.Close()
 	e.Cmd.Stderr = stderrW
@@ -221,16 +220,14 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 	if err != nil {
 		logger.WarnContext(ctx, "Local command failed to start", "error", err)
 
-		execResult := ExecResult{
+		// Emit the result of execution to the audit log
+		emitExecAuditEvent(e.Ctx, ExecResult{
 			Command: e.GetCommand(),
 			Code:    reexecconstants.RemoteCommandFailure,
 			Error:   err,
-		}
+		})
 
-		// Emit the result of execution to the audit log
-		emitExecAuditEvent(e.Ctx, execResult)
-
-		return &execResult, trace.ConvertSystemError(err)
+		return trace.ConvertSystemError(err)
 	}
 	// Close our half of the write pipe since it is only to be used by the child process.
 	// Not closing prevents being signaled when the child closes its half.
@@ -262,7 +259,7 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 
 	logger.InfoContext(ctx, "Started local command execution")
 
-	return nil, nil
+	return nil
 }
 
 // Wait will block while the command executes.
@@ -427,9 +424,8 @@ func (e *remoteExec) SetCommand(command string) {
 	e.command = command
 }
 
-// Start launches the given command returns (nil, nil) if successful.
-// ExecResult is only used to communicate an error while launching.
-func (e *remoteExec) Start(ctx context.Context, ch ssh.Channel) (*ExecResult, error) {
+// Start launches the given command.
+func (e *remoteExec) Start(ctx context.Context, ch ssh.Channel) error {
 	if _, err := checkSCPAllowed(e.ctx, e.GetCommand()); err != nil {
 		e.ctx.GetServer().EmitAuditEvent(context.WithoutCancel(ctx), &apievents.SFTP{
 			Metadata: apievents.Metadata{
@@ -441,7 +437,7 @@ func (e *remoteExec) Start(ctx context.Context, ch ssh.Channel) (*ExecResult, er
 			ServerMetadata: e.ctx.GetServer().EventMetadata(),
 			Error:          err.Error(),
 		})
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	// hook up stdout/err the channel so the user can interact with the command
@@ -449,7 +445,7 @@ func (e *remoteExec) Start(ctx context.Context, ch ssh.Channel) (*ExecResult, er
 	e.session.Stderr = ch.Stderr()
 	inputWriter, err := e.session.StdinPipe()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	go func() {
@@ -462,10 +458,10 @@ func (e *remoteExec) Start(ctx context.Context, ch ssh.Channel) (*ExecResult, er
 
 	err = e.session.Start(ctx, e.command)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Wait will block while the command executes.

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -57,7 +57,7 @@ type ExecResult struct {
 	// Code is return code that execution of the command resulted in.
 	Code int
 
-	// Error is a launch error or exit error from the child process.
+	// Error is a launch error from the child process.
 	Error error
 }
 
@@ -284,7 +284,6 @@ func (e *localExec) Wait() ExecResult {
 	result := ExecResult{
 		Command: e.GetCommand(),
 		Code:    exitCode(exitErr),
-		Error:   exitErr,
 	}
 
 	if e.childStderr != "" {
@@ -484,8 +483,14 @@ func (e *remoteExec) Wait() ExecResult {
 
 	result := ExecResult{
 		Command: e.command,
-		Code:    exitCode(err),
-		Error:   err,
+	}
+
+	var sshExitErr *ssh.ExitError
+	if errors.As(err, &sshExitErr) {
+		result.Code = sshExitErr.ExitStatus()
+	} else if err != nil {
+		result.Code = teleport.RemoteCommandFailure
+		result.Error = err
 	}
 
 	// Emit the result of execution to the Audit Log.

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -121,6 +121,11 @@ func TestEmitExecAuditEvent(t *testing.T) {
 			} else {
 				require.Empty(t, execEvent.Error)
 			}
+			if tt.inResult.Code == 0 {
+				require.Equal(t, events.ExecCode, execEvent.Code)
+			} else {
+				require.Equal(t, events.ExecFailureCode, execEvent.Code)
+			}
 			require.Equal(t, strconv.Itoa(tt.inResult.Code), execEvent.ExitCode)
 			require.Equal(t, expectedMeta, execEvent.UserMetadata)
 			require.Equal(t, "123", execEvent.ServerID)

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -19,7 +19,7 @@
 package srv
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"os/user"
 	"strconv"
@@ -82,47 +82,56 @@ func TestEmitExecAuditEvent(t *testing.T) {
 	}
 
 	tests := []struct {
-		inCommand  string
-		inError    error
-		outCommand string
-		outCode    string
+		name     string
+		inResult ExecResult
 	}{
-		// Successful execution.
 		{
-			inCommand:  "exit 0",
-			inError:    nil,
-			outCommand: "exit 0",
-			outCode:    strconv.Itoa(reexecconstants.RemoteCommandSuccess),
+			name: "success",
+			inResult: ExecResult{
+				Command: "exit 0",
+				Error:   nil,
+				Code:    reexecconstants.RemoteCommandSuccess,
+			},
 		},
-		// Exited with error.
 		{
-			inCommand:  "exit 255",
-			inError:    fmt.Errorf("unknown error"),
-			outCommand: "exit 255",
-			outCode:    strconv.Itoa(reexecconstants.RemoteCommandFailure),
+
+			name: "exit with error",
+			inResult: ExecResult{
+				Command: "exit 255",
+				Error:   errors.New("exit status 255"),
+				Code:    reexecconstants.RemoteCommandFailure,
+			},
 		},
-		// Command injection.
 		{
-			inCommand:  "/bin/teleport scp --remote-addr=127.0.0.1:50862 --local-addr=127.0.0.1:54895 -f ~/file.txt && touch /tmp/new.txt",
-			inError:    fmt.Errorf("unknown error"),
-			outCommand: "/bin/teleport scp --remote-addr=127.0.0.1:50862 --local-addr=127.0.0.1:54895 -f ~/file.txt && touch /tmp/new.txt",
-			outCode:    strconv.Itoa(reexecconstants.RemoteCommandFailure),
+			name: "command injection",
+			inResult: ExecResult{
+				Command: "/bin/teleport scp --remote-addr=127.0.0.1:50862 --local-addr=127.0.0.1:54895 -f ~/file.txt && touch /tmp/new.txt",
+				Error:   errors.New("unknown error"),
+				Code:    reexecconstants.RemoteCommandFailure,
+			},
 		},
 	}
 	for _, tt := range tests {
-		emitExecAuditEvent(scx, tt.inCommand, tt.inError)
-		execEvent := rec.emitter.LastEvent().(*apievents.Exec)
-		require.Equal(t, tt.outCommand, execEvent.Command)
-		require.Equal(t, tt.outCode, execEvent.ExitCode)
-		require.Equal(t, expectedMeta, execEvent.UserMetadata)
-		require.Equal(t, "123", execEvent.ServerID)
-		require.Equal(t, "abc", execEvent.ForwardedBy)
-		require.Equal(t, expectedHostname, execEvent.ServerHostname)
-		require.Equal(t, "testNamespace", execEvent.ServerNamespace)
-		require.Equal(t, "xxx", execEvent.SessionID)
-		require.Equal(t, "10.0.0.5:4817", execEvent.RemoteAddr)
-		require.Equal(t, "127.0.0.1:3022", execEvent.LocalAddr)
-		require.NotEmpty(t, events.EventID)
+		t.Run(tt.name, func(t *testing.T) {
+			emitExecAuditEvent(scx, tt.inResult)
+			execEvent := rec.emitter.LastEvent().(*apievents.Exec)
+			require.Equal(t, tt.inResult.Command, execEvent.Command)
+			if tt.inResult.Error != nil {
+				require.Equal(t, tt.inResult.Error.Error(), execEvent.Error)
+			} else {
+				require.Empty(t, execEvent.Error)
+			}
+			require.Equal(t, strconv.Itoa(tt.inResult.Code), execEvent.ExitCode)
+			require.Equal(t, expectedMeta, execEvent.UserMetadata)
+			require.Equal(t, "123", execEvent.ServerID)
+			require.Equal(t, "abc", execEvent.ForwardedBy)
+			require.Equal(t, expectedHostname, execEvent.ServerHostname)
+			require.Equal(t, "testNamespace", execEvent.ServerNamespace)
+			require.Equal(t, "xxx", execEvent.SessionID)
+			require.Equal(t, "10.0.0.5:4817", execEvent.RemoteAddr)
+			require.Equal(t, "127.0.0.1:3022", execEvent.LocalAddr)
+			require.NotEmpty(t, events.EventID)
+		})
 	}
 }
 

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1609,18 +1609,8 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 		return trace.Wrap(err)
 	}
 
-	// Start execution. If the program failed to start, send that result back.
-	result, err := execRequest.Start(ctx, channel)
-	if err != nil {
+	if err := execRequest.Start(ctx, channel); err != nil {
 		return trace.Wrap(err)
-	}
-	if result != nil {
-		s.logger.DebugContext(
-			ctx, "Exec request completed.",
-			"request", execRequest,
-			"result", result,
-		)
-		scx.SendExecResult(ctx, *result)
 	}
 
 	bpfEnabled := scx.srv.GetBPF().Enabled()

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1487,9 +1487,9 @@ func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *p
 	// once it is received wait for the io.Copy above to finish, then broadcast
 	// the "exit-status" to the client.
 	go func() {
-		result, err := s.term.Wait()
-		if err != nil {
-			s.logger.ErrorContext(ctx, "Received error waiting for the interactive session to finish.", "error", err)
+		result := s.term.Wait()
+		if result.Error != nil {
+			s.logger.ErrorContext(ctx, "Received error waiting for the interactive session to finish.", "error", result.Error)
 		}
 
 		// wait for copying from the pty to be complete or a timeout before
@@ -1501,14 +1501,12 @@ func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *p
 		case <-s.doneCh:
 		}
 
-		if result != nil {
-			if err := s.registry.broadcastResult(s.id, *result); err != nil {
-				s.logger.WarnContext(ctx, "Failed to broadcast session result.", "error", err)
-			}
+		if err := s.registry.broadcastResult(s.id, result); err != nil {
+			s.logger.WarnContext(ctx, "Failed to broadcast session result.", "error", err)
 		}
 
-		if execRequest, err := scx.GetExecRequest(); err == nil && execRequest.GetCommand() != "" {
-			emitExecAuditEvent(scx, execRequest.GetCommand(), err)
+		if result.Command != "" {
+			emitExecAuditEvent(scx, result)
 		}
 
 		s.emitSessionEndEvent()
@@ -1677,10 +1675,8 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 
 	// Process is running, wait for it to stop.
 	go func() {
-		result = execRequest.Wait()
-		if result != nil {
-			scx.SendExecResult(ctx, *result)
-		}
+		result := execRequest.Wait()
+		scx.SendExecResult(ctx, result)
 
 		// Wait a little bit to let all events filter through before closing the
 		// BPF session so everything can be recorded.

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -41,7 +41,6 @@ import (
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils/reexec"
-	"github.com/gravitational/teleport/session/reexec/reexecconstants"
 )
 
 const (
@@ -66,7 +65,7 @@ type Terminal interface {
 	Run(ctx context.Context, errorWriter io.Writer) error
 
 	// Wait will block until the terminal is complete.
-	Wait() (*ExecResult, error)
+	Wait() ExecResult
 
 	// ReadAuditSessionID reads the unique audit session ID of the process
 	// that will be used to correlate audit events to the SSH session for
@@ -276,27 +275,20 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 }
 
 // Wait will block until the terminal is complete.
-func (t *terminal) Wait() (*ExecResult, error) {
+func (t *terminal) Wait() ExecResult {
 	err := t.cmd.Wait()
 	t.waitForOutputStreams.Wait()
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			status := exitErr.Sys().(syscall.WaitStatus)
-			return &ExecResult{Code: status.ExitStatus(), Command: t.cmd.Path}, nil
-		}
-		return nil, err
+
+	var cmd string
+	if execRequest, err := t.serverContext.GetExecRequest(); err == nil {
+		cmd = execRequest.GetCommand()
 	}
 
-	status, ok := t.cmd.ProcessState.Sys().(syscall.WaitStatus)
-	if !ok {
-		return nil, trace.Errorf("unknown exit status: %T(%v)", t.cmd.ProcessState.Sys(), t.cmd.ProcessState.Sys())
+	return ExecResult{
+		Code:    exitCode(err),
+		Command: cmd,
+		Error:   err,
 	}
-
-	return &ExecResult{
-		Code:    status.ExitStatus(),
-		Command: t.cmd.Path,
-	}, nil
 }
 
 // ReadAuditSessionID reads the unique audit session ID of the process
@@ -640,32 +632,18 @@ func (t *remoteTerminal) Run(ctx context.Context, _ io.Writer) error {
 	return nil
 }
 
-func (t *remoteTerminal) Wait() (*ExecResult, error) {
-	execRequest, err := t.ctx.GetExecRequest()
-	if err != nil {
-		return nil, trace.Wrap(err)
+func (t *remoteTerminal) Wait() ExecResult {
+	var execCmd string
+	if execRequest, err := t.ctx.GetExecRequest(); err == nil {
+		execCmd = execRequest.GetCommand()
 	}
 
-	err = t.session.Wait()
-	if err != nil {
-		var exitErr *ssh.ExitError
-		if errors.As(err, &exitErr) {
-			return &ExecResult{
-				Code:    exitErr.ExitStatus(),
-				Command: execRequest.GetCommand(),
-			}, err
-		}
-
-		return &ExecResult{
-			Code:    reexecconstants.RemoteCommandFailure,
-			Command: execRequest.GetCommand(),
-		}, err
+	err := t.session.Wait()
+	return ExecResult{
+		Command: execCmd,
+		Code:    exitCode(err),
+		Error:   err,
 	}
-
-	return &ExecResult{
-		Code:    reexecconstants.RemoteCommandSuccess,
-		Command: execRequest.GetCommand(),
-	}, nil
 }
 
 func (t *remoteTerminal) ReadAuditSessionID() (uint32, error) {

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -155,6 +155,9 @@ type terminal struct {
 	// reexec and shell processes. This is necessary due to the use of custom pipes,
 	// which exec.Cmd does not wait for closure of in cmd.Wait().
 	waitForOutputStreams sync.WaitGroup
+	// childStderr is stderr read from the child process which may be populated once
+	// waitForOutputStreams completes.
+	childStderr string
 
 	pid int
 
@@ -247,6 +250,7 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 			return
 		}
 
+		t.childStderr = childErr
 		if _, err := crlfReplacer.WriteString(errorWriter, childErr); err != nil {
 			t.serverContext.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to all parties", "error", err)
 		}
@@ -276,7 +280,7 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 
 // Wait will block until the terminal is complete.
 func (t *terminal) Wait() ExecResult {
-	err := t.cmd.Wait()
+	exitErr := t.cmd.Wait()
 	t.waitForOutputStreams.Wait()
 
 	var cmd string
@@ -284,11 +288,17 @@ func (t *terminal) Wait() ExecResult {
 		cmd = execRequest.GetCommand()
 	}
 
-	return ExecResult{
-		Code:    exitCode(err),
+	result := ExecResult{
+		Code:    exitCode(exitErr),
 		Command: cmd,
-		Error:   err,
+		Error:   exitErr,
 	}
+
+	if t.childStderr != "" {
+		result.Error = errors.New(strings.TrimRight(t.childStderr, "\r\n"))
+	}
+
+	return result
 }
 
 // ReadAuditSessionID reads the unique audit session ID of the process

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -41,6 +41,7 @@ import (
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils/reexec"
+	"github.com/gravitational/teleport/session/reexec/reexecconstants"
 )
 
 const (
@@ -660,8 +661,9 @@ func (t *remoteTerminal) Wait() ExecResult {
 	var sshExitErr *ssh.ExitError
 	if errors.As(err, &sshExitErr) {
 		result.Code = sshExitErr.ExitStatus()
+		// Error omitted on purpose, we don't want trivial errors to be logged to audit.
 	} else if err != nil {
-		result.Code = teleport.RemoteCommandFailure
+		result.Code = reexecconstants.RemoteCommandFailure
 		result.Error = err
 	}
 

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -291,7 +291,6 @@ func (t *terminal) Wait() ExecResult {
 	result := ExecResult{
 		Code:    exitCode(exitErr),
 		Command: cmd,
-		Error:   exitErr,
 	}
 
 	if t.childStderr != "" {
@@ -643,17 +642,22 @@ func (t *remoteTerminal) Run(ctx context.Context, _ io.Writer) error {
 }
 
 func (t *remoteTerminal) Wait() ExecResult {
-	var execCmd string
+	var result ExecResult
+
 	if execRequest, err := t.ctx.GetExecRequest(); err == nil {
-		execCmd = execRequest.GetCommand()
+		result.Command = execRequest.GetCommand()
 	}
 
 	err := t.session.Wait()
-	return ExecResult{
-		Command: execCmd,
-		Code:    exitCode(err),
-		Error:   err,
+	var sshExitErr *ssh.ExitError
+	if errors.As(err, &sshExitErr) {
+		result.Code = sshExitErr.ExitStatus()
+	} else if err != nil {
+		result.Code = teleport.RemoteCommandFailure
+		result.Error = err
 	}
+
+	return result
 }
 
 func (t *remoteTerminal) ReadAuditSessionID() (uint32, error) {

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -291,10 +291,18 @@ func (t *terminal) Wait() ExecResult {
 	result := ExecResult{
 		Code:    exitCode(exitErr),
 		Command: cmd,
+		// Error omitted on purpose, we don't want trivial errors to be logged to audit.
 	}
 
 	if t.childStderr != "" {
 		result.Error = errors.New(strings.TrimRight(t.childStderr, "\r\n"))
+	} else if exitErr != nil {
+		// If we get a non exec.ExitError and no launch error, preserve the
+		// error from Wait as it may indicate some other genuine error.
+		var execExitErr *exec.ExitError
+		if !errors.As(exitErr, &execExitErr) {
+			result.Error = exitErr
+		}
 	}
 
 	return result

--- a/lib/srv/term_test.go
+++ b/lib/srv/term_test.go
@@ -116,9 +116,7 @@ func TestTerminal_KillUnderlyingShell(t *testing.T) {
 	go func() {
 		// Call wait to avoid creating zombie process.
 		// Ignore exit code as we're checking term.cmd.ProcessState already
-		_, err := term.Wait()
-
-		errors <- err
+		errors <- term.Wait().Error
 	}()
 
 	// Continue execution


### PR DESCRIPTION
Changelog: Fix an issue with exec failure audit logs having non descriptive, or in some cases missing, error fields.

Changes:
- Fix exec failure audit logs for `tsh ssh --tty`, which previously failed to populate both the `exitCode` and `exitError`
- Don't report the plain "exit status x" error in the exec audit events `exitError` field, as the `exitCode` already contains this info, and it is inaccurate for commands like `exit 255` that run and exit with the code successfully.
- When available, use the more descriptive [reexec child process launch error](https://github.com/gravitational/teleport/pull/63910) as the `exitError` in audit events.
  - Note: this change doesn't currently apply proxy recording mode as the forwarding node does not currently have a way to retrieve the launch error mixed into stdout. This can be added with a new custom `teleport-exit-error` ssh channel in a follow up to keep this PR small.

Depends on https://github.com/gravitational/teleport/pull/63910

<details>
<summary>Example output</summary>

Before:
```
# Without TTY - exit code and exit error are redundant
{
   ...
  "event": "exec",
  "exitCode": "255",
  "exitError": "exit status 255",
}

# With TTY - incorrect exit code, no error
{
   ...
  "event": "exec",
  "exitCode": "0",
}
```

After:
```json
# With or without TTY
{
   ...
  "event": "exec",
  "exitCode": "255",
  "exitError": "Failed to launch: user: unknown user dne.",
}
```

</details>

## Manual Test Plan

- [x] Success cases
  - [x] `tsh ssh server01 ls`
  - [x] `tsh ssh --tty server01 ls`
- [x] Launch failure cases
  - [x] `tsh ssh dne@server01 `
  - [x] `tsh ssh --tty dne@server01 ls`