### PR TITLE
Desktop Access: Support Shared Directory Removal (Backend only)

### DIFF
--- a/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
@@ -309,11 +309,12 @@ func (x *ClientHello) GetKeyboardLayout() uint32 {
 
 // Sent by server in response to a 'Client Hello'. Advertises server capabilities.
 type ServerHello struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	ActivationSpec   *ConnectionActivated   `protobuf:"bytes,1,opt,name=activation_spec,json=activationSpec,proto3" json:"activation_spec,omitempty"`
-	ClipboardEnabled bool                   `protobuf:"varint,2,opt,name=clipboard_enabled,json=clipboardEnabled,proto3" json:"clipboard_enabled,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state                    protoimpl.MessageState `protogen:"open.v1"`
+	ActivationSpec           *ConnectionActivated   `protobuf:"bytes,1,opt,name=activation_spec,json=activationSpec,proto3" json:"activation_spec,omitempty"`
+	ClipboardEnabled         bool                   `protobuf:"varint,2,opt,name=clipboard_enabled,json=clipboardEnabled,proto3" json:"clipboard_enabled,omitempty"`
+	DirectoryRemoveSupported bool                   `protobuf:"varint,3,opt,name=directory_remove_supported,json=directoryRemoveSupported,proto3" json:"directory_remove_supported,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *ServerHello) Reset() {
@@ -356,6 +357,13 @@ func (x *ServerHello) GetActivationSpec() *ConnectionActivated {
 func (x *ServerHello) GetClipboardEnabled() bool {
 	if x != nil {
 		return x.ClipboardEnabled
+	}
+	return false
+}
+
+func (x *ServerHello) GetDirectoryRemoveSupported() bool {
+	if x != nil {
+		return x.DirectoryRemoveSupported
 	}
 	return false
 }
@@ -1202,6 +1210,51 @@ func (x *SharedDirectoryAnnounce) GetName() string {
 	return ""
 }
 
+// Sent by client to remove a previously announced shared directory.
+type SharedDirectoryRemove struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DirectoryId   uint32                 `protobuf:"varint,1,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SharedDirectoryRemove) Reset() {
+	*x = SharedDirectoryRemove{}
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SharedDirectoryRemove) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SharedDirectoryRemove) ProtoMessage() {}
+
+func (x *SharedDirectoryRemove) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SharedDirectoryRemove.ProtoReflect.Descriptor instead.
+func (*SharedDirectoryRemove) Descriptor() ([]byte, []int) {
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *SharedDirectoryRemove) GetDirectoryId() uint32 {
+	if x != nil {
+		return x.DirectoryId
+	}
+	return 0
+}
+
 // Sent by server to acknowledge a new shared directory.
 type SharedDirectoryAcknowledge struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1213,7 +1266,7 @@ type SharedDirectoryAcknowledge struct {
 
 func (x *SharedDirectoryAcknowledge) Reset() {
 	*x = SharedDirectoryAcknowledge{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1225,7 +1278,7 @@ func (x *SharedDirectoryAcknowledge) String() string {
 func (*SharedDirectoryAcknowledge) ProtoMessage() {}
 
 func (x *SharedDirectoryAcknowledge) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[17]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1238,7 +1291,7 @@ func (x *SharedDirectoryAcknowledge) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryAcknowledge.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryAcknowledge) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{17}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SharedDirectoryAcknowledge) GetDirectoryId() uint32 {
@@ -1280,7 +1333,7 @@ type SharedDirectoryRequest struct {
 
 func (x *SharedDirectoryRequest) Reset() {
 	*x = SharedDirectoryRequest{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1292,7 +1345,7 @@ func (x *SharedDirectoryRequest) String() string {
 func (*SharedDirectoryRequest) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[18]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1305,7 +1358,7 @@ func (x *SharedDirectoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryRequest.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{18}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SharedDirectoryRequest) GetDirectoryId() uint32 {
@@ -1479,7 +1532,7 @@ type SharedDirectoryResponse struct {
 
 func (x *SharedDirectoryResponse) Reset() {
 	*x = SharedDirectoryResponse{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1491,7 +1544,7 @@ func (x *SharedDirectoryResponse) String() string {
 func (*SharedDirectoryResponse) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[19]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1504,7 +1557,7 @@ func (x *SharedDirectoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryResponse.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SharedDirectoryResponse) GetCompletionId() uint32 {
@@ -1666,7 +1719,7 @@ type FileSystemObject struct {
 
 func (x *FileSystemObject) Reset() {
 	*x = FileSystemObject{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1678,7 +1731,7 @@ func (x *FileSystemObject) String() string {
 func (*FileSystemObject) ProtoMessage() {}
 
 func (x *FileSystemObject) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[20]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1691,7 +1744,7 @@ func (x *FileSystemObject) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileSystemObject.ProtoReflect.Descriptor instead.
 func (*FileSystemObject) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{20}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *FileSystemObject) GetLastModified() uint64 {
@@ -1741,7 +1794,7 @@ type LatencyStats struct {
 
 func (x *LatencyStats) Reset() {
 	*x = LatencyStats{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1753,7 +1806,7 @@ func (x *LatencyStats) String() string {
 func (*LatencyStats) ProtoMessage() {}
 
 func (x *LatencyStats) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[21]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1766,7 +1819,7 @@ func (x *LatencyStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LatencyStats.ProtoReflect.Descriptor instead.
 func (*LatencyStats) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{21}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *LatencyStats) GetClientLatencyMs() uint32 {
@@ -1794,7 +1847,7 @@ type Ping struct {
 
 func (x *Ping) Reset() {
 	*x = Ping{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1806,7 +1859,7 @@ func (x *Ping) String() string {
 func (*Ping) ProtoMessage() {}
 
 func (x *Ping) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[22]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1819,7 +1872,7 @@ func (x *Ping) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Ping.ProtoReflect.Descriptor instead.
 func (*Ping) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{22}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *Ping) GetUuid() []byte {
@@ -1854,6 +1907,7 @@ type Envelope struct {
 	//	*Envelope_SharedDirectoryResponse
 	//	*Envelope_LatencyStats
 	//	*Envelope_Ping
+	//	*Envelope_SharedDirectoryRemove
 	Payload       isEnvelope_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1861,7 +1915,7 @@ type Envelope struct {
 
 func (x *Envelope) Reset() {
 	*x = Envelope{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1873,7 +1927,7 @@ func (x *Envelope) String() string {
 func (*Envelope) ProtoMessage() {}
 
 func (x *Envelope) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[23]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1886,7 +1940,7 @@ func (x *Envelope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Envelope.ProtoReflect.Descriptor instead.
 func (*Envelope) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{23}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Envelope) GetPayload() isEnvelope_Payload {
@@ -2076,6 +2130,15 @@ func (x *Envelope) GetPing() *Ping {
 	return nil
 }
 
+func (x *Envelope) GetSharedDirectoryRemove() *SharedDirectoryRemove {
+	if x != nil {
+		if x, ok := x.Payload.(*Envelope_SharedDirectoryRemove); ok {
+			return x.SharedDirectoryRemove
+		}
+	}
+	return nil
+}
+
 type isEnvelope_Payload interface {
 	isEnvelope_Payload()
 }
@@ -2160,6 +2223,10 @@ type Envelope_Ping struct {
 	Ping *Ping `protobuf:"bytes,20,opt,name=ping,proto3,oneof"`
 }
 
+type Envelope_SharedDirectoryRemove struct {
+	SharedDirectoryRemove *SharedDirectoryRemove `protobuf:"bytes,21,opt,name=shared_directory_remove,json=sharedDirectoryRemove,proto3,oneof"`
+}
+
 func (*Envelope_ClientHello) isEnvelope_Payload() {}
 
 func (*Envelope_ServerHello) isEnvelope_Payload() {}
@@ -2200,6 +2267,8 @@ func (*Envelope_LatencyStats) isEnvelope_Payload() {}
 
 func (*Envelope_Ping) isEnvelope_Payload() {}
 
+func (*Envelope_SharedDirectoryRemove) isEnvelope_Payload() {}
+
 // Info request.
 type SharedDirectoryRequest_Info struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2210,7 +2279,7 @@ type SharedDirectoryRequest_Info struct {
 
 func (x *SharedDirectoryRequest_Info) Reset() {
 	*x = SharedDirectoryRequest_Info{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2222,7 +2291,7 @@ func (x *SharedDirectoryRequest_Info) String() string {
 func (*SharedDirectoryRequest_Info) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[24]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2235,7 +2304,7 @@ func (x *SharedDirectoryRequest_Info) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryRequest_Info.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryRequest_Info) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{18, 0}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 0}
 }
 
 func (x *SharedDirectoryRequest_Info) GetPath() string {
@@ -2256,7 +2325,7 @@ type SharedDirectoryRequest_Create struct {
 
 func (x *SharedDirectoryRequest_Create) Reset() {
 	*x = SharedDirectoryRequest_Create{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2268,7 +2337,7 @@ func (x *SharedDirectoryRequest_Create) String() string {
 func (*SharedDirectoryRequest_Create) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Create) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[25]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2281,7 +2350,7 @@ func (x *SharedDirectoryRequest_Create) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryRequest_Create.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryRequest_Create) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{18, 1}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 1}
 }
 
 func (x *SharedDirectoryRequest_Create) GetPath() string {
@@ -2308,7 +2377,7 @@ type SharedDirectoryRequest_Delete struct {
 
 func (x *SharedDirectoryRequest_Delete) Reset() {
 	*x = SharedDirectoryRequest_Delete{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2320,7 +2389,7 @@ func (x *SharedDirectoryRequest_Delete) String() string {
 func (*SharedDirectoryRequest_Delete) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[26]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2333,7 +2402,7 @@ func (x *SharedDirectoryRequest_Delete) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryRequest_Delete.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryRequest_Delete) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{18, 2}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 2}
 }
 
 func (x *SharedDirectoryRequest_Delete) GetPath() string {
@@ -2353,7 +2422,7 @@ type SharedDirectoryRequest_List struct {
 
 func (x *SharedDirectoryRequest_List) Reset() {
 	*x = SharedDirectoryRequest_List{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2365,7 +2434,7 @@ func (x *SharedDirectoryRequest_List) String() string {
 func (*SharedDirectoryRequest_List) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_List) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[27]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2378,7 +2447,7 @@ func (x *SharedDirectoryRequest_List) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryRequest_List.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryRequest_List) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{18, 3}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 3}
 }
 
 func (x *SharedDirectoryRequest_List) GetPath() string {
@@ -2400,7 +2469,7 @@ type SharedDirectoryRequest_Read struct {
 
 func (x *SharedDirectoryRequest_Read) Reset() {
 	*x = SharedDirectoryRequest_Read{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2412,7 +2481,7 @@ func (x *SharedDirectoryRequest_Read) String() string {
 func (*SharedDirectoryRequest_Read) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Read) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[28]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2425,7 +2494,7 @@ func (x *SharedDirectoryRequest_Read) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryRequest_Read.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryRequest_Read) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{18, 4}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 4}
 }
 
 func (x *SharedDirectoryRequest_Read) GetPath() string {
@@ -2461,7 +2530,7 @@ type SharedDirectoryRequest_Write struct {
 
 func (x *SharedDirectoryRequest_Write) Reset() {
 	*x = SharedDirectoryRequest_Write{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2473,7 +2542,7 @@ func (x *SharedDirectoryRequest_Write) String() string {
 func (*SharedDirectoryRequest_Write) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Write) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[29]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2486,7 +2555,7 @@ func (x *SharedDirectoryRequest_Write) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryRequest_Write.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryRequest_Write) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{18, 5}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 5}
 }
 
 func (x *SharedDirectoryRequest_Write) GetPath() string {
@@ -2521,7 +2590,7 @@ type SharedDirectoryRequest_Move struct {
 
 func (x *SharedDirectoryRequest_Move) Reset() {
 	*x = SharedDirectoryRequest_Move{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2533,7 +2602,7 @@ func (x *SharedDirectoryRequest_Move) String() string {
 func (*SharedDirectoryRequest_Move) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[30]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2546,7 +2615,7 @@ func (x *SharedDirectoryRequest_Move) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryRequest_Move.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryRequest_Move) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{18, 6}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 6}
 }
 
 func (x *SharedDirectoryRequest_Move) GetOriginalPath() string {
@@ -2574,7 +2643,7 @@ type SharedDirectoryRequest_Truncate struct {
 
 func (x *SharedDirectoryRequest_Truncate) Reset() {
 	*x = SharedDirectoryRequest_Truncate{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2586,7 +2655,7 @@ func (x *SharedDirectoryRequest_Truncate) String() string {
 func (*SharedDirectoryRequest_Truncate) ProtoMessage() {}
 
 func (x *SharedDirectoryRequest_Truncate) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[31]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2599,7 +2668,7 @@ func (x *SharedDirectoryRequest_Truncate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryRequest_Truncate.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryRequest_Truncate) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{18, 7}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 7}
 }
 
 func (x *SharedDirectoryRequest_Truncate) GetPath() string {
@@ -2626,7 +2695,7 @@ type SharedDirectoryResponse_Info struct {
 
 func (x *SharedDirectoryResponse_Info) Reset() {
 	*x = SharedDirectoryResponse_Info{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2638,7 +2707,7 @@ func (x *SharedDirectoryResponse_Info) String() string {
 func (*SharedDirectoryResponse_Info) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[32]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2651,7 +2720,7 @@ func (x *SharedDirectoryResponse_Info) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryResponse_Info.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryResponse_Info) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 0}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{20, 0}
 }
 
 func (x *SharedDirectoryResponse_Info) GetFso() *FileSystemObject {
@@ -2671,7 +2740,7 @@ type SharedDirectoryResponse_Create struct {
 
 func (x *SharedDirectoryResponse_Create) Reset() {
 	*x = SharedDirectoryResponse_Create{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2683,7 +2752,7 @@ func (x *SharedDirectoryResponse_Create) String() string {
 func (*SharedDirectoryResponse_Create) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Create) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[33]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2696,7 +2765,7 @@ func (x *SharedDirectoryResponse_Create) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryResponse_Create.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryResponse_Create) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 1}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{20, 1}
 }
 
 func (x *SharedDirectoryResponse_Create) GetFso() *FileSystemObject {
@@ -2715,7 +2784,7 @@ type SharedDirectoryResponse_Delete struct {
 
 func (x *SharedDirectoryResponse_Delete) Reset() {
 	*x = SharedDirectoryResponse_Delete{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2727,7 +2796,7 @@ func (x *SharedDirectoryResponse_Delete) String() string {
 func (*SharedDirectoryResponse_Delete) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Delete) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[34]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2740,7 +2809,7 @@ func (x *SharedDirectoryResponse_Delete) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryResponse_Delete.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryResponse_Delete) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 2}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{20, 2}
 }
 
 // List response.
@@ -2753,7 +2822,7 @@ type SharedDirectoryResponse_List struct {
 
 func (x *SharedDirectoryResponse_List) Reset() {
 	*x = SharedDirectoryResponse_List{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2765,7 +2834,7 @@ func (x *SharedDirectoryResponse_List) String() string {
 func (*SharedDirectoryResponse_List) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_List) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[35]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2778,7 +2847,7 @@ func (x *SharedDirectoryResponse_List) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryResponse_List.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryResponse_List) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 3}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{20, 3}
 }
 
 func (x *SharedDirectoryResponse_List) GetFsoList() []*FileSystemObject {
@@ -2798,7 +2867,7 @@ type SharedDirectoryResponse_Read struct {
 
 func (x *SharedDirectoryResponse_Read) Reset() {
 	*x = SharedDirectoryResponse_Read{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2810,7 +2879,7 @@ func (x *SharedDirectoryResponse_Read) String() string {
 func (*SharedDirectoryResponse_Read) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Read) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[36]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2823,7 +2892,7 @@ func (x *SharedDirectoryResponse_Read) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryResponse_Read.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryResponse_Read) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 4}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{20, 4}
 }
 
 func (x *SharedDirectoryResponse_Read) GetData() []byte {
@@ -2843,7 +2912,7 @@ type SharedDirectoryResponse_Write struct {
 
 func (x *SharedDirectoryResponse_Write) Reset() {
 	*x = SharedDirectoryResponse_Write{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2855,7 +2924,7 @@ func (x *SharedDirectoryResponse_Write) String() string {
 func (*SharedDirectoryResponse_Write) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Write) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[37]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2868,7 +2937,7 @@ func (x *SharedDirectoryResponse_Write) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryResponse_Write.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryResponse_Write) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 5}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{20, 5}
 }
 
 func (x *SharedDirectoryResponse_Write) GetBytesWritten() uint32 {
@@ -2887,7 +2956,7 @@ type SharedDirectoryResponse_Move struct {
 
 func (x *SharedDirectoryResponse_Move) Reset() {
 	*x = SharedDirectoryResponse_Move{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2899,7 +2968,7 @@ func (x *SharedDirectoryResponse_Move) String() string {
 func (*SharedDirectoryResponse_Move) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[38]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2912,7 +2981,7 @@ func (x *SharedDirectoryResponse_Move) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryResponse_Move.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryResponse_Move) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 6}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{20, 6}
 }
 
 // Truncate response.
@@ -2924,7 +2993,7 @@ type SharedDirectoryResponse_Truncate struct {
 
 func (x *SharedDirectoryResponse_Truncate) Reset() {
 	*x = SharedDirectoryResponse_Truncate{}
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2936,7 +3005,7 @@ func (x *SharedDirectoryResponse_Truncate) String() string {
 func (*SharedDirectoryResponse_Truncate) ProtoMessage() {}
 
 func (x *SharedDirectoryResponse_Truncate) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[39]
+	mi := &file_teleport_desktop_v1_tdpb_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2949,7 +3018,7 @@ func (x *SharedDirectoryResponse_Truncate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SharedDirectoryResponse_Truncate.ProtoReflect.Descriptor instead.
 func (*SharedDirectoryResponse_Truncate) Descriptor() ([]byte, []int) {
-	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{19, 7}
+	return file_teleport_desktop_v1_tdpb_proto_rawDescGZIP(), []int{20, 7}
 }
 
 var File_teleport_desktop_v1_tdpb_proto protoreflect.FileDescriptor
@@ -2961,10 +3030,11 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\x12F\n" +
 	"\vscreen_spec\x18\x02 \x01(\v2%.teleport.desktop.v1.ClientScreenSpecR\n" +
 	"screenSpec\x12'\n" +
-	"\x0fkeyboard_layout\x18\x03 \x01(\rR\x0ekeyboardLayout\"\x8d\x01\n" +
+	"\x0fkeyboard_layout\x18\x03 \x01(\rR\x0ekeyboardLayout\"\xcb\x01\n" +
 	"\vServerHello\x12Q\n" +
 	"\x0factivation_spec\x18\x01 \x01(\v2(.teleport.desktop.v1.ConnectionActivatedR\x0eactivationSpec\x12+\n" +
-	"\x11clipboard_enabled\x18\x02 \x01(\bR\x10clipboardEnabled\"_\n" +
+	"\x11clipboard_enabled\x18\x02 \x01(\bR\x10clipboardEnabled\x12<\n" +
+	"\x1adirectory_remove_supported\x18\x03 \x01(\bR\x18directoryRemoveSupported\"_\n" +
 	"\tRectangle\x12\x12\n" +
 	"\x04left\x18\x01 \x01(\rR\x04left\x12\x10\n" +
 	"\x03top\x18\x02 \x01(\rR\x03top\x12\x14\n" +
@@ -3016,7 +3086,9 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x17authentication_response\x18\x04 \x01(\v2%.teleport.mfa.v1.AuthenticateResponseR\x16authenticationResponse\"P\n" +
 	"\x17SharedDirectoryAnnounce\x12!\n" +
 	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\"^\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\":\n" +
+	"\x15SharedDirectoryRemove\x12!\n" +
+	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\"^\n" +
 	"\x1aSharedDirectoryAcknowledge\x12!\n" +
 	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\x12\x1d\n" +
 	"\n" +
@@ -3095,7 +3167,7 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x11client_latency_ms\x18\x01 \x01(\rR\x0fclientLatencyMs\x12*\n" +
 	"\x11server_latency_ms\x18\x02 \x01(\rR\x0fserverLatencyMs\"\x1a\n" +
 	"\x04Ping\x12\x12\n" +
-	"\x04uuid\x18\x01 \x01(\fR\x04uuid\"\x8b\f\n" +
+	"\x04uuid\x18\x01 \x01(\fR\x04uuid\"\xf1\f\n" +
 	"\bEnvelope\x12E\n" +
 	"\fclient_hello\x18\x01 \x01(\v2 .teleport.desktop.v1.ClientHelloH\x00R\vclientHello\x12E\n" +
 	"\fserver_hello\x18\x02 \x01(\v2 .teleport.desktop.v1.ServerHelloH\x00R\vserverHello\x12<\n" +
@@ -3119,7 +3191,8 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x18shared_directory_request\x18\x11 \x01(\v2+.teleport.desktop.v1.SharedDirectoryRequestH\x00R\x16sharedDirectoryRequest\x12j\n" +
 	"\x19shared_directory_response\x18\x12 \x01(\v2,.teleport.desktop.v1.SharedDirectoryResponseH\x00R\x17sharedDirectoryResponse\x12H\n" +
 	"\rlatency_stats\x18\x13 \x01(\v2!.teleport.desktop.v1.LatencyStatsH\x00R\flatencyStats\x12/\n" +
-	"\x04ping\x18\x14 \x01(\v2\x19.teleport.desktop.v1.PingH\x00R\x04pingB\t\n" +
+	"\x04ping\x18\x14 \x01(\v2\x19.teleport.desktop.v1.PingH\x00R\x04ping\x12d\n" +
+	"\x17shared_directory_remove\x18\x15 \x01(\v2*.teleport.desktop.v1.SharedDirectoryRemoveH\x00R\x15sharedDirectoryRemoveB\t\n" +
 	"\apayload*\x8b\x01\n" +
 	"\x0fMouseButtonType\x12!\n" +
 	"\x1dMOUSE_BUTTON_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
@@ -3153,7 +3226,7 @@ func file_teleport_desktop_v1_tdpb_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_desktop_v1_tdpb_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_teleport_desktop_v1_tdpb_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_teleport_desktop_v1_tdpb_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_teleport_desktop_v1_tdpb_proto_goTypes = []any{
 	(MouseButtonType)(0),                     // 0: teleport.desktop.v1.MouseButtonType
 	(AlertSeverity)(0),                       // 1: teleport.desktop.v1.AlertSeverity
@@ -3176,31 +3249,32 @@ var file_teleport_desktop_v1_tdpb_proto_goTypes = []any{
 	(*ClipboardData)(nil),                    // 18: teleport.desktop.v1.ClipboardData
 	(*MFA)(nil),                              // 19: teleport.desktop.v1.MFA
 	(*SharedDirectoryAnnounce)(nil),          // 20: teleport.desktop.v1.SharedDirectoryAnnounce
-	(*SharedDirectoryAcknowledge)(nil),       // 21: teleport.desktop.v1.SharedDirectoryAcknowledge
-	(*SharedDirectoryRequest)(nil),           // 22: teleport.desktop.v1.SharedDirectoryRequest
-	(*SharedDirectoryResponse)(nil),          // 23: teleport.desktop.v1.SharedDirectoryResponse
-	(*FileSystemObject)(nil),                 // 24: teleport.desktop.v1.FileSystemObject
-	(*LatencyStats)(nil),                     // 25: teleport.desktop.v1.LatencyStats
-	(*Ping)(nil),                             // 26: teleport.desktop.v1.Ping
-	(*Envelope)(nil),                         // 27: teleport.desktop.v1.Envelope
-	(*SharedDirectoryRequest_Info)(nil),      // 28: teleport.desktop.v1.SharedDirectoryRequest.Info
-	(*SharedDirectoryRequest_Create)(nil),    // 29: teleport.desktop.v1.SharedDirectoryRequest.Create
-	(*SharedDirectoryRequest_Delete)(nil),    // 30: teleport.desktop.v1.SharedDirectoryRequest.Delete
-	(*SharedDirectoryRequest_List)(nil),      // 31: teleport.desktop.v1.SharedDirectoryRequest.List
-	(*SharedDirectoryRequest_Read)(nil),      // 32: teleport.desktop.v1.SharedDirectoryRequest.Read
-	(*SharedDirectoryRequest_Write)(nil),     // 33: teleport.desktop.v1.SharedDirectoryRequest.Write
-	(*SharedDirectoryRequest_Move)(nil),      // 34: teleport.desktop.v1.SharedDirectoryRequest.Move
-	(*SharedDirectoryRequest_Truncate)(nil),  // 35: teleport.desktop.v1.SharedDirectoryRequest.Truncate
-	(*SharedDirectoryResponse_Info)(nil),     // 36: teleport.desktop.v1.SharedDirectoryResponse.Info
-	(*SharedDirectoryResponse_Create)(nil),   // 37: teleport.desktop.v1.SharedDirectoryResponse.Create
-	(*SharedDirectoryResponse_Delete)(nil),   // 38: teleport.desktop.v1.SharedDirectoryResponse.Delete
-	(*SharedDirectoryResponse_List)(nil),     // 39: teleport.desktop.v1.SharedDirectoryResponse.List
-	(*SharedDirectoryResponse_Read)(nil),     // 40: teleport.desktop.v1.SharedDirectoryResponse.Read
-	(*SharedDirectoryResponse_Write)(nil),    // 41: teleport.desktop.v1.SharedDirectoryResponse.Write
-	(*SharedDirectoryResponse_Move)(nil),     // 42: teleport.desktop.v1.SharedDirectoryResponse.Move
-	(*SharedDirectoryResponse_Truncate)(nil), // 43: teleport.desktop.v1.SharedDirectoryResponse.Truncate
-	(*v1.AuthenticateChallenge)(nil),         // 44: teleport.mfa.v1.AuthenticateChallenge
-	(*v1.AuthenticateResponse)(nil),          // 45: teleport.mfa.v1.AuthenticateResponse
+	(*SharedDirectoryRemove)(nil),            // 21: teleport.desktop.v1.SharedDirectoryRemove
+	(*SharedDirectoryAcknowledge)(nil),       // 22: teleport.desktop.v1.SharedDirectoryAcknowledge
+	(*SharedDirectoryRequest)(nil),           // 23: teleport.desktop.v1.SharedDirectoryRequest
+	(*SharedDirectoryResponse)(nil),          // 24: teleport.desktop.v1.SharedDirectoryResponse
+	(*FileSystemObject)(nil),                 // 25: teleport.desktop.v1.FileSystemObject
+	(*LatencyStats)(nil),                     // 26: teleport.desktop.v1.LatencyStats
+	(*Ping)(nil),                             // 27: teleport.desktop.v1.Ping
+	(*Envelope)(nil),                         // 28: teleport.desktop.v1.Envelope
+	(*SharedDirectoryRequest_Info)(nil),      // 29: teleport.desktop.v1.SharedDirectoryRequest.Info
+	(*SharedDirectoryRequest_Create)(nil),    // 30: teleport.desktop.v1.SharedDirectoryRequest.Create
+	(*SharedDirectoryRequest_Delete)(nil),    // 31: teleport.desktop.v1.SharedDirectoryRequest.Delete
+	(*SharedDirectoryRequest_List)(nil),      // 32: teleport.desktop.v1.SharedDirectoryRequest.List
+	(*SharedDirectoryRequest_Read)(nil),      // 33: teleport.desktop.v1.SharedDirectoryRequest.Read
+	(*SharedDirectoryRequest_Write)(nil),     // 34: teleport.desktop.v1.SharedDirectoryRequest.Write
+	(*SharedDirectoryRequest_Move)(nil),      // 35: teleport.desktop.v1.SharedDirectoryRequest.Move
+	(*SharedDirectoryRequest_Truncate)(nil),  // 36: teleport.desktop.v1.SharedDirectoryRequest.Truncate
+	(*SharedDirectoryResponse_Info)(nil),     // 37: teleport.desktop.v1.SharedDirectoryResponse.Info
+	(*SharedDirectoryResponse_Create)(nil),   // 38: teleport.desktop.v1.SharedDirectoryResponse.Create
+	(*SharedDirectoryResponse_Delete)(nil),   // 39: teleport.desktop.v1.SharedDirectoryResponse.Delete
+	(*SharedDirectoryResponse_List)(nil),     // 40: teleport.desktop.v1.SharedDirectoryResponse.List
+	(*SharedDirectoryResponse_Read)(nil),     // 41: teleport.desktop.v1.SharedDirectoryResponse.Read
+	(*SharedDirectoryResponse_Write)(nil),    // 42: teleport.desktop.v1.SharedDirectoryResponse.Write
+	(*SharedDirectoryResponse_Move)(nil),     // 43: teleport.desktop.v1.SharedDirectoryResponse.Move
+	(*SharedDirectoryResponse_Truncate)(nil), // 44: teleport.desktop.v1.SharedDirectoryResponse.Truncate
+	(*v1.AuthenticateChallenge)(nil),         // 45: teleport.mfa.v1.AuthenticateChallenge
+	(*v1.AuthenticateResponse)(nil),          // 46: teleport.mfa.v1.AuthenticateResponse
 }
 var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	15, // 0: teleport.desktop.v1.ClientHello.screen_spec:type_name -> teleport.desktop.v1.ClientScreenSpec
@@ -3210,24 +3284,24 @@ var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	1,  // 4: teleport.desktop.v1.Alert.severity:type_name -> teleport.desktop.v1.AlertSeverity
 	2,  // 5: teleport.desktop.v1.MouseWheel.axis:type_name -> teleport.desktop.v1.MouseWheelAxis
 	3,  // 6: teleport.desktop.v1.MFA.type:type_name -> teleport.desktop.v1.MFAType
-	44, // 7: teleport.desktop.v1.MFA.challenge:type_name -> teleport.mfa.v1.AuthenticateChallenge
-	45, // 8: teleport.desktop.v1.MFA.authentication_response:type_name -> teleport.mfa.v1.AuthenticateResponse
-	28, // 9: teleport.desktop.v1.SharedDirectoryRequest.info:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Info
-	29, // 10: teleport.desktop.v1.SharedDirectoryRequest.create:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Create
-	30, // 11: teleport.desktop.v1.SharedDirectoryRequest.delete:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Delete
-	31, // 12: teleport.desktop.v1.SharedDirectoryRequest.list:type_name -> teleport.desktop.v1.SharedDirectoryRequest.List
-	32, // 13: teleport.desktop.v1.SharedDirectoryRequest.read:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Read
-	33, // 14: teleport.desktop.v1.SharedDirectoryRequest.write:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Write
-	34, // 15: teleport.desktop.v1.SharedDirectoryRequest.move:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Move
-	35, // 16: teleport.desktop.v1.SharedDirectoryRequest.truncate:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Truncate
-	36, // 17: teleport.desktop.v1.SharedDirectoryResponse.info:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Info
-	37, // 18: teleport.desktop.v1.SharedDirectoryResponse.create:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Create
-	38, // 19: teleport.desktop.v1.SharedDirectoryResponse.delete:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Delete
-	39, // 20: teleport.desktop.v1.SharedDirectoryResponse.list:type_name -> teleport.desktop.v1.SharedDirectoryResponse.List
-	40, // 21: teleport.desktop.v1.SharedDirectoryResponse.read:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Read
-	41, // 22: teleport.desktop.v1.SharedDirectoryResponse.write:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Write
-	42, // 23: teleport.desktop.v1.SharedDirectoryResponse.move:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Move
-	43, // 24: teleport.desktop.v1.SharedDirectoryResponse.truncate:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Truncate
+	45, // 7: teleport.desktop.v1.MFA.challenge:type_name -> teleport.mfa.v1.AuthenticateChallenge
+	46, // 8: teleport.desktop.v1.MFA.authentication_response:type_name -> teleport.mfa.v1.AuthenticateResponse
+	29, // 9: teleport.desktop.v1.SharedDirectoryRequest.info:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Info
+	30, // 10: teleport.desktop.v1.SharedDirectoryRequest.create:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Create
+	31, // 11: teleport.desktop.v1.SharedDirectoryRequest.delete:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Delete
+	32, // 12: teleport.desktop.v1.SharedDirectoryRequest.list:type_name -> teleport.desktop.v1.SharedDirectoryRequest.List
+	33, // 13: teleport.desktop.v1.SharedDirectoryRequest.read:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Read
+	34, // 14: teleport.desktop.v1.SharedDirectoryRequest.write:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Write
+	35, // 15: teleport.desktop.v1.SharedDirectoryRequest.move:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Move
+	36, // 16: teleport.desktop.v1.SharedDirectoryRequest.truncate:type_name -> teleport.desktop.v1.SharedDirectoryRequest.Truncate
+	37, // 17: teleport.desktop.v1.SharedDirectoryResponse.info:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Info
+	38, // 18: teleport.desktop.v1.SharedDirectoryResponse.create:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Create
+	39, // 19: teleport.desktop.v1.SharedDirectoryResponse.delete:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Delete
+	40, // 20: teleport.desktop.v1.SharedDirectoryResponse.list:type_name -> teleport.desktop.v1.SharedDirectoryResponse.List
+	41, // 21: teleport.desktop.v1.SharedDirectoryResponse.read:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Read
+	42, // 22: teleport.desktop.v1.SharedDirectoryResponse.write:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Write
+	43, // 23: teleport.desktop.v1.SharedDirectoryResponse.move:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Move
+	44, // 24: teleport.desktop.v1.SharedDirectoryResponse.truncate:type_name -> teleport.desktop.v1.SharedDirectoryResponse.Truncate
 	4,  // 25: teleport.desktop.v1.Envelope.client_hello:type_name -> teleport.desktop.v1.ClientHello
 	5,  // 26: teleport.desktop.v1.Envelope.server_hello:type_name -> teleport.desktop.v1.ServerHello
 	7,  // 27: teleport.desktop.v1.Envelope.png_frame:type_name -> teleport.desktop.v1.PNGFrame
@@ -3243,19 +3317,20 @@ var file_teleport_desktop_v1_tdpb_proto_depIdxs = []int32{
 	18, // 37: teleport.desktop.v1.Envelope.clipboard_data:type_name -> teleport.desktop.v1.ClipboardData
 	19, // 38: teleport.desktop.v1.Envelope.mfa:type_name -> teleport.desktop.v1.MFA
 	20, // 39: teleport.desktop.v1.Envelope.shared_directory_announce:type_name -> teleport.desktop.v1.SharedDirectoryAnnounce
-	21, // 40: teleport.desktop.v1.Envelope.shared_directory_acknowledge:type_name -> teleport.desktop.v1.SharedDirectoryAcknowledge
-	22, // 41: teleport.desktop.v1.Envelope.shared_directory_request:type_name -> teleport.desktop.v1.SharedDirectoryRequest
-	23, // 42: teleport.desktop.v1.Envelope.shared_directory_response:type_name -> teleport.desktop.v1.SharedDirectoryResponse
-	25, // 43: teleport.desktop.v1.Envelope.latency_stats:type_name -> teleport.desktop.v1.LatencyStats
-	26, // 44: teleport.desktop.v1.Envelope.ping:type_name -> teleport.desktop.v1.Ping
-	24, // 45: teleport.desktop.v1.SharedDirectoryResponse.Info.fso:type_name -> teleport.desktop.v1.FileSystemObject
-	24, // 46: teleport.desktop.v1.SharedDirectoryResponse.Create.fso:type_name -> teleport.desktop.v1.FileSystemObject
-	24, // 47: teleport.desktop.v1.SharedDirectoryResponse.List.fso_list:type_name -> teleport.desktop.v1.FileSystemObject
-	48, // [48:48] is the sub-list for method output_type
-	48, // [48:48] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	22, // 40: teleport.desktop.v1.Envelope.shared_directory_acknowledge:type_name -> teleport.desktop.v1.SharedDirectoryAcknowledge
+	23, // 41: teleport.desktop.v1.Envelope.shared_directory_request:type_name -> teleport.desktop.v1.SharedDirectoryRequest
+	24, // 42: teleport.desktop.v1.Envelope.shared_directory_response:type_name -> teleport.desktop.v1.SharedDirectoryResponse
+	26, // 43: teleport.desktop.v1.Envelope.latency_stats:type_name -> teleport.desktop.v1.LatencyStats
+	27, // 44: teleport.desktop.v1.Envelope.ping:type_name -> teleport.desktop.v1.Ping
+	21, // 45: teleport.desktop.v1.Envelope.shared_directory_remove:type_name -> teleport.desktop.v1.SharedDirectoryRemove
+	25, // 46: teleport.desktop.v1.SharedDirectoryResponse.Info.fso:type_name -> teleport.desktop.v1.FileSystemObject
+	25, // 47: teleport.desktop.v1.SharedDirectoryResponse.Create.fso:type_name -> teleport.desktop.v1.FileSystemObject
+	25, // 48: teleport.desktop.v1.SharedDirectoryResponse.List.fso_list:type_name -> teleport.desktop.v1.FileSystemObject
+	49, // [49:49] is the sub-list for method output_type
+	49, // [49:49] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_teleport_desktop_v1_tdpb_proto_init() }
@@ -3263,7 +3338,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 	if File_teleport_desktop_v1_tdpb_proto != nil {
 		return
 	}
-	file_teleport_desktop_v1_tdpb_proto_msgTypes[18].OneofWrappers = []any{
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[19].OneofWrappers = []any{
 		(*SharedDirectoryRequest_Info_)(nil),
 		(*SharedDirectoryRequest_Create_)(nil),
 		(*SharedDirectoryRequest_Delete_)(nil),
@@ -3273,7 +3348,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*SharedDirectoryRequest_Move_)(nil),
 		(*SharedDirectoryRequest_Truncate_)(nil),
 	}
-	file_teleport_desktop_v1_tdpb_proto_msgTypes[19].OneofWrappers = []any{
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[20].OneofWrappers = []any{
 		(*SharedDirectoryResponse_Info_)(nil),
 		(*SharedDirectoryResponse_Create_)(nil),
 		(*SharedDirectoryResponse_Delete_)(nil),
@@ -3283,7 +3358,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*SharedDirectoryResponse_Move_)(nil),
 		(*SharedDirectoryResponse_Truncate_)(nil),
 	}
-	file_teleport_desktop_v1_tdpb_proto_msgTypes[23].OneofWrappers = []any{
+	file_teleport_desktop_v1_tdpb_proto_msgTypes[24].OneofWrappers = []any{
 		(*Envelope_ClientHello)(nil),
 		(*Envelope_ServerHello)(nil),
 		(*Envelope_PngFrame)(nil),
@@ -3304,6 +3379,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 		(*Envelope_SharedDirectoryResponse)(nil),
 		(*Envelope_LatencyStats)(nil),
 		(*Envelope_Ping)(nil),
+		(*Envelope_SharedDirectoryRemove)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -3311,7 +3387,7 @@ func file_teleport_desktop_v1_tdpb_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_desktop_v1_tdpb_proto_rawDesc), len(file_teleport_desktop_v1_tdpb_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   40,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/desktop/v1/tdpb.proto
+++ b/api/proto/teleport/desktop/v1/tdpb.proto
@@ -36,6 +36,7 @@ message ClientHello {
 message ServerHello {
   ConnectionActivated activation_spec = 1;
   bool clipboard_enabled = 2;
+  bool directory_remove_supported = 3;
 }
 
 // Defines the boundaries that PNG frame will update.
@@ -168,6 +169,11 @@ message MFA {
 message SharedDirectoryAnnounce {
   uint32 directory_id = 1;
   string name = 2;
+}
+
+// Sent by client to remove a previously announced shared directory.
+message SharedDirectoryRemove {
+  uint32 directory_id = 1;
 }
 
 // Sent by server to acknowledge a new shared directory.
@@ -341,5 +347,6 @@ message Envelope {
     SharedDirectoryResponse shared_directory_response = 18;
     LatencyStats latency_stats = 19;
     Ping ping = 20;
+    SharedDirectoryRemove shared_directory_remove = 21;
   }
 }

--- a/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
+++ b/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
@@ -65,6 +65,10 @@ export interface ServerHello {
      * @generated from protobuf field: bool clipboard_enabled = 2;
      */
     clipboardEnabled: boolean;
+    /**
+     * @generated from protobuf field: bool directory_remove_supported = 3;
+     */
+    directoryRemoveSupported: boolean;
 }
 /**
  * Defines the boundaries that PNG frame will update.
@@ -317,6 +321,17 @@ export interface SharedDirectoryAnnounce {
      * @generated from protobuf field: string name = 2;
      */
     name: string;
+}
+/**
+ * Sent by client to remove a previously announced shared directory.
+ *
+ * @generated from protobuf message teleport.desktop.v1.SharedDirectoryRemove
+ */
+export interface SharedDirectoryRemove {
+    /**
+     * @generated from protobuf field: uint32 directory_id = 1;
+     */
+    directoryId: number;
 }
 /**
  * Sent by server to acknowledge a new shared directory.
@@ -853,6 +868,12 @@ export interface Envelope {
          */
         ping: Ping;
     } | {
+        oneofKind: "sharedDirectoryRemove";
+        /**
+         * @generated from protobuf field: teleport.desktop.v1.SharedDirectoryRemove shared_directory_remove = 21;
+         */
+        sharedDirectoryRemove: SharedDirectoryRemove;
+    } | {
         oneofKind: undefined;
     };
 }
@@ -1007,12 +1028,14 @@ class ServerHello$Type extends MessageType<ServerHello> {
     constructor() {
         super("teleport.desktop.v1.ServerHello", [
             { no: 1, name: "activation_spec", kind: "message", T: () => ConnectionActivated },
-            { no: 2, name: "clipboard_enabled", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 2, name: "clipboard_enabled", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 3, name: "directory_remove_supported", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<ServerHello>): ServerHello {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.clipboardEnabled = false;
+        message.directoryRemoveSupported = false;
         if (value !== undefined)
             reflectionMergePartial<ServerHello>(this, message, value);
         return message;
@@ -1027,6 +1050,9 @@ class ServerHello$Type extends MessageType<ServerHello> {
                     break;
                 case /* bool clipboard_enabled */ 2:
                     message.clipboardEnabled = reader.bool();
+                    break;
+                case /* bool directory_remove_supported */ 3:
+                    message.directoryRemoveSupported = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1046,6 +1072,9 @@ class ServerHello$Type extends MessageType<ServerHello> {
         /* bool clipboard_enabled = 2; */
         if (message.clipboardEnabled !== false)
             writer.tag(2, WireType.Varint).bool(message.clipboardEnabled);
+        /* bool directory_remove_supported = 3; */
+        if (message.directoryRemoveSupported !== false)
+            writer.tag(3, WireType.Varint).bool(message.directoryRemoveSupported);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1918,6 +1947,53 @@ class SharedDirectoryAnnounce$Type extends MessageType<SharedDirectoryAnnounce> 
  * @generated MessageType for protobuf message teleport.desktop.v1.SharedDirectoryAnnounce
  */
 export const SharedDirectoryAnnounce = new SharedDirectoryAnnounce$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class SharedDirectoryRemove$Type extends MessageType<SharedDirectoryRemove> {
+    constructor() {
+        super("teleport.desktop.v1.SharedDirectoryRemove", [
+            { no: 1, name: "directory_id", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+        ]);
+    }
+    create(value?: PartialMessage<SharedDirectoryRemove>): SharedDirectoryRemove {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.directoryId = 0;
+        if (value !== undefined)
+            reflectionMergePartial<SharedDirectoryRemove>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SharedDirectoryRemove): SharedDirectoryRemove {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint32 directory_id */ 1:
+                    message.directoryId = reader.uint32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: SharedDirectoryRemove, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint32 directory_id = 1; */
+        if (message.directoryId !== 0)
+            writer.tag(1, WireType.Varint).uint32(message.directoryId);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.desktop.v1.SharedDirectoryRemove
+ */
+export const SharedDirectoryRemove = new SharedDirectoryRemove$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class SharedDirectoryAcknowledge$Type extends MessageType<SharedDirectoryAcknowledge> {
     constructor() {
@@ -3189,7 +3265,8 @@ class Envelope$Type extends MessageType<Envelope> {
             { no: 17, name: "shared_directory_request", kind: "message", oneof: "payload", T: () => SharedDirectoryRequest },
             { no: 18, name: "shared_directory_response", kind: "message", oneof: "payload", T: () => SharedDirectoryResponse },
             { no: 19, name: "latency_stats", kind: "message", oneof: "payload", T: () => LatencyStats },
-            { no: 20, name: "ping", kind: "message", oneof: "payload", T: () => Ping }
+            { no: 20, name: "ping", kind: "message", oneof: "payload", T: () => Ping },
+            { no: 21, name: "shared_directory_remove", kind: "message", oneof: "payload", T: () => SharedDirectoryRemove }
         ]);
     }
     create(value?: PartialMessage<Envelope>): Envelope {
@@ -3324,6 +3401,12 @@ class Envelope$Type extends MessageType<Envelope> {
                         ping: Ping.internalBinaryRead(reader, reader.uint32(), options, (message.payload as any).ping)
                     };
                     break;
+                case /* teleport.desktop.v1.SharedDirectoryRemove shared_directory_remove */ 21:
+                    message.payload = {
+                        oneofKind: "sharedDirectoryRemove",
+                        sharedDirectoryRemove: SharedDirectoryRemove.internalBinaryRead(reader, reader.uint32(), options, (message.payload as any).sharedDirectoryRemove)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -3396,6 +3479,9 @@ class Envelope$Type extends MessageType<Envelope> {
         /* teleport.desktop.v1.Ping ping = 20; */
         if (message.payload.oneofKind === "ping")
             Ping.internalBinaryWrite(message.payload.ping, writer.tag(20, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.desktop.v1.SharedDirectoryRemove shared_directory_remove = 21; */
+        if (message.payload.oneofKind === "sharedDirectoryRemove")
+            SharedDirectoryRemove.internalBinaryWrite(message.payload.sharedDirectoryRemove, writer.tag(21, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -570,7 +570,7 @@ func (c *Client) startInputStreaming(stopCh chan struct{}) error {
 		// file transfer.
 		switch msg.(type) {
 		case *tdpb.KeyboardButton, *tdpb.MouseMove, *tdpb.MouseButton, *tdpb.MouseWheel,
-			*tdpb.SharedDirectoryAnnounce, *tdpb.SharedDirectoryResponse:
+			*tdpb.SharedDirectoryAnnounce, *tdpb.SharedDirectoryRemove, *tdpb.SharedDirectoryResponse:
 
 			c.UpdateClientActivity()
 		}
@@ -718,6 +718,14 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 				name:         driveName,
 			}); errCode != C.ErrCodeSuccess {
 				return trace.Errorf("SharedDirectoryAnnounce: failed with %v", errCode)
+			}
+		}
+	case *tdpb.SharedDirectoryRemove:
+		if c.cfg.AllowDirectorySharing {
+			if errCode := C.client_handle_tdp_sd_remove(C.uintptr_t(c.handle), C.CGOSharedDirectoryRemove{
+				directory_id: C.uint32_t(m.DirectoryId),
+			}); errCode != C.ErrCodeSuccess {
+				return trace.Errorf("SharedDirectoryRemove: failed with %v", errCode)
 			}
 		}
 	case *tdpb.SharedDirectoryResponse:

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -1052,7 +1052,8 @@ func (c *Client) handleRDPConnectionActivated(ioChannelID, userChannelID, screen
 			ScreenWidth:   uint32(screenWidth),
 			ScreenHeight:  uint32(screenHeight),
 		},
-		ClipboardEnabled: true,
+		ClipboardEnabled:         true,
+		DirectoryRemoveSupported: true,
 	}); err != nil {
 		c.cfg.Logger.ErrorContext(context.Background(), "failed handling connection initialization", "error", err)
 		return C.ErrCodeFailure

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -53,7 +53,7 @@ use ironrdp_pdu::rdp::RdpError;
 use ironrdp_pdu::PduError;
 use ironrdp_pdu::PduResult;
 use ironrdp_pdu::{encode_err, pdu_other_err};
-use ironrdp_rdpdr::pdu::efs::ClientDeviceListAnnounce;
+use ironrdp_rdpdr::pdu::efs::{ClientDeviceListAnnounce, ClientDeviceListRemove};
 use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::Rdpdr;
 use ironrdp_rdpsnd::client::{NoopRdpsndBackend, Rdpsnd};
@@ -454,6 +454,10 @@ impl Client {
                     Client::handle_tdp_sd_announce(&mut write_stream, x224_processor.clone(), sda)
                         .await?;
                 }
+                ClientFunction::HandleTdpSdRemove(sdr) => {
+                    Client::handle_tdp_sd_remove(&mut write_stream, x224_processor.clone(), sdr)
+                        .await?;
+                }
                 ClientFunction::HandleTdpSdInfoResponse(res) => {
                     Client::handle_tdp_sd_info_response(x224_processor.clone(), res).await?;
                 }
@@ -811,6 +815,22 @@ impl Client {
         Ok(())
     }
 
+    async fn handle_tdp_sd_remove(
+        write_stream: &mut RdpWriteStream,
+        x224_processor: Arc<Mutex<x224::Processor>>,
+        sdr: tdp::SharedDirectoryRemove,
+    ) -> ClientResult<()> {
+        debug!("received tdp: {:?}", sdr);
+        let pdu = Self::remove_drive(x224_processor.clone(), sdr.directory_id).await?;
+        Self::write_rdpdr(
+            write_stream,
+            x224_processor,
+            RdpdrPdu::ClientDeviceListRemove(pdu),
+        )
+        .await?;
+        Ok(())
+    }
+
     async fn handle_tdp_sd_info_response(
         x224_processor: Arc<Mutex<x224::Processor>>,
         res: tdp::SharedDirectoryInfoResponse,
@@ -932,6 +952,21 @@ impl Client {
             let rdpdr = Self::get_svc_processor_mut::<Rdpdr>(&mut x224_processor)?;
             let pdu = rdpdr.add_drive(sda.directory_id, sda.name);
             Ok(pdu)
+        })
+        .await?
+    }
+
+    async fn remove_drive(
+        x224_processor: Arc<Mutex<x224::Processor>>,
+        device_id: u32,
+    ) -> ClientResult<ClientDeviceListRemove> {
+        task::spawn_blocking(move || {
+            let mut x224_processor = Self::x224_lock(&x224_processor)?;
+            let rdpdr = Self::get_svc_processor_mut::<Rdpdr>(&mut x224_processor)?;
+            if let Some(pdu) = rdpdr.remove_device(device_id) {
+                return Ok(pdu);
+            }
+            Err(ClientError::UnknownDevice(device_id))
         })
         .await?
     }
@@ -1095,6 +1130,8 @@ enum ClientFunction {
     WriteScreenResize(u32, u32),
     /// Corresponds to [`Client::handle_tdp_sd_announce`]
     HandleTdpSdAnnounce(tdp::SharedDirectoryAnnounce),
+    /// Corresponds to [`Client::handle_tdp_sd_remove`]
+    HandleTdpSdRemove(tdp::SharedDirectoryRemove),
     /// Corresponds to [`Client::handle_tdp_sd_info_response`]
     HandleTdpSdInfoResponse(tdp::SharedDirectoryInfoResponse),
     /// Corresponds to [`Client::handle_tdp_sd_create_response`]
@@ -1184,6 +1221,10 @@ impl ClientHandle {
 
     pub fn handle_tdp_sd_announce(&self, sda: tdp::SharedDirectoryAnnounce) -> ClientResult<()> {
         self.blocking_send(ClientFunction::HandleTdpSdAnnounce(sda))
+    }
+
+    pub fn handle_tdp_sd_remove(&self, sda: tdp::SharedDirectoryRemove) -> ClientResult<()> {
+        self.blocking_send(ClientFunction::HandleTdpSdRemove(sda))
     }
 
     pub async fn handle_tdp_sd_announce_async(
@@ -1482,6 +1523,7 @@ pub enum ClientError {
     InternalError(String),
     UnknownAddress,
     InputEventError(InputEventError),
+    UnknownDevice(u32),
     UrlError(url::ParseError),
     #[cfg(feature = "fips")]
     ErrorStack(ErrorStack),
@@ -1525,6 +1567,7 @@ impl Display for ClientError {
             ClientError::EncodeError(e) => Display::fmt(e, f),
             ClientError::PduError(e) => Display::fmt(e, f),
             ClientError::UrlError(e) => Display::fmt(e, f),
+            ClientError::UnknownDevice(e) => Display::fmt(e, f),
             #[cfg(feature = "fips")]
             ClientError::ErrorStack(e) => Display::fmt(e, f),
             #[cfg(feature = "fips")]

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -62,7 +62,7 @@ use ironrdp_session::SessionErrorKind::Reason;
 use ironrdp_session::{reason_err, SessionError, SessionResult};
 use ironrdp_svc::{SvcMessage, SvcProcessor, SvcProcessorMessages};
 use ironrdp_tokio::{single_sequence_step_read, Framed, FramedWrite, TokioStream};
-use log::{debug, error};
+use log::{debug, error, warn};
 use rand::{Rng, TryRngCore};
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
@@ -821,14 +821,24 @@ impl Client {
         sdr: tdp::SharedDirectoryRemove,
     ) -> ClientResult<()> {
         debug!("received tdp: {:?}", sdr);
-        let pdu = Self::remove_drive(x224_processor.clone(), sdr.directory_id).await?;
-        Self::write_rdpdr(
-            write_stream,
-            x224_processor,
-            RdpdrPdu::ClientDeviceListRemove(pdu),
-        )
-        .await?;
-        Ok(())
+        let pdu = Self::remove_drive(x224_processor.clone(), sdr.directory_id).await;
+
+        match pdu {
+            Ok(remove) => {
+                Self::write_rdpdr(
+                    write_stream,
+                    x224_processor,
+                    RdpdrPdu::ClientDeviceListRemove(remove),
+                )
+                .await?;
+                Ok(())
+            }
+            Err(ClientError::UnknownDevice(id)) => {
+                warn!("attempted to remove unknown device id: {:?}", id);
+                Ok(())
+            }
+            Err(other) => Err(other),
+        }
     }
 
     async fn handle_tdp_sd_info_response(

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -37,8 +37,8 @@ use rdpdr::path::UnixPath;
 use rdpdr::tdp::{
     FileSystemObject, FileType, SharedDirectoryAcknowledge, SharedDirectoryCreateResponse,
     SharedDirectoryDeleteResponse, SharedDirectoryInfoResponse, SharedDirectoryListResponse,
-    SharedDirectoryMoveResponse, SharedDirectoryReadResponse, SharedDirectoryTruncateResponse,
-    SharedDirectoryWriteResponse, TdpErrCode,
+    SharedDirectoryMoveResponse, SharedDirectoryReadResponse, SharedDirectoryRemove,
+    SharedDirectoryTruncateResponse, SharedDirectoryWriteResponse, TdpErrCode,
 };
 use std::ffi::CString;
 use std::fmt::Debug;
@@ -256,6 +256,26 @@ pub unsafe extern "C" fn client_handle_tdp_sd_announce(
         cgo_handle,
         "client_handle_tdp_sd_announce",
         move |client_handle| client_handle.handle_tdp_sd_announce(sd_announce),
+    )
+}
+
+/// client_handle_tdp_sd_remove removes a drive that has been redirected over RDP
+///
+///
+/// # Safety
+///
+/// `cgo_handle` must be a valid handle.
+///
+#[no_mangle]
+pub unsafe extern "C" fn client_handle_tdp_sd_remove(
+    cgo_handle: CgoHandle,
+    sd_remove: CGOSharedDirectoryRemove,
+) -> CGOErrCode {
+    let sd_remove = SharedDirectoryRemove::from(sd_remove);
+    handle_operation(
+        cgo_handle,
+        "client_handle_tdp_sd_remove",
+        move |client_handle| client_handle.handle_tdp_sd_remove(sd_remove),
     )
 }
 
@@ -603,6 +623,11 @@ pub struct CGOSharedDirectoryAnnounce {
 }
 
 pub type CGOSharedDirectoryAcknowledge = SharedDirectoryAcknowledge;
+
+#[repr(C)]
+pub struct CGOSharedDirectoryRemove {
+    pub directory_id: u32,
+}
 
 #[repr(C)]
 pub struct CGOSharedDirectoryInfoRequest {

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
@@ -21,7 +21,7 @@ use crate::{
     CGOSharedDirectoryAnnounce, CGOSharedDirectoryCreateRequest, CGOSharedDirectoryCreateResponse,
     CGOSharedDirectoryDeleteRequest, CGOSharedDirectoryInfoRequest, CGOSharedDirectoryInfoResponse,
     CGOSharedDirectoryListRequest, CGOSharedDirectoryListResponse, CGOSharedDirectoryMoveRequest,
-    CGOSharedDirectoryReadRequest, CGOSharedDirectoryReadResponse,
+    CGOSharedDirectoryReadRequest, CGOSharedDirectoryReadResponse, CGOSharedDirectoryRemove,
     CGOSharedDirectoryTruncateRequest, CGOSharedDirectoryWriteRequest,
 };
 
@@ -53,6 +53,21 @@ impl From<CGOSharedDirectoryAnnounce> for SharedDirectoryAnnounce {
                 directory_id: cgo.directory_id,
                 name: from_c_string(cgo.name),
             }
+        }
+    }
+}
+
+/// SharedDirectoryAnnounce is sent by the TDP client to the server
+/// to announce a new directory to be shared over TDP.
+#[derive(Debug)]
+pub struct SharedDirectoryRemove {
+    pub directory_id: u32,
+}
+
+impl From<CGOSharedDirectoryRemove> for SharedDirectoryRemove {
+    fn from(cgo: CGOSharedDirectoryRemove) -> SharedDirectoryRemove {
+        SharedDirectoryRemove {
+            directory_id: cgo.directory_id,
         }
     }
 }

--- a/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
@@ -247,6 +247,18 @@ func (s *SharedDirectoryAnnounce) Encode() ([]byte, error) {
 	})
 }
 
+// SharedDirectoryRemove is sent by the client to stop sharing a directory.
+type SharedDirectoryRemove tdpbv1.SharedDirectoryRemove
+
+// Encode encodes a SharedDirectoryAnnounce message.
+func (s *SharedDirectoryRemove) Encode() ([]byte, error) {
+	return marshalWithHeader(&tdpbv1.Envelope{
+		Payload: &tdpbv1.Envelope_SharedDirectoryRemove{
+			SharedDirectoryRemove: (*tdpbv1.SharedDirectoryRemove)(s),
+		},
+	})
+}
+
 // SharedDirectoryAcknowledge is sent by the server to acknowledge a
 // new shared directory.
 type SharedDirectoryAcknowledge tdpbv1.SharedDirectoryAcknowledge
@@ -443,6 +455,8 @@ func messageFromEnvelope(e *tdpbv1.Envelope) tdp.Message {
 		return (*LatencyStats)(m.LatencyStats)
 	case *tdpbv1.Envelope_Ping:
 		return (*Ping)(m.Ping)
+	case *tdpbv1.Envelope_SharedDirectoryRemove:
+		return (*SharedDirectoryRemove)(m.SharedDirectoryRemove)
 	default:
 		return nil
 	}

--- a/lib/srv/desktop/tdp/protocol/tdpb/translate.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/translate.go
@@ -378,6 +378,8 @@ func TranslateToModern(msg tdp.Message) ([]tdp.Message, error) {
 			},
 			// Assume all legacy TDP servers support clipboard sharing
 			ClipboardEnabled: true,
+			// No data to map, default to false
+			DirectoryRemoveSupported: false,
 		}}, nil
 	case legacy.SyncKeys:
 		return []tdp.Message{&SyncKeys{


### PR DESCRIPTION
This PR adds support for the removal of shared directories to Windows Desktop Service. This will allow clients to remove/unshare directories without the user having to restarts the session.

<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local Cluster
### Test Cases
Regression tests only since this feature is not yet implemented in the client.
- [x] Desktop session starts without error
- [x] Clicking "Share a Directory" in the action menu creates a shared directory visible in Windows Explorer
- [x] Typical file operations succeed within the shared directory
