### PR TITLE
[v18] Bump golang.org/x/image from 0.35.0 to 0.38.0 in /build.assets/tools/goda

### DIFF
--- a/build.assets/tools/goda/go.mod
+++ b/build.assets/tools/goda/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/subcommands v1.2.0 // indirect
 	github.com/loov/goda v0.8.1 // indirect
-	golang.org/x/image v0.35.0 // indirect
+	golang.org/x/image v0.38.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect

--- a/build.assets/tools/goda/go.sum
+++ b/build.assets/tools/goda/go.sum
@@ -4,8 +4,8 @@ github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/loov/goda v0.8.1 h1:AJs7ZZQ2Cpx4qk01gCmL2y+fKBgRR/SdHslmenNNS9A=
 github.com/loov/goda v0.8.1/go.mod h1:puSm2mDa0WmEoOJybsJUchP3btnEbBvLNd4xTv08gag=
-golang.org/x/image v0.35.0 h1:LKjiHdgMtO8z7Fh18nGY6KDcoEtVfsgLDPeLyguqb7I=
-golang.org/x/image v0.35.0/go.mod h1:MwPLTVgvxSASsxdLzKrl8BRFuyqMyGhLwmC+TO1Sybk=
+golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
+golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
 golang.org/x/mod v0.32.0 h1:9F4d3PHLljb6x//jOyokMv3eX+YDeepZSEo3mFJy93c=
 golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=


### PR DESCRIPTION
Backport #65181 to branch/v18