### PR TITLE
Connect: Improve docs about dual-mode installations

### DIFF
--- a/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
@@ -49,6 +49,15 @@ To choose the mode explicitly, add `/allusers` (per-machine) or `/currentuser` (
 $ "Teleport Connect Setup-(=teleport.version=).exe" /S /allusers
 ```
 
+<Admonition
+    type="warning"
+    title="Avoid Dual Installations"
+>
+  Having both per-user and per-machine installations may cause the Start Menu shortcut to point to a different instance than expected.
+
+  Before installing the app in a different mode, [uninstall](#uninstalling-teleport-connect) the existing installation.
+</Admonition>
+
 </TabItem>
 </Tabs>
 

--- a/docs/pages/includes/uninstall-teleport-connect-windows.mdx
+++ b/docs/pages/includes/uninstall-teleport-connect-windows.mdx
@@ -2,11 +2,11 @@ You can uninstall Teleport Connect from the "Programs and Features" section of t
 
 For reference, Teleport Connect binaries are installed to:
 * Per-machine install (default): `%PROGRAMFILES%\Teleport Connect`
-* Per-user install: `%LOCALAPPDATA%\Teleport Connect`
+* Per-user install: `%LOCALAPPDATA%\Programs\Teleport Connect`
 
 To silently uninstall the app, open the Command Prompt and type:
 ```code
-# For per-machine (default):
+# For per-machine install (default):
 $ "%PROGRAMFILES%\Teleport Connect\Uninstall Teleport Connect.exe" /S /allusers
 
 # For per-user install:

--- a/docs/pages/includes/uninstall-teleport-connect-windows.mdx
+++ b/docs/pages/includes/uninstall-teleport-connect-windows.mdx
@@ -1,5 +1,14 @@
-  You can uninstall Teleport Connect from the "Apps and Features" section of the Control Panel.
+You can uninstall Teleport Connect from the "Programs and Features" section of the Control Panel.
 
-  For reference, Teleport Connect binaries are installed to:
-  * Per-machine install (default): `%PROGRAMFILES%\Teleport Connect`
-  * Per-user install: `%LOCALAPPDATA%\Teleport Connect`
+For reference, Teleport Connect binaries are installed to:
+* Per-machine install (default): `%PROGRAMFILES%\Teleport Connect`
+* Per-user install: `%LOCALAPPDATA%\Teleport Connect`
+
+To silently uninstall the app, open the Command Prompt and type:
+```code
+# For per-machine (default):
+$ "%PROGRAMFILES%\Teleport Connect\Uninstall Teleport Connect.exe" /S /allusers
+
+# For per-user install:
+$ "%LOCALAPPDATA%\Programs\Teleport Connect\Uninstall Teleport Connect.exe" /S /currentuser
+````

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -95,9 +95,9 @@ export const VnetSliderStep = (props: StepComponentProps) => {
               'missing-windows-service' && (
               <ErrorText>
                 VNet system service is not installed. <br />
-                To use VNet, reinstall Teleport Connect selecting &apos;Anyone
-                who uses this computer&apos; option. Administrator privileges
-                will be required.
+                To use VNet, uninstall Teleport Connect and install it again
+                selecting &apos;Anyone who uses this computer&apos; option.
+                Administrator privileges will be required.
               </ErrorText>
             )}
             {installTimeRequirementsCheck.reason.kind ===
@@ -106,9 +106,10 @@ export const VnetSliderStep = (props: StepComponentProps) => {
                 The VNet system service version does not match the application
                 version. <br />
                 This can happen if Teleport Connect is installed both per-user
-                and per-machine. To use VNet, reinstall Teleport Connect
-                selecting &apos;Anyone who uses this computer&apos; option.
-                Administrator privileges will be required.
+                and per-machine. To use VNet, uninstall Teleport Connect and
+                install it again selecting &apos;Anyone who uses this
+                computer&apos; option. Administrator privileges will be
+                required.
               </ErrorText>
             )}
             {installTimeRequirementsCheck.reason.kind === 'error' && (

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -106,10 +106,10 @@ export const VnetSliderStep = (props: StepComponentProps) => {
                 The VNet system service version does not match the application
                 version. <br />
                 This can happen if Teleport Connect is installed both per-user
-                and per-machine. To use VNet, uninstall Teleport Connect and
-                install it again selecting &apos;Anyone who uses this
-                computer&apos; option. Administrator privileges will be
-                required.
+                and per-machine. To use VNet, uninstall both Teleport Connect
+                installations and install it again selecting &apos;Anyone who
+                uses this computer&apos; option. Administrator privileges will
+                be required.
               </ErrorText>
             )}
             {installTimeRequirementsCheck.reason.kind === 'error' && (


### PR DESCRIPTION
While performing the final check on the v18 backport, I noticed that switching (or rather installing the app in a new mode) between per-user and per-machine installations behaves inconsistently.
Initially, I assumed that the most recent installation would simply overwrite the Start Menu shortcut. However, this is only true for users with administrative privileges.

Observed behavior
1. Admin user
   - Per-user -> per-machine (ok)
  The per-user installation is automatically removed (after the UAC prompt), leaving only the per-machine instance.
   - Per-machine -> per-user (ok) 
  The per-user installation overwrites the shortcut, and the Start Menu points to the per-user instance.
2. Standard user
   - Per-user -> per-machine (bug) 
  The per-machine installation completes after providing admin credentials via UAC, but the Start Menu shortcut still points to the per-user instance.
   - Per-machine -> per-user (ok)
  The per-user installation overwrites the shortcut, and the Start Menu points to the per-user instance.

This appears to be a bug in electron-builder. In the 2.1 scenario, the installer requires admin credentials, which causes the per-user uninstall step to run in the administrator's context rather than the original user's context. As a result, the per-user installation is not properly removed for the target user, leaving the shortcut (and the per-user app) in place.

Ideally, this should be fixed in electron-builder. However, I think for now it's reasonable to document this behavior in the docs and in the app.

I also added docs on how to uninstall the app from the command line.