### PR TITLE
Connect: Ensure cold launch from deep link on macOS always works

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -59,6 +59,17 @@ if (!process.defaultApp) {
 // https://github.com/electron/electron/issues/46538#issuecomment-2808806722
 app.commandLine.appendSwitch('gtk-version', '3');
 
+// On macOS, when the app is launched via a deep link, the 'open-url' event can be emitted very
+// early — before initializeApp finishes its async work and registers the real handler.
+// Buffer the URL at the module level so it's not lost.
+let bufferedOpenUrl: string | undefined;
+function bufferOpenUrl(_event: Electron.Event, url: string) {
+  bufferedOpenUrl = url;
+}
+if (process.platform === 'darwin') {
+  app.on('open-url', bufferOpenUrl);
+}
+
 if (app.requestSingleInstanceLock()) {
   initializeApp().catch(error =>
     showDialogWithError('Could not initialize the app', error)
@@ -121,9 +132,8 @@ async function initializeApp(): Promise<void> {
   // the listener which calls windowsManager.focusWindow. This way the focus will be brought to the
   // window before processing the listener for deep links.
   //
-  // This must be called as early as possible, before an async code.
-  // Otherwise, if the app is launched via a macOS deep link, the 'open-url' event may be emitted
-  // before a handler is registered, causing the link to be lost.
+  // On macOS, the 'open-url' event may be emitted before this point (during the async work above).
+  // A module-level listener buffers the URL so it's not lost. setUpDeepLinks drains the buffer.
   setUpDeepLinks(logger, windowsManager, settings);
 
   const tshHome = configService.get('tshHome').value;
@@ -277,6 +287,10 @@ function setUpDeepLinks(
   // https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app
 
   if (settings.platform === 'darwin') {
+    // Remove the early buffering listener registered at the module level and replace it with the
+    // real handler.
+    app.off('open-url', bufferOpenUrl);
+
     // Deep link click on macOS.
     app.on('open-url', (event, url) => {
       // When macOS launches an app as a result of a deep link click, macOS does bring focus to the
@@ -287,6 +301,15 @@ function setUpDeepLinks(
       logger.info(`Deep link launch from open-url, URL: ${url}`);
       launchDeepLink(logger, windowsManager, url);
     });
+
+    // Drain URL that arrived while initializeApp was doing async work.
+    if (bufferedOpenUrl) {
+      logger.info(
+        `Deep link launch from buffered open-url, URL: ${bufferedOpenUrl}`
+      );
+      launchDeepLink(logger, windowsManager, bufferedOpenUrl);
+      bufferedOpenUrl = undefined;
+    }
     return;
   }
 


### PR DESCRIPTION
#64613 optimized how `getRuntimeSettings` performs its work, replacing a couple of sync filesystem operations with async equivalents (see [`85dd9a225ac93`](https://github.com/gravitational/teleport/pull/64613/changes/85dd9a225ac93335b953f7c2702cc4dd3a3636bd)).

This made deep link handling more brittle: `setUpDeepLinks` is executed after `await getRuntimeSettings` but it depends on being called ASAP so that we register a handler for the `open-url` event in time on cold start (when the app is not already running). By changing sync functions to async functions, we added more event loop ticks during which the `open-url` event could be processed by Electron without a corresponding handler.

https://github.com/gravitational/teleport/blob/8f7cb166ba67034dcd564cf8d613a52a5cc8ef01/web/packages/teleterm/src/main.ts#L120-L127

The previous implementation was not bulletproof and we were kind of banking on us not breaking it by accident which we did. The fix is to register a handler for `open-url` immediately on app start from within the first tick. This handler saves the deep link from a cold start which gets processed later when the real handler is being set up.

This implementation has the potential to drop events if the `open-url` event is called multiple times. We're fine with that as there's no flow which depends on deep links being launched in quick succession.

This needs to be backported to v18 and v17 since #64613 was backported to those branches (but not yet released).

## Manual Test Plan
### Test Environment

A locally packaged app.

### Test Cases
- [x] Verify that Connect opens a deep link on macOS even when the open-url event gets buffered.

Some logs from when I was verifying this:

```
tail -F '/Users/m/Library/Application Support/Teleport Connect/logs/main.log' | rg "Deep link"                                                                        [12:11:13]
[01-04-26 12:11:27] [Main] info: Deep link launch from open-url, URL: teleport://rav@teleport-mbp.ocelot-paradise.ts.net:3030/authenticate_web_device?id=3875dcf2-421f-4362-9f33-b42fbd3e669c&token=tFqjTj9LM0rH3i4AwYvT9tWpkQPOtqdrQTRiiEe0wVA
[01-04-26 12:11:34] [Main] info: Deep link launch from open-url, URL: teleport://rav@teleport-mbp.ocelot-paradise.ts.net:3030/authenticate_web_device?id=3875dcf2-421f-4362-9f33-b42fbd3e669c&token=tFqjTj9LM0rH3i4AwYvT9tWpkQPOtqdrQTRiiEe0wVA
[01-04-26 12:11:39] [Main] info: Deep link launch from buffered open-url, URL: teleport://rav@teleport-mbp.ocelot-paradise.ts.net:3030/authenticate_web_device?id=3875dcf2-421f-4362-9f33-b42fbd3e669c&token=tFqjTj9LM0rH3i4AwYvT9tWpkQPOtqdrQTRiiEe0wVA
[01-04-26 12:11:45] [Main] info: Deep link launch from buffered open-url, URL: teleport://rav@teleport-mbp.ocelot-paradise.ts.net:3030/authenticate_web_device?id=3875dcf2-421f-4362-9f33-b42fbd3e669c&token=tFqjTj9LM0rH3i4AwYvT9tWpkQPOtqdrQTRiiEe0wVA
[01-04-26 12:11:53] [Main] info: Deep link launch from buffered open-url, URL: teleport://rav@teleport-mbp.ocelot-paradise.ts.net:3030/authenticate_web_device?id=3875dcf2-421f-4362-9f33-b42fbd3e669c&token=tFqjTj9LM0rH3i4AwYvT9tWpkQPOtqdrQTRiiEe0wVA
[01-04-26 12:11:58] [Main] info: Deep link launch from open-url, URL: teleport://rav@teleport-mbp.ocelot-paradise.ts.net:3030/authenticate_web_device?id=3875dcf2-421f-4362-9f33-b42fbd3e669c&token=tFqjTj9LM0rH3i4AwYvT9tWpkQPOtqdrQTRiiEe0wVA
```

The last two logs are from the same app session: the cold deep link is buffered but subsequent events are handled by the proper `open-url` handler.