### PR TITLE
[scopes] feat: add traces and metric to assignment materializer

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -796,6 +796,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		Reader:           cfg.ScopedAccess,
 		AccessListEvents: as.Cache,
 		AccessListReader: as.Cache,
+		Tracer:           cfg.Tracer,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -25,12 +25,17 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/prometheus/client_golang/prometheus"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
+	"github.com/gravitational/teleport"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+	"github.com/gravitational/teleport/lib/observability/tracing"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/cache/assignments"
 	"github.com/gravitational/teleport/lib/scopes/cache/roles"
@@ -46,10 +51,18 @@ type CacheConfig struct {
 
 	AccessListEvents types.Events
 	AccessListReader AccessListReader
+	Tracer           oteltrace.Tracer
 
 	MaxRetryPeriod    time.Duration
 	TTLCacheRetention time.Duration
 }
+
+var materializedAssignmentsMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: teleport.MetricNamespace,
+	Subsystem: "scoped_access_cache",
+	Name:      "materialized_assignments",
+	Help:      "Current number of materialized scoped role assignments tracked by the scoped access cache materializer.",
+})
 
 // CheckAndSetDefaults verifies required fields and sets default values as appropriate.
 func (c *CacheConfig) CheckAndSetDefaults() error {
@@ -75,6 +88,10 @@ func (c *CacheConfig) CheckAndSetDefaults() error {
 
 	if c.TTLCacheRetention <= 0 {
 		c.TTLCacheRetention = time.Second * 3
+	}
+
+	if c.Tracer == nil {
+		c.Tracer = tracing.NoopTracer("scoped_access_cache")
 	}
 
 	return nil
@@ -106,6 +123,9 @@ type Cache struct {
 // but performance may be suboptimal until watcher init has completed.
 func NewCache(cfg CacheConfig) (*Cache, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := metrics.RegisterPrometheusCollectors(materializedAssignmentsMetric); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -497,7 +517,7 @@ func (c *Cache) fetch(ctx context.Context) (state, *materializer, error) {
 		assignments: assignmentCache,
 	}
 
-	materializer := newMaterializer(c.cfg.AccessListReader)
+	materializer := newMaterializer(c.cfg.AccessListReader, c.cfg.Tracer)
 	if err := materializer.Init(ctx, s); err != nil {
 		return s, nil, trace.Wrap(err)
 	}

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -28,10 +28,13 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/gravitational/teleport"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -115,6 +118,7 @@ type materializer struct {
 	materializedAssignments map[materializedAssignmentKey]ancestorRelation
 
 	logger *slog.Logger
+	tracer oteltrace.Tracer
 
 	repairTimeMu                 sync.Mutex
 	repairEventC                 chan repairEvent
@@ -136,13 +140,14 @@ func (k materializedAssignmentKey) assignmentName() string {
 	return "acl-" + base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 }
 
-func newMaterializer(aclReader AccessListReader) *materializer {
+func newMaterializer(aclReader AccessListReader, tracer oteltrace.Tracer) *materializer {
 	now := time.Now()
 	return &materializer{
 		aclReader:                    aclReader,
 		ancestorCache:                newAncestorCache(),
 		materializedAssignments:      make(map[materializedAssignmentKey]ancestorRelation),
 		logger:                       slog.With(teleport.ComponentKey, "sra_materializer"),
+		tracer:                       tracer,
 		repairEventC:                 make(chan repairEvent),
 		wakeRepairLoop:               make(chan struct{}, 1),
 		nextExpiredMembersRepairTime: now.Add(century),
@@ -152,7 +157,11 @@ func newMaterializer(aclReader AccessListReader) *materializer {
 
 // Init materializes all necessary scoped role assignments into [state] based
 // on the current set of access list memberships.
-func (m *materializer) Init(ctx context.Context, state state) error {
+func (m *materializer) Init(ctx context.Context, state state) (err error) {
+	ctx, span := m.tracer.Start(ctx, "scoped_access_cache/materializer/init")
+	defer func() { tracing.EndSpan(span, err) }()
+	m.syncMaterializedAssignmentsMetric()
+
 	// First populate the ancestor cache with all list->list memberships and
 	// ownerships, it's critical for this to be up to date to process
 	// relationships and future changes. The ancestor cache should include even
@@ -175,6 +184,7 @@ func (m *materializer) Init(ctx context.Context, state state) error {
 		}
 	}
 	m.reportFutureMemberExpiry(ctx, nextExpiry)
+
 	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
 		if err != nil {
 			return trace.Wrap(err, "reading access lists")
@@ -204,7 +214,12 @@ func (m *materializer) Init(ctx context.Context, state state) error {
 
 // ProcessEvent is the entry point for all event-driven changes to materializer
 // state, driven by access list and access list member events.
-func (m *materializer) ProcessEvent(ctx context.Context, state state, event types.Event) error {
+func (m *materializer) ProcessEvent(ctx context.Context, state state, event types.Event) (err error) {
+	ctx, span := m.tracer.Start(ctx, "scoped_access_cache/materializer/process_event",
+		oteltrace.WithAttributes(materializerEventAttributes(event)...),
+	)
+	defer func() { tracing.EndSpan(span, err) }()
+
 	switch event.Type {
 	case types.OpPut:
 		switch item := event.Resource.(type) {
@@ -841,6 +856,7 @@ func (m *materializer) materializeAssignment(
 		return trace.Wrap(err, "putting materialized assignment into cache")
 	}
 	m.materializedAssignments[key] = relation
+	m.syncMaterializedAssignmentsMetric()
 	return nil
 }
 
@@ -851,8 +867,13 @@ func (m *materializer) deleteMaterializedAssignment(ctx context.Context, state s
 			"list", key.list)
 		state.assignments.Delete(key.assignmentName(), scopedaccess.SubKindMaterialized)
 		delete(m.materializedAssignments, key)
+		m.syncMaterializedAssignmentsMetric()
 
 	}
+}
+
+func (m *materializer) syncMaterializedAssignmentsMetric() {
+	materializedAssignmentsMetric.Set(float64(len(m.materializedAssignments)))
 }
 
 func (m *materializer) recheckAssignment(ctx context.Context, state state, key materializedAssignmentKey) error {
@@ -1387,6 +1408,11 @@ func (m *materializer) RepairEvents() <-chan repairEvent {
 // [materializer.RepairEvents]. It must not be called concurrently with
 // [materializer.ProcessEvent].
 func (m *materializer) ProcessRepairEvent(ctx context.Context, state state, event repairEvent) {
+	ctx, span := m.tracer.Start(ctx, "scoped_access_cache/materializer/process_repair_event",
+		oteltrace.WithAttributes(attribute.String("repair.type", event.String())),
+	)
+	defer span.End()
+
 	switch event {
 	case repairExpiredMembersEvent:
 		m.repairExpiredMembers(ctx, state)
@@ -1464,7 +1490,9 @@ func (m *materializer) repairExpiredMembers(ctx context.Context, state state) {
 	expiredMembersOf, nextExpiry := m.collectExpiredMembers(ctx)
 	m.reportFutureMemberExpiry(ctx, nextExpiry)
 
+	affected := 0
 	for key := range m.affectedAssignmentsForExpiredMembers(expiredMembersOf) {
+		affected++
 		if err := m.recheckAssignment(ctx, state, key); err != nil {
 			// Must pessimistically assume any assignment is invalid if we
 			// encountered an error trying to validate it.
@@ -1474,6 +1502,7 @@ func (m *materializer) repairExpiredMembers(ctx context.Context, state state) {
 			m.scheduleMissedMembersRepair(ctx)
 		}
 	}
+	oteltrace.SpanFromContext(ctx).SetAttributes(attribute.Int("assignments.affected", affected))
 }
 
 // collectExpiredMembers collects all expired access list members by parent
@@ -1488,6 +1517,7 @@ func (m *materializer) collectExpiredMembers(ctx context.Context) (expiredMember
 	nextExpiry = now.Add(century)
 
 	expiredMembersOf = make(map[string]expiredMembers)
+	expiredCount := 0
 
 	// Iterate all access list members to find any that are expired.
 	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
@@ -1520,7 +1550,9 @@ func (m *materializer) collectExpiredMembers(ctx context.Context) (expiredMember
 		knownExpiredMembers := expiredMembersOf[member.Spec.AccessList]
 		knownExpiredMembers.insert(member)
 		expiredMembersOf[member.Spec.AccessList] = knownExpiredMembers
+		expiredCount++
 	}
+	oteltrace.SpanFromContext(ctx).SetAttributes(attribute.Int("members.expired", expiredCount))
 
 	return expiredMembersOf, nextExpiry
 }
@@ -1626,16 +1658,20 @@ func (m *materializer) repairMissedMembers(ctx context.Context, state state) {
 
 	// Iterate all access lists to additively materialize assignments for all
 	// their members and owners.
+	repairedLists := 0
 	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
 		if err != nil {
 			m.logger.InfoContext(ctx, "Missed membership repair failed to read all access lists, scheduling another repair",
 				"error", err)
+			oteltrace.SpanFromContext(ctx).RecordError(err)
 			m.scheduleMissedMembersRepair(ctx)
 			return
 		}
+		repairedLists++
 		m.initAccessListMembers(ctx, state, list)
 		m.initAccessListOwners(ctx, state, list)
 	}
+	oteltrace.SpanFromContext(ctx).SetAttributes(attribute.Int("lists.repaired", repairedLists))
 }
 
 func hasMemberGrants(list *accesslist.AccessList) bool {
@@ -1652,4 +1688,29 @@ func hasMembershipRequires(list *accesslist.AccessList) bool {
 
 func hasOwnershipRequires(list *accesslist.AccessList) bool {
 	return !list.Spec.OwnershipRequires.IsEmpty()
+}
+
+func materializerEventAttributes(event types.Event) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String("event.type", event.Type.String()),
+	}
+	if event.Resource == nil {
+		return attrs
+	}
+	attrs = append(attrs,
+		attribute.String("resource.kind", event.Resource.GetKind()),
+		attribute.String("resource.name", event.Resource.GetName()),
+	)
+	return attrs
+}
+
+func (e repairEvent) String() string {
+	switch e {
+	case repairExpiredMembersEvent:
+		return "expired_members"
+	case repairMissedMembersEvent:
+		return "missed_members"
+	default:
+		return "unknown"
+	}
 }

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	cachepkg "github.com/gravitational/teleport/lib/cache"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/observability/tracing"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/cache/assignments"
 	"github.com/gravitational/teleport/lib/scopes/utils"
@@ -1223,7 +1224,7 @@ initializing acl cache: %v`, t1.Sub(t0), t2.Sub(t1), t3.Sub(t2))
 				// for each benchmark loop.
 				for b.Loop() {
 					state.assignments = assignments.NewAssignmentCache(assignments.AssignmentCacheConfig{})
-					materializer := newMaterializer(aclCache)
+					materializer := newMaterializer(aclCache, tracing.NoopTracer("test"))
 					require.NoError(b, materializer.Init(b.Context(), state))
 				}
 			})


### PR DESCRIPTION
This PR adds spans for materializer init and event processing. It also adds a prometheus guage for the current number of materialized assignments. As planned in RFD 243 https://github.com/gravitational/teleport/blob/master/rfd/0243-scoped-roles-in-access-lists.md#observability

## Manual Test Plan
### Test Environment

Run Jaeger in a local docker container

```
docker run --rm -it   -p 16686:16686   -p 4317:4317   -e COLLECTOR_OTLP_ENABLED=true   jaegertracing/all-in-one:latest
```

Configure auth service to export traces to jaeger

```
tracing_service:
  enabled: yes
  exporter_url: "grpc:127.0.0.1:4317"
  sampling_rate_per_million: 1000000
```

- Local cluster running this branch with `TELEPORT_UNSTABLE_SCOPES=yes`

#### Setup scoped roles

```bash
cat >./test-scoped-roles.yaml <<EOF
kind: scoped_role
version: v1
metadata:
  name: test-role
scope: /
spec:
  assignable_scopes:
    - /test/**
  allow:
    logins: ["tester"]
    node_labels:
      - name: "*"
        values: ["*"]
EOF

tctl create ./test-scoped-roles.yaml
```

#### Setup access list

```bash
cat >./test-access-list.yaml <<EOF
kind: access_list
version: v1
metadata:
  name: test-list
spec:
  title: test-list
  owners:
    - name: owner@example.com
      membership_kind: MEMBERSHIP_KIND_USER
  grants:
    scoped_roles:
      - role: test-role
        scope: /test/test
EOF

tctl create ./test-access-list.yaml
```

### Test Cases
- [x] Open the jaeger UI at http://localhost:16686/
- [x] On startup there is a span for materializer init
- [x] Add a member to test-list `tctl acl users add test-list tester`
- [x] There is a span for even handling
- [x] Open `tctl top`
- [x] Under "Raw Metrics" there is a guage for `teleport_scoped_access_cache_materialized_assignments`
