### PR TITLE
[terraform] fix plural resource update method

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
@@ -50,7 +50,6 @@ Optional:
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 - `namespace` (String) namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4.
-- `revision` (String) revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
@@ -50,7 +50,6 @@ Optional:
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 - `namespace` (String) namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4.
-- `revision` (String) revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/discovery_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/discovery_config.mdx
@@ -50,7 +50,6 @@ Optional:
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 - `namespace` (String) namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4.
-- `revision` (String) revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/vnet_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/vnet_config.mdx
@@ -35,7 +35,6 @@ Optional:
 - `description` (String) description is object description.
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
-- `name` (String) name is an object name.
 
 
 ### Nested Schema for `spec`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
@@ -93,7 +93,6 @@ Optional:
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 - `namespace` (String) namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4.
-- `revision` (String) revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
@@ -125,7 +125,6 @@ Optional:
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 - `namespace` (String) namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4.
-- `revision` (String) revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx
@@ -126,7 +126,6 @@ Optional:
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 - `namespace` (String) namespace is object namespace. The field should be called "namespace" when it returns in Teleport 2.4.
-- `revision` (String) revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/vnet_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/vnet_config.mdx
@@ -59,7 +59,6 @@ Optional:
 - `description` (String) description is object description.
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
-- `name` (String) name is an object name.
 
 
 ### Nested Schema for `spec`

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -20,8 +20,8 @@ package provider
 import (
 	"context"
 {{- if .RandomMetadataName }}
-    "crypto/rand"
-    "encoding/hex"
+	"crypto/rand"
+	"encoding/hex"
 {{- end }}
 	"fmt"
 {{- if .StatePoll }}
@@ -35,8 +35,8 @@ import (
 {{- end }}
 	{{.ProtoPackage}} "{{.ProtoPackagePath}}"
 	{{ if .ConvertPackagePath -}}
-    convert "{{.ConvertPackagePath}}"
-    {{- end}}
+	convert "{{.ConvertPackagePath}}"
+	{{- end}}
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -197,9 +197,9 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		tries = tries + 1
 		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}id{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(ctx.Err()), "{{.Kind}}"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(ctx.Err()), "{{.Kind}}"))
 				return
 			case <-retry.After():
 			}
@@ -464,7 +464,7 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(ctx.Err()), "{{.Kind}}"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(ctx.Err()), "{{.Kind}}"))
 			return
 		case <-retry.After():
 		}
@@ -484,6 +484,13 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		return
 	}
 	{{- end}}
+
+	{{- if .ConvertPackagePath}}
+	{{.VarName}} = convert.{{ if .ConvertToProtoFunc }}{{.ConvertToProtoFunc}}{{ else }}ToProto{{ end }}({{.VarName}}Resource)
+	{{- else }}
+	{{.VarName}} = {{.VarName}}Resource
+	{{- end }}
+
 	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/protoc-gen-terraform-accesslist.yaml
+++ b/integrations/terraform/protoc-gen-terraform-accesslist.yaml
@@ -50,17 +50,19 @@ exclude_fields:
     # Read only field
     - "Member.spec.ineligible_status"
 
+    # Revision must be excluded to avoid a permanent drift in state.
+    - "AccessList.header.metadata.revision"
+    - "Member.header.metadata.revision"
+
 # These fields will be marked as Computed: true
 computed_fields:
     - "AccessList.header.kind"
     - "AccessList.header.metadata.expires"
     - "AccessList.header.metadata.namespace"
-    - "AccessList.header.metadata.revision"
     - "AccessList.spec.audit.next_audit_date"
     - "Member.header.kind"
     - "Member.header.metadata.expires"
     - "Member.header.metadata.namespace"
-    - "Member.header.metadata.revision"
     - "Member.spec.name"
     - "Member.spec.joined"
     - "Member.spec.added_by"

--- a/integrations/terraform/protoc-gen-terraform-accessmonitoringrules.yaml
+++ b/integrations/terraform/protoc-gen-terraform-accessmonitoringrules.yaml
@@ -33,6 +33,8 @@ injected_fields:
 exclude_fields:
     # Metadata (we id resources by name on our side)
     - "AccessMonitoringRule.metadata.id"
+    # Revision must be excluded to avoid a permanent drift in state.
+    - "AccessMonitoringRule.metadata.revision"
 
 # These fields will be marked as Computed: true
 computed_fields:

--- a/integrations/terraform/protoc-gen-terraform-appauthconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-appauthconfig.yaml
@@ -34,13 +34,14 @@ injected_fields:
 exclude_fields:
   # Metadata (we id resources by name on our side)
   - "AppAuthConfig.metadata.id"
+  # Revision must be excluded to avoid a permanent drift in state.
+  - "AppAuthConfig.metadata.revision"
 
 # These fields will be marked as Computed: true
 computed_fields:
   # Metadata
   - "AppAuthConfig.metadata.expires"
   - "AppAuthConfig.metadata.namespace"
-  - "AppAuthConfig.metadata.revision"
   - "AppAuthConfig.kind"
 
 # These fields will be marked as Required: true

--- a/integrations/terraform/protoc-gen-terraform-devicetrust.yaml
+++ b/integrations/terraform/protoc-gen-terraform-devicetrust.yaml
@@ -50,6 +50,7 @@ exclude_fields:
     - "DeviceV1.Metadata.Namespace"
     - "DeviceV1.Metadata.Description"
     - "DeviceV1.Metadata.Expires"
+    - "DeviceV1.Metadata.Revision"
     - "DeviceV1.spec.create_time"
     - "DeviceV1.spec.update_time"
     - "DeviceV1.spec.credential"

--- a/integrations/terraform/protoc-gen-terraform-discoveryconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-discoveryconfig.yaml
@@ -35,13 +35,14 @@ exclude_fields:
   - 'DiscoveryConfig.header.metadata.id'
   # Read only field
   - 'DiscoveryConfig.status'
+  # Revision must be excluded to avoid a permanent drift in state.
+  - 'DiscoveryConfig.header.metadata.revision'
 
 # These fields will be marked as Computed: true
 computed_fields:
   # Metadata
   - 'DiscoveryConfig.header.metadata.expires'
   - 'DiscoveryConfig.header.metadata.namespace'
-  - 'DiscoveryConfig.header.metadata.revision'
   - 'DiscoveryConfig.header.kind'
   - 'DiscoveryConfig.header.sub_kind'
   - 'DiscoveryConfig.spec.azure.Params'

--- a/integrations/terraform/protoc-gen-terraform-healthcheckconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-healthcheckconfig.yaml
@@ -34,13 +34,14 @@ injected_fields:
 exclude_fields:
   # Metadata (we id resources by name on our side)
   - "HealthCheckConfig.metadata.id"
+  # Revision must be excluded to avoid a permanent drift in state.
+  - "HealthCheckConfig.metadata.revision"
 
 # These fields will be marked as Computed: true
 computed_fields:
   # Metadata
   - "HealthCheckConfig.metadata.expires"
   - "HealthCheckConfig.metadata.namespace"
-  - "HealthCheckConfig.metadata.revision"
   - "HealthCheckConfig.kind"
   - "HealthCheckConfig.sub_kind"
 

--- a/integrations/terraform/protoc-gen-terraform-loginrule.yaml
+++ b/integrations/terraform/protoc-gen-terraform-loginrule.yaml
@@ -29,6 +29,8 @@ injected_fields:
 exclude_fields:
     # Metadata (we id resources by name on our side)
     - "Metadata.ID"
+    # Revision must be excluded to avoid a permanent drift in state.
+    - "Metadata.Revision"
 
 # These fields will be marked as Computed: true
 computed_fields:

--- a/integrations/terraform/protoc-gen-terraform-scopedtoken.yaml
+++ b/integrations/terraform/protoc-gen-terraform-scopedtoken.yaml
@@ -32,12 +32,13 @@ exclude_fields:
   - "ScopedToken.metadata.id"
   # Usage tracking is server-side only
   - "ScopedToken.status"
+  # Revision must be excluded to avoid a permanent drift in state.
+  - "ScopedToken.metadata.revision"
 
 # These fields will be marked as Computed: true
 computed_fields:
   - "ScopedToken.metadata.expires"
   - "ScopedToken.metadata.namespace"
-  - "ScopedToken.metadata.revision"
   - "ScopedToken.kind"
 
 # These fields will be marked as Required: true

--- a/integrations/terraform/protoc-gen-terraform-statichostuser.yaml
+++ b/integrations/terraform/protoc-gen-terraform-statichostuser.yaml
@@ -34,6 +34,8 @@ injected_fields:
 exclude_fields:
   # Metadata (we id resources by name on our side)
   - "StaticHostUser.metadata.id"
+  # Revision must be excluded to avoid a permanent drift in state.
+  - "StaticHostUser.metadata.revision"
 
 # These fields will be marked as Computed: true
 computed_fields:

--- a/integrations/terraform/protoc-gen-terraform-summarizer.yaml
+++ b/integrations/terraform/protoc-gen-terraform-summarizer.yaml
@@ -61,20 +61,23 @@ exclude_fields:
   - "InferenceModel.spec.openai.temperature"
   - "InferenceModel.spec.bedrock.temperature"
 
+  # Revision must be excluded to avoid a permanent drift in state.
+  - "InferenceModel.metadata.revision"
+  - "InferenceSecret.metadata.revision"
+  - "InferencePolicy.metadata.revision"
+
+
 # These fields will be marked as Computed: true
 computed_fields:
   - "InferenceModel.kind"
   - "InferenceModel.metadata.expires"
   - "InferenceModel.metadata.namespace"
-  - "InferenceModel.metadata.revision"
   - "InferenceSecret.kind"
   - "InferenceSecret.metadata.expires"
   - "InferenceSecret.metadata.namespace"
-  - "InferenceSecret.metadata.revision"
   - "InferencePolicy.kind"
   - "InferencePolicy.metadata.expires"
   - "InferencePolicy.metadata.namespace"
-  - "InferencePolicy.metadata.revision"
 
 # These fields will be marked as Required: true
 required_fields:

--- a/integrations/terraform/protoc-gen-terraform-teleport.yaml
+++ b/integrations/terraform/protoc-gen-terraform-teleport.yaml
@@ -159,6 +159,8 @@ injected_fields:
 exclude_fields:
     # Metadata (we id resources by name on our side)
     - "Metadata.ID"
+    # Revision must be excluded to avoid a permanent drift in state.
+    - "Metadata.Revision"
 
     # AuthPreference
     - "AuthPreferenceV2.Metadata.Name" # It's a singleton resource
@@ -366,7 +368,8 @@ required_fields:
 
     # Provision token
     - "ProvisionTokenV2.Spec"
-    - "ProvisionTokenV2.Spec.Options"
+    # TODO: This attribute does not exist
+    # - "ProvisionTokenV2.Spec.Options"
     - "ProvisionTokenV2.Spec.Roles"
     - "ProvisionTokenV2.Version"
 

--- a/integrations/terraform/protoc-gen-terraform-teleport.yaml
+++ b/integrations/terraform/protoc-gen-terraform-teleport.yaml
@@ -368,8 +368,6 @@ required_fields:
 
     # Provision token
     - "ProvisionTokenV2.Spec"
-    # TODO: This attribute does not exist
-    # - "ProvisionTokenV2.Spec.Options"
     - "ProvisionTokenV2.Spec.Roles"
     - "ProvisionTokenV2.Version"
 

--- a/integrations/terraform/protoc-gen-terraform-vnetconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-vnetconfig.yaml
@@ -6,7 +6,7 @@ use_state_for_unknown_by_default: true
 
 # Top-level type names to export
 types:
-  - "VnetConfig"
+  - 'VnetConfig'
 
 # These import paths were not being automatically picked up by
 # protoc-gen-terraform without these overrides
@@ -32,8 +32,6 @@ injected_fields:
 # These fields will be excluded
 exclude_fields:
   # Metadata (we id resources by name on our side)
-  # This attribute does not exist?
-  - 'VnetConfig.id'
   - 'VnetConfig.metadata.name'
   # Revision must be excluded to avoid a permanent drift in state.
   - 'VnetConfig.metadata.revision'
@@ -42,8 +40,8 @@ exclude_fields:
 computed_fields:
   # Metadata
   - 'VnetConfig.metadata.namespace'
-  - "VnetConfig.kind"
-  - "VnetConfig.version"
+  - 'VnetConfig.kind'
+  - 'VnetConfig.version'
 
 # This must be defined for the generator to be happy, but in reality all time
 # fields are overridden (because the protobuf timestamps contain locks and the

--- a/integrations/terraform/protoc-gen-terraform-vnetconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-vnetconfig.yaml
@@ -6,7 +6,7 @@ use_state_for_unknown_by_default: true
 
 # Top-level type names to export
 types:
-  - 'VnetConfig'
+  - "VnetConfig"
 
 # These import paths were not being automatically picked up by
 # protoc-gen-terraform without these overrides
@@ -32,16 +32,18 @@ injected_fields:
 # These fields will be excluded
 exclude_fields:
   # Metadata (we id resources by name on our side)
+  # This attribute does not exist?
   - 'VnetConfig.id'
-  - 'VnetConfig.Metadata.Name'
+  - 'VnetConfig.metadata.name'
+  # Revision must be excluded to avoid a permanent drift in state.
+  - 'VnetConfig.metadata.revision'
 
 # These fields will be marked as Computed: true
 computed_fields:
   # Metadata
-  - 'VnetConfig.Metadata.Namespace'
-  - 'VnetConfig.Metadata.Revision'
-  - "VnetConfig.Kind"
-  - "VnetConfig.Version"
+  - 'VnetConfig.metadata.namespace'
+  - "VnetConfig.kind"
+  - "VnetConfig.version"
 
 # This must be defined for the generator to be happy, but in reality all time
 # fields are overridden (because the protobuf timestamps contain locks and the

--- a/integrations/terraform/protoc-gen-terraform-workloadidentity.yaml
+++ b/integrations/terraform/protoc-gen-terraform-workloadidentity.yaml
@@ -35,6 +35,8 @@ injected_fields:
 exclude_fields:
   # Metadata (we id resources by name on our side)
   - "WorkloadIdentity.metadata.id"
+  # Revision must be excluded to avoid a permanent drift in state.
+  - "WorkloadIdentity.metadata.revision"
 
   # The extra_claims field is a `google.protobuf.Struct` which isn't currently
   # supported by protoc-gen-terraform.

--- a/integrations/terraform/provider/resource_teleport_access_list.go
+++ b/integrations/terraform/provider/resource_teleport_access_list.go
@@ -123,9 +123,9 @@ func (r resourceTeleportAccessList) Create(ctx context.Context, req tfsdk.Create
 		tries = tries + 1
 		accessListI, err = r.p.Client.AccessListClient().GetAccessList(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessList", trace.Wrap(ctx.Err()), "access_list"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessList", trace.Wrap(ctx.Err()), "access_list"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportAccessList) Update(ctx context.Context, req tfsdk.Update
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessList", trace.Wrap(ctx.Err()), "access_list"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessList", trace.Wrap(ctx.Err()), "access_list"))
 			return
 		case <-retry.After():
 		}
@@ -286,6 +286,8 @@ func (r resourceTeleportAccessList) Update(ctx context.Context, req tfsdk.Update
 
 	accessListResource = accessListI
 	
+	accessList = convert.ToProto(accessListResource)
+
 	diags = schemav1.CopyAccessListToTerraform(ctx, accessList, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_access_list_member.go
+++ b/integrations/terraform/provider/resource_teleport_access_list_member.go
@@ -125,9 +125,9 @@ func (r resourceTeleportMember) Create(ctx context.Context, req tfsdk.CreateReso
 		tries = tries + 1
 		accessListMemberI, err = r.p.Client.AccessListClient().GetStaticAccessListMember(ctx, idPrefix, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Member", trace.Wrap(ctx.Err()), "access_list_member"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Member", trace.Wrap(ctx.Err()), "access_list_member"))
 				return
 			case <-retry.After():
 			}
@@ -282,7 +282,7 @@ func (r resourceTeleportMember) Update(ctx context.Context, req tfsdk.UpdateReso
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Member", trace.Wrap(ctx.Err()), "access_list_member"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading Member", trace.Wrap(ctx.Err()), "access_list_member"))
 			return
 		case <-retry.After():
 		}
@@ -295,6 +295,8 @@ func (r resourceTeleportMember) Update(ctx context.Context, req tfsdk.UpdateReso
 
 	accessListMemberResource = accessListMemberI
 	
+	accessListMember = convert.ToMemberProto(accessListMemberResource)
+
 	diags = schemav1.CopyMemberToTerraform(ctx, accessListMember, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
+++ b/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
@@ -117,9 +117,9 @@ func (r resourceTeleportAccessMonitoringRule) Create(ctx context.Context, req tf
 		tries = tries + 1
 		accessMonitoringRuleI, err = r.p.Client.AccessMonitoringRulesClient().GetAccessMonitoringRule(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessMonitoringRule", trace.Wrap(ctx.Err()), "access_monitoring_rule"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessMonitoringRule", trace.Wrap(ctx.Err()), "access_monitoring_rule"))
 				return
 			case <-retry.After():
 			}
@@ -260,7 +260,7 @@ func (r resourceTeleportAccessMonitoringRule) Update(ctx context.Context, req tf
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessMonitoringRule", trace.Wrap(ctx.Err()), "access_monitoring_rule"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessMonitoringRule", trace.Wrap(ctx.Err()), "access_monitoring_rule"))
 			return
 		case <-retry.After():
 		}
@@ -273,6 +273,8 @@ func (r resourceTeleportAccessMonitoringRule) Update(ctx context.Context, req tf
 
 	accessMonitoringRuleResource = accessMonitoringRuleI
 	
+	accessMonitoringRule = accessMonitoringRuleResource
+
 	diags = schemav1.CopyAccessMonitoringRuleToTerraform(ctx, accessMonitoringRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_app.go
+++ b/integrations/terraform/provider/resource_teleport_app.go
@@ -122,9 +122,9 @@ func (r resourceTeleportApp) Create(ctx context.Context, req tfsdk.CreateResourc
 		tries = tries + 1
 		appI, err = r.p.Client.GetApp(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Wrap(ctx.Err()), "app"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Wrap(ctx.Err()), "app"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportApp) Update(ctx context.Context, req tfsdk.UpdateResourc
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Wrap(ctx.Err()), "app"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Wrap(ctx.Err()), "app"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportApp) Update(ctx context.Context, req tfsdk.UpdateResourc
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Errorf("Can not convert %T to AppV3", appI), "app"))
 		return
 	}
+	app = appResource
+
 	diags = tfschema.CopyAppV3ToTerraform(ctx, app, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_app_auth_config.go
+++ b/integrations/terraform/provider/resource_teleport_app_auth_config.go
@@ -117,9 +117,9 @@ func (r resourceTeleportAppAuthConfig) Create(ctx context.Context, req tfsdk.Cre
 		tries = tries + 1
 		appauthconfigI, err = r.p.Client.GetAppAuthConfig(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading AppAuthConfig", trace.Wrap(ctx.Err()), "app_auth_config"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AppAuthConfig", trace.Wrap(ctx.Err()), "app_auth_config"))
 				return
 			case <-retry.After():
 			}
@@ -260,7 +260,7 @@ func (r resourceTeleportAppAuthConfig) Update(ctx context.Context, req tfsdk.Upd
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading AppAuthConfig", trace.Wrap(ctx.Err()), "app_auth_config"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AppAuthConfig", trace.Wrap(ctx.Err()), "app_auth_config"))
 			return
 		case <-retry.After():
 		}
@@ -273,6 +273,8 @@ func (r resourceTeleportAppAuthConfig) Update(ctx context.Context, req tfsdk.Upd
 
 	appauthconfigResource = appauthconfigI
 	
+	appauthconfig = appauthconfigResource
+
 	diags = schemav1.CopyAppAuthConfigToTerraform(ctx, appauthconfig, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_database.go
+++ b/integrations/terraform/provider/resource_teleport_database.go
@@ -122,9 +122,9 @@ func (r resourceTeleportDatabase) Create(ctx context.Context, req tfsdk.CreateRe
 		tries = tries + 1
 		databaseI, err = r.p.Client.GetDatabase(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Wrap(ctx.Err()), "db"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Wrap(ctx.Err()), "db"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportDatabase) Update(ctx context.Context, req tfsdk.UpdateRe
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Wrap(ctx.Err()), "db"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Wrap(ctx.Err()), "db"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportDatabase) Update(ctx context.Context, req tfsdk.UpdateRe
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Errorf("Can not convert %T to DatabaseV3", databaseI), "db"))
 		return
 	}
+	database = databaseResource
+
 	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, database, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_device_trust.go
+++ b/integrations/terraform/provider/resource_teleport_device_trust.go
@@ -119,9 +119,9 @@ func (r resourceTeleportDeviceV1) Create(ctx context.Context, req tfsdk.CreateRe
 		tries = tries + 1
 		trustedDeviceI, err = r.p.Client.GetDeviceResource(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading DeviceV1", trace.Wrap(ctx.Err()), "device"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading DeviceV1", trace.Wrap(ctx.Err()), "device"))
 				return
 			case <-retry.After():
 			}
@@ -261,7 +261,7 @@ func (r resourceTeleportDeviceV1) Update(ctx context.Context, req tfsdk.UpdateRe
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading DeviceV1", trace.Wrap(ctx.Err()), "device"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading DeviceV1", trace.Wrap(ctx.Err()), "device"))
 			return
 		case <-retry.After():
 		}
@@ -274,6 +274,8 @@ func (r resourceTeleportDeviceV1) Update(ctx context.Context, req tfsdk.UpdateRe
 
 	trustedDeviceResource = trustedDeviceI
 	
+	trustedDevice = trustedDeviceResource
+
 	diags = schemav1.CopyDeviceV1ToTerraform(ctx, trustedDevice, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_discovery_config.go
+++ b/integrations/terraform/provider/resource_teleport_discovery_config.go
@@ -120,9 +120,9 @@ func (r resourceTeleportDiscoveryConfig) Create(ctx context.Context, req tfsdk.C
 		tries = tries + 1
 		discoveryConfigI, err = r.p.Client.DiscoveryConfigClient().GetDiscoveryConfig(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading DiscoveryConfig", trace.Wrap(ctx.Err()), "discovery_config"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading DiscoveryConfig", trace.Wrap(ctx.Err()), "discovery_config"))
 				return
 			case <-retry.After():
 			}
@@ -267,7 +267,7 @@ func (r resourceTeleportDiscoveryConfig) Update(ctx context.Context, req tfsdk.U
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading DiscoveryConfig", trace.Wrap(ctx.Err()), "discovery_config"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading DiscoveryConfig", trace.Wrap(ctx.Err()), "discovery_config"))
 			return
 		case <-retry.After():
 		}
@@ -280,6 +280,8 @@ func (r resourceTeleportDiscoveryConfig) Update(ctx context.Context, req tfsdk.U
 
 	discoveryConfigResource = discoveryConfigI
 	
+	discoveryConfig = convert.ToProto(discoveryConfigResource)
+
 	diags = schemav1.CopyDiscoveryConfigToTerraform(ctx, discoveryConfig, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_dynamic_windows_desktop.go
+++ b/integrations/terraform/provider/resource_teleport_dynamic_windows_desktop.go
@@ -122,9 +122,9 @@ func (r resourceTeleportDynamicWindowsDesktop) Create(ctx context.Context, req t
 		tries = tries + 1
 		desktopI, err = r.p.Client.DynamicDesktopClient().GetDynamicWindowsDesktop(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading DynamicWindowsDesktop", trace.Wrap(ctx.Err()), "dynamic_windows_desktop"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading DynamicWindowsDesktop", trace.Wrap(ctx.Err()), "dynamic_windows_desktop"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportDynamicWindowsDesktop) Update(ctx context.Context, req t
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading DynamicWindowsDesktop", trace.Wrap(ctx.Err()), "dynamic_windows_desktop"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading DynamicWindowsDesktop", trace.Wrap(ctx.Err()), "dynamic_windows_desktop"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportDynamicWindowsDesktop) Update(ctx context.Context, req t
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading DynamicWindowsDesktop", trace.Errorf("Can not convert %T to DynamicWindowsDesktopV1", desktopI), "dynamic_windows_desktop"))
 		return
 	}
+	desktop = desktopResource
+
 	diags = tfschema.CopyDynamicWindowsDesktopV1ToTerraform(ctx, desktop, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_github_connector.go
+++ b/integrations/terraform/provider/resource_teleport_github_connector.go
@@ -122,9 +122,9 @@ func (r resourceTeleportGithubConnector) Create(ctx context.Context, req tfsdk.C
 		tries = tries + 1
 		githubConnectorI, err = r.p.Client.GetGithubConnector(ctx, id, true)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading GithubConnector", trace.Wrap(ctx.Err()), "github"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading GithubConnector", trace.Wrap(ctx.Err()), "github"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportGithubConnector) Update(ctx context.Context, req tfsdk.U
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading GithubConnector", trace.Wrap(ctx.Err()), "github"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading GithubConnector", trace.Wrap(ctx.Err()), "github"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportGithubConnector) Update(ctx context.Context, req tfsdk.U
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading GithubConnector", trace.Errorf("Can not convert %T to GithubConnectorV3", githubConnectorI), "github"))
 		return
 	}
+	githubConnector = githubConnectorResource
+
 	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, githubConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_health_check_config.go
+++ b/integrations/terraform/provider/resource_teleport_health_check_config.go
@@ -117,9 +117,9 @@ func (r resourceTeleportHealthCheckConfig) Create(ctx context.Context, req tfsdk
 		tries = tries + 1
 		healthCheckConfigI, err = r.p.Client.GetHealthCheckConfig(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading HealthCheckConfig", trace.Wrap(ctx.Err()), "health_check_config"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading HealthCheckConfig", trace.Wrap(ctx.Err()), "health_check_config"))
 				return
 			case <-retry.After():
 			}
@@ -260,7 +260,7 @@ func (r resourceTeleportHealthCheckConfig) Update(ctx context.Context, req tfsdk
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading HealthCheckConfig", trace.Wrap(ctx.Err()), "health_check_config"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading HealthCheckConfig", trace.Wrap(ctx.Err()), "health_check_config"))
 			return
 		case <-retry.After():
 		}
@@ -273,6 +273,8 @@ func (r resourceTeleportHealthCheckConfig) Update(ctx context.Context, req tfsdk
 
 	healthCheckConfigResource = healthCheckConfigI
 	
+	healthCheckConfig = healthCheckConfigResource
+
 	diags = schemav1.CopyHealthCheckConfigToTerraform(ctx, healthCheckConfig, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_inference_model.go
+++ b/integrations/terraform/provider/resource_teleport_inference_model.go
@@ -117,9 +117,9 @@ func (r resourceTeleportInferenceModel) Create(ctx context.Context, req tfsdk.Cr
 		tries = tries + 1
 		inferenceModelI, err = r.p.Client.SummarizerClient().GetInferenceModel(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceModel", trace.Wrap(ctx.Err()), "inference_model"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceModel", trace.Wrap(ctx.Err()), "inference_model"))
 				return
 			case <-retry.After():
 			}
@@ -260,7 +260,7 @@ func (r resourceTeleportInferenceModel) Update(ctx context.Context, req tfsdk.Up
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceModel", trace.Wrap(ctx.Err()), "inference_model"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceModel", trace.Wrap(ctx.Err()), "inference_model"))
 			return
 		case <-retry.After():
 		}
@@ -273,6 +273,8 @@ func (r resourceTeleportInferenceModel) Update(ctx context.Context, req tfsdk.Up
 
 	inferenceModelResource = inferenceModelI
 	
+	inferenceModel = inferenceModelResource
+
 	diags = schemav1.CopyInferenceModelToTerraform(ctx, inferenceModel, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_inference_policy.go
+++ b/integrations/terraform/provider/resource_teleport_inference_policy.go
@@ -117,9 +117,9 @@ func (r resourceTeleportInferencePolicy) Create(ctx context.Context, req tfsdk.C
 		tries = tries + 1
 		inferencePolicyI, err = r.p.Client.SummarizerClient().GetInferencePolicy(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferencePolicy", trace.Wrap(ctx.Err()), "inference_policy"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferencePolicy", trace.Wrap(ctx.Err()), "inference_policy"))
 				return
 			case <-retry.After():
 			}
@@ -260,7 +260,7 @@ func (r resourceTeleportInferencePolicy) Update(ctx context.Context, req tfsdk.U
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferencePolicy", trace.Wrap(ctx.Err()), "inference_policy"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferencePolicy", trace.Wrap(ctx.Err()), "inference_policy"))
 			return
 		case <-retry.After():
 		}
@@ -273,6 +273,8 @@ func (r resourceTeleportInferencePolicy) Update(ctx context.Context, req tfsdk.U
 
 	inferencePolicyResource = inferencePolicyI
 	
+	inferencePolicy = inferencePolicyResource
+
 	diags = schemav1.CopyInferencePolicyToTerraform(ctx, inferencePolicy, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_inference_secret.go
+++ b/integrations/terraform/provider/resource_teleport_inference_secret.go
@@ -123,9 +123,9 @@ func (r resourceTeleportInferenceSecret) Create(ctx context.Context, req tfsdk.C
 		tries = tries + 1
 		inferenceSecretI, err = r.p.Client.SummarizerClient().GetInferenceSecret(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceSecret", trace.Wrap(ctx.Err()), "inference_secret"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceSecret", trace.Wrap(ctx.Err()), "inference_secret"))
 				return
 			case <-retry.After():
 			}
@@ -268,7 +268,7 @@ func (r resourceTeleportInferenceSecret) Update(ctx context.Context, req tfsdk.U
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceSecret", trace.Wrap(ctx.Err()), "inference_secret"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading InferenceSecret", trace.Wrap(ctx.Err()), "inference_secret"))
 			return
 		case <-retry.After():
 		}
@@ -281,6 +281,8 @@ func (r resourceTeleportInferenceSecret) Update(ctx context.Context, req tfsdk.U
 
 	inferenceSecretResource = inferenceSecretI
 	
+	inferenceSecret = inferenceSecretResource
+
 	diags = schemav1.CopyInferenceSecretToTerraform(ctx, inferenceSecret, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_installer.go
+++ b/integrations/terraform/provider/resource_teleport_installer.go
@@ -122,9 +122,9 @@ func (r resourceTeleportInstaller) Create(ctx context.Context, req tfsdk.CreateR
 		tries = tries + 1
 		installerI, err = r.p.Client.GetInstaller(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Installer", trace.Wrap(ctx.Err()), "installer"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Installer", trace.Wrap(ctx.Err()), "installer"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportInstaller) Update(ctx context.Context, req tfsdk.UpdateR
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Installer", trace.Wrap(ctx.Err()), "installer"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading Installer", trace.Wrap(ctx.Err()), "installer"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportInstaller) Update(ctx context.Context, req tfsdk.UpdateR
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Installer", trace.Errorf("Can not convert %T to InstallerV1", installerI), "installer"))
 		return
 	}
+	installer = installerResource
+
 	diags = tfschema.CopyInstallerV1ToTerraform(ctx, installer, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_integration.go
+++ b/integrations/terraform/provider/resource_teleport_integration.go
@@ -122,9 +122,9 @@ func (r resourceTeleportIntegration) Create(ctx context.Context, req tfsdk.Creat
 		tries = tries + 1
 		integrationI, err = r.p.Client.GetIntegration(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Integration", trace.Wrap(ctx.Err()), "integration"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Integration", trace.Wrap(ctx.Err()), "integration"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportIntegration) Update(ctx context.Context, req tfsdk.Updat
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Integration", trace.Wrap(ctx.Err()), "integration"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading Integration", trace.Wrap(ctx.Err()), "integration"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportIntegration) Update(ctx context.Context, req tfsdk.Updat
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Integration", trace.Errorf("Can not convert %T to IntegrationV1", integrationI), "integration"))
 		return
 	}
+	integration = integrationResource
+
 	diags = tfschema.CopyIntegrationV1ToTerraform(ctx, integration, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_login_rule.go
+++ b/integrations/terraform/provider/resource_teleport_login_rule.go
@@ -115,9 +115,9 @@ func (r resourceTeleportLoginRule) Create(ctx context.Context, req tfsdk.CreateR
 		tries = tries + 1
 		loginRuleI, err = r.p.Client.GetLoginRule(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading LoginRule", trace.Wrap(ctx.Err()), "login_rule"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading LoginRule", trace.Wrap(ctx.Err()), "login_rule"))
 				return
 			case <-retry.After():
 			}
@@ -257,7 +257,7 @@ func (r resourceTeleportLoginRule) Update(ctx context.Context, req tfsdk.UpdateR
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading LoginRule", trace.Wrap(ctx.Err()), "login_rule"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading LoginRule", trace.Wrap(ctx.Err()), "login_rule"))
 			return
 		case <-retry.After():
 		}
@@ -270,6 +270,8 @@ func (r resourceTeleportLoginRule) Update(ctx context.Context, req tfsdk.UpdateR
 
 	loginRuleResource = loginRuleI
 	
+	loginRule = loginRuleResource
+
 	diags = schemav1.CopyLoginRuleToTerraform(ctx, loginRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_oidc_connector.go
+++ b/integrations/terraform/provider/resource_teleport_oidc_connector.go
@@ -122,9 +122,9 @@ func (r resourceTeleportOIDCConnector) Create(ctx context.Context, req tfsdk.Cre
 		tries = tries + 1
 		oidcConnectorI, err = r.p.Client.GetOIDCConnector(ctx, id, true)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading OIDCConnector", trace.Wrap(ctx.Err()), "oidc"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading OIDCConnector", trace.Wrap(ctx.Err()), "oidc"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportOIDCConnector) Update(ctx context.Context, req tfsdk.Upd
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading OIDCConnector", trace.Wrap(ctx.Err()), "oidc"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading OIDCConnector", trace.Wrap(ctx.Err()), "oidc"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportOIDCConnector) Update(ctx context.Context, req tfsdk.Upd
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading OIDCConnector", trace.Errorf("Can not convert %T to OIDCConnectorV3", oidcConnectorI), "oidc"))
 		return
 	}
+	oidcConnector = oidcConnectorResource
+
 	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, oidcConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_okta_import_rule.go
+++ b/integrations/terraform/provider/resource_teleport_okta_import_rule.go
@@ -122,9 +122,9 @@ func (r resourceTeleportOktaImportRule) Create(ctx context.Context, req tfsdk.Cr
 		tries = tries + 1
 		oktaImportRuleI, err = r.p.Client.OktaClient().GetOktaImportRule(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading OktaImportRule", trace.Wrap(ctx.Err()), "okta_import_rule"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading OktaImportRule", trace.Wrap(ctx.Err()), "okta_import_rule"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportOktaImportRule) Update(ctx context.Context, req tfsdk.Up
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading OktaImportRule", trace.Wrap(ctx.Err()), "okta_import_rule"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading OktaImportRule", trace.Wrap(ctx.Err()), "okta_import_rule"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportOktaImportRule) Update(ctx context.Context, req tfsdk.Up
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading OktaImportRule", trace.Errorf("Can not convert %T to OktaImportRuleV1", oktaImportRuleI), "okta_import_rule"))
 		return
 	}
+	oktaImportRule = oktaImportRuleResource
+
 	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, oktaImportRule, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_provision_token.go
+++ b/integrations/terraform/provider/resource_teleport_provision_token.go
@@ -19,8 +19,8 @@ package provider
 
 import (
 	"context"
-    "crypto/rand"
-    "encoding/hex"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 
 	apitypes "github.com/gravitational/teleport/api/types"
@@ -133,9 +133,9 @@ func (r resourceTeleportProvisionToken) Create(ctx context.Context, req tfsdk.Cr
 		tries = tries + 1
 		provisionTokenI, err = r.p.Client.GetToken(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Wrap(ctx.Err()), "token"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Wrap(ctx.Err()), "token"))
 				return
 			case <-retry.After():
 			}
@@ -284,7 +284,7 @@ func (r resourceTeleportProvisionToken) Update(ctx context.Context, req tfsdk.Up
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Wrap(ctx.Err()), "token"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Wrap(ctx.Err()), "token"))
 			return
 		case <-retry.After():
 		}
@@ -300,6 +300,8 @@ func (r resourceTeleportProvisionToken) Update(ctx context.Context, req tfsdk.Up
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Errorf("Can not convert %T to ProvisionTokenV2", provisionTokenI), "token"))
 		return
 	}
+	provisionToken = provisionTokenResource
+
 	diags = token.CopyProvisionTokenV2ToTerraform(ctx, provisionToken, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_role.go
+++ b/integrations/terraform/provider/resource_teleport_role.go
@@ -122,9 +122,9 @@ func (r resourceTeleportRole) Create(ctx context.Context, req tfsdk.CreateResour
 		tries = tries + 1
 		roleI, err = r.p.Client.GetRole(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Wrap(ctx.Err()), "role"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Wrap(ctx.Err()), "role"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportRole) Update(ctx context.Context, req tfsdk.UpdateResour
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Wrap(ctx.Err()), "role"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Wrap(ctx.Err()), "role"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportRole) Update(ctx context.Context, req tfsdk.UpdateResour
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Errorf("Can not convert %T to RoleV6", roleI), "role"))
 		return
 	}
+	role = roleResource
+
 	diags = tfschema.CopyRoleV6ToTerraform(ctx, role, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_saml_connector.go
+++ b/integrations/terraform/provider/resource_teleport_saml_connector.go
@@ -122,9 +122,9 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 		tries = tries + 1
 		samlConnectorI, err = r.p.Client.GetSAMLConnector(ctx, id, true)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(ctx.Err()), "saml"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(ctx.Err()), "saml"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(ctx.Err()), "saml"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(ctx.Err()), "saml"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportSAMLConnector) Update(ctx context.Context, req tfsdk.Upd
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Errorf("Can not convert %T to SAMLConnectorV2", samlConnectorI), "saml"))
 		return
 	}
+	samlConnector = samlConnectorResource
+
 	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_scoped_token.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_token.go
@@ -117,9 +117,9 @@ func (r resourceTeleportScopedToken) Create(ctx context.Context, req tfsdk.Creat
 		tries = tries + 1
 		scopedTokenI, err = r.p.Client.GetScopedToken(ctx, id, true)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading ScopedToken", trace.Wrap(ctx.Err()), "scoped_token"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading ScopedToken", trace.Wrap(ctx.Err()), "scoped_token"))
 				return
 			case <-retry.After():
 			}
@@ -260,7 +260,7 @@ func (r resourceTeleportScopedToken) Update(ctx context.Context, req tfsdk.Updat
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading ScopedToken", trace.Wrap(ctx.Err()), "scoped_token"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ScopedToken", trace.Wrap(ctx.Err()), "scoped_token"))
 			return
 		case <-retry.After():
 		}
@@ -273,6 +273,8 @@ func (r resourceTeleportScopedToken) Update(ctx context.Context, req tfsdk.Updat
 
 	scopedTokenResource = scopedTokenI
 	
+	scopedToken = scopedTokenResource
+
 	diags = schemav1.CopyScopedTokenToTerraform(ctx, scopedToken, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_server.go
+++ b/integrations/terraform/provider/resource_teleport_server.go
@@ -124,9 +124,9 @@ func (r resourceTeleportServer) Create(ctx context.Context, req tfsdk.CreateReso
 		tries = tries + 1
 		serverI, err = r.p.Client.GetNode(ctx, defaults.Namespace, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Server", trace.Wrap(ctx.Err()), "node"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Server", trace.Wrap(ctx.Err()), "node"))
 				return
 			case <-retry.After():
 			}
@@ -276,7 +276,7 @@ func (r resourceTeleportServer) Update(ctx context.Context, req tfsdk.UpdateReso
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading Server", trace.Wrap(ctx.Err()), "node"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading Server", trace.Wrap(ctx.Err()), "node"))
 			return
 		case <-retry.After():
 		}
@@ -292,6 +292,8 @@ func (r resourceTeleportServer) Update(ctx context.Context, req tfsdk.UpdateReso
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Server", trace.Errorf("Can not convert %T to ServerV2", serverI), "node"))
 		return
 	}
+	server = serverResource
+
 	diags = tfschema.CopyServerV2ToTerraform(ctx, server, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_static_host_user.go
+++ b/integrations/terraform/provider/resource_teleport_static_host_user.go
@@ -117,9 +117,9 @@ func (r resourceTeleportStaticHostUser) Create(ctx context.Context, req tfsdk.Cr
 		tries = tries + 1
 		staticHostUserI, err = r.p.Client.StaticHostUserClient().GetStaticHostUser(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading StaticHostUser", trace.Wrap(ctx.Err()), "static_host_user"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading StaticHostUser", trace.Wrap(ctx.Err()), "static_host_user"))
 				return
 			case <-retry.After():
 			}
@@ -260,7 +260,7 @@ func (r resourceTeleportStaticHostUser) Update(ctx context.Context, req tfsdk.Up
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading StaticHostUser", trace.Wrap(ctx.Err()), "static_host_user"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading StaticHostUser", trace.Wrap(ctx.Err()), "static_host_user"))
 			return
 		case <-retry.After():
 		}
@@ -273,6 +273,8 @@ func (r resourceTeleportStaticHostUser) Update(ctx context.Context, req tfsdk.Up
 
 	staticHostUserResource = staticHostUserI
 	
+	staticHostUser = staticHostUserResource
+
 	diags = schemav1.CopyStaticHostUserToTerraform(ctx, staticHostUser, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_trusted_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_trusted_cluster.go
@@ -122,9 +122,9 @@ func (r resourceTeleportTrustedCluster) Create(ctx context.Context, req tfsdk.Cr
 		tries = tries + 1
 		trustedClusterI, err = r.p.Client.GetTrustedCluster(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Wrap(ctx.Err()), "trusted_cluster"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Wrap(ctx.Err()), "trusted_cluster"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportTrustedCluster) Update(ctx context.Context, req tfsdk.Up
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Wrap(ctx.Err()), "trusted_cluster"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Wrap(ctx.Err()), "trusted_cluster"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportTrustedCluster) Update(ctx context.Context, req tfsdk.Up
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Errorf("Can not convert %T to TrustedClusterV2", trustedClusterI), "trusted_cluster"))
 		return
 	}
+	trustedCluster = trustedClusterResource
+
 	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, trustedCluster, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_user.go
+++ b/integrations/terraform/provider/resource_teleport_user.go
@@ -122,9 +122,9 @@ func (r resourceTeleportUser) Create(ctx context.Context, req tfsdk.CreateResour
 		tries = tries + 1
 		userI, err = r.p.Client.GetUser(ctx, id, false)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Wrap(ctx.Err()), "user"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Wrap(ctx.Err()), "user"))
 				return
 			case <-retry.After():
 			}
@@ -273,7 +273,7 @@ func (r resourceTeleportUser) Update(ctx context.Context, req tfsdk.UpdateResour
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Wrap(ctx.Err()), "user"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Wrap(ctx.Err()), "user"))
 			return
 		case <-retry.After():
 		}
@@ -289,6 +289,8 @@ func (r resourceTeleportUser) Update(ctx context.Context, req tfsdk.UpdateResour
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Errorf("Can not convert %T to UserV2", userI), "user"))
 		return
 	}
+	user = userResource
+
 	diags = tfschema.CopyUserV2ToTerraform(ctx, user, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/resource_teleport_workload_identity.go
+++ b/integrations/terraform/provider/resource_teleport_workload_identity.go
@@ -116,9 +116,9 @@ func (r resourceTeleportWorkloadIdentity) Create(ctx context.Context, req tfsdk.
 		tries = tries + 1
 		workloadIdentityI, err = r.p.Client.GetWorkloadIdentity(ctx, id)
 		if trace.IsNotFound(err) {
-		    select {
+			select {
 			case <-ctx.Done():
-			    resp.Diagnostics.Append(diagFromWrappedErr("Error reading WorkloadIdentity", trace.Wrap(ctx.Err()), "workload_identity"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading WorkloadIdentity", trace.Wrap(ctx.Err()), "workload_identity"))
 				return
 			case <-retry.After():
 			}
@@ -259,7 +259,7 @@ func (r resourceTeleportWorkloadIdentity) Update(ctx context.Context, req tfsdk.
 
 		select {
 		case <-ctx.Done():
-		    resp.Diagnostics.Append(diagFromWrappedErr("Error reading WorkloadIdentity", trace.Wrap(ctx.Err()), "workload_identity"))
+			resp.Diagnostics.Append(diagFromWrappedErr("Error reading WorkloadIdentity", trace.Wrap(ctx.Err()), "workload_identity"))
 			return
 		case <-retry.After():
 		}
@@ -272,6 +272,8 @@ func (r resourceTeleportWorkloadIdentity) Update(ctx context.Context, req tfsdk.
 
 	workloadIdentityResource = workloadIdentityI
 	
+	workloadIdentity = workloadIdentityResource
+
 	diags = schemav1.CopyWorkloadIdentityToTerraform(ctx, workloadIdentity, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/testlib/discovery_config_test.go
+++ b/integrations/terraform/testlib/discovery_config_test.go
@@ -124,7 +124,6 @@ func (s *TerraformSuiteOSS) TestImportDiscoveryConfig() {
 					require.Equal(t, existing.Metadata.Name, state[0].Attributes["header.metadata.name"])
 					require.Equal(t, existing.Metadata.Description, state[0].Attributes["header.metadata.description"])
 					require.Equal(t, "test", state[0].Attributes["header.metadata.labels.purpose"])
-					require.Equal(t, existing.Metadata.Revision, state[0].Attributes["header.metadata.revision"])
 					require.Equal(t, "test_group", state[0].Attributes["spec.discovery_group"])
 
 					return nil

--- a/integrations/terraform/testlib/health_check_config_test.go
+++ b/integrations/terraform/testlib/health_check_config_test.go
@@ -162,7 +162,6 @@ func (s *TerraformSuiteOSS) TestImportHealthCheckConfig() {
 					require.Equal(t, existing.Metadata.Namespace, state[0].Attributes["metadata.namespace"])
 					require.Equal(t, existing.Metadata.Description, state[0].Attributes["metadata.description"])
 					require.Equal(t, "test", state[0].Attributes["metadata.labels.purpose"])
-					require.Equal(t, existing.Metadata.Revision, state[0].Attributes["metadata.revision"])
 					require.Equal(t, "42s", state[0].Attributes["spec.interval"])
 					require.Empty(t, state[0].Attributes["spec.timeout"])
 					require.Equal(t, "3", state[0].Attributes["spec.healthy_threshold"])

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -88,13 +88,6 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
-						"revision": {
-							Computed:      true,
-							Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-							Optional:      true,
-							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-						},
 					}),
 					Description: "metadata is resource metadata.",
 					Optional:    true,
@@ -385,13 +378,6 @@ func GenSchemaMember(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
-						"revision": {
-							Computed:      true,
-							Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-							Optional:      true,
-							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-						},
 					}),
 					Description: "metadata is resource metadata.",
 					Optional:    true,
@@ -633,23 +619,6 @@ func CopyAccessListFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 											diags.Append(attrReadMissingDiag{"AccessList.header.metadata.expires"})
 										}
 										CopyFromTimestamp(diags, a, &obj.Expires)
-									}
-									{
-										a, ok := tf.Attrs["revision"]
-										if !ok {
-											diags.Append(attrReadMissingDiag{"AccessList.header.metadata.revision"})
-										} else {
-											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-											if !ok {
-												diags.Append(attrReadConversionFailureDiag{"AccessList.header.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-											} else {
-												var t string
-												if !v.Null && !v.Unknown {
-													t = string(v.Value)
-												}
-												obj.Revision = t
-											}
-										}
 									}
 								}
 							}
@@ -1760,28 +1729,6 @@ func CopyAccessListToTerraform(ctx context.Context, obj *github_com_gravitationa
 										} else {
 											v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 											tf.Attrs["expires"] = v
-										}
-									}
-									{
-										t, ok := tf.AttrTypes["revision"]
-										if !ok {
-											diags.Append(attrWriteMissingDiag{"AccessList.header.metadata.revision"})
-										} else {
-											v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-											if !ok {
-												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-												if err != nil {
-													diags.Append(attrWriteGeneralError{"AccessList.header.metadata.revision", err})
-												}
-												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-												if !ok {
-													diags.Append(attrWriteConversionFailureDiag{"AccessList.header.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-												}
-												v.Null = string(obj.Revision) == ""
-											}
-											v.Value = string(obj.Revision)
-											v.Unknown = false
-											tf.Attrs["revision"] = v
 										}
 									}
 								}
@@ -3422,23 +3369,6 @@ func CopyMemberFromTerraform(_ context.Context, tf github_com_hashicorp_terrafor
 										}
 										CopyFromTimestamp(diags, a, &obj.Expires)
 									}
-									{
-										a, ok := tf.Attrs["revision"]
-										if !ok {
-											diags.Append(attrReadMissingDiag{"Member.header.metadata.revision"})
-										} else {
-											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-											if !ok {
-												diags.Append(attrReadConversionFailureDiag{"Member.header.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-											} else {
-												var t string
-												if !v.Null && !v.Unknown {
-													t = string(v.Value)
-												}
-												obj.Revision = t
-											}
-										}
-									}
 								}
 							}
 						}
@@ -3816,28 +3746,6 @@ func CopyMemberToTerraform(ctx context.Context, obj *github_com_gravitational_te
 										} else {
 											v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 											tf.Attrs["expires"] = v
-										}
-									}
-									{
-										t, ok := tf.AttrTypes["revision"]
-										if !ok {
-											diags.Append(attrWriteMissingDiag{"Member.header.metadata.revision"})
-										} else {
-											v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-											if !ok {
-												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-												if err != nil {
-													diags.Append(attrWriteGeneralError{"Member.header.metadata.revision", err})
-												}
-												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-												if !ok {
-													diags.Append(attrWriteConversionFailureDiag{"Member.header.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-												}
-												v.Null = string(obj.Revision) == ""
-											}
-											v.Value = string(obj.Revision)
-											v.Unknown = false
-											tf.Attrs["revision"] = v
 										}
 									}
 								}

--- a/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
+++ b/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
@@ -87,11 +87,6 @@ func GenSchemaAccessMonitoringRule(ctx context.Context) (github_com_hashicorp_te
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "metadata is the rules's metadata.",
 			Optional:    true,
@@ -304,23 +299,6 @@ func CopyAccessMonitoringRuleFromTerraform(_ context.Context, tf github_com_hash
 							diags.Append(attrReadMissingDiag{"AccessMonitoringRule.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"AccessMonitoringRule.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"AccessMonitoringRule.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -901,28 +879,6 @@ func CopyAccessMonitoringRuleToTerraform(ctx context.Context, obj *github_com_gr
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"AccessMonitoringRule.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"AccessMonitoringRule.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"AccessMonitoringRule.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/appauthconfig/v1/appauthconfig_terraform.go
+++ b/integrations/terraform/tfschema/appauthconfig/v1/appauthconfig_terraform.go
@@ -91,13 +91,6 @@ func GenSchemaAppAuthConfig(ctx context.Context) (github_com_hashicorp_terraform
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Computed:      true,
-					Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata is the app auth config resource's metadata.",
 			Required:    true,
@@ -320,23 +313,6 @@ func CopyAppAuthConfigFromTerraform(_ context.Context, tf github_com_hashicorp_t
 							diags.Append(attrReadMissingDiag{"AppAuthConfig.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"AppAuthConfig.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"AppAuthConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -768,28 +744,6 @@ func CopyAppAuthConfigToTerraform(ctx context.Context, obj *github_com_gravitati
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"AppAuthConfig.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"AppAuthConfig.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"AppAuthConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/devicetrust/v1/device_terraform.go
+++ b/integrations/terraform/tfschema/devicetrust/v1/device_terraform.go
@@ -70,11 +70,6 @@ func GenSchemaDeviceV1(ctx context.Context) (github_com_hashicorp_terraform_plug
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Computed:      true,
 			Description:   "Metadata is resource metadata",
@@ -225,23 +220,6 @@ func CopyDeviceV1FromTerraform(_ context.Context, tf github_com_hashicorp_terraf
 										}
 									}
 								}
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"DeviceV1.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"DeviceV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
 							}
 						}
 					}
@@ -536,28 +514,6 @@ func CopyDeviceV1ToTerraform(ctx context.Context, obj *github_com_gravitational_
 								c.Unknown = false
 								tf.Attrs["labels"] = c
 							}
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"DeviceV1.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"DeviceV1.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"DeviceV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
+++ b/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
@@ -89,13 +89,6 @@ func GenSchemaDiscoveryConfig(ctx context.Context) (github_com_hashicorp_terrafo
 							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
-						"revision": {
-							Computed:      true,
-							Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-							Optional:      true,
-							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-						},
 					}),
 					Description: "metadata is resource metadata.",
 					Required:    true,
@@ -821,23 +814,6 @@ func CopyDiscoveryConfigFromTerraform(_ context.Context, tf github_com_hashicorp
 											diags.Append(attrReadMissingDiag{"DiscoveryConfig.header.metadata.expires"})
 										}
 										CopyFromTimestamp(diags, a, &obj.Expires)
-									}
-									{
-										a, ok := tf.Attrs["revision"]
-										if !ok {
-											diags.Append(attrReadMissingDiag{"DiscoveryConfig.header.metadata.revision"})
-										} else {
-											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-											if !ok {
-												diags.Append(attrReadConversionFailureDiag{"DiscoveryConfig.header.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-											} else {
-												var t string
-												if !v.Null && !v.Unknown {
-													t = string(v.Value)
-												}
-												obj.Revision = t
-											}
-										}
 									}
 								}
 							}
@@ -3030,28 +3006,6 @@ func CopyDiscoveryConfigToTerraform(ctx context.Context, obj *github_com_gravita
 										} else {
 											v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 											tf.Attrs["expires"] = v
-										}
-									}
-									{
-										t, ok := tf.AttrTypes["revision"]
-										if !ok {
-											diags.Append(attrWriteMissingDiag{"DiscoveryConfig.header.metadata.revision"})
-										} else {
-											v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-											if !ok {
-												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-												if err != nil {
-													diags.Append(attrWriteGeneralError{"DiscoveryConfig.header.metadata.revision", err})
-												}
-												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-												if !ok {
-													diags.Append(attrWriteConversionFailureDiag{"DiscoveryConfig.header.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-												}
-												v.Null = string(obj.Revision) == ""
-											}
-											v.Value = string(obj.Revision)
-											v.Unknown = false
-											tf.Attrs["revision"] = v
 										}
 									}
 								}

--- a/integrations/terraform/tfschema/healthcheckconfig/v1/health_check_config_terraform.go
+++ b/integrations/terraform/tfschema/healthcheckconfig/v1/health_check_config_terraform.go
@@ -92,13 +92,6 @@ func GenSchemaHealthCheckConfig(ctx context.Context) (github_com_hashicorp_terra
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Computed:      true,
-					Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata is the health check config resource's metadata.",
 			Required:    true,
@@ -347,23 +340,6 @@ func CopyHealthCheckConfigFromTerraform(_ context.Context, tf github_com_hashico
 							diags.Append(attrReadMissingDiag{"HealthCheckConfig.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"HealthCheckConfig.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"HealthCheckConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -876,28 +852,6 @@ func CopyHealthCheckConfigToTerraform(ctx context.Context, obj *github_com_gravi
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"HealthCheckConfig.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"HealthCheckConfig.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"HealthCheckConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/loginrule/v1/loginrule_terraform.go
+++ b/integrations/terraform/tfschema/loginrule/v1/loginrule_terraform.go
@@ -84,11 +84,6 @@ func GenSchemaLoginRule(ctx context.Context) (github_com_hashicorp_terraform_plu
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata is resource metadata.",
 			Optional:    true,
@@ -230,23 +225,6 @@ func CopyLoginRuleFromTerraform(_ context.Context, tf github_com_hashicorp_terra
 									t = &c
 								}
 								obj.Expires = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"LoginRule.metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"LoginRule.metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
 							}
 						}
 					}
@@ -539,28 +517,6 @@ func CopyLoginRuleToTerraform(ctx context.Context, obj *github_com_gravitational
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"LoginRule.metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"LoginRule.metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"LoginRule.metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -90,13 +90,6 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Computed:      true,
-					Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata contains the resource metadata.",
 			Required:    true,
@@ -530,23 +523,6 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 							diags.Append(attrReadMissingDiag{"ScopedToken.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ScopedToken.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ScopedToken.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -1844,28 +1820,6 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ScopedToken.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"ScopedToken.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ScopedToken.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/summarizer/v1/summarizer_terraform.go
+++ b/integrations/terraform/tfschema/summarizer/v1/summarizer_terraform.go
@@ -92,13 +92,6 @@ func GenSchemaInferenceModel(ctx context.Context) (github_com_hashicorp_terrafor
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Computed:      true,
-					Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "",
 			Required:    true,
@@ -218,13 +211,6 @@ func GenSchemaInferenceSecret(ctx context.Context) (github_com_hashicorp_terrafo
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Computed:      true,
-					Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "",
 			Required:    true,
@@ -298,13 +284,6 @@ func GenSchemaInferencePolicy(ctx context.Context) (github_com_hashicorp_terrafo
 				"namespace": {
 					Computed:      true,
 					Description:   "namespace is object namespace. The field should be called \"namespace\" when it returns in Teleport 2.4.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Computed:      true,
-					Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
@@ -499,23 +478,6 @@ func CopyInferenceModelFromTerraform(_ context.Context, tf github_com_hashicorp_
 							diags.Append(attrReadMissingDiag{"InferenceModel.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"InferenceModel.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"InferenceModel.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -921,28 +883,6 @@ func CopyInferenceModelToTerraform(ctx context.Context, obj *github_com_gravitat
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"InferenceModel.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"InferenceModel.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"InferenceModel.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -1365,23 +1305,6 @@ func CopyInferenceSecretFromTerraform(_ context.Context, tf github_com_hashicorp
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"InferenceSecret.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"InferenceSecret.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -1649,28 +1572,6 @@ func CopyInferenceSecretToTerraform(ctx context.Context, obj *github_com_gravita
 							tf.Attrs["expires"] = v
 						}
 					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"InferenceSecret.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"InferenceSecret.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"InferenceSecret.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
-						}
-					}
 				}
 				v.Unknown = false
 				tf.Attrs["metadata"] = v
@@ -1886,23 +1787,6 @@ func CopyInferencePolicyFromTerraform(_ context.Context, tf github_com_hashicorp
 							diags.Append(attrReadMissingDiag{"InferencePolicy.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"InferencePolicy.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"InferencePolicy.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -2213,28 +2097,6 @@ func CopyInferencePolicyToTerraform(ctx context.Context, obj *github_com_gravita
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"InferencePolicy.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"InferencePolicy.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"InferencePolicy.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -94,11 +94,6 @@ func GenSchemaDatabaseV3(ctx context.Context) (github_com_hashicorp_terraform_pl
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata is the database metadata.",
 			Optional:    true,
@@ -644,11 +639,6 @@ func GenSchemaServerV2(ctx context.Context) (github_com_hashicorp_terraform_plug
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Computed:      true,
 			Description:   "Metadata is resource metadata",
@@ -898,11 +888,6 @@ func GenSchemaAppV3(ctx context.Context) (github_com_hashicorp_terraform_plugin_
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "Metadata is the app resource metadata.",
@@ -1202,11 +1187,6 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "Metadata is resource metadata",
@@ -2043,11 +2023,6 @@ func GenSchemaClusterNetworkingConfigV2(ctx context.Context) (github_com_hashico
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata is resource metadata",
 			Optional:    true,
@@ -2206,11 +2181,6 @@ func GenSchemaSessionRecordingConfigV2(ctx context.Context) (github_com_hashicor
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata is resource metadata",
 			Optional:    true,
@@ -2357,11 +2327,6 @@ func GenSchemaAuthPreferenceV2(ctx context.Context) (github_com_hashicorp_terraf
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "Metadata is resource metadata",
@@ -2652,11 +2617,6 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "Metadata is resource metadata",
@@ -4020,11 +3980,6 @@ func GenSchemaUserV2(ctx context.Context) (github_com_hashicorp_terraform_plugin
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata is resource metadata",
 			Optional:    true,
@@ -4204,11 +4159,6 @@ func GenSchemaOIDCConnectorV3(ctx context.Context) (github_com_hashicorp_terrafo
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "Metadata holds resource metadata.",
@@ -4471,11 +4421,6 @@ func GenSchemaSAMLConnectorV2(ctx context.Context) (github_com_hashicorp_terrafo
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "Metadata holds resource metadata.",
@@ -4762,11 +4707,6 @@ func GenSchemaGithubConnectorV3(ctx context.Context) (github_com_hashicorp_terra
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata holds resource metadata.",
 			Optional:    true,
@@ -4943,11 +4883,6 @@ func GenSchemaTrustedClusterV2(ctx context.Context) (github_com_hashicorp_terraf
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata holds resource metadata.",
 			Optional:    true,
@@ -5061,11 +4996,6 @@ func GenSchemaDynamicWindowsDesktopV1(ctx context.Context) (github_com_hashicorp
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata is resource metadata",
 			Optional:    true,
@@ -5169,11 +5099,6 @@ func GenSchemaInstallerV1(ctx context.Context) (github_com_hashicorp_terraform_p
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Metadata is the resource metadata.",
 			Optional:    true,
@@ -5242,11 +5167,6 @@ func GenSchemaClusterMaintenanceConfigV1(ctx context.Context) (github_com_hashic
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "Metadata is resource metadata",
@@ -5338,11 +5258,6 @@ func GenSchemaOktaImportRuleV1(ctx context.Context) (github_com_hashicorp_terraf
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "Metadata is resource metadata",
@@ -5457,11 +5372,6 @@ func GenSchemaIntegrationV1(ctx context.Context) (github_com_hashicorp_terraform
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "Revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "Metadata is resource metadata",
@@ -5726,23 +5636,6 @@ func CopyDatabaseV3FromTerraform(_ context.Context, tf github_com_hashicorp_terr
 									t = &c
 								}
 								obj.Expires = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"DatabaseV3.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"DatabaseV3.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
 							}
 						}
 					}
@@ -7635,28 +7528,6 @@ func CopyDatabaseV3ToTerraform(ctx context.Context, obj *github_com_gravitationa
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"DatabaseV3.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"DatabaseV3.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"DatabaseV3.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -10238,23 +10109,6 @@ func CopyServerV2FromTerraform(_ context.Context, tf github_com_hashicorp_terraf
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ServerV2.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ServerV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -11139,28 +10993,6 @@ func CopyServerV2ToTerraform(ctx context.Context, obj *github_com_gravitational_
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ServerV2.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"ServerV2.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ServerV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -12277,23 +12109,6 @@ func CopyAppV3FromTerraform(_ context.Context, tf github_com_hashicorp_terraform
 									t = &c
 								}
 								obj.Expires = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"AppV3.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"AppV3.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
 							}
 						}
 					}
@@ -13434,28 +13249,6 @@ func CopyAppV3ToTerraform(ctx context.Context, obj *github_com_gravitational_tel
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"AppV3.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"AppV3.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"AppV3.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -15081,23 +14874,6 @@ func CopyProvisionTokenV2FromTerraform(_ context.Context, tf github_com_hashicor
 									t = &c
 								}
 								obj.Expires = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ProvisionTokenV2.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ProvisionTokenV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
 							}
 						}
 					}
@@ -18166,28 +17942,6 @@ func CopyProvisionTokenV2ToTerraform(ctx context.Context, obj *github_com_gravit
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ProvisionTokenV2.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"ProvisionTokenV2.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ProvisionTokenV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -22657,23 +22411,6 @@ func CopyClusterNetworkingConfigV2FromTerraform(_ context.Context, tf github_com
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ClusterNetworkingConfigV2.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ClusterNetworkingConfigV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -23189,28 +22926,6 @@ func CopyClusterNetworkingConfigV2ToTerraform(ctx context.Context, obj *github_c
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ClusterNetworkingConfigV2.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"ClusterNetworkingConfigV2.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ClusterNetworkingConfigV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -23808,23 +23523,6 @@ func CopySessionRecordingConfigV2FromTerraform(_ context.Context, tf github_com_
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"SessionRecordingConfigV2.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"SessionRecordingConfigV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -24350,28 +24048,6 @@ func CopySessionRecordingConfigV2ToTerraform(ctx context.Context, obj *github_co
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"SessionRecordingConfigV2.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"SessionRecordingConfigV2.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"SessionRecordingConfigV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -25011,23 +24687,6 @@ func CopyAuthPreferenceV2FromTerraform(_ context.Context, tf github_com_hashicor
 									t = &c
 								}
 								obj.Expires = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"AuthPreferenceV2.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"AuthPreferenceV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
 							}
 						}
 					}
@@ -25978,28 +25637,6 @@ func CopyAuthPreferenceV2ToTerraform(ctx context.Context, obj *github_com_gravit
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"AuthPreferenceV2.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"AuthPreferenceV2.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"AuthPreferenceV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -27301,23 +26938,6 @@ func CopyRoleV6FromTerraform(_ context.Context, tf github_com_hashicorp_terrafor
 									t = &c
 								}
 								obj.Expires = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"RoleV6.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"RoleV6.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
 							}
 						}
 					}
@@ -32617,28 +32237,6 @@ func CopyRoleV6ToTerraform(ctx context.Context, obj *github_com_gravitational_te
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"RoleV6.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"RoleV6.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"RoleV6.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -41371,23 +40969,6 @@ func CopyUserV2FromTerraform(_ context.Context, tf github_com_hashicorp_terrafor
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"UserV2.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"UserV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -42051,28 +41632,6 @@ func CopyUserV2ToTerraform(ctx context.Context, obj *github_com_gravitational_te
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"UserV2.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"UserV2.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"UserV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -42895,23 +42454,6 @@ func CopyOIDCConnectorV3FromTerraform(_ context.Context, tf github_com_hashicorp
 									t = &c
 								}
 								obj.Expires = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"OIDCConnectorV3.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"OIDCConnectorV3.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
 							}
 						}
 					}
@@ -43866,28 +43408,6 @@ func CopyOIDCConnectorV3ToTerraform(ctx context.Context, obj *github_com_gravita
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"OIDCConnectorV3.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"OIDCConnectorV3.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"OIDCConnectorV3.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -45116,23 +44636,6 @@ func CopySAMLConnectorV2FromTerraform(_ context.Context, tf github_com_hashicorp
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"SAMLConnectorV2.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"SAMLConnectorV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -46080,28 +45583,6 @@ func CopySAMLConnectorV2ToTerraform(ctx context.Context, obj *github_com_gravita
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"SAMLConnectorV2.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"SAMLConnectorV2.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"SAMLConnectorV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -47318,23 +46799,6 @@ func CopyGithubConnectorV3FromTerraform(_ context.Context, tf github_com_hashico
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"GithubConnectorV3.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"GithubConnectorV3.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -48031,28 +47495,6 @@ func CopyGithubConnectorV3ToTerraform(ctx context.Context, obj *github_com_gravi
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"GithubConnectorV3.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"GithubConnectorV3.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"GithubConnectorV3.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -48992,23 +48434,6 @@ func CopyTrustedClusterV2FromTerraform(_ context.Context, tf github_com_hashicor
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"TrustedClusterV2.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"TrustedClusterV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -49439,28 +48864,6 @@ func CopyTrustedClusterV2ToTerraform(ctx context.Context, obj *github_com_gravit
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"TrustedClusterV2.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"TrustedClusterV2.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"TrustedClusterV2.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -49937,23 +49340,6 @@ func CopyDynamicWindowsDesktopV1FromTerraform(_ context.Context, tf github_com_h
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"DynamicWindowsDesktopV1.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"DynamicWindowsDesktopV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -50322,28 +49708,6 @@ func CopyDynamicWindowsDesktopV1ToTerraform(ctx context.Context, obj *github_com
 							tf.Attrs["expires"] = v
 						}
 					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"DynamicWindowsDesktopV1.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"DynamicWindowsDesktopV1.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"DynamicWindowsDesktopV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
-						}
-					}
 				}
 				v.Unknown = false
 				tf.Attrs["metadata"] = v
@@ -50688,23 +50052,6 @@ func CopyInstallerV1FromTerraform(_ context.Context, tf github_com_hashicorp_ter
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"InstallerV1.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"InstallerV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -50987,28 +50334,6 @@ func CopyInstallerV1ToTerraform(ctx context.Context, obj *github_com_gravitation
 							tf.Attrs["expires"] = v
 						}
 					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"InstallerV1.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"InstallerV1.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"InstallerV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
-						}
-					}
 				}
 				v.Unknown = false
 				tf.Attrs["metadata"] = v
@@ -51213,23 +50538,6 @@ func CopyClusterMaintenanceConfigV1FromTerraform(_ context.Context, tf github_co
 									t = &c
 								}
 								obj.Expires = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"ClusterMaintenanceConfigV1.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"ClusterMaintenanceConfigV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
 							}
 						}
 					}
@@ -51553,28 +50861,6 @@ func CopyClusterMaintenanceConfigV1ToTerraform(ctx context.Context, obj *github_
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"ClusterMaintenanceConfigV1.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"ClusterMaintenanceConfigV1.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"ClusterMaintenanceConfigV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -51905,23 +51191,6 @@ func CopyOktaImportRuleV1FromTerraform(_ context.Context, tf github_com_hashicor
 									t = &c
 								}
 								obj.Expires = t
-							}
-						}
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"OktaImportRuleV1.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"OktaImportRuleV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
 							}
 						}
 					}
@@ -52398,28 +51667,6 @@ func CopyOktaImportRuleV1ToTerraform(ctx context.Context, obj *github_com_gravit
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"OktaImportRuleV1.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"OktaImportRuleV1.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"OktaImportRuleV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}
@@ -53024,23 +52271,6 @@ func CopyIntegrationV1FromTerraform(_ context.Context, tf github_com_hashicorp_t
 							}
 						}
 					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"IntegrationV1.Metadata.Revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"IntegrationV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
-					}
 				}
 			}
 		}
@@ -53574,28 +52804,6 @@ func CopyIntegrationV1ToTerraform(ctx context.Context, obj *github_com_gravitati
 							}
 							v.Unknown = false
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"IntegrationV1.Metadata.Revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"IntegrationV1.Metadata.Revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"IntegrationV1.Metadata.Revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/userprovisioning/v2/statichostuser_terraform.go
+++ b/integrations/terraform/tfschema/userprovisioning/v2/statichostuser_terraform.go
@@ -89,11 +89,6 @@ func GenSchemaStaticHostUser(ctx context.Context) (github_com_hashicorp_terrafor
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "metadata is resource metadata.",
 			Required:    true,
@@ -324,23 +319,6 @@ func CopyStaticHostUserFromTerraform(_ context.Context, tf github_com_hashicorp_
 							diags.Append(attrReadMissingDiag{"StaticHostUser.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"StaticHostUser.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"StaticHostUser.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -831,28 +809,6 @@ func CopyStaticHostUserToTerraform(ctx context.Context, obj *github_com_gravitat
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"StaticHostUser.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"StaticHostUser.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"StaticHostUser.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/vnet/v1/vnet_config_terraform.go
+++ b/integrations/terraform/tfschema/vnet/v1/vnet_config_terraform.go
@@ -51,9 +51,11 @@ func GenSchemaVnetConfig(ctx context.Context) (github_com_hashicorp_terraform_pl
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"kind": {
-			Description: "",
-			Optional:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Computed:      true,
+			Description:   "",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"metadata": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
@@ -72,20 +74,12 @@ func GenSchemaVnetConfig(ctx context.Context) (github_com_hashicorp_terraform_pl
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"name": {
-					Description: "name is an object name.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 				"namespace": {
-					Description: "namespace is object namespace. The field should be called \"namespace\" when it returns in Teleport 2.4.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					Computed:      true,
+					Description:   "namespace is object namespace. The field should be called \"namespace\" when it returns in Teleport 2.4.",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
 			Description: "",
@@ -117,9 +111,11 @@ func GenSchemaVnetConfig(ctx context.Context) (github_com_hashicorp_terraform_pl
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description: "",
-			Optional:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Computed:      true,
+			Description:   "",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 	}}, nil
 }
@@ -193,23 +189,6 @@ func CopyVnetConfigFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 					obj.Metadata = &github_com_gravitational_teleport_api_gen_proto_go_teleport_header_v1.Metadata{}
 					obj := obj.Metadata
 					{
-						a, ok := tf.Attrs["name"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.name"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"VnetConfig.metadata.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Name = t
-							}
-						}
-					}
-					{
 						a, ok := tf.Attrs["namespace"]
 						if !ok {
 							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.namespace"})
@@ -276,23 +255,6 @@ func CopyVnetConfigFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"VnetConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -483,28 +445,6 @@ func CopyVnetConfigToTerraform(ctx context.Context, obj *github_com_gravitationa
 					obj := obj.Metadata
 					tf := &v
 					{
-						t, ok := tf.AttrTypes["name"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"VnetConfig.metadata.name"})
-						} else {
-							v, ok := tf.Attrs["name"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"VnetConfig.metadata.name", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"VnetConfig.metadata.name", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Name) == ""
-							}
-							v.Value = string(obj.Name)
-							v.Unknown = false
-							tf.Attrs["name"] = v
-						}
-					}
-					{
 						t, ok := tf.AttrTypes["namespace"]
 						if !ok {
 							diags.Append(attrWriteMissingDiag{"VnetConfig.metadata.namespace"})
@@ -605,28 +545,6 @@ func CopyVnetConfigToTerraform(ctx context.Context, obj *github_com_gravitationa
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"VnetConfig.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"VnetConfig.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"VnetConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/workloadidentity/v1/resource_terraform.go
+++ b/integrations/terraform/tfschema/workloadidentity/v1/resource_terraform.go
@@ -89,11 +89,6 @@ func GenSchemaWorkloadIdentity(ctx context.Context) (github_com_hashicorp_terraf
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Description: "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Description: "Common metadata that all resources share.",
 			Optional:    true,
@@ -391,23 +386,6 @@ func CopyWorkloadIdentityFromTerraform(_ context.Context, tf github_com_hashicor
 							diags.Append(attrReadMissingDiag{"WorkloadIdentity.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"WorkloadIdentity.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"WorkloadIdentity.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -1126,28 +1104,6 @@ func CopyWorkloadIdentityToTerraform(ctx context.Context, obj *github_com_gravit
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"WorkloadIdentity.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"WorkloadIdentity.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"WorkloadIdentity.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/64651

This PR modifies the Terraform resource `Update` method to ensure that the latest Teleport state is written to local Terraform state.

Before this change, the `Update` method for plural resources was storing the Terraform plan as the updated state. 
As a result, the final state would not include computed values provided by Teleport. This would cause unexpected behavior for attributes computed during updates, such as `metadata.revision`, or attributes with computed defaults.

With this fix to the `Update` method, resources should no longer include `revision` as a computed field. If `revision` were to be computed, the Terraform provider would report an inconsistent state after apply. This is because the planned `revision` value would no longer match the applied `revision` value computed by Teleport during apply.

```console
teleport_role.test-0310: Modifying... [id=test-0310]
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to teleport_role.test-0310, provider "provider[\"terraform.releases.teleport.dev/gravitational/teleport\"]" produced an unexpected
│ new value: .metadata.revision: was cty.StringVal("a72b37a3-f650-42d0-89ac-c49d7938a5c8"), but now cty.StringVal("fb8fd4d7-f3fb-4c31-8cbf-a38e9e650ce1").
```

To help prevent the `revision` attribute from being added as a computed field again, I've excluded this attribute from all resources. This should have minimal impact on users, as users are not expected to use this value as an up-to-date identifier of a resource version. And as far as I can tell, the `revision` is not required to update a Teleport resource.

Note that this is a breaking change. Revision will no longer exist in state and users will need to refresh Terraform state.

```console
❯ terraform show
Failed to marshal state to json: unsupported attribute "revision"%

❯ terraform refresh
teleport_role.test-0310: Refreshing state... [id=test-0310]

❯ terraform show
# teleport_role.test-0310:
resource "teleport_role" "test-0310" {
    id       = "test-0310"
    kind     = "role"
    metadata = {
        name      = "test-0310"
        namespace = "default"
    }
    ...
    version  = "v8"
}
```

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed potential Terraform issues due to storing stale Terraform state on updates

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] Verify `revision` attribute is no longer present in Terraform state
- [ ] Verify resources can still be updated
- [ ] Verify resources do not report a permanent drift in state
