### PR TITLE
[tsh] add a common --jobs flag to tsh bench

### DIFF
--- a/lib/benchmark/benchmark.go
+++ b/lib/benchmark/benchmark.go
@@ -68,6 +68,9 @@ type Config struct {
 	MinimumWindow time.Duration
 	// MinimumMeasurments is the min amount of requests
 	MinimumMeasurements int
+	// Jobs is the maximum number of work items in flight when running a benchmark.
+	// By default this is the number of active inflight work items that are allowed, with 0 meaning unlimited.
+	Jobs int
 }
 
 // Result is a result of the benchmark
@@ -202,6 +205,10 @@ func (c *Config) Benchmark(ctx context.Context, tc *client.TeleportClient, suite
 	defer cancel()
 
 	resultC := make(chan benchMeasure)
+	var limiter chan struct{}
+	if c.Jobs > 0 {
+		limiter = make(chan struct{}, c.Jobs)
+	}
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
@@ -220,7 +227,23 @@ func (c *Config) Benchmark(ctx context.Context, tc *client.TeleportClient, suite
 					ResponseStart: t,
 				}
 
-				wg.Go(func() { work(ctx, measure, resultC, workload) })
+				if limiter != nil {
+					select {
+					case limiter <- struct{}{}:
+					default:
+						// Maintain the rate but skip when throttled.
+						continue
+					}
+				}
+
+				wg.Go(func() {
+					defer func() {
+						if limiter != nil {
+							<-limiter
+						}
+					}()
+					work(ctx, measure, resultC, workload)
+				})
 			case <-ctx.Done():
 				return
 			}

--- a/lib/benchmark/web.go
+++ b/lib/benchmark/web.go
@@ -329,8 +329,6 @@ func (s *webSession) getToken() string {
 type WebSessionBenchmark struct {
 	// Command to execute on the host.
 	Command []string
-	// Max number of sessions to have open at once.
-	Max int
 	// Duration of the test used to determine if renewing web sessions
 	// is necessary.
 	Duration time.Duration
@@ -344,17 +342,21 @@ func (s *WebSessionBenchmark) ConfigOverride(ctx context.Context, tc *client.Tel
 		return trace.Wrap(err)
 	}
 
+	if len(servers) == 0 {
+		return trace.NotFound("no servers found")
+	}
+
 	s.servers = servers
 
-	if s.Max == 0 {
-		s.Max = len(servers)
+	if cfg.Jobs <= 0 {
+		cfg.Jobs = len(servers)
 	}
 
 	// alter the minimum window such that the test will run
 	// for as long as is required to spawn all the sessions plus
 	// an additional minute.
 	interval := time.Duration(1 / float64(cfg.Rate) * float64(time.Second))
-	window := interval*time.Duration(s.Max) + (time.Minute)
+	window := interval*time.Duration(cfg.Jobs) + (time.Minute)
 	if cfg.MinimumWindow < window {
 		cfg.MinimumWindow = window
 	}
@@ -364,9 +366,6 @@ func (s *WebSessionBenchmark) ConfigOverride(ctx context.Context, tc *client.Tel
 
 // BenchBuilder returns a WorkloadFunc for the given benchmark suite.
 func (s *WebSessionBenchmark) BenchBuilder(ctx context.Context, tc *client.TeleportClient) (WorkloadFunc, error) {
-	if s.Max < 0 {
-		return nil, trace.BadParameter("max number of sessions cannot be negative, got: %d", s.Max)
-	}
 	// The benchmark runner may override stderr to be [io.Discard] which
 	// results in the login prompt being sent into the void and the user
 	// staring at a blank terminal. Temporarily override stderr to allow
@@ -398,19 +397,9 @@ func (s *WebSessionBenchmark) BenchBuilder(ctx context.Context, tc *client.Telep
 		next int
 	)
 
-	sem := make(chan struct{}, s.Max)
-
 	// Open a ssh session to the next host if the maximum
 	// number of connections has not already been reached.
 	return func(ctx context.Context) error {
-		select {
-		case sem <- struct{}{}:
-		case <-ctx.Done():
-			return nil
-		}
-
-		defer func() { <-sem }()
-
 		mu.Lock()
 		current := next
 		next = (next + 1) % len(s.servers)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -309,8 +309,8 @@ type CLIConf struct {
 	BenchExport bool
 	// BenchExportPath saves the latency profile in provided path
 	BenchExportPath string
-	// BenchMaxSessions is the maximum number of sessions to open
-	BenchMaxSessions int
+	// BenchJobs is the maximum number of work items in flight when running a benchmark. <=0 means no limit.
+	BenchJobs int
 	// BenchTicks ticks per half distance
 	BenchTicks int32
 	// BenchValueScale value at which to scale the values recorded
@@ -1305,6 +1305,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	bench.Flag("path", "Directory to save the latency profile to, default path is the current directory.").Default(".").StringVar(&cf.BenchExportPath)
 	bench.Flag("ticks", "Ticks per half distance.").Default("100").Int32Var(&cf.BenchTicks)
 	bench.Flag("scale", "Value scale in which to scale the recorded values.").Default("1.0").Float64Var(&cf.BenchValueScale)
+	bench.Flag("jobs", "Maximum number of concurrent operations.").Short('j').IntVar(&cf.BenchJobs)
 
 	benchSSH := bench.Command("ssh", "Run SSH benchmark tests.").Hidden()
 	benchSSH.Arg("[user@]host", "Remote hostname and the login to use.").Required().StringVar(&cf.UserHost)
@@ -1323,7 +1324,10 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	benchWebSessions := benchWeb.Command("sessions", "Run session benchmark tests.").Hidden()
 	benchWebSessions.Arg("[user@]host", "Remote hostname and the login to use.").Required().StringVar(&cf.UserHost)
 	benchWebSessions.Arg("command", "Command to execute on a remote host.").Required().StringsVar(&cf.RemoteCommand)
-	benchWebSessions.Flag("max", "The maximum number of sessions to open. If not specified a single session per node will be opened.").IntVar(&cf.BenchMaxSessions)
+	benchWebSessions.Flag("max", "DEPRECATED: use --jobs instead").Action(func(_ *kingpin.ParseContext) error {
+		logger.WarnContext(ctx, "--max is deprecated; use --jobs instead")
+		return nil
+	}).IntVar(&cf.BenchJobs)
 
 	var benchKubeOpts benchKubeOptions
 	benchKube := bench.Command("kube", "Run Kube benchmark tests.").Hidden()
@@ -1761,7 +1765,6 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 			&cf,
 			&benchmark.WebSessionBenchmark{
 				Command:  cf.RemoteCommand,
-				Max:      cf.BenchMaxSessions,
 				Duration: cf.BenchDuration,
 			},
 		)
@@ -4605,6 +4608,7 @@ func onBenchmark(cf *CLIConf, suite benchmark.Suite) error {
 	cnf := benchmark.Config{
 		MinimumWindow: cf.BenchDuration,
 		Rate:          cf.BenchRate,
+		Jobs:          cf.BenchJobs,
 	}
 
 	result, err := cnf.Benchmark(cf.Context, tc, suite)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1325,6 +1325,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	benchWebSessions.Arg("[user@]host", "Remote hostname and the login to use.").Required().StringVar(&cf.UserHost)
 	benchWebSessions.Arg("command", "Command to execute on a remote host.").Required().StringsVar(&cf.RemoteCommand)
 	benchWebSessions.Flag("max", "DEPRECATED: use --jobs instead").Action(func(_ *kingpin.ParseContext) error {
+		// TODO(okraport): delete in v20
 		logger.WarnContext(ctx, "--max is deprecated; use --jobs instead")
 		return nil
 	}).IntVar(&cf.BenchJobs)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1324,7 +1324,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	benchWebSessions := benchWeb.Command("sessions", "Run session benchmark tests.").Hidden()
 	benchWebSessions.Arg("[user@]host", "Remote hostname and the login to use.").Required().StringVar(&cf.UserHost)
 	benchWebSessions.Arg("command", "Command to execute on a remote host.").Required().StringsVar(&cf.RemoteCommand)
-	benchWebSessions.Flag("max", "DEPRECATED: use --jobs instead").Action(func(_ *kingpin.ParseContext) error {
+	benchWebSessions.Flag("max", "DEPRECATED: use --jobs instead.").Action(func(_ *kingpin.ParseContext) error {
 		// TODO(okraport): delete in v20
 		logger.WarnContext(ctx, "--max is deprecated; use --jobs instead")
 		return nil


### PR DESCRIPTION
This allows the user to limit the concurrency of work items in a benchmark invocation. This is useful when using the bench command to spawn a fixed number of long running sessions for profiling performance characteristics. This also replaces the `--max` flag for web sessions and works the same way. That makes the generic flag useful for long running benchmarks.

The `--max` flag can be considered deprecated but will continue to set the same configuration for the time being.

Changelog: `tsh bench` now supports `--jobs` flag to optionally limit concurrency of work items.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
* cloud tenant with agents in EKS

### Test Cases
- [ ] For each verify the bench command works as expected with concurrency limit:
  - [ ] tsh bench ssh
  - [ ] tsh bench web sessions

The behaviour is shared, using ssh and web is more convenient to verify the limiter with custom shell commands on the target. 