### PR TITLE
Add focus trap to `<Modal>`, use it in `<DocumentsReopen>` in Connect

### DIFF
--- a/e2e/tests/connect/stateRestoration.spec.ts
+++ b/e2e/tests/connect/stateRestoration.spec.ts
@@ -63,7 +63,9 @@ test.describe('state restoration from disk', () => {
       await using app = await launchApp(tempPath);
       const { page } = app;
       await expect(page.getByText('Reopen previous session')).toBeVisible();
-      await page.getByRole('button', { name: 'Reopen' }).click();
+      const reopenButton = page.getByRole('button', { name: 'Reopen' });
+      await expect(reopenButton).toBeFocused();
+      await reopenButton.click();
       await expect(page.getByText('Reopen previous session')).not.toBeVisible();
 
       // Both tabs should be restored.

--- a/web/packages/design/src/DialogConfirmation/DialogConfirmation.tsx
+++ b/web/packages/design/src/DialogConfirmation/DialogConfirmation.tsx
@@ -36,6 +36,10 @@ export function DialogConfirmation(props: {
     reason: 'escapeKeyDown' | 'backdropClick'
   ) => void;
   dialogCss?: StyleFunction<ComponentProps<'div'>>;
+  /**
+   * If `true`, focus is trapped inside the dialog.
+   */
+  trapFocus?: boolean;
 }) {
   return (
     <Dialog
@@ -44,6 +48,7 @@ export function DialogConfirmation(props: {
       onClose={props.onClose}
       open={props.open}
       keepInDOMAfterClose={props.keepInDOMAfterClose}
+      trapFocus={props.trapFocus}
     >
       {props.children}
     </Dialog>

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -177,36 +177,6 @@ test('closing dialog when attachCustomKeyEventHandler is set only hides it with 
 });
 
 describe('trapFocus', () => {
-  let originalOffsetParent: PropertyDescriptor | undefined;
-
-  beforeAll(() => {
-    // JSDOM doesn't implement layout, so offsetParent is always null. Mock it so that the
-    // focusable-element filter in handleFocusTrapTab can work.
-    originalOffsetParent = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      'offsetParent'
-    );
-    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
-      get() {
-        if (this.style.display === 'none') {
-          return null;
-        }
-        return this.parentElement; // oxlint-disable-line testing-library/no-node-access
-      },
-      configurable: true,
-    });
-  });
-
-  afterAll(() => {
-    if (originalOffsetParent) {
-      Object.defineProperty(
-        HTMLElement.prototype,
-        'offsetParent',
-        originalOffsetParent
-      );
-    }
-  });
-
   // In the following describe group, the focused element is removed during a re-render, leaving
   // lastModalFocus as a stale detached reference. Explicit keys ensure React unmounts the Removable
   // button rather than reconciling it with Stable.

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -274,6 +274,69 @@ describe('trapFocus', () => {
     expect(screen.getByRole('button', { name: 'Last' })).toHaveFocus();
   });
 
+  // In the following describe group, we simulate the browser Tab behavior manually: fire keyDown
+  // (which sets lastTabKeyDirection), then focus the outside element (which triggers focusin
+  // and lets handleFocusTrapFocusIn redirect focus into the modal).
+  describe('when nothing inside the modal was focused yet', () => {
+    test('Tab focuses the first element', () => {
+      render(
+        <>
+          <button>Outside</button>
+          <Modal open={true} trapFocus>
+            <div>
+              <button>First</button>
+              <button>Last</button>
+            </div>
+          </Modal>
+        </>
+      );
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+      screen.getByRole('button', { name: 'Outside' }).focus();
+      expect(screen.getByRole('button', { name: 'First' })).toHaveFocus();
+    });
+
+    test('Shift+Tab focuses the last element', () => {
+      render(
+        <>
+          <button>Outside</button>
+          <Modal open={true} trapFocus>
+            <div>
+              <button>First</button>
+              <button>Last</button>
+            </div>
+          </Modal>
+        </>
+      );
+
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+      screen.getByRole('button', { name: 'Outside' }).focus();
+      expect(screen.getByRole('button', { name: 'Last' })).toHaveFocus();
+    });
+
+    test('blurs the thief when focus is stolen programmatically', () => {
+      render(
+        <>
+          <button>Outside</button>
+          <Modal open={true} trapFocus>
+            <div>
+              <button>First</button>
+              <button>Second</button>
+            </div>
+          </Modal>
+        </>
+      );
+
+      // No element has autoFocus, so lastModalFocus is not pre-populated. The thief should be
+      // blurred rather than auto-focusing the first element inside the modal.
+      const outsideButton = screen.getByRole('button', { name: 'Outside' });
+      outsideButton.focus();
+      expect(outsideButton).not.toHaveFocus();
+      // JSDOM sets document.body as activeElement when blurring any other element.
+      expect(document.body).toHaveFocus();
+    });
+  });
+
   test('does not trap focus when trapFocus is not set', () => {
     render(<ModalWithOutsideButton />);
 

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -177,6 +177,33 @@ test('closing dialog when attachCustomKeyEventHandler is set only hides it with 
 });
 
 describe('trapFocus', () => {
+  let originalOffsetParent: PropertyDescriptor | undefined;
+
+  beforeAll(() => {
+    // JSDOM doesn't implement layout, so offsetParent is always null. Mock it so that the
+    // focusable-element filter in handleFocusTrapTab can work.
+    originalOffsetParent = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetParent'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      get() {
+        return this.parentElement;
+      },
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    if (originalOffsetParent) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'offsetParent',
+        originalOffsetParent
+      );
+    }
+  });
+
   test('returns focus to the modal when an outside element steals it', () => {
     render(<ModalWithOutsideButton trapFocus />);
 

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -242,6 +242,53 @@ describe('trapFocus', () => {
     });
   });
 
+  describe('when lastModalFocus becomes unfocusable', () => {
+    test('blurs programmatic focus theft', () => {
+      const { rerender } = render(
+        <ModalWithOutsideButton trapFocus>
+          <button>Target</button>
+          <button>Other</button>
+        </ModalWithOutsideButton>
+      );
+
+      screen.getByRole('button', { name: 'Target' }).focus();
+
+      // Disable the focused button — it stays in the DOM but can't receive focus.
+      rerender(
+        <ModalWithOutsideButton trapFocus>
+          <button disabled>Target</button>
+          <button>Other</button>
+        </ModalWithOutsideButton>
+      );
+
+      const outsideButton = screen.getByRole('button', { name: 'Outside' });
+      outsideButton.focus();
+      expect(outsideButton).not.toHaveFocus();
+    });
+
+    test('Tab focuses into the modal', () => {
+      const { rerender } = render(
+        <ModalWithOutsideButton trapFocus>
+          <button>Target</button>
+          <button>Other</button>
+        </ModalWithOutsideButton>
+      );
+
+      screen.getByRole('button', { name: 'Target' }).focus();
+
+      rerender(
+        <ModalWithOutsideButton trapFocus>
+          <button disabled>Target</button>
+          <button>Other</button>
+        </ModalWithOutsideButton>
+      );
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+      screen.getByRole('button', { name: 'Outside' }).focus();
+      expect(screen.getByRole('button', { name: 'Other' })).toHaveFocus();
+    });
+  });
+
   test('returns focus to the modal when an outside element steals it', () => {
     render(<ModalWithOutsideButton trapFocus />);
 

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -207,6 +207,71 @@ describe('trapFocus', () => {
     }
   });
 
+  // In the following describe group, the focused element is removed during a re-render, leaving
+  // lastModalFocus as a stale detached reference. Explicit keys ensure React unmounts the Removable
+  // button rather than reconciling it with Stable.
+  describe('when lastModalFocus was removed from the DOM', () => {
+    test('blurs programmatic focus theft', () => {
+      const { rerender } = render(
+        <>
+          <button>Outside</button>
+          <Modal open trapFocus>
+            <div>
+              <button key="removable">Removable</button>
+              <button key="stable">Stable</button>
+            </div>
+          </Modal>
+        </>
+      );
+
+      screen.getByRole('button', { name: 'Removable' }).focus();
+      rerender(
+        <>
+          <button>Outside</button>
+          <Modal open trapFocus>
+            <div>
+              <button key="stable">Stable</button>
+            </div>
+          </Modal>
+        </>
+      );
+
+      const outsideButton = screen.getByRole('button', { name: 'Outside' });
+      outsideButton.focus();
+      expect(outsideButton).not.toHaveFocus();
+    });
+
+    test('Tab focuses into the modal', () => {
+      const { rerender } = render(
+        <>
+          <button>Outside</button>
+          <Modal open trapFocus>
+            <div>
+              <button key="removable">Removable</button>
+              <button key="stable">Stable</button>
+            </div>
+          </Modal>
+        </>
+      );
+
+      screen.getByRole('button', { name: 'Removable' }).focus();
+      rerender(
+        <>
+          <button>Outside</button>
+          <Modal open trapFocus>
+            <div>
+              <button key="stable">Stable</button>
+            </div>
+          </Modal>
+        </>
+      );
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+      screen.getByRole('button', { name: 'Outside' }).focus();
+      expect(screen.getByRole('button', { name: 'Stable' })).toHaveFocus();
+    });
+  });
+
   test('returns focus to the modal when an outside element steals it', () => {
     render(<ModalWithOutsideButton trapFocus />);
 

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -312,6 +312,66 @@ describe('trapFocus', () => {
     expect(outsideButton).toHaveFocus();
   });
 
+  test('enables focus trap when trapFocus changes to true while modal is open', () => {
+    const { rerender } = render(
+      <>
+        <button>Outside</button>
+        <Modal open trapFocus={false}>
+          <div>
+            <button>Inside</button>
+          </div>
+        </Modal>
+      </>
+    );
+
+    screen.getByRole('button', { name: 'Inside' }).focus();
+
+    rerender(
+      <>
+        <button>Outside</button>
+        <Modal open trapFocus={true}>
+          <div>
+            <button>Inside</button>
+          </div>
+        </Modal>
+      </>
+    );
+
+    const outsideButton = screen.getByRole('button', { name: 'Outside' });
+    outsideButton.focus();
+    expect(screen.getByRole('button', { name: 'Inside' })).toHaveFocus();
+  });
+
+  test('disables focus trap when trapFocus changes to false while modal is open', () => {
+    const { rerender } = render(
+      <>
+        <button>Outside</button>
+        <Modal open trapFocus={true}>
+          <div>
+            <button>Inside</button>
+          </div>
+        </Modal>
+      </>
+    );
+
+    screen.getByRole('button', { name: 'Inside' }).focus();
+
+    rerender(
+      <>
+        <button>Outside</button>
+        <Modal open trapFocus={false}>
+          <div>
+            <button>Inside</button>
+          </div>
+        </Modal>
+      </>
+    );
+
+    const outsideButton = screen.getByRole('button', { name: 'Outside' });
+    outsideButton.focus();
+    expect(outsideButton).toHaveFocus();
+  });
+
   test('cleans up focus trap listeners on close', () => {
     // Use keepInDOMAfterClose so that the modal stays in the DOM when closed. Without it, the modal
     // is fully unmounted and the focusin handler would early-return due to modalEl being null,

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -26,7 +26,7 @@ import Modal, { ModalProps } from './Modal';
 
 const renderModal = (props: Omit<ModalProps, 'open'>) => {
   return render(
-    <Modal open={true} {...props}>
+    <Modal open {...props}>
       <div>Hello</div>
     </Modal>
   );
@@ -160,7 +160,7 @@ test('restores focus on close', async () => {
 
 test('closing dialog when attachCustomKeyEventHandler is set only hides it with DOM', async () => {
   const { rerender } = render(
-    <Modal open={true} keepInDOMAfterClose>
+    <Modal open keepInDOMAfterClose>
       <div>Hello</div>
     </Modal>
   );
@@ -288,7 +288,7 @@ describe('trapFocus', () => {
     render(
       <>
         <button>Outside</button>
-        <Modal open={true} trapFocus>
+        <Modal open trapFocus>
           <div>
             <button>First</button>
             <button autoFocus>Second</button>
@@ -444,7 +444,7 @@ describe('trapFocus', () => {
     const { rerender } = render(
       <>
         <button>Outside</button>
-        <Modal open={true} trapFocus keepInDOMAfterClose>
+        <Modal open trapFocus keepInDOMAfterClose>
           <div>
             <button>Inside</button>
           </div>

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -176,6 +176,131 @@ test('closing dialog when attachCustomKeyEventHandler is set only hides it with 
   expect(screen.getByText('Hello')).not.toBeVisible();
 });
 
+describe('trapFocus', () => {
+  test('returns focus to the modal when an outside element steals it', () => {
+    render(<ModalWithOutsideButton trapFocus />);
+
+    const insideButton = screen.getByRole('button', { name: 'Inside' });
+    insideButton.focus();
+    expect(insideButton).toHaveFocus();
+
+    // Simulate programmatic focus theft from outside the modal.
+    screen.getByRole('button', { name: 'Outside' }).focus();
+    expect(insideButton).toHaveFocus();
+  });
+
+  test('remembers autoFocus target and restores it after focus theft', () => {
+    render(
+      <>
+        <button>Outside</button>
+        <Modal open={true} trapFocus>
+          <div>
+            <button>First</button>
+            <button autoFocus>Second</button>
+          </div>
+        </Modal>
+      </>
+    );
+
+    const secondButton = screen.getByRole('button', { name: 'Second' });
+    expect(secondButton).toHaveFocus();
+
+    screen.getByRole('button', { name: 'Outside' }).focus();
+    expect(secondButton).toHaveFocus();
+  });
+
+  test('wraps focus from last to first element on Tab', () => {
+    render(
+      <>
+        <button>Outside</button>
+        <Modal open={true} trapFocus>
+          <div>
+            <button>First</button>
+            <button>Last</button>
+          </div>
+        </Modal>
+      </>
+    );
+
+    const lastButton = screen.getByRole('button', { name: 'Last' });
+    lastButton.focus();
+    fireEvent.keyDown(lastButton, { key: 'Tab' });
+    expect(screen.getByRole('button', { name: 'First' })).toHaveFocus();
+  });
+
+  test('wraps focus from first to last element on Shift+Tab', () => {
+    render(
+      <>
+        <button>Outside</button>
+        <Modal open={true} trapFocus>
+          <div>
+            <button>First</button>
+            <button>Last</button>
+          </div>
+        </Modal>
+      </>
+    );
+
+    const firstButton = screen.getByRole('button', { name: 'First' });
+    firstButton.focus();
+    fireEvent.keyDown(firstButton, { key: 'Tab', shiftKey: true });
+    expect(screen.getByRole('button', { name: 'Last' })).toHaveFocus();
+  });
+
+  test('does not trap focus when trapFocus is not set', () => {
+    render(<ModalWithOutsideButton />);
+
+    screen.getByRole('button', { name: 'Inside' }).focus();
+    const outsideButton = screen.getByRole('button', { name: 'Outside' });
+    outsideButton.focus();
+    expect(outsideButton).toHaveFocus();
+  });
+
+  test('cleans up focus trap listeners on close', () => {
+    // Use keepInDOMAfterClose so that the modal stays in the DOM when closed. Without it, the modal
+    // is fully unmounted and the focusin handler would early-return due to modalEl being null,
+    // making the test pass trivially.
+    const { rerender } = render(
+      <>
+        <button>Outside</button>
+        <Modal open={true} trapFocus keepInDOMAfterClose>
+          <div>
+            <button>Inside</button>
+          </div>
+        </Modal>
+      </>
+    );
+
+    screen.getByRole('button', { name: 'Inside' }).focus();
+
+    rerender(
+      <>
+        <button>Outside</button>
+        <Modal open={false} trapFocus keepInDOMAfterClose>
+          <div>
+            <button>Inside</button>
+          </div>
+        </Modal>
+      </>
+    );
+
+    const outsideButton = screen.getByRole('button', { name: 'Outside' });
+    outsideButton.focus();
+    expect(outsideButton).toHaveFocus();
+  });
+});
+
+const ModalWithOutsideButton = (props: { trapFocus?: boolean }) => (
+  <>
+    <button>Outside</button>
+    <Modal open={true} trapFocus={props.trapFocus}>
+      <div>
+        <button>Inside</button>
+      </div>
+    </Modal>
+  </>
+);
+
 const ToggleableModal = () => {
   const [isOpen, setIsOpen] = useState(false);
 

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -191,7 +191,7 @@ describe('trapFocus', () => {
         if (this.style.display === 'none') {
           return null;
         }
-        return this.parentElement;
+        return this.parentElement; // oxlint-disable-line testing-library/no-node-access
       },
       configurable: true,
     });

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -188,6 +188,9 @@ describe('trapFocus', () => {
     );
     Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
       get() {
+        if (this.style.display === 'none') {
+          return null;
+        }
         return this.parentElement;
       },
       configurable: true,
@@ -272,6 +275,19 @@ describe('trapFocus', () => {
       fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
       screen.getByRole('button', { name: 'Outside' }).focus();
       expect(screen.getByRole('button', { name: 'Last' })).toHaveFocus();
+    });
+
+    test('Tab skips hidden elements and focuses the first visible one', () => {
+      render(
+        <ModalWithOutsideButton trapFocus>
+          <button style={{ display: 'none' }}>Hidden</button>
+          <button>Visible</button>
+        </ModalWithOutsideButton>
+      );
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+      screen.getByRole('button', { name: 'Outside' }).focus();
+      expect(screen.getByRole('button', { name: 'Visible' })).toHaveFocus();
     });
 
     test('blurs the thief when focus is stolen programmatically', () => {

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -237,17 +237,7 @@ describe('trapFocus', () => {
   });
 
   test('wraps focus from last to first element on Tab', () => {
-    render(
-      <>
-        <button>Outside</button>
-        <Modal open={true} trapFocus>
-          <div>
-            <button>First</button>
-            <button>Last</button>
-          </div>
-        </Modal>
-      </>
-    );
+    render(<TwoButtonModalWithOutsideButton />);
 
     const lastButton = screen.getByRole('button', { name: 'Last' });
     lastButton.focus();
@@ -256,17 +246,7 @@ describe('trapFocus', () => {
   });
 
   test('wraps focus from first to last element on Shift+Tab', () => {
-    render(
-      <>
-        <button>Outside</button>
-        <Modal open={true} trapFocus>
-          <div>
-            <button>First</button>
-            <button>Last</button>
-          </div>
-        </Modal>
-      </>
-    );
+    render(<TwoButtonModalWithOutsideButton />);
 
     const firstButton = screen.getByRole('button', { name: 'First' });
     firstButton.focus();
@@ -279,17 +259,7 @@ describe('trapFocus', () => {
   // and lets handleFocusTrapFocusIn redirect focus into the modal).
   describe('when nothing inside the modal was focused yet', () => {
     test('Tab focuses the first element', () => {
-      render(
-        <>
-          <button>Outside</button>
-          <Modal open={true} trapFocus>
-            <div>
-              <button>First</button>
-              <button>Last</button>
-            </div>
-          </Modal>
-        </>
-      );
+      render(<TwoButtonModalWithOutsideButton />);
 
       fireEvent.keyDown(document, { key: 'Tab' });
       screen.getByRole('button', { name: 'Outside' }).focus();
@@ -297,17 +267,7 @@ describe('trapFocus', () => {
     });
 
     test('Shift+Tab focuses the last element', () => {
-      render(
-        <>
-          <button>Outside</button>
-          <Modal open={true} trapFocus>
-            <div>
-              <button>First</button>
-              <button>Last</button>
-            </div>
-          </Modal>
-        </>
-      );
+      render(<TwoButtonModalWithOutsideButton />);
 
       fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
       screen.getByRole('button', { name: 'Outside' }).focus();
@@ -315,17 +275,7 @@ describe('trapFocus', () => {
     });
 
     test('blurs the thief when focus is stolen programmatically', () => {
-      render(
-        <>
-          <button>Outside</button>
-          <Modal open={true} trapFocus>
-            <div>
-              <button>First</button>
-              <button>Second</button>
-            </div>
-          </Modal>
-        </>
-      );
+      render(<TwoButtonModalWithOutsideButton />);
 
       // No element has autoFocus, so lastModalFocus is not pre-populated. The thief should be
       // blurred rather than auto-focusing the first element inside the modal.
@@ -380,15 +330,28 @@ describe('trapFocus', () => {
   });
 });
 
-const ModalWithOutsideButton = (props: { trapFocus?: boolean }) => (
+const ModalWithOutsideButton = (
+  props: { trapFocus?: boolean } & Pick<ModalProps, 'keepInDOMAfterClose'> & {
+      children?: React.ReactNode;
+    }
+) => (
   <>
     <button>Outside</button>
-    <Modal open={true} trapFocus={props.trapFocus}>
-      <div>
-        <button>Inside</button>
-      </div>
+    <Modal
+      open
+      trapFocus={props.trapFocus}
+      keepInDOMAfterClose={props.keepInDOMAfterClose}
+    >
+      <div>{props.children ?? <button>Inside</button>}</div>
     </Modal>
   </>
+);
+
+const TwoButtonModalWithOutsideButton = () => (
+  <ModalWithOutsideButton trapFocus>
+    <button>First</button>
+    <button>Last</button>
+  </ModalWithOutsideButton>
 );
 
 const ToggleableModal = () => {

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -177,6 +177,43 @@ test('closing dialog when attachCustomKeyEventHandler is set only hides it with 
 });
 
 describe('trapFocus', () => {
+  let originalOffsetParent: PropertyDescriptor | undefined;
+
+  beforeAll(() => {
+    // JSDOM doesn't implement layout, so offsetParent is always null. Mock it to return the
+    // parent element (non-null) for elements that aren't hidden via display:none on themselves or
+    // an ancestor.
+    originalOffsetParent = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetParent'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      get(this: HTMLElement) {
+        // Walk up the ancestor chain — in real browsers, offsetParent is null when any
+        // ancestor has display:none.
+        let el: HTMLElement | null = this;
+        while (el) {
+          if (el.style.display === 'none') {
+            return null;
+          }
+          el = el.parentElement; // eslint-disable-line testing-library/no-node-access
+        }
+        return this.parentElement; // eslint-disable-line testing-library/no-node-access
+      },
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    if (originalOffsetParent) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'offsetParent',
+        originalOffsetParent
+      );
+    }
+  });
+
   // In the following describe group, the focused element is removed during a re-render, leaving
   // lastModalFocus as a stale detached reference. Explicit keys ensure React unmounts the Removable
   // button rather than reconciling it with Stable.
@@ -330,6 +367,28 @@ describe('trapFocus', () => {
     expect(screen.getByRole('button', { name: 'First' })).toHaveFocus();
   });
 
+  test('does not interfere with Tab when defaultPrevented', () => {
+    render(<TwoButtonModalWithOutsideButton />);
+
+    const lastButton = screen.getByRole('button', { name: 'Last' });
+    lastButton.focus();
+
+    // Simulate a component inside the modal calling preventDefault on Tab (e.g., a rich-text
+    // editor using Tab for indentation). The handler runs before the modal's document-level
+    // listener because it's registered on the element itself.
+    const preventTab = (e: Event) => {
+      if ((e as KeyboardEvent).key === 'Tab') {
+        e.preventDefault();
+      }
+    };
+    lastButton.addEventListener('keydown', preventTab);
+    fireEvent.keyDown(lastButton, { key: 'Tab' });
+    lastButton.removeEventListener('keydown', preventTab);
+
+    // Focus should stay on Last — the trap should not have intercepted the event.
+    expect(lastButton).toHaveFocus();
+  });
+
   test('wraps focus from first to last element on Shift+Tab', () => {
     render(<TwoButtonModalWithOutsideButton />);
 
@@ -365,6 +424,26 @@ describe('trapFocus', () => {
           <button style={{ display: 'none' }}>Hidden</button>
           <button>Visible</button>
         </ModalWithOutsideButton>
+      );
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+      screen.getByRole('button', { name: 'Outside' }).focus();
+      expect(screen.getByRole('button', { name: 'Visible' })).toHaveFocus();
+    });
+
+    test('Tab skips elements inside a hidden parent', () => {
+      render(
+        <>
+          <button>Outside</button>
+          <Modal open trapFocus>
+            <div>
+              <div style={{ display: 'none' }}>
+                <button>HiddenChild</button>
+              </div>
+              <button>Visible</button>
+            </div>
+          </Modal>
+        </>
       );
 
       fireEvent.keyDown(document, { key: 'Tab' });

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -246,8 +246,7 @@ export default class Modal extends React.Component<ModalProps> {
     } else if (this.lastTabKeyDirection) {
       // Tab/Shift+Tab moved focus outside the modal before anything inside was focused.
       // Direct focus to the appropriate element inside the modal.
-      const focusable =
-        this.modalEl.querySelectorAll<HTMLElement>(focusableSelector);
+      const focusable = this.getFocusableElements();
       const el =
         this.lastTabKeyDirection === 'forward'
           ? focusable[0]
@@ -270,12 +269,7 @@ export default class Modal extends React.Component<ModalProps> {
     // programmatic focus theft.
     this.lastTabKeyDirection = event.shiftKey ? 'backward' : 'forward';
 
-    const focusable = [
-      ...this.modalEl.querySelectorAll<HTMLElement>(focusableSelector),
-    ].filter(
-      el =>
-        el.offsetParent !== null && getComputedStyle(el).visibility !== 'hidden'
-    );
+    const focusable = this.getFocusableElements();
     if (focusable.length === 0) {
       return;
     }
@@ -290,6 +284,22 @@ export default class Modal extends React.Component<ModalProps> {
       event.preventDefault();
       first.focus();
     }
+  };
+
+  /** Return focusable elements within the modal that are visible and not disabled. */
+  getFocusableElements = (): HTMLElement[] => {
+    if (!this.modalEl) {
+      return [];
+    }
+
+    return [
+      ...this.modalEl.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      ),
+    ].filter(
+      el =>
+        el.offsetParent !== null && getComputedStyle(el).visibility !== 'hidden'
+    );
   };
 
   restoreLastFocus() {
@@ -350,10 +360,6 @@ export default class Modal extends React.Component<ModalProps> {
     );
   }
 }
-
-/** Focusable elements that are visible and not disabled. */
-const focusableSelector =
-  'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 export type BackdropProps = {
   /**

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -317,10 +317,10 @@ export default class Modal extends React.Component<ModalProps> {
       ...this.modalEl.querySelectorAll<HTMLElement>(
         'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
       ),
-    ].filter(
-      el =>
-        el.offsetParent !== null && getComputedStyle(el).visibility !== 'hidden'
-    );
+    ].filter(el => {
+      const style = getComputedStyle(el);
+      return style.display !== 'none' && style.visibility !== 'hidden';
+    });
   };
 
   restoreLastFocus() {

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -115,6 +115,7 @@ export default class Modal extends React.Component<ModalProps> {
   lastModalFocus: HTMLElement | undefined;
   modalEl: HTMLDivElement | null = null;
   mounted = false;
+  lastTabKeyDirection: 'forward' | 'backward' | null = null;
 
   componentDidMount() {
     this.mounted = true;
@@ -243,12 +244,26 @@ export default class Modal extends React.Component<ModalProps> {
     const target = event.target as HTMLElement;
 
     if (this.modalEl.contains(target)) {
-      // Focus moved within the modal — remember it.
       this.lastModalFocus = target;
+    } else if (this.lastModalFocus) {
+      // Focus escaped the modal — pull it back to the last focused element.
+      this.lastModalFocus.focus();
+    } else if (this.lastTabKeyDirection) {
+      // Tab/Shift+Tab moved focus outside the modal before anything inside was focused.
+      // Direct focus to the appropriate element inside the modal.
+      const focusable =
+        this.modalEl.querySelectorAll<HTMLElement>(focusableSelector);
+      const el =
+        this.lastTabKeyDirection === 'forward'
+          ? focusable[0]
+          : focusable[focusable.length - 1];
+      el?.focus();
     } else {
-      // Focus escaped the modal — pull it back.
-      this.lastModalFocus?.focus();
+      // Programmatic focus theft (Tab was not pressed) with nothing focused inside yet — just blur
+      // the thief.
+      target.blur();
     }
+    this.lastTabKeyDirection = null;
   };
 
   handleFocusTrapTab = (event: KeyboardEvent) => {
@@ -256,11 +271,12 @@ export default class Modal extends React.Component<ModalProps> {
       return;
     }
 
-    // Select focusable elements that are visible and not disabled.
+    // Record the Tab direction so that handleFocusTrapFocusIn can tell a Tab keypress apart from
+    // programmatic focus theft.
+    this.lastTabKeyDirection = event.shiftKey ? 'backward' : 'forward';
+
     const focusable = [
-      ...this.modalEl.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-      ),
+      ...this.modalEl.querySelectorAll<HTMLElement>(focusableSelector),
     ].filter(
       el =>
         el.offsetParent !== null && getComputedStyle(el).visibility !== 'hidden'
@@ -340,6 +356,10 @@ export default class Modal extends React.Component<ModalProps> {
     );
   }
 }
+
+/** Focusable elements that are visible and not disabled. */
+const focusableSelector =
+  'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 export type BackdropProps = {
   /**

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -101,10 +101,18 @@ export type ModalProps = {
    * dialog itself.
    */
   modalRef?: Ref<HTMLDivElement | null>;
+
+  /**
+   * If `true`, focus is trapped inside the modal. When something outside the modal tries to grab
+   * focus programmatically, focus is returned to the last focused element inside the modal.
+   * Tab/Shift+Tab cycling wraps around at the modal boundaries.
+   */
+  trapFocus?: boolean;
 };
 
 export default class Modal extends React.Component<ModalProps> {
   lastFocus: HTMLElement | undefined;
+  lastModalFocus: HTMLElement | undefined;
   modalEl: HTMLDivElement | null = null;
   mounted = false;
 
@@ -147,6 +155,7 @@ export default class Modal extends React.Component<ModalProps> {
 
   handleOpen = () => {
     document.addEventListener('keydown', this.handleDocumentKeyDown);
+    this.enableFocusTrap();
 
     if (this.dialogEl()) {
       this.handleOpened();
@@ -162,6 +171,7 @@ export default class Modal extends React.Component<ModalProps> {
 
   handleClose = () => {
     document.removeEventListener('keydown', this.handleDocumentKeyDown);
+    this.disableFocusTrap();
 
     this.restoreLastFocus();
   };
@@ -181,10 +191,12 @@ export default class Modal extends React.Component<ModalProps> {
   };
 
   handleDocumentKeyDown = (event: KeyboardEvent) => {
-    const ESC = 'Escape';
+    if (event.key === 'Tab') {
+      this.handleFocusTrapTab(event);
+    }
 
     // Ignore events that have been `event.preventDefault()` marked.
-    if (event.key !== ESC || event.defaultPrevented) {
+    if (event.key !== 'Escape' || event.defaultPrevented) {
       return;
     }
 
@@ -194,6 +206,72 @@ export default class Modal extends React.Component<ModalProps> {
 
     if (!this.props.disableEscapeKeyDown && this.props.onClose) {
       this.props.onClose(event, 'escapeKeyDown');
+    }
+  };
+
+  // Focus trap methods.
+  //
+  // When trapFocus is enabled, focus is kept inside the modal. Programmatic focus theft from
+  // outside (e.g., useRefAutoFocus on a Document) is reverted to the last focused element inside
+  // the modal. Tab/Shift+Tab cycling wraps around at the modal boundaries.
+
+  enableFocusTrap = () => {
+    if (!this.props.trapFocus) {
+      return;
+    }
+
+    // If focus is already inside the modal (e.g., from autoFocus on a button during render),
+    // remember it before registering the listener, so that programmatic focus theft can be
+    // reverted.
+    const activeEl = document.activeElement as HTMLElement;
+    if (activeEl && this.modalEl?.contains(activeEl)) {
+      this.lastModalFocus = activeEl;
+    }
+    document.addEventListener('focusin', this.handleFocusTrapFocusIn);
+  };
+
+  disableFocusTrap = () => {
+    document.removeEventListener('focusin', this.handleFocusTrapFocusIn);
+    this.lastModalFocus = undefined;
+  };
+
+  handleFocusTrapFocusIn = (event: FocusEvent) => {
+    if (!this.modalEl) {
+      return;
+    }
+
+    const target = event.target as HTMLElement;
+
+    if (this.modalEl.contains(target)) {
+      // Focus moved within the modal — remember it.
+      this.lastModalFocus = target;
+    } else {
+      // Focus escaped the modal — pull it back.
+      this.lastModalFocus?.focus();
+    }
+  };
+
+  handleFocusTrapTab = (event: KeyboardEvent) => {
+    if (!this.props.trapFocus || !this.modalEl) {
+      return;
+    }
+
+    const focusable = this.modalEl.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable.length === 0) {
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
     }
   };
 

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -229,6 +229,7 @@ export default class Modal extends React.Component<ModalProps> {
   disableFocusTrap = () => {
     document.removeEventListener('focusin', this.handleFocusTrapFocusIn);
     this.lastModalFocus = undefined;
+    this.lastTabKeyDirection = null;
   };
 
   handleFocusTrapFocusIn = (event: FocusEvent) => {

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -304,7 +304,7 @@ export default class Modal extends React.Component<ModalProps> {
   };
 
   handleFocusTrapTab = (event: KeyboardEvent) => {
-    if (!this.props.trapFocus || !this.modalEl) {
+    if (!this.props.trapFocus || !this.modalEl || event.defaultPrevented) {
       return;
     }
 
@@ -341,6 +341,13 @@ export default class Modal extends React.Component<ModalProps> {
       ),
     ].filter(el => {
       const style = getComputedStyle(el);
+      // offsetParent is null for elements hidden via an ancestor's display:none (which
+      // getComputedStyle on the element itself won't catch, since display isn't inherited).
+      // However, offsetParent is also null for position:fixed elements, so exclude those from
+      // the check.
+      if (el.offsetParent === null && style.position !== 'fixed') {
+        return false;
+      }
       return style.display !== 'none' && style.visibility !== 'hidden';
     });
   };

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -251,22 +251,32 @@ export default class Modal extends React.Component<ModalProps> {
 
     if (this.modalEl.contains(target)) {
       this.lastModalFocus = target;
-    } else if (this.lastModalFocus) {
-      // Focus escaped the modal — pull it back to the last focused element.
-      this.lastModalFocus.focus();
-    } else if (this.lastTabKeyDirection) {
-      // Tab/Shift+Tab moved focus outside the modal before anything inside was focused.
-      // Direct focus to the appropriate element inside the modal.
-      const focusable = this.getFocusableElements();
-      const el =
-        this.lastTabKeyDirection === 'forward'
-          ? focusable[0]
-          : focusable[focusable.length - 1];
-      el?.focus();
     } else {
-      // Programmatic focus theft (Tab was not pressed) with nothing focused inside yet — just blur
-      // the thief.
-      target.blur();
+      // Focus escaped the modal.
+
+      // Clear lastModalFocus if it points to an element that was removed from the DOM (e.g.,
+      // during a re-render), so we don't keep trying to focus a detached node.
+      if (this.lastModalFocus && !this.modalEl.contains(this.lastModalFocus)) {
+        this.lastModalFocus = undefined;
+      }
+
+      if (this.lastModalFocus) {
+        // Pull focus back to the last focused element inside the modal.
+        this.lastModalFocus.focus();
+      } else if (this.lastTabKeyDirection) {
+        // Tab/Shift+Tab moved focus outside the modal before anything inside was focused.
+        // Direct focus to the appropriate element inside the modal.
+        const focusable = this.getFocusableElements();
+        const el =
+          this.lastTabKeyDirection === 'forward'
+            ? focusable[0]
+            : focusable[focusable.length - 1];
+        el?.focus();
+      } else {
+        // Programmatic focus theft (Tab was not pressed) with nothing focused inside yet — just
+        // blur the thief.
+        target.blur();
+      }
     }
     this.lastTabKeyDirection = null;
   };

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -16,12 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {
-  cloneElement,
-  ComponentProps,
-  MutableRefObject,
-  Ref,
-} from 'react';
+import React, { cloneElement, ComponentProps, Ref, RefObject } from 'react';
 import { createPortal } from 'react-dom';
 import styled, { StyleFunction } from 'styled-components';
 
@@ -339,8 +334,7 @@ export default class Modal extends React.Component<ModalProps> {
             if (typeof modalRef === 'function') {
               modalRef(el);
             } else {
-              (modalRef as MutableRefObject<HTMLDivElement | null>).current =
-                el;
+              (modalRef as RefObject<HTMLDivElement | null>).current = el;
             }
           }
         }}

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -251,34 +251,56 @@ export default class Modal extends React.Component<ModalProps> {
 
     if (this.modalEl.contains(target)) {
       this.lastModalFocus = target;
+      this.lastTabKeyDirection = null;
+      return;
+    }
+
+    // Focus escaped the modal. Try to pull it back to the last focused element. The element may
+    // have been removed from the DOM (e.g., during a re-render) or become unfocusable (e.g.,
+    // dynamically disabled), in which case we fall through to the Tab/blur branches below.
+    if (this.tryFocusLastModalFocus()) {
+      this.lastTabKeyDirection = null;
+      return;
+    }
+
+    if (this.lastTabKeyDirection) {
+      // Tab/Shift+Tab moved focus outside the modal before anything inside was focused.
+      // Direct focus to the appropriate element inside the modal.
+      const focusable = this.getFocusableElements();
+      const el =
+        this.lastTabKeyDirection === 'forward'
+          ? focusable[0]
+          : focusable[focusable.length - 1];
+      el?.focus();
     } else {
-      // Focus escaped the modal.
-
-      // Clear lastModalFocus if it points to an element that was removed from the DOM (e.g.,
-      // during a re-render), so we don't keep trying to focus a detached node.
-      if (this.lastModalFocus && !this.modalEl.contains(this.lastModalFocus)) {
-        this.lastModalFocus = undefined;
-      }
-
-      if (this.lastModalFocus) {
-        // Pull focus back to the last focused element inside the modal.
-        this.lastModalFocus.focus();
-      } else if (this.lastTabKeyDirection) {
-        // Tab/Shift+Tab moved focus outside the modal before anything inside was focused.
-        // Direct focus to the appropriate element inside the modal.
-        const focusable = this.getFocusableElements();
-        const el =
-          this.lastTabKeyDirection === 'forward'
-            ? focusable[0]
-            : focusable[focusable.length - 1];
-        el?.focus();
-      } else {
-        // Programmatic focus theft (Tab was not pressed) with nothing focused inside yet — just
-        // blur the thief.
-        target.blur();
-      }
+      // Programmatic focus theft (Tab was not pressed) with nothing focused inside yet — just
+      // blur the thief.
+      target.blur();
     }
     this.lastTabKeyDirection = null;
+  };
+
+  /**
+   * Try to focus lastModalFocus. Returns true if focus was successfully moved. Clears the
+   * reference if the element is no longer in the DOM or is no longer focusable.
+   */
+  tryFocusLastModalFocus = (): boolean => {
+    if (!this.lastModalFocus) {
+      return false;
+    }
+    // Avoid calling .focus() on a detached node. This is redundant with the activeElement check
+    // below in JSDOM (where .focus() on detached nodes is a no-op), so tests pass without it,
+    // but in real browsers it skips an unnecessary .focus() call on a detached node.
+    if (!this.modalEl?.contains(this.lastModalFocus)) {
+      this.lastModalFocus = undefined;
+      return false;
+    }
+    this.lastModalFocus.focus();
+    if (document.activeElement !== this.lastModalFocus) {
+      this.lastModalFocus = undefined;
+      return false;
+    }
+    return true;
   };
 
   handleFocusTrapTab = (event: KeyboardEvent) => {

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -269,8 +269,8 @@ export default class Modal extends React.Component<ModalProps> {
       const focusable = this.getFocusableElements();
       const el =
         this.lastTabKeyDirection === 'forward'
-          ? focusable[0]
-          : focusable[focusable.length - 1];
+          ? focusable.at(0)
+          : focusable.at(-1);
       el?.focus();
     } else {
       // Programmatic focus theft (Tab was not pressed) with nothing focused inside yet — just
@@ -317,15 +317,15 @@ export default class Modal extends React.Component<ModalProps> {
       return;
     }
 
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
+    const first = focusable.at(0);
+    const last = focusable.at(-1);
 
     if (event.shiftKey && document.activeElement === first) {
       event.preventDefault();
-      last.focus();
+      last?.focus();
     } else if (!event.shiftKey && document.activeElement === last) {
       event.preventDefault();
-      first.focus();
+      first?.focus();
     }
   };
 

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -125,6 +125,16 @@ export default class Modal extends React.Component<ModalProps> {
     } else if (!prevProps.open && this.props.open) {
       this.lastFocus = document.activeElement as HTMLElement;
       this.handleOpen();
+    } else if (
+      this.props.open &&
+      prevProps.trapFocus !== this.props.trapFocus
+    ) {
+      // open didn't change but trapFocus did — toggle the trap without a full open/close cycle.
+      if (this.props.trapFocus) {
+        this.enableFocusTrap();
+      } else {
+        this.disableFocusTrap();
+      }
     }
   }
 

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -256,8 +256,14 @@ export default class Modal extends React.Component<ModalProps> {
       return;
     }
 
-    const focusable = this.modalEl.querySelectorAll<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    // Select focusable elements that are visible and not disabled.
+    const focusable = [
+      ...this.modalEl.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      ),
+    ].filter(
+      el =>
+        el.offsetParent !== null && getComputedStyle(el).visibility !== 'hidden'
     );
     if (focusable.length === 0) {
       return;

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
@@ -42,6 +42,7 @@ export function DocumentsReopen(props: {
     <DialogConfirmation
       open={!props.hidden}
       keepInDOMAfterClose
+      trapFocus
       onClose={props.onDiscard}
       dialogCss={() => ({
         maxWidth: '400px',


### PR DESCRIPTION
Closes #64691.

This PR adds `trapFocus` prop to `<Modal>` and then uses it in `<DocumentsReopen>` to fix #64691.

Changelog: Fixed an issue in Teleport Connect where the "Reopen" button in "Reopen previous session" modal would not automatically receive focus

I considered using [focus-trap-react](https://www.npmjs.com/package/focus-trap-react) which probably implements a much more comprehensive focus trap. But the package weighs a bit: 16.7 kB of uncompressed code of the package itself. Its two deps, focus-trap and tappable, weigh 17.1 kB and 6.15 kB _minimized_ respectively.

In the future we should enable this prop by default. I'll create an issue for that so we remember to do so before the next test plan. At the moment I just don't want to risk breaking stuff.

## Manual Test Plan
### Test Environment

A locally built app.

### Test Cases
- [x] `DocumentsReopen` receives focus.
