### PR TITLE
Fix OktaAssignment and AccessRequest watcher write race

### DIFF
--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1856,7 +1856,7 @@ func (c *oktaAssignmentCollector) getResourcesAndUpdateCurrent(ctx context.Conte
 
 	newCurrent := make(map[string]types.OktaAssignment, len(oktaAssignments))
 	for _, oktaAssignment := range oktaAssignments {
-		newCurrent[oktaAssignment.GetName()] = oktaAssignment
+		newCurrent[oktaAssignment.GetName()] = oktaAssignment.Copy()
 	}
 	c.mu.Lock()
 	c.current = newCurrent

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1253,7 +1253,7 @@ func (p *lockCollector) processEventsAndUpdateCurrent(ctx context.Context, event
 				continue
 			}
 			if lock.IsInForce(p.Clock.Now()) {
-				p.current[lock.GetName()] = lock
+				p.current[lock.GetName()] = lock.Clone()
 				eventsToEmit = append(eventsToEmit, event)
 			} else {
 				delete(p.current, lock.GetName())
@@ -1548,7 +1548,7 @@ func (c *caCollector) processEventsAndUpdateCurrent(ctx context.Context, events 
 				continue
 			}
 
-			c.cas[ca.GetType()][ca.GetName()] = ca
+			c.cas[ca.GetType()][ca.GetName()] = ca.Clone()
 			eventsToEmit = append(eventsToEmit, event)
 		default:
 			c.Logger.WarnContext(ctx, "Received unsupported event type", "event_type", event.Type)

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1219,7 +1219,7 @@ func (p *lockCollector) getResourcesAndUpdateCurrent(ctx context.Context) error 
 	p.isStale = false
 	p.defineCollectorAsInitialized()
 	for _, lock := range p.current {
-		p.fanout.Emit(types.Event{Type: types.OpPut, Resource: lock.Clone()})
+		p.fanout.Emit(types.Event{Type: types.OpPut, Resource: lock})
 	}
 	return nil
 }
@@ -1253,7 +1253,7 @@ func (p *lockCollector) processEventsAndUpdateCurrent(ctx context.Context, event
 				continue
 			}
 			if lock.IsInForce(p.Clock.Now()) {
-				p.current[lock.GetName()] = lock.Clone()
+				p.current[lock.GetName()] = lock
 				eventsToEmit = append(eventsToEmit, event)
 			} else {
 				delete(p.current, lock.GetName())
@@ -1548,7 +1548,7 @@ func (c *caCollector) processEventsAndUpdateCurrent(ctx context.Context, events 
 				continue
 			}
 
-			c.cas[ca.GetType()][ca.GetName()] = ca.Clone()
+			c.cas[ca.GetType()][ca.GetName()] = ca
 			eventsToEmit = append(eventsToEmit, event)
 		default:
 			c.Logger.WarnContext(ctx, "Received unsupported event type", "event_type", event.Type)

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1219,7 +1219,7 @@ func (p *lockCollector) getResourcesAndUpdateCurrent(ctx context.Context) error 
 	p.isStale = false
 	p.defineCollectorAsInitialized()
 	for _, lock := range p.current {
-		p.fanout.Emit(types.Event{Type: types.OpPut, Resource: lock})
+		p.fanout.Emit(types.Event{Type: types.OpPut, Resource: lock.Clone()})
 	}
 	return nil
 }
@@ -1680,7 +1680,7 @@ func (p *accessRequestCollector) getResourcesAndUpdateCurrent(ctx context.Contex
 	}
 	newCurrent := make(map[string]types.AccessRequest, len(accessRequests))
 	for _, accessRequest := range accessRequests {
-		newCurrent[accessRequest.GetName()] = accessRequest
+		newCurrent[accessRequest.GetName()] = accessRequest.Copy()
 	}
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -1448,8 +1448,8 @@ func TestAccessRequestWatcherRace(t *testing.T) {
 	dynamicAccessService := local.NewDynamicAccessService(bk)
 
 	for range 10 {
-		accessRequest1 := newAccessRequest(t, uuid.NewString())
-		accessRequest1, err = dynamicAccessService.CreateAccessRequestV2(ctx, accessRequest1)
+		accessRequest := newAccessRequest(t, uuid.NewString())
+		_, err = dynamicAccessService.CreateAccessRequestV2(ctx, accessRequest)
 		require.NoError(t, err)
 	}
 

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -1431,6 +1431,58 @@ func TestAccessRequestWatcher(t *testing.T) {
 	}
 }
 
+// TestAccessRequestWatcherRace ensures there are no races when editing AccessRequest resources
+// collected from the watcher.
+func TestAccessRequestWatcherRace(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	dynamicAccessService := local.NewDynamicAccessService(bk)
+
+	for range 10 {
+		accessRequest1 := newAccessRequest(t, uuid.NewString())
+		accessRequest1, err = dynamicAccessService.CreateAccessRequestV2(ctx, accessRequest1)
+		require.NoError(t, err)
+	}
+
+	type client struct {
+		services.DynamicAccessCore
+		types.Events
+	}
+
+	w, err := services.NewAccessRequestWatcher(ctx, services.AccessRequestWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: "test",
+			Client: &client{
+				DynamicAccessCore: dynamicAccessService,
+				Events:            local.NewEventsService(bk),
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+
+	select {
+	case changeset := <-w.AccessRequestsC:
+		for _, ar := range changeset {
+			ar.SetMaxDuration(ar.GetMaxDuration().Add(1))
+			_ = dynamicAccessService.UpsertAccessRequest(ctx, ar)
+		}
+	case <-w.Done():
+		t.Fatal("Watcher has unexpectedly exited.")
+	case <-time.After(30 * time.Second):
+		t.Fatal("Timeout processing the event.")
+	}
+}
+
 func newAccessRequest(t *testing.T, name string) types.AccessRequest {
 	accessRequest, err := types.NewAccessRequest(name, "test-user", "role1")
 	accessRequest.SetState(types.RequestState_PENDING)
@@ -1594,11 +1646,6 @@ func TestOktaAssignmentWatcherRace(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	type client struct {
-		services.OktaAssignments
-		types.Events
-	}
-
 	oktaService, err := local.NewOktaService(bk, clock)
 	require.NoError(t, err)
 
@@ -1606,6 +1653,11 @@ func TestOktaAssignmentWatcherRace(t *testing.T) {
 		a1 := newOktaAssignment(t, uuid.NewString())
 		_, err = oktaService.CreateOktaAssignment(ctx, a1)
 		require.NoError(t, err)
+	}
+
+	type client struct {
+		services.OktaAssignments
+		types.Events
 	}
 
 	w, err := services.NewOktaAssignmentWatcher(ctx, services.OktaAssignmentWatcherConfig{

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -563,7 +563,7 @@ func resourceDiff(res1, res2 types.Resource) string {
 func TestDatabaseWatcher(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	clock := clockwork.NewFakeClock()
 
 	bk, err := memory.New(memory.Config{
@@ -1577,6 +1577,59 @@ func TestOktaAssignmentWatcher(t *testing.T) {
 		t.Fatal("Watcher has unexpectedly exited.")
 	case <-time.After(2 * time.Second):
 		t.Fatal("Timeout waiting for the delete event.")
+	}
+}
+
+// TestOktaAssignmentWatcherRace ensures there are no races when editing OktaAssignment resources
+// collected from the watcher.
+func TestOktaAssignmentWatcherRace(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	type client struct {
+		services.OktaAssignments
+		types.Events
+	}
+
+	oktaService, err := local.NewOktaService(bk, clock)
+	require.NoError(t, err)
+
+	for range 10 {
+		a1 := newOktaAssignment(t, uuid.NewString())
+		_, err = oktaService.CreateOktaAssignment(ctx, a1)
+		require.NoError(t, err)
+	}
+
+	w, err := services.NewOktaAssignmentWatcher(ctx, services.OktaAssignmentWatcherConfig{
+		RWCfg: services.ResourceWatcherConfig{
+			Component: "test",
+			Client: &client{
+				OktaAssignments: oktaService,
+				Events:          local.NewEventsService(bk),
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+
+	select {
+	case changeset := <-w.CollectorChan():
+		for _, a := range changeset {
+			a.SetLastTransition(a.GetLastTransition().Add(1))
+			_, _ = oktaService.UpdateOktaAssignment(ctx, a)
+		}
+	case <-w.Done():
+		t.Fatal("Watcher has unexpectedly exited.")
+	case <-time.After(30 * time.Second):
+		t.Fatal("Timeout processing the event.")
 	}
 }
 


### PR DESCRIPTION
Got uncovered with this CI run https://github.com/gravitational/teleport.e/actions/runs/23816113680/job/69415978056?pr=8281 when `generic.Reconciler` (copying all assignments before dispatching) was removed from Okta assignments processor flow.

### Backports

- https://github.com/gravitational/teleport/pull/65259
- https://github.com/gravitational/teleport/pull/65260