### PR TITLE
Improve communication around `tctl auth sign --format cockroachdb ...`

### DIFF
--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/cockroachdb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/cockroachdb-self-hosted.mdx
@@ -139,7 +139,9 @@ In this configuration, Teleport's CA will be used to issue the server cert,
 
 (!docs/pages/includes/database-access/tctl-auth-sign.mdx!)
 
-Generate secrets for a CockroachDB node using `tctl`:
+Next, generate secrets for a CockroachDB node using `tctl`. If the output directory
+(i.e. the value of `--out`) does not already exist, it will be created. Secrets
+will be written to this directory:
 
 ```code
 $ tctl auth sign \

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -310,6 +310,11 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 		}
 
 	case FormatCockroach:
+		// Ensure that the directory we're writing files into exists
+		if err := os.MkdirAll(cfg.OutputPath, 0o700); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
 		// CockroachDB expects files to be named node.crt, node.key, ca.crt,
 		// ca-client.crt
 		certPath := filepath.Join(cfg.OutputPath, "node.crt")


### PR DESCRIPTION
While going through manual tests for cockroachdb, I wrote some scripts to set it up. I got confused by the enrollment docs - details are in [this PR comment](https://github.com/gravitational/teleport/pull/64778#issuecomment-4085911007) (and the following ones). This PR makes the changes we realized we need, specifically:
- Improve the error message when the output directory does not exist, is not accessible etc.
- Communicate that the secrets go into a directory for cockroachdb, rather than directly to files, as is the case with most (all?) other databases.

Changelog: Improve error messages in `tctl auth sign --format cockroachdb`.

## Manual Test Plan
### Test Environment

Manual build i.e. `make build/tctl` in the branch. Ran against cluster running `v19.0.0-prealpha.2`.

### Test Cases

For each of the following test cases, the following command was used:
```
build/tctl auth sign --format=cockroachdb --host=localhost --out=test-dir --ttl=2160h
```
- [x] When `test-dir/` does not exist, it is created with `700` permissions (giving only the owner access). Secrets are written into it.
- [x] When `test-dir/` does exist, its permissions are not modified. Secrets are written into it.
- [x] When `test-dir` is a file, and not a directory, an error saying so is printed.
- [x] When `test-dir/` is not readable/writable/executable by the current user, an error mentioning permissions is printed.