### PR TITLE
[scopes] add scoped role assignment status

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/assignment.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/assignment.pb.go
@@ -53,7 +53,9 @@ type ScopedRoleAssignment struct {
 	// Scope is the scope of the role assignment resource.
 	Scope string `protobuf:"bytes,5,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Spec is the role assignment specification.
-	Spec          *ScopedRoleAssignmentSpec `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	Spec *ScopedRoleAssignmentSpec `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	// Status is the status of the role assignment.
+	Status        *ScopedRoleAssignmentStatus `protobuf:"bytes,7,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -130,7 +132,14 @@ func (x *ScopedRoleAssignment) GetSpec() *ScopedRoleAssignmentSpec {
 	return nil
 }
 
-// ScopedRoleAssignmentSpec is the specification of a scoped role.
+func (x *ScopedRoleAssignment) GetStatus() *ScopedRoleAssignmentStatus {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+// ScopedRoleAssignmentSpec is the specification of a scoped role assignment.
 type ScopedRoleAssignmentSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// User is the user to whom all contained assignments apply.
@@ -263,18 +272,120 @@ func (x *Assignment) GetScope() string {
 	return ""
 }
 
+// ScopedRoleAssignmentStatus is the status of a scoped role assignment.
+type ScopedRoleAssignmentStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Origin describes the origin of the scoped role assignment.
+	Origin        *ScopedRoleAssignmentStatus_Origin `protobuf:"bytes,1,opt,name=origin,proto3" json:"origin,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScopedRoleAssignmentStatus) Reset() {
+	*x = ScopedRoleAssignmentStatus{}
+	mi := &file_teleport_scopes_access_v1_assignment_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRoleAssignmentStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRoleAssignmentStatus) ProtoMessage() {}
+
+func (x *ScopedRoleAssignmentStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_assignment_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedRoleAssignmentStatus.ProtoReflect.Descriptor instead.
+func (*ScopedRoleAssignmentStatus) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_assignment_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ScopedRoleAssignmentStatus) GetOrigin() *ScopedRoleAssignmentStatus_Origin {
+	if x != nil {
+		return x.Origin
+	}
+	return nil
+}
+
+// Origin describes the origin of a scoped role assignment.
+type ScopedRoleAssignmentStatus_Origin struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// CreatorKind is the kind of the scoped role assignment creator.
+	CreatorKind string `protobuf:"bytes,1,opt,name=creator_kind,json=creatorKind,proto3" json:"creator_kind,omitempty"`
+	// CreatorName is the name of the scoped role assignment creator.
+	CreatorName   string `protobuf:"bytes,2,opt,name=creator_name,json=creatorName,proto3" json:"creator_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScopedRoleAssignmentStatus_Origin) Reset() {
+	*x = ScopedRoleAssignmentStatus_Origin{}
+	mi := &file_teleport_scopes_access_v1_assignment_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRoleAssignmentStatus_Origin) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRoleAssignmentStatus_Origin) ProtoMessage() {}
+
+func (x *ScopedRoleAssignmentStatus_Origin) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_assignment_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedRoleAssignmentStatus_Origin.ProtoReflect.Descriptor instead.
+func (*ScopedRoleAssignmentStatus_Origin) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_assignment_proto_rawDescGZIP(), []int{3, 0}
+}
+
+func (x *ScopedRoleAssignmentStatus_Origin) GetCreatorKind() string {
+	if x != nil {
+		return x.CreatorKind
+	}
+	return ""
+}
+
+func (x *ScopedRoleAssignmentStatus_Origin) GetCreatorName() string {
+	if x != nil {
+		return x.CreatorName
+	}
+	return ""
+}
+
 var File_teleport_scopes_access_v1_assignment_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_assignment_proto_rawDesc = "" +
 	"\n" +
-	"*teleport/scopes/access/v1/assignment.proto\x12\x19teleport.scopes.access.v1\x1a!teleport/header/v1/metadata.proto\"\xf8\x01\n" +
+	"*teleport/scopes/access/v1/assignment.proto\x12\x19teleport.scopes.access.v1\x1a!teleport/header/v1/metadata.proto\"\xc7\x02\n" +
 	"\x14ScopedRoleAssignment\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12G\n" +
-	"\x04spec\x18\x06 \x01(\v23.teleport.scopes.access.v1.ScopedRoleAssignmentSpecR\x04spec\"\xaf\x01\n" +
+	"\x04spec\x18\x06 \x01(\v23.teleport.scopes.access.v1.ScopedRoleAssignmentSpecR\x04spec\x12M\n" +
+	"\x06status\x18\a \x01(\v25.teleport.scopes.access.v1.ScopedRoleAssignmentStatusR\x06status\"\xaf\x01\n" +
 	"\x18ScopedRoleAssignmentSpec\x12\x12\n" +
 	"\x04user\x18\x01 \x01(\tR\x04user\x12G\n" +
 	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x19\n" +
@@ -283,7 +394,12 @@ const file_teleport_scopes_access_v1_assignment_proto_rawDesc = "" +
 	"\n" +
 	"Assignment\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +
-	"\x05scope\x18\x02 \x01(\tR\x05scopeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\xc2\x01\n" +
+	"\x1aScopedRoleAssignmentStatus\x12T\n" +
+	"\x06origin\x18\x01 \x01(\v2<.teleport.scopes.access.v1.ScopedRoleAssignmentStatus.OriginR\x06origin\x1aN\n" +
+	"\x06Origin\x12!\n" +
+	"\fcreator_kind\x18\x01 \x01(\tR\vcreatorKind\x12!\n" +
+	"\fcreator_name\x18\x02 \x01(\tR\vcreatorNameBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
 var (
 	file_teleport_scopes_access_v1_assignment_proto_rawDescOnce sync.Once
@@ -297,22 +413,26 @@ func file_teleport_scopes_access_v1_assignment_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_assignment_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_assignment_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_teleport_scopes_access_v1_assignment_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_teleport_scopes_access_v1_assignment_proto_goTypes = []any{
-	(*ScopedRoleAssignment)(nil),     // 0: teleport.scopes.access.v1.ScopedRoleAssignment
-	(*ScopedRoleAssignmentSpec)(nil), // 1: teleport.scopes.access.v1.ScopedRoleAssignmentSpec
-	(*Assignment)(nil),               // 2: teleport.scopes.access.v1.Assignment
-	(*v1.Metadata)(nil),              // 3: teleport.header.v1.Metadata
+	(*ScopedRoleAssignment)(nil),              // 0: teleport.scopes.access.v1.ScopedRoleAssignment
+	(*ScopedRoleAssignmentSpec)(nil),          // 1: teleport.scopes.access.v1.ScopedRoleAssignmentSpec
+	(*Assignment)(nil),                        // 2: teleport.scopes.access.v1.Assignment
+	(*ScopedRoleAssignmentStatus)(nil),        // 3: teleport.scopes.access.v1.ScopedRoleAssignmentStatus
+	(*ScopedRoleAssignmentStatus_Origin)(nil), // 4: teleport.scopes.access.v1.ScopedRoleAssignmentStatus.Origin
+	(*v1.Metadata)(nil),                       // 5: teleport.header.v1.Metadata
 }
 var file_teleport_scopes_access_v1_assignment_proto_depIdxs = []int32{
-	3, // 0: teleport.scopes.access.v1.ScopedRoleAssignment.metadata:type_name -> teleport.header.v1.Metadata
+	5, // 0: teleport.scopes.access.v1.ScopedRoleAssignment.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.scopes.access.v1.ScopedRoleAssignment.spec:type_name -> teleport.scopes.access.v1.ScopedRoleAssignmentSpec
-	2, // 2: teleport.scopes.access.v1.ScopedRoleAssignmentSpec.assignments:type_name -> teleport.scopes.access.v1.Assignment
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	3, // 2: teleport.scopes.access.v1.ScopedRoleAssignment.status:type_name -> teleport.scopes.access.v1.ScopedRoleAssignmentStatus
+	2, // 3: teleport.scopes.access.v1.ScopedRoleAssignmentSpec.assignments:type_name -> teleport.scopes.access.v1.Assignment
+	4, // 4: teleport.scopes.access.v1.ScopedRoleAssignmentStatus.origin:type_name -> teleport.scopes.access.v1.ScopedRoleAssignmentStatus.Origin
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_assignment_proto_init() }
@@ -326,7 +446,7 @@ func file_teleport_scopes_access_v1_assignment_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_assignment_proto_rawDesc), len(file_teleport_scopes_access_v1_assignment_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/access/v1/assignment.proto
+++ b/api/proto/teleport/scopes/access/v1/assignment.proto
@@ -42,9 +42,12 @@ message ScopedRoleAssignment {
 
   // Spec is the role assignment specification.
   ScopedRoleAssignmentSpec spec = 6;
+
+  // Status is the status of the role assignment.
+  ScopedRoleAssignmentStatus status = 7;
 }
 
-// ScopedRoleAssignmentSpec is the specification of a scoped role.
+// ScopedRoleAssignmentSpec is the specification of a scoped role assignment.
 message ScopedRoleAssignmentSpec {
   // User is the user to whom all contained assignments apply.
   // Mutually exclusive with `bot_name`.
@@ -71,4 +74,19 @@ message Assignment {
   // Scope is the scope to which the role is assigned. This must be a member/child
   // of the scope of the [ScopedRoleAssignment] in which this assignment is contained.
   string scope = 2;
+}
+
+// ScopedRoleAssignmentStatus is the status of a scoped role assignment.
+message ScopedRoleAssignmentStatus {
+  // Origin describes the origin of a scoped role assignment.
+  message Origin {
+    // CreatorKind is the kind of the scoped role assignment creator.
+    string creator_kind = 1;
+
+    // CreatorName is the name of the scoped role assignment creator.
+    string creator_name = 2;
+  }
+
+  // Origin describes the origin of the scoped role assignment.
+  Origin origin = 1;
 }

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -143,6 +143,10 @@ func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedacce
 	if req.GetAssignment().GetMetadata().GetName() == "" {
 		req.GetAssignment().GetMetadata().Name = uuid.New().String()
 	}
+	// Currently, don't allow assignments created via the API to have a status,
+	// as they could impersonate an access-list-materialized assignment.
+	// TODO(nklaassen): set assignment status based on authenticated identity.
+	req.GetAssignment().Status = nil
 
 	if err := scopedaccess.StrongValidateAssignment(req.GetAssignment()); err != nil {
 		return nil, trace.Wrap(err)
@@ -492,6 +496,11 @@ func (s *Server) UpdateScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return nil, trace.Wrap(err)
 	}
 
+	// Currently, don't allow assignments created via the API to have a status,
+	// as they could impersonate an access-list-materialized assignment.
+	// TODO(nklaassen): set assignment status based on authenticated identity.
+	req.GetAssignment().Status = nil
+
 	return s.cfg.Writer.UpdateScopedRoleAssignment(ctx, req)
 }
 
@@ -541,6 +550,11 @@ func (s *Server) UpsertScopedRoleAssignment(ctx context.Context, req *scopedacce
 			"scope", req.GetAssignment().GetScope())
 		return nil, trace.Wrap(err)
 	}
+
+	// Currently, don't allow assignments created via the API to have a status,
+	// as they could impersonate an access-list-materialized assignment.
+	// TODO(nklaassen): set assignment status based on authenticated identity.
+	req.GetAssignment().Status = nil
 
 	return s.cfg.Writer.UpsertScopedRoleAssignment(ctx, req)
 }

--- a/lib/auth/scopes/access/service_test.go
+++ b/lib/auth/scopes/access/service_test.go
@@ -478,6 +478,14 @@ func TestAssignmentBasics(t *testing.T) {
 	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 
 	ctx := t.Context()
+	newForgedStatus := func() *scopedaccessv1.ScopedRoleAssignmentStatus {
+		return &scopedaccessv1.ScopedRoleAssignmentStatus{
+			Origin: &scopedaccessv1.ScopedRoleAssignmentStatus_Origin{
+				CreatorKind: scopedaccess.CreatorKindAccessList,
+				CreatorName: "forged-access-list",
+			},
+		}
+	}
 
 	bk := newBackendPack(t)
 	defer bk.Close()
@@ -588,11 +596,13 @@ func TestAssignmentBasics(t *testing.T) {
 
 	// verify expected successful create
 	a1 := newScopedRoleAssignmentAtScope("staging-admin", "/staging")
+	a1.Status = newForgedStatus()
 	carsp, err := srv.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: a1,
 	})
 	require.NoError(t, err)
 	require.Equal(t, a1.GetMetadata().GetName(), carsp.GetAssignment().GetMetadata().GetName())
+	require.Nil(t, carsp.GetAssignment().GetStatus())
 
 	// wait for assignments to be populated into cache
 	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
@@ -673,12 +683,14 @@ func TestAssignmentBasics(t *testing.T) {
 
 	// add a label and update
 	ca3rsp.Assignment.Metadata.Labels = map[string]string{"key": "val"}
+	ca3rsp.Assignment.Status = newForgedStatus()
 	ua3rsp, err := srv.UpdateScopedRoleAssignment(ctx, &scopedaccessv1.UpdateScopedRoleAssignmentRequest{
 		Assignment: ca3rsp.GetAssignment(),
 	})
 	require.NoError(t, err)
 	require.Equal(t, a3.GetMetadata().GetName(), ua3rsp.GetAssignment().GetMetadata().GetName())
 	require.NotEqual(t, ca3rsp.GetAssignment().GetMetadata().GetRevision(), ua3rsp.GetAssignment().GetMetadata().GetRevision())
+	require.Nil(t, ua3rsp.GetAssignment().GetStatus())
 
 	// observe change in cache
 	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
@@ -718,14 +730,17 @@ func TestAssignmentBasics(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Nil(t, garsp.GetAssignment().GetMetadata().GetLabels())
+	require.Nil(t, garsp.GetAssignment().GetStatus())
 
 	// verify expected successful upsert (creates new assignment)
 	a4 := newScopedRoleAssignmentAtScope("staging-admin", "/staging")
+	a4.Status = newForgedStatus()
 	ua4rsp, err := srv.UpsertScopedRoleAssignment(ctx, &scopedaccessv1.UpsertScopedRoleAssignmentRequest{
 		Assignment: a4,
 	})
 	require.NoError(t, err)
 	require.Equal(t, a4.GetMetadata().GetName(), ua4rsp.GetAssignment().GetMetadata().GetName())
+	require.Nil(t, ua4rsp.GetAssignment().GetStatus())
 
 	// wait for upserted assignment to appear in cache
 	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
@@ -739,12 +754,21 @@ func TestAssignmentBasics(t *testing.T) {
 
 	// verify expected successful upsert (updates existing assignment)
 	ua4rsp.Assignment.Metadata.Labels = map[string]string{"upserted": "true"}
+	ua4rsp.Assignment.Status = newForgedStatus()
 	ua4rsp2, err := srv.UpsertScopedRoleAssignment(ctx, &scopedaccessv1.UpsertScopedRoleAssignmentRequest{
 		Assignment: ua4rsp.GetAssignment(),
 	})
 	require.NoError(t, err)
 	require.Equal(t, a4.GetMetadata().GetName(), ua4rsp2.GetAssignment().GetMetadata().GetName())
 	require.Equal(t, "true", ua4rsp2.GetAssignment().GetMetadata().GetLabels()["upserted"])
+	require.Nil(t, ua4rsp2.GetAssignment().GetStatus())
+
+	garsp, err = bk.service.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+		Name:    a4.GetMetadata().GetName(),
+		SubKind: a4.GetSubKind(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, garsp.GetAssignment().GetStatus())
 
 	// verify expected denied upsert (out of scope)
 	a5 := newScopedRoleAssignmentAtScope("prod-admin", "/prod")

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -51,6 +51,10 @@ const (
 	// SubKindMaterialized is the sub kind of a scoped role assignment that has been materialized.
 	SubKindMaterialized = "materialized"
 
+	// CreatorKindAccessList indicates that the creator is an access list, for
+	// scoped role assignments materialized from access list membership.
+	CreatorKindAccessList = "access_list"
+
 	// maxAssignableScopes is the maximum number of assignable scopes that a given scoped role resource may contain. Note that
 	// unlike MaxRolesPerAssignment, this is a fairly arbitrary limit and there isn't a strong reason to keep it low other than
 	// to avoid excess resource size and to keep our options open for the future.

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -809,6 +809,12 @@ func (m *materializer) materializeAssignment(
 		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 			User: userName,
 		},
+		Status: &scopedaccessv1.ScopedRoleAssignmentStatus{
+			Origin: &scopedaccessv1.ScopedRoleAssignmentStatus_Origin{
+				CreatorKind: scopedaccess.CreatorKindAccessList,
+				CreatorName: list.GetName(),
+			},
+		},
 	}
 
 	if relation.isMember {

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -1408,6 +1408,12 @@ func expectedScopedRoleAssignment(userName, listName string, assignments []*scop
 			User:        userName,
 			Assignments: assignments,
 		},
+		Status: &scopedaccessv1.ScopedRoleAssignmentStatus{
+			Origin: &scopedaccessv1.ScopedRoleAssignmentStatus_Origin{
+				CreatorKind: scopedaccess.CreatorKindAccessList,
+				CreatorName: listName,
+			},
+		},
 	}
 }
 

--- a/lib/services/local/scoped_access_test.go
+++ b/lib/services/local/scoped_access_test.go
@@ -498,6 +498,12 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 				},
 			},
 		},
+		Status: &scopedaccessv1.ScopedRoleAssignmentStatus{
+			Origin: &scopedaccessv1.ScopedRoleAssignmentStatus_Origin{
+				CreatorKind: scopedaccess.CreatorKindAccessList,
+				CreatorName: "test-list",
+			},
+		},
 		Version: types.V1,
 	}
 

--- a/rfd/0243-scoped-roles-in-access-lists.md
+++ b/rfd/0243-scoped-roles-in-access-lists.md
@@ -301,7 +301,7 @@ spec:
     scope: /ops
 status:
   origin:
-    creator: access_list
+    creator_kind: access_list
     creator_name: west-admins
 version: v1
 ---
@@ -319,7 +319,7 @@ spec:
     scope: /ops
 status:
   origin:
-    creator: access_list
+    creator_kind: access_list
     creator_name: west-admins
 version: v1
 ```

--- a/rfd/cspell.json
+++ b/rfd/cspell.json
@@ -93,6 +93,7 @@
     "Backpressure",
     "barebones",
     "Bartosz",
+    "basicinfo",
     "bazel",
     "BCDEF",
     "behaviour",


### PR DESCRIPTION
The PR adds a status to scoped role assignments, as mentioned in [RFD 243](https://github.com/gravitational/teleport/blob/master/rfd/0243-scoped-roles-in-access-lists.md), to make it easy to see which access list resulted in an assignment being materialized.

The status is currently only populated for materialized assignments. Theoretically it could be populated for user and admin-created assignments too, but that is not currently planned.

## Manual Test Plan

### Test Environment

- Local cluster running this branch with `TELEPORT_UNSTABLE_SCOPES=yes`

#### Setup scoped roles

```bash
cat >./test-scoped-roles.yaml <<EOF
kind: scoped_role
version: v1
metadata:
  name: test-role
scope: /
spec:
  assignable_scopes:
    - /test/**
  allow:
    logins: ["tester"]
    node_labels:
      - name: "*"
        values: ["*"]
EOF

tctl create ./test-scoped-roles.yaml
```

#### Setup access list

```bash
cat >./test-access-list.yaml <<EOF
kind: access_list
version: v1
metadata:
  name: test-list
spec:
  title: test-list
  owners:
    - name: owner@example.com
      membership_kind: MEMBERSHIP_KIND_USER
  grants:
    scoped_roles:
      - role: test-role
        scope: /test/test
EOF

tctl create ./test-access-list.yaml
```

### Test Cases

- [x] Add a member to the access list

```bash
$ tctl acl users add test-list tester
```

- [x] A scoped role assignment should be materialized with a status naming the access list

```bash
$ tctl get scoped_role_assignments
kind: scoped_role_assignment
metadata:
  name: acl-j8H2xfsVfJbcegvThS7EGr6L2E9HMapKuMZY7g
scope: /
spec:
  assignments:
  - role: test-role
    scope: /test/test
  user: tester
status:
  origin:
    creator_kind: access_list
    creator_name: test-list
sub_kind: materialized
version: v1
```