### PR TITLE
Web: fix externalAuditStorage CTA

### DIFF
--- a/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.test.tsx
+++ b/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.test.tsx
@@ -28,8 +28,13 @@ import { storageService } from 'teleport/services/storageService';
 
 import { ExternalAuditStorageCta } from './ExternalAuditStorageCta';
 
+const defaultExternalAuditStorageEntitlement =
+  cfg.entitlements.ExternalAuditStorage;
+
 describe('externalAuditStorageCta', () => {
   afterEach(() => {
+    cfg.entitlements.ExternalAuditStorage =
+      defaultExternalAuditStorageEntitlement;
     jest.clearAllMocks();
   });
 
@@ -47,7 +52,10 @@ describe('externalAuditStorageCta', () => {
     });
 
     cfg.isCloud = isCloud;
-    cfg.externalAuditStorage = !lockedFeature;
+    cfg.entitlements.ExternalAuditStorage = {
+      enabled: !lockedFeature,
+      limit: 0,
+    };
 
     jest
       .spyOn(storageService, 'getExternalAuditStorageCtaDisabled')

--- a/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.tsx
+++ b/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.tsx
@@ -38,7 +38,7 @@ import { ButtonLockedFeature } from '../ButtonLockedFeature';
 export const ExternalAuditStorageCta = (props: BoxProps) => {
   const [showCta, setShowCta] = useState<boolean>(false);
   const ctx = useTeleport();
-  const featureEnabled = cfg.externalAuditStorage;
+  const featureEnabled = cfg.entitlements.ExternalAuditStorage.enabled;
   const userHasAccess = ctx.getFeatureFlags().enrollIntegrationsOrPlugins;
 
   useEffect(() => {

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -235,7 +235,6 @@ const cfg = {
   customTheme: '',
   isStripeManaged: false,
   hasQuestionnaire: false,
-  externalAuditStorage: false,
   premiumSupport: false,
 
   // sessionSummarizerEnabled refers to the AI session summary feature


### PR DESCRIPTION
regression from https://github.com/gravitational/teleport/pull/59618, the `ExternalAuditStorage` got removed in the backend but not in the frontend which made `cfg.externalAuditStorage` always false

this PR removes the frontends `cfg.externalAuditStorage` and replace usage with `cfg.entitlement.ExternalAuditStorage.enabled`

enterprise update: https://github.com/gravitational/teleport.e/pull/8361

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
version 19.0.0-prealpha.2, cloud staging

### Test Cases
- [x] cloud env, external audit storage CTA has a proper CTA button (prior used to say `contact sales` despite meeting all feature requirement, now it says `connect your aws storage`)
- [x] non cloud env does not render CTA banner

~~cloud env without external audit storage support renders `contact sales`~~ this doesn't look like a case anymore, there is no toggle in the salescenter for externalAuditStorage

https://github.com/gravitational/teleport/issues/64627