### PR TITLE
Connect: fix failing fresh silent NSIS installs

### DIFF
--- a/lib/teleterm/autoupdate/privilegedupdater/service_windows.go
+++ b/lib/teleterm/autoupdate/privilegedupdater/service_windows.go
@@ -409,6 +409,9 @@ func ensureDirIsSecure(dir string, sa *windows.SecurityAttributes) error {
 	if err != nil {
 		return trace.Wrap(err, "reading DACL from security descriptor")
 	}
+	if dacl == nil {
+		return trace.BadParameter("security violation: DACL must not be empty")
+	}
 
 	// Reapply directory ACLs.
 	err = windows.SetSecurityInfo(

--- a/web/packages/teleterm/build_resources/installer.nsh
+++ b/web/packages/teleterm/build_resources/installer.nsh
@@ -25,6 +25,22 @@
   LangString forAll ${LANG_ENGLISH} "Anyone who uses this computer (&all users). Includes VNet support."
 !macroend
 
+# For fresh silent installs with no explicit mode, align with selectPerMachineByDefault: true.
+# This is a workaround for https://github.com/electron-userland/electron-builder/issues/9644.
+# Remove once fixed.
+# Using customInit instead of customInstallMode, since this hook is always invoked (customInstallMode runs only in
+# non-silent mode).
+!macro customInit
+  ${If} ${Silent}
+  ${AndIfNot} ${isUpdated}
+  ${AndIfNot} ${isForAllUsers}
+  ${AndIfNot} ${isForCurrentUser}
+  ${AndIf} $hasPerMachineInstallation == "0"
+  ${AndIf} $hasPerUserInstallation == "0"
+    StrCpy $hasPerMachineInstallation "1"
+  ${EndIf}
+!macroend
+
 # Migration from one-click -> assisted multi-user.
 # In non-silent updater runs without an explicit mode flag (now set by NsisDualModeUpdater), elevated launches can wait
 # on the install-mode page without a visible UI. To prevent this, enforce a mode when the installer is run with --update but no install mode flag is provided.


### PR DESCRIPTION
Due to https://github.com/electron-userland/electron-builder/issues/9644, the app fails to install during a fresh silent installation when no explicit installation mode is specified. This happens because the app tries to install per-machine (as expected) but doesn't trigger UAC, so it has no permissions to perform the installation.

The workaround is to set `$hasPerMachineInstallation` flag if there's no explicit mode. This will trigger UAC later in the install flow.

I also included a small suggestion from https://github.com/gravitational/teleport/pull/63572#discussion_r3008808802.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Built the app from this branch.

### Test Cases
- [x] Running the installer with `/S` flag shows the UAC prompt, the app is installed.
