### PR TITLE
[v18] Bump node-forge from 1.3.2 to 1.4.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,8 +433,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4
       node-forge:
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^1.4.0
+        version: 1.4.0
       node-pty:
         specifier: 1.2.0-beta.11
         version: 1.2.0-beta.11
@@ -5522,8 +5522,8 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
-  node-forge@1.3.2:
-    resolution: {integrity: sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==}
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
 
   node-gyp@11.5.0:
@@ -12387,7 +12387,7 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  node-forge@1.3.2: {}
+  node-forge@1.4.0: {}
 
   node-gyp@11.5.0:
     dependencies:

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.13.3",
     "@types/which": "^3.0.4",
-    "node-forge": "^1.3.2",
+    "node-forge": "^1.4.0",
     "node-pty": "1.2.0-beta.11",
     "ring-buffer-ts": "^1.2.0",
     "split2": "4.2.0",


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/65160 to branch/v18

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
My computer.
### Test Cases
- [x] The app starts on Windows (node-forge is used to create certs for mTLS in gRPC).
