### PR TITLE
[v18] limiter: Fix custom rate bucket clobbering

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -4865,7 +4865,7 @@ func (g *GRPCServer) CreateAuthenticateChallenge(ctx context.Context, req *authp
 			return nil, trace.BadParameter("unable to find peer")
 		}
 
-		if err := g.createAuthenticateChallengeLimiter.RegisterRequestFromAddr(peerInfo.Addr, nil); err != nil {
+		if err := g.createAuthenticateChallengeLimiter.RegisterRequestFromAddr(peerInfo.Addr); err != nil {
 			return nil, trace.LimitExceeded("rate limit exceeded")
 		}
 	}

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -4760,6 +4760,12 @@ func TestCustomRateLimiting(t *testing.T) {
 			},
 		},
 		{
+			name: "RPC ChangePassword",
+			fn: func(ctx context.Context, clt *authclient.Client) error {
+				return clt.ChangePassword(ctx, &proto.ChangePasswordRequest{})
+			},
+		},
+		{
 			name: "RPC GetAccountRecoveryToken",
 			fn: func(ctx context.Context, clt *authclient.Client) error {
 				_, err := clt.GetAccountRecoveryToken(ctx, &proto.GetAccountRecoveryTokenRequest{})

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -179,6 +179,11 @@ func NewTLSServer(ctx context.Context, cfg TLSServerConfig) (*TLSServer, error) 
 		oldestSupportedVersion = nil
 	}
 
+	accountRecoveryLimiter, err := newAccountRecoveryLimiter()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// authMiddleware authenticates request assuming TLS client authentication
 	// adds authentication information to the context
 	// and passes it to the API server
@@ -186,6 +191,7 @@ func NewTLSServer(ctx context.Context, cfg TLSServerConfig) (*TLSServer, error) 
 		ClusterName:            localClusterName.GetClusterName(),
 		AcceptedUsage:          cfg.AcceptedUsage,
 		Limiter:                limiter,
+		accountRecoveryLimiter: accountRecoveryLimiter,
 		GRPCMetrics:            grpcMetrics,
 		OldestSupportedVersion: oldestSupportedVersion,
 		AlertCreator: func(ctx context.Context, a types.ClusterAlert) error {
@@ -360,6 +366,9 @@ type Middleware struct {
 	AcceptedUsage []string
 	// Limiter is a rate and connection limiter
 	Limiter *limiter.Limiter
+	// accountRecoveryLimiter rate-limits account recovery RPCs
+	// independently from the default limiter.
+	accountRecoveryLimiter *limiter.RateLimiter
 	// GRPCMetrics is the configured gRPC metrics for the interceptors
 	GRPCMetrics *grpcprom.ServerMetrics
 	// EnableCredentialsForwarding allows the middleware to receive impersonation
@@ -385,26 +394,55 @@ func (a *Middleware) Wrap(h http.Handler) {
 	a.Handler = h
 }
 
-func getCustomRate(endpoint string) *limiter.RateSet {
-	switch endpoint {
-	// Account recovery RPCs.
-	case
-		"/proto.AuthService/ChangeUserAuthentication",
-		"/proto.AuthService/ChangePassword",
-		"/proto.AuthService/GetAccountRecoveryToken",
-		"/proto.AuthService/StartAccountRecovery",
-		"/proto.AuthService/VerifyAccountRecovery":
-		rates := limiter.NewRateSet()
-		// This limit means: 1 request per minute with bursts up to 10 requests.
-		if err := rates.Add(time.Minute, 1, 10); err != nil {
-			logger.DebugContext(context.Background(), "Failed to define a custom rate for rpc method, using default rate",
-				"error", err,
-				"rpc_method", endpoint)
-			return nil
-		}
-		return rates
+// newAccountRecoveryLimiter creates the dedicated limiter for
+// account recovery RPCs (1 req/min, burst 10).
+func newAccountRecoveryLimiter() (*limiter.RateLimiter, error) {
+	return limiter.NewRateLimiter(limiter.Config{
+		Rates: []limiter.Rate{{Period: time.Minute, Average: 1, Burst: 10}},
+	})
+}
+
+// clientIPFromContext extracts the client IP from the gRPC peer in
+// the given context.
+func clientIPFromContext(ctx context.Context) (string, error) {
+	peerInfo, ok := peer.FromContext(ctx)
+	if !ok {
+		return "", trace.AccessDenied("missing peer info")
 	}
-	return nil
+	return utils.ClientIPFromAddr(peerInfo.Addr)
+}
+
+// rateLimitUnaryInterceptor returns a gRPC unary interceptor that
+// applies the default rate and connection limiter to all endpoints,
+// plus the stricter account recovery limiter on recovery endpoints.
+func (a *Middleware) rateLimitUnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		clientIP, err := clientIPFromContext(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		release, err := a.Limiter.RegisterRequestAndConnection(clientIP)
+		if err != nil {
+			return nil, trace.LimitExceeded("rate limit exceeded")
+		}
+		defer release()
+		// Additional rate check for account recovery endpoints.
+		switch info.FullMethod {
+		case
+			"/proto.AuthService/ChangeUserAuthentication",
+			"/proto.AuthService/ChangePassword",
+			"/proto.AuthService/GetAccountRecoveryToken",
+			"/proto.AuthService/StartAccountRecovery",
+			"/proto.AuthService/VerifyAccountRecovery":
+			if a.accountRecoveryLimiter != nil {
+				err := a.accountRecoveryLimiter.RegisterRequest(clientIP)
+				if err != nil {
+					return nil, trace.LimitExceeded("rate limit exceeded")
+				}
+			}
+		}
+		return handler(ctx, req)
+	}
 }
 
 // ValidateClientVersion inspects the client version for the connection and terminates
@@ -600,7 +638,7 @@ func (a *Middleware) UnaryInterceptors() []grpc.UnaryServerInterceptor {
 	return append(is,
 		interceptors.GRPCServerUnaryErrorInterceptor,
 		metadata.UnaryServerInterceptor,
-		a.Limiter.UnaryServerInterceptorWithCustomRate(getCustomRate),
+		a.rateLimitUnaryInterceptor(),
 		a.withAuthenticatedUserUnaryInterceptor,
 	)
 }

--- a/lib/limiter/internal/ratelimit/ratelimit.go
+++ b/lib/limiter/internal/ratelimit/ratelimit.go
@@ -134,7 +134,8 @@ func (tl *TokenLimiter) consumeRates(source string, amount int64) error {
 	return nil
 }
 
-// RateSet maintains a set of rates. It can contain only one rate per period at a time.
+// RateSet maintains a set of rates. It can contain only one rate per
+// period at a time.
 type RateSet struct {
 	m map[time.Duration]*rate
 }
@@ -146,7 +147,7 @@ type rate struct {
 	burst   int64
 }
 
-// NewRateSet crates an empty rate set.
+// NewRateSet creates an empty rate set.
 func NewRateSet() *RateSet {
 	return &RateSet{m: make(map[time.Duration]*rate)}
 }

--- a/lib/limiter/internal/ratelimit/tokenbucket.go
+++ b/lib/limiter/internal/ratelimit/tokenbucket.go
@@ -137,7 +137,7 @@ type tokenBucket struct {
 	lastConsumed int64
 }
 
-// newTokenBucket crates a tokenBucket instance for the specified rate.
+// newTokenBucket creates a tokenBucket instance for the specified rate.
 func newTokenBucket(rate *rate, clock clockwork.Clock) *tokenBucket {
 	period := cmp.Or(rate.period, time.Nanosecond)
 	return &tokenBucket{

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/peer"
 
 	"github.com/gravitational/teleport/lib/limiter/internal/ratelimit"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // Limiter helps limiting connections and request rates
@@ -71,11 +72,7 @@ func (l *Limiter) GetNumConnection(token string) (int64, error) {
 }
 
 func (l *Limiter) RegisterRequest(token string) error {
-	return l.rateLimiter.RegisterRequest(token, nil)
-}
-
-func (l *Limiter) RegisterRequestWithCustomRate(token string, customRate *ratelimit.RateSet) error {
-	return l.rateLimiter.RegisterRequest(token, customRate)
+	return l.rateLimiter.RegisterRequest(token)
 }
 
 func (l *Limiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -113,37 +110,23 @@ func (l *Limiter) RegisterRequestAndConnection(token string) (func(), error) {
 
 type RateSet = ratelimit.RateSet
 
-// NewRateSet crates an empty `RateSet` instance.
+// NewRateSet creates an empty RateSet instance.
 func NewRateSet() *RateSet { return ratelimit.NewRateSet() }
 
 // UnaryServerInterceptor returns a gRPC unary interceptor which
 // rate limits by client IP.
 func (l *Limiter) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	return l.UnaryServerInterceptorWithCustomRate(func(string) *RateSet {
-		return nil
-	})
-}
-
-// CustomRateFunc is a function type which returns a custom rate set
-// for a given endpoint string.
-type CustomRateFunc func(endpoint string) *RateSet
-
-// UnaryServerInterceptorWithCustomRate returns a gRPC unary interceptor which
-// rate limits by client IP. Accepts a CustomRateFunc to set custom rates for
-// specific gRPC methods.
-func (l *Limiter) UnaryServerInterceptorWithCustomRate(customRate CustomRateFunc) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		peerInfo, ok := peer.FromContext(ctx)
 		if !ok {
 			return nil, trace.AccessDenied("missing peer info")
 		}
 
-		// Limit requests per second and simultaneous connection by client IP.
-		clientIP, err := clientIPFromAddr(peerInfo.Addr)
+		clientIP, err := utils.ClientIPFromAddr(peerInfo.Addr)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if err := l.RegisterRequestWithCustomRate(clientIP, customRate(info.FullMethod)); err != nil {
+		if err := l.RegisterRequest(clientIP); err != nil {
 			return nil, trace.LimitExceeded("rate limit exceeded")
 		}
 		if err := l.connectionLimiter.AcquireConnection(clientIP); err != nil {
@@ -162,7 +145,7 @@ func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.Ser
 		return trace.AccessDenied("missing peer info")
 	}
 	// Limit requests per second and simultaneous connection by client IP.
-	clientIP, err := clientIPFromAddr(peerInfo.Addr)
+	clientIP, err := utils.ClientIPFromAddr(peerInfo.Addr)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -174,27 +157,6 @@ func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.Ser
 	}
 	defer l.connectionLimiter.ReleaseConnection(clientIP)
 	return handler(srv, serverStream)
-}
-
-func clientIPFromAddr(addr net.Addr) (string, error) {
-	if addr == nil {
-		return "", trace.BadParameter("missing client IP")
-	}
-
-	s := addr.String()
-
-	// bufconn peers don't include host:port, so use a stable synthetic key
-	// for request/connection limiting in tests.
-	if s == "bufconn" && addr.Network() == "bufconn" {
-		return "bufconn", nil
-	}
-
-	clientIP, _, err := net.SplitHostPort(s)
-	if err == nil {
-		return clientIP, nil
-	}
-
-	return "", trace.BadParameter("missing client IP")
 }
 
 // WrapListener returns a [Listener] that wraps the provided listener

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 
-	"github.com/gravitational/teleport/lib/limiter/internal/ratelimit"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -110,41 +109,6 @@ func TestRateLimiter(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCustomRate(t *testing.T) {
-	clock := clockwork.NewFakeClock()
-
-	limiter, err := NewLimiter(
-		Config{
-			Clock: clock,
-			Rates: []Rate{
-				// Default rate
-				{
-					Period:  10 * time.Millisecond,
-					Average: 10,
-					Burst:   20,
-				},
-			},
-		})
-	require.NoError(t, err)
-
-	customRate := ratelimit.NewRateSet()
-	err = customRate.Add(time.Minute, 1, 5)
-	require.NoError(t, err)
-
-	// Max out custom rate.
-	for i := 0; i < 5; i++ {
-		require.NoError(t, limiter.RegisterRequestWithCustomRate("token1", customRate))
-	}
-
-	// Test rate limit exceeded with custom rate.
-	require.Error(t, limiter.RegisterRequestWithCustomRate("token1", customRate))
-
-	// Test default rate still works.
-	for i := 0; i < 20; i++ {
-		require.NoError(t, limiter.RegisterRequest("token1"))
-	}
-}
-
 type mockAddr struct{}
 
 func (a mockAddr) Network() string {
@@ -156,56 +120,24 @@ func (a mockAddr) String() string {
 }
 
 func TestLimiter_UnaryServerInterceptor(t *testing.T) {
+	ctx := peer.NewContext(t.Context(), &peer.Peer{Addr: mockAddr{}})
+	req := "request"
+	serverInfo := &grpc.UnaryServerInfo{FullMethod: "/method"}
+	handler := func(context.Context, any) (any, error) { return nil, nil }
+
 	limiter, err := NewLimiter(Config{
 		MaxConnections: 1,
-		Rates: []Rate{
-			{
-				Period:  time.Minute,
-				Average: 1,
-				Burst:   1,
-			},
-		},
+		Rates:          []Rate{{Period: time.Minute, Average: 1, Burst: 1}},
 	})
 	require.NoError(t, err)
 
-	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: mockAddr{}})
-	req := "request"
-	serverInfo := &grpc.UnaryServerInfo{
-		FullMethod: "/method",
-	}
-	handler := func(context.Context, interface{}) (interface{}, error) { return nil, nil }
+	interceptor := limiter.UnaryServerInterceptor()
 
-	unaryInterceptor := limiter.UnaryServerInterceptor()
-
-	// pass at least once
-	_, err = unaryInterceptor(ctx, req, serverInfo, handler)
+	_, err = interceptor(ctx, req, serverInfo, handler)
 	require.NoError(t, err)
 
-	// should eventually fail, not testing the limiter behavior here
-	for i := 0; i < 10; i++ {
-		_, err = unaryInterceptor(ctx, req, serverInfo, handler)
-		if err != nil {
-			break
-		}
-	}
-	require.Error(t, err)
-
-	getCustomRate := func(endpoint string) *ratelimit.RateSet {
-		rates := ratelimit.NewRateSet()
-		err := rates.Add(2*time.Minute, 1, 2)
-		require.NoError(t, err)
-		return rates
-	}
-
-	unaryInterceptor = limiter.UnaryServerInterceptorWithCustomRate(getCustomRate)
-
-	// should pass at least once
-	_, err = unaryInterceptor(ctx, req, serverInfo, handler)
-	require.NoError(t, err)
-
-	// should eventually fail, not testing the limiter behavior here
-	for i := 0; i < 10; i++ {
-		_, err = unaryInterceptor(ctx, req, serverInfo, handler)
+	for range 10 {
+		_, err = interceptor(ctx, req, serverInfo, handler)
 		if err != nil {
 			break
 		}
@@ -235,7 +167,7 @@ func TestLimiter_StreamServerInterceptor(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: mockAddr{}})
+	ctx := peer.NewContext(t.Context(), &peer.Peer{Addr: mockAddr{}})
 	ss := mockServerStream{
 		ctx: ctx,
 	}
@@ -479,19 +411,19 @@ func TestRateLimiter_IsRateLimited(t *testing.T) {
 
 	// Consume some tokens but not all
 	for range 5 {
-		require.NoError(t, limiter.RegisterRequest("token1", nil))
+		require.NoError(t, limiter.RegisterRequest("token1"))
 	}
 
 	require.False(t, limiter.IsRateLimited("token1"))
 
 	// Consume the rest of the tokens
 	for range 4 {
-		require.NoError(t, limiter.RegisterRequest("token1", nil))
+		require.NoError(t, limiter.RegisterRequest("token1"))
 	}
 	require.False(t, limiter.IsRateLimited("token1"))
 
 	// Consume the last token
-	require.NoError(t, limiter.RegisterRequest("token1", nil))
+	require.NoError(t, limiter.RegisterRequest("token1"))
 	// Now token1 should be rate limited
 	require.True(t, limiter.IsRateLimited("token1"))
 	// token2 should not be rate limited
@@ -500,4 +432,41 @@ func TestRateLimiter_IsRateLimited(t *testing.T) {
 	clock.Advance(time.Minute)
 	// After time passes, token1 should not be rate limited anymore
 	require.False(t, limiter.IsRateLimited("token1"))
+}
+
+// TestIndependentLimiters verifies that two Limiter instances
+// maintain independent token buckets for the same client IP.
+func TestIndependentLimiters(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+
+	defaultLimiter, err := NewLimiter(Config{
+		Clock: clock,
+		Rates: []Rate{{Period: 10 * time.Millisecond, Average: 10, Burst: 20}},
+	})
+	require.NoError(t, err)
+
+	recoveryLimiter, err := NewLimiter(Config{
+		Clock: clock,
+		Rates: []Rate{{Period: time.Minute, Average: 1, Burst: 5}},
+	})
+	require.NoError(t, err)
+
+	// Exhaust the recovery limiter (burst 5).
+	for range 5 {
+		require.NoError(t, recoveryLimiter.RegisterRequest("127.0.0.1"))
+	}
+	require.Error(t, recoveryLimiter.RegisterRequest("127.0.0.1"))
+
+	// Default limiter for the same IP must still work.
+	require.NoError(t, defaultLimiter.RegisterRequest("127.0.0.1"))
+
+	// Recovery limiter must still be exhausted.
+	require.Error(t, recoveryLimiter.RegisterRequest("127.0.0.1"))
+
+	// Default limiter has its own independent bucket.
+	for range 19 {
+		require.NoError(t, defaultLimiter.RegisterRequest("127.0.0.1"))
+	}
+	require.Error(t, defaultLimiter.RegisterRequest("127.0.0.1"))
 }

--- a/lib/limiter/ratelimiter.go
+++ b/lib/limiter/ratelimiter.go
@@ -19,7 +19,6 @@
 package limiter
 
 import (
-	"cmp"
 	"context"
 	"net"
 	"net/http"
@@ -119,27 +118,26 @@ func (l *RateLimiter) IsRateLimited(token string) bool {
 	return bucket.IsRateLimited()
 }
 
-// RegisterRequest increases number of requests for the provided token
-// Returns error if there are too many requests with the provided token.
-func (l *RateLimiter) RegisterRequest(token string, customRate *ratelimit.RateSet) error {
+// RegisterRequest increases number of requests for the provided token.
+// It returns an error if there are too many requests with the provided
+// token.
+func (l *RateLimiter) RegisterRequest(token string) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	rate := cmp.Or(customRate, l.rates)
-
 	// We set the TTL as 10 times the rate period. E.g. if rate is 100 requests/second
 	// per client IP, the counters for this IP will expire after 10 seconds of inactivity.
-	ttl := rate.MaxPeriod()*10 + 1
+	ttl := l.rates.MaxPeriod()*10 + 1
 	bucketSet, err := utils.FnCacheGetWithTTL(context.TODO(), l.rateLimits, token, ttl,
 		func(ctx context.Context) (*ratelimit.TokenBucketSet, error) {
-			return ratelimit.NewTokenBucketSet(rate, l.clock), nil
+			return ratelimit.NewTokenBucketSet(l.rates, l.clock), nil
 		},
 	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	bucketSet.Update(rate)
+	bucketSet.Update(l.rates)
 
 	delay, err := bucketSet.Consume(1)
 	if err != nil {
@@ -151,15 +149,16 @@ func (l *RateLimiter) RegisterRequest(token string, customRate *ratelimit.RateSe
 	return nil
 }
 
-// RegisterRequestFromAddr increases the number of requests coming for the given
-// remote address, returning an error if the address is invalid or if there have
-// been too many requests from that address recently.
-func (l *RateLimiter) RegisterRequestFromAddr(addr net.Addr, customRate *ratelimit.RateSet) error {
-	token, err := clientIPFromAddr(addr)
+// RegisterRequestFromAddr increases the number of requests coming
+// for the given remote address, returning an error if the address is
+// invalid or if there have been too many requests from that address
+// recently.
+func (l *RateLimiter) RegisterRequestFromAddr(addr net.Addr) error {
+	token, err := utils.ClientIPFromAddr(addr)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return l.RegisterRequest(token, customRate)
+	return l.RegisterRequest(token)
 }
 
 // Add rate limiter to the handle

--- a/lib/utils/net.go
+++ b/lib/utils/net.go
@@ -25,6 +25,25 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// ClientIPFromAddr extracts the client IP from a network address.
+// For bufconn test addresses it returns the literal string "bufconn".
+func ClientIPFromAddr(addr net.Addr) (string, error) {
+	if addr == nil {
+		return "", trace.BadParameter("missing client IP")
+	}
+	s := addr.String()
+	// bufconn peers don't include host:port, so use a stable synthetic
+	// key for request/connection limiting in tests.
+	if s == "bufconn" && addr.Network() == "bufconn" {
+		return "bufconn", nil
+	}
+	clientIP, _, err := net.SplitHostPort(s)
+	if err != nil {
+		return "", trace.BadParameter("missing client IP")
+	}
+	return clientIP, nil
+}
+
 // ClientIPFromConn extracts host from provided remote address.
 func ClientIPFromConn(conn net.Conn) (string, error) {
 	clientRemoteAddr := conn.RemoteAddr()

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -5215,7 +5215,7 @@ func (h *Handler) conditionalLimiterFunc(fn httplib.HandlerFunc, limiter *limite
 		result, err := fn(w, r, p)
 		if err != nil {
 			if shouldLimit(err) {
-				if err := limiter.RegisterRequest(remoteAddr, nil); err != nil {
+				if err := limiter.RegisterRequest(remoteAddr); err != nil {
 					return nil, trace.Wrap(err)
 				}
 			}
@@ -5289,8 +5289,7 @@ func rateLimitRequest(r *http.Request, limiter *limiter.RateLimiter) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	return trace.Wrap(limiter.RegisterRequest(remote, nil /* customRate */))
+	return trace.Wrap(limiter.RegisterRequest(remote))
 }
 
 func (h *Handler) validateCookie(w http.ResponseWriter, r *http.Request) (*SessionContext, error) {


### PR DESCRIPTION
The `getCustomRate` middleware passes per-endpoint rate sets through
`RegisterRequestWithCustomRate`, which routes them into a shared FnCache
keyed only by client IP. When a default-rate request hits the same IP,
`TokenBucketSet.Update` overwrites the cached bucket with the default rate
parameters, resetting the stricter custom-rate state. A single default-rate
request between two recovery requests is enough to reset the recovery
bucket entirely.

Replace the shared-bucket approach with a dedicated `RateLimiter` instance
for account recovery RPCs. Each concern gets its own `RateLimiter` with its
own `FnCache`, so default-rate requests cannot clobber stricter per-endpoint
buckets.

Add a private `accountRecoveryLimiter` to the auth `Middleware` and wire it
into a single `rateLimitUnaryInterceptor` that applies the default limiter
to all endpoints and the recovery limiter to recovery endpoints on top.
Remove `getCustomRate`, `CustomRateFunc`, and
`UnaryServerInterceptorWithCustomRate`. Export `ClientIPFromContext` from
the limiter package so the middleware can extract the client IP without
duplicating peer-extraction logic.

Remove the `customRate` parameter from `RateLimiter.RegisterRequest` and
`RegisterRequestFromAddr` since rates are now fixed at construction time.

Issue: https://github.com/gravitational/teleport/issues/64830
Backport: https://github.com/gravitational/teleport/pull/64828

## Manual Test Plan

### Test Environment

Local single-node cluster, custom build from this branch (darwin arm64) with
config:

```yaml
teleport:
  connection_limits:
    rates:
      - period: 1h
        average: 1
        burst: 200
```

The slow refill rate (1 token/hour) means the bucket does not meaningfully
refill during testing. Burst 200 is the effective token budget per restart.

All test commands use `-client-ip 127.0.0.2` so that test requests get their own
rate limit bucket, isolated from `tctl` and proxy-to-auth traffic on
`127.0.0.1`. This requires a loopback alias:
`sudo ifconfig lo0 alias 127.0.0.2`.

"Passed" means the request got through the rate limiter. Recovery requests fail
at the auth layer (e.g. "access denied") but that is expected since we are
testing the rate limiter, not the auth flow.

<details>
<summary>Setup and test tool</summary>

Build and start teleport:

```bash
make full
cd build
./teleport start --config=/tmp/config.yaml
```

Create user and export admin identity and add loopback alias (first run only):

```bash
./tctl --config=/tmp/config.yaml users add admin --roles=editor,access
./tctl --config=/tmp/config.yaml auth sign --format=tls --user=admin --out=/tmp/clobber-admin --ttl=12h
sudo ifconfig lo0 alias 127.0.0.2
```

Compile the test tool (save `main.go` below, then):

```bash
go mod init ratetest
go mod tidy
go build -o ratetest .
```

Test tool (`ratetest/main.go`):

```go
package main

import (
	"context"
	"crypto/tls"
	"crypto/x509"
	"flag"
	"fmt"
	"log"
	"net"
	"os"
	"strings"

	"golang.org/x/sync/errgroup"
	"google.golang.org/grpc"
	"google.golang.org/grpc/credentials"

	proto "github.com/gravitational/teleport/api/client/proto"
)

var (
	addr     = flag.String("addr", "127.0.0.1:3025", "auth server address")
	cert     = flag.String("cert", "/tmp/clobber-admin.crt", "client cert")
	key      = flag.String("key", "/tmp/clobber-admin.key", "client key")
	ca       = flag.String("ca", "/tmp/clobber-admin.cas", "CA cert")
	clientIP = flag.String("client-ip", "", "source IP to bind (e.g. 127.0.0.2)")
	n        = flag.Int("n", 100, "number of requests")
	method   = flag.String("method", "ping", "method: ping or recovery")
	debug    = flag.Bool("debug", false, "print each request result")
)

func main() {
	flag.Parse()
	if *debug {
		fmt.Printf("addr=%s method=%s n=%d cert=%s key=%s ca=%s client-ip=%s\n", *addr, *method, *n, *cert, *key, *ca, *clientIP)
	}
	fn, err := methodFunc(*method)
	if err != nil {
		log.Fatal(err)
	}
	client, err := newClient(*addr, *cert, *key, *ca, *clientIP)
	if err != nil {
		log.Fatal(err)
	}
	run(client, fn, *n, *debug)
}

func methodFunc(name string) (func(proto.AuthServiceClient) error, error) {
	methods := map[string]func(proto.AuthServiceClient) error{
		"ping":     ping,
		"recovery": recovery,
	}
	fn, ok := methods[name]
	if !ok {
		return nil, fmt.Errorf("unknown method: %s (valid: ping, recovery)", name)
	}
	return fn, nil
}

func ping(client proto.AuthServiceClient) error {
	_, err := client.Ping(context.Background(), &proto.PingRequest{})
	return err
}

func recovery(client proto.AuthServiceClient) error {
	_, err := client.GetAccountRecoveryToken(context.Background(), &proto.GetAccountRecoveryTokenRequest{RecoveryTokenID: "fake-token-id"})
	return err
}

func newClient(addr, certFile, keyFile, caFile, local string) (proto.AuthServiceClient, error) {
	tlsCert, err := tls.LoadX509KeyPair(certFile, keyFile)
	if err != nil {
		return nil, fmt.Errorf("load cert: %w", err)
	}
	caData, err := os.ReadFile(caFile)
	if err != nil {
		return nil, fmt.Errorf("read ca: %w", err)
	}
	pool := x509.NewCertPool()
	pool.AppendCertsFromPEM(caData)
	tlsConfig := &tls.Config{Certificates: []tls.Certificate{tlsCert}, RootCAs: pool, ServerName: "teleport.cluster.local"}
	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
	if local != "" {
		opts = append(opts, grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
			la, err := net.ResolveTCPAddr("tcp", local+":0")
			if err != nil {
				return nil, err
			}
			return (&net.Dialer{LocalAddr: la}).DialContext(ctx, "tcp", addr)
		}))
	}
	conn, err := grpc.NewClient(addr, opts...)
	if err != nil {
		return nil, fmt.Errorf("dial: %w", err)
	}
	return proto.NewAuthServiceClient(conn), nil
}

func run(client proto.AuthServiceClient, fn func(proto.AuthServiceClient) error, n int, debug bool) {
	results := make([]error, n)
	g := new(errgroup.Group)
	for i := range n {
		g.Go(func() error {
			results[i] = fn(client)
			return nil
		})
	}
	_ = g.Wait()
	var ok, rateLimited, otherErr int
	for i, err := range results {
		switch {
		case err == nil:
			ok++
			if debug {
				fmt.Printf("%3d: ok\n", i+1)
			}
		case strings.Contains(err.Error(), "rate limit exceeded"):
			rateLimited++
			if debug {
				fmt.Printf("%3d: RATE LIMITED\n", i+1)
			}
		default:
			otherErr++
			if debug {
				fmt.Printf("%3d: %v\n", i+1, err)
			}
		}
	}
	fmt.Printf("%d passed, %d rate limited (of %d)\n", ok+otherErr, rateLimited, n)
}
```

</details>

### Test Cases

#### Test Case 1: default rate limiting works

Restart teleport, then:

```bash
$ ./ratetest -n 200 -client-ip 127.0.0.2
200 passed, 0 rate limited (of 200)

$ ./ratetest -n 1 -client-ip 127.0.0.2
0 passed, 1 rate limited (of 1)
```

- [x] First 200 requests succeed (burst 200)
- [x] Next request is rate limited (bucket exhausted, ~0 refill)

#### Test Case 2: recovery rate limiting works

The recovery limiter is hardcoded at 1 req/min, burst 10. Restart teleport,
then:

```bash
$ ./ratetest -n 10 -method recovery -client-ip 127.0.0.2
10 passed, 0 rate limited (of 10)

$ ./ratetest -n 1 -method recovery -client-ip 127.0.0.2
0 passed, 1 rate limited (of 1)
```

- [x] First 10 recovery requests pass the rate limiter
- [x] 11th recovery request is rate limited

#### Test Case 3: interleaved requests do not reset recovery bucket

This is the core bug fix. Restart teleport, then:

```bash
# Exhaust recovery bucket (10 requests)
$ ./ratetest -n 10 -method recovery -client-ip 127.0.0.2
10 passed, 0 rate limited (of 10)

# Send default-rate requests (should succeed, different bucket)
$ ./ratetest -n 3 -method ping -client-ip 127.0.0.2
3 passed, 0 rate limited (of 3)

# Recovery should still be rate limited
$ ./ratetest -n 1 -method recovery -client-ip 127.0.0.2
0 passed, 1 rate limited (of 1)

# Default-rate requests should still succeed
$ ./ratetest -n 3 -method ping -client-ip 127.0.0.2
3 passed, 0 rate limited (of 3)
```

- [x] Default-rate requests succeed after exhausting recovery bucket
- [x] Recovery requests remain rate limited after interleaved default requests
- [x] Before this fix, the interleaved default requests would reset the recovery
      bucket via `TokenBucketSet.Update`, allowing the final recovery request to
      pass
