### PR TITLE
e2e/.gitignore: Ignore all log and yaml files

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -7,12 +7,7 @@ runner/e2e
 runner/runner
 certs/
 data/
-config/teleport.yaml
-config/*-teleport.yaml
-config/state.yaml
-node/node.yaml
-node/*-node.yaml
-teleport.log
-teleport-*.log
-docker-node-*.log
+config/*.yaml
+node/*.yaml
+*.log
 .auth/


### PR DESCRIPTION
When I was adding a leaf cluster with an SSH node, I had to manually add specific gitignore lines for the new files. I figured we're probably better off just ignoring everything wholesale.

In the future when we add more files, those should already be ignored so we won't have to backport .gitignore changes just to have clean repo when switching between release branches.