### PR TITLE
[v17] Fix IP Pinning Bypass w/ direct dial to Node

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -416,7 +416,12 @@ func (a *authorizer) Authorize(ctx context.Context) (authCtx *Context, err error
 		return nil, trace.Wrap(err)
 	}
 
-	if err := CheckIPPinning(ctx, authContext.Identity.GetIdentity(), authContext.Checker.PinSourceIP(), a.logger); err != nil {
+	var clientAddr string
+	if clientSrcAddr, err := ClientSrcAddrFromContext(ctx); err == nil {
+		clientAddr = clientSrcAddr.String()
+	}
+
+	if err := CheckIPPinning(ctx, clientAddr, authContext.Identity.GetIdentity().PinnedIP, authContext.Checker.PinSourceIP(), a.logger); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -631,31 +636,40 @@ var ErrIPPinningNotAllowed = &trace.AccessDeniedError{Message: "IP pinning is no
 	"downgraded or are behind a L4 load balancers with PROXY protocol enabled without explicitly setting 'proxy_protocol: on'" +
 	"in the proxy_service and/or auth_service config."}
 
-// CheckIPPinning verifies IP pinning for the identity, using the client IP taken from context.
+// CheckIPPinning verifies IP pinning for the identity, using the provided client addr.
 // Check is considered successful if no error is returned.
-func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bool, log logrus.FieldLogger) error {
-	if identity.PinnedIP == "" {
+func CheckIPPinning(ctx context.Context, clientAddr string, pinnedIP string, pinSourceIP bool, log logrus.FieldLogger) error {
+	if pinnedIP == "" {
 		if pinSourceIP {
 			return trace.Wrap(ErrIPPinningMissing)
 		}
 		return nil
 	}
 
-	clientSrcAddr, err := ClientSrcAddrFromContext(ctx)
+	if clientAddr == "" {
+		return trace.BadParameter("pinned IP is required for the user, but the client IP was not provided")
+	}
+
+	clientHost, clientPort, err := net.SplitHostPort(clientAddr)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	clientIP, clientPort, err := net.SplitHostPort(clientSrcAddr.String())
-	if err != nil {
-		return trace.Wrap(err)
+	parsedClientIP := net.ParseIP(clientHost)
+	if parsedClientIP == nil {
+		return trace.BadParameter("client IP address %q is not a valid IP address", clientHost)
 	}
 
-	if clientIP != identity.PinnedIP {
+	parsedPinnedIP := net.ParseIP(pinnedIP)
+	if parsedPinnedIP == nil {
+		return trace.BadParameter("pinned IP address %q is not a valid IP address", pinnedIP)
+	}
+
+	if !parsedClientIP.Equal(net.ParseIP(pinnedIP)) {
 		if log != nil {
 			log.WithFields(logrus.Fields{
-				"client_ip": clientIP,
-				"pinned_ip": identity.PinnedIP,
+				"client_ip": parsedClientIP,
+				"pinned_ip": parsedPinnedIP,
 			}).Debug("Pinned IP and client IP mismatch")
 		}
 		return trace.Wrap(ErrIPPinningMismatch)
@@ -665,10 +679,10 @@ func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bo
 	if clientPort == "0" {
 		if log != nil {
 			log.WithFields(logrus.Fields{
-				"client_ip": clientIP,
-				"pinned_ip": identity.PinnedIP,
+				"client_ip": parsedClientIP,
+				"pinned_ip": pinnedIP,
 				"error":     ErrIPPinningNotAllowed.Message,
-			}).Debug("client address is not allowed ot use IP pinning")
+			}).Debug("client address is not allowed to use IP pinning")
 		}
 		return trace.Wrap(ErrIPPinningNotAllowed)
 	}

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -50,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
@@ -970,7 +969,7 @@ func TestCheckIPPinning(t *testing.T) {
 			desc:     "IP pinning enabled, missing client IP",
 			pinnedIP: "127.0.0.1",
 			pinIP:    true,
-			wantErr:  "client source address was not found in the context",
+			wantErr:  "client IP was not provided",
 		},
 		{
 			desc:       "IP pinning enabled, port=0 (marked by proxyProtocolMode unspecified)",
@@ -985,23 +984,51 @@ func TestCheckIPPinning(t *testing.T) {
 			pinnedIP:   "127.0.0.1",
 			pinIP:      true,
 		},
+		{
+			desc:       "invalid client IP",
+			clientAddr: "localhost:1",
+			pinnedIP:   "127.0.0.1:1",
+			pinIP:      true,
+			wantErr:    "\"localhost\" is not a valid IP address",
+		},
+		{
+			desc:       "invalid pinned IP",
+			clientAddr: "127.0.0.1:1",
+			pinnedIP:   "localhost",
+			pinIP:      true,
+			wantErr:    "\"localhost\" is not a valid IP address",
+		},
+		// IPv6
+		{
+			desc:       "IPv6: correct IP pinning",
+			clientAddr: "[2001:db8::1]:444",
+			pinnedIP:   "2001:db8::1",
+			pinIP:      true,
+		},
+		{
+			desc:       "IPv6: pinned IP doesn't match",
+			clientAddr: "[2001:db8::1]:444",
+			pinnedIP:   "2001:db8::2",
+			pinIP:      true,
+			wantErr:    authz.ErrIPPinningMismatch.Error(),
+		},
+		{
+			desc:       "IPv6: equivalency with compression",
+			clientAddr: "[2001:db8:0:0:0:0:0:1]:444",
+			pinnedIP:   "2001:db8::1",
+			pinIP:      true,
+		},
 	}
 
 	for _, tt := range testCases {
-		ctx := context.Background()
-		if tt.clientAddr != "" {
-			ctx = authz.ContextWithClientSrcAddr(ctx, utils.MustParseAddr(tt.clientAddr))
-		}
-		identity := tlsca.Identity{PinnedIP: tt.pinnedIP}
-
-		err := authz.CheckIPPinning(ctx, identity, tt.pinIP, nil)
-
-		if tt.wantErr != "" {
-			require.ErrorContains(t, err, tt.wantErr)
-		} else {
-			require.NoError(t, err)
-		}
-
+		t.Run(tt.desc, func(t *testing.T) {
+			err := authz.CheckIPPinning(context.Background(), tt.clientAddr, tt.pinnedIP, tt.pinIP, nil)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 

--- a/lib/srv/session_control.go
+++ b/lib/srv/session_control.go
@@ -38,6 +38,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/observability/metrics"
@@ -223,6 +224,10 @@ func (s *SessionController) AcquireSessionContext(ctx context.Context, identity 
 	}
 	if !requiredPolicy.IsSatisfiedBy(identity.UnmappedIdentity.PrivateKeyPolicy) {
 		return ctx, keys.NewPrivateKeyPolicyError(requiredPolicy)
+	}
+
+	if err := authz.CheckIPPinning(ctx, remoteAddr, identity.UnmappedIdentity.PinnedIP, identity.AccessChecker.PinSourceIP(), s.cfg.Logger); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// Don't apply the following checks in non-node contexts.

--- a/lib/srv/session_control_test.go
+++ b/lib/srv/session_control_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
@@ -92,6 +93,7 @@ type mockAccessChecker struct {
 	maxConnections int64
 	keyPolicy      keys.PrivateKeyPolicy
 	roleNames      []string
+	pinSourceIP    bool
 }
 
 func (m mockAccessChecker) LockingMode(defaultMode constants.LockingMode) constants.LockingMode {
@@ -108,6 +110,10 @@ func (m mockAccessChecker) PrivateKeyPolicy(defaultPolicy keys.PrivateKeyPolicy)
 
 func (m mockAccessChecker) RoleNames() []string {
 	return m.roleNames
+}
+
+func (m mockAccessChecker) PinSourceIP() bool {
+	return m.pinSourceIP
 }
 
 func TestSessionController_AcquireSessionContext(t *testing.T) {
@@ -479,6 +485,41 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 			identity:  botIdentity(),
 			assertion: func(t *testing.T, _ context.Context, err error, _ *eventstest.MockRecorderEmitter) {
 				assert.NoError(t, err, "AcquireSessionContext returned an unexpected error")
+			},
+		},
+		{
+			name: "session rejected due to pinned ip mismatch",
+			cfg: SessionControllerConfig{
+				Clock:      clock,
+				Semaphores: mockSemaphores{},
+				AccessPoint: mockAccessPoint{
+					authPreference: &types.AuthPreferenceV2{
+						Spec: types.AuthPreferenceSpecV2{
+							LockingMode: constants.LockingModeStrict,
+						},
+					},
+					clusterName: &types.ClusterNameV2{Spec: types.ClusterNameSpecV2{ClusterName: "llama"}},
+				},
+				LockEnforcer: mockLockEnforcer{},
+				Emitter:      emitter,
+				Component:    teleport.ComponentNode,
+				ServerID:     "1234",
+			},
+			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username: "alpaca",
+					PinnedIP: "1.2.3.4",
+				},
+				TeleportUser: "alpaca",
+				Login:        "alpaca",
+				AccessChecker: mockAccessChecker{
+					keyPolicy:      keys.PrivateKeyPolicyNone,
+					maxConnections: 1,
+					pinSourceIP:    true,
+				},
+			},
+			assertion: func(t *testing.T, ctx context.Context, err error, emitter *eventstest.MockRecorderEmitter) {
+				require.ErrorIs(t, err, authz.ErrIPPinningMismatch)
 			},
 		},
 	}

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -95,7 +95,8 @@ type Identity struct {
 	PreviousIdentityExpires time.Time
 	// LoginIP is an observed IP of the client on the moment of certificate creation.
 	LoginIP string
-	// PinnedIP is an IP from which client must communicate with Teleport.
+	// PinnedIP is an IP from which client must communicate with Teleport. If set,
+	// this implies that IP Pinning was required at the time of certificate creation.
 	PinnedIP string
 	// DisallowReissue flags that any attempt to request new certificates while
 	// authenticated with this cert should be denied.

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -1010,8 +1010,13 @@ func (s *sessionCache) getOrCreateSession(ctx context.Context, user, sessionID s
 		return nil, trace.Wrap(err)
 	}
 
+	var clientAddr string
+	if clientSrcAddr, err := authz.ClientSrcAddrFromContext(ctx); err == nil {
+		clientAddr = clientSrcAddr.String()
+	}
+
 	// Enforce IP Pinning if it is present in the user's certificate.
-	if err := authz.CheckIPPinning(ctx, *identity, false, s.log); err != nil {
+	if err := authz.CheckIPPinning(ctx, clientAddr, identity.PinnedIP, false, s.log); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -1151,7 +1156,12 @@ func (s *sessionCache) newSessionContextFromSession(ctx context.Context, session
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authz.CheckIPPinning(ctx, *identity, false, s.log); err != nil {
+	var clientAddr string
+	if clientSrcAddr, err := authz.ClientSrcAddrFromContext(ctx); err == nil {
+		clientAddr = clientSrcAddr.String()
+	}
+
+	if err := authz.CheckIPPinning(ctx, clientAddr, identity.PinnedIP, false, s.log); err != nil {
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Changelog: Fix an issue that allowed IP Pinning protections to be bypassed via direct dial to a Teleport Node.

OSS port of https://github.com/gravitational/teleport-private/pull/2359

Manual Test Plan:

1. Create a Teleport Cluster and Direct Dial node
2. Login to the cluster w/ `tsh -add-keys-to-agent=yes`
3. Enable IP Pinning
- [x] Connecting directly to the node address w/ OpenSSH fails - `ssh -p 3022 <node-addr>`
4. Re-login to pin IP
- [x] Connecting directly to the node address w/ OpenSSH succeeds - `ssh -p 3022 <node-addr>`
5. Change IP address
- [x] Connecting directly to the node address w/ OpenSSH fails - `ssh -p 3022 <node-addr>`