### PR TITLE
Reflect gsutil deprecation in GCP guide

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
@@ -42,8 +42,8 @@ accounts.
   <Admonition type="tip">
 
   While this guide focuses on `gcloud`, once you set up Google Cloud API access
-  with Teleport, you can also manage access to `gsutil` and other Google Cloud
-  CLI tools using the Teleport Application Service.
+  with Teleport, you can also manage access to other Google Cloud CLI tools
+  using the Teleport Application Service.
 
   </Admonition>
 
@@ -555,23 +555,10 @@ ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 ERROR: exit status 1
 ```
 
-<Admonition type="tip" title="Using gsutil with tsh">
-
-You can also use the `google-cloud-cli` application you registered with Teleport
-to run `gsutil` commands via the Teleport Application Service. As with `gcloud`,
-prefix a `gsutil` command with `tsh` in order to run it:
-
-```code
-$ tsh gsutil ls
-```
-
-</Admonition>
-
 ### Use Google Cloud CLI applications without `tsh`
 
-In addition to running `gcloud` and `gsutil` commands via `tsh`, you can grant
-secure access to any CLI application that executes commands against Google
-Cloud's APIs.
+In addition to running `gcloud` commands via `tsh`, you can grant secure access
+to any CLI application that executes commands against Google Cloud's APIs.
 
 To do this, use `tsh` to start a local proxy that forwards traffic from your CLI
 application to the Teleport Application Service. The Application Service uses
@@ -637,9 +624,8 @@ ERROR: (gcloud.iam.service-accounts.create) User [myuser] does not have permissi
 
 <Admonition type="info">
 
-When you run a `gcloud` or `gsutil` command via `tsh gcloud` or `tsh gsutil`,
-`tsh` starts the local proxy in the background and uses it to execute the
-command.
+When you run a `gcloud` command via `tsh gcloud`, `tsh` starts the local proxy
+in the background and uses it to execute the command.
 
 </Admonition>
 
@@ -651,12 +637,14 @@ command.
   our documentation on [Role Access
   Requests](../../../identity-governance/access-requests/role-requests.mdx) and [Access
   Request plugins](../../../identity-governance/access-requests/plugins/plugins.mdx).
-- You can proxy any `gcloud` or `gsutil` command via Teleport. For a full
-  reference of commands, view the Google Cloud documentation for
-  [`gcloud`](https://cloud.google.com/sdk/gcloud/reference) and
-  [`gsutil`](https://cloud.google.com/storage/docs/gsutil).
+- You can proxy any `gcloud` command via Teleport. For a full reference of
+  commands, view the Google Cloud documentation for
+  [`gcloud`](https://cloud.google.com/sdk/gcloud/reference).
 - For full details on how Teleport populates the `internal` and `external`
-  traits we illustrated in the Teleport roles within this guide, see
-  the [Access Controls
-  Reference](../../../reference/access-controls/roles.mdx).
+  traits we illustrated in the Teleport roles within this guide, see the [Access
+  Controls Reference](../../../reference/access-controls/roles.mdx).
+- After following this guide, you can also secure usage of the legacy `gsutil`
+  command with Teleport. Users can execute `gsutil` commands with `tsh gsutil`.
+  For more information, see the `tsh gsutil` entry in the [CLI
+  Reference](../../../reference/cli/tsh.mdx#tsh-gsutil).
 


### PR DESCRIPTION
Fixes #64825

Remove mentions of the deprecated `gsutil` tool until the end of the guide, when we explain that users of the tool can take advantage of `tsh gsutil`, with a link to the relevant reference entry.