### PR TITLE
Remove `rolldown` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "oxlint": "^1.55.0",
     "playwright": "^1.58.2",
     "react-select-event": "^5.5.1",
-    "rolldown": "^1.0.0-rc.9",
     "storybook": "^10.2.14",
     "svgo": "^4.0.1",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,9 +211,6 @@ importers:
       react-select-event:
         specifier: ^5.5.1
         version: 5.5.1
-      rolldown:
-        specifier: ^1.0.0-rc.9
-        version: 1.0.0-rc.9
       storybook:
         specifier: ^10.2.14
         version: 10.2.14(@testing-library/dom@10.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/web/packages/teleterm/electron.vite.config.mts
+++ b/web/packages/teleterm/electron.vite.config.mts
@@ -21,8 +21,7 @@ import { builtinModules } from 'node:module';
 import path from 'node:path';
 
 import { defineConfig, UserConfig } from 'electron-vite';
-import type { RolldownOptions } from 'rolldown';
-import type { Plugin } from 'vite';
+import type { Plugin, Rolldown } from 'vite';
 
 import { reactPlugin } from '@gravitational/build/vite/react.mjs';
 
@@ -47,7 +46,7 @@ const deps = Object.keys(pkg.dependencies || {}).filter(
   dep => !externalizeDeps.includes(dep)
 );
 
-const commonRolldownOptions: RolldownOptions = {
+const commonRolldownOptions: Rolldown.RolldownOptions = {
   onLog(level, log, defaultHandler) {
     // Suppress direct eval warning from @protobufjs/inquire.
     // The eval is intentional (to call require without bundler detection) and patching
@@ -62,7 +61,7 @@ const commonRolldownOptions: RolldownOptions = {
 
 // Main and preload run in Node.js, so we externalize electron, Node.js built-in
 // modules, and package.json dependencies (they'll be included during packaging).
-const nodeExternalOptions: RolldownOptions = {
+const nodeExternalOptions: Rolldown.RolldownOptions = {
   external: [
     'electron',
     /^electron\/.+/,


### PR DESCRIPTION
It was added in https://github.com/gravitational/teleport/pull/64600, but I don't think we need it. It already comes via `vite`, and `RolldownOptions` can be imported from `vite`.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Regular dev environment.
### Test Cases
- [x] pnpm build-ui-oss passes. 
