### PR TITLE
VNet macOS: Handle "No such process" race condition on the very first launch

### DIFF
--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -58,7 +58,9 @@ func RegisterAndCall(ctx context.Context, config Config) error {
 		C.OpenSystemSettingsLoginItems()
 	}
 
+	requiredEnablement := false
 	if initialStatus != ServiceStatusEnabled {
+		requiredEnablement = true
 		status, err := register(ctx, bundlePath)
 		if err != nil {
 			return trace.Wrap(err)
@@ -73,27 +75,40 @@ func RegisterAndCall(ctx context.Context, config Config) error {
 		}
 	}
 
-	if err = startByCalling(ctx, bundlePath, config); err != nil {
-		if !errors.Is(err, errAlreadyRunning) {
+	err = startByCalling(ctx, bundlePath, config)
+
+	// On the very first launch after the user enables the login item, the XPC connection can fail
+	// with NSXPCConnectionInvalid ("No such process") because SMAppService.status can report
+	// "enabled" before launchd has finished submitting the job and registering the XPC service.
+	// Retry a few times with a short delay to let launchd catch up.
+	for retries := 0; requiredEnablement && errors.Is(err, errXPCConnectionInvalid) && retries < 3; retries++ {
+		log.DebugContext(ctx, "XPC connection invalid, retrying after a short delay",
+			"retries", retries, "error", err)
+		const connInvalidInterval = 500 * time.Millisecond
+		if err := sleepOrDone(ctx, connInvalidInterval); err != nil {
 			return trace.Wrap(err)
 		}
+		err = startByCalling(ctx, bundlePath, config)
+	}
 
-		// If the daemon was already running, it might mean two things:
-		//
-		// 1. The user attempted to start a second instance of VNet.
-		// 2. The user has stopped the previous instance of VNet and immediately started a new one,
-		// before the daemon had a chance to notice that the previous instance was stopped and exit too.
-		//
-		// In the second case, we want to wait and repeat the call to the daemon, in case the daemon was
-		// just about to quit.
+	// If the daemon was already running, it might mean two things:
+	//
+	// 1. The user attempted to start a second instance of VNet.
+	// 2. The user has stopped the previous instance of VNet and immediately started a new one,
+	// before the daemon had a chance to notice that the previous instance was stopped and exit too.
+	//
+	// In the second case, we want to wait and repeat the call to the daemon, in case the daemon was
+	// just about to quit.
+	if errors.Is(err, errAlreadyRunning) {
 		log.DebugContext(ctx, "VNet daemon is already running, waiting to see if it's going to shut down")
 		if err := sleepOrDone(ctx, 2*CheckUnprivilegedProcessInterval); err != nil {
 			return trace.Wrap(err)
 		}
+		err = startByCalling(ctx, bundlePath, config)
+	}
 
-		if err := startByCalling(ctx, bundlePath, config); err != nil {
-			return trace.Wrap(err)
-		}
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
 	// TODO(ravicious): Implement monitoring the state of the daemon.
@@ -285,6 +300,11 @@ func startByCalling(ctx context.Context, bundlePath string, config Config) error
 				// NSXPCConnectionCodeSigningRequirementFailure. Without looking at logs, it's not possible
 				// to differentiate that from a "legitimate" failure caused by an incorrect requirement.
 				errC <- trace.Wrap(errXPCConnectionCodeSigningRequirementFailure, "either daemon is not signed correctly or it shut down before signature could be verified")
+				return
+			}
+
+			if errorDomain == nsCocoaErrorDomain && errorCode == errorCodeNSXPCConnectionInvalid {
+				errC <- trace.Wrap(errXPCConnectionInvalid, "%v", C.GoString(res.error_description))
 				return
 			}
 

--- a/lib/vnet/daemon/common_darwin.go
+++ b/lib/vnet/daemon/common_darwin.go
@@ -51,13 +51,17 @@ var (
 	// nsCocoaErrorDomain is a generic error domain used in a lot of Apple's Cocoa frameworks.
 	nsCocoaErrorDomain = "NSCocoaErrorDomain"
 
-	// https://developer.apple.com/documentation/foundation/1448136-nserror_codes/nsxpcconnectioninterrupted?changes=latest_major&language=objc
+	// https://developer.apple.com/documentation/foundation/nsxpcconnectioninterrupted-swift.var
 	errorCodeNSXPCConnectionInterrupted = int(C.NSXPCConnectionInterrupted)
 	errXPCConnectionInterrupted         = errors.New("XPC connection interrupted")
 
-	// https://developer.apple.com/documentation/foundation/1448136-nserror_codes/nsxpcconnectioncodesigningrequirementfailure?language=objc
+	// https://developer.apple.com/documentation/foundation/nsxpcconnectioncodesigningrequirementfailure-swift.var
 	errorCodeNSXPCConnectionCodeSigningRequirementFailure = int(C.NSXPCConnectionCodeSigningRequirementFailure)
 	errXPCConnectionCodeSigningRequirementFailure         = errors.New("code signing requirement failed")
+
+	// https://developer.apple.com/documentation/foundation/nsxpcconnectioninvalid-swift.var
+	errorCodeNSXPCConnectionInvalid = int(C.NSXPCConnectionInvalid)
+	errXPCConnectionInvalid         = errors.New("XPC connection invalid")
 )
 
 func DaemonLabel() (string, error) {


### PR DESCRIPTION
Fixes #65137.

Changelog: Fixed a "No such process" error that could happen on the very first launch of VNet on macOS

When I was going through the test plan, I've noticed that VNet quite consistently fails on the very first launch. I remember this not being the case on older versions of macOS because I was testing this flow a lot when I was first implementing it. I haven't made rigorous tests, but it's easier to trigger this on macOS 26.2/26.3 than 26.4. The error was:

> Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.goteleport.tshdev.vnetd was invalidated: Connection init failed at lookup with error 3 - No such process." 

This is `NSXPCConnectionInvalid`. Comparing logs from a successful first launch vs unsuccessful first launch (see https://github.com/gravitational/teleport/issues/65137#issuecomment-4144095751) seems to point at the fact that there's a small gap between registering the daemon through `SMAppService` and the daemon being available in launchd (signaled through `Submit job succeeded` in XPC logs). Attempting to launch the daemon in this window results in:

```
failed lookup: name = com.goteleport.tshdev.vnetd, flags = 0x8, requestor = tsh[751], error = 3: No such process
```

We attempt to launch the daemon immediately after `SMAppService` tells us that the background item has been enabled, checking every second for 50 seconds. The simplest fix is to sleep and repeat the start attempt on the very first launch if it fails due to `NSXPCConnectionInvalid`. We ensure that we run this logic only when the login item had to be enabled by the user (`requiredEnablement`).

Claude also suggested using some arcane C APIs to check if the daemon is available in launchd, namely `bootstrap_look_up`. But those APIs have almost no documentation, so I opted for a simple retry instead.

The logs from the successful first launch suggest that there's about 1s window between the background item being registered vs being available in launchd. Attempting to sleep 3 times for 500ms should be long enough, especially that we query for daemon status every second.

## Manual Test Plan
### Test Environment

A fresh macOS VM that has never seen Teleport Connect.

### Test Cases
- [x] Verify that VNet recovers from `NSXPCConnectionInvalid` on the very first launch.

Logs from such launch to show that it's indeed working:

```
[30-03-26 12:42:25] 2026-03-30T12:42:25.566+02:00 DEBU [VNET:DAEM] Daemon successfully added, but it requires approval ignored_error:Error Domain=SMAppServiceErrorDomain Code=1 "Operation not permitted" UserInfo={NSLocalizedFailureReason=Operation not permitted} daemon/client_darwin.go:144
[30-03-26 12:42:25] To start VNet, please enable the background item for tsh.app in the Login Items section of System Settings.
[30-03-26 12:42:25] Waiting for the background item to be enabled…
[30-03-26 12:42:31] 2026-03-30T12:42:31.678+02:00 DEBU [VNET:DAEM] XPC connection invalid, retrying after a short delay retries:0 error:[
[30-03-26 12:42:31] ERROR REPORT:
[30-03-26 12:42:31] Original Error: *errors.errorString XPC connection invalid
[30-03-26 12:42:31] Stack Trace:
[30-03-26 12:42:31] 	github.com/gravitational/teleport/lib/vnet/daemon/client_darwin.go:307 github.com/gravitational/teleport/lib/vnet/daemon.startByCalling.func1
[30-03-26 12:42:31] 	runtime/asm_arm64.s:1268 runtime.goexit
[30-03-26 12:42:31] User Message: connecting to the VNet daemon
[30-03-26 12:42:31] 	Error Domain=NSCocoaErrorDomain Code=4099 &#34;The connection to service named com.goteleport.tshdev.vnetd was invalidated: Connection init failed at lookup with error 3 - No such process.&#34; UserInfo={NSDebugDescription=The connection to service named com.goteleport.tshdev.vnetd was invalidated: Connection init failed at lookup with error 3 - No such process.}
[30-03-26 12:42:31] 		XPC connection invalid] daemon/client_darwin.go:85
[30-03-26 12:42:32] 2026-03-30T12:42:32.024+02:00 DEBU [DAEMON]    Retrieved client from cache cluster:cluster.mirrors.link clientcache/clientcache.go:138
```
