### PR TITLE
Connect: Don't pass position to `BrowserWindow` on Wayland

### DIFF
--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -113,13 +113,16 @@ export class WindowsManager {
   }
 
   createWindow(): void {
+    const usesWayland =
+      process.platform === 'linux' &&
+      app.commandLine.getSwitchValue('ozone-platform') === 'wayland';
     const activeTheme = nativeTheme.shouldUseDarkColors
       ? darkTheme
       : lightTheme;
     const windowState = this.getWindowState();
     const window = new BrowserWindow({
-      x: windowState.x,
-      y: windowState.y,
+      x: usesWayland ? undefined : windowState.x,
+      y: usesWayland ? undefined : windowState.y,
       width: windowState.width,
       height: windowState.height,
       backgroundColor: activeTheme.colors.levels.sunken,
@@ -183,10 +186,7 @@ export class WindowsManager {
     // The ready-to-show event doesn't always fire on Wayland because of an Electron bug.
     // Use the `did-finish-load` event on the web contents instead as that is similar enough.
     // https://github.com/electron/electron/issues/48859
-    if (
-      process.platform === 'linux' &&
-      app.commandLine.getSwitchValue('ozone-platform') === 'wayland'
-    ) {
+    if (usesWayland) {
       window.webContents.once('did-finish-load', () => window.show());
     } else {
       // Shows the window when the DOM is ready, so we don't have a brief flash of a blank screen


### PR DESCRIPTION
Changelog: Teleport Connect on Linux no longer explicitly tells Electron to use `0,0` as the window position on Wayland

This is a partial "fix" for #64889. I found that when we don't set `x` and `y` for `BrowserWindow`, Wayland seems to at least not start Connect right in the top left (see the video from #64889 vs the one attached to this issue).

It's not easy to reproduce before & after, because it seems like not sending `x` and `y` inadvertently affects some kind of Wayland cache and at least on both systems that I've tried (Ubuntu 24 LTS in a VM and in a real device) Wayland stops placing the window at 0,0 on launch, even when I change the code to go back to always sending `0,0`.

The current code always sends `0,0` because `BrowserWindow.prototype.getNormalBounds` and [any function that has to do with window position returns `0` for `x` and `y`](https://www.electronjs.org/docs/latest/api/browser-window#wingetbounds) because [Wayland does not allow setting the window position](https://www.electronjs.org/blog/tech-talk-wayland#waylands-house-waylands-rules).

[The docs say this](https://www.electronjs.org/docs/latest/api/browser-window#platform-notices):

> On Wayland (Linux) it is generally not possible to programmatically resize windows after creation, or to position, move, focus, or blur windows without user input. If your app needs these capabilities, run it in Xwayland by appending the flag `--ozone-platform=x11`.

But I don't think we want to do this since as [the Electron blogpost about Wayland](https://www.electronjs.org/blog/tech-talk-wayland#waylands-house-waylands-rules) says, X11 support will be dropped eventually in KDE and GNOME.

To be honest, I'm not even sure if this change in the code has any real effect. Maybe all the changes in behavior I observed are dependent on some kind of other thing – I'd expect Electron to just ignore x and y when using Wayland. But well, as long as the empirical tests have shown that sending `undefined` as x and y has some effect, I think we should just go with it.

## Manual Test Plan
### Test Environment

`pnpm start-term` on a Linux device.

### Test Cases
- [x] Verify that Teleport Connect is no longer starts in the upper left corner.
- [x] Verify that window position restoration still works if Wayland is not used.

Here's a recording where I use `--ozone-platform=x11` to run the app in Xwayland (and there's a small patch which changes the window title depending on whether Wayland is used or not).

[wayland.webm](https://github.com/user-attachments/assets/65ffc468-f787-4596-934b-3c60e7037217)

