### PR TITLE
[v18] Fix IP Pinning Bypass w/ direct dial to Node

### DIFF
--- a/api/gen/proto/go/teleport/decision/v1alpha1/ssh_access.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/ssh_access.pb.go
@@ -153,6 +153,61 @@ func (HostUserMode) EnumDescriptor() ([]byte, []int) {
 	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{1}
 }
 
+// PreconditionKind defines the types of preconditions that can be specified.
+type PreconditionKind int32
+
+const (
+	// PreconditionKindUnspecified indicates that no precondition is specified and represents an uninitialized or invalid
+	// state. If a permit holds this value, access should be denied. This value should be treated as an error in any
+	// context where a specific precondition is required.
+	PreconditionKind_PRECONDITION_KIND_UNSPECIFIED PreconditionKind = 0
+	// PreconditionKindInBandMFA requires in-band MFA to be completed.
+	PreconditionKind_PRECONDITION_KIND_IN_BAND_MFA PreconditionKind = 1
+	// PreconditionKindPinSourceIP enforces the client IP observed at login matches the client IP of SSH connections.
+	PreconditionKind_PRECONDITION_KIND_PIN_SOURCE_IP PreconditionKind = 2
+)
+
+// Enum value maps for PreconditionKind.
+var (
+	PreconditionKind_name = map[int32]string{
+		0: "PRECONDITION_KIND_UNSPECIFIED",
+		1: "PRECONDITION_KIND_IN_BAND_MFA",
+		2: "PRECONDITION_KIND_PIN_SOURCE_IP",
+	}
+	PreconditionKind_value = map[string]int32{
+		"PRECONDITION_KIND_UNSPECIFIED":   0,
+		"PRECONDITION_KIND_IN_BAND_MFA":   1,
+		"PRECONDITION_KIND_PIN_SOURCE_IP": 2,
+	}
+)
+
+func (x PreconditionKind) Enum() *PreconditionKind {
+	p := new(PreconditionKind)
+	*p = x
+	return p
+}
+
+func (x PreconditionKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PreconditionKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_decision_v1alpha1_ssh_access_proto_enumTypes[2].Descriptor()
+}
+
+func (PreconditionKind) Type() protoreflect.EnumType {
+	return &file_teleport_decision_v1alpha1_ssh_access_proto_enumTypes[2]
+}
+
+func (x PreconditionKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PreconditionKind.Descriptor instead.
+func (PreconditionKind) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{2}
+}
+
 // EvaluateSSHAccessRequest describes a request to evaluate whether or not a
 // given ssh access attempt should be permitted.
 type EvaluateSSHAccessRequest struct {
@@ -364,6 +419,9 @@ type SSHAccessPermit struct {
 	// HostUserInfo encodes relevant information for host user creation. Omitted if
 	// host user creation  is not permitted.
 	HostUsersInfo *HostUsersInfo `protobuf:"bytes,24,opt,name=host_users_info,json=hostUsersInfo,proto3" json:"host_users_info,omitempty"`
+	// Preconditions is a list of conditions that must be satisfied before access is granted.
+	// If any precondition is not satisfied, access must be denied.
+	Preconditions []*Precondition `protobuf:"bytes,26,rep,name=preconditions,proto3" json:"preconditions,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -513,6 +571,13 @@ func (x *SSHAccessPermit) GetMappedRoles() []string {
 func (x *SSHAccessPermit) GetHostUsersInfo() *HostUsersInfo {
 	if x != nil {
 		return x.HostUsersInfo
+	}
+	return nil
+}
+
+func (x *SSHAccessPermit) GetPreconditions() []*Precondition {
+	if x != nil {
+		return x.Preconditions
 	}
 	return nil
 }
@@ -777,6 +842,52 @@ func (x *HostUsersInfo) GetShell() string {
 	return ""
 }
 
+// Precondition represents a condition that must be satisfied before access is granted.
+type Precondition struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Kind specifies the type of precondition.
+	Kind          PreconditionKind `protobuf:"varint,1,opt,name=kind,proto3,enum=teleport.decision.v1alpha1.PreconditionKind" json:"kind,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Precondition) Reset() {
+	*x = Precondition{}
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Precondition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Precondition) ProtoMessage() {}
+
+func (x *Precondition) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Precondition.ProtoReflect.Descriptor instead.
+func (*Precondition) Descriptor() ([]byte, []int) {
+	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *Precondition) GetKind() PreconditionKind {
+	if x != nil {
+		return x.Kind
+	}
+	return PreconditionKind_PRECONDITION_KIND_UNSPECIFIED
+}
+
 var File_teleport_decision_v1alpha1_ssh_access_proto protoreflect.FileDescriptor
 
 const file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc = "" +
@@ -792,7 +903,7 @@ const file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc = "" +
 	"\x06permit\x18\x01 \x01(\v2+.teleport.decision.v1alpha1.SSHAccessPermitH\x00R\x06permit\x12E\n" +
 	"\x06denial\x18\x02 \x01(\v2+.teleport.decision.v1alpha1.SSHAccessDenialH\x00R\x06denialB\n" +
 	"\n" +
-	"\bdecision\"\xca\a\n" +
+	"\bdecision\"\x9a\b\n" +
 	"\x0fSSHAccessPermit\x12F\n" +
 	"\bmetadata\x18\x01 \x01(\v2*.teleport.decision.v1alpha1.PermitMetadataR\bmetadata\x12#\n" +
 	"\rforward_agent\x18\x03 \x01(\bR\fforwardAgent\x12Z\n" +
@@ -812,7 +923,8 @@ const file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc = "" +
 	"\x12private_key_policy\x18\x15 \x01(\tR\x10privateKeyPolicy\x12I\n" +
 	"\flock_targets\x18\x16 \x03(\v2&.teleport.decision.v1alpha1.LockTargetR\vlockTargets\x12!\n" +
 	"\fmapped_roles\x18\x17 \x03(\tR\vmappedRoles\x12Q\n" +
-	"\x0fhost_users_info\x18\x18 \x01(\v2).teleport.decision.v1alpha1.HostUsersInfoR\rhostUsersInfoJ\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\a\x10\bJ\x04\b\f\x10\rJ\x04\b\r\x10\x0eJ\x04\b\x0f\x10\x10J\x04\b\x10\x10\x11J\x04\b\x11\x10\x12\"Y\n" +
+	"\x0fhost_users_info\x18\x18 \x01(\v2).teleport.decision.v1alpha1.HostUsersInfoR\rhostUsersInfo\x12N\n" +
+	"\rpreconditions\x18\x1a \x03(\v2(.teleport.decision.v1alpha1.PreconditionR\rpreconditionsJ\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\a\x10\bJ\x04\b\f\x10\rJ\x04\b\r\x10\x0eJ\x04\b\x0f\x10\x10J\x04\b\x10\x10\x11J\x04\b\x11\x10\x12\"Y\n" +
 	"\x0fSSHAccessDenial\x12F\n" +
 	"\bmetadata\x18\x01 \x01(\v2*.teleport.decision.v1alpha1.DenialMetadataR\bmetadata\"\xb5\x02\n" +
 	"\n" +
@@ -835,7 +947,9 @@ const file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc = "" +
 	"\x04mode\x18\x02 \x01(\x0e2(.teleport.decision.v1alpha1.HostUserModeR\x04mode\x12\x10\n" +
 	"\x03uid\x18\x03 \x01(\tR\x03uid\x12\x10\n" +
 	"\x03gid\x18\x04 \x01(\tR\x03gid\x12\x14\n" +
-	"\x05shell\x18\x05 \x01(\tR\x05shell*\xbb\x01\n" +
+	"\x05shell\x18\x05 \x01(\tR\x05shell\"P\n" +
+	"\fPrecondition\x12@\n" +
+	"\x04kind\x18\x01 \x01(\x0e2,.teleport.decision.v1alpha1.PreconditionKindR\x04kind*\xbb\x01\n" +
 	"\x12SSHPortForwardMode\x12%\n" +
 	"!SSH_PORT_FORWARD_MODE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19SSH_PORT_FORWARD_MODE_OFF\x10\x01\x12\x1c\n" +
@@ -846,7 +960,11 @@ const file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc = "" +
 	"\x1aHOST_USER_MODE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13HOST_USER_MODE_KEEP\x10\x01\x12\x17\n" +
 	"\x13HOST_USER_MODE_DROP\x10\x02\x12\x19\n" +
-	"\x15HOST_USER_MODE_STATIC\x10\x03BZZXgithub.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1;decisionpbb\x06proto3"
+	"\x15HOST_USER_MODE_STATIC\x10\x03*}\n" +
+	"\x10PreconditionKind\x12!\n" +
+	"\x1dPRECONDITION_KIND_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dPRECONDITION_KIND_IN_BAND_MFA\x10\x01\x12#\n" +
+	"\x1fPRECONDITION_KIND_PIN_SOURCE_IP\x10\x02BZZXgithub.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1;decisionpbb\x06proto3"
 
 var (
 	file_teleport_decision_v1alpha1_ssh_access_proto_rawDescOnce sync.Once
@@ -860,46 +978,50 @@ func file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP() []byte {
 	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescData
 }
 
-var file_teleport_decision_v1alpha1_ssh_access_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_teleport_decision_v1alpha1_ssh_access_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_teleport_decision_v1alpha1_ssh_access_proto_goTypes = []any{
 	(SSHPortForwardMode)(0),           // 0: teleport.decision.v1alpha1.SSHPortForwardMode
 	(HostUserMode)(0),                 // 1: teleport.decision.v1alpha1.HostUserMode
-	(*EvaluateSSHAccessRequest)(nil),  // 2: teleport.decision.v1alpha1.EvaluateSSHAccessRequest
-	(*EvaluateSSHAccessResponse)(nil), // 3: teleport.decision.v1alpha1.EvaluateSSHAccessResponse
-	(*SSHAccessPermit)(nil),           // 4: teleport.decision.v1alpha1.SSHAccessPermit
-	(*SSHAccessDenial)(nil),           // 5: teleport.decision.v1alpha1.SSHAccessDenial
-	(*LockTarget)(nil),                // 6: teleport.decision.v1alpha1.LockTarget
-	(*HostUsersInfo)(nil),             // 7: teleport.decision.v1alpha1.HostUsersInfo
-	(*RequestMetadata)(nil),           // 8: teleport.decision.v1alpha1.RequestMetadata
-	(*SSHAuthority)(nil),              // 9: teleport.decision.v1alpha1.SSHAuthority
-	(*SSHIdentity)(nil),               // 10: teleport.decision.v1alpha1.SSHIdentity
-	(*Resource)(nil),                  // 11: teleport.decision.v1alpha1.Resource
-	(*PermitMetadata)(nil),            // 12: teleport.decision.v1alpha1.PermitMetadata
-	(*durationpb.Duration)(nil),       // 13: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),     // 14: google.protobuf.Timestamp
-	(*DenialMetadata)(nil),            // 15: teleport.decision.v1alpha1.DenialMetadata
+	(PreconditionKind)(0),             // 2: teleport.decision.v1alpha1.PreconditionKind
+	(*EvaluateSSHAccessRequest)(nil),  // 3: teleport.decision.v1alpha1.EvaluateSSHAccessRequest
+	(*EvaluateSSHAccessResponse)(nil), // 4: teleport.decision.v1alpha1.EvaluateSSHAccessResponse
+	(*SSHAccessPermit)(nil),           // 5: teleport.decision.v1alpha1.SSHAccessPermit
+	(*SSHAccessDenial)(nil),           // 6: teleport.decision.v1alpha1.SSHAccessDenial
+	(*LockTarget)(nil),                // 7: teleport.decision.v1alpha1.LockTarget
+	(*HostUsersInfo)(nil),             // 8: teleport.decision.v1alpha1.HostUsersInfo
+	(*Precondition)(nil),              // 9: teleport.decision.v1alpha1.Precondition
+	(*RequestMetadata)(nil),           // 10: teleport.decision.v1alpha1.RequestMetadata
+	(*SSHAuthority)(nil),              // 11: teleport.decision.v1alpha1.SSHAuthority
+	(*SSHIdentity)(nil),               // 12: teleport.decision.v1alpha1.SSHIdentity
+	(*Resource)(nil),                  // 13: teleport.decision.v1alpha1.Resource
+	(*PermitMetadata)(nil),            // 14: teleport.decision.v1alpha1.PermitMetadata
+	(*durationpb.Duration)(nil),       // 15: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),     // 16: google.protobuf.Timestamp
+	(*DenialMetadata)(nil),            // 17: teleport.decision.v1alpha1.DenialMetadata
 }
 var file_teleport_decision_v1alpha1_ssh_access_proto_depIdxs = []int32{
-	8,  // 0: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.metadata:type_name -> teleport.decision.v1alpha1.RequestMetadata
-	9,  // 1: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.ssh_authority:type_name -> teleport.decision.v1alpha1.SSHAuthority
-	10, // 2: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.ssh_identity:type_name -> teleport.decision.v1alpha1.SSHIdentity
-	11, // 3: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.node:type_name -> teleport.decision.v1alpha1.Resource
-	4,  // 4: teleport.decision.v1alpha1.EvaluateSSHAccessResponse.permit:type_name -> teleport.decision.v1alpha1.SSHAccessPermit
-	5,  // 5: teleport.decision.v1alpha1.EvaluateSSHAccessResponse.denial:type_name -> teleport.decision.v1alpha1.SSHAccessDenial
-	12, // 6: teleport.decision.v1alpha1.SSHAccessPermit.metadata:type_name -> teleport.decision.v1alpha1.PermitMetadata
+	10, // 0: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.metadata:type_name -> teleport.decision.v1alpha1.RequestMetadata
+	11, // 1: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.ssh_authority:type_name -> teleport.decision.v1alpha1.SSHAuthority
+	12, // 2: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.ssh_identity:type_name -> teleport.decision.v1alpha1.SSHIdentity
+	13, // 3: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.node:type_name -> teleport.decision.v1alpha1.Resource
+	5,  // 4: teleport.decision.v1alpha1.EvaluateSSHAccessResponse.permit:type_name -> teleport.decision.v1alpha1.SSHAccessPermit
+	6,  // 5: teleport.decision.v1alpha1.EvaluateSSHAccessResponse.denial:type_name -> teleport.decision.v1alpha1.SSHAccessDenial
+	14, // 6: teleport.decision.v1alpha1.SSHAccessPermit.metadata:type_name -> teleport.decision.v1alpha1.PermitMetadata
 	0,  // 7: teleport.decision.v1alpha1.SSHAccessPermit.port_forward_mode:type_name -> teleport.decision.v1alpha1.SSHPortForwardMode
-	13, // 8: teleport.decision.v1alpha1.SSHAccessPermit.client_idle_timeout:type_name -> google.protobuf.Duration
-	14, // 9: teleport.decision.v1alpha1.SSHAccessPermit.disconnect_expired_cert:type_name -> google.protobuf.Timestamp
-	6,  // 10: teleport.decision.v1alpha1.SSHAccessPermit.lock_targets:type_name -> teleport.decision.v1alpha1.LockTarget
-	7,  // 11: teleport.decision.v1alpha1.SSHAccessPermit.host_users_info:type_name -> teleport.decision.v1alpha1.HostUsersInfo
-	15, // 12: teleport.decision.v1alpha1.SSHAccessDenial.metadata:type_name -> teleport.decision.v1alpha1.DenialMetadata
-	1,  // 13: teleport.decision.v1alpha1.HostUsersInfo.mode:type_name -> teleport.decision.v1alpha1.HostUserMode
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	15, // 8: teleport.decision.v1alpha1.SSHAccessPermit.client_idle_timeout:type_name -> google.protobuf.Duration
+	16, // 9: teleport.decision.v1alpha1.SSHAccessPermit.disconnect_expired_cert:type_name -> google.protobuf.Timestamp
+	7,  // 10: teleport.decision.v1alpha1.SSHAccessPermit.lock_targets:type_name -> teleport.decision.v1alpha1.LockTarget
+	8,  // 11: teleport.decision.v1alpha1.SSHAccessPermit.host_users_info:type_name -> teleport.decision.v1alpha1.HostUsersInfo
+	9,  // 12: teleport.decision.v1alpha1.SSHAccessPermit.preconditions:type_name -> teleport.decision.v1alpha1.Precondition
+	17, // 13: teleport.decision.v1alpha1.SSHAccessDenial.metadata:type_name -> teleport.decision.v1alpha1.DenialMetadata
+	1,  // 14: teleport.decision.v1alpha1.HostUsersInfo.mode:type_name -> teleport.decision.v1alpha1.HostUserMode
+	2,  // 15: teleport.decision.v1alpha1.Precondition.kind:type_name -> teleport.decision.v1alpha1.PreconditionKind
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_teleport_decision_v1alpha1_ssh_access_proto_init() }
@@ -921,8 +1043,8 @@ func file_teleport_decision_v1alpha1_ssh_access_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc), len(file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc)),
-			NumEnums:      2,
-			NumMessages:   6,
+			NumEnums:      3,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/decision/v1alpha1/ssh_access.proto
+++ b/api/proto/teleport/decision/v1alpha1/ssh_access.proto
@@ -115,6 +115,10 @@ message SSHAccessPermit {
   // HostUserInfo encodes relevant information for host user creation. Omitted if
   // host user creation  is not permitted.
   HostUsersInfo host_users_info = 24;
+
+  // Preconditions is a list of conditions that must be satisfied before access is granted.
+  // If any precondition is not satisfied, access must be denied.
+  repeated Precondition preconditions = 26;
 }
 
 // SSHAccessDenial describes an SSH access denial.
@@ -201,4 +205,22 @@ message HostUsersInfo {
 
   // Shell is the default login shell for a host user
   string shell = 5;
+}
+
+// Precondition represents a condition that must be satisfied before access is granted.
+message Precondition {
+  // Kind specifies the type of precondition.
+  PreconditionKind kind = 1;
+}
+
+// PreconditionKind defines the types of preconditions that can be specified.
+enum PreconditionKind {
+  // PreconditionKindUnspecified indicates that no precondition is specified and represents an uninitialized or invalid
+  // state. If a permit holds this value, access should be denied. This value should be treated as an error in any
+  // context where a specific precondition is required.
+  PRECONDITION_KIND_UNSPECIFIED = 0;
+  // PreconditionKindInBandMFA requires in-band MFA to be completed.
+  PRECONDITION_KIND_IN_BAND_MFA = 1;
+  // PreconditionKindPinSourceIP enforces the client IP observed at login matches the client IP of SSH connections.
+  PRECONDITION_KIND_PIN_SOURCE_IP = 2;
 }

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/tlsca"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // NewAdminContext returns new admin auth context
@@ -429,7 +430,12 @@ func (a *authorizer) Authorize(ctx context.Context) (authCtx *Context, err error
 		return nil, trace.Wrap(err)
 	}
 
-	if err := CheckIPPinning(ctx, authContext.Identity.GetIdentity(), authContext.Checker.PinSourceIP(), a.logger); err != nil {
+	var clientAddr string
+	if clientSrcAddr, err := ClientSrcAddrFromContext(ctx); err == nil {
+		clientAddr = clientSrcAddr.String()
+	}
+
+	if err := CheckIPPinning(ctx, clientAddr, authContext.Identity.GetIdentity().PinnedIP, authContext.Checker.PinSourceIP(), a.logger); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -646,31 +652,40 @@ var ErrIPPinningNotAllowed = &trace.AccessDeniedError{Message: "IP pinning is no
 	"downgraded or are behind a L4 load balancers with PROXY protocol enabled without explicitly setting 'proxy_protocol: on'" +
 	"in the proxy_service and/or auth_service config."}
 
-// CheckIPPinning verifies IP pinning for the identity, using the client IP taken from context.
+// CheckIPPinning verifies IP pinning for the identity, using the provided client addr.
 // Check is considered successful if no error is returned.
-func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bool, log *slog.Logger) error {
-	if identity.PinnedIP == "" {
+func CheckIPPinning(ctx context.Context, clientAddr string, pinnedIP string, pinSourceIP bool, log *slog.Logger) error {
+	if pinnedIP == "" {
 		if pinSourceIP {
 			return trace.Wrap(ErrIPPinningMissing)
 		}
 		return nil
 	}
 
-	clientSrcAddr, err := ClientSrcAddrFromContext(ctx)
+	if clientAddr == "" {
+		return trace.BadParameter("pinned IP is required for the user, but the client IP was not provided")
+	}
+
+	clientHost, clientPort, err := net.SplitHostPort(clientAddr)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	clientIP, clientPort, err := net.SplitHostPort(clientSrcAddr.String())
-	if err != nil {
-		return trace.Wrap(err)
+	parsedClientIP := net.ParseIP(clientHost)
+	if parsedClientIP == nil {
+		return trace.BadParameter("client IP address %q is not a valid IP address", clientHost)
 	}
 
-	if clientIP != identity.PinnedIP {
+	parsedPinnedIP := net.ParseIP(pinnedIP)
+	if parsedPinnedIP == nil {
+		return trace.BadParameter("pinned IP address %q is not a valid IP address", pinnedIP)
+	}
+
+	if !parsedClientIP.Equal(net.ParseIP(pinnedIP)) {
 		if log != nil {
 			log.DebugContext(ctx, "Pinned IP and client IP mismatch",
-				"client_ip", clientIP,
-				"pinned_ip", identity.PinnedIP,
+				"client_ip", logutils.StringerAttr(parsedClientIP),
+				"pinned_ip", logutils.StringerAttr(parsedPinnedIP),
 			)
 		}
 		return trace.Wrap(ErrIPPinningMismatch)
@@ -679,7 +694,7 @@ func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bo
 	// For security reason we don't allow such connection for IP pinning because we can't rely on client IP being correct.
 	if clientPort == "0" {
 		if log != nil {
-			log.DebugContext(ctx, "client address is not allowed to use IP pinning", "client_ip", clientIP, "pinned_ip", identity.PinnedIP, "error", ErrIPPinningNotAllowed.Message)
+			log.DebugContext(ctx, "client address is not allowed to use IP pinning", "client_ip", parsedClientIP, "pinned_ip", pinnedIP, "error", ErrIPPinningNotAllowed.Message)
 		}
 		return trace.Wrap(ErrIPPinningNotAllowed)
 	}

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -50,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
@@ -981,7 +980,7 @@ func TestCheckIPPinning(t *testing.T) {
 			desc:     "IP pinning enabled, missing client IP",
 			pinnedIP: "127.0.0.1",
 			pinIP:    true,
-			wantErr:  "client source address was not found in the context",
+			wantErr:  "client IP was not provided",
 		},
 		{
 			desc:       "IP pinning enabled, port=0 (marked by proxyProtocolMode unspecified)",
@@ -996,23 +995,51 @@ func TestCheckIPPinning(t *testing.T) {
 			pinnedIP:   "127.0.0.1",
 			pinIP:      true,
 		},
+		{
+			desc:       "invalid client IP",
+			clientAddr: "localhost:1",
+			pinnedIP:   "127.0.0.1:1",
+			pinIP:      true,
+			wantErr:    "\"localhost\" is not a valid IP address",
+		},
+		{
+			desc:       "invalid pinned IP",
+			clientAddr: "127.0.0.1:1",
+			pinnedIP:   "localhost",
+			pinIP:      true,
+			wantErr:    "\"localhost\" is not a valid IP address",
+		},
+		// IPv6
+		{
+			desc:       "IPv6: correct IP pinning",
+			clientAddr: "[2001:db8::1]:444",
+			pinnedIP:   "2001:db8::1",
+			pinIP:      true,
+		},
+		{
+			desc:       "IPv6: pinned IP doesn't match",
+			clientAddr: "[2001:db8::1]:444",
+			pinnedIP:   "2001:db8::2",
+			pinIP:      true,
+			wantErr:    authz.ErrIPPinningMismatch.Error(),
+		},
+		{
+			desc:       "IPv6: equivalency with compression",
+			clientAddr: "[2001:db8:0:0:0:0:0:1]:444",
+			pinnedIP:   "2001:db8::1",
+			pinIP:      true,
+		},
 	}
 
 	for _, tt := range testCases {
-		ctx := context.Background()
-		if tt.clientAddr != "" {
-			ctx = authz.ContextWithClientSrcAddr(ctx, utils.MustParseAddr(tt.clientAddr))
-		}
-		identity := tlsca.Identity{PinnedIP: tt.pinnedIP}
-
-		err := authz.CheckIPPinning(ctx, identity, tt.pinIP, nil)
-
-		if tt.wantErr != "" {
-			require.ErrorContains(t, err, tt.wantErr)
-		} else {
-			require.NoError(t, err)
-		}
-
+		t.Run(tt.desc, func(t *testing.T) {
+			err := authz.CheckIPPinning(t.Context(), tt.clientAddr, tt.pinnedIP, tt.pinIP, nil)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 

--- a/lib/decision/service.go
+++ b/lib/decision/service.go
@@ -250,7 +250,9 @@ func (s *Service) EvaluateSSHAccess(ctx context.Context, req *decisionpb.Evaluat
 	}
 
 	if accessChecker.PinSourceIP() {
-		permit.Preconditions = append(permit.Preconditions, &decisionpb.Precondition{Kind: decisionpb.PreconditionKind_PRECONDITION_KIND_PIN_SOURCE_IP})
+		permit.Preconditions = append(permit.Preconditions, &decisionpb.Precondition{
+			Kind: decisionpb.PreconditionKind_PRECONDITION_KIND_PIN_SOURCE_IP,
+		})
 	}
 
 	return &decisionpb.EvaluateSSHAccessResponse{

--- a/lib/decision/service.go
+++ b/lib/decision/service.go
@@ -249,6 +249,10 @@ func (s *Service) EvaluateSSHAccess(ctx context.Context, req *decisionpb.Evaluat
 		HostUsersInfo:         hostUsersInfo,
 	}
 
+	if accessChecker.PinSourceIP() {
+		permit.Preconditions = append(permit.Preconditions, &decisionpb.Precondition{Kind: decisionpb.PreconditionKind_PRECONDITION_KIND_PIN_SOURCE_IP})
+	}
+
 	return &decisionpb.EvaluateSSHAccessResponse{
 		Decision: &decisionpb.EvaluateSSHAccessResponse_Permit{
 			Permit: permit,

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -1021,7 +1021,7 @@ func (a *ahLoginChecker) evaluateScopedSSHAccess(ident *sshca.Identity, ca types
 		hostUsersInfo = nil
 	}
 
-	return &decisionpb.SSHAccessPermit{
+	permit := &decisionpb.SSHAccessPermit{
 		ForwardAgent:          checker.Common().CheckAgentForward(osUser) == nil,
 		X11Forwarding:         checker.Common().PermitX11Forwarding(),
 		MaxConnections:        checker.Common().MaxConnections(),
@@ -1038,7 +1038,15 @@ func (a *ahLoginChecker) evaluateScopedSSHAccess(ident *sshca.Identity, ca types
 		HostSudoers:           hostSudoers,
 		BpfEvents:             bpfEvents,
 		HostUsersInfo:         hostUsersInfo,
-	}, nil
+	}
+
+	if checker.Common().PinSourceIP() {
+		permit.Preconditions = append(permit.Preconditions, &decisionpb.Precondition{
+			Kind: decisionpb.PreconditionKind_PRECONDITION_KIND_PIN_SOURCE_IP,
+		})
+	}
+
+	return permit, nil
 }
 
 // evaluateSSHAccess checks the given certificate (supplied by a connected
@@ -1129,7 +1137,7 @@ func (a *ahLoginChecker) evaluateSSHAccess(ident *sshca.Identity, ca types.CertA
 		hostUsersInfo = nil
 	}
 
-	return &decisionpb.SSHAccessPermit{
+	permit := &decisionpb.SSHAccessPermit{
 		ForwardAgent:          accessChecker.CheckAgentForward(osUser) == nil,
 		X11Forwarding:         accessChecker.PermitX11Forwarding(),
 		MaxConnections:        accessChecker.MaxConnections(),
@@ -1146,7 +1154,15 @@ func (a *ahLoginChecker) evaluateSSHAccess(ident *sshca.Identity, ca types.CertA
 		HostSudoers:           hostSudoers,
 		BpfEvents:             bpfEvents,
 		HostUsersInfo:         hostUsersInfo,
-	}, nil
+	}
+
+	if accessChecker.PinSourceIP() {
+		permit.Preconditions = append(permit.Preconditions, &decisionpb.Precondition{
+			Kind: decisionpb.PreconditionKind_PRECONDITION_KIND_PIN_SOURCE_IP,
+		})
+	}
+
+	return permit, nil
 }
 
 // fetchAccessInfo fetches the services.AccessChecker (after role mapping)

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -815,6 +815,7 @@ type proxyingPermit struct {
 	DisconnectExpiredCert time.Time
 	MappedRoles           []string
 	SessionRecordingMode  constants.SessionRecordingMode
+	PinSourceIP           bool
 }
 
 func (a *ahLoginChecker) evaluateProxying(ident *sshca.Identity, ca types.CertAuthority, clusterName string) (*proxyingPermit, error) {
@@ -861,6 +862,7 @@ func (a *ahLoginChecker) evaluateProxying(ident *sshca.Identity, ca types.CertAu
 		DisconnectExpiredCert: getDisconnectExpiredCertFromSSHIdentity(accessChecker, authPref, ident),
 		MappedRoles:           accessInfo.Roles,
 		SessionRecordingMode:  accessChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH),
+		PinSourceIP:           accessChecker.PinSourceIP(),
 	}, nil
 }
 

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -901,14 +901,29 @@ func TestRBACJoinMFA(t *testing.T) {
 	_, err = server.auth.CreateRole(ctx, joinRole)
 	require.NoError(t, err)
 
+	pinJoinRole, err := types.NewRole("pinJoin", types.RoleSpecV6{
+		Options: types.RoleOptions{
+			PinSourceIP: true,
+		},
+		Allow: types.RoleConditions{
+			NodeLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+		},
+	})
+	require.NoError(t, err)
+	_, err = server.auth.CreateRole(ctx, pinJoinRole)
+	require.NoError(t, err)
+
 	_, err = server.auth.CreateClusterNetworkingConfig(ctx, types.DefaultClusterNetworkingConfig())
 	require.NoError(t, err)
 
 	tests := []struct {
-		name      string
-		authPref  types.AuthPreference
-		role      string
-		testError func(t *testing.T, err error)
+		name              string
+		authPref          types.AuthPreference
+		role              string
+		expectPinSourceIP bool
+		testError         func(t *testing.T, err error)
 	}{
 		{
 			name:     "MFA cluster auth, MFA role",
@@ -941,6 +956,15 @@ func TestRBACJoinMFA(t *testing.T) {
 			name:     "no MFA cluster auth, no MFA role",
 			authPref: noMFAAuthPref,
 			role:     joinRole.GetName(),
+			testError: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:              "no MFA cluster auth, pin source IP role",
+			authPref:          noMFAAuthPref,
+			role:              pinJoinRole.GetName(),
+			expectPinSourceIP: true,
 			testError: func(t *testing.T, err error) {
 				require.NoError(t, err)
 			},
@@ -978,8 +1002,13 @@ func TestRBACJoinMFA(t *testing.T) {
 			ident, err := sshca.DecodeIdentity(cert)
 			require.NoError(t, err)
 
-			_, err = ah.evaluateSSHAccess(ident, userCA, clusterName, node, teleport.SSHSessionJoinPrincipal)
+			permit, err := ah.evaluateSSHAccess(ident, userCA, clusterName, node, teleport.SSHSessionJoinPrincipal)
 			tt.testError(t, err)
+			if err == nil && tt.expectPinSourceIP {
+				require.Contains(t, permit.Preconditions, &decisionpb.Precondition{
+					Kind: decisionpb.PreconditionKind_PRECONDITION_KIND_PIN_SOURCE_IP,
+				})
+			}
 		})
 	}
 }

--- a/lib/srv/session_control.go
+++ b/lib/srv/session_control.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -33,11 +34,13 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/decision"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/events"
@@ -165,6 +168,7 @@ type webSessionPermit struct {
 	LockTargets      []types.LockTarget
 	PrivateKeyPolicy keys.PrivateKeyPolicy
 	MaxConnections   int64
+	PinSourceIP      bool
 }
 
 // WebSessionController is a wrapper around [SessionController] which can be
@@ -209,6 +213,7 @@ func WebSessionController(controller *SessionController) func(ctx context.Contex
 			PrivateKeyPolicy: privateKeyPolicy,
 			LockTargets:      lockTargets,
 			MaxConnections:   accessChecker.MaxConnections(),
+			PinSourceIP:      accessChecker.PinSourceIP(),
 		}
 
 		identity := IdentityContext{
@@ -251,22 +256,28 @@ func (s *SessionController) AcquireSessionContext(ctx context.Context, identity 
 	var lockTargets []types.LockTarget
 	var requiredPolicy keys.PrivateKeyPolicy
 	var maxConnections int64
+	var pinSourceIP bool
 	switch {
 	case identity.AccessPermit != nil:
 		lockingMode = constants.LockingMode(identity.AccessPermit.LockingMode)
 		lockTargets = decision.LockTargetsFromProto(identity.AccessPermit.LockTargets)
 		requiredPolicy = keys.PrivateKeyPolicy(identity.AccessPermit.PrivateKeyPolicy)
 		maxConnections = identity.AccessPermit.MaxConnections
+		pinSourceIP = slices.ContainsFunc(identity.AccessPermit.Preconditions, func(p *decisionpb.Precondition) bool {
+			return p.Kind == decisionpb.PreconditionKind_PRECONDITION_KIND_PIN_SOURCE_IP
+		})
 	case identity.ProxyingPermit != nil:
 		lockingMode = identity.ProxyingPermit.LockingMode
 		lockTargets = identity.ProxyingPermit.LockTargets
 		requiredPolicy = identity.ProxyingPermit.PrivateKeyPolicy
 		maxConnections = identity.ProxyingPermit.MaxConnections
+		pinSourceIP = identity.ProxyingPermit.PinSourceIP
 	case identity.webSessionPermit != nil:
 		lockingMode = identity.webSessionPermit.LockingMode
 		lockTargets = identity.webSessionPermit.LockTargets
 		requiredPolicy = identity.webSessionPermit.PrivateKeyPolicy
 		maxConnections = identity.webSessionPermit.MaxConnections
+		pinSourceIP = identity.webSessionPermit.PinSourceIP
 	default:
 		return nil, trace.BadParameter("session context requires one of AccessPermit, ProxyingPermit, or webSessionPermit to be set (this is a bug)")
 	}
@@ -278,6 +289,10 @@ func (s *SessionController) AcquireSessionContext(ctx context.Context, identity 
 
 	if !requiredPolicy.IsSatisfiedBy(identity.UnmappedIdentity.PrivateKeyPolicy) {
 		return ctx, keys.NewPrivateKeyPolicyError(requiredPolicy)
+	}
+
+	if err := authz.CheckIPPinning(ctx, remoteAddr, identity.UnmappedIdentity.PinnedIP, pinSourceIP, s.cfg.Logger); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// Don't apply the following checks in non-node contexts.

--- a/lib/srv/session_control_test.go
+++ b/lib/srv/session_control_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
@@ -454,6 +455,45 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 			identity:  botIdentity(),
 			assertion: func(t *testing.T, _ context.Context, err error, _ *eventstest.MockRecorderEmitter) {
 				assert.NoError(t, err, "AcquireSessionContext returned an unexpected error")
+			},
+		},
+		{
+			name: "session rejected due to pinned ip mismatch",
+			cfg: SessionControllerConfig{
+				Clock:      clock,
+				Semaphores: mockSemaphores{},
+				AccessPoint: mockAccessPoint{
+					authPreference: &types.AuthPreferenceV2{
+						Spec: types.AuthPreferenceSpecV2{
+							LockingMode: constants.LockingModeStrict,
+						},
+					},
+					clusterName: &types.ClusterNameV2{Spec: types.ClusterNameSpecV2{ClusterName: "llama"}},
+				},
+				LockEnforcer: mockLockEnforcer{},
+				Emitter:      emitter,
+				Component:    teleport.ComponentNode,
+				ServerID:     "1234",
+			},
+			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username: "alpaca",
+					PinnedIP: "1.2.3.4",
+				},
+				TeleportUser: "alpaca",
+				Login:        "alpaca",
+				AccessPermit: &decisionpb.SSHAccessPermit{
+					MaxConnections:   1,
+					PrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
+					Preconditions: []*decisionpb.Precondition{
+						{
+							Kind: decisionpb.PreconditionKind_PRECONDITION_KIND_PIN_SOURCE_IP,
+						},
+					},
+				},
+			},
+			assertion: func(t *testing.T, ctx context.Context, err error, emitter *eventstest.MockRecorderEmitter) {
+				require.ErrorIs(t, err, authz.ErrIPPinningMismatch)
 			},
 		},
 	}

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -102,7 +102,8 @@ type Identity struct {
 	PreviousIdentityExpires time.Time
 	// LoginIP is an observed IP of the client on the moment of certificate creation.
 	LoginIP string
-	// PinnedIP is an IP from which client must communicate with Teleport.
+	// PinnedIP is an IP from which client must communicate with Teleport. If set,
+	// this implies that IP Pinning was required at the time of certificate creation.
 	PinnedIP string
 	// DisallowReissue flags that any attempt to request new certificates while
 	// authenticated with this cert should be denied.

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -1022,8 +1022,13 @@ func (s *sessionCache) getOrCreateSession(ctx context.Context, user, sessionID s
 		return nil, trace.Wrap(err)
 	}
 
+	var clientAddr string
+	if clientSrcAddr, err := authz.ClientSrcAddrFromContext(ctx); err == nil {
+		clientAddr = clientSrcAddr.String()
+	}
+
 	// Enforce IP Pinning if it is present in the user's certificate.
-	if err := authz.CheckIPPinning(ctx, *identity, false, s.log); err != nil {
+	if err := authz.CheckIPPinning(ctx, clientAddr, identity.PinnedIP, false, s.log); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -1163,7 +1168,12 @@ func (s *sessionCache) newSessionContextFromSession(ctx context.Context, session
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authz.CheckIPPinning(ctx, *identity, false, s.log); err != nil {
+	var clientAddr string
+	if clientSrcAddr, err := authz.ClientSrcAddrFromContext(ctx); err == nil {
+		clientAddr = clientSrcAddr.String()
+	}
+
+	if err := authz.CheckIPPinning(ctx, clientAddr, identity.PinnedIP, false, s.log); err != nil {
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Changelog: Fix an issue that allowed IP Pinning protections to be bypassed via direct dial to a Teleport Node.

OSS port of https://github.com/gravitational/teleport-private/pull/2358

Manual Test Plan:

1. Create a Teleport Cluster and Direct Dial node
2. Login to the cluster w/ `tsh -add-keys-to-agent=yes`
3. Enable IP Pinning
- [x] Connecting directly to the node address w/ OpenSSH fails - `ssh -p 3022 <node-addr>`
4. Re-login to pin IP
- [x] Connecting directly to the node address w/ OpenSSH succeeds - `ssh -p 3022 <node-addr>`
5. Change IP address
- [x] Connecting directly to the node address w/ OpenSSH fails - `ssh -p 3022 <node-addr>`