### PR TITLE
Update Redis docs url in tctl auth command

### DIFF
--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -826,7 +826,7 @@ tls-key-file /path/to/{{.output}}.key
 tls-protocols "TLSv1.2 TLSv1.3"
 
 For information on enabling Redis Cluster bus communication TLS, see:
-https://goteleport.com/docs/database-access/guides/redis-cluster
+https://goteleport.com/docs/enroll-resources/database-access/enrollment/self-hosted/redis-cluster/
 `))
 
 	snowflakeAuthSignTpl = template.Must(template.New("").Parse(`Database credentials have been written to {{.files}}.


### PR DESCRIPTION
Corrects docs url to current one for `tctl auth` command for Redis. Currently showing 404.

## Manual Test Plan
### Test Environment

  Dev Environment

### Test Cases
- [x] Confirm working docs url is shown in `tctl -c /tmp/t.yaml  auth sign --format=redis --host=test --out=redis`
