### PR TITLE
[v18] Fix UpsertAccessListWithMembers and validate member.spec.access…

### DIFF
--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -131,7 +131,7 @@ func ValidateAccessListMember(
 	member *accesslist.AccessListMember,
 	g AccessListAndMembersGetter,
 ) error {
-	if err := validateAccessListMemberBasic(member); err != nil {
+	if err := validateAccessListMemberBasic(parentList, member); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, member.GetName(), RelationshipKindMember, member.Spec.MembershipKind, g); err != nil {
@@ -140,8 +140,9 @@ func ValidateAccessListMember(
 	return nil
 }
 
-// validateAccessListMemberBasic performs basic fields validation for AccessListMember.
-func validateAccessListMemberBasic(member *accesslist.AccessListMember) error {
+// validateAccessListMemberBasic performs basic fields validation for AccessListMember
+// and performs the cross membership integrity check.
+func validateAccessListMemberBasic(parent *accesslist.AccessList, member *accesslist.AccessListMember) error {
 	if member.Spec.AccessList == "" {
 		return trace.BadParameter("member %s: access_list field empty", member.Metadata.Name)
 	}
@@ -153,6 +154,10 @@ func validateAccessListMemberBasic(member *accesslist.AccessListMember) error {
 	}
 	if member.Spec.AddedBy == "" {
 		return trace.BadParameter("member %s: added_by field is empty", member.Metadata.Name)
+	}
+	// The member must belong to the parent access list.
+	if member.Spec.AccessList != parent.GetName() {
+		return trace.BadParameter("member %s: spec.access_list field %q doesn't match parent list name %q", member.Metadata.Name, member.Spec.AccessList, parent.GetName())
 	}
 	return nil
 }

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -815,7 +815,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 			}
 		}
 
-		if err := a.insertMembersAndUpdateNestedRelationships(ctx, slices.Collect(maps.Values(membersMap))); err != nil {
+		if err := a.insertMembersAndUpdateNestedRelationships(ctx, accessList.GetName(), slices.Collect(maps.Values(membersMap))); err != nil {
 			return trace.Wrap(err)
 		}
 		return nil
@@ -1159,19 +1159,19 @@ func keepAWSIdentityCenterLabels(old, new *accesslist.AccessListMember) {
 	}
 }
 
-func (a *AccessListService) insertMembersAndUpdateNestedRelationships(ctx context.Context, members []*accesslist.AccessListMember) error {
-	if err := a.insertMembers(ctx, members); err != nil {
+func (a *AccessListService) insertMembersAndUpdateNestedRelationships(ctx context.Context, accessListName string, members []*accesslist.AccessListMember) error {
+	if err := a.insertMembers(ctx, accessListName, members); err != nil {
 		return trace.Wrap(err)
 	}
 	// In case of nested access list members.
-	if err := a.updatedMembersNestedRelationships(ctx, members); err != nil {
+	if err := a.updatedMembersNestedRelationships(ctx, accessListName, members); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-func (a *AccessListService) insertMembers(ctx context.Context, members []*accesslist.AccessListMember) error {
-	items, err := a.membersToBackendItems(members)
+func (a *AccessListService) insertMembers(ctx context.Context, acl string, members []*accesslist.AccessListMember) error {
+	items, err := a.membersToBackendItems(acl, members)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1186,10 +1186,10 @@ func (a *AccessListService) insertMembers(ctx context.Context, members []*access
 	return nil
 }
 
-func (a *AccessListService) membersToBackendItems(members []*accesslist.AccessListMember) ([]backend.Item, error) {
+func (a *AccessListService) membersToBackendItems(acl string, members []*accesslist.AccessListMember) ([]backend.Item, error) {
 	out := make([]backend.Item, 0, len(members))
 	for _, member := range members {
-		item, err := a.memberService.WithPrefix(member.Spec.AccessList).MakeBackendItem(member)
+		item, err := a.memberService.WithPrefix(acl).MakeBackendItem(member)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1198,13 +1198,13 @@ func (a *AccessListService) membersToBackendItems(members []*accesslist.AccessLi
 	return out, nil
 }
 
-func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Context, members []*accesslist.AccessListMember) error {
+func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Context, acl string, members []*accesslist.AccessListMember) error {
 	for _, member := range members {
 		if member.Spec.MembershipKind != accesslist.MembershipKindList {
 			continue
 		}
 		// Update memberOf field if nested list.
-		if err := a.updateAccessListMemberOf(ctx, member.Spec.AccessList, member.Spec.Name, true); err != nil {
+		if err := a.updateAccessListMemberOf(ctx, acl, member.Spec.Name, true); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -2933,6 +2933,71 @@ func TestAccessListDeletePrevention_MissingReferences(t *testing.T) {
 	)
 }
 
+// TestAccessListUpsertUpdateWithMembersValidation tests that Upsert/UpdateAccessListWithMembers validates that
+// all members in the list reference the correct AccessList.
+// This prevents cross-references between access lists, allowing validation to detect and reject
+// incorrectly linked members to another access list in the upsert request.
+func TestAccessListUpsertUpdateWithMembersValidation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+	mainAcl := createAccessList(t, service, "test-acl-"+uuid.NewString(), clock)
+	otherAcl := createAccessList(t, service, "test-acl-"+uuid.NewString(), clock)
+
+	t.Run("empty member access list name", func(t *testing.T) {
+		m := newAccessListMember(t, mainAcl.GetName(), "alice")
+		m.Spec.AccessList = ""
+		_, _, err = service.UpsertAccessListWithMembers(ctx, mainAcl, []*accesslist.AccessListMember{m})
+		require.True(t, trace.IsBadParameter(err))
+
+		_, _, err = service.UpdateAccessListAndOverwriteMembers(ctx, mainAcl, []*accesslist.AccessListMember{m})
+		require.True(t, trace.IsBadParameter(err))
+
+	})
+
+	t.Run("wrong m.Spec.AccessList ref should be rejected", func(t *testing.T) {
+		m := newAccessListMember(t, mainAcl.GetName(), "alice")
+		m.Spec.AccessList = otherAcl.GetName()
+		// The call is trying to changes in Main ACL, but the member is referencing other ACL, this should be
+		// validated and rejected, otherwise it can lead to cross-references vulnerability.
+		_, _, err = service.UpsertAccessListWithMembers(ctx, mainAcl, []*accesslist.AccessListMember{m})
+		require.True(t, trace.IsBadParameter(err))
+
+		_, _, err = service.UpdateAccessListAndOverwriteMembers(ctx, mainAcl, []*accesslist.AccessListMember{m})
+		require.True(t, trace.IsBadParameter(err))
+	})
+
+	t.Run("correct m.Spec.AccessList ref should succeed", func(t *testing.T) {
+		m := newAccessListMember(t, mainAcl.GetName(), "alice")
+		m.Spec.AccessList = mainAcl.GetName()
+		// the member correctly references the parent ACL, so the upsert call should succeed.
+		_, _, err = service.UpsertAccessListWithMembers(ctx, mainAcl, []*accesslist.AccessListMember{m})
+		require.NoError(t, err)
+	})
+
+	t.Run("mix of valid correct and incorrect references should be rejected", func(t *testing.T) {
+		m1 := newAccessListMember(t, mainAcl.GetName(), "alice")
+		m2 := newAccessListMember(t, mainAcl.GetName(), "bob")
+		m3 := newAccessListMember(t, mainAcl.GetName(), "charlie")
+
+		m2.Spec.AccessList = otherAcl.GetName()
+		// This call attempts to upsert/update three members to the main ACL, but m2 (bob) references otherAcl. Reject the entire request.
+		_, _, err = service.UpsertAccessListWithMembers(ctx, mainAcl, []*accesslist.AccessListMember{m1, m2, m3})
+		require.True(t, trace.IsBadParameter(err))
+
+		_, _, err = service.UpdateAccessListAndOverwriteMembers(ctx, mainAcl, []*accesslist.AccessListMember{m1, m2, m3})
+		require.True(t, trace.IsBadParameter(err))
+	})
+}
+
 func addListOwner(accessList, owner *accesslist.AccessList) {
 	accessList.Spec.Owners = append(accessList.Spec.Owners, accesslist.Owner{
 		Name:           owner.GetName(),


### PR DESCRIPTION
### What

Backport https://github.com/gravitational/teleport-private/pull/2370 




<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
This bug can't be performed via manual UI flow. The bug is related to gRPC api that are not used by tctl, terraform, tsh where FE flow is not affected.

### Test Cases
- [x] The testing was performed by e E2E test coverage: https://github.com/gravitational/teleport.e/pull/8093 and manually with debugger tracking the code flow.

changelog: Fix Cross-access-list member injection in raw gRPC UpsertAccessListWithMembers call due to missing member.Spec.AccessList field validation.
