### PR TITLE
[v18] Remove expired Baltimore CyberTrust Root

### DIFF
--- a/lib/srv/db/ca.go
+++ b/lib/srv/db/ca.go
@@ -504,7 +504,7 @@ const (
 	// https://www.amazontrust.com/repository/
 	amazonRootCA1URL = "https://www.amazontrust.com/repository/AmazonRootCA1.pem"
 
-	// azureCAURLDigiCert is the URL of the new CA certificate for validating
+	// azureCAURLDigiCert is the URL of the CA certificate for validating
 	// certificates presented by Azure hosted databases.
 	azureCAURLDigiCert = "https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem"
 

--- a/lib/srv/db/ca.go
+++ b/lib/srv/db/ca.go
@@ -199,7 +199,6 @@ func (s *Server) getCACertPaths(database types.Database) ([]string, error) {
 
 	case types.DatabaseTypeAzure:
 		return []string{
-			filepath.Join(s.cfg.DataDir, filepath.Base(azureCAURLBaltimore)),
 			filepath.Join(s.cfg.DataDir, filepath.Base(azureCAURLDigiCert)),
 		}, nil
 
@@ -325,9 +324,7 @@ func (d *realDownloader) Download(ctx context.Context, database types.Database, 
 	case types.DatabaseTypeCloudSQL:
 		return d.downloadForCloudSQL(ctx, database)
 	case types.DatabaseTypeAzure:
-		if strings.HasSuffix(azureCAURLBaltimore, hint) {
-			return d.downloadFromURL(azureCAURLBaltimore)
-		} else if strings.HasSuffix(azureCAURLDigiCert, hint) {
+		if strings.HasSuffix(azureCAURLDigiCert, hint) {
 			return d.downloadFromURL(azureCAURLDigiCert)
 		}
 		return nil, nil, trace.BadParameter("unknown Azure CA %q", hint)
@@ -352,9 +349,7 @@ func (d *realDownloader) GetVersion(ctx context.Context, database types.Database
 		types.DatabaseTypeMemoryDB:
 		return d.getVersionFromURL(database, amazonRootCA1URL)
 	case types.DatabaseTypeAzure:
-		if strings.HasSuffix(azureCAURLBaltimore, hint) {
-			return d.getVersionFromURL(database, azureCAURLBaltimore)
-		} else if strings.HasSuffix(azureCAURLDigiCert, hint) {
+		if strings.HasSuffix(azureCAURLDigiCert, hint) {
 			return d.getVersionFromURL(database, azureCAURLDigiCert)
 		}
 		return nil, trace.BadParameter("unknown Azure CA %q", hint)
@@ -509,12 +504,6 @@ const (
 	// https://www.amazontrust.com/repository/
 	amazonRootCA1URL = "https://www.amazontrust.com/repository/AmazonRootCA1.pem"
 
-	// azureCAURLBaltimore is the URL of the CA certificate for validating certificates
-	// presented by Azure hosted databases. See:
-	//
-	// https://docs.microsoft.com/en-us/azure/postgresql/concepts-ssl-connection-security
-	// https://docs.microsoft.com/en-us/azure/mysql/howto-configure-ssl
-	azureCAURLBaltimore = "https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem"
 	// azureCAURLDigiCert is the URL of the new CA certificate for validating
 	// certificates presented by Azure hosted databases.
 	azureCAURLDigiCert = "https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem"

--- a/lib/srv/db/ca_test.go
+++ b/lib/srv/db/ca_test.go
@@ -456,7 +456,7 @@ func TestInitAzureCAs(t *testing.T) {
 	})
 
 	require.NoError(t, databaseServer.initCACert(ctx, azureDB))
-	require.Equal(t, initialCA, azureDB.GetStatusCA())
+	require.Equal(t, string(initialCA), azureDB.GetStatusCA())
 }
 
 func generateDatabaseCA(t *testing.T) []byte {

--- a/lib/srv/db/ca_test.go
+++ b/lib/srv/db/ca_test.go
@@ -19,7 +19,6 @@
 package db
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
@@ -240,7 +239,7 @@ func TestInitCACert(t *testing.T) {
 		{
 			desc:     "should download Azure CA when it's not set",
 			database: azureMySQL.GetName(),
-			cert:     fixtures.TLSCACertPEM + "\n" + fixtures.TLSCACertPEM, // Two CA files.
+			cert:     fixtures.TLSCACertPEM,
 		},
 		{
 			desc:     "should download MongoDB Atlas CA when it's not set",
@@ -435,7 +434,7 @@ func TestInitAzureCAs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	supportedHints := []string{filepath.Base(azureCAURLBaltimore), filepath.Base(azureCAURLDigiCert)}
+	supportedHints := []string{filepath.Base(azureCAURLDigiCert)}
 	initialCA := generateDatabaseCA(t)
 	caDownloader := &fakeDownloader{
 		cert:    initialCA,
@@ -457,9 +456,7 @@ func TestInitAzureCAs(t *testing.T) {
 	})
 
 	require.NoError(t, databaseServer.initCACert(ctx, azureDB))
-	// It must have the contents of two CAs. Since we're returning the same
-	// content for both, it should have 2 instances of "initialCA".
-	require.Equal(t, string(bytes.Join([][]byte{initialCA, initialCA}, []byte("\n"))), azureDB.GetStatusCA())
+	require.Equal(t, initialCA, azureDB.GetStatusCA())
 }
 
 func generateDatabaseCA(t *testing.T) []byte {


### PR DESCRIPTION
Backport #65072 to branch/v18

changelog: Removed expired Baltimore CyberTrust Root CA used for Azure databases

## Manual Test Plan
### Test Environment

- Teleport Cloud tenant `tener-test-v18.cloud.gravitational.io`

### Test Cases
- [x] Azure Flexible MySQL Server works
- [x] Azure Flexible Postgres Server works