### PR TITLE
Emphasize AI agents in Teleport user descriptions

### DIFF
--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -207,6 +207,12 @@ Read our [guide to Teleport roles](zero-trust-access/rbac-get-started/role-templ
 
 ### Teleport users
 
+A Teleport user is an identity, whether of an AI agent, human, or machine, that
+is registered with a Teleport cluster. The **Teleport Auth Service** verifies
+that a client or service attempting to connect has a valid Teleport-issued
+certificate. It then uses the subject of the certificate—including its username
+and Teleport roles—to authorize the user.
+
 Teleport allows for two kinds of users:
 
 - **Local users** correspond to a `user` **configuration resource** stored on
@@ -216,14 +222,16 @@ Teleport allows for two kinds of users:
   solution, Teleport issues a certificate for the user and creates a temporary
   **local user** that is valid for the lifetime of the certificate.
 
-Ultimately, a Teleport user is the subject of a certificate issued by the
-**Teleport Auth Service**. The Auth Service verifies that a client or service
-attempting to connect has a valid Teleport-issued certificate. It then uses the
-subject of the certificate—including its username and Teleport roles—to
-authorize the user.
+Only humans can authenticate as SSO users. Humans, machines and AI agents can
+authenticate as local users. Machines and AI agents join a cluster using a
+Machine and Workload Identity join token. See the [Machine & Workload Identity
+introduction](machine-workload-identity/introduction.mdx) for how Machine &
+Workload Identity works.
 
-Read more about [local users](reference/access-controls/authentication.mdx) and how [SSO
-authentication works in Teleport](zero-trust-access/sso/sso.mdx).
+Read more:
+- [Local users](reference/access-controls/authentication.mdx)
+- [How SSO authentication works in Teleport](zero-trust-access/sso/sso.mdx)
+- [Teleport user types](reference/access-controls/user-types.mdx)
 
 ### Authentication connector
 

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -16,10 +16,11 @@ capabilities.
 
 To enroll a web application with your Teleport cluster, you deploy the Teleport
 Application Service, which uses a join token to establish trust with the
-Teleport Auth Service. Users visit Teleport-protected web applications through
-the Teleport Web UI. The Teleport Proxy Service routes browser traffic to the
-Teleport Application Service, which forwards HTTP requests to and from target
-applications.
+Teleport Auth Service. Users visit a Teleport-protected web application through
+the Teleport Web UI or by accessing the URL of the application, a subdomain of
+the Teleport Proxy Service address. The Teleport Proxy Service routes browser
+traffic to the Teleport Application Service, which forwards HTTP requests to and
+from target applications.
 
 ## Prerequisites
 

--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -61,9 +61,9 @@ include:
 
 ## Teleport Zero Trust Access
 
-**Teleport Zero Trust Access** provides engineers with least privileged access
-to applications, servers, databases, Kubernetes clusters, and other resources
-across distributed infrastructures.
+**Teleport Zero Trust Access** provides AI agents, humans, and machines with
+least-privileged access to applications, servers, databases, Kubernetes
+clusters, and other resources across distributed infrastructures.
 
 |  | **Enterprise (Cloud)** | **Enterprise (Self-Hosted)** | **Community Edition** |
 |---|:---:|:---:|:---:|

--- a/docs/pages/get-started/access.mdx
+++ b/docs/pages/get-started/access.mdx
@@ -11,7 +11,11 @@ import Icon from '@site/src/components/Icon';
 
 Teleport uses **Role-Based Access Control (RBAC)** to determine who can access what across your infrastructure.
 
-Every Teleport user is assigned one or more roles. These roles define the user's permissions, such as:
+The Teleport user is a backend resource that represents an AI agent, human, or
+machine.
+
+Every Teleport user is assigned one or more roles. These roles define the user's
+permissions, such as:
 
 - What infrastructure resources they can access
 - Whether they can request temporary access

--- a/docs/pages/identity-security/usage/graph-explorer.mdx
+++ b/docs/pages/identity-security/usage/graph-explorer.mdx
@@ -72,11 +72,13 @@ Access Graph divides your infrastructure into six main components:
 
 ![Identity Node](../../../img/access-graph/identity-node.png)
 
-Identities are the actors that can access your infrastructure. They can be employees, contractors, machines or bots.
+Identities are the actors that can access your infrastructure. For example, they
+can be AI agents, employees, contractors, machines or bots.
 
-Users are created from Teleport Users.  Local users are imported as soon as they
-are created.  External users (created from authentication connectors for GitHub,
-SAML, etc.) are imported when they log in for the first time.
+Users are created from instances of the Teleport `user` resource. Local users
+are imported as soon as they are created. SSO users (created from authentication
+connectors for GitHub, SAML, etc.) are imported when they log in for the first
+time.
 
 The number on the right hand side shows **standing privileges**. The standing privileges metric indicates the number of
 resources that an identity can access without creating an Access Request.

--- a/docs/pages/machine-workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/getting-started.mdx
@@ -185,9 +185,9 @@ $ tctl create -f role.yaml
 
 ## Step 3/5. Create a bot
 
-In Teleport, a **Bot** represents an identity for a machine. This is similar to
-how a user represents the identity of a human. Like users, bots are assigned
-roles to manage their access to resources.
+In Teleport, a **Bot user** represents an identity for a machine or AI agent.
+Like SSO users and local users bots are assigned roles to manage their access to
+resources.
 
 You'll now create a bot to represent the GitHub Actions workflow.
 

--- a/docs/pages/machine-workload-identity/introduction.mdx
+++ b/docs/pages/machine-workload-identity/introduction.mdx
@@ -30,7 +30,10 @@ The tbot agent manages identity requests and renewals, authenticating to the Tel
 
 ## Zero Trust Access for machines
 
-Teleport provides machines with an identity ("bot") that can authenticate to the Teleport cluster. Bots are similar to human users with access controlled by roles and activities recorded in audit logs.
+Teleport provides machines with an identity ("bot") that can authenticate to the
+Teleport cluster. Bots have one or more Teleport roles, governing their access
+to resources in your infrastructure, and Teleport records
+their activity using audit logs.
 
 Bots authenticate using join tokens that specify which bot user they grant access to and what proof (join method) is needed. Each tbot client connection creates a server-side Bot Instance to track installations over time.
 

--- a/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
@@ -33,9 +33,9 @@ AWS APIs in a few ways:
   Machine & Workload Identity and therefore cannot be used when a machine needs
   to authenticate with AWS.
 
-Whilst this guide is primarily aimed at allowing a machine to access AWS, the
-`tsh svid issue` command can be used in place of `tbot` to allow a client to
-authenticate using AWS Roles Anywhere.
+Whilst this guide is primarily aimed at allowing a machine to access AWS,
+the `tsh svid issue` command can be used in place of `tbot` to allow a human
+user to authenticate using AWS Roles Anywhere.
 
 ## OIDC Federation vs Roles Anywhere
 
@@ -247,8 +247,8 @@ $ tctl create -f role.yaml
 
 (!docs/pages/includes/create-role-using-web.mdx!)
 
-If you intend this SPIFFE ID to be issued by a `tsh` client, you now need to
-assign this role to their `user` resource:
+If you intend this SPIFFE ID to be issued by a human, you now need to assign
+this role to their user:
 
 ```code
 $ tctl edit user/my-user
@@ -264,10 +264,7 @@ $ tctl bots update my-bot --add-roles example-workload-identity-issuer
 
 ## Step 3/4. Issue Workload Identity certificates
 
-Now that you have configured RBAC in AWS and Teleport, you can configure
-Teleport client tools to issue SPIFFE SVIDs for workloads.
-
-### Using `tbot`
+### For machines using `tbot`
 
 For machines, the `tbot` service can be used to issue and renew SPIFFE SVIDs
 as a background process.
@@ -293,10 +290,10 @@ Replace:
 
 Restart your `tbot` service to apply the new configuration.
 
-### Using `tsh`
+### For humans using `tsh`
 
-Teleport clients can use the `tsh` CLI to issue a SPIFFE SVID
-using their pre-existing authentication session.
+For humans, the `tsh` CLI can be used to issue a SPIFFE SVID using their
+pre-existing authentication session.
 
 The `tsh` command will need to be re-invoked when the SVID expires. By default,
 SVIDs are issued with a TTL of 1 hour, but this can be configured to be up to

--- a/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
@@ -33,9 +33,9 @@ AWS APIs in a few ways:
   Machine & Workload Identity and therefore cannot be used when a machine needs
   to authenticate with AWS.
 
-Whilst this guide is primarily aimed at allowing a machine to access AWS,
-the `tsh svid issue` command can be used in place of `tbot` to allow a human
-user to authenticate using AWS Roles Anywhere.
+Whilst this guide is primarily aimed at allowing a machine to access AWS, the
+`tsh svid issue` command can be used in place of `tbot` to allow a client to
+authenticate using AWS Roles Anywhere.
 
 ## OIDC Federation vs Roles Anywhere
 
@@ -247,8 +247,8 @@ $ tctl create -f role.yaml
 
 (!docs/pages/includes/create-role-using-web.mdx!)
 
-If you intend this SPIFFE ID to be issued by a human, you now need to assign
-this role to their user:
+If you intend this SPIFFE ID to be issued by a `tsh` client, you now need to
+assign this role to their `user` resource:
 
 ```code
 $ tctl edit user/my-user
@@ -264,7 +264,10 @@ $ tctl bots update my-bot --add-roles example-workload-identity-issuer
 
 ## Step 3/4. Issue Workload Identity certificates
 
-### For machines using `tbot`
+Now that you have configured RBAC in AWS and Teleport, you can configure
+Teleport client tools to issue SPIFFE SVIDs for workloads.
+
+### Using `tbot`
 
 For machines, the `tbot` service can be used to issue and renew SPIFFE SVIDs
 as a background process.
@@ -290,10 +293,10 @@ Replace:
 
 Restart your `tbot` service to apply the new configuration.
 
-### For humans using `tsh`
+### Using `tsh`
 
-For humans, the `tsh` CLI can be used to issue a SPIFFE SVID using their
-pre-existing authentication session.
+Teleport clients can use the `tsh` CLI to issue a SPIFFE SVID
+using their pre-existing authentication session.
 
 The `tsh` command will need to be re-invoked when the SVID expires. By default,
 SVIDs are issued with a TTL of 1 hour, but this can be configured to be up to

--- a/docs/pages/machine-workload-identity/workload-identity/tsh.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/tsh.mdx
@@ -12,7 +12,7 @@ tags:
 In some scenarios, you may wish to issue a SPIFFE SVID manually, without using
 `tbot`. This can be useful in scenarios where you need to impersonate a service
 for the purposes of debugging or could provide a mechanism for providing
-human access to services which use SPIFFE SVIDs for authentication.
+access to services that use SPIFFE SVIDs for authentication.
 
 In this guide, you will use the `tsh` tool to issue a SPIFFE SVID.
 

--- a/docs/pages/reference/access-controls/authentication.mdx
+++ b/docs/pages/reference/access-controls/authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: Authentication options
+title: Authentication Options
 description: A reference for Teleport's authentication connectors
 tags:
  - reference
@@ -9,6 +9,14 @@ tags:
 
 Teleport authenticates users either via the Proxy Service or with an identity
 provider via **authentication connectors**.
+
+<Admonition type="tip">
+
+This guide explains authentication options for human users. For AI agents and
+machines, see [Machine & Workload
+ID](../../machine-workload-identity/introduction.mdx).
+
+</Admonition>
 
 ## Local (no authentication connector)
 

--- a/docs/pages/reference/architecture/architecture.mdx
+++ b/docs/pages/reference/architecture/architecture.mdx
@@ -75,10 +75,10 @@ infrastructure resources with a Teleport cluster:
 
 ### Teleport Agents
 
-Teleport Agents proxy traffic from users, human or machine, to resources in your infrastructure.
-Agents are instances of the `teleport` binary configured to run certain
-services, e.g., the Teleport SSH Service and Teleport Kubernetes Service, and
-administrators deploy Agents on their own infrastructure.
+Teleport Agents proxy traffic from humans, machines, and AI agents to resources
+in your infrastructure. Agents are instances of the `teleport` binary configured
+to run certain services, e.g., the Teleport SSH Service and Teleport Kubernetes
+Service, and administrators deploy Agents on their own infrastructure.
 
 Agents verify a user's certificate against a certificate authority maintained by
 the Teleport Auth Service. Since a user's Teleport roles are encoded in their
@@ -107,8 +107,8 @@ about the architecture of Teleport Agent features:
 
 Machine & Workload Identity is a Teleport product that enables automated
 services to access Teleport-protected infrastructure with regularly updated
-credentials. Administrators register a Bot user with Teleport that, like a human
-user, is assigned Teleport roles.
+credentials. Administrators register a Bot user with Teleport that, like a local
+or SSO user, is assigned Teleport roles.
 
 Instances of the `tbot` binary communicate with the Teleport Auth Service to
 continuously refresh credentials. As with Agents, administrators must deploy

--- a/docs/pages/reference/architecture/authentication.mdx
+++ b/docs/pages/reference/architecture/authentication.mdx
@@ -9,7 +9,8 @@ tags:
 
 Teleport handles both authentication and authorization.
 
-- Authentication is about proving an identity of a user or a service.
+- Authentication is about proving an identity of an AI agent, human user, or
+  service.
 - Authorization is proving access rights to something.
 
 This guide explains how Teleport handles authentication with short-lived

--- a/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
+++ b/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
@@ -17,8 +17,8 @@ when starting new:
 - Application sessions
 - Desktop sessions
 
-This is an advanced security feature that protects users against compromises of
-their on-disk Teleport certificates.
+This is an advanced security feature that protects human users against
+compromises of their on-disk Teleport certificates.
 
 Per-session MFA checks can be satisfied by a webauthn device or by [delegating MFA checks to your IdP](../sso/sso-for-mfa.mdx).
 

--- a/docs/pages/zero-trust-access/rbac-get-started/users.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/users.mdx
@@ -18,6 +18,14 @@ This guide shows you how to:
 - [Edit existing users](./users.mdx#editing-users)
 - [Delete users](./users.mdx#deleting-users)
 
+<Admonition type="tip">
+
+This guide shows you how to manage human users. For AI agents and machines, see
+[Machine & Workload Identity -
+Introduction](../../machine-workload-identity/introduction.mdx).
+
+</Admonition>
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)


### PR DESCRIPTION
While we want to position Teleport as an infrastructure identity platform for AI agents alongside humans and machines, some parts of the docs create the impression that users are primarily human. Edit the docs to lend more prominence to AI use cases.

- Rewrite the user definition in the Core Concepts page to include AI agents and machines alongside humans. Note that only humans can use SSO.
- Add a note to `get-started/access.mdx` that the Teleport `user` resource can represent an AI agent, human, or machine.
- Add tip Admonitions to the Authentication Options reference and the Local Users guide pointing readers to Machine & Workload Identity for agent and machine use cases.
- Scope per-session MFA language to "human users" since this is not available to AI agents.
- In `workload-identity/aws-roles-anywhere.mdx`, imply that non-humans can use `tsh`. Use the "Teleport client" language instead.
- Edit paragraphs that mention humans to either mention other kinds of Teleport users as well or remove the use of "human".