### PR TITLE
feat(beams): Preparation for Beams web UI

### DIFF
--- a/web/packages/teleport/src/Navigation/CategoryIcon.tsx
+++ b/web/packages/teleport/src/Navigation/CategoryIcon.tsx
@@ -61,6 +61,9 @@ export function CategoryIcon({
     case NavigationCategory.MachineWorkloadId:
       Icon = Icons.Bots;
       break;
+    case NavigationCategory.Beams:
+      Icon = Icons.Planet;
+      break;
     default:
       return null;
   }

--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -44,6 +44,7 @@ import { useUser } from 'teleport/User/UserContext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 
 import {
+  BEAMS_NAVIGATION_CATEGORIES,
   CustomNavigationSubcategory,
   NAVIGATION_CATEGORIES,
   SidenavCategory,
@@ -123,7 +124,11 @@ export type NavigationSubsection = {
 function getNavigationSections(
   features: TeleportFeature[]
 ): NavigationSection[] {
-  const navigationSections = NAVIGATION_CATEGORIES.map(category => ({
+  // Override the order for beams UI
+  const categories = cfg.beamsUi
+    ? BEAMS_NAVIGATION_CATEGORIES
+    : NAVIGATION_CATEGORIES;
+  const navigationSections = categories.map(category => ({
     category,
     subsections: getSubsectionsForCategory(category, features),
   }));

--- a/web/packages/teleport/src/Navigation/categories.ts
+++ b/web/packages/teleport/src/Navigation/categories.ts
@@ -23,6 +23,7 @@ export enum NavigationCategory {
   IdentityGovernance = 'Identity Governance',
   IdentitySecurity = 'Identity Security',
   Audit = 'Audit',
+  Beams = 'Beams',
   AddNew = 'Add New',
 }
 
@@ -44,6 +45,20 @@ export enum CustomNavigationSubcategory {
 export type SidenavCategory = NavigationCategory | CustomNavigationCategory;
 
 export const NAVIGATION_CATEGORIES = [
+  NavigationCategory.ZeroTrustAccess,
+  NavigationCategory.MachineWorkloadId,
+  NavigationCategory.IdentityGovernance,
+  NavigationCategory.IdentitySecurity,
+  NavigationCategory.Beams,
+  NavigationCategory.Audit,
+  NavigationCategory.AddNew,
+];
+
+// BEAMS_NAVIGATION_CATEGORIES is a re-ordered list of categories for the beams
+// onboarding experience. Some categories (such as MachineWorkloadId) won't
+// have features, but keeping them here for consistency.
+export const BEAMS_NAVIGATION_CATEGORIES = [
+  NavigationCategory.Beams,
   NavigationCategory.ZeroTrustAccess,
   NavigationCategory.MachineWorkloadId,
   NavigationCategory.IdentityGovernance,

--- a/web/packages/teleport/src/Navigation/categories.ts
+++ b/web/packages/teleport/src/Navigation/categories.ts
@@ -55,14 +55,8 @@ export const NAVIGATION_CATEGORIES = [
 ];
 
 // BEAMS_NAVIGATION_CATEGORIES is a re-ordered list of categories for the beams
-// onboarding experience. Some categories (such as MachineWorkloadId) won't
-// have features, but keeping them here for consistency.
-export const BEAMS_NAVIGATION_CATEGORIES = [
+// onboarding experience.
+export const BEAMS_NAVIGATION_CATEGORIES: typeof NAVIGATION_CATEGORIES = [
   NavigationCategory.Beams,
-  NavigationCategory.ZeroTrustAccess,
-  NavigationCategory.MachineWorkloadId,
-  NavigationCategory.IdentityGovernance,
-  NavigationCategory.IdentitySecurity,
-  NavigationCategory.Audit,
-  NavigationCategory.AddNew,
+  ...NAVIGATION_CATEGORIES.filter(c => c !== NavigationCategory.Beams),
 ];

--- a/web/packages/teleport/src/components/Layout/Layout.tsx
+++ b/web/packages/teleport/src/components/Layout/Layout.tsx
@@ -43,6 +43,7 @@ const FeatureHeader = styled(Flex)`
  */
 const FeatureHeaderTitle = styled(H1)`
   white-space: nowrap;
+  flex-shrink: 0;
 `;
 
 /**

--- a/web/packages/teleport/src/components/Layout/Layout.tsx
+++ b/web/packages/teleport/src/components/Layout/Layout.tsx
@@ -43,7 +43,6 @@ const FeatureHeader = styled(Flex)`
  */
 const FeatureHeaderTitle = styled(H1)`
   white-space: nowrap;
-  flex-shrink: 0;
 `;
 
 /**

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -240,6 +240,9 @@ const cfg = {
   // sessionSummarizerEnabled refers to the AI session summary feature
   sessionSummarizerEnabled: false,
 
+  // beamsUI indicates whether the Beams lite-mode UI is enabled
+  beamsUi: false,
+
   configDir: '$HOME/.config/teleport',
 
   baseUrl: window.location.origin,

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -44,6 +44,10 @@ export default class StoreUserContext extends Store<UserContext> {
     return this.state.cluster.authVersion;
   }
 
+  getClusterPublicUrl() {
+    return this.state.cluster.publicURL;
+  }
+
   getEventAccess() {
     return this.state.acl.events;
   }

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -115,6 +115,9 @@ export enum NavTitle {
 
   Support = 'Support',
   Downloads = 'Downloads',
+
+  // Beams
+  BeamsQuickstart = 'Quickstart',
 }
 
 export interface TeleportFeatureRoute {


### PR DESCRIPTION
## Summary

This change includes the OSS changes required to set up the Beams web UI (enterprise only).

Most notably, this change sets up the navigation categories for beams features. Beams will use a custom order for nav items.

Depends on: https://github.com/gravitational/teleport/pull/65083 for entitlement and beams UI mode
Related to: https://github.com/gravitational/teleport.e/pull/8378
RFD: https://github.com/gravitational/teleport.e/blob/rfd/0037e-beams-ux/rfd/0039e-beams-ux.md

## Changes

- Add `beamsUi` flag to webconfig
- Add `getClusterPublicUrl` to `UserContext` - this will be used later
- Prepare navigation for beams
- ~~Fix an issue where the standard feature title shrinks when in a flex container that has overflowed~~

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
Testing will be covered in the teleport.e changes which add the rest of the beams UI.
