### PR TITLE
Web: Improve navigation stepper when it gets too long

### DIFF
--- a/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.tsx
+++ b/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.tsx
@@ -53,6 +53,7 @@ export function TextSelectCopyMulti({
 
   return (
     <Box
+      width="100%"
       bg="bgTerminal"
       pl={3}
       pt={2}

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
@@ -25,10 +25,11 @@ import { rotate360 } from 'design/keyframes';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 import { useValidation } from 'shared/components/Validation';
 
+import { CopyTerraformButton } from 'teleport/components/Terraform/CopyTerraformButton';
 import cfg from 'teleport/config';
 import { IntegrationKind } from 'teleport/services/integrations';
 
-import { CircleNumber, CopyTerraformButton } from '../Shared';
+import { CircleNumber } from '../Shared';
 
 type DeploymentMethodSectionProps = {
   terraformConfig?: string;

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
@@ -25,7 +25,7 @@ import { rotate360 } from 'design/keyframes';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 import { useValidation } from 'shared/components/Validation';
 
-import { CopyTerraformButton } from 'teleport/components/Terraform/CopyTerraformButton';
+import { TerraformCopyButton } from 'teleport/components/TerraformCopyButton';
 import cfg from 'teleport/config';
 import { IntegrationKind } from 'teleport/services/integrations';
 
@@ -87,7 +87,7 @@ export function DeploymentMethodSection({
             configuration.
           </Text>
           <Box>
-            <CopyTerraformButton
+            <TerraformCopyButton
               onClick={e => {
                 const isValid = validator.validate();
                 if (!isValid) {

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/InfoGuide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/InfoGuide.tsx
@@ -32,9 +32,9 @@ import { marginTransitionCss } from 'shared/components/SlidingSidePanel/InfoGuid
 import { useValidation } from 'shared/components/Validation';
 
 import { SlidingSidePanel } from 'teleport/components/SlidingSidePanel/SlidingSidePanel';
+import { CopyTerraformButton } from 'teleport/components/Terraform/CopyTerraformButton';
 import { zIndexMap } from 'teleport/Navigation/zIndexMap';
 
-import { CopyTerraformButton } from './common';
 import LiveTextEditor from './LiveTextEditor';
 
 export const PANEL_WIDTH = 500;

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/InfoGuide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/InfoGuide.tsx
@@ -32,7 +32,7 @@ import { marginTransitionCss } from 'shared/components/SlidingSidePanel/InfoGuid
 import { useValidation } from 'shared/components/Validation';
 
 import { SlidingSidePanel } from 'teleport/components/SlidingSidePanel/SlidingSidePanel';
-import { CopyTerraformButton } from 'teleport/components/Terraform/CopyTerraformButton';
+import { TerraformCopyButton } from 'teleport/components/TerraformCopyButton';
 import { zIndexMap } from 'teleport/Navigation/zIndexMap';
 
 import LiveTextEditor from './LiveTextEditor';
@@ -102,7 +102,7 @@ export function TerraformInfoGuide({
         data={[{ content: terraformConfig, type: 'terraform' }]}
       />
       <Box p={3}>
-        <CopyTerraformButton
+        <TerraformCopyButton
           onClick={e => {
             const isValid = validator.validate();
             if (!isValid) {

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/common.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/common.tsx
@@ -26,30 +26,6 @@ import { Check, Copy } from 'design/Icon';
 import cfg from 'teleport/config';
 import { IntegrationKind } from 'teleport/services/integrations';
 
-export function CopyTerraformButton({
-  onClick,
-}: {
-  onClick: (e: React.SyntheticEvent) => void;
-}) {
-  const [configCopied, setConfigCopied] = useState(false);
-
-  const handleClick = (e: React.SyntheticEvent) => {
-    onClick(e);
-
-    if (!e.defaultPrevented) {
-      setConfigCopied(true);
-      setTimeout(() => setConfigCopied(false), 1000);
-    }
-  };
-
-  return (
-    <Button fill="border" intent="primary" onClick={handleClick} gap={2}>
-      {configCopied ? <Check size="small" /> : <Copy size="small" />}
-      Copy Terraform Module
-    </Button>
-  );
-}
-
 type CheckIntegrationButtonProps = {
   integrationExists?: boolean;
   integrationName?: string;

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/common.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/common.tsx
@@ -16,12 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
 import { Link as InternalLink } from 'react-router';
 import styled from 'styled-components';
 
-import { Button, ButtonPrimary, Flex } from 'design';
-import { Check, Copy } from 'design/Icon';
+import { ButtonPrimary, Flex } from 'design';
 
 import cfg from 'teleport/config';
 import { IntegrationKind } from 'teleport/services/integrations';

--- a/web/packages/teleport/src/components/Terraform/CopyTerraformButton.tsx
+++ b/web/packages/teleport/src/components/Terraform/CopyTerraformButton.tsx
@@ -1,0 +1,54 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+
+import {  Button } from 'design';
+import { Check, Copy, } from 'design/Icon';
+
+export function CopyTerraformButton({
+  onClick,
+  disabled = false,
+}: {
+  onClick: (e: React.SyntheticEvent) => void;
+  disabled?: boolean;
+}) {
+  const [configCopied, setConfigCopied] = useState(false);
+
+  const handleClick = (e: React.SyntheticEvent) => {
+    onClick(e);
+
+    if (!e.defaultPrevented) {
+      setConfigCopied(true);
+      setTimeout(() => setConfigCopied(false), 1000);
+    }
+  };
+
+  return (
+    <Button
+      fill="border"
+      intent="primary"
+      onClick={handleClick}
+      gap={2}
+      disabled={disabled}
+    >
+      {configCopied ? <Check size="small" /> : <Copy size="small" />}
+      Copy Terraform Module
+    </Button>
+  );
+}

--- a/web/packages/teleport/src/components/TerraformCopyButton.tsx
+++ b/web/packages/teleport/src/components/TerraformCopyButton.tsx
@@ -16,21 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
+import { useState, MouseEvent } from 'react';
 
-import {  Button } from 'design';
-import { Check, Copy, } from 'design/Icon';
+import { Button } from 'design';
+import { Check, Copy } from 'design/Icon';
 
-export function CopyTerraformButton({
+export function TerraformCopyButton({
   onClick,
   disabled = false,
 }: {
-  onClick: (e: React.SyntheticEvent) => void;
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
 }) {
   const [configCopied, setConfigCopied] = useState(false);
 
-  const handleClick = (e: React.SyntheticEvent) => {
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     onClick(e);
 
     if (!e.defaultPrevented) {

--- a/web/packages/teleport/src/components/Wizard/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/Navigation.tsx
@@ -179,7 +179,7 @@ export function Navigation<T>({
       <Flex
         flex={1}
         minWidth={0}
-        css="overflow-x: auto; "
+        css="overflow-x: auto;"
         data-scrollbar="default"
       >
         <StepList views={views} currentStep={currentStep} />

--- a/web/packages/teleport/src/components/Wizard/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/Navigation.tsx
@@ -167,7 +167,7 @@ export function Navigation<T>({
   startWithIcon,
 }: NavigationProps<T>) {
   return (
-    <Flex>
+    <Flex minWidth={0} width="100%">
       {startWithIcon && (
         <StepsContainer>
           <StepTitle css={{ fontWeight: 'bold' }}>
@@ -176,7 +176,14 @@ export function Navigation<T>({
           </StepTitle>
         </StepsContainer>
       )}
-      <StepList views={views} currentStep={currentStep} />
+      <Flex
+        flex={1}
+        minWidth={0}
+        css="overflow-x: auto; "
+        data-scrollbar="default"
+      >
+        <StepList views={views} currentStep={currentStep} />
+      </Flex>
     </Flex>
   );
 }

--- a/web/packages/teleport/src/components/Wizard/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/Navigation.tsx
@@ -176,12 +176,7 @@ export function Navigation<T>({
           </StepTitle>
         </StepsContainer>
       )}
-      <Flex
-        flex={1}
-        minWidth={0}
-        css="overflow-x: auto;"
-        data-scrollbar="default"
-      >
+      <Flex flex={1} css="overflow-x: auto;">
         <StepList views={views} currentStep={currentStep} />
       </Flex>
     </Flex>

--- a/web/packages/teleport/src/components/Wizard/Navigation/Shared.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/Shared.tsx
@@ -22,6 +22,7 @@ export const StepTitle = styled.div`
   display: flex;
   align-items: center;
   font-size: ${p => p.theme.fontSizes[1]}px;
+  white-space: nowrap;
 `;
 
 export const StepsContainer = styled.div<{ active?: boolean }>`


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/8271

Improves navigation stepper by allowing horizontal scrolling instead of texts squeezing and elongating to make room 

Sneaks in:
- Pulled out CopyTerraformButton into own file to be used outside of where it lived
- TextSelectCopyMulti now expands to full width by default




<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

local

### Test Cases
- [x] CopyTerraformButton works as before
- [x] checked a few places with TextSelectCopyMulti
- [x] checked step navigation renders and when text overfills horizontal scrolling is possible

step nav demo:

https://github.com/user-attachments/assets/895be2f4-d707-4249-a645-049eb662f521

