### PR TITLE
Display a friendly resource name on SubCAService.Get/Delete errors

### DIFF
--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gravitational/trace"
 
@@ -45,6 +46,11 @@ func newCAOverridesPrefix() backend.Key {
 type CertAuthorityOverrideID struct {
 	ClusterName string
 	CAType      string
+}
+
+// displayName returns a user-friendly string for the ID.
+func (id *CertAuthorityOverrideID) displayName() string {
+	return fmt.Sprintf("%s/%s", id.CAType, id.ClusterName)
 }
 
 // CertAuthorityOverrideIDFromResource returns the id of the specified resource.
@@ -152,7 +158,10 @@ func (s *SubCAService) GetCertAuthorityOverride(
 		return nil, trace.Wrap(err)
 	}
 
-	resource, err := service.GetResource(ctx, "")
+	// Name has no effect on the query, it's only used for errors.
+	name := id.displayName()
+
+	resource, err := service.GetResource(ctx, name)
 	return resource, trace.Wrap(err)
 }
 
@@ -180,7 +189,10 @@ func (s *SubCAService) DeleteCertAuthorityOverride(
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(service.DeleteResource(ctx, ""))
+	// Name has no effect on the query, it's only used for errors.
+	name := id.displayName()
+
+	return trace.Wrap(service.DeleteResource(ctx, name))
 }
 
 func (s *SubCAService) serviceForResource(

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gravitational/trace"
 
@@ -50,7 +49,7 @@ type CertAuthorityOverrideID struct {
 
 // displayName returns a user-friendly string for the ID.
 func (id *CertAuthorityOverrideID) displayName() string {
-	return fmt.Sprintf("%s/%s", id.CAType, id.ClusterName)
+	return id.CAType + "/" + id.ClusterName
 }
 
 // CertAuthorityOverrideIDFromResource returns the id of the specified resource.
@@ -159,6 +158,7 @@ func (s *SubCAService) GetCertAuthorityOverride(
 	}
 
 	// Name has no effect on the query, it's only used for errors.
+	// See serviceForClusterAndType() / generic.Service.WithNameKeyFunc().
 	name := id.displayName()
 
 	resource, err := service.GetResource(ctx, name)
@@ -190,6 +190,7 @@ func (s *SubCAService) DeleteCertAuthorityOverride(
 	}
 
 	// Name has no effect on the query, it's only used for errors.
+	// See serviceForClusterAndType() / generic.Service.WithNameKeyFunc().
 	name := id.displayName()
 
 	return trace.Wrap(service.DeleteResource(ctx, name))

--- a/lib/services/local/subca_service_test.go
+++ b/lib/services/local/subca_service_test.go
@@ -17,6 +17,7 @@
 package local_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -340,4 +341,31 @@ func TestSubCAService_Update_wrongRevision(t *testing.T) {
 	_, err = service.UpdateCertAuthorityOverride(ctx, caOverride)
 	assert.ErrorAs(t, err, new(*trace.CompareFailedError),
 		"UpdateCertAuthorityOverride() revision mismatch error")
+}
+
+func TestSubCAService_GetDeleteNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	env := subcaenv.New(t, subcaenv.EnvParams{
+		SkipExternalRoot: true,
+	})
+	service := env.SubCA
+
+	id := local.CertAuthorityOverrideID{
+		ClusterName: env.ClusterName,
+		CAType:      string(types.WindowsCA),
+	}
+	wantErr := fmt.Sprintf(`"%s/%s" doesn't exist`, id.CAType, id.ClusterName)
+
+	t.Run("Get", func(t *testing.T) {
+		t.Parallel()
+		_, err := service.GetCertAuthorityOverride(t.Context(), id)
+		assert.ErrorContains(t, err, wantErr)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		t.Parallel()
+		err := service.DeleteCertAuthorityOverride(t.Context(), id)
+		assert.ErrorContains(t, err, wantErr)
+	})
 }


### PR DESCRIPTION
Display a friendly resource name on read errors.

Because of SubCAService's use of `generic.Service.WithNameKeyFunc()`, the resource name in Get() and Delete() calls is irrelevant and was passed as empty. This is fine for successful reads, but returns an error with an empty resource name on failures.

This PRs changes errors like:

`cert_authority_override "" doesn't exist`

to:

`cert_authority_override "windows/zarquon" doesn't exist`

https://github.com/gravitational/teleport.e/issues/7675