### PR TITLE
Fix IP Pinning bypass when using the WebUI

### DIFF
--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -64,6 +64,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -964,8 +965,11 @@ type TLSServerConfig struct {
 	AuthServer *AuthServer
 	// Limiter is a connection and request limiter
 	Limiter *limiter.Config
-	// Listener is a listener to serve requests on
+	// Listener is an optional listener to use instead of the
+	// default tcp listener when creating the Mux.
 	Listener net.Listener
+	// Mux is a multiplexer to serve requests on
+	Mux *multiplexer.Mux
 	// AuthDialer is a dialer to use when making auth clients.
 	AuthDialer client.ContextDialer
 	// AcceptedUsage is a list of accepted usage restrictions
@@ -1040,15 +1044,35 @@ func NewTestTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	tlsConfig.Time = cfg.AuthServer.Clock().Now
 	tlsCert := tlsConfig.Certificates[0]
 
-	if srv.Listener == nil {
-		srv.Listener, err = net.Listen("tcp", "127.0.0.1:0")
+	listener := cfg.Listener
+	if listener == nil {
+		listener, err = net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
 
+	muxCAGetter := func(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
+		return cfg.AuthServer.AuthServer.GetCertAuthority(ctx, id, loadKeys)
+	}
+
+	// use multiplexer to leverage support for proxy protocol.
+	mux, err := multiplexer.New(multiplexer.Config{
+		PROXYProtocolMode:   multiplexer.PROXYProtocolUnspecified,
+		Listener:            listener,
+		ID:                  teleport.Component(cfg.AuthServer.AuthServer.ServerID),
+		CertAuthorityGetter: muxCAGetter,
+		LocalClusterName:    cfg.AuthServer.ClusterName,
+	})
+	if err != nil {
+		listener.Close()
+		return nil, trace.Wrap(err)
+	}
+	go mux.Serve()
+
+	srv.Mux = mux
 	srv.TLSServer, err = auth.NewTLSServer(context.Background(), auth.TLSServerConfig{
-		Listener:             srv.Listener,
+		Listener:             mux.TLS(),
 		AccessPoint:          srv.AuthServer.AuthServer.Cache,
 		TLS:                  tlsConfig,
 		GetClientCertificate: func() (*tls.Certificate, error) { return &tlsCert, nil },
@@ -1057,6 +1081,7 @@ func NewTestTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		AcceptedUsage:        cfg.AcceptedUsage,
 	})
 	if err != nil {
+		mux.Close()
 		return nil, trace.Wrap(err)
 	}
 	if err := srv.Start(); err != nil {
@@ -1348,7 +1373,7 @@ func (t *TLSServer) NewClient(identity TestIdentity) (*authclient.Client, error)
 
 // Addr returns address of TLS server
 func (t *TLSServer) Addr() net.Addr {
-	return t.Listener.Addr()
+	return t.Mux.Listener.Addr()
 }
 
 // Start starts TLS server on loopback address on the first listening socket
@@ -1378,10 +1403,8 @@ func (t *TLSServer) Shutdown(ctx context.Context) error {
 		errs = append(errs, err)
 	}
 
-	if t.Listener != nil {
-		if err := t.Listener.Close(); err != nil && !utils.IsUseOfClosedNetworkError(err) {
-			errs = append(errs, err)
-		}
+	if t.Mux != nil {
+		t.Mux.Close()
 	}
 
 	if err := t.AuthServer.Close(); err != nil {
@@ -1397,12 +1420,9 @@ func (t *TLSServer) Stop() error {
 	if err := t.TLSServer.Close(); err != nil {
 		errs = append(errs, err)
 	}
-	if t.Listener != nil {
-		if err := t.Listener.Close(); err != nil && !utils.IsUseOfClosedNetworkError(err) {
-			errs = append(errs, err)
-		}
+	if t.Mux != nil {
+		t.Mux.Close()
 	}
-
 	return trace.NewAggregate(errs...)
 }
 

--- a/lib/join/join_test.go
+++ b/lib/join/join_test.go
@@ -528,7 +528,7 @@ func TestJoinError(t *testing.T) {
 		{
 			desc: "auth direct",
 			joinParams: joinclient.JoinParams{
-				AuthServers: []utils.NetAddr{utils.FromAddr(authService.TLS.Listener.Addr())},
+				AuthServers: []utils.NetAddr{utils.FromAddr(authService.TLS.Addr())},
 			},
 			assertErr: func(t assert.TestingT, err error, msgAndArgs ...any) bool {
 				// Should get AccessDenied and should not fall back to joining
@@ -680,7 +680,7 @@ func (p *fakeProxy) runGRPCServer(t *testing.T, l net.Listener) {
 
 	grpcCreds := credentials.NewTLS(tlsConfig)
 
-	authenticatedAuthClientConn, err := grpc.NewClient(p.auth.TLS.Listener.Addr().String(),
+	authenticatedAuthClientConn, err := grpc.NewClient(p.auth.TLS.Addr().String(),
 		grpc.WithTransportCredentials(grpcCreds),
 		grpc.WithStreamInterceptor(interceptors.GRPCClientStreamErrorInterceptor),
 	)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1079,7 +1079,7 @@ func testInstanceSelfRepair(t *testing.T, params instanceSelfRepairParams) {
 	const hostName = "testhost"
 	newStartedProcess := func(token string, sshEnabled bool) *TeleportProcess {
 		cfg := servicecfg.MakeDefaultConfig()
-		cfg.SetAuthServerAddress(*utils.MustParseAddr(tlsServer.Listener.Addr().String()))
+		cfg.SetAuthServerAddress(*utils.MustParseAddr(tlsServer.Addr().String()))
 		cfg.Clock = clockwork.NewRealClock()
 		cfg.DataDir = dataDir
 		cfg.Hostname = hostName
@@ -1168,7 +1168,7 @@ func TestSSHPrincipals(t *testing.T) {
 	logger := logtest.NewLogger()
 	const hostName = "testhost"
 	nodeCfg := servicecfg.MakeDefaultConfig()
-	nodeCfg.SetAuthServerAddress(*utils.MustParseAddr(authServer.TLS.Listener.Addr().String()))
+	nodeCfg.SetAuthServerAddress(*utils.MustParseAddr(authServer.TLS.Addr().String()))
 	nodeCfg.Clock = clockwork.NewRealClock()
 	nodeCfg.DataDir = t.TempDir()
 	nodeCfg.Hostname = hostName

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -238,6 +238,9 @@ type webSuiteConfig struct {
 
 	// modules to inject into components.
 	modules *modulestest.Modules
+
+	// middleware adds optional middleware to the test handler.
+	middleware func(next http.Handler) http.Handler
 }
 
 func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
@@ -322,7 +325,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 			Name:      "auth",
 		},
 		Spec: types.ServerSpecV2{
-			Addr:     s.server.TLS.Listener.Addr().String(),
+			Addr:     s.server.TLS.Addr().String(),
 			Hostname: "localhost",
 			Version:  teleport.Version,
 		},
@@ -495,7 +498,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		DatabaseServerWatcher: databaseServerWatcher,
 		CertAuthorityWatcher:  caWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
-		LocalAuthAddresses:    []string{s.server.TLS.Listener.Addr().String()},
+		LocalAuthAddresses:    []string{s.server.TLS.Addr().String()},
 		Clock:                 s.clock,
 		EICESigner: func(ctx context.Context, target types.Server, integration types.Integration, login, token string, ap cryptosuites.AuthPreferenceGetter) (ssh.Signer, error) {
 			return nil, errors.New("eice disabled in tests")
@@ -564,6 +567,12 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	require.NoError(t, err)
 	proxyClientCert, err := keys.X509KeyPair(proxyIdentity.TLSCertBytes, proxyIdentity.KeyBytes)
 	require.NoError(t, err)
+	getProxyClientCert := func() (*tls.Certificate, error) {
+		return &proxyClientCert, nil
+	}
+
+	proxySigner, err := multiplexer.NewPROXYSigner(s.server.ClusterName(), getProxyClientCert, s.clock, false)
+	require.NoError(t, err)
 
 	handlerConfig := Config{
 		ClusterFeatures:                 features,
@@ -587,16 +596,15 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 			ctx, err := controller(ctx, sctx, login, localAddr, remoteAddr)
 			return ctx, trace.Wrap(err)
 		}),
-		Router:               router,
-		HealthCheckAppServer: cfg.HealthCheckAppServer,
-		UI:                   cfg.uiConfig,
-		PresenceChecker:      cfg.presenceChecker,
-		GetProxyClientCertificate: func() (*tls.Certificate, error) {
-			return &proxyClientCert, nil
-		},
-		IntegrationAppHandler: &mockIntegrationAppHandler{},
-		DatabaseREPLRegistry:  cfg.databaseREPLGetter,
-		ALPNHandler:           cfg.alpnHandler,
+		Router:                    router,
+		HealthCheckAppServer:      cfg.HealthCheckAppServer,
+		UI:                        cfg.uiConfig,
+		PresenceChecker:           cfg.presenceChecker,
+		GetProxyClientCertificate: getProxyClientCert,
+		IntegrationAppHandler:     &mockIntegrationAppHandler{},
+		DatabaseREPLRegistry:      cfg.databaseREPLGetter,
+		ALPNHandler:               cfg.alpnHandler,
+		PROXYSigner:               proxySigner,
 	}
 
 	if handlerConfig.HealthCheckAppServer == nil {
@@ -607,8 +615,8 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	require.NoError(t, err)
 
 	var httpTestHandler http.Handler = handler
-	if cfg.trustXForwardedFor {
-		httpTestHandler = NewXForwardedForMiddleware(httpTestHandler)
+	if cfg.middleware != nil {
+		httpTestHandler = cfg.middleware(handler)
 	}
 
 	s.webServer = httptest.NewUnstartedServer(httpTestHandler)
@@ -789,8 +797,7 @@ func (s *WebSuite) authPack(t *testing.T, user string, roles ...string) *authPac
 
 	s.createUser(t, user, login, pass, otpSecret, roles...)
 
-	ctx := context.Background()
-	sessionResp, httpResp := loginWebOTP(t, ctx, loginWebOTPParams{
+	sessionResp, httpResp := loginWebOTP(t, t.Context(), loginWebOTPParams{
 		webClient: s.client(t),
 		clock:     s.clock,
 		user:      user,
@@ -8396,7 +8403,7 @@ func newWebPack(t *testing.T, numProxies int, opts ...webPackOptions) *webPack {
 			Name:      "auth",
 		},
 		Spec: types.ServerSpecV2{
-			Addr:     server.TLS.Listener.Addr().String(),
+			Addr:     server.TLS.Addr().String(),
 			Hostname: "localhost",
 			Version:  teleport.Version,
 		},
@@ -8655,7 +8662,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		AppServerWatcher:      appServerWatcher,
 		DatabaseServerWatcher: databaseServerWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
-		LocalAuthAddresses:    []string{authServer.Listener.Addr().String()},
+		LocalAuthAddresses:    []string{authServer.Addr().String()},
 		EICESigner: func(ctx context.Context, target types.Server, integration types.Integration, login, token string, ap cryptosuites.AuthPreferenceGetter) (ssh.Signer, error) {
 			return nil, errors.New("eice disabled in tests")
 		},
@@ -8690,7 +8697,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 
 	mux, err := multiplexer.New(multiplexer.Config{
 		Listener:          proxyListener,
-		PROXYProtocolMode: multiplexer.PROXYProtocolOff,
+		PROXYProtocolMode: multiplexer.PROXYProtocolUnspecified,
 		ID:                teleport.Component(teleport.ComponentProxy, "ssh"),
 		CertAuthorityGetter: func(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
 			return client.GetCertAuthority(ctx, id, loadKeys)
@@ -11560,4 +11567,53 @@ func TestAuthenticateReqForAccessGraphAPI(t *testing.T) {
 		require.NotNil(t, sctx)
 		require.Equal(t, pack.user, sctx.GetUser())
 	})
+}
+
+func TestIPPinning(t *testing.T) {
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
+
+	clientAddr := utils.MustParseAddr("1.2.3.4:1234")
+	hostAddr := utils.MustParseAddr("127.0.0.1:3080")
+	clientAddrMiddleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := authz.ContextWithClientAddrs(r.Context(), clientAddr, hostAddr)
+			r.RemoteAddr = clientAddr.String()
+			r = r.WithContext(ctx)
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	s := newWebSuiteWithConfig(t, webSuiteConfig{
+		middleware: clientAddrMiddleware,
+	})
+
+	// Create a role that enforces IP Pinning.
+	ipPinningRole, err := types.NewRole("pinned-ip", types.RoleSpecV6{
+		Options: types.RoleOptions{
+			PinSourceIP: true,
+		},
+	})
+	require.NoError(t, err)
+	ipPinningRole, err = s.server.Auth().UpsertRole(s.ctx, ipPinningRole)
+	require.NoError(t, err)
+
+	// create a user with the ip pinning role and login.
+	pack := s.authPack(t, "foo", ipPinningRole.GetName())
+
+	// IP is pinned on login. Making an Auth server request with the web session
+	// with the same IP should succeed.
+	clusterName := s.server.ClusterName()
+	endpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "nodes")
+	_, err = pack.clt.Get(t.Context(), endpoint, url.Values{})
+	require.NoError(t, err)
+
+	// Requests with a different IP should fail.
+	*clientAddr = *utils.MustParseAddr("5.6.7.8:5678")
+	_, err = pack.clt.Get(t.Context(), endpoint, url.Values{})
+	require.ErrorIs(t, err, authz.ErrIPPinningMismatch)
+
+	// Requests with the correct IP should succeed again after intermittent failure.
+	*clientAddr = *utils.MustParseAddr("1.2.3.4:1234")
+	_, err = pack.clt.Get(t.Context(), endpoint, url.Values{})
+	require.NoError(t, err)
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -11604,12 +11604,20 @@ func TestIPPinning(t *testing.T) {
 	_, err = pack.clt.Get(t.Context(), endpoint, url.Values{})
 	require.NoError(t, err)
 
-	// Requests with a different IP should fail.
-	*clientAddr = *utils.MustParseAddr("5.6.7.8:5678")
-	_, err = pack.clt.Get(t.Context(), endpoint, url.Values{})
-	require.ErrorIs(t, err, authz.ErrIPPinningMismatch)
+	// Requests with a different IP should fail. Use a different client to simulate a cookie hijacking.
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
 
-	// Requests with the correct IP should succeed again after intermittent failure.
+	clt := s.client(t, roundtrip.BearerAuth(pack.session.Token), roundtrip.CookieJar(jar))
+	jar.SetCookies(s.url(), pack.cookies)
+
+	*clientAddr = *utils.MustParseAddr("5.6.7.8:5678")
+	_, err = clt.Get(t.Context(), endpoint, url.Values{})
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error but got %q", err)
+	require.Len(t, jar.Cookies(s.url()), 1)
+	require.Empty(t, jar.Cookies(s.url())[0].Value, "expected hijacked client cookie to be cleared")
+
+	// Requests from the correct IP should succeed.
 	*clientAddr = *utils.MustParseAddr("1.2.3.4:1234")
 	_, err = pack.clt.Get(t.Context(), endpoint, url.Values{})
 	require.NoError(t, err)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -233,9 +233,6 @@ type webSuiteConfig struct {
 	// alpnHandler allows setting custom alpnHandler.
 	alpnHandler ConnectionHandler
 
-	// trustXForwardedFor enables NewXForwardedForMiddleware.
-	trustXForwardedFor bool
-
 	// modules to inject into components.
 	modules *modulestest.Modules
 

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -637,7 +637,7 @@ func TestConnectDatabaseInteractiveSession(t *testing.T) {
 			}
 			return nil
 		},
-		trustXForwardedFor: true,
+		middleware: NewXForwardedForMiddleware,
 	})
 	s.webHandler.handler.cfg.PublicProxyAddr = s.webHandler.handler.cfg.ProxyWebAddr.String()
 

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -116,13 +116,6 @@ type SessionContextConfig struct {
 
 	// newRemoteClient is used by tests to override how remote clients are constructed to allow for fake clusters
 	newRemoteClient func(ctx context.Context, sessionContext *SessionContext, cluster reversetunnelclient.Cluster) (authclient.ClientI, error)
-
-	// ClientIP is the real client IP associated with this client session. Since the web server
-	// opens and caches the client connection on behalf of the user, it sends a signed PROXY header
-	// with the client's IP address. If the client reconnects to the same session with a different
-	// IP address, the session context and open client connection is discarded to ensure the real
-	// Client IP remains accurate throughout the session.
-	ClientIP string
 }
 
 func (c *SessionContextConfig) CheckAndSetDefaults() error {
@@ -1163,12 +1156,19 @@ func (s *sessionCache) newSessionContextFromSession(ctx context.Context, session
 		return nil, trace.Wrap(err)
 	}
 
-	var clientIP string
-	if clientAddr, _ := authz.ClientAddrsFromContext(ctx); clientAddr != nil {
-		clientIP, _, err = net.SplitHostPort(clientAddr.String())
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+	// Enforce IP Pinning if it is present in the user's certificate.
+	cert, err := tlsca.ParseCertificatePEM(session.GetTLSCert())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authz.CheckIPPinning(ctx, *identity, false, s.log); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	userClient, err := authclient.NewClient(apiclient.Config{
@@ -1193,7 +1193,6 @@ func (s *sessionCache) newSessionContextFromSession(ctx context.Context, session
 		Resources:              s.upsertSessionContext(session.GetUser()),
 		Session:                session,
 		RootClusterName:        s.clusterName,
-		ClientIP:               clientIP,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -1013,34 +1013,7 @@ func (s *sessionCache) getOrCreateSession(ctx context.Context, user, sessionID s
 	i, err, _ := s.sessionGroup.Do(key, func() (any, error) {
 		sessionCtx, ok := s.getContext(key)
 		if ok {
-			if sessionCtx.cfg.ClientIP == "" {
-				return sessionCtx, nil
-			}
-
-			clientAddr, err := authz.ClientSrcAddrFromContext(ctx)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			clientIP, _, err := net.SplitHostPort(clientAddr.String())
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			if clientIP == sessionCtx.cfg.ClientIP {
-				return sessionCtx, nil
-			}
-
-			// The client IP has changed. We need to open a new connection with a new proxy header.
-			// If IP Pinning is enforced and the client IP changed, the session will fail to reconnect.
-			slog.DebugContext(ctx, "Discarding session context due to IP mismatch", "client_ip", clientIP, "original_client_ip", sessionCtx.cfg.ClientIP)
-
-			s.mu.Lock()
-			if err = s.removeSessionContextLocked(ctx, user, sessionID); err != nil {
-				s.mu.Unlock()
-				return nil, trace.Wrap(err)
-			}
-			s.mu.Unlock()
+			return sessionCtx, nil
 		}
 
 		return s.newSessionContext(ctx, user, sessionID)
@@ -1053,6 +1026,16 @@ func (s *sessionCache) getOrCreateSession(ctx context.Context, user, sessionID s
 	sctx, ok := i.(*SessionContext)
 	if !ok {
 		return nil, trace.BadParameter("expected SessionContext, got %T", i)
+	}
+
+	identity, err := sctx.GetIdentity()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Enforce IP Pinning if it is present in the user's certificate.
+	if err := authz.CheckIPPinning(ctx, *identity, false, s.log); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return sctx, nil

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -116,6 +116,13 @@ type SessionContextConfig struct {
 
 	// newRemoteClient is used by tests to override how remote clients are constructed to allow for fake clusters
 	newRemoteClient func(ctx context.Context, sessionContext *SessionContext, cluster reversetunnelclient.Cluster) (authclient.ClientI, error)
+
+	// ClientIP is the real client IP associated with this client session. Since the web server
+	// opens and caches the client connection on behalf of the user, it sends a signed PROXY header
+	// with the client's IP address. If the client reconnects to the same session with a different
+	// IP address, the session context and open client connection is discarded to ensure the real
+	// Client IP remains accurate throughout the session.
+	ClientIP string
 }
 
 func (c *SessionContextConfig) CheckAndSetDefaults() error {
@@ -1006,7 +1013,34 @@ func (s *sessionCache) getOrCreateSession(ctx context.Context, user, sessionID s
 	i, err, _ := s.sessionGroup.Do(key, func() (any, error) {
 		sessionCtx, ok := s.getContext(key)
 		if ok {
-			return sessionCtx, nil
+			if sessionCtx.cfg.ClientIP == "" {
+				return sessionCtx, nil
+			}
+
+			clientAddr, err := authz.ClientSrcAddrFromContext(ctx)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			clientIP, _, err := net.SplitHostPort(clientAddr.String())
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			if clientIP == sessionCtx.cfg.ClientIP {
+				return sessionCtx, nil
+			}
+
+			// The client IP has changed. We need to open a new connection with a new proxy header.
+			// If IP Pinning is enforced and the client IP changed, the session will fail to reconnect.
+			slog.DebugContext(ctx, "Discarding session context due to IP mismatch", "client_ip", clientIP, "original_client_ip", sessionCtx.cfg.ClientIP)
+
+			s.mu.Lock()
+			if err = s.removeSessionContextLocked(ctx, user, sessionID); err != nil {
+				s.mu.Unlock()
+				return nil, trace.Wrap(err)
+			}
+			s.mu.Unlock()
 		}
 
 		return s.newSessionContext(ctx, user, sessionID)
@@ -1146,6 +1180,14 @@ func (s *sessionCache) newSessionContextFromSession(ctx context.Context, session
 		return nil, trace.Wrap(err)
 	}
 
+	var clientIP string
+	if clientAddr, _ := authz.ClientAddrsFromContext(ctx); clientAddr != nil {
+		clientIP, _, err = net.SplitHostPort(clientAddr.String())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	userClient, err := authclient.NewClient(apiclient.Config{
 		Addrs:                utils.NetAddrsToStrings(s.authServers),
 		Credentials:          []apiclient.Credentials{apiclient.LoadTLS(tlsConfig)},
@@ -1168,6 +1210,7 @@ func (s *sessionCache) newSessionContextFromSession(ctx context.Context, session
 		Resources:              s.upsertSessionContext(session.GetUser()),
 		Session:                session,
 		RootClusterName:        s.clusterName,
+		ClientIP:               clientIP,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Changelog: Fix an issue that allowed IP Pinning protections to be bypassed via the WebUI. Also fix an issue with sporadic WebUI connection errors when the Proxy sees an unexpected client IP even though IP Pinning is not enforced. 

This PR is a partial OSS port of https://github.com/gravitational/teleport-private/pull/2286, which a significant departure in implementation to fix some issues discovered in the v18.7.3/v17.7.21 release. See the second sentence in the changelog.

Fixes https://github.com/gravitational/teleport/issues/65042

Manual Test Plan:
- IP Pinning enforced:
  - Login to the WebUI
    - [x] Login success
    - [x] Grab the web session cookie
    - [x] Connect to a server
  - Change your IP address (e.g. connect through a different network). Note: You may need to force quit the browser to refresh the IP.
    - [x] Navigating to the WebUI should send you straight to the login page and clear the web session cookie
  - Change you IP address back to the original, and manually set your web session cookie to the one we grabbed earlier. It should still be valid for the 
    - [x] Navigating the WebUI succeeds
    - [x] Connect to a server
- IP Pinning not enforced:
  - Login to the WebUI
    - [x] Login success
  - Change your IP address (e.g. connect through a different network)
    - [x] Navigating the WebUI succeeds