### PR TITLE
Clear ssh certs from local key agent when switching scopes

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2334,17 +2334,6 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 		return trace.Wrap(err)
 	}
 
-	// When the scope changes between logins (e.g. scoped→unscoped or vice
-	// versa), clear all Teleport keys for this proxy from the SSH agent.
-	if scopeChanged {
-		if agent := tc.LocalAgent(); agent != nil {
-			proxyIdx := client.KeyRingIndex{ProxyHost: tc.WebProxyHost()}
-			if err := agent.UnloadKeyRing(proxyIdx); err != nil {
-				logger.WarnContext(cf.Context, "Failed to unload old keys from agent on scope change", "error", err)
-			}
-		}
-	}
-
 	// If the user requested tracing and the login succeeds (even if the user
 	// was already logged in) report the tracing client to the trace provider
 	// to that spans can be exported.
@@ -2529,6 +2518,17 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 	// the login operation may update the username and should be considered the more
 	// "authoritative" source.
 	cf.Username = tc.Username
+
+	// When the scope changes between logins (e.g. scoped→unscoped or vice
+	// versa), clear all Teleport keys for this proxy from the SSH agent.
+	if scopeChanged {
+		if agent := tc.LocalAgent(); agent != nil {
+			proxyIdx := client.KeyRingIndex{ProxyHost: tc.WebProxyHost()}
+			if err := agent.UnloadKeyRing(proxyIdx); err != nil {
+				logger.WarnContext(cf.Context, "Failed to unload old keys from agent on scope change", "error", err)
+			}
+		}
+	}
 
 	clusterClient, rootAuthClient, err := tc.ConnectToRootCluster(cf.Context, keyRing)
 	if err != nil {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2334,6 +2334,17 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 		return trace.Wrap(err)
 	}
 
+	// When the scope changes between logins (e.g. scoped→unscoped or vice
+	// versa), clear all Teleport keys for this proxy from the SSH agent.
+	if scopeChanged {
+		if agent := tc.LocalAgent(); agent != nil {
+			proxyIdx := client.KeyRingIndex{ProxyHost: tc.WebProxyHost()}
+			if err := agent.UnloadKeyRing(proxyIdx); err != nil {
+				logger.WarnContext(cf.Context, "Failed to unload old keys from agent on scope change", "error", err)
+			}
+		}
+	}
+
 	// If the user requested tracing and the login succeeds (even if the user
 	// was already logged in) report the tracing client to the trace provider
 	// to that spans can be exported.

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -836,6 +836,102 @@ func switchProxyListenerMode(t *testing.T, authServer *auth.Server, mode types.P
 	})
 }
 
+// TestLoginScopeChangeClearsAgentKeys verifies that when the login scope changes
+// between logins from unscoped to scoped as different users, the keyring is cleared of all previous certs.
+func TestLoginScopeChangeClearsAgentKeys(t *testing.T) {
+	tmpHomePath := t.TempDir()
+
+	// Start a test SSH agent so we can inspect keys across login calls.
+	keyring, _ := createAgent(t)
+
+	connector := mockConnector(t)
+
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetRoles([]string{"access"})
+
+	bob, err := types.NewUser("bob@example.com")
+	require.NoError(t, err)
+	bob.SetRoles([]string{"access"})
+
+	max, err := types.NewUser("max@example.com")
+	require.NoError(t, err)
+	max.SetRoles([]string{"access"})
+
+	authProcess, proxyProcess := makeTestServers(t, withBootstrap(connector, alice, bob, max))
+	authServer := authProcess.GetAuthServer()
+	require.NotNil(t, authServer)
+
+	proxyAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Login as alice unscoped
+	err = Run(context.Background(), []string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--proxy", proxyAddr.String(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, alice, connector.GetName()))
+	require.NoError(t, err)
+
+	keysAfterAlice, err := keyring.List()
+	require.NoError(t, err)
+	require.NotEmpty(t, keysAfterAlice)
+
+	// Login as bob unscoped — switches active profile to bob shows as expired.
+	// Need to relogin as bob.
+	err = Run(context.Background(), []string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--proxy", proxyAddr.String(),
+		"--user", bob.GetName(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, bob, connector.GetName()))
+	require.NoError(t, err)
+
+	// Login as bob again to generate the certs
+	err = Run(context.Background(), []string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--proxy", proxyAddr.String(),
+		"--user", bob.GetName(),
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, bob, connector.GetName()))
+	require.NoError(t, err)
+
+	keysAfterBob, err := keyring.List()
+	require.NoError(t, err)
+	require.NotEmpty(t, keysAfterBob)
+
+	for _, key := range keysAfterBob {
+		if strings.HasPrefix(key.Comment, "teleport:") {
+			require.True(t, strings.Contains(key.Comment, bob.GetName()) || strings.Contains(key.Comment, alice.GetName()))
+		}
+	}
+
+	// Logging in with max scoped clears the keyring.
+	err = Run(context.Background(), []string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--proxy", proxyAddr.String(),
+		"--user", max.GetName(),
+		"--scope", "/prod/us-west",
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, max, connector.GetName()))
+	require.NoError(t, err)
+
+	keysAfterMax, err := keyring.List()
+	require.NoError(t, err)
+	require.NotEmpty(t, keysAfterMax)
+	for _, key := range keysAfterMax {
+		if !strings.HasPrefix(key.Comment, "teleport:") {
+			continue
+		}
+		require.NotContains(t, key.Comment, alice.GetName())
+		require.NotContains(t, key.Comment, bob.GetName())
+	}
+}
+
 func TestRelogin(t *testing.T) {
 	t.Parallel()
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -938,6 +938,23 @@ func TestLoginScopeChangeClearsAgentKeys(t *testing.T) {
 		require.NotContains(t, key.Comment, alice.GetName())
 		require.NotContains(t, key.Comment, bob.GetName())
 	}
+
+	// Logging in with max in a different scope clears the agent, and sets new certs for max
+	err = Run(context.Background(), []string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--proxy", proxyAddr.String(),
+		"--user", max.GetName(),
+		"--scope", "/prod/us-east",
+	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, max, connector.GetName()))
+	require.NoError(t, err)
+
+	keysAfterMaxRescoped, err := keyring.List()
+	require.NoError(t, err)
+	require.NotEmpty(t, keysAfterMaxRescoped)
+
+	require.NotElementsMatch(t, keysAfterMax, keysAfterMaxRescoped)
 }
 
 func TestRelogin(t *testing.T) {

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -866,7 +866,7 @@ func TestLoginScopeChangeClearsAgentKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	// Login as alice unscoped
-	err = Run(context.Background(), []string{
+	err = Run(t.Context(), []string{
 		"login",
 		"--insecure",
 		"--debug",
@@ -880,7 +880,7 @@ func TestLoginScopeChangeClearsAgentKeys(t *testing.T) {
 
 	// Login as bob unscoped — switches active profile to bob shows as expired.
 	// Need to relogin as bob.
-	err = Run(context.Background(), []string{
+	err = Run(t.Context(), []string{
 		"login",
 		"--insecure",
 		"--debug",
@@ -890,7 +890,7 @@ func TestLoginScopeChangeClearsAgentKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	// Login as bob again to generate the certs
-	err = Run(context.Background(), []string{
+	err = Run(t.Context(), []string{
 		"login",
 		"--insecure",
 		"--debug",
@@ -903,13 +903,21 @@ func TestLoginScopeChangeClearsAgentKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, keysAfterBob)
 
+	hasBobKey, hasAliceKey := false, false
 	for _, key := range keysAfterBob {
 		if strings.HasPrefix(key.Comment, "teleport:") {
-			require.True(t, strings.Contains(key.Comment, bob.GetName()) || strings.Contains(key.Comment, alice.GetName()))
+			if strings.Contains(key.Comment, bob.GetName()) {
+				hasBobKey = true
+			}
+			if strings.Contains(key.Comment, alice.GetName()) {
+				hasAliceKey = true
+			}
 		}
 	}
+	require.True(t, hasBobKey)
+	require.True(t, hasAliceKey)
 
-	// Logging in with max scoped clears the keyring.
+	// Logging in with max, a scoped user, clears the agent
 	err = Run(context.Background(), []string{
 		"login",
 		"--insecure",

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -918,7 +918,7 @@ func TestLoginScopeChangeClearsAgentKeys(t *testing.T) {
 	require.True(t, hasAliceKey)
 
 	// Logging in with max, a scoped user, clears the agent
-	err = Run(context.Background(), []string{
+	err = Run(t.Context(), []string{
 		"login",
 		"--insecure",
 		"--debug",
@@ -940,7 +940,7 @@ func TestLoginScopeChangeClearsAgentKeys(t *testing.T) {
 	}
 
 	// Logging in with max in a different scope clears the agent, and sets new certs for max
-	err = Run(context.Background(), []string{
+	err = Run(t.Context(), []string{
 		"login",
 		"--insecure",
 		"--debug",
@@ -954,7 +954,7 @@ func TestLoginScopeChangeClearsAgentKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, keysAfterMaxRescoped)
 
-	require.NotElementsMatch(t, keysAfterMax, keysAfterMaxRescoped)
+	require.NotContains(t, keysAfterMaxRescoped, keysAfterMax)
 }
 
 func TestRelogin(t *testing.T) {


### PR DESCRIPTION

### Purpose
Currently, when logging in between unscoped to scoped for 2 different users, the local ssh agent keeps the unscoped user's certs. This leads to the scoped user being able to access the logins that the unscoped user has access to. This leads to weird ux for scoped users.

### Implementation:
Rescoping already forces the user to do a full reauth flow - this already clears the certs in the ssh agent.
This change makes sure that switching between users and going from unscoped to scoped also clears the ssh certs in the local ssh agent.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Clear certs from local ssh agent when switching between unscoped user to scoped user


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local Cluster

### Test Cases
- [x] log in as unscoped user with access to everything (user will)
- [x] log in as scoped user that can view nodes but cannot login to any node (alice at scope /fruit/banana)
- [x] confirm that user cannot log to any node
- [x] confirm that ssh agent only has certs for the scoped user and vice versa when switching between users
- [x] confirm that the local ssh agent keeps certs for 2 users when logged in as unscoped for both users (will and alice unscoped)
