### PR TITLE
[scopes] feat: collect inherited scoped role grants

### DIFF
--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -23,7 +23,6 @@ import (
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	conv "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
-	traitv1 "github.com/gravitational/teleport/api/types/trait/convert/v1"
 )
 
 // Client is an access list client that conforms to the following lib/services interfaces:
@@ -145,10 +144,8 @@ func (c *Client) GetInheritedGrants(ctx context.Context, accessListID string) (*
 		return nil, trace.Wrap(err)
 	}
 
-	return &accesslist.Grants{
-		Roles:  resp.Grants.Roles,
-		Traits: traitv1.FromProto(resp.Grants.Traits),
-	}, nil
+	grants := conv.ConvertGrantsFromProto(resp.GetGrants())
+	return &grants, nil
 }
 
 // UpsertAccessList creates or updates an access list resource.

--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -48,8 +48,8 @@ func FromProto(msg *accesslistv1.AccessList, opts ...AccessListOption) (*accessl
 		Audit:              convertAuditFromProto(spec.GetAudit()),
 		MembershipRequires: convertRequiresFromProto(spec.GetMembershipRequires()),
 		OwnershipRequires:  convertRequiresFromProto(spec.GetOwnershipRequires()),
-		Grants:             convertGrantsFromProto(spec.GetGrants()),
-		OwnerGrants:        convertGrantsFromProto(spec.GetOwnerGrants()),
+		Grants:             ConvertGrantsFromProto(spec.GetGrants()),
+		OwnerGrants:        ConvertGrantsFromProto(spec.GetOwnerGrants()),
 	}
 
 	accessList, err := accesslist.NewAccessList(metadata, accessListSpec)
@@ -84,8 +84,8 @@ func ToProto(accessList *accesslist.AccessList) *accesslistv1.AccessList {
 			Audit:              convertAuditToProto(accessList.Spec.Audit),
 			MembershipRequires: convertRequiresToProto(accessList.Spec.MembershipRequires),
 			OwnershipRequires:  convertRequiresToProto(accessList.Spec.OwnershipRequires),
-			Grants:             convertGrantsToProto(accessList.Spec.Grants),
-			OwnerGrants:        convertGrantsToProto(accessList.Spec.OwnerGrants),
+			Grants:             ConvertGrantsToProto(accessList.Spec.Grants),
+			OwnerGrants:        ConvertGrantsToProto(accessList.Spec.OwnerGrants),
 		},
 		Status: convertStatusToProto(&accessList.Status),
 	}
@@ -139,7 +139,7 @@ func convertOwnersFromProto(protoOwners []*accesslistv1.AccessListOwner) []acces
 	return owners
 }
 
-func convertGrantsFromProto(protoGrants *accesslistv1.AccessListGrants) accesslist.Grants {
+func ConvertGrantsFromProto(protoGrants *accesslistv1.AccessListGrants) accesslist.Grants {
 	if protoGrants == nil {
 		return accesslist.Grants{}
 	}
@@ -313,7 +313,7 @@ func convertOwnersToProto(owners []accesslist.Owner) []*accesslistv1.AccessListO
 	return protoOwners
 }
 
-func convertGrantsToProto(grants accesslist.Grants) *accesslistv1.AccessListGrants {
+func ConvertGrantsToProto(grants accesslist.Grants) *accesslistv1.AccessListGrants {
 	return &accesslistv1.AccessListGrants{
 		Roles:       grants.Roles,
 		Traits:      traitv1.ToProto(grants.Traits),

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -502,5 +502,5 @@ func Test_convertGrantsToProto_never_nil(t *testing.T) {
 	//
 	// See https://github.com/gravitational/teleport/issues/58948
 	emptyGrants := accesslist.Grants{}
-	require.NotNil(t, convertGrantsToProto(emptyGrants))
+	require.NotNil(t, ConvertGrantsToProto(emptyGrants))
 }

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -19,6 +19,7 @@
 package accesslists
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"maps"
@@ -750,16 +751,23 @@ func GetInheritedGrants(ctx context.Context, accessList *accesslist.AccessList, 
 	}
 
 	collectedRoles := make(map[string]struct{})
+	collectedScopedRoles := make(map[accesslist.ScopedRoleGrant]struct{})
 	collectedTraits := make(map[string]map[string]struct{})
 
-	addGrants := func(grantRoles []string, grantTraits trait.Traits) {
-		for _, role := range grantRoles {
+	addGrants := func(grantsToAdd accesslist.Grants) {
+		for _, role := range grantsToAdd.Roles {
 			if _, exists := collectedRoles[role]; !exists {
 				grants.Roles = append(grants.Roles, role)
 				collectedRoles[role] = struct{}{}
 			}
 		}
-		for traitKey, traitValues := range grantTraits {
+		for _, scopedRoleGrant := range grantsToAdd.ScopedRoles {
+			if _, exists := collectedScopedRoles[scopedRoleGrant]; !exists {
+				grants.ScopedRoles = append(grants.ScopedRoles, scopedRoleGrant)
+				collectedScopedRoles[scopedRoleGrant] = struct{}{}
+			}
+		}
+		for traitKey, traitValues := range grantsToAdd.Traits {
 			if _, exists := collectedTraits[traitKey]; !exists {
 				collectedTraits[traitKey] = make(map[string]struct{})
 			}
@@ -778,8 +786,7 @@ func GetInheritedGrants(ctx context.Context, accessList *accesslist.AccessList, 
 		return nil, trace.Wrap(err)
 	}
 	for _, ancestor := range ancestorLists {
-		memberGrants := ancestor.GetGrants()
-		addGrants(memberGrants.Roles, memberGrants.Traits)
+		addGrants(ancestor.GetGrants())
 	}
 
 	// Get ancestors via owner relationship
@@ -788,16 +795,20 @@ func GetInheritedGrants(ctx context.Context, accessList *accesslist.AccessList, 
 		return nil, trace.Wrap(err)
 	}
 	for _, ancestorOwner := range ancestorOwnerLists {
-		ownerGrants := ancestorOwner.GetOwnerGrants()
-		addGrants(ownerGrants.Roles, ownerGrants.Traits)
+		addGrants(ancestorOwner.GetOwnerGrants())
 	}
 
 	slices.Sort(grants.Roles)
-	grants.Roles = slices.Compact(grants.Roles)
 
-	for k, v := range grants.Traits {
-		slices.Sort(v)
-		grants.Traits[k] = slices.Compact(v)
+	slices.SortFunc(grants.ScopedRoles, func(a, b accesslist.ScopedRoleGrant) int {
+		if c := cmp.Compare(a.Role, b.Role); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Scope, b.Scope)
+	})
+
+	for _, values := range grants.Traits {
+		slices.Sort(values)
 	}
 
 	return &grants, nil

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -625,19 +625,41 @@ func TestGetInheritedGrants(t *testing.T) {
 	acl2 := newAccessList(t, "2", clock)
 
 	// aclroot has a trait for owners - "root-owner-trait", and a role for owners - "root-owner-role"
+	// and 2 scoped roles for owners
 	aclroot.Spec.OwnerGrants = accesslist.Grants{
 		Traits: map[string][]string{
 			"root-owner-trait": {"root-owner-value"},
 		},
 		Roles: []string{"root-owner-role"},
+		ScopedRoles: []accesslist.ScopedRoleGrant{
+			{
+				Role:  "root-scoped-role",
+				Scope: "/root/bb",
+			},
+			{
+				Role:  "root-scoped-role",
+				Scope: "/root/aa",
+			},
+		},
 	}
 
 	// acl1 has a trait for members - "1-member-trait", and a role for members - "1-member-role"
+	// and 2 scoped roles for members
 	acl1.Spec.Grants = accesslist.Grants{
 		Traits: map[string][]string{
 			"1-member-trait": {"1-member-value"},
 		},
 		Roles: []string{"1-member-role"},
+		ScopedRoles: []accesslist.ScopedRoleGrant{
+			{
+				Role:  "1-scoped-role",
+				Scope: "/1/bb",
+			},
+			{
+				Role:  "1-scoped-role",
+				Scope: "/1/aa",
+			},
+		},
 	}
 
 	// acl2 has no traits or roles
@@ -669,6 +691,24 @@ func TestGetInheritedGrants(t *testing.T) {
 			"root-owner-trait": {"root-owner-value"},
 		},
 		Roles: []string{"1-member-role", "root-owner-role"},
+		ScopedRoles: []accesslist.ScopedRoleGrant{
+			{
+				Role:  "1-scoped-role",
+				Scope: "/1/aa",
+			},
+			{
+				Role:  "1-scoped-role",
+				Scope: "/1/bb",
+			},
+			{
+				Role:  "root-scoped-role",
+				Scope: "/root/aa",
+			},
+			{
+				Role:  "root-scoped-role",
+				Scope: "/root/bb",
+			},
+		},
 	}
 
 	grants, err := GetInheritedGrants(ctx, acl2, accessListAndMembersGetter)

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -499,7 +499,9 @@ func (s *Server) UpdateScopedRoleAssignment(ctx context.Context, req *scopedacce
 	// Currently, don't allow assignments created via the API to have a status,
 	// as they could impersonate an access-list-materialized assignment.
 	// TODO(nklaassen): set assignment status based on authenticated identity.
-	req.GetAssignment().Status = nil
+	if req.GetAssignment().GetStatus() != nil {
+		req.GetAssignment().Status = nil
+	}
 
 	return s.cfg.Writer.UpdateScopedRoleAssignment(ctx, req)
 }
@@ -554,7 +556,9 @@ func (s *Server) UpsertScopedRoleAssignment(ctx context.Context, req *scopedacce
 	// Currently, don't allow assignments created via the API to have a status,
 	// as they could impersonate an access-list-materialized assignment.
 	// TODO(nklaassen): set assignment status based on authenticated identity.
-	req.GetAssignment().Status = nil
+	if req.GetAssignment().GetStatus() != nil {
+		req.GetAssignment().Status = nil
+	}
 
 	return s.cfg.Writer.UpsertScopedRoleAssignment(ctx, req)
 }


### PR DESCRIPTION
This change makes accesslists.GetInheritedGrants properly collect inherited scoped role grants, in addition to the existing role and trait grants.

I'm also exporting the methods for converting grants to/from their protobuf types so they can be used in teleport.e where these inherited grants are returned to the UI

## Manual Test Plan

This should be manually tested along with a following PR to teleport.e that makes these inherited grants visible in the UI.