### PR TITLE
Move Device Trust from IG to ZTA (index.mdx)

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -159,6 +159,11 @@ import listBulletsSvg from "@site/src/components/Icon/teleport-svg/list-bullets.
           href: './zero-trust-access/authentication/passwordless'
         },
         {
+          title: 'Require Managed Devices for Access',
+          description: 'Guarantee access only from trusted devices',
+          href: './zero-trust-access/device-trust/'
+        },
+        {
           title: 'Integrate with SSO Providers',
           description: 'Connect Okta, Entra ID, Google, and more',
           href: './zero-trust-access/sso/'
@@ -247,11 +252,6 @@ import listBulletsSvg from "@site/src/components/Icon/teleport-svg/list-bullets.
           title: 'Manage Standing Access for Teams',
           description: 'Sync IdP groups to roles w/ automated reviews',
           href: './identity-governance/integrations/okta/app-and-group-sync/'
-        },
-        {
-          title: 'Require Managed Devices for Access',
-          description: 'Guarantee access only from trusted devices',
-          href: './zero-trust-access/device-trust/'
         },
         {
           title: 'Instantly Lock Identities & Sessions',


### PR DESCRIPTION
Moving device trust docs from Identity Governance to Zero Trust Access to reflect Teleport's current offerings.

Followup on #63961 since I didn't catch moving this section until backporting that PR.
No backport required because these changes have already been included in the original backports

## Manual Test Plan
### Test Environment
Tested on Amplify
### Test Cases
- [x] Device Trust section should appear under Zero Trust Access and not Identity Governance
- [x] Link to Device Trust page works
