### PR TITLE
Access requests: Test that expired requests are rendered correctly in menu

### DIFF
--- a/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.test.tsx
@@ -36,6 +36,7 @@ import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspace
 import { AccessRequestsContextProvider } from './AccessRequestsContext';
 
 test('assuming or dropping a request calls API', async () => {
+  const user = userEvent.setup();
   const appContext = new MockAppContext();
   const accessRequest = makeAccessRequest();
   const cluster = makeRootCluster({
@@ -76,17 +77,17 @@ test('assuming or dropping a request calls API', async () => {
   );
 
   const accessRequestsMenu = await screen.findByTitle('Access Requests');
-  await userEvent.click(accessRequestsMenu);
+  await user.click(accessRequestsMenu);
 
   const item = await screen.findByText(accessRequest.resources.at(0).id.name);
-  await userEvent.click(item);
+  await user.click(item);
   expect(appContext.clustersService.assumeRoles).toHaveBeenCalledTimes(1);
   expect(appContext.clustersService.assumeRoles).toHaveBeenCalledWith(
     cluster.uri,
     [accessRequest.id]
   );
   expect(await screen.findByText(/access assumed/i)).toBeInTheDocument();
-  await userEvent.click(item);
+  await user.click(item);
   expect(appContext.clustersService.dropRoles).toHaveBeenCalledTimes(1);
   expect(appContext.clustersService.dropRoles).toHaveBeenCalledWith(
     cluster.uri,
@@ -95,6 +96,7 @@ test('assuming or dropping a request calls API', async () => {
 });
 
 test('assumed request are always visible, even if getAccessRequests no longer returns them', async () => {
+  const user = userEvent.setup();
   const requestA = makeAccessRequest({
     id: '67bea2b6-9390-43a5-af47-c391561dbfba',
     resources: [],
@@ -137,7 +139,7 @@ test('assumed request are always visible, even if getAccessRequests no longer re
   );
 
   const accessRequestsMenu = await screen.findByTitle('Access Requests');
-  await userEvent.click(accessRequestsMenu);
+  await user.click(accessRequestsMenu);
 
   // Even though getAccessRequests only returned requestA, the UI always displays the assumed requests:
   // - requestB, which details exists in the useAssumedRequests cache

--- a/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.test.tsx
@@ -18,8 +18,10 @@
 
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { addHours, subHours } from 'date-fns';
 
 import { render } from 'design/utils/testing';
+import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import {
@@ -148,5 +150,65 @@ test('assumed request are always visible, even if getAccessRequests no longer re
   expect(await screen.findByText('access-b')).toBeInTheDocument();
   expect(
     await screen.findByText('request-with-details-not-available')
+  ).toBeInTheDocument();
+});
+
+test('after assuming a request and waiting for it to expire, the menu says the request has expired', async () => {
+  const user = userEvent.setup();
+  const appContext = new MockAppContext();
+  const now = new Date();
+  const futureExpires = Timestamp.fromDate(addHours(now, 4));
+  const pastExpires = Timestamp.fromDate(subHours(now, 5));
+  const accessRequest = makeAccessRequest({
+    resources: [],
+    roles: ['allow-users-with-short-ttl'],
+    expires: futureExpires,
+  });
+  const cluster = makeRootCluster({
+    features: { advancedAccessWorkflows: true, isUsageBasedBilling: false },
+  });
+  appContext.addRootCluster(cluster);
+  jest
+    .spyOn(appContext.clustersService, 'assumeRoles')
+    .mockImplementation(async () => {
+      appContext.clustersService.setState(state => {
+        state.clusters.get(cluster.uri).loggedInUser.activeRequests = [
+          accessRequest.id,
+        ];
+      });
+    });
+  appContext.tshd.getAccessRequests = () =>
+    new MockedUnaryCall({ requests: [accessRequest] });
+  appContext.tshd.getAccessRequest = () =>
+    new MockedUnaryCall({ request: accessRequest });
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <ResourcesContextProvider>
+        <MockWorkspaceContextProvider rootClusterUri={cluster.uri}>
+          <AccessRequestsContextProvider rootClusterUri={cluster.uri}>
+            <SelectorMenu />
+          </AccessRequestsContextProvider>
+        </MockWorkspaceContextProvider>
+      </ResourcesContextProvider>
+    </MockAppContextProvider>
+  );
+
+  // Open the menu and assume the request.
+  await user.click(await screen.findByTitle('Access Requests'));
+  await user.click(await screen.findByText('allow-users-with-short-ttl'));
+  expect(
+    await screen.findByText(/access assumed · expires in/i)
+  ).toBeInTheDocument();
+
+  // Simulate the request expiring by updating the mock to return a past expiry.
+  accessRequest.expires = pastExpires;
+
+  // Close and re-open the menu to trigger a refetch.
+  await user.click(await screen.findByTitle('Access Requests'));
+  await user.click(await screen.findByTitle('Access Requests'));
+
+  expect(
+    await screen.findByText('Access assumed · Expired')
   ).toBeInTheDocument();
 });


### PR DESCRIPTION
This test is meant to replace the item from the test plan:

> Verify that after re-assuming `allow-users-with-short-ttl` role and waiting until the request expires (up to 4 minutes), the Access Requests menu says that the request has expired.

I was able to write e2e tests for everything else except this one item. I figured it's better to just address it in a unit test instead.