### PR TITLE
Scoped role options

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -285,7 +285,9 @@ type ScopedRoleSSH struct {
 	// over an SSH session. It defaults to true unless explicitly set to false.
 	SshFileCopy *bool `protobuf:"varint,5,opt,name=ssh_file_copy,json=sshFileCopy,proto3,oneof" json:"ssh_file_copy,omitempty"`
 	// ForwardAgent is SSH agent forwarding.
-	ForwardAgent  *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
+	ForwardAgent *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
+	// HostSudoers is a list of entries to include in a users sudoer file
+	HostSudoers   []string `protobuf:"bytes,7,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -360,6 +362,13 @@ func (x *ScopedRoleSSH) GetForwardAgent() bool {
 		return *x.ForwardAgent
 	}
 	return false
+}
+
+func (x *ScopedRoleSSH) GetHostSudoers() []string {
+	if x != nil {
+		return x.HostSudoers
+	}
+	return nil
 }
 
 // ScopedRule maps resources to verbs. This is the underlying type used to describe
@@ -437,14 +446,15 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03sshJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xd3\x02\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xf6\x02\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
 	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x127\n" +
 	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12'\n" +
 	"\rssh_file_copy\x18\x05 \x01(\bH\x01R\vsshFileCopy\x88\x01\x01\x12(\n" +
-	"\rforward_agent\x18\x06 \x01(\bH\x02R\fforwardAgent\x88\x01\x01B\x18\n" +
+	"\rforward_agent\x18\x06 \x01(\bH\x02R\fforwardAgent\x88\x01\x01\x12!\n" +
+	"\fhost_sudoers\x18\a \x03(\tR\vhostSudoersB\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_ssh_file_copyB\x10\n" +
 	"\x0e_forward_agent\"@\n" +

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -281,8 +281,11 @@ type ScopedRoleSSH struct {
 	// PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions.
 	// If not set, X11 forwarding is not permitted.
 	PermitX11Forwarding *bool `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof" json:"permit_x11_forwarding,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
+	// over an SSH session. It defaults to true unless explicitly set to false.
+	SshFileCopy   *bool `protobuf:"varint,5,opt,name=ssh_file_copy,json=sshFileCopy,proto3,oneof" json:"ssh_file_copy,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSSH) Reset() {
@@ -339,6 +342,13 @@ func (x *ScopedRoleSSH) GetClientIdleTimeout() string {
 func (x *ScopedRoleSSH) GetPermitX11Forwarding() bool {
 	if x != nil && x.PermitX11Forwarding != nil {
 		return *x.PermitX11Forwarding
+	}
+	return false
+}
+
+func (x *ScopedRoleSSH) GetSshFileCopy() bool {
+	if x != nil && x.SshFileCopy != nil {
+		return *x.SshFileCopy
 	}
 	return false
 }
@@ -418,13 +428,15 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03sshJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xdc\x01\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\x97\x02\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
 	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x127\n" +
-	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01B\x18\n" +
-	"\x16_permit_x11_forwarding\"@\n" +
+	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12'\n" +
+	"\rssh_file_copy\x18\x05 \x01(\bH\x01R\vsshFileCopy\x88\x01\x01B\x18\n" +
+	"\x16_permit_x11_forwardingB\x10\n" +
+	"\x0e_ssh_file_copy\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -152,9 +152,7 @@ type ScopedRoleSpec struct {
 	// Rules describes basic resource:verb permissions (e.g. scoped_role:read).
 	Rules []*ScopedRule `protobuf:"bytes,6,rep,name=rules,proto3" json:"rules,omitempty"`
 	// Ssh specifies controls that govern SSH access.
-	Ssh *ScopedRoleSSH `protobuf:"bytes,7,opt,name=ssh,proto3" json:"ssh,omitempty"`
-	// The kubernetes specific configuration for a scoped role.
-	Kube          *ScopedRoleKube `protobuf:"bytes,8,opt,name=kube,proto3" json:"kube,omitempty"`
+	Ssh           *ScopedRoleSSH `protobuf:"bytes,7,opt,name=ssh,proto3" json:"ssh,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -213,13 +211,6 @@ func (x *ScopedRoleSpec) GetRules() []*ScopedRule {
 func (x *ScopedRoleSpec) GetSsh() *ScopedRoleSSH {
 	if x != nil {
 		return x.Ssh
-	}
-	return nil
-}
-
-func (x *ScopedRoleSpec) GetKube() *ScopedRoleKube {
-	if x != nil {
-		return x.Kube
 	}
 	return nil
 }
@@ -287,8 +278,11 @@ type ScopedRoleSSH struct {
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
 	ClientIdleTimeout string `protobuf:"bytes,3,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions.
+	// If not set, X11 forwarding is not permitted.
+	PermitX11Forwarding *bool `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof" json:"permit_x11_forwarding,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSSH) Reset() {
@@ -342,83 +336,11 @@ func (x *ScopedRoleSSH) GetClientIdleTimeout() string {
 	return ""
 }
 
-// The group of all scoped role fields relevant to kube access. Fields within the kube block
-// encompass selection criteria and preconditions for access, as well as the controls to be applied in
-// cases where access is permitted. A kube block is the primary source of truth for controls to be applied
-// to the kube access it permits, but defaults and global or scope-bound controls may also affect the nature of
-// the resulting access.
-type ScopedRoleKube struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// The map of kubernetes cluster labels used for RBAC.
-	Labels []*v11.Label `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty"`
-	// The list of kubernetes groups this role allows.
-	Groups []string `protobuf:"bytes,2,rep,name=groups,proto3" json:"groups,omitempty"`
-	// An optional list of impersonatable kubernetes users this role allows.
-	Users []string `protobuf:"bytes,3,rep,name=users,proto3" json:"users,omitempty"`
-	// Overrides the defaults block idle timeout specifically for kube sessions.
-	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
-	// (or global default) applies.
-	ClientIdleTimeout string `protobuf:"bytes,5,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
-}
-
-func (x *ScopedRoleKube) Reset() {
-	*x = ScopedRoleKube{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ScopedRoleKube) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ScopedRoleKube) ProtoMessage() {}
-
-func (x *ScopedRoleKube) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
+func (x *ScopedRoleSSH) GetPermitX11Forwarding() bool {
+	if x != nil && x.PermitX11Forwarding != nil {
+		return *x.PermitX11Forwarding
 	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use ScopedRoleKube.ProtoReflect.Descriptor instead.
-func (*ScopedRoleKube) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *ScopedRoleKube) GetLabels() []*v11.Label {
-	if x != nil {
-		return x.Labels
-	}
-	return nil
-}
-
-func (x *ScopedRoleKube) GetGroups() []string {
-	if x != nil {
-		return x.Groups
-	}
-	return nil
-}
-
-func (x *ScopedRoleKube) GetUsers() []string {
-	if x != nil {
-		return x.Users
-	}
-	return nil
-}
-
-func (x *ScopedRoleKube) GetClientIdleTimeout() string {
-	if x != nil {
-		return x.ClientIdleTimeout
-	}
-	return ""
+	return false
 }
 
 // ScopedRule maps resources to verbs. This is the underlying type used to describe
@@ -435,7 +357,7 @@ type ScopedRule struct {
 
 func (x *ScopedRule) Reset() {
 	*x = ScopedRule{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -447,7 +369,7 @@ func (x *ScopedRule) String() string {
 func (*ScopedRule) ProtoMessage() {}
 
 func (x *ScopedRule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -460,7 +382,7 @@ func (x *ScopedRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScopedRule.ProtoReflect.Descriptor instead.
 func (*ScopedRule) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{5}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ScopedRule) GetResources() []string {
@@ -489,24 +411,20 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12=\n" +
-	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\xdc\x02\n" +
+	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\x9d\x02\n" +
 	"\x0eScopedRoleSpec\x12+\n" +
 	"\x11assignable_scopes\x18\x01 \x03(\tR\x10assignableScopes\x12I\n" +
 	"\bdefaults\x18\x05 \x01(\v2-.teleport.scopes.access.v1.ScopedRoleDefaultsR\bdefaults\x12;\n" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
-	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
-	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
+	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03sshJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\x89\x01\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xdc\x01\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
-	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\"\xb1\x01\n" +
-	"\x0eScopedRoleKube\x120\n" +
-	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
-	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
-	"\x05users\x18\x03 \x03(\tR\x05users\x12.\n" +
-	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeoutJ\x04\b\x04\x10\x05R\tresources\"@\n" +
+	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x127\n" +
+	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01B\x18\n" +
+	"\x16_permit_x11_forwarding\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -524,31 +442,28 @@ func file_teleport_scopes_access_v1_role_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_role_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),         // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),     // 1: teleport.scopes.access.v1.ScopedRoleSpec
 	(*ScopedRoleDefaults)(nil), // 2: teleport.scopes.access.v1.ScopedRoleDefaults
 	(*ScopedRoleSSH)(nil),      // 3: teleport.scopes.access.v1.ScopedRoleSSH
-	(*ScopedRoleKube)(nil),     // 4: teleport.scopes.access.v1.ScopedRoleKube
-	(*ScopedRule)(nil),         // 5: teleport.scopes.access.v1.ScopedRule
-	(*v1.Metadata)(nil),        // 6: teleport.header.v1.Metadata
-	(*v11.Label)(nil),          // 7: teleport.label.v1.Label
+	(*ScopedRule)(nil),         // 4: teleport.scopes.access.v1.ScopedRule
+	(*v1.Metadata)(nil),        // 5: teleport.header.v1.Metadata
+	(*v11.Label)(nil),          // 6: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	6, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	5, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2, // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
-	5, // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
+	4, // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
 	3, // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
-	4, // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
-	7, // 6: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	7, // 7: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	6, // 5: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	6, // [6:6] is the sub-list for method output_type
+	6, // [6:6] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -556,13 +471,14 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	if File_teleport_scopes_access_v1_role_proto != nil {
 		return
 	}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -347,10 +347,13 @@ type ScopedRoleSSH struct {
 	ForwardAgent *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
 	// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
 	SshPortForwarding *SSHPortForwarding `protobuf:"bytes,7,opt,name=ssh_port_forwarding,json=sshPortForwarding,proto3,oneof" json:"ssh_port_forwarding,omitempty"`
-	// CreateHostUser
+	// CreateHostUser configures the creation of host users.
 	CreateHostUser *CreateHostUser `protobuf:"bytes,8,opt,name=create_host_user,json=createHostUser,proto3,oneof" json:"create_host_user,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// MaxSessions defines the maximum number of
+	// concurrent sessions per connection.
+	MaxSessions   *int64 `protobuf:"varint,9,opt,name=max_sessions,json=maxSessions,proto3,oneof" json:"max_sessions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSSH) Reset() {
@@ -439,14 +442,19 @@ func (x *ScopedRoleSSH) GetCreateHostUser() *CreateHostUser {
 	return nil
 }
 
+func (x *ScopedRoleSSH) GetMaxSessions() int64 {
+	if x != nil && x.MaxSessions != nil {
+		return *x.MaxSessions
+	}
+	return 0
+}
+
 // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
 // over an SSH session. It defaults to true unless explicitly set to false.
 type SSHFileCopy struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// specifies that user is only allowed to download
-	Download *bool `protobuf:"varint,1,opt,name=download,proto3,oneof" json:"download,omitempty"`
-	// specifies that user is only allowed to upload
-	Upload        *bool `protobuf:"varint,2,opt,name=upload,proto3,oneof" json:"upload,omitempty"`
+	// Allow for remote file operations via SCP or SFTP.
+	Enabled       *bool `protobuf:"varint,1,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -481,16 +489,9 @@ func (*SSHFileCopy) Descriptor() ([]byte, []int) {
 	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *SSHFileCopy) GetDownload() bool {
-	if x != nil && x.Download != nil {
-		return *x.Download
-	}
-	return false
-}
-
-func (x *SSHFileCopy) GetUpload() bool {
-	if x != nil && x.Upload != nil {
-		return *x.Upload
+func (x *SSHFileCopy) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
 	}
 	return false
 }
@@ -698,7 +699,7 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03sshJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xe5\x04\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\x9e\x05\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
@@ -707,17 +708,18 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\rssh_file_copy\x18\x05 \x01(\v2&.teleport.scopes.access.v1.SSHFileCopyH\x01R\vsshFileCopy\x88\x01\x01\x12(\n" +
 	"\rforward_agent\x18\x06 \x01(\bH\x02R\fforwardAgent\x88\x01\x01\x12a\n" +
 	"\x13ssh_port_forwarding\x18\a \x01(\v2,.teleport.scopes.access.v1.SSHPortForwardingH\x03R\x11sshPortForwarding\x88\x01\x01\x12X\n" +
-	"\x10create_host_user\x18\b \x01(\v2).teleport.scopes.access.v1.CreateHostUserH\x04R\x0ecreateHostUser\x88\x01\x01B\x18\n" +
+	"\x10create_host_user\x18\b \x01(\v2).teleport.scopes.access.v1.CreateHostUserH\x04R\x0ecreateHostUser\x88\x01\x01\x12&\n" +
+	"\fmax_sessions\x18\t \x01(\x03H\x05R\vmaxSessions\x88\x01\x01B\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_ssh_file_copyB\x10\n" +
 	"\x0e_forward_agentB\x16\n" +
 	"\x14_ssh_port_forwardingB\x13\n" +
-	"\x11_create_host_user\"c\n" +
-	"\vSSHFileCopy\x12\x1f\n" +
-	"\bdownload\x18\x01 \x01(\bH\x00R\bdownload\x88\x01\x01\x12\x1b\n" +
-	"\x06upload\x18\x02 \x01(\bH\x01R\x06upload\x88\x01\x01B\v\n" +
-	"\t_downloadB\t\n" +
-	"\a_upload\"@\n" +
+	"\x11_create_host_userB\x0f\n" +
+	"\r_max_sessions\"8\n" +
+	"\vSSHFileCopy\x12\x1d\n" +
+	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01B\n" +
+	"\n" +
+	"\b_enabled\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -287,9 +287,10 @@ type ScopedRoleSSH struct {
 	// ForwardAgent is SSH agent forwarding.
 	ForwardAgent *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
 	// HostSudoers is a list of entries to include in a users sudoer file
-	HostSudoers   []string `protobuf:"bytes,7,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	HostSudoers       []string           `protobuf:"bytes,7,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
+	SshPortForwarding *SSHPortForwarding `protobuf:"bytes,8,opt,name=ssh_port_forwarding,json=sshPortForwarding,proto3,oneof" json:"ssh_port_forwarding,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSSH) Reset() {
@@ -371,6 +372,13 @@ func (x *ScopedRoleSSH) GetHostSudoers() []string {
 	return nil
 }
 
+func (x *ScopedRoleSSH) GetSshPortForwarding() *SSHPortForwarding {
+	if x != nil {
+		return x.SshPortForwarding
+	}
+	return nil
+}
+
 // ScopedRule maps resources to verbs. This is the underlying type used to describe
 // permissions like 'scoped_role:read' or 'scoped_role_assignment:create'.
 type ScopedRule struct {
@@ -427,6 +435,61 @@ func (x *ScopedRule) GetVerbs() []string {
 	return nil
 }
 
+// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
+type SSHPortForwarding struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Allow local port forwarding
+	Local *bool `protobuf:"varint,1,opt,name=local,proto3,oneof" json:"local,omitempty"`
+	// Allow remote port forwarding
+	Remote        *bool `protobuf:"varint,2,opt,name=remote,proto3,oneof" json:"remote,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SSHPortForwarding) Reset() {
+	*x = SSHPortForwarding{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SSHPortForwarding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SSHPortForwarding) ProtoMessage() {}
+
+func (x *SSHPortForwarding) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SSHPortForwarding.ProtoReflect.Descriptor instead.
+func (*SSHPortForwarding) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SSHPortForwarding) GetLocal() bool {
+	if x != nil && x.Local != nil {
+		return *x.Local
+	}
+	return false
+}
+
+func (x *SSHPortForwarding) GetRemote() bool {
+	if x != nil && x.Remote != nil {
+		return *x.Remote
+	}
+	return false
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -446,7 +509,7 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03sshJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xf6\x02\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xf1\x03\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
@@ -454,14 +517,21 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12'\n" +
 	"\rssh_file_copy\x18\x05 \x01(\bH\x01R\vsshFileCopy\x88\x01\x01\x12(\n" +
 	"\rforward_agent\x18\x06 \x01(\bH\x02R\fforwardAgent\x88\x01\x01\x12!\n" +
-	"\fhost_sudoers\x18\a \x03(\tR\vhostSudoersB\x18\n" +
+	"\fhost_sudoers\x18\a \x03(\tR\vhostSudoers\x12a\n" +
+	"\x13ssh_port_forwarding\x18\b \x01(\v2,.teleport.scopes.access.v1.SSHPortForwardingH\x03R\x11sshPortForwarding\x88\x01\x01B\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_ssh_file_copyB\x10\n" +
-	"\x0e_forward_agent\"@\n" +
+	"\x0e_forward_agentB\x16\n" +
+	"\x14_ssh_port_forwarding\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
-	"\x05verbs\x18\x02 \x03(\tR\x05verbsBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x05verbs\x18\x02 \x03(\tR\x05verbs\"`\n" +
+	"\x11SSHPortForwarding\x12\x19\n" +
+	"\x05local\x18\x01 \x01(\bH\x00R\x05local\x88\x01\x01\x12\x1b\n" +
+	"\x06remote\x18\x02 \x01(\bH\x01R\x06remote\x88\x01\x01B\b\n" +
+	"\x06_localB\t\n" +
+	"\a_remoteBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
 var (
 	file_teleport_scopes_access_v1_role_proto_rawDescOnce sync.Once
@@ -475,28 +545,30 @@ func file_teleport_scopes_access_v1_role_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_role_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),         // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),     // 1: teleport.scopes.access.v1.ScopedRoleSpec
 	(*ScopedRoleDefaults)(nil), // 2: teleport.scopes.access.v1.ScopedRoleDefaults
 	(*ScopedRoleSSH)(nil),      // 3: teleport.scopes.access.v1.ScopedRoleSSH
 	(*ScopedRule)(nil),         // 4: teleport.scopes.access.v1.ScopedRule
-	(*v1.Metadata)(nil),        // 5: teleport.header.v1.Metadata
-	(*v11.Label)(nil),          // 6: teleport.label.v1.Label
+	(*SSHPortForwarding)(nil),  // 5: teleport.scopes.access.v1.SSHPortForwarding
+	(*v1.Metadata)(nil),        // 6: teleport.header.v1.Metadata
+	(*v11.Label)(nil),          // 7: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	5, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	6, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2, // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
 	4, // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
 	3, // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
-	6, // 5: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	7, // 5: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	5, // 6: teleport.scopes.access.v1.ScopedRoleSSH.ssh_port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -505,13 +577,14 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 		return
 	}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[5].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -611,7 +611,7 @@ func (x *SSHPortForwarding) GetRemote() bool {
 type CreateHostUser struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// CreateHostUserMode specifies how the host user should be created.
-	CreateHostUserMode CreateHostUserMode `protobuf:"varint,1,opt,name=create_host_user_mode,json=createHostUserMode,proto3,enum=teleport.scopes.access.v1.CreateHostUserMode" json:"create_host_user_mode,omitempty"`
+	CreateHostUserMode *CreateHostUserMode `protobuf:"varint,1,opt,name=create_host_user_mode,json=createHostUserMode,proto3,enum=teleport.scopes.access.v1.CreateHostUserMode,oneof" json:"create_host_user_mode,omitempty"`
 	// HostSudoers is a list of entries to include in a users sudoer file
 	HostSudoers []string `protobuf:"bytes,2,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
 	// HostGroups is a list of host groups to add the user to.
@@ -653,8 +653,8 @@ func (*CreateHostUser) Descriptor() ([]byte, []int) {
 }
 
 func (x *CreateHostUser) GetCreateHostUserMode() CreateHostUserMode {
-	if x != nil {
-		return x.CreateHostUserMode
+	if x != nil && x.CreateHostUserMode != nil {
+		return *x.CreateHostUserMode
 	}
 	return CreateHostUserMode_CREATE_HOST_USER_MODE_UNSPECIFIED
 }
@@ -728,14 +728,15 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05local\x18\x01 \x01(\bH\x00R\x05local\x88\x01\x01\x12\x1b\n" +
 	"\x06remote\x18\x02 \x01(\bH\x01R\x06remote\x88\x01\x01B\b\n" +
 	"\x06_localB\t\n" +
-	"\a_remote\"\xe9\x01\n" +
-	"\x0eCreateHostUser\x12`\n" +
-	"\x15create_host_user_mode\x18\x01 \x01(\x0e2-.teleport.scopes.access.v1.CreateHostUserModeR\x12createHostUserMode\x12!\n" +
+	"\a_remote\"\x88\x02\n" +
+	"\x0eCreateHostUser\x12e\n" +
+	"\x15create_host_user_mode\x18\x01 \x01(\x0e2-.teleport.scopes.access.v1.CreateHostUserModeH\x00R\x12createHostUserMode\x88\x01\x01\x12!\n" +
 	"\fhost_sudoers\x18\x02 \x03(\tR\vhostSudoers\x12\x1f\n" +
 	"\vhost_groups\x18\x03 \x03(\tR\n" +
 	"hostGroups\x12\"\n" +
 	"\n" +
-	"host_shell\x18\x04 \x01(\tH\x00R\thostShell\x88\x01\x01B\r\n" +
+	"host_shell\x18\x04 \x01(\tH\x01R\thostShell\x88\x01\x01B\x18\n" +
+	"\x16_create_host_user_modeB\r\n" +
 	"\v_host_shell*\xa3\x01\n" +
 	"\x12CreateHostUserMode\x12%\n" +
 	"!CREATE_HOST_USER_MODE_UNSPECIFIED\x10\x00\x12\x1d\n" +

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -211,7 +211,9 @@ type ScopedRoleSpec struct {
 	// Rules describes basic resource:verb permissions (e.g. scoped_role:read).
 	Rules []*ScopedRule `protobuf:"bytes,6,rep,name=rules,proto3" json:"rules,omitempty"`
 	// Ssh specifies controls that govern SSH access.
-	Ssh           *ScopedRoleSSH `protobuf:"bytes,7,opt,name=ssh,proto3" json:"ssh,omitempty"`
+	Ssh *ScopedRoleSSH `protobuf:"bytes,7,opt,name=ssh,proto3" json:"ssh,omitempty"`
+	// The kubernetes specific configuration for a scoped role.
+	Kube          *ScopedRoleKube `protobuf:"bytes,8,opt,name=kube,proto3" json:"kube,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -270,6 +272,13 @@ func (x *ScopedRoleSpec) GetRules() []*ScopedRule {
 func (x *ScopedRoleSpec) GetSsh() *ScopedRoleSSH {
 	if x != nil {
 		return x.Ssh
+	}
+	return nil
+}
+
+func (x *ScopedRoleSpec) GetKube() *ScopedRoleKube {
+	if x != nil {
+		return x.Kube
 	}
 	return nil
 }
@@ -496,6 +505,85 @@ func (x *SSHFileCopy) GetEnabled() bool {
 	return false
 }
 
+// The group of all scoped role fields relevant to kube access. Fields within the kube block
+// encompass selection criteria and preconditions for access, as well as the controls to be applied in
+// cases where access is permitted. A kube block is the primary source of truth for controls to be applied
+// to the kube access it permits, but defaults and global or scope-bound controls may also affect the nature of
+// the resulting access.
+type ScopedRoleKube struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The map of kubernetes cluster labels used for RBAC.
+	Labels []*v11.Label `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty"`
+	// The list of kubernetes groups this role allows.
+	Groups []string `protobuf:"bytes,2,rep,name=groups,proto3" json:"groups,omitempty"`
+	// An optional list of impersonatable kubernetes users this role allows.
+	Users []string `protobuf:"bytes,3,rep,name=users,proto3" json:"users,omitempty"`
+	// Overrides the defaults block idle timeout specifically for kube sessions.
+	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
+	// (or global default) applies.
+	ClientIdleTimeout string `protobuf:"bytes,5,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ScopedRoleKube) Reset() {
+	*x = ScopedRoleKube{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRoleKube) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRoleKube) ProtoMessage() {}
+
+func (x *ScopedRoleKube) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedRoleKube.ProtoReflect.Descriptor instead.
+func (*ScopedRoleKube) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ScopedRoleKube) GetLabels() []*v11.Label {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
+func (x *ScopedRoleKube) GetGroups() []string {
+	if x != nil {
+		return x.Groups
+	}
+	return nil
+}
+
+func (x *ScopedRoleKube) GetUsers() []string {
+	if x != nil {
+		return x.Users
+	}
+	return nil
+}
+
+func (x *ScopedRoleKube) GetClientIdleTimeout() string {
+	if x != nil {
+		return x.ClientIdleTimeout
+	}
+	return ""
+}
+
 // ScopedRule maps resources to verbs. This is the underlying type used to describe
 // permissions like 'scoped_role:read' or 'scoped_role_assignment:create'.
 type ScopedRule struct {
@@ -510,7 +598,7 @@ type ScopedRule struct {
 
 func (x *ScopedRule) Reset() {
 	*x = ScopedRule{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -522,7 +610,7 @@ func (x *ScopedRule) String() string {
 func (*ScopedRule) ProtoMessage() {}
 
 func (x *ScopedRule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -535,7 +623,7 @@ func (x *ScopedRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScopedRule.ProtoReflect.Descriptor instead.
 func (*ScopedRule) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{5}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ScopedRule) GetResources() []string {
@@ -565,7 +653,7 @@ type SSHPortForwarding struct {
 
 func (x *SSHPortForwarding) Reset() {
 	*x = SSHPortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -577,7 +665,7 @@ func (x *SSHPortForwarding) String() string {
 func (*SSHPortForwarding) ProtoMessage() {}
 
 func (x *SSHPortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -590,7 +678,7 @@ func (x *SSHPortForwarding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSHPortForwarding.ProtoReflect.Descriptor instead.
 func (*SSHPortForwarding) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{6}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *SSHPortForwarding) GetLocal() bool {
@@ -624,7 +712,7 @@ type CreateHostUser struct {
 
 func (x *CreateHostUser) Reset() {
 	*x = CreateHostUser{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -636,7 +724,7 @@ func (x *CreateHostUser) String() string {
 func (*CreateHostUser) ProtoMessage() {}
 
 func (x *CreateHostUser) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -649,7 +737,7 @@ func (x *CreateHostUser) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateHostUser.ProtoReflect.Descriptor instead.
 func (*CreateHostUser) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{7}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *CreateHostUser) GetCreateHostUserMode() CreateHostUserMode {
@@ -692,12 +780,13 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12=\n" +
-	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\x9d\x02\n" +
+	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\xdc\x02\n" +
 	"\x0eScopedRoleSpec\x12+\n" +
 	"\x11assignable_scopes\x18\x01 \x03(\tR\x10assignableScopes\x12I\n" +
 	"\bdefaults\x18\x05 \x01(\v2-.teleport.scopes.access.v1.ScopedRoleDefaultsR\bdefaults\x12;\n" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
-	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03sshJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
+	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
+	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
 	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\x9e\x05\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
@@ -719,7 +808,12 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\vSSHFileCopy\x12\x1d\n" +
 	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01B\n" +
 	"\n" +
-	"\b_enabled\"@\n" +
+	"\b_enabled\"\xb1\x01\n" +
+	"\x0eScopedRoleKube\x120\n" +
+	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
+	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
+	"\x05users\x18\x03 \x03(\tR\x05users\x12.\n" +
+	"\x13client_idle_timeout\x18\x05 \x01(\tR\x11clientIdleTimeoutJ\x04\b\x04\x10\x05R\tresources\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -757,7 +851,7 @@ func file_teleport_scopes_access_v1_role_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_scopes_access_v1_role_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(CreateHostUserMode)(0),    // 0: teleport.scopes.access.v1.CreateHostUserMode
 	(*ScopedRole)(nil),         // 1: teleport.scopes.access.v1.ScopedRole
@@ -765,28 +859,31 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRoleDefaults)(nil), // 3: teleport.scopes.access.v1.ScopedRoleDefaults
 	(*ScopedRoleSSH)(nil),      // 4: teleport.scopes.access.v1.ScopedRoleSSH
 	(*SSHFileCopy)(nil),        // 5: teleport.scopes.access.v1.SSHFileCopy
-	(*ScopedRule)(nil),         // 6: teleport.scopes.access.v1.ScopedRule
-	(*SSHPortForwarding)(nil),  // 7: teleport.scopes.access.v1.SSHPortForwarding
-	(*CreateHostUser)(nil),     // 8: teleport.scopes.access.v1.CreateHostUser
-	(*v1.Metadata)(nil),        // 9: teleport.header.v1.Metadata
-	(*v11.Label)(nil),          // 10: teleport.label.v1.Label
+	(*ScopedRoleKube)(nil),     // 6: teleport.scopes.access.v1.ScopedRoleKube
+	(*ScopedRule)(nil),         // 7: teleport.scopes.access.v1.ScopedRule
+	(*SSHPortForwarding)(nil),  // 8: teleport.scopes.access.v1.SSHPortForwarding
+	(*CreateHostUser)(nil),     // 9: teleport.scopes.access.v1.CreateHostUser
+	(*v1.Metadata)(nil),        // 10: teleport.header.v1.Metadata
+	(*v11.Label)(nil),          // 11: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	9,  // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	10, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	2,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	3,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
-	6,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
+	7,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
 	4,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
-	10, // 5: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	5,  // 6: teleport.scopes.access.v1.ScopedRoleSSH.ssh_file_copy:type_name -> teleport.scopes.access.v1.SSHFileCopy
-	7,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.ssh_port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
-	8,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.create_host_user:type_name -> teleport.scopes.access.v1.CreateHostUser
-	0,  // 9: teleport.scopes.access.v1.CreateHostUser.create_host_user_mode:type_name -> teleport.scopes.access.v1.CreateHostUserMode
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	6,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
+	11, // 6: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	5,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.ssh_file_copy:type_name -> teleport.scopes.access.v1.SSHFileCopy
+	8,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.ssh_port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	9,  // 9: teleport.scopes.access.v1.ScopedRoleSSH.create_host_user:type_name -> teleport.scopes.access.v1.CreateHostUser
+	11, // 10: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	0,  // 11: teleport.scopes.access.v1.CreateHostUser.create_host_user_mode:type_name -> teleport.scopes.access.v1.CreateHostUserMode
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -796,15 +893,15 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[4].OneofWrappers = []any{}
-	file_teleport_scopes_access_v1_role_proto_msgTypes[6].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[7].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[8].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -283,7 +283,9 @@ type ScopedRoleSSH struct {
 	PermitX11Forwarding *bool `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof" json:"permit_x11_forwarding,omitempty"`
 	// SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
 	// over an SSH session. It defaults to true unless explicitly set to false.
-	SshFileCopy   *bool `protobuf:"varint,5,opt,name=ssh_file_copy,json=sshFileCopy,proto3,oneof" json:"ssh_file_copy,omitempty"`
+	SshFileCopy *bool `protobuf:"varint,5,opt,name=ssh_file_copy,json=sshFileCopy,proto3,oneof" json:"ssh_file_copy,omitempty"`
+	// ForwardAgent is SSH agent forwarding.
+	ForwardAgent  *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -349,6 +351,13 @@ func (x *ScopedRoleSSH) GetPermitX11Forwarding() bool {
 func (x *ScopedRoleSSH) GetSshFileCopy() bool {
 	if x != nil && x.SshFileCopy != nil {
 		return *x.SshFileCopy
+	}
+	return false
+}
+
+func (x *ScopedRoleSSH) GetForwardAgent() bool {
+	if x != nil && x.ForwardAgent != nil {
+		return *x.ForwardAgent
 	}
 	return false
 }
@@ -428,15 +437,17 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03sshJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\x97\x02\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xd3\x02\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
 	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x127\n" +
 	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12'\n" +
-	"\rssh_file_copy\x18\x05 \x01(\bH\x01R\vsshFileCopy\x88\x01\x01B\x18\n" +
+	"\rssh_file_copy\x18\x05 \x01(\bH\x01R\vsshFileCopy\x88\x01\x01\x12(\n" +
+	"\rforward_agent\x18\x06 \x01(\bH\x02R\fforwardAgent\x88\x01\x01B\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
-	"\x0e_ssh_file_copy\"@\n" +
+	"\x0e_ssh_file_copyB\x10\n" +
+	"\x0e_forward_agent\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -37,6 +37,65 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// CreateHostUserMode determines whether host user creation should be
+// disabled or if host users should be cleaned up or kept after
+// sessions end.
+type CreateHostUserMode int32
+
+const (
+	CreateHostUserMode_CREATE_HOST_USER_MODE_UNSPECIFIED CreateHostUserMode = 0
+	// CREATE_HOST_USER_MODE_OFF disables host user creation.
+	CreateHostUserMode_CREATE_HOST_USER_MODE_OFF CreateHostUserMode = 1
+	// CREATE_HOST_USER_MODE_KEEP enables host user creation and leaves users behind at session end.
+	CreateHostUserMode_CREATE_HOST_USER_MODE_KEEP CreateHostUserMode = 2
+	// CREATE_HOST_USER_MODE_INSECURE_DROP enables host user creation without a home directory and deletes
+	// users at session end.
+	CreateHostUserMode_CREATE_HOST_USER_MODE_INSECURE_DROP CreateHostUserMode = 3
+)
+
+// Enum value maps for CreateHostUserMode.
+var (
+	CreateHostUserMode_name = map[int32]string{
+		0: "CREATE_HOST_USER_MODE_UNSPECIFIED",
+		1: "CREATE_HOST_USER_MODE_OFF",
+		2: "CREATE_HOST_USER_MODE_KEEP",
+		3: "CREATE_HOST_USER_MODE_INSECURE_DROP",
+	}
+	CreateHostUserMode_value = map[string]int32{
+		"CREATE_HOST_USER_MODE_UNSPECIFIED":   0,
+		"CREATE_HOST_USER_MODE_OFF":           1,
+		"CREATE_HOST_USER_MODE_KEEP":          2,
+		"CREATE_HOST_USER_MODE_INSECURE_DROP": 3,
+	}
+)
+
+func (x CreateHostUserMode) Enum() *CreateHostUserMode {
+	p := new(CreateHostUserMode)
+	*p = x
+	return p
+}
+
+func (x CreateHostUserMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CreateHostUserMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_scopes_access_v1_role_proto_enumTypes[0].Descriptor()
+}
+
+func (CreateHostUserMode) Type() protoreflect.EnumType {
+	return &file_teleport_scopes_access_v1_role_proto_enumTypes[0]
+}
+
+func (x CreateHostUserMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CreateHostUserMode.Descriptor instead.
+func (CreateHostUserMode) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{0}
+}
+
 // ScopedRole is a role whose resource and permissions are scoped. Scoped roles implement a subset of role
 // features tailored to the usecases of scoped access and scoped access administration. Scoped roles may be
 // assigned to the same user multiple times at various scopes. Scoped roles do not contain deny rules.
@@ -282,15 +341,16 @@ type ScopedRoleSSH struct {
 	// If not set, X11 forwarding is not permitted.
 	PermitX11Forwarding *bool `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof" json:"permit_x11_forwarding,omitempty"`
 	// SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
-	// over an SSH session. It defaults to true unless explicitly set to false.
-	SshFileCopy *bool `protobuf:"varint,5,opt,name=ssh_file_copy,json=sshFileCopy,proto3,oneof" json:"ssh_file_copy,omitempty"`
+	// over an SSH session. It defaults to allowing the user to download and upload files by default.
+	SshFileCopy *SSHFileCopy `protobuf:"bytes,5,opt,name=ssh_file_copy,json=sshFileCopy,proto3,oneof" json:"ssh_file_copy,omitempty"`
 	// ForwardAgent is SSH agent forwarding.
 	ForwardAgent *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
-	// HostSudoers is a list of entries to include in a users sudoer file
-	HostSudoers       []string           `protobuf:"bytes,7,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
-	SshPortForwarding *SSHPortForwarding `protobuf:"bytes,8,opt,name=ssh_port_forwarding,json=sshPortForwarding,proto3,oneof" json:"ssh_port_forwarding,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
+	SshPortForwarding *SSHPortForwarding `protobuf:"bytes,7,opt,name=ssh_port_forwarding,json=sshPortForwarding,proto3,oneof" json:"ssh_port_forwarding,omitempty"`
+	// CreateHostUser
+	CreateHostUser *CreateHostUser `protobuf:"bytes,8,opt,name=create_host_user,json=createHostUser,proto3,oneof" json:"create_host_user,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSSH) Reset() {
@@ -351,11 +411,11 @@ func (x *ScopedRoleSSH) GetPermitX11Forwarding() bool {
 	return false
 }
 
-func (x *ScopedRoleSSH) GetSshFileCopy() bool {
-	if x != nil && x.SshFileCopy != nil {
-		return *x.SshFileCopy
+func (x *ScopedRoleSSH) GetSshFileCopy() *SSHFileCopy {
+	if x != nil {
+		return x.SshFileCopy
 	}
-	return false
+	return nil
 }
 
 func (x *ScopedRoleSSH) GetForwardAgent() bool {
@@ -365,18 +425,74 @@ func (x *ScopedRoleSSH) GetForwardAgent() bool {
 	return false
 }
 
-func (x *ScopedRoleSSH) GetHostSudoers() []string {
-	if x != nil {
-		return x.HostSudoers
-	}
-	return nil
-}
-
 func (x *ScopedRoleSSH) GetSshPortForwarding() *SSHPortForwarding {
 	if x != nil {
 		return x.SshPortForwarding
 	}
 	return nil
+}
+
+func (x *ScopedRoleSSH) GetCreateHostUser() *CreateHostUser {
+	if x != nil {
+		return x.CreateHostUser
+	}
+	return nil
+}
+
+// SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
+// over an SSH session. It defaults to true unless explicitly set to false.
+type SSHFileCopy struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// specifies that user is only allowed to download
+	Download *bool `protobuf:"varint,1,opt,name=download,proto3,oneof" json:"download,omitempty"`
+	// specifies that user is only allowed to upload
+	Upload        *bool `protobuf:"varint,2,opt,name=upload,proto3,oneof" json:"upload,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SSHFileCopy) Reset() {
+	*x = SSHFileCopy{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SSHFileCopy) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SSHFileCopy) ProtoMessage() {}
+
+func (x *SSHFileCopy) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SSHFileCopy.ProtoReflect.Descriptor instead.
+func (*SSHFileCopy) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *SSHFileCopy) GetDownload() bool {
+	if x != nil && x.Download != nil {
+		return *x.Download
+	}
+	return false
+}
+
+func (x *SSHFileCopy) GetUpload() bool {
+	if x != nil && x.Upload != nil {
+		return *x.Upload
+	}
+	return false
 }
 
 // ScopedRule maps resources to verbs. This is the underlying type used to describe
@@ -393,7 +509,7 @@ type ScopedRule struct {
 
 func (x *ScopedRule) Reset() {
 	*x = ScopedRule{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -405,7 +521,7 @@ func (x *ScopedRule) String() string {
 func (*ScopedRule) ProtoMessage() {}
 
 func (x *ScopedRule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -418,7 +534,7 @@ func (x *ScopedRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScopedRule.ProtoReflect.Descriptor instead.
 func (*ScopedRule) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{4}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ScopedRule) GetResources() []string {
@@ -448,7 +564,7 @@ type SSHPortForwarding struct {
 
 func (x *SSHPortForwarding) Reset() {
 	*x = SSHPortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -460,7 +576,7 @@ func (x *SSHPortForwarding) String() string {
 func (*SSHPortForwarding) ProtoMessage() {}
 
 func (x *SSHPortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -473,7 +589,7 @@ func (x *SSHPortForwarding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSHPortForwarding.ProtoReflect.Descriptor instead.
 func (*SSHPortForwarding) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{5}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *SSHPortForwarding) GetLocal() bool {
@@ -488,6 +604,79 @@ func (x *SSHPortForwarding) GetRemote() bool {
 		return *x.Remote
 	}
 	return false
+}
+
+// CreateHostUser configures what types of host user creation are allowed by a role.
+type CreateHostUser struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// CreateHostUserMode specifies how the host user should be created.
+	CreateHostUserMode CreateHostUserMode `protobuf:"varint,1,opt,name=create_host_user_mode,json=createHostUserMode,proto3,enum=teleport.scopes.access.v1.CreateHostUserMode" json:"create_host_user_mode,omitempty"`
+	// HostSudoers is a list of entries to include in a users sudoer file
+	HostSudoers []string `protobuf:"bytes,2,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
+	// HostGroups is a list of host groups to add the user to.
+	HostGroups []string `protobuf:"bytes,3,rep,name=host_groups,json=hostGroups,proto3" json:"host_groups,omitempty"`
+	// HostShell is the shell to set for the user.
+	HostShell     *string `protobuf:"bytes,4,opt,name=host_shell,json=hostShell,proto3,oneof" json:"host_shell,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateHostUser) Reset() {
+	*x = CreateHostUser{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateHostUser) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateHostUser) ProtoMessage() {}
+
+func (x *CreateHostUser) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateHostUser.ProtoReflect.Descriptor instead.
+func (*CreateHostUser) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *CreateHostUser) GetCreateHostUserMode() CreateHostUserMode {
+	if x != nil {
+		return x.CreateHostUserMode
+	}
+	return CreateHostUserMode_CREATE_HOST_USER_MODE_UNSPECIFIED
+}
+
+func (x *CreateHostUser) GetHostSudoers() []string {
+	if x != nil {
+		return x.HostSudoers
+	}
+	return nil
+}
+
+func (x *CreateHostUser) GetHostGroups() []string {
+	if x != nil {
+		return x.HostGroups
+	}
+	return nil
+}
+
+func (x *CreateHostUser) GetHostShell() string {
+	if x != nil && x.HostShell != nil {
+		return *x.HostShell
+	}
+	return ""
 }
 
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
@@ -509,20 +698,26 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03sshJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xf1\x03\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xe5\x04\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
 	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x127\n" +
-	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12'\n" +
-	"\rssh_file_copy\x18\x05 \x01(\bH\x01R\vsshFileCopy\x88\x01\x01\x12(\n" +
-	"\rforward_agent\x18\x06 \x01(\bH\x02R\fforwardAgent\x88\x01\x01\x12!\n" +
-	"\fhost_sudoers\x18\a \x03(\tR\vhostSudoers\x12a\n" +
-	"\x13ssh_port_forwarding\x18\b \x01(\v2,.teleport.scopes.access.v1.SSHPortForwardingH\x03R\x11sshPortForwarding\x88\x01\x01B\x18\n" +
+	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12O\n" +
+	"\rssh_file_copy\x18\x05 \x01(\v2&.teleport.scopes.access.v1.SSHFileCopyH\x01R\vsshFileCopy\x88\x01\x01\x12(\n" +
+	"\rforward_agent\x18\x06 \x01(\bH\x02R\fforwardAgent\x88\x01\x01\x12a\n" +
+	"\x13ssh_port_forwarding\x18\a \x01(\v2,.teleport.scopes.access.v1.SSHPortForwardingH\x03R\x11sshPortForwarding\x88\x01\x01\x12X\n" +
+	"\x10create_host_user\x18\b \x01(\v2).teleport.scopes.access.v1.CreateHostUserH\x04R\x0ecreateHostUser\x88\x01\x01B\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_ssh_file_copyB\x10\n" +
 	"\x0e_forward_agentB\x16\n" +
-	"\x14_ssh_port_forwarding\"@\n" +
+	"\x14_ssh_port_forwardingB\x13\n" +
+	"\x11_create_host_user\"c\n" +
+	"\vSSHFileCopy\x12\x1f\n" +
+	"\bdownload\x18\x01 \x01(\bH\x00R\bdownload\x88\x01\x01\x12\x1b\n" +
+	"\x06upload\x18\x02 \x01(\bH\x01R\x06upload\x88\x01\x01B\v\n" +
+	"\t_downloadB\t\n" +
+	"\a_upload\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -531,7 +726,20 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05local\x18\x01 \x01(\bH\x00R\x05local\x88\x01\x01\x12\x1b\n" +
 	"\x06remote\x18\x02 \x01(\bH\x01R\x06remote\x88\x01\x01B\b\n" +
 	"\x06_localB\t\n" +
-	"\a_remoteBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\a_remote\"\xe9\x01\n" +
+	"\x0eCreateHostUser\x12`\n" +
+	"\x15create_host_user_mode\x18\x01 \x01(\x0e2-.teleport.scopes.access.v1.CreateHostUserModeR\x12createHostUserMode\x12!\n" +
+	"\fhost_sudoers\x18\x02 \x03(\tR\vhostSudoers\x12\x1f\n" +
+	"\vhost_groups\x18\x03 \x03(\tR\n" +
+	"hostGroups\x12\"\n" +
+	"\n" +
+	"host_shell\x18\x04 \x01(\tH\x00R\thostShell\x88\x01\x01B\r\n" +
+	"\v_host_shell*\xa3\x01\n" +
+	"\x12CreateHostUserMode\x12%\n" +
+	"!CREATE_HOST_USER_MODE_UNSPECIFIED\x10\x00\x12\x1d\n" +
+	"\x19CREATE_HOST_USER_MODE_OFF\x10\x01\x12\x1e\n" +
+	"\x1aCREATE_HOST_USER_MODE_KEEP\x10\x02\x12'\n" +
+	"#CREATE_HOST_USER_MODE_INSECURE_DROP\x10\x03BWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
 var (
 	file_teleport_scopes_access_v1_role_proto_rawDescOnce sync.Once
@@ -545,30 +753,37 @@ func file_teleport_scopes_access_v1_role_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_role_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_teleport_scopes_access_v1_role_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
-	(*ScopedRole)(nil),         // 0: teleport.scopes.access.v1.ScopedRole
-	(*ScopedRoleSpec)(nil),     // 1: teleport.scopes.access.v1.ScopedRoleSpec
-	(*ScopedRoleDefaults)(nil), // 2: teleport.scopes.access.v1.ScopedRoleDefaults
-	(*ScopedRoleSSH)(nil),      // 3: teleport.scopes.access.v1.ScopedRoleSSH
-	(*ScopedRule)(nil),         // 4: teleport.scopes.access.v1.ScopedRule
-	(*SSHPortForwarding)(nil),  // 5: teleport.scopes.access.v1.SSHPortForwarding
-	(*v1.Metadata)(nil),        // 6: teleport.header.v1.Metadata
-	(*v11.Label)(nil),          // 7: teleport.label.v1.Label
+	(CreateHostUserMode)(0),    // 0: teleport.scopes.access.v1.CreateHostUserMode
+	(*ScopedRole)(nil),         // 1: teleport.scopes.access.v1.ScopedRole
+	(*ScopedRoleSpec)(nil),     // 2: teleport.scopes.access.v1.ScopedRoleSpec
+	(*ScopedRoleDefaults)(nil), // 3: teleport.scopes.access.v1.ScopedRoleDefaults
+	(*ScopedRoleSSH)(nil),      // 4: teleport.scopes.access.v1.ScopedRoleSSH
+	(*SSHFileCopy)(nil),        // 5: teleport.scopes.access.v1.SSHFileCopy
+	(*ScopedRule)(nil),         // 6: teleport.scopes.access.v1.ScopedRule
+	(*SSHPortForwarding)(nil),  // 7: teleport.scopes.access.v1.SSHPortForwarding
+	(*CreateHostUser)(nil),     // 8: teleport.scopes.access.v1.CreateHostUser
+	(*v1.Metadata)(nil),        // 9: teleport.header.v1.Metadata
+	(*v11.Label)(nil),          // 10: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	6, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
-	1, // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
-	2, // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
-	4, // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
-	3, // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
-	7, // 5: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	5, // 6: teleport.scopes.access.v1.ScopedRoleSSH.ssh_port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	9,  // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	2,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
+	3,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
+	6,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
+	4,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
+	10, // 5: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	5,  // 6: teleport.scopes.access.v1.ScopedRoleSSH.ssh_file_copy:type_name -> teleport.scopes.access.v1.SSHFileCopy
+	7,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.ssh_port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	8,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.create_host_user:type_name -> teleport.scopes.access.v1.CreateHostUser
+	0,  // 9: teleport.scopes.access.v1.CreateHostUser.create_host_user_mode:type_name -> teleport.scopes.access.v1.CreateHostUserMode
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -577,19 +792,22 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 		return
 	}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
-	file_teleport_scopes_access_v1_role_proto_msgTypes[5].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[4].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[6].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[7].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   6,
+			NumEnums:      1,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_teleport_scopes_access_v1_role_proto_goTypes,
 		DependencyIndexes: file_teleport_scopes_access_v1_role_proto_depIdxs,
+		EnumInfos:         file_teleport_scopes_access_v1_role_proto_enumTypes,
 		MessageInfos:      file_teleport_scopes_access_v1_role_proto_msgTypes,
 	}.Build()
 	File_teleport_scopes_access_v1_role_proto = out.File

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -37,65 +37,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// CreateHostUserMode determines whether host user creation should be
-// disabled or if host users should be cleaned up or kept after
-// sessions end.
-type CreateHostUserMode int32
-
-const (
-	CreateHostUserMode_CREATE_HOST_USER_MODE_UNSPECIFIED CreateHostUserMode = 0
-	// CREATE_HOST_USER_MODE_OFF disables host user creation.
-	CreateHostUserMode_CREATE_HOST_USER_MODE_OFF CreateHostUserMode = 1
-	// CREATE_HOST_USER_MODE_KEEP enables host user creation and leaves users behind at session end.
-	CreateHostUserMode_CREATE_HOST_USER_MODE_KEEP CreateHostUserMode = 2
-	// CREATE_HOST_USER_MODE_INSECURE_DROP enables host user creation without a home directory and deletes
-	// users at session end.
-	CreateHostUserMode_CREATE_HOST_USER_MODE_INSECURE_DROP CreateHostUserMode = 3
-)
-
-// Enum value maps for CreateHostUserMode.
-var (
-	CreateHostUserMode_name = map[int32]string{
-		0: "CREATE_HOST_USER_MODE_UNSPECIFIED",
-		1: "CREATE_HOST_USER_MODE_OFF",
-		2: "CREATE_HOST_USER_MODE_KEEP",
-		3: "CREATE_HOST_USER_MODE_INSECURE_DROP",
-	}
-	CreateHostUserMode_value = map[string]int32{
-		"CREATE_HOST_USER_MODE_UNSPECIFIED":   0,
-		"CREATE_HOST_USER_MODE_OFF":           1,
-		"CREATE_HOST_USER_MODE_KEEP":          2,
-		"CREATE_HOST_USER_MODE_INSECURE_DROP": 3,
-	}
-)
-
-func (x CreateHostUserMode) Enum() *CreateHostUserMode {
-	p := new(CreateHostUserMode)
-	*p = x
-	return p
-}
-
-func (x CreateHostUserMode) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (CreateHostUserMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_teleport_scopes_access_v1_role_proto_enumTypes[0].Descriptor()
-}
-
-func (CreateHostUserMode) Type() protoreflect.EnumType {
-	return &file_teleport_scopes_access_v1_role_proto_enumTypes[0]
-}
-
-func (x CreateHostUserMode) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use CreateHostUserMode.Descriptor instead.
-func (CreateHostUserMode) EnumDescriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{0}
-}
-
 // ScopedRole is a role whose resource and permissions are scoped. Scoped roles implement a subset of role
 // features tailored to the usecases of scoped access and scoped access administration. Scoped roles may be
 // assigned to the same user multiple times at various scopes. Scoped roles do not contain deny rules.
@@ -351,13 +292,13 @@ type ScopedRoleSSH struct {
 	PermitX11Forwarding *bool `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof" json:"permit_x11_forwarding,omitempty"`
 	// SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
 	// over an SSH session. It defaults to allowing the user to download and upload files by default.
-	SshFileCopy *SSHFileCopy `protobuf:"bytes,5,opt,name=ssh_file_copy,json=sshFileCopy,proto3,oneof" json:"ssh_file_copy,omitempty"`
+	SshFileCopy *SSHFileCopy `protobuf:"bytes,5,opt,name=ssh_file_copy,json=sshFileCopy,proto3" json:"ssh_file_copy,omitempty"`
 	// ForwardAgent is SSH agent forwarding.
 	ForwardAgent *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
 	// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
-	SshPortForwarding *SSHPortForwarding `protobuf:"bytes,7,opt,name=ssh_port_forwarding,json=sshPortForwarding,proto3,oneof" json:"ssh_port_forwarding,omitempty"`
-	// CreateHostUser configures the creation of host users.
-	CreateHostUser *CreateHostUser `protobuf:"bytes,8,opt,name=create_host_user,json=createHostUser,proto3,oneof" json:"create_host_user,omitempty"`
+	SshPortForwarding *SSHPortForwarding `protobuf:"bytes,7,opt,name=ssh_port_forwarding,json=sshPortForwarding,proto3" json:"ssh_port_forwarding,omitempty"`
+	// HostUserCreation configures the creation of host users.
+	HostUserCreation *CreateHostUser `protobuf:"bytes,8,opt,name=host_user_creation,json=hostUserCreation,proto3" json:"host_user_creation,omitempty"`
 	// MaxSessions defines the maximum number of
 	// concurrent sessions per connection.
 	MaxSessions   *int64 `protobuf:"varint,9,opt,name=max_sessions,json=maxSessions,proto3,oneof" json:"max_sessions,omitempty"`
@@ -444,9 +385,9 @@ func (x *ScopedRoleSSH) GetSshPortForwarding() *SSHPortForwarding {
 	return nil
 }
 
-func (x *ScopedRoleSSH) GetCreateHostUser() *CreateHostUser {
+func (x *ScopedRoleSSH) GetHostUserCreation() *CreateHostUser {
 	if x != nil {
-		return x.CreateHostUser
+		return x.HostUserCreation
 	}
 	return nil
 }
@@ -459,11 +400,15 @@ func (x *ScopedRoleSSH) GetMaxSessions() int64 {
 }
 
 // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
-// over an SSH session. It defaults to true unless explicitly set to false.
+// over an SSH session. It defaults to allowing the user to download and upload files by default.
+// Currently we only allow roles to have both download and upload set to true or false.
+// We currently do not support only allowing uploads and disallowing downloads, and vice versa.
 type SSHFileCopy struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Allow for remote file operations via SCP or SFTP.
-	Enabled       *bool `protobuf:"varint,1,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
+	// Allow for remote file downloads.
+	Download *bool `protobuf:"varint,1,opt,name=download,proto3,oneof" json:"download,omitempty"`
+	// Allow for remote file uploads.
+	Upload        *bool `protobuf:"varint,2,opt,name=upload,proto3,oneof" json:"upload,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -498,9 +443,16 @@ func (*SSHFileCopy) Descriptor() ([]byte, []int) {
 	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *SSHFileCopy) GetEnabled() bool {
-	if x != nil && x.Enabled != nil {
-		return *x.Enabled
+func (x *SSHFileCopy) GetDownload() bool {
+	if x != nil && x.Download != nil {
+		return *x.Download
+	}
+	return false
+}
+
+func (x *SSHFileCopy) GetUpload() bool {
+	if x != nil && x.Upload != nil {
+		return *x.Upload
 	}
 	return false
 }
@@ -643,10 +595,10 @@ func (x *ScopedRule) GetVerbs() []string {
 // SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
 type SSHPortForwarding struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Allow local port forwarding
-	Local *bool `protobuf:"varint,1,opt,name=local,proto3,oneof" json:"local,omitempty"`
-	// Allow remote port forwarding
-	Remote        *bool `protobuf:"varint,2,opt,name=remote,proto3,oneof" json:"remote,omitempty"`
+	// Allow for local port forwarding.
+	Local *SSHLocalPortForwarding `protobuf:"bytes,1,opt,name=local,proto3" json:"local,omitempty"`
+	// Allow for remote port forwarding.
+	Remote        *SSHRemotePortForwarding `protobuf:"bytes,2,opt,name=remote,proto3" json:"remote,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -681,16 +633,106 @@ func (*SSHPortForwarding) Descriptor() ([]byte, []int) {
 	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *SSHPortForwarding) GetLocal() bool {
-	if x != nil && x.Local != nil {
-		return *x.Local
+func (x *SSHPortForwarding) GetLocal() *SSHLocalPortForwarding {
+	if x != nil {
+		return x.Local
+	}
+	return nil
+}
+
+func (x *SSHPortForwarding) GetRemote() *SSHRemotePortForwarding {
+	if x != nil {
+		return x.Remote
+	}
+	return nil
+}
+
+// SSHLocalPortForwarding configures access controls for local SSH port forwarding.
+type SSHLocalPortForwarding struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       *bool                  `protobuf:"varint,1,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SSHLocalPortForwarding) Reset() {
+	*x = SSHLocalPortForwarding{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SSHLocalPortForwarding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SSHLocalPortForwarding) ProtoMessage() {}
+
+func (x *SSHLocalPortForwarding) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SSHLocalPortForwarding.ProtoReflect.Descriptor instead.
+func (*SSHLocalPortForwarding) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SSHLocalPortForwarding) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
 	}
 	return false
 }
 
-func (x *SSHPortForwarding) GetRemote() bool {
-	if x != nil && x.Remote != nil {
-		return *x.Remote
+// SSHRemotePortForwarding configures access controls for remote SSH port forwarding.
+type SSHRemotePortForwarding struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       *bool                  `protobuf:"varint,1,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SSHRemotePortForwarding) Reset() {
+	*x = SSHRemotePortForwarding{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SSHRemotePortForwarding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SSHRemotePortForwarding) ProtoMessage() {}
+
+func (x *SSHRemotePortForwarding) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SSHRemotePortForwarding.ProtoReflect.Descriptor instead.
+func (*SSHRemotePortForwarding) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *SSHRemotePortForwarding) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
 	}
 	return false
 }
@@ -699,20 +741,20 @@ func (x *SSHPortForwarding) GetRemote() bool {
 type CreateHostUser struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// CreateHostUserMode specifies how the host user should be created.
-	CreateHostUserMode *CreateHostUserMode `protobuf:"varint,1,opt,name=create_host_user_mode,json=createHostUserMode,proto3,enum=teleport.scopes.access.v1.CreateHostUserMode,oneof" json:"create_host_user_mode,omitempty"`
-	// HostSudoers is a list of entries to include in a users sudoer file
-	HostSudoers []string `protobuf:"bytes,2,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
-	// HostGroups is a list of host groups to add the user to.
-	HostGroups []string `protobuf:"bytes,3,rep,name=host_groups,json=hostGroups,proto3" json:"host_groups,omitempty"`
-	// HostShell is the shell to set for the user.
-	HostShell     *string `protobuf:"bytes,4,opt,name=host_shell,json=hostShell,proto3,oneof" json:"host_shell,omitempty"`
+	CreateHostUserMode string `protobuf:"bytes,1,opt,name=create_host_user_mode,json=createHostUserMode,proto3" json:"create_host_user_mode,omitempty"`
+	// Sudoers is a list of entries to include in a users sudoer file
+	Sudoers []string `protobuf:"bytes,2,rep,name=sudoers,proto3" json:"sudoers,omitempty"`
+	// Groups is a list of host groups to add the user to.
+	Groups []string `protobuf:"bytes,3,rep,name=groups,proto3" json:"groups,omitempty"`
+	// Shell is the shell to set for the user.
+	Shell         string `protobuf:"bytes,4,opt,name=shell,proto3" json:"shell,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateHostUser) Reset() {
 	*x = CreateHostUser{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -724,7 +766,7 @@ func (x *CreateHostUser) String() string {
 func (*CreateHostUser) ProtoMessage() {}
 
 func (x *CreateHostUser) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -737,33 +779,33 @@ func (x *CreateHostUser) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateHostUser.ProtoReflect.Descriptor instead.
 func (*CreateHostUser) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{8}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{10}
 }
 
-func (x *CreateHostUser) GetCreateHostUserMode() CreateHostUserMode {
-	if x != nil && x.CreateHostUserMode != nil {
-		return *x.CreateHostUserMode
-	}
-	return CreateHostUserMode_CREATE_HOST_USER_MODE_UNSPECIFIED
-}
-
-func (x *CreateHostUser) GetHostSudoers() []string {
+func (x *CreateHostUser) GetCreateHostUserMode() string {
 	if x != nil {
-		return x.HostSudoers
+		return x.CreateHostUserMode
+	}
+	return ""
+}
+
+func (x *CreateHostUser) GetSudoers() []string {
+	if x != nil {
+		return x.Sudoers
 	}
 	return nil
 }
 
-func (x *CreateHostUser) GetHostGroups() []string {
+func (x *CreateHostUser) GetGroups() []string {
 	if x != nil {
-		return x.HostGroups
+		return x.Groups
 	}
 	return nil
 }
 
-func (x *CreateHostUser) GetHostShell() string {
-	if x != nil && x.HostShell != nil {
-		return *x.HostShell
+func (x *CreateHostUser) GetShell() string {
+	if x != nil {
+		return x.Shell
 	}
 	return ""
 }
@@ -788,27 +830,25 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
 	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\x9e\x05\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xd4\x04\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
 	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x127\n" +
-	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12O\n" +
-	"\rssh_file_copy\x18\x05 \x01(\v2&.teleport.scopes.access.v1.SSHFileCopyH\x01R\vsshFileCopy\x88\x01\x01\x12(\n" +
-	"\rforward_agent\x18\x06 \x01(\bH\x02R\fforwardAgent\x88\x01\x01\x12a\n" +
-	"\x13ssh_port_forwarding\x18\a \x01(\v2,.teleport.scopes.access.v1.SSHPortForwardingH\x03R\x11sshPortForwarding\x88\x01\x01\x12X\n" +
-	"\x10create_host_user\x18\b \x01(\v2).teleport.scopes.access.v1.CreateHostUserH\x04R\x0ecreateHostUser\x88\x01\x01\x12&\n" +
-	"\fmax_sessions\x18\t \x01(\x03H\x05R\vmaxSessions\x88\x01\x01B\x18\n" +
+	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12J\n" +
+	"\rssh_file_copy\x18\x05 \x01(\v2&.teleport.scopes.access.v1.SSHFileCopyR\vsshFileCopy\x12(\n" +
+	"\rforward_agent\x18\x06 \x01(\bH\x01R\fforwardAgent\x88\x01\x01\x12\\\n" +
+	"\x13ssh_port_forwarding\x18\a \x01(\v2,.teleport.scopes.access.v1.SSHPortForwardingR\x11sshPortForwarding\x12W\n" +
+	"\x12host_user_creation\x18\b \x01(\v2).teleport.scopes.access.v1.CreateHostUserR\x10hostUserCreation\x12&\n" +
+	"\fmax_sessions\x18\t \x01(\x03H\x02R\vmaxSessions\x88\x01\x01B\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
-	"\x0e_ssh_file_copyB\x10\n" +
-	"\x0e_forward_agentB\x16\n" +
-	"\x14_ssh_port_forwardingB\x13\n" +
-	"\x11_create_host_userB\x0f\n" +
-	"\r_max_sessions\"8\n" +
-	"\vSSHFileCopy\x12\x1d\n" +
-	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01B\n" +
-	"\n" +
-	"\b_enabled\"\xb1\x01\n" +
+	"\x0e_forward_agentB\x0f\n" +
+	"\r_max_sessions\"c\n" +
+	"\vSSHFileCopy\x12\x1f\n" +
+	"\bdownload\x18\x01 \x01(\bH\x00R\bdownload\x88\x01\x01\x12\x1b\n" +
+	"\x06upload\x18\x02 \x01(\bH\x01R\x06upload\x88\x01\x01B\v\n" +
+	"\t_downloadB\t\n" +
+	"\a_upload\"\xb1\x01\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
@@ -817,26 +857,23 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
-	"\x05verbs\x18\x02 \x03(\tR\x05verbs\"`\n" +
-	"\x11SSHPortForwarding\x12\x19\n" +
-	"\x05local\x18\x01 \x01(\bH\x00R\x05local\x88\x01\x01\x12\x1b\n" +
-	"\x06remote\x18\x02 \x01(\bH\x01R\x06remote\x88\x01\x01B\b\n" +
-	"\x06_localB\t\n" +
-	"\a_remote\"\x88\x02\n" +
-	"\x0eCreateHostUser\x12e\n" +
-	"\x15create_host_user_mode\x18\x01 \x01(\x0e2-.teleport.scopes.access.v1.CreateHostUserModeH\x00R\x12createHostUserMode\x88\x01\x01\x12!\n" +
-	"\fhost_sudoers\x18\x02 \x03(\tR\vhostSudoers\x12\x1f\n" +
-	"\vhost_groups\x18\x03 \x03(\tR\n" +
-	"hostGroups\x12\"\n" +
+	"\x05verbs\x18\x02 \x03(\tR\x05verbs\"\xa8\x01\n" +
+	"\x11SSHPortForwarding\x12G\n" +
+	"\x05local\x18\x01 \x01(\v21.teleport.scopes.access.v1.SSHLocalPortForwardingR\x05local\x12J\n" +
+	"\x06remote\x18\x02 \x01(\v22.teleport.scopes.access.v1.SSHRemotePortForwardingR\x06remote\"C\n" +
+	"\x16SSHLocalPortForwarding\x12\x1d\n" +
+	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01B\n" +
 	"\n" +
-	"host_shell\x18\x04 \x01(\tH\x01R\thostShell\x88\x01\x01B\x18\n" +
-	"\x16_create_host_user_modeB\r\n" +
-	"\v_host_shell*\xa3\x01\n" +
-	"\x12CreateHostUserMode\x12%\n" +
-	"!CREATE_HOST_USER_MODE_UNSPECIFIED\x10\x00\x12\x1d\n" +
-	"\x19CREATE_HOST_USER_MODE_OFF\x10\x01\x12\x1e\n" +
-	"\x1aCREATE_HOST_USER_MODE_KEEP\x10\x02\x12'\n" +
-	"#CREATE_HOST_USER_MODE_INSECURE_DROP\x10\x03BWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\b_enabled\"D\n" +
+	"\x17SSHRemotePortForwarding\x12\x1d\n" +
+	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01B\n" +
+	"\n" +
+	"\b_enabled\"\x8b\x01\n" +
+	"\x0eCreateHostUser\x121\n" +
+	"\x15create_host_user_mode\x18\x01 \x01(\tR\x12createHostUserMode\x12\x18\n" +
+	"\asudoers\x18\x02 \x03(\tR\asudoers\x12\x16\n" +
+	"\x06groups\x18\x03 \x03(\tR\x06groups\x12\x14\n" +
+	"\x05shell\x18\x04 \x01(\tR\x05shellBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
 var (
 	file_teleport_scopes_access_v1_role_proto_rawDescOnce sync.Once
@@ -850,40 +887,41 @@ func file_teleport_scopes_access_v1_role_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_role_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_role_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
-	(CreateHostUserMode)(0),    // 0: teleport.scopes.access.v1.CreateHostUserMode
-	(*ScopedRole)(nil),         // 1: teleport.scopes.access.v1.ScopedRole
-	(*ScopedRoleSpec)(nil),     // 2: teleport.scopes.access.v1.ScopedRoleSpec
-	(*ScopedRoleDefaults)(nil), // 3: teleport.scopes.access.v1.ScopedRoleDefaults
-	(*ScopedRoleSSH)(nil),      // 4: teleport.scopes.access.v1.ScopedRoleSSH
-	(*SSHFileCopy)(nil),        // 5: teleport.scopes.access.v1.SSHFileCopy
-	(*ScopedRoleKube)(nil),     // 6: teleport.scopes.access.v1.ScopedRoleKube
-	(*ScopedRule)(nil),         // 7: teleport.scopes.access.v1.ScopedRule
-	(*SSHPortForwarding)(nil),  // 8: teleport.scopes.access.v1.SSHPortForwarding
-	(*CreateHostUser)(nil),     // 9: teleport.scopes.access.v1.CreateHostUser
-	(*v1.Metadata)(nil),        // 10: teleport.header.v1.Metadata
-	(*v11.Label)(nil),          // 11: teleport.label.v1.Label
+	(*ScopedRole)(nil),              // 0: teleport.scopes.access.v1.ScopedRole
+	(*ScopedRoleSpec)(nil),          // 1: teleport.scopes.access.v1.ScopedRoleSpec
+	(*ScopedRoleDefaults)(nil),      // 2: teleport.scopes.access.v1.ScopedRoleDefaults
+	(*ScopedRoleSSH)(nil),           // 3: teleport.scopes.access.v1.ScopedRoleSSH
+	(*SSHFileCopy)(nil),             // 4: teleport.scopes.access.v1.SSHFileCopy
+	(*ScopedRoleKube)(nil),          // 5: teleport.scopes.access.v1.ScopedRoleKube
+	(*ScopedRule)(nil),              // 6: teleport.scopes.access.v1.ScopedRule
+	(*SSHPortForwarding)(nil),       // 7: teleport.scopes.access.v1.SSHPortForwarding
+	(*SSHLocalPortForwarding)(nil),  // 8: teleport.scopes.access.v1.SSHLocalPortForwarding
+	(*SSHRemotePortForwarding)(nil), // 9: teleport.scopes.access.v1.SSHRemotePortForwarding
+	(*CreateHostUser)(nil),          // 10: teleport.scopes.access.v1.CreateHostUser
+	(*v1.Metadata)(nil),             // 11: teleport.header.v1.Metadata
+	(*v11.Label)(nil),               // 12: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	10, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
-	2,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
-	3,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
-	7,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
-	4,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
-	6,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
-	11, // 6: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	5,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.ssh_file_copy:type_name -> teleport.scopes.access.v1.SSHFileCopy
-	8,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.ssh_port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
-	9,  // 9: teleport.scopes.access.v1.ScopedRoleSSH.create_host_user:type_name -> teleport.scopes.access.v1.CreateHostUser
-	11, // 10: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	0,  // 11: teleport.scopes.access.v1.CreateHostUser.create_host_user_mode:type_name -> teleport.scopes.access.v1.CreateHostUserMode
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	11, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
+	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
+	6,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
+	3,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
+	5,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
+	12, // 6: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	4,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.ssh_file_copy:type_name -> teleport.scopes.access.v1.SSHFileCopy
+	7,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.ssh_port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	10, // 9: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
+	12, // 10: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	8,  // 11: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	9,  // 12: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -893,21 +931,20 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[4].OneofWrappers = []any{}
-	file_teleport_scopes_access_v1_role_proto_msgTypes[7].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[8].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[9].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   9,
+			NumEnums:      0,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_teleport_scopes_access_v1_role_proto_goTypes,
 		DependencyIndexes: file_teleport_scopes_access_v1_role_proto_depIdxs,
-		EnumInfos:         file_teleport_scopes_access_v1_role_proto_enumTypes,
 		MessageInfos:      file_teleport_scopes_access_v1_role_proto_msgTypes,
 	}.Build()
 	File_teleport_scopes_access_v1_role_proto = out.File

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -292,16 +292,18 @@ type ScopedRoleSSH struct {
 	PermitX11Forwarding *bool `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof" json:"permit_x11_forwarding,omitempty"`
 	// SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
 	// over an SSH session. It defaults to allowing the user to download and upload files by default.
-	SshFileCopy *SSHFileCopy `protobuf:"bytes,5,opt,name=ssh_file_copy,json=sshFileCopy,proto3" json:"ssh_file_copy,omitempty"`
+	FileCopy *SSHFileCopy `protobuf:"bytes,5,opt,name=file_copy,json=fileCopy,proto3" json:"file_copy,omitempty"`
 	// ForwardAgent is SSH agent forwarding.
 	ForwardAgent *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
 	// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
-	SshPortForwarding *SSHPortForwarding `protobuf:"bytes,7,opt,name=ssh_port_forwarding,json=sshPortForwarding,proto3" json:"ssh_port_forwarding,omitempty"`
+	PortForwarding *SSHPortForwarding `protobuf:"bytes,7,opt,name=port_forwarding,json=portForwarding,proto3" json:"port_forwarding,omitempty"`
 	// HostUserCreation configures the creation of host users.
 	HostUserCreation *CreateHostUser `protobuf:"bytes,8,opt,name=host_user_creation,json=hostUserCreation,proto3" json:"host_user_creation,omitempty"`
 	// MaxSessions defines the maximum number of
 	// concurrent sessions per connection.
-	MaxSessions   *int64 `protobuf:"varint,9,opt,name=max_sessions,json=maxSessions,proto3,oneof" json:"max_sessions,omitempty"`
+	MaxSessions *int64 `protobuf:"varint,9,opt,name=max_sessions,json=maxSessions,proto3,oneof" json:"max_sessions,omitempty"`
+	// Sudoers is a list of entries to include in a users sudoer file
+	HostSudoers   []string `protobuf:"bytes,10,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -364,9 +366,9 @@ func (x *ScopedRoleSSH) GetPermitX11Forwarding() bool {
 	return false
 }
 
-func (x *ScopedRoleSSH) GetSshFileCopy() *SSHFileCopy {
+func (x *ScopedRoleSSH) GetFileCopy() *SSHFileCopy {
 	if x != nil {
-		return x.SshFileCopy
+		return x.FileCopy
 	}
 	return nil
 }
@@ -378,9 +380,9 @@ func (x *ScopedRoleSSH) GetForwardAgent() bool {
 	return false
 }
 
-func (x *ScopedRoleSSH) GetSshPortForwarding() *SSHPortForwarding {
+func (x *ScopedRoleSSH) GetPortForwarding() *SSHPortForwarding {
 	if x != nil {
-		return x.SshPortForwarding
+		return x.PortForwarding
 	}
 	return nil
 }
@@ -399,16 +401,20 @@ func (x *ScopedRoleSSH) GetMaxSessions() int64 {
 	return 0
 }
 
+func (x *ScopedRoleSSH) GetHostSudoers() []string {
+	if x != nil {
+		return x.HostSudoers
+	}
+	return nil
+}
+
 // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
 // over an SSH session. It defaults to allowing the user to download and upload files by default.
 // Currently we only allow roles to have both download and upload set to true or false.
 // We currently do not support only allowing uploads and disallowing downloads, and vice versa.
 type SSHFileCopy struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Allow for remote file downloads.
-	Download *bool `protobuf:"varint,1,opt,name=download,proto3,oneof" json:"download,omitempty"`
-	// Allow for remote file uploads.
-	Upload        *bool `protobuf:"varint,2,opt,name=upload,proto3,oneof" json:"upload,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       *bool                  `protobuf:"varint,1,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -443,16 +449,9 @@ func (*SSHFileCopy) Descriptor() ([]byte, []int) {
 	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *SSHFileCopy) GetDownload() bool {
-	if x != nil && x.Download != nil {
-		return *x.Download
-	}
-	return false
-}
-
-func (x *SSHFileCopy) GetUpload() bool {
-	if x != nil && x.Upload != nil {
-		return *x.Upload
+func (x *SSHFileCopy) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
 	}
 	return false
 }
@@ -740,14 +739,12 @@ func (x *SSHRemotePortForwarding) GetEnabled() bool {
 // CreateHostUser configures what types of host user creation are allowed by a role.
 type CreateHostUser struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// CreateHostUserMode specifies how the host user should be created.
-	CreateHostUserMode string `protobuf:"bytes,1,opt,name=create_host_user_mode,json=createHostUserMode,proto3" json:"create_host_user_mode,omitempty"`
-	// Sudoers is a list of entries to include in a users sudoer file
-	Sudoers []string `protobuf:"bytes,2,rep,name=sudoers,proto3" json:"sudoers,omitempty"`
+	// Mode specifies how the host user should be created.
+	Mode string `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
 	// Groups is a list of host groups to add the user to.
-	Groups []string `protobuf:"bytes,3,rep,name=groups,proto3" json:"groups,omitempty"`
+	Groups []string `protobuf:"bytes,2,rep,name=groups,proto3" json:"groups,omitempty"`
 	// Shell is the shell to set for the user.
-	Shell         string `protobuf:"bytes,4,opt,name=shell,proto3" json:"shell,omitempty"`
+	Shell         string `protobuf:"bytes,3,opt,name=shell,proto3" json:"shell,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -782,18 +779,11 @@ func (*CreateHostUser) Descriptor() ([]byte, []int) {
 	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{10}
 }
 
-func (x *CreateHostUser) GetCreateHostUserMode() string {
+func (x *CreateHostUser) GetMode() string {
 	if x != nil {
-		return x.CreateHostUserMode
+		return x.Mode
 	}
 	return ""
-}
-
-func (x *CreateHostUser) GetSudoers() []string {
-	if x != nil {
-		return x.Sudoers
-	}
-	return nil
 }
 
 func (x *CreateHostUser) GetGroups() []string {
@@ -830,25 +820,26 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
 	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xd4\x04\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xe9\x04\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
 	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x127\n" +
-	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12J\n" +
-	"\rssh_file_copy\x18\x05 \x01(\v2&.teleport.scopes.access.v1.SSHFileCopyR\vsshFileCopy\x12(\n" +
-	"\rforward_agent\x18\x06 \x01(\bH\x01R\fforwardAgent\x88\x01\x01\x12\\\n" +
-	"\x13ssh_port_forwarding\x18\a \x01(\v2,.teleport.scopes.access.v1.SSHPortForwardingR\x11sshPortForwarding\x12W\n" +
+	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12C\n" +
+	"\tfile_copy\x18\x05 \x01(\v2&.teleport.scopes.access.v1.SSHFileCopyR\bfileCopy\x12(\n" +
+	"\rforward_agent\x18\x06 \x01(\bH\x01R\fforwardAgent\x88\x01\x01\x12U\n" +
+	"\x0fport_forwarding\x18\a \x01(\v2,.teleport.scopes.access.v1.SSHPortForwardingR\x0eportForwarding\x12W\n" +
 	"\x12host_user_creation\x18\b \x01(\v2).teleport.scopes.access.v1.CreateHostUserR\x10hostUserCreation\x12&\n" +
-	"\fmax_sessions\x18\t \x01(\x03H\x02R\vmaxSessions\x88\x01\x01B\x18\n" +
+	"\fmax_sessions\x18\t \x01(\x03H\x02R\vmaxSessions\x88\x01\x01\x12!\n" +
+	"\fhost_sudoers\x18\n" +
+	" \x03(\tR\vhostSudoersB\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_forward_agentB\x0f\n" +
-	"\r_max_sessions\"c\n" +
-	"\vSSHFileCopy\x12\x1f\n" +
-	"\bdownload\x18\x01 \x01(\bH\x00R\bdownload\x88\x01\x01\x12\x1b\n" +
-	"\x06upload\x18\x02 \x01(\bH\x01R\x06upload\x88\x01\x01B\v\n" +
-	"\t_downloadB\t\n" +
-	"\a_upload\"\xb1\x01\n" +
+	"\r_max_sessions\"8\n" +
+	"\vSSHFileCopy\x12\x1d\n" +
+	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01B\n" +
+	"\n" +
+	"\b_enabled\"\xb1\x01\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
@@ -868,12 +859,11 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x17SSHRemotePortForwarding\x12\x1d\n" +
 	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01B\n" +
 	"\n" +
-	"\b_enabled\"\x8b\x01\n" +
-	"\x0eCreateHostUser\x121\n" +
-	"\x15create_host_user_mode\x18\x01 \x01(\tR\x12createHostUserMode\x12\x18\n" +
-	"\asudoers\x18\x02 \x03(\tR\asudoers\x12\x16\n" +
-	"\x06groups\x18\x03 \x03(\tR\x06groups\x12\x14\n" +
-	"\x05shell\x18\x04 \x01(\tR\x05shellBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\b_enabled\"R\n" +
+	"\x0eCreateHostUser\x12\x12\n" +
+	"\x04mode\x18\x01 \x01(\tR\x04mode\x12\x16\n" +
+	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
+	"\x05shell\x18\x03 \x01(\tR\x05shellBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
 var (
 	file_teleport_scopes_access_v1_role_proto_rawDescOnce sync.Once
@@ -911,8 +901,8 @@ var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
 	3,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
 	5,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
 	12, // 6: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	4,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.ssh_file_copy:type_name -> teleport.scopes.access.v1.SSHFileCopy
-	7,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.ssh_port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	4,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.file_copy:type_name -> teleport.scopes.access.v1.SSHFileCopy
+	7,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
 	10, // 9: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
 	12, // 10: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
 	8,  // 11: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -290,9 +290,6 @@ type ScopedRoleSSH struct {
 	// PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions.
 	// If not set, X11 forwarding is not permitted.
 	PermitX11Forwarding *bool `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof" json:"permit_x11_forwarding,omitempty"`
-	// SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
-	// over an SSH session. It defaults to allowing the user to download and upload files by default.
-	FileCopy *SSHFileCopy `protobuf:"bytes,5,opt,name=file_copy,json=fileCopy,proto3" json:"file_copy,omitempty"`
 	// ForwardAgent is SSH agent forwarding.
 	ForwardAgent *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
 	// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
@@ -303,7 +300,10 @@ type ScopedRoleSSH struct {
 	// concurrent sessions per connection.
 	MaxSessions *int64 `protobuf:"varint,9,opt,name=max_sessions,json=maxSessions,proto3,oneof" json:"max_sessions,omitempty"`
 	// Sudoers is a list of entries to include in a users sudoer file
-	HostSudoers   []string `protobuf:"bytes,10,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
+	HostSudoers []string `protobuf:"bytes,10,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
+	// FileCopy indicates whether remote file operations via SCP or SFTP are allowed
+	// over an SSH session. It defaults to allowing the user to download and upload files by default.
+	FileCopy      *bool `protobuf:"varint,11,opt,name=file_copy,json=fileCopy,proto3,oneof" json:"file_copy,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -366,13 +366,6 @@ func (x *ScopedRoleSSH) GetPermitX11Forwarding() bool {
 	return false
 }
 
-func (x *ScopedRoleSSH) GetFileCopy() *SSHFileCopy {
-	if x != nil {
-		return x.FileCopy
-	}
-	return nil
-}
-
 func (x *ScopedRoleSSH) GetForwardAgent() bool {
 	if x != nil && x.ForwardAgent != nil {
 		return *x.ForwardAgent
@@ -408,50 +401,9 @@ func (x *ScopedRoleSSH) GetHostSudoers() []string {
 	return nil
 }
 
-// SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
-// over an SSH session. It defaults to allowing the user to download and upload files by default.
-// Currently we only allow roles to have both download and upload set to true or false.
-// We currently do not support only allowing uploads and disallowing downloads, and vice versa.
-type SSHFileCopy struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Enabled       *bool                  `protobuf:"varint,1,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *SSHFileCopy) Reset() {
-	*x = SSHFileCopy{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *SSHFileCopy) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*SSHFileCopy) ProtoMessage() {}
-
-func (x *SSHFileCopy) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use SSHFileCopy.ProtoReflect.Descriptor instead.
-func (*SSHFileCopy) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *SSHFileCopy) GetEnabled() bool {
-	if x != nil && x.Enabled != nil {
-		return *x.Enabled
+func (x *ScopedRoleSSH) GetFileCopy() bool {
+	if x != nil && x.FileCopy != nil {
+		return *x.FileCopy
 	}
 	return false
 }
@@ -479,7 +431,7 @@ type ScopedRoleKube struct {
 
 func (x *ScopedRoleKube) Reset() {
 	*x = ScopedRoleKube{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -491,7 +443,7 @@ func (x *ScopedRoleKube) String() string {
 func (*ScopedRoleKube) ProtoMessage() {}
 
 func (x *ScopedRoleKube) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -504,7 +456,7 @@ func (x *ScopedRoleKube) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScopedRoleKube.ProtoReflect.Descriptor instead.
 func (*ScopedRoleKube) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{5}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ScopedRoleKube) GetLabels() []*v11.Label {
@@ -549,7 +501,7 @@ type ScopedRule struct {
 
 func (x *ScopedRule) Reset() {
 	*x = ScopedRule{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -561,7 +513,7 @@ func (x *ScopedRule) String() string {
 func (*ScopedRule) ProtoMessage() {}
 
 func (x *ScopedRule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -574,7 +526,7 @@ func (x *ScopedRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScopedRule.ProtoReflect.Descriptor instead.
 func (*ScopedRule) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{6}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ScopedRule) GetResources() []string {
@@ -604,7 +556,7 @@ type SSHPortForwarding struct {
 
 func (x *SSHPortForwarding) Reset() {
 	*x = SSHPortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -616,7 +568,7 @@ func (x *SSHPortForwarding) String() string {
 func (*SSHPortForwarding) ProtoMessage() {}
 
 func (x *SSHPortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -629,7 +581,7 @@ func (x *SSHPortForwarding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSHPortForwarding.ProtoReflect.Descriptor instead.
 func (*SSHPortForwarding) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{7}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *SSHPortForwarding) GetLocal() *SSHLocalPortForwarding {
@@ -656,7 +608,7 @@ type SSHLocalPortForwarding struct {
 
 func (x *SSHLocalPortForwarding) Reset() {
 	*x = SSHLocalPortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -668,7 +620,7 @@ func (x *SSHLocalPortForwarding) String() string {
 func (*SSHLocalPortForwarding) ProtoMessage() {}
 
 func (x *SSHLocalPortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -681,7 +633,7 @@ func (x *SSHLocalPortForwarding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSHLocalPortForwarding.ProtoReflect.Descriptor instead.
 func (*SSHLocalPortForwarding) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{8}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *SSHLocalPortForwarding) GetEnabled() bool {
@@ -701,7 +653,7 @@ type SSHRemotePortForwarding struct {
 
 func (x *SSHRemotePortForwarding) Reset() {
 	*x = SSHRemotePortForwarding{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -713,7 +665,7 @@ func (x *SSHRemotePortForwarding) String() string {
 func (*SSHRemotePortForwarding) ProtoMessage() {}
 
 func (x *SSHRemotePortForwarding) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -726,7 +678,7 @@ func (x *SSHRemotePortForwarding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSHRemotePortForwarding.ProtoReflect.Descriptor instead.
 func (*SSHRemotePortForwarding) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{9}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *SSHRemotePortForwarding) GetEnabled() bool {
@@ -751,7 +703,7 @@ type CreateHostUser struct {
 
 func (x *CreateHostUser) Reset() {
 	*x = CreateHostUser{}
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -763,7 +715,7 @@ func (x *CreateHostUser) String() string {
 func (*CreateHostUser) ProtoMessage() {}
 
 func (x *CreateHostUser) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -776,7 +728,7 @@ func (x *CreateHostUser) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateHostUser.ProtoReflect.Descriptor instead.
 func (*CreateHostUser) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{10}
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *CreateHostUser) GetMode() string {
@@ -820,26 +772,24 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
 	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xe9\x04\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xd4\x04\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
 	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x127\n" +
-	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12C\n" +
-	"\tfile_copy\x18\x05 \x01(\v2&.teleport.scopes.access.v1.SSHFileCopyR\bfileCopy\x12(\n" +
+	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12(\n" +
 	"\rforward_agent\x18\x06 \x01(\bH\x01R\fforwardAgent\x88\x01\x01\x12U\n" +
 	"\x0fport_forwarding\x18\a \x01(\v2,.teleport.scopes.access.v1.SSHPortForwardingR\x0eportForwarding\x12W\n" +
 	"\x12host_user_creation\x18\b \x01(\v2).teleport.scopes.access.v1.CreateHostUserR\x10hostUserCreation\x12&\n" +
 	"\fmax_sessions\x18\t \x01(\x03H\x02R\vmaxSessions\x88\x01\x01\x12!\n" +
 	"\fhost_sudoers\x18\n" +
-	" \x03(\tR\vhostSudoersB\x18\n" +
+	" \x03(\tR\vhostSudoers\x12 \n" +
+	"\tfile_copy\x18\v \x01(\bH\x03R\bfileCopy\x88\x01\x01B\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_forward_agentB\x0f\n" +
-	"\r_max_sessions\"8\n" +
-	"\vSSHFileCopy\x12\x1d\n" +
-	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01B\n" +
+	"\r_max_sessionsB\f\n" +
 	"\n" +
-	"\b_enabled\"\xb1\x01\n" +
+	"_file_copy\"\xb1\x01\n" +
 	"\x0eScopedRoleKube\x120\n" +
 	"\x06labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
@@ -877,41 +827,39 @@ func file_teleport_scopes_access_v1_role_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_role_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),              // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),          // 1: teleport.scopes.access.v1.ScopedRoleSpec
 	(*ScopedRoleDefaults)(nil),      // 2: teleport.scopes.access.v1.ScopedRoleDefaults
 	(*ScopedRoleSSH)(nil),           // 3: teleport.scopes.access.v1.ScopedRoleSSH
-	(*SSHFileCopy)(nil),             // 4: teleport.scopes.access.v1.SSHFileCopy
-	(*ScopedRoleKube)(nil),          // 5: teleport.scopes.access.v1.ScopedRoleKube
-	(*ScopedRule)(nil),              // 6: teleport.scopes.access.v1.ScopedRule
-	(*SSHPortForwarding)(nil),       // 7: teleport.scopes.access.v1.SSHPortForwarding
-	(*SSHLocalPortForwarding)(nil),  // 8: teleport.scopes.access.v1.SSHLocalPortForwarding
-	(*SSHRemotePortForwarding)(nil), // 9: teleport.scopes.access.v1.SSHRemotePortForwarding
-	(*CreateHostUser)(nil),          // 10: teleport.scopes.access.v1.CreateHostUser
-	(*v1.Metadata)(nil),             // 11: teleport.header.v1.Metadata
-	(*v11.Label)(nil),               // 12: teleport.label.v1.Label
+	(*ScopedRoleKube)(nil),          // 4: teleport.scopes.access.v1.ScopedRoleKube
+	(*ScopedRule)(nil),              // 5: teleport.scopes.access.v1.ScopedRule
+	(*SSHPortForwarding)(nil),       // 6: teleport.scopes.access.v1.SSHPortForwarding
+	(*SSHLocalPortForwarding)(nil),  // 7: teleport.scopes.access.v1.SSHLocalPortForwarding
+	(*SSHRemotePortForwarding)(nil), // 8: teleport.scopes.access.v1.SSHRemotePortForwarding
+	(*CreateHostUser)(nil),          // 9: teleport.scopes.access.v1.CreateHostUser
+	(*v1.Metadata)(nil),             // 10: teleport.header.v1.Metadata
+	(*v11.Label)(nil),               // 11: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	11, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	10, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
-	6,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
+	5,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
 	3,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
-	5,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
-	12, // 6: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	4,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.file_copy:type_name -> teleport.scopes.access.v1.SSHFileCopy
-	7,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
-	10, // 9: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
-	12, // 10: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	8,  // 11: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	9,  // 12: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	4,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
+	11, // 6: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	6,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	9,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
+	11, // 9: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	7,  // 10: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	8,  // 11: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -920,16 +868,15 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 		return
 	}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
-	file_teleport_scopes_access_v1_role_proto_msgTypes[4].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[7].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[8].OneofWrappers = []any{}
-	file_teleport_scopes_access_v1_role_proto_msgTypes[9].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   11,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -290,7 +290,7 @@ type ScopedRoleSSH struct {
 	// PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions.
 	// If not set, X11 forwarding is not permitted.
 	PermitX11Forwarding *bool `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof" json:"permit_x11_forwarding,omitempty"`
-	// ForwardAgent is SSH agent forwarding.
+	// ForwardAgent enables SSH agent forwarding.
 	ForwardAgent *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
 	// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
 	PortForwarding *SSHPortForwarding `protobuf:"bytes,7,opt,name=port_forwarding,json=portForwarding,proto3" json:"port_forwarding,omitempty"`

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -116,6 +116,8 @@ message ScopedRoleSSH {
 
   // HostSudoers is a list of entries to include in a users sudoer file
   repeated string host_sudoers = 7;
+
+  optional SSHPortForwarding ssh_port_forwarding = 8;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block
@@ -149,4 +151,12 @@ message ScopedRule {
   repeated string resources = 1;
   // Verbs is the list of action verbs (e.g. 'read') that apply to the above resources.
   repeated string verbs = 2;
+}
+
+// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
+message SSHPortForwarding {
+  // Allow local port forwarding
+  optional bool local = 1;
+  // Allow remote port forwarding
+  optional bool remote = 2;
 }

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -110,6 +110,9 @@ message ScopedRoleSSH {
   // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
   // over an SSH session. It defaults to true unless explicitly set to false.
   optional bool ssh_file_copy = 5;
+
+  // ForwardAgent is SSH agent forwarding.
+  optional bool forward_agent = 6;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -108,16 +108,26 @@ message ScopedRoleSSH {
   optional bool permit_x11_forwarding = 4;
 
   // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
-  // over an SSH session. It defaults to true unless explicitly set to false.
-  optional bool ssh_file_copy = 5;
+  // over an SSH session. It defaults to allowing the user to download and upload files by default.
+  optional SSHFileCopy ssh_file_copy = 5;
 
   // ForwardAgent is SSH agent forwarding.
   optional bool forward_agent = 6;
 
-  // HostSudoers is a list of entries to include in a users sudoer file
-  repeated string host_sudoers = 7;
+  // SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
+  optional SSHPortForwarding ssh_port_forwarding = 7;
 
-  optional SSHPortForwarding ssh_port_forwarding = 8;
+  // CreateHostUser
+  optional CreateHostUser create_host_user = 8;
+}
+
+// SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
+// over an SSH session. It defaults to true unless explicitly set to false.
+message SSHFileCopy {
+  // specifies that user is only allowed to download
+  optional bool download = 1;
+  // specifies that user is only allowed to upload
+  optional bool upload = 2;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block
@@ -159,4 +169,32 @@ message SSHPortForwarding {
   optional bool local = 1;
   // Allow remote port forwarding
   optional bool remote = 2;
+}
+
+// CreateHostUser configures what types of host user creation are allowed by a role.
+message CreateHostUser {
+  // CreateHostUserMode specifies how the host user should be created.
+  CreateHostUserMode create_host_user_mode = 1;
+  // HostSudoers is a list of entries to include in a users sudoer file
+  repeated string host_sudoers = 2;
+
+  // HostGroups is a list of host groups to add the user to.
+  repeated string host_groups = 3;
+
+  // HostShell is the shell to set for the user.
+  optional string host_shell = 4;
+}
+
+// CreateHostUserMode determines whether host user creation should be
+// disabled or if host users should be cleaned up or kept after
+// sessions end.
+enum CreateHostUserMode {
+  CREATE_HOST_USER_MODE_UNSPECIFIED = 0;
+  // CREATE_HOST_USER_MODE_OFF disables host user creation.
+  CREATE_HOST_USER_MODE_OFF = 1;
+  // CREATE_HOST_USER_MODE_KEEP enables host user creation and leaves users behind at session end.
+  CREATE_HOST_USER_MODE_KEEP = 2;
+  // CREATE_HOST_USER_MODE_INSECURE_DROP enables host user creation without a home directory and deletes
+  // users at session end.
+  CREATE_HOST_USER_MODE_INSECURE_DROP = 3;
 }

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -102,6 +102,10 @@ message ScopedRoleSSH {
   // Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
   // (or global default) applies.
   string client_idle_timeout = 3;
+
+  // PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions.
+  // If not set, X11 forwarding is not permitted.
+  optional bool permit_x11_forwarding = 4;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -106,6 +106,10 @@ message ScopedRoleSSH {
   // PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions.
   // If not set, X11 forwarding is not permitted.
   optional bool permit_x11_forwarding = 4;
+
+  // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
+  // over an SSH session. It defaults to true unless explicitly set to false.
+  optional bool ssh_file_copy = 5;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -117,17 +117,19 @@ message ScopedRoleSSH {
   // SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
   optional SSHPortForwarding ssh_port_forwarding = 7;
 
-  // CreateHostUser
+  // CreateHostUser configures the creation of host users.
   optional CreateHostUser create_host_user = 8;
+
+  // MaxSessions defines the maximum number of
+  // concurrent sessions per connection.
+  optional int64 max_sessions = 9;
 }
 
 // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
 // over an SSH session. It defaults to true unless explicitly set to false.
 message SSHFileCopy {
-  // specifies that user is only allowed to download
-  optional bool download = 1;
-  // specifies that user is only allowed to upload
-  optional bool upload = 2;
+  // Allow for remote file operations via SCP or SFTP.
+  optional bool enabled = 1;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -176,7 +176,7 @@ message SSHPortForwarding {
 // CreateHostUser configures what types of host user creation are allowed by a role.
 message CreateHostUser {
   // CreateHostUserMode specifies how the host user should be created.
-  CreateHostUserMode create_host_user_mode = 1;
+  optional CreateHostUserMode create_host_user_mode = 1;
   // HostSudoers is a list of entries to include in a users sudoer file
   repeated string host_sudoers = 2;
 

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -113,6 +113,9 @@ message ScopedRoleSSH {
 
   // ForwardAgent is SSH agent forwarding.
   optional bool forward_agent = 6;
+
+  // HostSudoers is a list of entries to include in a users sudoer file
+  repeated string host_sudoers = 7;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -109,13 +109,13 @@ message ScopedRoleSSH {
 
   // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
   // over an SSH session. It defaults to allowing the user to download and upload files by default.
-  SSHFileCopy ssh_file_copy = 5;
+  SSHFileCopy file_copy = 5;
 
   // ForwardAgent is SSH agent forwarding.
   optional bool forward_agent = 6;
 
   // SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
-  SSHPortForwarding ssh_port_forwarding = 7;
+  SSHPortForwarding port_forwarding = 7;
 
   // HostUserCreation configures the creation of host users.
   CreateHostUser host_user_creation = 8;
@@ -123,6 +123,9 @@ message ScopedRoleSSH {
   // MaxSessions defines the maximum number of
   // concurrent sessions per connection.
   optional int64 max_sessions = 9;
+
+  // Sudoers is a list of entries to include in a users sudoer file
+  repeated string host_sudoers = 10;
 }
 
 // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
@@ -130,10 +133,7 @@ message ScopedRoleSSH {
 // Currently we only allow roles to have both download and upload set to true or false.
 // We currently do not support only allowing uploads and disallowing downloads, and vice versa.
 message SSHFileCopy {
-  // Allow for remote file downloads.
-  optional bool download = 1;
-  // Allow for remote file uploads.
-  optional bool upload = 2;
+  optional bool enabled = 1;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block
@@ -189,15 +189,12 @@ message SSHRemotePortForwarding {
 
 // CreateHostUser configures what types of host user creation are allowed by a role.
 message CreateHostUser {
-  // CreateHostUserMode specifies how the host user should be created.
-  string create_host_user_mode = 1;
-
-  // Sudoers is a list of entries to include in a users sudoer file
-  repeated string sudoers = 2;
+  // Mode specifies how the host user should be created.
+  string mode = 1;
 
   // Groups is a list of host groups to add the user to.
-  repeated string groups = 3;
+  repeated string groups = 2;
 
   // Shell is the shell to set for the user.
-  string shell = 4;
+  string shell = 3;
 }

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -109,16 +109,16 @@ message ScopedRoleSSH {
 
   // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
   // over an SSH session. It defaults to allowing the user to download and upload files by default.
-  optional SSHFileCopy ssh_file_copy = 5;
+  SSHFileCopy ssh_file_copy = 5;
 
   // ForwardAgent is SSH agent forwarding.
   optional bool forward_agent = 6;
 
   // SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
-  optional SSHPortForwarding ssh_port_forwarding = 7;
+  SSHPortForwarding ssh_port_forwarding = 7;
 
-  // CreateHostUser configures the creation of host users.
-  optional CreateHostUser create_host_user = 8;
+  // HostUserCreation configures the creation of host users.
+  CreateHostUser host_user_creation = 8;
 
   // MaxSessions defines the maximum number of
   // concurrent sessions per connection.
@@ -126,10 +126,14 @@ message ScopedRoleSSH {
 }
 
 // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
-// over an SSH session. It defaults to true unless explicitly set to false.
+// over an SSH session. It defaults to allowing the user to download and upload files by default.
+// Currently we only allow roles to have both download and upload set to true or false.
+// We currently do not support only allowing uploads and disallowing downloads, and vice versa.
 message SSHFileCopy {
-  // Allow for remote file operations via SCP or SFTP.
-  optional bool enabled = 1;
+  // Allow for remote file downloads.
+  optional bool download = 1;
+  // Allow for remote file uploads.
+  optional bool upload = 2;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block
@@ -167,36 +171,33 @@ message ScopedRule {
 
 // SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
 message SSHPortForwarding {
-  // Allow local port forwarding
-  optional bool local = 1;
-  // Allow remote port forwarding
-  optional bool remote = 2;
+  // Allow for local port forwarding.
+  SSHLocalPortForwarding local = 1;
+  // Allow for remote port forwarding.
+  SSHRemotePortForwarding remote = 2;
+}
+
+// SSHLocalPortForwarding configures access controls for local SSH port forwarding.
+message SSHLocalPortForwarding {
+  optional bool enabled = 1;
+}
+
+// SSHRemotePortForwarding configures access controls for remote SSH port forwarding.
+message SSHRemotePortForwarding {
+  optional bool enabled = 1;
 }
 
 // CreateHostUser configures what types of host user creation are allowed by a role.
 message CreateHostUser {
   // CreateHostUserMode specifies how the host user should be created.
-  optional CreateHostUserMode create_host_user_mode = 1;
-  // HostSudoers is a list of entries to include in a users sudoer file
-  repeated string host_sudoers = 2;
+  string create_host_user_mode = 1;
 
-  // HostGroups is a list of host groups to add the user to.
-  repeated string host_groups = 3;
+  // Sudoers is a list of entries to include in a users sudoer file
+  repeated string sudoers = 2;
 
-  // HostShell is the shell to set for the user.
-  optional string host_shell = 4;
-}
+  // Groups is a list of host groups to add the user to.
+  repeated string groups = 3;
 
-// CreateHostUserMode determines whether host user creation should be
-// disabled or if host users should be cleaned up or kept after
-// sessions end.
-enum CreateHostUserMode {
-  CREATE_HOST_USER_MODE_UNSPECIFIED = 0;
-  // CREATE_HOST_USER_MODE_OFF disables host user creation.
-  CREATE_HOST_USER_MODE_OFF = 1;
-  // CREATE_HOST_USER_MODE_KEEP enables host user creation and leaves users behind at session end.
-  CREATE_HOST_USER_MODE_KEEP = 2;
-  // CREATE_HOST_USER_MODE_INSECURE_DROP enables host user creation without a home directory and deletes
-  // users at session end.
-  CREATE_HOST_USER_MODE_INSECURE_DROP = 3;
+  // Shell is the shell to set for the user.
+  string shell = 4;
 }

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -107,11 +107,7 @@ message ScopedRoleSSH {
   // If not set, X11 forwarding is not permitted.
   optional bool permit_x11_forwarding = 4;
 
-  // SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
-  // over an SSH session. It defaults to allowing the user to download and upload files by default.
-  SSHFileCopy file_copy = 5;
-
-  // ForwardAgent is SSH agent forwarding.
+  // ForwardAgent enables SSH agent forwarding.
   optional bool forward_agent = 6;
 
   // SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
@@ -126,14 +122,10 @@ message ScopedRoleSSH {
 
   // Sudoers is a list of entries to include in a users sudoer file
   repeated string host_sudoers = 10;
-}
 
-// SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed
-// over an SSH session. It defaults to allowing the user to download and upload files by default.
-// Currently we only allow roles to have both download and upload set to true or false.
-// We currently do not support only allowing uploads and disallowing downloads, and vice versa.
-message SSHFileCopy {
-  optional bool enabled = 1;
+  // FileCopy indicates whether remote file operations via SCP or SFTP are allowed
+  // over an SSH session. It defaults to allowing the user to download and upload files by default.
+  optional bool file_copy = 11;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -2549,6 +2549,11 @@ func (h *CreateHostUserMode) UnmarshalJSON(data []byte) error {
 	return trace.Wrap(err)
 }
 
+// UnmarshalText supports parsing CreateHostUserMode from string.
+func (h *CreateHostUserMode) UnmarshalText(text []byte) error {
+	return h.decode(string(text))
+}
+
 const (
 	createDatabaseUserModeOffString            = "off"
 	createDatabaseUserModeKeepString           = "keep"

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -2551,11 +2551,12 @@ func (h *CreateHostUserMode) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText supports parsing CreateHostUserMode from string.
 //
-// decoders will not call this method because CreateHostUserMode
-// also implements json.Unmarshaler for json and yaml.Unmarshaler, which takes precedence.
+// The JSON and YAML unmarshaller will not call this method because CreateHostUserMode
+// also implements yaml/json.Unmarshaler, which takes precedence.
 // Callers that have a plain string should call UnmarshalText directly.
 func (h *CreateHostUserMode) UnmarshalText(text []byte) error {
-	return h.decode(string(text))
+	err := h.decode(string(text))
+	return trace.Wrap(err)
 }
 
 const (

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -2550,6 +2550,10 @@ func (h *CreateHostUserMode) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalText supports parsing CreateHostUserMode from string.
+//
+// decoders will not call this method because CreateHostUserMode
+// also implements json.Unmarshaler for json and yaml.Unmarshaler, which takes precedence.
+// Callers that have a plain string should call UnmarshalText directly.
 func (h *CreateHostUserMode) UnmarshalText(text []byte) error {
 	return h.decode(string(text))
 }

--- a/api/types/role_test.go
+++ b/api/types/role_test.go
@@ -990,6 +990,23 @@ func TestUnmarshallCreateHostUserModeYAML(t *testing.T) {
 	}
 }
 
+func TestUnmarshalCreateHostUserModeText(t *testing.T) {
+	for _, tc := range []struct {
+		input    string
+		expected CreateHostUserMode
+	}{
+		{input: "off", expected: CreateHostUserMode_HOST_USER_MODE_OFF},
+		{input: "", expected: CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED},
+		{input: "keep", expected: CreateHostUserMode_HOST_USER_MODE_KEEP},
+		{input: "insecure-drop", expected: CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP},
+	} {
+		var got CreateHostUserMode
+		err := got.UnmarshalText([]byte(tc.input))
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, got)
+	}
+}
+
 func TestUnmarshallCreateDatabaseUserModeJSON(t *testing.T) {
 	for _, tc := range []struct {
 		input    any

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -226,11 +226,22 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 
 	// For now, we only support roles when both download and upload are the same values
 	if fileCopy := role.GetSpec().GetSsh().GetSshFileCopy(); fileCopy != nil {
-		download := fileCopy.GetDownload()
-		upload := fileCopy.GetUpload()
-		if download != upload {
+		if fileCopy.GetDownload() != fileCopy.GetUpload() {
 			return trace.BadParameter("scoped role %q has mismatched ssh_file_copy download and upload values, both must be the same", role.GetMetadata().GetName())
 		}
+	}
+
+	// verify that create_host_user_mode is a recognized value
+	if mode := role.GetSpec().GetSsh().GetHostUserCreation().GetCreateHostUserMode(); mode != "" {
+		var hostUserMode types.CreateHostUserMode
+		if err := hostUserMode.UnmarshalJSON([]byte(`"` + mode + `"`)); err != nil {
+			return trace.BadParameter("scoped role %q has invalid ssh.host_user_creation.create_host_user_mode %q", role.GetMetadata().GetName(), mode)
+		}
+	}
+
+	// verify that max_sessions is non-negative
+	if ms := role.GetSpec().GetSsh().GetMaxSessions(); ms < 0 {
+		return trace.BadParameter("scoped role %q has invalid ssh.max_sessions %d: must be non-negative", role.GetMetadata().GetName(), ms)
 	}
 
 	// verify that kube labels are well-formed

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -224,6 +224,15 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		}
 	}
 
+	// For now, we only support roles when both download and upload are the same values
+	if fileCopy := role.GetSpec().GetSsh().GetSshFileCopy(); fileCopy != nil {
+		download := fileCopy.GetDownload()
+		upload := fileCopy.GetUpload()
+		if download != upload {
+			return trace.BadParameter("scoped role %q has mismatched ssh_file_copy download and upload values, both must be the same", role.GetMetadata().GetName())
+		}
+	}
+
 	// verify that kube labels are well-formed
 	for _, label := range role.GetSpec().GetKube().GetLabels() {
 		// we currently don't support any form of wildcard/regex/substitution in scoped role

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -224,17 +224,10 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		}
 	}
 
-	// For now, we only support roles when both download and upload are the same values
-	if fileCopy := role.GetSpec().GetSsh().GetSshFileCopy(); fileCopy != nil {
-		if fileCopy.GetDownload() != fileCopy.GetUpload() {
-			return trace.BadParameter("scoped role %q has mismatched ssh_file_copy download and upload values, both must be the same", role.GetMetadata().GetName())
-		}
-	}
-
 	// verify that create_host_user_mode is a recognized value
-	if mode := role.GetSpec().GetSsh().GetHostUserCreation().GetCreateHostUserMode(); mode != "" {
+	if mode := role.GetSpec().GetSsh().GetHostUserCreation().GetMode(); mode != "" {
 		var hostUserMode types.CreateHostUserMode
-		if err := hostUserMode.UnmarshalJSON([]byte(`"` + mode + `"`)); err != nil {
+		if err := hostUserMode.UnmarshalText([]byte(mode)); err != nil {
 			return trace.BadParameter("scoped role %q has invalid ssh.host_user_creation.create_host_user_mode %q", role.GetMetadata().GetName(), mode)
 		}
 	}

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -298,6 +298,152 @@ func TestValidateRole(t *testing.T) {
 			strongOk: false,
 			weakOk:   true,
 		},
+		{
+			name: "ssh_file_copy download and upload mismatch",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						SshFileCopy: &scopedaccessv1.SSHFileCopy{
+							Download: proto.Bool(true),
+							Upload:   proto.Bool(false),
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "ssh_file_copy download and upload both true",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						SshFileCopy: &scopedaccessv1.SSHFileCopy{
+							Download: proto.Bool(true),
+							Upload:   proto.Bool(true),
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "ssh_file_copy download and upload both false",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						SshFileCopy: &scopedaccessv1.SSHFileCopy{
+							Download: proto.Bool(false),
+							Upload:   proto.Bool(false),
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "invalid create_host_user_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						HostUserCreation: &scopedaccessv1.CreateHostUser{
+							CreateHostUserMode: "invalid-mode",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "valid create_host_user_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						HostUserCreation: &scopedaccessv1.CreateHostUser{
+							CreateHostUserMode: "keep",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "negative max_sessions",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						MaxSessions: proto.Int64(-1),
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "positive max_sessions",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						MaxSessions: proto.Int64(1),
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
 	}
 
 	for _, tt := range tts {
@@ -961,7 +1107,21 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			Labels: []*labelv1.Label{
 				{Name: "env", Values: []string{"prod"}},
 			},
-			ClientIdleTimeout: "1h",
+			ClientIdleTimeout:   "1h",
+			PermitX11Forwarding: proto.Bool(true),
+			SshFileCopy:         &scopedaccessv1.SSHFileCopy{Download: proto.Bool(true), Upload: proto.Bool(true)},
+			ForwardAgent:        proto.Bool(true),
+			SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+				Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(true)},
+				Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(true)},
+			},
+			HostUserCreation: &scopedaccessv1.CreateHostUser{
+				CreateHostUserMode: "keep",
+				Sudoers:            []string{"ALL=(ALL) NOPASSWD:ALL"},
+				Groups:             []string{"wheel"},
+				Shell:              "/bin/bash",
+			},
+			MaxSessions: proto.Int64(10),
 		},
 		Kube: &scopedaccessv1.ScopedRoleKube{
 			Groups: []string{"viewer"},

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -299,28 +299,6 @@ func TestValidateRole(t *testing.T) {
 			weakOk:   true,
 		},
 		{
-			name: "ssh_file_copy download and upload mismatch",
-			role: &scopedaccessv1.ScopedRole{
-				Kind: KindScopedRole,
-				Metadata: &headerv1.Metadata{
-					Name: "test",
-				},
-				Scope: "/",
-				Spec: &scopedaccessv1.ScopedRoleSpec{
-					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						SshFileCopy: &scopedaccessv1.SSHFileCopy{
-							Download: proto.Bool(true),
-							Upload:   proto.Bool(false),
-						},
-					},
-				},
-				Version: types.V1,
-			},
-			strongOk: false,
-			weakOk:   true,
-		},
-		{
 			name: "ssh_file_copy download and upload both true",
 			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
@@ -331,9 +309,8 @@ func TestValidateRole(t *testing.T) {
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						SshFileCopy: &scopedaccessv1.SSHFileCopy{
-							Download: proto.Bool(true),
-							Upload:   proto.Bool(true),
+						FileCopy: &scopedaccessv1.SSHFileCopy{
+							Enabled: proto.Bool(true),
 						},
 					},
 				},
@@ -353,9 +330,8 @@ func TestValidateRole(t *testing.T) {
 				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						SshFileCopy: &scopedaccessv1.SSHFileCopy{
-							Download: proto.Bool(false),
-							Upload:   proto.Bool(false),
+						FileCopy: &scopedaccessv1.SSHFileCopy{
+							Enabled: proto.Bool(false),
 						},
 					},
 				},
@@ -376,7 +352,7 @@ func TestValidateRole(t *testing.T) {
 					AssignableScopes: []string{"/foo"},
 					Ssh: &scopedaccessv1.ScopedRoleSSH{
 						HostUserCreation: &scopedaccessv1.CreateHostUser{
-							CreateHostUserMode: "invalid-mode",
+							Mode: "invalid-mode",
 						},
 					},
 				},
@@ -397,7 +373,7 @@ func TestValidateRole(t *testing.T) {
 					AssignableScopes: []string{"/foo"},
 					Ssh: &scopedaccessv1.ScopedRoleSSH{
 						HostUserCreation: &scopedaccessv1.CreateHostUser{
-							CreateHostUserMode: "keep",
+							Mode: "keep",
 						},
 					},
 				},
@@ -1109,18 +1085,18 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			},
 			ClientIdleTimeout:   "1h",
 			PermitX11Forwarding: proto.Bool(true),
-			SshFileCopy:         &scopedaccessv1.SSHFileCopy{Download: proto.Bool(true), Upload: proto.Bool(true)},
+			FileCopy:            &scopedaccessv1.SSHFileCopy{Enabled: proto.Bool(true)},
 			ForwardAgent:        proto.Bool(true),
-			SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+			PortForwarding: &scopedaccessv1.SSHPortForwarding{
 				Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(true)},
 				Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(true)},
 			},
 			HostUserCreation: &scopedaccessv1.CreateHostUser{
-				CreateHostUserMode: "keep",
-				Sudoers:            []string{"ALL=(ALL) NOPASSWD:ALL"},
-				Groups:             []string{"wheel"},
-				Shell:              "/bin/bash",
+				Mode:   "keep",
+				Groups: []string{"wheel"},
+				Shell:  "/bin/bash",
 			},
+			HostSudoers: []string{"ALL=(ALL) NOPASSWD:ALL"},
 			MaxSessions: proto.Int64(10),
 		},
 		Kube: &scopedaccessv1.ScopedRoleKube{

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -299,48 +299,6 @@ func TestValidateRole(t *testing.T) {
 			weakOk:   true,
 		},
 		{
-			name: "ssh_file_copy download and upload both true",
-			role: &scopedaccessv1.ScopedRole{
-				Kind: KindScopedRole,
-				Metadata: &headerv1.Metadata{
-					Name: "test",
-				},
-				Scope: "/",
-				Spec: &scopedaccessv1.ScopedRoleSpec{
-					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						FileCopy: &scopedaccessv1.SSHFileCopy{
-							Enabled: proto.Bool(true),
-						},
-					},
-				},
-				Version: types.V1,
-			},
-			strongOk: true,
-			weakOk:   true,
-		},
-		{
-			name: "ssh_file_copy download and upload both false",
-			role: &scopedaccessv1.ScopedRole{
-				Kind: KindScopedRole,
-				Metadata: &headerv1.Metadata{
-					Name: "test",
-				},
-				Scope: "/",
-				Spec: &scopedaccessv1.ScopedRoleSpec{
-					AssignableScopes: []string{"/foo"},
-					Ssh: &scopedaccessv1.ScopedRoleSSH{
-						FileCopy: &scopedaccessv1.SSHFileCopy{
-							Enabled: proto.Bool(false),
-						},
-					},
-				},
-				Version: types.V1,
-			},
-			strongOk: true,
-			weakOk:   true,
-		},
-		{
 			name: "invalid create_host_user_mode",
 			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
@@ -1085,7 +1043,7 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			},
 			ClientIdleTimeout:   "1h",
 			PermitX11Forwarding: proto.Bool(true),
-			FileCopy:            &scopedaccessv1.SSHFileCopy{Enabled: proto.Bool(true)},
+			FileCopy:            proto.Bool(true),
 			ForwardAgent:        proto.Bool(true),
 			PortForwarding: &scopedaccessv1.SSHPortForwarding{
 				Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(true)},

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -290,7 +290,7 @@ func TestSSHPortForwardingNotInClassicRole(t *testing.T) {
 
 	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.SshPortForwarding = &scopedaccessv1.SSHPortForwarding{
+	sr.Spec.Ssh.PortForwarding = &scopedaccessv1.SSHPortForwarding{
 		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
 		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
 	}
@@ -305,7 +305,7 @@ func TestHostUserCreationNotInClassicRole(t *testing.T) {
 
 	sr := baseScopedRole()
 	sr.Spec.Ssh.HostUserCreation = &scopedaccessv1.CreateHostUser{
-		CreateHostUserMode: "keep",
+		Mode: "keep",
 	}
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
@@ -318,9 +318,8 @@ func TestSSHFileCopyNotInClassicRole(t *testing.T) {
 
 	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.SshFileCopy = &scopedaccessv1.SSHFileCopy{
-		Download: boolPtr(false),
-		Upload:   boolPtr(false),
+	sr.Spec.Ssh.FileCopy = &scopedaccessv1.SSHFileCopy{
+		Enabled: boolPtr(false),
 	}
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -246,6 +246,8 @@ func TestClientIdleTimeoutNotInClassicRole(t *testing.T) {
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
 	require.NotNil(t, role)
+	// ClientIdleTimeout must be zero in the converted role; it is evaluated at access-check time
+	// via SSHAccessChecker.AdjustClientIdleTimeout reading directly from the scoped role proto.
 	require.Zero(t, role.GetOptions().ClientIdleTimeout.Duration())
 }
 

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -318,9 +318,7 @@ func TestSSHFileCopyNotInClassicRole(t *testing.T) {
 
 	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.FileCopy = &scopedaccessv1.SSHFileCopy{
-		Enabled: boolPtr(false),
-	}
+	sr.Spec.Ssh.FileCopy = boolPtr(false)
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -221,31 +221,111 @@ func TestRulesConversion(t *testing.T) {
 	}
 }
 
+func baseScopedRole() *scopedaccessv1.ScopedRole {
+	return &scopedaccessv1.ScopedRole{
+		Kind:     KindScopedRole,
+		Metadata: &headerv1.Metadata{Name: "test"},
+		Scope:    "/foo",
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{"/foo/bar"},
+			Ssh:              &scopedaccessv1.ScopedRoleSSH{},
+		},
+		Version: types.V1,
+	}
+}
+
 // TestClientIdleTimeoutNotInClassicRole verifies that ScopedRoleToRole does not populate ClientIdleTimeout
 // in the classic role options. Per the scoped role design, client_idle_timeout is read directly from the
 // appropriate protocol block on the scoped role, which does not have a direct classic role equivalent.
 func TestClientIdleTimeoutNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	role, err := ScopedRoleToRole(&scopedaccessv1.ScopedRole{
-		Kind: KindScopedRole,
-		Metadata: &headerv1.Metadata{
-			Name: "test",
-		},
-		Scope: "/foo",
-		Spec: &scopedaccessv1.ScopedRoleSpec{
-			AssignableScopes: []string{"/foo/bar"},
-			Ssh: &scopedaccessv1.ScopedRoleSSH{
-				ClientIdleTimeout: "30m",
-			},
-		},
-		Version: types.V1,
-	}, "/foo/bar")
+	sr := baseScopedRole()
+	sr.Spec.Ssh.ClientIdleTimeout = "30m"
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
 	require.NotNil(t, role)
-	// ClientIdleTimeout must be zero in the converted role; it is evaluated at access-check time
-	// via SSHAccessChecker.AdjustClientIdleTimeout reading directly from the scoped role proto.
 	require.Zero(t, role.GetOptions().ClientIdleTimeout.Duration())
+}
+
+func TestX11ForwardingNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(v bool) *bool { return &v }
+	sr := baseScopedRole()
+	sr.Spec.Ssh.PermitX11Forwarding = boolPtr(true)
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, types.NewBool(false), role.GetOptions().PermitX11Forwarding)
+}
+
+func TestForwardAgentNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(v bool) *bool { return &v }
+	sr := baseScopedRole()
+	sr.Spec.Ssh.ForwardAgent = boolPtr(true)
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, types.NewBool(UnstableGetScopedForwardAgent()), role.GetOptions().ForwardAgent)
+}
+
+func TestMaxSessionsNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	int64Ptr := func(v int64) *int64 { return &v }
+	sr := baseScopedRole()
+	sr.Spec.Ssh.MaxSessions = int64Ptr(10)
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), role.GetOptions().MaxSessions)
+}
+
+func TestSSHPortForwardingNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(v bool) *bool { return &v }
+	sr := baseScopedRole()
+	sr.Spec.Ssh.SshPortForwarding = &scopedaccessv1.SSHPortForwarding{
+		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
+		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(getScopedPortForwardingConfig(), role.GetOptions().SSHPortForwarding))
+}
+
+func TestHostUserCreationNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	sr := baseScopedRole()
+	sr.Spec.Ssh.HostUserCreation = &scopedaccessv1.CreateHostUser{
+		CreateHostUserMode: "keep",
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, types.CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED, role.GetOptions().CreateHostUserMode)
+}
+
+func TestSSHFileCopyNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(v bool) *bool { return &v }
+	sr := baseScopedRole()
+	sr.Spec.Ssh.SshFileCopy = &scopedaccessv1.SSHFileCopy{
+		Download: boolPtr(false),
+		Upload:   boolPtr(false),
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, types.NewBoolOption(true), role.GetOptions().SSHFileCopy)
 }
 
 // TestKubeConversion verifies the various kube-related scoped role conversion scenarios.

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -116,7 +116,7 @@ func (c *SSHAccessChecker) PermitX11Forwarding() bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.PermitX11Forwarding()
 	}
-	return c.checker.scopedCompatChecker.PermitX11Forwarding()
+	return c.checker.role.GetSpec().GetSsh().GetPermitX11Forwarding()
 }
 
 // SSHPortForwardMode returns the SSH port forwarding mode.

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -192,5 +192,5 @@ func (c *SSHAccessChecker) CanCopyFiles() bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.CanCopyFiles()
 	}
-	return c.checker.scopedCompatChecker.CanCopyFiles()
+	return c.checker.role.Spec.Ssh.GetSshFileCopy()
 }

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -108,7 +108,7 @@ func (c *SSHAccessChecker) CanForwardAgents() bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.CanForwardAgents()
 	}
-	return c.checker.scopedCompatChecker.CanForwardAgents()
+	return c.checker.role.GetSpec().GetSsh().GetForwardAgent()
 }
 
 // PermitX11Forwarding returns true if X11 forwarding is permitted.
@@ -192,5 +192,5 @@ func (c *SSHAccessChecker) CanCopyFiles() bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.CanCopyFiles()
 	}
-	return c.checker.role.Spec.Ssh.GetSshFileCopy()
+	return c.checker.role.GetSpec().GetSsh().GetSshFileCopy()
 }

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -145,7 +146,7 @@ func (c *SSHAccessChecker) HostSudoers(srv types.Server) ([]string, error) {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.HostSudoers(srv)
 	}
-	return c.checker.role.GetSpec().GetSsh().GetHostSudoers(), nil
+	return c.checker.role.GetSpec().GetSsh().GetCreateHostUser().GetHostSudoers(), nil
 }
 
 // EnhancedRecordingSet returns the set of enhanced session recording events to capture.
@@ -161,7 +162,56 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*HostUsersDecision, erro
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.HostUsers(srv)
 	}
-	return c.checker.scopedCompatChecker.HostUsers(srv)
+
+	createHostUser := c.checker.role.GetSpec().GetSsh().GetCreateHostUser()
+
+	// If no create_host_user block, or mode is OFF/UNSPECIFIED, host user creation is disabled.
+	mode := createHostUser.GetCreateHostUserMode()
+	if mode == accessv1.CreateHostUserMode_CREATE_HOST_USER_MODE_UNSPECIFIED ||
+		mode == accessv1.CreateHostUserMode_CREATE_HOST_USER_MODE_OFF {
+		return &HostUsersDecision{
+			Info: nil,
+			DeniedBy: []*decisionpb.Determinant{{
+				Kind: c.checker.role.GetKind(),
+				Name: c.checker.role.GetMetadata().GetName(),
+			}},
+		}, nil
+	}
+
+	// Convert scoped CreateHostUserMode to decision proto HostUserMode.
+	var decisionMode decisionpb.HostUserMode
+	switch mode {
+	case accessv1.CreateHostUserMode_CREATE_HOST_USER_MODE_KEEP:
+		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_KEEP
+	case accessv1.CreateHostUserMode_CREATE_HOST_USER_MODE_INSECURE_DROP:
+		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_DROP
+	default:
+		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_UNSPECIFIED
+	}
+
+	// UID/GID from user traits (same as classic path).
+	traits := c.checker.Traits()
+	var uid, gid string
+	if uidL := traits[constants.TraitHostUserUID]; len(uidL) >= 1 {
+		uid = uidL[0]
+	}
+	if gidL := traits[constants.TraitHostUserGID]; len(gidL) >= 1 {
+		gid = gidL[0]
+	}
+
+	return &HostUsersDecision{
+		Info: &decisionpb.HostUsersInfo{
+			Groups: createHostUser.GetHostGroups(),
+			Mode:   decisionMode,
+			Uid:    uid,
+			Gid:    gid,
+			Shell:  createHostUser.GetHostShell(),
+		},
+		AllowedBy: []*decisionpb.Determinant{{
+			Kind: c.checker.role.GetKind(),
+			Name: c.checker.role.GetMetadata().GetName(),
+		}},
+	}, nil
 }
 
 // CheckAgentForward checks whether SSH agent forwarding is permitted for the given login.
@@ -187,7 +237,7 @@ func (c *SSHAccessChecker) MaxSessions() int64 {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.MaxSessions()
 	}
-	return c.checker.scopedCompatChecker.MaxSessions()
+	return c.checker.role.GetSpec().GetSsh().GetMaxSessions()
 }
 
 // getScopedLogins returns the OS logins permitted by this scoped role. Returns nil for unscoped
@@ -201,9 +251,15 @@ func (c *SSHAccessChecker) getScopedLogins() []string {
 }
 
 // CanCopyFiles returns true if remote file operations via SCP or SFTP are permitted.
+// If GetSshFileCopy is nil, then we default to true.
 func (c *SSHAccessChecker) CanCopyFiles() bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.CanCopyFiles()
 	}
-	return c.checker.role.GetSpec().GetSsh().GetSshFileCopy()
+
+	fileCopy := c.checker.role.GetSpec().GetSsh().GetSshFileCopy()
+	if fileCopy == nil || fileCopy.Enabled == nil {
+		return true
+	}
+	return fileCopy.GetEnabled()
 }

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -132,7 +132,7 @@ func (c *SSHAccessChecker) HostSudoers(srv types.Server) ([]string, error) {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.HostSudoers(srv)
 	}
-	return c.checker.scopedCompatChecker.HostSudoers(srv)
+	return c.checker.role.GetSpec().GetSsh().GetHostSudoers(), nil
 }
 
 // EnhancedRecordingSet returns the set of enhanced session recording events to capture.

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -124,7 +124,20 @@ func (c *SSHAccessChecker) SSHPortForwardMode() decisionpb.SSHPortForwardMode {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.SSHPortForwardMode()
 	}
-	return c.checker.scopedCompatChecker.SSHPortForwardMode()
+
+	denyRemote := c.checker.role.GetSpec().GetSsh().GetSshPortForwarding().GetRemote()
+	denyLocal := c.checker.role.GetSpec().GetSsh().GetSshPortForwarding().GetLocal()
+	// enforcing implicit allow and preferring allow over explicit deny
+	switch {
+	case denyRemote && denyLocal:
+		return decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_OFF
+	case denyRemote:
+		return decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_LOCAL
+	case denyLocal:
+		return decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_REMOTE
+	default:
+		return decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON
+	}
 }
 
 // HostSudoers returns the sudoers rules for the host.

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -108,7 +108,7 @@ func (c *SSHAccessChecker) CanForwardAgents() bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.CanForwardAgents()
 	}
-	return c.checker.role.GetSpec().GetSsh().GetForwardAgent()
+	return c.checker.scopedCompatChecker.CanForwardAgents()
 }
 
 // PermitX11Forwarding returns true if X11 forwarding is permitted.
@@ -129,10 +129,10 @@ func (c *SSHAccessChecker) SSHPortForwardMode() decisionpb.SSHPortForwardMode {
 	local := c.checker.role.GetSpec().GetSsh().GetSshPortForwarding().GetLocal()
 
 	var denyRemote, denyLocal bool
-	if remote != nil && !remote.GetEnabled() {
+	if remote != nil && remote.Enabled != nil && !*remote.Enabled {
 		denyRemote = true
 	}
-	if local != nil && !local.GetEnabled() {
+	if local != nil && local.Enabled != nil && !*local.Enabled {
 		denyLocal = true
 	}
 
@@ -173,16 +173,15 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*HostUsersDecision, erro
 
 	createHostUser := c.checker.role.GetSpec().GetSsh().GetHostUserCreation()
 
-	var legacyHostUserMode types.CreateHostUserMode
-
-	// If no create_host_user block, or mode is OFF/UNSPECIFIED, host user creation is disabled.
-	mode := createHostUser.GetCreateHostUserMode()
-	if err := legacyHostUserMode.UnmarshalJSON([]byte(mode)); err != nil {
+	var hostUserMode types.CreateHostUserMode
+	// quote the strings so it's valid json
+	if err := hostUserMode.UnmarshalJSON([]byte(`"` + createHostUser.GetCreateHostUserMode() + `"`)); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if legacyHostUserMode == types.CreateHostUserMode_HOST_USER_MODE_OFF ||
-		legacyHostUserMode == types.CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED {
+	// If no create_host_user block, or mode is OFF/UNSPECIFIED, host user creation is disabled.
+	if hostUserMode == types.CreateHostUserMode_HOST_USER_MODE_OFF ||
+		hostUserMode == types.CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED {
 		return &HostUsersDecision{
 			Info: nil,
 			DeniedBy: []*decisionpb.Determinant{{
@@ -194,7 +193,7 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*HostUsersDecision, erro
 
 	// Convert to decision
 	var decisionMode decisionpb.HostUserMode
-	switch legacyHostUserMode {
+	switch hostUserMode {
 	case types.CreateHostUserMode_HOST_USER_MODE_KEEP:
 		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_KEEP
 	case types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP:
@@ -203,7 +202,6 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*HostUsersDecision, erro
 		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_UNSPECIFIED
 	}
 
-	// UID/GID from user traits (same as classic path).
 	traits := c.checker.Traits()
 	var uid, gid string
 	if uidL := traits[constants.TraitHostUserUID]; len(uidL) >= 1 {
@@ -233,7 +231,11 @@ func (c *SSHAccessChecker) CheckAgentForward(login string) error {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.CheckAgentForward(login)
 	}
-	return c.checker.scopedCompatChecker.CheckAgentForward(login)
+	if !c.checker.role.GetSpec().GetSsh().GetForwardAgent() {
+		return trace.AccessDenied("agent forwarding is not permitted for scoped role %q",
+			c.checker.role.GetMetadata().GetName())
+	}
+	return nil
 }
 
 // MaxConnections returns the maximum number of concurrent SSH connections permitted.
@@ -274,19 +276,13 @@ func (c *SSHAccessChecker) CanCopyFiles() bool {
 	}
 
 	fileCopy := c.checker.role.GetSpec().GetSsh().GetSshFileCopy()
-	if fileCopy == nil {
+	// If both fields is unset, we default to allow.
+	if fileCopy == nil || fileCopy.Download == nil && fileCopy.Upload == nil {
 		return true
 	}
 
-	// Both download and upload must be explicitly enabled.
-	// If either is set to false, file copying is disabled.
-	download := fileCopy.GetDownload()
-	upload := fileCopy.GetUpload()
-
-	if !download {
-		return false
-	}
-	if !upload {
+	// Deny when either are set to false.
+	if !fileCopy.GetDownload() || !fileCopy.GetUpload() {
 		return false
 	}
 

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
-	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -126,8 +125,17 @@ func (c *SSHAccessChecker) SSHPortForwardMode() decisionpb.SSHPortForwardMode {
 		return c.checker.unscopedChecker.SSHPortForwardMode()
 	}
 
-	denyRemote := c.checker.role.GetSpec().GetSsh().GetSshPortForwarding().GetRemote()
-	denyLocal := c.checker.role.GetSpec().GetSsh().GetSshPortForwarding().GetLocal()
+	remote := c.checker.role.GetSpec().GetSsh().GetSshPortForwarding().GetRemote()
+	local := c.checker.role.GetSpec().GetSsh().GetSshPortForwarding().GetLocal()
+
+	var denyRemote, denyLocal bool
+	if remote != nil && !remote.GetEnabled() {
+		denyRemote = true
+	}
+	if local != nil && !local.GetEnabled() {
+		denyLocal = true
+	}
+
 	// enforcing implicit allow and preferring allow over explicit deny
 	switch {
 	case denyRemote && denyLocal:
@@ -146,7 +154,7 @@ func (c *SSHAccessChecker) HostSudoers(srv types.Server) ([]string, error) {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.HostSudoers(srv)
 	}
-	return c.checker.role.GetSpec().GetSsh().GetCreateHostUser().GetHostSudoers(), nil
+	return c.checker.role.GetSpec().GetSsh().GetHostUserCreation().GetSudoers(), nil
 }
 
 // EnhancedRecordingSet returns the set of enhanced session recording events to capture.
@@ -163,12 +171,18 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*HostUsersDecision, erro
 		return c.checker.unscopedChecker.HostUsers(srv)
 	}
 
-	createHostUser := c.checker.role.GetSpec().GetSsh().GetCreateHostUser()
+	createHostUser := c.checker.role.GetSpec().GetSsh().GetHostUserCreation()
+
+	var legacyHostUserMode types.CreateHostUserMode
 
 	// If no create_host_user block, or mode is OFF/UNSPECIFIED, host user creation is disabled.
 	mode := createHostUser.GetCreateHostUserMode()
-	if mode == accessv1.CreateHostUserMode_CREATE_HOST_USER_MODE_UNSPECIFIED ||
-		mode == accessv1.CreateHostUserMode_CREATE_HOST_USER_MODE_OFF {
+	if err := legacyHostUserMode.UnmarshalJSON([]byte(mode)); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if legacyHostUserMode == types.CreateHostUserMode_HOST_USER_MODE_OFF ||
+		legacyHostUserMode == types.CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED {
 		return &HostUsersDecision{
 			Info: nil,
 			DeniedBy: []*decisionpb.Determinant{{
@@ -178,12 +192,12 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*HostUsersDecision, erro
 		}, nil
 	}
 
-	// Convert scoped CreateHostUserMode to decision proto HostUserMode.
+	// Convert to decision
 	var decisionMode decisionpb.HostUserMode
-	switch mode {
-	case accessv1.CreateHostUserMode_CREATE_HOST_USER_MODE_KEEP:
+	switch legacyHostUserMode {
+	case types.CreateHostUserMode_HOST_USER_MODE_KEEP:
 		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_KEEP
-	case accessv1.CreateHostUserMode_CREATE_HOST_USER_MODE_INSECURE_DROP:
+	case types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP:
 		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_DROP
 	default:
 		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_UNSPECIFIED
@@ -201,11 +215,11 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*HostUsersDecision, erro
 
 	return &HostUsersDecision{
 		Info: &decisionpb.HostUsersInfo{
-			Groups: createHostUser.GetHostGroups(),
+			Groups: createHostUser.GetGroups(),
 			Mode:   decisionMode,
 			Uid:    uid,
 			Gid:    gid,
-			Shell:  createHostUser.GetHostShell(),
+			Shell:  createHostUser.GetShell(),
 		},
 		AllowedBy: []*decisionpb.Determinant{{
 			Kind: c.checker.role.GetKind(),
@@ -252,14 +266,29 @@ func (c *SSHAccessChecker) getScopedLogins() []string {
 
 // CanCopyFiles returns true if remote file operations via SCP or SFTP are permitted.
 // If GetSshFileCopy is nil, then we default to true.
+// We currently only support setting both download and upload to true or false.
+// If a user has set download to false and upload to true, or vice versa, we don't allow for file copying.
 func (c *SSHAccessChecker) CanCopyFiles() bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.CanCopyFiles()
 	}
 
 	fileCopy := c.checker.role.GetSpec().GetSsh().GetSshFileCopy()
-	if fileCopy == nil || fileCopy.Enabled == nil {
+	if fileCopy == nil {
 		return true
 	}
-	return fileCopy.GetEnabled()
+
+	// Both download and upload must be explicitly enabled.
+	// If either is set to false, file copying is disabled.
+	download := fileCopy.GetDownload()
+	upload := fileCopy.GetUpload()
+
+	if !download {
+		return false
+	}
+	if !upload {
+		return false
+	}
+
+	return true
 }

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -272,10 +272,10 @@ func (c *SSHAccessChecker) CanCopyFiles() bool {
 		return c.checker.unscopedChecker.CanCopyFiles()
 	}
 
-	fileCopy := c.checker.role.GetSpec().GetSsh().GetFileCopy()
-	if fileCopy == nil {
+	fileCopy := c.checker.role.GetSpec().GetSsh()
+	if fileCopy.FileCopy == nil {
 		return true
 	}
-	return fileCopy.GetEnabled()
+	return fileCopy.GetFileCopy()
 
 }

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -272,10 +272,10 @@ func (c *SSHAccessChecker) CanCopyFiles() bool {
 		return c.checker.unscopedChecker.CanCopyFiles()
 	}
 
-	fileCopy := c.checker.role.GetSpec().GetSsh()
-	if fileCopy.FileCopy == nil {
+	ssh := c.checker.role.GetSpec().GetSsh()
+	if ssh == nil || ssh.FileCopy == nil {
 		return true
 	}
-	return fileCopy.GetFileCopy()
+	return ssh.GetFileCopy()
 
 }

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -125,8 +125,8 @@ func (c *SSHAccessChecker) SSHPortForwardMode() decisionpb.SSHPortForwardMode {
 		return c.checker.unscopedChecker.SSHPortForwardMode()
 	}
 
-	remote := c.checker.role.GetSpec().GetSsh().GetSshPortForwarding().GetRemote()
-	local := c.checker.role.GetSpec().GetSsh().GetSshPortForwarding().GetLocal()
+	remote := c.checker.role.GetSpec().GetSsh().GetPortForwarding().GetRemote()
+	local := c.checker.role.GetSpec().GetSsh().GetPortForwarding().GetLocal()
 
 	var denyRemote, denyLocal bool
 	if remote != nil && remote.Enabled != nil && !*remote.Enabled {
@@ -154,7 +154,7 @@ func (c *SSHAccessChecker) HostSudoers(srv types.Server) ([]string, error) {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.HostSudoers(srv)
 	}
-	return c.checker.role.GetSpec().GetSsh().GetHostUserCreation().GetSudoers(), nil
+	return c.checker.role.GetSpec().GetSsh().GetHostSudoers(), nil
 }
 
 // EnhancedRecordingSet returns the set of enhanced session recording events to capture.
@@ -174,8 +174,7 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*HostUsersDecision, erro
 	createHostUser := c.checker.role.GetSpec().GetSsh().GetHostUserCreation()
 
 	var hostUserMode types.CreateHostUserMode
-	// quote the strings so it's valid json
-	if err := hostUserMode.UnmarshalJSON([]byte(`"` + createHostUser.GetCreateHostUserMode() + `"`)); err != nil {
+	if err := hostUserMode.UnmarshalText([]byte(createHostUser.GetMode())); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -268,23 +267,15 @@ func (c *SSHAccessChecker) getScopedLogins() []string {
 
 // CanCopyFiles returns true if remote file operations via SCP or SFTP are permitted.
 // If GetSshFileCopy is nil, then we default to true.
-// We currently only support setting both download and upload to true or false.
-// If a user has set download to false and upload to true, or vice versa, we don't allow for file copying.
 func (c *SSHAccessChecker) CanCopyFiles() bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.CanCopyFiles()
 	}
 
-	fileCopy := c.checker.role.GetSpec().GetSsh().GetSshFileCopy()
-	// If both fields is unset, we default to allow.
-	if fileCopy == nil || fileCopy.Download == nil && fileCopy.Upload == nil {
+	fileCopy := c.checker.role.GetSpec().GetSsh().GetFileCopy()
+	if fileCopy == nil {
 		return true
 	}
+	return fileCopy.GetEnabled()
 
-	// Deny when either are set to false.
-	if !fileCopy.GetDownload() || !fileCopy.GetUpload() {
-		return false
-	}
-
-	return true
 }

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -188,3 +188,7 @@ func TestSSHAccessCheckerAdjustClientIdleTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestSSHAccessCheckerX11Forwarding(t *testing.T) {
+
+}

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -24,9 +24,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
+	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
 )
 
 // newScopedCheckerWithRole is a test helper that builds a minimal ScopedAccessChecker
@@ -189,6 +192,509 @@ func TestSSHAccessCheckerAdjustClientIdleTimeout(t *testing.T) {
 	}
 }
 
-func TestSSHAccessCheckerX11Forwarding(t *testing.T) {
+func boolPtr(v bool) *bool { return &v }
 
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestSSHAccessCheckerPermitX11Forwarding(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect bool
+	}{
+		{
+			name: "nil ssh block defaults to false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{},
+			},
+			expect: false,
+		},
+		{
+			name: "set true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					PermitX11Forwarding: boolPtr(true),
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "set false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					PermitX11Forwarding: boolPtr(false),
+				},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.PermitX11Forwarding())
+		})
+	}
+}
+
+func TestSSHAccessCheckerCheckAgentForward(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name      string
+		spec      *scopedaccessv1.ScopedRoleSpec
+		expectErr bool
+	}{
+		{
+			name: "nil agent forwarding denies",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{},
+			},
+			expectErr: true,
+		},
+		{
+			name: "set true allows",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					ForwardAgent: boolPtr(true),
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "set false denies",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					ForwardAgent: boolPtr(false),
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			err := checker.CheckAgentForward("testuser")
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSSHAccessCheckerCanCopyFiles(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect bool
+	}{
+		{
+			name: "nil file_copy defaults to true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshFileCopy: nil,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "both true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshFileCopy: &scopedaccessv1.SSHFileCopy{
+						Download: boolPtr(true),
+						Upload:   boolPtr(true),
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "both false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshFileCopy: &scopedaccessv1.SSHFileCopy{
+						Download: boolPtr(false),
+						Upload:   boolPtr(false),
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "both nil (unset) defaults to true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshFileCopy: &scopedaccessv1.SSHFileCopy{},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "download false upload nil",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshFileCopy: &scopedaccessv1.SSHFileCopy{
+						Download: boolPtr(false),
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "download nil upload false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshFileCopy: &scopedaccessv1.SSHFileCopy{
+						Upload: boolPtr(false),
+					},
+				},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.CanCopyFiles())
+		})
+	}
+}
+
+func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect decisionpb.SSHPortForwardMode
+	}{
+		{
+			name: "nil port forwarding defaults to ON",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshPortForwarding: nil,
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON,
+		},
+		{
+			name: "both enabled",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(true)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(true)},
+					},
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON,
+		},
+		{
+			name: "both disabled",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
+					},
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_OFF,
+		},
+		{
+			name: "local enabled remote disabled",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(true)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
+					},
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_LOCAL,
+		},
+		{
+			name: "local disabled remote enabled",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(true)},
+					},
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_REMOTE,
+		},
+		{
+			name: "local and remote enabled not set defaults to ON",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{},
+					},
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.SSHPortForwardMode())
+		})
+	}
+}
+
+func TestSSHAccessCheckerMaxSessions(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect int64
+	}{
+		{
+			name: "not set defaults to 0",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{},
+			},
+			expect: 0,
+		},
+		{
+			name: "set to 5",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					MaxSessions: int64Ptr(5),
+				},
+			},
+			expect: 5,
+		},
+		{
+			name: "set to 0",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					MaxSessions: int64Ptr(0),
+				},
+			},
+			expect: 0,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.MaxSessions())
+		})
+	}
+}
+
+func TestSSHAccessCheckerHostSudoers(t *testing.T) {
+	t.Parallel()
+
+	srv := &types.ServerV2{}
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect []string
+	}{
+		{
+			name: "nil host user creation block",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: nil,
+				},
+			},
+			expect: nil,
+		},
+		{
+			name: "no sudoers",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{},
+				},
+			},
+			expect: nil,
+		},
+		{
+			name: "has sudoers",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						Sudoers: []string{"ALL=(ALL) NOPASSWD: ALL"},
+					},
+				},
+			},
+			expect: []string{"ALL=(ALL) NOPASSWD: ALL"},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			sudoers, err := checker.HostSudoers(srv)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, sudoers)
+		})
+	}
+}
+
+func TestSSHAccessCheckerHostUsers(t *testing.T) {
+	t.Parallel()
+
+	srv := &types.ServerV2{}
+
+	tts := []struct {
+		name         string
+		spec         *scopedaccessv1.ScopedRoleSpec
+		traits       wrappers.Traits
+		expectNil    bool
+		expectErr    bool
+		expectMode   decisionpb.HostUserMode
+		expectGroups []string
+		expectShell  string
+		expectUID    string
+		expectGID    string
+	}{
+		{
+			name: "nil host_user_creation - denied",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: nil,
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "empty mode string - denied",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						CreateHostUserMode: "",
+					},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "mode off - denied",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						CreateHostUserMode: "off",
+					},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "mode keep",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						CreateHostUserMode: "keep",
+						Groups:             []string{"test"},
+						Shell:              "/bin/bash",
+					},
+				},
+			},
+			expectNil:    false,
+			expectMode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
+			expectGroups: []string{"test"},
+			expectShell:  "/bin/bash",
+		},
+		{
+			name: "mode insecure-drop",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						CreateHostUserMode: "insecure-drop",
+						Groups:             []string{"test"},
+					},
+				},
+			},
+			expectNil:    false,
+			expectMode:   decisionpb.HostUserMode_HOST_USER_MODE_DROP,
+			expectGroups: []string{"test"},
+		},
+		{
+			name: "uid and gid from traits",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						CreateHostUserMode: "keep",
+					},
+				},
+			},
+			traits: wrappers.Traits{
+				constants.TraitHostUserUID: []string{"1001"},
+				constants.TraitHostUserGID: []string{"1001"},
+			},
+			expectNil:  false,
+			expectMode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
+			expectUID:  "1001",
+			expectGID:  "1001",
+		},
+		{
+			name: "invalid mode returns error",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						CreateHostUserMode: "invalid",
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			checker.checker.scopedCompatChecker = newAccessChecker(&AccessInfo{
+				Traits: tt.traits,
+			}, "local", NewRoleSet())
+
+			decision, err := checker.HostUsers(srv)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, decision)
+
+			if tt.expectNil {
+				require.Nil(t, decision.Info)
+				require.NotEmpty(t, decision.DeniedBy)
+				return
+			}
+
+			require.NotNil(t, decision.Info, "expected Info to be non-nil (allowed)")
+			require.NotEmpty(t, decision.AllowedBy, "expected AllowedBy to be populated")
+			require.Equal(t, tt.expectMode, decision.Info.Mode)
+			require.Equal(t, tt.expectGroups, decision.Info.Groups)
+			require.Equal(t, tt.expectShell, decision.Info.Shell)
+			require.Equal(t, tt.expectUID, decision.Info.Uid)
+			require.Equal(t, tt.expectGID, decision.Info.Gid)
+		})
+	}
 }

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -310,9 +310,7 @@ func TestSSHAccessCheckerCanCopyFiles(t *testing.T) {
 			name: "true",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					FileCopy: &scopedaccessv1.SSHFileCopy{
-						Enabled: boolPtr(true),
-					},
+					FileCopy: boolPtr(true),
 				},
 			},
 			expect: true,
@@ -321,23 +319,10 @@ func TestSSHAccessCheckerCanCopyFiles(t *testing.T) {
 			name: "false",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					FileCopy: &scopedaccessv1.SSHFileCopy{
-						Enabled: boolPtr(false),
-					},
+					FileCopy: boolPtr(false),
 				},
 			},
 			expect: false,
-		},
-		{
-			name: "enabled nil (unset) defaults to true",
-			spec: &scopedaccessv1.ScopedRoleSpec{
-				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					FileCopy: &scopedaccessv1.SSHFileCopy{
-						Enabled: nil,
-					},
-				},
-			},
-			expect: true,
 		},
 	}
 

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -192,9 +192,7 @@ func TestSSHAccessCheckerAdjustClientIdleTimeout(t *testing.T) {
 	}
 }
 
-func boolPtr(v bool) *bool { return &v }
-
-func int64Ptr(v int64) *int64 { return &v }
+func ptr[T any](v T) *T { return &v }
 
 func TestSSHAccessCheckerPermitX11Forwarding(t *testing.T) {
 	t.Parallel()
@@ -215,7 +213,7 @@ func TestSSHAccessCheckerPermitX11Forwarding(t *testing.T) {
 			name: "set true",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					PermitX11Forwarding: boolPtr(true),
+					PermitX11Forwarding: ptr(true),
 				},
 			},
 			expect: true,
@@ -224,7 +222,7 @@ func TestSSHAccessCheckerPermitX11Forwarding(t *testing.T) {
 			name: "set false",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					PermitX11Forwarding: boolPtr(false),
+					PermitX11Forwarding: ptr(false),
 				},
 			},
 			expect: false,
@@ -259,7 +257,7 @@ func TestSSHAccessCheckerCheckAgentForward(t *testing.T) {
 			name: "set true allows",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					ForwardAgent: boolPtr(true),
+					ForwardAgent: ptr(true),
 				},
 			},
 			expectErr: false,
@@ -268,7 +266,7 @@ func TestSSHAccessCheckerCheckAgentForward(t *testing.T) {
 			name: "set false denies",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					ForwardAgent: boolPtr(false),
+					ForwardAgent: ptr(false),
 				},
 			},
 			expectErr: true,
@@ -310,7 +308,7 @@ func TestSSHAccessCheckerCanCopyFiles(t *testing.T) {
 			name: "true",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					FileCopy: boolPtr(true),
+					FileCopy: ptr(true),
 				},
 			},
 			expect: true,
@@ -319,7 +317,7 @@ func TestSSHAccessCheckerCanCopyFiles(t *testing.T) {
 			name: "false",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					FileCopy: boolPtr(false),
+					FileCopy: ptr(false),
 				},
 			},
 			expect: false,
@@ -357,8 +355,8 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
 					PortForwarding: &scopedaccessv1.SSHPortForwarding{
-						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(true)},
-						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(true)},
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: ptr(true)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: ptr(true)},
 					},
 				},
 			},
@@ -369,8 +367,8 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
 					PortForwarding: &scopedaccessv1.SSHPortForwarding{
-						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
-						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: ptr(false)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: ptr(false)},
 					},
 				},
 			},
@@ -381,8 +379,8 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
 					PortForwarding: &scopedaccessv1.SSHPortForwarding{
-						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(true)},
-						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: ptr(true)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: ptr(false)},
 					},
 				},
 			},
@@ -393,8 +391,8 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
 					PortForwarding: &scopedaccessv1.SSHPortForwarding{
-						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
-						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(true)},
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: ptr(false)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: ptr(true)},
 					},
 				},
 			},
@@ -442,7 +440,7 @@ func TestSSHAccessCheckerMaxSessions(t *testing.T) {
 			name: "set to 5",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					MaxSessions: int64Ptr(5),
+					MaxSessions: ptr(int64(5)),
 				},
 			},
 			expect: 5,
@@ -451,7 +449,7 @@ func TestSSHAccessCheckerMaxSessions(t *testing.T) {
 			name: "set to 0",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					MaxSessions: int64Ptr(0),
+					MaxSessions: ptr(int64(0)),
 				},
 			},
 			expect: 0,

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -301,65 +301,43 @@ func TestSSHAccessCheckerCanCopyFiles(t *testing.T) {
 			name: "nil file_copy defaults to true",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshFileCopy: nil,
+					FileCopy: nil,
 				},
 			},
 			expect: true,
 		},
 		{
-			name: "both true",
+			name: "true",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshFileCopy: &scopedaccessv1.SSHFileCopy{
-						Download: boolPtr(true),
-						Upload:   boolPtr(true),
+					FileCopy: &scopedaccessv1.SSHFileCopy{
+						Enabled: boolPtr(true),
 					},
 				},
 			},
 			expect: true,
 		},
 		{
-			name: "both false",
+			name: "false",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshFileCopy: &scopedaccessv1.SSHFileCopy{
-						Download: boolPtr(false),
-						Upload:   boolPtr(false),
+					FileCopy: &scopedaccessv1.SSHFileCopy{
+						Enabled: boolPtr(false),
 					},
 				},
 			},
 			expect: false,
 		},
 		{
-			name: "both nil (unset) defaults to true",
+			name: "enabled nil (unset) defaults to true",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshFileCopy: &scopedaccessv1.SSHFileCopy{},
+					FileCopy: &scopedaccessv1.SSHFileCopy{
+						Enabled: nil,
+					},
 				},
 			},
 			expect: true,
-		},
-		{
-			name: "download false upload nil",
-			spec: &scopedaccessv1.ScopedRoleSpec{
-				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshFileCopy: &scopedaccessv1.SSHFileCopy{
-						Download: boolPtr(false),
-					},
-				},
-			},
-			expect: false,
-		},
-		{
-			name: "download nil upload false",
-			spec: &scopedaccessv1.ScopedRoleSpec{
-				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshFileCopy: &scopedaccessv1.SSHFileCopy{
-						Upload: boolPtr(false),
-					},
-				},
-			},
-			expect: false,
 		},
 	}
 
@@ -384,7 +362,7 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 			name: "nil port forwarding defaults to ON",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshPortForwarding: nil,
+					PortForwarding: nil,
 				},
 			},
 			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON,
@@ -393,7 +371,7 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 			name: "both enabled",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+					PortForwarding: &scopedaccessv1.SSHPortForwarding{
 						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(true)},
 						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(true)},
 					},
@@ -405,7 +383,7 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 			name: "both disabled",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+					PortForwarding: &scopedaccessv1.SSHPortForwarding{
 						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
 						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
 					},
@@ -417,7 +395,7 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 			name: "local enabled remote disabled",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+					PortForwarding: &scopedaccessv1.SSHPortForwarding{
 						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(true)},
 						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
 					},
@@ -429,7 +407,7 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 			name: "local disabled remote enabled",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+					PortForwarding: &scopedaccessv1.SSHPortForwarding{
 						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
 						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(true)},
 					},
@@ -441,7 +419,7 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 			name: "local and remote enabled not set defaults to ON",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					SshPortForwarding: &scopedaccessv1.SSHPortForwarding{
+					PortForwarding: &scopedaccessv1.SSHPortForwarding{
 						Local:  &scopedaccessv1.SSHLocalPortForwarding{},
 						Remote: &scopedaccessv1.SSHRemotePortForwarding{},
 					},
@@ -515,19 +493,10 @@ func TestSSHAccessCheckerHostSudoers(t *testing.T) {
 		expect []string
 	}{
 		{
-			name: "nil host user creation block",
-			spec: &scopedaccessv1.ScopedRoleSpec{
-				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					HostUserCreation: nil,
-				},
-			},
-			expect: nil,
-		},
-		{
 			name: "no sudoers",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					HostUserCreation: &scopedaccessv1.CreateHostUser{},
+					HostSudoers: nil,
 				},
 			},
 			expect: nil,
@@ -536,9 +505,7 @@ func TestSSHAccessCheckerHostSudoers(t *testing.T) {
 			name: "has sudoers",
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
-					HostUserCreation: &scopedaccessv1.CreateHostUser{
-						Sudoers: []string{"ALL=(ALL) NOPASSWD: ALL"},
-					},
+					HostSudoers: []string{"ALL=(ALL) NOPASSWD: ALL"},
 				},
 			},
 			expect: []string{"ALL=(ALL) NOPASSWD: ALL"},
@@ -587,7 +554,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
 					HostUserCreation: &scopedaccessv1.CreateHostUser{
-						CreateHostUserMode: "",
+						Mode: "",
 					},
 				},
 			},
@@ -598,7 +565,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
 					HostUserCreation: &scopedaccessv1.CreateHostUser{
-						CreateHostUserMode: "off",
+						Mode: "off",
 					},
 				},
 			},
@@ -609,9 +576,9 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
 					HostUserCreation: &scopedaccessv1.CreateHostUser{
-						CreateHostUserMode: "keep",
-						Groups:             []string{"test"},
-						Shell:              "/bin/bash",
+						Mode:   "keep",
+						Groups: []string{"test"},
+						Shell:  "/bin/bash",
 					},
 				},
 			},
@@ -625,8 +592,8 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
 					HostUserCreation: &scopedaccessv1.CreateHostUser{
-						CreateHostUserMode: "insecure-drop",
-						Groups:             []string{"test"},
+						Mode:   "insecure-drop",
+						Groups: []string{"test"},
 					},
 				},
 			},
@@ -639,7 +606,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
 					HostUserCreation: &scopedaccessv1.CreateHostUser{
-						CreateHostUserMode: "keep",
+						Mode: "keep",
 					},
 				},
 			},
@@ -657,7 +624,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 			spec: &scopedaccessv1.ScopedRoleSpec{
 				Ssh: &scopedaccessv1.ScopedRoleSSH{
 					HostUserCreation: &scopedaccessv1.CreateHostUser{
-						CreateHostUserMode: "invalid",
+						Mode: "invalid",
 					},
 				},
 			},

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -1629,16 +1629,10 @@ func TestScopedSSHFileCopy(t *testing.T) {
 	const copyUnset = "copy-unset"
 
 	enabled := baseScopedRoleForAuthz(copyEnabled)
-	enabled.Spec.Ssh.SshFileCopy = &scopedaccessv1.SSHFileCopy{
-		Download: proto.Bool(true),
-		Upload:   proto.Bool(true),
-	}
+	enabled.Spec.Ssh.FileCopy = proto.Bool(true)
 
 	disabled := baseScopedRoleForAuthz(copyDisabled)
-	disabled.Spec.Ssh.SshFileCopy = &scopedaccessv1.SSHFileCopy{
-		Download: proto.Bool(false),
-		Upload:   proto.Bool(false),
-	}
+	disabled.Spec.Ssh.FileCopy = proto.Bool(false)
 
 	unset := baseScopedRoleForAuthz(copyUnset)
 
@@ -1669,19 +1663,19 @@ func TestScopedSSHPortForwarding(t *testing.T) {
 	const pfUnset = "pf-unset"
 
 	bothOn := baseScopedRoleForAuthz(pfBothOn)
-	bothOn.Spec.Ssh.SshPortForwarding = &scopedaccessv1.SSHPortForwarding{
+	bothOn.Spec.Ssh.PortForwarding = &scopedaccessv1.SSHPortForwarding{
 		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(true)},
 		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(true)},
 	}
 
 	bothOff := baseScopedRoleForAuthz(pfBothOff)
-	bothOff.Spec.Ssh.SshPortForwarding = &scopedaccessv1.SSHPortForwarding{
+	bothOff.Spec.Ssh.PortForwarding = &scopedaccessv1.SSHPortForwarding{
 		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(false)},
 		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(false)},
 	}
 
 	localOnly := baseScopedRoleForAuthz(pfLocalOnly)
-	localOnly.Spec.Ssh.SshPortForwarding = &scopedaccessv1.SSHPortForwarding{
+	localOnly.Spec.Ssh.PortForwarding = &scopedaccessv1.SSHPortForwarding{
 		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(true)},
 		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(false)},
 	}
@@ -1748,15 +1742,14 @@ func TestScopedHostUserCreation(t *testing.T) {
 
 	keep := baseScopedRoleForAuthz(hostUserKeep)
 	keep.Spec.Ssh.HostUserCreation = &scopedaccessv1.CreateHostUser{
-		CreateHostUserMode: "keep",
-		Sudoers:            []string{"ALL=(ALL) NOPASSWD:ALL"},
-		Groups:             []string{"wheel"},
-		Shell:              "/bin/bash",
+		Mode:   "keep",
+		Groups: []string{"wheel"},
+		Shell:  "/bin/bash",
 	}
 
 	off := baseScopedRoleForAuthz(hostUserOff)
 	off.Spec.Ssh.HostUserCreation = &scopedaccessv1.CreateHostUser{
-		CreateHostUserMode: "off",
+		Mode: "off",
 	}
 
 	unset := baseScopedRoleForAuthz(hostUserUnset)
@@ -1781,6 +1774,34 @@ func TestScopedHostUserCreation(t *testing.T) {
 			} else {
 				require.NotNil(t, permit.HostUsersInfo)
 			}
+		})
+	}
+}
+
+func TestHostSudoers(t *testing.T) {
+	const sudoersPresent = "sudoers-present"
+	const sudoersUnset = "sudoers-unset"
+
+	present := baseScopedRoleForAuthz(sudoersPresent)
+	expectedSudoers := []string{"ALL=(ALL) NOPASSWD:ALL"}
+	present.Spec.Ssh.HostSudoers = expectedSudoers
+	unset := baseScopedRoleForAuthz(sudoersUnset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{present, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect []string
+	}{
+		{"enabled", pinForRole(sudoersPresent), expectedSudoers},
+		{"unset defaults to false", pinForRole(sudoersUnset), nil},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.HostSudoers)
 		})
 	}
 }

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
@@ -1501,6 +1502,285 @@ func TestScopedClientIdleTimeout(t *testing.T) {
 			actualTimeout := permit.ClientIdleTimeout.AsDuration()
 			require.Equal(t, tt.expectTimeout, actualTimeout,
 				"ClientIdleTimeout should be %v but got %v", tt.expectTimeout, actualTimeout)
+		})
+	}
+}
+
+// newScopedSSHPermitTestPack is a helper to create newScopedAccessAuthzPack
+func newScopedSSHPermitTestPack(t *testing.T, roles []*scopedaccessv1.ScopedRole) *scopedAccessAuthzPack {
+	t.Helper()
+
+	node, err := types.NewNode("testnode", types.SubKindTeleportNode, types.ServerSpecV2{
+		Addr:     "1.2.3.4:22",
+		Hostname: "testnode",
+	}, map[string]string{
+		"env": "test",
+	})
+	require.NoError(t, err)
+
+	serverV2 := node.(*types.ServerV2)
+	serverV2.Scope = "/staging/west"
+
+	// add standard logins and labels to each role so they match the test node
+	for _, role := range roles {
+		if role.Spec.Ssh.Logins == nil {
+			role.Spec.Ssh.Logins = []string{"testuser"}
+		}
+		if role.Spec.Ssh.Labels == nil {
+			role.Spec.Ssh.Labels = []*labelv1.Label{
+				{Name: "env", Values: []string{"test"}},
+			}
+		}
+	}
+
+	return newScopedAccessAuthzPack(t, serverV2, roles, types.DefaultClusterNetworkingConfig())
+}
+
+func pinForRole(roleName string) *scopesv1.Pin {
+	return &scopesv1.Pin{
+		Scope: "/staging",
+		AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+			"/staging/west": {"/staging/west": {roleName}},
+		}),
+	}
+}
+
+func baseScopedRoleForAuthz(name string) *scopedaccessv1.ScopedRole {
+	return &scopedaccessv1.ScopedRole{
+		Kind:     scopedaccess.KindScopedRole,
+		Metadata: &headerv1.Metadata{Name: name},
+		Scope:    "/staging/west",
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{"/staging/west"},
+			Ssh:              &scopedaccessv1.ScopedRoleSSH{},
+		},
+		Version: types.V1,
+	}
+}
+
+func TestScopedX11Forwarding(t *testing.T) {
+	const x11enabled = "x11-enabled"
+	const x11disabled = "x11-disabled"
+	const x11unset = "x11-unset"
+	enabled := baseScopedRoleForAuthz(x11enabled)
+	enabled.Spec.Ssh.PermitX11Forwarding = proto.Bool(true)
+
+	disabled := baseScopedRoleForAuthz(x11disabled)
+	disabled.Spec.Ssh.PermitX11Forwarding = proto.Bool(false)
+
+	unset := baseScopedRoleForAuthz(x11unset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{enabled, disabled, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect bool
+	}{
+		{"enabled", pinForRole(x11enabled), true},
+		{"disabled", pinForRole(x11disabled), false},
+		{"unset defaults to false", pinForRole(x11unset), false},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.X11Forwarding)
+		})
+	}
+}
+
+func TestScopedForwardAgent(t *testing.T) {
+	const agentEnabled = "agent-enabled"
+	const agentDisabled = "agent-disabled"
+	const agentUnset = "agent-unset"
+
+	enabled := baseScopedRoleForAuthz(agentEnabled)
+	enabled.Spec.Ssh.ForwardAgent = proto.Bool(true)
+
+	disabled := baseScopedRoleForAuthz(agentDisabled)
+	disabled.Spec.Ssh.ForwardAgent = proto.Bool(false)
+
+	unset := baseScopedRoleForAuthz(agentUnset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{enabled, disabled, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect bool
+	}{
+		{"enabled", pinForRole(agentEnabled), true},
+		{"disabled", pinForRole(agentDisabled), false},
+		{"unset defaults to false", pinForRole(agentUnset), false},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.ForwardAgent)
+		})
+	}
+}
+
+func TestScopedSSHFileCopy(t *testing.T) {
+	const copyEnabled = "copy-enabled"
+	const copyDisabled = "copy-disabled"
+	const copyUnset = "copy-unset"
+
+	enabled := baseScopedRoleForAuthz(copyEnabled)
+	enabled.Spec.Ssh.SshFileCopy = &scopedaccessv1.SSHFileCopy{
+		Download: proto.Bool(true),
+		Upload:   proto.Bool(true),
+	}
+
+	disabled := baseScopedRoleForAuthz(copyDisabled)
+	disabled.Spec.Ssh.SshFileCopy = &scopedaccessv1.SSHFileCopy{
+		Download: proto.Bool(false),
+		Upload:   proto.Bool(false),
+	}
+
+	unset := baseScopedRoleForAuthz(copyUnset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{enabled, disabled, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect bool
+	}{
+		{"enabled", pinForRole(copyEnabled), true},
+		{"disabled", pinForRole(copyDisabled), false},
+		{"unset defaults to true", pinForRole(copyUnset), true},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.SshFileCopy)
+		})
+	}
+}
+
+func TestScopedSSHPortForwarding(t *testing.T) {
+	const pfBothOn = "pf-both-on"
+	const pfBothOff = "pf-both-off"
+	const pfLocalOnly = "pf-local-only"
+	const pfUnset = "pf-unset"
+
+	bothOn := baseScopedRoleForAuthz(pfBothOn)
+	bothOn.Spec.Ssh.SshPortForwarding = &scopedaccessv1.SSHPortForwarding{
+		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(true)},
+		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(true)},
+	}
+
+	bothOff := baseScopedRoleForAuthz(pfBothOff)
+	bothOff.Spec.Ssh.SshPortForwarding = &scopedaccessv1.SSHPortForwarding{
+		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(false)},
+		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(false)},
+	}
+
+	localOnly := baseScopedRoleForAuthz(pfLocalOnly)
+	localOnly.Spec.Ssh.SshPortForwarding = &scopedaccessv1.SSHPortForwarding{
+		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(true)},
+		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(false)},
+	}
+
+	unset := baseScopedRoleForAuthz(pfUnset)
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{bothOn, bothOff, localOnly, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect decisionpb.SSHPortForwardMode
+	}{
+		{"both on", pinForRole(pfBothOn), decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON},
+		{"both off", pinForRole(pfBothOff), decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_OFF},
+		{"local only", pinForRole(pfLocalOnly), decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_LOCAL},
+		{"unset defaults to on", pinForRole(pfUnset), decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.PortForwardMode)
+		})
+	}
+}
+
+func TestScopedMaxSessions(t *testing.T) {
+	const sessions5 = "sessions-5"
+	const sessions1 = "sessions-1"
+	const sessionsUnset = "sessions-unset"
+
+	five := baseScopedRoleForAuthz(sessions5)
+	five.Spec.Ssh.MaxSessions = proto.Int64(5)
+
+	one := baseScopedRoleForAuthz(sessions1)
+	one.Spec.Ssh.MaxSessions = proto.Int64(1)
+
+	unset := baseScopedRoleForAuthz(sessionsUnset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{five, one, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect int64
+	}{
+		{"set to 5", pinForRole(sessions5), 5},
+		{"set to 1", pinForRole(sessions1), 1},
+		{"unset defaults to 0", pinForRole(sessionsUnset), 0},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.MaxSessions)
+		})
+	}
+}
+
+func TestScopedHostUserCreation(t *testing.T) {
+	const hostUserKeep = "host-user-keep"
+	const hostUserOff = "host-user-off"
+	const hostUserUnset = "host-user-unset"
+
+	keep := baseScopedRoleForAuthz(hostUserKeep)
+	keep.Spec.Ssh.HostUserCreation = &scopedaccessv1.CreateHostUser{
+		CreateHostUserMode: "keep",
+		Sudoers:            []string{"ALL=(ALL) NOPASSWD:ALL"},
+		Groups:             []string{"wheel"},
+		Shell:              "/bin/bash",
+	}
+
+	off := baseScopedRoleForAuthz(hostUserOff)
+	off.Spec.Ssh.HostUserCreation = &scopedaccessv1.CreateHostUser{
+		CreateHostUserMode: "off",
+	}
+
+	unset := baseScopedRoleForAuthz(hostUserUnset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{keep, off, unset})
+
+	tts := []struct {
+		name      string
+		pin       *scopesv1.Pin
+		expectNil bool
+	}{
+		{"mode keep", pinForRole(hostUserKeep), false},
+		{"mode off", pinForRole(hostUserOff), true},
+		{"unset defaults to denied", pinForRole(hostUserUnset), true},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			if tt.expectNil {
+				require.Nil(t, permit.HostUsersInfo)
+			} else {
+				require.NotNil(t, permit.HostUsersInfo)
+			}
 		})
 	}
 }


### PR DESCRIPTION




<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Add x11 forwarding, SSH File Copying, Agent Forwarding, SSH Port Forwarding, Create Host User, and Max Sessions to scoped ssh role options

Updates:

Updated protos
Updated tests


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

Docker containers running ubuntu and connected as nodes to the local cluster

### Test Cases

X11 Forwarding
- [x] When enabled, can run xeyes in the node
- [x] When disabled, cannot run xeyes in the node

SSH File Copying
- [x] When enabled, can copy file to node
- [x] When enabled, can copy file from node
- [x] When disabled, both directions are rejected

Forward Agent
- [x] When enabled, devtsh ssh -A, then ssh-add -l shows forwarded keys
- [x] When disabled, devtsh ssh -A, then ssh-add -l doesn't show keys

SSH Port Forwarding
- [x] When local=true, devtsh ssh -L 8080:localhost:80 + curl localhost:8080 returns response
- [x] When local=false, devtsh ssh -L 8080:localhost:80 + curl localhost:8080 is rejected
- [x] When remote=true, devtsh ssh -R 9090:localhost:9090 + curl localhost:9090 from node returns response
- [x] When remote=false, devtsh ssh -R 9090:localhost:9090 + curl localhost:9090 from node is rejected

Create Host User
- [x] When mode="keep"(2), SSH as nonexistent user creates OS user that persists after logout
- [x] When mode="drop"(3), SSH as nonexistent user creates OS user that is deleted after logout
- [x] When mode="off"(1), SSH as nonexistent user is rejected
- [x] host_groups: created user is added to specified groups
- [x] host_sudoers: sudo whoami returns root without password prompt `- 'ALL=(ALL) NOPASSWD: ALL'`
- [x] host_shell: echo $SHELL shows /bin/bash

Max Sessions
- [x] With max_sessions=3, opening 3 sessions over one connection succeeds and the 4th one is rejected - repeat by changing the values and making sure that the xth+1 connection fails toconnect.