### PR TITLE
Fix example README.md links to current docs

### DIFF
--- a/examples/access-plugin-minimal/README.md
+++ b/examples/access-plugin-minimal/README.md
@@ -2,4 +2,4 @@
 
 This is a minimal working example of an Access Request plugin. To use it, follow
 the setup steps we describe in the [Teleport
-documentation](http://goteleport.com/docs/api/access-plugin/).
+documentation](https://goteleport.com/docs/identity-governance/access-requests/plugins/how-to-build/).

--- a/examples/api-sync-roles/README.md
+++ b/examples/api-sync-roles/README.md
@@ -3,4 +3,4 @@
 This is a minimal working example of a Teleport API client that generates
 Teleport roles based on an external RBAC system, in this case, a Kubernetes
 cluster. To use it, follow the setup steps in the [Teleport
-documentation](https://goteleport.com/docs/api/rbac).
+documentation](https://goteleport.com/docs/zero-trust-access/api/rbac/).

--- a/examples/aws/terraform/README.md
+++ b/examples/aws/terraform/README.md
@@ -12,7 +12,7 @@ If you are planning on using our Terraform example in production, please referen
 We recommend familiarizing yourself with the following resources prior to reviewing our Terraform examples:
 
 - [Teleport Architecture](https://goteleport.com/docs/reference/architecture/)
-- [Admin Guide](https://goteleport.com/docs/admin-guides/management/admin/)
+- [Admin Guide](https://goteleport.com/docs/zero-trust-access/management/)
 
 In order to spin up AWS resources using these Terraform examples, you need the following software:
 
@@ -39,4 +39,4 @@ Please [see the AMIS.md file](AMIS.md) for a list of public Teleport AMI IDs tha
 
 ## This is not the Teleport Terraform Provider
 
-If you are looking for Teleport's [Terraform Provider](https://goteleport.com/docs/reference/terraform-provider/) which can be used to provision users, roles, auth connectors and other resources inside an existing Teleport cluster, its source code can be found here: https://github.com/gravitational/teleport/tree/master/integrations/terraform
+If you are looking for Teleport's [Terraform Provider](https://goteleport.com/docs/reference/infrastructure-as-code/terraform-provider/) which can be used to provision users, roles, auth connectors and other resources inside an existing Teleport cluster, its source code can be found here: https://github.com/gravitational/teleport/tree/master/integrations/terraform

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -21,8 +21,8 @@ the ports to the other parts.
 We recommend familiarizing yourself with the following resources prior to reviewing our Terraform examples:
 
 - [Teleport Architecture](https://goteleport.com/docs/reference/architecture/)
-- [Admin Guide](https://goteleport.com/docs/admin-guides/management/admin/)
-- [Running Teleport Enterprise in High Availability mode on AWS](https://goteleport.com/docs/admin-guides/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform/)
+- [Admin Guide](https://goteleport.com/docs/zero-trust-access/management/)
+- [Running Teleport Enterprise in High Availability mode on AWS](https://goteleport.com/docs/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform/)
 
 In order to spin up AWS resources using these Terraform examples, you need the following software:
 
@@ -73,7 +73,7 @@ export TF_VAR_key_name="example"
 export TF_VAR_use_acm="false"
 
 # (optional) Set to true to use TLS routing to multiplex all Teleport traffic over one port
-# See https://goteleport.com/docs/architecture/tls-routing for more information
+# See https://goteleport.com/docs/reference/architecture/tls-routing/ for more information
 # Setting this will disable ALL separate listener ports. If you also use ACM, then:
 # - you must use Teleport and tsh v13+
 # - you must use `tsh proxy` commands for Kubernetes/database access

--- a/examples/aws/terraform/starter-cluster/README.md
+++ b/examples/aws/terraform/starter-cluster/README.md
@@ -6,7 +6,7 @@ Do not use this in production! This example should be used for demo, proof-of-co
 
 ## How does this work?
 
-Teleport AMIs are built so you only need to specify environment variables to bring a fully configured instance online. See `data.tpl` or our [documentation](https://goteleport.com/docs/admin-guides/deploy-a-cluster/deployments/aws-starter-cluster-terraform/#set-up-variables) to learn more about supported environment variables.
+Teleport AMIs are built so you only need to specify environment variables to bring a fully configured instance online. See `data.tpl` or our [documentation](https://goteleport.com/docs/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform/#set-up-variables) to learn more about supported environment variables.
 
 A series of systemd [units](https://github.com/gravitational/teleport/tree/master/assets/aws/files/system) bootstrap the instance, via several bash [scripts](https://github.com/gravitational/teleport/tree/master/assets/aws/files/bin).
 
@@ -29,7 +29,7 @@ It can optionally also configure the following AWS resources:
 
 ### Accompanying documentation
 
-- [Teleport Single-Instance Deployment on AWS](https://goteleport.com/docs/admin-guides/deploy-a-cluster/deployments/aws-starter-cluster-terraform/)
+- [Teleport Single-Instance Deployment on AWS](https://goteleport.com/docs/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform/)
 
 ### Build Requirements
 
@@ -144,14 +144,14 @@ export TF_VAR_use_letsencrypt="true"
 export TF_VAR_use_acm="false"
 
 # Set to true to use TLS routing to multiplex all Teleport traffic over one port
-# See https://goteleport.com/docs/architecture/tls-routing for more information
+# See https://goteleport.com/docs/reference/architecture/tls-routing/ for more information
 # Setting this will disable ALL separate listener ports.
 # This setting is automatically set to "true" when using ACM with the starter-cluster Terraform
 # and will be ignored.
 export TF_VAR_use_tls_routing="true"
 
 # This value can be used to change the default authentication type used for the Teleport cluster.
-# See https://goteleport.com/docs/reference/authentication for more information.
+# See https://goteleport.com/docs/zero-trust-access/authentication/ for more information.
 # This is useful for persisting a different default authentication type across AMI upgrades when you have a SAML, OIDC
 # or GitHub connector configured in DynamoDB. The default is "local".
 # Teleport Community Edition supports "local" or "github"

--- a/examples/chart/access/datadog/README.md
+++ b/examples/chart/access/datadog/README.md
@@ -4,7 +4,7 @@ This chart sets up and configures a Deployment for the Access Request Datadog In
 
 ## Installation
 
-See the [Access Requests with Datadog Incident Management guide](https://goteleport.com/docs/admin-guides/access-controls/access-request-plugins/datadog-hosted/).
+See the [Access Requests with Datadog Incident Management guide](https://goteleport.com/docs/identity-governance/access-requests/plugins/datadog-hosted/).
 
 ## Values
 

--- a/examples/chart/access/discord/README.md
+++ b/examples/chart/access/discord/README.md
@@ -4,7 +4,7 @@ This chart sets up and configures a Deployment for the Access Request Discord pl
 
 ## Installation
 
-See the [Access Requests with Discord guide](https://goteleport.com/docs/admin-guides/access-controls/access-request-plugins/ssh-approval-discord/)
+See the [Access Requests with Discord guide](https://goteleport.com/docs/identity-governance/access-requests/plugins/discord/)
 which covers how to create the Discord bot and how to deploy the access plugin.
 
 ## Values

--- a/examples/chart/access/email/README.md
+++ b/examples/chart/access/email/README.md
@@ -4,7 +4,7 @@ This chart sets up and configures a Deployment for the Access Request Email plug
 
 ## Installation
 
-See the [Access Requests with Email guide](https://goteleport.com/docs/admin-guides/access-controls/access-request-plugins/ssh-approval-email/).
+See the [Access Requests with Email guide](https://goteleport.com/docs/identity-governance/access-requests/plugins/email/).
 
 ## Values
 

--- a/examples/chart/access/jira/README.md
+++ b/examples/chart/access/jira/README.md
@@ -4,7 +4,7 @@ This chart sets up and configures a Deployment for the Access Request Jira plugi
 
 ## Installation
 
-See the [Access Requests with JIRA guide](https://goteleport.com/docs/access-controls/access-request-plugins/ssh-approval-jira/).
+See the [Access Requests with JIRA guide](https://goteleport.com/docs/identity-governance/access-requests/plugins/jira/).
 
 ## Values
 

--- a/examples/chart/access/mattermost/README.md
+++ b/examples/chart/access/mattermost/README.md
@@ -4,7 +4,7 @@ This chart sets up and configures a Deployment for the Access Request Mattermost
 
 ## Installation
 
-See the [Access Requests with Mattermost guide](https://goteleport.com/docs/access-controls/access-request-plugins/ssh-approval-mattermost/).
+See the [Access Requests with Mattermost guide](https://goteleport.com/docs/identity-governance/access-requests/plugins/mattermost/).
 
 ## Values
 

--- a/examples/chart/access/msteams/README.md
+++ b/examples/chart/access/msteams/README.md
@@ -4,7 +4,7 @@ This chart sets up and configures a Deployment for the Access Request MsTeams pl
 
 ## Installation
 
-See the [Access Requests with Microsoft Teams guide](https://goteleport.com/docs/access-controls/access-request-plugins/ssh-approval-msteams/).
+See the [Access Requests with Microsoft Teams guide](https://goteleport.com/docs/identity-governance/access-requests/plugins/msteams/).
 
 ## Values
 

--- a/examples/chart/access/pagerduty/README.md
+++ b/examples/chart/access/pagerduty/README.md
@@ -4,7 +4,7 @@ This chart sets up and configures a Deployment for the Access Request PagerDuty 
 
 ## Installation
 
-See the [Access Requests with PagerDuty guide](https://goteleport.com/docs/access-controls/access-request-plugins/ssh-approval-pagerduty/).
+See the [Access Requests with PagerDuty guide](https://goteleport.com/docs/identity-governance/access-requests/plugins/pagerduty/).
 
 ## Values
 

--- a/examples/chart/access/slack/README.md
+++ b/examples/chart/access/slack/README.md
@@ -4,7 +4,7 @@ This chart sets up and configures a Deployment for the Access Request Slack plug
 
 ## Installation
 
-See the [Access Requests with Slack guide](https://goteleport.com/docs/access-controls/access-request-plugins/ssh-approval-slack/).
+See the [Access Requests with Slack guide](https://goteleport.com/docs/identity-governance/access-requests/plugins/slack/).
 
 ## Values
 

--- a/examples/chart/event-handler/README.md
+++ b/examples/chart/event-handler/README.md
@@ -4,7 +4,7 @@ This chart sets up and configures a Deployment for the Event Handler plugin.
 
 ## Installation
 
-See the [Export Events with FluentD Guide](https://goteleport.com/docs/management/export-audit-events/fluentd/).
+See the [Export Events with FluentD Guide](https://goteleport.com/docs/zero-trust-access/export-audit-events/fluentd/).
 
 ## Values
 

--- a/examples/chart/tbot/README.md
+++ b/examples/chart/tbot/README.md
@@ -8,7 +8,7 @@ To use it, you will need to know:
 - The address of your Teleport Proxy Service or Auth Service
 - The name of your Teleport cluster
 - The name of a join token configured for Machine ID and your Kubernetes cluster
-  (https://goteleport.com/docs/enroll-resources/machine-id/deployment/kubernetes/)
+  (https://goteleport.com/docs/machine-workload-identity/deployment/kubernetes/)
 
 By default, this chart is designed to use the `kubernetes` join method but it
 can be customised to use any delegated join method. We do not recommend that

--- a/examples/chart/teleport-cluster/README.md
+++ b/examples/chart/teleport-cluster/README.md
@@ -8,7 +8,7 @@ provide high-availability.
 
 - The chart version follows the Teleport version. e.g. chart v10.x can run Teleport v10.x and v11.x, but is not compatible with Teleport 9.x
 - Teleport does mutual TLS to authenticate clients. Establishing mTLS through a L7
-  LoadBalancer, like a Kubernetes `Ingress` [requires ALPN support](https://goteleport.com/docs/architecture/tls-routing/#working-with-layer-7-load-balancers-or-reverse-proxies).
+  LoadBalancer, like a Kubernetes `Ingress` [requires ALPN support](https://goteleport.com/docs/reference/architecture/tls-routing/#working-with-layer-7-load-balancers-or-reverse-proxies).
   Exposing Teleport through a `Service` with type `LoadBalancer` is still recommended
   because its the most flexible and least complex setup.
 
@@ -37,10 +37,10 @@ or by installing [cert-manager](https://cert-manager.io/docs/) and setting the `
 
 ### Replicated setup guides
 
-- [Running an HA Teleport cluster in Kubernetes using an AWS EKS Cluster](https://goteleport.com/docs/admin-guides/deploy-a-cluster/helm-deployments/aws/)
-- [Running an HA Teleport cluster in Kubernetes using an Google Cloud GKE cluster](https://goteleport.com/docs/admin-guides/deploy-a-cluster/helm-deployments/gcp/)
-- [Running an HA Teleport cluster in Kubernetes using an Azure AKS cluster](https://goteleport.com/docs/admin-guides/deploy-a-cluster/helm-deployments/azure/)
-- [Running a Teleport cluster in Kubernetes with a custom Teleport config](https://goteleport.com/docs/admin-guides/deploy-a-cluster/helm-deployments/custom/)
+- [Running an HA Teleport cluster in Kubernetes using an AWS EKS Cluster](https://goteleport.com/docs/zero-trust-access/deploy-a-cluster/helm-deployments/aws/)
+- [Running an HA Teleport cluster in Kubernetes using an Google Cloud GKE cluster](https://goteleport.com/docs/zero-trust-access/deploy-a-cluster/helm-deployments/gcp/)
+- [Running an HA Teleport cluster in Kubernetes using an Azure AKS cluster](https://goteleport.com/docs/zero-trust-access/deploy-a-cluster/helm-deployments/azure/)
+- [Running a Teleport cluster in Kubernetes with a custom Teleport config](https://goteleport.com/docs/zero-trust-access/deploy-a-cluster/helm-deployments/custom/)
 
 ### Creating first user
 
@@ -60,7 +60,7 @@ helm uninstall --namespace teleport-cluster teleport-cluster
 
 ## Documentation
 
-See https://goteleport.com/docs/admin-guides/deploy-a-cluster/helm-deployments/ for guides on setting up HA Teleport clusters
+See https://goteleport.com/docs/zero-trust-access/deploy-a-cluster/helm-deployments/ for guides on setting up HA Teleport clusters
 in EKS or GKE, plus a comprehensive chart reference.
 
 ## Contributing to the chart

--- a/examples/chart/teleport-cluster/charts/teleport-operator/README.md
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/README.md
@@ -16,9 +16,9 @@ The chart can be deployed in two ways:
   ```code
   helm install teleport/teleport-operator teleport-operator --set authAddr=teleport.example.com:443 --set token=my-operator-token
   ```
-  See [the standalone guide](https://goteleport.com/docs/admin-guides/infrastructure-as-code/teleport-operator/teleport-operator-standalone/) for more details.
+  See [the standalone guide](https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-standalone/) for more details.
 - as a dependency of the `teleport-cluster` Helm chart by adding `--set operator.enabled=true`. See
-  [the operator within teleport-cluster chart guide](https://goteleport.com/docs/admin-guides/infrastructure-as-code/teleport-operator/teleport-operator-helm/).
+  [the operator within teleport-cluster chart guide](https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-helm/).
 
 ## Values and reference
 

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -13,7 +13,7 @@ To use it, you will need:
 - a reachable proxy endpoint (`$PROXY_ENDPOINT` e.g. `teleport.example.com:3080` or `teleport.example.com:443`)
 - a reachable reverse tunnel port on the proxy (e.g. `teleport.example.com:3024`). The address is automatically
   retrieved from the Teleport proxy configuration.
-- a join token for the Teleport Cluster. For this Teleport cluster (`$JOIN_TOKEN`) is used by default. See the [Join Methods and Token Reference](https://goteleport.com/docs/reference/join-methods/) for supported join methods and creating tokens.
+- a join token for the Teleport Cluster. For this Teleport cluster (`$JOIN_TOKEN`) is used by default. See the [Join Methods and Token Reference](https://goteleport.com/docs/reference/deployment/join-methods/) for supported join methods and creating tokens.
 
 ## Combining roles
 
@@ -88,7 +88,7 @@ detailed below.
 
 ### Dynamic Registration mode
 
-To use Teleport application access in [dynamic registration mode](https://goteleport.com/docs/enroll-resources/application-access/guides/dynamic-registration/),
+To use Teleport application access in [dynamic registration mode](https://goteleport.com/docs/enroll-resources/application-access/configuration/dynamic-registration/),
 you will need to know the application resource selector. (`$APP_RESOURCE_KEY` and `$APP_RESOURCE_VALUE`)
 
 To listen for all application resources, set both variables to `*`.
@@ -251,7 +251,7 @@ for the app service, so it can expose discovered apps.
 
 ## Jamf service
 
-To use [Teleport Jamf service](https://goteleport.com/docs/access-controls/device-trust/jamf-integration/), 
+To use [Teleport Jamf service](https://goteleport.com/docs/identity-governance/device-trust/jamf-integration/), 
 you will also need:
 - provide your Jamf Pro API endpoint
 - provide your Jamf Pro API credentials

--- a/examples/go-client/README.md
+++ b/examples/go-client/README.md
@@ -40,9 +40,9 @@ $ go run main.go
 
 To see more information on the Go Client and how to use it, visit our API documentation:
 
-- [Introduction](https:/goteleport.com/docs/reference/api/introduction)
-- [Getting Started](https:/goteleport.com/docs/reference/api/getting-started)
-- [Architecture](https:/goteleport.com/docs/reference/api/architecture)
+- [Introduction](https://goteleport.com/docs/zero-trust-access/api/)
+- [Getting Started](https://goteleport.com/docs/zero-trust-access/api/getting-started/)
+- [Architecture](https://goteleport.com/docs/reference/architecture/api-architecture/)
 - [pkg.go.dev](https://pkg.go.dev/github.com/gravitational/teleport/api/client)
   - [Client type](https://pkg.go.dev/github.com/gravitational/teleport/api/client#Client)
   - [Credentials type](https://pkg.go.dev/github.com/gravitational/teleport/api/client#Credentials)

--- a/examples/service-discovery-api-client/README.md
+++ b/examples/service-discovery-api-client/README.md
@@ -3,4 +3,4 @@
 This is a minimal working example of a Teleport API client that registers agents
 in sync with a service discovery example. To use it, follow the setup steps we
 describe in the [Teleport
-documentation](https://goteleport.com/docs/admin-guides/api/automatically-register-agents/).
+documentation](https://goteleport.com/docs/zero-trust-access/api/automatically-register-agents/).

--- a/examples/systemd/machine-id/README.md
+++ b/examples/systemd/machine-id/README.md
@@ -3,7 +3,7 @@
 > **Warning**  
 > This is a rough guide for using the provided systemd file in this directory. 
 > For detailed instructions on configuring Machine ID, see
-> https://goteleport.com/docs/machine-id/introduction/
+> https://goteleport.com/docs/machine-workload-identity/introduction/
 
 Create and fill out a configuration file for Machine ID at `/etc/tbot.yaml`.
 

--- a/examples/terraform/entra-id-integration/README.md
+++ b/examples/terraform/entra-id-integration/README.md
@@ -15,7 +15,7 @@ Entra ID configuration involves:
 
   In both the cases, you will need to configure three API permissions: `Application.ReadWrite.OwnedBy, Group.Read.All, User.Read.All`.
 
-This example is best followed with the official [Teleport Entra ID integration](https://goteleport.com/docs/identity-governance/entra-id/terraform) guide. 
+This example is best followed with the official [Teleport Entra ID integration](https://goteleport.com/docs/identity-governance/integrations/entra-id/setup/terraform/) guide. 
 
 ### Set up Azure CLI
 


### PR DESCRIPTION
Updated to current docs content. Many of these links (http://goteleport.com/docs/api/access-plugin/) would go to page not found. 

## Manual Test Plan
### Test Environment

   Dev machine

### Test Cases
- [x] Confirm updated urls work and arrive at intended content 
