### PR TITLE
[v17] web: Fix resource views to deduplicate dynamic and static labels

### DIFF
--- a/docs/pages/zero-trust-access/management/admin/labels.mdx
+++ b/docs/pages/zero-trust-access/management/admin/labels.mdx
@@ -33,7 +33,8 @@ process or editing the configuration file.
 
 You can add multiple static, dynamic, and resource-based labels for the same resource.
 However, you can't add static labels that use the same key with different values or use
-a static label to define multiple potential values.
+a static label to define multiple potential values. If a static label and dynamic label have
+the same key, the dynamic label always takes precedence in resource filtering and RBAC permissions.
 
 Dynamic labels are especially useful for decoupling a label value from the Teleport configuration.
 For example, if you start Teleport on an Amazon EC2 instance, you can use a dynamic label to set the

--- a/lib/teleterm/apiserver/handler/handler_kubes.go
+++ b/lib/teleterm/apiserver/handler/handler_kubes.go
@@ -57,10 +57,8 @@ func (s *Handler) ListKubernetesResources(ctx context.Context, req *api.ListKube
 }
 
 func newAPIKube(kube clusters.Kube) *api.Kube {
-	staticLabels := kube.KubernetesCluster.GetStaticLabels()
-	dynamicLabels := kube.KubernetesCluster.GetDynamicLabels()
 	apiLabels := makeAPILabels(
-		ui.MakeLabelsWithoutInternalPrefixes(staticLabels, ui.TransformCommandLabels(dynamicLabels)),
+		ui.MakeLabelsWithoutInternalPrefixes(kube.KubernetesCluster.GetAllLabels()),
 	)
 
 	return &api.Kube{

--- a/lib/teleterm/apiserver/handler/handler_servers.go
+++ b/lib/teleterm/apiserver/handler/handler_servers.go
@@ -47,10 +47,8 @@ func (s *Handler) GetServers(ctx context.Context, req *api.GetServersRequest) (*
 }
 
 func newAPIServer(server clusters.Server) *api.Server {
-	serverLabels := server.GetStaticLabels()
-	serverCmdLabels := server.GetCmdLabels()
 	apiLabels := makeAPILabels(
-		ui.MakeLabelsWithoutInternalPrefixes(serverLabels, ui.TransformCommandLabels(serverCmdLabels)),
+		ui.MakeLabelsWithoutInternalPrefixes(server.GetAllLabels()),
 	)
 
 	return &api.Server{

--- a/lib/web/ui/git_server.go
+++ b/lib/web/ui/git_server.go
@@ -55,9 +55,7 @@ type GitHubServerMetadata struct {
 
 // MakeGitServer creates a git server object for the web ui
 func MakeGitServer(clusterName string, server types.Server, requiresRequest bool) GitServer {
-	serverLabels := server.GetStaticLabels()
-	serverCmdLabels := server.GetCmdLabels()
-	uiLabels := ui.MakeLabelsWithoutInternalPrefixes(serverLabels, ui.TransformCommandLabels(serverCmdLabels))
+	uiLabels := ui.MakeLabelsWithoutInternalPrefixes(server.GetAllLabels())
 
 	uiServer := GitServer{
 		Kind:            server.GetKind(),

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -69,9 +69,7 @@ type AWSMetadata struct {
 
 // MakeServer creates a server object for the web ui
 func MakeServer(clusterName string, server types.Server, logins []string, requiresRequest bool) Server {
-	serverLabels := server.GetStaticLabels()
-	serverCmdLabels := server.GetCmdLabels()
-	uiLabels := ui.MakeLabelsWithoutInternalPrefixes(serverLabels, ui.TransformCommandLabels(serverCmdLabels))
+	uiLabels := ui.MakeLabelsWithoutInternalPrefixes(server.GetAllLabels())
 
 	uiServer := Server{
 		Kind:            server.GetKind(),
@@ -131,9 +129,7 @@ type KubeCluster struct {
 
 // MakeKubeCluster creates a kube cluster object for the web ui
 func MakeKubeCluster(cluster types.KubeCluster, accessChecker services.AccessChecker, requiresRequest bool) KubeCluster {
-	staticLabels := cluster.GetStaticLabels()
-	dynamicLabels := cluster.GetDynamicLabels()
-	uiLabels := ui.MakeLabelsWithoutInternalPrefixes(staticLabels, ui.TransformCommandLabels(dynamicLabels))
+	uiLabels := ui.MakeLabelsWithoutInternalPrefixes(cluster.GetAllLabels())
 	kubeUsers, kubeGroups := getAllowedKubeUsersAndGroupsForCluster(accessChecker, cluster)
 	return KubeCluster{
 		Kind:            cluster.GetKind(),
@@ -168,9 +164,7 @@ func MakeEKSClusters(clusters []*integrationv1.EKSCluster) []EKSCluster {
 func MakeKubeClusters(clusters []types.KubeCluster, accessChecker services.AccessChecker) []KubeCluster {
 	uiKubeClusters := make([]KubeCluster, 0, len(clusters))
 	for _, cluster := range clusters {
-		staticLabels := cluster.GetStaticLabels()
-		dynamicLabels := cluster.GetDynamicLabels()
-		uiLabels := ui.MakeLabelsWithoutInternalPrefixes(staticLabels, ui.TransformCommandLabels(dynamicLabels))
+		uiLabels := ui.MakeLabelsWithoutInternalPrefixes(cluster.GetAllLabels())
 
 		kubeUsers, kubeGroups := getAllowedKubeUsersAndGroupsForCluster(accessChecker, cluster)
 


### PR DESCRIPTION
Backport #64820 to branch/v17

Changelog: Fixed minor bug in Web UI and Connect where static and dynamic labels with the same key are duplicated

## Manual Test Plan
### Test Environment
Teleport Enterprise Cloud

### Test Cases
- [x] Verify that when static and dynamic labels share a key, only the dynamic label's key:value pair is present in resource view