### PR TITLE
docs: add YT video to MWI docs page

### DIFF
--- a/docs/pages/machine-workload-identity/use-cases/ai-agents-mwi.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/ai-agents-mwi.mdx
@@ -8,6 +8,8 @@ tags:
  - ai
 ---
 
+import TextWithMedia from "@site/src/components/Pages/Landing/TextWithMedia";
+
 Teleport enables you to enforce access and privileges for agents.
 
 Security must be enforced deterministically. AI agents cannot be trusted to follow high-level instructions like "don't delete production". 
@@ -16,6 +18,13 @@ This allows Teleport to apply Role-Based Access Control (RBAC) at both the netwo
 
 Teleport can secure infrastructure components such as SSH servers, Kubernetes clusters, databases, or MCP servers, when accessed by agents. 
 All queries, commands, and requests executed by the agent are logged, providing full visibility and [auditability](../../reference/deployment/monitoring/audit.mdx).
+<br />
+<TextWithMedia
+  title="AI agent access demo"
+  youtubeVideoId="D9tBqJZmIdA"
+>
+  This video demonstrates how to grant an AI agent controlled, read-only access to a Kubernetes cluster using Teleport’s `tbot` binary. The agent operates with its own identity and RBAC restrictions, ensuring it can only perform authorized actions.
+</TextWithMedia>
 
 ## Interested in a Design Partnership?
 


### PR DESCRIPTION
This commit uses the TextWithMedia component to add a YouTube demo video to the `/machine-workload-identity/use-cases/ai-agents-mwi.mdx` page along with a blurb. This page did not have any examples for AI agents, thus adding the video demo.

Preview page - https://travis-rodgers-add-yt-video-to-mwi-page.d212ksyjt6y4yg.amplifyapp.com/docs/machine-workload-identity/use-cases/ai-agents-mwi/
