### PR TITLE
[scopes] handle acl member expiry and attempt to recover from failed reads

### DIFF
--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -346,7 +346,7 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go materializer.RefreshEventLoop(ctx)
+	go materializer.RepairEventLoop(ctx)
 
 	// start processing and applying changes
 	for {
@@ -359,8 +359,8 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 			if err := materializer.ProcessEvent(ctx, state, event); err != nil {
 				return trace.Errorf("materializer failed during event processing: %w", err)
 			}
-		case event := <-materializer.RefreshEvents():
-			materializer.ProcessRefreshEvent(ctx, state, event)
+		case event := <-materializer.RepairEvents():
+			materializer.ProcessRepairEvent(ctx, state, event)
 		case <-watcher.Done():
 			if err := watcher.Error(); err != nil {
 				// watcher errors are expected if the watcher is closed before init completes.

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -346,6 +346,7 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	go materializer.RefreshEventLoop(ctx)
 
 	// start processing and applying changes
 	for {
@@ -358,6 +359,8 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 			if err := materializer.ProcessEvent(ctx, state, event); err != nil {
 				return trace.Errorf("materializer failed during event processing: %w", err)
 			}
+		case event := <-materializer.RefreshEvents():
+			materializer.ProcessRefreshEvent(ctx, state, event)
 		case <-watcher.Done():
 			if err := watcher.Error(); err != nil {
 				// watcher errors are expected if the watcher is closed before init completes.

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -1613,13 +1613,22 @@ func (f *assignmentFilter) merge(other assignmentFilter) {
 	f.users.Union(other.users)
 }
 
+// repairMissedMembers additively materializes assignments for all members and
+// owners in all lists.
 func (m *materializer) repairMissedMembers(ctx context.Context, state state) {
 	m.logger.InfoContext(ctx, "Running missed membership repair")
-	// Re-run init to re-process all access list memberships additively.
-	if err := m.Init(ctx, state); err != nil {
-		m.logger.InfoContext(ctx, "Missed membership repair failed, will schedule another repair",
-			"error", err)
-		m.scheduleMissedMembersRepair(ctx)
+
+	// Iterate all access lists to additively materialize assignments for all
+	// their members and owners.
+	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
+		if err != nil {
+			m.logger.InfoContext(ctx, "Missed membership repair failed to read all access lists, scheduling another repair",
+				"error", err)
+			m.scheduleMissedMembersRepair(ctx)
+			return
+		}
+		m.initAccessListMembers(ctx, state, list)
+		m.initAccessListOwners(ctx, state, list)
 	}
 }
 

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -24,6 +24,7 @@ import (
 	"iter"
 	"log/slog"
 	"maps"
+	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -36,6 +37,17 @@ import (
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/utils/set"
+)
+
+type refreshEvent int
+
+const (
+	optimisticRefreshEvent refreshEvent = iota
+	pessimisticRefreshEvent
+
+	forever                   time.Duration = 100 * 365 * 24 * time.Hour
+	pessimisticRefreshBackoff               = 30 * time.Second
+	optimisticRefreshBackoff                = 30 * time.Second
 )
 
 // AccessListReader provides the upstream source of access list and member resources.
@@ -72,6 +84,12 @@ func listAccessListMembers(aclReader AccessListReader, listName string) func(con
 // The materializer is not safe for concurrent use, it is meant to be driven
 // from a single event loop, pushing events into [materializer.ProcessEvent].
 //
+// If the materializer is expected to be long-lived, callers should run
+// [materializer.RefreshEventLoop] in a goroutine after [materializer.Init]
+// succeeds.
+// Then, in the main event loop, events from [materializer.RefreshEvents]
+// should be received and pushed into [materializer.ProcessRefreshEvent].
+//
 // Notably, the materializer never reads the actual scoped roles it is
 // generating assignments for. It does not attempt to validate that scoped role
 // exist or that the assigned scope is allowed by the scoped role definition.
@@ -95,6 +113,12 @@ type materializer struct {
 	materializedAssignments map[materializedAssignmentKey]ancestorRelation
 
 	logger *slog.Logger
+
+	refreshTimeMu              sync.Mutex
+	refreshEventC              chan refreshEvent
+	wakeRefreshLoop            chan struct{}
+	nextPessimisticRefreshTime time.Time
+	nextOptimisticRefreshTime  time.Time
 }
 
 type materializedAssignmentKey struct {
@@ -111,11 +135,16 @@ func (k materializedAssignmentKey) assignmentName() string {
 }
 
 func newMaterializer(aclReader AccessListReader) *materializer {
+	now := time.Now()
 	return &materializer{
-		aclReader:               aclReader,
-		ancestorCache:           newAncestorCache(),
-		materializedAssignments: make(map[materializedAssignmentKey]ancestorRelation),
-		logger:                  slog.With(teleport.ComponentKey, "sra_materializer"),
+		aclReader:                  aclReader,
+		ancestorCache:              newAncestorCache(),
+		materializedAssignments:    make(map[materializedAssignmentKey]ancestorRelation),
+		logger:                     slog.With(teleport.ComponentKey, "sra_materializer"),
+		refreshEventC:              make(chan refreshEvent),
+		wakeRefreshLoop:            make(chan struct{}, 1),
+		nextPessimisticRefreshTime: now.Add(forever),
+		nextOptimisticRefreshTime:  now.Add(forever),
 	}
 }
 
@@ -127,6 +156,11 @@ func (m *materializer) Init(ctx context.Context, state state) error {
 	// relationships and future changes. The ancestor cache should include even
 	// expired or invalid membership edges for defensive handling of delete
 	// events.
+	//
+	// Also track the earliest member expiration that's in the future, so we
+	// can react to member expiration.
+	now := time.Now()
+	nextExpiry := now.Add(forever)
 	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
 		if err != nil {
 			return trace.Wrap(err, "reading access list members")
@@ -134,8 +168,11 @@ func (m *materializer) Init(ctx context.Context, state state) error {
 		if member.Spec.MembershipKind == accesslist.MembershipKindList {
 			m.ancestorCache.addMembership(member.Spec.AccessList, member.GetName())
 		}
-		// TODO(nic): queue handler for member resource expiry.
+		if member.Spec.Expires.After(now) && member.Spec.Expires.Before(nextExpiry) {
+			nextExpiry = member.Spec.Expires
+		}
 	}
+	m.reportFutureMemberExpiry(ctx, nextExpiry)
 	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
 		if err != nil {
 			return trace.Wrap(err, "reading access lists")
@@ -220,7 +257,7 @@ func (m *materializer) handleUserMemberPut(ctx context.Context, state state, mem
 		m.handleUserMemberDeleteOrExpired(ctx, state, listName, userName)
 		return
 	}
-	// TODO(nic): queue handler for member resource expiry.
+	m.reportFutureMemberExpiry(ctx, member.Spec.Expires)
 
 	list, err := m.aclReader.GetAccessList(ctx, listName)
 	if err != nil {
@@ -228,7 +265,7 @@ func (m *materializer) handleUserMemberPut(ctx context.Context, state state, mem
 			"error", err,
 			"list", listName,
 			"user", userName)
-		// TODO(nic): schedule a refresh to recover.
+		m.scheduleOptimisticRefresh(ctx)
 		return
 	}
 
@@ -252,7 +289,9 @@ func (m *materializer) handleUserMemberPut(ctx context.Context, state state, mem
 		m.logger.InfoContext(ctx, "Error while validating access list ancestors, some scoped role assignments may not be materialized",
 			"error", validationError)
 	}
-	// TODO(nic): schedule a refresh to recover if len(validationErrors) > 0
+	if len(validationErrors) > 0 {
+		m.scheduleOptimisticRefresh(ctx)
+	}
 
 	// As a member of this list, the user shares the list's relationship with
 	// all of its ancestors, make sure assignments are materialized.
@@ -287,7 +326,7 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 		m.handleListMemberExpired(ctx, state, parentListName)
 		return
 	}
-	// TODO(nic): queue handler for member resource expiry.
+	m.reportFutureMemberExpiry(ctx, member.Spec.Expires)
 
 	// Every user that is a nested member of memberList may have just become a
 	// member of parentList and all lists it is a nested member of. They also
@@ -298,7 +337,7 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 			"error", err,
 			"list", parentListName,
 			"member_list", memberListName)
-		// TODO(nic): schedule a refresh to recover.
+		m.scheduleOptimisticRefresh(ctx)
 		return
 	}
 	memberList, err := m.aclReader.GetAccessList(ctx, memberListName)
@@ -307,7 +346,7 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 			"error", err,
 			"list", memberListName,
 			"parent_list", parentListName)
-		// TODO(nic): schedule a refresh to recover.
+		m.scheduleOptimisticRefresh(ctx)
 		return
 	}
 
@@ -326,14 +365,16 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 		m.logger.InfoContext(ctx, "Error while validating access list ancestors, some scoped role assignments may not be materialized",
 			"error", validationError)
 	}
-	// TODO(nic): schedule a refresh to recover if len(validationErrors) > 0
+	if len(validationErrors) > 0 {
+		m.scheduleOptimisticRefresh(ctx)
+	}
 
 	for member, err := range m.walkUserMembers(ctx, memberList) {
 		if err != nil {
 			m.logger.WarnContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
 				"error", err,
 				"list", memberListName)
-			// TODO(nic): schedule a refresh to recover.
+			m.scheduleOptimisticRefresh(ctx)
 			// walkUserMembers may yield errors from walking members of any
 			// member lists, but it may not be done, so continue the loop.
 			continue
@@ -414,7 +455,7 @@ func (m *materializer) handleListMemberExpired(ctx context.Context, state state,
 			m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
 				"error", err)
 			m.deleteMaterializedAssignment(ctx, state, key)
-			// TODO(nic): schedule a refresh to recover.
+			m.scheduleOptimisticRefresh(ctx)
 		}
 	}
 }
@@ -443,7 +484,7 @@ func (m *materializer) handleUserMemberDeleteOrExpired(ctx context.Context, stat
 			m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
 				"error", err)
 			m.deleteMaterializedAssignment(ctx, state, key)
-			// TODO(nic): schedule a refresh to recover.
+			m.scheduleOptimisticRefresh(ctx)
 		}
 	}
 }
@@ -486,7 +527,7 @@ func (m *materializer) handleAccessListPut(ctx context.Context, state state, lis
 				m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
 					"error", err)
 				m.deleteMaterializedAssignment(ctx, state, key)
-				// TODO(nic): schedule a refresh to recover.
+				m.scheduleOptimisticRefresh(ctx)
 			}
 		} else {
 			// If the list doesn't grant any scoped roles, we can just delete
@@ -510,7 +551,7 @@ func (m *materializer) handleAccessListPut(ctx context.Context, state state, lis
 					m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
 						"error", err)
 					m.deleteMaterializedAssignment(ctx, state, key)
-					// TODO(nic): schedule a refresh to recover.
+					m.scheduleOptimisticRefresh(ctx)
 				}
 			}
 		}
@@ -537,7 +578,9 @@ func (m *materializer) initAccessListMembers(ctx context.Context, state state, l
 		m.logger.InfoContext(ctx, "Error while validating access list ancestors, some scoped role assignments may not be materialized",
 			"error", validationError)
 	}
-	// TODO(nic): schedule a refresh to recover if len(validationErrors) > 0
+	if len(validationErrors) > 0 {
+		m.scheduleOptimisticRefresh(ctx)
+	}
 
 	hasMemberGrants := hasMemberGrants(list)
 	if !hasMemberGrants && len(ancestors) == 0 {
@@ -554,7 +597,7 @@ func (m *materializer) initAccessListMembers(ctx context.Context, state state, l
 			m.logger.InfoContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
 				"error", err,
 				"list", list.GetName())
-			// TODO(nic): schedule a refresh to recover.
+			m.scheduleOptimisticRefresh(ctx)
 			// walkUserMembers may yield errors from walking members of any
 			// member lists, but it may not be done, so continue the loop.
 			continue
@@ -621,7 +664,7 @@ func (m *materializer) initAccessListOwners(ctx context.Context, state state, li
 		if err != nil {
 			m.logger.InfoContext(ctx, "Failed to get owner list, some scoped role assignments may not be materialized for owners",
 				"error", err)
-			// TODO(nic): schedule a refresh to recover.
+			m.scheduleOptimisticRefresh(ctx)
 			continue
 
 		}
@@ -633,7 +676,7 @@ func (m *materializer) initAccessListOwners(ctx context.Context, state state, li
 				m.logger.WarnContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
 					"error", err,
 					"list", list.GetName())
-				// TODO(nic): schedule a refresh to recover.
+				m.scheduleOptimisticRefresh(ctx)
 				// walkUserMembersRecursive may yield errors from walking members of any
 				// member lists, but it may not be done, so continue the loop.
 				continue
@@ -684,7 +727,7 @@ func (m *materializer) handleAccessListDelete(ctx context.Context, state state, 
 			m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
 				"error", err)
 			m.deleteMaterializedAssignment(ctx, state, key)
-			// TODO(nic): schedule a refresh to recover.
+			m.scheduleOptimisticRefresh(ctx)
 		}
 	}
 }
@@ -1289,6 +1332,175 @@ func (m *materializer) collectAncestors(ctx context.Context, startListName strin
 		}
 	}
 	return filteredAncestors, validationErrors
+}
+
+// RefreshEventLoop should be called in a goroutine after materializer init
+// if the materializer is expected to be long-lived. It runs continuously until
+// ctx is done, it will send an event on [materializer.RefreshEvents] at the
+// time of each scheduled refresh event.
+func (m *materializer) RefreshEventLoop(ctx context.Context) {
+	for {
+		nextEvent, nextEventTime := m.nextRefreshEvent()
+
+		// If the next scheduled refresh event is in the future, wait until
+		// that time or we get woken up because the time has been moved
+		// earlier.
+		waitFor := time.Until(nextEventTime)
+		if waitFor > 0 {
+			select {
+			case <-time.After(waitFor):
+			case <-ctx.Done():
+				return
+			case <-m.wakeRefreshLoop:
+				continue
+			}
+		}
+
+		// We have a refresh event scheduled for now, send it on refreshEventC.
+		// Reset the refresh time before sending it in case it gets set again
+		// while handling the refresh event.
+		m.resetRefreshTime(nextEvent)
+		select {
+		case m.refreshEventC <- nextEvent:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// RefreshEvents returns a channel from which events should be received and
+// passed to [materializer.ProcessRefreshEvent]. This facilitates
+// single-threaded processing of cache events and refresh events.
+func (m *materializer) RefreshEvents() <-chan refreshEvent {
+	return m.refreshEventC
+}
+
+// ProcessRefreshEvent should be called with refresh events read from
+// [materializer.RefreshEvents]. It must not be called concurrently with
+// [materializer.ProcessEvent].
+func (m *materializer) ProcessRefreshEvent(ctx context.Context, state state, event refreshEvent) {
+	switch event {
+	case pessimisticRefreshEvent:
+		m.pessimisticRefresh(ctx, state)
+	case optimisticRefreshEvent:
+		m.optimisticRefresh(ctx, state)
+	}
+}
+
+func (m *materializer) scheduleRefresh(ctx context.Context, event refreshEvent, t time.Time) {
+	m.refreshTimeMu.Lock()
+	defer m.refreshTimeMu.Unlock()
+
+	switch event {
+	case pessimisticRefreshEvent:
+		if t.Before(m.nextPessimisticRefreshTime) {
+			m.nextPessimisticRefreshTime = t
+			m.logger.DebugContext(ctx, "Scheduled next pessimistic refresh", "refresh_time", t)
+			select {
+			case m.wakeRefreshLoop <- struct{}{}:
+			default:
+			}
+		}
+	case optimisticRefreshEvent:
+		if t.Before(m.nextOptimisticRefreshTime) {
+			m.nextOptimisticRefreshTime = t
+			m.logger.DebugContext(ctx, "Scheduled next optimistic refresh", "refresh_time", t)
+			select {
+			case m.wakeRefreshLoop <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+func (m *materializer) resetRefreshTime(event refreshEvent) {
+	m.refreshTimeMu.Lock()
+	defer m.refreshTimeMu.Unlock()
+	switch event {
+	case pessimisticRefreshEvent:
+		m.nextPessimisticRefreshTime = time.Now().Add(forever)
+	case optimisticRefreshEvent:
+		m.nextOptimisticRefreshTime = time.Now().Add(forever)
+	}
+}
+
+// reportFutureMemberExpiry schedules a pessimistic refresh for the expiry
+// time, if one is not already scheduled for earlier.
+func (m *materializer) reportFutureMemberExpiry(ctx context.Context, expires time.Time) {
+	if expires.IsZero() {
+		return
+	}
+	m.scheduleRefresh(ctx, pessimisticRefreshEvent, expires)
+}
+
+// scheduleOptimisticRefresh schedules an optimistic refresh for some time in
+// the future.
+func (m *materializer) scheduleOptimisticRefresh(ctx context.Context) {
+	m.scheduleRefresh(ctx, optimisticRefreshEvent, time.Now().Add(optimisticRefreshBackoff))
+}
+
+func (m *materializer) nextRefreshEvent() (refreshEvent, time.Time) {
+	m.refreshTimeMu.Lock()
+	defer m.refreshTimeMu.Unlock()
+	if m.nextOptimisticRefreshTime.Before(m.nextPessimisticRefreshTime) {
+		return optimisticRefreshEvent, m.nextOptimisticRefreshTime
+	}
+	return pessimisticRefreshEvent, m.nextPessimisticRefreshTime
+}
+
+// A pessimistic refresh processes all expired member resources to make sure
+// that any invalid materialized assignments are cleared.
+func (m *materializer) pessimisticRefresh(ctx context.Context, state state) {
+	m.logger.InfoContext(ctx, "Running pessimistic materializer refresh")
+
+	// Keep track of the nearest member expiry time that's in the future to
+	// reschedule the pessimistic refresh.
+	now := time.Now()
+	nextExpiry := now.Add(forever)
+
+	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
+		if err != nil {
+			// Failed to iterate access list member resources, there's nothing
+			// we can really do but schedule another pessimistic refresh and
+			// return.
+			m.scheduleRefresh(ctx, pessimisticRefreshEvent, time.Now().Add(pessimisticRefreshBackoff))
+			return
+		}
+
+		if !member.IsExpired(now) {
+			// This member is not expired yet, record the expiry time to schedule
+			// the next pessimistic refresh.
+			if member.Spec.Expires.After(now) && member.Spec.Expires.Before(nextExpiry) {
+				nextExpiry = member.Spec.Expires
+			}
+			continue
+		}
+
+		// Process the membership as expired.
+		m.logger.DebugContext(ctx, "Found expired member resource",
+			"list", member.Spec.AccessList,
+			"member", member.GetName(),
+			"membership_kind", member.Spec.MembershipKind,
+			"expired", member.Spec.Expires)
+		if member.IsUser() {
+			m.handleUserMemberDeleteOrExpired(ctx, state, member.Spec.AccessList, member.GetName())
+		}
+		if member.Spec.MembershipKind == accesslist.MembershipKindList {
+			m.handleListMemberExpired(ctx, state, member.Spec.AccessList)
+		}
+	}
+
+	m.reportFutureMemberExpiry(ctx, nextExpiry)
+}
+
+func (m *materializer) optimisticRefresh(ctx context.Context, state state) {
+	m.logger.InfoContext(ctx, "Running optimistic materializer refresh")
+	// Re-run init to re-process all access list memberships additively.
+	if err := m.Init(ctx, state); err != nil {
+		m.logger.InfoContext(ctx, "Optimistic refresh failed, will schedule another optimistic refresh",
+			"error", err)
+		m.scheduleOptimisticRefresh(ctx)
+	}
 }
 
 func hasMemberGrants(list *accesslist.AccessList) bool {

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -39,15 +39,17 @@ import (
 	"github.com/gravitational/teleport/lib/utils/set"
 )
 
-type refreshEvent int
+type repairEvent int
 
 const (
-	optimisticRefreshEvent refreshEvent = iota
-	pessimisticRefreshEvent
+	repairExpiredMembersEvent repairEvent = iota
+	repairMissedMembersEvent
 
-	forever                   time.Duration = 100 * 365 * 24 * time.Hour
-	pessimisticRefreshBackoff               = 30 * time.Second
-	optimisticRefreshBackoff                = 30 * time.Second
+	// A century is close enough to forever for scheduling the repair
+	// indefinitely in the future when it's not needed.
+	century                     time.Duration = 100 * 365 * 24 * time.Hour
+	expiredMembersRepairBackoff               = 30 * time.Second
+	missedMembersRepairBackoff                = 30 * time.Second
 )
 
 // AccessListReader provides the upstream source of access list and member resources.
@@ -85,10 +87,10 @@ func listAccessListMembers(aclReader AccessListReader, listName string) func(con
 // from a single event loop, pushing events into [materializer.ProcessEvent].
 //
 // If the materializer is expected to be long-lived, callers should run
-// [materializer.RefreshEventLoop] in a goroutine after [materializer.Init]
+// [materializer.RepairEventLoop] in a goroutine after [materializer.Init]
 // succeeds.
-// Then, in the main event loop, events from [materializer.RefreshEvents]
-// should be received and pushed into [materializer.ProcessRefreshEvent].
+// Then, in the main event loop, events from [materializer.RepairEvents]
+// should be received and pushed into [materializer.ProcessRepairEvent].
 //
 // Notably, the materializer never reads the actual scoped roles it is
 // generating assignments for. It does not attempt to validate that scoped role
@@ -114,11 +116,11 @@ type materializer struct {
 
 	logger *slog.Logger
 
-	refreshTimeMu              sync.Mutex
-	refreshEventC              chan refreshEvent
-	wakeRefreshLoop            chan struct{}
-	nextPessimisticRefreshTime time.Time
-	nextOptimisticRefreshTime  time.Time
+	repairTimeMu                 sync.Mutex
+	repairEventC                 chan repairEvent
+	wakeRepairLoop               chan struct{}
+	nextExpiredMembersRepairTime time.Time
+	nextRepairMissedMembersTime  time.Time
 }
 
 type materializedAssignmentKey struct {
@@ -137,14 +139,14 @@ func (k materializedAssignmentKey) assignmentName() string {
 func newMaterializer(aclReader AccessListReader) *materializer {
 	now := time.Now()
 	return &materializer{
-		aclReader:                  aclReader,
-		ancestorCache:              newAncestorCache(),
-		materializedAssignments:    make(map[materializedAssignmentKey]ancestorRelation),
-		logger:                     slog.With(teleport.ComponentKey, "sra_materializer"),
-		refreshEventC:              make(chan refreshEvent),
-		wakeRefreshLoop:            make(chan struct{}, 1),
-		nextPessimisticRefreshTime: now.Add(forever),
-		nextOptimisticRefreshTime:  now.Add(forever),
+		aclReader:                    aclReader,
+		ancestorCache:                newAncestorCache(),
+		materializedAssignments:      make(map[materializedAssignmentKey]ancestorRelation),
+		logger:                       slog.With(teleport.ComponentKey, "sra_materializer"),
+		repairEventC:                 make(chan repairEvent),
+		wakeRepairLoop:               make(chan struct{}, 1),
+		nextExpiredMembersRepairTime: now.Add(century),
+		nextRepairMissedMembersTime:  now.Add(century),
 	}
 }
 
@@ -160,7 +162,7 @@ func (m *materializer) Init(ctx context.Context, state state) error {
 	// Also track the earliest member expiration that's in the future, so we
 	// can react to member expiration.
 	now := time.Now()
-	nextExpiry := now.Add(forever)
+	nextExpiry := now.Add(century)
 	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
 		if err != nil {
 			return trace.Wrap(err, "reading access list members")
@@ -265,7 +267,7 @@ func (m *materializer) handleUserMemberPut(ctx context.Context, state state, mem
 			"error", err,
 			"list", listName,
 			"user", userName)
-		m.scheduleOptimisticRefresh(ctx)
+		m.scheduleMissedMembersRepair(ctx)
 		return
 	}
 
@@ -290,7 +292,7 @@ func (m *materializer) handleUserMemberPut(ctx context.Context, state state, mem
 			"error", validationError)
 	}
 	if len(validationErrors) > 0 {
-		m.scheduleOptimisticRefresh(ctx)
+		m.scheduleMissedMembersRepair(ctx)
 	}
 
 	// As a member of this list, the user shares the list's relationship with
@@ -337,7 +339,7 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 			"error", err,
 			"list", parentListName,
 			"member_list", memberListName)
-		m.scheduleOptimisticRefresh(ctx)
+		m.scheduleMissedMembersRepair(ctx)
 		return
 	}
 	memberList, err := m.aclReader.GetAccessList(ctx, memberListName)
@@ -346,7 +348,7 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 			"error", err,
 			"list", memberListName,
 			"parent_list", parentListName)
-		m.scheduleOptimisticRefresh(ctx)
+		m.scheduleMissedMembersRepair(ctx)
 		return
 	}
 
@@ -366,7 +368,7 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 			"error", validationError)
 	}
 	if len(validationErrors) > 0 {
-		m.scheduleOptimisticRefresh(ctx)
+		m.scheduleMissedMembersRepair(ctx)
 	}
 
 	for member, err := range m.walkUserMembers(ctx, memberList) {
@@ -374,7 +376,7 @@ func (m *materializer) handleListMemberPut(ctx context.Context, state state, mem
 			m.logger.WarnContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
 				"error", err,
 				"list", memberListName)
-			m.scheduleOptimisticRefresh(ctx)
+			m.scheduleMissedMembersRepair(ctx)
 			// walkUserMembers may yield errors from walking members of any
 			// member lists, but it may not be done, so continue the loop.
 			continue
@@ -430,7 +432,7 @@ func (m *materializer) handleListMemberDelete(ctx context.Context, state state, 
 // handleListMemberExpired handles the event where an access list membership
 // has been deleted or has expired. Any nested members of the member list may
 // no longer be valid members or owners of the parent list or any of its
-// ancestors. At risk of being overly pessimisted, we re-check every
+// ancestors. At risk of being overly pessimistic, we re-check every
 // materialized assignment for the parent list and all of its ancestors.
 func (m *materializer) handleListMemberExpired(ctx context.Context, state state, parentListName string) {
 	// We must iterate all ancestors without relying on paging through
@@ -455,7 +457,7 @@ func (m *materializer) handleListMemberExpired(ctx context.Context, state state,
 			m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
 				"error", err)
 			m.deleteMaterializedAssignment(ctx, state, key)
-			m.scheduleOptimisticRefresh(ctx)
+			m.scheduleMissedMembersRepair(ctx)
 		}
 	}
 }
@@ -484,7 +486,7 @@ func (m *materializer) handleUserMemberDeleteOrExpired(ctx context.Context, stat
 			m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
 				"error", err)
 			m.deleteMaterializedAssignment(ctx, state, key)
-			m.scheduleOptimisticRefresh(ctx)
+			m.scheduleMissedMembersRepair(ctx)
 		}
 	}
 }
@@ -527,7 +529,7 @@ func (m *materializer) handleAccessListPut(ctx context.Context, state state, lis
 				m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
 					"error", err)
 				m.deleteMaterializedAssignment(ctx, state, key)
-				m.scheduleOptimisticRefresh(ctx)
+				m.scheduleMissedMembersRepair(ctx)
 			}
 		} else {
 			// If the list doesn't grant any scoped roles, we can just delete
@@ -551,7 +553,7 @@ func (m *materializer) handleAccessListPut(ctx context.Context, state state, lis
 					m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
 						"error", err)
 					m.deleteMaterializedAssignment(ctx, state, key)
-					m.scheduleOptimisticRefresh(ctx)
+					m.scheduleMissedMembersRepair(ctx)
 				}
 			}
 		}
@@ -579,7 +581,7 @@ func (m *materializer) initAccessListMembers(ctx context.Context, state state, l
 			"error", validationError)
 	}
 	if len(validationErrors) > 0 {
-		m.scheduleOptimisticRefresh(ctx)
+		m.scheduleMissedMembersRepair(ctx)
 	}
 
 	hasMemberGrants := hasMemberGrants(list)
@@ -597,7 +599,7 @@ func (m *materializer) initAccessListMembers(ctx context.Context, state state, l
 			m.logger.InfoContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
 				"error", err,
 				"list", list.GetName())
-			m.scheduleOptimisticRefresh(ctx)
+			m.scheduleMissedMembersRepair(ctx)
 			// walkUserMembers may yield errors from walking members of any
 			// member lists, but it may not be done, so continue the loop.
 			continue
@@ -664,7 +666,7 @@ func (m *materializer) initAccessListOwners(ctx context.Context, state state, li
 		if err != nil {
 			m.logger.InfoContext(ctx, "Failed to get owner list, some scoped role assignments may not be materialized for owners",
 				"error", err)
-			m.scheduleOptimisticRefresh(ctx)
+			m.scheduleMissedMembersRepair(ctx)
 			continue
 
 		}
@@ -676,7 +678,7 @@ func (m *materializer) initAccessListOwners(ctx context.Context, state state, li
 				m.logger.WarnContext(ctx, "Error while walking members of access list, some scoped role assignments may not be materialized",
 					"error", err,
 					"list", list.GetName())
-				m.scheduleOptimisticRefresh(ctx)
+				m.scheduleMissedMembersRepair(ctx)
 				// walkUserMembersRecursive may yield errors from walking members of any
 				// member lists, but it may not be done, so continue the loop.
 				continue
@@ -727,7 +729,7 @@ func (m *materializer) handleAccessListDelete(ctx context.Context, state state, 
 			m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
 				"error", err)
 			m.deleteMaterializedAssignment(ctx, state, key)
-			m.scheduleOptimisticRefresh(ctx)
+			m.scheduleMissedMembersRepair(ctx)
 		}
 	}
 }
@@ -1334,15 +1336,15 @@ func (m *materializer) collectAncestors(ctx context.Context, startListName strin
 	return filteredAncestors, validationErrors
 }
 
-// RefreshEventLoop should be called in a goroutine after materializer init
+// RepairEventLoop should be called in a goroutine after materializer init
 // if the materializer is expected to be long-lived. It runs continuously until
-// ctx is done, it will send an event on [materializer.RefreshEvents] at the
-// time of each scheduled refresh event.
-func (m *materializer) RefreshEventLoop(ctx context.Context) {
+// ctx is done. It will send an event on [materializer.RepairEvents] at the
+// time of each scheduled repair event.
+func (m *materializer) RepairEventLoop(ctx context.Context) {
 	for {
-		nextEvent, nextEventTime := m.nextRefreshEvent()
+		nextEvent, nextEventTime := m.nextRepairEvent()
 
-		// If the next scheduled refresh event is in the future, wait until
+		// If the next scheduled repair event is in the future, wait until
 		// that time or we get woken up because the time has been moved
 		// earlier.
 		waitFor := time.Until(nextEventTime)
@@ -1351,155 +1353,273 @@ func (m *materializer) RefreshEventLoop(ctx context.Context) {
 			case <-time.After(waitFor):
 			case <-ctx.Done():
 				return
-			case <-m.wakeRefreshLoop:
+			case <-m.wakeRepairLoop:
 				continue
 			}
 		}
 
-		// We have a refresh event scheduled for now, send it on refreshEventC.
-		// Reset the refresh time before sending it in case it gets set again
-		// while handling the refresh event.
-		m.resetRefreshTime(nextEvent)
+		// We have a repair event scheduled for now, send it on repairEventC.
+		// Reset the repair time before sending it in case it gets set again
+		// while handling the repair event.
+		m.resetRepairTime(nextEvent)
 		select {
-		case m.refreshEventC <- nextEvent:
+		case m.repairEventC <- nextEvent:
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-// RefreshEvents returns a channel from which events should be received and
-// passed to [materializer.ProcessRefreshEvent]. This facilitates
-// single-threaded processing of cache events and refresh events.
-func (m *materializer) RefreshEvents() <-chan refreshEvent {
-	return m.refreshEventC
+// RepairEvents returns a channel from which events should be received and
+// passed to [materializer.ProcessRepairEvent]. This facilitates
+// single-threaded processing of cache events and repair events.
+func (m *materializer) RepairEvents() <-chan repairEvent {
+	return m.repairEventC
 }
 
-// ProcessRefreshEvent should be called with refresh events read from
-// [materializer.RefreshEvents]. It must not be called concurrently with
+// ProcessRepairEvent should be called with repair events read from
+// [materializer.RepairEvents]. It must not be called concurrently with
 // [materializer.ProcessEvent].
-func (m *materializer) ProcessRefreshEvent(ctx context.Context, state state, event refreshEvent) {
+func (m *materializer) ProcessRepairEvent(ctx context.Context, state state, event repairEvent) {
 	switch event {
-	case pessimisticRefreshEvent:
-		m.pessimisticRefresh(ctx, state)
-	case optimisticRefreshEvent:
-		m.optimisticRefresh(ctx, state)
+	case repairExpiredMembersEvent:
+		m.repairExpiredMembers(ctx, state)
+	case repairMissedMembersEvent:
+		m.repairMissedMembers(ctx, state)
 	}
 }
 
-func (m *materializer) scheduleRefresh(ctx context.Context, event refreshEvent, t time.Time) {
-	m.refreshTimeMu.Lock()
-	defer m.refreshTimeMu.Unlock()
+func (m *materializer) scheduleRepair(ctx context.Context, event repairEvent, t time.Time) {
+	m.repairTimeMu.Lock()
+	defer m.repairTimeMu.Unlock()
 
 	switch event {
-	case pessimisticRefreshEvent:
-		if t.Before(m.nextPessimisticRefreshTime) {
-			m.nextPessimisticRefreshTime = t
-			m.logger.DebugContext(ctx, "Scheduled next pessimistic refresh", "refresh_time", t)
+	case repairExpiredMembersEvent:
+		if t.Before(m.nextExpiredMembersRepairTime) {
+			m.nextExpiredMembersRepairTime = t
+			m.logger.DebugContext(ctx, "Scheduled next expired membership repair", "repair_time", t)
 			select {
-			case m.wakeRefreshLoop <- struct{}{}:
+			case m.wakeRepairLoop <- struct{}{}:
 			default:
 			}
 		}
-	case optimisticRefreshEvent:
-		if t.Before(m.nextOptimisticRefreshTime) {
-			m.nextOptimisticRefreshTime = t
-			m.logger.DebugContext(ctx, "Scheduled next optimistic refresh", "refresh_time", t)
+	case repairMissedMembersEvent:
+		if t.Before(m.nextRepairMissedMembersTime) {
+			m.nextRepairMissedMembersTime = t
+			m.logger.DebugContext(ctx, "Scheduled next missed membership repair", "repair_time", t)
 			select {
-			case m.wakeRefreshLoop <- struct{}{}:
+			case m.wakeRepairLoop <- struct{}{}:
 			default:
 			}
 		}
 	}
 }
 
-func (m *materializer) resetRefreshTime(event refreshEvent) {
-	m.refreshTimeMu.Lock()
-	defer m.refreshTimeMu.Unlock()
+func (m *materializer) resetRepairTime(event repairEvent) {
+	m.repairTimeMu.Lock()
+	defer m.repairTimeMu.Unlock()
 	switch event {
-	case pessimisticRefreshEvent:
-		m.nextPessimisticRefreshTime = time.Now().Add(forever)
-	case optimisticRefreshEvent:
-		m.nextOptimisticRefreshTime = time.Now().Add(forever)
+	case repairExpiredMembersEvent:
+		m.nextExpiredMembersRepairTime = time.Now().Add(century)
+	case repairMissedMembersEvent:
+		m.nextRepairMissedMembersTime = time.Now().Add(century)
 	}
 }
 
-// reportFutureMemberExpiry schedules a pessimistic refresh for the expiry
-// time, if one is not already scheduled for earlier.
+// reportFutureMemberExpiry schedules repairExpiredMembers for the expiry time,
+// if one is not already scheduled for earlier.
 func (m *materializer) reportFutureMemberExpiry(ctx context.Context, expires time.Time) {
 	if expires.IsZero() {
 		return
 	}
-	m.scheduleRefresh(ctx, pessimisticRefreshEvent, expires)
+	m.scheduleRepair(ctx, repairExpiredMembersEvent, expires)
 }
 
-// scheduleOptimisticRefresh schedules an optimistic refresh for some time in
+// scheduleMissedMembersRepair schedules repairMissedMembers for some time in
 // the future.
-func (m *materializer) scheduleOptimisticRefresh(ctx context.Context) {
-	m.scheduleRefresh(ctx, optimisticRefreshEvent, time.Now().Add(optimisticRefreshBackoff))
+func (m *materializer) scheduleMissedMembersRepair(ctx context.Context) {
+	m.scheduleRepair(ctx, repairMissedMembersEvent, time.Now().Add(missedMembersRepairBackoff))
 }
 
-func (m *materializer) nextRefreshEvent() (refreshEvent, time.Time) {
-	m.refreshTimeMu.Lock()
-	defer m.refreshTimeMu.Unlock()
-	if m.nextOptimisticRefreshTime.Before(m.nextPessimisticRefreshTime) {
-		return optimisticRefreshEvent, m.nextOptimisticRefreshTime
+func (m *materializer) nextRepairEvent() (repairEvent, time.Time) {
+	m.repairTimeMu.Lock()
+	defer m.repairTimeMu.Unlock()
+	if m.nextRepairMissedMembersTime.Before(m.nextExpiredMembersRepairTime) {
+		return repairMissedMembersEvent, m.nextRepairMissedMembersTime
 	}
-	return pessimisticRefreshEvent, m.nextPessimisticRefreshTime
+	return repairExpiredMembersEvent, m.nextExpiredMembersRepairTime
 }
 
-// A pessimistic refresh processes all expired member resources to make sure
+// repairExpiredMembers processes all expired member resources to make sure
 // that any invalid materialized assignments are cleared.
-func (m *materializer) pessimisticRefresh(ctx context.Context, state state) {
-	m.logger.InfoContext(ctx, "Running pessimistic materializer refresh")
+func (m *materializer) repairExpiredMembers(ctx context.Context, state state) {
+	m.logger.InfoContext(ctx, "Running expired membership repair")
 
-	// Keep track of the nearest member expiry time that's in the future to
-	// reschedule the pessimistic refresh.
+	expiredMembersOf, nextExpiry := m.collectExpiredMembers(ctx)
+	m.reportFutureMemberExpiry(ctx, nextExpiry)
+
+	for key := range m.affectedAssignmentsForExpiredMembers(expiredMembersOf) {
+		if err := m.recheckAssignment(ctx, state, key); err != nil {
+			// Must pessimistically assume any assignment is invalid if we
+			// encountered an error trying to validate it.
+			m.logger.InfoContext(ctx, "Encountered an error validating materialized assignment, will delete the assignment",
+				"error", err)
+			m.deleteMaterializedAssignment(ctx, state, key)
+			m.scheduleMissedMembersRepair(ctx)
+		}
+	}
+}
+
+// collectExpiredMembers collects all expired access list members by parent
+// list, and returns the earliest seen future expiry.
+func (m *materializer) collectExpiredMembers(ctx context.Context) (expiredMembersOf map[string]expiredMembers, nextExpiry time.Time) {
+	// Use a consistent time for "now" so that this will report all members
+	// expired before this time, and schedule another repair for any members
+	// expiring after this time.
 	now := time.Now()
-	nextExpiry := now.Add(forever)
 
+	// Keep track of the nearest seen member expiry time that's in the future.
+	nextExpiry = now.Add(century)
+
+	expiredMembersOf = make(map[string]expiredMembers)
+
+	// Iterate all access list members to find any that are expired.
 	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
 		if err != nil {
-			// Failed to iterate access list member resources, there's nothing
-			// we can really do but schedule another pessimistic refresh and
-			// return.
-			m.scheduleRefresh(ctx, pessimisticRefreshEvent, time.Now().Add(pessimisticRefreshBackoff))
-			return
+			// Failed to iterate all access list member resources, we may have
+			// missed an expired member or one that will be expiring soon.
+			m.logger.WarnContext(ctx, "Failed to iterate access list members, some stale scoped role assignments may remain despite expired access list membership",
+				"error", err)
+			nextRepairAt := time.Now().Add(expiredMembersRepairBackoff)
+			if nextRepairAt.Before(nextExpiry) {
+				nextExpiry = nextRepairAt
+			}
+			continue
 		}
 
 		if !member.IsExpired(now) {
-			// This member is not expired yet, record the expiry time to schedule
-			// the next pessimistic refresh.
-			if member.Spec.Expires.After(now) && member.Spec.Expires.Before(nextExpiry) {
+			if !member.Spec.Expires.IsZero() && member.Spec.Expires.Before(nextExpiry) {
 				nextExpiry = member.Spec.Expires
 			}
 			continue
 		}
 
-		// Process the membership as expired.
 		m.logger.DebugContext(ctx, "Found expired member resource",
 			"list", member.Spec.AccessList,
 			"member", member.GetName(),
 			"membership_kind", member.Spec.MembershipKind,
 			"expired", member.Spec.Expires)
-		if member.IsUser() {
-			m.handleUserMemberDeleteOrExpired(ctx, state, member.Spec.AccessList, member.GetName())
-		}
-		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			m.handleListMemberExpired(ctx, state, member.Spec.AccessList)
+
+		// Collect the expired membership.
+		knownExpiredMembers := expiredMembersOf[member.Spec.AccessList]
+		knownExpiredMembers.insert(member)
+		expiredMembersOf[member.Spec.AccessList] = knownExpiredMembers
+	}
+
+	return expiredMembersOf, nextExpiry
+}
+
+// affectedAssignmentsForExpiredMembers returns an iterator of all current
+// materialized assignments that may be affected by an expired membership.
+func (m *materializer) affectedAssignmentsForExpiredMembers(expiredMembersOf map[string]expiredMembers) iter.Seq[materializedAssignmentKey] {
+	assignmentFilters := make(map[string]assignmentFilter)
+	for parentListName, knownExpiredMembers := range expiredMembersOf {
+		currFilter := assignmentFilters[parentListName]
+		currFilter.merge(assignmentFilter{
+			// If this list has an expired list member, assignments for any
+			// user in this list may be affected.
+			anyUser: knownExpiredMembers.hasExpiredListMember,
+			// If this list has expired user members, assignments for those
+			// users in this list may be affected.
+			users: knownExpiredMembers.users,
+		})
+		assignmentFilters[parentListName] = currFilter
+
+		// Assignments for any ancestor list may be affected. Collect all
+		// ancestor lists without validation to avoid missing any due to
+		// read/paging errors.
+		ancestors := m.collectAncestorListsWithoutValidation(parentListName)
+		for ancestorListName := range ancestors {
+			currFilter := assignmentFilters[ancestorListName]
+			currFilter.merge(assignmentFilter{
+				// If the original list has an expired list member, assignments
+				// for any user in this ancestor list may be affected.
+				anyUser: knownExpiredMembers.hasExpiredListMember,
+				// If the original list has expired user members, assignments
+				// for those users in this ancestor list may be affected.
+				users: knownExpiredMembers.users,
+			})
+			assignmentFilters[ancestorListName] = currFilter
 		}
 	}
 
-	m.reportFutureMemberExpiry(ctx, nextExpiry)
+	return func(yield func(materializedAssignmentKey) bool) {
+		for key := range m.materializedAssignments {
+			if !assignmentFilters[key.list].match(key.user) {
+				continue
+			}
+			if !yield(key) {
+				return
+			}
+		}
+	}
 }
 
-func (m *materializer) optimisticRefresh(ctx context.Context, state state) {
-	m.logger.InfoContext(ctx, "Running optimistic materializer refresh")
+type expiredMembers struct {
+	hasExpiredListMember bool
+	users                set.Set[string]
+}
+
+func (m *expiredMembers) insert(member *accesslist.AccessListMember) {
+	m.hasExpiredListMember = m.hasExpiredListMember || member.Spec.MembershipKind == accesslist.MembershipKindList
+	if m.hasExpiredListMember {
+		// users set is unneeded if there is an expired list member.
+		m.users = nil
+		return
+	}
+	if member.IsUser() {
+		if m.users == nil {
+			m.users = set.NewWithCapacity[string](1)
+		}
+		m.users.Add(member.GetName())
+	}
+}
+
+type assignmentFilter struct {
+	anyUser bool
+	users   set.Set[string]
+}
+
+func (f assignmentFilter) match(user string) bool {
+	if f.anyUser {
+		return true
+	}
+	return f.users.Contains(user)
+}
+
+func (f *assignmentFilter) merge(other assignmentFilter) {
+	f.anyUser = f.anyUser || other.anyUser
+	if f.anyUser {
+		// users set is unneeded if matching any user.
+		f.users = nil
+		return
+	}
+	if other.users.Len() == 0 {
+		return
+	}
+	if f.users == nil {
+		f.users = set.NewWithCapacity[string](other.users.Len())
+	}
+	f.users.Union(other.users)
+}
+
+func (m *materializer) repairMissedMembers(ctx context.Context, state state) {
+	m.logger.InfoContext(ctx, "Running missed membership repair")
 	// Re-run init to re-process all access list memberships additively.
 	if err := m.Init(ctx, state); err != nil {
-		m.logger.InfoContext(ctx, "Optimistic refresh failed, will schedule another optimistic refresh",
+		m.logger.InfoContext(ctx, "Missed membership repair failed, will schedule another repair",
 			"error", err)
-		m.scheduleOptimisticRefresh(ctx)
+		m.scheduleMissedMembersRepair(ctx)
 	}
 }
 

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -840,6 +840,87 @@ func TestMaterializerDiamond(t *testing.T) {
 	})
 }
 
+func TestMaterializerCascadingMemberExpiries(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+
+		testStart := time.Now()
+
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.Collection{
+				AccessListsByName: map[string]*accesslist.AccessList{
+					"testlist": newAccessList(t, "testlist", withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Scope: "/test",
+						Role:  "testrole",
+					}})),
+				},
+				MembersByAccessList: map[string][]*accesslist.AccessListMember{
+					"testlist": {
+						newAccessListMember(t, "testlist", "alice", accesslist.MembershipKindUser, withExpires(testStart.Add(time.Minute))),
+						newAccessListMember(t, "testlist", "bob", accesslist.MembershipKindUser, withExpires(testStart.Add(2*time.Minute))),
+						newAccessListMember(t, "testlist", "charlie", accesslist.MembershipKindUser, withExpires(testStart.Add(3*time.Minute))),
+					},
+				},
+			},
+			// Initially all users are valid members of testlist.
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				expectedScopedRoleAssignment("alice", "testlist", []*scopedaccessv1.Assignment{{
+					Role:  "testrole",
+					Scope: "/test",
+				}}),
+				expectedScopedRoleAssignment("bob", "testlist", []*scopedaccessv1.Assignment{{
+					Role:  "testrole",
+					Scope: "/test",
+				}}),
+				expectedScopedRoleAssignment("charlie", "testlist", []*scopedaccessv1.Assignment{{
+					Role:  "testrole",
+					Scope: "/test",
+				}}),
+			},
+			steps: []materializerTestcaseStep{
+				{
+					// Sleep until alice's membership expires.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						synctest.Wait()
+						time.Sleep(time.Minute)
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("bob", "testlist", []*scopedaccessv1.Assignment{{
+							Role:  "testrole",
+							Scope: "/test",
+						}}),
+						expectedScopedRoleAssignment("charlie", "testlist", []*scopedaccessv1.Assignment{{
+							Role:  "testrole",
+							Scope: "/test",
+						}}),
+					},
+				},
+				{
+					// Sleep until bob's membership expires.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						synctest.Wait()
+						time.Sleep(time.Minute)
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("charlie", "testlist", []*scopedaccessv1.Assignment{{
+							Role:  "testrole",
+							Scope: "/test",
+						}}),
+					},
+				},
+				{
+					// Sleep until charlie's membership expires.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						synctest.Wait()
+						time.Sleep(time.Minute)
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{},
+				},
+			},
+		})
+	})
+}
+
 func TestMaterializerDiamondExpiry(t *testing.T) {
 	// The initial condition will look like this, we'll then break the
 	// membership path through left, then break the membership path through

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -840,6 +840,107 @@ func TestMaterializerDiamond(t *testing.T) {
 	})
 }
 
+func TestMaterializerDiamondExpiry(t *testing.T) {
+	// The initial condition will look like this, we'll then break the
+	// membership path through left, then break the membership path through
+	// right, then restore the membership path through left.
+	//
+	//       top
+	//       / \
+	//      /   \
+	//     /     \
+	//   left   right
+	//     \     /
+	//      \   /
+	//       \ /
+	//      bottom
+	//        |
+	//        v
+	//      tester
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+
+		testStart := time.Now()
+		leftExpires := testStart.Add(time.Minute)
+		rightExpires := testStart.Add(3 * time.Hour)
+
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.Collection{
+				AccessListsByName: map[string]*accesslist.AccessList{
+					"top": newAccessList(t, "top", withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Scope: "/aa",
+						Role:  "toprole",
+					}})),
+					"left":   newAccessList(t, "left"),
+					"right":  newAccessList(t, "right"),
+					"bottom": newAccessList(t, "bottom"),
+				},
+				MembersByAccessList: map[string][]*accesslist.AccessListMember{
+					"top": {
+						newAccessListMember(t, "top", "left", accesslist.MembershipKindList, withExpires(leftExpires)),
+						newAccessListMember(t, "top", "right", accesslist.MembershipKindList, withExpires(rightExpires)),
+					},
+					"left": {
+						newAccessListMember(t, "left", "bottom", accesslist.MembershipKindList),
+					},
+					"right": {
+						newAccessListMember(t, "right", "bottom", accesslist.MembershipKindList),
+					},
+					"bottom": {
+						newAccessListMember(t, "bottom", "tester", accesslist.MembershipKindUser),
+					},
+				},
+			},
+			// Initially the user is a valid member of the top list by 2 paths.
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+				expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{{
+					Role:  "toprole",
+					Scope: "/aa",
+				}}),
+			},
+			steps: []materializerTestcaseStep{
+				{
+					// Sleep until the left membership path expires, the
+					// assignment should stay via the right list.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						synctest.Wait()
+						time.Sleep(time.Minute)
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{{
+							Role:  "toprole",
+							Scope: "/aa",
+						}}),
+					},
+				},
+				{
+					// Sleep until the right membership path expires, the
+					// assignment should be deleted as there is no more path.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						synctest.Wait()
+						time.Sleep(3 * time.Hour)
+					},
+					expectedAssignments: nil,
+				},
+				{
+					// Upsert the left membership with a future expiry, the assignment should come back.
+					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+						member := newAccessListMember(t, "top", "left", accesslist.MembershipKindList, withExpires(time.Now().Add(time.Minute)))
+						_, err := aclService.UpsertAccessListMember(t.Context(), member)
+						require.NoError(t, err)
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", "top", []*scopedaccessv1.Assignment{{
+							Role:  "toprole",
+							Scope: "/aa",
+						}}),
+					},
+				},
+			},
+		})
+	})
+}
+
 func BenchmarkMaterializerInit(b *testing.B) {
 	for _, tc := range []struct {
 		listCount      int
@@ -1084,6 +1185,12 @@ func newAccessList(t require.TestingT, name string, opts ...aclOption) *accessli
 }
 
 type memberOption func(*accesslist.AccessListMember)
+
+func withExpires(expires time.Time) memberOption {
+	return func(member *accesslist.AccessListMember) {
+		member.Spec.Expires = expires
+	}
+}
 
 func newAccessListMember(t require.TestingT, parent, member, membershipKind string, opts ...memberOption) *accesslist.AccessListMember {
 	memberResource, err := accesslist.NewAccessListMember(header.Metadata{

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -17,8 +17,10 @@
 package access
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -59,8 +61,13 @@ type materializerTestcase struct {
 }
 
 type materializerTestcaseStep struct {
-	mutateState         func(t *testing.T, aclService *local.AccessListService)
+	mutateState         func(t *testing.T, state *materializerTestcaseState)
 	expectedAssignments []*scopedaccessv1.ScopedRoleAssignment
+}
+
+type materializerTestcaseState struct {
+	aclService         *local.AccessListService
+	breakableACLReader *breakableAccessListReader
 }
 
 func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
@@ -97,16 +104,25 @@ func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
 	defer aclCache.Close()
 	<-aclCache.FirstInit()
 
+	breakableACLReader := &breakableAccessListReader{
+		AccessListReader: aclCache,
+	}
+
 	// Create the scoped access cache.
 	cache, err := NewCache(CacheConfig{
 		Events:           events,
 		Reader:           scopedAccessService,
 		AccessListEvents: aclCache,
-		AccessListReader: aclCache,
+		AccessListReader: breakableACLReader,
 	})
 	require.NoError(t, err)
 	defer cache.Close()
 	<-cache.Init()
+
+	state := &materializerTestcaseState{
+		aclService:         aclService,
+		breakableACLReader: breakableACLReader,
+	}
 
 	assertMaterializedAssignments := func(t *testing.T, expectedAssignments []*scopedaccessv1.ScopedRoleAssignment) {
 		t.Helper()
@@ -138,11 +154,10 @@ func runMaterializerTestcase(t *testing.T, tc materializerTestcase) {
 	// Run through each step and assert the final assignments.
 	for i, step := range tc.steps {
 		t.Logf("Running step %d", i)
-		step.mutateState(t, aclService)
+		step.mutateState(t, state)
 		synctest.Wait()
 		assertMaterializedAssignments(t, step.expectedAssignments)
 	}
-
 }
 
 func TestMaterializerSimpleChain(t *testing.T) {
@@ -348,8 +363,8 @@ func TestMaterializerUserMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 				}}),
 			},
 			steps: []materializerTestcaseStep{{
-				mutateState: func(t *testing.T, aclService *local.AccessListService) {
-					_, err := aclService.UpsertAccessListMember(t.Context(),
+				mutateState: func(t *testing.T, state *materializerTestcaseState) {
+					_, err := state.aclService.UpsertAccessListMember(t.Context(),
 						newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser))
 					require.NoError(t, err)
 				},
@@ -409,8 +424,8 @@ func TestMaterializerListMemberPutPreservesExistingOwnerGrant(t *testing.T) {
 				}}),
 			},
 			steps: []materializerTestcaseStep{{
-				mutateState: func(t *testing.T, aclService *local.AccessListService) {
-					_, err := aclService.UpsertAccessListMember(t.Context(),
+				mutateState: func(t *testing.T, state *materializerTestcaseState) {
+					_, err := state.aclService.UpsertAccessListMember(t.Context(),
 						newAccessListMember(t, "parent", "child", accesslist.MembershipKindList))
 					require.NoError(t, err)
 				},
@@ -471,10 +486,10 @@ func TestMaterializerAccessListPutPreservesExistingOwnerGrant(t *testing.T) {
 				}}),
 			},
 			steps: []materializerTestcaseStep{{
-				mutateState: func(t *testing.T, aclService *local.AccessListService) {
+				mutateState: func(t *testing.T, state *materializerTestcaseState) {
 					// remove the membership requirements so that tester
 					// becomes a legitimate member of child and granted lists.
-					_, err := aclService.UpsertAccessList(t.Context(), newAccessList(t, "child"))
+					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "child"))
 					require.NoError(t, err)
 				},
 				expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
@@ -528,15 +543,15 @@ func TestMaterializerOwnerRequirements(t *testing.T) {
 				}}),
 			},
 			steps: []materializerTestcaseStep{{
-				mutateState: func(t *testing.T, aclService *local.AccessListService) {
+				mutateState: func(t *testing.T, state *materializerTestcaseState) {
 					// Add a nested list as a member of the owners list.
-					_, err := aclService.UpsertAccessList(t.Context(), newAccessList(t, "nested"))
+					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "nested"))
 					require.NoError(t, err)
-					_, err = aclService.UpsertAccessListMember(t.Context(),
+					_, err = state.aclService.UpsertAccessListMember(t.Context(),
 						newAccessListMember(t, "owners", "nested", accesslist.MembershipKindList))
 					require.NoError(t, err)
 					// Add a user as a member of the nested list.
-					_, err = aclService.UpsertAccessListMember(t.Context(),
+					_, err = state.aclService.UpsertAccessListMember(t.Context(),
 						newAccessListMember(t, "nested", "nested_tester", accesslist.MembershipKindUser))
 					require.NoError(t, err)
 				},
@@ -654,8 +669,8 @@ func TestMaterializerAccessListPutWithMembershipRequirements(t *testing.T) {
 				// Add membership requires to the middle list, the materialized
 				// assignment for the top list should be deleted as the
 				// membership path is broken.
-				mutateState: func(t *testing.T, aclService *local.AccessListService) {
-					_, err := aclService.UpsertAccessList(t.Context(), newAccessList(t, "middle", withMembershipRequires()))
+				mutateState: func(t *testing.T, state *materializerTestcaseState) {
+					_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "middle", withMembershipRequires()))
 					require.NoError(t, err)
 				},
 				expectedAssignments: nil,
@@ -697,12 +712,12 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 			steps: []materializerTestcaseStep{
 				{
 					// Update the member resource in place to change the membership kind from list to user.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
-						member, err := aclService.GetAccessListMember(t.Context(), "parent", "child")
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						member, err := state.aclService.GetAccessListMember(t.Context(), "parent", "child")
 						require.NoError(t, err)
 
 						member.Spec.MembershipKind = accesslist.MembershipKindUser
-						updatedMember, err := aclService.UpdateAccessListMember(t.Context(), member)
+						updatedMember, err := state.aclService.UpdateAccessListMember(t.Context(), member)
 						require.NoError(t, err)
 						require.Equal(t, accesslist.MembershipKindUser, updatedMember.Spec.MembershipKind)
 					},
@@ -721,12 +736,12 @@ func TestMaterializerAccessListMemberKindUpdateInvalidatesPriorKind(t *testing.T
 					// Update the member resource in place again to change it
 					// back to a list, and the original assignment should be
 					// restored.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
-						member, err := aclService.GetAccessListMember(t.Context(), "parent", "child")
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						member, err := state.aclService.GetAccessListMember(t.Context(), "parent", "child")
 						require.NoError(t, err)
 
 						member.Spec.MembershipKind = accesslist.MembershipKindList
-						updatedMember, err := aclService.UpdateAccessListMember(t.Context(), member)
+						updatedMember, err := state.aclService.UpdateAccessListMember(t.Context(), member)
 						require.NoError(t, err)
 						require.Equal(t, accesslist.MembershipKindList, updatedMember.Spec.MembershipKind)
 					},
@@ -799,9 +814,9 @@ func TestMaterializerDiamond(t *testing.T) {
 				{
 					// Add membership requires to the left list, the assignment
 					// should stay via the right list.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						// Upsert the access list to remove the membership requires.
-						_, err := aclService.UpsertAccessList(t.Context(), newAccessList(t, "left", withMembershipRequires()))
+						_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "left", withMembershipRequires()))
 						require.NoError(t, err)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
@@ -814,8 +829,8 @@ func TestMaterializerDiamond(t *testing.T) {
 				{
 					// Delete the membership path on the right, the assignment
 					// should be deleted as there is no more path.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
-						err := aclService.DeleteAccessListMember(t.Context(), "top", "right")
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						err := state.aclService.DeleteAccessListMember(t.Context(), "top", "right")
 						require.NoError(t, err)
 					},
 					expectedAssignments: nil,
@@ -823,9 +838,9 @@ func TestMaterializerDiamond(t *testing.T) {
 				{
 					// Remove membership requires from the left list, the assignment
 					// should come back.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						// Upsert the access list to remove the membership requires.
-						_, err := aclService.UpsertAccessList(t.Context(), newAccessList(t, "left"))
+						_, err := state.aclService.UpsertAccessList(t.Context(), newAccessList(t, "left"))
 						require.NoError(t, err)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
@@ -880,7 +895,7 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 			steps: []materializerTestcaseStep{
 				{
 					// Sleep until alice's membership expires.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						synctest.Wait()
 						time.Sleep(time.Minute)
 					},
@@ -897,7 +912,7 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 				},
 				{
 					// Sleep until bob's membership expires.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						synctest.Wait()
 						time.Sleep(time.Minute)
 					},
@@ -910,11 +925,97 @@ func TestMaterializerCascadingMemberExpiries(t *testing.T) {
 				},
 				{
 					// Sleep until charlie's membership expires.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						synctest.Wait()
 						time.Sleep(time.Minute)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{},
+				},
+			},
+		})
+	})
+}
+
+func TestMaterializerRepairFailedReads(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runMaterializerTestcase(t, materializerTestcase{
+			collection: accesslists.Collection{
+				AccessListsByName: map[string]*accesslist.AccessList{
+					"parent": newAccessList(t, "parent", withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Scope: "/test/parent",
+						Role:  "testrole",
+					}})),
+					"child": newAccessList(t, "child", withMemberGrants([]accesslist.ScopedRoleGrant{{
+						Scope: "/test/child",
+						Role:  "testrole",
+					}})),
+				},
+				MembersByAccessList: map[string][]*accesslist.AccessListMember{
+					"parent": {},
+					"child":  {},
+				},
+			},
+			// Initially there are no members and therefore no assignments.
+			expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{},
+			steps: []materializerTestcaseStep{
+				{
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						// Add tester as a user member of the child list, but
+						// with the access list reader broken, the assignment
+						// cannot be validated and should not be materialized.
+						state.breakableACLReader.Break()
+						state.aclService.UpsertAccessListMember(t.Context(), newAccessListMember(t, "child", "tester", accesslist.MembershipKindUser))
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{},
+				},
+				{
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						// Fix the access list reader and the assignment should be materialized.
+						synctest.Wait()
+						state.breakableACLReader.Fix()
+						time.Sleep(missedMembersRepairBackoff)
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", "child", []*scopedaccessv1.Assignment{{
+							Role:  "testrole",
+							Scope: "/test/child",
+						}}),
+					},
+				},
+				{
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						// Break the access list reader again and add the child
+						// list as a member of parent list.
+						state.breakableACLReader.Break()
+						state.aclService.UpsertAccessListMember(t.Context(), newAccessListMember(t, "parent", "child", accesslist.MembershipKindList))
+					},
+					// The access list service will update the child list with
+					// a Status.MemberOf reference. While handling the access
+					// list put event, the materializer will revalidate all
+					// materialized assignments for members of the child list.
+					// Because the reader is broken, it fails to validate the
+					// existing assignment and deletes it.
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{},
+				},
+				{
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
+						// Fix the access list reader again and both
+						// assignments should be materialized.
+						synctest.Wait()
+						state.breakableACLReader.Fix()
+						time.Sleep(missedMembersRepairBackoff)
+					},
+					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
+						expectedScopedRoleAssignment("tester", "child", []*scopedaccessv1.Assignment{{
+							Role:  "testrole",
+							Scope: "/test/child",
+						}}),
+						expectedScopedRoleAssignment("tester", "parent", []*scopedaccessv1.Assignment{{
+							Role:  "testrole",
+							Scope: "/test/parent",
+						}}),
+					},
 				},
 			},
 		})
@@ -983,7 +1084,7 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 				{
 					// Sleep until the left membership path expires, the
 					// assignment should stay via the right list.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						synctest.Wait()
 						time.Sleep(time.Minute)
 					},
@@ -997,7 +1098,7 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 				{
 					// Sleep until the right membership path expires, the
 					// assignment should be deleted as there is no more path.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						synctest.Wait()
 						time.Sleep(3 * time.Hour)
 					},
@@ -1005,9 +1106,9 @@ func TestMaterializerDiamondExpiry(t *testing.T) {
 				},
 				{
 					// Upsert the left membership with a future expiry, the assignment should come back.
-					mutateState: func(t *testing.T, aclService *local.AccessListService) {
+					mutateState: func(t *testing.T, state *materializerTestcaseState) {
 						member := newAccessListMember(t, "top", "left", accesslist.MembershipKindList, withExpires(time.Now().Add(time.Minute)))
-						_, err := aclService.UpsertAccessListMember(t.Context(), member)
+						_, err := state.aclService.UpsertAccessListMember(t.Context(), member)
 						require.NoError(t, err)
 					},
 					expectedAssignments: []*scopedaccessv1.ScopedRoleAssignment{
@@ -1308,4 +1409,57 @@ func expectedScopedRoleAssignment(userName, listName string, assignments []*scop
 			Assignments: assignments,
 		},
 	}
+}
+
+type breakableAccessListReader struct {
+	AccessListReader
+
+	broken atomic.Bool
+}
+
+func (b *breakableAccessListReader) Break() {
+	b.broken.Store(true)
+}
+
+func (b *breakableAccessListReader) Fix() {
+	b.broken.Store(false)
+}
+
+func (b *breakableAccessListReader) err() error {
+	return fmt.Errorf("access list reader is broken")
+}
+
+func (b *breakableAccessListReader) ListAccessLists(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
+	if b.broken.Load() {
+		return nil, "", b.err()
+	}
+	return b.AccessListReader.ListAccessLists(ctx, pageSize, pageToken)
+}
+
+func (b *breakableAccessListReader) GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
+	if b.broken.Load() {
+		return nil, b.err()
+	}
+	return b.AccessListReader.GetAccessList(ctx, accessListName)
+}
+
+func (b *breakableAccessListReader) ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+	if b.broken.Load() {
+		return nil, "", b.err()
+	}
+	return b.AccessListReader.ListAllAccessListMembers(ctx, pageSize, pageToken)
+}
+
+func (b *breakableAccessListReader) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+	if b.broken.Load() {
+		return nil, "", b.err()
+	}
+	return b.AccessListReader.ListAccessListMembers(ctx, accessListName, pageSize, pageToken)
+}
+
+func (b *breakableAccessListReader) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
+	if b.broken.Load() {
+		return nil, b.err()
+	}
+	return b.AccessListReader.GetAccessListMember(ctx, accessList, memberName)
 }


### PR DESCRIPTION
This PR builds on https://github.com/gravitational/teleport/pull/65150 to automatically update materialized assignments as soon as an access list member resource expires, and attempt to optimistically recover from failed access list cache reads.

## Manual Test Plan

### Test Environment

- Local cluster running this branch with `TELEPORT_UNSTABLE_SCOPES=yes`

#### Setup scoped roles

```bash
cat >./test-scoped-roles.yaml <<EOF
kind: scoped_role
version: v1
metadata:
  name: test-role
scope: /
spec:
  assignable_scopes:
    - /test/**
  ssh:
    logins: ["tester"]
    labels:
      - name: "*"
        values: ["*"]
EOF

tctl create ./test-scoped-roles.yaml
```

#### Setup access list

```bash
cat >./test-access-list.yaml <<EOF
kind: access_list
version: v1
metadata:
  name: test-list
spec:
  title: test-list
  owners:
    - name: owner@example.com
      membership_kind: MEMBERSHIP_KIND_USER
  grants:
    scoped_roles:
      - role: test-role
        scope: /test/test
EOF

tctl create ./test-access-list.yaml
```

### Test Cases

- [x] Add a member to the access list that expires in 1 minute

```bash
$ tctl acl users add test-list tester `date -u -v+1M +"%Y-%m-%dT%H:%M:%SZ"`
```

- [x] A scoped role assignment should be materialized

```bash
$ tctl get scoped_role_assignments
kind: scoped_role_assignment
metadata:
  name: acl-j8H2xfsVfJbcegvThS7EGr6L2E9HMapKuMZY7g
scope: /
spec:
  assignments:
  - role: test-role
    scope: /test/test
  user: tester
sub_kind: materialized
version: v1
```

- [x] Wait 1 minute
- [x] The materialized scoped role assignment should be deleted

```bash
$ tctl get scoped_role_assignments
[]
```

- [x] Recreate the member with a fresh expiry

```bash
$ tctl acl users add test-list tester `date -u -v+1M +"%Y-%m-%dT%H:%M:%SZ"`
```

- [x] The scoped role assignment should be rematerialized

```bash
$ tctl get scoped_role_assignments
kind: scoped_role_assignment
metadata:
  name: acl-j8H2xfsVfJbcegvThS7EGr6L2E9HMapKuMZY7g
scope: /
spec:
  assignments:
  - role: test-role
    scope: /test/test
  user: tester
sub_kind: materialized
version: v1
```