### PR TITLE
Add the "tctl auth pub-key-hash" command

### DIFF
--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -52,11 +52,13 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	libsubca "github.com/gravitational/teleport/lib/subca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/winpki"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
+	subcacmd "github.com/gravitational/teleport/tool/tctl/common/subca"
 )
 
 // authCommandClient is aggregated client interface for auth command.
@@ -109,10 +111,12 @@ type AuthCommand struct {
 	// testInsecureSkipVerify is used to skip TLS verification during tests
 	// when connecting to the proxy ping address.
 	testInsecureSkipVerify bool
+
+	subCACommand *subcacmd.Command
 }
 
 // Initialize allows TokenCommand to plug itself into the CLI parser
-func (a *AuthCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
+func (a *AuthCommand) Initialize(app *kingpin.Application, cliFlags *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
 	a.config = config
 	// operations with authorities
 	auth := app.Command("auth", "Operations with user and host certificate authorities (CAs).").Hidden()
@@ -174,11 +178,21 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	a.authCRL = auth.Command("crl", "Export empty certificate revocation list (CRL) for Teleport certificate authorities.")
 	a.authCRL.Flag("type", fmt.Sprintf("Certificate authority type, one of: %s", strings.Join(allowedCRLCertificateTypes, ", "))).Required().EnumVar(&a.caType, allowedCRLCertificateTypes...)
 	a.authCRL.Flag("out", "If set, writes exported revocation lists to files with the given path prefix").StringVar(&a.output)
+
+	if libsubca.Enabled() {
+		a.subCACommand = &subcacmd.Command{}
+		a.subCACommand.Initialize(auth, cliFlags, config)
+	}
 }
 
 // TryRun takes the CLI command as an argument (like "auth gen") and executes it
 // or returns match=false if 'cmd' does not belong to it
 func (a *AuthCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
+	if a.subCACommand != nil {
+		if match, err := a.subCACommand.TryRun(ctx, cmd, clientFunc); match || err != nil {
+			return match, trace.Wrap(err)
+		}
+	}
 	if match, err := a.authRotate.TryRun(ctx, cmd, clientFunc); match || err != nil {
 		return match, trace.Wrap(err)
 	}

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -1,0 +1,147 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/utils/tlsutils"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/subca"
+	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
+	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
+)
+
+// Command is the subset of "tctl auth" commands that deal with Sub CAs.
+//
+// Namely:
+//   - tctl auth create-override-csr
+//   - tctl auth create-override
+//   - tctl auth update-override
+//   - tctl auth delete-override
+//   - tctl auth pub-key-hash
+type Command struct {
+	// Stdin is a test-friendly pointer to stdin.
+	// Initialized by the Initialize function.
+	Stdin io.Reader
+	// Stdout and Stderr are test-friendly pointers to stdout/stderr.
+	// Initialized by the Initialize function.
+	Stdout, Stderr io.Writer
+
+	pubKeyHash pubKeyHashCommand
+}
+
+// Initialize initializes all Sub CA commands. Parent is expected to be "tctl
+// auth".
+//
+// Mimics CLICommand.Initialize.
+func (c *Command) Initialize(
+	parent *kingpin.CmdClause,
+	_ *tctlcfg.GlobalCLIFlags,
+	_ *servicecfg.Config,
+) {
+	if c.Stdin == nil {
+		c.Stdin = os.Stdin
+	}
+	if c.Stdout == nil {
+		c.Stdout = os.Stdout
+	}
+	if c.Stderr == nil {
+		c.Stderr = os.Stderr
+	}
+
+	c.pubKeyHash.CmdClause = parent.Command(
+		"pub-key-hash", "Extract and print the public key hash of a PEM certificate")
+	c.pubKeyHash.Flag("cert", "Certificate file in PEM format. Use '-' to read from stdin.").
+		Required().
+		StringVar(&c.pubKeyHash.certFile)
+}
+
+// TryRun attempts to run the selected command. Returns true if the commands
+// matches, false otherwise.
+//
+// Mimics tool/tctl/common.CLICommand.TryRun.
+func (c *Command) TryRun(
+	ctx context.Context,
+	selectedCommand string,
+	clientFunc commonclient.InitFunc,
+) (match bool, err error) {
+	if selectedCommand == c.pubKeyHash.FullCommand() {
+		return true, trace.Wrap(c.pubKeyHash.Run(ctx, clientFunc, c.state()))
+	}
+	return false, nil
+}
+
+func (c *Command) state() *commandState {
+	return &commandState{
+		Stdin:  c.Stdin,
+		Stdout: c.Stdout,
+		Sdterr: c.Stderr,
+	}
+}
+
+type commandState struct {
+	Stdin          io.Reader
+	Stdout, Sdterr io.Writer
+}
+
+type pubKeyHashCommand struct {
+	*kingpin.CmdClause
+
+	certFile string
+}
+
+func (c *pubKeyHashCommand) Run(
+	ctx context.Context,
+	_ commonclient.InitFunc,
+	s *commandState,
+) error {
+	// Defensive, shouldn't happen.
+	if c.certFile == "" {
+		return trace.BadParameter("certificate required")
+	}
+
+	var source io.Reader
+	if c.certFile == "-" {
+		source = s.Stdin
+	} else {
+		f, err := os.Open(c.certFile)
+		if err != nil {
+			return trace.Wrap(err, "open file")
+		}
+		defer f.Close()
+		source = f
+	}
+
+	certPEM, err := io.ReadAll(source)
+	if err != nil {
+		return trace.Wrap(err, "read certificate")
+	}
+	cert, err := tlsutils.ParseCertificatePEM(certPEM)
+	if err != nil {
+		return trace.Wrap(err, "parse certificate PEM")
+	}
+
+	fmt.Fprintln(s.Stdout, subca.HashCertificatePublicKey(cert))
+	return nil
+}

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -96,13 +96,13 @@ func (c *Command) state() *commandState {
 	return &commandState{
 		Stdin:  c.Stdin,
 		Stdout: c.Stdout,
-		Sdterr: c.Stderr,
+		Stderr: c.Stderr,
 	}
 }
 
 type commandState struct {
 	Stdin          io.Reader
-	Stdout, Sdterr io.Writer
+	Stdout, Stderr io.Writer
 }
 
 type pubKeyHashCommand struct {

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -1,0 +1,138 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/tool/tctl/common/subca"
+)
+
+func TestSubCACommand(t *testing.T) {
+	t.Parallel()
+
+	const certPEM = `-----BEGIN CERTIFICATE-----
+MIIERzCCAq+gAwIBAgIRAMZcaomNE+VygiNyxoSwzr8wDQYJKoZIhvcNAQELBQAw
+fTEeMBwGA1UEChMVbWtjZXJ0IGRldmVsb3BtZW50IENBMSkwJwYDVQQLDCBhbGFu
+QHphcnF1b24yLmxvY2FsIChBbGFuIFBhcnJhKTEwMC4GA1UEAwwnbWtjZXJ0IGFs
+YW5AemFycXVvbjIubG9jYWwgKEFsYW4gUGFycmEpMB4XDTI2MDMzMDE0NTI0OVoX
+DTI4MDYzMDE0NTI0OVowSTEnMCUGA1UEChMebWtjZXJ0IGRldmVsb3BtZW50IGNl
+cnRpZmljYXRlMR4wHAYDVQQLDBVhbGFuQE1hYyAoQWxhbiBQYXJyYSkwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDb43vlSk68rJMK/kKjGEP06y81A4kt
+e+sfwsGXbevwk0565FfXsN3oraUkb5QG0/Cv6pZotBMOx8g8Gbkb0Od4OoESD9l1
+SQF1F+9DNyrGQscLg9cz+qVaG9q0DIwGMKNmchZwZES0PGeA6l6CAgsR06NoTht3
+Cv8id6myHlOg+pKoil5iQ9kydxrU9qku4dRlYggbMynn9KaEm0i5g7ipIsnvnRkL
+WOJup9qLPYdQIwQfKtQiJ6SG95pypnkxku4qbPsWKqReYH694HwWBo5XKERbFEX2
+5lQNGpwWRLFxquZiheiu7C/jxxzxLnxnScGcERpI6om3plK1OgbRPx9RAgMBAAGj
+djB0MA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAfBgNVHSME
+GDAWgBRIeRs75N2PBLqa0s7ILgxvFho9PTAsBgNVHREEJTAjgglsb2NhbGhvc3SH
+BH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEwDQYJKoZIhvcNAQELBQADggGBAA52BvfF
+Xs084HMVyRu09FYwu9fiHfD3Whyq7khPhBhF9/r+/VBEjie5oi4Vk9z/OVWPSp37
+XN+UeNvAHQh07ntAW+7m/Gfrt4lX7kK46+Gjgzu8YPBNhAkYEhJz8ViJshSSfRnu
+itwRn/9J7qVzGud6Hhn+Zc+CBrIe467jT+iUoA1iiZDUjZHqo1O14SwomuB2/CzC
+t4C4ZQSxU6yOEcvJP6C0hwSZYKht5+WGwLy95cvX9kk+RrqEysLatbUfr1xrE35y
+2VEVbb8ppWMrd6njbJjGXBO1bb1kNUgj0GYI+0oJeu5W4AXBYS97tAntNWFcfeFS
+O/sfRlbBpQNYxA045fO/Dc3qKhZAVfLLWL/mK3XSRS8gz0iBESlDXDVqChKeOzZV
+Fv4gVOCfPBtGRcyntw5YMjRBr1M5E7lR7f0EiEf98XK+7qCyrgBa63/F1YConCCK
+OCILEpSS/B19NPlXOYipYx7lPCoRHCsDQk/RuQ0doilw+Gx1f/lMMH3Z/g==
+-----END CERTIFICATE-----`
+	// Pre-calculated pub key hash of certPEM.
+	const want = "0fa1e6306b74b68aca58636482dc3cb5ff64ba17dbff6d808cf901169745e6be\n"
+
+	tests := []struct {
+		name         string
+		prepareFlags func(t *testing.T, stdin *bytes.Buffer) []string
+	}{
+		{
+			name: "--cert=file",
+			prepareFlags: func(t *testing.T, stdin *bytes.Buffer) []string {
+				tmp := t.TempDir()
+				name := tmp + "/cert.pem"
+				require.NoError(t,
+					os.WriteFile(name, []byte(certPEM), 0644),
+					"Write test certificate",
+				)
+				// "tctl auth pub-key-hash --cert=cert.pem"
+				return []string{"auth", "pub-key-hash", "--cert", name}
+			},
+		},
+		{
+			name: "--cert='-' (stdin)",
+			prepareFlags: func(t *testing.T, stdin *bytes.Buffer) []string {
+				stdin.WriteString(certPEM)
+				// "tctl auth pub-key-hash --cert='-'"
+				return []string{"auth", "pub-key-hash", "--cert=-"}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := newCommand(t)
+
+			// Prepare/parse flags.
+			flags := test.prepareFlags(t, env.Stdin)
+			selectedCommand, err := env.App.Parse(flags)
+			require.NoError(t, err, "app.Parse()")
+
+			// Run.
+			match, err := env.Cmd.TryRun(t.Context(), selectedCommand, nil)
+			require.True(t, match, "TryRun() returned match=false")
+			require.NoError(t, err, "TryRun() errored")
+
+			// Verify output.
+			got := env.Stdout.String()
+			assert.Equal(t, want, got, "pub-key-hash output mismatch")
+		})
+	}
+}
+
+type commandEnv struct {
+	App                   *kingpin.Application
+	Cmd                   *subca.Command
+	Stdin, Stdout, Stderr *bytes.Buffer
+}
+
+func newCommand(_ *testing.T) *commandEnv {
+	app := kingpin.New("tctl", "")
+	authCmd := app.Command("auth", "")
+
+	stdin := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	subCACmd := &subca.Command{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+	subCACmd.Initialize(authCmd, nil, nil)
+
+	return &commandEnv{
+		App:    app,
+		Cmd:    subCACmd,
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+}

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -60,12 +60,12 @@ OCILEpSS/B19NPlXOYipYx7lPCoRHCsDQk/RuQ0doilw+Gx1f/lMMH3Z/g==
 	const want = "0fa1e6306b74b68aca58636482dc3cb5ff64ba17dbff6d808cf901169745e6be\n"
 
 	tests := []struct {
-		name         string
-		prepareFlags func(t *testing.T, stdin *bytes.Buffer) []string
+		name           string
+		prepareCommand func(t *testing.T, stdin *bytes.Buffer) []string
 	}{
 		{
 			name: "--cert=file",
-			prepareFlags: func(t *testing.T, stdin *bytes.Buffer) []string {
+			prepareCommand: func(t *testing.T, stdin *bytes.Buffer) []string {
 				tmp := t.TempDir()
 				name := tmp + "/cert.pem"
 				require.NoError(t,
@@ -78,7 +78,7 @@ OCILEpSS/B19NPlXOYipYx7lPCoRHCsDQk/RuQ0doilw+Gx1f/lMMH3Z/g==
 		},
 		{
 			name: "--cert='-' (stdin)",
-			prepareFlags: func(t *testing.T, stdin *bytes.Buffer) []string {
+			prepareCommand: func(t *testing.T, stdin *bytes.Buffer) []string {
 				stdin.WriteString(certPEM)
 				// "tctl auth pub-key-hash --cert='-'"
 				return []string{"auth", "pub-key-hash", "--cert=-"}
@@ -92,7 +92,7 @@ OCILEpSS/B19NPlXOYipYx7lPCoRHCsDQk/RuQ0doilw+Gx1f/lMMH3Z/g==
 			env := newCommand(t)
 
 			// Prepare/parse flags.
-			flags := test.prepareFlags(t, env.Stdin)
+			flags := test.prepareCommand(t, env.Stdin)
 			selectedCommand, err := env.App.Parse(flags)
 			require.NoError(t, err, "app.Parse()")
 

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gravitational/teleport/tool/tctl/common/subca"
 )
 
-func TestSubCACommand(t *testing.T) {
+func TestCommand_PubKeyHash(t *testing.T) {
 	t.Parallel()
 
 	const certPEM = `-----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Add the "tctl auth pub-key-hash" command.

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan
### Test Environment
Local / dev.

### Test Cases
- [x] `go run -tags=subca ./tool/tctl auth pub-key-hash --cert=/path/to/cert.pem`
- [x] `go run -tags=subca ./tool/tctl auth pub-key-hash --cert='-' </path/to/cert.pem`
- [x] `go run ./tool/tctl auth --help` # pub-key-hash doesn't exist
- [x] `go run ./tool/tctl auth pub-key-hash` # unexpected command