### PR TITLE
Update docs link for SAML cert expiry alert

### DIFF
--- a/lib/auth/connector_monitor.go
+++ b/lib/auth/connector_monitor.go
@@ -61,7 +61,7 @@ const (
 	samlCertMonitorLockRefreshInterval = 20 * time.Second
 	// retryJitter is the jitter duration applied when restarting the monitor after failure.
 	retryJitter = 5 * time.Second
-	// samlCertExpiryAlertLink is the documentation linked to from the "Learn More" link on the alert
+	// samlCertExpiryAlertLink is the documentation linked to from the link on the alert
 	samlCertExpiryAlertLink = "https://goteleport.com/docs/zero-trust-access/sso/saml-cert-rotation/"
 	// samlCertExpiryAlertLabel is the label for the documentation link on the alert
 	samlCertExpiryAlertLabel = "Learn More"
@@ -287,7 +287,7 @@ func (m *SAMLCertExpiryMonitor) upsertAlert(ctx context.Context, id, message str
 func (m *SAMLCertExpiryMonitor) buildAlertMessage(connectorName string, cert *x509.Certificate) string {
 	expiredTemplate := "SAML SSO users are no longer able to authenticate to Teleport. Connector '%s' references a certificate that expired at %s. Please rotate the expired certificate. %s"
 	expiringTemplate := "SAML SSO users will no longer be able to authenticate to Teleport in %d days. Connector '%s' references a certificate that expires at %s. Please rotate the expiring certificate. %s"
-	learnMore := "Click 'Learn More' for more details about rotating certificates."
+	learnMore := fmt.Sprintf("Click '%s' for more details about rotating certificates.", samlCertExpiryAlertLabel)
 
 	remaining := cert.NotAfter.Sub(m.Clock.Now())
 	expiry := cert.NotAfter.UTC().Format("2006-01-02 15:04:05")

--- a/lib/auth/connector_monitor.go
+++ b/lib/auth/connector_monitor.go
@@ -61,10 +61,10 @@ const (
 	samlCertMonitorLockRefreshInterval = 20 * time.Second
 	// retryJitter is the jitter duration applied when restarting the monitor after failure.
 	retryJitter = 5 * time.Second
-	// alertLink is the documentation linked to from the "Learn More" link on the alert
-	alertLink = "https://goteleport.com/docs/zero-trust-access/sso/saml-cert-rotation/"
-	// alertLabel is the label for the documentation link on the alert
-	alertLabel = "Learn More"
+	// samlCertExpiryAlertLink is the documentation linked to from the "Learn More" link on the alert
+	samlCertExpiryAlertLink = "https://goteleport.com/docs/zero-trust-access/sso/saml-cert-rotation/"
+	// samlCertExpiryAlertLabel is the label for the documentation link on the alert
+	samlCertExpiryAlertLabel = "Learn More"
 )
 
 // SAMLCertExpiryMonitorConfig is embedded in the SAMLCertExpiryMonitor to provide access
@@ -273,8 +273,8 @@ func (m *SAMLCertExpiryMonitor) upsertAlert(ctx context.Context, id, message str
 		types.WithAlertLabel(types.AlertVerbPermit, fmt.Sprintf("%s:%s", types.KindSAML, types.VerbRead)),
 		types.WithAlertExpires(m.Clock.Now().Add(samlCertExpiryAlertExpires)),
 		types.WithAlertLabel(types.AlertOnLogin, "yes"),
-		types.WithAlertLabel(types.AlertLink, alertLink),
-		types.WithAlertLabel(types.AlertLinkText, alertLabel),
+		types.WithAlertLabel(types.AlertLink, samlCertExpiryAlertLink),
+		types.WithAlertLabel(types.AlertLinkText, samlCertExpiryAlertLabel),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/connector_monitor.go
+++ b/lib/auth/connector_monitor.go
@@ -61,6 +61,10 @@ const (
 	samlCertMonitorLockRefreshInterval = 20 * time.Second
 	// retryJitter is the jitter duration applied when restarting the monitor after failure.
 	retryJitter = 5 * time.Second
+	// alertLink is the documentation linked to from the "Learn More" link on the alert
+	alertLink = "https://goteleport.com/docs/zero-trust-access/sso/saml-cert-rotation/"
+	// alertLabel is the label for the documentation link on the alert
+	alertLabel = "Learn More"
 )
 
 // SAMLCertExpiryMonitorConfig is embedded in the SAMLCertExpiryMonitor to provide access
@@ -269,9 +273,8 @@ func (m *SAMLCertExpiryMonitor) upsertAlert(ctx context.Context, id, message str
 		types.WithAlertLabel(types.AlertVerbPermit, fmt.Sprintf("%s:%s", types.KindSAML, types.VerbRead)),
 		types.WithAlertExpires(m.Clock.Now().Add(samlCertExpiryAlertExpires)),
 		types.WithAlertLabel(types.AlertOnLogin, "yes"),
-		// TODO(nixpig): Link to better documentation page when it's created.
-		types.WithAlertLabel(types.AlertLink, "https://goteleport.com/docs/reference/infrastructure-as-code/teleport-resources/saml-connector-v2/#saml-connector-spec-v2"),
-		types.WithAlertLabel(types.AlertLinkText, "Learn More"),
+		types.WithAlertLabel(types.AlertLink, alertLink),
+		types.WithAlertLabel(types.AlertLinkText, alertLabel),
 	)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Update the link in the SAML signing certificate expiry alert to the new documentation page. 
