### PR TITLE
[v17] Fix newAccessCacheForServices metrics registration

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2742,6 +2742,7 @@ func (process *TeleportProcess) newAccessCacheForClient(cfg accesspoint.Config, 
 	cfg.ProcessID = process.id
 	cfg.TracingProvider = process.TracingProvider
 	cfg.MaxRetryPeriod = process.Config.CachePolicy.MaxRetryPeriod
+	cfg.Registerer = process.metricsRegistry
 
 	cfg.Access = client
 	cfg.AccessLists = client.AccessListClient()


### PR DESCRIPTION
Backport #65104 to branch/v17