### PR TITLE
Document proxy protocol v2 support

### DIFF
--- a/docs/pages/zero-trust-access/management/security/proxy-protocol.mdx
+++ b/docs/pages/zero-trust-access/management/security/proxy-protocol.mdx
@@ -42,6 +42,10 @@ Here is an example of the PROXYv1 protocol header:
 PROXY TCP4 127.0.0.1 127.0.0.2 12345 42\r\n
 ```
 
+<Admonition type="note">
+Teleport supports both PROXY protocol v1 and v2.
+</Admonition>
+
 ## Prerequisites
 
 - A self-hosted Teleport Enterprise account. If you want to get started with


### PR DESCRIPTION
Minimal change to document that we support proxy protocol v1 and v2. I searched for this info 2 months ago and had to dig into the github issues and PRs to get the answer.