### PR TITLE
MWI Scopes[2]: Scoped Role Assignments

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/assignment.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/assignment.pb.go
@@ -134,9 +134,17 @@ func (x *ScopedRoleAssignment) GetSpec() *ScopedRoleAssignmentSpec {
 type ScopedRoleAssignmentSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// User is the user to whom all contained assignments apply.
+	// Mutually exclusive with `bot_name`.
 	User string `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
 	// Assignments is a list of individual role @ scope assignments.
-	Assignments   []*Assignment `protobuf:"bytes,2,rep,name=assignments,proto3" json:"assignments,omitempty"`
+	Assignments []*Assignment `protobuf:"bytes,2,rep,name=assignments,proto3" json:"assignments,omitempty"`
+	// Name of the Bot to whom all contained assignments apply.
+	// Mutually exclusive with `user`.
+	BotName string `protobuf:"bytes,3,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
+	// Scope of the Bot to whom all contained assignments apply.
+	// Required if `bot_name` is set.
+	// If specified, assignment scopes must be equal or descendent of this scope.
+	BotScope      string `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -183,6 +191,20 @@ func (x *ScopedRoleAssignmentSpec) GetAssignments() []*Assignment {
 		return x.Assignments
 	}
 	return nil
+}
+
+func (x *ScopedRoleAssignmentSpec) GetBotName() string {
+	if x != nil {
+		return x.BotName
+	}
+	return ""
+}
+
+func (x *ScopedRoleAssignmentSpec) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
 }
 
 // Assignment is a role/scope pair that defines an individual assignment.
@@ -252,10 +274,12 @@ const file_teleport_scopes_access_v1_assignment_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12G\n" +
-	"\x04spec\x18\x06 \x01(\v23.teleport.scopes.access.v1.ScopedRoleAssignmentSpecR\x04spec\"w\n" +
+	"\x04spec\x18\x06 \x01(\v23.teleport.scopes.access.v1.ScopedRoleAssignmentSpecR\x04spec\"\xaf\x01\n" +
 	"\x18ScopedRoleAssignmentSpec\x12\x12\n" +
 	"\x04user\x18\x01 \x01(\tR\x04user\x12G\n" +
-	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\"6\n" +
+	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x19\n" +
+	"\bbot_name\x18\x03 \x01(\tR\abotName\x12\x1b\n" +
+	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"6\n" +
 	"\n" +
 	"Assignment\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +

--- a/api/proto/teleport/scopes/access/v1/assignment.proto
+++ b/api/proto/teleport/scopes/access/v1/assignment.proto
@@ -47,10 +47,20 @@ message ScopedRoleAssignment {
 // ScopedRoleAssignmentSpec is the specification of a scoped role.
 message ScopedRoleAssignmentSpec {
   // User is the user to whom all contained assignments apply.
+  // Mutually exclusive with `bot_name`.
   string user = 1;
 
   // Assignments is a list of individual role @ scope assignments.
   repeated Assignment assignments = 2;
+
+  // Name of the Bot to whom all contained assignments apply.
+  // Mutually exclusive with `user`.
+  string bot_name = 3;
+
+  // Scope of the Bot to whom all contained assignments apply.
+  // Required if `bot_name` is set.
+  // If specified, assignment scopes must be equal or descendent of this scope.
+  string bot_scope = 4;
 }
 
 // Assignment is a role/scope pair that defines an individual assignment.

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -423,6 +423,25 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		return trace.BadParameter("scoped role assignment %q contains too many sub-assignments (max %d)", assignment.GetMetadata().GetName(), MaxRolesPerAssignment)
 	}
 
+	// Assigning to Bot is mutually exclusive with assigning to User. When
+	// assigning to Bot, we also want to ensure Bot's scope is specified.
+	botSet := assignment.GetSpec().GetBotName() != ""
+	botScope := assignment.GetSpec().GetBotScope()
+	if botSet && assignment.GetSpec().GetUser() != "" {
+		return trace.BadParameter("scoped role assignment %q cannot have both spec.bot_name and spec.user set", assignment.GetMetadata().GetName())
+	}
+	if botSet && botScope == "" {
+		return trace.BadParameter("scoped role assignment %q with spec.bot_name set must also have spec.bot_scope set", assignment.GetMetadata().GetName())
+	}
+	if !botSet && botScope != "" {
+		return trace.BadParameter("scoped role assignment %q with spec.bot_scope set must also have spec.bot_name set", assignment.GetMetadata().GetName())
+	}
+	if botSet {
+		if err := scopes.StrongValidate(botScope); err != nil {
+			return trace.BadParameter("scoped role assignment %q has invalid spec.bot_scope: %v", assignment.GetMetadata().GetName(), err)
+		}
+	}
+
 	for i, subAssignment := range assignment.GetSpec().GetAssignments() {
 		if subAssignment.GetRole() == "" {
 			return trace.BadParameter("scoped role assignment %q is missing role in sub-assignment %d", assignment.GetMetadata().GetName(), i)
@@ -442,6 +461,26 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 
 		if !scopes.ScopeOfOrigin(assignment.GetScope()).IsAssignableToScopeOfEffect(subAssignment.GetScope()) {
 			return trace.BadParameter("scoped role assignment %q has sub-assignment %d with scope %q that is not a sub-scope of the assignment's scope %q", assignment.GetMetadata().GetName(), i, subAssignment.GetScope(), assignment.GetScope())
+		}
+
+		// As per the MWI Scopes RFD, we enforce a special requirement for Bot
+		// assignments. Bot's can only be assigned privileges in scopes
+		// equivalent or descendent to their scope.
+		if botSet {
+			// TODO(strideynet): For Forrest, is it appropriate to use:
+			// > scopes.ScopeOfOrigin(botScope).IsAssignableToScopeOfEffect(assignmentScope)??
+			// or is another helper more appropriate? or new helper needed?
+			assignmentScope := subAssignment.GetScope()
+			rel := scopes.Compare(botScope, assignmentScope)
+			if rel != scopes.Equivalent && rel != scopes.Descendant {
+				return trace.BadParameter(
+					"scoped role assignment %q has sub-assignment %d with scope %q that is not a sub-scope of the bot's declared scope %q",
+					assignment.GetMetadata().GetName(),
+					i,
+					subAssignment.GetScope(),
+					assignment.GetSpec().GetBotScope(),
+				)
+			}
 		}
 	}
 
@@ -473,8 +512,8 @@ func commonValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		return trace.BadParameter("scoped role assignment %q is missing scope", assignment.GetMetadata().GetName())
 	}
 
-	if assignment.GetSpec().GetUser() == "" {
-		return trace.BadParameter("scoped role assignment %q is missing spec.user", assignment.GetMetadata().GetName())
+	if assignment.GetSpec().GetUser() == "" && assignment.GetSpec().GetBotName() == "" {
+		return trace.BadParameter("scoped role assignment %q is missing spec.user or spec.bot_name", assignment.GetMetadata().GetName())
 	}
 
 	return nil

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -467,12 +467,8 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		// assignments. Bot's can only be assigned privileges in scopes
 		// equivalent or descendent to their scope.
 		if botSet {
-			// TODO(strideynet): For Forrest, is it appropriate to use:
-			// > scopes.ScopeOfOrigin(botScope).IsAssignableToScopeOfEffect(assignmentScope)??
-			// or is another helper more appropriate? or new helper needed?
 			assignmentScope := subAssignment.GetScope()
-			rel := scopes.Compare(botScope, assignmentScope)
-			if rel != scopes.Equivalent && rel != scopes.Descendant {
+			if !scopes.ScopeOfOrigin(botScope).IsAssignableToScopeOfEffect(assignmentScope) {
 				return trace.BadParameter(
 					"scoped role assignment %q has sub-assignment %d with scope %q that is not a sub-scope of the bot's declared scope %q",
 					assignment.GetMetadata().GetName(),

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -759,6 +759,156 @@ func TestValidateAsssignment(t *testing.T) {
 			strongOk: true,
 			weakOk:   true,
 		},
+		{
+			name: "valid bot assignment",
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
+				Kind:    KindScopedRoleAssignment,
+				SubKind: SubKindDynamic,
+				Metadata: &headerv1.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+					BotName:  "mybot",
+					BotScope: "/foo/bar",
+					Assignments: []*scopedaccessv1.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo/bar/child",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "bot_name and user both set",
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
+				Kind:    KindScopedRoleAssignment,
+				SubKind: SubKindDynamic,
+				Metadata: &headerv1.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+					User:     "alice",
+					BotName:  "mybot",
+					BotScope: "/foo/bar",
+					Assignments: []*scopedaccessv1.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "bot_name without bot_scope",
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
+				Kind:    KindScopedRoleAssignment,
+				SubKind: SubKindDynamic,
+				Metadata: &headerv1.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+					BotName: "mybot",
+					Assignments: []*scopedaccessv1.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "bot_scope without bot_name",
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
+				Kind:    KindScopedRoleAssignment,
+				SubKind: SubKindDynamic,
+				Metadata: &headerv1.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+					User:     "alice",
+					BotScope: "/foo/bar",
+					Assignments: []*scopedaccessv1.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "invalid bot_scope",
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
+				Kind:    KindScopedRoleAssignment,
+				SubKind: SubKindDynamic,
+				Metadata: &headerv1.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+					BotName:  "mybot",
+					BotScope: "not-a-scope",
+					Assignments: []*scopedaccessv1.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "sub-assignment scope outside bot scope",
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
+				Kind:    KindScopedRoleAssignment,
+				SubKind: SubKindDynamic,
+				Metadata: &headerv1.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+					BotName:  "mybot",
+					BotScope: "/foo/bar",
+					Assignments: []*scopedaccessv1.Assignment{
+						// Valid
+						{
+							Role:  "test",
+							Scope: "/foo/bar",
+						},
+						// Invalid
+						{
+							Role:  "test",
+							Scope: "/foo/baz",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
 	}
 
 	for _, tt := range tts {

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -213,6 +213,23 @@ func (c *Cache) PopulatePinnedAssignmentsForUser(ctx context.Context, user strin
 	return state.assignments.PopulatePinnedAssignmentsForUser(ctx, user, pin)
 }
 
+// PopulatePinnedAssignmentsForBot populates the provided scope pin with all
+// relevant assignments related to the given bot. The provided pin must already
+// have its Scope field set.
+//
+// botScope should be the scope at which the bot in question is defined. This
+// must have already been validated to ensure this matches join token.
+func (c *Cache) PopulatePinnedAssignmentsForBot(
+	ctx context.Context, botName string, botScope string, pin *scopesv1.Pin,
+) error {
+	state, err := c.read(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return state.assignments.PopulatePinnedAssignmentsForBot(ctx, botName, botScope, pin)
+}
+
 // Close stops cache background operations and causes future reads to fail. It is safe to call multiple times.
 func (c *Cache) Close() error {
 	c.cancel()

--- a/lib/scopes/cache/assignments/pinning.go
+++ b/lib/scopes/cache/assignments/pinning.go
@@ -138,3 +138,157 @@ func (c *AssignmentCache) PopulatePinnedAssignmentsForUser(ctx context.Context, 
 
 	return nil
 }
+
+// PopulatePinnedAssignmentsForBot populates the provided scope pin with all relevant assignments related to the
+// given bot. The provided pin must already have its Scope field set.
+//
+// botScope should be the scope at which the bot in question is defined. This
+// must have already been validated to ensure this matches join token.
+//
+// TODO: Noah - Speak to Forrest and determine if this should be merged w/
+// the function above? or if separate is clearer.
+//
+// This deviates from the user implementation in the following way:
+// 1) Filters out assignments for users - i.e that don't specify bot_name and bot_scope.
+// 2) Ensures that the bot_scope within the SRA matches the specified bot_scope, else ignores.
+// 3) Ensures that sub-assignments are to a scope that is equiv or descendent to the Bot scope.
+// 4) Ensures that the pin scope is also equiv or descendent to the bot scope.
+// 3&4 will be relaxed with the introduction of cross-scope privilege for MWI.
+func (c *AssignmentCache) PopulatePinnedAssignmentsForBot(
+	ctx context.Context, botName string, botScope string, pin *scopesv1.Pin,
+) error {
+	if botName == "" {
+		return trace.BadParameter("missing bot name in scoped assignment population request")
+	}
+	if botScope == "" {
+		return trace.BadParameter("missing bot scope in scoped assignment population request for bot %q", botName)
+	}
+	if pin == nil {
+		return trace.BadParameter("missing scope pin in assignment population request for bot %q", botName)
+	}
+	if pin.GetAssignmentTree() != nil {
+		return trace.BadParameter("assignment population attempted with pin that already contains an assignment tree (this is a bug)")
+	}
+
+	// validate the pin scope before proceeding. in theory the caller should be auth certificate generation logic which has
+	// already done strong validation, but a malformed scope pin would be a bad thing to have and catching the malformed scope
+	// during later pin validation steps produces confusing error messages.
+	if err := scopes.WeakValidate(pin.GetScope()); err != nil {
+		return trace.Errorf("invalid scope %q in assignment population request for bot %q: %w", pin.GetScope(), botName, err)
+	}
+	if err := scopes.WeakValidate(botScope); err != nil {
+		return trace.Errorf("invalid bot scope %q in assignment population request for bot %q: %w", botScope, botName, err)
+	}
+
+	// Ensure the scope we are pinning to is descendant or equiv to the bot scope.
+	// nb: This restriction may be relaxed w/ introduction of cross-scope privilege.
+	// TODO(strideynet): For forrest, is there a more appropriate helper to use here?
+	rel := scopes.Compare(botScope, pin.GetScope())
+	if rel != scopes.Equivalent && rel != scopes.Descendant {
+		return trace.BadParameter(
+			"pinned scope %q is not subject to bot scope %q in assignment population request for bot %q",
+			pin.GetScope(), botScope, botName,
+		)
+	}
+
+	// Track whether we've added any assignments to detect the empty case
+	assignmentCount := 0
+
+	// track the last error encountered when writing assignments. we generally want to just skip malformed assignments, but
+	// if all assignments seem malformed then we want to bubble up the error.
+	var lastErr error
+
+	// all non-orthogonal assignments for this bot *may* assign roles relevant to this pin
+	assignments := c.cache.AllNonOrthogonalResources(pin.Scope, c.cache.WithFilter(func(assignment *scopedaccessv1.ScopedRoleAssignment) bool {
+		matchesBotName := assignment.GetSpec().GetBotName() == botName
+		// ignore assignments where actual bot scope mismatches bot scope
+		// specified in SRA. this mitigates name reuse attacks across scopes.
+		matchesBotScope := assignment.GetSpec().GetBotScope() == botScope
+		return matchesBotName && matchesBotScope
+	}))
+
+	// iterate over all potentially relevant assignments and populate the assignment tree
+	for scope := range assignments {
+		for assignment := range scope.Items() {
+			// Scope of Origin is the scope of the assignment resource itself - this represents
+			// the authority/provenance of the policy.
+			scopeOfOrigin := assignment.GetScope()
+
+			for subAssignment := range scopedaccess.WeakValidatedSubAssignments(assignment) {
+				// Scope of Effect is the scope at which the role's privileges apply
+				scopeOfEffect := subAssignment.GetScope()
+
+				if scopes.Compare(scopeOfEffect, pin.GetScope()) == scopes.Orthogonal {
+					// a non-orthogonal assignment may still have sub-assignments that are orthogonal to the pin scope
+					// (e.g. an assignment at `/foo` is non-orthogonal to a pin at `/foo/bar`, but may contain a
+					// sub-assignment at `/foo/bin`).
+					continue
+				}
+				if subAssignment.GetRole() == "" {
+					// some future-proofing, we don't currently support sub-assignments without a role, but may at some
+					// point in the future.
+					continue
+				}
+				// Skip assignments where scope of effect is above the Bot as
+				// per the RFD.
+				// nb: we may eventually loosen up this restriction.
+				rel := scopes.Compare(botScope, scopeOfEffect)
+				if rel != scopes.Equivalent && rel != scopes.Descendant {
+					continue
+				}
+
+				// write the role assignment to the pin's assignment tree. the write function will automatically handle
+				// deduplication and maintain proper tree structure for evaluation ordering.
+				if err := pinning.WriteRoleAssignment(pin, pinning.RoleAssignment{
+					ScopeOfOrigin: scopeOfOrigin,
+					ScopeOfEffect: scopeOfEffect,
+					RoleName:      subAssignment.GetRole(),
+				}); err != nil {
+					slog.WarnContext(
+						ctx,
+						"failed to write role assignment to scope pin",
+						"role_name", subAssignment.GetRole(),
+						"scope_of_origin", scopeOfOrigin,
+						"scope_of_effect", scopeOfEffect,
+						"bot", botName,
+						"error", err,
+					)
+					lastErr = trace.Wrap(err)
+					continue
+				}
+
+				assignmentCount++
+			}
+		}
+	}
+
+	if assignmentCount == 0 {
+		// if the assignment count is zero due to error(s) encountered during writing, return the most recent error.
+		if lastErr != nil {
+			return trace.Errorf("failed to populate any scoped role assignments for bot %q applicable to pinned scope %q: last error: %w", botName, pin.GetScope(), lastErr)
+		}
+		// in theory there isn't any harm in allowing pins to be created without any assignments, but we're choosing to err
+		// on the side of caution for now. this limitation may be lifted later. this condition would also be caught by standard
+		// strong validation, but the resulting error message would be confusing.
+		// NOTE: if lifting this restriction, the equivalent check in the strong pin validation logic must also be lifted.
+		return trace.NotFound("no scoped role assignments found for bot %q applicable to pinned scope %q", botName, pin.GetScope())
+	}
+
+	// Prune the assignment tree if it exceeds the maximum encoded size. See [pinning.PruneAssignmentTree] for a detailed
+	// discussion of the rationale for pruning and the justification for the specific pruning strategy employed.
+	if prunedCount := pinning.PruneAssignmentTree(ctx, pin, c.cfg.MaxAssignmentTreeBytes); prunedCount > 0 {
+		slog.WarnContext(ctx, "pruned assignment tree to limit certificate size, bot may experience degraded privileges until assignments are reduced",
+			"bot", botName,
+			"pin_scope", pin.GetScope(),
+			"total_pruned", prunedCount,
+			"max_bytes", c.cfg.MaxAssignmentTreeBytes)
+	}
+
+	// perform a final weak validation of the pin to ensure that it is well-formed. this should be redundant since auth performs strong
+	// validation of all pins prior to encoding them on certs, but its worth being defensive due to how critical scope pins are.
+	if err := pinning.WeakValidate(pin); err != nil {
+		return trace.Errorf("pin for scope %q was invalid post-population (this is a bug): %w", pin.GetScope(), trace.Wrap(err))
+	}
+
+	return nil
+}

--- a/lib/scopes/cache/assignments/pinning.go
+++ b/lib/scopes/cache/assignments/pinning.go
@@ -145,8 +145,9 @@ func (c *AssignmentCache) PopulatePinnedAssignmentsForUser(ctx context.Context, 
 // botScope should be the scope at which the bot in question is defined. This
 // must have already been validated to ensure this matches join token.
 //
-// TODO: Noah - Speak to Forrest and determine if this should be merged w/
-// the function above? or if separate is clearer.
+// TODO(noah/scopes): When we loosen restrictions on scope of effect being above
+// scope of bot origin, we can merge this function back into
+// PopulatePinnedAssignmentsForUser with some minor adjustments.
 //
 // This deviates from the user implementation in the following way:
 // 1) Filters out assignments for users - i.e that don't specify bot_name and bot_scope.
@@ -182,9 +183,7 @@ func (c *AssignmentCache) PopulatePinnedAssignmentsForBot(
 
 	// Ensure the scope we are pinning to is descendant or equiv to the bot scope.
 	// nb: This restriction may be relaxed w/ introduction of cross-scope privilege.
-	// TODO(strideynet): For forrest, is there a more appropriate helper to use here?
-	rel := scopes.Compare(botScope, pin.GetScope())
-	if rel != scopes.Equivalent && rel != scopes.Descendant {
+	if !scopes.ScopeOfOrigin(botScope).IsAssignableToScopeOfEffect(pin.GetScope()) {
 		return trace.BadParameter(
 			"pinned scope %q is not subject to bot scope %q in assignment population request for bot %q",
 			pin.GetScope(), botScope, botName,
@@ -232,8 +231,7 @@ func (c *AssignmentCache) PopulatePinnedAssignmentsForBot(
 				// Skip assignments where scope of effect is above the Bot as
 				// per the RFD.
 				// nb: we may eventually loosen up this restriction.
-				rel := scopes.Compare(botScope, scopeOfEffect)
-				if rel != scopes.Equivalent && rel != scopes.Descendant {
+				if !scopes.ScopeOfOrigin(botScope).IsAssignableToScopeOfEffect(scopeOfEffect) {
 					continue
 				}
 

--- a/lib/scopes/cache/assignments/pinning_test.go
+++ b/lib/scopes/cache/assignments/pinning_test.go
@@ -368,3 +368,254 @@ func TestAssignmentTreePruning(t *testing.T) {
 	require.Equal(t, expectedTree, actualTree,
 		"pruning should preserve highest authority assignments (root level)")
 }
+
+func TestPopulatePinnedAssignmentsForBot(t *testing.T) {
+	t.Parallel()
+
+	bernardScope := "/aa"
+	assignments := []*scopedaccessv1.ScopedRoleAssignment{
+		// Very "normal" assignment. Scope of SRA matches Bot scope, and
+		// assigned scope is same.
+		{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Metadata: &headerpb.Metadata{
+				Name: "bernard-01",
+			},
+			Scope: bernardScope,
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				BotName:  "bernard",
+				BotScope: bernardScope,
+				Assignments: []*scopedaccessv1.Assignment{
+					{
+						Role:  "role-01",
+						Scope: bernardScope,
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		// Assignment to child-scope of main scope
+		{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Metadata: &headerpb.Metadata{
+				Name: "bernard-02",
+			},
+			Scope: bernardScope,
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				BotName:  "bernard",
+				BotScope: bernardScope,
+				Assignments: []*scopedaccessv1.Assignment{
+					{
+						Role:  "role-02",
+						Scope: bernardScope + "/child",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		// SRA in parent scope, assigning to bot scope.
+		{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Metadata: &headerpb.Metadata{
+				Name: "bernard-03",
+			},
+			Scope: "/",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				BotName:  "bernard",
+				BotScope: bernardScope,
+				Assignments: []*scopedaccessv1.Assignment{
+					{
+						Role:  "role-03",
+						Scope: bernardScope,
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		// SRA in parent scope, assigning to bot's child scope
+		{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Metadata: &headerpb.Metadata{
+				Name: "bernard-04",
+			},
+			Scope: "/",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				BotName:  "bernard",
+				BotScope: bernardScope,
+				Assignments: []*scopedaccessv1.Assignment{
+					{
+						Role:  "role-04",
+						Scope: bernardScope + "/child",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		// `bot_scope` mismatches bot's actual scope - this should be ignored.
+		{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Metadata: &headerpb.Metadata{
+				Name: "bernard-invalid-01",
+			},
+			Scope: bernardScope,
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				BotName:  "bernard",
+				BotScope: "/mismatched",
+				Assignments: []*scopedaccessv1.Assignment{
+					{
+						Role:  "bernard-invalid-01",
+						Scope: bernardScope,
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		// SRA above bot scope ignored.
+		// nb: we may eventually loosen this to behave more like users.
+		{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Metadata: &headerpb.Metadata{
+				Name: "bernard-invalid-02",
+			},
+			Scope: "/",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				BotName:  "bernard",
+				BotScope: bernardScope,
+				Assignments: []*scopedaccessv1.Assignment{
+					{
+						Role:  "bernard-invalid-02",
+						Scope: "/",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+	}
+
+	cache := NewAssignmentCache(AssignmentCacheConfig{})
+	for _, assignment := range assignments {
+		_, err := cache.GetScopedRoleAssignment(t.Context(), &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name:    assignment.GetMetadata().GetName(),
+			SubKind: scopedaccess.SubKindDynamic,
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
+
+		require.NoError(t, cache.Put(assignment))
+
+		rsp, err := cache.GetScopedRoleAssignment(t.Context(), &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name:    assignment.GetMetadata().GetName(),
+			SubKind: scopedaccess.SubKindDynamic,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.GetAssignment())
+	}
+
+	tts := []struct {
+		name        string
+		botName     string
+		botScope    string
+		pin         *scopesv1.Pin
+		errContains string
+		expect      *scopesv1.Pin
+	}{
+		{
+			name:     "standard",
+			botName:  "bernard",
+			botScope: bernardScope,
+			pin: &scopesv1.Pin{
+				Scope: bernardScope,
+			},
+			expect: &scopesv1.Pin{
+				Scope: bernardScope,
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					"/":          {bernardScope: {"role-03"}, bernardScope + "/child": {"role-04"}},
+					bernardScope: {bernardScope: {"role-01"}, bernardScope + "/child": {"role-02"}},
+				}),
+			},
+		},
+		{
+			name:     "pin scope at child of bot scope",
+			botName:  "bernard",
+			botScope: bernardScope,
+			pin: &scopesv1.Pin{
+				Scope: bernardScope + "/child",
+			},
+			expect: &scopesv1.Pin{
+				Scope: bernardScope + "/child",
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					"/":          {bernardScope: {"role-03"}, bernardScope + "/child": {"role-04"}},
+					bernardScope: {bernardScope: {"role-01"}, bernardScope + "/child": {"role-02"}},
+				}),
+			},
+		},
+		{
+			name:     "pin scope outside bot scope",
+			botName:  "bernard",
+			botScope: bernardScope,
+			pin: &scopesv1.Pin{
+				Scope: "/bb",
+			},
+			errContains: "is not subject to bot scope",
+		},
+		{
+			name:     "no matching assignments",
+			botName:  "no-such-bot",
+			botScope: "/aa",
+			pin: &scopesv1.Pin{
+				Scope: "/aa",
+			},
+			errContains: "no scoped role assignments found",
+		},
+		{
+			name:     "empty bot name",
+			botScope: "/aa",
+			pin: &scopesv1.Pin{
+				Scope: "/aa",
+			},
+			errContains: "missing bot name",
+		},
+		{
+			name:    "empty bot scope",
+			botName: "bernard",
+			pin: &scopesv1.Pin{
+				Scope: "/aa",
+			},
+			errContains: "missing bot scope",
+		},
+		{
+			name:     "pin with pre-existing assignment tree",
+			botName:  "bernard",
+			botScope: bernardScope,
+			pin: &scopesv1.Pin{
+				Scope: bernardScope,
+				AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+					"/": {bernardScope: {"role-03"}},
+				}),
+			},
+			errContains: "already contains an assignment tree",
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			pin := proto.CloneOf(tt.pin)
+			err := cache.PopulatePinnedAssignmentsForBot(
+				t.Context(), tt.botName, tt.botScope, pin,
+			)
+			if tt.errContains != "" {
+				require.ErrorContains(t, err, tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, pin)
+			require.Empty(t, cmp.Diff(pin, tt.expect, protocmp.Transform()))
+		})
+	}
+}


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/63195

Depends on https://github.com/gravitational/teleport/pull/64551

Introduces the `bot_name` and `bot_scope` fields to the Scoped Role Assignment, validation and implements `PopulatePinnedAssignmentsForBot` for calculating Bot role assignments. This codepath cannot yet be invoked until the PR which adds Scoped Joining for Bots.

This PR is the second of a stack that will fully implement MWI Scopes.

Changelog will be held until the final PRs are in place.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local environment

### Test Cases

- [x] Create SRA:
  - [x] For human user (as to ensure no regression)
  - [x] For Bot (simple)
  - [x] For Bot - Should Fail:
    - [x] Bot/User SRA mutual exclusivity
    - [x] Bot configured w/o scope
    - [x] Bot configured with invalid scope
    - [x] Assignment above/orthogonal to Bot scope
