### PR TITLE
MWI Scopes[5]: Bot Instances

### DIFF
--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance.pb.go
@@ -177,7 +177,11 @@ type BotInstance struct {
 	Spec *BotInstanceSpec `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
 	// Fields that are set by the server as results of operations. These should
 	// not be modified by users.
-	Status        *BotInstanceStatus `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
+	Status *BotInstanceStatus `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
+	// Scope of the BotInstance. This is determined based on the scope of the Bot
+	// associated with this instance, and may be used for scoped RBAC on the
+	// BotInstance resource.
+	Scope         string `protobuf:"bytes,7,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -252,6 +256,13 @@ func (x *BotInstance) GetStatus() *BotInstanceStatus {
 		return x.Status
 	}
 	return nil
+}
+
+func (x *BotInstance) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
 }
 
 // BotInstanceSpec contains fields
@@ -811,14 +822,15 @@ var File_teleport_machineid_v1_bot_instance_proto protoreflect.FileDescriptor
 
 const file_teleport_machineid_v1_bot_instance_proto_rawDesc = "" +
 	"\n" +
-	"(teleport/machineid/v1/bot_instance.proto\x12\x15teleport.machineid.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\x1a!teleport/legacy/types/types.proto\x1a-teleport/workloadidentity/v1/join_attrs.proto\"\x8e\x02\n" +
+	"(teleport/machineid/v1/bot_instance.proto\x12\x15teleport.machineid.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\x1a!teleport/legacy/types/types.proto\x1a-teleport/workloadidentity/v1/join_attrs.proto\"\xa4\x02\n" +
 	"\vBotInstance\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12:\n" +
 	"\x04spec\x18\x05 \x01(\v2&.teleport.machineid.v1.BotInstanceSpecR\x04spec\x12@\n" +
-	"\x06status\x18\x06 \x01(\v2(.teleport.machineid.v1.BotInstanceStatusR\x06status\"\x8a\x01\n" +
+	"\x06status\x18\x06 \x01(\v2(.teleport.machineid.v1.BotInstanceStatusR\x06status\x12\x14\n" +
+	"\x05scope\x18\a \x01(\tR\x05scope\"\x8a\x01\n" +
 	"\x0fBotInstanceSpec\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +

--- a/api/proto/teleport/machineid/v1/bot_instance.proto
+++ b/api/proto/teleport/machineid/v1/bot_instance.proto
@@ -41,6 +41,10 @@ message BotInstance {
   // Fields that are set by the server as results of operations. These should
   // not be modified by users.
   BotInstanceStatus status = 6;
+  // Scope of the BotInstance. This is determined based on the scope of the Bot
+  // associated with this instance, and may be used for scoped RBAC on the
+  // BotInstance resource.
+  string scope = 7;
 }
 
 // BotInstanceSpec contains fields

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/bot-instance.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/bot-instance.mdx
@@ -28,11 +28,13 @@ version: "string"
 metadata: # [...]
 spec: # [...]
 status: # [...]
+scope: "string"
 ```
 |Field Name|Description|Type|
 |---|---|---|
 |kind|The kind of resource represented.|string|
 |metadata|Common metadata that all resources share.|[Metadata](#metadata)|
+|scope|Of the BotInstance. This is determined based on the scope of the Bot associated with this instance, and may be used for scoped RBAC on the BotInstance resource.|string|
 |spec|The configured properties of a BotInstance.|[Bot Instance Spec](#bot-instance-spec)|
 |status|Fields that are set by the server as results of operations. These should not be modified by users.|[Bot Instance Status](#bot-instance-status)|
 |sub_kind|Differentiates variations of the same kind. All resources should contain one, even if it is never populated.|string|

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4031,9 +4031,15 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 
 		// Update the bot instance based on this authentication. This may create
 		// a new bot instance record if the identity is missing an instance ID.
+		//
+		// botScope is always empty - this code path is only invoked for `token`
+		// joining bots, and we do not support `token` join method for scoped
+		// bots.
+		botScope := ""
 		if err := a.authServer.updateBotInstance(
 			ctx, &certReq, user.GetName(), certReq.BotName,
 			certReq.BotInstanceID, nil, int32(currentIdentityGeneration),
+			botScope,
 		); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -318,6 +318,7 @@ func (a *Server) updateBotInstance(
 	username, botName, botInstanceID string,
 	templateAuthRecord *machineidv1pb.BotInstanceStatusAuthentication,
 	currentIdentityGeneration int32,
+	scope string,
 ) error {
 	if botName == "" {
 		// Only applies to bot identities
@@ -421,6 +422,7 @@ func (a *Server) updateBotInstance(
 			BotName:    botName,
 			InstanceId: instanceID.String(),
 		}, authRecord, expires)
+		bi.Scope = scope
 
 		if _, err := a.BotInstance.CreateBotInstance(ctx, bi); err != nil {
 			return trace.Wrap(err)
@@ -652,7 +654,7 @@ func (a *Server) generateInitialBotCerts(
 		// value sent by the client, so we can trust it.
 		if err := a.updateBotInstance(
 			ctx, &certReq, username, botName, existingInstanceID,
-			initialAuth, currentIdentityGeneration,
+			initialAuth, currentIdentityGeneration, botScope,
 		); err != nil {
 			return nil, "", trace.Wrap(err)
 		}

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -635,6 +635,7 @@ func (a *Server) generateInitialBotCerts(
 			InstanceId:         uuid.String(),
 			PreviousInstanceId: previousInstanceID,
 		}, initialAuth, expires.Add(machineidv1.ExpiryMargin))
+		bi.Scope = botScope
 
 		_, err = a.BotInstance.CreateBotInstance(ctx, bi)
 		if err != nil {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6172,7 +6172,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	machineidv1pb.RegisterBotServiceServer(server, botService)
 
 	botInstanceService, err := machineidv1.NewBotInstanceService(machineidv1.BotInstanceServiceConfig{
-		Authorizer: cfg.Authorizer,
+		Authorizer: cfg.ScopedAuthorizer,
 		Cache:      cfg.AuthServer.Cache,
 		Backend:    cfg.AuthServer.Services.BotInstance,
 		Clock:      cfg.AuthServer.GetClock(),

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -19,6 +19,7 @@
 package machineidv1
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
 	"os"
@@ -33,6 +34,7 @@ import (
 	pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -68,7 +70,7 @@ type BotInstancesCache interface {
 // BotInstanceServiceConfig holds configuration options for the BotInstance gRPC
 // service.
 type BotInstanceServiceConfig struct {
-	Authorizer authz.Authorizer
+	Authorizer authz.ScopedAuthorizer
 	Cache      BotInstancesCache
 	Backend    services.BotInstance
 	Logger     *slog.Logger
@@ -107,7 +109,7 @@ type BotInstanceService struct {
 	pb.UnimplementedBotInstanceServiceServer
 
 	backend    services.BotInstance
-	authorizer authz.Authorizer
+	authorizer authz.ScopedAuthorizer
 	cache      BotInstancesCache
 	logger     *slog.Logger
 	clock      clockwork.Clock
@@ -115,20 +117,51 @@ type BotInstanceService struct {
 
 // DeleteBotInstance deletes a bot specific bot instance
 func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.DeleteBotInstanceRequest) (*emptypb.Empty, error) {
-	authCtx, err := b.authorizer.Authorize(ctx)
+	authCtx, err := b.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindBotInstance, types.VerbDelete); err != nil {
+	// Perform pre-authz check to see if they might have access, to avoid
+	// reading cache or backend if unauthorized.
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
+		&ruleCtx, types.KindBotInstance, types.VerbDelete,
+	); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+	instance, err := b.backend.GetBotInstance(ctx, req.BotName, req.InstanceId)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := b.backend.DeleteBotInstance(ctx, req.BotName, req.InstanceId); err != nil {
+	ruleCtx.Resource153 = instance
+	if err := authCtx.CheckerContext.Decision(
+		ctx,
+		cmp.Or(instance.Scope, scopes.Root),
+		func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(
+				&ruleCtx,
+				types.KindBotInstance,
+				types.VerbDelete,
+			)
+		},
+	); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Scoped authorizer does not yet support MFA, so for now, only perform
+	// against unscoped identities.
+	// TODO(strideynet): when we support scoped MFA, change this...
+	if unscoped, ok := authCtx.UnscopedContext(); ok {
+		if err := unscoped.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	if err := b.backend.DeleteBotInstance(
+		ctx, instance.Spec.BotName, instance.Spec.InstanceId,
+	); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -137,17 +170,37 @@ func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.Dele
 
 // GetBotInstance retrieves a specific bot instance
 func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *pb.GetBotInstanceRequest) (*pb.BotInstance, error) {
-	authCtx, err := b.authorizer.Authorize(ctx)
+	authCtx, err := b.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindBotInstance, types.VerbRead); err != nil {
+	// Perform pre-authz check to see if they might have access, to avoid
+	// reading cache or backend if unauthorized.
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
+		&ruleCtx, types.KindBotInstance, types.VerbReadNoSecrets,
+	); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	res, err := b.cache.GetBotInstance(ctx, req.BotName, req.InstanceId)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx.Resource153 = res
+	if err := authCtx.CheckerContext.Decision(
+		ctx,
+		cmp.Or(res.Scope, scopes.Root),
+		func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(
+				&ruleCtx,
+				types.KindBotInstance,
+				types.VerbReadNoSecrets,
+			)
+		},
+	); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -176,35 +229,69 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, req *pb.ListB
 
 // ListBotInstancesV2 returns a list of bot instances matching the criteria in the request
 func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.ListBotInstancesV2Request) (*pb.ListBotInstancesResponse, error) {
-	authCtx, err := b.authorizer.Authorize(ctx)
+	authCtx, err := b.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindBotInstance, types.VerbRead, types.VerbList); err != nil {
+	// Perform pre-authz check to see if they might have access, to avoid
+	// reading cache or backend if unauthorized.
+	ruleCtx := authCtx.RuleContext()
+	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
+		&ruleCtx, types.KindBotInstance, types.VerbReadNoSecrets, types.VerbList,
+	); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	res, nextToken, err := b.cache.ListBotInstances(ctx, int(req.PageSize), req.PageToken, &services.ListBotInstancesRequestOptions{
-		SortField:        req.GetSortField(),
-		SortDesc:         req.GetSortDesc(),
-		FilterBotName:    req.GetFilter().GetBotName(),
-		FilterSearchTerm: req.GetFilter().GetSearchTerm(),
-		FilterQuery:      req.GetFilter().GetQuery(),
-	})
+	// TODO(strideynet): Ideally, at some point in the future, we should switch
+	// to some kind of stream from the cache, or pass a filter func in to allow
+	// us to avoid returning un-full pages due to completing authz checks after.
+	botInstances, nextToken, err := b.cache.ListBotInstances(
+		ctx,
+		int(req.PageSize),
+		req.PageToken,
+		&services.ListBotInstancesRequestOptions{
+			SortField:        req.GetSortField(),
+			SortDesc:         req.GetSortDesc(),
+			FilterBotName:    req.GetFilter().GetBotName(),
+			FilterSearchTerm: req.GetFilter().GetSearchTerm(),
+			FilterQuery:      req.GetFilter().GetQuery(),
+		},
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return &pb.ListBotInstancesResponse{
-		BotInstances:  res,
+	res := &pb.ListBotInstancesResponse{
+		BotInstances:  make([]*pb.BotInstance, 0, len(botInstances)),
 		NextPageToken: nextToken,
-	}, nil
+	}
+	for _, botInstance := range botInstances {
+		ruleCtx := authCtx.RuleContext()
+		ruleCtx.Resource153 = botInstance
+		if err := authCtx.CheckerContext.Decision(
+			ctx,
+			cmp.Or(botInstance.Scope, scopes.Root),
+			func(checker *services.ScopedAccessChecker) error {
+				return checker.CheckAccessToRules(
+					&ruleCtx,
+					types.KindBotInstance,
+					types.VerbReadNoSecrets,
+					types.VerbList,
+				)
+			},
+		); err != nil {
+			// Skip bot instances they don't have access to.
+			continue
+		}
+		res.BotInstances = append(res.BotInstances, botInstance)
+	}
+	return res, nil
 }
 
 // SubmitHeartbeat records heartbeat information for a bot
 func (b *BotInstanceService) SubmitHeartbeat(ctx context.Context, req *pb.SubmitHeartbeatRequest) (*pb.SubmitHeartbeatResponse, error) {
-	authCtx, err := b.authorizer.Authorize(ctx)
+	authCtx, err := b.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -224,13 +311,24 @@ func (b *BotInstanceService) SubmitHeartbeat(ctx context.Context, req *pb.Submit
 	}
 
 	// Enforce that the connecting client is a bot and has a bot instance ID.
-	botName := authCtx.Identity.GetIdentity().BotName
-	botInstanceID := authCtx.Identity.GetIdentity().BotInstanceID
+	ident := authCtx.Identity.GetIdentity()
+	botName := ident.BotName
+	botInstanceID := ident.BotInstanceID
 	switch {
 	case botName == "":
 		return nil, trace.AccessDenied("identity did not contain bot name")
 	case botInstanceID == "":
 		return nil, trace.AccessDenied("identity did not contain bot instance ID")
+	}
+
+	// For now, we just require that Scoped Bots have the BotInternal identity
+	// flag set - however - once sufficient time has passed and we're sure all
+	// existing bots will have the BotInternal flag set in their certs, we can
+	// make this check always applied.
+	if ident.ScopePin != nil && ident.ScopePin.Scope != "" {
+		if !ident.BotInternal {
+			return nil, trace.AccessDenied("identity not marked BotInternal")
+		}
 	}
 
 	b.logger.DebugContext(

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -241,9 +241,6 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 		return nil, trace.Wrap(err)
 	}
 
-	// TODO(strideynet): Ideally, at some point in the future, we should switch
-	// to some kind of stream from the cache, or pass a filter func in to allow
-	// us to avoid returning un-full pages due to completing authz checks after.
 	botInstances, nextToken, err := b.cache.ListBotInstances(
 		ctx,
 		int(req.PageSize),
@@ -254,37 +251,33 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 			FilterBotName:    req.GetFilter().GetBotName(),
 			FilterSearchTerm: req.GetFilter().GetSearchTerm(),
 			FilterQuery:      req.GetFilter().GetQuery(),
+			FilterFn: func(botInstance *pb.BotInstance) bool {
+				ruleCtx := authCtx.RuleContext()
+				ruleCtx.Resource153 = botInstance
+				err := authCtx.CheckerContext.Decision(
+					ctx,
+					botInstance.Scope,
+					func(checker *services.ScopedAccessChecker) error {
+						return checker.CheckAccessToRules(
+							&ruleCtx,
+							types.KindBotInstance,
+							types.VerbReadNoSecrets,
+							types.VerbList,
+						)
+					},
+				)
+				return err == nil
+			},
 		},
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	res := &pb.ListBotInstancesResponse{
-		BotInstances:  make([]*pb.BotInstance, 0, len(botInstances)),
+	return &pb.ListBotInstancesResponse{
+		BotInstances:  botInstances,
 		NextPageToken: nextToken,
-	}
-	for _, botInstance := range botInstances {
-		ruleCtx := authCtx.RuleContext()
-		ruleCtx.Resource153 = botInstance
-		if err := authCtx.CheckerContext.Decision(
-			ctx,
-			botInstance.Scope,
-			func(checker *services.ScopedAccessChecker) error {
-				return checker.CheckAccessToRules(
-					&ruleCtx,
-					types.KindBotInstance,
-					types.VerbReadNoSecrets,
-					types.VerbList,
-				)
-			},
-		); err != nil {
-			// Skip bot instances they don't have access to.
-			continue
-		}
-		res.BotInstances = append(res.BotInstances, botInstance)
-	}
-	return res, nil
+	}, nil
 }
 
 // SubmitHeartbeat records heartbeat information for a bot

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -19,7 +19,6 @@
 package machineidv1
 
 import (
-	"cmp"
 	"context"
 	"log/slog"
 	"os"
@@ -34,7 +33,6 @@ import (
 	pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
-	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -139,7 +137,7 @@ func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.Dele
 	ruleCtx.Resource153 = instance
 	if err := authCtx.CheckerContext.Decision(
 		ctx,
-		cmp.Or(instance.Scope, scopes.Root),
+		instance.Scope,
 		func(checker *services.ScopedAccessChecker) error {
 			return checker.CheckAccessToRules(
 				&ruleCtx,
@@ -192,7 +190,7 @@ func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *pb.GetBotI
 	ruleCtx.Resource153 = res
 	if err := authCtx.CheckerContext.Decision(
 		ctx,
-		cmp.Or(res.Scope, scopes.Root),
+		res.Scope,
 		func(checker *services.ScopedAccessChecker) error {
 			return checker.CheckAccessToRules(
 				&ruleCtx,
@@ -271,7 +269,7 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 		ruleCtx.Resource153 = botInstance
 		if err := authCtx.CheckerContext.Decision(
 			ctx,
-			cmp.Or(botInstance.Scope, scopes.Root),
+			botInstance.Scope,
 			func(checker *services.ScopedAccessChecker) error {
 				return checker.CheckAccessToRules(
 					&ruleCtx,

--- a/lib/auth/machineid/machineidv1/bot_instance_service_test.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service_test.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -43,6 +44,19 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+const (
+	testBotName    = "access-test-bot"
+	testInstanceID = "access-test-instance-id"
+)
+
+func insertTestBotInstance(t *testing.T, backend *local.BotInstanceService) {
+	t.Helper()
+	bi := newBotInstance(testBotName)
+	bi.Spec.InstanceId = testInstanceID
+	_, err := backend.CreateBotInstance(t.Context(), bi)
+	require.NoError(t, err)
+}
 
 // TestBotInstanceServiceAccess ensures RBAC an admin state rules are applied properly
 func TestBotInstanceServiceAccess(t *testing.T) {
@@ -60,7 +74,7 @@ func TestBotInstanceServiceAccess(t *testing.T) {
 				authz.AdminActionAuthUnauthorized, authz.AdminActionAuthNotRequired,
 				authz.AdminActionAuthMFAVerified, authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
-			allowedVerbs: []string{types.VerbRead},
+			allowedVerbs: []string{types.VerbReadNoSecrets},
 		},
 		{
 			name: "ListBotInstances",
@@ -68,7 +82,7 @@ func TestBotInstanceServiceAccess(t *testing.T) {
 				authz.AdminActionAuthUnauthorized, authz.AdminActionAuthNotRequired,
 				authz.AdminActionAuthMFAVerified, authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
-			allowedVerbs: []string{types.VerbRead, types.VerbList},
+			allowedVerbs: []string{types.VerbReadNoSecrets, types.VerbList},
 		},
 		{
 			name: "ListBotInstancesV2",
@@ -76,7 +90,7 @@ func TestBotInstanceServiceAccess(t *testing.T) {
 				authz.AdminActionAuthUnauthorized, authz.AdminActionAuthNotRequired,
 				authz.AdminActionAuthMFAVerified, authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
-			allowedVerbs: []string{types.VerbRead, types.VerbList},
+			allowedVerbs: []string{types.VerbReadNoSecrets, types.VerbList},
 		},
 		{
 			name: "DeleteBotInstance",
@@ -104,6 +118,7 @@ func TestBotInstanceServiceAccess(t *testing.T) {
 						for _, verbs := range utils.Combinations(tt.allowedVerbs) {
 							t.Run(fmt.Sprintf("verbs=%v", verbs), func(t *testing.T) {
 								backend := newBotInstanceBackend(t)
+								insertTestBotInstance(t, backend)
 								service := newBotInstanceService(t, backend, state, fakeChecker{allowedVerbs: verbs})
 								err := callMethod(t, service, tt.name)
 
@@ -131,6 +146,7 @@ func TestBotInstanceServiceAccess(t *testing.T) {
 						// it is enough to test against tt.allowedVerbs,
 						// this is the only different data point compared to the test cases above.
 						backend := newBotInstanceBackend(t)
+						insertTestBotInstance(t, backend)
 						service := newBotInstanceService(t, backend, state, fakeChecker{allowedVerbs: tt.allowedVerbs})
 						err := callMethod(t, service, tt.name)
 						require.True(t, trace.IsAccessDenied(err))
@@ -174,7 +190,7 @@ func TestBotInstanceServiceReadDelete(t *testing.T) {
 	}
 
 	// Make a service with all useful permissions that doesn't require admin auth
-	checker := fakeChecker{allowedVerbs: []string{types.VerbRead, types.VerbList, types.VerbDelete}}
+	checker := fakeChecker{allowedVerbs: []string{types.VerbReadNoSecrets, types.VerbList, types.VerbDelete}}
 	service := newBotInstanceService(t, backend, authz.AdminActionAuthNotRequired, checker)
 
 	// Make sure we can get all foo instances
@@ -405,6 +421,39 @@ func TestBotInstanceServiceSubmitHeartbeat(t *testing.T) {
 			},
 			wantHeartbeat: false,
 		},
+		{
+			name:              "scoped identity without BotInternal",
+			createBotInstance: true,
+			req: &machineidv1.SubmitHeartbeatRequest{
+				Heartbeat: &machineidv1.BotInstanceStatusHeartbeat{Hostname: "llama"},
+			},
+			identity: tlsca.Identity{
+				BotName:       botName,
+				BotInstanceID: botInstanceID,
+				ScopePin:      &scopesv1.Pin{Scope: "/scopes/test"},
+				BotInternal:   false,
+			},
+			assertErr: func(t assert.TestingT, err error, i ...any) bool {
+				return assert.True(t, trace.IsAccessDenied(err)) &&
+					assert.Contains(t, err.Error(), "identity not marked BotInternal")
+			},
+			wantHeartbeat: false,
+		},
+		{
+			name:              "scoped identity with BotInternal",
+			createBotInstance: true,
+			req: &machineidv1.SubmitHeartbeatRequest{
+				Heartbeat: &machineidv1.BotInstanceStatusHeartbeat{Hostname: "llama"},
+			},
+			identity: tlsca.Identity{
+				BotName:       botName,
+				BotInstanceID: botInstanceID,
+				ScopePin:      &scopesv1.Pin{Scope: "/scopes/test"},
+				BotInternal:   true,
+			},
+			assertErr:     assert.NoError,
+			wantHeartbeat: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -413,13 +462,14 @@ func TestBotInstanceServiceSubmitHeartbeat(t *testing.T) {
 			service, err := NewBotInstanceService(BotInstanceServiceConfig{
 				Backend: backend,
 				Cache:   backend,
-				Authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-					return &authz.Context{
+				Authorizer: &fakeScopedAuthorizer{
+					ctx: authz.ScopedContextFromUnscopedContext(&authz.Context{
 						Identity: identityGetterFn(func() tlsca.Identity {
 							return tt.identity
 						}),
-					}, nil
-				}),
+						Checker: fakeChecker{},
+					}),
+				},
 			})
 			require.NoError(t, err)
 
@@ -478,16 +528,17 @@ func TestBotInstanceServiceSubmitHeartbeat_HeartbeatLimit(t *testing.T) {
 	service, err := NewBotInstanceService(BotInstanceServiceConfig{
 		Backend: backend,
 		Cache:   backend,
-		Authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-			return &authz.Context{
+		Authorizer: &fakeScopedAuthorizer{
+			ctx: authz.ScopedContextFromUnscopedContext(&authz.Context{
 				Identity: identityGetterFn(func() tlsca.Identity {
 					return tlsca.Identity{
 						BotName:       botName,
 						BotInstanceID: botInstanceID,
 					}
 				}),
-			}, nil
-		}),
+				Checker: fakeChecker{},
+			}),
+		},
 	})
 	require.NoError(t, err)
 
@@ -544,6 +595,14 @@ func otherAdminStates(states []authz.AdminActionAuthState) []authz.AdminActionAu
 	return out
 }
 
+type fakeScopedAuthorizer struct {
+	ctx *authz.ScopedContext
+}
+
+func (a *fakeScopedAuthorizer) AuthorizeScoped(_ context.Context) (*authz.ScopedContext, error) {
+	return a.ctx, nil
+}
+
 type fakeChecker struct {
 	allowedVerbs []string
 	services.AccessChecker
@@ -559,11 +618,31 @@ func (f fakeChecker) CheckAccessToRule(_ services.RuleContext, _ string, resourc
 	return trace.AccessDenied("access denied to rule=%v/verb=%v", resource, verb)
 }
 
+func (f fakeChecker) GuessIfAccessIsPossible(_ services.RuleContext, _ string, resource string, verb string) error {
+	if resource == types.KindBotInstance {
+		if slices.Contains(f.allowedVerbs, verb) {
+			return nil
+		}
+	}
+
+	return trace.AccessDenied("access denied to rule=%v/verb=%v", resource, verb)
+}
+
 // callMethod calls a method with given name in the BotInstanceService
 func callMethod(t *testing.T, service *BotInstanceService, method string) error {
 	for _, desc := range machineidv1.BotInstanceService_ServiceDesc.Methods {
 		if desc.MethodName == method {
-			_, err := desc.Handler(service, context.Background(), func(_ any) error { return nil }, nil)
+			_, err := desc.Handler(service, context.Background(), func(req any) error {
+				switch r := req.(type) {
+				case *machineidv1.GetBotInstanceRequest:
+					r.BotName = testBotName
+					r.InstanceId = testInstanceID
+				case *machineidv1.DeleteBotInstanceRequest:
+					r.BotName = testBotName
+					r.InstanceId = testInstanceID
+				}
+				return nil
+			}, nil)
 			return err
 		}
 	}
@@ -652,18 +731,16 @@ func newBotInstanceService(
 ) *BotInstanceService {
 	t.Helper()
 
-	authorizer := authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
-		user, err := types.NewUser("example")
-		if err != nil {
-			return nil, err
-		}
+	user, err := types.NewUser("example")
+	require.NoError(t, err)
 
-		return &authz.Context{
+	authorizer := &fakeScopedAuthorizer{
+		ctx: authz.ScopedContextFromUnscopedContext(&authz.Context{
 			User:                 user,
 			Checker:              checker,
 			AdminActionAuthState: authState,
-		}, nil
-	})
+		}),
+	}
 
 	service, err := NewBotInstanceService(BotInstanceServiceConfig{
 		Authorizer: authorizer,

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -20,6 +20,7 @@ package machineidv1_test
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
@@ -46,12 +47,14 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 func TestMain(m *testing.M) {
@@ -3081,6 +3084,545 @@ func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*scopedacce
 			require.NoError(t, err)
 		}
 	}, 10*time.Second, 100*time.Millisecond)
+}
+
+func createBotInstance(
+	t *testing.T,
+	srv *authtest.TLSServer,
+	botName, scope, instanceID string,
+) *machineidv1pb.BotInstance {
+	t.Helper()
+	if instanceID == "" {
+		instanceID = uuid.NewString()
+	}
+	bi := &machineidv1pb.BotInstance{
+		Kind:    types.KindBotInstance,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Expires: timestamppb.New(srv.Clock().Now().Add(time.Hour)),
+		},
+		Spec: &machineidv1pb.BotInstanceSpec{
+			BotName:    botName,
+			InstanceId: instanceID,
+		},
+		Status: &machineidv1pb.BotInstanceStatus{},
+		Scope:  scope,
+	}
+	created, err := srv.Auth().BotInstance.CreateBotInstance(t.Context(), bi)
+	require.NoError(t, err)
+	return created
+}
+
+func TestBotInstanceService_DeleteBotInstance(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	srv, _ := newTestTLSServer(t)
+	ctx := t.Context()
+
+	unscopedUser, _, err := authtest.CreateUserAndRole(
+		srv.Auth(),
+		"bot-instance-deleter",
+		[]string{},
+		[]types.Rule{
+			{
+				Resources: []string{types.KindBotInstance},
+				Verbs:     []string{types.VerbDelete},
+			},
+		})
+	require.NoError(t, err)
+
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+
+	scopedSvc := adminClient.ScopedAccessServiceClient()
+	scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-bot-instance-deleter",
+			},
+			Scope: "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
+				Rules: []*scopedaccessv1.ScopedRule{
+					{
+						Verbs:     []string{types.VerbDelete},
+						Resources: []string{types.KindBotInstance},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user")
+	require.NoError(t, err)
+
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			SubKind: scopedaccess.SubKindDynamic,
+			Scope:   "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/granted"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+
+	// Create one bot instance per test case since delete is destructive.
+	unscopedForUnscoped := createBotInstance(t, srv, "bot-a", "", "")
+	scopedForUnscoped := createBotInstance(t, srv, "bot-b", "/scopes/granted", "")
+	unscopedForScoped := createBotInstance(t, srv, "bot-c", "", "")
+	scopedGranted := createBotInstance(t, srv, "bot-d", "/scopes/granted", "")
+	scopedUngranted := createBotInstance(t, srv, "bot-e", "/scopes/ungranted", "")
+
+	tests := []struct {
+		name        string
+		identity    authtest.TestIdentity
+		instance    *machineidv1pb.BotInstance
+		assertError require.ErrorAssertionFunc
+	}{
+		{
+			name:        "unscoped user deletes unscoped instance",
+			identity:    authtest.TestUser(unscopedUser.GetName()),
+			instance:    unscopedForUnscoped,
+			assertError: require.NoError,
+		},
+		{
+			name:        "unscoped user deletes scoped instance",
+			identity:    authtest.TestUser(unscopedUser.GetName()),
+			instance:    scopedForUnscoped,
+			assertError: require.NoError,
+		},
+		{
+			name:     "scoped user fails to delete unscoped instance",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			instance: unscopedForScoped,
+			assertError: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+			},
+		},
+		{
+			name:        "scoped user deletes instance in granted scope",
+			identity:    authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			instance:    scopedGranted,
+			assertError: require.NoError,
+		},
+		{
+			name:     "scoped user fails to delete instance in ungranted scope",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			instance: scopedUngranted,
+			assertError: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := srv.NewClient(tt.identity)
+			require.NoError(t, err)
+
+			_, err = client.BotInstanceServiceClient().DeleteBotInstance(ctx, &machineidv1pb.DeleteBotInstanceRequest{
+				BotName:    tt.instance.Spec.BotName,
+				InstanceId: tt.instance.Spec.InstanceId,
+			})
+			tt.assertError(t, err)
+		})
+	}
+}
+
+func TestBotInstanceService_GetBotInstance(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	srv, _ := newTestTLSServer(t)
+	ctx := t.Context()
+
+	unscopedUser, _, err := authtest.CreateUserAndRole(
+		srv.Auth(),
+		"bot-instance-reader",
+		[]string{},
+		[]types.Rule{
+			{
+				Resources: []string{types.KindBotInstance},
+				Verbs:     []string{types.VerbReadNoSecrets},
+			},
+		})
+	require.NoError(t, err)
+
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+
+	scopedSvc := adminClient.ScopedAccessServiceClient()
+	scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-bot-instance-reader",
+			},
+			Scope: "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
+				Rules: []*scopedaccessv1.ScopedRule{
+					{
+						Verbs:     []string{types.VerbReadNoSecrets},
+						Resources: []string{types.KindBotInstance},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user")
+	require.NoError(t, err)
+
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			SubKind: scopedaccess.SubKindDynamic,
+			Scope:   "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/granted"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+
+	unscopedInstance := createBotInstance(t, srv, "bot-a", "", "")
+	scopedGrantedInstance := createBotInstance(t, srv, "bot-b", "/scopes/granted", "")
+	scopedUngrantedInstance := createBotInstance(t, srv, "bot-c", "/scopes/ungranted", "")
+
+	tests := []struct {
+		name        string
+		identity    authtest.TestIdentity
+		instance    *machineidv1pb.BotInstance
+		assertError require.ErrorAssertionFunc
+	}{
+		{
+			name:        "unscoped user gets unscoped instance",
+			identity:    authtest.TestUser(unscopedUser.GetName()),
+			instance:    unscopedInstance,
+			assertError: require.NoError,
+		},
+		{
+			name:        "unscoped user gets scoped instance",
+			identity:    authtest.TestUser(unscopedUser.GetName()),
+			instance:    scopedGrantedInstance,
+			assertError: require.NoError,
+		},
+		{
+			name:     "scoped user fails to get unscoped instance",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			instance: unscopedInstance,
+			assertError: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+			},
+		},
+		{
+			name:        "scoped user gets instance in granted scope",
+			identity:    authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			instance:    scopedGrantedInstance,
+			assertError: require.NoError,
+		},
+		{
+			name:     "scoped user fails to get instance in ungranted scope",
+			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
+			instance: scopedUngrantedInstance,
+			assertError: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := srv.NewClient(tt.identity)
+			require.NoError(t, err)
+
+			got, err := client.BotInstanceServiceClient().GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
+				BotName:    tt.instance.Spec.BotName,
+				InstanceId: tt.instance.Spec.InstanceId,
+			})
+			tt.assertError(t, err)
+			if err == nil {
+				require.Equal(t, tt.instance.Spec.InstanceId, got.Spec.InstanceId)
+			}
+		})
+	}
+}
+
+func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	srv, _ := newTestTLSServer(t)
+	ctx := t.Context()
+
+	unscopedUser, _, err := authtest.CreateUserAndRole(
+		srv.Auth(),
+		"bot-instance-lister",
+		[]string{},
+		[]types.Rule{
+			{
+				Resources: []string{types.KindBotInstance},
+				Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+			},
+		})
+	require.NoError(t, err)
+
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+
+	scopedSvc := adminClient.ScopedAccessServiceClient()
+	scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "scoped-bot-instance-lister",
+			},
+			Scope: "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
+				Rules: []*scopedaccessv1.ScopedRule{
+					{
+						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						Resources: []string{types.KindBotInstance},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user")
+	require.NoError(t, err)
+
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			SubKind: scopedaccess.SubKindDynamic,
+			Scope:   "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/granted"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+
+	// Create a mix of bot instances.
+	unscopedInstances := []*machineidv1pb.BotInstance{
+		createBotInstance(t, srv, "bot-a", "", ""),
+		createBotInstance(t, srv, "bot-b", "", ""),
+	}
+	grantedInstances := []*machineidv1pb.BotInstance{
+		createBotInstance(t, srv, "bot-c", "/scopes/granted", ""),
+		createBotInstance(t, srv, "bot-d", "/scopes/granted", ""),
+	}
+	ungrantedInstances := []*machineidv1pb.BotInstance{
+		createBotInstance(t, srv, "bot-e", "/scopes/ungranted", ""),
+	}
+
+	allInstances := make([]*machineidv1pb.BotInstance, 0)
+	allInstances = append(allInstances, unscopedInstances...)
+	allInstances = append(allInstances, grantedInstances...)
+	allInstances = append(allInstances, ungrantedInstances...)
+
+	allIDs := make(map[string]struct{})
+	for _, bi := range allInstances {
+		allIDs[bi.Spec.InstanceId] = struct{}{}
+	}
+	grantedIDs := make(map[string]struct{})
+	for _, bi := range grantedInstances {
+		grantedIDs[bi.Spec.InstanceId] = struct{}{}
+	}
+
+	listAll := func(t *testing.T, client machineidv1pb.BotInstanceServiceClient) []*machineidv1pb.BotInstance {
+		t.Helper()
+		var results []*machineidv1pb.BotInstance
+		var nextToken string
+		for {
+			res, err := client.ListBotInstancesV2(ctx, &machineidv1pb.ListBotInstancesV2Request{
+				PageToken: nextToken,
+			})
+			require.NoError(t, err)
+			results = append(results, res.BotInstances...)
+			nextToken = res.NextPageToken
+			if nextToken == "" {
+				break
+			}
+		}
+		return results
+	}
+
+	t.Run("unscoped user sees all instances", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		got := listAll(t, client.BotInstanceServiceClient())
+		require.Len(t, got, len(allInstances))
+		for _, bi := range got {
+			require.Contains(t, allIDs, bi.Spec.InstanceId)
+		}
+	})
+
+	t.Run("scoped user sees only instances in granted scope", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"))
+		require.NoError(t, err)
+
+		got := listAll(t, client.BotInstanceServiceClient())
+		require.Len(t, got, len(grantedInstances))
+		for _, bi := range got {
+			require.Contains(t, grantedIDs, bi.Spec.InstanceId)
+		}
+	})
+}
+
+func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	srv, _ := newTestTLSServer(t)
+	ctx := t.Context()
+
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+
+	testRole, err := authtest.CreateRole(ctx, srv.Auth(), "heartbeat-test-role", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	// newBotClient creates a TLS client for the given bot identity and returns both the
+	// client and the BotInstanceID embedded in its certificate. This is needed because
+	// GenerateUserTestCerts assigns a random BotInstanceID, and SubmitHeartbeat resolves
+	// the bot instance by the ID from the caller's identity.
+	newBotClient := func(t *testing.T, identity authtest.TestIdentity) (*authclient.Client, string) {
+		t.Helper()
+		tlsCfg, err := srv.ClientTLSConfig(identity)
+		require.NoError(t, err)
+		require.NotEmpty(t, tlsCfg.Certificates)
+		cert, err := x509.ParseCertificate(tlsCfg.Certificates[0].Certificate[0])
+		require.NoError(t, err)
+		ident, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+		require.NoError(t, err)
+		require.NotEmpty(t, ident.BotInstanceID)
+		clt, err := srv.NewClientWithCert(tlsCfg.Certificates[0])
+		require.NoError(t, err)
+		return clt, ident.BotInstanceID
+	}
+
+	t.Run("unscoped bot", func(t *testing.T) {
+		const botName = "heartbeat-unscoped"
+		_, err := adminClient.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
+			Bot: &machineidv1pb.Bot{
+				Metadata: &headerv1.Metadata{Name: botName},
+				Spec:     &machineidv1pb.BotSpec{Roles: []string{testRole.GetName()}},
+			},
+		})
+		require.NoError(t, err)
+
+		botClient, instanceID := newBotClient(t, authtest.TestBot(botName, false))
+		createBotInstance(t, srv, botName, "", instanceID)
+
+		_, err = botClient.BotInstanceServiceClient().SubmitHeartbeat(ctx, &machineidv1pb.SubmitHeartbeatRequest{
+			Heartbeat: &machineidv1pb.BotInstanceStatusHeartbeat{Hostname: "unscoped-host"},
+		})
+		require.NoError(t, err)
+
+		got, err := adminClient.BotInstanceServiceClient().GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
+			BotName:    botName,
+			InstanceId: instanceID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Status.InitialHeartbeat)
+		require.Equal(t, "unscoped-host", got.Status.InitialHeartbeat.Hostname)
+	})
+
+	t.Run("scoped bot", func(t *testing.T) {
+		const botName = "heartbeat-scoped"
+		_, err := adminClient.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
+			Bot: &machineidv1pb.Bot{
+				Metadata: &headerv1.Metadata{Name: botName},
+				Scope:    "/scopes/test",
+				Spec:     &machineidv1pb.BotSpec{},
+			},
+		})
+		require.NoError(t, err)
+
+		// We need to assign our bot a scoped role otherwise we won't be able
+		// to generate certificates for it.
+		scopedSvc := adminClient.ScopedAccessServiceClient()
+		scopedRole, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+			Role: &scopedaccessv1.ScopedRole{
+				Kind:    scopedaccess.KindScopedRole,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "scoped-heartbeat-role",
+				},
+				Scope: "/scopes",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/scopes/test"},
+					Rules:            []*scopedaccessv1.ScopedRule{},
+				},
+			},
+		})
+		require.NoError(t, err)
+		sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			Assignment: &scopedaccessv1.ScopedRoleAssignment{
+				Kind:    scopedaccess.KindScopedRoleAssignment,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: uuid.NewString(),
+				},
+				SubKind: scopedaccess.SubKindDynamic,
+				Scope:   "/scopes",
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+					BotName:  botName,
+					BotScope: "/scopes/test",
+					Assignments: []*scopedaccessv1.Assignment{
+						{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/test"},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		waitForSRACache(t, srv, sraResp)
+
+		botClient, instanceID := newBotClient(t, authtest.TestScopedBot(botName, "/scopes/test", true))
+		createBotInstance(t, srv, botName, "/scopes/test", instanceID)
+
+		_, err = botClient.BotInstanceServiceClient().SubmitHeartbeat(ctx, &machineidv1pb.SubmitHeartbeatRequest{
+			Heartbeat: &machineidv1pb.BotInstanceStatusHeartbeat{Hostname: "scoped-host"},
+		})
+		require.NoError(t, err)
+
+		got, err := adminClient.BotInstanceServiceClient().GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
+			BotName:    botName,
+			InstanceId: instanceID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Status.InitialHeartbeat)
+		require.Equal(t, "scoped-host", got.Status.InitialHeartbeat.Hostname)
+	})
 }
 
 func newTestTLSServer(t testing.TB) (*authtest.TLSServer, *eventstest.MockRecorderEmitter) {

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -47,11 +47,13 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -3397,7 +3399,7 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 			},
 			Scope: "/scopes",
 			Spec: &scopedaccessv1.ScopedRoleSpec{
-				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
+				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted", "/scopes/other"},
 				Rules: []*scopedaccessv1.ScopedRule{
 					{
 						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
@@ -3412,7 +3414,7 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 	scopedUser, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user")
 	require.NoError(t, err)
 
-	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+	sra1Resp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: &scopedaccessv1.ScopedRoleAssignment{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			Version: types.V1,
@@ -3430,7 +3432,25 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	waitForSRACache(t, srv, sraResp)
+	sra2Resp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			SubKind: scopedaccess.SubKindDynamic,
+			Scope:   "/scopes",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: scopedUser.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRole.Role.Metadata.Name, Scope: "/scopes/other"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sra1Resp, sra2Resp)
 
 	// Create a mix of bot instances.
 	unscopedInstances := []*machineidv1pb.BotInstance{
@@ -3461,20 +3481,20 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 
 	listAll := func(t *testing.T, client machineidv1pb.BotInstanceServiceClient) []*machineidv1pb.BotInstance {
 		t.Helper()
-		var results []*machineidv1pb.BotInstance
-		var nextToken string
-		for {
-			res, err := client.ListBotInstancesV2(ctx, &machineidv1pb.ListBotInstancesV2Request{
-				PageToken: nextToken,
-			})
-			require.NoError(t, err)
-			results = append(results, res.BotInstances...)
-			nextToken = res.NextPageToken
-			if nextToken == "" {
-				break
-			}
-		}
-		return results
+		out, err := stream.Collect(clientutils.Resources(
+			t.Context(),
+			func(
+				ctx context.Context, limit int, nextToken string,
+			) ([]*machineidv1pb.BotInstance, string, error) {
+				res, err := client.ListBotInstancesV2(ctx, &machineidv1pb.ListBotInstancesV2Request{
+					PageToken: nextToken,
+					PageSize:  int32(limit),
+				})
+				return res.BotInstances, res.NextPageToken, err
+			}),
+		)
+		require.NoError(t, err)
+		return out
 	}
 
 	t.Run("unscoped user sees all instances", func(t *testing.T) {
@@ -3497,6 +3517,14 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		for _, bi := range got {
 			require.Contains(t, grantedIDs, bi.Spec.InstanceId)
 		}
+	})
+
+	t.Run("scoped user sees no bot instances", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestScopedUser(scopedUser.GetName(), "/scopes/other"))
+		require.NoError(t, err)
+
+		got := listAll(t, client.BotInstanceServiceClient())
+		require.Empty(t, got)
 	})
 }
 

--- a/lib/cache/bot_instance.go
+++ b/lib/cache/bot_instance.go
@@ -144,7 +144,13 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 			return c.Config.BotInstanceService.ListBotInstances(ctx, limit, start, options)
 		},
 		filter: func(b *machineidv1.BotInstance) bool {
-			return services.MatchBotInstance(b, options.GetFilterBotName(), options.GetFilterSearchTerm(), exp)
+			if !services.MatchBotInstance(b, options.GetFilterBotName(), options.GetFilterSearchTerm(), exp) {
+				return false
+			}
+			if fn := options.GetFilterFn(); fn != nil {
+				return fn(b)
+			}
+			return true
 		},
 		nextToken: func(b *machineidv1.BotInstance) string {
 			return keyFn(b)

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -448,6 +448,91 @@ func TestBotInstanceCacheSorting(t *testing.T) {
 	})
 }
 
+// TestBotInstanceCacheFilterFn tests that FilterFn is applied during cache
+// iteration and that pages are filled correctly even when some items are
+// filtered out.
+func TestBotInstanceCacheFilterFn(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	// Create 10 instances across two bots: bot-0 and bot-1.
+	for n := range 10 {
+		_, err := p.botInstanceService.CreateBotInstance(ctx, &machineidv1.BotInstance{
+			Kind:     types.KindBotInstance,
+			Version:  types.V1,
+			Metadata: &headerv1.Metadata{},
+			Spec: &machineidv1.BotInstanceSpec{
+				BotName:    "bot-" + strconv.Itoa(n%2),
+				InstanceId: "instance-" + strconv.Itoa(n),
+			},
+			Status: &machineidv1.BotInstanceStatus{},
+		})
+		require.NoError(t, err)
+	}
+
+	// Let the cache catch up
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
+		require.NoError(t, err)
+		require.Len(t, results, 10)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// FilterFn that only accepts even-numbered instances.
+	filterFn := func(b *machineidv1.BotInstance) bool {
+		id := b.GetSpec().GetInstanceId()
+		n := id[len(id)-1]
+		return n == '0' || n == '2' || n == '4' || n == '6' || n == '8'
+	}
+
+	// FilterFn alone: all even instances across both bots.
+	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
+		FilterFn: filterFn,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 5)
+
+	// Pages should be full: request 3 items with a filter that accepts half.
+	results, nextPageToken, err := p.cache.ListBotInstances(ctx, 3, "", &services.ListBotInstancesRequestOptions{
+		FilterFn: filterFn,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	require.NotEmpty(t, nextPageToken)
+
+	// Next page should contain the remaining 2 items.
+	results, nextPageToken, err = p.cache.ListBotInstances(ctx, 3, nextPageToken, &services.ListBotInstancesRequestOptions{
+		FilterFn: filterFn,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	require.Empty(t, nextPageToken)
+
+	// FilterFn composed with FilterBotName: bot-0 has instances 0,2,4,6,8
+	// (even-numbered), all of which pass the FilterFn. bot-1 has instances
+	// 1,3,5,7,9 (odd-numbered), none of which pass the FilterFn.
+	results, _, err = p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
+		FilterBotName: "bot-0",
+		FilterFn:      filterFn,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 5)
+	for _, b := range results {
+		require.Equal(t, "bot-0", b.GetSpec().GetBotName())
+	}
+
+	// bot-1 instances are all odd-numbered, so FilterFn rejects them all.
+	results, _, err = p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
+		FilterBotName: "bot-1",
+		FilterFn:      filterFn,
+	})
+	require.NoError(t, err)
+	require.Empty(t, results)
+}
+
 // TestBotInstanceCacheFallback tests that requests fallback to the upstream when the cache is unhealthy.
 func TestBotInstanceCacheFallback(t *testing.T) {
 	t.Parallel()

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1819,6 +1819,14 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 	firstInstance, generation := testExtractBotParamsFromCerts(t, joinResult.Certs)
 	require.Equal(t, uint64(1), generation)
 
+	// The BotInstance should have the scope set.
+	botInstance, err := adminClient.BotInstanceServiceClient().GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
+		BotName:    "test-scoped",
+		InstanceId: firstInstance,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "/test", botInstance.GetScope())
+
 	// Status should be updated.
 	token, err := adminClient.GetScopedToken(ctx, "example-token", false)
 	require.NoError(t, err)

--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -33,6 +33,9 @@ func isAllowedScopedRule(kind string, verb string) bool {
 	case types.KindBot:
 		// bots can be read/written, and do not currently contain a concept of a secret.
 		return isReadWriteNoSecrets(verb)
+	case types.KindBotInstance:
+		// bot instances can be read/written, and do not currently contain a concept of a secret.
+		return isReadWriteNoSecrets(verb)
 	default:
 		return false
 	}

--- a/lib/services/bot_instance.go
+++ b/lib/services/bot_instance.go
@@ -158,6 +158,8 @@ type ListBotInstancesRequestOptions struct {
 	FilterSearchTerm string
 	// A Teleport predicate language query used to filter the results.
 	FilterQuery string
+	// FilterFn is an optional additional filter applied during iteration.
+	FilterFn func(*machineidv1.BotInstance) bool
 }
 
 func (o *ListBotInstancesRequestOptions) GetSortField() string {
@@ -193,6 +195,13 @@ func (o *ListBotInstancesRequestOptions) GetFilterQuery() string {
 		return ""
 	}
 	return o.FilterQuery
+}
+
+func (o *ListBotInstancesRequestOptions) GetFilterFn() func(*machineidv1.BotInstance) bool {
+	if o == nil {
+		return nil
+	}
+	return o.FilterFn
 }
 
 // BotResourceName returns the default name for resources associated with the

--- a/lib/services/local/bot_instance.go
+++ b/lib/services/local/bot_instance.go
@@ -124,13 +124,20 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 		}
 	}
 
-	if options.GetFilterSearchTerm() == "" && exp == nil {
+	filterFn := options.GetFilterFn()
+	if options.GetFilterSearchTerm() == "" && exp == nil && filterFn == nil {
 		r, nextToken, err := service.ListResources(ctx, pageSize, lastKey)
 		return r, nextToken, trace.Wrap(err)
 	}
 
 	r, nextToken, err := service.ListResourcesWithFilter(ctx, pageSize, lastKey, func(item *machineidv1.BotInstance) bool {
-		return services.MatchBotInstance(item, "", options.GetFilterSearchTerm(), exp)
+		if !services.MatchBotInstance(item, "", options.GetFilterSearchTerm(), exp) {
+			return false
+		}
+		if filterFn != nil {
+			return filterFn(item)
+		}
+		return true
 	})
 
 	return r, nextToken, trace.Wrap(err)

--- a/lib/services/local/bot_instance_test.go
+++ b/lib/services/local/bot_instance_test.go
@@ -527,3 +527,48 @@ func TestBotInstanceListWithSort(t *testing.T) {
 	_, _, err = service.ListBotInstances(ctx, 0, "", nil)
 	require.NoError(t, err)
 }
+
+func TestBotInstanceListWithFilterFn(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	// Create 10 instances for "test-bot".
+	var created []*machineidv1.BotInstance
+	for range 10 {
+		bi := newBotInstance("test-bot")
+		_, err := service.CreateBotInstance(ctx, bi)
+		require.NoError(t, err)
+		created = append(created, bi)
+	}
+
+	// Use a FilterFn that only accepts even-indexed instances.
+	accepted := map[string]struct{}{}
+	for i, bi := range created {
+		if i%2 == 0 {
+			accepted[bi.Spec.InstanceId] = struct{}{}
+		}
+	}
+
+	instances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
+		FilterFn: func(bi *machineidv1.BotInstance) bool {
+			_, ok := accepted[bi.GetSpec().GetInstanceId()]
+			return ok
+		},
+	})
+
+	require.Len(t, instances, len(accepted))
+	for _, bi := range instances {
+		require.Contains(t, accepted, bi.Spec.InstanceId)
+	}
+}


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/63195

Depends on https://github.com/gravitational/teleport/pull/65366

Changelog will be held until the final PRs are in place.

## Manual Test Plan
### Test Environment

Local cluster with `tbot` built from the next PR in the stack: https://github.com/gravitational/teleport/pull/65351

### Test Cases

- [x] Unscoped bot joins and renews succesfully
- [x] Scoped bot joins and renews succesfully, scope is included in created Bot Instance record.
- [x] Unscoped user:
  - [x] List BotInstances (see scoped and unscoped)
  - [x] Get unscoped BotInstance
  - [x] Get scoped BotInstance
- [x] Scoped user:
  - [x] List BotInstances (see only BotInstances in scope's they hold privilege)
  - [x] Get unscoped BotInstance (fail)
  - [x] Get scoped BotInstance in scope they hold privilege for
  - [x] Get scoped BotInstance in scope they do not hold privilege for (fail)
