### PR TITLE
[v18] Fix a bug where .Values and .Values.auth were not merged properly

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/_config.aws.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.aws.tpl
@@ -3,58 +3,60 @@
 {{- end -}}
 
 {{- define "teleport-cluster.auth.config.aws.overrides" -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 teleport:
   storage:
     type: dynamodb
-    region: {{ required "aws.region is required in chart values" .Values.aws.region }}
-    table_name: {{ required "aws.backendTable is required in chart values" .Values.aws.backendTable }}
+    region: {{ required "aws.region is required in chart values" $auth.aws.region }}
+    table_name: {{ required "aws.backendTable is required in chart values" $auth.aws.backendTable }}
     audit_events_uri: {{- include "teleport-cluster.auth.config.aws.audit" . | nindent 4 }}
-    audit_sessions_uri: s3://{{ required "aws.sessionRecordingBucket is required in chart values" .Values.aws.sessionRecordingBucket }}
-    continuous_backups: {{ required "aws.backups is required in chart values" .Values.aws.backups }}
-  {{- if .Values.aws.dynamoAutoScaling }}
+    audit_sessions_uri: s3://{{ required "aws.sessionRecordingBucket is required in chart values" $auth.aws.sessionRecordingBucket }}
+    continuous_backups: {{ required "aws.backups is required in chart values" $auth.aws.backups }}
+  {{- if $auth.aws.dynamoAutoScaling }}
     auto_scaling: true
     billing_mode: provisioned
-    read_min_capacity: {{ required "aws.readMinCapacity is required when aws.dynamoAutoScaling is true" .Values.aws.readMinCapacity }}
-    read_max_capacity: {{ required "aws.readMaxCapacity is required when aws.dynamoAutoScaling is true" .Values.aws.readMaxCapacity }}
-    read_target_value: {{ required "aws.readTargetValue is required when aws.dynamoAutoScaling is true" .Values.aws.readTargetValue }}
-    write_min_capacity: {{ required "aws.writeMinCapacity is required when aws.dynamoAutoScaling is true" .Values.aws.writeMinCapacity }}
-    write_max_capacity: {{ required "aws.writeMaxCapacity is required when aws.dynamoAutoScaling is true" .Values.aws.writeMaxCapacity }}
-    write_target_value: {{ required "aws.writeTargetValue is required when aws.dynamoAutoScaling is true" .Values.aws.writeTargetValue }}
+    read_min_capacity: {{ required "aws.readMinCapacity is required when aws.dynamoAutoScaling is true" $auth.aws.readMinCapacity }}
+    read_max_capacity: {{ required "aws.readMaxCapacity is required when aws.dynamoAutoScaling is true" $auth.aws.readMaxCapacity }}
+    read_target_value: {{ required "aws.readTargetValue is required when aws.dynamoAutoScaling is true" $auth.aws.readTargetValue }}
+    write_min_capacity: {{ required "aws.writeMinCapacity is required when aws.dynamoAutoScaling is true" $auth.aws.writeMinCapacity }}
+    write_max_capacity: {{ required "aws.writeMaxCapacity is required when aws.dynamoAutoScaling is true" $auth.aws.writeMaxCapacity }}
+    write_target_value: {{ required "aws.writeTargetValue is required when aws.dynamoAutoScaling is true" $auth.aws.writeTargetValue }}
   {{- else }}
     auto_scaling: false
   {{- end }}
-  {{- if .Values.aws.accessMonitoring.enabled }}
-    {{- if not .Values.aws.athenaURL }}
+  {{- if $auth.aws.accessMonitoring.enabled }}
+    {{- if not $auth.aws.athenaURL }}
       {{- fail "AccessMonitoring requires an Athena Event backend" }}
     {{- end }}
 auth_service:
   access_monitoring:
     enabled: true
-    report_results: {{ .Values.aws.accessMonitoring.reportResults | quote }}
-    role_arn: {{ .Values.aws.accessMonitoring.roleARN | quote }}
-    workgroup: {{ .Values.aws.accessMonitoring.workgroup | quote }}
+    report_results: {{ $auth.aws.accessMonitoring.reportResults | quote }}
+    role_arn: {{ $auth.aws.accessMonitoring.roleARN | quote }}
+    workgroup: {{ $auth.aws.accessMonitoring.workgroup | quote }}
   {{- end }}
 {{- end -}}
 
 {{- define "teleport-cluster.auth.config.aws.audit" -}}
-  {{- if and .Values.aws.auditLogTable (not .Values.aws.athenaURL) -}}
-- 'dynamodb://{{.Values.aws.auditLogTable}}'
-  {{- else if and (not .Values.aws.auditLogTable) .Values.aws.athenaURL -}}
-- {{ .Values.aws.athenaURL | quote }}
-  {{- else if and .Values.aws.auditLogTable .Values.aws.athenaURL -}}
-    {{- if eq .Values.aws.auditLogPrimaryBackend "dynamo" -}}
-- 'dynamodb://{{.Values.aws.auditLogTable}}'
-- {{ .Values.aws.athenaURL | quote }}
-    {{- else if eq .Values.aws.auditLogPrimaryBackend "athena" -}}
-- {{ .Values.aws.athenaURL | quote }}
-- 'dynamodb://{{.Values.aws.auditLogTable}}'
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
+  {{- if and $auth.aws.auditLogTable (not $auth.aws.athenaURL) -}}
+- 'dynamodb://{{$auth.aws.auditLogTable}}'
+  {{- else if and (not $auth.aws.auditLogTable) $auth.aws.athenaURL -}}
+- {{ $auth.aws.athenaURL | quote }}
+  {{- else if and $auth.aws.auditLogTable $auth.aws.athenaURL -}}
+    {{- if eq $auth.aws.auditLogPrimaryBackend "dynamo" -}}
+- 'dynamodb://{{$auth.aws.auditLogTable}}'
+- {{ $auth.aws.athenaURL | quote }}
+    {{- else if eq $auth.aws.auditLogPrimaryBackend "athena" -}}
+- {{ $auth.aws.athenaURL | quote }}
+- 'dynamodb://{{$auth.aws.auditLogTable}}'
     {{- else -}}
       {{- fail "Both Dynamo and Athena audit backends are enabled. You must specify the primary backend by setting `aws.auditLogPrimaryBackend` to either 'dynamo' or 'athena'." -}}
     {{- end -}}
   {{- else -}}
     {{- fail "You need an audit backend. In AWS mode, you must set at least one of `aws.auditLogTable` (Dynamo) and `aws.athenaURL` (Athena)." -}}
   {{- end -}}
-  {{- if .Values.aws.auditLogMirrorOnStdout }}
+  {{- if $auth.aws.auditLogMirrorOnStdout }}
 - 'stdout://'
   {{- end -}}
 {{- end -}}

--- a/examples/chart/teleport-cluster/templates/auth/_config.azure.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.azure.tpl
@@ -1,38 +1,40 @@
 {{/* Helper to build the database connection string, adds paraneters if needed */}}
 {{- define "teleport-cluster.auth.config.azure.conn_string.query" }}
-  {{- if .Values.azure.databasePoolMaxConnections -}}
-    {{- printf "sslmode=verify-full&pool_max_conns=%v" .Values.azure.databasePoolMaxConnections -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
+  {{- if $auth.azure.databasePoolMaxConnections -}}
+    {{- printf "sslmode=verify-full&pool_max_conns=%v" $auth.azure.databasePoolMaxConnections -}}
   {{- else -}}
     sslmode=verify-full
   {{- end -}}
 {{- end -}}
 
 {{- define "teleport-cluster.auth.config.azure" -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{ include "teleport-cluster.auth.config.common" . }}
   storage:
     type: postgresql
     auth_mode: azure
     conn_string: {{ urlJoin (dict
       "scheme" "postgresql"
-      "userinfo" .Values.azure.databaseUser
-      "host" .Values.azure.databaseHost
-      "path" .Values.azure.backendDatabase
+      "userinfo" $auth.azure.databaseUser
+      "host" $auth.azure.databaseHost
+      "path" $auth.azure.backendDatabase
       "query" (include "teleport-cluster.auth.config.azure.conn_string.query" .)
     ) | toYaml }}
     audit_sessions_uri: {{ urlJoin (dict
       "scheme" "azblob"
-      "host" .Values.azure.sessionRecordingStorageAccount
+      "host" $auth.azure.sessionRecordingStorageAccount
     ) | toYaml }}
     audit_events_uri:
       - {{ urlJoin (dict
           "scheme" "postgresql"
-          "userinfo" .Values.azure.databaseUser
-          "host" .Values.azure.databaseHost
-          "path" .Values.azure.auditLogDatabase
+          "userinfo" $auth.azure.databaseUser
+          "host" $auth.azure.databaseHost
+          "path" $auth.azure.auditLogDatabase
           "query" "sslmode=verify-full"
           "fragment" "auth_mode=azure"
         ) | toYaml }}
-{{- if .Values.azure.auditLogMirrorOnStdout }}
+{{- if $auth.azure.auditLogMirrorOnStdout }}
       - "stdout://"
 {{- end }}
 {{- end -}}

--- a/examples/chart/teleport-cluster/templates/auth/_config.gcp.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.gcp.tpl
@@ -1,16 +1,17 @@
 {{- define "teleport-cluster.auth.config.gcp" -}}
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{ include "teleport-cluster.auth.config.common" . }}
   storage:
     type: firestore
-    project_id: {{ required "gcp.projectId is required in chart values" .Values.gcp.projectId }}
-    collection_name: {{ required "gcp.backendTable is required in chart values" .Values.gcp.backendTable }}
-    {{- if .Values.gcp.credentialSecretName }}
+    project_id: {{ required "gcp.projectId is required in chart values" $auth.gcp.projectId }}
+    collection_name: {{ required "gcp.backendTable is required in chart values" $auth.gcp.backendTable }}
+    {{- if $auth.gcp.credentialSecretName }}
     credentials_path: /etc/teleport-secrets/gcp-credentials.json
     {{- end }}
-    {{- if .Values.gcp.auditLogMirrorOnStdout }}
-    audit_events_uri: ['firestore://{{ required "gcp.auditLogTable is required in chart values" .Values.gcp.auditLogTable }}?projectID={{ required "gcp.projectId is required in chart values" .Values.gcp.projectId }}{{ empty .Values.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}', 'stdout://']
+    {{- if $auth.gcp.auditLogMirrorOnStdout }}
+    audit_events_uri: ['firestore://{{ required "gcp.auditLogTable is required in chart values" $auth.gcp.auditLogTable }}?projectID={{ required "gcp.projectId is required in chart values" $auth.gcp.projectId }}{{ empty $auth.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}', 'stdout://']
     {{- else }}
-    audit_events_uri: ['firestore://{{ required "gcp.auditLogTable is required in chart values" .Values.gcp.auditLogTable }}?projectID={{ required "gcp.projectId is required in chart values" .Values.gcp.projectId }}{{ empty .Values.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}']
+    audit_events_uri: ['firestore://{{ required "gcp.auditLogTable is required in chart values" $auth.gcp.auditLogTable }}?projectID={{ required "gcp.projectId is required in chart values" $auth.gcp.projectId }}{{ empty $auth.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}']
     {{- end }}
-    audit_sessions_uri: "gs://{{ required "gcp.sessionRecordingBucket is required in chart values" .Values.gcp.sessionRecordingBucket }}?projectID={{ required "gcp.projectId is required in chart values" .Values.gcp.projectId }}{{ empty .Values.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}"
+    audit_sessions_uri: "gs://{{ required "gcp.sessionRecordingBucket is required in chart values" $auth.gcp.sessionRecordingBucket }}?projectID={{ required "gcp.projectId is required in chart values" $auth.gcp.projectId }}{{ empty $auth.gcp.credentialSecretName | ternary "" "&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"}}"
 {{- end -}}

--- a/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
@@ -59,21 +59,21 @@ spec:
         args:
           - "--test"
           - "/etc/teleport/teleport.yaml"
-{{- if .Values.securityContext }}
-        securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+{{- if $auth.securityContext }}
+        securityContext: {{- toYaml $auth.securityContext | nindent 10 }}
 {{- end }}
         volumeMounts:
-{{- if .Values.enterprise }}
+{{- if $auth.enterprise }}
         - mountPath: /var/lib/license
           name: "license"
           readOnly: true
 {{- end }}
-{{- if and (.Values.gcp.credentialSecretName) (eq .Values.chartMode "gcp") }}
+{{- if and ($auth.gcp.credentialSecretName) (eq $auth.chartMode "gcp") }}
         - mountPath: /etc/teleport-secrets
           name: "gcp-credentials"
           readOnly: true
 {{- end }}
-{{- if .Values.tls.existingCASecretName }}
+{{- if $auth.tls.existingCASecretName }}
         - mountPath: /etc/teleport-tls-ca
           name: "teleport-tls-ca"
           readOnly: true
@@ -83,32 +83,32 @@ spec:
           readOnly: true
         - mountPath: /var/lib/teleport
           name: "data"
-{{- if .Values.extraVolumeMounts }}
-  {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
+{{- if $auth.extraVolumeMounts }}
+  {{- toYaml $auth.extraVolumeMounts | nindent 8 }}
 {{- end }}
       volumes:
-{{- if .Values.enterprise }}
+{{- if $auth.enterprise }}
       - name: license
         secret:
-          secretName: {{ .Values.licenseSecretName | quote }}
+          secretName: {{ $auth.licenseSecretName | quote }}
 {{- end }}
-{{- if and (.Values.gcp.credentialSecretName) (eq .Values.chartMode "gcp") }}
+{{- if and ($auth.gcp.credentialSecretName) (eq $auth.chartMode "gcp") }}
       - name: gcp-credentials
         secret:
-          secretName: {{ .Values.gcp.credentialSecretName | quote }}
+          secretName: {{ $auth.gcp.credentialSecretName | quote }}
 {{- end }}
-{{- if .Values.tls.existingCASecretName }}
+{{- if $auth.tls.existingCASecretName }}
       - name: teleport-tls-ca
         secret:
-          secretName: {{ .Values.tls.existingCASecretName }}
+          secretName: {{ $auth.tls.existingCASecretName }}
 {{- end }}
       - name: "config"
         configMap:
           name: {{ .Release.Name }}-auth-test
       - name: "data"
         emptyDir: {}
-{{- if .Values.extraVolumes }}
-  {{- toYaml .Values.extraVolumes | nindent 6 }}
+{{- if $auth.extraVolumes }}
+  {{- toYaml $auth.extraVolumes | nindent 6 }}
 {{- end }}
       serviceAccountName: {{ include "teleport-cluster.auth.hookServiceAccountName" . }}
 {{- end }}

--- a/examples/chart/teleport-cluster/templates/proxy/_config.common.tpl
+++ b/examples/chart/teleport-cluster/templates/proxy/_config.common.tpl
@@ -1,5 +1,6 @@
 {{- define "teleport-cluster.proxy.config.common" -}}
-{{- $logLevel := (coalesce .Values.logLevel .Values.log.level "INFO") -}}
+{{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
+{{- $logLevel := (coalesce $proxy.logLevel $proxy.log.level "INFO") -}}
 version: v3
 teleport:
   join_params:
@@ -8,72 +9,72 @@ teleport:
   auth_server: "{{ include "teleport-cluster.auth.serviceFQDN" . }}:3025"
   log:
     severity: {{ $logLevel }}
-    output: {{ .Values.log.output }}
+    output: {{ $proxy.log.output }}
     format:
-      output: {{ .Values.log.format }}
-      extra_fields: {{ .Values.log.extraFields | toJson }}
+      output: {{ $proxy.log.format }}
+      extra_fields: {{ $proxy.log.extraFields | toJson }}
 ssh_service:
   enabled: false
 auth_service:
   enabled: false
 proxy_service:
   enabled: true
-{{- if .Values.publicAddr }}
-  public_addr: {{- toYaml .Values.publicAddr | nindent 8 }}
+{{- if $proxy.publicAddr }}
+  public_addr: {{- toYaml $proxy.publicAddr | nindent 8 }}
 {{- else }}
-  public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
+  public_addr: '{{ required "clusterName is required in chart values" $proxy.clusterName }}:443'
 {{- end }}
-{{- if ne .Values.proxyListenerMode "multiplex" }}
+{{- if ne $proxy.proxyListenerMode "multiplex" }}
   listen_addr: 0.0.0.0:3023
-  {{- if .Values.sshPublicAddr }}
-  ssh_public_addr: {{- toYaml .Values.sshPublicAddr | nindent 8 }}
+  {{- if $proxy.sshPublicAddr }}
+  ssh_public_addr: {{- toYaml $proxy.sshPublicAddr | nindent 8 }}
   {{- end }}
   tunnel_listen_addr: 0.0.0.0:3024
-  {{- if .Values.tunnelPublicAddr }}
-  tunnel_public_addr: {{- toYaml .Values.tunnelPublicAddr | nindent 8 }}
+  {{- if $proxy.tunnelPublicAddr }}
+  tunnel_public_addr: {{- toYaml $proxy.tunnelPublicAddr | nindent 8 }}
   {{- end }}
   kube_listen_addr: 0.0.0.0:3026
-  {{- if .Values.kubePublicAddr }}
-  kube_public_addr: {{- toYaml .Values.kubePublicAddr | nindent 8 }}
+  {{- if $proxy.kubePublicAddr }}
+  kube_public_addr: {{- toYaml $proxy.kubePublicAddr | nindent 8 }}
   {{- end }}
   mysql_listen_addr: 0.0.0.0:3036
-  {{- if .Values.mysqlPublicAddr }}
-  mysql_public_addr: {{- toYaml .Values.mysqlPublicAddr | nindent 8 }}
+  {{- if $proxy.mysqlPublicAddr }}
+  mysql_public_addr: {{- toYaml $proxy.mysqlPublicAddr | nindent 8 }}
   {{- end }}
-  {{- if .Values.separatePostgresListener }}
+  {{- if $proxy.separatePostgresListener }}
   postgres_listen_addr: 0.0.0.0:5432
-    {{- if .Values.postgresPublicAddr }}
-  postgres_public_addr: {{- toYaml .Values.postgresPublicAddr | nindent 8 }}
+    {{- if $proxy.postgresPublicAddr }}
+  postgres_public_addr: {{- toYaml $proxy.postgresPublicAddr | nindent 8 }}
     {{- else }}
-  postgres_public_addr: {{ .Values.clusterName }}:5432
+  postgres_public_addr: {{ $proxy.clusterName }}:5432
     {{- end }}
   {{- end }}
-  {{- if .Values.separateMongoListener }}
+  {{- if $proxy.separateMongoListener }}
   mongo_listen_addr: 0.0.0.0:27017
-    {{- if .Values.mongoPublicAddr }}
-  mongo_public_addr: {{- toYaml .Values.mongoPublicAddr | nindent 8 }}
+    {{- if $proxy.mongoPublicAddr }}
+  mongo_public_addr: {{- toYaml $proxy.mongoPublicAddr | nindent 8 }}
     {{- else }}
-  mongo_public_addr: {{ .Values.clusterName }}:27017
+  mongo_public_addr: {{ $proxy.clusterName }}:27017
     {{- end }}
   {{- end }}
 {{- end }}
-{{- if or .Values.highAvailability.certManager.enabled .Values.tls.existingSecretName }}
+{{- if or $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName }}
   https_keypairs:
   - key_file: /etc/teleport-tls/tls.key
     cert_file: /etc/teleport-tls/tls.crt
   https_keypairs_reload_interval: 12h
-{{- else if .Values.acme }}
+{{- else if $proxy.acme }}
   acme:
-    enabled: {{ .Values.acme }}
-    email: {{ required "acmeEmail is required in chart values" .Values.acmeEmail }}
-  {{- if .Values.acmeURI }}
-    uri: {{ .Values.acmeURI }}
+    enabled: {{ $proxy.acme }}
+    email: {{ required "acmeEmail is required in chart values" $proxy.acmeEmail }}
+  {{- if $proxy.acmeURI }}
+    uri: {{ $proxy.acmeURI }}
   {{- end }}
 {{- end }}
-{{- if .Values.proxyProtocol }}
-  proxy_protocol: {{ .Values.proxyProtocol | quote }}
+{{- if $proxy.proxyProtocol }}
+  proxy_protocol: {{ $proxy.proxyProtocol | quote }}
 {{- end }}
-{{- if and .Values.ingress.enabled (semverCompare ">= 14.0.0-0" (include "teleport-cluster.version" .)) }}
+{{- if and $proxy.ingress.enabled (semverCompare ">= 14.0.0-0" (include "teleport-cluster.version" .)) }}
   trust_x_forwarded_for: true
 {{- end }}
 {{- end -}}

--- a/examples/chart/teleport-cluster/templates/proxy/certificate.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/certificate.yaml
@@ -4,9 +4,9 @@
   {{- $domainList := list (required "clusterName is required in chartValues when certManager is enabled" $proxy.clusterName) -}}
   {{- $domainList := append $domainList (printf "*.%s" (required "clusterName is required in chartValues when certManager is enabled" $proxy.clusterName)) -}}
   {{- /* If the config option is enabled and at least one publicAddr is set, append all public addresses to the list of dnsNames */ -}}
-  {{- if and $proxy.highAvailability.certManager.addPublicAddrs (gt (len .Values.publicAddr) 0) -}}
+  {{- if and $proxy.highAvailability.certManager.addPublicAddrs (gt (len $proxy.publicAddr) 0) -}}
     {{- /* Trim ports from all public addresses if present */ -}}
-    {{- range .Values.publicAddr -}}
+    {{- range $proxy.publicAddr -}}
       {{- $address := . -}}
       {{- if (contains ":" $address) -}}
         {{- $split := split ":" $address -}}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/56869 to `branch/v18`

Changelog: Fix a bug in the `teleport-cluster` chart causing some `auth.*` values to not be used when rendering hooks or config manifests.

## Manual Test Plan
### Test Environment

- GKE cluster

### Test Cases
- [x] Example values from docs still deploy
- [x] Auth and proxy can have different log levels
