### PR TITLE
Add a feature guard API to lib/subca

### DIFF
--- a/lib/subca/feature.go
+++ b/lib/subca/feature.go
@@ -1,0 +1,26 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca
+
+// Enabled returns true if the Sub CA feature is enabled.
+//
+// Testable components should not depend on this function directly. Instead,
+// they take should take "SubCAEnabled bool" or "SubCAEnabled func() bool" as
+// part of their config.
+func Enabled() bool {
+	return enabled
+}

--- a/lib/subca/feature_disabled.go
+++ b/lib/subca/feature_disabled.go
@@ -1,0 +1,21 @@
+//go:build !subca
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca
+
+const enabled = false

--- a/lib/subca/feature_enabled.go
+++ b/lib/subca/feature_enabled.go
@@ -1,0 +1,21 @@
+//go:build subca
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca
+
+const enabled = true


### PR DESCRIPTION
Add a feature flag for Sub CAs, to be used by follow up OSS and e/ PRs.

The build tag is for convenience. This is all to be removed once the feature is released.

https://github.com/gravitational/teleport.e/issues/7675