### PR TITLE
app: Use constant-time bearer token comparison

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -468,8 +468,7 @@ func (h *Handler) getAppSessionFromCookie(r *http.Request) (types.WebSession, er
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if ws.GetBearerToken() != subjectValue {
-		err := trace.AccessDenied("subject session token does not match")
+	if err := checkSubjectToken(subjectValue, ws); err != nil {
 		h.c.AuthClient.EmitAuditEvent(h.closeContext, &apievents.AuthAttempt{
 			Metadata: apievents.Metadata{
 				Type: events.AuthAttemptEvent,


### PR DESCRIPTION
`getAppSessionFromCookie` in `lib/web/app/handler.go` compared the
bearer token using `!=`, which is vulnerable to timing side-channel
attacks. Replace it with `checkSubjectToken`, which already exists in
the same package and uses `subtle.ConstantTimeCompare`. The audit event
on mismatch is preserved.

The other code path (`checkSubjectToken` in `auth.go`) was already
correct.