### PR TITLE
[scopes] feat: materialize scoped role assignments from access lists

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -644,14 +644,6 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		}
 	}
 
-	scopedAccessCache, err := scopedaccesscache.NewCache(scopedaccesscache.CacheConfig{
-		Events: cfg.Events,
-		Reader: cfg.ScopedAccess,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	services := &Services{
 		TrustInternal:                   cfg.Trust,
 		PresenceInternal:                cfg.Presence,
@@ -743,7 +735,6 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		Services:                     services,
 		Cache:                        services,
 		scopedAccessBackend:          cfg.ScopedAccess,
-		ScopedAccessCache:            scopedAccessCache,
 		keyStore:                     cfg.KeyStore,
 		traceClient:                  cfg.TraceClient,
 		fips:                         cfg.FIPS,
@@ -796,6 +787,17 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	scopedAccessCache, err := scopedaccesscache.NewCache(scopedaccesscache.CacheConfig{
+		Events:           cfg.Events,
+		Reader:           cfg.ScopedAccess,
+		AccessListEvents: as.Cache,
+		AccessListReader: as.Cache,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	as.ScopedAccessCache = scopedAccessCache
 
 	_, cacheEnabled := as.getCache()
 

--- a/lib/auth/scopes/access/service_test.go
+++ b/lib/auth/scopes/access/service_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedaccesscache "github.com/gravitational/teleport/lib/scopes/cache/access"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
@@ -140,10 +141,17 @@ func newBackendPack(t *testing.T) *backendPack {
 	service := local.NewScopedAccessService(backend)
 	classicService := local.NewAccessService(backend)
 	events := local.NewEventsService(backend)
+	aclService, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
+		Backend: backend,
+		Modules: modulestest.EnterpriseModules(),
+	})
+	require.NoError(t, err)
 
 	cache, err := scopedaccesscache.NewCache(scopedaccesscache.CacheConfig{
-		Events: events,
-		Reader: service,
+		Events:           events,
+		Reader:           service,
+		AccessListEvents: events,
+		AccessListReader: aclService,
 	})
 	require.NoError(t, err)
 

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -41,8 +41,12 @@ import (
 
 // CacheConfig configures the scoped access cache.
 type CacheConfig struct {
-	Events            types.Events
-	Reader            services.ScopedAccessReader
+	Events types.Events
+	Reader services.ScopedAccessReader
+
+	AccessListEvents types.Events
+	AccessListReader AccessListReader
+
 	MaxRetryPeriod    time.Duration
 	TTLCacheRetention time.Duration
 }
@@ -55,6 +59,14 @@ func (c *CacheConfig) CheckAndSetDefaults() error {
 
 	if c.Reader == nil {
 		return trace.BadParameter("missing required parameter Reader in scoped access cache config")
+	}
+
+	if c.AccessListEvents == nil {
+		return trace.BadParameter("missing required parameter AccessListEvents in scoped access cache config")
+	}
+
+	if c.AccessListReader == nil {
+		return trace.BadParameter("missing required parameter AccessListReader in scoped access cache config")
 	}
 
 	if c.MaxRetryPeriod <= 0 {
@@ -269,28 +281,33 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 	if err != nil {
 		return trace.Errorf("failed to create watcher: %w", err)
 	}
-
 	defer watcher.Close()
 
-	select {
-	case event := <-watcher.Events():
-		if event.Type != types.OpInit {
-			return trace.BadParameter("expected init event, got %v instead", event.Type)
-		}
-	case <-watcher.Done():
-		if err := watcher.Error(); err != nil {
-			// watcher errors are expected if the watcher is closed before init completes.
-			return trace.Errorf("watcher failed while waiting for init event: %w", err)
-		}
-		return trace.Errorf("watcher failed while waiting for init event")
-	case <-time.After(retryutils.SeventhJitter(time.Minute)):
-		return trace.Errorf("timed out waiting for init event from watcher")
-	case <-ctx.Done():
-		return trace.Wrap(ctx.Err())
+	// Access list watcher watches cache events, it's separate from the base
+	// watcher which watches backend events. It is used for driving changes to
+	// scoped role assignments materialized from access lists and their
+	// memberships.
+	aclWatcher, err := c.cfg.AccessListEvents.NewWatcher(ctx, types.Watch{
+		Name: "scoped-access-cache-acl-watcher",
+		Kinds: []types.WatchKind{
+			{Kind: types.KindAccessList},
+			{Kind: types.KindAccessListMember},
+		},
+	})
+	if err != nil {
+		return trace.Errorf("failed to create access list watcher: %w", err)
+	}
+	defer aclWatcher.Close()
+
+	if err := waitForWatcherInit(ctx, watcher); err != nil {
+		return trace.Wrap(err, "waiting for backend watcher init")
+	}
+	if err := waitForWatcherInit(ctx, aclWatcher); err != nil {
+		return trace.Wrap(err, "waiting for access list watcher init")
 	}
 
 	fetchStart := time.Now()
-	state, err := c.fetch(ctx)
+	state, materializer, err := c.fetch(ctx)
 	if err != nil {
 		return trace.Errorf("failed to fetch initial state: %w", err)
 	}
@@ -310,6 +327,9 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 		close(c.init)
 	})
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// start processing and applying changes
 	for {
 		select {
@@ -317,15 +337,44 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 			if err := processEvent(ctx, state, event); err != nil {
 				return trace.Errorf("failed to process event: %w", err)
 			}
+		case event := <-aclWatcher.Events():
+			if err := materializer.ProcessEvent(ctx, state, event); err != nil {
+				return trace.Errorf("materializer failed during event processing: %w", err)
+			}
 		case <-watcher.Done():
 			if err := watcher.Error(); err != nil {
 				// watcher errors are expected if the watcher is closed before init completes.
 				return trace.Errorf("watcher failed during event processing: %w", err)
 			}
 			return trace.Errorf("watcher failed during event processing")
+		case <-aclWatcher.Done():
+			if err := aclWatcher.Error(); err != nil {
+				return trace.Errorf("access list watcher failed during event processing: %w", err)
+			}
+			return trace.Errorf("access list watcher failed during event processing")
 		case <-ctx.Done():
 			return trace.Wrap(ctx.Err())
 		}
+	}
+}
+
+func waitForWatcherInit(ctx context.Context, watcher types.Watcher) error {
+	select {
+	case event := <-watcher.Events():
+		if event.Type != types.OpInit {
+			return trace.BadParameter("expected init event, got %v instead", event.Type)
+		}
+		return nil
+	case <-watcher.Done():
+		if err := watcher.Error(); err != nil {
+			// watcher errors are expected if the watcher is closed before init completes.
+			return trace.Errorf("watcher failed while waiting for init event: %w", err)
+		}
+		return trace.Errorf("watcher failed while waiting for init event")
+	case <-time.After(retryutils.SeventhJitter(time.Minute)):
+		return trace.Errorf("timed out waiting for init event from watcher")
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
 	}
 }
 
@@ -381,7 +430,8 @@ func (c *Cache) read(ctx context.Context) (state, error) {
 
 	// the cache is not ready, load a frozen readonly copy via ttl cache
 	temp, err := utils.FnCacheGet(ctx, c.ttlCache, "access-cache", func(ctx context.Context) (state, error) {
-		return c.fetch(ctx)
+		state, _, err := c.fetch(ctx)
+		return state, err
 	})
 
 	// primary may have been concurrently loaded. prefer using it if so.
@@ -397,16 +447,16 @@ func (c *Cache) read(ctx context.Context) (state, error) {
 }
 
 // fetch loads all currently available roles and assignments from the upstream and builds a cache state.
-func (c *Cache) fetch(ctx context.Context) (state, error) {
+func (c *Cache) fetch(ctx context.Context) (state, *materializer, error) {
 	roleCache := roles.NewRoleCache()
 
 	for role, err := range scopedutils.RangeScopedRoles(ctx, c.cfg.Reader, &scopedaccessv1.ListScopedRolesRequest{}) {
 		if err != nil {
-			return state{}, trace.Wrap(err)
+			return state{}, nil, trace.Wrap(err)
 		}
 
 		if err := roleCache.Put(role); err != nil {
-			return state{}, trace.Wrap(err)
+			return state{}, nil, trace.Wrap(err)
 		}
 	}
 
@@ -414,16 +464,23 @@ func (c *Cache) fetch(ctx context.Context) (state, error) {
 
 	for assignment, err := range scopedutils.RangeScopedRoleAssignments(ctx, c.cfg.Reader, &scopedaccessv1.ListScopedRoleAssignmentsRequest{}) {
 		if err != nil {
-			return state{}, trace.Wrap(err)
+			return state{}, nil, trace.Wrap(err)
 		}
 
 		if err := assignmentCache.Put(assignment); err != nil {
-			return state{}, trace.Wrap(err)
+			return state{}, nil, trace.Wrap(err)
 		}
 	}
 
-	return state{
+	s := state{
 		roles:       roleCache,
 		assignments: assignmentCache,
-	}, nil
+	}
+
+	materializer := newMaterializer(c.cfg.AccessListReader)
+	if err := materializer.Init(ctx, s); err != nil {
+		return s, nil, trace.Wrap(err)
+	}
+
+	return s, materializer, nil
 }

--- a/lib/scopes/cache/access/access_test.go
+++ b/lib/scopes/cache/access/access_test.go
@@ -31,6 +31,8 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	libcache "github.com/gravitational/teleport/lib/cache"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
 	"github.com/gravitational/teleport/lib/services"
@@ -86,10 +88,28 @@ func TestScopedAccessCacheReplication(t *testing.T) {
 		expectedAssignmentNames = append(expectedAssignmentNames, assignment.GetMetadata().GetName())
 	}
 
+	aclService, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
+		Backend: backend,
+		Modules: modulestest.EnterpriseModules(),
+	})
+	require.NoError(t, err)
+	aclCache, err := libcache.New(libcache.Config{
+		Events: events,
+		Watches: []types.WatchKind{
+			{Kind: types.KindAccessList},
+			{Kind: types.KindAccessListMember},
+		},
+		AccessLists: aclService,
+	})
+	require.NoError(t, err)
+	defer aclCache.Close()
+
 	// start the cache with the service and events.
 	cache, err := NewCache(CacheConfig{
 		Events:            events,
 		Reader:            service,
+		AccessListEvents:  aclCache,
+		AccessListReader:  aclCache,
 		TTLCacheRetention: time.Hour, // ensures state-changes are from watcher events rather than ttl cache reloads
 	})
 	require.NoError(t, err)
@@ -312,10 +332,29 @@ func TestScopedAccessCacheFallback(t *testing.T) {
 		expectedAssignmentNames = append(expectedAssignmentNames, assignment.GetMetadata().GetName())
 	}
 
+	aclService, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
+		Backend: backend,
+		Modules: modulestest.EnterpriseModules(),
+	})
+	require.NoError(t, err)
+	aclCache, err := libcache.New(libcache.Config{
+		Events: events,
+		Watches: []types.WatchKind{
+			{Kind: types.KindAccessList},
+			{Kind: types.KindAccessListMember},
+		},
+		AccessLists: aclService,
+		Unstarted:   true,
+	})
+	require.NoError(t, err)
+	defer aclCache.Close()
+
 	// start the cache with the service and never-events.
 	cache, err := NewCache(CacheConfig{
 		Events:            events,
 		Reader:            service,
+		AccessListEvents:  aclCache,
+		AccessListReader:  aclCache,
 		TTLCacheRetention: time.Millisecond * 10, // ensure we don't spend more than 1 cycle waiting
 	})
 	require.NoError(t, err)

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -1,0 +1,1270 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package access
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"iter"
+	"log/slog"
+	"maps"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/utils/set"
+)
+
+// AccessListReader provides the upstream source of access list and member resources.
+type AccessListReader interface {
+	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
+	GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error)
+
+	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
+	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+}
+
+// listAccessListMembers is a helper for calling clientutils.Resources to range
+// over all members of [listName].
+func listAccessListMembers(aclReader AccessListReader, listName string) func(context.Context, int, string) ([]*accesslist.AccessListMember, string, error) {
+	return func(ctx context.Context, pageSize int, cursor string) ([]*accesslist.AccessListMember, string, error) {
+		return aclReader.ListAccessListMembers(ctx, listName, pageSize, cursor)
+	}
+}
+
+// materializer is responsible for "materializing" scoped role assignments into
+// the scoped access cache as they are derived from access lists and their
+// members and owners. See RFD 243 for design decisions.
+//
+// The goal is for every (user, list) pair, where user is a valid explicit or
+// inherited member or owner of list and where list has scoped role grants, to
+// result in 1 materialized scoped role assignment. Each materialized
+// assignment for (user, list) will grant exactly the scoped roles defined in
+// the spec of that list for members, owners, or both depending on the user's
+// relationship with the list.
+//
+// [materializer.Init] must always be called before any other methods.
+//
+// The materializer is not safe for concurrent use, it is meant to be driven
+// from a single event loop, pushing events into [materializer.ProcessEvent].
+//
+// Notably, the materializer never reads the actual scoped roles it is
+// generating assignments for. It does not attempt to validate that scoped role
+// exist or that the assigned scope is allowed by the scoped role definition.
+// This validation is the responsibility of the backend service. Anything that
+// reads scoped role assignments must also validate them before using them for
+// access decisions.
+type materializer struct {
+	// aclReader is used for upstream reads of access lists and members, it is
+	// expected to be an in-memory cache, and all events are expected to be
+	// pushed in to ProcessEvent after the state has been persisted to the
+	// cache.
+	aclReader AccessListReader
+
+	// ancestorCache holds all possible direct membership and ownership edges,
+	// even if they may be expired or invalid based on membership or ownership
+	// requirements.
+	ancestorCache *ancestorCache
+
+	// materializedAssignments is just internal bookkeeping holding the current
+	// set of assignments that have been "materialized" into the cache state.
+	materializedAssignments map[materializedAssignmentKey]ancestorRelation
+
+	logger *slog.Logger
+}
+
+type materializedAssignmentKey struct {
+	user string
+	list string
+}
+
+func (k materializedAssignmentKey) assignmentName() string {
+	h := sha256.New224()
+	binary.Write(h, binary.LittleEndian, uint16(len(k.user)))
+	h.Write([]byte(k.user))
+	h.Write([]byte(k.list))
+	return "acl-" + base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}
+
+func newMaterializer(aclReader AccessListReader) *materializer {
+	return &materializer{
+		aclReader:               aclReader,
+		ancestorCache:           newAncestorCache(),
+		materializedAssignments: make(map[materializedAssignmentKey]ancestorRelation),
+		logger:                  slog.With(teleport.ComponentKey, "sra_materializer"),
+	}
+}
+
+// Init materializes all necessary scoped role assignments into [state] based
+// on the current set of access list memberships.
+func (m *materializer) Init(ctx context.Context, state state) error {
+	// First populate the ancestor cache with all list->list memberships and
+	// ownerships, it's critical for this to be up to date to process
+	// relationships and future changes. The ancestor cache should include even
+	// expired or invalid membership edges for defensive handling of delete
+	// events.
+	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
+		if err != nil {
+			return trace.Wrap(err, "reading access list members")
+		}
+		if member.Spec.MembershipKind == accesslist.MembershipKindList {
+			m.ancestorCache.addMembership(member.Spec.AccessList, member.GetName())
+		}
+		// TODO(nic): queue handler for member resource expiry.
+	}
+	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
+		if err != nil {
+			return trace.Wrap(err, "reading access lists")
+		}
+		for _, owner := range list.Spec.Owners {
+			if owner.MembershipKind == accesslist.MembershipKindList {
+				m.ancestorCache.addOwnership(owner.Name, list.GetName())
+			}
+		}
+	}
+
+	// We iterate the access lists again separately so that the ancestor cache
+	// is fully initialized before it may be referenced in
+	// m.initAccessListMembers.
+	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
+		if err != nil {
+			return trace.Wrap(err, "reading access lists")
+		}
+		// Materialize assignments as necessary for all members of every access list.
+		m.initAccessListMembers(ctx, state, list)
+		// Materialize assignments as necessary for all owners of every access list.
+		m.initAccessListOwners(ctx, state, list)
+	}
+
+	return nil
+}
+
+// ProcessEvent is the entry point for all event-driven changes to materializer
+// state, driven by access list and access list member events.
+func (m *materializer) ProcessEvent(ctx context.Context, state state, event types.Event) error {
+	switch event.Type {
+	case types.OpPut:
+		switch item := event.Resource.(type) {
+		case *accesslist.AccessList:
+			m.handleAccessListPut(ctx, state, item)
+		case *accesslist.AccessListMember:
+			m.handleAccessListMemberPut(ctx, state, item)
+		}
+	case types.OpDelete:
+		switch event.Resource.GetKind() {
+		case types.KindAccessList:
+			m.handleAccessListDelete(ctx, state, event.Resource.GetName())
+		case types.KindAccessListMember:
+			listName := event.Resource.GetMetadata().Description
+			if listName == "" {
+				// This is a bug, return a hard failure.
+				return trace.Errorf("missing access list name in access list member delete event description")
+			}
+			m.handleAccessListMemberDelete(ctx, state, listName, event.Resource.GetName())
+		}
+	}
+	return nil
+}
+
+func (m *materializer) handleAccessListMemberPut(ctx context.Context, state state, member *accesslist.AccessListMember) {
+	if member.IsUser() {
+		m.handleUserMemberPut(ctx, state, member)
+	}
+	if member.Spec.MembershipKind == accesslist.MembershipKindList {
+		m.handleListMemberPut(ctx, state, member)
+	}
+}
+
+// handleUserMemberPut materializes an assignment for user in list and all
+// ancestors of list.
+//
+// If the member resource is expired, it re-checks all materialized assignments
+// for the user in case they were granted via this membership.
+func (m *materializer) handleUserMemberPut(ctx context.Context, state state, member *accesslist.AccessListMember) {
+	listName := member.Spec.AccessList
+	userName := member.GetName()
+
+	if m.ancestorCache.children.Get(listName).Contains(userName) {
+		// This access list member must have had membership kind list before,
+		// and was updated to membership kind user.
+		m.handleListMemberDelete(ctx, state, listName, userName)
+	}
+
+	if member.IsExpired(time.Now()) {
+		m.handleUserMemberDeleteOrExpired(ctx, state, listName, userName)
+		return
+	}
+	// TODO(nic): queue handler for member resource expiry.
+
+	list, err := m.aclReader.GetAccessList(ctx, listName)
+	if err != nil {
+		m.logger.InfoContext(ctx, "Failed to get access list while handling member put",
+			"error", err,
+			"list", listName,
+			"user", userName)
+		// TODO(nic): schedule a refresh to recover.
+		return
+	}
+
+	if hasMembershipRequires(list) {
+		// Memberships paths through access lists that have any member
+		// requirements are not considered for scoped role assignment
+		// materialization. Including member requirements in any access list
+		// that may transitively grant a scoped role is considered invalid.
+		return
+	}
+
+	if err := m.addMemberAssignment(ctx, state, list, userName); err != nil {
+		m.logger.WarnContext(ctx, "Failed to materialize assignment",
+			"error", err,
+			"user", userName,
+			"list", list.GetName())
+	}
+
+	ancestors, validationErrors := m.collectAncestors(ctx, list.GetName())
+	for _, validationError := range validationErrors {
+		m.logger.InfoContext(ctx, "Error while validating access list ancestors, some scoped role assignments may not be materialized",
+			"error", validationError)
+	}
+	// TODO(nic): schedule a refresh to recover if len(validationErrors) > 0
+
+	// As a member of this list, the user shares the list's relationship with
+	// all of its ancestors, make sure assignments are materialized.
+	for _, ancestor := range ancestors {
+		if err := m.mergeAncestorAssignment(ctx, state, ancestor.list, ancestor.relation, userName); err != nil {
+			m.logger.WarnContext(ctx, "Failed to materialize assignment",
+				"error", err,
+				"user", userName,
+				"list", ancestor.list.GetName())
+		}
+	}
+}
+
+// handleListMemberPut adds the direct membership to the ancestor cache,
+// and then makes sure that all nested members of the member list have
+// materialized assignments for the parent list and all ancestors of the
+// parent list.
+//
+// If the member resource is expired, it re-checks all materialized assignments
+// for the parent list and all of its ancestors, in case they were granted via this membership.
+func (m *materializer) handleListMemberPut(ctx context.Context, state state, member *accesslist.AccessListMember) {
+	parentListName, memberListName := member.Spec.AccessList, member.Spec.Name
+
+	// It's possible this member resource used to have membership kind user and
+	// was updated to have membership kind list, so we must clear anything
+	// related to a previous user membership.
+	m.handleUserMemberDeleteOrExpired(ctx, state, parentListName, memberListName)
+
+	m.ancestorCache.addMembership(parentListName, memberListName)
+
+	if member.IsExpired(time.Now()) {
+		m.handleListMemberExpired(ctx, state, parentListName)
+		return
+	}
+	// TODO(nic): queue handler for member resource expiry.
+
+	// Every user that is a nested member of memberList may have just become a
+	// member of parentList and all lists it is a nested member of. They also
+	// may have become an owner of every list parentList is an owner of.
+	parentList, err := m.aclReader.GetAccessList(ctx, parentListName)
+	if err != nil {
+		m.logger.InfoContext(ctx, "Failed to get access list while handling list member put, some scoped role assignments may not be materialized",
+			"error", err,
+			"list", parentListName,
+			"member_list", memberListName)
+		// TODO(nic): schedule a refresh to recover.
+		return
+	}
+	memberList, err := m.aclReader.GetAccessList(ctx, memberListName)
+	if err != nil {
+		m.logger.InfoContext(ctx, "Failed to get access list while handling list member put, some scoped role assignments may not be materialized",
+			"error", err,
+			"list", memberListName,
+			"parent_list", parentListName)
+		// TODO(nic): schedule a refresh to recover.
+		return
+	}
+
+	if hasMembershipRequires(parentList) {
+		// Membership paths through access lists that have any member
+		// requirements are not considered for scoped role assignment
+		// materialization. Including member requirements in any role that may
+		// transitively grant a scoped role is considered invalid.
+		return
+	}
+
+	// Collect all ancestors of the parent list, in case any (nested) members
+	// of the new member list just became members or owners of the ancestor.
+	ancestors, validationErrors := m.collectAncestors(ctx, parentListName)
+	for _, validationError := range validationErrors {
+		m.logger.InfoContext(ctx, "Error while validating access list ancestors, some scoped role assignments may not be materialized",
+			"error", validationError)
+	}
+	// TODO(nic): schedule a refresh to recover if len(validationErrors) > 0
+
+	for member, err := range m.walkUserMembers(ctx, memberList) {
+		if err != nil {
+			m.logger.WarnContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
+				"error", err,
+				"list", memberListName)
+			// TODO(nic): schedule a refresh to recover.
+			// walkUserMembers may yield errors from walking members of any
+			// member lists, but it may not be done, so continue the loop.
+			continue
+		}
+
+		// User is now a member of the parent list, materialize an assignment.
+		if err := m.addMemberAssignment(ctx, state, parentList, member.GetName()); err != nil {
+			m.logger.WarnContext(ctx, "Failed to materialize assignment",
+				"error", err,
+				"user", member.GetName(),
+				"list", parentListName)
+		}
+
+		// As a member of the parent list, the user now shares the parent
+		// list's relationship with all of its ancestors, make sure assignments
+		// are materialized.
+		for _, ancestor := range ancestors {
+			if err := m.mergeAncestorAssignment(ctx, state, ancestor.list, ancestor.relation, member.GetName()); err != nil {
+				m.logger.WarnContext(ctx, "Failed to materialize assignment",
+					"error", err,
+					"user", member.GetName(),
+					"list", ancestor.list.GetName())
+			}
+		}
+	}
+}
+
+func (m *materializer) handleAccessListMemberDelete(ctx context.Context, state state, listName, memberName string) {
+	// We don't get enough info from the event to know if the deleted member
+	// was a user or a list. Luckily member names are unique, so we know that
+	// if this membership is present in the ancestor cache then the deleted
+	// member is a list.
+	if m.ancestorCache.children.Get(listName).Contains(memberName) {
+		m.handleListMemberDelete(ctx, state, listName, memberName)
+	}
+	m.handleUserMemberDeleteOrExpired(ctx, state, listName, memberName)
+}
+
+// handleListMemberDelete handles delete events for nested access list memberships.
+func (m *materializer) handleListMemberDelete(ctx context.Context, state state, parentListName, memberListName string) {
+	// First and foremost, always keep the ancestor cache up to date will all
+	// direct list->list memberships.
+	m.ancestorCache.removeMembership(parentListName, memberListName)
+
+	// The membership being deleted is equivalent to it being expired. Expired
+	// memberships remain in the ancestor cache.
+	m.handleListMemberExpired(ctx, state, parentListName)
+}
+
+// handleListMemberExpired handles the event where an access list membership
+// has been deleted or has expired. Any nested members of the member list may
+// no longer be valid members or owners of the parent list or any of its
+// ancestors. At risk of being overly pessimisted, we re-check every
+// materialized assignment for the parent list and all of its ancestors.
+func (m *materializer) handleListMemberExpired(ctx context.Context, state state, parentListName string) {
+	// We must iterate all ancestors without relying on paging through
+	// collections in the cache to make sure we don't miss any assignments that
+	// need to be invalidated due to a paging error or any other transient
+	// error. The ancestor cache maintains all known direct list->list
+	// memberships and ownerships, which is sufficient.
+	ancestors := m.collectAncestorListsWithoutValidation(parentListName)
+
+	// Iterate all currently materialized assignments.
+	for key := range m.materializedAssignments {
+		_, isAncestor := ancestors[key.list]
+		if key.list != parentListName && !isAncestor {
+			// We don't need to validate any assignments that are not for the
+			// parent list or any of its ancestors.
+			continue
+		}
+
+		if err := m.recheckAssignment(ctx, state, key); err != nil {
+			// Must pessimistically assume any assignment is invalid if we
+			// encountered an error trying to validate it.
+			m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
+				"error", err)
+			m.deleteMaterializedAssignment(ctx, state, key)
+			// TODO(nic): schedule a refresh to recover.
+		}
+	}
+}
+
+// User is no longer a direct member of list but could still be a nested member.
+// It's possible they are no longer a valid member of the parent list or any of
+// its ancestors. We need to re-check all current materialized assignments for
+// this user in the initial list or any of its ancestors.
+func (m *materializer) handleUserMemberDeleteOrExpired(ctx context.Context, state state, parentListName, userName string) {
+	// We must iterate all ancestors without relying on paging through
+	// collections in the cache to make sure we don't miss any assignments that
+	// need to be invalidated due to a paging error or any other transient
+	// error. The ancestor cache maintains all known direct list->list
+	// memberships and ownerships, which is sufficient.
+	ancestors := m.collectAncestorListsWithoutValidation(parentListName)
+	for key := range m.materializedAssignmentsForUser(userName) {
+		_, isAncestor := ancestors[key.list]
+		if key.list != parentListName && !isAncestor {
+			// We don't need to validate any assignments that are not for the
+			// parent list or any of its ancestors.
+			continue
+		}
+		if err := m.recheckAssignment(ctx, state, key); err != nil {
+			// Must pessimistically assume any assignment is invalid if we
+			// encountered an error trying to validate it.
+			m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
+				"error", err)
+			m.deleteMaterializedAssignment(ctx, state, key)
+			// TODO(nic): schedule a refresh to recover.
+		}
+	}
+}
+
+// handleAccessListPut handles put events for access lists.
+//
+// It must first update any owner list edges in the ancestor cache, as the
+// source of truth for owners is the access list resource.
+//
+// In case the scoped role grants or owners were modified, it must re-check all
+// materialized assignments for the list.
+// As a slight optimization, it can just delete any extant assignments of the
+// new version of the role does not grant any scoped roles.
+//
+// If the list has any direct user owners they may be new, make sure there's a
+// materialized assignment for them.
+//
+// If the list has any scoped owner grants and any owner lists were added,
+// materialize an assignment for them.
+func (m *materializer) handleAccessListPut(ctx context.Context, state state, list *accesslist.AccessList) {
+	// Update any owner list edges in the ancestor cache.
+	m.ancestorCache.clearOwnersOf(list.GetName())
+	for _, owner := range list.Spec.Owners {
+		if owner.MembershipKind != accesslist.MembershipKindList {
+			continue
+		}
+		m.ancestorCache.addOwnership(owner.Name, list.GetName())
+	}
+
+	// Re-check all extant assignments for this list in case any grants were added
+	// or removed or ownership status changed.
+	hasScopedGrants := hasMemberGrants(list) || hasOwnerGrants(list)
+	for key := range m.materializedAssignmentsForList(list.GetName()) {
+		if hasScopedGrants {
+			// The list has some grants we should re-check. This may delete
+			// assignments as necessary.
+			if err := m.recheckAssignment(ctx, state, key); err != nil {
+				// Must pessimistically assume any assignment is invalid if we
+				// encountered an error trying to validate it.
+				m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
+					"error", err)
+				m.deleteMaterializedAssignment(ctx, state, key)
+				// TODO(nic): schedule a refresh to recover.
+			}
+		} else {
+			// If the list doesn't grant any scoped roles, we can just delete
+			// all extant assignments for it without actually checking
+			// anything.
+			m.deleteMaterializedAssignment(ctx, state, key)
+		}
+	}
+
+	// If the list now has membership requirements, it's possible that this
+	// update has broken membership paths for any ancestor lists. Otherwise it
+	// is not possible for an access list update to invalidate membership in
+	// any other lists.
+	if hasMembershipRequires(list) {
+		ancestors := m.collectAncestorListsWithoutValidation(list.GetName())
+		for ancestorListName := range ancestors {
+			for key := range m.materializedAssignmentsForList(ancestorListName) {
+				if err := m.recheckAssignment(ctx, state, key); err != nil {
+					// Must pessimistically assume any assignment is invalid if we
+					// encountered an error trying to validate it.
+					m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
+						"error", err)
+					m.deleteMaterializedAssignment(ctx, state, key)
+					// TODO(nic): schedule a refresh to recover.
+				}
+			}
+		}
+	}
+
+	// Now that any invalidated assignments have been deleted, we can call
+	// initAccessListMembers and initAccessListOwners to materialize any
+	// necessary new assignments.
+	m.initAccessListMembers(ctx, state, list)
+	m.initAccessListOwners(ctx, state, list)
+}
+
+// initAccessListMembers additively materializes scoped role assignments for
+// all members of the given list.
+func (m *materializer) initAccessListMembers(ctx context.Context, state state, list *accesslist.AccessList) {
+	if hasMembershipRequires(list) {
+		// membership requires are not supported, do not follow any membership
+		// edges if this list has membership requires.
+		return
+	}
+
+	ancestors, validationErrors := m.collectAncestors(ctx, list.GetName())
+	for _, validationError := range validationErrors {
+		m.logger.InfoContext(ctx, "Error while validating access list ancestors, some scoped role assignments may not be materialized",
+			"error", validationError)
+	}
+	// TODO(nic): schedule a refresh to recover if len(validationErrors) > 0
+
+	hasMemberGrants := hasMemberGrants(list)
+	if !hasMemberGrants && len(ancestors) == 0 {
+		// There will be no scoped role grants to materialize assignments for
+		// in this list or any of its ancestors, return early.
+		return
+	}
+
+	// Walk all user members of this list and materialize necessary scoped role
+	// assignments for their membership in list and/or membership and/or
+	// ownership in any ancestor list.
+	for member, err := range m.walkUserMembers(ctx, list) {
+		if err != nil {
+			m.logger.InfoContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
+				"error", err,
+				"list", list.GetName())
+			// TODO(nic): schedule a refresh to recover.
+			// walkUserMembers may yield errors from walking members of any
+			// member lists, but it may not be done, so continue the loop.
+			continue
+		}
+
+		if hasMemberGrants {
+			// This user is a confirmed member, make sure a member assignment is materialized.
+			if err := m.addMemberAssignment(ctx, state, list, member.GetName()); err != nil {
+				m.logger.WarnContext(ctx, "Failed to materialize assignment",
+					"error", err,
+					"user", member.GetName(),
+					"list", list.GetName())
+			}
+		}
+
+		// As a member of this list, the user shares the list's relationship
+		// with all of its ancestors, make sure assignments are materialized.
+		for _, ancestor := range ancestors {
+			if err := m.mergeAncestorAssignment(ctx, state, ancestor.list, ancestor.relation, member.GetName()); err != nil {
+				m.logger.WarnContext(ctx, "Failed to materialize assignment",
+					"error", err,
+					"user", member.GetName(),
+					"list", ancestor.list.GetName())
+			}
+
+		}
+	}
+}
+
+// initAccessListOwners additively materializes scoped role assignments for
+// all owners of the given list. That includes direct owers and (nested)
+// members of owner lists.
+func (m *materializer) initAccessListOwners(ctx context.Context, state state, list *accesslist.AccessList) {
+	if hasOwnershipRequires(list) || !hasOwnerGrants(list) {
+		// There is nothing to materialize for owners of this list.
+		return
+	}
+
+	// Keep track of users and lists that have already been seen across member
+	// iterations to avoid duplicating work if the same user or list is a
+	// member of multiple owner lists.
+	seenLists := set.New[string]()
+	seenUsers := set.New[string]()
+
+	for _, owner := range list.Spec.Owners {
+		if owner.IsMembershipKindUser() {
+			// This user is a confirmed direct owner, make sure an owner
+			// assignment is materialized.
+			seenUsers.Add(owner.Name)
+			if err := m.addOwnerAssignment(ctx, state, list, owner.Name); err != nil {
+				m.logger.WarnContext(ctx, "Failed to materialize assignment",
+					"error", err,
+					"user", owner.Name,
+					"list", list.GetName())
+			}
+			continue
+		}
+
+		if owner.MembershipKind != accesslist.MembershipKindList {
+			continue
+		}
+
+		ownerList, err := m.aclReader.GetAccessList(ctx, owner.Name)
+		if err != nil {
+			m.logger.InfoContext(ctx, "Failed to get owner list, some scoped role assignments may not be materialized for owners",
+				"error", err)
+			// TODO(nic): schedule a refresh to recover.
+			continue
+
+		}
+
+		// All nested members of owners lists are owners of this list
+		// and a scoped role assignment should be materialized.
+		for member, err := range m.walkUserMembersRecursive(ctx, ownerList, seenLists, seenUsers) {
+			if err != nil {
+				m.logger.WarnContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
+					"error", err,
+					"list", list.GetName())
+				// TODO(nic): schedule a refresh to recover.
+				// walkUserMembersRecursive may yield errors from walking members of any
+				// member lists, but it may not be done, so continue the loop.
+				continue
+			}
+			if err := m.addOwnerAssignment(ctx, state, list, member.GetName()); err != nil {
+				m.logger.WarnContext(ctx, "Failed to materialize assignment",
+					"error", err,
+					"user", member.GetName(),
+					"list", list.GetName())
+			}
+		}
+	}
+}
+
+// handleAccessListDelete handles delete events for access lists.
+// Access lists cannot be deleted if they are a member or owner of another
+// list, but they may have materialized assignments for their own owners.
+func (m *materializer) handleAccessListDelete(ctx context.Context, state state, listName string) {
+	for owner := range m.ancestorCache.ownersOf.Get(listName).Items() {
+		m.ancestorCache.removeOwnership(owner, listName)
+	}
+	for key := range m.materializedAssignmentsForList(listName) {
+		m.deleteMaterializedAssignment(ctx, state, key)
+	}
+}
+
+// addMemberAssignment adds the given user as a member of list, additively merges
+// with any existing materialized assignment for the user in case the user is
+// already a known owner of the list, and materializes an assignment.
+func (m *materializer) addMemberAssignment(ctx context.Context, state state, list *accesslist.AccessList, userName string) error {
+	relation := ancestorRelation{isMember: true}
+	return m.mergeAncestorAssignment(ctx, state, list, relation, userName)
+}
+
+// addOwnerAssignment adds the given user as an owner of list, additively
+// merges with any existing materialized assignment for the user in case the
+// user is already a known member of the list, and materializes an assignment.
+func (m *materializer) addOwnerAssignment(ctx context.Context, state state, list *accesslist.AccessList, userName string) error {
+	relation := ancestorRelation{isOwner: true}
+	return m.mergeAncestorAssignment(ctx, state, list, relation, userName)
+}
+
+// mergeAncestorAssignment adds list as an ancestor of the user and additively
+// merges the given relation with the current relation of any existing
+// materialized assignment for the user. It materializes an assignment for the
+// (user, list) pair.
+func (m *materializer) mergeAncestorAssignment(
+	ctx context.Context,
+	state state,
+	list *accesslist.AccessList,
+	relation ancestorRelation,
+	userName string,
+) error {
+	currentRelation := m.materializedAssignments[materializedAssignmentKey{
+		list: list.GetName(),
+		user: userName,
+	}]
+	relation.isMember = relation.isMember || currentRelation.isMember
+	relation.isOwner = relation.isOwner || currentRelation.isOwner
+	return m.materializeAssignment(ctx, state, list, relation, userName)
+}
+
+// materializeAssignment materializes a scoped role assignment for the given
+// (user, list) pair with the given relation between the user and list.
+//
+// The assignment will be injected into state.assignments, unless it contains
+// no grants, in which case any extant assignment in the state will be deleted.
+func (m *materializer) materializeAssignment(
+	ctx context.Context,
+	state state,
+	list *accesslist.AccessList,
+	relation ancestorRelation,
+	userName string,
+) error {
+	key := materializedAssignmentKey{
+		user: userName,
+		list: list.GetName(),
+	}
+
+	if (!relation.isMember || !hasMemberGrants(list)) && (!relation.isOwner || !hasOwnerGrants(list)) {
+		// This access list does not grant any scoped roles to this user,
+		// delete any existing materialized assignment if present.
+		m.deleteMaterializedAssignment(ctx, state, key)
+		return nil
+	}
+
+	assignment := &scopedaccessv1.ScopedRoleAssignment{
+		Kind:    scopedaccess.KindScopedRoleAssignment,
+		SubKind: scopedaccess.SubKindMaterialized,
+		Version: types.V1,
+		Scope:   "/",
+		Metadata: &headerv1.Metadata{
+			Name: key.assignmentName(),
+		},
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+			User: userName,
+		},
+	}
+
+	if relation.isMember {
+		for _, grant := range list.Spec.Grants.ScopedRoles {
+			assignment.Spec.Assignments = append(assignment.Spec.Assignments, &scopedaccessv1.Assignment{
+				Role:  grant.Role,
+				Scope: grant.Scope,
+			})
+		}
+	}
+	if relation.isOwner {
+		for _, grant := range list.Spec.OwnerGrants.ScopedRoles {
+			assignment.Spec.Assignments = append(assignment.Spec.Assignments, &scopedaccessv1.Assignment{
+				Role:  grant.Role,
+				Scope: grant.Scope,
+			})
+		}
+	}
+
+	m.logger.DebugContext(ctx, "Materializing scoped role assignment",
+		"user", key.user,
+		"list", key.list)
+	if err := state.assignments.Put(assignment); err != nil {
+		return trace.Wrap(err, "putting materialized assignment into cache")
+	}
+	m.materializedAssignments[key] = relation
+	return nil
+}
+
+func (m *materializer) deleteMaterializedAssignment(ctx context.Context, state state, key materializedAssignmentKey) {
+	if _, ok := m.materializedAssignments[key]; ok {
+		m.logger.DebugContext(ctx, "Deleting materialized scoped role assignment",
+			"user", key.user,
+			"list", key.list)
+		state.assignments.Delete(key.assignmentName(), scopedaccess.SubKindMaterialized)
+		delete(m.materializedAssignments, key)
+
+	}
+}
+
+func (m *materializer) recheckAssignment(ctx context.Context, state state, key materializedAssignmentKey) error {
+	list, err := m.aclReader.GetAccessList(ctx, key.list)
+	if err != nil {
+		return trace.Wrap(err, "getting access list %v", key.list)
+	}
+
+	relation := ancestorRelation{
+		isOwner:  m.checkNestedOwnership(ctx, list, key.user),
+		isMember: m.checkNestedMembership(ctx, list, key.user),
+	}
+
+	if err := m.materializeAssignment(ctx, state, list, relation, key.user); err != nil {
+		return trace.Wrap(err, "materializing assignment")
+	}
+	return nil
+}
+
+func (m *materializer) checkNestedOwnership(ctx context.Context, list *accesslist.AccessList, userName string) bool {
+	if hasOwnershipRequires(list) {
+		// Ownerships can not be valid, for the puposes of granting scoped
+		// roles, if the list has any ownership requires.
+		return false
+	}
+
+	// First check if the user is directly an owner.
+	for _, owner := range list.Spec.Owners {
+		if !owner.IsMembershipKindUser() {
+			continue
+		}
+		if owner.Name == userName {
+			return true
+		}
+	}
+
+	// Then check if user is a member or nested member of any owner lists.
+	for _, owner := range list.Spec.Owners {
+		if owner.MembershipKind != accesslist.MembershipKindList {
+			continue
+		}
+		ownerList, err := m.aclReader.GetAccessList(ctx, owner.Name)
+		if err != nil {
+			// Must assume any membership is invalid if we can't fetch the access list.
+			continue
+		}
+		if m.checkNestedMembership(ctx, ownerList, userName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *materializer) checkNestedMembership(ctx context.Context, list *accesslist.AccessList, userName string) bool {
+	seen := set.New[string]()
+
+	var checkNestedMembershipRecursive func(*accesslist.AccessList) bool
+	checkNestedMembershipRecursive = func(list *accesslist.AccessList) bool {
+		if seen.Contains(list.GetName()) {
+			return false
+		}
+		seen.Add(list.GetName())
+
+		if hasMembershipRequires(list) {
+			// Memberships can not be valid, for the purposes of granting scoped
+			// roles, if the list has any ownership requires.
+			return false
+		}
+
+		// Check if the user is a non-expired direct member of this list.
+		member, err := m.aclReader.GetAccessListMember(ctx, list.GetName(), userName)
+		if err == nil {
+			if member.IsUser() && !member.IsExpired(time.Now()) {
+				// This user is a valid member.
+				return true
+			}
+		}
+
+		// Recursively check if the user is a valid member of any child lists.
+		for childListName := range m.ancestorCache.children.Get(list.GetName()).Items() {
+			listMember, err := m.aclReader.GetAccessListMember(ctx, list.GetName(), childListName)
+			if err != nil || listMember.IsExpired(time.Now()) {
+				// Couldn't fetch child list member or its membership is
+				// expired, don't walk this membership path.
+				continue
+			}
+			childList, err := m.aclReader.GetAccessList(ctx, childListName)
+			if err != nil {
+				// Must assume any membership is invalid if we can't fetch the access list.
+				continue
+			}
+			if checkNestedMembershipRecursive(childList) {
+				return true
+			}
+		}
+
+		// User was not a member of this list or any of its children.
+		return false
+	}
+
+	return checkNestedMembershipRecursive(list)
+}
+
+func (m *materializer) materializedAssignmentsForList(listName string) iter.Seq2[materializedAssignmentKey, ancestorRelation] {
+	return func(yield func(materializedAssignmentKey, ancestorRelation) bool) {
+		for key, relation := range m.materializedAssignments {
+			if key.list != listName {
+				continue
+			}
+			if !yield(key, relation) {
+				return
+			}
+		}
+	}
+}
+
+func (m *materializer) materializedAssignmentsForUser(userName string) iter.Seq2[materializedAssignmentKey, ancestorRelation] {
+	return func(yield func(materializedAssignmentKey, ancestorRelation) bool) {
+		for key, relation := range m.materializedAssignments {
+			if key.user != userName {
+				continue
+			}
+			if !yield(key, relation) {
+				return
+			}
+		}
+	}
+}
+
+// walkUserMembers returns an iterator that yields all nested user members of
+// [list], i.e. all its direct user members and all members of all its member
+// lists, recursively. Each user member will be yielded at most once.
+//
+// Each list is checked that it does not contain membership requires and that
+// the member resources exists and is not expired -> invalid edges are not
+// followed.
+//
+// It will yield any errors encountered while fetching list or member resources
+// but may continue iterating over other lists/members.
+func (m *materializer) walkUserMembers(ctx context.Context, list *accesslist.AccessList) iter.Seq2[*accesslist.AccessListMember, error] {
+	seenLists := set.New[string]()
+	seenUsers := set.New[string]()
+	return m.walkUserMembersRecursive(ctx, list, seenLists, seenUsers)
+}
+
+// walkUserMembers returns an iterator that yields all nested user members of
+// [list], i.e. all its direct user members and all members of all its member
+// lists, recursively.
+//
+// It will not walk members of any lists already present in [seenLists], and
+// each list will be added as it is walked.
+// It will not yield any users already present in [seenUsers], and each user
+// will be added as it is yielded, so that it is yielded at most once.
+//
+// This can be called multiple times with the same seenLists/seenUsers to walk
+// multiple list subtrees without repeating lists/users multiple times.
+//
+// Each list is checked that it does not contain membership requires and that
+// the member resources exists and is not expired -> invalid edges are not
+// followed.
+//
+// It will yield any errors encountered while fetching list or member resources
+// but may continue iterating over other lists/members.
+func (m *materializer) walkUserMembersRecursive(ctx context.Context, list *accesslist.AccessList, seenLists set.Set[string], seenUsers set.Set[string]) iter.Seq2[*accesslist.AccessListMember, error] {
+	return func(yield func(*accesslist.AccessListMember, error) bool) {
+		seenLists.Add(list.GetName())
+		if hasMembershipRequires(list) {
+			// membership requires are not supported in lists that transitively
+			// grant scoped roles, do not walk members of this list.
+			return
+		}
+
+		for member, err := range clientutils.Resources(ctx, listAccessListMembers(m.aclReader, list.GetName())) {
+			if err != nil {
+				if !yield(nil, trace.Wrap(err)) {
+					return
+				}
+				continue
+			}
+
+			if member.IsExpired(time.Now()) {
+				// Do not follow expired memberships.
+				continue
+			}
+
+			if member.IsUser() {
+				// Found a legitimate user member, yield it if it has not
+				// already been yielded.
+				if seenUsers.Contains(member.GetName()) {
+					continue
+				}
+				seenUsers.Add(member.GetName())
+				if !yield(member, nil) {
+					return
+				}
+			}
+
+			if member.Spec.MembershipKind != accesslist.MembershipKindList {
+				// Currently members can only be users or lists, may need to
+				// handle bots in the future.
+				continue
+			}
+
+			// Don't walk through this list if has already been seen.
+			if seenLists.Contains(member.GetName()) {
+				continue
+			}
+
+			// Fetch the member list resource so the recursive call can check
+			// if it has any membership requires.
+			memberList, err := m.aclReader.GetAccessList(ctx, member.GetName())
+			if err != nil {
+				// Yield the error so the caller can handle it how it wants,
+				// but continue iterating other nested members.
+				if !yield(nil, trace.Wrap(err, "fetching member list")) {
+					return
+				}
+				continue
+			}
+
+			// Walk and yield all nested members of this member list.
+			m.walkUserMembersRecursive(ctx, memberList, seenLists, seenUsers)(yield)
+		}
+	}
+}
+
+type mapStringSet struct {
+	m map[string]set.Set[string]
+}
+
+func newMapStringSet() mapStringSet {
+	return mapStringSet{
+		m: make(map[string]set.Set[string]),
+	}
+}
+
+// readOnlySet implements a read-only view of a set.Set[string] that only
+// contains methods guaranteed to work even if the underlying map is nil.
+type readOnlySet struct {
+	s set.Set[string]
+}
+
+// Contains implements a membership test for the readOnlySet.
+func (s readOnlySet) Contains(key string) bool {
+	return s.s.Contains(key)
+}
+
+// Items returns an iterator over all items in the set.
+func (s readOnlySet) Items() iter.Seq[string] {
+	return maps.Keys(s.s)
+}
+
+// Get returns a read-only view of the set for the given key, it does not
+// allocate a set if the key is not present.
+func (m *mapStringSet) Get(key string) readOnlySet {
+	return readOnlySet{m.m[key]}
+}
+
+// Ensure returns a set for the given key, creating an empty set if one is not
+// currently present. Prefer [mapStringSet.Get] if the retuned set does not
+// need to be mutated.
+func (m *mapStringSet) Ensure(key string) set.Set[string] {
+	if s, ok := m.m[key]; ok {
+		return s
+	}
+	s := set.New[string]()
+	m.m[key] = s
+	return s
+}
+
+type ancestorCache struct {
+	parents  mapStringSet
+	children mapStringSet
+	ownedBy  mapStringSet
+	ownersOf mapStringSet
+}
+
+func newAncestorCache() *ancestorCache {
+	return &ancestorCache{
+		parents:  newMapStringSet(),
+		children: newMapStringSet(),
+		ownedBy:  newMapStringSet(),
+		ownersOf: newMapStringSet(),
+	}
+}
+
+func (c *ancestorCache) addMembership(parent, member string) {
+	c.parents.Ensure(member).Add(parent)
+	c.children.Ensure(parent).Add(member)
+}
+
+func (c *ancestorCache) removeMembership(parent, member string) {
+	c.parents.Ensure(member).Remove(parent)
+	c.children.Ensure(parent).Remove(member)
+}
+
+func (c *ancestorCache) addOwnership(owner, owned string) {
+	c.ownedBy.Ensure(owner).Add(owned)
+	c.ownersOf.Ensure(owned).Add(owner)
+}
+
+func (c *ancestorCache) removeOwnership(owner, owned string) {
+	c.ownedBy.Ensure(owner).Remove(owned)
+	c.ownersOf.Ensure(owned).Remove(owner)
+}
+
+func (c *ancestorCache) clearOwnersOf(owned string) {
+	for owner := range c.ownersOf.Get(owned).Items() {
+		c.removeOwnership(owner, owned)
+	}
+}
+
+type collectAncestorListsParams struct {
+	startListName      string
+	validateMembership func(parentListName, memberListName string) bool
+	validateOwnership  func(ownerListName, ownedListName string) bool
+}
+
+type ancestorRelation struct {
+	isOwner  bool
+	isMember bool
+}
+
+// collectAncestorLists returns a collection of all ancestor lists of the given
+// list, that is all lists where the given list is a (nested) member or owner.
+// This may be useful for calculating all related lists that may require an
+// assignment to be materialized for members of the starting list.
+func (c *ancestorCache) collectAncestorLists(params collectAncestorListsParams) map[string]ancestorRelation {
+	result := make(map[string]ancestorRelation)
+	markOwned := func(ownedListName string) {
+		curr := result[ownedListName]
+		curr.isOwner = true
+		result[ownedListName] = curr
+	}
+	markMember := func(parentListName string) {
+		curr := result[parentListName]
+		curr.isMember = true
+		result[parentListName] = curr
+	}
+
+	seen := set.New[string]()
+
+	var collectAncestorsRecursive func(currListName string)
+	collectAncestorsRecursive = func(currListName string) {
+		if seen.Contains(currListName) {
+			return
+		}
+		seen.Add(currListName)
+
+		// User is a member of currList, which implies they are an owner of all
+		// lists owned by currList.
+		for ownedListName := range c.ownedBy.Get(currListName).Items() {
+			if !params.validateOwnership(currListName, ownedListName) {
+				continue
+			}
+			markOwned(ownedListName)
+		}
+
+		// User is a member of currList, which implies they are a member of all
+		// lists where currList is a member.
+		for parentListName := range c.parents.Get(currListName).Items() {
+			if !params.validateMembership(parentListName, currListName) {
+				continue
+			}
+			markMember(parentListName)
+			collectAncestorsRecursive(parentListName)
+		}
+	}
+
+	collectAncestorsRecursive(params.startListName)
+	return result
+}
+
+// collectAncestorListsWithoutValidation returns a collection of all ancestor
+// lists of the given list, that is all lists where the given list is a
+// (nested) member or owner.
+//
+// This variant does no validation on membership or ownerships and is infallible:
+// if m.ancestorCache is in a correct state, this is guaranteed to return all
+// potential ancestors of the starting list, even if no access list or member
+// resources can be fetched.
+//
+// This is useful when handling membership deletions, which requires
+// pessimistic validation of every possible already-materialized assignment
+// that may need to be invalidated.
+func (m *materializer) collectAncestorListsWithoutValidation(startListName string) map[string]ancestorRelation {
+	return m.ancestorCache.collectAncestorLists(collectAncestorListsParams{
+		startListName:      startListName,
+		validateMembership: func(string, string) bool { return true },
+		validateOwnership:  func(string, string) bool { return true },
+	})
+}
+
+// ancestor represents an ancestor access list and its relation to a starting
+// access list.
+type ancestor struct {
+	relation ancestorRelation
+	list     *accesslist.AccessList
+}
+
+// collectAncestors returns a filtered and validated view of all ancestor
+// lists of the given starting list. This is the set of all access lists that
+// should grant scoped roles to a user based on membership in the starting
+// list.
+//
+// Initially, all lists where the starting list is a (nested) member OR an
+// owner are considered an ancestor.
+//
+// Every member relationship is validated to assert that it is not expired and
+// the parent list does not contain any membership_requires. Membership paths
+// through invalid member resources or access lists are now followed.
+//
+// Every owner relationship is validated to assert that the owned list does not
+// contain any ownership requires.
+//
+// Finally, any lists that do not contain any effective scoped role grants are
+// filted out. It is safe to materialize an assignment for all returned lists
+// without any further validation.
+func (m *materializer) collectAncestors(ctx context.Context, startListName string) ([]ancestor, []error) {
+	var validationErrors []error
+	fetchedLists := make(map[string]*accesslist.AccessList)
+	ancestorRelations := m.ancestorCache.collectAncestorLists(collectAncestorListsParams{
+		startListName: startListName,
+		validateMembership: func(parentListName, memberListName string) bool {
+			memberResource, err := m.aclReader.GetAccessListMember(ctx, parentListName, memberListName)
+			if err != nil {
+				validationErrors = append(validationErrors,
+					trace.Wrap(err, "getting access list member %q in list %q", memberListName, parentListName))
+				return false
+			}
+			if memberResource.IsExpired(time.Now()) {
+				// This is not a validation error, expired member resources are
+				// expected but should not be followed.
+				return false
+			}
+			parentList, err := m.aclReader.GetAccessList(ctx, parentListName)
+			if err != nil {
+				validationErrors = append(validationErrors,
+					trace.Wrap(err, "getting access list %q", parentListName))
+				return false
+			}
+			fetchedLists[parentListName] = parentList
+			if hasMembershipRequires(parentList) {
+				// This is not necessarily a validation error, many lists may
+				// have membership requires, which is fine as long as they
+				// don't grant scoped roles, we just don't need to follow the
+				// edge.
+				return false
+			}
+			return true
+		},
+		validateOwnership: func(parentListName, ownedListName string) bool {
+			ownedList, err := m.aclReader.GetAccessList(ctx, ownedListName)
+			if err != nil {
+				validationErrors = append(validationErrors,
+					trace.Wrap(err, "getting access list %q", ownedListName))
+				return false
+			}
+			fetchedLists[ownedListName] = ownedList
+			if hasOwnershipRequires(ownedList) {
+				// This is not necessarily a validation error, many lists may
+				// have ownership requires, which is fine as long as they
+				// don't grant scoped roles, we just don't need to follow the
+				// edge.
+				return false
+			}
+			return true
+		},
+	})
+
+	var filteredAncestors []ancestor
+	for ancestorListName, ancestorRelation := range ancestorRelations {
+		ancestorList, ok := fetchedLists[ancestorListName]
+		if !ok {
+			validationErrors = append(validationErrors, trace.Errorf("ancestor list was not fetched, this is a bug"))
+			continue
+		}
+		if hasMemberGrants(ancestorList) && ancestorRelation.isMember ||
+			hasOwnerGrants(ancestorList) && ancestorRelation.isOwner {
+			filteredAncestors = append(filteredAncestors, ancestor{
+				list:     ancestorList,
+				relation: ancestorRelation,
+			})
+		}
+	}
+	return filteredAncestors, validationErrors
+}
+
+func hasMemberGrants(list *accesslist.AccessList) bool {
+	return len(list.Spec.Grants.ScopedRoles) > 0
+}
+
+func hasOwnerGrants(list *accesslist.AccessList) bool {
+	return len(list.Spec.OwnerGrants.ScopedRoles) > 0
+}
+
+func hasMembershipRequires(list *accesslist.AccessList) bool {
+	return !list.Spec.MembershipRequires.IsEmpty()
+}
+
+func hasOwnershipRequires(list *accesslist.AccessList) bool {
+	return !list.Spec.OwnershipRequires.IsEmpty()
+}

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -240,7 +240,7 @@ func (m *materializer) handleUserMemberPut(ctx context.Context, state state, mem
 		return
 	}
 
-	if err := m.addMemberAssignment(ctx, state, list, userName); err != nil {
+	if err := m.addMemberRelationshipAndMaterialize(ctx, state, list, userName); err != nil {
 		m.logger.WarnContext(ctx, "Failed to materialize assignment",
 			"error", err,
 			"user", userName,
@@ -257,7 +257,7 @@ func (m *materializer) handleUserMemberPut(ctx context.Context, state state, mem
 	// As a member of this list, the user shares the list's relationship with
 	// all of its ancestors, make sure assignments are materialized.
 	for _, ancestor := range ancestors {
-		if err := m.mergeAncestorAssignment(ctx, state, ancestor.list, ancestor.relation, userName); err != nil {
+		if err := m.updateRelationshipAndMaterialize(ctx, state, ancestor.list, ancestor.relation, userName); err != nil {
 			m.logger.WarnContext(ctx, "Failed to materialize assignment",
 				"error", err,
 				"user", userName,
@@ -340,7 +340,7 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 		}
 
 		// User is now a member of the parent list, materialize an assignment.
-		if err := m.addMemberAssignment(ctx, state, parentList, member.GetName()); err != nil {
+		if err := m.addMemberRelationshipAndMaterialize(ctx, state, parentList, member.GetName()); err != nil {
 			m.logger.WarnContext(ctx, "Failed to materialize assignment",
 				"error", err,
 				"user", member.GetName(),
@@ -351,7 +351,7 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 		// list's relationship with all of its ancestors, make sure assignments
 		// are materialized.
 		for _, ancestor := range ancestors {
-			if err := m.mergeAncestorAssignment(ctx, state, ancestor.list, ancestor.relation, member.GetName()); err != nil {
+			if err := m.updateRelationshipAndMaterialize(ctx, state, ancestor.list, ancestor.relation, member.GetName()); err != nil {
 				m.logger.WarnContext(ctx, "Failed to materialize assignment",
 					"error", err,
 					"user", member.GetName(),
@@ -364,17 +364,20 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 func (m *materializer) handleAccessListMemberDelete(ctx context.Context, state state, listName, memberName string) {
 	// We don't get enough info from the event to know if the deleted member
 	// was a user or a list. Luckily member names are unique, so we know that
-	// if this membership is present in the ancestor cache then the deleted
-	// member is a list.
+	// if this membership is present in the ancestor cache as a list, then this
+	// member was last observed as a list. If it is not present in the ancestor
+	// cache, then it was last observed as a user (or not observed at all) and
+	// we handle it as a user member delete.
 	if m.ancestorCache.children.Get(listName).Contains(memberName) {
 		m.handleListMemberDelete(ctx, state, listName, memberName)
+		return
 	}
 	m.handleUserMemberDeleteOrExpired(ctx, state, listName, memberName)
 }
 
 // handleListMemberDelete handles delete events for nested access list memberships.
 func (m *materializer) handleListMemberDelete(ctx context.Context, state state, parentListName, memberListName string) {
-	// First and foremost, always keep the ancestor cache up to date will all
+	// First and foremost, always keep the ancestor cache up to date with all
 	// direct list->list memberships.
 	m.ancestorCache.removeMembership(parentListName, memberListName)
 
@@ -559,7 +562,7 @@ func (m *materializer) initAccessListMembers(ctx context.Context, state state, l
 
 		if hasMemberGrants {
 			// This user is a confirmed member, make sure a member assignment is materialized.
-			if err := m.addMemberAssignment(ctx, state, list, member.GetName()); err != nil {
+			if err := m.addMemberRelationshipAndMaterialize(ctx, state, list, member.GetName()); err != nil {
 				m.logger.WarnContext(ctx, "Failed to materialize assignment",
 					"error", err,
 					"user", member.GetName(),
@@ -570,7 +573,7 @@ func (m *materializer) initAccessListMembers(ctx context.Context, state state, l
 		// As a member of this list, the user shares the list's relationship
 		// with all of its ancestors, make sure assignments are materialized.
 		for _, ancestor := range ancestors {
-			if err := m.mergeAncestorAssignment(ctx, state, ancestor.list, ancestor.relation, member.GetName()); err != nil {
+			if err := m.updateRelationshipAndMaterialize(ctx, state, ancestor.list, ancestor.relation, member.GetName()); err != nil {
 				m.logger.WarnContext(ctx, "Failed to materialize assignment",
 					"error", err,
 					"user", member.GetName(),
@@ -601,7 +604,7 @@ func (m *materializer) initAccessListOwners(ctx context.Context, state state, li
 			// This user is a confirmed direct owner, make sure an owner
 			// assignment is materialized.
 			seenUsers.Add(owner.Name)
-			if err := m.addOwnerAssignment(ctx, state, list, owner.Name); err != nil {
+			if err := m.addOwnerRelationshipAndMaterialize(ctx, state, list, owner.Name); err != nil {
 				m.logger.WarnContext(ctx, "Failed to materialize assignment",
 					"error", err,
 					"user", owner.Name,
@@ -635,7 +638,7 @@ func (m *materializer) initAccessListOwners(ctx context.Context, state state, li
 				// member lists, but it may not be done, so continue the loop.
 				continue
 			}
-			if err := m.addOwnerAssignment(ctx, state, list, member.GetName()); err != nil {
+			if err := m.addOwnerRelationshipAndMaterialize(ctx, state, list, member.GetName()); err != nil {
 				m.logger.WarnContext(ctx, "Failed to materialize assignment",
 					"error", err,
 					"user", member.GetName(),
@@ -686,27 +689,31 @@ func (m *materializer) handleAccessListDelete(ctx context.Context, state state, 
 	}
 }
 
-// addMemberAssignment adds the given user as a member of list, additively merges
-// with any existing materialized assignment for the user in case the user is
-// already a known owner of the list, and materializes an assignment.
-func (m *materializer) addMemberAssignment(ctx context.Context, state state, list *accesslist.AccessList, userName string) error {
+// addMemberRelationshipAndMaterialize adds the given user as a member of list,
+// additively merges with any existing materialized assignment for the user in
+// case the user is already a known owner of the list, and materializes an
+// assignment.
+func (m *materializer) addMemberRelationshipAndMaterialize(ctx context.Context, state state, list *accesslist.AccessList, userName string) error {
 	relation := ancestorRelation{isMember: true}
-	return m.mergeAncestorAssignment(ctx, state, list, relation, userName)
+	return m.updateRelationshipAndMaterialize(ctx, state, list, relation, userName)
 }
 
-// addOwnerAssignment adds the given user as an owner of list, additively
-// merges with any existing materialized assignment for the user in case the
-// user is already a known member of the list, and materializes an assignment.
-func (m *materializer) addOwnerAssignment(ctx context.Context, state state, list *accesslist.AccessList, userName string) error {
+// addOwnerRelationshipAndMaterialize adds the given user as an owner of list,
+// additively merges with any existing materialized assignment for the user in
+// case the user is already a known member of the list, and materializes an
+// assignment.
+func (m *materializer) addOwnerRelationshipAndMaterialize(ctx context.Context, state state, list *accesslist.AccessList, userName string) error {
 	relation := ancestorRelation{isOwner: true}
-	return m.mergeAncestorAssignment(ctx, state, list, relation, userName)
+	return m.updateRelationshipAndMaterialize(ctx, state, list, relation, userName)
 }
 
-// mergeAncestorAssignment adds list as an ancestor of the user and additively
-// merges the given relation with the current relation of any existing
-// materialized assignment for the user. It materializes an assignment for the
-// (user, list) pair.
-func (m *materializer) mergeAncestorAssignment(
+// updateRelationshipAndMaterialize additively updates our knowledge about a
+// given user's relationship (owner and/or member) to a given list, without
+// clearing previously set relationships. Ensures the corresponding materialized
+// assignment is created or updated as-needed. This function is called both for
+// direct relationships, and to record the transitive relationships implied by
+// nested lists.
+func (m *materializer) updateRelationshipAndMaterialize(
 	ctx context.Context,
 	state state,
 	list *accesslist.AccessList,

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -644,14 +644,43 @@ func (m *materializer) initAccessListOwners(ctx context.Context, state state, li
 }
 
 // handleAccessListDelete handles delete events for access lists.
-// Access lists cannot be deleted if they are a member or owner of another
-// list, but they may have materialized assignments for their own owners.
+// Access lists are unlikely to be deleted if they are a member or owner of
+// another list (the access list service attempts to prevent it), but to be
+// defensive we re-check assignments for all ancestors anyway in case a
+// membership path through this list has been broken.
 func (m *materializer) handleAccessListDelete(ctx context.Context, state state, listName string) {
+	// First of all, keep the ancestor cache up to date with respect to owners.
+	// Access lists are the source of truth for direct owner relationships.
+	// While the deletion of the access list may invalidate a direct membership
+	// involving this list, the source of truth is the member resource, and the
+	// ancestor cache for members will be reconciled in response to member
+	// events.
 	for owner := range m.ancestorCache.ownersOf.Get(listName).Items() {
 		m.ancestorCache.removeOwnership(owner, listName)
 	}
-	for key := range m.materializedAssignmentsForList(listName) {
-		m.deleteMaterializedAssignment(ctx, state, key)
+
+	// Assignments for any ancestor list may be affected if a membership path
+	// through this deleted list is now broken. Collect all ancestor lists
+	// without validation to avoid missing any due to read/paging errors.
+	ancestors := m.collectAncestorListsWithoutValidation(listName)
+
+	// Iterate all currently materialized assignments.
+	for key := range m.materializedAssignments {
+		_, isAncestor := ancestors[key.list]
+		if key.list != listName && !isAncestor {
+			// We don't need to validate any assignments that are not for the
+			// deleted list or any of its ancestors.
+			continue
+		}
+
+		if err := m.recheckAssignment(ctx, state, key); err != nil {
+			// Must pessimistically assume any assignment is invalid if we
+			// encountered an error trying to validate it.
+			m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
+				"error", err)
+			m.deleteMaterializedAssignment(ctx, state, key)
+			// TODO(nic): schedule a refresh to recover.
+		}
 	}
 }
 

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -209,8 +209,10 @@ func (m *materializer) handleUserMemberPut(ctx context.Context, state state, mem
 	userName := member.GetName()
 
 	if m.ancestorCache.children.Get(listName).Contains(userName) {
-		// This access list member must have had membership kind list before,
-		// and was updated to membership kind user.
+		// Due to presence in the ancestor cache, this access list member must
+		// have been observed with membership kind list before, and now has
+		// membership kind user. Process a list member delete first, and then
+		// carry on to handle the user member put.
 		m.handleListMemberDelete(ctx, state, listName, userName)
 	}
 

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -1,0 +1,1123 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package access
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/accesslists"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	cachepkg "github.com/gravitational/teleport/lib/cache"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/scopes/cache/assignments"
+	"github.com/gravitational/teleport/lib/scopes/utils"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
+
+type materializerTestcase struct {
+	// An initial collection of access lists and members for the test case.
+	collection accesslists.Collection
+	// Expected assignments after cache init (and materialization).
+	expectedAssignments []*scopedaccessv1.ScopedRoleAssignment
+	// Optional extra mutation steps the test may run.
+	steps []materializerTestcaseStep
+}
+
+type materializerTestcaseStep struct {
+	mutateState         func(t *testing.T, aclService *local.AccessListService)
+	expectedAssignments []*scopedaccessv1.ScopedRoleAssignment
+}
+
+func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
+	// Setup prequisites for the cache
+	backend, err := memory.New(memory.Config{
+		Context: t.Context(),
+	})
+	require.NoError(t, err)
+	defer backend.Close()
+
+	events := local.NewEventsService(backend)
+	scopedAccessService := local.NewScopedAccessService(backend)
+
+	aclService, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
+		Backend: backend,
+		Modules: modulestest.EnterpriseModules(),
+	})
+	require.NoError(t, err)
+
+	// Insert the access lists and members into the backend.
+	require.NoError(t, aclService.InsertAccessListCollection(t.Context(), &tc.collection))
+
+	// Create the access lists cache.
+	aclCache, err := cachepkg.New(cachepkg.Config{
+		Context: t.Context(),
+		Events:  events,
+		Watches: []types.WatchKind{
+			{Kind: types.KindAccessList},
+			{Kind: types.KindAccessListMember},
+		},
+		AccessLists: aclService,
+	})
+	require.NoError(t, err)
+	defer aclCache.Close()
+	<-aclCache.FirstInit()
+
+	// Create the scoped access cache.
+	cache, err := NewCache(CacheConfig{
+		Events:           events,
+		Reader:           scopedAccessService,
+		AccessListEvents: aclCache,
+		AccessListReader: aclCache,
+	})
+	require.NoError(t, err)
+	defer cache.Close()
+	<-cache.Init()
+
+	assertMaterializedAssignments := func(t *testing.T, expectedAssignments []*scopedaccessv1.ScopedRoleAssignment) {
+		t.Helper()
+
+		// Assert that all expected assignments were materialized (and there are no extras).
+		expectedAssignmentsMap := make(map[string]*scopedaccessv1.ScopedRoleAssignment, len(expectedAssignments))
+		for _, assignment := range expectedAssignments {
+			expectedAssignmentsMap[assignment.GetMetadata().GetName()] = assignment
+		}
+
+		for assignment, err := range utils.RangeScopedRoleAssignments(t.Context(), cache, &scopedaccessv1.ListScopedRoleAssignmentsRequest{}) {
+			require.NoError(t, err)
+			expectedAssignment, ok := expectedAssignmentsMap[assignment.GetMetadata().GetName()]
+			if !ok {
+				assert.Fail(t, "found unexpected scoped role assignment", "%v", assignment)
+				continue
+			}
+			assert.Empty(t, cmp.Diff(expectedAssignment, assignment, protocmp.Transform()))
+			delete(expectedAssignmentsMap, assignment.GetMetadata().GetName())
+		}
+		for _, expectedAssignment := range expectedAssignmentsMap {
+			assert.Fail(t, "expected assignment was not found", "%v", expectedAssignment)
+		}
+	}
+
+	// Assert the initial materialized assignments.
+	assertMaterializedAssignments(t, tc.expectedAssignments)
+
+	// Run through each step and assert the final assignments.
+	for i, step := range tc.steps {
+		t.Logf("Running step %d", i)
+		step.mutateState(t, aclService)
+		synctest.Wait()
+		assertMaterializedAssignments(t, step.expectedAssignments)
+	}
+
+}
+
+func TestMaterializerSimpleChain(t *testing.T) {
+	t.Parallel()
+	runMaterializerTestcase(t, materializerTestcase{
+		collection: accesslists.Collection{
+			AccessListsByName: map[string]*accesslist.AccessList{
+				"grandparent": newAccessList(t, "grandparent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/aa/bb/cc",
+					Role:  "grandparentrole",
+				}})),
+				"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/aa/bb",
+					Role:  "parentrole",
+				}})),
+				"base": newAccessList(t, "base", withMemberGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/aa",
+					Role:  "baserole",
+				}})),
+			},
+			MembersByAccessList: map[string][]*accesslist.AccessListMember{
+				"grandparent": {
+					newAccessListMember(t, "grandparent", "parent", accesslist.MembershipKindList),
+				},
+				"parent": {
+					newAccessListMember(t, "parent", "base", accesslist.MembershipKindList),
+				},
+				"base": {
+					newAccessListMember(t, "base", "tester", accesslist.MembershipKindUser),
+				},
+			},
+		},
+		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+			expectedScopedRoleAssignment("tester", "base", []*scopedaccessv1.Assignment{{
+				Role:  "baserole",
+				Scope: "/aa",
+			}}),
+			expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{{
+				Role:  "parentrole",
+				Scope: "/aa/bb",
+			}}),
+			expectedScopedRoleAssignment("tester", "grandparent", []*scopedaccessv1.Assignment{{
+				Role:  "grandparentrole",
+				Scope: "/aa/bb/cc",
+			}}),
+		},
+	})
+}
+
+func TestMaterializerDoubleListMembership(t *testing.T) {
+	t.Parallel()
+	runMaterializerTestcase(t, materializerTestcase{
+		collection: accesslists.Collection{
+			AccessListsByName: map[string]*accesslist.AccessList{
+				"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/parentscope",
+					Role:  "parentrole",
+				}})),
+				"memberListA": newAccessList(t, "memberListA"),
+				"memberListB": newAccessList(t, "memberListB"),
+			},
+			MembersByAccessList: map[string][]*accesslist.AccessListMember{
+				"parent": {
+					newAccessListMember(t, "parent", "memberListA", accesslist.MembershipKindList),
+					newAccessListMember(t, "parent", "memberListB", accesslist.MembershipKindList),
+					newAccessListMember(t, "parent", "testerD", accesslist.MembershipKindUser),
+				},
+				"memberListA": {
+					newAccessListMember(t, "memberListA", "testerA", accesslist.MembershipKindUser),
+					newAccessListMember(t, "memberListA", "testerC", accesslist.MembershipKindUser),
+				},
+				"memberListB": {
+					newAccessListMember(t, "memberListB", "testerB", accesslist.MembershipKindUser),
+					newAccessListMember(t, "memberListB", "testerC", accesslist.MembershipKindUser),
+				},
+			},
+		},
+		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+			// All users should be direct or nested members of the parent role,
+			// expect exactly one materialized assignment each.
+			expectedScopedRoleAssignment("testerA", "parent", []*scopedaccessv1.Assignment{{
+				Role:  "parentrole",
+				Scope: "/parentscope",
+			}}),
+			expectedScopedRoleAssignment("testerB", "parent", []*scopedaccessv1.Assignment{{
+				Role:  "parentrole",
+				Scope: "/parentscope",
+			}}),
+			expectedScopedRoleAssignment("testerC", "parent", []*scopedaccessv1.Assignment{{
+				Role:  "parentrole",
+				Scope: "/parentscope",
+			}}),
+			expectedScopedRoleAssignment("testerD", "parent", []*scopedaccessv1.Assignment{{
+				Role:  "parentrole",
+				Scope: "/parentscope",
+			}}),
+		},
+	})
+}
+
+func TestMaterializerDoubleListParents(t *testing.T) {
+	t.Parallel()
+	runMaterializerTestcase(t, materializerTestcase{
+		collection: accesslists.Collection{
+			AccessListsByName: map[string]*accesslist.AccessList{
+				"parentA": newAccessList(t, "parentA", withMemberGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/aa",
+					Role:  "roleA",
+				}})),
+				"parentB": newAccessList(t, "parentB", withMemberGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/bb",
+					Role:  "roleB",
+				}})),
+				"child": newAccessList(t, "child"),
+			},
+			MembersByAccessList: map[string][]*accesslist.AccessListMember{
+				"parentA": {
+					newAccessListMember(t, "parentA", "child", accesslist.MembershipKindList),
+				},
+				"parentB": {
+					newAccessListMember(t, "parentB", "child", accesslist.MembershipKindList),
+				},
+				"child": {
+					newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+				},
+			},
+		},
+		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+			// User should be a nested member of both parents and get an assignment for each.
+			expectedScopedRoleAssignment("tester", "parentA", []*scopedaccessv1.Assignment{{
+				Role:  "roleA",
+				Scope: "/aa",
+			}}),
+			expectedScopedRoleAssignment("tester", "parentB", []*scopedaccessv1.Assignment{{
+				Role:  "roleB",
+				Scope: "/bb",
+			}}),
+		},
+	})
+}
+
+func TestMaterializerDirectOwner(t *testing.T) {
+	t.Parallel()
+	runMaterializerTestcase(t, materializerTestcase{
+		collection: accesslists.Collection{
+			AccessListsByName: map[string]*accesslist.AccessList{
+				"testlist": newAccessList(t, "testlist", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/aa",
+					Role:  "testrole",
+				}}), withOwners([]accesslist.Owner{{
+					Name:           "tester",
+					MembershipKind: accesslist.MembershipKindUser,
+				}})),
+			},
+			MembersByAccessList: map[string][]*accesslist.AccessListMember{
+				"testlist": {},
+			},
+		},
+		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+			// The user is simply a direct owner of the access list and an
+			// assignment is expected.
+			expectedScopedRoleAssignment("tester", "testlist", []*scopedaccessv1.Assignment{{
+				Role:  "testrole",
+				Scope: "/aa",
+			}}),
+		},
+	})
+}
+
+func TestMaterializerUserMemberPutPreservesExistingOwnerGrant(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.Collection{
+				AccessListsByName: map[string]*accesslist.AccessList{
+					"granted": newAccessList(t, "granted",
+						withMemberGrants([]accesslist.ScopedRoleGrant{{
+							Scope: "/member",
+							Role:  "memberrole",
+						}}),
+						withOwnerGrants([]accesslist.ScopedRoleGrant{{
+							Scope: "/owner",
+							Role:  "ownerrole",
+						}}),
+						withOwners([]accesslist.Owner{{
+							Name:           "tester",
+							MembershipKind: accesslist.MembershipKindUser,
+						}}),
+					),
+					"child": newAccessList(t, "child"),
+				},
+				MembersByAccessList: map[string][]*accesslist.AccessListMember{
+					"granted": {
+						newAccessListMember(t, "granted", "child", accesslist.MembershipKindList),
+					},
+					"child": {},
+				},
+			},
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{{
+					Role:  "ownerrole",
+					Scope: "/owner",
+				}}),
+			},
+			steps: []materializerTestcaseStep{{
+				mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					_, err := aclService.UpsertAccessListMember(t.Context(),
+						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser))
+					require.NoError(t, err)
+				},
+				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+					// tester is now both a direct owner of granted and a nested member via child,
+					// so the materialized assignment must include both grants.
+					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{{
+						Role:  "memberrole",
+						Scope: "/member",
+					}, {
+						Role:  "ownerrole",
+						Scope: "/owner",
+					}}),
+				},
+			}},
+		})
+	})
+}
+
+func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.Collection{
+				AccessListsByName: map[string]*accesslist.AccessList{
+					"granted": newAccessList(t, "granted",
+						withMemberGrants([]accesslist.ScopedRoleGrant{{
+							Scope: "/member",
+							Role:  "memberrole",
+						}}),
+						withOwnerGrants([]accesslist.ScopedRoleGrant{{
+							Scope: "/owner",
+							Role:  "ownerrole",
+						}}),
+						withOwners([]accesslist.Owner{{
+							Name:           "tester",
+							MembershipKind: accesslist.MembershipKindUser,
+						}}),
+					),
+					"parent": newAccessList(t, "parent"),
+					"child":  newAccessList(t, "child"),
+				},
+				MembersByAccessList: map[string][]*accesslist.AccessListMember{
+					"granted": {
+						newAccessListMember(t, "granted", "parent", accesslist.MembershipKindList),
+					},
+					"parent": {},
+					"child": {
+						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+					},
+				},
+			},
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{{
+					Role:  "ownerrole",
+					Scope: "/owner",
+				}}),
+			},
+			steps: []materializerTestcaseStep{{
+				mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					_, err := aclService.UpsertAccessListMember(t.Context(),
+						newAccessListMember(t, "parent", "child", accesslist.MembershipKindList))
+					require.NoError(t, err)
+				},
+				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+					// tester is now both a direct owner of granted and a nested member via
+					// parent->child, so the materialized assignment must include both grants.
+					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{{
+						Role:  "memberrole",
+						Scope: "/member",
+					}, {
+						Role:  "ownerrole",
+						Scope: "/owner",
+					}}),
+				},
+			}},
+		})
+	})
+}
+
+func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.Collection{
+				AccessListsByName: map[string]*accesslist.AccessList{
+					"granted": newAccessList(t, "granted",
+						withMemberGrants([]accesslist.ScopedRoleGrant{{
+							Scope: "/member",
+							Role:  "memberrole",
+						}}),
+						withOwnerGrants([]accesslist.ScopedRoleGrant{{
+							Scope: "/owner",
+							Role:  "ownerrole",
+						}}),
+						withOwners([]accesslist.Owner{{
+							Name:           "tester",
+							MembershipKind: accesslist.MembershipKindUser,
+						}}),
+					),
+					// child list starts with membership requirements, so any
+					// memberships are initially invalid.
+					"child": newAccessList(t, "child", withMembershipRequires()),
+				},
+				MembersByAccessList: map[string][]*accesslist.AccessListMember{
+					"granted": {
+						newAccessListMember(t, "granted", "child", accesslist.MembershipKindList),
+					},
+					"child": {
+						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+					},
+				},
+			},
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				// tests is initially ownly an owner of the granted list.
+				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{{
+					Role:  "ownerrole",
+					Scope: "/owner",
+				}}),
+			},
+			steps: []materializerTestcaseStep{{
+				mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					// remove the membership requirements so that tester
+					// becomes a legitimate member of child and granted lists.
+					_, err := aclService.UpsertAccessList(t.Context(), newAccessList(t, "child"))
+					require.NoError(t, err)
+				},
+				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+					// as tests is now a member and owner of granted, make sure
+					// the materialiazed assignment includes both grants.
+					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{{
+						Role:  "memberrole",
+						Scope: "/member",
+					}, {
+						Role:  "ownerrole",
+						Scope: "/owner",
+					}}),
+				},
+			}},
+		})
+	})
+}
+
+func TestMaterializerOwnerRequirements(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.Collection{
+				AccessListsByName: map[string]*accesslist.AccessList{
+					// Ownership requirements in the owner list should not block
+					// _members_ of the owner list from receiving owner grants
+					// present in the granted list.
+					"granted": newAccessList(t, "granted", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+						Scope: "/aa",
+						Role:  "ownerrole",
+					}}), withOwners([]accesslist.Owner{{
+						Name:           "owners",
+						MembershipKind: accesslist.MembershipKindList,
+					}})),
+					"owners": newAccessList(t, "owners", withOwnershipRequires()),
+				},
+				MembersByAccessList: map[string][]*accesslist.AccessListMember{
+					"granted": {},
+					"owners": {
+						newAccessListMember(t, "owners", "tester", accesslist.MembershipKindUser),
+					},
+				},
+			},
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				// tester is a valid member of list "owners". All valid members of
+				// list "owners" are valid _owners_ of list "granted", so the
+				// assignment should be materialized.
+				expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{{
+					Role:  "ownerrole",
+					Scope: "/aa",
+				}}),
+			},
+			steps: []materializerTestcaseStep{{
+				mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					// Add a nested list as a member of the owners list.
+					_, err := aclService.UpsertAccessList(t.Context(), newAccessList(t, "nested"))
+					require.NoError(t, err)
+					_, err = aclService.UpsertAccessListMember(t.Context(),
+						newAccessListMember(t, "owners", "nested", accesslist.MembershipKindList))
+					require.NoError(t, err)
+					// Add a user as a member of the nested list.
+					_, err = aclService.UpsertAccessListMember(t.Context(),
+						newAccessListMember(t, "nested", "nested_tester", accesslist.MembershipKindUser))
+					require.NoError(t, err)
+				},
+				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+					// The nested user is also a valid member of the owners list so
+					// should also have an assignment materialized.
+					expectedScopedRoleAssignment("tester", "granted", []*scopedaccessv1.Assignment{{
+						Role:  "ownerrole",
+						Scope: "/aa",
+					}}),
+					expectedScopedRoleAssignment("nested_tester", "granted", []*scopedaccessv1.Assignment{{
+						Role:  "ownerrole",
+						Scope: "/aa",
+					}}),
+				},
+			}},
+		})
+	})
+}
+
+func TestMaterializerOwnerChain(t *testing.T) {
+	t.Parallel()
+	runMaterializerTestcase(t, materializerTestcase{
+		collection: accesslists.Collection{
+			AccessListsByName: map[string]*accesslist.AccessList{
+				"grandparent": newAccessList(t, "grandparent", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/aa/bb/cc",
+					Role:  "grandparentownerrole",
+				}}), withOwners([]accesslist.Owner{{
+					Name:           "parent",
+					MembershipKind: accesslist.MembershipKindList,
+				}})),
+				"parent": newAccessList(t, "parent", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/aa/bb",
+					Role:  "parentownerrole",
+				}}), withOwners([]accesslist.Owner{{
+					Name:           "base",
+					MembershipKind: accesslist.MembershipKindList,
+				}})),
+				"base": newAccessList(t, "base", withOwnerGrants([]accesslist.ScopedRoleGrant{{
+					Scope: "/aa",
+					Role:  "baseownerrole",
+				}}), withOwners([]accesslist.Owner{{
+					Name:           "baseowner",
+					MembershipKind: accesslist.MembershipKindUser,
+				}})),
+			},
+			MembersByAccessList: map[string][]*accesslist.AccessListMember{
+				"grandparent": {
+					newAccessListMember(t, "grandparent", "parent", accesslist.MembershipKindList),
+					newAccessListMember(t, "grandparent", "grandparentmember", accesslist.MembershipKindUser),
+				},
+				"parent": {
+					newAccessListMember(t, "parent", "base", accesslist.MembershipKindList),
+					newAccessListMember(t, "parent", "parentmember", accesslist.MembershipKindUser),
+				},
+				"base": {
+					newAccessListMember(t, "base", "basemember", accesslist.MembershipKindUser),
+				},
+			},
+		},
+		expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+			// baseowner is a direct owner of base list. Ownership is not inherited.
+			expectedScopedRoleAssignment("baseowner", "base", []*scopedaccessv1.Assignment{{
+				Role:  "baseownerrole",
+				Scope: "/aa",
+			}}),
+			// basemember is a member of base list, base list is an owner of parent list.
+			expectedScopedRoleAssignment("basemember", "parent", []*scopedaccessv1.Assignment{{
+				Role:  "parentownerrole",
+				Scope: "/aa/bb",
+			}}),
+			// basemember is a nested member of parent list, parent list is an owner of grandparent list.
+			expectedScopedRoleAssignment("basemember", "grandparent", []*scopedaccessv1.Assignment{{
+				Role:  "grandparentownerrole",
+				Scope: "/aa/bb/cc",
+			}}),
+			// parentmember is a member of parent list, parent list is an owner of grandparent list.
+			expectedScopedRoleAssignment("parentmember", "grandparent", []*scopedaccessv1.Assignment{{
+				Role:  "grandparentownerrole",
+				Scope: "/aa/bb/cc",
+			}}),
+		},
+	})
+}
+
+func TestMaterializerAccessListPutWithMembershipRequirements(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.Collection{
+				AccessListsByName: map[string]*accesslist.AccessList{
+					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Scope: "/aa",
+						Role:  "toprole",
+					}})),
+					"middle": newAccessList(t, "middle"),
+				},
+				MembersByAccessList: map[string][]*accesslist.AccessListMember{
+					"top": {
+						newAccessListMember(t, "top", "middle", accesslist.MembershipKindList),
+					},
+					"middle": {
+						newAccessListMember(t, "middle", "tester", accesslist.MembershipKindUser),
+					},
+				},
+			},
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{{
+					Role:  "toprole",
+					Scope: "/aa",
+				}}),
+			},
+			steps: []materializerTestcaseStep{{
+				// Add membership requires to the middle list, the materialized
+				// assignment for the top list should be deleted as the
+				// membership path is broken.
+				mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					_, err := aclService.UpsertAccessList(t.Context(), newAccessList(t, "middle", withMembershipRequires()))
+					require.NoError(t, err)
+				},
+				expectedAssignments: nil,
+			}},
+		})
+	})
+}
+
+func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.Collection{
+				AccessListsByName: map[string]*accesslist.AccessList{
+					"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Scope: "/aa",
+						Role:  "parentrole",
+					}})),
+					"child": newAccessList(t, "child"),
+				},
+				MembersByAccessList: map[string][]*accesslist.AccessListMember{
+					"parent": {
+						newAccessListMember(t, "parent", "child", accesslist.MembershipKindList),
+					},
+					"child": {
+						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser),
+					},
+				},
+			},
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				// Initially tester is a member of list child which is a member
+				// of list parent, resulting in a materialized assignment for
+				// tester in parent.
+				expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{{
+					Role:  "parentrole",
+					Scope: "/aa",
+				}}),
+			},
+			steps: []materializerTestcaseStep{
+				{
+					// Update the member resource in place to change the membership kind from list to user.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						member, err := aclService.GetAccessListMember(t.Context(), "parent", "child")
+						require.NoError(t, err)
+
+						member.Spec.MembershipKind = accesslist.MembershipKindUser
+						updatedMember, err := aclService.UpdateAccessListMember(t.Context(), member)
+						require.NoError(t, err)
+						require.Equal(t, accesslist.MembershipKindUser, updatedMember.Spec.MembershipKind)
+					},
+					// Now there should be a "user" named child that is a
+					// member of the parent list, and tester is no longer a
+					// member because the path through the list named child is
+					// now broken.
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("child", "parent", []*scopedaccessv1.Assignment{{
+							Role:  "parentrole",
+							Scope: "/aa",
+						}}),
+					},
+				},
+				{
+					// Update the member resource in place again to change it
+					// back to a list, and the original assignment should be
+					// restored.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						member, err := aclService.GetAccessListMember(t.Context(), "parent", "child")
+						require.NoError(t, err)
+
+						member.Spec.MembershipKind = accesslist.MembershipKindList
+						updatedMember, err := aclService.UpdateAccessListMember(t.Context(), member)
+						require.NoError(t, err)
+						require.Equal(t, accesslist.MembershipKindList, updatedMember.Spec.MembershipKind)
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{{
+							Role:  "parentrole",
+							Scope: "/aa",
+						}}),
+					},
+				},
+			},
+		})
+	})
+}
+
+func TestMaterializerDiamond(t *testing.T) {
+	// The initial condition will look like this, we'll then break the
+	// membership path through left, then break the membership path through
+	// right, then restore the membership path through left.
+	//
+	//       top
+	//       / \
+	//      /   \
+	//     /     \
+	//   left   right
+	//     \     /
+	//      \   /
+	//       \ /
+	//      bottom
+	//        |
+	//        v
+	//      tester
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.Collection{
+				AccessListsByName: map[string]*accesslist.AccessList{
+					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Scope: "/aa",
+						Role:  "toprole",
+					}})),
+					"left":   newAccessList(t, "left"),
+					"right":  newAccessList(t, "right"),
+					"bottom": newAccessList(t, "bottom"),
+				},
+				MembersByAccessList: map[string][]*accesslist.AccessListMember{
+					"top": {
+						newAccessListMember(t, "top", "left", accesslist.MembershipKindList),
+						newAccessListMember(t, "top", "right", accesslist.MembershipKindList),
+					},
+					"left": {
+						newAccessListMember(t, "left", "bottom", accesslist.MembershipKindList),
+					},
+					"right": {
+						newAccessListMember(t, "right", "bottom", accesslist.MembershipKindList),
+					},
+					"bottom": {
+						newAccessListMember(t, "bottom", "tester", accesslist.MembershipKindUser),
+					},
+				},
+			},
+			// Initially the user is a valid member of the top list by 2 paths.
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{{
+					Role:  "toprole",
+					Scope: "/aa",
+				}}),
+			},
+			steps: []materializerTestcaseStep{
+				{
+					// Add membership requires to the left list, the assignment
+					// should stay via the right list.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						// Upsert the access list to remove the membership requires.
+						_, err := aclService.UpsertAccessList(t.Context(), newAccessList(t, "left", withMembershipRequires()))
+						require.NoError(t, err)
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{{
+							Role:  "toprole",
+							Scope: "/aa",
+						}}),
+					},
+				},
+				{
+					// Delete the membership path on the right, the assignment
+					// should be deleted as there is no more path.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						err := aclService.DeleteAccessListMember(t.Context(), "top", "right")
+						require.NoError(t, err)
+					},
+					expectedAssignments: nil,
+				},
+				{
+					// Remove membership requires from the left list, the assignment
+					// should come back.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						// Upsert the access list to remove the membership requires.
+						_, err := aclService.UpsertAccessList(t.Context(), newAccessList(t, "left"))
+						require.NoError(t, err)
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{{
+							Role:  "toprole",
+							Scope: "/aa",
+						}}),
+					},
+				},
+			},
+		})
+	})
+}
+
+func BenchmarkMaterializerInit(b *testing.B) {
+	for _, tc := range []struct {
+		listCount      int
+		membersPerList int
+		nestingDepth   int
+	}{
+		{
+			listCount:      1000,
+			membersPerList: 100,
+		},
+		{
+			listCount:      100,
+			membersPerList: 1000,
+		},
+		{
+			listCount:      100,
+			membersPerList: 1000,
+			// Each list will have 1 parent lists, meaning each of 100k users
+			// are members of 2 lists, resulting in 200k materialized assignments.
+			nestingDepth: 1,
+		},
+		{
+			listCount:      100,
+			membersPerList: 1000,
+			// Each list will have 2 parent lists, meaning each of 100k users
+			// are members of 3 lists, resulting in 300k materialized assignments.
+			nestingDepth: 2,
+		},
+		// These cases are theoretically realistic for very large clusters, but pretty slow to run in CI.
+		// {
+		//  // benchmarked this case at 6.2 seconds for a materializer init,
+		//  // vs 3.4 seconds for the baseline case that just copies the
+		//  // assignments with no logic. It materializes 2 million assignments.
+		// 	listCount:      100,
+		// 	membersPerList: 20000,
+		// },
+		// {
+		//  // benchmarked this case at 26.6 seconds for a materializer init,
+		//  // vs 14.7 seconds for the baseline case that just copies the
+		//  // assignments with no logic. It materializes 5 million assignments.
+		// 	listCount:      25000,
+		// 	membersPerList: 200,
+		// },
+	} {
+		b.Run(fmt.Sprintf("lists=%d,members=%d,depth=%d", tc.listCount, tc.membersPerList, tc.nestingDepth), func(b *testing.B) {
+			// Setup prequisites for the cache
+			backend, err := memory.New(memory.Config{
+				Context: b.Context(),
+			})
+			require.NoError(b, err)
+			defer backend.Close()
+
+			aclService, err := local.NewAccessListServiceV2(local.AccessListServiceConfig{
+				Backend: backend,
+				Modules: modulestest.EnterpriseModules(),
+			})
+			require.NoError(b, err)
+
+			t0 := time.Now()
+
+			collection := createBenchmarkCollection(b, tc.listCount, tc.membersPerList, tc.nestingDepth)
+
+			t1 := time.Now()
+
+			// Insert the access lists and members into the backend.
+			require.NoError(b, aclService.InsertAccessListCollection(b.Context(), collection))
+
+			t2 := time.Now()
+
+			// Create and init the access lists cache.
+			aclCache, err := cachepkg.New(cachepkg.Config{
+				Context: b.Context(),
+				Events:  local.NewEventsService(backend),
+				Watches: []types.WatchKind{
+					{Kind: types.KindAccessList},
+					{Kind: types.KindAccessListMember},
+				},
+				AccessLists: aclService,
+			})
+			require.NoError(b, err)
+			defer aclCache.Close()
+			<-aclCache.FirstInit()
+
+			t3 := time.Now()
+
+			b.Logf(`Setup timing:
+creating the input:     %v
+inserting to backend:   %v
+initializing acl cache: %v`, t1.Sub(t0), t2.Sub(t1), t3.Sub(t2))
+
+			// Store the state outside the benchmark loop just so we can
+			// reference the final materialized assignments after the benchmark
+			// is done.
+			state := state{}
+
+			b.Run("init", func(b *testing.B) {
+				// Initialize a new materializer with a new assignment state
+				// for each benchmark loop.
+				for b.Loop() {
+					state.assignments = assignments.NewAssignmentCache(assignments.AssignmentCacheConfig{})
+					materializer := newMaterializer(aclCache)
+					require.NoError(b, materializer.Init(b.Context(), state))
+				}
+			})
+
+			b.Logf("Materialized %d assignments", state.assignments.Len())
+
+			// How long does it take to literally just copy every already
+			// materialized assignment into a new assignment cache. This is a
+			// nice baseline for how fast it's physically possible to go.
+			b.Run("init baseline", func(b *testing.B) {
+				for b.Loop() {
+					assignmentCache := assignments.NewAssignmentCache(assignments.AssignmentCacheConfig{})
+					for assignment, err := range utils.RangeScopedRoleAssignments(b.Context(), state.assignments, &scopedaccessv1.ListScopedRoleAssignmentsRequest{}) {
+						require.NoError(b, err)
+						assignmentCache.Put(assignment)
+					}
+				}
+			})
+
+			// Assert there's an assignment for every direct member. This
+			// doesn't cover nested members, it's mostly a smoke test to make
+			// sure the benchmark is actually doing something.
+			for listName, members := range collection.MembersByAccessList {
+				for _, member := range members {
+					if !member.IsUser() {
+						continue
+					}
+					key := materializedAssignmentKey{
+						list: listName,
+						user: member.GetName(),
+					}
+					_, err := state.assignments.GetScopedRoleAssignment(b.Context(), &scopedaccessv1.GetScopedRoleAssignmentRequest{
+						Name:    key.assignmentName(),
+						SubKind: scopedaccess.SubKindMaterialized,
+					})
+					assert.NoError(b, err)
+				}
+			}
+		})
+	}
+}
+
+func createBenchmarkCollection(b require.TestingT, listCount, membersPerList, nestingDepth int) *accesslists.Collection {
+	var collection accesslists.Collection
+
+	grants := []accesslist.ScopedRoleGrant{{
+		Role:  "testrole",
+		Scope: "/aa",
+	}}
+	listIndex := 0
+	memberIndex := 0
+	for range listCount {
+		listName := fmt.Sprintf("list-%d", listIndex)
+		listIndex++
+
+		list := newAccessList(b, listName, withMemberGrants(grants))
+
+		members := make([]*accesslist.AccessListMember, membersPerList)
+		for i := range membersPerList {
+			memberName := fmt.Sprintf("user-%d", listIndex*membersPerList+memberIndex)
+			memberIndex++
+
+			members[i] = newAccessListMember(b, listName, memberName, accesslist.MembershipKindUser)
+		}
+
+		require.NoError(b, collection.AddAccessList(list, members))
+	}
+
+	// Each layer of nesting has listCount/2 lists with 2 list members from the previous layer.
+	ancestorListCount := listCount
+	childListIndex := 0
+	for range nestingDepth {
+		ancestorListCount = ancestorListCount / 2
+
+		for range ancestorListCount {
+			listName := fmt.Sprintf("list-%d", listIndex)
+			listIndex++
+
+			list := newAccessList(b, listName, withMemberGrants(grants))
+
+			members := make([]*accesslist.AccessListMember, 2)
+			for i := range 2 {
+				childListName := fmt.Sprintf("list-%d", childListIndex)
+				childListIndex++
+
+				members[i] = newAccessListMember(b, listName, childListName, accesslist.MembershipKindList)
+			}
+
+			require.NoError(b, collection.AddAccessList(list, members))
+		}
+	}
+	return &collection
+}
+
+type aclOption func(*accesslist.AccessList)
+
+func withMemberGrants(grants []accesslist.ScopedRoleGrant) aclOption {
+	return func(list *accesslist.AccessList) {
+		list.Spec.Grants.ScopedRoles = grants
+	}
+}
+
+func withOwnerGrants(grants []accesslist.ScopedRoleGrant) aclOption {
+	return func(list *accesslist.AccessList) {
+		list.Spec.OwnerGrants.ScopedRoles = grants
+	}
+}
+
+func withOwners(owners []accesslist.Owner) aclOption {
+	return func(list *accesslist.AccessList) {
+		list.Spec.Owners = owners
+	}
+}
+
+func withMembershipRequires() aclOption {
+	return func(list *accesslist.AccessList) {
+		list.Spec.MembershipRequires.Roles = []string{"access"}
+	}
+}
+func withOwnershipRequires() aclOption {
+	return func(list *accesslist.AccessList) {
+		list.Spec.OwnershipRequires.Roles = []string{"access"}
+	}
+}
+
+func newAccessList(t require.TestingT, name string, opts ...aclOption) *accesslist.AccessList {
+	list, err := accesslist.NewAccessList(header.Metadata{
+		Name: name,
+	}, accesslist.Spec{
+		Title: name,
+		Owners: []accesslist.Owner{{
+			Name:           "testowner",
+			MembershipKind: accesslist.MembershipKindUser,
+		}},
+	})
+	require.NoError(t, err)
+	for _, opt := range opts {
+		opt(list)
+	}
+	return list
+}
+
+type memberOption func(*accesslist.AccessListMember)
+
+func newAccessListMember(t require.TestingT, parent, member, membershipKind string, opts ...memberOption) *accesslist.AccessListMember {
+	memberResource, err := accesslist.NewAccessListMember(header.Metadata{
+		Name: member,
+	}, accesslist.AccessListMemberSpec{
+		AccessList:     parent,
+		Name:           member,
+		MembershipKind: membershipKind,
+		Joined:         time.Now(),
+		AddedBy:        "testowner",
+	})
+	require.NoError(t, err)
+	for _, opt := range opts {
+		opt(memberResource)
+	}
+	return memberResource
+}
+
+func expectedScopedRoleAssignment(userName, listName string, assignments []*scopedaccessv1.Assignment) *scopedaccessv1.ScopedRoleAssignment {
+	key := materializedAssignmentKey{
+		user: userName,
+		list: listName,
+	}
+	return &scopedaccessv1.ScopedRoleAssignment{
+		Kind:    scopedaccess.KindScopedRoleAssignment,
+		SubKind: scopedaccess.SubKindMaterialized,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: key.assignmentName(),
+		},
+		Scope: "/",
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+			User:        userName,
+			Assignments: assignments,
+		},
+	}
+}

--- a/lib/scopes/cache/assignments/assignment_cache.go
+++ b/lib/scopes/cache/assignments/assignment_cache.go
@@ -229,6 +229,11 @@ func (c *AssignmentCache) Delete(name, subKind string) {
 	}.String())
 }
 
+// Len returns the total number of assignments in the cache.
+func (c *AssignmentCache) Len() int {
+	return c.cache.Len()
+}
+
 type assignmentKey struct {
 	name    string
 	subKind string


### PR DESCRIPTION
This commit implements the bulk of [RFD 243](https://github.com/gravitational/teleport/blob/master/rfd/0243-scoped-roles-in-access-lists.md) by populating scoped role assignments into the scoped access cache based on scoped role grants present in access lists.

Handling of access list member expiry, and optimistic refreshes after failed cache reads, has been pulled out into https://github.com/gravitational/teleport/pull/65235

## Manual Test Plan

### Test Environment

- Local cluster running this branch

#### Setup scoped roles

```bash
cat >./test-scoped-roles.yaml <<EOF
kind: scoped_role
version: v1
metadata:
  name: test-role
scope: /
spec:
  assignable_scopes:
    - /test/**
  ssh:
    logins: ["tester"]
    labels:
      - name: "*"
        values: ["*"]
EOF

tctl create ./test-scoped-roles.yaml
```

### Test Cases

- [x] Create access lists to use in test cases, currently without members

```bash
cat ./test-access-lists.yaml
---
kind: access_list
version: v1
metadata:
  name: owner-members
spec:
  title: owner-members
  owners:
    - name: owner@example.com
      membership_kind: MEMBERSHIP_KIND_USER
---
kind: access_list
version: v1
metadata:
  name: owners
spec:
  title: owners
  owners:
    - name: owner@example.com
      membership_kind: MEMBERSHIP_KIND_USER
    - name: owner-members
      membership_kind: MEMBERSHIP_KIND_LIST
---
kind: access_list
version: v1
metadata:
  name: top
spec:
  title: top
  owners:
    - name: owner@example.com
      membership_kind: MEMBERSHIP_KIND_USER
  grants:
    scoped_roles:
      - role: test-role
        scope: /test/top
  owner_grants:
    scoped_roles:
      - role: test-role
        scope: /test/top-owner
---
kind: access_list
version: v1
metadata:
  name: middle
spec:
  title: middle
  owners:
    - name: owner@example.com
      membership_kind: MEMBERSHIP_KIND_USER
---
kind: access_list
version: v1
metadata:
  name: bottom
spec:
  title: bottom
  owners:
    - name: owners
      membership_kind: MEMBERSHIP_KIND_LIST
  grants:
    scoped_roles:
      - role: test-role
        scope: /test/bottom
  owner_grants:
    scoped_roles:
      - role: test-role
        scope: /test/bottom-owner

$ tctl create ./test-access-lists.yaml
```

- [x] Expect materialized scoped role assignments for `owner@example.com` as a
      direct owner of `top`.

```bash
$ tctl get scoped_role_assignment --format json | jq -r '.[] | [.spec.user, (.spec.assignments | map("\(.role)@\(.scope)") | join(","))] | @tsv'
owner@example.com       test-role@/test/top-owner
```

- [x] Make `alice@example.com` a member of list `bottom`.

```bash
tctl acl users add --kind=user bottom "alice@example.com"
```

- [x] Verify `alice@example.com` gets a materialized assignment from list `bottom`

```bash
$ tctl get scoped_role_assignment --format json | jq -r '.[] | [.spec.user, (.spec.assignments | map("\(.role)@\(.scope)") | join(","))] | @tsv'
alice@example.com       test-role@/test/bottom
owner@example.com       test-role@/test/top-owner
```

- [x] Make list `bottom` a list member of list `middle`

```bash
$ tctl acl users add --kind=list middle bottom
```

- [x] Expect no changes because `middle` doesn't grant any scoped roles

```bash
$ tctl get scoped_role_assignment --format json | jq -r '.[] | [.spec.user, (.spec.assignments | map("\(.role)@\(.scope)") | join(","))] | @tsv'
alice@example.com       test-role@/test/bottom
owner@example.com       test-role@/test/top-owner
```

- [x] Make list `middle` a list member of list `top`

```bash
$ tctl acl users add --kind=list top middle
```

- [x] Verify `alice@example.com` gets another materialized assignment from list `top`.

```bash
$ tctl get scoped_role_assignment --format json | jq -r '.[] | [.spec.user, (.spec.assignments | map("\(.role)@\(.scope)") | join(","))] | @tsv'
alice@example.com       test-role@/test/top
alice@example.com       test-role@/test/bottom
owner@example.com       test-role@/test/top-owner
```

- [x] Add membership_requires to the middle list and verify the assignment from top is removed

```bash
$ tctl get access_list/middle --format json | jq '.[] | .spec.membership_requires = {"roles":["definitely-not-present"]}' | tctl create -f -
$ tctl get scoped_role_assignment --format json | jq -r '.[] | [.spec.user, (.spec.assignments | map("\(.role)@\(.scope)") | join(","))] | @tsv'
alice@example.com       test-role@/test/bottom
owner@example.com       test-role@/test/top-owner
```

- [x] Remove membership_requires and verify the inherited assignment comes back

```bash
$ tctl get access_list/middle --format json | jq '.[] | .spec.membership_requires = {}' | tc create -f -
$ tctl get scoped_role_assignment --format json | jq -r '.[] | [.spec.user, (.spec.assignments | map("\(.role)@\(.scope)") | join(","))] | @tsv'
alice@example.com       test-role@/test/top
alice@example.com       test-role@/test/bottom
owner@example.com       test-role@/test/top-owner
```

- [x] Verify owner grants materialize through an owner list

```bash
$ tctl acl users add owners testowner@exmaple.com
$ tctl get scoped_role_assignment --format json | jq -r '.[] | [.spec.user, (.spec.assignments | map("\(.role)@\(.scope)") | join(","))] | @tsv'
testowner@example.com   test-role@/test/bottom-owner
alice@example.com       test-role@/test/top
alice@example.com       test-role@/test/bottom
owner@example.com       test-role@/test/top-owner
```

- [x] Verify owner grants also materialize through nested members of the owner list

```bash
$ tctl acl users add --kind=list owners owner-members
$ tctl acl users add owner-members nested-testowner@example.com
$ tctl get scoped_role_assignment --format json | jq -r '.[] | [.spec.user, (.spec.assignments | map("\(.role)@\(.scope)") | join(","))] | @tsv'
nested-testowner@example.com    test-role@/test/bottom-owner
testowner@example.com   test-role@/test/bottom-owner
alice@example.com       test-role@/test/top
alice@example.com       test-role@/test/bottom
owner@example.com       test-role@/test/top-owner
```