### PR TITLE
[v18] Revise predicate language docs and add `contains(set, item)`

### DIFF
--- a/docs/pages/reference/access-controls/predicate-language.mdx
+++ b/docs/pages/reference/access-controls/predicate-language.mdx
@@ -161,9 +161,9 @@ The language also supports the following functions:
 
 | Functions | Description | Example |
 |-----------|-------------|---------|
-| `contains_any(set, items)` | Returns true if `set` contains an exact match for any element of `items` | `contains_any(user.traits["team"], set("dev", "stage"))` |
-| `contains_all(set, items)` | Returns true if `set` contains an exact match for all elements of `items` | `contains_all(set("dev"), access_request.spec.roles)` |
-| `set.contains(item)` | Returns true if `set` contains an exact match for `item` | `access_request.spec.roles.contains("example_role")` |
+| `contains_any(set, items)` | Returns true if `set` contains an exact match for any element of `items` | `contains_any(access_request.spec.roles, set("dev", "security", "cloud"))` |
+| `contains_all(set, items)` | Returns true if `set` contains an exact match for all elements of `items` | `contains_all(access_request.spec.roles, set("dev", "security", "cloud"))` |
+| `contains(set, item)`, `set.contains(item)` | Returns true if `set` contains an exact match for `item` | `contains(access_request.spec.roles, "dev")` |
 | `regexp.match(set, re)` | Returns true if `set` contains a match for `re` | `regexp.match(set(access_request.spec.request_reason), "*on-call*")` |
 | `is_empty(set)`| Returns true if `set` contains no elements | `is_empty(access_request.spec.roles)` |
 

--- a/docs/pages/reference/access-controls/predicate-language.mdx
+++ b/docs/pages/reference/access-controls/predicate-language.mdx
@@ -161,7 +161,7 @@ The language also supports the following functions:
 
 | Functions | Description | Example |
 |-----------|-------------|---------|
-| `contains_any(set, items)` | Returns true if `set` contains an exact match for any element of `items` | `contains_any(access_request.spec.roles, set("dev", "security", "cloud"))` |
+| `contains_any(set, items)` | Returns true if `set` contains an exact match for any element of `items` | `contains_any(user.traits["team"], set("dev", "stage"))` |
 | `contains_all(set, items)` | Returns true if `set` contains an exact match for all elements of `items` | `contains_all(access_request.spec.roles, set("dev", "security", "cloud"))` |
 | `contains(set, item)`, `set.contains(item)` | Returns true if `set` contains an exact match for `item` | `contains(access_request.spec.roles, "dev")` |
 | `regexp.match(set, re)` | Returns true if `set` contains a match for `re` | `regexp.match(set(access_request.spec.request_reason), "*on-call*")` |

--- a/lib/accessmonitoring/request_mapping_test.go
+++ b/lib/accessmonitoring/request_mapping_test.go
@@ -96,7 +96,7 @@ func TestEvaluateCondition(t *testing.T) {
 		{
 			description: "does not match any role",
 			condition: `
-                contains_any(access_request.spec.roles, set("no-match")) ||
+                contains_any(access_request.spec.roles, set("no-match")) &&
                 access_request.spec.roles.contains_any(set("no-match"))`,
 			env: AccessRequestExpressionEnv{
 				Roles: []string{"dev", "stage", "prod"},
@@ -116,7 +116,7 @@ func TestEvaluateCondition(t *testing.T) {
 		{
 			description: "does not match all requested roles",
 			condition: `
-                contains_all(set("dev"), access_request.spec.roles) ||
+                contains_all(set("dev"), access_request.spec.roles) &&
                 set("dev").contains_all(access_request.spec.roles)`,
 			env: AccessRequestExpressionEnv{
 				Roles: []string{"dev", "stage", "prod"},
@@ -126,7 +126,7 @@ func TestEvaluateCondition(t *testing.T) {
 		{
 			description: "requested roles is empty",
 			condition: `
-                contains_all(set("dev"), access_request.spec.roles) ||
+                contains_all(set("dev"), access_request.spec.roles) &&
                 set("dev").contains_all(access_request.spec.roles)`,
 			env: AccessRequestExpressionEnv{
 				Roles: []string{},
@@ -136,7 +136,7 @@ func TestEvaluateCondition(t *testing.T) {
 		{
 			description: "both sets are empty",
 			condition: `
-                contains_all(set(), access_request.spec.roles) ||
+                contains_all(set(), access_request.spec.roles) &&
                 set().contains_all(access_request.spec.roles)`,
 			env: AccessRequestExpressionEnv{
 				Roles: []string{},
@@ -146,8 +146,8 @@ func TestEvaluateCondition(t *testing.T) {
 		{
 			description: "(union) single resource has label",
 			condition: `
-                access_request.spec.resource_labels_union["env"].
-                    contains("test")`,
+                access_request.spec.resource_labels_union["env"].contains("test") &&
+				contains(access_request.spec.resource_labels_union["env"], "test")`,
 			env: AccessRequestExpressionEnv{
 				RequestedResources: []types.ResourceWithLabels{
 					&types.ServerV2{
@@ -183,8 +183,8 @@ func TestEvaluateCondition(t *testing.T) {
 		{
 			description: "(intersection) single resource has label",
 			condition: `
-                access_request.spec.resource_labels_intersection["env"].
-                    contains("test")`,
+                access_request.spec.resource_labels_intersection["env"].contains("test") &&
+				contains(access_request.spec.resource_labels_intersection["env"], "test")`,
 			env: AccessRequestExpressionEnv{
 				RequestedResources: []types.ResourceWithLabels{
 					&types.ServerV2{
@@ -199,8 +199,8 @@ func TestEvaluateCondition(t *testing.T) {
 		{
 			description: "(intersection) multiple resources have label",
 			condition: `
-                access_request.spec.resource_labels_intersection["env"].
-                    contains("test")`,
+                access_request.spec.resource_labels_intersection["env"].contains("test") &&
+				contains(access_request.spec.resource_labels_intersection["env"], "test")`,
 			env: AccessRequestExpressionEnv{
 				RequestedResources: []types.ResourceWithLabels{
 					&types.ServerV2{

--- a/lib/expression/parser.go
+++ b/lib/expression/parser.go
@@ -146,6 +146,10 @@ func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
 					// If it's not a time, try semver comparison
 					return SemverBetween(value, arg1, arg2)
 				}),
+			"contains": typical.BinaryFunction[evaluationEnv](
+				func(s Set, str string) (bool, error) {
+					return s.contains(str), nil
+				}),
 			"contains_any": typical.BinaryFunction[evaluationEnv](
 				func(s1, s2 Set) (bool, error) {
 					for v := range s2.s {


### PR DESCRIPTION
Backport #64864 to branch/v18

changelog: Extended access monitoring predicate language with `contains(set, item)` expression

## Manual Test Plan
### Test Environment

Locally tested

### Test Cases
- [x] Added unit tests for predicate expression matching for `contains(set, item)`