### PR TITLE
Remove whatwg-url as Connect dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,9 +466,6 @@ importers:
       '@types/tar-fs':
         specifier: ^2.0.4
         version: 2.0.4
-      '@types/whatwg-url':
-        specifier: ^13.0.0
-        version: 13.0.0
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -496,9 +493,6 @@ importers:
       react-dnd-html5-backend:
         specifier: ^14.0.2
         version: 14.1.0
-      whatwg-url:
-        specifier: ^16.0.1
-        version: 16.0.1
 
 packages:
 
@@ -3248,12 +3242,6 @@ packages:
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
-
-  '@types/webidl-conversions@7.0.1':
-    resolution: {integrity: sha512-8hKOnOan+Uu+NgMaCouhg3cT9x5fFZ92Jwf+uDLXLu/MFRbXxlWwGeQY7KVHkeSft6RvY+tdxklUBuyY9eIEKg==}
-
-  '@types/whatwg-url@13.0.0':
-    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
 
   '@types/which@3.0.4':
     resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
@@ -9698,12 +9686,6 @@ snapshots:
 
   '@types/verror@1.10.11':
     optional: true
-
-  '@types/webidl-conversions@7.0.1': {}
-
-  '@types/whatwg-url@13.0.0':
-    dependencies:
-      '@types/webidl-conversions': 7.0.1
 
   '@types/which@3.0.4': {}
 

--- a/web/packages/build/jest/jest-environment-patched-jsdom.js
+++ b/web/packages/build/jest/jest-environment-patched-jsdom.js
@@ -7,7 +7,7 @@ import { TestEnvironment as JSDOMEnvironment } from 'jest-environment-jsdom';
 
 // When using jest-environment-jsdom, TextEncoder and TextDecoder are not defined. This poses a
 // problem when writing tests for code which uses TextEncoder and TextDecoder directly or that
-// imports libraries which depend on those globals (for example whatwg-url).
+// imports libraries which depend on those globals.
 //
 // It's unclear if that's a problem with Jest or JSDOM itself, see
 // https://github.com/jsdom/jsdom/issues/2524#issuecomment-902027138

--- a/web/packages/shared/deepLinks.ts
+++ b/web/packages/shared/deepLinks.ts
@@ -17,9 +17,13 @@
  */
 
 /*
- * This file does not import whatwg-url and thus does not perform any parsing on purpose. whatwg-url
- * provides uniform parsing across browser implementations but it weights a ton [1], so we should
+ * This file does not perform any parsing on purpose. We used to do it with whatwg-url which
+ * provided uniform parsing across browser implementations but it weighs a ton [1], so we wanted to
  * avoid pulling it into the deps of Web UI.
+ *
+ * While we no longer use whatwg-url, it's probably a good idea to keep this file parser-free as
+ * only teleterm needs to actually parse deep links for use. The Web UI just needs to be able to
+ * construct them.
  *
  * [1] https://bundlephobia.com/package/whatwg-url@13.0.0
  */
@@ -37,7 +41,7 @@ export type Path = DeepURL['pathname'];
  *
  * Since DeepLinkParseResult goes through IPC in Electron [1], anything included in it is subject to
  * Structured Clone Algorithm [2]. As such, getters and setters are dropped which means were not
- * able to pass whatwg.URL without casting it to an object.
+ * able to pass an URL instance without casting it to an object.
  *
  * [1] https://www.electronjs.org/docs/latest/tutorial/ipc
  * [2] https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
@@ -54,7 +58,7 @@ type BaseDeepURL = {
   hostname: string;
   port: string;
   /**
-   * username is percent-decoded username from the URL. whatwg-url encodes usernames found in URLs.
+   * username is percent-decoded username from the URL. The URL API encodes usernames found in URLs.
    * parseDeepLink decodes them so that other parts of the app don't have to deal with this.
    */
   username: string;

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -41,7 +41,6 @@
     "@protobuf-ts/grpc-transport": "^2.11.1",
     "@types/node-forge": "^1.3.14",
     "@types/tar-fs": "^2.0.4",
-    "@types/whatwg-url": "^13.0.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "electron": "40.1.0",
@@ -50,8 +49,7 @@
     "electron-vite": "^5.0.0",
     "events": "3.3.0",
     "react-dnd": "^14.0.4",
-    "react-dnd-html5-backend": "^14.0.2",
-    "whatwg-url": "^16.0.1"
+    "react-dnd-html5-backend": "^14.0.2"
   },
   "productName": "Teleport Connect"
 }

--- a/web/packages/teleterm/src/deepLinks.node.test.ts
+++ b/web/packages/teleterm/src/deepLinks.node.test.ts
@@ -1,6 +1,9 @@
 /**
+ * @jest-environment node
+ */
+/**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2026  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -18,4 +21,4 @@
 
 import { registerDeepLinkTests } from './deepLinks.testcases';
 
-registerDeepLinkTests('jsdom');
+registerDeepLinkTests('node');

--- a/web/packages/teleterm/src/deepLinks.test.ts
+++ b/web/packages/teleterm/src/deepLinks.test.ts
@@ -131,7 +131,9 @@ describe('parseDeepLink', () => {
         output: {
           status: 'error',
           reason: 'malformed-url',
-          error: expect.any(TypeError),
+          error: expect.objectContaining({
+            code: 'ERR_INVALID_URL',
+          }),
         },
       },
       {

--- a/web/packages/teleterm/src/deepLinks.testcases.ts
+++ b/web/packages/teleterm/src/deepLinks.testcases.ts
@@ -1,0 +1,305 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { DeepURL, makeDeepLinkWithSafeInput } from 'shared/deepLinks';
+
+import {
+  DeepLinkParseResult,
+  DeepLinkParseResultSuccess,
+  parseDeepLink,
+} from './deepLinks';
+
+/**
+ * Registers shared deep link tests that must pass in both Node (Electron main process) and jsdom
+ * (Chromium renderer) environments.
+ *
+ * The env param is the expected Jest environment, used to adjust assertions for known differences
+ * between Node and jsdom URL implementations to verify that the tests run under correct envs.
+ */
+export function registerDeepLinkTests(env: 'node' | 'jsdom') {
+  // Verify that the test is running in the expected environment. Node's URL constructor includes a
+  // code property on TypeError (e.g. 'ERR_INVALID_URL'), while JSDOM's does not.
+  test('runs in the correct Jest environment', () => {
+    let error: unknown;
+    try {
+      new URL('not a valid URL');
+    } catch (e) {
+      error = e;
+    }
+
+    if (env === 'node') {
+      expect(error).toHaveProperty('code', 'ERR_INVALID_URL');
+    } else {
+      expect(error).not.toHaveProperty('code');
+    }
+  });
+
+  describe('parseDeepLink', () => {
+    describe('valid input', () => {
+      const tests: Array<{
+        input: string;
+        expectedURL: DeepURL;
+      }> = [
+        {
+          input: 'teleport://cluster.example.com/connect_my_computer',
+          expectedURL: {
+            host: 'cluster.example.com',
+            hostname: 'cluster.example.com',
+            port: '',
+            pathname: '/connect_my_computer',
+            username: '',
+            searchParams: {},
+          },
+        },
+        {
+          input:
+            'teleport://cluster.example.com/authenticate_web_device?id=123&token=234',
+          expectedURL: {
+            host: 'cluster.example.com',
+            hostname: 'cluster.example.com',
+            port: '',
+            pathname: '/authenticate_web_device',
+            username: '',
+            searchParams: {
+              id: '123',
+              token: '234',
+              redirect_uri: null,
+            },
+          },
+        },
+        {
+          input:
+            'teleport://cluster.example.com/authenticate_web_device?id=123&token=234&redirect_uri=http://cluster.example.com/web/users',
+          expectedURL: {
+            host: 'cluster.example.com',
+            hostname: 'cluster.example.com',
+            port: '',
+            pathname: '/authenticate_web_device',
+            username: '',
+            searchParams: {
+              id: '123',
+              token: '234',
+              redirect_uri: 'http://cluster.example.com/web/users',
+            },
+          },
+        },
+        {
+          input: 'teleport://alice@cluster.example.com/connect_my_computer',
+          expectedURL: {
+            host: 'cluster.example.com',
+            hostname: 'cluster.example.com',
+            port: '',
+            pathname: '/connect_my_computer',
+            username: 'alice',
+            searchParams: {},
+          },
+        },
+        {
+          input:
+            'teleport://alice.bobson%40example.com@cluster.example.com:1337/connect_my_computer',
+          expectedURL: {
+            host: 'cluster.example.com:1337',
+            hostname: 'cluster.example.com',
+            port: '1337',
+            pathname: '/connect_my_computer',
+            username: 'alice.bobson@example.com',
+            searchParams: {},
+          },
+        },
+        // The example below is a bit contrived, usernames in URL should be percent-encoded.
+        // However, Firefox and Safari will let you launch a link without percent-encoded username
+        // anyway, so we just want to make sure that we correctly handle such cases.
+        {
+          input:
+            'teleport://alice.bobson@example.com@cluster.example.com/connect_my_computer',
+          expectedURL: {
+            host: 'cluster.example.com',
+            hostname: 'cluster.example.com',
+            port: '',
+            pathname: '/connect_my_computer',
+            username: 'alice.bobson@example.com',
+            searchParams: {},
+          },
+        },
+      ];
+
+      test.each(tests)('$input', ({ input, expectedURL }) => {
+        const result = parseDeepLink(input);
+
+        expect(result.status).toBe('success');
+        expect(result.status === 'success' && result.url).toEqual(expectedURL);
+      });
+    });
+
+    describe('invalid input', () => {
+      const tests: Array<{ input: string; output: DeepLinkParseResult }> = [
+        {
+          input: 'teleport://hello\\foo@bar:baz',
+          output: {
+            status: 'error',
+            reason: 'malformed-url',
+            error: expect.objectContaining({ name: 'TypeError' }),
+          },
+        },
+        {
+          input: 'teleport:///clusters/foo',
+          output: {
+            status: 'error',
+            reason: 'unsupported-url',
+          },
+        },
+        {
+          input: 'teleport://cluster.example.com/foo',
+          output: {
+            status: 'error',
+            reason: 'unsupported-url',
+          },
+        },
+        {
+          input: 'teleport:///foo/bar',
+          output: {
+            status: 'error',
+            reason: 'unsupported-url',
+          },
+        },
+        {
+          input: 'foobar:///clusters/foo/connect_my_computer',
+          output: {
+            status: 'error',
+            reason: 'unknown-protocol',
+            protocol: 'foobar:',
+          },
+        },
+        {
+          input: 'teleport://cluster.example.com/authenticate_web_device',
+          output: {
+            error: new TypeError(
+              'id and token must be included in the deep link for authenticating a web device'
+            ),
+            status: 'error',
+            reason: 'malformed-url',
+          },
+        },
+      ];
+
+      test.each(tests)('$input', ({ input, output }) => {
+        const result = parseDeepLink(input);
+        expect(result).toEqual(output);
+      });
+    });
+  });
+
+  describe('makeDeepLinkWithSafeInput followed by parseDeepLink gives the same result', () => {
+    const inputs: Array<Parameters<typeof makeDeepLinkWithSafeInput>[0]> = [
+      {
+        proxyHost: 'cluster.example.com',
+        path: '/connect_my_computer',
+        username: undefined,
+        searchParams: {},
+      },
+      {
+        proxyHost: 'cluster.example.com',
+        path: '/connect_my_computer',
+        username: 'alice',
+        searchParams: {},
+      },
+      {
+        proxyHost: 'cluster.example.com:1337',
+        path: '/connect_my_computer',
+        username: 'alice.bobson@example.com',
+        searchParams: {},
+      },
+      {
+        proxyHost: 'cluster.example.com:1337',
+        path: '/authenticate_web_device',
+        username: 'alice.bobson@example.com',
+        searchParams: {
+          token: '123',
+          id: '123',
+        },
+      },
+      {
+        proxyHost: 'cluster.example.com:1337',
+        path: '/authenticate_web_device',
+        username: 'alice.bobson@example.com',
+        searchParams: {
+          token: '123',
+          id: '123',
+          redirect_uri: 'http://cluster.example.com:1337/web/users',
+        },
+      },
+      {
+        proxyHost: 'cluster.example.com:1337',
+        path: '/authenticate_web_device',
+        username: 'alice.bobson@example.com',
+        searchParams: {
+          token: '123',
+          id: '123',
+          redirect_uri:
+            'https://cluster.example.com:1337/web/cluster/enterprise-local/resources?sort=name%3Adesc&pinnedOnly=false&kinds=app',
+        },
+      },
+    ];
+
+    test.each(inputs)('%j', input => {
+      const deepLink = makeDeepLinkWithSafeInput(input);
+      const parseResult = parseDeepLink(deepLink);
+      expect(parseResult).toMatchObject({
+        status: 'success',
+        url: {
+          host: input.proxyHost,
+          pathname: input.path,
+          username: input.username === undefined ? '' : input.username,
+          searchParams: input.searchParams,
+        },
+      });
+    });
+  });
+
+  describe('parseDeepLink followed by makeDeepLinkWithSafeInput gives the same result', () => {
+    const inputs: string[] = [
+      'teleport://cluster.example.com/connect_my_computer',
+      'teleport://alice@cluster.example.com/connect_my_computer',
+      'teleport://alice.bobson%40example.com@cluster.example.com:1337/connect_my_computer',
+      'teleport://alice@cluster.example.com/authenticate_web_device?id=123&token=234',
+      'teleport://alice@cluster.example.com/authenticate_web_device?id=123&token=234&redirect_uri=http%3A%2F%2Fcluster.example.com%2Fweb%2Fusers',
+      'teleport://alice@cluster.example.com/authenticate_web_device?id=123&token=234&redirect_uri=http%3A%2F%2Fcluster.example.com%2Fweb%2Fusers',
+      // redirect_uri which includes its own query params.
+      'teleport://alice@cluster.example.com:3030/authenticate_web_device?id=423535c9-5da5-4b0e-a3cc-4c629ec09848&token=m83K7v2waTYCJJsFRHlKHDWHZ7CszFwBTj5NHmG_32Q&redirect_uri=https%3A%2F%2Fcluster.example.com%3A3030%2Fweb%2Fcluster%2Fenterprise-local%2Fresources%3Fsort%3Dname%253Adesc%26pinnedOnly%3Dfalse%26kinds%3Dapp',
+      // Triple-nested redirect_uri: it points to an app launch URL of the dumper app which is
+      // supposed to redirect to a URL which in itself has a custom_url query param with some kind
+      // of a URL with query params. You can imagine that originally the user wanted to visit this
+      // URL:
+      // https://dumper.cluster.example.com:3030/hello?custom_url=https%3A%2F%2Fcluster.example.com%3A3030%2Fweb%2Fcluster%2Fenterprise-local%2Fresources%3Fsort%3Dname%253Adesc%26pinnedOnly%3Dfalse%26kinds%3Dapp
+      'teleport://alice@cluster.example.com:3030/authenticate_web_device?id=e8fce168-3cb1-4731-90d6-a59b2aeb343e&token=5-8lLKZ0VPU9_dqkx2OhAXLwGMth005QlPtVWHfnvXU&redirect_uri=https%3A%2F%2Fcluster.example.com%3A3030%2Fweb%2Flaunch%2Fdumper.cluster.example.com%3Fpath%3D%252Fhello%26query%3Dcustom_url%253Dhttps%25253A%25252F%25252Fcluster.example.com%25253A3030%25252Fweb%25252Fcluster%25252Fenterprise-local%25252Fresources%25253Fsort%25253Dname%2525253Adesc%252526pinnedOnly%25253Dfalse%252526kinds%25253Dapp',
+    ];
+
+    test.each(inputs)('%s', input => {
+      const parseResult = parseDeepLink(input);
+      expect(parseResult).toMatchObject({ status: 'success' });
+      const { url } = parseResult as DeepLinkParseResultSuccess;
+      const deepLink = makeDeepLinkWithSafeInput({
+        proxyHost: url.host,
+        path: url.pathname,
+        username: url.username,
+        searchParams: url.searchParams,
+      });
+      expect(deepLink).toEqual(input);
+    });
+  });
+}

--- a/web/packages/teleterm/src/deepLinks.ts
+++ b/web/packages/teleterm/src/deepLinks.ts
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import * as whatwg from 'whatwg-url';
-
 import {
   AuthenticateWebDeviceDeepURL,
   ConnectMyComputerDeepURL,
@@ -67,32 +65,30 @@ type ParseError<Reason, AdditionalData = void> = AdditionalData extends void
  * have to be parsed on both ends.
  */
 export function parseDeepLink(rawUrl: string): DeepLinkParseResult {
-  let whatwgURL: whatwg.URL;
+  let parsedURL: URL;
   try {
-    whatwgURL = new whatwg.URL(rawUrl);
+    parsedURL = new URL(rawUrl);
   } catch (error) {
-    if (error instanceof TypeError) {
-      // Invalid URL.
-      return { status: 'error', reason: 'malformed-url', error };
-    }
-    throw error;
+    // `error instanceof TypeError` doesn't work in tests. The URL constructor shouldn't throw other
+    // errors anyway.
+    return { status: 'error', reason: 'malformed-url', error };
   }
 
-  if (whatwgURL.protocol !== `${CUSTOM_PROTOCOL}:`) {
+  if (parsedURL.protocol !== `${CUSTOM_PROTOCOL}:`) {
     return {
       status: 'error',
       reason: 'unknown-protocol',
-      protocol: whatwgURL.protocol,
+      protocol: parsedURL.protocol,
     };
   }
 
-  const { host, hostname, port, username, pathname, searchParams } = whatwgURL;
+  const { host, hostname, port, username, pathname, searchParams } = parsedURL;
   const baseUrl = {
     host,
     hostname,
     port,
-    // whatwg-url percent-encodes usernames. We decode them here so that the rest of the app doesn't
-    // have to do this. https://url.spec.whatwg.org/#set-the-username
+    // The URL API percent-encodes usernames. We decode them here so that the rest of the app
+    // doesn't have to do this. https://url.spec.whatwg.org/#set-the-username
     username: decodeURIComponent(username),
   };
 

--- a/web/packages/teleterm/src/mainProcess/protocolHandler.ts
+++ b/web/packages/teleterm/src/mainProcess/protocolHandler.ts
@@ -75,27 +75,19 @@ function disableUnusedProtocols() {
 
 /**
  * Registers the 'http://' protocol handler.
- * Adds cross-origin headers to the document response to enable features requiring
- * cross-origin isolation.
  */
 function handleHttpProtocol(): void {
   protocol.handle('http', async request => {
-    const response = await net.fetch(request, {
+    return await net.fetch(request, {
       // Must be true to prevent the handler from calling itself and entering an infinite loop.
       bypassCustomProtocolHandlers: true,
     });
-    if (request.url === DEV_APP_WINDOW_URL) {
-      setCrossOriginIsolationHeaders(response.headers);
-    }
-    return response;
   });
 }
 
 /**
  * Registers the 'app-file://' protocol handler.
- * Serves application files from the build directory and adds
- * cross-origin header to the document response, enabling features that
- * require cross-origin isolation.
+ * Serves application files from the build directory.
  */
 function handleAppFileProtocol(): void {
   const appPath = app.getAppPath();
@@ -129,25 +121,12 @@ function handleAppFileProtocol(): void {
     // Use net.fetch to serve local files.
     // It automatically determines and sets the correct Content-Type (MIME) header,
     // unlike fs.readFile.
-    const response = await net.fetch(pathToFileURL(realPath).toString(), {
+    return await net.fetch(pathToFileURL(realPath).toString(), {
       // 'file' protocol was disabled in disableUnusedProtocols.
       // We can bypass it because we performed the path traversal checks.
       bypassCustomProtocolHandlers: true,
     });
-    if (request.url === PACKAGED_APP_WINDOW_URL) {
-      setCrossOriginIsolationHeaders(response.headers);
-    }
-    return response;
   });
-}
-
-/**
- * To use features like SharedArrayBuffer, the document must be in a secure context
- * and cross-origin isolated.
- */
-function setCrossOriginIsolationHeaders(headers: Headers): void {
-  headers.set('Cross-Origin-Opener-Policy', 'same-origin');
-  headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
 }
 
 /**
@@ -170,8 +149,7 @@ export function registerAppFileProtocol(): void {
 /**
  * Configures protocol handling:
  * - Disables unused web protocols.
- * - Registers handlers for `app-file://` and `http://` (for Vite dev server)
- * to enforce cross-origin isolation, enabling features like `SharedArrayBuffer`.
+ * - Registers handlers for `app-file://` and `http://` (for Vite dev server).
  */
 export function setUpProtocolHandlers(dev: boolean): void {
   disableUnusedProtocols();

--- a/web/packages/teleterm/src/services/tshd/cluster.test.ts
+++ b/web/packages/teleterm/src/services/tshd/cluster.test.ts
@@ -62,7 +62,7 @@ describe('proxyHostToBrowserProxyHost', () => {
         input: 'https://cluster.example.com:3090',
       },
       {
-        name: 'whatwg-url parsing error',
+        name: 'URL parsing error',
         input: '<teleport>',
       },
     ];

--- a/web/packages/teleterm/src/services/tshd/cluster.ts
+++ b/web/packages/teleterm/src/services/tshd/cluster.ts
@@ -55,18 +55,6 @@ export function proxyHostToBrowserProxyHost(proxyHost: string) {
   return parsedURL.host;
 }
 
-export function proxyHostname(proxyHost: string) {
-  let parsedURL: URL;
-
-  try {
-    parsedURL = new URL(`https://${proxyHost}`);
-  } catch {
-    return proxyHost;
-  }
-
-  return parsedURL.hostname;
-}
-
 /**
  * Creates a cluster by merging properties that can be read from
  * the profile from disk with properties from details.

--- a/web/packages/teleterm/src/services/tshd/cluster.ts
+++ b/web/packages/teleterm/src/services/tshd/cluster.ts
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import * as whatwg from 'whatwg-url';
-
 import { TrustedDeviceRequirement } from 'gen-proto-ts/teleport/legacy/types/trusted_device_requirement_pb';
 import {
   Cluster,
@@ -41,35 +39,32 @@ import {
  * browser against a host that we got from a Go service.
  */
 export function proxyHostToBrowserProxyHost(proxyHost: string) {
-  let whatwgURL: whatwg.URL;
+  let parsedURL: URL;
 
   try {
-    whatwgURL = new whatwg.URL(`https://${proxyHost}`);
+    parsedURL = new URL(`https://${proxyHost}`);
   } catch (error) {
-    if (error instanceof TypeError) {
-      throw new Error(`Invalid proxy host ${proxyHost}`, { cause: error });
-    }
-    throw error;
+    throw new Error(`Invalid proxy host ${proxyHost}`, { cause: error });
   }
 
   // Catches cases where proxyHost itself includes a "https://" prefix.
-  if (whatwgURL.pathname !== '/') {
+  if (parsedURL.pathname !== '/') {
     throw new Error(`Invalid proxy host ${proxyHost}`);
   }
 
-  return whatwgURL.host;
+  return parsedURL.host;
 }
 
 export function proxyHostname(proxyHost: string) {
-  let whatwgURL: whatwg.URL;
+  let parsedURL: URL;
 
   try {
-    whatwgURL = new whatwg.URL(`https://${proxyHost}`);
+    parsedURL = new URL(`https://${proxyHost}`);
   } catch {
     return proxyHost;
   }
 
-  return whatwgURL.hostname;
+  return parsedURL.hostname;
 }
 
 /**

--- a/web/packages/teleterm/src/ui/Vnet/integration.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/integration.test.tsx
@@ -24,7 +24,6 @@ import * as proto from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
 
 import Logger, { NullService } from 'teleterm/logger';
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
-import { proxyHostname } from 'teleterm/services/tshd/cluster';
 import { makeApp, makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { App } from 'teleterm/ui/App';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
@@ -269,3 +268,15 @@ test('launching VNet for the first time from the connections panel does not open
     within(visibleDoc).queryByText(/VNet automatically proxies connections/)
   ).not.toBeInTheDocument();
 });
+
+function proxyHostname(proxyHost: string) {
+  let parsedURL: URL;
+
+  try {
+    parsedURL = new URL(`https://${proxyHost}`);
+  } catch {
+    return proxyHost;
+  }
+
+  return parsedURL.hostname;
+}


### PR DESCRIPTION
Closes #64671

Changelog: Reimplemented how Teleport Connect handles deep links for Device Trust auth and launching VNet from the Web UI

(Adding a changelog so that if something breaks it's easier to identify that it's because of the changes in deep links implementation)

This PR removes whatwg-url and replaces it with the built-in URL API. See #64671 for rationale and todo list. The main problem that this PR solves is it unblocks Electron version upgrades. The tests for `deepLinks.ts` now run in both environments to ensure that the implementation works the same way in the renderer and in the main process.

## Manual Test Plan
### Test Environment

A locally built app.

### Test Cases
- [x] Verify that `pnpm start-term` launches the app that doesn't crash.
- [x] Verify that the packaged version of the app doesn't crash.
- [x] Verify that the packaged version of the app can be launched from a deep link.
