### PR TITLE
Update to correct product tier for SAML doc

### DIFF
--- a/docs/pages/zero-trust-access/sso/saml-cert-rotation.mdx
+++ b/docs/pages/zero-trust-access/sso/saml-cert-rotation.mdx
@@ -6,7 +6,7 @@ tags:
  - zero-trust
  - sso
  - how-to
-enterprise: Identity Governance
+enterprise: Enterprise SSO
 ---
 
 SAML signing certificates are used by the identity provider to sign SAML assertions, 


### PR DESCRIPTION
Update the `enterprise` frontmatter to reference the correct license on the docs page for rotating SAML signing certificates. 