### PR TITLE
[v18] Fix URL components for SAML auth connector ACS URL in tests, error me…

### DIFF
--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -516,7 +516,7 @@ func (o *SAMLConnectorV2) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing acs - assertion consumer service parameter, set service URL that will receive POST requests from SAML")
 	}
 	if o.Spec.AllowIDPInitiated && !strings.HasSuffix(o.Spec.AssertionConsumerService, "/"+o.Metadata.Name) {
-		return trace.BadParameter("acs - assertion consumer service parameter must end with /%v when allow_idp_initiated is set to true, eg https://cluster.domain/webapi/v1/saml/acs/%v. Ensure this URI matches the one configured at the identity provider.", o.Metadata.Name, o.Metadata.Name)
+		return trace.BadParameter("acs - assertion consumer service parameter must end with /%v when allow_idp_initiated is set to true, eg https://cluster.domain/v1/webapi/saml/acs/%v. Ensure this URI matches the one configured at the identity provider.", o.Metadata.Name, o.Metadata.Name)
 	}
 	if o.Spec.ServiceProviderIssuer == "" {
 		o.Spec.ServiceProviderIssuer = o.Spec.AssertionConsumerService

--- a/api/types/saml_test.go
+++ b/api/types/saml_test.go
@@ -49,7 +49,7 @@ func TestSAMLSecretsStrip(t *testing.T) {
 // TestSAMLAcsUriHasConnector tests that the ACS URI has the connector ID as the last part if IdP-initiated login is enabled.
 func TestSAMLACSURIHasConnectorName(t *testing.T) {
 	connector, err := types.NewSAMLConnector("myBusinessConnector", types.SAMLConnectorSpecV2{
-		AssertionConsumerService: "https://teleport.local/webapi/v1/saml/acs",
+		AssertionConsumerService: "https://teleport.local/v1/webapi/saml/acs",
 		SSO:                      "test",
 		EntityDescriptor:         "test",
 		AllowIDPInitiated:        true,
@@ -59,7 +59,7 @@ func TestSAMLACSURIHasConnectorName(t *testing.T) {
 	require.Error(t, err)
 
 	connector, err = types.NewSAMLConnector("myBusinessConnector", types.SAMLConnectorSpecV2{
-		AssertionConsumerService: "https://teleport.local/webapi/v1/saml/acs/myBusinessConnector",
+		AssertionConsumerService: "https://teleport.local/v1/webapi/saml/acs/myBusinessConnector",
 		SSO:                      "test",
 		EntityDescriptor:         "test",
 		AllowIDPInitiated:        true,


### PR DESCRIPTION
Backport #65193 to branch/v18

changelog: Fix URL components for SAML auth connector ACS URL in tests, error message

## Manual Test Plan

Same as #65193 

### Test Environment

Any, using the teleport binary built from this PR.

### Test Cases
- [x] Verify example ACS URL in error message contains `/v1/webapi/`, **not** `/webapi/v1`.

    ```
    $ tctl create -f - <<'EOF'
    kind: saml
    metadata:
      name: my-saml
    spec:
      # Intentionally wrong ('_' vs '-') to trigger error message
      acs: https://teleport.local/v1/webapi/saml/acs/my_saml
      # Required to get error message
      allow_idp_initiated: true
      attributes_to_roles:
      - name: http://schemas.microsoft.com/identity/claims/objectidentifier
        roles:
        - requester
        value: '*'
      audience: https://teleport.local/v1/webapi/saml/acs/my_saml
      service_provider_issuer: https://teleport.local/v1/webapi/saml/acs/my_saml
      display: Entra ID
      entity_descriptor_url: https://myidp.com/some/url/here
    version: v2
    EOF
    
    ERROR: acs - assertion consumer service parameter must end with /entra-id when allow_idp_initiated is set to true, eg https://cluster.domain/v1/webapi/saml/acs/entra-id. Ensure this URI matches the one configured at the identity provider.
    ``` 