### PR TITLE
Fix access graph feature not rendering in web UI

### DIFF
--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -95,6 +95,9 @@ type WebConfig struct {
 	// IdentitySecurity contains identity security features and settings.
 	// The individual identity security entitlements should be read from the Entitlements field.
 	IdentitySecurity IdentitySecurity `json:"identitySecurity"`
+	// IsPolicyEnabled is true if [Features.Policy] = true
+	// Deprecated, use entitlements
+	IsPolicyEnabled bool `json:"isPolicyEnabled"`
 }
 
 // IdentitySecurity contains identity security features and settings.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2161,6 +2161,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		PremiumSupport:                 clusterFeatures.GetSupportType() == proto.SupportType_SUPPORT_TYPE_PREMIUM,
 		PlayableDatabaseProtocols:      player.SupportedDatabaseProtocols,
 		SessionSummarizerEnabled:       sessionSummarizerEnabled,
+		IsPolicyEnabled:                modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy).Enabled,
 		// if Entitlements are not present, GetWebCfgEntitlements will return a map of entitlement to {enabled:false}
 		// if Entitlements are present, GetWebCfgEntitlements will populate the fields appropriately
 		Entitlements: GetWebCfgEntitlements(clusterFeatures.GetEntitlements()),

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -265,7 +265,7 @@ const cfg = {
   /** @deprecated Use entitlements instead; remove in v20 */
   saml: false,
   // isPolicyEnabled refers to the Teleport Policy product
-  /** @deprecated Use entitlements instead; remove in v20 */
+  /** @deprecated Use entitlements.Policy.enabled instead;*/
   isPolicyEnabled: false,
 
   ui: {


### PR DESCRIPTION
fixes a regression from https://github.com/gravitational/teleport/pull/59618 where it removed the `isPolicyEnabled` in the backend, but the flag was kept in the frontend. This made the flag always false despite policy license setting and access graph didn't render.

This PR brings the backend flag back.

If we want to remove the `isPolicyEnabled` duplicate flag, we must change all usage of `cfg.isPolicyEnabled` in the frontend to `entitlements.Policy.enabled` and keep the backend flag for 2 major versions. I didn't change this in this PR since there were actually a lot of places that used it and we are pretty much finished with the test plan. 


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

cloud staging

### Test Cases
- [x] access graph renders for roles and access list
- [x] tested without license to make sure empty states worked correctly  
