### PR TITLE
Add tctl resource support for ca_overrides

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -105,6 +105,7 @@ import (
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	secreportsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/secreports/v1"
 	stableunixusersv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/stableunixusers/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userloginstatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
@@ -6234,4 +6235,10 @@ func (c *Client) DeleteWorkloadCluster(ctx context.Context, name string) error {
 		Name: name,
 	})
 	return trace.Wrap(err)
+}
+
+// SubCAClient returns an unadorned Sub CA client, using the underlying Auth
+// gRPC connection.
+func (c *Client) SubCAClient() subcav1.SubCAServiceClient {
+	return subcav1.NewSubCAServiceClient(c.conn)
 }

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -170,6 +170,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindUser, nil
 	case types.KindCertAuthority, "cert_authorities", "cas":
 		return types.KindCertAuthority, nil
+	case types.KindCertAuthorityOverride, "cert_authority_overrides", "ca_override", "ca_overrides":
+		return types.KindCertAuthorityOverride, nil
 	case types.KindReverseTunnel, "reverse_tunnels", "rts":
 		return types.KindReverseTunnel, nil
 	case types.KindTrustedCluster, "tc", "cluster", "clusters":

--- a/lib/services/resource_test.go
+++ b/lib/services/resource_test.go
@@ -73,6 +73,11 @@ func TestParseShortcut(t *testing.T) {
 		"cert_authorities": {expectedOutput: types.KindCertAuthority},
 		"cas":              {expectedOutput: types.KindCertAuthority},
 
+		"cert_authority_override":  {expectedOutput: types.KindCertAuthorityOverride},
+		"cert_authority_overrides": {expectedOutput: types.KindCertAuthorityOverride},
+		"ca_override":              {expectedOutput: types.KindCertAuthorityOverride},
+		"ca_overrides":             {expectedOutput: types.KindCertAuthorityOverride},
+
 		"tunnel":          {expectedOutput: types.KindReverseTunnel},
 		"reverse_tunnels": {expectedOutput: types.KindReverseTunnel},
 		"rts":             {expectedOutput: types.KindReverseTunnel},

--- a/tool/tctl/common/resources/cert_authority_override.go
+++ b/tool/tctl/common/resources/cert_authority_override.go
@@ -1,0 +1,250 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/trace"
+
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/api/utils/tlsutils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/subca"
+)
+
+type certAuthorityOverrideCollection struct {
+	overrides []*subcav1.CertAuthorityOverride
+}
+
+func (c *certAuthorityOverrideCollection) Resources() []types.Resource {
+	ret := make([]types.Resource, len(c.overrides))
+	for i, o := range c.overrides {
+		ret[i] = types.Resource153ToLegacy(o)
+	}
+	return ret
+}
+
+func (c *certAuthorityOverrideCollection) WriteText(w io.Writer, verbose bool) error {
+	// Mimics the CA table.
+	// One entry per certificate override, or one entry per "empty" CA override.
+	t := asciitable.MakeTable([]string{"Cluster Name", "CA Type", "Public Key Hash"})
+
+	for _, caOverride := range c.overrides {
+		overrides := caOverride.GetSpec().GetCertificateOverrides()
+		if len(overrides) == 0 {
+			t.AddRow([]string{
+				caOverride.GetMetadata().GetName(),
+				caOverride.GetSubKind(),
+				"<none>",
+			})
+			continue
+		}
+
+		for _, o := range overrides {
+			pkh := o.PublicKey
+			if pkh == "" {
+				cert, err := tlsutils.ParseCertificatePEM([]byte(o.Certificate))
+				if err != nil {
+					return trace.Wrap(err, "parse CA override certificate")
+				}
+				pkh = subca.HashCertificatePublicKey(cert)
+			}
+			t.AddRow([]string{
+				caOverride.GetMetadata().GetName(),
+				caOverride.GetSubKind(),
+				pkh,
+			})
+		}
+	}
+
+	return trace.Wrap(t.WriteTo(w))
+}
+
+func certAuthorityOverrideHandler() Handler {
+	return Handler{
+		getHandler:    getCertAuthorityOverride,
+		createHandler: createCertAuthorityOverride,
+		updateHandler: updateCertAuthorityOverride,
+		deleteHandler: deleteCertAuthorityOverride,
+		singleton:     false,
+		mfaRequired:   false,
+		description:   "CA overrides for Teleport CA certificates. Allows admins to chain Teleport CAs to an external trust root.",
+	}
+}
+
+func getCertAuthorityOverride(
+	ctx context.Context,
+	authClient *authclient.Client,
+	ref services.Ref,
+	opts GetOpts,
+) (Collection, error) {
+	subCA := authClient.SubCAClient()
+
+	var caOverrides []*subcav1.CertAuthorityOverride
+	switch {
+	// Get by {ca_type}.
+	case ref.SubKind == "" && ref.Name != "":
+		caType := ref.Name
+		resp, err := subCA.GetCertAuthorityOverride(ctx, &subcav1.GetCertAuthorityOverrideRequest{
+			CaId: &subcav1.CertAuthorityOverrideID{
+				CaType: caType,
+			},
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		caOverrides = []*subcav1.CertAuthorityOverride{resp.CaOverride}
+
+	// List.
+	default:
+		var err error
+		caOverrides, err = stream.Collect(clientutils.Resources(
+			ctx,
+			func(ctx context.Context, pageSize int, pageToken string) ([]*subcav1.CertAuthorityOverride, string, error) {
+				resp, err := subCA.ListCertAuthorityOverride(ctx, &subcav1.ListCertAuthorityOverrideRequest{
+					PageSize:  int32(pageSize),
+					PageToken: pageToken,
+				})
+				return resp.GetCaOverrides(), resp.GetNextPageToken(), trace.Wrap(err)
+			},
+		))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return &certAuthorityOverrideCollection{overrides: caOverrides}, nil
+}
+
+func createCertAuthorityOverride(ctx context.Context,
+	authClient *authclient.Client,
+	raw services.UnknownResource,
+	opts CreateOpts,
+) error {
+	caOverride, err := services.UnmarshalCertAuthorityOverride(
+		raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	subCA := authClient.SubCAClient()
+
+	var created *subcav1.CertAuthorityOverride
+	if opts.Force {
+		resp, err1 := subCA.UpsertCertAuthorityOverride(ctx, &subcav1.UpsertCertAuthorityOverrideRequest{
+			CaOverride: caOverride,
+		})
+		created = resp.GetCaOverride()
+		err = err1
+	} else {
+		resp, err1 := subCA.CreateCertAuthorityOverride(ctx, &subcav1.CreateCertAuthorityOverrideRequest{
+			CaOverride: caOverride,
+		})
+		created = resp.GetCaOverride()
+		err = err1
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf("%s %s/%s created\n",
+		types.KindCertAuthorityOverride,
+		created.SubKind,
+		created.Metadata.Name,
+	)
+	return nil
+}
+
+func updateCertAuthorityOverride(
+	ctx context.Context,
+	authClient *authclient.Client,
+	raw services.UnknownResource,
+	opts CreateOpts,
+) error {
+	caOverride, err := services.UnmarshalCertAuthorityOverride(
+		raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	resp, err := authClient.
+		SubCAClient().
+		UpdateCertAuthorityOverride(ctx, &subcav1.UpdateCertAuthorityOverrideRequest{
+			CaOverride: caOverride,
+		})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	updated := resp.CaOverride
+
+	fmt.Printf("%s %s/%s updated\n",
+		types.KindCertAuthorityOverride,
+		updated.SubKind,
+		updated.Metadata.Name,
+	)
+	return nil
+}
+
+func deleteCertAuthorityOverride(
+	ctx context.Context,
+	authClient *authclient.Client,
+	ref services.Ref,
+) error {
+	caType, err := validateCertAuthorityOverrideCATypeRef(ref)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := authClient.
+		SubCAClient().
+		DeleteCertAuthorityOverride(ctx, &subcav1.DeleteCertAuthorityOverrideRequest{
+			CaId: &subcav1.CertAuthorityOverrideID{
+				CaType: caType,
+			},
+		}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf("%s %s deleted\n",
+		types.KindCertAuthorityOverride,
+		caType,
+	)
+	return nil
+}
+
+func validateCertAuthorityOverrideCATypeRef(ref services.Ref) (caType string, _ error) {
+	if ref.Kind == types.KindCertAuthorityOverride &&
+		ref.SubKind == "" &&
+		ref.Name != "" {
+		return ref.Name, nil
+	}
+	// TODO(codingllama): Support "ca_override/{ca_type}/{name}" queries in tctl?
+
+	return "", trace.BadParameter(
+		"%s: expected resource name in the format %s/{ca_type}",
+		types.KindCertAuthorityOverride,
+		types.KindCertAuthorityOverride,
+	)
+}

--- a/tool/tctl/common/resources/cert_authority_override.go
+++ b/tool/tctl/common/resources/cert_authority_override.go
@@ -150,27 +150,31 @@ func createCertAuthorityOverride(ctx context.Context,
 	subCA := authClient.SubCAClient()
 
 	var created *subcav1.CertAuthorityOverride
+	var action string
 	if opts.Force {
 		resp, err1 := subCA.UpsertCertAuthorityOverride(ctx, &subcav1.UpsertCertAuthorityOverrideRequest{
 			CaOverride: caOverride,
 		})
 		created = resp.GetCaOverride()
 		err = err1
+		action = "updated"
 	} else {
 		resp, err1 := subCA.CreateCertAuthorityOverride(ctx, &subcav1.CreateCertAuthorityOverrideRequest{
 			CaOverride: caOverride,
 		})
 		created = resp.GetCaOverride()
 		err = err1
+		action = "created"
 	}
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	fmt.Printf("%s %s/%s created\n",
+	fmt.Printf("%s %s/%s %s\n",
 		types.KindCertAuthorityOverride,
 		created.SubKind,
 		created.Metadata.Name,
+		action,
 	)
 	return nil
 }

--- a/tool/tctl/common/resources/cert_authority_override.go
+++ b/tool/tctl/common/resources/cert_authority_override.go
@@ -88,8 +88,6 @@ func certAuthorityOverrideHandler() Handler {
 		createHandler: createCertAuthorityOverride,
 		updateHandler: updateCertAuthorityOverride,
 		deleteHandler: deleteCertAuthorityOverride,
-		singleton:     false,
-		mfaRequired:   false,
 		description:   "CA overrides for Teleport CA certificates. Allows admins to chain Teleport CAs to an external trust root.",
 	}
 }

--- a/tool/tctl/common/resources/cert_authority_override.go
+++ b/tool/tctl/common/resources/cert_authority_override.go
@@ -98,27 +98,20 @@ func getCertAuthorityOverride(
 	ref services.Ref,
 	opts GetOpts,
 ) (Collection, error) {
+	// Defensive. Shouldn't happen. Only 3 forms of ref are possible:
+	//   - kind ("tctl get ca_overrides")
+	//   - kind + name ("tctl get ca_overrides/{ca_type}")
+	//   - kind + subKind + name ("tctl get ca_overrides/{ca_type}/{cluster_name}")
+	if ref.Kind != types.KindCertAuthorityOverride ||
+		(ref.SubKind != "" && ref.Name == "") {
+		return nil, trace.BadParameter("invalid ref: %#v", ref)
+	}
+
 	subCA := authClient.SubCAClient()
 
-	var caOverrides []*subcav1.CertAuthorityOverride
-	switch {
-	// Get by {ca_type}.
-	case ref.SubKind == "" && ref.Name != "":
-		caType := ref.Name
-		resp, err := subCA.GetCertAuthorityOverride(ctx, &subcav1.GetCertAuthorityOverrideRequest{
-			CaId: &subcav1.CertAuthorityOverrideID{
-				CaType: caType,
-			},
-		})
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		caOverrides = []*subcav1.CertAuthorityOverride{resp.CaOverride}
-
 	// List.
-	default:
-		var err error
-		caOverrides, err = stream.Collect(clientutils.Resources(
+	if ref.SubKind == "" && ref.Name == "" {
+		caOverrides, err := stream.Collect(clientutils.Resources(
 			ctx,
 			func(ctx context.Context, pageSize int, pageToken string) ([]*subcav1.CertAuthorityOverride, string, error) {
 				resp, err := subCA.ListCertAuthorityOverride(ctx, &subcav1.ListCertAuthorityOverrideRequest{
@@ -131,9 +124,37 @@ func getCertAuthorityOverride(
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+		return &certAuthorityOverrideCollection{overrides: caOverrides}, nil
 	}
 
-	return &certAuthorityOverrideCollection{overrides: caOverrides}, nil
+	// Get by {caType} or {caType}/{clusterName}.
+	var caType, clusterName string
+	if ref.SubKind != "" {
+		caType = ref.SubKind
+		clusterName = ref.Name
+	} else {
+		caType = ref.Name
+	}
+
+	// TODO(codingllama): Support cluster_name in ca_override Gets.
+	resp, err := subCA.GetCertAuthorityOverride(ctx, &subcav1.GetCertAuthorityOverrideRequest{
+		CaId: &subcav1.CertAuthorityOverrideID{
+			CaType: caType,
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	caOverride := resp.CaOverride
+
+	// Simulate a Get-by-name if the name was specified.
+	if clusterName != "" && caOverride.Metadata.Name != clusterName {
+		return nil, trace.NotFound("%s %s/%s not found", ref.Kind, caType, clusterName)
+	}
+
+	return &certAuthorityOverrideCollection{
+		overrides: []*subcav1.CertAuthorityOverride{caOverride},
+	}, nil
 }
 
 func createCertAuthorityOverride(ctx context.Context,
@@ -214,11 +235,18 @@ func deleteCertAuthorityOverride(
 	authClient *authclient.Client,
 	ref services.Ref,
 ) error {
-	caType, err := validateCertAuthorityOverrideCATypeRef(ref)
-	if err != nil {
-		return trace.Wrap(err)
+	if ref.Kind != types.KindCertAuthorityOverride ||
+		ref.SubKind != "" ||
+		ref.Name == "" {
+		return trace.BadParameter(
+			"%s deletes must the in the format %s/{ca_type}",
+			types.KindCertAuthorityOverride,
+			types.KindCertAuthorityOverride,
+		)
 	}
+	caType := ref.Name
 
+	// TODO(codingllama): Support cluster_name in ca_override Deletes.
 	if _, err := authClient.
 		SubCAClient().
 		DeleteCertAuthorityOverride(ctx, &subcav1.DeleteCertAuthorityOverrideRequest{
@@ -234,19 +262,4 @@ func deleteCertAuthorityOverride(
 		caType,
 	)
 	return nil
-}
-
-func validateCertAuthorityOverrideCATypeRef(ref services.Ref) (caType string, _ error) {
-	if ref.Kind == types.KindCertAuthorityOverride &&
-		ref.SubKind == "" &&
-		ref.Name != "" {
-		return ref.Name, nil
-	}
-	// TODO(codingllama): Support "ca_override/{ca_type}/{name}" queries in tctl?
-
-	return "", trace.BadParameter(
-		"%s: expected resource name in the format %s/{ca_type}",
-		types.KindCertAuthorityOverride,
-		types.KindCertAuthorityOverride,
-	)
 }

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/subca"
 )
 
 // Handlers returns a map of Handler per kind.
@@ -34,7 +35,7 @@ import (
 // to the Handler format.
 func Handlers() map[string]Handler {
 	// When adding resources, please keep the map alphabetically ordered.
-	return map[string]Handler{
+	m := map[string]Handler{
 		types.KindAccessGraphSettings:                accessGraphSettingsHandler(),
 		types.KindAccessList:                         accessListHandler(),
 		types.KindAccessMonitoringRule:               accessMonitoringRuleHandler(),
@@ -98,6 +99,12 @@ func Handlers() map[string]Handler {
 		types.KindWorkloadCluster:                    workloadClusterHandler(),
 		scopedaccess.KindScopedToken:                 scopedTokenHandler(),
 	}
+
+	if subca.Enabled() {
+		m[types.KindCertAuthorityOverride] = certAuthorityOverrideHandler()
+	}
+
+	return m
 }
 
 // Handler represents a resource supported by the tctl resource command.


### PR DESCRIPTION
Add tctl resource support for ca_overrides, specifically "tctl create/edit/get/rm".

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan

### Test Environment
* Dev binaries built with -tags=subca
* Needs a shell of SubCA RPCs (presently a modified copy of [e#codingllama/subca-all-e](https://github.com/gravitational/teleport.e/tree/codingllama/subca-all-e)).

### Test Cases
- [x] tctl create ca_override.yaml (create)
- [x] tctl create -f ca_override.yaml (upsert)
- [x] tctl edit ca_overrides/ca_type (update)
- [x] tctl get ca_overrides/ca_type (get)
- [x] tctl get ca_overrides (list)
- [x] tctl get ca_overrides --format=text (list, exercises WriteText())
- [x] tctl rm ca_overrides/ca_type (delete)
