### PR TITLE
[v18] Fix "tctl edit" multiple resource bugs

### DIFF
--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -152,11 +152,22 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 	}
 
 	key := func(r services.UnknownResource) string {
-		return fmt.Sprintf("%s/%s", r.Kind, r.GetName())
+		return r.Kind + "/" + r.SubKind + "/" + r.GetName()
 	}
 	originalResourcesMap := make(map[string][]byte)
 	for _, r := range originalResources {
 		originalResourcesMap[key(r)] = r.Raw
+	}
+	if len(originalResourcesMap) != len(originalResources) {
+		slog.DebugContext(ctx, "tctl edit clobbered resources on originalResourcesMap",
+			"ref", e.ref,
+			"original_resources_map_len", len(originalResourcesMap),
+			"original_resources_len", len(originalResources),
+		)
+		return trace.BadParameter(
+			"tctl edit cannot handle multiple resources of kind %q, please specify a single resource to edit",
+			e.ref.Kind,
+		)
 	}
 
 	if err := e.runEditor(ctx, f.Name()); err != nil {
@@ -178,9 +189,18 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
 	if len(newResources) != len(originalResources) {
 		return trace.BadParameter("one or more resources were added or removed, renaming resources is not supported with tctl edit")
+	}
+
+	// Verify keying of new resources, similarly to originalResources.
+	newResourcesMap := make(map[string]struct{}, len(newResources))
+	for _, r := range newResources {
+		newResourcesMap[key(r)] = struct{}{}
+	}
+	if len(newResourcesMap) != len(newResources) {
+		return trace.BadParameter(
+			"one or more edited resources have duplicate kind/sub_kind/name keys, each resource must be unique")
 	}
 
 	for _, newResource := range newResources {

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -19,17 +19,23 @@
 package common
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"slices"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -42,8 +48,10 @@ import (
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
@@ -63,61 +71,65 @@ func TestEditResources(t *testing.T) {
 	t.Cleanup(func() { _ = rootClient.Close() })
 
 	tests := []struct {
-		kind string
+		name string
 		edit func(t *testing.T, clt *authclient.Client)
 	}{
 		{
-			kind: types.KindGithubConnector,
+			name: types.KindGithubConnector,
 			edit: testEditGithubConnector,
 		},
 		{
-			kind: types.KindRole,
+			name: types.KindRole,
 			edit: testEditRole,
 		},
 		{
-			kind: types.KindUser,
+			name: types.KindUser,
 			edit: testEditUser,
 		},
 		{
-			kind: types.KindClusterNetworkingConfig,
+			name: types.KindClusterNetworkingConfig,
 			edit: testEditClusterNetworkingConfig,
 		},
 		{
-			kind: types.KindClusterAuthPreference,
+			name: types.KindClusterAuthPreference,
 			edit: testEditAuthPreference,
 		},
 		{
-			kind: types.KindSessionRecordingConfig,
+			name: types.KindSessionRecordingConfig,
 			edit: testEditSessionRecordingConfig,
 		},
 		{
-			kind: types.KindStaticHostUser,
+			name: types.KindStaticHostUser,
 			edit: testEditStaticHostUser,
 		},
 		{
-			kind: types.KindAutoUpdateConfig,
+			name: types.KindAutoUpdateConfig,
 			edit: testEditAutoUpdateConfig,
 		},
 		{
-			kind: types.KindAutoUpdateVersion,
+			name: types.KindAutoUpdateVersion,
 			edit: testEditAutoUpdateVersion,
 		},
 		{
-			kind: types.KindDynamicWindowsDesktop,
+			name: types.KindDynamicWindowsDesktop,
 			edit: testEditDynamicWindowsDesktop,
 		},
 		{
-			kind: types.KindHealthCheckConfig,
+			name: types.KindHealthCheckConfig,
 			edit: testEditHealthCheckConfig,
 		},
 		{
-			kind: types.KindScopedToken,
+			name: types.KindScopedToken,
 			edit: testEditScopedToken,
+		},
+		{
+			name: "edit multiple resources with SubKind (" + types.KindCertAuthority + ")",
+			edit: testEditMultipleWithSubKind,
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(test.kind, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			test.edit(t, rootClient)
 		})
 	}
@@ -741,6 +753,215 @@ func testEditScopedToken(t *testing.T, clt *authclient.Client) {
 	_, err = runEditCommand(t, clt, []string{"edit", types.KindScopedToken + "/" + created.GetMetadata().GetName()}, withEditor(editor))
 	require.Error(t, err)
 	require.True(t, trace.IsCompareFailed(err))
+}
+
+func testEditMultipleWithSubKind(t *testing.T, clt *authclient.Client) {
+	t.Parallel()
+
+	overwriteFile := func(f *os.File, valsYAML [][]byte) error {
+		if err := f.Truncate(0); err != nil {
+			return fmt.Errorf("truncate: %w", err)
+		}
+		if _, err := f.Seek(0, 0); err != nil {
+			return fmt.Errorf("seek to zero: %w", err)
+		}
+
+		for i, val := range valsYAML {
+			if i > 0 {
+				if _, err := f.WriteString("---\n"); err != nil {
+					return fmt.Errorf("write: %w", err)
+				}
+			}
+			if _, err := f.Write(val); err != nil {
+				return fmt.Errorf("write: %w", err)
+			}
+			if !bytes.HasSuffix(val, []byte("\n")) {
+				if _, err := f.WriteString("\n"); err != nil {
+					return fmt.Errorf("write: %w", err)
+				}
+			}
+		}
+
+		return nil
+	}
+
+	// Test add/remove detection when the number of resources stays the same.
+	t.Run("add/remove", func(t *testing.T) {
+		t.Parallel()
+
+		cn, err := clt.GetClusterName(t.Context())
+		require.NoError(t, err, "read cluster name")
+
+		const loadKeys = false
+		winCA, err := clt.GetCertAuthority(t.Context(), types.CertAuthID{
+			Type:       types.WindowsCA,
+			DomainName: cn.GetClusterName(),
+		}, loadKeys)
+		require.NoError(t, err, "read Windows CA")
+
+		winJSON, err := services.MarshalCertAuthority(winCA)
+		require.NoError(t, err, "marshal Windows CA")
+		winYAML, err := yaml.JSONToYAML(winJSON)
+		require.NoError(t, err, "convert JSON to YAML")
+
+		editor := func(name string) error {
+			// Replace the editor file contents with the Windows CA.
+			return os.WriteFile(name, winYAML, 0644)
+		}
+
+		// Edit cas/host, then replace it with cas/windows.
+		_, err = runEditCommand(t, clt, []string{"edit", "cas/host"}, withEditor(editor))
+		assert.ErrorContains(t, err, "was added or removed", "tctl edit error mismatch")
+	})
+
+	// Test replacing one of the resources with a duplicate of another.
+	t.Run("duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		editor := func(name string) error {
+			f, err := os.OpenFile(name, os.O_RDWR, 0644)
+			if err != nil {
+				return fmt.Errorf("read editor file: %w", err)
+			}
+			defer f.Close()
+
+			// Read CA YAMLs.
+			dec := kyaml.NewYAMLOrJSONDecoder(f, defaults.LookaheadBufSize)
+			var casYAML [][]byte
+			for {
+				var raw services.UnknownResource
+				if err := dec.Decode(&raw); errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					return fmt.Errorf("decode raw resource: %w", err)
+				}
+				casYAML = append(casYAML, raw.Raw)
+			}
+
+			// Replace an item with a duplicate.
+			casYAML[0] = casYAML[1]
+
+			// Overwrite.
+			if err := overwriteFile(f, casYAML); err != nil {
+				return fmt.Errorf("write editor file: %w", err)
+			}
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("close editor file: %w", err)
+			}
+
+			return nil
+		}
+
+		// Edit all CAs, then replace one of them with a duplicate.
+		_, err := runEditCommand(t, clt, []string{"edit", "cas"}, withEditor(editor))
+		assert.ErrorContains(t, err, "duplicate kind/sub_kind/name", "tctl edit error mismatch")
+	})
+
+	t.Run("edit", func(t *testing.T) {
+		t.Parallel()
+
+		const caType1 = types.HostCA
+		const caType2 = types.WindowsCA
+
+		getCAs := func(t *testing.T) (_, _ types.CertAuthority) {
+			ctx := t.Context()
+			const loadKeys = false
+
+			cas1, err := clt.GetCertAuthorities(ctx, caType1, loadKeys)
+			require.NoError(t, err, "CA not found: %s", caType1)
+			require.Len(t, cas1, 1)
+
+			cas2, err := clt.GetCertAuthorities(ctx, caType2, loadKeys)
+			require.NoError(t, err, "CA not found: %s", caType2)
+			require.Len(t, cas2, 1)
+
+			return cas1[0], cas2[0]
+		}
+
+		// Prepare wanted CAs.
+		ca1, ca2 := getCAs(t)
+		md := ca1.GetMetadata()
+		md.Description = "description 1"
+		ca1.SetMetadata(md)
+		md = ca2.GetMetadata()
+		md.Description = "description 2"
+		ca2.SetMetadata(md)
+
+		editor := func(name string) error {
+			f, err := os.OpenFile(name, os.O_RDWR, 0644)
+			if err != nil {
+				return fmt.Errorf("read editor file: %w", err)
+			}
+			defer f.Close()
+
+			// Parse/edit CAs.
+			dec := kyaml.NewYAMLOrJSONDecoder(f, defaults.LookaheadBufSize)
+			var casYAML [][]byte
+			editCount := 0
+			for {
+				var raw services.UnknownResource
+				if err := dec.Decode(&raw); errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					return fmt.Errorf("decode raw resource: %w", err)
+				}
+				ca, err := services.UnmarshalCertAuthority(raw.Raw)
+				if err != nil {
+					return fmt.Errorf("unmarshal CA resource: %w", err)
+				}
+
+				switch ca.GetType() {
+				case ca1.GetType():
+					ca.SetMetadata(ca1.GetMetadata())
+					editCount++
+				case ca2.GetType():
+					ca.SetMetadata(ca2.GetMetadata())
+					editCount++
+				default:
+					// Don't change non-edited YAMLs.
+					casYAML = append(casYAML, raw.Raw)
+					continue
+				}
+
+				caJSON, err := services.MarshalCertAuthority(ca)
+				if err != nil {
+					return fmt.Errorf("marshal CA: %w", err)
+				}
+				caYAML, err := yaml.JSONToYAML(caJSON)
+				if err != nil {
+					return fmt.Errorf("convert JSON to YAML: %w", err)
+				}
+				casYAML = append(casYAML, caYAML)
+			}
+
+			const wantEdits = 2
+			if wantEdits != editCount {
+				return fmt.Errorf("edit count mismatch (want %d, got %d)", wantEdits, editCount)
+			}
+
+			// Write edited CAs.
+			if err := overwriteFile(f, casYAML); err != nil {
+				return fmt.Errorf("write editor file: %w", err)
+			}
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("close editor file: %w", err)
+			}
+
+			return nil
+		}
+
+		_, err := runEditCommand(t, clt, []string{"edit", "cas"}, withEditor(editor))
+		require.NoError(t, err, "tctl edit errored")
+
+		// Verify CA updates.
+		gotCA1, gotCA2 := getCAs(t)
+		ca1.SetRevision(gotCA1.GetRevision())
+		ca2.SetRevision(gotCA2.GetRevision())
+		assert.Equal(t, ca1, gotCA1, "CA1 edit failed")
+		assert.Equal(t, ca2, gotCA2, "CA2 edit failed")
+	})
 }
 
 func TestMultipleRoles(t *testing.T) {

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -787,7 +787,7 @@ func testEditMultipleWithSubKind(t *testing.T, clt *authclient.Client) {
 
 	// Test add/remove detection when the number of resources stays the same.
 	t.Run("add/remove", func(t *testing.T) {
-		t.Parallel()
+		// Don't t.Parallel(), may edit resources on failure.
 
 		cn, err := clt.GetClusterName(t.Context())
 		require.NoError(t, err, "read cluster name")
@@ -816,7 +816,7 @@ func testEditMultipleWithSubKind(t *testing.T, clt *authclient.Client) {
 
 	// Test replacing one of the resources with a duplicate of another.
 	t.Run("duplicate", func(t *testing.T) {
-		t.Parallel()
+		// Don't t.Parallel(), may edit resources on failure.
 
 		editor := func(name string) error {
 			f, err := os.OpenFile(name, os.O_RDWR, 0644)
@@ -859,7 +859,7 @@ func testEditMultipleWithSubKind(t *testing.T, clt *authclient.Client) {
 	})
 
 	t.Run("edit", func(t *testing.T) {
-		t.Parallel()
+		// Don't t.Parallel(), edits resources.
 
 		const caType1 = types.HostCA
 		const caType2 = types.WindowsCA


### PR DESCRIPTION
Backport #65268 to branch/v18.

Changelog: Fix "tctl edit" bugs when editing multiple resources, or resources with sub_kinds (for example, CAs)

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan

### Test Environment

Any Teleport instance does it. There are plenty of CAs to edit.

### Test Cases
- [x] `tctl edit cas` allows editing multiple CAs (eg, add/modify the description)
- [x] `tctl edit cas` detects added entries
- [x] `tctl edit cas` detects removed entries
- [x] `tctl edit cas` detects replaced entries (number of entries is the same)