### PR TITLE
Fix app session creation bypassing Resource Access Requests' AllowedResourceIDs

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2838,25 +2838,26 @@ func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCert
 // GenerateUserTestCertsRequest is a request to generate test certificates.
 // TODO(tross): Figure out how to move this into test only code.
 type GenerateUserTestCertsRequest struct {
-	SSHPubKey               []byte
-	TLSPubKey               []byte
-	Username                string
-	TTL                     time.Duration
-	Compatibility           string
-	RouteToCluster          string
-	PinnedIP                string
-	MFAVerified             string
-	SSHAttestationStatement *hardwarekey.AttestationStatement
-	TLSAttestationStatement *hardwarekey.AttestationStatement
-	AppName                 string
-	AppSessionID            string
-	DeviceExtensions        DeviceExtensions
-	Renewable               bool
-	Generation              uint64
-	ActiveRequests          []string
-	KubernetesCluster       string
-	Usage                   []string
-	Scope                   string
+	SSHPubKey                []byte
+	TLSPubKey                []byte
+	Username                 string
+	TTL                      time.Duration
+	Compatibility            string
+	RouteToCluster           string
+	PinnedIP                 string
+	MFAVerified              string
+	SSHAttestationStatement  *hardwarekey.AttestationStatement
+	TLSAttestationStatement  *hardwarekey.AttestationStatement
+	AppName                  string
+	AppSessionID             string
+	DeviceExtensions         DeviceExtensions
+	Renewable                bool
+	Generation               uint64
+	ActiveRequests           []string
+	AllowedResourceAccessIDs []types.ResourceAccessID
+	KubernetesCluster        string
+	Usage                    []string
+	Scope                    string
 }
 
 // GenerateUserTestCerts is used to generate user certificate, used internally for tests
@@ -2872,7 +2873,10 @@ func (a *Server) GenerateUserTestCertsWithContext(ctx context.Context, req Gener
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	checkerContext, err := a.accessCheckerForScope(ctx, req.Scope, userState)
+	// Propagate AllowedResourceAccessIDs from the req, so AccessChecker
+	// doesn't fall back to role-based checks alone if resource-level restrictions
+	// are present on caller's identity.
+	checkerContext, err := a.accessCheckerForScope(ctx, req.Scope, userState, req.AllowedResourceAccessIDs)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3810,6 +3810,11 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 				Traits:         accessInfo.Traits,
 				Roles:          accessInfo.Roles,
 				AccessRequests: req.AccessRequests,
+				// Propagate AllowedResourceAccessIDs so the app session cert
+				// carries resource-level restrictions from the caller's identity.
+				// Without this, checkAllowedResources() at the app service sees an
+				// empty list and falls back to role-based checks alone.
+				RequestedResourceAccessIDs: accessInfo.AllowedResourceAccessIDs,
 				// App sessions created through generateUserCerts are securely contained
 				// to the Proxy and Auth roles, and thus should pass hardware key requirements
 				// through the "web_session" attestation. User's will be required to provide

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -739,18 +739,19 @@ func generateCertificate(authServer *auth.Server, identity TestIdentity) ([]byte
 		}
 
 		_, tlsCert, err := authServer.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
-			SSHPubKey:        sshPublicKeyPEM,
-			TLSPubKey:        tlsPublicKeyPEM,
-			Username:         id.Username,
-			TTL:              identity.TTL,
-			RouteToCluster:   identity.RouteToCluster,
-			PinnedIP:         id.Identity.PinnedIP,
-			MFAVerified:      id.Identity.MFAVerified,
-			DeviceExtensions: auth.DeviceExtensions(id.Identity.DeviceExtensions),
-			Generation:       id.Identity.Generation,
-			Renewable:        identity.Renewable,
-			Usage:            identity.AcceptedUsage,
-			Scope:            identity.Scope,
+			SSHPubKey:                sshPublicKeyPEM,
+			TLSPubKey:                tlsPublicKeyPEM,
+			Username:                 id.Username,
+			TTL:                      identity.TTL,
+			RouteToCluster:           identity.RouteToCluster,
+			PinnedIP:                 id.Identity.PinnedIP,
+			MFAVerified:              id.Identity.MFAVerified,
+			DeviceExtensions:         auth.DeviceExtensions(id.Identity.DeviceExtensions),
+			Generation:               id.Identity.Generation,
+			AllowedResourceAccessIDs: id.Identity.AllowedResourceAccessIDs,
+			Renewable:                identity.Renewable,
+			Usage:                    identity.AcceptedUsage,
+			Scope:                    identity.Scope,
 		})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -974,6 +974,104 @@ func TestCreateAppSession_deviceExtensions(t *testing.T) {
 	}
 }
 
+func TestCreateAppSession_allowedResourceAccessIDs(t *testing.T) {
+	modulestest.SetTestModules(t, modulestest.Modules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.App: {Enabled: true},
+			},
+		},
+	})
+	ctx := context.Background()
+	testServer := newTestTLSServer(t)
+	authServer := testServer.Auth()
+
+	user, _, err := authtest.CreateUserAndRole(authServer, "teleport-user", []string{"teleport-user"}, nil)
+	require.NoError(t, err, "CreateUserAndRole failed")
+
+	app, err := types.NewAppV3(
+		types.Metadata{
+			Name: "someapp",
+		}, types.AppSpecV3{
+			URI:        "http://localhost:8080",
+			PublicAddr: "someapp.example.com",
+		})
+	require.NoError(t, err)
+	appServer, err := types.NewAppServerV3FromApp(app, "host", uuid.New().String())
+	require.NoError(t, err)
+	_, err = authServer.UpsertApplicationServer(ctx, appServer)
+	require.NoError(t, err)
+
+	wantResourceAccessIDs := []types.ResourceAccessID{
+		{
+			Id: types.ResourceID{
+				ClusterName: testServer.ClusterName(),
+				Kind:        types.KindApp,
+				Name:        "someapp",
+			},
+			Constraints: &types.ResourceConstraints{
+				Version: types.V1,
+				Details: &types.ResourceConstraints_AwsConsole{
+					AwsConsole: &types.AWSConsoleResourceConstraints{
+						RoleArns: []string{"arn:aws:iam::123456789012:role/someapprole"},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		modifyUser func(u *authtest.TestIdentity)
+		assertCert func(t *testing.T, cert *x509.Certificate)
+	}{
+		{
+			name: "identity with no AllowedResourceAccessIDs",
+		},
+		{
+			name: "identity with AllowedResourceAccessIDs",
+			modifyUser: func(u *authtest.TestIdentity) {
+				lu := u.I.(authz.LocalUser)
+				lu.Identity.AllowedResourceAccessIDs = wantResourceAccessIDs
+				u.I = lu
+			},
+			assertCert: func(t *testing.T, cert *x509.Certificate) {
+				gotIdentity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+				require.NoError(t, err)
+				require.Empty(t, cmp.Diff(wantResourceAccessIDs, gotIdentity.AllowedResourceAccessIDs, protocmp.Transform()))
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			u := authtest.TestUser(user.GetName())
+			if test.modifyUser != nil {
+				test.modifyUser(&u)
+			}
+
+			userClient, err := testServer.NewClient(u)
+			require.NoError(t, err)
+
+			session, err := userClient.CreateAppSession(ctx, &proto.CreateAppSessionRequest{
+				Username:    user.GetName(),
+				PublicAddr:  app.GetPublicAddr(),
+				ClusterName: testServer.ClusterName(),
+			})
+			require.NoError(t, err)
+
+			block, _ := pem.Decode(session.GetTLSCert())
+			require.NotNil(t, block)
+			gotCert, err := x509.ParseCertificate(block.Bytes)
+			require.NoError(t, err)
+
+			if test.assertCert != nil {
+				test.assertCert(t, gotCert)
+			}
+		})
+	}
+}
+
 func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -59,7 +59,7 @@ const (
 	maxUserAgentLen = 2048
 )
 
-func (a *Server) accessCheckerForScope(ctx context.Context, scope string, userState services.UserState) (*services.SplitAccessCheckerContext, error) {
+func (a *Server) accessCheckerForScope(ctx context.Context, scope string, userState services.UserState, allowedResourceAccessIDs []types.ResourceAccessID) (*services.SplitAccessCheckerContext, error) {
 	clusterName, err := a.GetClusterName(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -71,6 +71,9 @@ func (a *Server) accessCheckerForScope(ctx context.Context, scope string, userSt
 	if scope == "" {
 		// this is an unscoped login attempt, so the user's capabilities are determined solely by their user state.
 		accessInfo := services.AccessInfoFromUserState(userState)
+		if len(allowedResourceAccessIDs) > 0 {
+			accessInfo.AllowedResourceAccessIDs = allowedResourceAccessIDs
+		}
 
 		unscopedChecker, err := services.NewAccessChecker(accessInfo, clusterName.GetClusterName(), a)
 		if err != nil {
@@ -97,6 +100,9 @@ func (a *Server) accessCheckerForScope(ctx context.Context, scope string, userSt
 
 	// build the user's access info based on the scope pin and userState
 	accessInfo := services.ScopePinnedAccessInfoFromUserState(userState, scopePin)
+	if len(allowedResourceAccessIDs) > 0 {
+		accessInfo.AllowedResourceAccessIDs = allowedResourceAccessIDs
+	}
 
 	// create a scoped access checker context. Note that scoped certificate parameters differ from unscoped
 	// certificate parameters in that they are generally not role-determined. We still need to create the full
@@ -161,7 +167,7 @@ func (a *Server) authenticateUserLogin(ctx context.Context, req authclient.Authe
 		return nil, nil, trace.Wrap(err)
 	}
 
-	checker, err := a.accessCheckerForScope(ctx, req.Scope, userState)
+	checker, err := a.accessCheckerForScope(ctx, req.Scope, userState, nil)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -508,6 +508,11 @@ func (a *Server) CreateAppSession(ctx context.Context, req *proto.CreateAppSessi
 			Roles:          roles,
 			Traits:         traits,
 			AccessRequests: identity.ActiveRequests,
+			// Propagate AllowedResourceAccessIDs so the app session cert
+			// carries resource-level restrictions from the caller's identity.
+			// Without this, checkAllowedResources() at the app service sees an
+			// empty list and falls back to role-based checks alone.
+			RequestedResourceAccessIDs: identity.AllowedResourceAccessIDs,
 			// If the user's current identity is attested as a "web_session", its secrets are only
 			// available to the Proxy and Auth roles, meaning this request is coming from the Proxy
 			// service on behalf of the user's Web Session. We can safely attest this child app session
@@ -552,10 +557,13 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 	}
 
 	checker, err := services.NewAccessChecker(&services.AccessInfo{
-		Username:                 req.User,
-		Roles:                    req.Roles,
-		Traits:                   req.Traits,
-		AllowedResourceAccessIDs: req.RequestedResourceAccessIDs,
+		Username: req.User,
+		Roles:    req.Roles,
+		Traits:   req.Traits,
+		// Propagate AllowedResourceAccessIDs from the req, so AccessChecker
+		// doesn't fall back to role-based checks alone if resource-level restrictions
+		// are present on caller's identity.
+		AllowedResourceAccessIDs: req.NewWebSessionRequest.RequestedResourceAccessIDs,
 	}, clusterName.GetClusterName(), a)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -795,7 +803,7 @@ func (a *Server) CreateSessionCerts(ctx context.Context, req *SessionCertsReques
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
-	checker, err := a.accessCheckerForScope(ctx, req.Scope, req.UserState)
+	checker, err := a.accessCheckerForScope(ctx, req.Scope, req.UserState, nil)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/services/access_checker_test.go
+++ b/lib/services/access_checker_test.go
@@ -1447,6 +1447,22 @@ func TestAccessChecker_Constraints_AwsConsole(t *testing.T) {
 		NewAppAWSLoginMatcher("arn:aws:iam::123456789012:role/ReadOnly"),
 	)
 	require.NoError(t, err)
+
+	// 3) Should fail with AWSRoleARNMatcher: same constraint check as (1)
+	err = ac.CheckAccess(
+		&app,
+		AccessState{MFARequired: MFARequiredNever},
+		&AWSRoleARNMatcher{RoleARN: "arn:aws:iam::123456789012:role/Admin"},
+	)
+	require.Error(t, err)
+
+	// 4) Should pass with AWSRoleARNMatcher: same constraint check as (2)
+	err = ac.CheckAccess(
+		&app,
+		AccessState{MFARequired: MFARequiredNever},
+		&AWSRoleARNMatcher{RoleARN: "arn:aws:iam::123456789012:role/ReadOnly"},
+	)
+	require.NoError(t, err)
 }
 
 // TestUserSessionRoleNotFoundError ensures that role not found errors during user session access checks include UserSessionRoleNotFoundErrorMsg when appropriate,

--- a/lib/services/resource_constraints.go
+++ b/lib/services/resource_constraints.go
@@ -60,12 +60,17 @@ func WithConstraints(rc *types.ResourceConstraints) MatcherTransform {
 		}
 
 		return func(m RoleMatcher) RoleMatcher {
-			lm, ok := m.(*awsAppLoginMatcher)
-			if !ok {
+			var awsRole string
+			switch lm := m.(type) {
+			case *awsAppLoginMatcher:
+				awsRole = lm.awsRole
+			case *AWSRoleARNMatcher:
+				awsRole = lm.RoleARN
+			default:
 				return m
 			}
 			return RoleMatcherFunc(func(role types.Role, cond types.RoleConditionType) (bool, error) {
-				if _, ok := allowedSet[lm.awsRole]; !ok {
+				if _, ok := allowedSet[awsRole]; !ok {
 					return false, nil
 				}
 				return m.Match(role, cond)


### PR DESCRIPTION
changelog: Fix an issue that allowed bypassing Resource Access Requests' AllowedResourceIDs when creating app sessions.

OSS port of https://github.com/gravitational/teleport-private/pull/2409.
