### PR TITLE
Fix newAccessCacheForServices metrics registration

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3139,6 +3139,7 @@ func (process *TeleportProcess) newAccessCacheForClient(cfg accesspoint.Config, 
 	cfg.ProcessID = process.id
 	cfg.TracingProvider = process.TracingProvider
 	cfg.MaxRetryPeriod = process.Config.CachePolicy.MaxRetryPeriod
+	cfg.Registerer = process.metricsRegistry
 
 	cfg.Access = client
 	cfg.AccessLists = client.AccessListClient()


### PR DESCRIPTION
### What

After PR #64919 fixed metrics.RegisterCollectors to respect the provided registry parameter the newAccessCacheForClient never set cfg.Registerer, so it defaulted to prometheus.DefaultRegisterer where metrics where overlapping with backend global metrics.  

In the result the  metrics collection error was occurring:  
<img width="3262" height="1494" alt="Screenshot 2026-03-26 at 19 51 36" src="https://github.com/user-attachments/assets/a2832a00-2c12-4c31-8b3c-f4907c5d2659" />




## Manual Test Plan
### Test Environment
 Could tenant
### Test Cases
- [x] Deploy a tenant with the fix and verify the `"message":"error gathering metrics` is not longer a issue 