### PR TITLE
Fix audit events mismatched event code and types

### DIFF
--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -1372,6 +1372,7 @@ export type RawEvents = {
     {
       sid: string;
       user: string;
+      session_type?: string;
     }
   >;
   [eventCodes.SSMRUN_SUCCESS]: RawEvent<
@@ -1405,7 +1406,7 @@ export type RawEvents = {
     }
   >;
   [eventCodes.BOT_JOIN_FAILURE]: RawEvent<
-    typeof eventCodes.BOT_JOIN,
+    typeof eventCodes.BOT_JOIN_FAILURE,
     {
       bot_name: string;
       method: string;
@@ -1421,7 +1422,7 @@ export type RawEvents = {
     }
   >;
   [eventCodes.INSTANCE_JOIN_FAILURE]: RawEvent<
-    typeof eventCodes.INSTANCE_JOIN,
+    typeof eventCodes.INSTANCE_JOIN_FAILURE,
     {
       node_name: string;
       method: string;
@@ -1573,7 +1574,7 @@ export type RawEvents = {
     }
   >;
   [eventCodes.OKTA_ASSIGNMENT_CLEANUP]: RawEvent<
-    typeof eventCodes.OKTA_ASSIGNMENT_PROCESS,
+    typeof eventCodes.OKTA_ASSIGNMENT_CLEANUP,
     {
       name: string;
       source: string;


### PR DESCRIPTION
While copying over this file to the Identity security repo, we got a couple build errors that were related to mismatched event codes and types.

We fixed the problems there, and we're back porting the relevant changes to Teleport. I also included `session_type?: string` as part of the `SESSION_RECORDING_ACCESS` event since the Identity Activity Center uses this to construct the URL and it is present in the [event](https://github.com/gravitational/teleport/blob/main/api/proto/teleport/legacy/types/events/events.proto#L5665) and gets filled [here](https://github.com/gravitational/teleport/blob/master/lib/auth/auth_with_roles.go#L6703). 


## Manual Test Plan
### Test Environment
- Local environment with production build.

### Test Cases
- [X] Made sure that type-check and lint were passing, and ran the application locally as a sanity check that all was working.
- [X] Tested that the audit log page loads properly, and that the events are shown correctly. 
