### PR TITLE
Adds support for `tsh kube login` while using scoped identities

### DIFF
--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -87,6 +87,8 @@ type KubeCluster interface {
 	SetStatus(*KubernetesClusterStatus)
 	// GetScope gets the scope of the kube cluster.
 	GetScope() string
+	// SetScope sets the scope of the kube cluster.
+	SetScope(string)
 }
 
 // DiscoveredEKSCluster represents a server discovered by EKS discovery fetchers.
@@ -370,6 +372,15 @@ func (k *KubernetesClusterV3) GetScope() string {
 	}
 
 	return k.Scope
+}
+
+// SetScope sets the scope of the kube cluster.
+func (k *KubernetesClusterV3) SetScope(scope string) {
+	if k == nil {
+		return
+	}
+
+	k.Scope = scope
 }
 
 // MatchSearch goes through select field values and tries to

--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -363,7 +363,7 @@ func (k *KubernetesClusterV3) SetStatus(status *KubernetesClusterStatus) {
 	k.Status = status
 }
 
-// GetScope returns the scope of the kube cluster.
+// GetScope gets the scope of the kube cluster.
 func (k *KubernetesClusterV3) GetScope() string {
 	if k == nil {
 		return ""

--- a/api/types/kubernetes_server.go
+++ b/api/types/kubernetes_server.go
@@ -232,6 +232,10 @@ func (s *KubernetesServerV3) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing kube server Cluster")
 	}
 
+	if s.Scope != "" {
+		s.Spec.Cluster.SetScope(s.Scope)
+	}
+
 	if err := s.Spec.Cluster.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -140,6 +140,13 @@ type ResourceWithLabels interface {
 	MatchSearch(searchValues []string) bool
 }
 
+// ScopedResourceWithLabels is a common interface for scoped resources that have labels.
+type ScopedResourceWithLabels interface {
+	ResourceWithLabels
+	// GetScope returns the resource's scope.
+	GetScope() string
+}
+
 // EnrichedResource is a [ResourceWithLabels] wrapped with
 // additional user-specific information.
 type EnrichedResource struct {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3828,21 +3828,21 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 	}
 
 	var (
-		kubeGroups, kubeUsers []string
-		dbNames, dbUsers      []string
-		roleARNs              []string
-		azureIdentities       []string
-		gcpAccounts           []string
+		dbNames, dbUsers []string
+		roleARNs         []string
+		azureIdentities  []string
+		gcpAccounts      []string
 	)
+
+	kubeGroups, kubeUsers, err := certParams.GetKubeGroupsAndUsersForTTL(ctx, sessionTTL, req.OverrideRoleTTL)
+	// NotFound errors are acceptable - this user may have no k8s access
+	// granted and that shouldn't prevent us from issuing a TLS cert.
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
 
 	// only unscoped identities currently support kube groups/users.
 	if unscoped := certParams.UnscopedCertParams(); unscoped != nil {
-		kubeGroups, kubeUsers, err = unscoped.CheckKubeGroupsAndUsers(sessionTTL, req.OverrideRoleTTL)
-		// NotFound errors are acceptable - this user may have no k8s access
-		// granted and that shouldn't prevent us from issuing a TLS cert.
-		if err != nil && !trace.IsNotFound(err) {
-			return nil, trace.Wrap(err)
-		}
 
 		// See which database names and users this user is allowed to use.
 		dbNames, dbUsers, err = unscoped.CheckDatabaseNamesAndUsers(sessionTTL, req.OverrideRoleTTL)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3841,7 +3841,6 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 		return nil, trace.Wrap(err)
 	}
 
-	// only unscoped identities currently support kube groups/users.
 	if unscoped := certParams.UnscopedCertParams(); unscoped != nil {
 
 		// See which database names and users this user is allowed to use.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3678,227 +3678,7 @@ func getBotName(user services.UserState) string {
 	return ""
 }
 
-func (a *ServerWithRoles) generateScopedUserCerts(ctx context.Context, req proto.UserCertsRequest, opts ...certRequestOption) (*proto.Certs, error) {
-	// Device trust: authorize device before issuing certificates.
-	readOnlyAuthPref, err := a.authServer.GetReadOnlyAuthPreference(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := a.verifyUserDeviceForCertIssuance(ctx, req.Usage, readOnlyAuthPref.GetDeviceTrust()); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// scoped identities don't support impersonation
-	if req.Username != a.scopedContext.User.GetName() {
-		return nil, trace.AccessDenied("access denied: impersonation is not allowed")
-	}
-
-	identity := a.scopedContext.Identity.GetIdentity()
-	if identity.DisallowReissue {
-		return nil, trace.AccessDenied("access denied: identity is not allowed to reissue certificates")
-	}
-
-	// Extract the user and role set for whom the certificate will be generated.
-	// This should be safe since this is typically done against a local user.
-	//
-	// This call bypasses RBAC check for users read on purpose.
-	// Users who are allowed to impersonate other users might not have
-	// permissions to read user data.
-	user, err := a.authServer.GetUser(ctx, req.Username, false)
-	if err != nil {
-		a.authServer.logger.DebugContext(ctx, "Could not impersonate user, the user could not be fetched from local store",
-			"error", err,
-			"user", req.Username,
-		)
-		return nil, trace.AccessDenied("access denied")
-	}
-
-	// Note that user and their login states can be out of sync in the backend.
-	// For example, GitHub identities obtained from GitHub proxy OAuth flow are
-	// preserved in user login state, where local users may get updated roles
-	// from ConnectMyComputer setup. So here we retrieve additional fields from
-	// user login state. Ideally we should solve this some other way.
-	if githubIdentities := user.GetGithubIdentities(); len(githubIdentities) == 0 {
-		uls, err := a.authServer.Services.GetUserLoginState(ctx, user.GetName())
-		if trace.IsNotFound(err) {
-			// Nothing to do.
-		} else if err != nil {
-			return nil, trace.Wrap(err, "updating GitHub identities")
-		} else if githubIdentities := uls.GetGithubIdentities(); len(githubIdentities) > 0 {
-			user.SetGithubIdentities(githubIdentities)
-		}
-	}
-
-	sessionExpires := identity.Expires
-	if sessionExpires.IsZero() {
-		a.authServer.logger.WarnContext(ctx, "Denied cert issuance for identity with no expiry",
-			"identity", identity.Username,
-		)
-		return nil, trace.AccessDenied("access denied")
-	}
-	if req.Expires.Before(a.authServer.GetClock().Now()) {
-		return nil, trace.Wrap(client.ErrClientCredentialsHaveExpired)
-	}
-
-	if identity.Renewable {
-		// Bot self-renewal or role impersonation can request certs with an
-		// expiry up to the global maximum allowed value.
-		if maxTime := a.authServer.GetClock().Now().Add(defaults.MaxRenewableCertTTL); req.Expires.After(maxTime) {
-			req.Expires = maxTime
-		}
-	} else if !isCertWrittenToDiskFlow(&req) {
-		// If requested certificate is for a flow that does not involve writing the certificate to disk
-		// (e.g. tsh proxy of DB, Kube, App, and AWS App Access using credential process)
-		// it is limited by max session ttl or mfa_verification_interval or req.Expires.
-
-		// Calculate the expiration time.
-		roleSet, err := services.FetchRoles(user.GetRoles(), a, user.GetTraits())
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		// [roleSet.AdjustMFAVerificationInterval] will reduce the adjusted sessionTTL if any of the roles requires
-		// MFA tap and `mfa_verification_interval` is set and lower than [roleSet.AdjustSessionTTL].
-		sessionTTL := roleSet.AdjustMFAVerificationInterval(
-			roleSet.AdjustSessionTTL(readOnlyAuthPref.GetDefaultSessionTTL().Duration()),
-			readOnlyAuthPref.GetRequireMFAType().IsSessionMFARequired())
-		adjustedSessionExpires := a.authServer.GetClock().Now().UTC().Add(sessionTTL)
-		if req.Expires.After(adjustedSessionExpires) {
-			req.Expires = adjustedSessionExpires
-		}
-	} else if req.Expires.After(sessionExpires) {
-		// Standard user impersonation has an expiry limited to the expiry
-		// of the current session. This prevents a user renewing their
-		// own certificates indefinitely to avoid re-authenticating.
-		req.Expires = sessionExpires
-	}
-
-	// we're going to extend the roles list based on the access requests, so we
-	// ensure that all the current requests are added to the new certificate
-	// (and are checked again)
-	req.AccessRequests = append(req.AccessRequests, a.scopedContext.Identity.GetIdentity().ActiveRequests...)
-	if req.Username != a.scopedContext.User.GetName() && len(req.AccessRequests) > 0 {
-		return nil, trace.AccessDenied("user %q requested cert for %q and included access requests, this is not supported.", a.scopedContext.User.GetName(), req.Username)
-	}
-
-	accessInfo, err := a.desiredAccessInfo(ctx, &req, user)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Generate certificate, note that the roles TTL will be ignored because
-	// the request is coming from "tctl auth sign" itself.
-	certReq := cert.Request{
-		User:                             user,
-		TTL:                              req.Expires.Sub(a.authServer.GetClock().Now()),
-		Compatibility:                    req.Format,
-		SSHPublicKey:                     req.SSHPublicKey,
-		TLSPublicKey:                     req.TLSPublicKey,
-		SSHPublicKeyAttestationStatement: hardwarekey.AttestationStatementFromProto(req.SSHPublicKeyAttestationStatement),
-		TLSPublicKeyAttestationStatement: hardwarekey.AttestationStatementFromProto(req.TLSPublicKeyAttestationStatement),
-		OverrideRoleTTL:                  a.hasBuiltinRole(types.RoleAdmin),
-		RouteToCluster:                   req.RouteToCluster,
-		RequesterName:                    req.RequesterName,
-		KubernetesCluster:                req.KubernetesCluster,
-		DBService:                        req.RouteToDatabase.ServiceName,
-		DBProtocol:                       req.RouteToDatabase.Protocol,
-		DBUser:                           req.RouteToDatabase.Username,
-		DBName:                           req.RouteToDatabase.Database,
-		DBRoles:                          req.RouteToDatabase.Roles,
-		AppName:                          req.RouteToApp.Name,
-		AppPublicAddr:                    req.RouteToApp.PublicAddr,
-		AppURI:                           req.RouteToApp.URI,
-		AppTargetPort:                    int(req.RouteToApp.TargetPort),
-		AppClusterName:                   req.RouteToApp.ClusterName,
-		AWSRoleARN:                       req.RouteToApp.AWSRoleARN,
-		AzureIdentity:                    req.RouteToApp.AzureIdentity,
-		GCPServiceAccount:                req.RouteToApp.GCPServiceAccount,
-		CheckerContext:                   a.scopedContext.CheckerContext, // TODO(fspmarshall/scopes): add scoping support to generateUserCerts.
-		// Copy IP from current identity to the generated certificate, if present,
-		// to avoid generateUserCerts() being used to drop IP pinning in the new certificates.
-		LoginIP:                a.scopedContext.Identity.GetIdentity().LoginIP,
-		Traits:                 accessInfo.Traits,
-		ActiveRequests:         req.AccessRequests,
-		ConnectionDiagnosticID: req.ConnectionDiagnosticID,
-		BotName:                getBotName(user),
-
-		// Always pass through a bot instance ID if available. Legacy bots
-		// joining without an instance ID may have one generated when
-		// `updateBotInstance()` is called below, and this (empty) value will be
-		// overridden.
-		BotInstanceID: a.scopedContext.Identity.GetIdentity().BotInstanceID,
-		JoinToken:     a.scopedContext.Identity.GetIdentity().JoinToken,
-		// Propagate any join attributes from the current identity to the new
-		// identity.
-		JoinAttributes: a.scopedContext.Identity.GetIdentity().JoinAttributes,
-	}
-
-	switch req.Usage {
-	case proto.UserCertsRequest_Database:
-		certReq.Usage = []string{teleport.UsageDatabaseOnly}
-	case proto.UserCertsRequest_App:
-		certReq.Usage = []string{teleport.UsageAppsOnly}
-	case proto.UserCertsRequest_Kubernetes:
-		certReq.Usage = []string{teleport.UsageKubeOnly}
-	case proto.UserCertsRequest_SSH:
-		// SSH certs are ssh-only by definition, certReq.usage only applies to
-		// TLS certs.
-	case proto.UserCertsRequest_All:
-		// Unrestricted usage.
-	case proto.UserCertsRequest_WindowsDesktop:
-		// Desktop certs.
-		certReq.Usage = []string{teleport.UsageWindowsDesktopOnly}
-	default:
-		return nil, trace.BadParameter("unsupported cert usage %q", req.Usage)
-	}
-	for _, o := range opts {
-		o(&certReq)
-	}
-
-	// If the user is renewing a renewable cert, make sure the renewable flag
-	// remains for subsequent requests of the primary certificate. The
-	// renewable flag should never be carried over for impersonation, role
-	// requests, or when the disallow-reissue flag has already been set.
-	if a.scopedContext.Identity.GetIdentity().Renewable &&
-		req.Username == a.scopedContext.User.GetName() &&
-		!isRoleImpersonation(req) &&
-		!certReq.DisallowReissue {
-		certReq.Renewable = true
-	}
-
-	// If the cert is renewable, process any bot instance updates (generation
-	// counter, auth records, etc). `updateBotInstance()` may modify certain
-	// `certReq` attributes (generation, botInstanceID).
-	if certReq.Renewable {
-		currentIdentityGeneration := a.scopedContext.Identity.GetIdentity().Generation
-
-		// If we're handling a renewal for a bot, we want to return the
-		// Host CAs as well as the User CAs.
-		if certReq.BotName != "" {
-			certReq.IncludeHostCA = true
-		}
-
-		// Update the bot instance based on this authentication. This may create
-		// a new bot instance record if the identity is missing an instance ID.
-		if err := a.authServer.updateBotInstance(
-			ctx, &certReq, user.GetName(), certReq.BotName,
-			certReq.BotInstanceID, nil, int32(currentIdentityGeneration),
-		); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
-	certs, err := a.authServer.generateUserCert(ctx, certReq)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return certs, nil
-}
-
 func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserCertsRequest, opts ...certRequestOption) (*proto.Certs, error) {
-	if a.scopedContext != nil {
-		return a.generateScopedUserCerts(ctx, req, opts...)
-	}
 	// Device trust: authorize device before issuing certificates.
 	readOnlyAuthPref, err := a.authServer.GetReadOnlyAuthPreference(ctx)
 	if err != nil {
@@ -3924,13 +3704,19 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		verifiedMFADeviceID = mfaData.Device.Id
 	}
 
+	unscopedCtx, isUnscoped := a.scopedContext.UnscopedContext()
+
+	hasAdminRole := isUnscoped && authz.HasBuiltinRole(*unscopedCtx, string(types.RoleAdmin))
+	// only unscoped identities can impersonate
+	canImpersonate := isUnscoped && (hasAdminRole || unscopedCtx.Checker.CanImpersonateSomeone())
+
 	// this prevents clients who have no chance at getting a cert and impersonating anyone
 	// from enumerating local users and hitting database
-	if !a.hasBuiltinRole(types.RoleAdmin) && !a.context.Checker.CanImpersonateSomeone() && req.Username != a.context.User.GetName() {
+	if !canImpersonate && req.Username != a.getUser().GetName() {
 		return nil, trace.AccessDenied("access denied: impersonation is not allowed")
 	}
 
-	if a.context.Identity.GetIdentity().DisallowReissue {
+	if a.getIdentity().DisallowReissue {
 		return nil, trace.AccessDenied("access denied: identity is not allowed to reissue certificates")
 	}
 
@@ -3949,7 +3735,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	// and `ci`, however these impersonated identities, Alice(access) and
 	// Alice(ci), should not be able to issue any new certificates.
 	//
-	if a.context.Identity != nil && a.context.Identity.GetIdentity().Impersonator != "" {
+	if a.getIdentity().Impersonator != "" {
 		if len(req.AccessRequests) > 0 {
 			return nil, trace.AccessDenied("access denied: impersonated user can not request new roles")
 		}
@@ -3958,7 +3744,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 			// impersonation, to reduce the risk of privilege escalation.
 			return nil, trace.AccessDenied("access denied: impersonated roles can not request other roles")
 		}
-		if req.Username != a.context.User.GetName() {
+		if req.Username != a.getUser().GetName() {
 			return nil, trace.AccessDenied("access denied: impersonated user can not impersonate anyone else")
 		}
 	}
@@ -3995,9 +3781,9 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	}
 
 	// Do not allow SSO users to be impersonated.
-	if req.Username != a.context.User.GetName() && user.GetUserType() == types.UserTypeSSO {
+	if req.Username != a.getUser().GetName() && user.GetUserType() == types.UserTypeSSO {
 		a.authServer.logger.WarnContext(ctx, "User tried to issue a cert for externally managed user",
-			"user", a.context.User.GetName(),
+			"user", a.getUser().GetName(),
 			"external_user", req.Username,
 		)
 		return nil, trace.AccessDenied("access denied")
@@ -4005,8 +3791,8 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 
 	// For users renewing certificates limit the TTL to the duration of the session, to prevent
 	// users renewing certificates forever.
-	if req.Username == a.context.User.GetName() {
-		identity := a.context.Identity.GetIdentity()
+	if req.Username == a.getUser().GetName() {
+		identity := a.getIdentity()
 		sessionExpires := identity.Expires
 		if sessionExpires.IsZero() {
 			a.authServer.logger.WarnContext(ctx, "Denied cert issuance for identity with no expiry",
@@ -4024,10 +3810,13 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 			if maxTime := a.authServer.GetClock().Now().Add(defaults.MaxRenewableCertTTL); req.Expires.After(maxTime) {
 				req.Expires = maxTime
 			}
-		} else if !isCertWrittenToDiskFlow(&req) {
+		} else if !isCertWrittenToDiskFlow(&req) && isUnscoped {
 			// If requested certificate is for a flow that does not involve writing the certificate to disk
 			// (e.g. tsh proxy of DB, Kube, App, and AWS App Access using credential process)
 			// it is limited by max session ttl or mfa_verification_interval or req.Expires.
+			//
+			// Because we can't know the specific scoped role that will grant access at the time of cert generation,
+			// we skip this for scoped identities.
 
 			// Calculate the expiration time.
 			roleSet, err := services.FetchRoles(user.GetRoles(), a, user.GetTraits())
@@ -4052,10 +3841,11 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	}
 
 	// If the user is not a user cert renewal (impersonation, etc.), this is an
-	// admin action and requires MFA.
-	if req.Username != a.context.User.GetName() {
+	// admin action and requires MFA. We would have returned already if this was
+	// a scoped identity, so we can assume unscopedCtx.
+	if req.Username != a.getUser().GetName() {
 		// Admin action MFA is not used to create mfa verified certs.
-		if err := a.context.AuthorizeAdminAction(); err != nil {
+		if err := unscopedCtx.AuthorizeAdminAction(); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -4063,9 +3853,9 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	// we're going to extend the roles list based on the access requests, so we
 	// ensure that all the current requests are added to the new certificate
 	// (and are checked again)
-	req.AccessRequests = append(req.AccessRequests, a.context.Identity.GetIdentity().ActiveRequests...)
-	if req.Username != a.context.User.GetName() && len(req.AccessRequests) > 0 {
-		return nil, trace.AccessDenied("user %q requested cert for %q and included access requests, this is not supported.", a.context.User.GetName(), req.Username)
+	req.AccessRequests = append(req.AccessRequests, a.getIdentity().ActiveRequests...)
+	if req.Username != a.getUser().GetName() && len(req.AccessRequests) > 0 {
+		return nil, trace.AccessDenied("user %q requested cert for %q and included access requests, this is not supported.", a.getUser().GetName(), req.Username)
 	}
 
 	accessInfo, err := a.desiredAccessInfo(ctx, &req, user)
@@ -4086,10 +3876,14 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	checker := services.NewAccessCheckerWithRoleSet(accessInfo, clusterName.GetClusterName(), roleSet)
 
 	switch {
-	case a.hasBuiltinRole(types.RoleAdmin):
+	case !isUnscoped:
+		// scoped identities do not support impersonation, so we would have
+		// already returned an error at this point if this were an impersonation
+		break
+	case authz.HasBuiltinRole(*unscopedCtx, string(types.RoleAdmin)):
 		// builtin admins can impersonate anyone
 		// this is required for local tctl commands to work
-	case req.Username == a.context.User.GetName():
+	case req.Username == a.getUser().GetName():
 		// users can impersonate themselves, but role impersonation requests
 		// must be checked.
 		if isRoleImpersonation(req) {
@@ -4098,13 +3892,13 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 			// to the current identity. If not explicitly denied (as above),
 			// this could allow a role-impersonated certificate to request new
 			// certificates with alternate RoleRequests.
-			err = a.context.Checker.CheckImpersonateRoles(a.context.User, parsedRoles)
+			err = unscopedCtx.Checker.CheckImpersonateRoles(a.getUser(), parsedRoles)
 			if err != nil {
 				a.authServer.logger.WarnContext(ctx, "user request for role impersonation denied",
-					"user", a.context.User.GetName(),
+					"user", a.getUser().GetName(),
 					"error", err,
 				)
-				err := trace.AccessDenied("user %q has requested role impersonation for %q", a.context.User.GetName(), accessInfo.Roles)
+				err := trace.AccessDenied("user %q has requested role impersonation for %q", a.getUser().GetName(), accessInfo.Roles)
 				if err := a.authServer.emitter.EmitAuditEvent(a.CloseContext(), &apievents.UserLogin{
 					Metadata: apievents.Metadata{
 						Type: events.UserLoginEvent,
@@ -4124,17 +3918,17 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		}
 	default:
 		// check if this user is allowed to impersonate other users
-		err = a.context.Checker.CheckImpersonate(a.context.User, user, parsedRoles)
+		err = unscopedCtx.Checker.CheckImpersonate(a.getUser(), user, parsedRoles)
 		// adjust session TTL based on the impersonated role set limit
 		ttl := req.Expires.Sub(a.authServer.GetClock().Now())
 		ttl = checker.AdjustSessionTTL(ttl)
 		req.Expires = a.authServer.GetClock().Now().Add(ttl)
 		if err != nil {
 			a.authServer.logger.WarnContext(ctx, "user request for user impersonation denied",
-				"user", a.context.User.GetName(),
+				"user", a.getUser().GetName(),
 				"error", err,
 			)
-			err := trace.AccessDenied("user %q has requested to generate certs for %q.", a.context.User.GetName(), accessInfo.Roles)
+			err := trace.AccessDenied("user %q has requested to generate certs for %q.", a.getUser().GetName(), accessInfo.Roles)
 			if err := a.authServer.emitter.EmitAuditEvent(a.CloseContext(), &apievents.UserLogin{
 				Metadata: apievents.Metadata{
 					Type: events.UserLoginEvent,
@@ -4156,6 +3950,9 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	if req.Usage == proto.UserCertsRequest_AccessGraphAPI {
 		if !a.authServer.modules.Features().GetEntitlement(entitlements.Policy).Enabled {
 			return nil, trace.AccessDenied("access graph requires a Teleport Policy license")
+		}
+		if !isUnscoped {
+			return nil, trace.AccessDenied("access graph is not supported for scoped identities")
 		}
 		user, err := types.NewUser(req.Username)
 		if err != nil {
@@ -4180,7 +3977,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		ws, err := a.authServer.CreateAppSessionFromReq(ctx, NewAppSessionRequest{
 			NewWebSessionRequest: NewWebSessionRequest{
 				User:           req.Username,
-				LoginIP:        a.context.Identity.GetIdentity().LoginIP,
+				LoginIP:        a.getIdentity().LoginIP,
 				SessionTTL:     req.Expires.Sub(a.authServer.GetClock().Now()),
 				Traits:         accessInfo.Traits,
 				Roles:          accessInfo.Roles,
@@ -4202,7 +3999,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 			AzureIdentity:     req.RouteToApp.AzureIdentity,
 			GCPServiceAccount: req.RouteToApp.GCPServiceAccount,
 			MFAVerified:       verifiedMFADeviceID,
-			DeviceExtensions:  DeviceExtensions(a.context.Identity.GetIdentity().DeviceExtensions),
+			DeviceExtensions:  DeviceExtensions(a.getIdentity().DeviceExtensions),
 			AppName:           req.RouteToApp.Name,
 			AppURI:            req.RouteToApp.URI,
 			AppTargetPort:     int(req.RouteToApp.TargetPort),
@@ -4212,7 +4009,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 			// joining without an instance ID may have one generated when
 			// `updateBotInstance()` is called below, and this (empty) value will be
 			// overridden.
-			BotInstanceID: a.context.Identity.GetIdentity().BotInstanceID,
+			BotInstanceID: a.getIdentity().BotInstanceID,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -4225,7 +4022,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		wsSession, err := a.authServer.CreateWebSessionFromReq(ctx, NewWebSessionRequest{
 			User:             req.Username,
 			SessionTTL:       req.Expires.Sub(a.authServer.GetClock().Now()),
-			LoginIP:          a.context.Identity.GetIdentity().LoginIP,
+			LoginIP:          a.getIdentity().LoginIP,
 			Roles:            accessInfo.Roles,
 			Traits:           accessInfo.Traits,
 			LoginTime:        a.authServer.clock.Now().UTC(),
@@ -4239,6 +4036,10 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		webSessionID = wsSession.GetName()
 	}
 
+	checkerCtx := a.scopedContext.CheckerContext
+	if isUnscoped {
+		checkerCtx = services.NewScopedAccessCheckerContextFromUnscoped(checker)
+	}
 	// Generate certificate, note that the roles TTL will be ignored because
 	// the request is coming from "tctl auth sign" itself.
 	certReq := cert.Request{
@@ -4250,7 +4051,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		TLSPublicKey:                     req.TLSPublicKey,
 		SSHPublicKeyAttestationStatement: hardwarekey.AttestationStatementFromProto(req.SSHPublicKeyAttestationStatement),
 		TLSPublicKeyAttestationStatement: hardwarekey.AttestationStatementFromProto(req.TLSPublicKeyAttestationStatement),
-		OverrideRoleTTL:                  a.hasBuiltinRole(types.RoleAdmin),
+		OverrideRoleTTL:                  hasAdminRole,
 		RouteToCluster:                   req.RouteToCluster,
 		RequesterName:                    req.RequesterName,
 		KubernetesCluster:                req.KubernetesCluster,
@@ -4268,10 +4069,10 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		AWSRoleARN:                       req.RouteToApp.AWSRoleARN,
 		AzureIdentity:                    req.RouteToApp.AzureIdentity,
 		GCPServiceAccount:                req.RouteToApp.GCPServiceAccount,
-		CheckerContext:                   services.NewScopedAccessCheckerContextFromUnscoped(checker), // TODO(fspmarshall/scopes): add scoping support to generateUserCerts.
+		CheckerContext:                   checkerCtx,
 		// Copy IP from current identity to the generated certificate, if present,
 		// to avoid generateUserCerts() being used to drop IP pinning in the new certificates.
-		LoginIP:                a.context.Identity.GetIdentity().LoginIP,
+		LoginIP:                a.getIdentity().LoginIP,
 		Traits:                 accessInfo.Traits,
 		ActiveRequests:         req.AccessRequests,
 		ConnectionDiagnosticID: req.ConnectionDiagnosticID,
@@ -4281,19 +4082,19 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		// joining without an instance ID may have one generated when
 		// `updateBotInstance()` is called below, and this (empty) value will be
 		// overridden.
-		BotInstanceID: a.context.Identity.GetIdentity().BotInstanceID,
-		JoinToken:     a.context.Identity.GetIdentity().JoinToken,
+		BotInstanceID: a.getIdentity().BotInstanceID,
+		JoinToken:     a.getIdentity().JoinToken,
 		// Propagate any join attributes from the current identity to the new
 		// identity.
-		JoinAttributes: a.context.Identity.GetIdentity().JoinAttributes,
+		JoinAttributes: a.getIdentity().JoinAttributes,
 		WebSessionID:   webSessionID,
 	}
 
-	if user.GetName() != a.context.User.GetName() {
-		certReq.Impersonator = a.context.User.GetName()
+	if user.GetName() != a.getUser().GetName() {
+		certReq.Impersonator = a.getUser().GetName()
 	} else if isRoleImpersonation(req) {
 		// Role impersonation uses the user's own name as the impersonator value.
-		certReq.Impersonator = a.context.User.GetName()
+		certReq.Impersonator = a.getUser().GetName()
 
 		// By default, deny reissuing certs to prevent privilege re-escalation.
 		// (E.g a cert generated intended for use for Kubernetes Access against
@@ -4305,9 +4106,9 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		if req.ReissuableRoleImpersonation {
 			certReq.DisallowReissue = false
 		}
-	} else if a.context.Identity != nil && a.context.Identity.GetIdentity().Impersonator != "" {
+	} else if a.getIdentity().Impersonator != "" {
 		// impersonating users can receive new certs
-		certReq.Impersonator = a.context.Identity.GetIdentity().Impersonator
+		certReq.Impersonator = a.getIdentity().Impersonator
 	}
 	switch req.Usage {
 	case proto.UserCertsRequest_Database:
@@ -4337,8 +4138,8 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	// remains for subsequent requests of the primary certificate. The
 	// renewable flag should never be carried over for impersonation, role
 	// requests, or when the disallow-reissue flag has already been set.
-	if a.context.Identity.GetIdentity().Renewable &&
-		req.Username == a.context.User.GetName() &&
+	if a.getIdentity().Renewable &&
+		req.Username == a.getUser().GetName() &&
 		!isRoleImpersonation(req) &&
 		!certReq.DisallowReissue {
 		certReq.Renewable = true
@@ -4348,7 +4149,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	// counter, auth records, etc). `updateBotInstance()` may modify certain
 	// `certReq` attributes (generation, botInstanceID).
 	if certReq.Renewable {
-		currentIdentityGeneration := a.context.Identity.GetIdentity().Generation
+		currentIdentityGeneration := a.getIdentity().Generation
 
 		// If we're handling a renewal for a bot, we want to return the
 		// Host CAs as well as the User CAs.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2091,6 +2091,11 @@ func (a *ServerWithRoles) ResolveSSHTarget(ctx context.Context, req *proto.Resol
 
 // ListResources returns a paginated list of resources filtered by user access.
 func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+	if a.scopedContext == nil {
+		// This doesn't mean unscoped identities can't list resources, they just need to
+		// to be wrapped in a scoped auth context first
+		return nil, trace.AccessDenied("resource listings must use a scoped auth context")
+	}
 	// Check if auth server has a license for this resource type but only return an
 	// error if the requester is not a builtin or remote server.
 	// Builtin and remote server roles are allowed to list resources to avoid crashes
@@ -2319,7 +2324,12 @@ func (r *resourceChecker) CanAccess(ctx context.Context, resource types.Resource
 // - types.KindWindowsDesktop
 // - types.KindApp with IsAWSConsole() == true
 func (r *resourceChecker) GetAllowedLoginsForResource(ctx context.Context, resource services.AccessCheckable) ([]string, error) {
-	for checker, err := range r.scopedCheckerCtx.CheckersForResourceScope(ctx, scopes.Root) {
+	scope := scopes.Root
+	scopedResource, ok := resource.(services.ScopedAccessCheckable)
+	if ok {
+		scope = scopedResource.GetScope()
+	}
+	for checker, err := range r.scopedCheckerCtx.CheckersForResourceScope(ctx, scope) {
 		if err != nil {
 			continue
 		}
@@ -6552,7 +6562,7 @@ func (a *ServerWithRoles) GetKubernetesServers(ctx context.Context) ([]types.Kub
 			return nil, trace.Wrap(err)
 		}
 
-		if a.authorizeScopedAction(ctx, types.KindKubeServer, types.VerbList, types.VerbRead) != nil {
+		if err := a.authorizeScopedAction(ctx, types.KindKubeServer, types.VerbList, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3907,17 +3907,16 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	checker := services.NewAccessCheckerWithRoleSet(accessInfo, clusterName.GetClusterName(), roleSet)
 
 	switch {
-	case !isUnscoped:
-		// scoped identities do not support impersonation, so we would have
-		// already returned an error at this point if this were an impersonation
-		break
-	case authz.HasBuiltinRole(*unscopedCtx, string(types.RoleAdmin)):
+	case isUnscoped && authz.HasBuiltinRole(*unscopedCtx, string(types.RoleAdmin)):
 		// builtin admins can impersonate anyone
 		// this is required for local tctl commands to work
 	case req.Username == a.getUser().GetName():
 		// users can impersonate themselves, but role impersonation requests
 		// must be checked.
 		if isRoleImpersonation(req) {
+			if !isUnscoped {
+				return nil, trace.Wrap(services.ErrScopedIdentity, "impersonation not permitted")
+			}
 			// Note: CheckImpersonateRoles() checks against the _stored_
 			// impersonate roles for the user rather than the set available
 			// to the current identity. If not explicitly denied (as above),
@@ -3948,6 +3947,9 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 			}
 		}
 	default:
+		if !isUnscoped {
+			return nil, trace.Wrap(services.ErrScopedIdentity, "impersonation not permitted")
+		}
 		// check if this user is allowed to impersonate other users
 		err = unscopedCtx.Checker.CheckImpersonate(a.getUser(), user, parsedRoles)
 		// adjust session TTL based on the impersonated role set limit

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1306,9 +1306,7 @@ func (a *ServerWithRoles) hasWatchPermissionForKind(
 // DeleteAllNodes deletes all nodes in a given namespace
 func (a *ServerWithRoles) DeleteAllNodes(ctx context.Context, namespace string) error {
 	if err := a.actionNamespace(namespace, types.KindNode, types.VerbDelete); err != nil {
-		if !errors.Is(err, services.ErrScopedIdentity) {
-			return trace.Wrap(err)
-		}
+		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteAllNodes(ctx, namespace)
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3718,7 +3718,13 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		verifiedMFADeviceID = mfaData.Device.Id
 	}
 
-	unscopedCtx, isUnscoped := a.scopedContext.UnscopedContext()
+	// NOTE (eriktate): there shouldn't be any remaining cases where a.scopedContext is nil, but
+	// just in case we do all of that book keeping here.
+	unscopedCtx := &a.context
+	isUnscoped := true
+	if a.scopedContext != nil {
+		unscopedCtx, isUnscoped = a.scopedContext.UnscopedContext()
+	}
 
 	hasAdminRole := isUnscoped && authz.HasBuiltinRole(*unscopedCtx, string(types.RoleAdmin))
 	// only unscoped identities can impersonate
@@ -4050,9 +4056,11 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		webSessionID = wsSession.GetName()
 	}
 
-	checkerCtx := a.scopedContext.CheckerContext
+	var checkerCtx *services.ScopedAccessCheckerContext
 	if isUnscoped {
 		checkerCtx = services.NewScopedAccessCheckerContextFromUnscoped(checker)
+	} else {
+		checkerCtx = a.scopedContext.CheckerContext
 	}
 	// Generate certificate, note that the roles TTL will be ignored because
 	// the request is coming from "tctl auth sign" itself.
@@ -7172,7 +7180,12 @@ func (a *ServerWithRoles) GetKubernetesClusters(ctx context.Context) (result []t
 // ListKubernetesClusters returns a page of registered kubernetes clusters.
 func (a *ServerWithRoles) ListKubernetesClusters(ctx context.Context, limit int, start string) ([]types.KubeCluster, string, error) {
 	if err := a.authorizeAction(types.KindKubernetesCluster, types.VerbList, types.VerbRead); err != nil {
-		return nil, "", trace.Wrap(err)
+		if !errors.Is(err, services.ErrScopedIdentity) {
+			return nil, "", trace.Wrap(err)
+		}
+		if err := a.authorizeScopedAction(ctx, types.KindKubernetesCluster, types.VerbList, types.VerbRead); err != nil {
+			return nil, "", trace.Wrap(err)
+		}
 	}
 
 	return generic.CollectPageAndCursor(

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -183,7 +183,7 @@ func (a *ServerWithRoles) currentUserAction(ctx context.Context, username string
 		var isUnscoped bool
 		unscopedCtx, isUnscoped = a.scopedContext.UnscopedContext()
 		if !isUnscoped {
-			if !authz.ScopedIsCurrentUser(a.scopedContext, username) {
+			if authz.ScopedIsCurrentUser(a.scopedContext, username) {
 				return nil
 			}
 			return trace.AccessDenied("scoped users can not modify users other than themselves")
@@ -2151,7 +2151,12 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 		// but got removed shortly afterwards in:
 		//   https://github.com/gravitational/teleport/pull/1224
 		if err := a.checkAction(req.Namespace, req.ResourceType, types.VerbList); err != nil {
-			return nil, trace.Wrap(err)
+			if !errors.Is(err, services.ErrScopedIdentity) {
+				return nil, trace.Wrap(err)
+			}
+			if err := a.preAuthorizeScopedAction(req.ResourceType, types.VerbList, types.VerbRead); err != nil {
+				return nil, trace.Wrap(err)
+			}
 		}
 	case types.KindDatabaseServer,
 		types.KindDatabaseService,
@@ -2165,7 +2170,12 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 		types.KindIdentityCenterAccountAssignment,
 		types.KindGitServer:
 		if err := a.checkAction(req.Namespace, req.ResourceType, types.VerbList, types.VerbRead); err != nil {
-			return nil, trace.Wrap(err)
+			if !errors.Is(err, services.ErrScopedIdentity) {
+				return nil, trace.Wrap(err)
+			}
+			if err := a.preAuthorizeScopedAction(req.ResourceType, types.VerbList, types.VerbRead); err != nil {
+				return nil, trace.Wrap(err)
+			}
 		}
 	default:
 		return nil, trace.NotImplemented("resource type %s does not support pagination", req.ResourceType)
@@ -6550,7 +6560,7 @@ func (a *ServerWithRoles) Close() error {
 
 func (a *ServerWithRoles) checkAccessToKubeCluster(ctx context.Context, cluster types.KubeCluster) error {
 	if a.scopedContext != nil {
-		return a.scopedContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return a.scopedContext.CheckerContext.Decision(ctx, cmp.Or(cluster.GetScope(), scopes.Root), func(checker *services.ScopedAccessChecker) error {
 			return checker.Kube().CanAccessCluster(cluster)
 		})
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1671,7 +1671,7 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 			return nil, trace.AccessDenied(
 				"kind %q not one of the kinds supported for scoped identities (%s)",
 				kind,
-				strings.Join(slices.Collect(maps.Keys(supportedScopedResourceKinds)), ", "),
+				strings.Join(slices.Sorted(maps.Keys(supportedScopedResourceKinds)), ", "),
 			)
 		}
 		kindSet[kind] = struct{}{}
@@ -1736,6 +1736,8 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 				return checker.SSH().CanAccessSSHServer(res)
 			case *types.KubernetesServerV3:
 				return checker.Kube().CanAccessServer(res)
+			case *types.KubernetesClusterV3:
+				return checker.Kube().CanAccessCluster(res)
 			default:
 				return trace.BadParameter("generic resource could not be cast to a supported scoped type")
 			}
@@ -1844,7 +1846,7 @@ func (a *ServerWithRoles) GetNodes(ctx context.Context, namespace string) ([]typ
 	a.authServer.logger.DebugContext(ctx, "Retrieved servers",
 		"node_count", len(nodes),
 		"filtered_node_count", len(filteredNodes),
-		"user", a.scopedContext.User.GetName(),
+		"user", a.getUser().GetName(),
 		"elapsed_fetch", elapsedFetch,
 		"elapsed_filter", elapsedFilter,
 		"elapsed_total", elapsedFetch+elapsedFilter,
@@ -3696,18 +3698,6 @@ func (a *ServerWithRoles) generateScopedUserCerts(ctx context.Context, req proto
 		}
 	}
 
-	// Do not allow SSO users to be impersonated.
-	if req.Username != a.scopedContext.User.GetName() && user.GetUserType() == types.UserTypeSSO {
-		a.authServer.logger.WarnContext(ctx, "User tried to issue a cert for externally managed user",
-			"user", a.scopedContext.User.GetName(),
-			"external_user", req.Username,
-		)
-		return nil, trace.AccessDenied("access denied")
-	}
-
-	if req.Username != a.scopedContext.User.GetName() {
-		return nil, trace.AccessDenied("access denied: impersonation is not allowed")
-	}
 	sessionExpires := identity.Expires
 	if sessionExpires.IsZero() {
 		a.authServer.logger.WarnContext(ctx, "Denied cert issuance for identity with no expiry",
@@ -3719,7 +3709,7 @@ func (a *ServerWithRoles) generateScopedUserCerts(ctx context.Context, req proto
 		return nil, trace.Wrap(client.ErrClientCredentialsHaveExpired)
 	}
 
-	if identity.Renewable || isRoleImpersonation(req) {
+	if identity.Renewable {
 		// Bot self-renewal or role impersonation can request certs with an
 		// expiry up to the global maximum allowed value.
 		if maxTime := a.authServer.GetClock().Now().Add(defaults.MaxRenewableCertTTL); req.Expires.After(maxTime) {
@@ -6725,8 +6715,7 @@ func (a *ServerWithRoles) checkAccessToKubeCluster(ctx context.Context, cluster 
 
 // GetKubernetesServers returns all registered kubernetes servers.
 func (a *ServerWithRoles) GetKubernetesServers(ctx context.Context) ([]types.KubeServer, error) {
-	ruleCtx := a.scopedContext.RuleContext()
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubeServer, types.VerbList, types.VerbRead); err != nil {
+	if err := a.authorizeAction(types.KindKubeServer, types.VerbList, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -178,22 +178,23 @@ func (a *ServerWithRoles) preAuthorizeScopedAction(resource string, verbs ...str
 // even if they are not admins, e.g. update their own passwords,
 // or generate certificates, otherwise it will require admin privileges
 func (a *ServerWithRoles) currentUserAction(ctx context.Context, username string) error {
+	unscopedCtx := &a.context
 	if a.scopedContext != nil {
-		if authz.ScopedIsCurrentUser(a.scopedContext, username) {
-			return nil
+		var isUnscoped bool
+		unscopedCtx, isUnscoped = a.scopedContext.UnscopedContext()
+		if !isUnscoped {
+			if !authz.ScopedIsCurrentUser(a.scopedContext, username) {
+				return nil
+			}
+			return trace.AccessDenied("scoped users can not modify users other than themselves")
 		}
-		ruleCtx := a.scopedContext.RuleContext()
-		ruleCtx.User = a.getUser()
-		return trace.Wrap(a.scopedContext.CheckerContext.RiskyUnpinnedDecision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindUser, types.VerbCreate)
-		}))
 	}
 
-	if authz.IsCurrentUser(a.context, username) {
+	if authz.IsCurrentUser(*unscopedCtx, username) {
 		return nil
 	}
 
-	return a.context.Checker.CheckAccessToRule(&services.Context{User: a.getUser()},
+	return unscopedCtx.Checker.CheckAccessToRule(&services.Context{User: a.getUser()},
 		apidefaults.Namespace, types.KindUser, types.VerbCreate)
 }
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -125,6 +125,11 @@ func (a *ServerWithRoles) actionWithContext(ctx *services.Context, resource stri
 }
 
 func (a *ServerWithRoles) actionNamespace(namespace, resource string, verb string, extraVerbs ...string) error {
+	if a.scopedContext != nil {
+		ruleCtx := a.scopedContext.RuleContext()
+		return a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, resource, slices.Concat([]string{verb}, extraVerbs)...)
+	}
+
 	var errs []error
 
 	if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, verb); err != nil {
@@ -1283,7 +1288,7 @@ func (a *ServerWithRoles) GetNode(ctx context.Context, namespace, name string) (
 		return nil, trace.Wrap(err)
 	}
 
-	if err := a.checkAccessToNode(node); err != nil {
+	if err := a.checkAccessToNode(ctx, node); err != nil {
 		if trace.IsAccessDenied(err) {
 			return nil, trace.NotFound("not found")
 		}
@@ -1312,7 +1317,7 @@ type unifiedResourceLister struct {
 	requestableMap map[string]struct{}
 }
 
-func (c *unifiedResourceLister) canList(resource types.ResourceWithLabels, filter services.MatchResourceFilter) (bool, error) {
+func (c *unifiedResourceLister) canList(ctx context.Context, resource types.ResourceWithLabels, filter services.MatchResourceFilter) (bool, error) {
 	resourceKind := resource.GetKind()
 
 	if canAccessErr := c.kindAccessErrMap[resourceKind]; canAccessErr != nil {
@@ -1341,7 +1346,7 @@ func (c *unifiedResourceLister) canList(resource types.ResourceWithLabels, filte
 	}
 
 	// If the resource is accessible with the primary access checker, allow listing.
-	if err := c.accessChecker.CanAccess(resource); err == nil {
+	if err := c.accessChecker.CanAccess(ctx, resource); err == nil {
 		return true, nil
 	} else if !trace.IsAccessDenied(err) {
 		return false, trace.Wrap(err)
@@ -1355,7 +1360,7 @@ func (c *unifiedResourceLister) canList(resource types.ResourceWithLabels, filte
 
 	// If the resource is requestable, allow listing it as requestable (and put it in the the
 	// requestableMap if not nil).
-	if err := c.requestableAccessChecker.CanAccess(resource); err == nil {
+	if err := c.requestableAccessChecker.CanAccess(ctx, resource); err == nil {
 		if c.requestableMap != nil {
 			c.requestableMap[resource.GetName()] = struct{}{}
 		}
@@ -1367,12 +1372,12 @@ func (c *unifiedResourceLister) canList(resource types.ResourceWithLabels, filte
 	return false, nil
 }
 
-func (l *unifiedResourceLister) getAllowedLogins(resource services.AccessCheckable) ([]string, error) {
+func (l *unifiedResourceLister) getAllowedLogins(ctx context.Context, resource services.AccessCheckable) ([]string, error) {
 	if l.requestableAccessChecker != nil {
-		logins, err := l.requestableAccessChecker.GetAllowedLoginsForResource(resource)
+		logins, err := l.requestableAccessChecker.GetAllowedLoginsForResource(ctx, resource)
 		return logins, trace.Wrap(err)
 	} else {
-		logins, err := l.accessChecker.GetAllowedLoginsForResource(resource)
+		logins, err := l.accessChecker.GetAllowedLoginsForResource(ctx, resource)
 		return logins, trace.Wrap(err)
 	}
 }
@@ -1403,6 +1408,12 @@ var (
 	}
 
 	defaultUnifiedResourceKinds = slices.Collect(maps.Keys(supportedUnifiedResourceKinds))
+
+	supportedScopedResourceKinds = map[string]struct{}{
+		types.KindNode:              {},
+		types.KindKubeServer:        {},
+		types.KindKubernetesCluster: {},
+	}
 )
 
 func (a *ServerWithRoles) checkKindAccess(kind string) error {
@@ -1472,7 +1483,15 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 		kindAccessErrMap: kindAccessErrMap,
 	}
 
-	resourceLister.accessChecker, err = newResourceAccessChecker(a.context, types.KindUnifiedResource)
+	// TODO (eriktate): remove this once ListUnifiedResources supports scoped identities. For now it shouldn't be
+	// possible to get here with a scoped identity, but we're guarding against the possibility just in case.
+	var scopedCheckerCtx *services.ScopedAccessCheckerContext
+	if a.scopedContext != nil {
+		scopedCheckerCtx = a.scopedContext.CheckerContext
+	} else {
+		scopedCheckerCtx = services.NewScopedAccessCheckerContextFromUnscoped(a.context.Checker)
+	}
+	resourceLister.accessChecker, err = newResourceAccessChecker(scopedCheckerCtx, types.KindUnifiedResource)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1494,7 +1513,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 		}
 
 		var requestableAccessChecker resourceCheckerI
-		requestableAccessChecker, err = newResourceAccessChecker(*extendedAuthCtx, types.KindUnifiedResource)
+		requestableAccessChecker, err = newResourceAccessChecker(extendedAuthCtx, types.KindUnifiedResource)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1525,7 +1544,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 			return &proto.ListUnifiedResourcesResponse{}, nil
 		}
 		unifiedResources, err = a.authServer.UnifiedResourceCache.GetUnifiedResourcesByIDs(ctx, prefs.ClusterPreferences.PinnedResources.GetResourceIds(), func(resource types.ResourceWithLabels) (bool, error) {
-			match, err := resourceLister.canList(resource, userFilter)
+			match, err := resourceLister.canList(ctx, resource, userFilter)
 			return match, trace.Wrap(err)
 		})
 		if err != nil {
@@ -1540,7 +1559,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 		}
 	} else {
 		unifiedResources, nextKey, err = a.authServer.UnifiedResourceCache.IterateUnifiedResources(ctx, func(resource types.ResourceWithLabels) (bool, error) {
-			match, err := resourceLister.canList(resource, userFilter)
+			match, err := resourceLister.canList(ctx, resource, userFilter)
 			return match, trace.Wrap(err)
 		}, req)
 		if err != nil {
@@ -1556,7 +1575,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 	if req.IncludeLogins {
 		for _, r := range paginatedResources {
 			if n := r.GetNode(); n != nil {
-				logins, err := resourceLister.getAllowedLogins(n)
+				logins, err := resourceLister.getAllowedLogins(ctx, n)
 				if err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for node",
 						"error", err,
@@ -1566,7 +1585,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 				}
 				r.Logins = logins
 			} else if d := r.GetWindowsDesktop(); d != nil {
-				logins, err := resourceLister.getAllowedLogins(d)
+				logins, err := resourceLister.getAllowedLogins(ctx, d)
 				if err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for desktop",
 						"error", err,
@@ -1581,7 +1600,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 				// view of the account we check access for each Permission Set, filter out those that have
 				// no access and treat the whole app as requiring an access request if _any_ of the contained
 				// permission sets require one.
-				if err := a.filterICPermissionSets(r, d.GetApp(), resourceLister); err != nil {
+				if err := a.filterICPermissionSets(ctx, r, d.GetApp(), resourceLister); err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to filter",
 						"error", err,
 						"resource", d.GetApp().GetName(),
@@ -1589,7 +1608,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 					continue
 				}
 
-				logins, err := resourceLister.getAllowedLogins(d.GetApp())
+				logins, err := resourceLister.getAllowedLogins(ctx, d.GetApp())
 				if err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for app",
 						"error", err,
@@ -1623,8 +1642,16 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 		return nil, trace.AccessDenied("include_logins is not supported for scoped identities")
 	}
 
-	if len(req.Kinds) != 1 || req.Kinds[0] != types.KindNode {
-		return nil, trace.AccessDenied("only node kind is supported for scoped identities")
+	kindSet := make(map[string]struct{})
+	for _, kind := range req.Kinds {
+		if _, ok := supportedScopedResourceKinds[kind]; !ok {
+			return nil, trace.AccessDenied(
+				"kind %q not one of the kinds supported for scoped identities (%s)",
+				kind,
+				strings.Join(slices.Collect(maps.Keys(supportedScopedResourceKinds)), ", "),
+			)
+		}
+		kindSet[kind] = struct{}{}
 	}
 
 	userFilter := services.MatchResourceFilter{
@@ -1643,13 +1670,15 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 
 	ruleCtx := a.scopedContext.RuleContext()
 
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, types.VerbList); err != nil {
-		return nil, trace.Wrap(err)
+	for kind := range kindSet {
+		if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, kind, types.VerbList); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	unifiedResources, nextKey, err := a.authServer.UnifiedResourceCache.IterateUnifiedResources(ctx, func(resource types.ResourceWithLabels) (bool, error) {
-		// currently only nodes are supported
-		if resource.GetKind() != types.KindNode {
+		// only return supported kinds
+		if _, ok := supportedScopedResourceKinds[resource.GetKind()]; !ok {
 			return false, nil
 		}
 
@@ -1667,22 +1696,26 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 			return false, nil
 		}
 
-		server, ok := resource.(*types.ServerV2)
+		scopedRes, ok := resource.(types.ScopedResourceWithLabels)
 		if !ok {
-			logger.WarnContext(ctx, "Unable to cast unified resource to server",
+			logger.WarnContext(ctx, "Unable to cast unified resource to scoped resource",
 				"resource_name", resource.GetName(),
 				"resource_kind", resource.GetKind(),
 			)
 			return false, nil
 		}
 
-		serverScope := scopes.Root
-		if server.Scope != "" {
-			serverScope = server.Scope
-		}
+		resourceScope := cmp.Or(scopedRes.GetScope(), scopes.Root)
 
-		if err := a.scopedContext.CheckerContext.Decision(ctx, serverScope, func(checker *services.ScopedAccessChecker) error {
-			return checker.SSH().CanAccessSSHServer(server)
+		if err := a.scopedContext.CheckerContext.Decision(ctx, resourceScope, func(checker *services.ScopedAccessChecker) error {
+			switch res := resource.(type) {
+			case *types.ServerV2:
+				return checker.SSH().CanAccessSSHServer(res)
+			case *types.KubernetesServerV3:
+				return checker.Kube().CanAccessServer(res)
+			default:
+				return trace.BadParameter("generic resource could not be cast to a supported scoped type")
+			}
 		}); err == nil {
 			return true, nil
 		} else if !trace.IsAccessDenied(err) {
@@ -1706,7 +1739,7 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 	}, nil
 }
 
-func (a *ServerWithRoles) filterICPermissionSets(r *proto.PaginatedResource, app types.Application, checker *unifiedResourceLister) error {
+func (a *ServerWithRoles) filterICPermissionSets(ctx context.Context, r *proto.PaginatedResource, app types.Application, checker *unifiedResourceLister) error {
 	appV3, ok := app.(*types.AppV3)
 	if !ok {
 		return trace.BadParameter("resource must be an app")
@@ -1736,7 +1769,7 @@ func (a *ServerWithRoles) filterICPermissionSets(r *proto.PaginatedResource, app
 		assignment.Metadata.Name = ps.AssignmentID
 		permissionSetQuery.Arn = ps.ARN
 
-		hasAccess, err := checker.canList(checkable, services.MatchResourceFilter{
+		hasAccess, err := checker.canList(ctx, checkable, services.MatchResourceFilter{
 			ResourceKind: types.KindIdentityCenterAccountAssignment,
 		})
 		if err != nil {
@@ -1773,7 +1806,7 @@ func (a *ServerWithRoles) GetNodes(ctx context.Context, namespace string) ([]typ
 	filteredNodes := make([]types.Server, 0)
 	startFilter := time.Now()
 	for _, node := range nodes {
-		if err := a.checkAccessToNode(node); err != nil {
+		if err := a.checkAccessToNode(ctx, node); err != nil {
 			if trace.IsAccessDenied(err) {
 				continue
 			}
@@ -1788,7 +1821,7 @@ func (a *ServerWithRoles) GetNodes(ctx context.Context, namespace string) ([]typ
 	a.authServer.logger.DebugContext(ctx, "Retrieved servers",
 		"node_count", len(nodes),
 		"filtered_node_count", len(filteredNodes),
-		"user", a.context.User.GetName(),
+		"user", a.scopedContext.User.GetName(),
 		"elapsed_fetch", elapsedFetch,
 		"elapsed_filter", elapsedFilter,
 		"elapsed_total", elapsedFetch+elapsedFilter,
@@ -1802,17 +1835,26 @@ func (a *ServerWithRoles) GetNodes(ctx context.Context, namespace string) ([]typ
 // but does not already have access to.
 // Extra roles are determined from the user's search_as_roles and
 // preview_as_roles if [req] requested that each be used.
-func (a *ServerWithRoles) authContextForSearch(ctx context.Context, req *proto.ListResourcesRequest) (*authz.Context, error) {
+func (a *ServerWithRoles) authContextForSearch(ctx context.Context, req *proto.ListResourcesRequest) (*services.ScopedAccessCheckerContext, error) {
+	unscopedCtx, ok := a.resolveUnscopedAuthContext()
+	if !ok {
+		return nil, trace.AccessDenied("extended search context is not supported for scoped identities")
+	}
+
 	var extraRoles []string
 	if req.UseSearchAsRoles {
-		extraRoles = append(extraRoles, a.context.Checker.GetAllowedSearchAsRoles()...)
+		extraRoles = append(extraRoles, unscopedCtx.Checker.GetAllowedSearchAsRoles()...)
 	}
 	if req.UsePreviewAsRoles {
-		extraRoles = append(extraRoles, a.context.Checker.GetAllowedPreviewAsRoles()...)
+		extraRoles = append(extraRoles, unscopedCtx.Checker.GetAllowedPreviewAsRoles()...)
 	}
 	if len(extraRoles) == 0 {
 		// Return the current auth context unmodified.
-		return &a.context, nil
+		if a.scopedContext != nil {
+			return a.scopedContext.CheckerContext, nil
+		} else {
+			return services.NewScopedAccessCheckerContextFromUnscoped(unscopedCtx.Checker), nil
+		}
 	}
 
 	clusterName, err := a.authServer.GetClusterName(ctx)
@@ -1821,12 +1863,12 @@ func (a *ServerWithRoles) authContextForSearch(ctx context.Context, req *proto.L
 	}
 
 	// Get a new auth context with the additional roles
-	extendedContext, err := a.context.WithExtraRoles(a.authServer, clusterName.GetClusterName(), extraRoles)
+	extendedContext, err := unscopedCtx.WithExtraRoles(a.authServer, clusterName.GetClusterName(), extraRoles)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return extendedContext, nil
+	return services.NewScopedAccessCheckerContextFromUnscoped(extendedContext.Checker), nil
 }
 
 var disableUnqualifiedLookups = os.Getenv("TELEPORT_UNSTABLE_DISABLE_UNQUALIFIED_LOOKUPS") == "yes"
@@ -2010,10 +2052,10 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		baseContext := a.context
-		a.context = *extendedContext
+		baseContext := a.scopedContext.CheckerContext
+		a.scopedContext.CheckerContext = extendedContext
 		defer func() {
-			a.context = baseContext
+			a.scopedContext.CheckerContext = baseContext
 		}()
 	}
 
@@ -2087,7 +2129,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 	// the next key.
 	req.Limit++
 
-	resourceChecker, err := newResourceAccessChecker(a.context, req.ResourceType)
+	resourceChecker, err := newResourceAccessChecker(a.scopedContext.CheckerContext, req.ResourceType)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2099,7 +2141,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 			return ErrDone
 		}
 
-		if err := resourceChecker.CanAccess(resource); err != nil {
+		if err := resourceChecker.CanAccess(ctx, resource); err != nil {
 			if trace.IsAccessDenied(err) {
 				return nil
 			}
@@ -2117,7 +2159,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 					checkableResource = appServer.GetApp()
 				}
 
-				logins, err := resourceChecker.GetAllowedLoginsForResource(checkableResource)
+				logins, err := resourceChecker.GetAllowedLoginsForResource(ctx, checkableResource)
 				if err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for resource",
 						"error", err,
@@ -2144,73 +2186,94 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 
 // resourceCheckerI is an interface for [resourceChecker] allowing extending the resourceChecker.
 type resourceCheckerI interface {
-	CanAccess(resource types.ResourceWithLabels) error
-	GetAllowedLoginsForResource(resource services.AccessCheckable) ([]string, error)
+	CanAccess(ctx context.Context, resource types.ResourceWithLabels) error
+	GetAllowedLoginsForResource(ctx context.Context, resource services.AccessCheckable) ([]string, error)
 }
 
 // resourceChecker is a pass through checker that utilizes the provided [services.AccessChecker] to
 // check access to an untyped resource.
 type resourceChecker struct {
-	services.AccessChecker
+	scopedCheckerCtx *services.ScopedAccessCheckerContext
 }
 
 // CanAccess handles providing the proper services.AccessCheckable resource
 // to the services.AccessChecker
-func (r *resourceChecker) CanAccess(resource types.ResourceWithLabels) error {
+func (r *resourceChecker) CanAccess(ctx context.Context, resource types.ResourceWithLabels) error {
 	// MFA is not required for operations on app resources but
 	// will be enforced at the connection time.
 	state := services.AccessState{MFAVerified: true}
 	switch rr := resource.(type) {
 	case types.AppServer:
 		if rr.GetSubKind() == types.KindIdentityCenterAccount {
-			return r.CheckAccess(rr.GetApp(), state, services.NewIdentityCenterAppMatcher(rr.GetApp()))
+			return r.scopedCheckerCtx.UnscopedCheckAccess(rr.GetApp(), state, services.NewIdentityCenterAppMatcher(rr.GetApp()))
 		}
 
-		return r.CheckAccess(rr.GetApp(), state)
+		return r.scopedCheckerCtx.UnscopedCheckAccess(rr.GetApp(), state)
 	case types.KubeServer:
-		return r.CheckAccess(rr.GetCluster(), state)
+		return r.scopedCheckerCtx.Decision(ctx, rr.GetScope(), func(checker *services.ScopedAccessChecker) error {
+			return checker.Kube().CanAccessCluster(rr.GetCluster())
+		})
 	case types.DatabaseServer:
-		return r.CheckAccess(rr.GetDatabase(), state)
+		return r.scopedCheckerCtx.UnscopedCheckAccess(rr.GetDatabase(), state)
 	case types.DatabaseService:
-		return r.CheckAccess(rr, state)
+		return r.scopedCheckerCtx.UnscopedCheckAccess(rr, state)
 	case types.Database:
-		return r.CheckAccess(rr, state)
+		return r.scopedCheckerCtx.UnscopedCheckAccess(rr, state)
 	case types.Server:
-		return r.CheckAccess(rr, state)
+		return r.scopedCheckerCtx.Decision(ctx, rr.GetScope(), func(checker *services.ScopedAccessChecker) error {
+			return checker.SSH().CanAccessSSHServer(rr)
+		})
 	case types.WindowsDesktop:
-		return r.CheckAccess(rr, state)
+		return r.scopedCheckerCtx.UnscopedCheckAccess(rr, state)
 	case types.WindowsDesktopService:
-		return r.CheckAccess(rr, state)
+		return r.scopedCheckerCtx.UnscopedCheckAccess(rr, state)
 	case types.UserGroup:
 		// Because usergroup only has ResourceWithLabels, it looks like this will match
 		// everything. To get around this, we'll match on it last and then double check
 		// that the kind is equal to usergroup. If it's not, we'll fall through and return
 		// the bad parameter as expected.
 		if rr.GetKind() == types.KindUserGroup {
-			return r.CheckAccess(rr, state)
+			return r.scopedCheckerCtx.UnscopedCheckAccess(rr, state)
 		}
 	case types.SAMLIdPServiceProvider:
-		return r.CheckAccessToSAMLIdP(rr,
+		return r.scopedCheckerCtx.UnscopedCheckAccessToSAMLIdP(rr,
 			nil, /* cluster auth preference will be checked during connection */
 			state,
 		)
 	case types.Resource153UnwrapperT[services.IdentityCenterAccount]:
 		checkable, isCheckable := rr.(services.AccessCheckable)
 		if isCheckable {
-			return r.CheckAccess(checkable, state, services.NewIdentityCenterAccountMatcher(rr.UnwrapT()))
+			return r.scopedCheckerCtx.UnscopedCheckAccess(checkable, state, services.NewIdentityCenterAccountMatcher(rr.UnwrapT()))
 		}
 	case types.Resource153UnwrapperT[services.IdentityCenterAccountAssignment]:
 		checkable, isCheckable := rr.(services.AccessCheckable)
 		if isCheckable {
-			return r.CheckAccess(checkable, state, services.NewIdentityCenterAccountAssignmentMatcher(rr.UnwrapT()))
+			return r.scopedCheckerCtx.UnscopedCheckAccess(checkable, state, services.NewIdentityCenterAccountAssignmentMatcher(rr.UnwrapT()))
 		}
 	}
 
 	return trace.BadParameter("could not check access to resource type %T", resource)
 }
 
+// GetAllowedLoginsForResource returns all of the allowed logins for the passed resource.
+//
+// Supports the following resource types:
+//
+// - types.Server with GetKind() == types.KindNode
+// - types.KindWindowsDesktop
+// - types.KindApp with IsAWSConsole() == true
+func (r *resourceChecker) GetAllowedLoginsForResource(ctx context.Context, resource services.AccessCheckable) ([]string, error) {
+	for checker, err := range r.scopedCheckerCtx.CheckersForResourceScope(ctx, scopes.Root) {
+		if err != nil {
+			continue
+		}
+		return checker.GetAllowedLoginsForResource(resource)
+	}
+	return []string{}, nil
+}
+
 // newResourceAccessChecker creates a resourceChecker for the provided resource type
-func newResourceAccessChecker(authCtx authz.Context, resource string) (*resourceChecker, error) {
+func newResourceAccessChecker(scopedCheckerCtx *services.ScopedAccessCheckerContext, resource string) (*resourceChecker, error) {
 	switch resource {
 	case types.KindAppServer,
 		types.KindDatabaseServer,
@@ -2225,7 +2288,7 @@ func newResourceAccessChecker(authCtx authz.Context, resource string) (*resource
 		types.KindIdentityCenterAccount,
 		types.KindIdentityCenterAccountAssignment,
 		types.KindGitServer:
-		return &resourceChecker{AccessChecker: authCtx.Checker}, nil
+		return &resourceChecker{scopedCheckerCtx: scopedCheckerCtx}, nil
 	default:
 		return nil, trace.BadParameter("could not check access to resource type %s", resource)
 	}
@@ -2252,15 +2315,15 @@ type oktaRequestableResoruceChecker struct {
 	readOnly   bool
 }
 
-func (c *oktaRequestableResoruceChecker) CanAccess(resource types.ResourceWithLabels) error {
+func (c *oktaRequestableResoruceChecker) CanAccess(ctx context.Context, resource types.ResourceWithLabels) error {
 	if c.readOnly && resource.Origin() == types.OriginOkta {
 		return trace.AccessDenied("resource not requestable due to disabled Okta bidirectional sync")
 	}
-	return trace.Wrap(c.underlying.CanAccess(resource))
+	return trace.Wrap(c.underlying.CanAccess(ctx, resource))
 }
 
-func (c *oktaRequestableResoruceChecker) GetAllowedLoginsForResource(resource services.AccessCheckable) ([]string, error) {
-	logins, err := c.underlying.GetAllowedLoginsForResource(resource)
+func (c *oktaRequestableResoruceChecker) GetAllowedLoginsForResource(ctx context.Context, resource services.AccessCheckable) ([]string, error) {
+	logins, err := c.underlying.GetAllowedLoginsForResource(ctx, resource)
 	return logins, trace.Wrap(err)
 }
 
@@ -2413,7 +2476,7 @@ func (a *ServerWithRoles) listResourcesWithSort(ctx context.Context, req proto.L
 				return r, nil
 			}
 
-			resourceChecker, err := newResourceAccessChecker(a.context, req.ResourceType)
+			resourceChecker, err := newResourceAccessChecker(a.scopedContext.CheckerContext, req.ResourceType)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -2423,7 +2486,7 @@ func (a *ServerWithRoles) listResourcesWithSort(ctx context.Context, req proto.L
 				checkableResource = appServer.GetApp()
 			}
 
-			logins, err := resourceChecker.GetAllowedLoginsForResource(checkableResource)
+			logins, err := resourceChecker.GetAllowedLoginsForResource(ctx, checkableResource)
 			if err != nil {
 				a.authServer.logger.WarnContext(ctx, "Unable to determine logins for resource",
 					"error", err,
@@ -6077,7 +6140,11 @@ func (a *ServerWithRoles) canImpersonateBuiltinRole(role types.SystemRole) error
 }
 
 func (a *ServerWithRoles) checkAccessToApp(app types.Application) error {
-	return a.context.Checker.CheckAccess(
+	unscopedCtx, ok := a.resolveUnscopedAuthContext()
+	if !ok {
+		return trace.AccessDenied("scopes do not yet support apps")
+	}
+	return unscopedCtx.Checker.CheckAccess(
 		app,
 		// MFA is not required for operations on app resources but
 		// will be enforced at the connection time.
@@ -6389,7 +6456,12 @@ func (a *ServerWithRoles) Close() error {
 	return a.authServer.Close()
 }
 
-func (a *ServerWithRoles) checkAccessToKubeCluster(cluster types.KubeCluster) error {
+func (a *ServerWithRoles) checkAccessToKubeCluster(ctx context.Context, cluster types.KubeCluster) error {
+	if a.scopedContext != nil {
+		return a.scopedContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
+			return checker.Kube().CanAccessCluster(cluster)
+		})
+	}
 	return a.context.Checker.CheckAccess(
 		cluster,
 		// MFA is not required for operations on kube clusters resources but
@@ -6399,7 +6471,8 @@ func (a *ServerWithRoles) checkAccessToKubeCluster(cluster types.KubeCluster) er
 
 // GetKubernetesServers returns all registered kubernetes servers.
 func (a *ServerWithRoles) GetKubernetesServers(ctx context.Context) ([]types.KubeServer, error) {
-	if err := a.authorizeAction(types.KindKubeServer, types.VerbList, types.VerbRead); err != nil {
+	ruleCtx := a.scopedContext.RuleContext()
+	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubeServer, types.VerbList, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -6407,10 +6480,11 @@ func (a *ServerWithRoles) GetKubernetesServers(ctx context.Context) ([]types.Kub
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	slog.Warn("found kube servers", "servers", servers)
 	// Filter out kube servers the caller doesn't have access to.
 	var filtered []types.KubeServer
 	for _, server := range servers {
-		err := a.checkAccessToKubeCluster(server.GetCluster())
+		err := a.checkAccessToKubeCluster(ctx, server.GetCluster())
 		if err != nil && !trace.IsAccessDenied(err) {
 			return nil, trace.Wrap(err)
 		} else if err == nil {
@@ -6906,7 +6980,7 @@ func (a *ServerWithRoles) CreateKubernetesCluster(ctx context.Context, cluster t
 	}
 	// Don't allow users create clusters they wouldn't have access to (e.g.
 	// non-matching labels).
-	if err := a.checkAccessToKubeCluster(cluster); err != nil {
+	if err := a.checkAccessToKubeCluster(ctx, cluster); err != nil {
 		return trace.Wrap(err)
 	}
 	// Don't allow discovery service to create clusters with dynamic labels.
@@ -6927,10 +7001,10 @@ func (a *ServerWithRoles) UpdateKubernetesCluster(ctx context.Context, cluster t
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.checkAccessToKubeCluster(existing); err != nil {
+	if err := a.checkAccessToKubeCluster(ctx, existing); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.checkAccessToKubeCluster(cluster); err != nil {
+	if err := a.checkAccessToKubeCluster(ctx, cluster); err != nil {
 		return trace.Wrap(err)
 	}
 	// Don't allow discovery service to create clusters with dynamic labels.
@@ -6949,7 +7023,7 @@ func (a *ServerWithRoles) GetKubernetesCluster(ctx context.Context, name string)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := a.checkAccessToKubeCluster(kubeCluster); err != nil {
+	if err := a.checkAccessToKubeCluster(ctx, kubeCluster); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return kubeCluster, nil
@@ -6965,7 +7039,7 @@ func (a *ServerWithRoles) GetKubernetesClusters(ctx context.Context) (result []t
 			a.authServer.RangeKubernetesClusters(ctx, "", ""),
 			func(cluster types.KubeCluster) (types.KubeCluster, bool) {
 				// Filter out kube clusters user doesn't have access to.
-				if a.checkAccessToKubeCluster(cluster) == nil {
+				if a.checkAccessToKubeCluster(ctx, cluster) == nil {
 					return cluster, true
 				}
 				return nil, false
@@ -6990,7 +7064,7 @@ func (a *ServerWithRoles) ListKubernetesClusters(ctx context.Context, limit int,
 			a.authServer.RangeKubernetesClusters(ctx, start, ""),
 			func(cluster types.KubeCluster) (types.KubeCluster, bool) {
 				// Filter out kube clusters user doesn't have access to.
-				if a.checkAccessToKubeCluster(cluster) == nil {
+				if a.checkAccessToKubeCluster(ctx, cluster) == nil {
 					return cluster, true
 				}
 				return nil, false
@@ -7011,7 +7085,7 @@ func (a *ServerWithRoles) DeleteKubernetesCluster(ctx context.Context, name stri
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.checkAccessToKubeCluster(cluster); err != nil {
+	if err := a.checkAccessToKubeCluster(ctx, cluster); err != nil {
 		return trace.Wrap(err)
 	}
 	return trace.Wrap(a.authServer.DeleteKubernetesCluster(ctx, name))
@@ -7028,7 +7102,7 @@ func (a *ServerWithRoles) DeleteAllKubernetesClusters(ctx context.Context) error
 		return trace.Wrap(err)
 	}
 	for _, cluster := range clusters {
-		if err := a.checkAccessToKubeCluster(cluster); err == nil {
+		if err := a.checkAccessToKubeCluster(ctx, cluster); err == nil {
 			if err := a.authServer.DeleteKubernetesCluster(ctx, cluster.GetName()); err != nil {
 				return trace.Wrap(err)
 			}
@@ -7037,29 +7111,41 @@ func (a *ServerWithRoles) DeleteAllKubernetesClusters(ctx context.Context) error
 	return nil
 }
 
-func (a *ServerWithRoles) checkAccessToNode(node types.Server) error {
-	// For certain built-in roles, continue to allow full access and return
-	// the full set of nodes to not break existing clusters during migration.
-	//
-	// In addition, allow proxy (and remote proxy) to access all nodes for its
-	// smart resolution address resolution. Once the smart resolution logic is
-	// moved to the auth server, this logic can be removed.
-	builtinRole := authz.HasBuiltinRole(a.context, string(types.RoleAdmin)) ||
-		authz.HasBuiltinRole(a.context, string(types.RoleProxy)) ||
-		HasRemoteBuiltinRole(a.context, string(types.RoleRemoteProxy))
+func (a *ServerWithRoles) checkAccessToNode(ctx context.Context, node types.Server) error {
+	unscopedCtx, ok := a.resolveUnscopedAuthContext()
+	if ok {
+		// For certain built-in roles, continue to allow full access and return
+		// the full set of nodes to not break existing clusters during migration.
+		//
+		// In addition, allow proxy (and remote proxy) to access all nodes for its
+		// smart resolution address resolution. Once the smart resolution logic is
+		// moved to the auth server, this logic can be removed.
+		builtinRole := authz.HasBuiltinRole(a.context, string(types.RoleAdmin)) ||
+			authz.HasBuiltinRole(a.context, string(types.RoleProxy)) ||
+			HasRemoteBuiltinRole(a.context, string(types.RoleRemoteProxy))
 
-	if builtinRole {
-		return nil
+		if builtinRole {
+			return nil
+		}
+
+		return unscopedCtx.Checker.CheckAccess(node,
+			// MFA is not required for operations on node resources but
+			// will be enforced at the connection time.
+			services.AccessState{MFAVerified: true})
 	}
 
-	return a.context.Checker.CheckAccess(node,
-		// MFA is not required for operations on node resources but
-		// will be enforced at the connection time.
-		services.AccessState{MFAVerified: true})
+	return a.scopedContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return checker.SSH().CanAccessSSHServer(node)
+	})
 }
 
 func (a *ServerWithRoles) checkAccessToDatabase(database types.Database) error {
-	return a.context.Checker.CheckAccess(database,
+	unscopedCtx, ok := a.resolveUnscopedAuthContext()
+	if !ok {
+		return trace.AccessDenied("scopes do not yet support databases")
+	}
+
+	return unscopedCtx.Checker.CheckAccess(database,
 		// MFA is not required for operations on database resources but
 		// will be enforced at the connection time.
 		services.AccessState{MFAVerified: true})
@@ -7419,7 +7505,12 @@ func (a *ServerWithRoles) filterWindowsDesktops(desktops []types.WindowsDesktop)
 }
 
 func (a *ServerWithRoles) checkAccessToWindowsDesktop(w types.WindowsDesktop) error {
-	return a.context.Checker.CheckAccess(w,
+	unscopedCtx, ok := a.resolveUnscopedAuthContext()
+	if !ok {
+		return trace.AccessDenied("scopes do not yet support windows desktops")
+	}
+
+	return unscopedCtx.Checker.CheckAccess(w,
 		// MFA is not required for operations on desktop resources
 		services.AccessState{MFAVerified: true},
 		// Note: we don't use the Windows login matcher here, as we won't know what OS user
@@ -7703,11 +7794,16 @@ func (a *ServerWithRoles) ListReleases(ctx context.Context) ([]*types.Release, e
 }
 
 func (a *ServerWithRoles) checkAccessToSAMLIdPServiceProvider(ctx context.Context, sp types.SAMLIdPServiceProvider) error {
+	unscopedCtx, ok := a.resolveUnscopedAuthContext()
+	if !ok {
+		return trace.AccessDenied("scopes do not yet support SAML IdP service providers")
+	}
+
 	authPref, err := a.authServer.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return a.context.Checker.CheckAccessToSAMLIdP(
+	return unscopedCtx.Checker.CheckAccessToSAMLIdP(
 		sp,
 		authPref,
 		// TODO(sshah): remove MFAVerified once the Web UI supports
@@ -8004,7 +8100,11 @@ func (a *ServerWithRoles) DeleteAllSAMLIdPServiceProviders(ctx context.Context) 
 }
 
 func (a *ServerWithRoles) checkAccessToUserGroup(userGroup types.UserGroup) error {
-	return a.context.Checker.CheckAccess(
+	unscopedCtx, ok := a.resolveUnscopedAuthContext()
+	if !ok {
+		return trace.AccessDenied("scopes do not yet support user groups")
+	}
+	return unscopedCtx.Checker.CheckAccess(
 		userGroup,
 		// MFA is not required for operations on user group resources.
 		services.AccessState{MFAVerified: true})
@@ -8469,4 +8569,12 @@ func checkOktaLockAccess(ctx context.Context, authzCtx *authz.Context, locks ser
 	}
 
 	return okta.CheckAccess(authzCtx, existingLock, verb)
+}
+
+func (a *ServerWithRoles) resolveUnscopedAuthContext() (*authz.Context, bool) {
+	if a.scopedContext != nil {
+		return a.scopedContext.UnscopedContext()
+	}
+
+	return &a.context, true
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1748,13 +1748,13 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 			return false, nil
 		}
 
-		resourceScope := scopedRes.GetScope()
+		resourceScope := cmp.Or(scopedRes.GetScope(), scopes.Root)
 		if err := a.scopedContext.CheckerContext.Decision(ctx, resourceScope, func(checker *services.ScopedAccessChecker) error {
 			switch res := resource.(type) {
 			case *types.ServerV2:
 				return checker.SSH().CanAccessSSHServer(res)
 			case *types.KubernetesServerV3:
-				return checker.Kube().CanAccessServer(res)
+				return checker.Kube().CanAccessCluster(res.GetCluster())
 			case *types.KubernetesClusterV3:
 				return checker.Kube().CanAccessCluster(res)
 			default:
@@ -2342,7 +2342,7 @@ func (r *resourceChecker) GetAllowedLoginsForResource(ctx context.Context, resou
 	scope := scopes.Root
 	scopedResource, ok := resource.(services.ScopedAccessCheckable)
 	if ok {
-		scope = scopedResource.GetScope()
+		scope = cmp.Or(scopedResource.GetScope(), scopes.Root)
 	}
 	for checker, err := range r.scopedCtx.CheckerContext.CheckersForResourceScope(ctx, scope) {
 		if err != nil {
@@ -6569,7 +6569,7 @@ func (a *ServerWithRoles) Close() error {
 
 func (a *ServerWithRoles) checkAccessToKubeCluster(ctx context.Context, cluster types.KubeCluster) error {
 	if a.scopedContext != nil {
-		return a.scopedContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return a.scopedContext.CheckerContext.Decision(ctx, cmp.Or(cluster.GetScope(), scopes.Root), func(checker *services.ScopedAccessChecker) error {
 			return checker.Kube().CanAccessCluster(cluster)
 		})
 	}
@@ -7276,7 +7276,7 @@ func (a *ServerWithRoles) checkAccessToNode(ctx context.Context, node types.Serv
 			services.AccessState{MFAVerified: true})
 	}
 
-	return a.scopedContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+	return a.scopedContext.CheckerContext.Decision(ctx, cmp.Or(node.GetScope(), scopes.Root), func(checker *services.ScopedAccessChecker) error {
 		return checker.SSH().CanAccessSSHServer(node)
 	})
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5513,7 +5513,7 @@ func (a *ServerWithRoles) GetRole(ctx context.Context, name string) (types.Role,
 	// Current-user exception: we always allow users to read roles
 	// that they hold.  This requirement is checked first to avoid
 	// misleading denial messages in the logs.
-	if slices.Contains(a.context.User.GetRoles(), name) {
+	if slices.Contains(a.getUser().GetRoles(), name) {
 		role, err := a.authServer.GetRole(ctx, name)
 		if err != nil && trace.IsNotFound(err) {
 			// Add the UserSessionRoleNotFoundErrorMsg message to indicate this role not found error was
@@ -6722,7 +6722,6 @@ func (a *ServerWithRoles) GetKubernetesServers(ctx context.Context) ([]types.Kub
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	slog.Warn("found kube servers", "servers", servers)
 	// Filter out kube servers the caller doesn't have access to.
 	var filtered []types.KubeServer
 	for _, server := range servers {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -280,7 +280,11 @@ func (a *ServerWithRoles) actionForKindSession(ctx context.Context, sid session.
 
 // localServerAction returns an access denied error if the role is not one of the builtin server roles.
 func (a *ServerWithRoles) localServerAction() error {
-	role, ok := a.context.Identity.(authz.BuiltinRole)
+	identity := a.context.Identity
+	if a.scopedContext != nil {
+		identity = a.scopedContext.Identity
+	}
+	role, ok := identity.(authz.BuiltinRole)
 	if !ok || !role.IsServer() {
 		return trace.AccessDenied("this request can be only executed by a teleport built-in server")
 	}
@@ -289,7 +293,15 @@ func (a *ServerWithRoles) localServerAction() error {
 
 // remoteServerAction returns an access denied error if the role is not one of the remote builtin server roles.
 func (a *ServerWithRoles) remoteServerAction() error {
-	role, ok := a.context.UnmappedIdentity.(authz.RemoteBuiltinRole)
+	unmappedIdent := a.context.UnmappedIdentity
+	if a.scopedContext != nil {
+		unscopedCtx, ok := a.scopedContext.UnscopedContext()
+		if !ok {
+			return trace.AccessDenied("scoped identities do not support remote server actions")
+		}
+		unmappedIdent = unscopedCtx.UnmappedIdentity
+	}
+	role, ok := unmappedIdent.(authz.RemoteBuiltinRole)
 	if !ok || !role.IsRemoteServer() {
 		return trace.AccessDenied("this request can be only executed by a teleport remote server")
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -75,6 +75,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -161,10 +162,20 @@ func (a *ServerWithRoles) authorizeAction(resource string, verb string, extraVer
 // even if they are not admins, e.g. update their own passwords,
 // or generate certificates, otherwise it will require admin privileges
 func (a *ServerWithRoles) currentUserAction(username string) error {
-	if authz.IsCurrentUser(a.context, username) {
+	authCtx := &a.context
+	if a.scopedContext != nil {
+		var isUnscoped bool
+		authCtx, isUnscoped = a.scopedContext.UnscopedContext()
+		if !isUnscoped {
+			return trace.AccessDenied("current user actions not allowed for scoped identities")
+		}
+	}
+
+	// TODO(eriktate): see if this can be converted to using a scoped context
+	if authz.IsCurrentUser(*authCtx, username) {
 		return nil
 	}
-	return a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User},
+	return authCtx.Checker.CheckAccessToRule(&services.Context{User: authCtx.User},
 		apidefaults.Namespace, types.KindUser, types.VerbCreate)
 }
 
@@ -3455,27 +3466,27 @@ func (a *ServerWithRoles) GetCurrentUserRoles(ctx context.Context) ([]types.Role
 // `req.AccessRequests` and potentially shorten `req.Expires` based on the
 // access request expirations.
 func (a *ServerWithRoles) desiredAccessInfo(ctx context.Context, req *proto.UserCertsRequest, user services.UserState) (*services.AccessInfo, error) {
-	if req.Username != a.context.User.GetName() {
+	if req.Username != a.getUser().GetName() {
 		if isRoleImpersonation(*req) {
 			a.authServer.logger.WarnContext(ctx, "User tried to issue a cert for another user while adding role requests",
-				"user", a.context.User.GetName(),
+				"user", a.getUser().GetName(),
 				"requested_user", req.Username,
 			)
-			return nil, trace.AccessDenied("User %v tried to issue a cert for %v and added role requests. This is not supported.", a.context.User.GetName(), req.Username)
+			return nil, trace.AccessDenied("User %v tried to issue a cert for %v and added role requests. This is not supported.", a.getUser().GetName(), req.Username)
 		}
 		if len(req.AccessRequests) > 0 {
 			a.authServer.logger.WarnContext(ctx, "User tried to issue a cert for another user while adding access requests",
-				"user", a.context.User.GetName(),
+				"user", a.getUser().GetName(),
 				"requested_user", req.Username,
 			)
-			return nil, trace.AccessDenied("User %v tried to issue a cert for %v and added access requests. This is not supported.", a.context.User.GetName(), req.Username)
+			return nil, trace.AccessDenied("User %v tried to issue a cert for %v and added access requests. This is not supported.", a.getUser().GetName(), req.Username)
 		}
 		return a.desiredAccessInfoForImpersonation(user)
 	}
 	if isRoleImpersonation(*req) {
 		if len(req.AccessRequests) > 0 {
-			a.authServer.logger.WarnContext(ctx, "User tried to issue a cert with both role and access requests", "user", a.context.User.GetName())
-			return nil, trace.AccessDenied("User %v tried to issue a cert with both role and access requests. This is not supported.", a.context.User.GetName())
+			a.authServer.logger.WarnContext(ctx, "User tried to issue a cert with both role and access requests", "user", a.getUser().GetName())
+			return nil, trace.AccessDenied("User %v tried to issue a cert with both role and access requests. This is not supported.", a.getUser().GetName())
 		}
 		return a.desiredAccessInfoForRoleRequest(req, user.GetTraits())
 	}
@@ -3516,7 +3527,7 @@ func (a *ServerWithRoles) desiredAccessInfoForRoleRequest(req *proto.UserCertsRe
 // desiredAccessInfoForUser returns the desired AccessInfo
 // cert request which may contain access requests.
 func (a *ServerWithRoles) desiredAccessInfoForUser(ctx context.Context, req *proto.UserCertsRequest, user services.UserState) (*services.AccessInfo, error) {
-	currentIdentity := a.context.Identity.GetIdentity()
+	currentIdentity := a.getIdentity()
 
 	// Start with the base AccessInfo for current logged-in identity, before
 	// considering new or dropped access requests. This will include roles from
@@ -3595,10 +3606,9 @@ func (a *ServerWithRoles) desiredAccessInfoForUser(ctx context.Context, req *pro
 
 // GenerateUserCerts generates users certificates
 func (a *ServerWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-	identity := a.context.Identity.GetIdentity()
 	return a.generateUserCerts(
 		ctx, req,
-		certRequestDeviceExtensions(identity.DeviceExtensions),
+		certRequestDeviceExtensions(a.getIdentity().DeviceExtensions),
 	)
 }
 
@@ -3623,7 +3633,239 @@ func getBotName(user services.UserState) string {
 	return ""
 }
 
+func (a *ServerWithRoles) generateScopedUserCerts(ctx context.Context, req proto.UserCertsRequest, opts ...certRequestOption) (*proto.Certs, error) {
+	// Device trust: authorize device before issuing certificates.
+	readOnlyAuthPref, err := a.authServer.GetReadOnlyAuthPreference(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := a.verifyUserDeviceForCertIssuance(ctx, req.Usage, readOnlyAuthPref.GetDeviceTrust()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// scoped identities don't support impersonation
+	if req.Username != a.scopedContext.User.GetName() {
+		return nil, trace.AccessDenied("access denied: impersonation is not allowed")
+	}
+
+	identity := a.scopedContext.Identity.GetIdentity()
+	if identity.DisallowReissue {
+		return nil, trace.AccessDenied("access denied: identity is not allowed to reissue certificates")
+	}
+
+	// Extract the user and role set for whom the certificate will be generated.
+	// This should be safe since this is typically done against a local user.
+	//
+	// This call bypasses RBAC check for users read on purpose.
+	// Users who are allowed to impersonate other users might not have
+	// permissions to read user data.
+	user, err := a.authServer.GetUser(ctx, req.Username, false)
+	if err != nil {
+		a.authServer.logger.DebugContext(ctx, "Could not impersonate user, the user could not be fetched from local store",
+			"error", err,
+			"user", req.Username,
+		)
+		return nil, trace.AccessDenied("access denied")
+	}
+
+	// Note that user and their login states can be out of sync in the backend.
+	// For example, GitHub identities obtained from GitHub proxy OAuth flow are
+	// preserved in user login state, where local users may get updated roles
+	// from ConnectMyComputer setup. So here we retrieve additional fields from
+	// user login state. Ideally we should solve this some other way.
+	if githubIdentities := user.GetGithubIdentities(); len(githubIdentities) == 0 {
+		uls, err := a.authServer.Services.GetUserLoginState(ctx, user.GetName())
+		if trace.IsNotFound(err) {
+			// Nothing to do.
+		} else if err != nil {
+			return nil, trace.Wrap(err, "updating GitHub identities")
+		} else if githubIdentities := uls.GetGithubIdentities(); len(githubIdentities) > 0 {
+			user.SetGithubIdentities(githubIdentities)
+		}
+	}
+
+	// Do not allow SSO users to be impersonated.
+	if req.Username != a.scopedContext.User.GetName() && user.GetUserType() == types.UserTypeSSO {
+		a.authServer.logger.WarnContext(ctx, "User tried to issue a cert for externally managed user",
+			"user", a.scopedContext.User.GetName(),
+			"external_user", req.Username,
+		)
+		return nil, trace.AccessDenied("access denied")
+	}
+
+	if req.Username != a.scopedContext.User.GetName() {
+		return nil, trace.AccessDenied("access denied: impersonation is not allowed")
+	}
+	sessionExpires := identity.Expires
+	if sessionExpires.IsZero() {
+		a.authServer.logger.WarnContext(ctx, "Denied cert issuance for identity with no expiry",
+			"identity", identity.Username,
+		)
+		return nil, trace.AccessDenied("access denied")
+	}
+	if req.Expires.Before(a.authServer.GetClock().Now()) {
+		return nil, trace.Wrap(client.ErrClientCredentialsHaveExpired)
+	}
+
+	if identity.Renewable || isRoleImpersonation(req) {
+		// Bot self-renewal or role impersonation can request certs with an
+		// expiry up to the global maximum allowed value.
+		if maxTime := a.authServer.GetClock().Now().Add(defaults.MaxRenewableCertTTL); req.Expires.After(maxTime) {
+			req.Expires = maxTime
+		}
+	} else if !isCertWrittenToDiskFlow(&req) {
+		// If requested certificate is for a flow that does not involve writing the certificate to disk
+		// (e.g. tsh proxy of DB, Kube, App, and AWS App Access using credential process)
+		// it is limited by max session ttl or mfa_verification_interval or req.Expires.
+
+		// Calculate the expiration time.
+		roleSet, err := services.FetchRoles(user.GetRoles(), a, user.GetTraits())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		// [roleSet.AdjustMFAVerificationInterval] will reduce the adjusted sessionTTL if any of the roles requires
+		// MFA tap and `mfa_verification_interval` is set and lower than [roleSet.AdjustSessionTTL].
+		sessionTTL := roleSet.AdjustMFAVerificationInterval(
+			roleSet.AdjustSessionTTL(readOnlyAuthPref.GetDefaultSessionTTL().Duration()),
+			readOnlyAuthPref.GetRequireMFAType().IsSessionMFARequired())
+		adjustedSessionExpires := a.authServer.GetClock().Now().UTC().Add(sessionTTL)
+		if req.Expires.After(adjustedSessionExpires) {
+			req.Expires = adjustedSessionExpires
+		}
+	} else if req.Expires.After(sessionExpires) {
+		// Standard user impersonation has an expiry limited to the expiry
+		// of the current session. This prevents a user renewing their
+		// own certificates indefinitely to avoid re-authenticating.
+		req.Expires = sessionExpires
+	}
+
+	// we're going to extend the roles list based on the access requests, so we
+	// ensure that all the current requests are added to the new certificate
+	// (and are checked again)
+	req.AccessRequests = append(req.AccessRequests, a.scopedContext.Identity.GetIdentity().ActiveRequests...)
+	if req.Username != a.scopedContext.User.GetName() && len(req.AccessRequests) > 0 {
+		return nil, trace.AccessDenied("user %q requested cert for %q and included access requests, this is not supported.", a.scopedContext.User.GetName(), req.Username)
+	}
+
+	accessInfo, err := a.desiredAccessInfo(ctx, &req, user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Generate certificate, note that the roles TTL will be ignored because
+	// the request is coming from "tctl auth sign" itself.
+	certReq := cert.Request{
+		User:                             user,
+		TTL:                              req.Expires.Sub(a.authServer.GetClock().Now()),
+		Compatibility:                    req.Format,
+		SSHPublicKey:                     req.SSHPublicKey,
+		TLSPublicKey:                     req.TLSPublicKey,
+		SSHPublicKeyAttestationStatement: hardwarekey.AttestationStatementFromProto(req.SSHPublicKeyAttestationStatement),
+		TLSPublicKeyAttestationStatement: hardwarekey.AttestationStatementFromProto(req.TLSPublicKeyAttestationStatement),
+		OverrideRoleTTL:                  a.hasBuiltinRole(types.RoleAdmin),
+		RouteToCluster:                   req.RouteToCluster,
+		RequesterName:                    req.RequesterName,
+		KubernetesCluster:                req.KubernetesCluster,
+		DBService:                        req.RouteToDatabase.ServiceName,
+		DBProtocol:                       req.RouteToDatabase.Protocol,
+		DBUser:                           req.RouteToDatabase.Username,
+		DBName:                           req.RouteToDatabase.Database,
+		DBRoles:                          req.RouteToDatabase.Roles,
+		AppName:                          req.RouteToApp.Name,
+		AppPublicAddr:                    req.RouteToApp.PublicAddr,
+		AppURI:                           req.RouteToApp.URI,
+		AppTargetPort:                    int(req.RouteToApp.TargetPort),
+		AppClusterName:                   req.RouteToApp.ClusterName,
+		AWSRoleARN:                       req.RouteToApp.AWSRoleARN,
+		AzureIdentity:                    req.RouteToApp.AzureIdentity,
+		GCPServiceAccount:                req.RouteToApp.GCPServiceAccount,
+		CheckerContext:                   a.scopedContext.CheckerContext, // TODO(fspmarshall/scopes): add scoping support to generateUserCerts.
+		// Copy IP from current identity to the generated certificate, if present,
+		// to avoid generateUserCerts() being used to drop IP pinning in the new certificates.
+		LoginIP:                a.scopedContext.Identity.GetIdentity().LoginIP,
+		Traits:                 accessInfo.Traits,
+		ActiveRequests:         req.AccessRequests,
+		ConnectionDiagnosticID: req.ConnectionDiagnosticID,
+		BotName:                getBotName(user),
+
+		// Always pass through a bot instance ID if available. Legacy bots
+		// joining without an instance ID may have one generated when
+		// `updateBotInstance()` is called below, and this (empty) value will be
+		// overridden.
+		BotInstanceID: a.scopedContext.Identity.GetIdentity().BotInstanceID,
+		JoinToken:     a.scopedContext.Identity.GetIdentity().JoinToken,
+		// Propagate any join attributes from the current identity to the new
+		// identity.
+		JoinAttributes: a.scopedContext.Identity.GetIdentity().JoinAttributes,
+	}
+
+	switch req.Usage {
+	case proto.UserCertsRequest_Database:
+		certReq.Usage = []string{teleport.UsageDatabaseOnly}
+	case proto.UserCertsRequest_App:
+		certReq.Usage = []string{teleport.UsageAppsOnly}
+	case proto.UserCertsRequest_Kubernetes:
+		certReq.Usage = []string{teleport.UsageKubeOnly}
+	case proto.UserCertsRequest_SSH:
+		// SSH certs are ssh-only by definition, certReq.usage only applies to
+		// TLS certs.
+	case proto.UserCertsRequest_All:
+		// Unrestricted usage.
+	case proto.UserCertsRequest_WindowsDesktop:
+		// Desktop certs.
+		certReq.Usage = []string{teleport.UsageWindowsDesktopOnly}
+	default:
+		return nil, trace.BadParameter("unsupported cert usage %q", req.Usage)
+	}
+	for _, o := range opts {
+		o(&certReq)
+	}
+
+	// If the user is renewing a renewable cert, make sure the renewable flag
+	// remains for subsequent requests of the primary certificate. The
+	// renewable flag should never be carried over for impersonation, role
+	// requests, or when the disallow-reissue flag has already been set.
+	if a.scopedContext.Identity.GetIdentity().Renewable &&
+		req.Username == a.scopedContext.User.GetName() &&
+		!isRoleImpersonation(req) &&
+		!certReq.DisallowReissue {
+		certReq.Renewable = true
+	}
+
+	// If the cert is renewable, process any bot instance updates (generation
+	// counter, auth records, etc). `updateBotInstance()` may modify certain
+	// `certReq` attributes (generation, botInstanceID).
+	if certReq.Renewable {
+		currentIdentityGeneration := a.scopedContext.Identity.GetIdentity().Generation
+
+		// If we're handling a renewal for a bot, we want to return the
+		// Host CAs as well as the User CAs.
+		if certReq.BotName != "" {
+			certReq.IncludeHostCA = true
+		}
+
+		// Update the bot instance based on this authentication. This may create
+		// a new bot instance record if the identity is missing an instance ID.
+		if err := a.authServer.updateBotInstance(
+			ctx, &certReq, user.GetName(), certReq.BotName,
+			certReq.BotInstanceID, nil, int32(currentIdentityGeneration),
+		); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	certs, err := a.authServer.generateUserCert(ctx, certReq)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return certs, nil
+}
+
 func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserCertsRequest, opts ...certRequestOption) (*proto.Certs, error) {
+	if a.scopedContext != nil {
+		return a.generateScopedUserCerts(ctx, req, opts...)
+	}
 	// Device trust: authorize device before issuing certificates.
 	readOnlyAuthPref, err := a.authServer.GetReadOnlyAuthPreference(ctx)
 	if err != nil {
@@ -4119,7 +4361,7 @@ func (a *ServerWithRoles) verifyUserDeviceForCertIssuance(ctx context.Context, u
 		return nil
 	}
 
-	identity := a.context.Identity.GetIdentity()
+	identity := a.getIdentity()
 	return trace.Wrap(dtauthz.VerifyTLSUser(ctx, dt, identity))
 }
 
@@ -8577,4 +8819,18 @@ func (a *ServerWithRoles) resolveUnscopedAuthContext() (*authz.Context, bool) {
 	}
 
 	return &a.context, true
+}
+
+func (a *ServerWithRoles) getIdentity() tlsca.Identity {
+	if a.scopedContext != nil {
+		return a.scopedContext.Identity.GetIdentity()
+	}
+	return a.context.Identity.GetIdentity()
+}
+
+func (a *ServerWithRoles) getUser() types.User {
+	if a.scopedContext != nil {
+		return a.scopedContext.User
+	}
+	return a.context.User
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -177,21 +177,25 @@ func (a *ServerWithRoles) authorizeScopedAction(ctx context.Context, resource st
 // currentUserAction is a special checker that allows certain actions for users
 // even if they are not admins, e.g. update their own passwords,
 // or generate certificates, otherwise it will require admin privileges
-func (a *ServerWithRoles) currentUserAction(username string) error {
-	authCtx := &a.context
+func (a *ServerWithRoles) currentUserAction(ctx context.Context, username string) error {
 	if a.scopedContext != nil {
-		var isUnscoped bool
-		authCtx, isUnscoped = a.scopedContext.UnscopedContext()
-		if !isUnscoped {
-			return trace.AccessDenied("current user actions not allowed for scoped identities")
+		if authz.ScopedIsCurrentUser(a.scopedContext, username) {
+			return nil
+		}
+		ruleCtx := a.scopedContext.RuleContext()
+		ruleCtx.User = a.getUser()
+		if err := a.scopedContext.CheckerContext.RiskyUnpinnedDecision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, types.KindUser, types.VerbCreate)
+		}); err != nil {
+			return trace.Wrap(err)
 		}
 	}
 
-	// TODO(eriktate): see if this can be converted to using a scoped context
-	if authz.IsCurrentUser(*authCtx, username) {
+	if authz.IsCurrentUser(a.context, username) {
 		return nil
 	}
-	return authCtx.Checker.CheckAccessToRule(&services.Context{User: authCtx.User},
+
+	return a.context.Checker.CheckAccessToRule(&services.Context{User: a.getUser()},
 		apidefaults.Namespace, types.KindUser, types.VerbCreate)
 }
 
@@ -1258,7 +1262,7 @@ func (a *ServerWithRoles) hasWatchPermissionForKind(
 		}
 
 		// Users can watch their own access requests.
-		if filter.User != "" && a.currentUserAction(filter.User) == nil {
+		if filter.User != "" && a.currentUserAction(ctx, filter.User) == nil {
 			return nil
 		}
 	case types.KindWebSession:
@@ -1277,7 +1281,7 @@ func (a *ServerWithRoles) hasWatchPermissionForKind(
 		}
 
 		// Users can watch their own web sessions without secrets.
-		if filter.User != "" && !kind.LoadSecrets && a.currentUserAction(filter.User) == nil {
+		if filter.User != "" && !kind.LoadSecrets && a.currentUserAction(ctx, filter.User) == nil {
 			return nil
 		}
 	case types.KindHeadlessAuthentication:
@@ -2951,7 +2955,7 @@ func (a *ServerWithRoles) ChangePassword(
 	ctx context.Context,
 	req *proto.ChangePasswordRequest,
 ) error {
-	if err := a.currentUserAction(req.User); err != nil {
+	if err := a.currentUserAction(ctx, req.User); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.ChangePassword(ctx, req)
@@ -2959,7 +2963,7 @@ func (a *ServerWithRoles) ChangePassword(
 
 // CreateWebSession creates a new web session for the specified user
 func (a *ServerWithRoles) CreateWebSession(ctx context.Context, user string) (types.WebSession, error) {
-	if err := a.currentUserAction(user); err != nil {
+	if err := a.currentUserAction(ctx, user); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.CreateWebSession(ctx, user)
@@ -2969,7 +2973,7 @@ func (a *ServerWithRoles) CreateWebSession(ctx context.Context, user string) (ty
 // Additional roles are appended to initial roles if there is an approved access request.
 // The new session expiration time will not exceed the expiration time of the old session.
 func (a *ServerWithRoles) ExtendWebSession(ctx context.Context, req authclient.WebSessionReq) (types.WebSession, error) {
-	if err := a.currentUserAction(req.User); err != nil {
+	if err := a.currentUserAction(ctx, req.User); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.ExtendWebSession(ctx, req, a.context.Identity.GetIdentity())
@@ -2979,7 +2983,7 @@ func (a *ServerWithRoles) ExtendWebSession(ctx context.Context, req authclient.W
 // The session is stripped of any authentication details.
 // Implements auth.WebUIService
 func (a *ServerWithRoles) GetWebSessionInfo(ctx context.Context, user, sessionID string) (types.WebSession, error) {
-	if err := a.currentUserAction(user); err != nil {
+	if err := a.currentUserAction(ctx, user); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetWebSessionInfo(ctx, user, sessionID)
@@ -3029,7 +3033,7 @@ func (*webSessionsWithRoles) Upsert(ctx context.Context, session types.WebSessio
 
 // Delete removes the web session specified with req.
 func (r *webSessionsWithRoles) Delete(ctx context.Context, req types.DeleteWebSessionRequest) error {
-	if err := r.c.canDeleteWebSession(req.User); err != nil {
+	if err := r.c.canDeleteWebSession(ctx, req.User); err != nil {
 		return trace.Wrap(err)
 	}
 	return r.ws.Delete(ctx, req)
@@ -3053,7 +3057,7 @@ type webSessionsWithRoles struct {
 
 // GetWebToken returns the web token specified with req.
 func (a *ServerWithRoles) GetWebToken(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
-	if err := a.currentUserAction(req.User); err != nil {
+	if err := a.currentUserAction(ctx, req.User); err != nil {
 		if err := a.authorizeAction(types.KindWebToken, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -3097,7 +3101,7 @@ func (a *ServerWithRoles) ListWebTokens(ctx context.Context, limit int, start st
 
 // DeleteWebToken removes the web token specified with req.
 func (a *ServerWithRoles) DeleteWebToken(ctx context.Context, req types.DeleteWebTokenRequest) error {
-	if err := a.currentUserAction(req.User); err != nil {
+	if err := a.currentUserAction(ctx, req.User); err != nil {
 		if err := a.authorizeAction(types.KindWebToken, types.VerbDelete); err != nil {
 			return trace.Wrap(err)
 		}
@@ -3120,8 +3124,8 @@ func (a *ServerWithRoles) DeleteAllWebTokens(ctx context.Context) error {
 
 type accessChecker interface {
 	authorizeAction(resource string, verb string, extraVerbs ...string) error
-	currentUserAction(user string) error
-	canDeleteWebSession(username string) error
+	currentUserAction(ctx context.Context, user string) error
+	canDeleteWebSession(ctx context.Context, username string) error
 }
 
 func (a *ServerWithRoles) GetAccessRequests(ctx context.Context, filter types.AccessRequestFilter) ([]types.AccessRequest, error) {
@@ -3175,7 +3179,7 @@ func (a *ServerWithRoles) ListAccessRequests(ctx context.Context, req *proto.Lis
 
 	// users can always view their own access requests unless the read or list
 	// verbs are explicitly denied
-	if req.Filter.User != "" && a.currentUserAction(req.Filter.User) == nil {
+	if req.Filter.User != "" && a.currentUserAction(ctx, req.Filter.User) == nil {
 		return a.authServer.ListAccessRequests(ctx, req)
 	}
 
@@ -3234,7 +3238,7 @@ func (a *ServerWithRoles) CreateAccessRequestV2(ctx context.Context, req types.A
 	if err := a.authorizeAction(types.KindAccessRequest, types.VerbCreate); err != nil {
 		// An exception is made to allow users to create *pending* access requests
 		// for themselves unless the create verb was explicitly denied.
-		if services.IsAccessExplicitlyDenied(err) || !req.GetState().IsPending() || a.currentUserAction(req.GetUser()) != nil {
+		if services.IsAccessExplicitlyDenied(err) || !req.GetState().IsPending() || a.currentUserAction(ctx, req.GetUser()) != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -3360,7 +3364,7 @@ func (a *ServerWithRoles) GetAccessCapabilities(ctx context.Context, req types.A
 	}
 
 	// all users can check their own capabilities
-	if a.currentUserAction(req.User) != nil {
+	if a.currentUserAction(ctx, req.User) != nil {
 		if err := a.authorizeAction(types.KindUser, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -6299,7 +6303,7 @@ func (a *ServerWithRoles) GetAppSession(ctx context.Context, req types.GetAppSes
 	}
 
 	// Users can fetch their own app sessions without secrets.
-	if err := a.currentUserAction(session.GetUser()); err == nil {
+	if err := a.currentUserAction(ctx, session.GetUser()); err == nil {
 		return session.WithoutSecrets(), nil
 	}
 
@@ -6318,7 +6322,7 @@ func (a *ServerWithRoles) GetSnowflakeSession(ctx context.Context, req types.Get
 	// Check if this a database service.
 	if !a.hasBuiltinRole(types.RoleDatabase) {
 		// Users can only fetch their own web sessions.
-		if err := a.currentUserAction(session.GetUser()); err != nil {
+		if err := a.currentUserAction(ctx, session.GetUser()); err != nil {
 			if err := a.authorizeAction(types.KindWebSession, types.VerbRead); err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -6373,7 +6377,7 @@ func (a *ServerWithRoles) ListSnowflakeSessions(ctx context.Context, limit int, 
 // CreateAppSession creates an application web session. Application web
 // sessions represent a browser session the client holds.
 func (a *ServerWithRoles) CreateAppSession(ctx context.Context, req *proto.CreateAppSessionRequest) (types.WebSession, error) {
-	if err := a.currentUserAction(req.Username); err != nil {
+	if err := a.currentUserAction(ctx, req.Username); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -6389,7 +6393,7 @@ func (a *ServerWithRoles) CreateAppSession(ctx context.Context, req *proto.Creat
 func (a *ServerWithRoles) CreateSnowflakeSession(ctx context.Context, req types.CreateSnowflakeSessionRequest) (types.WebSession, error) {
 	// Check if this a database service.
 	if !a.hasBuiltinRole(types.RoleDatabase) {
-		if err := a.currentUserAction(req.Username); err != nil {
+		if err := a.currentUserAction(ctx, req.Username); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -6408,7 +6412,7 @@ func (a *ServerWithRoles) DeleteAppSession(ctx context.Context, req types.Delete
 		return trace.Wrap(err)
 	}
 	// Check if user can delete this web session.
-	if err := a.canDeleteWebSession(session.GetUser()); err != nil {
+	if err := a.canDeleteWebSession(ctx, session.GetUser()); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.authServer.DeleteAppSession(ctx, req); err != nil {
@@ -6463,7 +6467,7 @@ func (a *ServerWithRoles) DeleteSnowflakeSession(ctx context.Context, req types.
 	}
 	// Check if user can delete this web session.
 	if !a.hasBuiltinRole(types.RoleDatabase) {
-		if err := a.canDeleteWebSession(snowflakeSession.GetUser()); err != nil {
+		if err := a.canDeleteWebSession(ctx, snowflakeSession.GetUser()); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -6502,7 +6506,7 @@ func (a *ServerWithRoles) DeleteAllAppSessions(ctx context.Context) error {
 // DeleteUserAppSessions deletes all user’s application sessions.
 func (a *ServerWithRoles) DeleteUserAppSessions(ctx context.Context, req *proto.DeleteUserAppSessionsRequest) error {
 	// First, check if the current user can delete the request user sessions.
-	if err := a.canDeleteWebSession(req.Username); err != nil {
+	if err := a.canDeleteWebSession(ctx, req.Username); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -6515,8 +6519,8 @@ func (a *ServerWithRoles) DeleteUserAppSessions(ctx context.Context, req *proto.
 
 // canDeleteWebSession checks if the current user can delete
 // WebSessions from the provided `username`.
-func (a *ServerWithRoles) canDeleteWebSession(username string) error {
-	if err := a.currentUserAction(username); err != nil {
+func (a *ServerWithRoles) canDeleteWebSession(ctx context.Context, username string) error {
+	if err := a.currentUserAction(ctx, username); err != nil {
 		if err := a.authorizeAction(types.KindWebSession, types.VerbList, types.VerbDelete); err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"log/slog"
@@ -126,19 +127,23 @@ func (a *ServerWithRoles) actionWithContext(ctx *services.Context, resource stri
 }
 
 func (a *ServerWithRoles) actionNamespace(namespace, resource string, verb string, extraVerbs ...string) error {
+	unscopedCtx := &a.context
 	if a.scopedContext != nil {
-		ruleCtx := a.scopedContext.RuleContext()
-		return a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, resource, slices.Concat([]string{verb}, extraVerbs)...)
+		// paths that support scoped identities should call authorizeScopedAction in response to
+		// receiving services.ErrScopedIdentity
+		var isUnscoped bool
+		if unscopedCtx, isUnscoped = a.scopedContext.UnscopedContext(); !isUnscoped {
+			return trace.Wrap(services.ErrScopedIdentity)
+		}
 	}
-
 	var errs []error
 
-	if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, verb); err != nil {
+	if err := unscopedCtx.Checker.CheckAccessToRule(&services.Context{User: a.getUser()}, namespace, resource, verb); err != nil {
 		errs = append(errs, err)
 	}
 
 	for _, verb := range extraVerbs {
-		if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, verb); err != nil {
+		if err := unscopedCtx.Checker.CheckAccessToRule(&services.Context{User: a.getUser()}, namespace, resource, verb); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -156,6 +161,17 @@ func (a *ServerWithRoles) authorizeActionWithOrigin(resourceKind string, origin 
 
 func (a *ServerWithRoles) authorizeAction(resource string, verb string, extraVerbs ...string) error {
 	return a.actionNamespace(apidefaults.Namespace, resource, verb, extraVerbs...)
+}
+
+func (a *ServerWithRoles) authorizeScopedAction(ctx context.Context, resource string, verbs ...string) error {
+	if a.scopedContext == nil {
+		return trace.AccessDenied("cannot authorize scoped action for unscoped context")
+	}
+
+	ruleCtx := a.scopedContext.RuleContext()
+	return a.scopedContext.CheckerContext.RiskyUnpinnedDecision(ctx, "", func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, resource, verbs...)
+	})
 }
 
 // currentUserAction is a special checker that allows certain actions for users
@@ -1288,7 +1304,12 @@ func (a *ServerWithRoles) hasWatchPermissionForKind(
 // DeleteAllNodes deletes all nodes in a given namespace
 func (a *ServerWithRoles) DeleteAllNodes(ctx context.Context, namespace string) error {
 	if err := a.actionNamespace(namespace, types.KindNode, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
+		if !errors.Is(err, services.ErrScopedIdentity) {
+			return trace.Wrap(err)
+		}
+		if err := a.authorizeScopedAction(ctx, types.KindNode, types.VerbDelete); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return a.authServer.DeleteAllNodes(ctx, namespace)
 }
@@ -1304,7 +1325,12 @@ func (a *ServerWithRoles) DeleteNode(ctx context.Context, namespace, node string
 // GetNode gets a node by name and namespace.
 func (a *ServerWithRoles) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
 	if err := a.actionNamespace(namespace, types.KindNode, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+		if !errors.Is(err, services.ErrScopedIdentity) {
+			return nil, trace.Wrap(err)
+		}
+		if err := a.authorizeScopedAction(ctx, types.KindNode, types.VerbRead); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	node, err := a.authServer.GetNode(ctx, namespace, name)
 	if err != nil {
@@ -1816,7 +1842,12 @@ func (a *ServerWithRoles) filterICPermissionSets(ctx context.Context, r *proto.P
 
 func (a *ServerWithRoles) GetNodes(ctx context.Context, namespace string) ([]types.Server, error) {
 	if err := a.actionNamespace(namespace, types.KindNode, types.VerbList); err != nil {
-		return nil, trace.Wrap(err)
+		if !errors.Is(err, services.ErrScopedIdentity) {
+			return nil, trace.Wrap(err)
+		}
+		if err := a.authorizeScopedAction(ctx, types.KindNode, types.VerbList); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// Fetch full list of nodes in the backend.
@@ -6716,7 +6747,13 @@ func (a *ServerWithRoles) checkAccessToKubeCluster(ctx context.Context, cluster 
 // GetKubernetesServers returns all registered kubernetes servers.
 func (a *ServerWithRoles) GetKubernetesServers(ctx context.Context) ([]types.KubeServer, error) {
 	if err := a.authorizeAction(types.KindKubeServer, types.VerbList, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+		if !errors.Is(err, services.ErrScopedIdentity) {
+			return nil, trace.Wrap(err)
+		}
+
+		if a.authorizeScopedAction(ctx, types.KindKubeServer, types.VerbList, types.VerbRead) != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	servers, err := a.authServer.GetKubernetesServers(ctx)
@@ -7218,7 +7255,12 @@ func (a *ServerWithRoles) DeleteAllApps(ctx context.Context) error {
 // CreateKubernetesCluster creates a new kubernetes cluster resource.
 func (a *ServerWithRoles) CreateKubernetesCluster(ctx context.Context, cluster types.KubeCluster) error {
 	if err := a.authorizeAction(types.KindKubernetesCluster, types.VerbCreate); err != nil {
-		return trace.Wrap(err)
+		if !errors.Is(err, services.ErrScopedIdentity) {
+			return trace.Wrap(err)
+		}
+		if err := a.authorizeScopedAction(ctx, types.KindKubernetesCluster, types.VerbCreate); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	// Don't allow users create clusters they wouldn't have access to (e.g.
 	// non-matching labels).
@@ -7235,7 +7277,12 @@ func (a *ServerWithRoles) CreateKubernetesCluster(ctx context.Context, cluster t
 // UpdateKubernetesCluster updates existing kubernetes cluster resource.
 func (a *ServerWithRoles) UpdateKubernetesCluster(ctx context.Context, cluster types.KubeCluster) error {
 	if err := a.authorizeAction(types.KindKubernetesCluster, types.VerbUpdate); err != nil {
-		return trace.Wrap(err)
+		if !errors.Is(err, services.ErrScopedIdentity) {
+			return trace.Wrap(err)
+		}
+		if err := a.authorizeScopedAction(ctx, types.KindKubernetesCluster, types.VerbUpdate); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	// Don't allow users update clusters they don't have access to (e.g.
 	// non-matching labels). Make sure to check existing cluster too.
@@ -7259,8 +7306,14 @@ func (a *ServerWithRoles) UpdateKubernetesCluster(ctx context.Context, cluster t
 // GetKubernetesCluster returns specified kubernetes cluster resource.
 func (a *ServerWithRoles) GetKubernetesCluster(ctx context.Context, name string) (types.KubeCluster, error) {
 	if err := a.authorizeAction(types.KindKubernetesCluster, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+		if !errors.Is(err, services.ErrScopedIdentity) {
+			return nil, trace.Wrap(err)
+		}
+		if err := a.authorizeScopedAction(ctx, types.KindKubernetesCluster, types.VerbRead); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
+
 	kubeCluster, err := a.authServer.GetKubernetesCluster(ctx, name)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -7274,8 +7327,14 @@ func (a *ServerWithRoles) GetKubernetesCluster(ctx context.Context, name string)
 // GetKubernetesClusters returns all kubernetes cluster resources.
 func (a *ServerWithRoles) GetKubernetesClusters(ctx context.Context) (result []types.KubeCluster, err error) {
 	if err := a.authorizeAction(types.KindKubernetesCluster, types.VerbList, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+		if !errors.Is(err, services.ErrScopedIdentity) {
+			return nil, trace.Wrap(err)
+		}
+		if err := a.authorizeScopedAction(ctx, types.KindKubernetesCluster, types.VerbList, types.VerbRead); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
+
 	out, err := iterstream.Collect(
 		iterstream.FilterMap(
 			a.authServer.RangeKubernetesClusters(ctx, "", ""),

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -163,15 +163,15 @@ func (a *ServerWithRoles) authorizeAction(resource string, verb string, extraVer
 	return a.actionNamespace(apidefaults.Namespace, resource, verb, extraVerbs...)
 }
 
-func (a *ServerWithRoles) authorizeScopedAction(ctx context.Context, resource string, verbs ...string) error {
+// preAuthorizeScopedAction runs a more efficient check to see if an action is definitely not possible before doing
+// more expensive per-resource checks
+func (a *ServerWithRoles) preAuthorizeScopedAction(resource string, verbs ...string) error {
 	if a.scopedContext == nil {
-		return trace.AccessDenied("cannot authorize scoped action for unscoped context")
+		return trace.AccessDenied("cannot pre authorize scoped action for unscoped context")
 	}
 
 	ruleCtx := a.scopedContext.RuleContext()
-	return a.scopedContext.CheckerContext.RiskyUnpinnedDecision(ctx, "", func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, resource, verbs...)
-	})
+	return trace.Wrap(a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, resource, verbs...))
 }
 
 // currentUserAction is a special checker that allows certain actions for users
@@ -1311,9 +1311,6 @@ func (a *ServerWithRoles) DeleteAllNodes(ctx context.Context, namespace string) 
 		if !errors.Is(err, services.ErrScopedIdentity) {
 			return trace.Wrap(err)
 		}
-		if err := a.authorizeScopedAction(ctx, types.KindNode, types.VerbDelete); err != nil {
-			return trace.Wrap(err)
-		}
 	}
 	return a.authServer.DeleteAllNodes(ctx, namespace)
 }
@@ -1332,7 +1329,7 @@ func (a *ServerWithRoles) GetNode(ctx context.Context, namespace, name string) (
 		if !errors.Is(err, services.ErrScopedIdentity) {
 			return nil, trace.Wrap(err)
 		}
-		if err := a.authorizeScopedAction(ctx, types.KindNode, types.VerbRead); err != nil {
+		if err := a.preAuthorizeScopedAction(types.KindNode, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -1849,7 +1846,7 @@ func (a *ServerWithRoles) GetNodes(ctx context.Context, namespace string) ([]typ
 		if !errors.Is(err, services.ErrScopedIdentity) {
 			return nil, trace.Wrap(err)
 		}
-		if err := a.authorizeScopedAction(ctx, types.KindNode, types.VerbList); err != nil {
+		if err := a.preAuthorizeScopedAction(types.KindNode, types.VerbList); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -6574,7 +6571,7 @@ func (a *ServerWithRoles) GetKubernetesServers(ctx context.Context) ([]types.Kub
 			return nil, trace.Wrap(err)
 		}
 
-		if err := a.authorizeScopedAction(ctx, types.KindKubeServer, types.VerbList, types.VerbRead); err != nil {
+		if err := a.preAuthorizeScopedAction(types.KindKubeServer, types.VerbList, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -7081,7 +7078,7 @@ func (a *ServerWithRoles) CreateKubernetesCluster(ctx context.Context, cluster t
 		if !errors.Is(err, services.ErrScopedIdentity) {
 			return trace.Wrap(err)
 		}
-		if err := a.authorizeScopedAction(ctx, types.KindKubernetesCluster, types.VerbCreate); err != nil {
+		if err := a.preAuthorizeScopedAction(types.KindKubernetesCluster, types.VerbCreate); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -7103,7 +7100,7 @@ func (a *ServerWithRoles) UpdateKubernetesCluster(ctx context.Context, cluster t
 		if !errors.Is(err, services.ErrScopedIdentity) {
 			return trace.Wrap(err)
 		}
-		if err := a.authorizeScopedAction(ctx, types.KindKubernetesCluster, types.VerbUpdate); err != nil {
+		if err := a.preAuthorizeScopedAction(types.KindKubernetesCluster, types.VerbUpdate); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -7132,7 +7129,7 @@ func (a *ServerWithRoles) GetKubernetesCluster(ctx context.Context, name string)
 		if !errors.Is(err, services.ErrScopedIdentity) {
 			return nil, trace.Wrap(err)
 		}
-		if err := a.authorizeScopedAction(ctx, types.KindKubernetesCluster, types.VerbRead); err != nil {
+		if err := a.preAuthorizeScopedAction(types.KindKubernetesCluster, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -7153,7 +7150,7 @@ func (a *ServerWithRoles) GetKubernetesClusters(ctx context.Context) (result []t
 		if !errors.Is(err, services.ErrScopedIdentity) {
 			return nil, trace.Wrap(err)
 		}
-		if err := a.authorizeScopedAction(ctx, types.KindKubernetesCluster, types.VerbList, types.VerbRead); err != nil {
+		if err := a.preAuthorizeScopedAction(types.KindKubernetesCluster, types.VerbList, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -7183,7 +7180,7 @@ func (a *ServerWithRoles) ListKubernetesClusters(ctx context.Context, limit int,
 		if !errors.Is(err, services.ErrScopedIdentity) {
 			return nil, "", trace.Wrap(err)
 		}
-		if err := a.authorizeScopedAction(ctx, types.KindKubernetesCluster, types.VerbList, types.VerbRead); err != nil {
+		if err := a.preAuthorizeScopedAction(types.KindKubernetesCluster, types.VerbList, types.VerbRead); err != nil {
 			return nil, "", trace.Wrap(err)
 		}
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2339,12 +2339,11 @@ func (r *resourceChecker) CanAccess(ctx context.Context, resource types.Resource
 // - types.KindWindowsDesktop
 // - types.KindApp with IsAWSConsole() == true
 func (r *resourceChecker) GetAllowedLoginsForResource(ctx context.Context, resource services.AccessCheckable) ([]string, error) {
-	scope := scopes.Root
-	scopedResource, ok := resource.(services.ScopedAccessCheckable)
-	if ok {
-		scope = cmp.Or(scopedResource.GetScope(), scopes.Root)
+	switch target := resource.(type) {
+	case types.Server:
+		return r.scopedCtx.CheckerContext.GetPossibleLoginsForSSHServer(ctx, target)
 	}
-	for checker, err := range r.scopedCtx.CheckerContext.CheckersForResourceScope(ctx, scope) {
+	for checker, err := range r.scopedCtx.CheckerContext.CheckersForResourceScope(ctx, scopes.Root) {
 		if err != nil {
 			continue
 		}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -7246,9 +7246,9 @@ func (a *ServerWithRoles) checkAccessToNode(ctx context.Context, node types.Serv
 		// In addition, allow proxy (and remote proxy) to access all nodes for its
 		// smart resolution address resolution. Once the smart resolution logic is
 		// moved to the auth server, this logic can be removed.
-		builtinRole := authz.HasBuiltinRole(a.context, string(types.RoleAdmin)) ||
-			authz.HasBuiltinRole(a.context, string(types.RoleProxy)) ||
-			HasRemoteBuiltinRole(a.context, string(types.RoleRemoteProxy))
+		builtinRole := authz.HasBuiltinRole(*unscopedCtx, string(types.RoleAdmin)) ||
+			authz.HasBuiltinRole(*unscopedCtx, string(types.RoleProxy)) ||
+			HasRemoteBuiltinRole(*unscopedCtx, string(types.RoleRemoteProxy))
 
 		if builtinRole {
 			return nil

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -184,11 +184,9 @@ func (a *ServerWithRoles) currentUserAction(ctx context.Context, username string
 		}
 		ruleCtx := a.scopedContext.RuleContext()
 		ruleCtx.User = a.getUser()
-		if err := a.scopedContext.CheckerContext.RiskyUnpinnedDecision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
+		return trace.Wrap(a.scopedContext.CheckerContext.RiskyUnpinnedDecision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
 			return checker.CheckAccessToRules(&ruleCtx, types.KindUser, types.VerbCreate)
-		}); err != nil {
-			return trace.Wrap(err)
-		}
+		}))
 	}
 
 	if authz.IsCurrentUser(a.context, username) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -75,6 +75,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/local/generic"
+	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -1532,13 +1533,8 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 
 	// TODO (eriktate): remove this once ListUnifiedResources supports scoped identities. For now it shouldn't be
 	// possible to get here with a scoped identity, but we're guarding against the possibility just in case.
-	var scopedCheckerCtx *services.ScopedAccessCheckerContext
-	if a.scopedContext != nil {
-		scopedCheckerCtx = a.scopedContext.CheckerContext
-	} else {
-		scopedCheckerCtx = services.NewScopedAccessCheckerContextFromUnscoped(a.context.Checker)
-	}
-	resourceLister.accessChecker, err = newResourceAccessChecker(scopedCheckerCtx, types.KindUnifiedResource)
+	scopedCtx := cmp.Or(a.scopedContext, authz.ScopedContextFromUnscopedContext(&a.context))
+	resourceLister.accessChecker, err = newResourceAccessChecker(scopedCtx, types.KindUnifiedResource)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1752,8 +1748,7 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 			return false, nil
 		}
 
-		resourceScope := cmp.Or(scopedRes.GetScope(), scopes.Root)
-
+		resourceScope := scopedRes.GetScope()
 		if err := a.scopedContext.CheckerContext.Decision(ctx, resourceScope, func(checker *services.ScopedAccessChecker) error {
 			switch res := resource.(type) {
 			case *types.ServerV2:
@@ -1889,7 +1884,7 @@ func (a *ServerWithRoles) GetNodes(ctx context.Context, namespace string) ([]typ
 // but does not already have access to.
 // Extra roles are determined from the user's search_as_roles and
 // preview_as_roles if [req] requested that each be used.
-func (a *ServerWithRoles) authContextForSearch(ctx context.Context, req *proto.ListResourcesRequest) (*services.ScopedAccessCheckerContext, error) {
+func (a *ServerWithRoles) authContextForSearch(ctx context.Context, req *proto.ListResourcesRequest) (*authz.ScopedContext, error) {
 	unscopedCtx, ok := a.resolveUnscopedAuthContext()
 	if !ok {
 		return nil, trace.AccessDenied("extended search context is not supported for scoped identities")
@@ -1904,11 +1899,7 @@ func (a *ServerWithRoles) authContextForSearch(ctx context.Context, req *proto.L
 	}
 	if len(extraRoles) == 0 {
 		// Return the current auth context unmodified.
-		if a.scopedContext != nil {
-			return a.scopedContext.CheckerContext, nil
-		} else {
-			return services.NewScopedAccessCheckerContextFromUnscoped(unscopedCtx.Checker), nil
-		}
+		return cmp.Or(a.scopedContext, authz.ScopedContextFromUnscopedContext(unscopedCtx)), nil
 	}
 
 	clusterName, err := a.authServer.GetClusterName(ctx)
@@ -1922,7 +1913,7 @@ func (a *ServerWithRoles) authContextForSearch(ctx context.Context, req *proto.L
 		return nil, trace.Wrap(err)
 	}
 
-	return services.NewScopedAccessCheckerContextFromUnscoped(extendedContext.Checker), nil
+	return authz.ScopedContextFromUnscopedContext(extendedContext), nil
 }
 
 var disableUnqualifiedLookups = os.Getenv("TELEPORT_UNSTABLE_DISABLE_UNQUALIFIED_LOOKUPS") == "yes"
@@ -2111,10 +2102,10 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		baseContext := a.scopedContext.CheckerContext
-		a.scopedContext.CheckerContext = extendedContext
+		baseContext := a.scopedContext
+		a.scopedContext = extendedContext
 		defer func() {
-			a.scopedContext.CheckerContext = baseContext
+			a.scopedContext = baseContext
 		}()
 	}
 
@@ -2198,7 +2189,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 	// the next key.
 	req.Limit++
 
-	resourceChecker, err := newResourceAccessChecker(a.scopedContext.CheckerContext, req.ResourceType)
+	resourceChecker, err := newResourceAccessChecker(a.scopedContext, req.ResourceType)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2262,7 +2253,23 @@ type resourceCheckerI interface {
 // resourceChecker is a pass through checker that utilizes the provided [services.AccessChecker] to
 // check access to an untyped resource.
 type resourceChecker struct {
-	scopedCheckerCtx *services.ScopedAccessCheckerContext
+	scopedCtx *authz.ScopedContext
+}
+
+func (r *resourceChecker) unscopedCheckAccess(resource services.AccessCheckable, state services.AccessState, matchers ...services.RoleMatcher) error {
+	unscopedCtx, isUnscoped := r.scopedCtx.UnscopedContext()
+	if !isUnscoped {
+		return trace.Wrap(services.ErrScopedIdentity)
+	}
+	return unscopedCtx.Checker.CheckAccess(resource, state, matchers...)
+}
+
+func (r *resourceChecker) unscopedCheckAccessToSAMLIdP(resource types.ResourceWithLabels, authPref readonly.AuthPreference, state services.AccessState, matchers ...services.RoleMatcher) error {
+	unscopedCtx, isUnscoped := r.scopedCtx.UnscopedContext()
+	if !isUnscoped {
+		return trace.Wrap(services.ErrScopedIdentity)
+	}
+	return unscopedCtx.Checker.CheckAccessToSAMLIdP(resource, authPref, state, matchers...)
 }
 
 // CanAccess handles providing the proper services.AccessCheckable resource
@@ -2274,50 +2281,50 @@ func (r *resourceChecker) CanAccess(ctx context.Context, resource types.Resource
 	switch rr := resource.(type) {
 	case types.AppServer:
 		if rr.GetSubKind() == types.KindIdentityCenterAccount {
-			return r.scopedCheckerCtx.UnscopedCheckAccess(rr.GetApp(), state, services.NewIdentityCenterAppMatcher(rr.GetApp()))
+			return r.unscopedCheckAccess(rr.GetApp(), state, services.NewIdentityCenterAppMatcher(rr.GetApp()))
 		}
 
-		return r.scopedCheckerCtx.UnscopedCheckAccess(rr.GetApp(), state)
+		return r.unscopedCheckAccess(rr.GetApp(), state)
 	case types.KubeServer:
-		return r.scopedCheckerCtx.Decision(ctx, rr.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return r.scopedCtx.CheckerContext.Decision(ctx, rr.GetScope(), func(checker *services.ScopedAccessChecker) error {
 			return checker.Kube().CanAccessCluster(rr.GetCluster())
 		})
 	case types.DatabaseServer:
-		return r.scopedCheckerCtx.UnscopedCheckAccess(rr.GetDatabase(), state)
+		return r.unscopedCheckAccess(rr.GetDatabase(), state)
 	case types.DatabaseService:
-		return r.scopedCheckerCtx.UnscopedCheckAccess(rr, state)
+		return r.unscopedCheckAccess(rr, state)
 	case types.Database:
-		return r.scopedCheckerCtx.UnscopedCheckAccess(rr, state)
+		return r.unscopedCheckAccess(rr, state)
 	case types.Server:
-		return r.scopedCheckerCtx.Decision(ctx, rr.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return r.scopedCtx.CheckerContext.Decision(ctx, rr.GetScope(), func(checker *services.ScopedAccessChecker) error {
 			return checker.SSH().CanAccessSSHServer(rr)
 		})
 	case types.WindowsDesktop:
-		return r.scopedCheckerCtx.UnscopedCheckAccess(rr, state)
+		return r.unscopedCheckAccess(rr, state)
 	case types.WindowsDesktopService:
-		return r.scopedCheckerCtx.UnscopedCheckAccess(rr, state)
+		return r.unscopedCheckAccess(rr, state)
 	case types.UserGroup:
 		// Because usergroup only has ResourceWithLabels, it looks like this will match
 		// everything. To get around this, we'll match on it last and then double check
 		// that the kind is equal to usergroup. If it's not, we'll fall through and return
 		// the bad parameter as expected.
 		if rr.GetKind() == types.KindUserGroup {
-			return r.scopedCheckerCtx.UnscopedCheckAccess(rr, state)
+			return r.unscopedCheckAccess(rr, state)
 		}
 	case types.SAMLIdPServiceProvider:
-		return r.scopedCheckerCtx.UnscopedCheckAccessToSAMLIdP(rr,
+		return r.unscopedCheckAccessToSAMLIdP(rr,
 			nil, /* cluster auth preference will be checked during connection */
 			state,
 		)
 	case types.Resource153UnwrapperT[services.IdentityCenterAccount]:
 		checkable, isCheckable := rr.(services.AccessCheckable)
 		if isCheckable {
-			return r.scopedCheckerCtx.UnscopedCheckAccess(checkable, state, services.NewIdentityCenterAccountMatcher(rr.UnwrapT()))
+			return r.unscopedCheckAccess(checkable, state, services.NewIdentityCenterAccountMatcher(rr.UnwrapT()))
 		}
 	case types.Resource153UnwrapperT[services.IdentityCenterAccountAssignment]:
 		checkable, isCheckable := rr.(services.AccessCheckable)
 		if isCheckable {
-			return r.scopedCheckerCtx.UnscopedCheckAccess(checkable, state, services.NewIdentityCenterAccountAssignmentMatcher(rr.UnwrapT()))
+			return r.unscopedCheckAccess(checkable, state, services.NewIdentityCenterAccountAssignmentMatcher(rr.UnwrapT()))
 		}
 	}
 
@@ -2337,7 +2344,7 @@ func (r *resourceChecker) GetAllowedLoginsForResource(ctx context.Context, resou
 	if ok {
 		scope = scopedResource.GetScope()
 	}
-	for checker, err := range r.scopedCheckerCtx.CheckersForResourceScope(ctx, scope) {
+	for checker, err := range r.scopedCtx.CheckerContext.CheckersForResourceScope(ctx, scope) {
 		if err != nil {
 			continue
 		}
@@ -2347,7 +2354,7 @@ func (r *resourceChecker) GetAllowedLoginsForResource(ctx context.Context, resou
 }
 
 // newResourceAccessChecker creates a resourceChecker for the provided resource type
-func newResourceAccessChecker(scopedCheckerCtx *services.ScopedAccessCheckerContext, resource string) (*resourceChecker, error) {
+func newResourceAccessChecker(scopedCtx *authz.ScopedContext, resource string) (*resourceChecker, error) {
 	switch resource {
 	case types.KindAppServer,
 		types.KindDatabaseServer,
@@ -2362,7 +2369,7 @@ func newResourceAccessChecker(scopedCheckerCtx *services.ScopedAccessCheckerCont
 		types.KindIdentityCenterAccount,
 		types.KindIdentityCenterAccountAssignment,
 		types.KindGitServer:
-		return &resourceChecker{scopedCheckerCtx: scopedCheckerCtx}, nil
+		return &resourceChecker{scopedCtx: scopedCtx}, nil
 	default:
 		return nil, trace.BadParameter("could not check access to resource type %s", resource)
 	}
@@ -2550,7 +2557,7 @@ func (a *ServerWithRoles) listResourcesWithSort(ctx context.Context, req proto.L
 				return r, nil
 			}
 
-			resourceChecker, err := newResourceAccessChecker(a.scopedContext.CheckerContext, req.ResourceType)
+			resourceChecker, err := newResourceAccessChecker(a.scopedContext, req.ResourceType)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -6560,7 +6567,7 @@ func (a *ServerWithRoles) Close() error {
 
 func (a *ServerWithRoles) checkAccessToKubeCluster(ctx context.Context, cluster types.KubeCluster) error {
 	if a.scopedContext != nil {
-		return a.scopedContext.CheckerContext.Decision(ctx, cmp.Or(cluster.GetScope(), scopes.Root), func(checker *services.ScopedAccessChecker) error {
+		return a.scopedContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
 			return checker.Kube().CanAccessCluster(cluster)
 		})
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1092,9 +1092,9 @@ func TestSSODiagnosticInfo(t *testing.T) {
 }
 
 func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
+	os.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	t.Parallel()
 
-	os.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -4949,8 +4949,8 @@ func TestGetAndList_WindowsDesktops(t *testing.T) {
 }
 
 func TestListResources_KindKubernetesCluster(t *testing.T) {
-	t.Parallel()
 	os.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	t.Parallel()
 	ctx := context.Background()
 	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4882,10 +4882,10 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 	authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, authtest.TestBuiltin(types.RoleProxy).I))
 	require.NoError(t, err)
 
-	s := auth.NewServerWithRoles(
+	s := auth.NewScopedServerWithRoles(
 		srv.AuthServer,
 		srv.AuditLog,
-		*authContext,
+		authz.ScopedContextFromUnscopedContext(authContext),
 	)
 
 	testNames := []string{"a", "b", "c", "d"}
@@ -5020,10 +5020,10 @@ func TestListResources_KindUserGroup(t *testing.T) {
 	authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, authtest.TestUserWithRoles(user.GetName(), []string{role.GetName()}).I))
 	require.NoError(t, err)
 
-	s := auth.NewServerWithRoles(
+	s := auth.NewScopedServerWithRoles(
 		srv.AuthServer,
 		srv.AuditLog,
-		*authContext,
+		authz.ScopedContextFromUnscopedContext(authContext),
 	)
 
 	// Test create.

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1163,7 +1163,6 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 
 	role := roleResp.GetRole()
 	_, err = srv.Auth().ScopedAccess().CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
-		RoleRevisions: map[string]string{role.GetMetadata().GetName(): role.GetMetadata().GetRevision()},
 		Assignment: &scopedaccessv1.ScopedRoleAssignment{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			SubKind: scopedaccess.SubKindDynamic,
@@ -4990,7 +4989,6 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 
 		role := roleResp.GetRole()
 		_, err = srv.AuthServer.ScopedAccess().CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
-			RoleRevisions: map[string]string{role.GetMetadata().GetName(): role.GetMetadata().GetRevision()},
 			Assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind:    scopedaccess.KindScopedRoleAssignment,
 				SubKind: scopedaccess.SubKindDynamic,

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -52,6 +53,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
+	labelsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
@@ -4874,12 +4876,90 @@ func TestGetAndList_WindowsDesktops(t *testing.T) {
 
 func TestListResources_KindKubernetesCluster(t *testing.T) {
 	t.Parallel()
+	os.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	ctx := context.Background()
 	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, srv.Close()) })
 
+	scopes := []string{"/test", "/other"}
+	getScopeAsName := func(scope string) string {
+		return strings.ReplaceAll(strings.Trim(scope, "/"), "/", "-")
+	}
+	// create scoped roles, users, and assignments
+	for _, scope := range scopes {
+		roleResp, err := srv.AuthServer.ScopedAccess().CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+			Role: &scopedaccessv1.ScopedRole{
+				Kind:    scopedaccess.KindScopedRole,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: getScopeAsName(scope) + "-role",
+				},
+				Scope: scope,
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{scope},
+					Kube: &scopedaccessv1.ScopedRoleKube{
+						Users:  []string{"kube_user"},
+						Groups: []string{"kube_group"},
+						Labels: []*labelsv1.Label{
+							{
+								Name:   types.Wildcard,
+								Values: []string{types.Wildcard},
+							},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		user, err := authtest.CreateUser(ctx, srv.AuthServer, getScopeAsName(scope)+"-reader")
+		require.NoError(t, err)
+
+		role := roleResp.GetRole()
+		_, err = srv.AuthServer.ScopedAccess().CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			RoleRevisions: map[string]string{role.GetMetadata().GetName(): role.GetMetadata().GetRevision()},
+			Assignment: &scopedaccessv1.ScopedRoleAssignment{
+				Kind:    scopedaccess.KindScopedRoleAssignment,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: uuid.NewString(),
+				},
+				Scope: scope,
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+					User: user.GetName(),
+					Assignments: []*scopedaccessv1.Assignment{
+						{Role: role.GetMetadata().GetName(), Scope: scope},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+	}
 	authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, authtest.TestBuiltin(types.RoleProxy).I))
+	require.NoError(t, err)
+
+	scopedIdent := authtest.TestScopedUser(
+		getScopeAsName(scopes[0])+"-reader",
+		scopes[0],
+		map[string]map[string][]string{
+			scopes[0]: {scopes[0]: {getScopeAsName(scopes[0]) + "-role"}},
+		},
+	).I
+
+	otherScopedIdent := authtest.TestScopedUser(
+		getScopeAsName(scopes[1])+"-reader",
+		scopes[1],
+		map[string]map[string][]string{
+			scopes[1]: {scopes[1]: {getScopeAsName(scopes[1]) + "-role"}},
+		},
+	).I
+
+	scopedCtx, err := srv.ScopedAuthorizer.AuthorizeScoped(authz.ContextWithUser(ctx, scopedIdent))
+	require.NoError(t, err)
+
+	otherScopedCtx, err := srv.ScopedAuthorizer.AuthorizeScoped(authz.ContextWithUser(ctx, otherScopedIdent))
 	require.NoError(t, err)
 
 	s := auth.NewScopedServerWithRoles(
@@ -4888,19 +4968,39 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 		authz.ScopedContextFromUnscopedContext(authContext),
 	)
 
+	scopedS := auth.NewScopedServerWithRoles(
+		srv.AuthServer,
+		srv.AuditLog,
+		scopedCtx,
+	)
+
+	otherScopedS := auth.NewScopedServerWithRoles(
+		srv.AuthServer,
+		srv.AuditLog,
+		otherScopedCtx,
+	)
+
 	testNames := []string{"a", "b", "c", "d"}
 
 	// Add a kube service with 3 clusters.
-	createKubeServer(t, s, []string{"d", "b", "a"}, "host1")
+	createKubeServer(t, s, []string{"d", "b", "a"}, "host1", "")
 
 	// Add a kube service with 2 clusters.
 	// Includes a duplicate cluster name to test deduplicate.
-	createKubeServer(t, s, []string{"a", "c"}, "host2")
+	createKubeServer(t, s, []string{"a", "c"}, "host2", "")
+
+	// Add scoped variants of the kube services
+	createKubeServer(t, srv.AuthServer, []string{"b", "a"}, "scoped_host1", scopes[0])
+
+	// Add a kube service with 2 clusters.
+	// Includes a duplicate cluster name to test deduplicate.
+	createKubeServer(t, srv.AuthServer, []string{"a", "c"}, "scoped_host2", scopes[0])
 
 	// Test upsert.
 	kubeServers, err := s.GetKubernetesServers(ctx)
 	require.NoError(t, err)
-	require.Len(t, kubeServers, 5)
+	// 5 unscoped and 4 scoped kube servers
+	require.Len(t, kubeServers, 9)
 
 	t.Run("fetch all", func(t *testing.T) {
 		t.Parallel()
@@ -4912,7 +5012,7 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, res.Resources, len(testNames))
 		require.Empty(t, res.NextKey)
-		// There is 2 kube services, but 4 unique clusters.
+		// There are 4 unique clusters across all kube services.
 		require.Equal(t, 4, res.TotalCount)
 
 		clusters, err := types.ResourcesWithLabels(res.Resources).AsKubeClusters()
@@ -4967,17 +5067,56 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 		require.NoError(t, err)
 		require.IsDecreasing(t, names)
 	})
+
+	t.Run("fetch all scoped", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := scopedS.ListResources(ctx, proto.ListResourcesRequest{
+			ResourceType: types.KindKubernetesCluster,
+			Limit:        10,
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Resources, 3)
+		require.Empty(t, res.NextKey)
+		// There are 2 scoped kube services referencing 3 unique clusters.
+		require.Equal(t, 3, res.TotalCount)
+
+		clusters, err := types.ResourcesWithLabels(res.Resources).AsKubeClusters()
+		require.NoError(t, err)
+		names, err := types.KubeClusters(clusters).GetFieldVals(types.ResourceMetadataName)
+		require.NoError(t, err)
+		require.ElementsMatch(t, names, []string{"a", "b", "c"})
+	})
+
+	t.Run("fetch all scoped - orthogonal scope", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := otherScopedS.ListResources(ctx, proto.ListResourcesRequest{
+			ResourceType: types.KindKubernetesCluster,
+			Limit:        10,
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Resources, 0, "expected no resources when listing from orthogonal scope")
+		require.Equal(t, 0, res.TotalCount, "expected no resources when listing from orthogonal scope")
+		require.Empty(t, res.NextKey)
+	})
 }
 
-func createKubeServer(t *testing.T, s *auth.ServerWithRoles, clusterNames []string, hostID string) {
+type kubeServerUpserter interface {
+	UpsertKubernetesServer(context.Context, types.KubeServer) (*types.KeepAlive, error)
+}
+
+func createKubeServer(t *testing.T, upserter kubeServerUpserter, clusterNames []string, hostID, scope string) {
 	for _, clusterName := range clusterNames {
 		kubeCluster, err := types.NewKubernetesClusterV3(types.Metadata{
 			Name: clusterName,
 		}, types.KubernetesClusterSpecV3{})
 		require.NoError(t, err)
+		kubeCluster.Scope = scope
 		kubeServer, err := types.NewKubernetesServerV3FromCluster(kubeCluster, hostID, hostID)
 		require.NoError(t, err)
-		_, err = s.UpsertKubernetesServer(context.Background(), kubeServer)
+		kubeServer.Scope = scope
+		_, err = upserter.UpsertKubernetesServer(context.Background(), kubeServer)
 		require.NoError(t, err)
 	}
 }

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1093,6 +1093,7 @@ func TestSSODiagnosticInfo(t *testing.T) {
 func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 	t.Parallel()
 
+	os.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
@@ -1130,6 +1131,57 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 	user2, role2, err := authtest.CreateUserAndRole(srv.Auth(), "user2", []string{"role2"}, nil)
 	require.NoError(t, err)
 
+	getScopeAsName := func(scope string) string {
+		return strings.ReplaceAll(strings.Trim(scope, "/"), "/", "-")
+	}
+
+	scope := "/test"
+	roleResp, err := srv.Auth().ScopedAccess().CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: getScopeAsName(scope) + "-role",
+			},
+			Scope: scope,
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{scope},
+				Kube: &scopedaccessv1.ScopedRoleKube{
+					Users:  []string{"kube_user"},
+					Groups: []string{"kube_group"},
+					Labels: []*labelsv1.Label{
+						{
+							Name:   types.Wildcard,
+							Values: []string{types.Wildcard},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	role := roleResp.GetRole()
+	_, err = srv.Auth().ScopedAccess().CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		RoleRevisions: map[string]string{role.GetMetadata().GetName(): role.GetMetadata().GetRevision()},
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			Scope: scope,
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: user1.GetName(),
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: role.GetMetadata().GetName(), Scope: scope},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
 	role2Opts := role2.GetOptions()
 	role2Opts.MaxSessionTTL = types.NewDuration(2 * time.Hour)
 	role2.SetOptions(role2Opts)
@@ -1151,6 +1203,7 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 	testCases := []struct {
 		desc       string
 		user       types.User
+		scope      string
 		expiration time.Time
 	}{
 		{
@@ -1163,13 +1216,27 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 			user:       user2,
 			expiration: srv.Auth().GetClock().Now().Add(2 * time.Hour),
 		},
+		{
+			desc:       "Scoped role",
+			user:       user1,
+			scope:      scope,
+			expiration: srv.Auth().GetClock().Now().Add(defaultDuration),
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
-			user := authtest.TestUser(tt.user.GetName())
-			user.TTL = defaultDuration
-			client, err := srv.NewClient(user)
+			var ident authtest.TestIdentity
+			if tt.scope != "" {
+				ident = authtest.TestScopedUser(tt.user.GetName(), tt.scope, map[string]map[string][]string{
+					tt.scope: {tt.scope: {getScopeAsName(tt.scope) + "-role"}},
+				})
+			} else {
+				ident = authtest.TestUser(tt.user.GetName())
+			}
+
+			ident.TTL = defaultDuration
+			client, err := srv.NewClient(ident)
 			require.NoError(t, err)
 
 			certs, err := client.GenerateUserCerts(ctx, proto.UserCertsRequest{
@@ -1188,6 +1255,11 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 			require.NoError(t, err)
 			identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
 			require.NoError(t, err)
+			if tt.scope != "" {
+				require.Equal(t, tt.scope, identity.ScopePin.Scope)
+			} else {
+				require.Nil(t, identity.ScopePin)
+			}
 
 			sshCert, err := sshutils.ParseCertificate(certs.SSH)
 			require.NoError(t, err)
@@ -4921,6 +4993,7 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 			RoleRevisions: map[string]string{role.GetMetadata().GetName(): role.GetMetadata().GetRevision()},
 			Assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind:    scopedaccess.KindScopedRoleAssignment,
+				SubKind: scopedaccess.SubKindDynamic,
 				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.NewString(),
@@ -5096,7 +5169,7 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 			Limit:        10,
 		})
 		require.NoError(t, err)
-		require.Len(t, res.Resources, 0, "expected no resources when listing from orthogonal scope")
+		require.Empty(t, res.Resources, "expected no resources when listing from orthogonal scope")
 		require.Equal(t, 0, res.TotalCount, "expected no resources when listing from orthogonal scope")
 		require.Empty(t, res.NextKey)
 	})

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1146,8 +1146,8 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{scope},
 				Kube: &scopedaccessv1.ScopedRoleKube{
-					Users:  []string{"kube_user"},
-					Groups: []string{"kube_group"},
+					Users:  []string{"scoped_kube_user"},
+					Groups: []string{"scoped_kube_group"},
 					Labels: []*labelsv1.Label{
 						{
 							Name:   types.Wildcard,
@@ -1192,38 +1192,47 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 
 	user2, err = srv.Auth().UpdateUser(ctx, user2)
 	require.NoError(t, err)
-	authPrefs, err := srv.Auth().GetAuthPreference(ctx)
-	require.NoError(t, err)
 
 	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
-	defaultDuration := authPrefs.GetDefaultSessionTTL().Duration()
+	ttl := time.Hour
 
 	testCases := []struct {
-		desc       string
-		user       types.User
-		scope      string
-		expiration time.Time
+		desc             string
+		user             types.User
+		scope            string
+		expiration       time.Time
+		expectKubeUsers  []string
+		expectKubeGroups []string
 	}{
 		{
-			desc:       "Roles don't have max_session_ttl set",
-			user:       user1,
-			expiration: srv.Auth().GetClock().Now().Add(defaultDuration),
+			desc:             "Roles don't have max_session_ttl set",
+			user:             user1,
+			expiration:       srv.Auth().GetClock().Now().Add(ttl),
+			expectKubeUsers:  []string{"kube_user"},
+			expectKubeGroups: []string{"kube_group"},
 		},
 		{
-			desc:       "Roles have max_session_ttl set, cert expiration adjusted",
-			user:       user2,
-			expiration: srv.Auth().GetClock().Now().Add(2 * time.Hour),
+			desc:             "Roles have max_session_ttl set, cert expiration adjusted",
+			user:             user2,
+			expiration:       srv.Auth().GetClock().Now().Add(2 * time.Hour),
+			expectKubeUsers:  []string{"kube_user"},
+			expectKubeGroups: []string{"kube_group"},
 		},
 		{
-			desc:       "Scoped role",
-			user:       user1,
-			scope:      scope,
-			expiration: srv.Auth().GetClock().Now().Add(defaultDuration),
+			desc:             "Scoped role",
+			user:             user1,
+			scope:            scope,
+			expiration:       srv.Auth().GetClock().Now().Add(ttl),
+			expectKubeUsers:  []string{"scoped_kube_user"},
+			expectKubeGroups: []string{"scoped_kube_group"},
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
+			if tt.desc != "Scoped role" {
+				t.Skip()
+			}
 			var ident authtest.TestIdentity
 			if tt.scope != "" {
 				ident = authtest.TestScopedUser(tt.user.GetName(), tt.scope, func(i *tlsca.Identity) {
@@ -1235,7 +1244,7 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 				ident = authtest.TestUser(tt.user.GetName())
 			}
 
-			ident.TTL = defaultDuration
+			ident.TTL = ttl
 			client, err := srv.NewClient(ident)
 			require.NoError(t, err)
 
@@ -1243,7 +1252,7 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 				SSHPublicKey:      sshPubKey,
 				TLSPublicKey:      tlsPubKey,
 				Username:          tt.user.GetName(),
-				Expires:           srv.Auth().GetClock().Now().Add(defaultDuration),
+				Expires:           srv.Auth().GetClock().Now().Add(ttl),
 				KubernetesCluster: kubeClusterName,
 				RequesterName:     proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_HEADLESS,
 				Usage:             proto.UserCertsRequest_Kubernetes,
@@ -1261,6 +1270,8 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 				require.Nil(t, identity.ScopePin)
 			}
 
+			require.ElementsMatch(t, tt.expectKubeUsers, identity.KubernetesUsers)
+			require.ElementsMatch(t, tt.expectKubeGroups, identity.KubernetesGroups)
 			sshCert, err := sshutils.ParseCertificate(certs.SSH)
 			require.NoError(t, err)
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -88,6 +88,7 @@ import (
 	"github.com/gravitational/teleport/lib/okta/oktatest"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/joining"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/session"
@@ -1227,8 +1228,10 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			var ident authtest.TestIdentity
 			if tt.scope != "" {
-				ident = authtest.TestScopedUser(tt.user.GetName(), tt.scope, map[string]map[string][]string{
-					tt.scope: {tt.scope: {getScopeAsName(tt.scope) + "-role"}},
+				ident = authtest.TestScopedUser(tt.user.GetName(), tt.scope, func(i *tlsca.Identity) {
+					i.ScopePin.AssignmentTree = pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+						tt.scope: {tt.scope: {getScopeAsName(tt.scope) + "-role"}},
+					})
 				})
 			} else {
 				ident = authtest.TestUser(tt.user.GetName())
@@ -5014,16 +5017,20 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 	scopedIdent := authtest.TestScopedUser(
 		getScopeAsName(scopes[0])+"-reader",
 		scopes[0],
-		map[string]map[string][]string{
-			scopes[0]: {scopes[0]: {getScopeAsName(scopes[0]) + "-role"}},
+		func(i *tlsca.Identity) {
+			i.ScopePin.AssignmentTree = pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+				scopes[0]: {scopes[0]: {getScopeAsName(scopes[0]) + "-role"}},
+			})
 		},
 	).I
 
 	otherScopedIdent := authtest.TestScopedUser(
 		getScopeAsName(scopes[1])+"-reader",
 		scopes[1],
-		map[string]map[string][]string{
-			scopes[1]: {scopes[1]: {getScopeAsName(scopes[1]) + "-role"}},
+		func(i *tlsca.Identity) {
+			i.ScopePin.AssignmentTree = pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+				scopes[1]: {scopes[1]: {getScopeAsName(scopes[1]) + "-role"}},
+			})
 		},
 	).I
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -25,7 +25,6 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"net/url"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -1092,8 +1091,7 @@ func TestSSODiagnosticInfo(t *testing.T) {
 }
 
 func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
-	os.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	t.Parallel()
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
@@ -4949,8 +4947,7 @@ func TestGetAndList_WindowsDesktops(t *testing.T) {
 }
 
 func TestListResources_KindKubernetesCluster(t *testing.T) {
-	os.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
-	t.Parallel()
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	ctx := context.Background()
 	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1123,11 +1123,17 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create test user1.
-	user1, _, err := authtest.CreateUserAndRole(srv.Auth(), "user1", []string{"role1"}, nil)
+	user1, _, err := authtest.CreateUserAndRole(srv.Auth(), "user1", []string{"role1"}, nil, authtest.WithRoleMutator(func(role types.Role) {
+		role.SetKubeGroups(types.Allow, []string{"kube_group"})
+		role.SetKubeUsers(types.Allow, []string{"kube_user"})
+	}))
 	require.NoError(t, err)
 
 	// Create test user2.
-	user2, role2, err := authtest.CreateUserAndRole(srv.Auth(), "user2", []string{"role2"}, nil)
+	user2, role2, err := authtest.CreateUserAndRole(srv.Auth(), "user2", []string{"role2"}, nil, authtest.WithRoleMutator(func(role types.Role) {
+		role.SetKubeGroups(types.Allow, []string{"kube_group"})
+		role.SetKubeUsers(types.Allow, []string{"kube_user"})
+	}))
 	require.NoError(t, err)
 
 	getScopeAsName := func(scope string) string {
@@ -1193,9 +1199,13 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 	user2, err = srv.Auth().UpdateUser(ctx, user2)
 	require.NoError(t, err)
 
-	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
-	ttl := time.Hour
+	authPrefs, err := srv.Auth().GetAuthPreference(ctx)
+	require.NoError(t, err)
 
+	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
+	defaultDuration := authPrefs.GetDefaultSessionTTL().Duration()
+
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES_SESSION_TTL", defaultDuration.String())
 	testCases := []struct {
 		desc             string
 		user             types.User
@@ -1207,7 +1217,7 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 		{
 			desc:             "Roles don't have max_session_ttl set",
 			user:             user1,
-			expiration:       srv.Auth().GetClock().Now().Add(ttl),
+			expiration:       srv.Auth().GetClock().Now().Add(defaultDuration),
 			expectKubeUsers:  []string{"kube_user"},
 			expectKubeGroups: []string{"kube_group"},
 		},
@@ -1219,10 +1229,11 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 			expectKubeGroups: []string{"kube_group"},
 		},
 		{
-			desc:             "Scoped role",
+			// scopes don't support max_session_ttl
+			desc:             "Scoped role, no max_session_ttl set",
 			user:             user1,
 			scope:            scope,
-			expiration:       srv.Auth().GetClock().Now().Add(ttl),
+			expiration:       srv.Auth().GetClock().Now().Add(defaultDuration),
 			expectKubeUsers:  []string{"scoped_kube_user"},
 			expectKubeGroups: []string{"scoped_kube_group"},
 		},
@@ -1230,9 +1241,6 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
-			if tt.desc != "Scoped role" {
-				t.Skip()
-			}
 			var ident authtest.TestIdentity
 			if tt.scope != "" {
 				ident = authtest.TestScopedUser(tt.user.GetName(), tt.scope, func(i *tlsca.Identity) {
@@ -1244,7 +1252,7 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 				ident = authtest.TestUser(tt.user.GetName())
 			}
 
-			ident.TTL = ttl
+			ident.TTL = defaultDuration
 			client, err := srv.NewClient(ident)
 			require.NoError(t, err)
 
@@ -1252,7 +1260,7 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 				SSHPublicKey:      sshPubKey,
 				TLSPublicKey:      tlsPubKey,
 				Username:          tt.user.GetName(),
-				Expires:           srv.Auth().GetClock().Now().Add(ttl),
+				Expires:           srv.Auth().GetClock().Now().Add(defaultDuration),
 				KubernetesCluster: kubeClusterName,
 				RequesterName:     proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_HEADLESS,
 				Usage:             proto.UserCertsRequest_Kubernetes,

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -67,7 +67,6 @@ import (
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
-	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -1114,19 +1113,24 @@ func TestUser(username string) TestIdentity {
 	return TestUserWithRoles(username, nil)
 }
 
+type TestIdentityOpt func(i *tlsca.Identity)
+
 // TestScopedUser returns a TestIdentity for a local user with a scoped identity
 // pinned to the given scope.
-func TestScopedUser(username, scope string, assignments map[string]map[string][]string) TestIdentity {
+func TestScopedUser(username, scope string, opts ...TestIdentityOpt) TestIdentity {
+	ident := tlsca.Identity{
+		Username: username,
+		ScopePin: &scopesv1.Pin{
+			Scope: scope,
+		},
+	}
+	for _, opt := range opts {
+		opt(&ident)
+	}
 	return TestIdentity{
 		I: authz.LocalUser{
 			Username: username,
-			Identity: tlsca.Identity{
-				Username: username,
-				ScopePin: &scopesv1.Pin{
-					Scope:          scope,
-					AssignmentTree: pinning.AssignmentTreeFromMap(assignments),
-				},
-			},
+			Identity: ident,
 		},
 		Scope: scope,
 	}

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -66,6 +67,7 @@ import (
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -1114,12 +1116,16 @@ func TestUser(username string) TestIdentity {
 
 // TestScopedUser returns a TestIdentity for a local user with a scoped identity
 // pinned to the given scope.
-func TestScopedUser(username string, scope string) TestIdentity {
+func TestScopedUser(username, scope string, assignments map[string]map[string][]string) TestIdentity {
 	return TestIdentity{
 		I: authz.LocalUser{
 			Username: username,
 			Identity: tlsca.Identity{
 				Username: username,
+				ScopePin: &scopesv1.Pin{
+					Scope:          scope,
+					AssignmentTree: pinning.AssignmentTreeFromMap(assignments),
+				},
 			},
 		},
 		Scope: scope,
@@ -1219,6 +1225,19 @@ func TestBuiltin(role types.SystemRole) TestIdentity {
 		I: authz.BuiltinRole{
 			Role:     role,
 			Username: string(role),
+		},
+	}
+}
+
+// TestScopedBuiltin returns a scoped TestIdentity for builtin user
+func TestScopedBuiltin(role types.SystemRole, scope string) TestIdentity {
+	return TestIdentity{
+		I: authz.BuiltinRole{
+			Role:     role,
+			Username: string(role),
+			Identity: tlsca.Identity{
+				AgentScope: scope,
+			},
 		},
 	}
 }

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -282,6 +282,14 @@ func NewServerWithRoles(srv *Server, alog events.AuditLogSessionStreamer, authzC
 	}
 }
 
+func NewScopedServerWithRoles(srv *Server, alog events.AuditLogSessionStreamer, authzContext *authz.ScopedContext) *ServerWithRoles {
+	return &ServerWithRoles{
+		authServer:    srv,
+		alog:          alog,
+		scopedContext: authzContext,
+	}
+}
+
 func NewKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertAuthID) (types.CAKeySet, error) {
 	return newKeySet(ctx, keyStore, caID)
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -668,13 +668,17 @@ func resourceLabel(event types.Event) string {
 }
 
 func (g *GRPCServer) GenerateUserCerts(ctx context.Context, req *authpb.UserCertsRequest) (*authpb.Certs, error) {
-	if err := validateUserCertsRequest(req); err != nil {
-		g.logger.DebugContext(ctx, "Validation of user certs request failed", "error", err)
-		return nil, trace.Wrap(err)
-	}
-
 	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// deny access to scoped bots
+	if ident := auth.getIdentity(); ident.IsBot() && ident.ScopePin != nil {
+		return nil, trace.AccessDenied("scoped bots can not generate user certs")
+	}
+
+	if err := validateUserCertsRequest(req); err != nil {
+		g.logger.DebugContext(ctx, "Validation of user certs request failed", "error", err)
 		return nil, trace.Wrap(err)
 	}
 	if req.Purpose == authpb.UserCertsRequest_CERT_PURPOSE_SINGLE_USE_CERTS {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -668,24 +668,15 @@ func resourceLabel(event types.Event) string {
 }
 
 func (g *GRPCServer) GenerateUserCerts(ctx context.Context, req *authpb.UserCertsRequest) (*authpb.Certs, error) {
-
 	if err := validateUserCertsRequest(req); err != nil {
 		g.logger.DebugContext(ctx, "Validation of user certs request failed", "error", err)
 		return nil, trace.Wrap(err)
 	}
 
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
-		if errors.Is(err, services.ErrScopedIdentity) {
-			scopedAuth, err := g.scopedAuthenticate(ctx)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return scopedAuth.GenerateUserCerts(ctx, *req)
-		}
 		return nil, trace.Wrap(err)
 	}
-
 	if req.Purpose == authpb.UserCertsRequest_CERT_PURPOSE_SINGLE_USE_CERTS {
 		// Single-use certs require current user.
 		if err := auth.currentUserAction(req.Username); err != nil {
@@ -783,8 +774,8 @@ func validateAccessGraphcertificateReq(req *authpb.UserCertsRequest) error {
 }
 
 // generateUserSingleUseCerts issues single-use user certificates.
-func (g *GRPCServer) generateUserSingleUseCerts(ctx context.Context, authCtx *grpcContext, req *authpb.UserCertsRequest) (*authpb.Certs, error) {
-	setUserSingleUseCertsTTL(authCtx, req)
+func (g *GRPCServer) generateUserSingleUseCerts(ctx context.Context, authCtx *scopedGRPCContext, req *authpb.UserCertsRequest) (*authpb.Certs, error) {
+	setUserSingleUseCertsTTL(authCtx.authServer, req)
 
 	// We don't do MFA requirement validations here.
 	// Callers are supposed to use either use
@@ -2817,7 +2808,7 @@ func (g *GRPCServer) GenerateUserSingleUseCerts(stream authpb.AuthService_Genera
 	return trace.NotImplemented("method GenerateUserSingleUseCerts is deprecated, use GenerateUserCerts instead")
 }
 
-func setUserSingleUseCertsTTL(authCtx *grpcContext, req *authpb.UserCertsRequest) {
+func setUserSingleUseCertsTTL(srv *Server, req *authpb.UserCertsRequest) {
 	if !isCertWrittenToDiskFlow(req) {
 		// Don't limit the cert expiry to 1 minute for certs that are not written to disk.
 		// When MFA is required, cert expiration time is bounded by the lifetime of the local proxy process
@@ -2825,7 +2816,7 @@ func setUserSingleUseCertsTTL(authCtx *grpcContext, req *authpb.UserCertsRequest
 		return
 	}
 
-	maxExpiry := authCtx.authServer.GetClock().Now().Add(teleport.UserSingleUseCertTTL)
+	maxExpiry := srv.GetClock().Now().Add(teleport.UserSingleUseCertTTL)
 	if req.Expires.After(maxExpiry) {
 		req.Expires = maxExpiry
 	}
@@ -2858,7 +2849,7 @@ func isCertWrittenToDiskFlow(req *authpb.UserCertsRequest) bool {
 	return !isInMemoryCertRequest(req) && !isCredentialsStdoutCertRequest(req)
 }
 
-func userSingleUseCertsGenerate(ctx context.Context, actx *grpcContext, req authpb.UserCertsRequest) (*authpb.Certs, error) {
+func userSingleUseCertsGenerate(ctx context.Context, actx *scopedGRPCContext, req authpb.UserCertsRequest) (*authpb.Certs, error) {
 	// Get the client IP.
 	clientPeer, ok := peer.FromContext(ctx)
 	if !ok {
@@ -2872,9 +2863,9 @@ func userSingleUseCertsGenerate(ctx context.Context, actx *grpcContext, req auth
 	// MFA certificates are supposed to be always pinned to IP, but it was decided to turn this off until
 	// IP pinning comes out of preview. Here we would add option to pin the cert, see commit of this comment for restoring.
 	opts := []certRequestOption{
-		certRequestPreviousIdentityExpires(actx.Identity.GetIdentity().Expires),
+		certRequestPreviousIdentityExpires(actx.scopedContext.Identity.GetIdentity().Expires),
 		certRequestLoginIP(clientIP),
-		certRequestDeviceExtensions(actx.Identity.GetIdentity().DeviceExtensions),
+		certRequestDeviceExtensions(actx.scopedContext.Identity.GetIdentity().DeviceExtensions),
 	}
 
 	// Generate the cert.

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -668,16 +668,30 @@ func resourceLabel(event types.Event) string {
 }
 
 func (g *GRPCServer) GenerateUserCerts(ctx context.Context, req *authpb.UserCertsRequest) (*authpb.Certs, error) {
-	auth, err := g.authenticate(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := validateUserCertsRequest(auth, req); err != nil {
+
+	if err := validateUserCertsRequest(req); err != nil {
 		g.logger.DebugContext(ctx, "Validation of user certs request failed", "error", err)
 		return nil, trace.Wrap(err)
 	}
 
+	auth, err := g.authenticate(ctx)
+	if err != nil {
+		if errors.Is(services.ErrScopedIdentity, err) {
+			scopedAuth, err := g.scopedAuthenticate(ctx)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return scopedAuth.GenerateUserCerts(ctx, *req)
+		}
+		return nil, trace.Wrap(err)
+	}
+
 	if req.Purpose == authpb.UserCertsRequest_CERT_PURPOSE_SINGLE_USE_CERTS {
+		// Single-use certs require current user.
+		if err := auth.currentUserAction(req.Username); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
 		certs, err := g.generateUserSingleUseCerts(ctx, auth, req)
 		return certs, trace.Wrap(err)
 	}
@@ -689,7 +703,7 @@ func (g *GRPCServer) GenerateUserCerts(ctx context.Context, req *authpb.UserCert
 	return certs, nil
 }
 
-func validateUserCertsRequest(actx *grpcContext, req *authpb.UserCertsRequest) error {
+func validateUserCertsRequest(req *authpb.UserCertsRequest) error {
 	if err := validateCertUsage(req); err != nil {
 		return trace.Wrap(err)
 	}
@@ -711,11 +725,6 @@ func validateUserCertsRequest(actx *grpcContext, req *authpb.UserCertsRequest) e
 		if req.MFAResponse.GetTOTP() != nil {
 			return trace.BadParameter("per-session MFA is not satisfied by OTP devices")
 		}
-	}
-
-	// Single-use certs require current user.
-	if err := actx.currentUserAction(req.Username); err != nil {
-		return trace.Wrap(err)
 	}
 
 	return nil
@@ -774,8 +783,8 @@ func validateAccessGraphcertificateReq(req *authpb.UserCertsRequest) error {
 }
 
 // generateUserSingleUseCerts issues single-use user certificates.
-func (g *GRPCServer) generateUserSingleUseCerts(ctx context.Context, actx *grpcContext, req *authpb.UserCertsRequest) (*authpb.Certs, error) {
-	setUserSingleUseCertsTTL(actx, req)
+func (g *GRPCServer) generateUserSingleUseCerts(ctx context.Context, authCtx *grpcContext, req *authpb.UserCertsRequest) (*authpb.Certs, error) {
+	setUserSingleUseCertsTTL(authCtx, req)
 
 	// We don't do MFA requirement validations here.
 	// Callers are supposed to use either use
@@ -788,7 +797,7 @@ func (g *GRPCServer) generateUserSingleUseCerts(ctx context.Context, actx *grpcC
 	// Generate the cert
 	singleUseCert, err := userSingleUseCertsGenerate(
 		ctx,
-		actx,
+		authCtx,
 		*req)
 	if err != nil {
 		g.logger.WarnContext(ctx, "Failed to generate single-use cert", "error", err)
@@ -2808,7 +2817,7 @@ func (g *GRPCServer) GenerateUserSingleUseCerts(stream authpb.AuthService_Genera
 	return trace.NotImplemented("method GenerateUserSingleUseCerts is deprecated, use GenerateUserCerts instead")
 }
 
-func setUserSingleUseCertsTTL(actx *grpcContext, req *authpb.UserCertsRequest) {
+func setUserSingleUseCertsTTL(authCtx *grpcContext, req *authpb.UserCertsRequest) {
 	if !isCertWrittenToDiskFlow(req) {
 		// Don't limit the cert expiry to 1 minute for certs that are not written to disk.
 		// When MFA is required, cert expiration time is bounded by the lifetime of the local proxy process
@@ -2816,7 +2825,7 @@ func setUserSingleUseCertsTTL(actx *grpcContext, req *authpb.UserCertsRequest) {
 		return
 	}
 
-	maxExpiry := actx.authServer.GetClock().Now().Add(teleport.UserSingleUseCertTTL)
+	maxExpiry := authCtx.authServer.GetClock().Now().Add(teleport.UserSingleUseCertTTL)
 	if req.Expires.After(maxExpiry) {
 		req.Expires = maxExpiry
 	}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -679,7 +679,7 @@ func (g *GRPCServer) GenerateUserCerts(ctx context.Context, req *authpb.UserCert
 	}
 	if req.Purpose == authpb.UserCertsRequest_CERT_PURPOSE_SINGLE_USE_CERTS {
 		// Single-use certs require current user.
-		if err := auth.currentUserAction(req.Username); err != nil {
+		if err := auth.currentUserAction(ctx, req.Username); err != nil {
 			return nil, trace.Wrap(err)
 		}
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -676,7 +676,7 @@ func (g *GRPCServer) GenerateUserCerts(ctx context.Context, req *authpb.UserCert
 
 	auth, err := g.authenticate(ctx)
 	if err != nil {
-		if errors.Is(services.ErrScopedIdentity, err) {
+		if errors.Is(err, services.ErrScopedIdentity) {
 			scopedAuth, err := g.scopedAuthenticate(ctx)
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -2900,6 +2900,10 @@ func userSingleUseCertsGenerate(ctx context.Context, actx *grpcContext, req auth
 func (g *GRPCServer) IsMFARequired(ctx context.Context, req *authpb.IsMFARequiredRequest) (*authpb.IsMFARequiredResponse, error) {
 	actx, err := g.authenticate(ctx)
 	if err != nil {
+		if errors.Is(err, services.ErrScopedIdentity) {
+			// MFA is not supported for scoped identities, so return false
+			return &authpb.IsMFARequiredResponse{Required: false}, nil
+		}
 		return nil, trace.Wrap(err)
 	}
 	resp, err := actx.IsMFARequired(ctx, req)

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5008,7 +5008,7 @@ func (g *GRPCServer) scopedListUnifiedResources(ctx context.Context, req *authpb
 
 // ListResources retrieves a paginated list of resources.
 func (g *GRPCServer) ListResources(ctx context.Context, req *authpb.ListResourcesRequest) (*authpb.ListResourcesResponse, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -59,7 +59,10 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	vnetv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/metadata"
@@ -88,6 +91,7 @@ import (
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/server/installer"
@@ -6827,4 +6831,152 @@ func TestGenerateUserCerts_accessGraphUsage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateUserCertsScopedBot(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	testServer := newTestTLSServer(t, withModules(&modulestest.Modules{
+		TestBuildType: modules.BuildEnterprise, // required for Device Trust.
+		TestFeatures: modules.Features{
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.Policy: {Enabled: true},
+			},
+		},
+	}))
+	adminClient, err := testServer.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		botName  string
+		scope    string
+		internal bool
+		expect   func(t *testing.T, err error)
+	}{
+		{
+			name:     "internal scoped",
+			botName:  "scoped_internal",
+			internal: true,
+			scope:    "/test",
+			expect: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.True(t, trace.IsAccessDenied(err))
+				require.Contains(t, err.Error(), "scoped bots can not generate user certs")
+
+			},
+		},
+		{
+			name:    "scoped bot",
+			botName: "scoped_bot",
+			scope:   "/test",
+			expect: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.True(t, trace.IsAccessDenied(err))
+				require.Contains(t, err.Error(), "scoped bots can not generate user certs")
+			},
+		},
+		{
+			name:     "internal unscoped",
+			botName:  "internal",
+			internal: true,
+		},
+		{
+			name:    "unscoped",
+			botName: "unscoped",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := t.Context()
+			bot, err := adminClient.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{
+				Bot: &machineidv1.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
+					Metadata: &headerv1.Metadata{
+						Name: c.botName,
+					},
+					Scope: c.scope,
+					Spec:  &machineidv1.BotSpec{},
+				},
+			})
+			require.NoError(t, err)
+
+			ident := authtest.TestBot(c.botName, c.internal)
+			if c.scope != "" {
+				scopedSvc := adminClient.ScopedAccessServiceClient()
+				roleResp, err := scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+					Role: &scopedaccessv1.ScopedRole{
+						Kind:    scopedaccess.KindScopedRole,
+						Version: types.V1,
+						Metadata: &headerv1.Metadata{
+							Name: c.botName + "-role",
+						},
+						Scope: c.scope,
+						Spec: &scopedaccessv1.ScopedRoleSpec{
+							AssignableScopes: []string{c.scope},
+						},
+					},
+				})
+				require.NoError(t, err)
+
+				sra, err := testServer.Auth().ScopedAccess().CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+					Assignment: &scopedaccessv1.ScopedRoleAssignment{
+						Kind:    scopedaccess.KindScopedRoleAssignment,
+						SubKind: scopedaccess.SubKindDynamic,
+						Version: types.V1,
+						Metadata: &headerv1.Metadata{
+							Name: uuid.NewString(),
+						},
+						Scope: c.scope,
+						Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+							BotName:  bot.GetMetadata().GetName(),
+							BotScope: c.scope,
+							Assignments: []*scopedaccessv1.Assignment{
+								{Role: roleResp.GetRole().GetMetadata().GetName(), Scope: c.scope},
+							},
+						},
+					},
+				})
+				require.NoError(t, err)
+
+				waitForSRACache(t, testServer, sra)
+				ident = authtest.TestScopedBot(c.botName, c.scope, c.internal)
+			}
+
+			client, err := testServer.NewClient(ident)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = client.Close() })
+
+			_, sshPub, _, _ := newSSHAndTLSKeyPairs(t)
+			_, err = client.GenerateUserCerts(ctx, proto.UserCertsRequest{
+				SSHPublicKey:   sshPub,
+				Username:       ident.GetUsername(),
+				Expires:        time.Now().Add(time.Hour),
+				RouteToCluster: testServer.ClusterName(),
+				NodeName:       "mynode",
+				Usage:          proto.UserCertsRequest_SSH,
+				SSHLogin:       "llama",
+			})
+			if c.expect != nil {
+				c.expect(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*scopedaccessv1.CreateScopedRoleAssignmentResponse) {
+	t.Helper()
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, resp := range resps {
+			_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+				Name:    resp.GetAssignment().GetMetadata().GetName(),
+				SubKind: resp.GetAssignment().GetSubKind(),
+			})
+			require.NoError(t, err)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1539,7 +1539,7 @@ func TestAuthPreferenceSettings_ScopedIdentity(t *testing.T) {
 		require.NoError(t, err)
 	}, 10*time.Second, 100*time.Millisecond)
 
-	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
+	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope", nil))
 	require.NoError(t, err)
 	defer scopedClt.Close()
 
@@ -2626,7 +2626,7 @@ func TestGetCertAuthority_ScopedIdentity(t *testing.T) {
 		require.NoError(t, err)
 	}, 10*time.Second, 100*time.Millisecond)
 
-	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
+	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope", nil))
 	require.NoError(t, err)
 	defer scopedClt.Close()
 
@@ -5041,7 +5041,7 @@ func TestWatchEvents_ScopedIdentity(t *testing.T) {
 		require.NoError(t, err)
 	}, 10*time.Second, 100*time.Millisecond)
 
-	scopedClient, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
+	scopedClient, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope", nil))
 	require.NoError(t, err)
 	defer scopedClient.Close()
 

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1539,7 +1539,7 @@ func TestAuthPreferenceSettings_ScopedIdentity(t *testing.T) {
 		require.NoError(t, err)
 	}, 10*time.Second, 100*time.Millisecond)
 
-	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope", nil))
+	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
 	require.NoError(t, err)
 	defer scopedClt.Close()
 
@@ -2626,7 +2626,7 @@ func TestGetCertAuthority_ScopedIdentity(t *testing.T) {
 		require.NoError(t, err)
 	}, 10*time.Second, 100*time.Millisecond)
 
-	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope", nil))
+	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
 	require.NoError(t, err)
 	defer scopedClt.Close()
 
@@ -5041,7 +5041,7 @@ func TestWatchEvents_ScopedIdentity(t *testing.T) {
 		require.NoError(t, err)
 	}, 10*time.Second, 100*time.Millisecond)
 
-	scopedClient, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope", nil))
+	scopedClient, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
 	require.NoError(t, err)
 	defer scopedClient.Close()
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1935,6 +1935,18 @@ func IsCurrentUser(authContext Context, username string) bool {
 	return IsLocalUser(authContext) && authContext.User.GetName() == username
 }
 
+// ScopedIsCurrentUser checks if the scoped identity is a local user matching the given username.
+// If the scoped context wraps an unscoped context, then this function defers to IsCurrentUser.
+func ScopedIsCurrentUser(scopedContext *ScopedContext, username string) bool {
+	unscopedCtx, isUnscoped := scopedContext.UnscopedContext()
+	if isUnscoped {
+		return IsCurrentUser(*unscopedCtx, username)
+	}
+
+	_, ok := scopedContext.Identity.(LocalUser)
+	return ok && scopedContext.User.GetName() == username
+}
+
 // IsRemoteUser checks if the identity is a remote user.
 func IsRemoteUser(authContext Context) bool {
 	_, ok := authContext.UnmappedIdentity.(RemoteUser)

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1936,13 +1936,7 @@ func IsCurrentUser(authContext Context, username string) bool {
 }
 
 // ScopedIsCurrentUser checks if the scoped identity is a local user matching the given username.
-// If the scoped context wraps an unscoped context, then this function defers to IsCurrentUser.
 func ScopedIsCurrentUser(scopedContext *ScopedContext, username string) bool {
-	unscopedCtx, isUnscoped := scopedContext.UnscopedContext()
-	if isUnscoped {
-		return IsCurrentUser(*unscopedCtx, username)
-	}
-
 	_, ok := scopedContext.Identity.(LocalUser)
 	return ok && scopedContext.User.GetName() == username
 }

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -1228,6 +1228,7 @@ func (c *Controller) handleKubernetesServerHB(handle *upstreamHandle, kubernetes
 	now := time.Now()
 
 	kubernetesServer.SetExpiry(now.Add(c.serverTTL).UTC())
+	kubernetesServer.GetCluster().SetScope(kubernetesServer.Scope)
 
 	lease, err := c.auth.UpsertKubernetesServer(c.closeContext, kubernetesServer)
 	if err == nil {

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -181,6 +181,7 @@ type ForwarderConfig struct {
 	// ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.
 	// It is used to determine if the cluster is licensed for Kubernetes usage.
 	ClusterFeatures ClusterFeaturesGetter
+	scope           string
 }
 
 // ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -181,7 +181,9 @@ type ForwarderConfig struct {
 	// ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.
 	// It is used to determine if the cluster is licensed for Kubernetes usage.
 	ClusterFeatures ClusterFeaturesGetter
-	scope           string
+	// scope is the scope assigned to the forwarder at startup. When provided, all kube servers
+	// and clusters served by the forwarder should have the same scope applied.
+	scope string
 }
 
 // ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -121,6 +121,7 @@ type TLSServerConfig struct {
 	InventoryHandle inventory.DownstreamHandle
 	// HealthCheckManager manages checking the health of Kubernetes clusters.
 	HealthCheckManager healthcheck.Manager
+	Scope              string
 }
 
 type awsClientsGetter struct{}
@@ -221,6 +222,7 @@ type TLSServer struct {
 	// reconcileCh triggers reconciliation of proxied kube_clusters.
 	reconcileCh chan struct{}
 	log         *slog.Logger
+	scope       string
 }
 
 // NewTLSServer returns new unstarted TLS server
@@ -237,6 +239,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	}
 
 	cfg.ForwarderConfig.log = log
+	cfg.ForwarderConfig.scope = cfg.scope
 	fwd, err := NewForwarder(cfg.ForwarderConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -540,6 +543,7 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 			RelayIds:   relayIDs,
 		},
 	)
+	srv.Scope = t.scope
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -298,6 +298,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		},
 		reconcileCh: make(chan struct{}),
 		log:         log,
+		scope:       cfg.Scope,
 	}
 	server.TLS.GetConfigForClient = server.GetConfigForClient
 	server.closeContext, server.closeFunc = context.WithCancel(cfg.Context)
@@ -543,10 +544,10 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 			RelayIds:   relayIDs,
 		},
 	)
-	srv.Scope = t.scope
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	srv.Scope = t.scope
 	srv.SetExpiry(t.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL))
 
 	// Get the kube cluster health and send it to the auth server.
@@ -649,7 +650,6 @@ func (t *TLSServer) getKubeClusterWithServiceLabels(name string) (*types.Kuberne
 	}
 
 	t.setServiceLabels(clusterWithoutCreds)
-
 	return clusterWithoutCreds, nil
 }
 

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -121,7 +121,9 @@ type TLSServerConfig struct {
 	InventoryHandle inventory.DownstreamHandle
 	// HealthCheckManager manages checking the health of Kubernetes clusters.
 	HealthCheckManager healthcheck.Manager
-	Scope              string
+	// Scope is the scope the server will impose on the kube servers and clusters it serves unless
+	// operating in proxy mode.
+	Scope string
 }
 
 type awsClientsGetter struct{}
@@ -222,7 +224,6 @@ type TLSServer struct {
 	// reconcileCh triggers reconciliation of proxied kube_clusters.
 	reconcileCh chan struct{}
 	log         *slog.Logger
-	scope       string
 }
 
 // NewTLSServer returns new unstarted TLS server
@@ -239,7 +240,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	}
 
 	cfg.ForwarderConfig.log = log
-	cfg.ForwarderConfig.scope = cfg.scope
+	cfg.ForwarderConfig.scope = cfg.Scope
 	fwd, err := NewForwarder(cfg.ForwarderConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -298,7 +299,6 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		},
 		reconcileCh: make(chan struct{}),
 		log:         log,
-		scope:       cfg.Scope,
 	}
 	server.TLS.GetConfigForClient = server.GetConfigForClient
 	server.closeContext, server.closeFunc = context.WithCancel(cfg.Context)
@@ -547,7 +547,7 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	srv.Scope = t.scope
+	srv.Scope = t.Scope
 	srv.SetExpiry(t.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL))
 
 	// Get the kube cluster health and send it to the auth server.
@@ -771,6 +771,8 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
+			srv.Scope = t.scope
+			srv.Spec.Cluster.SetScope(t.scope)
 			return []types.KubeServer{srv}, nil
 		}, nil
 	case ProxyService:

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -771,8 +771,10 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			srv.Scope = t.scope
-			srv.Spec.Cluster.SetScope(t.scope)
+			if t.scope != "" {
+				srv.Scope = t.scope
+				srv.Spec.Cluster.SetScope(t.scope)
+			}
 			return []types.KubeServer{srv}, nil
 		}, nil
 	case ProxyService:
@@ -797,6 +799,10 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 			srv, err := types.NewKubernetesServerV3FromCluster(kube, "", t.HostID)
 			if err != nil {
 				return nil, trace.Wrap(err)
+			}
+			if t.scope != "" {
+				srv.Scope = t.scope
+				srv.Spec.Cluster.SetScope(t.scope)
 			}
 			return []types.KubeServer{srv}, nil
 		}, nil

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -305,6 +305,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		PROXYProtocolMode:    multiplexer.PROXYProtocolOff, // Kube service doesn't need to process unsigned PROXY headers.
 		InventoryHandle:      process.inventoryHandle,
 		HealthCheckManager:   healthCheckManager,
+		Scope:                conn.Scope(),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/cert_access_checker.go
+++ b/lib/services/cert_access_checker.go
@@ -228,7 +228,7 @@ func (c *CertificateParameterContext) GetKubeGroupsAndUsersForTTL(ctx context.Co
 
 		groups, users, err := checker.Kube().GetGroupsAndUsers(ttl, overrideTTL, matchers...)
 		if err != nil {
-			if !trace.IsAccessDenied(err) {
+			if trace.IsAccessDenied(err) {
 				continue
 			}
 			return nil, nil, trace.Wrap(err)

--- a/lib/services/cert_access_checker.go
+++ b/lib/services/cert_access_checker.go
@@ -20,6 +20,7 @@ package services
 
 import (
 	"context"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -40,7 +41,6 @@ type UnscopedCertificateParameters interface {
 	RoleNames() []string
 	CertificateFormat() string
 	CertificateExtensions() []*types.CertExtension
-	CheckKubeGroupsAndUsers(ttl time.Duration, overrideTTL bool, matchers ...RoleMatcher) ([]string, []string, error)
 	CheckDatabaseNamesAndUsers(ttl time.Duration, overrideTTL bool) ([]string, []string, error)
 	CheckAWSRoleARNs(ttl time.Duration, overrideTTL bool) ([]string, error)
 	CheckAzureIdentities(ttl time.Duration, overrideTTL bool) ([]string, error)
@@ -205,4 +205,43 @@ func (c *CertificateParameterContext) LockingMode(defaultMode constants.LockingM
 	// TODO(fspmarshall/scopes): determine how to handle locking mode for scoped certificates given that
 	// role-affected locking behavior during certificate creation doesn't map well to pinned certificates.
 	return defaultMode
+}
+
+// GetKubeGroupsAndUsersForTTL verifies that the requested session TTL is valid and returns the list of
+// allowed groups and users for the certificate.
+//   - Unscoped: Returns groups and users from roles, restricted by role TTL rules
+//   - Scoped: Returns all possible groups and users across all roles in the pin. This behavior is necessary
+//     because we cannot determine the effective role without knowing the target resource. Subsequent access
+//     checks will enforce group and user restrictions based on the effective role once the target resource
+//     is known.
+func (c *CertificateParameterContext) GetKubeGroupsAndUsersForTTL(ctx context.Context, ttl time.Duration, overrideTTL bool, matchers ...RoleMatcher) ([]string, []string, error) {
+	if !c.ctx.isScoped() {
+		return c.ctx.unscopedChecker.CheckKubeGroupsAndUsers(ttl, overrideTTL, matchers...)
+	}
+
+	groupSet := make(map[string]struct{})
+	userSet := make(map[string]struct{})
+	for checker, err := range c.ctx.riskyEnumerateScopedCheckers(ctx) {
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		groups, users, err := checker.Kube().GetGroupsAndUsers(ttl, overrideTTL, matchers...)
+		if err != nil {
+			if !trace.IsAccessDenied(err) {
+				continue
+			}
+			return nil, nil, trace.Wrap(err)
+		}
+
+		for _, group := range groups {
+			groupSet[group] = struct{}{}
+		}
+
+		for _, user := range users {
+			userSet[user] = struct{}{}
+		}
+	}
+
+	return slices.Collect(maps.Keys(groupSet)), slices.Collect(maps.Keys(userSet)), nil
 }

--- a/lib/services/cert_access_checker.go
+++ b/lib/services/cert_access_checker.go
@@ -228,10 +228,10 @@ func (c *CertificateParameterContext) GetKubeGroupsAndUsersForTTL(ctx context.Co
 
 		groups, users, err := checker.Kube().GetGroupsAndUsers(ttl, overrideTTL, matchers...)
 		if err != nil {
-			if trace.IsNotFound(err) {
-				continue
+			if IsAccessExplicitlyDenied(err) {
+				return nil, nil, trace.Wrap(err)
 			}
-			return nil, nil, trace.Wrap(err)
+			continue
 		}
 
 		for _, group := range groups {

--- a/lib/services/cert_access_checker.go
+++ b/lib/services/cert_access_checker.go
@@ -227,8 +227,11 @@ func (c *CertificateParameterContext) GetKubeGroupsAndUsersForTTL(ctx context.Co
 		}
 
 		groups, users, err := checker.Kube().GetGroupsAndUsers(ttl, overrideTTL, matchers...)
-		if trace.IsNotFound(err) {
-			continue
+		if err != nil {
+			if trace.IsNotFound(err) {
+				continue
+			}
+			return nil, nil, trace.Wrap(err)
 		}
 
 		for _, group := range groups {

--- a/lib/services/cert_access_checker.go
+++ b/lib/services/cert_access_checker.go
@@ -227,7 +227,7 @@ func (c *CertificateParameterContext) GetKubeGroupsAndUsersForTTL(ctx context.Co
 		}
 
 		groups, users, err := checker.Kube().GetGroupsAndUsers(ttl, overrideTTL, matchers...)
-		if err != nil {
+		if trace.IsNotFound(err) {
 			continue
 		}
 

--- a/lib/services/cert_access_checker.go
+++ b/lib/services/cert_access_checker.go
@@ -228,10 +228,7 @@ func (c *CertificateParameterContext) GetKubeGroupsAndUsersForTTL(ctx context.Co
 
 		groups, users, err := checker.Kube().GetGroupsAndUsers(ttl, overrideTTL, matchers...)
 		if err != nil {
-			if trace.IsAccessDenied(err) {
-				continue
-			}
-			return nil, nil, trace.Wrap(err)
+			continue
 		}
 
 		for _, group := range groups {

--- a/lib/services/cert_access_checker.go
+++ b/lib/services/cert_access_checker.go
@@ -240,5 +240,5 @@ func (c *CertificateParameterContext) GetKubeGroupsAndUsersForTTL(ctx context.Co
 		}
 	}
 
-	return slices.Collect(maps.Keys(groupSet)), slices.Collect(maps.Keys(userSet)), nil
+	return slices.Sorted(maps.Keys(groupSet)), slices.Sorted(maps.Keys(userSet)), nil
 }

--- a/lib/services/kube_access_checker.go
+++ b/lib/services/kube_access_checker.go
@@ -19,6 +19,8 @@
 package services
 
 import (
+	"time"
+
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -62,4 +64,13 @@ func (c *KubeAccessChecker) CanAccessCluster(target types.KubeCluster) error {
 		return c.checker.unscopedChecker.CheckAccess(target, AccessState{MFAVerified: true})
 	}
 	return c.checker.scopedCompatChecker.CheckAccess(target, AccessState{MFAVerified: true})
+}
+
+// GetGroupsAndUsers returns the kube groups and users that are permitted for
+// impersonation.
+func (c *KubeAccessChecker) GetGroupsAndUsers(ttl time.Duration, overrideTTL bool, matchers ...RoleMatcher) ([]string, []string, error) {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.CheckKubeGroupsAndUsers(ttl, overrideTTL, matchers...)
+	}
+	return c.checker.scopedCompatChecker.CheckKubeGroupsAndUsers(ttl, overrideTTL, matchers...)
 }

--- a/lib/services/kube_access_checker.go
+++ b/lib/services/kube_access_checker.go
@@ -1,0 +1,65 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"github.com/gravitational/teleport/api/types"
+)
+
+// KubeAccessChecker provides kube-specific access checking, abstracting over scoped and unscoped identities.
+// It is obtained from [ScopedAccessChecker.Kube] and should not be constructed directly. Methods on this type
+// implement kube-specific behavior, branching internally between the scoped and unscoped paths of the underlying
+// [ScopedAccessChecker].
+type KubeAccessChecker struct {
+	checker *ScopedAccessChecker
+}
+
+// CheckAccessToServer checks access to a kube server.
+func (c *KubeAccessChecker) CheckAccessToServer(target types.KubeServer, state AccessState) error {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.CheckAccess(target, state)
+	}
+	return c.checker.scopedCompatChecker.CheckAccess(target, state)
+}
+
+// CanAccessServer checks whether read access to the specified kube server is possible without
+// regard to a specific MFA state. Used for listing/filtering.
+func (c *KubeAccessChecker) CanAccessServer(target types.KubeServer) error {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.CheckAccess(target, AccessState{MFAVerified: true})
+	}
+	return c.checker.scopedCompatChecker.CheckAccess(target, AccessState{MFAVerified: true})
+}
+
+// CheckAccessToCluster checks access to a kube cluster.
+func (c *KubeAccessChecker) CheckAccessToCluster(target types.KubeCluster, state AccessState) error {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.CheckAccess(target, state)
+	}
+	return c.checker.scopedCompatChecker.CheckAccess(target, state)
+}
+
+// CanAccessCluster checks whether read access to the specified kube server is possible without
+// regard to a specific MFA state. Used for listing/filtering.
+func (c *KubeAccessChecker) CanAccessCluster(target types.KubeCluster) error {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.CheckAccess(target, AccessState{MFAVerified: true})
+	}
+	return c.checker.scopedCompatChecker.CheckAccess(target, AccessState{MFAVerified: true})
+}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2614,6 +2614,12 @@ type AccessCheckable interface {
 	GetAllLabels() map[string]string
 }
 
+// ScopedAccessCheckable is an AccessCheckable that can also return a resource's scope.
+type ScopedAccessCheckable interface {
+	AccessCheckable
+	GetScope() string
+}
+
 var rbacLogger = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentRBAC)
 
 // resourceRequiresLabelMatching decides if a resource requires label matching

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -197,6 +197,12 @@ func (c *ScopedAccessChecker) SSH() *SSHAccessChecker {
 	return &SSHAccessChecker{checker: c}
 }
 
+// Kube returns a kube-specific access checker backed by this checker. All kube-specific methods
+// (users, groups, idle timeout, etc.) live on [KubeAccessChecker].
+func (c *ScopedAccessChecker) Kube() *KubeAccessChecker {
+	return &KubeAccessChecker{checker: c}
+}
+
 // AccessInfo returns the AccessInfo that this access checker is based on.
 func (c *ScopedAccessChecker) AccessInfo() *AccessInfo {
 	if !c.isScoped() {

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -282,6 +282,14 @@ func (c *ScopedAccessChecker) LockingMode(defaultMode constants.LockingMode) con
 	return c.scopedCompatChecker.LockingMode(defaultMode)
 }
 
+// GetAllowedLoginsForResource returns all of the allowed logins for the passed resource.
+func (c *ScopedAccessChecker) GetAllowedLoginsForResource(resource AccessCheckable) ([]string, error) {
+	if !c.isScoped() {
+		return c.unscopedChecker.GetAllowedLoginsForResource(resource)
+	}
+	return c.scopedCompatChecker.GetAllowedLoginsForResource(resource)
+}
+
 // checkAccessToRulesImpl verifies that *all* of a series of verbs are permitted for the specified resource. This
 // function differs from AccessChecker.CheckAccessToRule in that it does not support advanced context-based features
 // or namespacing, and accepts a set of verbs all of which must evaluate to allow for the check to succeed.

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
-	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/utils/once"
 )
@@ -313,28 +312,4 @@ func (c *ScopedAccessCheckerContext) Traits() wrappers.Traits {
 // This should not be used outside of certificate generation logic.
 func (c *ScopedAccessCheckerContext) CertParams() *CertificateParameterContext {
 	return &CertificateParameterContext{ctx: c}
-}
-
-// UnscopedCheckAccess is equivalent to calling [AccessChecker].CheckAccess when [ScopedAccessCheckerContext] is
-// unscoped. It results in a [trace.AccessDeniedError] for scoped identities. This function should only be used
-// in situations where we need to maintain backwards compatibility for codepaths that deal with both scoped and
-// unscoped resources. Otherwise, more explicit access checking functions should always be preferred.
-func (c *ScopedAccessCheckerContext) UnscopedCheckAccess(r AccessCheckable, state AccessState, matchers ...RoleMatcher) error {
-	if !c.isScoped() {
-		return c.unscopedChecker.CheckAccess(r, state, matchers...)
-	}
-
-	return trace.AccessDenied("unscoped access check is not allowed for scoped identities")
-}
-
-// UnscopedCheckAccessToSAMLIdP is equivalent to [AccessChecker].CheckAccessToSAMLIdP when [ScopedAccessCheckerContext]
-// is unscoped. It results in a [trace.AccessDeniedError] for scoped identities. This function should only be used
-// in situations where we need to maintain backwards compatibility for codepaths that deal with both scoped and unscoped
-// resources. Otherwise, more explicit access checking functions should always be preferred.
-func (c *ScopedAccessCheckerContext) UnscopedCheckAccessToSAMLIdP(r AccessCheckable, authPref readonly.AuthPreference, state AccessState, matchers ...RoleMatcher) error {
-	if !c.isScoped() {
-		return c.unscopedChecker.CheckAccessToSAMLIdP(r, authPref, state, matchers...)
-	}
-
-	return trace.AccessDenied("unscoped access check is not allowed for scoped identities")
 }

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
+	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/utils/once"
 )
@@ -312,4 +313,28 @@ func (c *ScopedAccessCheckerContext) Traits() wrappers.Traits {
 // This should not be used outside of certificate generation logic.
 func (c *ScopedAccessCheckerContext) CertParams() *CertificateParameterContext {
 	return &CertificateParameterContext{ctx: c}
+}
+
+// UnscopedCheckAccess is equivalent to calling [AccessChecker].CheckAccess when [ScopedAccessCheckerContext] is
+// unscoped. It results in a [trace.AccessDeniedError] for scoped identities. This function should only be used
+// in situations where we need to maintain backwards compatibility for codepaths that deal with both scoped and
+// unscoped resources. Otherwise, more explicit access checking functions should always be preferred.
+func (c *ScopedAccessCheckerContext) UnscopedCheckAccess(r AccessCheckable, state AccessState, matchers ...RoleMatcher) error {
+	if !c.isScoped() {
+		return c.unscopedChecker.CheckAccess(r, state, matchers...)
+	}
+
+	return trace.AccessDenied("unscoped access check is not allowed for scoped identities")
+}
+
+// UnscopedCheckAccessToSAMLIdP is equivalent to [AccessChecker].CheckAccessToSAMLIdP when [ScopedAccessCheckerContext]
+// is unscoped. It results in a [trace.AccessDeniedError] for scoped identities. This function should only be used
+// in situations where we need to maintain backwards compatibility for codepaths that deal with both scoped and unscoped
+// resources. Otherwise, more explicit access checking functions should always be preferred.
+func (c *ScopedAccessCheckerContext) UnscopedCheckAccessToSAMLIdP(r AccessCheckable, authPref readonly.AuthPreference, state AccessState, matchers ...RoleMatcher) error {
+	if !c.isScoped() {
+		return c.unscopedChecker.CheckAccessToSAMLIdP(r, authPref, state, matchers...)
+	}
+
+	return trace.AccessDenied("unscoped access check is not allowed for scoped identities")
 }

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -21,10 +21,13 @@ package services
 import (
 	"context"
 	"log/slog"
+	"maps"
+	"slices"
 
 	"github.com/gravitational/trace"
 
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/itertools/stream"
@@ -312,4 +315,31 @@ func (c *ScopedAccessCheckerContext) Traits() wrappers.Traits {
 // This should not be used outside of certificate generation logic.
 func (c *ScopedAccessCheckerContext) CertParams() *CertificateParameterContext {
 	return &CertificateParameterContext{ctx: c}
+}
+
+// GetPossibleLoginsForSSHServer returns a list of all possible logins for the given SSH server.
+// For both scoped and unscoped identities, this returns the aggregate of all logins provided by each assigned role.
+// Scoped identities will source from all attached roles discoverable in their scope pin.
+func (c *ScopedAccessCheckerContext) GetPossibleLoginsForSSHServer(ctx context.Context, target types.Server) ([]string, error) {
+	if !c.isScoped() {
+		return c.unscopedChecker.GetAllowedLoginsForResource(target)
+	}
+
+	logins := make(map[string]struct{})
+	for checker, err := range c.CheckersForResourceScope(ctx, target.GetScope()) {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if err := checker.SSH().CanAccessSSHServer(target); err != nil {
+			if IsAccessExplicitlyDenied(err) {
+				return nil, trace.Wrap(err)
+			}
+			continue
+		}
+		for _, login := range checker.SSH().getScopedLogins() {
+			logins[login] = struct{}{}
+		}
+	}
+
+	return slices.Sorted(maps.Keys(logins)), nil
 }


### PR DESCRIPTION
Adds support for listing kube clusters and logging in with `tsh kube login` when using a scoped identity. This primarily involves:
- Supporting scoped access checking for the `ListResources` RPC, particularly for kube server and cluster kinds.
- Supporting scoped access for the `GenerateUserCerts` RPC.
- Generating a scope pinned user cert suitable for kube access.

There were a lot of dependent functions I updated to try and reduce the number of forks we have to do between working with `authz.Context` and `authz.ScopedContext` which makes up a decent portion of the diff.

## Manual Test Plan
### Test Environment
```yml
# scoped role for kube access
version: v1
kind: scoped_role
metadata:
  name: kube-admin
scope: /kube
spec:
  assignable_scopes:
  - /kube
  kube:
    groups:
    - insert_group_here
    users:
    - insert_user_here
    labels:
    - name: "*"
      values:
      - "*"
```
```yml
# scoped role assignment for kube access
version: v1
kind: scoped_role_assignment
scope: /local/k8s
spec:
  assignments:
  - role: kube-admin
    scope: /kube
  user: your_user
```

### Test Cases
- [x] Create an unscoped kube cluster
- [x] Create a scoped kube cluster using a scoped join token
- [x] Confirm unscoped credentials allow access to both
  - [x] `tsh kube ls` should list both clusters
  - [x] `tsh kube login <kube-cluster>` should succeed for both
- [x] Create and assign a scoped role that allows for kube access within the same scope as the scoped kube cluster
- [x] Login with scoped credentials `tsh login --scope=/test --proxy=<proxy-addr>`
- [x] List kube clusters `tsh kube ls`
- [x] Confirm the unscoped cluster is no longer present
- [x] Login to the scoped cluster `tsh kube login <scoped-cluster>`
