### PR TITLE
[v18] limiter: Short-circuit when no limits configured

### DIFF
--- a/lib/limiter/connlimiter.go
+++ b/lib/limiter/connlimiter.go
@@ -41,8 +41,9 @@ type ConnectionsLimiter struct {
 	connections map[string]int64
 }
 
-// NewConnectionsLimiter returns new connection limiter, in case if connection
-// limits are not set, they won't be tracked
+// NewConnectionsLimiter returns a new connection limiter. If
+// maxConnections is zero, the limiter performs no tracking and
+// all requests pass through.
 func NewConnectionsLimiter(maxConnections int64) *ConnectionsLimiter {
 	return &ConnectionsLimiter{
 		maxConnections: maxConnections,
@@ -60,6 +61,11 @@ func (l *ConnectionsLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if l.next == nil {
 		sc := http.StatusInternalServerError
 		http.Error(w, http.StatusText(sc), sc)
+		return
+	}
+
+	if l.maxConnections == 0 {
+		l.next.ServeHTTP(w, r)
 		return
 	}
 
@@ -82,7 +88,9 @@ func (l *ConnectionsLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	l.next.ServeHTTP(w, r)
 }
 
-// AcquireConnection acquires connection and bumps counter
+// AcquireConnection increments the connection count for the
+// given token. If maxConnections is zero, it returns nil
+// immediately without tracking.
 func (l *ConnectionsLimiter) AcquireConnection(token string) error {
 	if l.maxConnections == 0 {
 		return nil
@@ -105,7 +113,8 @@ func (l *ConnectionsLimiter) AcquireConnection(token string) error {
 	return nil
 }
 
-// ReleaseConnection decrements the counter
+// ReleaseConnection decrements the connection count for the
+// given token. If maxConnections is zero, it returns immediately.
 func (l *ConnectionsLimiter) ReleaseConnection(token string) {
 	if l.maxConnections == 0 {
 		return
@@ -126,7 +135,9 @@ func (l *ConnectionsLimiter) ReleaseConnection(token string) {
 	}
 }
 
-// GetNumConnection returns the current number of connections for a token
+// GetNumConnection returns the current connection count for the
+// given token. If maxConnections is zero, it returns 0 because
+// connections are not tracked.
 func (l *ConnectionsLimiter) GetNumConnection(token string) (int64, error) {
 	if l.maxConnections == 0 {
 		return 0, nil

--- a/lib/limiter/internal/ratelimit/ratelimit.go
+++ b/lib/limiter/internal/ratelimit/ratelimit.go
@@ -47,8 +47,8 @@ type TokenLimiterConfig struct {
 }
 
 func (t *TokenLimiterConfig) CheckAndSetDefaults() error {
-	if len(t.Rates.m) == 0 {
-		return trace.BadParameter("missing required rates")
+	if t.Rates == nil {
+		t.Rates = &RateSet{m: make(map[time.Duration]*rate)}
 	}
 
 	if t.Clock == nil {
@@ -71,17 +71,23 @@ func New(config TokenLimiterConfig) (*TokenLimiter, error) {
 		log: slog.With(teleport.ComponentKey, "ratelimiter"),
 	}
 
-	bucketSets, err := utils.NewFnCache(utils.FnCacheConfig{
-		// The default TTL here is not super important because we set the
-		// TTL explicitly for each entry we insert.
-		TTL:   10 * time.Second,
-		Clock: config.Clock,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
+	// Skip FnCache creation when no rates are configured. Creating
+	// an FnCache allocates an internal map and a context that the
+	// noop path in ServeHTTP never uses.
+	if config.Rates.Len() > 0 {
+		bucketSets, err := utils.NewFnCache(utils.FnCacheConfig{
+			// The default TTL only drives the cleanup sweep interval
+			// (TTL * 16). All entries use their own TTL via
+			// FnCacheGetWithTTL in consumeRates.
+			TTL:   10 * time.Second,
+			Clock: config.Clock,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		tl.bucketSets = bucketSets
 	}
 
-	tl.bucketSets = bucketSets
 	return tl, nil
 }
 
@@ -90,6 +96,16 @@ func (tl *TokenLimiter) Wrap(next http.Handler) {
 }
 
 func (tl *TokenLimiter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if tl.next == nil {
+		sc := http.StatusInternalServerError
+		http.Error(w, http.StatusText(sc), sc)
+		return
+	}
+	if tl.defaultRates.Len() == 0 {
+		tl.next.ServeHTTP(w, req)
+		return
+	}
+
 	clientIP, err := ExtractClientIP(req)
 	if err != nil {
 		ServeHTTPError(w, req, err)
@@ -166,6 +182,15 @@ func (rs *RateSet) Add(period time.Duration, average int64, burst int64) error {
 	}
 	rs.m[period] = &rate{period, average, burst}
 	return nil
+}
+
+// Len returns the number of rates in the set. It is safe to call on a
+// nil receiver.
+func (rs *RateSet) Len() int {
+	if rs == nil {
+		return 0
+	}
+	return len(rs.m)
 }
 
 // MaxPeriod returns the maximum period in the rate set.

--- a/lib/limiter/internal/ratelimit/ratelimit_test.go
+++ b/lib/limiter/internal/ratelimit/ratelimit_test.go
@@ -120,3 +120,9 @@ func TestTokenBucketSet_IsRateLimited(t *testing.T) {
 		require.True(t, tbs.IsRateLimited())
 	})
 }
+
+func TestRateSetLenNilReceiver(t *testing.T) {
+	t.Parallel()
+	var rs *RateSet
+	require.Equal(t, 0, rs.Len())
+}

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -110,7 +110,7 @@ func (l *Limiter) RegisterRequestAndConnection(token string) (func(), error) {
 
 type RateSet = ratelimit.RateSet
 
-// NewRateSet creates an empty RateSet instance.
+// NewRateSet creates an empty RateSet.
 func NewRateSet() *RateSet { return ratelimit.NewRateSet() }
 
 // UnaryServerInterceptor returns a gRPC unary interceptor which

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -392,6 +392,152 @@ func mustServeAndReceiveStatusCode(t *testing.T, handler http.Handler, wantStatu
 	require.Equal(t, wantStatusCode, response.StatusCode)
 }
 
+func TestNoRates_RegisterRequest(t *testing.T) {
+	t.Parallel()
+
+	limiter, err := NewLimiter(Config{})
+	require.NoError(t, err)
+
+	// With no rates configured, RegisterRequest should never reject.
+	for range 100 {
+		require.NoError(t, limiter.RegisterRequest("token1"))
+	}
+}
+
+func TestNoRates_Middleware(t *testing.T) {
+	t.Parallel()
+
+	limiter, err := NewLimiter(Config{})
+	require.NoError(t, err)
+
+	middleware := MakeMiddleware(limiter)
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	// With no rates and no max connections, every request should pass through.
+	for range 100 {
+		mustServeAndReceiveStatusCode(t, handler, http.StatusAccepted)
+	}
+}
+
+func TestNoRates_IsRateLimited(t *testing.T) {
+	t.Parallel()
+
+	limiter, err := NewRateLimiter(Config{})
+	require.NoError(t, err)
+
+	// With no rates configured, IsRateLimited should always return false.
+	require.False(t, limiter.IsRateLimited("token1"))
+
+	// RegisterRequest is a no-op, so even after many calls the token
+	// should not appear rate-limited.
+	for range 100 {
+		require.NoError(t, limiter.RegisterRequest("token1"))
+	}
+	require.False(t, limiter.IsRateLimited("token1"))
+}
+
+func TestNoRates_UnaryServerInterceptor(t *testing.T) {
+	t.Parallel()
+
+	limiter, err := NewLimiter(Config{})
+	require.NoError(t, err)
+
+	ctx := peer.NewContext(t.Context(), &peer.Peer{Addr: mockAddr{}})
+	serverInfo := &grpc.UnaryServerInfo{FullMethod: "/method"}
+	handler := func(context.Context, any) (any, error) { return "ok", nil }
+
+	interceptor := limiter.UnaryServerInterceptor()
+
+	// With no rates, the interceptor should never reject.
+	for range 100 {
+		resp, err := interceptor(ctx, "request", serverInfo, handler)
+		require.NoError(t, err)
+		require.Equal(t, "ok", resp)
+	}
+}
+
+func TestNoRates_StreamServerInterceptor(t *testing.T) {
+	t.Parallel()
+
+	limiter, err := NewLimiter(Config{})
+	require.NoError(t, err)
+
+	ctx := peer.NewContext(t.Context(), &peer.Peer{Addr: mockAddr{}})
+	ss := mockServerStream{ctx: ctx}
+	info := &grpc.StreamServerInfo{}
+	handler := func(srv any, stream grpc.ServerStream) error { return nil }
+
+	// With no rates, the interceptor should never reject.
+	for range 100 {
+		require.NoError(t, limiter.StreamServerInterceptor(nil, ss, info, handler))
+	}
+}
+
+func TestNoRates_RegisterRequestAndConnection(t *testing.T) {
+	t.Parallel()
+
+	limiter, err := NewLimiter(Config{})
+	require.NoError(t, err)
+
+	// With no rates and no max connections, should never reject.
+	for range 100 {
+		release, err := limiter.RegisterRequestAndConnection("127.0.0.1")
+		require.NoError(t, err)
+		release()
+	}
+}
+
+func TestNoRates_WithMaxConnections(t *testing.T) {
+	t.Parallel()
+
+	limiter, err := NewLimiter(Config{MaxConnections: 2})
+	require.NoError(t, err)
+
+	// Rate limiting should pass through (no rates), but connection
+	// limiting should still enforce.
+	for range 100 {
+		require.NoError(t, limiter.RegisterRequest("token1"))
+	}
+
+	// Connection limit should still work.
+	release1, err := limiter.RegisterRequestAndConnection("127.0.0.1")
+	require.NoError(t, err)
+	release2, err := limiter.RegisterRequestAndConnection("127.0.0.1")
+	require.NoError(t, err)
+
+	// Third connection should be rejected.
+	_, err = limiter.RegisterRequestAndConnection("127.0.0.1")
+	require.Error(t, err)
+	require.True(t, trace.IsLimitExceeded(err))
+
+	// Release one, then the third should succeed.
+	release1()
+	release3, err := limiter.RegisterRequestAndConnection("127.0.0.1")
+	require.NoError(t, err)
+	release2()
+	release3()
+}
+
+func TestNoRates_MiddlewareWithMaxConnections(t *testing.T) {
+	t.Parallel()
+
+	limiter, err := NewLimiter(Config{MaxConnections: 1})
+	require.NoError(t, err)
+
+	// Verify rate limiting passes through in HTTP path by sending
+	// many sequential requests (no concurrent connections).
+	middleware := MakeMiddleware(limiter)
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	for range 100 {
+		mustServeAndReceiveStatusCode(t, handler, http.StatusAccepted)
+	}
+}
+
 func TestRateLimiter_IsRateLimited(t *testing.T) {
 	t.Parallel()
 

--- a/lib/limiter/ratelimiter.go
+++ b/lib/limiter/ratelimiter.go
@@ -32,12 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-const (
-	// defaultRate is the maximum number of requests per second that the limiter
-	// will allow when no rate limits are configured
-	defaultRate = 100_000_000
-)
-
 // RateLimiter controls connection rate using the token bucket algorithm.
 // See: https://en.wikipedia.org/wiki/Token_bucket
 type RateLimiter struct {
@@ -66,12 +60,6 @@ func NewRateLimiter(config Config) (*RateLimiter, error) {
 			return nil, trace.Wrap(err)
 		}
 	}
-	if len(config.Rates) == 0 {
-		err := limiter.rates.Add(time.Second, defaultRate, defaultRate)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
 
 	if config.Clock == nil {
 		config.Clock = clockwork.NewRealClock()
@@ -88,23 +76,29 @@ func NewRateLimiter(config Config) (*RateLimiter, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	limiter.rateLimits, err = utils.NewFnCache(utils.FnCacheConfig{
-		// The default TTL here is not super important because we set the
-		// TTL explicitly for each entry we insert.
-		TTL:   10 * time.Second,
-		Clock: config.Clock,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if limiter.rates.Len() > 0 {
+		limiter.rateLimits, err = utils.NewFnCache(utils.FnCacheConfig{
+			// The default TTL here is not super important because we set
+			// the TTL explicitly for each entry we insert.
+			TTL:   10 * time.Second,
+			Clock: config.Clock,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	return &limiter, nil
 }
 
-// IsRateLimited checks if the provided token is currently rate-limited without
-// consuming any tokens. Returns true if the token would be rate-limited, false otherwise.
-// This is useful for checking rate limit status before executing expensive operations.
+// IsRateLimited checks if the provided token is currently
+// rate-limited without consuming any tokens.
 func (l *RateLimiter) IsRateLimited(token string) bool {
+	// No rates configured means no buckets can exist, so skip the
+	// lock entirely.
+	if l.rates.Len() == 0 {
+		return false
+	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	bucketSet, ok := l.rateLimits.GetIfExists(token)
@@ -120,8 +114,13 @@ func (l *RateLimiter) IsRateLimited(token string) bool {
 
 // RegisterRequest increases number of requests for the provided token.
 // It returns an error if there are too many requests with the provided
-// token.
+// token. If no rates are configured, the request passes through
+// without any limiting.
 func (l *RateLimiter) RegisterRequest(token string) error {
+	if l.rates.Len() == 0 {
+		return nil
+	}
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -161,7 +160,7 @@ func (l *RateLimiter) RegisterRequestFromAddr(addr net.Addr) error {
 	return l.RegisterRequest(token)
 }
 
-// Add rate limiter to the handle
+// WrapHandle wraps the given HTTP handler with the rate limiter.
 func (l *RateLimiter) WrapHandle(h http.Handler) {
 	l.TokenLimiter.Wrap(h)
 }


### PR DESCRIPTION
Remove the fake default rate of 100M req/s that `NewRateLimiter`
injected when no `connection_limits` are set, and add early returns so
the limiter honestly does nothing when unconfigured.

Issue: https://github.com/gravitational/teleport/issues/64830
Backport: https://github.com/gravitational/teleport/pull/63751