### PR TITLE
feat: added vnet support for db access using connect

### DIFF
--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
@@ -462,6 +462,7 @@ type ResolveFQDNResponse struct {
 	//	*ResolveFQDNResponse_MatchedTcpApp
 	//	*ResolveFQDNResponse_MatchedWebApp
 	//	*ResolveFQDNResponse_MatchedCluster
+	//	*ResolveFQDNResponse_MatchedDatabase
 	Match         isResolveFQDNResponse_Match `protobuf_oneof:"match"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -531,6 +532,15 @@ func (x *ResolveFQDNResponse) GetMatchedCluster() *MatchedCluster {
 	return nil
 }
 
+func (x *ResolveFQDNResponse) GetMatchedDatabase() *MatchedDatabase {
+	if x != nil {
+		if x, ok := x.Match.(*ResolveFQDNResponse_MatchedDatabase); ok {
+			return x.MatchedDatabase
+		}
+	}
+	return nil
+}
+
 type isResolveFQDNResponse_Match interface {
 	isResolveFQDNResponse_Match()
 }
@@ -552,11 +562,18 @@ type ResolveFQDNResponse_MatchedCluster struct {
 	MatchedCluster *MatchedCluster `protobuf:"bytes,3,opt,name=matched_cluster,json=matchedCluster,proto3,oneof"`
 }
 
+type ResolveFQDNResponse_MatchedDatabase struct {
+	// MatchedDatabase will be set when the query matched a database resource.
+	MatchedDatabase *MatchedDatabase `protobuf:"bytes,4,opt,name=matched_database,json=matchedDatabase,proto3,oneof"`
+}
+
 func (*ResolveFQDNResponse_MatchedTcpApp) isResolveFQDNResponse_Match() {}
 
 func (*ResolveFQDNResponse_MatchedWebApp) isResolveFQDNResponse_Match() {}
 
 func (*ResolveFQDNResponse_MatchedCluster) isResolveFQDNResponse_Match() {}
+
+func (*ResolveFQDNResponse_MatchedDatabase) isResolveFQDNResponse_Match() {}
 
 // MatchedTCPApp holds info about a TCP app that matched a query.
 type MatchedTCPApp struct {
@@ -2119,6 +2136,493 @@ func (x *ExchangeSSHKeysResponse) GetUserPublicKey() []byte {
 	return nil
 }
 
+// MatchedDatabase holds info about a database that matched a query.
+type MatchedDatabase struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// DatabaseInfo holds all necessary info for making connections to the resolved database.
+	DatabaseInfo  *DatabaseInfo `protobuf:"bytes,1,opt,name=database_info,json=databaseInfo,proto3" json:"database_info,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MatchedDatabase) Reset() {
+	*x = MatchedDatabase{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MatchedDatabase) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MatchedDatabase) ProtoMessage() {}
+
+func (x *MatchedDatabase) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MatchedDatabase.ProtoReflect.Descriptor instead.
+func (*MatchedDatabase) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *MatchedDatabase) GetDatabaseInfo() *DatabaseInfo {
+	if x != nil {
+		return x.DatabaseInfo
+	}
+	return nil
+}
+
+// DatabaseInfo holds all necessary info for making connections to VNet databases.
+type DatabaseInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// DatabaseKey uniquely identifies a database.
+	DatabaseKey *DatabaseKey `protobuf:"bytes,1,opt,name=database_key,json=databaseKey,proto3" json:"database_key,omitempty"`
+	// Cluster is the name of the cluster in which the database is found.
+	// Iff the database is in a leaf cluster, this will match database_key.leaf_cluster.
+	Cluster string `protobuf:"bytes,2,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	// Protocol is the database wire protocol (e.g. "postgres", "mysql", "mongodb").
+	Protocol string `protobuf:"bytes,3,opt,name=protocol,proto3" json:"protocol,omitempty"`
+	// Username is the database user parsed from the FQDN. May be empty when the
+	// user is auto-provisioned or when only one database user is allowed.
+	Username string `protobuf:"bytes,4,opt,name=username,proto3" json:"username,omitempty"`
+	// Ipv4CidrRange is the CIDR range from which an IPv4 address should be
+	// assigned to the database.
+	Ipv4CidrRange string `protobuf:"bytes,5,opt,name=ipv4_cidr_range,json=ipv4CidrRange,proto3" json:"ipv4_cidr_range,omitempty"`
+	// DialOptions holds options that should be used when dialing the root cluster
+	// of the database.
+	DialOptions   *DialOptions `protobuf:"bytes,6,opt,name=dial_options,json=dialOptions,proto3" json:"dial_options,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DatabaseInfo) Reset() {
+	*x = DatabaseInfo{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DatabaseInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DatabaseInfo) ProtoMessage() {}
+
+func (x *DatabaseInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DatabaseInfo.ProtoReflect.Descriptor instead.
+func (*DatabaseInfo) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *DatabaseInfo) GetDatabaseKey() *DatabaseKey {
+	if x != nil {
+		return x.DatabaseKey
+	}
+	return nil
+}
+
+func (x *DatabaseInfo) GetCluster() string {
+	if x != nil {
+		return x.Cluster
+	}
+	return ""
+}
+
+func (x *DatabaseInfo) GetProtocol() string {
+	if x != nil {
+		return x.Protocol
+	}
+	return ""
+}
+
+func (x *DatabaseInfo) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *DatabaseInfo) GetIpv4CidrRange() string {
+	if x != nil {
+		return x.Ipv4CidrRange
+	}
+	return ""
+}
+
+func (x *DatabaseInfo) GetDialOptions() *DialOptions {
+	if x != nil {
+		return x.DialOptions
+	}
+	return nil
+}
+
+// DatabaseKey uniquely identifies a database in a specific profile and cluster.
+type DatabaseKey struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Profile is the profile in which the database is found.
+	Profile string `protobuf:"bytes,1,opt,name=profile,proto3" json:"profile,omitempty"`
+	// LeafCluster is the leaf cluster in which the database is found. If empty,
+	// the database is in the root cluster for the profile.
+	LeafCluster string `protobuf:"bytes,2,opt,name=leaf_cluster,json=leafCluster,proto3" json:"leaf_cluster,omitempty"`
+	// Name is the name of the database resource.
+	Name          string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DatabaseKey) Reset() {
+	*x = DatabaseKey{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DatabaseKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DatabaseKey) ProtoMessage() {}
+
+func (x *DatabaseKey) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DatabaseKey.ProtoReflect.Descriptor instead.
+func (*DatabaseKey) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *DatabaseKey) GetProfile() string {
+	if x != nil {
+		return x.Profile
+	}
+	return ""
+}
+
+func (x *DatabaseKey) GetLeafCluster() string {
+	if x != nil {
+		return x.LeafCluster
+	}
+	return ""
+}
+
+func (x *DatabaseKey) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+// ReissueDBCertRequest is a request for ReissueDBCert.
+type ReissueDBCertRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// DatabaseInfo contains info about the database, every ReissueDBCertRequest
+	// must include a database_info as returned from ResolveFQDN.
+	DatabaseInfo  *DatabaseInfo `protobuf:"bytes,1,opt,name=database_info,json=databaseInfo,proto3" json:"database_info,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReissueDBCertRequest) Reset() {
+	*x = ReissueDBCertRequest{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReissueDBCertRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReissueDBCertRequest) ProtoMessage() {}
+
+func (x *ReissueDBCertRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReissueDBCertRequest.ProtoReflect.Descriptor instead.
+func (*ReissueDBCertRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *ReissueDBCertRequest) GetDatabaseInfo() *DatabaseInfo {
+	if x != nil {
+		return x.DatabaseInfo
+	}
+	return nil
+}
+
+// ReissueDBCertResponse is a response for ReissueDBCert.
+type ReissueDBCertResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Cert is the issued database certificate in x509 DER format.
+	Cert          []byte `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReissueDBCertResponse) Reset() {
+	*x = ReissueDBCertResponse{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReissueDBCertResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReissueDBCertResponse) ProtoMessage() {}
+
+func (x *ReissueDBCertResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReissueDBCertResponse.ProtoReflect.Descriptor instead.
+func (*ReissueDBCertResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *ReissueDBCertResponse) GetCert() []byte {
+	if x != nil {
+		return x.Cert
+	}
+	return nil
+}
+
+// SignForDBRequest is a request to sign data with a private key that the
+// server has cached for the database_key. The database_key must match a
+// previous successful call to ReissueDBCert. The private key used for the
+// signature will match the subject public key of the issued x509 certificate.
+type SignForDBRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// DatabaseKey uniquely identifies a database, it must match the key of a
+	// database from a previous successful call to ReissueDBCert.
+	DatabaseKey *DatabaseKey `protobuf:"bytes,1,opt,name=database_key,json=databaseKey,proto3" json:"database_key,omitempty"`
+	// Sign holds signature request details.
+	Sign          *SignRequest `protobuf:"bytes,2,opt,name=sign,proto3" json:"sign,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignForDBRequest) Reset() {
+	*x = SignForDBRequest{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignForDBRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignForDBRequest) ProtoMessage() {}
+
+func (x *SignForDBRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignForDBRequest.ProtoReflect.Descriptor instead.
+func (*SignForDBRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *SignForDBRequest) GetDatabaseKey() *DatabaseKey {
+	if x != nil {
+		return x.DatabaseKey
+	}
+	return nil
+}
+
+func (x *SignForDBRequest) GetSign() *SignRequest {
+	if x != nil {
+		return x.Sign
+	}
+	return nil
+}
+
+// SignForDBResponse is a response for SignForDB.
+type SignForDBResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Signature is the signature.
+	Signature     []byte `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignForDBResponse) Reset() {
+	*x = SignForDBResponse{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignForDBResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignForDBResponse) ProtoMessage() {}
+
+func (x *SignForDBResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignForDBResponse.ProtoReflect.Descriptor instead.
+func (*SignForDBResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *SignForDBResponse) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
+// OnNewDBConnectionRequest is a request for OnNewDBConnection.
+type OnNewDBConnectionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// DatabaseKey identifies the database the connection is being made for.
+	DatabaseKey   *DatabaseKey `protobuf:"bytes,1,opt,name=database_key,json=databaseKey,proto3" json:"database_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OnNewDBConnectionRequest) Reset() {
+	*x = OnNewDBConnectionRequest{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OnNewDBConnectionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OnNewDBConnectionRequest) ProtoMessage() {}
+
+func (x *OnNewDBConnectionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OnNewDBConnectionRequest.ProtoReflect.Descriptor instead.
+func (*OnNewDBConnectionRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *OnNewDBConnectionRequest) GetDatabaseKey() *DatabaseKey {
+	if x != nil {
+		return x.DatabaseKey
+	}
+	return nil
+}
+
+// OnNewDBConnectionResponse is a response for OnNewDBConnection.
+type OnNewDBConnectionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OnNewDBConnectionResponse) Reset() {
+	*x = OnNewDBConnectionResponse{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OnNewDBConnectionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OnNewDBConnectionResponse) ProtoMessage() {}
+
+func (x *OnNewDBConnectionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OnNewDBConnectionResponse.ProtoReflect.Descriptor instead.
+func (*OnNewDBConnectionResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{45}
+}
+
 var File_teleport_lib_vnet_v1_client_application_service_proto protoreflect.FileDescriptor
 
 const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
@@ -2139,11 +2643,12 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\vPingRequest\"\x0e\n" +
 	"\fPingResponse\"(\n" +
 	"\x12ResolveFQDNRequest\x12\x12\n" +
-	"\x04fqdn\x18\x01 \x01(\tR\x04fqdn\"\x8d\x02\n" +
+	"\x04fqdn\x18\x01 \x01(\tR\x04fqdn\"\xe1\x02\n" +
 	"\x13ResolveFQDNResponse\x12M\n" +
 	"\x0fmatched_tcp_app\x18\x01 \x01(\v2#.teleport.lib.vnet.v1.MatchedTCPAppH\x00R\rmatchedTcpApp\x12M\n" +
 	"\x0fmatched_web_app\x18\x02 \x01(\v2#.teleport.lib.vnet.v1.MatchedWebAppH\x00R\rmatchedWebApp\x12O\n" +
-	"\x0fmatched_cluster\x18\x03 \x01(\v2$.teleport.lib.vnet.v1.MatchedClusterH\x00R\x0ematchedClusterB\a\n" +
+	"\x0fmatched_cluster\x18\x03 \x01(\v2$.teleport.lib.vnet.v1.MatchedClusterH\x00R\x0ematchedCluster\x12R\n" +
+	"\x10matched_database\x18\x04 \x01(\v2%.teleport.lib.vnet.v1.MatchedDatabaseH\x00R\x0fmatchedDatabaseB\a\n" +
 	"\x05match\"I\n" +
 	"\rMatchedTCPApp\x128\n" +
 	"\bapp_info\x18\x01 \x01(\v2\x1d.teleport.lib.vnet.v1.AppInfoR\aappInfo\"\x0f\n" +
@@ -2233,11 +2738,36 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\x16ExchangeSSHKeysRequest\x12&\n" +
 	"\x0fhost_public_key\x18\x01 \x01(\fR\rhostPublicKey\"A\n" +
 	"\x17ExchangeSSHKeysResponse\x12&\n" +
-	"\x0fuser_public_key\x18\x01 \x01(\fR\ruserPublicKey*<\n" +
+	"\x0fuser_public_key\x18\x01 \x01(\fR\ruserPublicKey\"Z\n" +
+	"\x0fMatchedDatabase\x12G\n" +
+	"\rdatabase_info\x18\x01 \x01(\v2\".teleport.lib.vnet.v1.DatabaseInfoR\fdatabaseInfo\"\x94\x02\n" +
+	"\fDatabaseInfo\x12D\n" +
+	"\fdatabase_key\x18\x01 \x01(\v2!.teleport.lib.vnet.v1.DatabaseKeyR\vdatabaseKey\x12\x18\n" +
+	"\acluster\x18\x02 \x01(\tR\acluster\x12\x1a\n" +
+	"\bprotocol\x18\x03 \x01(\tR\bprotocol\x12\x1a\n" +
+	"\busername\x18\x04 \x01(\tR\busername\x12&\n" +
+	"\x0fipv4_cidr_range\x18\x05 \x01(\tR\ripv4CidrRange\x12D\n" +
+	"\fdial_options\x18\x06 \x01(\v2!.teleport.lib.vnet.v1.DialOptionsR\vdialOptions\"^\n" +
+	"\vDatabaseKey\x12\x18\n" +
+	"\aprofile\x18\x01 \x01(\tR\aprofile\x12!\n" +
+	"\fleaf_cluster\x18\x02 \x01(\tR\vleafCluster\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\"_\n" +
+	"\x14ReissueDBCertRequest\x12G\n" +
+	"\rdatabase_info\x18\x01 \x01(\v2\".teleport.lib.vnet.v1.DatabaseInfoR\fdatabaseInfo\"+\n" +
+	"\x15ReissueDBCertResponse\x12\x12\n" +
+	"\x04cert\x18\x01 \x01(\fR\x04cert\"\x8f\x01\n" +
+	"\x10SignForDBRequest\x12D\n" +
+	"\fdatabase_key\x18\x01 \x01(\v2!.teleport.lib.vnet.v1.DatabaseKeyR\vdatabaseKey\x125\n" +
+	"\x04sign\x18\x02 \x01(\v2!.teleport.lib.vnet.v1.SignRequestR\x04sign\"1\n" +
+	"\x11SignForDBResponse\x12\x1c\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature\"`\n" +
+	"\x18OnNewDBConnectionRequest\x12D\n" +
+	"\fdatabase_key\x18\x01 \x01(\v2!.teleport.lib.vnet.v1.DatabaseKeyR\vdatabaseKey\"\x1b\n" +
+	"\x19OnNewDBConnectionResponse*<\n" +
 	"\x04Hash\x12\x14\n" +
 	"\x10HASH_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tHASH_NONE\x10\x01\x12\x0f\n" +
-	"\vHASH_SHA256\x10\x022\xc5\f\n" +
+	"\vHASH_SHA256\x10\x022\x83\x0f\n" +
 	"\x18ClientApplicationService\x12z\n" +
 	"\x13AuthenticateProcess\x120.teleport.lib.vnet.v1.AuthenticateProcessRequest\x1a1.teleport.lib.vnet.v1.AuthenticateProcessResponse\x12\x83\x01\n" +
 	"\x16ReportNetworkStackInfo\x123.teleport.lib.vnet.v1.ReportNetworkStackInfoRequest\x1a4.teleport.lib.vnet.v1.ReportNetworkStackInfoResponse\x12M\n" +
@@ -2253,7 +2783,10 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\x0eSignForUserTLS\x12+.teleport.lib.vnet.v1.SignForUserTLSRequest\x1a,.teleport.lib.vnet.v1.SignForUserTLSResponse\x12q\n" +
 	"\x10SessionSSHConfig\x12-.teleport.lib.vnet.v1.SessionSSHConfigRequest\x1a..teleport.lib.vnet.v1.SessionSSHConfigResponse\x12t\n" +
 	"\x11SignForSSHSession\x12..teleport.lib.vnet.v1.SignForSSHSessionRequest\x1a/.teleport.lib.vnet.v1.SignForSSHSessionResponse\x12n\n" +
-	"\x0fExchangeSSHKeys\x12,.teleport.lib.vnet.v1.ExchangeSSHKeysRequest\x1a-.teleport.lib.vnet.v1.ExchangeSSHKeysResponseBLZJgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1;vnetv1b\x06proto3"
+	"\x0fExchangeSSHKeys\x12,.teleport.lib.vnet.v1.ExchangeSSHKeysRequest\x1a-.teleport.lib.vnet.v1.ExchangeSSHKeysResponse\x12h\n" +
+	"\rReissueDBCert\x12*.teleport.lib.vnet.v1.ReissueDBCertRequest\x1a+.teleport.lib.vnet.v1.ReissueDBCertResponse\x12\\\n" +
+	"\tSignForDB\x12&.teleport.lib.vnet.v1.SignForDBRequest\x1a'.teleport.lib.vnet.v1.SignForDBResponse\x12t\n" +
+	"\x11OnNewDBConnection\x12..teleport.lib.vnet.v1.OnNewDBConnectionRequest\x1a/.teleport.lib.vnet.v1.OnNewDBConnectionResponseBLZJgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1;vnetv1b\x06proto3"
 
 var (
 	file_teleport_lib_vnet_v1_client_application_service_proto_rawDescOnce sync.Once
@@ -2268,7 +2801,7 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP() []
 }
 
 var file_teleport_lib_vnet_v1_client_application_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
 var file_teleport_lib_vnet_v1_client_application_service_proto_goTypes = []any{
 	(Hash)(0),                                // 0: teleport.lib.vnet.v1.Hash
 	(*AuthenticateProcessRequest)(nil),       // 1: teleport.lib.vnet.v1.AuthenticateProcessRequest
@@ -2308,60 +2841,83 @@ var file_teleport_lib_vnet_v1_client_application_service_proto_goTypes = []any{
 	(*SignForSSHSessionResponse)(nil),        // 35: teleport.lib.vnet.v1.SignForSSHSessionResponse
 	(*ExchangeSSHKeysRequest)(nil),           // 36: teleport.lib.vnet.v1.ExchangeSSHKeysRequest
 	(*ExchangeSSHKeysResponse)(nil),          // 37: teleport.lib.vnet.v1.ExchangeSSHKeysResponse
-	(*types.AppV3)(nil),                      // 38: types.AppV3
+	(*MatchedDatabase)(nil),                  // 38: teleport.lib.vnet.v1.MatchedDatabase
+	(*DatabaseInfo)(nil),                     // 39: teleport.lib.vnet.v1.DatabaseInfo
+	(*DatabaseKey)(nil),                      // 40: teleport.lib.vnet.v1.DatabaseKey
+	(*ReissueDBCertRequest)(nil),             // 41: teleport.lib.vnet.v1.ReissueDBCertRequest
+	(*ReissueDBCertResponse)(nil),            // 42: teleport.lib.vnet.v1.ReissueDBCertResponse
+	(*SignForDBRequest)(nil),                 // 43: teleport.lib.vnet.v1.SignForDBRequest
+	(*SignForDBResponse)(nil),                // 44: teleport.lib.vnet.v1.SignForDBResponse
+	(*OnNewDBConnectionRequest)(nil),         // 45: teleport.lib.vnet.v1.OnNewDBConnectionRequest
+	(*OnNewDBConnectionResponse)(nil),        // 46: teleport.lib.vnet.v1.OnNewDBConnectionResponse
+	(*types.AppV3)(nil),                      // 47: types.AppV3
 }
 var file_teleport_lib_vnet_v1_client_application_service_proto_depIdxs = []int32{
 	4,  // 0: teleport.lib.vnet.v1.ReportNetworkStackInfoRequest.network_stack_info:type_name -> teleport.lib.vnet.v1.NetworkStackInfo
 	10, // 1: teleport.lib.vnet.v1.ResolveFQDNResponse.matched_tcp_app:type_name -> teleport.lib.vnet.v1.MatchedTCPApp
 	11, // 2: teleport.lib.vnet.v1.ResolveFQDNResponse.matched_web_app:type_name -> teleport.lib.vnet.v1.MatchedWebApp
 	12, // 3: teleport.lib.vnet.v1.ResolveFQDNResponse.matched_cluster:type_name -> teleport.lib.vnet.v1.MatchedCluster
-	13, // 4: teleport.lib.vnet.v1.MatchedTCPApp.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
-	14, // 5: teleport.lib.vnet.v1.AppInfo.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	38, // 6: teleport.lib.vnet.v1.AppInfo.app:type_name -> types.AppV3
-	15, // 7: teleport.lib.vnet.v1.AppInfo.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
-	13, // 8: teleport.lib.vnet.v1.ReissueAppCertRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
-	14, // 9: teleport.lib.vnet.v1.SignForAppRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	19, // 10: teleport.lib.vnet.v1.SignForAppRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
-	0,  // 11: teleport.lib.vnet.v1.SignRequest.hash:type_name -> teleport.lib.vnet.v1.Hash
-	14, // 12: teleport.lib.vnet.v1.OnNewAppConnectionRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	13, // 13: teleport.lib.vnet.v1.OnInvalidLocalPortRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
-	27, // 14: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse.target_os_configuration:type_name -> teleport.lib.vnet.v1.TargetOSConfiguration
-	15, // 15: teleport.lib.vnet.v1.UserTLSCertResponse.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
-	19, // 16: teleport.lib.vnet.v1.SignForUserTLSRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
-	19, // 17: teleport.lib.vnet.v1.SignForSSHSessionRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
-	1,  // 18: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:input_type -> teleport.lib.vnet.v1.AuthenticateProcessRequest
-	3,  // 19: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:input_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoRequest
-	6,  // 20: teleport.lib.vnet.v1.ClientApplicationService.Ping:input_type -> teleport.lib.vnet.v1.PingRequest
-	8,  // 21: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:input_type -> teleport.lib.vnet.v1.ResolveFQDNRequest
-	16, // 22: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:input_type -> teleport.lib.vnet.v1.ReissueAppCertRequest
-	18, // 23: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:input_type -> teleport.lib.vnet.v1.SignForAppRequest
-	21, // 24: teleport.lib.vnet.v1.ClientApplicationService.OnNewAppConnection:input_type -> teleport.lib.vnet.v1.OnNewAppConnectionRequest
-	23, // 25: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:input_type -> teleport.lib.vnet.v1.OnInvalidLocalPortRequest
-	25, // 26: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:input_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
-	28, // 27: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:input_type -> teleport.lib.vnet.v1.UserTLSCertRequest
-	30, // 28: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:input_type -> teleport.lib.vnet.v1.SignForUserTLSRequest
-	32, // 29: teleport.lib.vnet.v1.ClientApplicationService.SessionSSHConfig:input_type -> teleport.lib.vnet.v1.SessionSSHConfigRequest
-	34, // 30: teleport.lib.vnet.v1.ClientApplicationService.SignForSSHSession:input_type -> teleport.lib.vnet.v1.SignForSSHSessionRequest
-	36, // 31: teleport.lib.vnet.v1.ClientApplicationService.ExchangeSSHKeys:input_type -> teleport.lib.vnet.v1.ExchangeSSHKeysRequest
-	2,  // 32: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:output_type -> teleport.lib.vnet.v1.AuthenticateProcessResponse
-	5,  // 33: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:output_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
-	7,  // 34: teleport.lib.vnet.v1.ClientApplicationService.Ping:output_type -> teleport.lib.vnet.v1.PingResponse
-	9,  // 35: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:output_type -> teleport.lib.vnet.v1.ResolveFQDNResponse
-	17, // 36: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:output_type -> teleport.lib.vnet.v1.ReissueAppCertResponse
-	20, // 37: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:output_type -> teleport.lib.vnet.v1.SignForAppResponse
-	22, // 38: teleport.lib.vnet.v1.ClientApplicationService.OnNewAppConnection:output_type -> teleport.lib.vnet.v1.OnNewAppConnectionResponse
-	24, // 39: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:output_type -> teleport.lib.vnet.v1.OnInvalidLocalPortResponse
-	26, // 40: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:output_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
-	29, // 41: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:output_type -> teleport.lib.vnet.v1.UserTLSCertResponse
-	31, // 42: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:output_type -> teleport.lib.vnet.v1.SignForUserTLSResponse
-	33, // 43: teleport.lib.vnet.v1.ClientApplicationService.SessionSSHConfig:output_type -> teleport.lib.vnet.v1.SessionSSHConfigResponse
-	35, // 44: teleport.lib.vnet.v1.ClientApplicationService.SignForSSHSession:output_type -> teleport.lib.vnet.v1.SignForSSHSessionResponse
-	37, // 45: teleport.lib.vnet.v1.ClientApplicationService.ExchangeSSHKeys:output_type -> teleport.lib.vnet.v1.ExchangeSSHKeysResponse
-	32, // [32:46] is the sub-list for method output_type
-	18, // [18:32] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	38, // 4: teleport.lib.vnet.v1.ResolveFQDNResponse.matched_database:type_name -> teleport.lib.vnet.v1.MatchedDatabase
+	13, // 5: teleport.lib.vnet.v1.MatchedTCPApp.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
+	14, // 6: teleport.lib.vnet.v1.AppInfo.app_key:type_name -> teleport.lib.vnet.v1.AppKey
+	47, // 7: teleport.lib.vnet.v1.AppInfo.app:type_name -> types.AppV3
+	15, // 8: teleport.lib.vnet.v1.AppInfo.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
+	13, // 9: teleport.lib.vnet.v1.ReissueAppCertRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
+	14, // 10: teleport.lib.vnet.v1.SignForAppRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
+	19, // 11: teleport.lib.vnet.v1.SignForAppRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
+	0,  // 12: teleport.lib.vnet.v1.SignRequest.hash:type_name -> teleport.lib.vnet.v1.Hash
+	14, // 13: teleport.lib.vnet.v1.OnNewAppConnectionRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
+	13, // 14: teleport.lib.vnet.v1.OnInvalidLocalPortRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
+	27, // 15: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse.target_os_configuration:type_name -> teleport.lib.vnet.v1.TargetOSConfiguration
+	15, // 16: teleport.lib.vnet.v1.UserTLSCertResponse.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
+	19, // 17: teleport.lib.vnet.v1.SignForUserTLSRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
+	19, // 18: teleport.lib.vnet.v1.SignForSSHSessionRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
+	39, // 19: teleport.lib.vnet.v1.MatchedDatabase.database_info:type_name -> teleport.lib.vnet.v1.DatabaseInfo
+	40, // 20: teleport.lib.vnet.v1.DatabaseInfo.database_key:type_name -> teleport.lib.vnet.v1.DatabaseKey
+	15, // 21: teleport.lib.vnet.v1.DatabaseInfo.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
+	39, // 22: teleport.lib.vnet.v1.ReissueDBCertRequest.database_info:type_name -> teleport.lib.vnet.v1.DatabaseInfo
+	40, // 23: teleport.lib.vnet.v1.SignForDBRequest.database_key:type_name -> teleport.lib.vnet.v1.DatabaseKey
+	19, // 24: teleport.lib.vnet.v1.SignForDBRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
+	40, // 25: teleport.lib.vnet.v1.OnNewDBConnectionRequest.database_key:type_name -> teleport.lib.vnet.v1.DatabaseKey
+	1,  // 26: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:input_type -> teleport.lib.vnet.v1.AuthenticateProcessRequest
+	3,  // 27: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:input_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoRequest
+	6,  // 28: teleport.lib.vnet.v1.ClientApplicationService.Ping:input_type -> teleport.lib.vnet.v1.PingRequest
+	8,  // 29: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:input_type -> teleport.lib.vnet.v1.ResolveFQDNRequest
+	16, // 30: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:input_type -> teleport.lib.vnet.v1.ReissueAppCertRequest
+	18, // 31: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:input_type -> teleport.lib.vnet.v1.SignForAppRequest
+	21, // 32: teleport.lib.vnet.v1.ClientApplicationService.OnNewAppConnection:input_type -> teleport.lib.vnet.v1.OnNewAppConnectionRequest
+	23, // 33: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:input_type -> teleport.lib.vnet.v1.OnInvalidLocalPortRequest
+	25, // 34: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:input_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
+	28, // 35: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:input_type -> teleport.lib.vnet.v1.UserTLSCertRequest
+	30, // 36: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:input_type -> teleport.lib.vnet.v1.SignForUserTLSRequest
+	32, // 37: teleport.lib.vnet.v1.ClientApplicationService.SessionSSHConfig:input_type -> teleport.lib.vnet.v1.SessionSSHConfigRequest
+	34, // 38: teleport.lib.vnet.v1.ClientApplicationService.SignForSSHSession:input_type -> teleport.lib.vnet.v1.SignForSSHSessionRequest
+	36, // 39: teleport.lib.vnet.v1.ClientApplicationService.ExchangeSSHKeys:input_type -> teleport.lib.vnet.v1.ExchangeSSHKeysRequest
+	41, // 40: teleport.lib.vnet.v1.ClientApplicationService.ReissueDBCert:input_type -> teleport.lib.vnet.v1.ReissueDBCertRequest
+	43, // 41: teleport.lib.vnet.v1.ClientApplicationService.SignForDB:input_type -> teleport.lib.vnet.v1.SignForDBRequest
+	45, // 42: teleport.lib.vnet.v1.ClientApplicationService.OnNewDBConnection:input_type -> teleport.lib.vnet.v1.OnNewDBConnectionRequest
+	2,  // 43: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:output_type -> teleport.lib.vnet.v1.AuthenticateProcessResponse
+	5,  // 44: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:output_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
+	7,  // 45: teleport.lib.vnet.v1.ClientApplicationService.Ping:output_type -> teleport.lib.vnet.v1.PingResponse
+	9,  // 46: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:output_type -> teleport.lib.vnet.v1.ResolveFQDNResponse
+	17, // 47: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:output_type -> teleport.lib.vnet.v1.ReissueAppCertResponse
+	20, // 48: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:output_type -> teleport.lib.vnet.v1.SignForAppResponse
+	22, // 49: teleport.lib.vnet.v1.ClientApplicationService.OnNewAppConnection:output_type -> teleport.lib.vnet.v1.OnNewAppConnectionResponse
+	24, // 50: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:output_type -> teleport.lib.vnet.v1.OnInvalidLocalPortResponse
+	26, // 51: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:output_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
+	29, // 52: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:output_type -> teleport.lib.vnet.v1.UserTLSCertResponse
+	31, // 53: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:output_type -> teleport.lib.vnet.v1.SignForUserTLSResponse
+	33, // 54: teleport.lib.vnet.v1.ClientApplicationService.SessionSSHConfig:output_type -> teleport.lib.vnet.v1.SessionSSHConfigResponse
+	35, // 55: teleport.lib.vnet.v1.ClientApplicationService.SignForSSHSession:output_type -> teleport.lib.vnet.v1.SignForSSHSessionResponse
+	37, // 56: teleport.lib.vnet.v1.ClientApplicationService.ExchangeSSHKeys:output_type -> teleport.lib.vnet.v1.ExchangeSSHKeysResponse
+	42, // 57: teleport.lib.vnet.v1.ClientApplicationService.ReissueDBCert:output_type -> teleport.lib.vnet.v1.ReissueDBCertResponse
+	44, // 58: teleport.lib.vnet.v1.ClientApplicationService.SignForDB:output_type -> teleport.lib.vnet.v1.SignForDBResponse
+	46, // 59: teleport.lib.vnet.v1.ClientApplicationService.OnNewDBConnection:output_type -> teleport.lib.vnet.v1.OnNewDBConnectionResponse
+	43, // [43:60] is the sub-list for method output_type
+	26, // [26:43] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_vnet_v1_client_application_service_proto_init() }
@@ -2373,6 +2929,7 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_init() {
 		(*ResolveFQDNResponse_MatchedTcpApp)(nil),
 		(*ResolveFQDNResponse_MatchedWebApp)(nil),
 		(*ResolveFQDNResponse_MatchedCluster)(nil),
+		(*ResolveFQDNResponse_MatchedDatabase)(nil),
 	}
 	file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[18].OneofWrappers = []any{}
 	type x struct{}
@@ -2381,7 +2938,7 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc), len(file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   37,
+			NumMessages:   46,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
@@ -2445,7 +2445,11 @@ type SignForDBRequest struct {
 	// database from a previous successful call to ReissueDBCert.
 	DatabaseKey *DatabaseKey `protobuf:"bytes,1,opt,name=database_key,json=databaseKey,proto3" json:"database_key,omitempty"`
 	// Sign holds signature request details.
-	Sign          *SignRequest `protobuf:"bytes,2,opt,name=sign,proto3" json:"sign,omitempty"`
+	Sign *SignRequest `protobuf:"bytes,2,opt,name=sign,proto3" json:"sign,omitempty"`
+	// Username is the database user for which the cert was issued. Required
+	// because different users connecting to the same database get different
+	// certs and signers.
+	Username      string `protobuf:"bytes,3,opt,name=username,proto3" json:"username,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2492,6 +2496,13 @@ func (x *SignForDBRequest) GetSign() *SignRequest {
 		return x.Sign
 	}
 	return nil
+}
+
+func (x *SignForDBRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
 }
 
 // SignForDBResponse is a response for SignForDB.
@@ -2755,10 +2766,11 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\x14ReissueDBCertRequest\x12G\n" +
 	"\rdatabase_info\x18\x01 \x01(\v2\".teleport.lib.vnet.v1.DatabaseInfoR\fdatabaseInfo\"+\n" +
 	"\x15ReissueDBCertResponse\x12\x12\n" +
-	"\x04cert\x18\x01 \x01(\fR\x04cert\"\x8f\x01\n" +
+	"\x04cert\x18\x01 \x01(\fR\x04cert\"\xab\x01\n" +
 	"\x10SignForDBRequest\x12D\n" +
 	"\fdatabase_key\x18\x01 \x01(\v2!.teleport.lib.vnet.v1.DatabaseKeyR\vdatabaseKey\x125\n" +
-	"\x04sign\x18\x02 \x01(\v2!.teleport.lib.vnet.v1.SignRequestR\x04sign\"1\n" +
+	"\x04sign\x18\x02 \x01(\v2!.teleport.lib.vnet.v1.SignRequestR\x04sign\x12\x1a\n" +
+	"\busername\x18\x03 \x01(\tR\busername\"1\n" +
 	"\x11SignForDBResponse\x12\x1c\n" +
 	"\tsignature\x18\x01 \x01(\fR\tsignature\"`\n" +
 	"\x18OnNewDBConnectionRequest\x12D\n" +

--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service_grpc.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service_grpc.pb.go
@@ -49,6 +49,9 @@ const (
 	ClientApplicationService_SessionSSHConfig_FullMethodName         = "/teleport.lib.vnet.v1.ClientApplicationService/SessionSSHConfig"
 	ClientApplicationService_SignForSSHSession_FullMethodName        = "/teleport.lib.vnet.v1.ClientApplicationService/SignForSSHSession"
 	ClientApplicationService_ExchangeSSHKeys_FullMethodName          = "/teleport.lib.vnet.v1.ClientApplicationService/ExchangeSSHKeys"
+	ClientApplicationService_ReissueDBCert_FullMethodName            = "/teleport.lib.vnet.v1.ClientApplicationService/ReissueDBCert"
+	ClientApplicationService_SignForDB_FullMethodName                = "/teleport.lib.vnet.v1.ClientApplicationService/SignForDB"
+	ClientApplicationService_OnNewDBConnection_FullMethodName        = "/teleport.lib.vnet.v1.ClientApplicationService/OnNewDBConnection"
 )
 
 // ClientApplicationServiceClient is the client API for ClientApplicationService service.
@@ -98,6 +101,14 @@ type ClientApplicationServiceClient interface {
 	// ExchangeSSHKeys sends VNet's SSH host CA key to the client application and
 	// returns the user public key.
 	ExchangeSSHKeys(ctx context.Context, in *ExchangeSSHKeysRequest, opts ...grpc.CallOption) (*ExchangeSSHKeysResponse, error)
+	// ReissueDBCert issues a new database cert.
+	ReissueDBCert(ctx context.Context, in *ReissueDBCertRequest, opts ...grpc.CallOption) (*ReissueDBCertResponse, error)
+	// SignForDB issues a signature with the private key associated with an x509
+	// certificate previously issued for a requested database.
+	SignForDB(ctx context.Context, in *SignForDBRequest, opts ...grpc.CallOption) (*SignForDBResponse, error)
+	// OnNewDBConnection gets called whenever a new database connection is about to
+	// be established through VNet for observability.
+	OnNewDBConnection(ctx context.Context, in *OnNewDBConnectionRequest, opts ...grpc.CallOption) (*OnNewDBConnectionResponse, error)
 }
 
 type clientApplicationServiceClient struct {
@@ -248,6 +259,36 @@ func (c *clientApplicationServiceClient) ExchangeSSHKeys(ctx context.Context, in
 	return out, nil
 }
 
+func (c *clientApplicationServiceClient) ReissueDBCert(ctx context.Context, in *ReissueDBCertRequest, opts ...grpc.CallOption) (*ReissueDBCertResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReissueDBCertResponse)
+	err := c.cc.Invoke(ctx, ClientApplicationService_ReissueDBCert_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *clientApplicationServiceClient) SignForDB(ctx context.Context, in *SignForDBRequest, opts ...grpc.CallOption) (*SignForDBResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SignForDBResponse)
+	err := c.cc.Invoke(ctx, ClientApplicationService_SignForDB_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *clientApplicationServiceClient) OnNewDBConnection(ctx context.Context, in *OnNewDBConnectionRequest, opts ...grpc.CallOption) (*OnNewDBConnectionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(OnNewDBConnectionResponse)
+	err := c.cc.Invoke(ctx, ClientApplicationService_OnNewDBConnection_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ClientApplicationServiceServer is the server API for ClientApplicationService service.
 // All implementations must embed UnimplementedClientApplicationServiceServer
 // for forward compatibility.
@@ -295,6 +336,14 @@ type ClientApplicationServiceServer interface {
 	// ExchangeSSHKeys sends VNet's SSH host CA key to the client application and
 	// returns the user public key.
 	ExchangeSSHKeys(context.Context, *ExchangeSSHKeysRequest) (*ExchangeSSHKeysResponse, error)
+	// ReissueDBCert issues a new database cert.
+	ReissueDBCert(context.Context, *ReissueDBCertRequest) (*ReissueDBCertResponse, error)
+	// SignForDB issues a signature with the private key associated with an x509
+	// certificate previously issued for a requested database.
+	SignForDB(context.Context, *SignForDBRequest) (*SignForDBResponse, error)
+	// OnNewDBConnection gets called whenever a new database connection is about to
+	// be established through VNet for observability.
+	OnNewDBConnection(context.Context, *OnNewDBConnectionRequest) (*OnNewDBConnectionResponse, error)
 	mustEmbedUnimplementedClientApplicationServiceServer()
 }
 
@@ -346,6 +395,15 @@ func (UnimplementedClientApplicationServiceServer) SignForSSHSession(context.Con
 }
 func (UnimplementedClientApplicationServiceServer) ExchangeSSHKeys(context.Context, *ExchangeSSHKeysRequest) (*ExchangeSSHKeysResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ExchangeSSHKeys not implemented")
+}
+func (UnimplementedClientApplicationServiceServer) ReissueDBCert(context.Context, *ReissueDBCertRequest) (*ReissueDBCertResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReissueDBCert not implemented")
+}
+func (UnimplementedClientApplicationServiceServer) SignForDB(context.Context, *SignForDBRequest) (*SignForDBResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SignForDB not implemented")
+}
+func (UnimplementedClientApplicationServiceServer) OnNewDBConnection(context.Context, *OnNewDBConnectionRequest) (*OnNewDBConnectionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method OnNewDBConnection not implemented")
 }
 func (UnimplementedClientApplicationServiceServer) mustEmbedUnimplementedClientApplicationServiceServer() {
 }
@@ -621,6 +679,60 @@ func _ClientApplicationService_ExchangeSSHKeys_Handler(srv interface{}, ctx cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ClientApplicationService_ReissueDBCert_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReissueDBCertRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ClientApplicationServiceServer).ReissueDBCert(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ClientApplicationService_ReissueDBCert_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClientApplicationServiceServer).ReissueDBCert(ctx, req.(*ReissueDBCertRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ClientApplicationService_SignForDB_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignForDBRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ClientApplicationServiceServer).SignForDB(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ClientApplicationService_SignForDB_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClientApplicationServiceServer).SignForDB(ctx, req.(*SignForDBRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ClientApplicationService_OnNewDBConnection_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(OnNewDBConnectionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ClientApplicationServiceServer).OnNewDBConnection(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ClientApplicationService_OnNewDBConnection_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClientApplicationServiceServer).OnNewDBConnection(ctx, req.(*OnNewDBConnectionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ClientApplicationService_ServiceDesc is the grpc.ServiceDesc for ClientApplicationService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -683,6 +795,18 @@ var ClientApplicationService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ExchangeSSHKeys",
 			Handler:    _ClientApplicationService_ExchangeSSHKeys_Handler,
+		},
+		{
+			MethodName: "ReissueDBCert",
+			Handler:    _ClientApplicationService_ReissueDBCert_Handler,
+		},
+		{
+			MethodName: "SignForDB",
+			Handler:    _ClientApplicationService_SignForDB_Handler,
+		},
+		{
+			MethodName: "OnNewDBConnection",
+			Handler:    _ClientApplicationService_OnNewDBConnection_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -100,6 +100,11 @@ func (c *Cluster) GetDatabase(ctx context.Context, authClient authclient.ClientI
 	}, err
 }
 
+// ReissueDBCerts issues new certificates for specific DB access.
+func (c *Cluster) ReissueDBCerts(ctx context.Context, clusterClient *client.ClusterClient, routeToDatabase tlsca.RouteToDatabase) (tls.Certificate, error) {
+	return c.reissueDBCerts(ctx, clusterClient, routeToDatabase)
+}
+
 // reissueDBCerts issues new certificates for specific DB access and saves them to disk.
 func (c *Cluster) reissueDBCerts(ctx context.Context, clusterClient *client.ClusterClient, routeToDatabase tlsca.RouteToDatabase) (tls.Certificate, error) {
 	if dbrole.RequireDatabaseUserMatcher(routeToDatabase.Protocol) && routeToDatabase.Username == "" {

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -100,11 +100,6 @@ func (c *Cluster) GetDatabase(ctx context.Context, authClient authclient.ClientI
 	}, err
 }
 
-// ReissueDBCerts issues new certificates for specific DB access.
-func (c *Cluster) ReissueDBCerts(ctx context.Context, clusterClient *client.ClusterClient, routeToDatabase tlsca.RouteToDatabase) (tls.Certificate, error) {
-	return c.reissueDBCerts(ctx, clusterClient, routeToDatabase)
-}
-
 // reissueDBCerts issues new certificates for specific DB access and saves them to disk.
 func (c *Cluster) reissueDBCerts(ctx context.Context, clusterClient *client.ClusterClient, routeToDatabase tlsca.RouteToDatabase) (tls.Certificate, error) {
 	if dbrole.RequireDatabaseUserMatcher(routeToDatabase.Protocol) && routeToDatabase.Username == "" {

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/clusteridcache"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
+	"github.com/gravitational/teleport/lib/tlsca"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/lib/vnet"
 	"github.com/gravitational/teleport/lib/vnet/diag"
@@ -474,6 +475,81 @@ func (p *clientApplication) ReissueAppCert(ctx context.Context, appInfo *vnetv1.
 	return cert, nil
 }
 
+func (p *clientApplication) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (tls.Certificate, error) {
+	dbKey := dbInfo.GetDatabaseKey()
+	clusterURI := uri.NewClusterURI(dbKey.GetProfile()).AppendLeafCluster(dbKey.GetLeafCluster())
+	dbURI := clusterURI.AppendDB(dbKey.GetName())
+
+	routeToDatabase := vnet.RouteToDatabase(dbInfo)
+
+	reloginReq := &apiteleterm.ReloginRequest{
+		RootClusterUri: clusterURI.GetRootClusterURI().String(),
+		Reason: &apiteleterm.ReloginRequest_VnetCertExpired{
+			VnetCertExpired: &apiteleterm.VnetCertExpired{
+				TargetUri: dbURI.String(),
+			},
+		},
+	}
+
+	var cert tls.Certificate
+
+	reissueCert := func() error {
+		cluster, _, err := p.daemonService.ResolveClusterURI(clusterURI)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		client, err := p.daemonService.GetCachedClient(ctx, clusterURI)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		cert, err = cluster.ReissueDBCerts(ctx, client, tlsca.RouteToDatabase{
+			ServiceName: routeToDatabase.ServiceName,
+			Protocol:    routeToDatabase.Protocol,
+			Username:    routeToDatabase.Username,
+		})
+		return trace.Wrap(err)
+	}
+
+	if err := p.daemonService.RetryWithRelogin(ctx, reloginReq, reissueCert); err != nil {
+		notifyErr := p.daemonService.NotifyApp(ctx, &apiteleterm.SendNotificationRequest{
+			Subject: &apiteleterm.SendNotificationRequest_CannotProxyVnetConnection{
+				CannotProxyVnetConnection: &apiteleterm.CannotProxyVnetConnection{
+					TargetUri: dbURI.String(),
+					Reason: &apiteleterm.CannotProxyVnetConnection_CertReissueError{
+						CertReissueError: &apiteleterm.CertReissueError{
+							Error: err.Error(),
+						},
+					},
+				},
+			},
+		})
+		if notifyErr != nil {
+			log.ErrorContext(ctx, "Failed to send a notification for an error encountered during VNet database cert reissue",
+				"cert_reissue_error", err, "notify_error", notifyErr)
+		}
+
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+
+	return cert, nil
+}
+
+// OnNewDBConnection submits a database usage event.
+func (p *clientApplication) OnNewDBConnection(ctx context.Context, dbKey *vnetv1.DatabaseKey) error {
+	// Enqueue the event from a separate goroutine since we don't care about errors anyway and we also
+	// don't want to slow down VNet connections.
+	go func() {
+		dbURI := uri.NewClusterURI(dbKey.GetProfile()).AppendLeafCluster(dbKey.GetLeafCluster()).AppendDB(dbKey.GetName())
+		if err := p.usageReporter.ReportDB(dbURI); err != nil {
+			log.ErrorContext(ctx, "Failed to submit database usage event", "db", dbURI, "error", err)
+		}
+	}()
+
+	return nil
+}
+
 // UserTLSCert returns the user TLS certificate for the given profile.
 func (p *clientApplication) UserTLSCert(ctx context.Context, profileName string) (tls.Certificate, error) {
 	// We don't have easy access to the user TLS cert from here, the only way
@@ -619,6 +695,7 @@ func (p *clientApplication) OnInvalidLocalPort(ctx context.Context, appInfo *vne
 
 type usageReporter interface {
 	ReportApp(uri.ResourceURI) error
+	ReportDB(uri.ResourceURI) error
 	ReportSSHSession(profileName, rootClusterName string) error
 	Stop()
 }
@@ -737,6 +814,18 @@ func (r *daemonUsageReporter) ReportSSHSession(profileName, rootClusterName stri
 // ReportApp adds an event related to the given app to the events queue, if the app wasn't reported
 // already. Only one invocation of ReportApp can be in flight at a time.
 func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
+	return r.reportProtocolUsage(appURI, "app")
+}
+
+// ReportDB adds an event related to the given database to the events queue, if the database wasn't
+// reported already. Only one invocation of ReportDB can be in flight at a time.
+func (r *daemonUsageReporter) ReportDB(dbURI uri.ResourceURI) error {
+	return r.reportProtocolUsage(dbURI, "db")
+}
+
+// reportProtocolUsage adds a protocol usage event for the given resource to the events queue, if it
+// wasn't reported already. Only one invocation can be in flight at a time.
+func (r *daemonUsageReporter) reportProtocolUsage(resourceURI uri.ResourceURI, protocol string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -744,7 +833,7 @@ func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 		return trace.CompareFailed("usage reporter has been stopped")
 	}
 
-	if _, hasAppBeenReported := r.reportedApps[appURI.String()]; hasAppBeenReported {
+	if _, hasBeenReported := r.reportedApps[resourceURI.String()]; hasBeenReported {
 		return nil
 	}
 
@@ -759,13 +848,13 @@ func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 		}
 	}()
 
-	rootClusterURI := appURI.GetRootClusterURI()
-	client, err := r.cfg.ClientCache.GetCachedClient(ctx, appURI)
+	rootClusterURI := resourceURI.GetRootClusterURI()
+	client, err := r.cfg.ClientCache.GetCachedClient(ctx, resourceURI)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	rootClusterName := client.RootClusterName()
-	_, tc, err := r.cfg.ClientCache.ResolveClusterURI(appURI)
+	_, tc, err := r.cfg.ClientCache.ResolveClusterURI(resourceURI)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -775,7 +864,7 @@ func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 		return trace.NotFound("cluster ID for %q not found", rootClusterURI)
 	}
 
-	log.DebugContext(ctx, "Reporting app usage event", "app", appURI.String())
+	log.DebugContext(ctx, "Reporting protocol usage event", "uri", resourceURI.String(), "protocol", protocol)
 
 	if err := r.cfg.EventConsumer.ReportUsageEvent(&apiteleterm.ReportUsageEventRequest{
 		AuthClusterId: clusterID,
@@ -786,17 +875,17 @@ func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 				ProtocolUse: &prehogv1alpha.ConnectProtocolUseEvent{
 					ClusterName:   rootClusterName,
 					UserName:      tc.Username,
-					Protocol:      "app",
+					Protocol:      protocol,
 					Origin:        "vnet",
 					AccessThrough: "vnet",
 				},
 			},
 		},
 	}); err != nil {
-		return trace.Wrap(err, "adding app usage event to queue")
+		return trace.Wrap(err, "adding %s usage event to queue", protocol)
 	}
 
-	r.reportedApps[appURI.String()] = struct{}{}
+	r.reportedApps[resourceURI.String()] = struct{}{}
 
 	return nil
 }
@@ -821,6 +910,11 @@ type disabledTelemetryUsageReporter struct{}
 
 func (r *disabledTelemetryUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 	log.DebugContext(context.Background(), "Skipping app usage event, usage reporting is turned off", "app", appURI.String())
+	return nil
+}
+
+func (r *disabledTelemetryUsageReporter) ReportDB(dbURI uri.ResourceURI) error {
+	log.DebugContext(context.Background(), "Skipping database usage event, usage reporting is turned off", "db", dbURI.String())
 	return nil
 }
 

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	prehogv1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
@@ -474,15 +475,89 @@ func (p *clientApplication) ReissueAppCert(ctx context.Context, appInfo *vnetv1.
 	return cert, nil
 }
 
-// ReissueDBCert issues a new cert for the target database.
-// TODO(ohin): Full implementation will be added in a follow-up PR for Teleport Connect VNet database support.
 func (p *clientApplication) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (tls.Certificate, error) {
-	return tls.Certificate{}, trace.NotImplemented("database VNet support in Connect is not yet implemented")
+	dbKey := dbInfo.GetDatabaseKey()
+	clusterURI := uri.NewClusterURI(dbKey.GetProfile()).AppendLeafCluster(dbKey.GetLeafCluster())
+	dbURI := clusterURI.AppendDB(dbKey.GetName())
+
+	routeToDatabase := vnet.RouteToDatabase(dbInfo)
+
+	reloginReq := &apiteleterm.ReloginRequest{
+		RootClusterUri: clusterURI.GetRootClusterURI().String(),
+		Reason: &apiteleterm.ReloginRequest_VnetCertExpired{
+			VnetCertExpired: &apiteleterm.VnetCertExpired{
+				TargetUri: dbURI.String(),
+			},
+		},
+	}
+
+	var cert tls.Certificate
+
+	reissueCert := func() error {
+		_, tc, err := p.daemonService.ResolveClusterURI(clusterURI)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		clusterClient, err := p.daemonService.GetCachedClient(ctx, clusterURI)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		var accessRequests []string
+		if profile, err := tc.ProfileStatus(); err == nil {
+			accessRequests = profile.ActiveRequests
+		}
+
+		result, err := clusterClient.IssueUserCertsWithMFA(ctx, client.ReissueParams{
+			RouteToCluster:  dbKey.GetLeafCluster(),
+			RouteToDatabase: *routeToDatabase,
+			AccessRequests:  accessRequests,
+			RequesterName:   proto.UserCertsRequest_TSH_DB_LOCAL_PROXY_TUNNEL,
+			TTL:             tc.KeyTTL,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		cert, err = result.KeyRing.DBTLSCert(routeToDatabase.ServiceName)
+		return trace.Wrap(err)
+	}
+
+	if err := p.daemonService.RetryWithRelogin(ctx, reloginReq, reissueCert); err != nil {
+		notifyErr := p.daemonService.NotifyApp(ctx, &apiteleterm.SendNotificationRequest{
+			Subject: &apiteleterm.SendNotificationRequest_CannotProxyVnetConnection{
+				CannotProxyVnetConnection: &apiteleterm.CannotProxyVnetConnection{
+					TargetUri: dbURI.String(),
+					Reason: &apiteleterm.CannotProxyVnetConnection_CertReissueError{
+						CertReissueError: &apiteleterm.CertReissueError{
+							Error: err.Error(),
+						},
+					},
+				},
+			},
+		})
+		if notifyErr != nil {
+			log.ErrorContext(ctx, "Failed to send a notification for an error encountered during VNet database cert reissue",
+				"cert_reissue_error", err, "notify_error", notifyErr)
+		}
+
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+
+	return cert, nil
 }
 
-// OnNewDBConnection is called when a new database connection is established through VNet.
-// TODO(ohin): Full implementation will be added in a follow-up PR for Teleport Connect VNet database support.
+// OnNewDBConnection submits a database usage event.
 func (p *clientApplication) OnNewDBConnection(ctx context.Context, dbKey *vnetv1.DatabaseKey) error {
+	// Enqueue the event from a separate goroutine since we don't care about errors anyway and we also
+	// don't want to slow down VNet connections.
+	go func() {
+		dbURI := uri.NewClusterURI(dbKey.GetProfile()).AppendLeafCluster(dbKey.GetLeafCluster()).AppendDB(dbKey.GetName())
+		if err := p.usageReporter.ReportDB(dbURI); err != nil {
+			log.ErrorContext(ctx, "Failed to submit database usage event", "db", dbURI, "error", err)
+		}
+	}()
+
 	return nil
 }
 
@@ -631,6 +706,7 @@ func (p *clientApplication) OnInvalidLocalPort(ctx context.Context, appInfo *vne
 
 type usageReporter interface {
 	ReportApp(uri.ResourceURI) error
+	ReportDB(uri.ResourceURI) error
 	ReportSSHSession(profileName, rootClusterName string) error
 	Stop()
 }
@@ -749,6 +825,18 @@ func (r *daemonUsageReporter) ReportSSHSession(profileName, rootClusterName stri
 // ReportApp adds an event related to the given app to the events queue, if the app wasn't reported
 // already. Only one invocation of ReportApp can be in flight at a time.
 func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
+	return r.reportProtocolUsage(appURI, "app")
+}
+
+// ReportDB adds an event related to the given database to the events queue, if the database wasn't
+// reported already. Only one invocation of ReportDB can be in flight at a time.
+func (r *daemonUsageReporter) ReportDB(dbURI uri.ResourceURI) error {
+	return r.reportProtocolUsage(dbURI, "db")
+}
+
+// reportProtocolUsage adds a protocol usage event for the given resource to the events queue, if it
+// wasn't reported already. Only one invocation can be in flight at a time.
+func (r *daemonUsageReporter) reportProtocolUsage(resourceURI uri.ResourceURI, protocol string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -756,7 +844,7 @@ func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 		return trace.CompareFailed("usage reporter has been stopped")
 	}
 
-	if _, hasAppBeenReported := r.reportedApps[appURI.String()]; hasAppBeenReported {
+	if _, hasBeenReported := r.reportedApps[resourceURI.String()]; hasBeenReported {
 		return nil
 	}
 
@@ -771,13 +859,13 @@ func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 		}
 	}()
 
-	rootClusterURI := appURI.GetRootClusterURI()
-	client, err := r.cfg.ClientCache.GetCachedClient(ctx, appURI)
+	rootClusterURI := resourceURI.GetRootClusterURI()
+	client, err := r.cfg.ClientCache.GetCachedClient(ctx, resourceURI)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	rootClusterName := client.RootClusterName()
-	_, tc, err := r.cfg.ClientCache.ResolveClusterURI(appURI)
+	_, tc, err := r.cfg.ClientCache.ResolveClusterURI(resourceURI)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -787,7 +875,7 @@ func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 		return trace.NotFound("cluster ID for %q not found", rootClusterURI)
 	}
 
-	log.DebugContext(ctx, "Reporting app usage event", "app", appURI.String())
+	log.DebugContext(ctx, "Reporting protocol usage event", "uri", resourceURI.String(), "protocol", protocol)
 
 	if err := r.cfg.EventConsumer.ReportUsageEvent(&apiteleterm.ReportUsageEventRequest{
 		AuthClusterId: clusterID,
@@ -798,17 +886,17 @@ func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 				ProtocolUse: &prehogv1alpha.ConnectProtocolUseEvent{
 					ClusterName:   rootClusterName,
 					UserName:      tc.Username,
-					Protocol:      "app",
+					Protocol:      protocol,
 					Origin:        "vnet",
 					AccessThrough: "vnet",
 				},
 			},
 		},
 	}); err != nil {
-		return trace.Wrap(err, "adding app usage event to queue")
+		return trace.Wrap(err, "adding %s usage event to queue", protocol)
 	}
 
-	r.reportedApps[appURI.String()] = struct{}{}
+	r.reportedApps[resourceURI.String()] = struct{}{}
 
 	return nil
 }
@@ -833,6 +921,11 @@ type disabledTelemetryUsageReporter struct{}
 
 func (r *disabledTelemetryUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 	log.DebugContext(context.Background(), "Skipping app usage event, usage reporting is turned off", "app", appURI.String())
+	return nil
+}
+
+func (r *disabledTelemetryUsageReporter) ReportDB(dbURI uri.ResourceURI) error {
+	log.DebugContext(context.Background(), "Skipping database usage event, usage reporting is turned off", "db", dbURI.String())
 	return nil
 }
 

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -474,6 +474,18 @@ func (p *clientApplication) ReissueAppCert(ctx context.Context, appInfo *vnetv1.
 	return cert, nil
 }
 
+// ReissueDBCert issues a new cert for the target database.
+// TODO(ohin): Full implementation will be added in a follow-up PR for Teleport Connect VNet database support.
+func (p *clientApplication) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (tls.Certificate, error) {
+	return tls.Certificate{}, trace.NotImplemented("database VNet support in Connect is not yet implemented")
+}
+
+// OnNewDBConnection is called when a new database connection is established through VNet.
+// TODO(ohin): Full implementation will be added in a follow-up PR for Teleport Connect VNet database support.
+func (p *clientApplication) OnNewDBConnection(ctx context.Context, dbKey *vnetv1.DatabaseKey) error {
+	return nil
+}
+
 // UserTLSCert returns the user TLS certificate for the given profile.
 func (p *clientApplication) UserTLSCert(ctx context.Context, profileName string) (tls.Certificate, error) {
 	// We don't have easy access to the user TLS cert from here, the only way

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	prehogv1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
@@ -475,83 +474,6 @@ func (p *clientApplication) ReissueAppCert(ctx context.Context, appInfo *vnetv1.
 	return cert, nil
 }
 
-func (p *clientApplication) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (tls.Certificate, error) {
-	dbKey := dbInfo.GetDatabaseKey()
-	clusterURI := uri.NewClusterURI(dbKey.GetProfile()).AppendLeafCluster(dbKey.GetLeafCluster())
-	dbURI := clusterURI.AppendDB(dbKey.GetName())
-
-	routeToDatabase := vnet.RouteToDatabase(dbInfo)
-
-	reloginReq := &apiteleterm.ReloginRequest{
-		RootClusterUri: clusterURI.GetRootClusterURI().String(),
-		Reason: &apiteleterm.ReloginRequest_VnetCertExpired{
-			VnetCertExpired: &apiteleterm.VnetCertExpired{
-				TargetUri: dbURI.String(),
-			},
-		},
-	}
-
-	var cert tls.Certificate
-
-	reissueCert := func() error {
-		clusterClient, err := p.daemonService.GetCachedClient(ctx, clusterURI)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		// Using IssueUserCertsWithMFA over cluster.ReissueDBCerts because the latter
-		// rejects empty usernames which is correct for database gateways but not for VNet
-		// as for vnet, the username may come from the wire protocol.
-		result, err := clusterClient.IssueUserCertsWithMFA(ctx, client.ReissueParams{
-			RouteToCluster:  dbKey.GetLeafCluster(),
-			RouteToDatabase: *routeToDatabase,
-			RequesterName:   proto.UserCertsRequest_TSH_DB_LOCAL_PROXY_TUNNEL,
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		cert, err = result.KeyRing.DBTLSCert(routeToDatabase.ServiceName)
-		return trace.Wrap(err)
-	}
-
-	if err := p.daemonService.RetryWithRelogin(ctx, reloginReq, reissueCert); err != nil {
-		notifyErr := p.daemonService.NotifyApp(ctx, &apiteleterm.SendNotificationRequest{
-			Subject: &apiteleterm.SendNotificationRequest_CannotProxyVnetConnection{
-				CannotProxyVnetConnection: &apiteleterm.CannotProxyVnetConnection{
-					TargetUri: dbURI.String(),
-					Reason: &apiteleterm.CannotProxyVnetConnection_CertReissueError{
-						CertReissueError: &apiteleterm.CertReissueError{
-							Error: err.Error(),
-						},
-					},
-				},
-			},
-		})
-		if notifyErr != nil {
-			log.ErrorContext(ctx, "Failed to send a notification for an error encountered during VNet database cert reissue",
-				"cert_reissue_error", err, "notify_error", notifyErr)
-		}
-
-		return tls.Certificate{}, trace.Wrap(err)
-	}
-
-	return cert, nil
-}
-
-// OnNewDBConnection submits a database usage event.
-func (p *clientApplication) OnNewDBConnection(ctx context.Context, dbKey *vnetv1.DatabaseKey) error {
-	// Enqueue the event from a separate goroutine since we don't care about errors anyway and we also
-	// don't want to slow down VNet connections.
-	go func() {
-		dbURI := uri.NewClusterURI(dbKey.GetProfile()).AppendLeafCluster(dbKey.GetLeafCluster()).AppendDB(dbKey.GetName())
-		if err := p.usageReporter.ReportDB(dbURI); err != nil {
-			log.ErrorContext(ctx, "Failed to submit database usage event", "db", dbURI, "error", err)
-		}
-	}()
-
-	return nil
-}
-
 // UserTLSCert returns the user TLS certificate for the given profile.
 func (p *clientApplication) UserTLSCert(ctx context.Context, profileName string) (tls.Certificate, error) {
 	// We don't have easy access to the user TLS cert from here, the only way
@@ -697,7 +619,6 @@ func (p *clientApplication) OnInvalidLocalPort(ctx context.Context, appInfo *vne
 
 type usageReporter interface {
 	ReportApp(uri.ResourceURI) error
-	ReportDB(uri.ResourceURI) error
 	ReportSSHSession(profileName, rootClusterName string) error
 	Stop()
 }
@@ -816,18 +737,6 @@ func (r *daemonUsageReporter) ReportSSHSession(profileName, rootClusterName stri
 // ReportApp adds an event related to the given app to the events queue, if the app wasn't reported
 // already. Only one invocation of ReportApp can be in flight at a time.
 func (r *daemonUsageReporter) ReportApp(appURI uri.ResourceURI) error {
-	return r.reportProtocolUsage(appURI, "app")
-}
-
-// ReportDB adds an event related to the given database to the events queue, if the database wasn't
-// reported already. Only one invocation of ReportDB can be in flight at a time.
-func (r *daemonUsageReporter) ReportDB(dbURI uri.ResourceURI) error {
-	return r.reportProtocolUsage(dbURI, "db")
-}
-
-// reportProtocolUsage adds a protocol usage event for the given resource to the events queue, if it
-// wasn't reported already. Only one invocation can be in flight at a time.
-func (r *daemonUsageReporter) reportProtocolUsage(resourceURI uri.ResourceURI, protocol string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -835,7 +744,7 @@ func (r *daemonUsageReporter) reportProtocolUsage(resourceURI uri.ResourceURI, p
 		return trace.CompareFailed("usage reporter has been stopped")
 	}
 
-	if _, hasBeenReported := r.reportedApps[resourceURI.String()]; hasBeenReported {
+	if _, hasAppBeenReported := r.reportedApps[appURI.String()]; hasAppBeenReported {
 		return nil
 	}
 
@@ -850,13 +759,13 @@ func (r *daemonUsageReporter) reportProtocolUsage(resourceURI uri.ResourceURI, p
 		}
 	}()
 
-	rootClusterURI := resourceURI.GetRootClusterURI()
-	client, err := r.cfg.ClientCache.GetCachedClient(ctx, resourceURI)
+	rootClusterURI := appURI.GetRootClusterURI()
+	client, err := r.cfg.ClientCache.GetCachedClient(ctx, appURI)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	rootClusterName := client.RootClusterName()
-	_, tc, err := r.cfg.ClientCache.ResolveClusterURI(resourceURI)
+	_, tc, err := r.cfg.ClientCache.ResolveClusterURI(appURI)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -866,7 +775,7 @@ func (r *daemonUsageReporter) reportProtocolUsage(resourceURI uri.ResourceURI, p
 		return trace.NotFound("cluster ID for %q not found", rootClusterURI)
 	}
 
-	log.DebugContext(ctx, "Reporting protocol usage event", "uri", resourceURI.String(), "protocol", protocol)
+	log.DebugContext(ctx, "Reporting app usage event", "app", appURI.String())
 
 	if err := r.cfg.EventConsumer.ReportUsageEvent(&apiteleterm.ReportUsageEventRequest{
 		AuthClusterId: clusterID,
@@ -877,17 +786,17 @@ func (r *daemonUsageReporter) reportProtocolUsage(resourceURI uri.ResourceURI, p
 				ProtocolUse: &prehogv1alpha.ConnectProtocolUseEvent{
 					ClusterName:   rootClusterName,
 					UserName:      tc.Username,
-					Protocol:      protocol,
+					Protocol:      "app",
 					Origin:        "vnet",
 					AccessThrough: "vnet",
 				},
 			},
 		},
 	}); err != nil {
-		return trace.Wrap(err, "adding %s usage event to queue", protocol)
+		return trace.Wrap(err, "adding app usage event to queue")
 	}
 
-	r.reportedApps[resourceURI.String()] = struct{}{}
+	r.reportedApps[appURI.String()] = struct{}{}
 
 	return nil
 }
@@ -912,11 +821,6 @@ type disabledTelemetryUsageReporter struct{}
 
 func (r *disabledTelemetryUsageReporter) ReportApp(appURI uri.ResourceURI) error {
 	log.DebugContext(context.Background(), "Skipping app usage event, usage reporting is turned off", "app", appURI.String())
-	return nil
-}
-
-func (r *disabledTelemetryUsageReporter) ReportDB(dbURI uri.ResourceURI) error {
-	log.DebugContext(context.Background(), "Skipping database usage event, usage reporting is turned off", "db", dbURI.String())
 	return nil
 }
 

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	prehogv1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
@@ -42,7 +43,6 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/clusteridcache"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
-	"github.com/gravitational/teleport/lib/tlsca"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/lib/vnet"
 	"github.com/gravitational/teleport/lib/vnet/diag"
@@ -494,21 +494,23 @@ func (p *clientApplication) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.Da
 	var cert tls.Certificate
 
 	reissueCert := func() error {
-		cluster, _, err := p.daemonService.ResolveClusterURI(clusterURI)
+		clusterClient, err := p.daemonService.GetCachedClient(ctx, clusterURI)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		client, err := p.daemonService.GetCachedClient(ctx, clusterURI)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		cert, err = cluster.ReissueDBCerts(ctx, client, tlsca.RouteToDatabase{
-			ServiceName: routeToDatabase.ServiceName,
-			Protocol:    routeToDatabase.Protocol,
-			Username:    routeToDatabase.Username,
+		// Using IssueUserCertsWithMFA over cluster.ReissueDBCerts because the latter
+		// rejects empty usernames which is correct for database gateways but not for VNet
+		// as for vnet, the username may come from the wire protocol.
+		result, err := clusterClient.IssueUserCertsWithMFA(ctx, client.ReissueParams{
+			RouteToCluster:  dbKey.GetLeafCluster(),
+			RouteToDatabase: *routeToDatabase,
+			RequesterName:   proto.UserCertsRequest_TSH_DB_LOCAL_PROXY_TUNNEL,
 		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		cert, err = result.KeyRing.DBTLSCert(routeToDatabase.ServiceName)
 		return trace.Wrap(err)
 	}
 

--- a/lib/vnet/admin_process_common.go
+++ b/lib/vnet/admin_process_common.go
@@ -35,6 +35,7 @@ func newNetworkStackConfig(ctx context.Context, tun tunDevice, clt *clientApplic
 	tcpHandlerResolver := newTCPHandlerResolver(&tcpHandlerResolverConfig{
 		clt:         clt,
 		appProvider: newAppProvider(clt),
+		dbProvider:  newDBProvider(clt),
 		sshProvider: sshProvider,
 		clock:       clock,
 	})

--- a/lib/vnet/app_handler.go
+++ b/lib/vnet/app_handler.go
@@ -90,37 +90,23 @@ func (h *tcpAppHandler) getOrInitializeLocalProxy(ctx context.Context, localPort
 		targetPort:  localPort,
 	}
 	certChecker := client.NewCertChecker(appCertIssuer, h.cfg.clock)
-	middleware := &localProxyMiddleware{
+	middleware := &vnetLocalProxyMiddleware{
 		certChecker: certChecker,
-		appProvider: h.cfg.appProvider,
-		appKey:      h.cfg.appInfo.GetAppKey(),
-	}
-	dialOptions := h.cfg.appInfo.GetDialOptions()
-	localProxyConfig := alpnproxy.LocalProxyConfig{
-		RemoteProxyAddr:         dialOptions.GetWebProxyAddr(),
-		Protocols:               []alpncommon.Protocol{alpncommon.ProtocolTCP},
-		ParentContext:           ctx,
-		SNI:                     dialOptions.GetSni(),
-		ALPNConnUpgradeRequired: dialOptions.GetAlpnConnUpgradeRequired(),
-		Middleware:              middleware,
-		InsecureSkipVerify:      dialOptions.GetInsecureSkipVerify(),
-		Clock:                   h.cfg.clock,
-	}
-	if dialOptions.GetAlpnConnUpgradeRequired() || h.cfg.alwaysTrustRootClusterCA {
-		certPoolPEM := dialOptions.GetRootClusterCaCertPool()
-		if len(certPoolPEM) == 0 {
-			return nil, trace.BadParameter("ALPN conn upgrade required but no root CA cert pool provided")
-		}
-		caPool := x509.NewCertPool()
-		if !caPool.AppendCertsFromPEM(certPoolPEM) {
-			return nil, trace.Errorf("failed to parse root cluster CA certs")
-		}
-		localProxyConfig.RootCAs = caPool
+		onNewConnection: func(ctx context.Context) error {
+			return h.cfg.appProvider.OnNewAppConnection(ctx, h.cfg.appInfo.GetAppKey())
+		},
 	}
 	h.log.DebugContext(ctx, "Creating local proxy", "target_port", localPort)
-	newLP, err := alpnproxy.NewLocalProxy(localProxyConfig)
+	newLP, err := newLocalProxyForVnet(localProxyConfig{
+		dialOptions:              h.cfg.appInfo.GetDialOptions(),
+		protocols:                []alpncommon.Protocol{alpncommon.ProtocolTCP},
+		parentContext:            ctx,
+		middleware:               middleware,
+		clock:                    h.cfg.clock,
+		alwaysTrustRootClusterCA: h.cfg.alwaysTrustRootClusterCA,
+	})
 	if err != nil {
-		return nil, trace.Wrap(err, "creating local proxy")
+		return nil, trace.Wrap(err)
 	}
 	h.portToLocalProxy[localPort] = newLP
 	return newLP, nil
@@ -162,26 +148,6 @@ func (i *appCertIssuer) IssueCert(ctx context.Context) (tls.Certificate, error) 
 		return i.appProvider.ReissueAppCert(ctx, i.appInfo, i.targetPort)
 	})
 	return cert.(tls.Certificate), trace.Wrap(err)
-}
-
-// localProxyMiddleware wraps around [client.CertChecker] and additionally makes it so that its
-// OnNewConnection method calls OnNewAppConnection on [appProvider].
-type localProxyMiddleware struct {
-	appKey      *vnetv1.AppKey
-	certChecker *client.CertChecker
-	appProvider *appProvider
-}
-
-func (m *localProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpnproxy.LocalProxy) error {
-	err := m.certChecker.OnNewConnection(ctx, lp)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return trace.Wrap(m.appProvider.OnNewAppConnection(ctx, m.appKey))
-}
-
-func (m *localProxyMiddleware) OnStart(ctx context.Context, lp *alpnproxy.LocalProxy) error {
-	return trace.Wrap(m.certChecker.OnStart(ctx, lp))
 }
 
 // RouteToApp returns a *proto.RouteToApp populated from appInfo and targetPort.

--- a/lib/vnet/app_provider.go
+++ b/lib/vnet/app_provider.go
@@ -19,7 +19,6 @@ package vnet
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 
 	"github.com/gravitational/trace"
 
@@ -57,21 +56,13 @@ func (p *appProvider) ReissueAppCert(ctx context.Context, appInfo *vnetv1.AppInf
 }
 
 func (p *appProvider) newAppCertSigner(cert []byte, appKey *vnetv1.AppKey, targetPort uint16) (*rpcSigner, error) {
-	x509Cert, err := x509.ParseCertificate(cert)
-	if err != nil {
-		return nil, trace.Wrap(err, "parsing x509 certificate")
-	}
-	pub := x509Cert.PublicKey
-	return &rpcSigner{
-		pub: pub,
-		sendRequest: func(req *vnetv1.SignRequest) ([]byte, error) {
-			return p.clt.SignForApp(context.TODO(), &vnetv1.SignForAppRequest{
-				AppKey:     appKey,
-				TargetPort: uint32(targetPort),
-				Sign:       req,
-			})
-		},
-	}, nil
+	return newRPCCertSigner(cert, func(req *vnetv1.SignRequest) ([]byte, error) {
+		return p.clt.SignForApp(context.TODO(), &vnetv1.SignForAppRequest{
+			AppKey:     appKey,
+			TargetPort: uint32(targetPort),
+			Sign:       req,
+		})
+	})
 }
 
 // OnNewAppConnection reports a new TCP connection to the target app.

--- a/lib/vnet/client_application_service.go
+++ b/lib/vnet/client_application_service.go
@@ -67,6 +67,12 @@ type clientApplicationService struct {
 	// previously associated with the same session, it is not some Teleport
 	// session identifier.
 	sshSigners *utils.FnCache
+
+	// dbSignerMu protects dbSignerCache.
+	dbSignerMu sync.RWMutex
+	// dbSignerCache caches the crypto.Signer for each certificate issued by
+	// ReissueDBCert so that SignForDB can later use that signer.
+	dbSignerCache map[dbKey]crypto.Signer
 }
 
 type clientApplicationServiceConfig struct {
@@ -89,6 +95,7 @@ func newClientApplicationService(cfg *clientApplicationServiceConfig) (*clientAp
 		cfg:              cfg,
 		networkStackInfo: make(chan *vnetv1.NetworkStackInfo, 1),
 		appSignerCache:   make(map[appKey]crypto.Signer),
+		dbSignerCache:    make(map[dbKey]crypto.Signer),
 		sshSigners:       sshSigners,
 	}, nil
 }
@@ -443,4 +450,108 @@ func checkAppKey(key *vnetv1.AppKey) error {
 		return trace.BadParameter("app key name must be set")
 	}
 	return nil
+}
+
+// dbKey is a clone of [vnetv1.DatabaseKey] that is not a protobuf type so it
+// can be used as a key in maps.
+type dbKey struct {
+	profile, leafCluster, name string
+}
+
+func newDBKey(protoDBKey *vnetv1.DatabaseKey) dbKey {
+	return dbKey{
+		profile:     protoDBKey.GetProfile(),
+		leafCluster: protoDBKey.GetLeafCluster(),
+		name:        protoDBKey.GetName(),
+	}
+}
+
+func (s *clientApplicationService) setSignerForDB(key *vnetv1.DatabaseKey, signer crypto.Signer) {
+	s.dbSignerMu.Lock()
+	defer s.dbSignerMu.Unlock()
+	s.dbSignerCache[newDBKey(key)] = signer
+}
+
+func (s *clientApplicationService) getSignerForDB(key *vnetv1.DatabaseKey) (crypto.Signer, bool) {
+	s.dbSignerMu.RLock()
+	defer s.dbSignerMu.RUnlock()
+	signer, ok := s.dbSignerCache[newDBKey(key)]
+	return signer, ok
+}
+
+// checkDBKey checks that at least the database profile and name are set, which
+// are necessary to disambiguate databases. LeafCluster is expected to be empty
+// if the database is in a root cluster.
+func checkDBKey(key *vnetv1.DatabaseKey) error {
+	switch {
+	case key == nil:
+		return trace.BadParameter("database key must not be nil")
+	case key.GetProfile() == "":
+		return trace.BadParameter("database key profile must be set")
+	case key.GetName() == "":
+		return trace.BadParameter("database key name must be set")
+	}
+	return nil
+}
+
+// ReissueDBCert implements [vnetv1.ClientApplicationServiceServer.ReissueDBCert].
+// It caches the signer issued for each database so that it can later be used to
+// issue signatures in [clientApplicationService.SignForDB].
+func (s *clientApplicationService) ReissueDBCert(ctx context.Context, req *vnetv1.ReissueDBCertRequest) (*vnetv1.ReissueDBCertResponse, error) {
+	dbInfo := req.GetDatabaseInfo()
+	if dbInfo == nil {
+		return nil, trace.BadParameter("missing DatabaseInfo")
+	}
+	dbKey := dbInfo.GetDatabaseKey()
+	if err := checkDBKey(dbKey); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cert, err := s.cfg.clientApplication.ReissueDBCert(ctx, dbInfo)
+	if err != nil {
+		return nil, trace.Wrap(err, "reissuing database certificate")
+	}
+	s.setSignerForDB(dbKey, cert.PrivateKey.(crypto.Signer))
+	return &vnetv1.ReissueDBCertResponse{
+		Cert: cert.Certificate[0],
+	}, nil
+}
+
+// SignForDB implements [vnetv1.ClientApplicationServiceServer.SignForDB].
+// It uses a cached signer for the requested database, which must have previously
+// been issued a certificate via [clientApplicationService.ReissueDBCert].
+func (s *clientApplicationService) SignForDB(ctx context.Context, req *vnetv1.SignForDBRequest) (*vnetv1.SignForDBResponse, error) {
+	signReq := req.GetSign()
+	log.DebugContext(ctx, "Got SignForDB request",
+		"db", req.GetDatabaseKey(),
+		"hash", signReq.GetHash(),
+		"is_rsa_pss", signReq.PssSaltLength != nil,
+		"pss_salt_len", signReq.GetPssSaltLength(),
+		"digest_len", len(signReq.GetDigest()),
+	)
+
+	dbKey := req.GetDatabaseKey()
+	if err := checkDBKey(dbKey); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	signer, ok := s.getSignerForDB(dbKey)
+	if !ok {
+		return nil, trace.BadParameter("no signer for database %v", dbKey)
+	}
+
+	signature, err := sign(signer, signReq)
+	if err != nil {
+		return nil, trace.Wrap(err, "signing for database %v", dbKey)
+	}
+	return &vnetv1.SignForDBResponse{
+		Signature: signature,
+	}, nil
+}
+
+// OnNewDBConnection gets called whenever a new database connection is about to
+// be established through VNet for observability.
+func (s *clientApplicationService) OnNewDBConnection(ctx context.Context, req *vnetv1.OnNewDBConnectionRequest) (*vnetv1.OnNewDBConnectionResponse, error) {
+	if err := s.cfg.clientApplication.OnNewDBConnection(ctx, req.GetDatabaseKey()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &vnetv1.OnNewDBConnectionResponse{}, nil
 }

--- a/lib/vnet/client_application_service.go
+++ b/lib/vnet/client_application_service.go
@@ -452,30 +452,42 @@ func checkAppKey(key *vnetv1.AppKey) error {
 	return nil
 }
 
-// dbKey is a clone of [vnetv1.DatabaseKey] that is not a protobuf type so it
-// can be used as a key in maps.
+// dbKey is a clone of [vnetv1.DatabaseKey] plus username that is not a protobuf
+// type so it can be used as a key in maps. Username is included because
+// different database users connecting to the same database resource get
+// different certs with different RouteToDatabase subjects.
 type dbKey struct {
-	profile, leafCluster, name string
+	profile, leafCluster, name, username string
 }
 
-func newDBKey(protoDBKey *vnetv1.DatabaseKey) dbKey {
+func newDBKeyFromInfo(dbInfo *vnetv1.DatabaseInfo) dbKey {
 	return dbKey{
-		profile:     protoDBKey.GetProfile(),
-		leafCluster: protoDBKey.GetLeafCluster(),
-		name:        protoDBKey.GetName(),
+		profile:     dbInfo.GetDatabaseKey().GetProfile(),
+		leafCluster: dbInfo.GetDatabaseKey().GetLeafCluster(),
+		name:        dbInfo.GetDatabaseKey().GetName(),
+		username:    dbInfo.GetUsername(),
 	}
 }
 
-func (s *clientApplicationService) setSignerForDB(key *vnetv1.DatabaseKey, signer crypto.Signer) {
-	s.dbSignerMu.Lock()
-	defer s.dbSignerMu.Unlock()
-	s.dbSignerCache[newDBKey(key)] = signer
+func newDBKeyFromSignReq(req *vnetv1.SignForDBRequest) dbKey {
+	return dbKey{
+		profile:     req.GetDatabaseKey().GetProfile(),
+		leafCluster: req.GetDatabaseKey().GetLeafCluster(),
+		name:        req.GetDatabaseKey().GetName(),
+		username:    req.GetUsername(),
+	}
 }
 
-func (s *clientApplicationService) getSignerForDB(key *vnetv1.DatabaseKey) (crypto.Signer, bool) {
+func (s *clientApplicationService) setSignerForDB(dbInfo *vnetv1.DatabaseInfo, signer crypto.Signer) {
+	s.dbSignerMu.Lock()
+	defer s.dbSignerMu.Unlock()
+	s.dbSignerCache[newDBKeyFromInfo(dbInfo)] = signer
+}
+
+func (s *clientApplicationService) getSignerForDB(req *vnetv1.SignForDBRequest) (crypto.Signer, bool) {
 	s.dbSignerMu.RLock()
 	defer s.dbSignerMu.RUnlock()
-	signer, ok := s.dbSignerCache[newDBKey(key)]
+	signer, ok := s.dbSignerCache[newDBKeyFromSignReq(req)]
 	return signer, ok
 }
 
@@ -510,7 +522,7 @@ func (s *clientApplicationService) ReissueDBCert(ctx context.Context, req *vnetv
 	if err != nil {
 		return nil, trace.Wrap(err, "reissuing database certificate")
 	}
-	s.setSignerForDB(dbKey, cert.PrivateKey.(crypto.Signer))
+	s.setSignerForDB(dbInfo, cert.PrivateKey.(crypto.Signer))
 	return &vnetv1.ReissueDBCertResponse{
 		Cert: cert.Certificate[0],
 	}, nil
@@ -533,9 +545,9 @@ func (s *clientApplicationService) SignForDB(ctx context.Context, req *vnetv1.Si
 	if err := checkDBKey(dbKey); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	signer, ok := s.getSignerForDB(dbKey)
+	signer, ok := s.getSignerForDB(req)
 	if !ok {
-		return nil, trace.BadParameter("no signer for database %v", dbKey)
+		return nil, trace.BadParameter("no signer for database %v (username %s)", dbKey, req.GetUsername())
 	}
 
 	signature, err := sign(signer, signReq)

--- a/lib/vnet/client_application_service_client.go
+++ b/lib/vnet/client_application_service_client.go
@@ -233,6 +233,34 @@ func (c *clientApplicationServiceClient) ExchangeSSHKeys(ctx context.Context, ho
 	return userPublicKey, nil
 }
 
+// ReissueDBCert issues a new certificate for the requested database.
+func (c *clientApplicationServiceClient) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) ([]byte, error) {
+	resp, err := c.clt.ReissueDBCert(ctx, &vnetv1.ReissueDBCertRequest{
+		DatabaseInfo: dbInfo,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "calling ReissueDBCert rpc")
+	}
+	return resp.GetCert(), nil
+}
+
+// SignForDB returns a cryptographic signature with the key associated with the database.
+func (c *clientApplicationServiceClient) SignForDB(ctx context.Context, req *vnetv1.SignForDBRequest) ([]byte, error) {
+	resp, err := c.clt.SignForDB(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err, "calling SignForDB rpc")
+	}
+	return resp.GetSignature(), nil
+}
+
+// OnNewDBConnection reports a new database connection for observability.
+func (c *clientApplicationServiceClient) OnNewDBConnection(ctx context.Context, dbKey *vnetv1.DatabaseKey) error {
+	_, err := c.clt.OnNewDBConnection(ctx, &vnetv1.OnNewDBConnectionRequest{
+		DatabaseKey: dbKey,
+	})
+	return trace.Wrap(err, "calling OnNewDBConnection rpc")
+}
+
 // rpcSigner implements [crypto.Signer] for signatures that are issued by the
 // client application over gRPC.
 type rpcSigner struct {

--- a/lib/vnet/client_application_service_client.go
+++ b/lib/vnet/client_application_service_client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/rsa"
+	"crypto/x509"
 	"io"
 
 	"github.com/gravitational/trace"
@@ -259,6 +260,21 @@ func (c *clientApplicationServiceClient) OnNewDBConnection(ctx context.Context, 
 		DatabaseKey: dbKey,
 	})
 	return trace.Wrap(err, "calling OnNewDBConnection rpc")
+}
+
+// newRPCCertSigner creates an [rpcSigner] from a DER-encoded certificate and a
+// function that sends sign requests over gRPC. It parses the x509 certificate
+// to extract the public key. This is the shared implementation used by both
+// [appProvider] and [dbProvider].
+func newRPCCertSigner(certDER []byte, sendRequest func(*vnetv1.SignRequest) ([]byte, error)) (*rpcSigner, error) {
+	x509Cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing x509 certificate")
+	}
+	return &rpcSigner{
+		pub:         x509Cert.PublicKey,
+		sendRequest: sendRequest,
+	}, nil
 }
 
 // rpcSigner implements [crypto.Signer] for signatures that are issued by the

--- a/lib/vnet/db_fqdn.go
+++ b/lib/vnet/db_fqdn.go
@@ -1,0 +1,75 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"strings"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// dbFQDNInfix is the DNS label that separates the database-specific prefix
+// (user and resource name) from the proxy address suffix in VNet database
+// FQDNs.
+const dbFQDNInfix = ".db."
+
+// parseDatabaseFQDN attempts to parse fqdn as a database FQDN of the form
+// [<db-user>.]<db-resource-name>.db.<zone>. where zone is a fully-qualified
+// proxy address.
+//
+// It returns the database user (may be empty if omitted), the database resource
+// name, or errNoMatch if fqdn does not match the expected pattern for the given
+// zone.
+//
+// Since database resource names cannot contain dots (enforced by
+// ValidateDatabaseName), parsing splits the prefix on the last dot to separate
+// the optional database user from the resource name.
+func parseDatabaseFQDN(fqdn string, zone string) (dbUser, dbName string, err error) {
+	suffix := dbFQDNInfix + fullyQualify(zone)
+	if !strings.HasSuffix(fqdn, suffix) {
+		return "", "", errNoMatch
+	}
+	prefix := strings.TrimSuffix(fqdn, suffix)
+	if prefix == "" {
+		return "", "", errNoMatch
+	}
+
+	// Database resource names cannot contain dots. If there's a dot in the
+	// prefix, everything after the last dot is the db name and everything
+	// before is the db user (which can contain dots).
+	if lastDot := strings.LastIndex(prefix, "."); lastDot >= 0 {
+		dbUser = prefix[:lastDot]
+		dbName = prefix[lastDot+1:]
+	} else {
+		// for auto-user provisioning, the db name is the prefix as there is no user
+		dbName = prefix
+	}
+
+	if dbName == "" {
+		return "", "", errNoMatch
+	}
+
+	// Validate that dbName looks like a valid database resource name. This
+	// prevents predicate expression injection when the name is used in API
+	// queries and avoids unnecessary cluster API calls for obviously invalid
+	// names.
+	if err := types.ValidateDatabaseName(dbName); err != nil {
+		return "", "", errNoMatch
+	}
+
+	return dbUser, dbName, nil
+}

--- a/lib/vnet/db_fqdn.go
+++ b/lib/vnet/db_fqdn.go
@@ -27,48 +27,41 @@ import (
 // FQDNs.
 const dbFQDNInfix = ".db."
 
+// hasDBZoneSuffix checks if fqdn ends with .db.<zone>. Used for lightweight
+func hasDBZoneSuffix(fqdn string, zone string) bool {
+	return strings.HasSuffix(fqdn, dbFQDNInfix+fullyQualify(zone))
+}
+
+// splitDBUserAndName splits a prefix (the part before .db.<zone>) into a
+// database user and database resource name.
+func splitDBUserAndName(prefix string) (dbUser, dbName string) {
+	if lastDot := strings.LastIndex(prefix, "."); lastDot >= 0 {
+		return prefix[:lastDot], prefix[lastDot+1:]
+	}
+	// No dot — the entire prefix is the database name with no user
+	// (auto-user provisioning or single allowed user).
+	return "", prefix
+}
+
 // parseDatabaseFQDN attempts to parse fqdn as a database FQDN of the form
 // [<db-user>.]<db-resource-name>.db.<zone>. where zone is a fully-qualified
 // proxy address.
-//
-// It returns the database user (may be empty if omitted), the database resource
-// name, or errNoMatch if fqdn does not match the expected pattern for the given
-// zone.
-//
-// Since database resource names cannot contain dots (enforced by
-// ValidateDatabaseName), parsing splits the prefix on the last dot to separate
-// the optional database user from the resource name.
-//
-// Note: DNS labels are limited to 63 characters. Database resource names or
-// usernames longer than 63 characters cannot be used in VNet FQDNs. Database
-// usernames with characters invalid in DNS labels (such as '@') also cannot be
-// used. Those users must connect via other means such as 'tsh db connect' or through the proxy's API.
 func parseDatabaseFQDN(fqdn string, zone string) (dbUser, dbName string, err error) {
-	suffix := dbFQDNInfix + fullyQualify(zone)
-	if !strings.HasSuffix(fqdn, suffix) {
+	if !hasDBZoneSuffix(fqdn, zone) {
 		return "", "", errNoMatch
 	}
-	prefix := strings.TrimSuffix(fqdn, suffix)
+	prefix := strings.TrimSuffix(fqdn, dbFQDNInfix+fullyQualify(zone))
 	if prefix == "" {
 		return "", "", errNoMatch
 	}
 
-	// Database resource names cannot contain dots. If there's a dot in the
-	// prefix, everything after the last dot is the db name and everything
-	// before is the db user (which can contain dots).
-	if lastDot := strings.LastIndex(prefix, "."); lastDot >= 0 {
-		dbUser = prefix[:lastDot]
-		dbName = prefix[lastDot+1:]
-	} else {
-		// for auto-user provisioning, the db name is the prefix as there is no user
-		dbName = prefix
-	}
-
+	dbUser, dbName = splitDBUserAndName(prefix)
 	if dbName == "" {
 		return "", "", errNoMatch
 	}
 
-	// This avoids unnecessary cluster API calls for obviously invalid database names
+	// Validate that dbName looks like a valid database resource name. This
+	// avoids unnecessary cluster API calls for invalid names
 	if err := types.ValidateDatabaseName(dbName); err != nil {
 		return "", "", errNoMatch
 	}

--- a/lib/vnet/db_fqdn.go
+++ b/lib/vnet/db_fqdn.go
@@ -38,6 +38,11 @@ const dbFQDNInfix = ".db."
 // Since database resource names cannot contain dots (enforced by
 // ValidateDatabaseName), parsing splits the prefix on the last dot to separate
 // the optional database user from the resource name.
+//
+// Note: DNS labels are limited to 63 characters. Database resource names or
+// usernames longer than 63 characters cannot be used in VNet FQDNs. Database
+// usernames with characters invalid in DNS labels (such as '@') also cannot be
+// used. Those users must connect via other means such as 'tsh db connect' or through the proxy's API.
 func parseDatabaseFQDN(fqdn string, zone string) (dbUser, dbName string, err error) {
 	suffix := dbFQDNInfix + fullyQualify(zone)
 	if !strings.HasSuffix(fqdn, suffix) {

--- a/lib/vnet/db_fqdn.go
+++ b/lib/vnet/db_fqdn.go
@@ -63,10 +63,7 @@ func parseDatabaseFQDN(fqdn string, zone string) (dbUser, dbName string, err err
 		return "", "", errNoMatch
 	}
 
-	// Validate that dbName looks like a valid database resource name. This
-	// prevents predicate expression injection when the name is used in API
-	// queries and avoids unnecessary cluster API calls for obviously invalid
-	// names.
+	// This avoids unnecessary cluster API calls for obviously invalid database names
 	if err := types.ValidateDatabaseName(dbName); err != nil {
 		return "", "", errNoMatch
 	}

--- a/lib/vnet/db_fqdn.go
+++ b/lib/vnet/db_fqdn.go
@@ -39,7 +39,6 @@ func splitDBUserAndName(prefix string) (dbUser, dbName string) {
 		return prefix[:lastDot], prefix[lastDot+1:]
 	}
 	// No dot — the entire prefix is the database name with no user
-	// (auto-user provisioning or single allowed user).
 	return "", prefix
 }
 

--- a/lib/vnet/db_fqdn_test.go
+++ b/lib/vnet/db_fqdn_test.go
@@ -1,0 +1,106 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDatabaseFQDN(t *testing.T) {
+	tests := []struct {
+		name       string
+		fqdn       string
+		zone       string
+		wantUser   string
+		wantDBName string
+		wantErr    error
+	}{
+		{
+			name:       "user and db name",
+			fqdn:       "reader.my-postgres.db.proxy.example.com.",
+			zone:       "proxy.example.com",
+			wantUser:   "reader",
+			wantDBName: "my-postgres",
+		},
+		{
+			name:       "db name only (no user)",
+			fqdn:       "my-postgres.db.proxy.example.com.",
+			zone:       "proxy.example.com",
+			wantUser:   "",
+			wantDBName: "my-postgres",
+		},
+		{
+			name:       "dotted username",
+			fqdn:       "some.dotted.user.my-db.db.proxy.example.com.",
+			zone:       "proxy.example.com",
+			wantUser:   "some.dotted.user",
+			wantDBName: "my-db",
+		},
+		{
+			name:       "zone already fully qualified",
+			fqdn:       "reader.my-postgres.db.proxy.example.com.",
+			zone:       "proxy.example.com.",
+			wantUser:   "reader",
+			wantDBName: "my-postgres",
+		},
+		{
+			name:    "no db infix",
+			fqdn:    "app.proxy.example.com.",
+			zone:    "proxy.example.com",
+			wantErr: errNoMatch,
+		},
+		{
+			name:    "wrong zone",
+			fqdn:    "reader.my-postgres.db.other.example.com.",
+			zone:    "proxy.example.com",
+			wantErr: errNoMatch,
+		},
+		{
+			name:    "empty prefix",
+			fqdn:    ".db.proxy.example.com.",
+			zone:    "proxy.example.com",
+			wantErr: errNoMatch,
+		},
+		{
+			name:    "only db infix and zone",
+			fqdn:    "db.proxy.example.com.",
+			zone:    "proxy.example.com",
+			wantErr: errNoMatch,
+		},
+		{
+			name:    "trailing dot user only (empty db name)",
+			fqdn:    "reader..db.proxy.example.com.",
+			zone:    "proxy.example.com",
+			wantErr: errNoMatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotUser, gotDBName, err := parseDatabaseFQDN(tt.fqdn, tt.zone)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantUser, gotUser)
+			require.Equal(t, tt.wantDBName, gotDBName)
+		})
+	}
+}

--- a/lib/vnet/db_fqdn_test.go
+++ b/lib/vnet/db_fqdn_test.go
@@ -104,3 +104,95 @@ func TestParseDatabaseFQDN(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDBUserForProtocol(t *testing.T) {
+	tests := []struct {
+		name     string
+		dbUser   string
+		dbName   string
+		protocol string
+		wantErr  bool
+	}{
+		{
+			name:     "postgres without user — valid",
+			protocol: "postgres",
+			dbName:   "my-postgres",
+			dbUser:   "",
+			wantErr:  false,
+		},
+		{
+			name:     "postgres with user — rejected",
+			protocol: "postgres",
+			dbName:   "my-postgres",
+			dbUser:   "alice",
+			wantErr:  true,
+		},
+		{
+			name:     "mysql without user — valid",
+			protocol: "mysql",
+			dbName:   "my-mysql",
+			dbUser:   "",
+			wantErr:  false,
+		},
+		{
+			name:     "mysql with user — rejected",
+			protocol: "mysql",
+			dbName:   "my-mysql",
+			dbUser:   "alice",
+			wantErr:  true,
+		},
+		{
+			name:     "cockroachdb without user — valid",
+			protocol: "cockroachdb",
+			dbName:   "my-crdb",
+			dbUser:   "",
+			wantErr:  false,
+		},
+		{
+			name:     "sqlserver without user — valid",
+			protocol: "sqlserver",
+			dbName:   "my-sqlserver",
+			dbUser:   "",
+			wantErr:  false,
+		},
+		{
+			name:     "mongodb with user — valid",
+			protocol: "mongodb",
+			dbName:   "my-mongo",
+			dbUser:   "admin",
+			wantErr:  false,
+		},
+		{
+			name:     "mongodb without user — rejected",
+			protocol: "mongodb",
+			dbName:   "my-mongo",
+			dbUser:   "",
+			wantErr:  true,
+		},
+		{
+			name:     "clickhouse with user — valid",
+			protocol: "clickhouse",
+			dbName:   "my-clickhouse",
+			dbUser:   "default",
+			wantErr:  false,
+		},
+		{
+			name:     "clickhouse without user — rejected",
+			protocol: "clickhouse",
+			dbName:   "my-clickhouse",
+			dbUser:   "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDBUserForProtocol(tt.dbUser, tt.dbName, tt.protocol)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/lib/vnet/db_handler.go
+++ b/lib/vnet/db_handler.go
@@ -1,5 +1,5 @@
 // Teleport
-// Copyright (C) 2025 Gravitational, Inc.
+// Copyright (C) 2026 Gravitational, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -46,9 +46,12 @@ type tcpDBHandler struct {
 }
 
 type tcpDBHandlerConfig struct {
-	dbInfo                   *vnetv1.DatabaseInfo
-	dbProvider               *dbProvider
-	clock                    clockwork.Clock
+	dbInfo     *vnetv1.DatabaseInfo
+	dbProvider *dbProvider
+	clock      clockwork.Clock
+	// alwaysTrustRootClusterCA can be set in tests so that TLS dials to the
+	// proxy always trust the root cluster CA rather than the system cert pool,
+	// even when ALPN conn upgrades are not required.
 	alwaysTrustRootClusterCA bool
 }
 
@@ -123,7 +126,6 @@ func (h *tcpDBHandler) getOrInitializeLocalProxy(ctx context.Context) (*alpnprox
 // handleTCPConnector handles an incoming TCP connection from VNet by passing it
 // to the local ALPN proxy, which is configured with middleware to automatically
 // handle certificate renewal and re-logins.
-// localPort is unused — databases don't have multi-port support unlike TCP apps.
 func (h *tcpDBHandler) handleTCPConnector(ctx context.Context, localPort uint16, connector func() (net.Conn, error)) error {
 	lp, err := h.getOrInitializeLocalProxy(ctx)
 	if err != nil {

--- a/lib/vnet/db_handler.go
+++ b/lib/vnet/db_handler.go
@@ -1,0 +1,184 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"log/slog"
+	"net"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy"
+	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+type tcpDBHandler struct {
+	cfg *tcpDBHandlerConfig
+	log *slog.Logger
+
+	mu         sync.Mutex
+	localProxy *alpnproxy.LocalProxy
+}
+
+type tcpDBHandlerConfig struct {
+	dbInfo                   *vnetv1.DatabaseInfo
+	dbProvider               *dbProvider
+	clock                    clockwork.Clock
+	alwaysTrustRootClusterCA bool
+}
+
+func newTCPDBHandler(cfg *tcpDBHandlerConfig) *tcpDBHandler {
+	return &tcpDBHandler{
+		cfg: cfg,
+		log: log.With(
+			teleport.ComponentKey, teleport.Component("vnet", "tcp-db-handler"),
+			"profile", cfg.dbInfo.GetDatabaseKey().GetProfile(),
+			"leaf_cluster", cfg.dbInfo.GetDatabaseKey().GetLeafCluster(),
+			"db_name", cfg.dbInfo.GetDatabaseKey().GetName(),
+			"db_user", cfg.dbInfo.GetUsername(),
+			"protocol", cfg.dbInfo.GetProtocol()),
+	}
+}
+
+func (h *tcpDBHandler) getOrInitializeLocalProxy(ctx context.Context) (*alpnproxy.LocalProxy, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.localProxy != nil {
+		return h.localProxy, nil
+	}
+
+	alpnProtocol, err := alpncommon.ToALPNProtocol(h.cfg.dbInfo.GetProtocol())
+	if err != nil {
+		return nil, trace.Wrap(err, "mapping database protocol %q to ALPN protocol", h.cfg.dbInfo.GetProtocol())
+	}
+
+	dbCertIssuer := &dbCertIssuer{
+		dbProvider: h.cfg.dbProvider,
+		dbInfo:     h.cfg.dbInfo,
+	}
+	certChecker := client.NewCertChecker(dbCertIssuer, h.cfg.clock)
+	middleware := &dbLocalProxyMiddleware{
+		certChecker: certChecker,
+		dbProvider:  h.cfg.dbProvider,
+		dbKey:       h.cfg.dbInfo.GetDatabaseKey(),
+	}
+
+	dialOptions := h.cfg.dbInfo.GetDialOptions()
+	localProxyConfig := alpnproxy.LocalProxyConfig{
+		RemoteProxyAddr:         dialOptions.GetWebProxyAddr(),
+		Protocols:               []alpncommon.Protocol{alpnProtocol},
+		ParentContext:           ctx,
+		SNI:                     dialOptions.GetSni(),
+		ALPNConnUpgradeRequired: dialOptions.GetAlpnConnUpgradeRequired(),
+		Middleware:              middleware,
+		InsecureSkipVerify:      dialOptions.GetInsecureSkipVerify(),
+		Clock:                   h.cfg.clock,
+	}
+	if dialOptions.GetAlpnConnUpgradeRequired() || h.cfg.alwaysTrustRootClusterCA {
+		certPoolPEM := dialOptions.GetRootClusterCaCertPool()
+		if len(certPoolPEM) == 0 {
+			return nil, trace.BadParameter("ALPN conn upgrade required but no root CA cert pool provided")
+		}
+		caPool := x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(certPoolPEM) {
+			return nil, trace.Errorf("failed to parse root cluster CA certs")
+		}
+		localProxyConfig.RootCAs = caPool
+	}
+
+	h.log.DebugContext(ctx, "Creating local proxy for database")
+	lp, err := alpnproxy.NewLocalProxy(localProxyConfig)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating local proxy")
+	}
+	h.localProxy = lp
+	return lp, nil
+}
+
+// handleTCPConnector handles an incoming TCP connection from VNet by passing it
+// to the local ALPN proxy, which is configured with middleware to automatically
+// handle certificate renewal and re-logins.
+// localPort is unused — databases don't have multi-port support unlike TCP apps.
+func (h *tcpDBHandler) handleTCPConnector(ctx context.Context, localPort uint16, connector func() (net.Conn, error)) error {
+	lp, err := h.getOrInitializeLocalProxy(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(lp.HandleTCPConnector(ctx, connector), "handling TCP connector")
+}
+
+// dbCertIssuer implements [client.CertIssuer] for VNet database access.
+type dbCertIssuer struct {
+	dbProvider *dbProvider
+	dbInfo     *vnetv1.DatabaseInfo
+	group      singleflight.Group
+}
+
+func (i *dbCertIssuer) CheckCert(cert *x509.Certificate) error {
+	return alpnproxy.CheckDBCertSubject(cert, tlsca.RouteToDatabase{
+		ServiceName: i.dbInfo.GetDatabaseKey().GetName(),
+		Protocol:    i.dbInfo.GetProtocol(),
+		Username:    i.dbInfo.GetUsername(),
+	})
+}
+
+func (i *dbCertIssuer) IssueCert(ctx context.Context) (tls.Certificate, error) {
+	cert, err, _ := i.group.Do("", func() (any, error) {
+		return i.dbProvider.ReissueDBCert(ctx, i.dbInfo)
+	})
+	return cert.(tls.Certificate), trace.Wrap(err)
+}
+
+// dbLocalProxyMiddleware wraps around [client.CertChecker] and additionally
+// calls OnNewDBConnection on [dbProvider] for observability.
+type dbLocalProxyMiddleware struct {
+	dbKey       *vnetv1.DatabaseKey
+	certChecker *client.CertChecker
+	dbProvider  *dbProvider
+}
+
+func (m *dbLocalProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpnproxy.LocalProxy) error {
+	err := m.certChecker.OnNewConnection(ctx, lp)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(m.dbProvider.OnNewDBConnection(ctx, m.dbKey))
+}
+
+func (m *dbLocalProxyMiddleware) OnStart(ctx context.Context, lp *alpnproxy.LocalProxy) error {
+	return trace.Wrap(m.certChecker.OnStart(ctx, lp))
+}
+
+// RouteToDatabase returns a proto.RouteToDatabase populated from dbInfo.
+func RouteToDatabase(dbInfo *vnetv1.DatabaseInfo) *proto.RouteToDatabase {
+	return &proto.RouteToDatabase{
+		ServiceName: dbInfo.GetDatabaseKey().GetName(),
+		Protocol:    dbInfo.GetProtocol(),
+		Username:    dbInfo.GetUsername(),
+	}
+}

--- a/lib/vnet/db_handler.go
+++ b/lib/vnet/db_handler.go
@@ -85,39 +85,24 @@ func (h *tcpDBHandler) getOrInitializeLocalProxy(ctx context.Context) (*alpnprox
 		dbInfo:     h.cfg.dbInfo,
 	}
 	certChecker := client.NewCertChecker(dbCertIssuer, h.cfg.clock)
-	middleware := &dbLocalProxyMiddleware{
+	middleware := &vnetLocalProxyMiddleware{
 		certChecker: certChecker,
-		dbProvider:  h.cfg.dbProvider,
-		dbKey:       h.cfg.dbInfo.GetDatabaseKey(),
-	}
-
-	dialOptions := h.cfg.dbInfo.GetDialOptions()
-	localProxyConfig := alpnproxy.LocalProxyConfig{
-		RemoteProxyAddr:         dialOptions.GetWebProxyAddr(),
-		Protocols:               []alpncommon.Protocol{alpnProtocol},
-		ParentContext:           ctx,
-		SNI:                     dialOptions.GetSni(),
-		ALPNConnUpgradeRequired: dialOptions.GetAlpnConnUpgradeRequired(),
-		Middleware:              middleware,
-		InsecureSkipVerify:      dialOptions.GetInsecureSkipVerify(),
-		Clock:                   h.cfg.clock,
-	}
-	if dialOptions.GetAlpnConnUpgradeRequired() || h.cfg.alwaysTrustRootClusterCA {
-		certPoolPEM := dialOptions.GetRootClusterCaCertPool()
-		if len(certPoolPEM) == 0 {
-			return nil, trace.BadParameter("ALPN conn upgrade required but no root CA cert pool provided")
-		}
-		caPool := x509.NewCertPool()
-		if !caPool.AppendCertsFromPEM(certPoolPEM) {
-			return nil, trace.Errorf("failed to parse root cluster CA certs")
-		}
-		localProxyConfig.RootCAs = caPool
+		onNewConnection: func(ctx context.Context) error {
+			return h.cfg.dbProvider.OnNewDBConnection(ctx, h.cfg.dbInfo.GetDatabaseKey())
+		},
 	}
 
 	h.log.DebugContext(ctx, "Creating local proxy for database")
-	lp, err := alpnproxy.NewLocalProxy(localProxyConfig)
+	lp, err := newLocalProxyForVnet(localProxyConfig{
+		dialOptions:              h.cfg.dbInfo.GetDialOptions(),
+		protocols:                []alpncommon.Protocol{alpnProtocol},
+		parentContext:            ctx,
+		middleware:               middleware,
+		clock:                    h.cfg.clock,
+		alwaysTrustRootClusterCA: h.cfg.alwaysTrustRootClusterCA,
+	})
 	if err != nil {
-		return nil, trace.Wrap(err, "creating local proxy")
+		return nil, trace.Wrap(err)
 	}
 	h.localProxy = lp
 	return lp, nil
@@ -154,26 +139,6 @@ func (i *dbCertIssuer) IssueCert(ctx context.Context) (tls.Certificate, error) {
 		return i.dbProvider.ReissueDBCert(ctx, i.dbInfo)
 	})
 	return cert.(tls.Certificate), trace.Wrap(err)
-}
-
-// dbLocalProxyMiddleware wraps around [client.CertChecker] and additionally
-// calls OnNewDBConnection on [dbProvider] for observability.
-type dbLocalProxyMiddleware struct {
-	dbKey       *vnetv1.DatabaseKey
-	certChecker *client.CertChecker
-	dbProvider  *dbProvider
-}
-
-func (m *dbLocalProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpnproxy.LocalProxy) error {
-	err := m.certChecker.OnNewConnection(ctx, lp)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return trace.Wrap(m.dbProvider.OnNewDBConnection(ctx, m.dbKey))
-}
-
-func (m *dbLocalProxyMiddleware) OnStart(ctx context.Context, lp *alpnproxy.LocalProxy) error {
-	return trace.Wrap(m.certChecker.OnStart(ctx, lp))
 }
 
 // RouteToDatabase returns a proto.RouteToDatabase populated from dbInfo.

--- a/lib/vnet/db_provider.go
+++ b/lib/vnet/db_provider.go
@@ -19,7 +19,6 @@ package vnet
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 
 	"github.com/gravitational/trace"
 
@@ -58,21 +57,13 @@ func (p *dbProvider) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseI
 }
 
 func (p *dbProvider) newDBCertSigner(cert []byte, dbInfo *vnetv1.DatabaseInfo) (*rpcSigner, error) {
-	x509Cert, err := x509.ParseCertificate(cert)
-	if err != nil {
-		return nil, trace.Wrap(err, "parsing x509 certificate")
-	}
-	pub := x509Cert.PublicKey
-	return &rpcSigner{
-		pub: pub,
-		sendRequest: func(req *vnetv1.SignRequest) ([]byte, error) {
-			return p.clt.SignForDB(context.TODO(), &vnetv1.SignForDBRequest{
-				DatabaseKey: dbInfo.GetDatabaseKey(),
-				Username:    dbInfo.GetUsername(),
-				Sign:        req,
-			})
-		},
-	}, nil
+	return newRPCCertSigner(cert, func(req *vnetv1.SignRequest) ([]byte, error) {
+		return p.clt.SignForDB(context.TODO(), &vnetv1.SignForDBRequest{
+			DatabaseKey: dbInfo.GetDatabaseKey(),
+			Username:    dbInfo.GetUsername(),
+			Sign:        req,
+		})
+	})
 }
 
 // OnNewDBConnection reports a new TCP connection to the target database.

--- a/lib/vnet/db_provider.go
+++ b/lib/vnet/db_provider.go
@@ -1,0 +1,83 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+
+	"github.com/gravitational/trace"
+
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+)
+
+// dbProvider implements methods related to database access. It lives in the
+// admin process and communicates with the user process over gRPC.
+type dbProvider struct {
+	clt *clientApplicationServiceClient
+}
+
+func newDBProvider(clt *clientApplicationServiceClient) *dbProvider {
+	return &dbProvider{
+		clt: clt,
+	}
+}
+
+// ReissueDBCert issues a new cert for the target database. Signatures made with
+// the returned [tls.Certificate] happen over gRPC as the key never leaves the
+// client application process.
+func (p *dbProvider) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (tls.Certificate, error) {
+	cert, err := p.clt.ReissueDBCert(ctx, dbInfo)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "reissuing certificate for database %s", dbInfo.GetDatabaseKey().GetName())
+	}
+	signer, err := p.newDBCertSigner(cert, dbInfo.GetDatabaseKey())
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{cert},
+		PrivateKey:  signer,
+	}
+	return tlsCert, nil
+}
+
+func (p *dbProvider) newDBCertSigner(cert []byte, dbKey *vnetv1.DatabaseKey) (*rpcSigner, error) {
+	x509Cert, err := x509.ParseCertificate(cert)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing x509 certificate")
+	}
+	pub := x509Cert.PublicKey
+	return &rpcSigner{
+		pub: pub,
+		sendRequest: func(req *vnetv1.SignRequest) ([]byte, error) {
+			return p.clt.SignForDB(context.TODO(), &vnetv1.SignForDBRequest{
+				DatabaseKey: dbKey,
+				Sign:        req,
+			})
+		},
+	}, nil
+}
+
+// OnNewDBConnection reports a new TCP connection to the target database.
+func (p *dbProvider) OnNewDBConnection(ctx context.Context, dbKey *vnetv1.DatabaseKey) error {
+	if err := p.clt.OnNewDBConnection(ctx, dbKey); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/lib/vnet/db_provider.go
+++ b/lib/vnet/db_provider.go
@@ -46,7 +46,7 @@ func (p *dbProvider) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseI
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err, "reissuing certificate for database %s", dbInfo.GetDatabaseKey().GetName())
 	}
-	signer, err := p.newDBCertSigner(cert, dbInfo.GetDatabaseKey())
+	signer, err := p.newDBCertSigner(cert, dbInfo)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}
@@ -57,7 +57,7 @@ func (p *dbProvider) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseI
 	return tlsCert, nil
 }
 
-func (p *dbProvider) newDBCertSigner(cert []byte, dbKey *vnetv1.DatabaseKey) (*rpcSigner, error) {
+func (p *dbProvider) newDBCertSigner(cert []byte, dbInfo *vnetv1.DatabaseInfo) (*rpcSigner, error) {
 	x509Cert, err := x509.ParseCertificate(cert)
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing x509 certificate")
@@ -67,7 +67,8 @@ func (p *dbProvider) newDBCertSigner(cert []byte, dbKey *vnetv1.DatabaseKey) (*r
 		pub: pub,
 		sendRequest: func(req *vnetv1.SignRequest) ([]byte, error) {
 			return p.clt.SignForDB(context.TODO(), &vnetv1.SignForDBRequest{
-				DatabaseKey: dbKey,
+				DatabaseKey: dbInfo.GetDatabaseKey(),
+				Username:    dbInfo.GetUsername(),
 				Sign:        req,
 			})
 		},

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+	"github.com/gravitational/teleport/lib/defaults"
 )
 
 // fqdnResolver resolves fully-qualified domain names to possible VNet targets.
@@ -440,13 +441,21 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 	}
 
 	db := resp.Resources[0].GetDatabase()
+	protocol := db.GetProtocol()
+
+	if err := validateDBUserForProtocol(dbUser, dbName, protocol); err != nil {
+		log.InfoContext(ctx, "Database FQDN username validation failed",
+			"protocol", protocol, "db_name", dbName, "db_user", dbUser, "error", err)
+		return nil, errNoMatch
+	}
+
 	dialOpts, err := r.cfg.clientApplication.GetDialOptions(ctx, candidate.profileName)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to get cluster dial options", "error", err)
 		return nil, trace.Wrap(err, "getting dial options for matching database")
 	}
 
-	log.InfoContext(ctx, "Query matched a database", "db_name", dbName, "db_user", dbUser, "protocol", db.GetProtocol())
+	log.InfoContext(ctx, "Query matched a database", "db_name", dbName, "db_user", dbUser, "protocol", protocol)
 	dbInfo := &vnetv1.DatabaseInfo{
 		DatabaseKey: &vnetv1.DatabaseKey{
 			Profile:     candidate.profileName,
@@ -454,7 +463,7 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 			Name:        db.GetName(),
 		},
 		Cluster:       candidate.clusterName,
-		Protocol:      db.GetProtocol(),
+		Protocol:      protocol,
 		Username:      dbUser,
 		Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
 		DialOptions:   dialOpts,
@@ -538,4 +547,31 @@ func rootProxyHostFromProfile(profileName string) string {
 		return host
 	}
 	return profileName
+}
+
+// validateDBUserForProtocol checks that the db-user parsed from the FQDN is
+// appropriate for the database protocol
+func validateDBUserForProtocol(dbUser, dbName, protocol string) error {
+	if shouldGetDBUsernameFromWireProtocol(protocol) {
+		if dbUser != "" {
+			return trace.BadParameter("database does not support username in domain name")
+		}
+		return nil
+	}
+	if dbUser == "" {
+		return trace.BadParameter("database requires username in domain name ")
+	}
+	return nil
+}
+
+// shouldGetDBUsernameFromWireProtocol returns true for database protocols where the
+// db_service extracts the database username from the wire protocol
+func shouldGetDBUsernameFromWireProtocol(protocol string) bool {
+	switch protocol {
+	case defaults.ProtocolPostgres, defaults.ProtocolCockroachDB,
+		defaults.ProtocolMySQL, defaults.ProtocolSQLServer:
+		return true
+	default:
+		return false
+	}
 }

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -175,6 +175,10 @@ func (r *fqdnResolver) clusterResolutionCandidatesInProfile(ctx context.Context,
 		// checking configured DNS zones.
 		shouldYieldAllCandidates := isDirectSubdomain(fqdn, profileName)
 
+		// Check if fqdn looks like a database FQDN using the root proxy address
+		rootProxyHost := rootProxyHostFromProfile(profileName)
+		fqdnMatchesDBZone := strings.HasSuffix(fqdn, dbFQDNInfix+fullyQualify(rootProxyHost))
+
 		shouldYieldCandidate := func(candidate clusterResolutionCandidate) bool {
 			if shouldYieldAllCandidates {
 				return true
@@ -182,6 +186,12 @@ func (r *fqdnResolver) clusterResolutionCandidatesInProfile(ctx context.Context,
 
 			if isDescendantSubdomain(fqdn, candidate.clusterName) {
 				// This may match an SSH server, must yield the client.
+				return true
+			}
+
+			if fqdnMatchesDBZone {
+				// This FQDN has a .db.<root-proxy> pattern, so it may
+				// match a database in any cluster (including leaves).
 				return true
 			}
 
@@ -392,10 +402,7 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 	// reader.my-db.db.root-proxy.example.com), but the leaf cluster's
 	// ProxyPublicAddr may differ. Also try the root proxy address (the
 	// profileName with port stripped) so leaf cluster databases resolve.
-	rootProxyHost := candidate.profileName
-	if host, _, err := net.SplitHostPort(candidate.profileName); err == nil {
-		rootProxyHost = host
-	}
+	rootProxyHost := rootProxyHostFromProfile(candidate.profileName)
 	if rootProxyHost != clusterConfig.ProxyPublicAddr {
 		zones = append(zones, rootProxyHost)
 	}
@@ -421,6 +428,9 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 		Limit:               1,
 	})
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, trace.Wrap(err)
+		}
 		log.InfoContext(ctx, "Failed to list database servers", "error", err)
 		return nil, errNoMatch
 	}
@@ -520,4 +530,12 @@ func fullyQualify(domain string) string {
 		return domain
 	}
 	return domain + "."
+}
+
+// rootProxyHostFromProfile returns the root proxy hostname from a profile name,
+func rootProxyHostFromProfile(profileName string) string {
+	if host, _, err := net.SplitHostPort(profileName); err == nil {
+		return host
+	}
+	return profileName
 }

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"net"
 	"slices"
 	"strings"
 
@@ -76,6 +77,16 @@ func (r *fqdnResolver) ResolveFQDN(ctx context.Context, fqdn string) (*vnetv1.Re
 		switch {
 		case err == nil:
 			// Found a matching app, return it immediately.
+			return result, nil
+		case !errors.Is(err, errNoMatch):
+			return nil, err
+		}
+
+		// Check if there's a matching database in this cluster.
+		result, err = r.resolveDBInfoForCluster(ctx, candidate, fqdn)
+		switch {
+		case err == nil:
+			// Found a matching database, return it immediately.
 			return result, nil
 		case !errors.Is(err, errNoMatch):
 			return nil, err
@@ -352,6 +363,96 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 		Match: &vnetv1.ResolveFQDNResponse_MatchedTcpApp{
 			MatchedTcpApp: &vnetv1.MatchedTCPApp{
 				AppInfo: appInfo,
+			},
+		},
+	}, nil
+}
+
+func (r *fqdnResolver) resolveDBInfoForCluster(
+	ctx context.Context,
+	candidate clusterResolutionCandidate,
+	fqdn string,
+) (*vnetv1.ResolveFQDNResponse, error) {
+	log := log.With("profile", candidate.profileName, "leaf_cluster", candidate.leafClusterName, "fqdn", fqdn)
+
+	// Try to parse the FQDN as a database FQDN against each possible zone.
+	// Use the proxy public addr from the cluster config (which has the port
+	// stripped) as the primary zone. The profileName may contain a port
+	// (e.g. "proxy.example.com:3080") which is not valid in DNS names.
+	clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, candidate.client)
+	if err != nil {
+		log.ErrorContext(ctx, "Failed to get VNet config for database resolution", "error", err)
+		return nil, errNoMatch
+	}
+	if clusterConfig.ProxyPublicAddr == "" {
+		return nil, errNoMatch
+	}
+	zones := []string{clusterConfig.ProxyPublicAddr}
+	// For leaf clusters, the FQDN uses the root proxy address (e.g.
+	// reader.my-db.db.root-proxy.example.com), but the leaf cluster's
+	// ProxyPublicAddr may differ. Also try the root proxy address (the
+	// profileName with port stripped) so leaf cluster databases resolve.
+	rootProxyHost := candidate.profileName
+	if host, _, err := net.SplitHostPort(candidate.profileName); err == nil {
+		rootProxyHost = host
+	}
+	if rootProxyHost != clusterConfig.ProxyPublicAddr {
+		zones = append(zones, rootProxyHost)
+	}
+
+	var dbUser, dbName string
+	var matched bool
+	for _, zone := range zones {
+		dbUser, dbName, err = parseDatabaseFQDN(fqdn, zone)
+		if err == nil {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return nil, errNoMatch
+	}
+
+	// Query the cluster for a database server matching the parsed name.
+	expr := fmt.Sprintf(`name == "%s"`, dbName)
+	resp, err := apiclient.GetResourcePage[types.DatabaseServer](ctx, candidate.client.CurrentCluster(), &proto.ListResourcesRequest{
+		ResourceType:        types.KindDatabaseServer,
+		PredicateExpression: expr,
+		Limit:               1,
+	})
+	if err != nil {
+		log.InfoContext(ctx, "Failed to list database servers", "error", err)
+		return nil, errNoMatch
+	}
+	if len(resp.Resources) == 0 {
+		log.DebugContext(ctx, "Found no matching database servers")
+		return nil, errNoMatch
+	}
+
+	db := resp.Resources[0].GetDatabase()
+	dialOpts, err := r.cfg.clientApplication.GetDialOptions(ctx, candidate.profileName)
+	if err != nil {
+		log.ErrorContext(ctx, "Failed to get cluster dial options", "error", err)
+		return nil, trace.Wrap(err, "getting dial options for matching database")
+	}
+
+	log.InfoContext(ctx, "Query matched a database", "db_name", dbName, "db_user", dbUser, "protocol", db.GetProtocol())
+	dbInfo := &vnetv1.DatabaseInfo{
+		DatabaseKey: &vnetv1.DatabaseKey{
+			Profile:     candidate.profileName,
+			LeafCluster: candidate.leafClusterName,
+			Name:        db.GetName(),
+		},
+		Cluster:       candidate.clusterName,
+		Protocol:      db.GetProtocol(),
+		Username:      dbUser,
+		Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
+		DialOptions:   dialOpts,
+	}
+	return &vnetv1.ResolveFQDNResponse{
+		Match: &vnetv1.ResolveFQDNResponse_MatchedDatabase{
+			MatchedDatabase: &vnetv1.MatchedDatabase{
+				DatabaseInfo: dbInfo,
 			},
 		},
 	}, nil

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -552,21 +552,21 @@ func rootProxyHostFromProfile(profileName string) string {
 // validateDBUserForProtocol checks that the db-user parsed from the FQDN is
 // appropriate for the database protocol
 func validateDBUserForProtocol(dbUser, dbName, protocol string) error {
-	if shouldGetDBUsernameFromWireProtocol(protocol) {
+	if dbProtocolExtractsUsernameFromWire(protocol) {
 		if dbUser != "" {
-			return trace.BadParameter("database does not support username in domain name")
+			return trace.BadParameter("database protocol %q does not support username in domain name, specify the user in the client connection string instead", protocol)
 		}
 		return nil
 	}
 	if dbUser == "" {
-		return trace.BadParameter("database requires username in domain name ")
+		return trace.BadParameter("database protocol %q requires username in domain name", protocol)
 	}
 	return nil
 }
 
-// shouldGetDBUsernameFromWireProtocol returns true for database protocols where the
-// db_service extracts the database username from the wire protocol
-func shouldGetDBUsernameFromWireProtocol(protocol string) bool {
+// dbProtocolExtractsUsernameFromWire returns true for database protocols where
+// the db_service extracts the database username from the wire protocol
+func dbProtocolExtractsUsernameFromWire(protocol string) bool {
 	switch protocol {
 	case defaults.ProtocolPostgres, defaults.ProtocolCockroachDB,
 		defaults.ProtocolMySQL, defaults.ProtocolSQLServer:

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -177,7 +177,7 @@ func (r *fqdnResolver) clusterResolutionCandidatesInProfile(ctx context.Context,
 
 		// Check if fqdn looks like a database FQDN using the root proxy address
 		rootProxyHost := rootProxyHostFromProfile(profileName)
-		fqdnMatchesDBZone := strings.HasSuffix(fqdn, dbFQDNInfix+fullyQualify(rootProxyHost))
+		fqdnMatchesDBZone := hasDBZoneSuffix(fqdn, rootProxyHost)
 
 		shouldYieldCandidate := func(candidate clusterResolutionCandidate) bool {
 			if shouldYieldAllCandidates {

--- a/lib/vnet/local_proxy.go
+++ b/lib/vnet/local_proxy.go
@@ -1,0 +1,92 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"crypto/x509"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy"
+	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+)
+
+// localProxyConfig holds the parameters needed to create a LocalProxy for VNet.
+type localProxyConfig struct {
+	dialOptions              *vnetv1.DialOptions
+	protocols                []alpncommon.Protocol
+	parentContext            context.Context
+	middleware               alpnproxy.LocalProxyMiddleware
+	clock                    clockwork.Clock
+	alwaysTrustRootClusterCA bool
+}
+
+// newLocalProxyForVnet creates a new [alpnproxy.LocalProxy] configured for VNet
+// use. It handles the common setup of dial options, ALPN protocols, and the
+// optional RootCAs configuration for ALPN connection upgrades.
+func newLocalProxyForVnet(cfg localProxyConfig) (*alpnproxy.LocalProxy, error) {
+	dialOptions := cfg.dialOptions
+	proxyConfig := alpnproxy.LocalProxyConfig{
+		RemoteProxyAddr:         dialOptions.GetWebProxyAddr(),
+		Protocols:               cfg.protocols,
+		ParentContext:           cfg.parentContext,
+		SNI:                     dialOptions.GetSni(),
+		ALPNConnUpgradeRequired: dialOptions.GetAlpnConnUpgradeRequired(),
+		Middleware:              cfg.middleware,
+		InsecureSkipVerify:      dialOptions.GetInsecureSkipVerify(),
+		Clock:                   cfg.clock,
+	}
+	if dialOptions.GetAlpnConnUpgradeRequired() || cfg.alwaysTrustRootClusterCA {
+		certPoolPEM := dialOptions.GetRootClusterCaCertPool()
+		if len(certPoolPEM) == 0 {
+			return nil, trace.BadParameter("ALPN conn upgrade required but no root CA cert pool provided")
+		}
+		caPool := x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(certPoolPEM) {
+			return nil, trace.Errorf("failed to parse root cluster CA certs")
+		}
+		proxyConfig.RootCAs = caPool
+	}
+	lp, err := alpnproxy.NewLocalProxy(proxyConfig)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating local proxy")
+	}
+	return lp, nil
+}
+
+// vnetLocalProxyMiddleware is a shared [alpnproxy.LocalProxyMiddleware]
+// implementation. It delegates cert checking to a [client.CertChecker]
+// and calls a connection callback for observability on each new connection.
+type vnetLocalProxyMiddleware struct {
+	certChecker     *client.CertChecker
+	onNewConnection func(ctx context.Context) error
+}
+
+func (m *vnetLocalProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpnproxy.LocalProxy) error {
+	if err := m.certChecker.OnNewConnection(ctx, lp); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(m.onNewConnection(ctx))
+}
+
+func (m *vnetLocalProxyMiddleware) OnStart(ctx context.Context, lp *alpnproxy.LocalProxy) error {
+	return trace.Wrap(m.certChecker.OnStart(ctx, lp))
+}

--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -78,6 +78,9 @@ func (r *tcpHandlerResolver) resolveTCPHandler(ctx context.Context, fqdn string)
 			}),
 		}, nil
 	}
+	// Database matches are checked after TCP app matches (which have the most
+	// specific public_addr matching) but before web app and cluster fallbacks.
+	// This implements the resolution order: App → DB → SSH
 	if matchedDB := resp.GetMatchedDatabase(); matchedDB != nil {
 		dbInfo := matchedDB.GetDatabaseInfo()
 		return &tcpHandlerSpec{

--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -79,8 +79,6 @@ func (r *tcpHandlerResolver) resolveTCPHandler(ctx context.Context, fqdn string)
 		}, nil
 	}
 	if matchedDB := resp.GetMatchedDatabase(); matchedDB != nil {
-		// The query matched a valid database, return a handler that will proxy
-		// all connections to that database.
 		dbInfo := matchedDB.GetDatabaseInfo()
 		return &tcpHandlerSpec{
 			ipv4CIDRRange: dbInfo.GetIpv4CidrRange(),

--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -40,6 +40,7 @@ type tcpHandlerResolver struct {
 type tcpHandlerResolverConfig struct {
 	clt                      *clientApplicationServiceClient
 	appProvider              *appProvider
+	dbProvider               *dbProvider
 	sshProvider              *sshProvider
 	clock                    clockwork.Clock
 	alwaysTrustRootClusterCA bool
@@ -72,6 +73,20 @@ func (r *tcpHandlerResolver) resolveTCPHandler(ctx context.Context, fqdn string)
 			tcpHandler: newTCPAppHandler(&tcpAppHandlerConfig{
 				appInfo:                  appInfo,
 				appProvider:              r.cfg.appProvider,
+				clock:                    r.cfg.clock,
+				alwaysTrustRootClusterCA: r.cfg.alwaysTrustRootClusterCA,
+			}),
+		}, nil
+	}
+	if matchedDB := resp.GetMatchedDatabase(); matchedDB != nil {
+		// The query matched a valid database, return a handler that will proxy
+		// all connections to that database.
+		dbInfo := matchedDB.GetDatabaseInfo()
+		return &tcpHandlerSpec{
+			ipv4CIDRRange: dbInfo.GetIpv4CidrRange(),
+			tcpHandler: newTCPDBHandler(&tcpDBHandlerConfig{
+				dbInfo:                   dbInfo,
+				dbProvider:               r.cfg.dbProvider,
 				clock:                    r.cfg.clock,
 				alwaysTrustRootClusterCA: r.cfg.alwaysTrustRootClusterCA,
 			}),
@@ -215,6 +230,19 @@ func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uin
 		})
 		h.setDecidedHandler(tcpAppHandler)
 		return tcpAppHandler.handleTCPConnector(ctx, localPort, connector)
+	}
+	if matchedDB := resp.GetMatchedDatabase(); matchedDB != nil {
+		// If matched a database, build a tcpDBHandler that will be used for this
+		// and all subsequent connections to this address.
+		log.DebugContext(ctx, "Resolved FQDN to a matched database")
+		dbHandler := newTCPDBHandler(&tcpDBHandlerConfig{
+			dbInfo:                   matchedDB.GetDatabaseInfo(),
+			dbProvider:               h.cfg.dbProvider,
+			clock:                    h.cfg.clock,
+			alwaysTrustRootClusterCA: h.cfg.alwaysTrustRootClusterCA,
+		})
+		h.setDecidedHandler(dbHandler)
+		return dbHandler.handleTCPConnector(ctx, localPort, connector)
 	}
 	if matchedWebApp := resp.GetMatchedWebApp(); matchedWebApp != nil && localPort == h.webProxyPort {
 		// If matched a web app, build a webAppHandler that will be used for this

--- a/lib/vnet/user_process.go
+++ b/lib/vnet/user_process.go
@@ -67,6 +67,17 @@ type ClientApplication interface {
 	// OnInvalidLocalPort gets called before VNet refuses to handle a connection to a multi-port TCP app
 	// because the provided port does not match any of the TCP ports in the app spec.
 	OnInvalidLocalPort(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16)
+
+	// ReissueDBCert issues a new cert for the target database.
+	ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (tls.Certificate, error)
+
+	// OnNewDBConnection gets called whenever a new database connection is about to be established
+	// through VNet. By the time OnNewDBConnection is called, VNet has already verified that the user
+	// holds a valid cert for the database.
+	//
+	// The connection won't be established until OnNewDBConnection returns. Returning an error prevents
+	// the connection from being made.
+	OnNewDBConnection(ctx context.Context, dbKey *vnetv1.DatabaseKey) error
 }
 
 // ClusterClient is an interface defining the subset of [client.ClusterClient]

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -1251,6 +1251,7 @@ func TestDialFakeDatabase(t *testing.T) {
 				databases: []dbSpec{
 					{name: "my-postgres", protocol: "postgres"},
 					{name: "my-mysql", protocol: "mysql"},
+					{name: "my-mongo", protocol: "mongodb"},
 				},
 				cidrRange: "192.168.2.0/24",
 				leafClusters: map[string]testClusterSpec{
@@ -1278,17 +1279,7 @@ func TestDialFakeDatabase(t *testing.T) {
 		expectRouteToDatabase proto.RouteToDatabase
 	}{
 		{
-			name:       "root cluster postgres with user",
-			fqdn:       "reader.my-postgres.db.root1.example.com",
-			expectCIDR: "192.168.2.0/24",
-			expectRouteToDatabase: proto.RouteToDatabase{
-				ServiceName: "my-postgres",
-				Protocol:    "postgres",
-				Username:    "reader",
-			},
-		},
-		{
-			name:       "root cluster postgres without user",
+			name:       "postgres without user in FQDN",
 			fqdn:       "my-postgres.db.root1.example.com",
 			expectCIDR: "192.168.2.0/24",
 			expectRouteToDatabase: proto.RouteToDatabase{
@@ -1298,33 +1289,33 @@ func TestDialFakeDatabase(t *testing.T) {
 			},
 		},
 		{
-			name:       "root cluster mysql with user",
-			fqdn:       "admin.my-mysql.db.root1.example.com",
+			name:       "mysql without user in FQDN",
+			fqdn:       "my-mysql.db.root1.example.com",
 			expectCIDR: "192.168.2.0/24",
 			expectRouteToDatabase: proto.RouteToDatabase{
 				ServiceName: "my-mysql",
 				Protocol:    "mysql",
-				Username:    "admin",
+				Username:    "",
 			},
 		},
 		{
 			name:       "leaf cluster postgres via root proxy",
-			fqdn:       "reader.leaf-postgres.db.root1.example.com",
+			fqdn:       "leaf-postgres.db.root1.example.com",
 			expectCIDR: typesvnet.DefaultIPv4CIDRRange,
 			expectRouteToDatabase: proto.RouteToDatabase{
 				ServiceName: "leaf-postgres",
 				Protocol:    "postgres",
-				Username:    "reader",
+				Username:    "", // user stripped — postgres gets it from wire protocol
 			},
 		},
 		{
-			name:       "dotted username",
-			fqdn:       "some.dotted.user.my-postgres.db.root1.example.com",
+			name:       "mongodb with user in FQDN",
+			fqdn:       "admin.my-mongo.db.root1.example.com",
 			expectCIDR: "192.168.2.0/24",
 			expectRouteToDatabase: proto.RouteToDatabase{
-				ServiceName: "my-postgres",
-				Protocol:    "postgres",
-				Username:    "some.dotted.user",
+				ServiceName: "my-mongo",
+				Protocol:    "mongodb",
+				Username:    "admin", // mongodb requires user in cert
 			},
 		},
 	}
@@ -1427,7 +1418,7 @@ func TestOnNewDBConnection(t *testing.T) {
 	require.Equal(t, uint32(0), clientApp.onNewDBConnectionCallCount.Load())
 
 	// Connect to a valid database and verify OnNewDBConnection was called.
-	conn, err := p.dialHost(ctx, "reader.my-postgres.db.root1.example.com", 5432)
+	conn, err := p.dialHost(ctx, "my-postgres.db.root1.example.com", 5432)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 	require.Equal(t, uint32(1), clientApp.onNewDBConnectionCallCount.Load())

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -355,12 +355,18 @@ func (s *appSpec) getURI() string {
 	return "tcp://" + s.publicAddr
 }
 
+type dbSpec struct {
+	name     string
+	protocol string
+}
+
 type nodeSpec struct {
 	denyAccess bool
 }
 
 type testClusterSpec struct {
 	apps           []appSpec
+	databases      []dbSpec
 	nodes          map[string]nodeSpec
 	cidrRange      string
 	customDNSZones []string
@@ -382,10 +388,14 @@ type fakeClientApp struct {
 
 	onNewSSHSessionCallCount    atomic.Uint32
 	onNewAppConnectionCallCount atomic.Uint32
+	onNewDBConnectionCallCount  atomic.Uint32
 	onInvalidLocalPortCallCount atomic.Uint32
 	// requestedRouteToApps indexed by public address.
 	requestedRouteToApps   map[string][]*proto.RouteToApp
 	requestedRouteToAppsMu sync.RWMutex
+	// requestedRouteToDatabases indexed by database name.
+	requestedRouteToDatabases   map[string][]*proto.RouteToDatabase
+	requestedRouteToDatabasesMu sync.RWMutex
 
 	forwardedAgents *forwardedAgents
 }
@@ -424,13 +434,14 @@ func newFakeClientApp(ctx context.Context, t *testing.T, cfg *fakeClientAppConfi
 	})
 
 	return &fakeClientApp{
-		cfg:                  cfg,
-		tlsCA:                tlsCA,
-		dialOpts:             dialOpts,
-		teleportHostCA:       teleportHostCA,
-		teleportUserCA:       teleportUserCA,
-		requestedRouteToApps: make(map[string][]*proto.RouteToApp),
-		forwardedAgents:      forwardedAgents,
+		cfg:                       cfg,
+		tlsCA:                     tlsCA,
+		dialOpts:                  dialOpts,
+		teleportHostCA:            teleportHostCA,
+		teleportUserCA:            teleportUserCA,
+		requestedRouteToApps:      make(map[string][]*proto.RouteToApp),
+		requestedRouteToDatabases: make(map[string][]*proto.RouteToDatabase),
+		forwardedAgents:           forwardedAgents,
 	}
 }
 
@@ -595,18 +606,33 @@ func (p *fakeClientApp) OnInvalidLocalPort(_ context.Context, _ *vnetv1.AppInfo,
 }
 
 func (p *fakeClientApp) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (tls.Certificate, error) {
-	// Return a test certificate for database access.
-	return p.ReissueAppCert(ctx, &vnetv1.AppInfo{
-		AppKey: &vnetv1.AppKey{
-			Profile:     dbInfo.GetDatabaseKey().GetProfile(),
-			LeafCluster: dbInfo.GetDatabaseKey().GetLeafCluster(),
-			Name:        dbInfo.GetDatabaseKey().GetName(),
-		},
-		DialOptions: dbInfo.GetDialOptions(),
-	}, 0)
+	p.requestedRouteToDatabasesMu.Lock()
+	defer p.requestedRouteToDatabasesMu.Unlock()
+
+	routeToDatabase := RouteToDatabase(dbInfo)
+	p.requestedRouteToDatabases[routeToDatabase.ServiceName] = append(
+		p.requestedRouteToDatabases[routeToDatabase.ServiceName], routeToDatabase)
+
+	return newClientCert(ctx,
+		p.tlsCA,
+		"testclient",
+		p.cfg.clock.Now().Add(appCertLifetime),
+		p.cfg.signatureAlgorithmSuite,
+		cryptosuites.UserTLS)
+}
+
+func (p *fakeClientApp) RequestedRouteToDatabases(dbName string) []*proto.RouteToDatabase {
+	p.requestedRouteToDatabasesMu.RLock()
+	defer p.requestedRouteToDatabasesMu.RUnlock()
+
+	routes := p.requestedRouteToDatabases[dbName]
+	returnedRoutes := make([]*proto.RouteToDatabase, len(routes))
+	copy(returnedRoutes, routes)
+	return returnedRoutes
 }
 
 func (p *fakeClientApp) OnNewDBConnection(_ context.Context, _ *vnetv1.DatabaseKey) error {
+	p.onNewDBConnectionCallCount.Add(1)
 	return nil
 }
 
@@ -720,6 +746,48 @@ func (c *fakeAuthClient) GetResources(ctx context.Context, req *proto.ListResour
 		return nil, trace.Wrap(err)
 	}
 	resp := &proto.ListResourcesResponse{}
+
+	// Only iterate resources matching the requested type. Predicate
+	// expressions are type-specific (e.g. resource.spec.public_addr is only
+	// valid for app servers) and would fail on other resource types.
+	if req.ResourceType == types.KindDatabaseServer {
+		for _, db := range c.clusterSpec.databases {
+			dbServer := &types.DatabaseServerV3{
+				Kind: types.KindDatabaseServer,
+				Metadata: types.Metadata{
+					Name: db.name,
+				},
+				Spec: types.DatabaseServerSpecV3{
+					Database: &types.DatabaseV3{
+						Metadata: types.Metadata{
+							Name: db.name,
+						},
+						Spec: types.DatabaseSpecV3{
+							Protocol: db.protocol,
+							URI:      "localhost:5432",
+						},
+					},
+				},
+			}
+
+			match, err := services.MatchResourceByFilters(dbServer, filter, nil /* seenMap */)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if !match {
+				continue
+			}
+
+			resp.Resources = append(resp.Resources, &proto.PaginatedResource{
+				Resource: &proto.PaginatedResource_DatabaseServer{
+					DatabaseServer: dbServer,
+				},
+			})
+		}
+		resp.TotalCount = int32(len(resp.Resources))
+		return resp, nil
+	}
+
 	for _, app := range c.clusterSpec.apps {
 		appServer := &types.AppServerV3{
 			Kind: types.KindAppServer,
@@ -756,6 +824,7 @@ func (c *fakeAuthClient) GetResources(ctx context.Context, req *proto.ListResour
 			},
 		})
 	}
+
 	resp.TotalCount = int32(len(resp.Resources))
 	return resp, nil
 }
@@ -1167,6 +1236,201 @@ func TestOnNewAppConnection(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 	require.Equal(t, uint32(1), clientApp.onNewAppConnectionCallCount.Load())
+}
+
+// TestDialFakeDatabase tests basic functionality of database access via VNet.
+func TestDialFakeDatabase(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	clock := clockwork.NewFakeClockAt(time.Now())
+
+	clientApp := newFakeClientApp(ctx, t, &fakeClientAppConfig{
+		clusters: map[string]testClusterSpec{
+			"root1.example.com": {
+				databases: []dbSpec{
+					{name: "my-postgres", protocol: "postgres"},
+					{name: "my-mysql", protocol: "mysql"},
+				},
+				cidrRange: "192.168.2.0/24",
+				leafClusters: map[string]testClusterSpec{
+					"leaf1.example.com": {
+						databases: []dbSpec{
+							{name: "leaf-postgres", protocol: "postgres"},
+						},
+					},
+				},
+			},
+		},
+		clock:                   clock,
+		signatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1,
+	})
+
+	p := newTestPack(t, ctx, testPackConfig{
+		fakeClientApp: clientApp,
+		clock:         clock,
+	})
+
+	validTestCases := []struct {
+		name                  string
+		fqdn                  string
+		expectCIDR            string
+		expectRouteToDatabase proto.RouteToDatabase
+	}{
+		{
+			name:       "root cluster postgres with user",
+			fqdn:       "reader.my-postgres.db.root1.example.com",
+			expectCIDR: "192.168.2.0/24",
+			expectRouteToDatabase: proto.RouteToDatabase{
+				ServiceName: "my-postgres",
+				Protocol:    "postgres",
+				Username:    "reader",
+			},
+		},
+		{
+			name:       "root cluster postgres without user",
+			fqdn:       "my-postgres.db.root1.example.com",
+			expectCIDR: "192.168.2.0/24",
+			expectRouteToDatabase: proto.RouteToDatabase{
+				ServiceName: "my-postgres",
+				Protocol:    "postgres",
+				Username:    "",
+			},
+		},
+		{
+			name:       "root cluster mysql with user",
+			fqdn:       "admin.my-mysql.db.root1.example.com",
+			expectCIDR: "192.168.2.0/24",
+			expectRouteToDatabase: proto.RouteToDatabase{
+				ServiceName: "my-mysql",
+				Protocol:    "mysql",
+				Username:    "admin",
+			},
+		},
+		{
+			name:       "leaf cluster postgres via root proxy",
+			fqdn:       "reader.leaf-postgres.db.root1.example.com",
+			expectCIDR: typesvnet.DefaultIPv4CIDRRange,
+			expectRouteToDatabase: proto.RouteToDatabase{
+				ServiceName: "leaf-postgres",
+				Protocol:    "postgres",
+				Username:    "reader",
+			},
+		},
+		{
+			name:       "dotted username",
+			fqdn:       "some.dotted.user.my-postgres.db.root1.example.com",
+			expectCIDR: "192.168.2.0/24",
+			expectRouteToDatabase: proto.RouteToDatabase{
+				ServiceName: "my-postgres",
+				Protocol:    "postgres",
+				Username:    "some.dotted.user",
+			},
+		},
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		for _, tc := range validTestCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, expectNet, err := net.ParseCIDR(tc.expectCIDR)
+				require.NoError(t, err)
+
+				conn, err := p.dialHost(ctx, tc.fqdn, 5432)
+				require.NoError(t, err)
+				t.Cleanup(func() { assert.NoError(t, conn.Close()) })
+
+				remoteAddr, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+				require.NoError(t, err)
+				remoteIP := net.ParseIP(remoteAddr)
+				require.NotNil(t, remoteIP)
+
+				// Verify the assigned IP is in the expected CIDR range.
+				remoteIPSuffix := remoteIP[len(remoteIP)-4:]
+				assert.True(t, expectNet.Contains(remoteIPSuffix),
+					"expected CIDR range %s does not include remote IP %s", expectNet, remoteIPSuffix)
+
+				testEchoConnection(t, conn)
+
+				// Verify that a cert was requested with the correct RouteToDatabase.
+				requestedRoutes := clientApp.RequestedRouteToDatabases(tc.expectRouteToDatabase.ServiceName)
+				assert.True(t, slices.ContainsFunc(requestedRoutes, func(route *proto.RouteToDatabase) bool {
+					return route.ServiceName == tc.expectRouteToDatabase.ServiceName &&
+						route.Protocol == tc.expectRouteToDatabase.Protocol &&
+						route.Username == tc.expectRouteToDatabase.Username
+				}), "expected RouteToDatabase %v to be in requested routes %v", tc.expectRouteToDatabase, requestedRoutes)
+			})
+		}
+	})
+
+	// Test that FQDNs for completely unknown zones fail DNS resolution.
+	// Note: FQDNs that match a known cluster subdomain (like
+	// "reader.not-a-db.db.root1.example.com") will still resolve to an IP
+	// via the SSH cluster fallback, which is expected VNet behavior.
+	t.Run("invalid database FQDN", func(t *testing.T) {
+		t.Parallel()
+
+		lookupShouldFailFast := func(t *testing.T, host string) {
+			t.Helper()
+			lookupCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			defer cancel()
+			_, err := p.lookupHost(lookupCtx, host)
+			require.Error(t, err)
+		}
+
+		invalidFQDNs := []struct {
+			name string
+			fqdn string
+		}{
+			{
+				name: "wrong proxy address",
+				fqdn: "reader.my-postgres.db.wrong.example.com",
+			},
+		}
+
+		for _, tc := range invalidFQDNs {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				lookupShouldFailFast(t, tc.fqdn)
+			})
+		}
+	})
+}
+
+// TestOnNewDBConnection tests that the client application's OnNewDBConnection method
+// is called when a user connects to a valid database via VNet.
+func TestOnNewDBConnection(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	clock := clockwork.NewFakeClockAt(time.Now())
+
+	clientApp := newFakeClientApp(ctx, t, &fakeClientAppConfig{
+		clusters: map[string]testClusterSpec{
+			"root1.example.com": {
+				databases: []dbSpec{
+					{name: "my-postgres", protocol: "postgres"},
+				},
+				cidrRange:    "192.168.2.0/24",
+				leafClusters: map[string]testClusterSpec{},
+			},
+		},
+		clock:                   clock,
+		signatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1,
+	})
+
+	p := newTestPack(t, ctx, testPackConfig{
+		clock:         clock,
+		fakeClientApp: clientApp,
+	})
+
+	// Verify OnNewDBConnection is not called until a valid database connection is made.
+	require.Equal(t, uint32(0), clientApp.onNewDBConnectionCallCount.Load())
+
+	// Connect to a valid database and verify OnNewDBConnection was called.
+	conn, err := p.dialHost(ctx, "reader.my-postgres.db.root1.example.com", 5432)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	require.Equal(t, uint32(1), clientApp.onNewDBConnectionCallCount.Load())
 }
 
 // TestWithAlgorithmSuites tests basic VNet functionality with each signature
@@ -1972,10 +2236,7 @@ func mustStartFakeWebProxy(
 		Certificates: []tls.Certificate{proxyCert},
 		ClientAuth:   tls.VerifyClientCertIfGiven,
 		ClientCAs:    roots,
-		NextProtos: []string{
-			string(alpncommon.ProtocolProxySSH),
-			string(alpncommon.ProtocolTCP),
-		},
+		NextProtos:   fakeWebProxyALPNProtocols(),
 	}
 
 	tcpAppHandler := func(conn net.Conn) error {
@@ -2020,10 +2281,14 @@ func mustStartFakeWebProxy(
 		return trace.Wrap(runTestSSHServerInstance(conn, serverConfig))
 	}
 
-	// Run a simplified TLS router for the test.
+	// Run a simplified TLS router for the test. Database protocols use the
+	// same echo handler as TCP apps since we're just testing the VNet plumbing.
 	protocolHandlers := map[alpncommon.Protocol]func(net.Conn) error{
 		alpncommon.ProtocolTCP:      tcpAppHandler,
 		alpncommon.ProtocolProxySSH: sshHandler,
+	}
+	for _, dbProto := range alpncommon.DatabaseProtocols {
+		protocolHandlers[dbProto] = tcpAppHandler
 	}
 
 	listener, err := tls.Listen("tcp", "localhost:0", proxyTLSConfig)
@@ -2096,6 +2361,19 @@ func mustStartFakeWebProxy(
 		Sni:                   proxyCN,
 	}
 	return dialOpts
+}
+
+// fakeWebProxyALPNProtocols returns the list of ALPN protocols the fake web
+// proxy should advertise. This includes TCP app, SSH, and all database protocols.
+func fakeWebProxyALPNProtocols() []string {
+	protos := []string{
+		string(alpncommon.ProtocolProxySSH),
+		string(alpncommon.ProtocolTCP),
+	}
+	for _, dbProto := range alpncommon.DatabaseProtocols {
+		protos = append(protos, string(dbProto))
+	}
+	return protos
 }
 
 // forwardedAgents is a crude way of tracking all the forwarded SSH agents and

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -166,6 +166,7 @@ func newTestPack(t *testing.T, ctx context.Context, cfg testPackConfig) *testPac
 	tcpHandlerResolver := newTCPHandlerResolver(&tcpHandlerResolverConfig{
 		clt:                      clt,
 		appProvider:              appProvider,
+		dbProvider:               newDBProvider(clt),
 		sshProvider:              sshProvider,
 		clock:                    cfg.clock,
 		alwaysTrustRootClusterCA: true,
@@ -591,6 +592,22 @@ func (p *fakeClientApp) OnNewAppConnection(_ context.Context, _ *vnetv1.AppKey) 
 
 func (p *fakeClientApp) OnInvalidLocalPort(_ context.Context, _ *vnetv1.AppInfo, _ uint16) {
 	p.onInvalidLocalPortCallCount.Add(1)
+}
+
+func (p *fakeClientApp) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (tls.Certificate, error) {
+	// Return a test certificate for database access.
+	return p.ReissueAppCert(ctx, &vnetv1.AppInfo{
+		AppKey: &vnetv1.AppKey{
+			Profile:     dbInfo.GetDatabaseKey().GetProfile(),
+			LeafCluster: dbInfo.GetDatabaseKey().GetLeafCluster(),
+			Name:        dbInfo.GetDatabaseKey().GetName(),
+		},
+		DialOptions: dbInfo.GetDialOptions(),
+	}, 0)
+}
+
+func (p *fakeClientApp) OnNewDBConnection(_ context.Context, _ *vnetv1.DatabaseKey) error {
+	return nil
 }
 
 func (p *fakeClientApp) dialSSHNode(

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -1223,8 +1223,8 @@ func TestOnNewAppConnection(t *testing.T) {
 		fakeClientApp: clientApp,
 	})
 
-	// Attempt to establish a connection to an invalid app and verify that OnNewAppConnection was not
-	// called.
+	// Attempt to establish a connection to an invalid app and verify
+	// that OnNewAppConnection was not called.
 	lookupCtx, lookupCtxCancel := context.WithTimeout(ctx, 200*time.Millisecond)
 	defer lookupCtxCancel()
 	_, err := p.lookupHost(lookupCtx, invalidAppName)
@@ -2281,8 +2281,7 @@ func mustStartFakeWebProxy(
 		return trace.Wrap(runTestSSHServerInstance(conn, serverConfig))
 	}
 
-	// Run a simplified TLS router for the test. Database protocols use the
-	// same echo handler as TCP apps since we're just testing the VNet plumbing.
+	// Run a simplified TLS router for the test.
 	protocolHandlers := map[alpncommon.Protocol]func(net.Conn) error{
 		alpncommon.ProtocolTCP:      tcpAppHandler,
 		alpncommon.ProtocolProxySSH: sshHandler,

--- a/proto/teleport/lib/vnet/v1/client_application_service.proto
+++ b/proto/teleport/lib/vnet/v1/client_application_service.proto
@@ -465,6 +465,10 @@ message SignForDBRequest {
   DatabaseKey database_key = 1;
   // Sign holds signature request details.
   SignRequest sign = 2;
+  // Username is the database user for which the cert was issued. Required
+  // because different users connecting to the same database get different
+  // certs and signers.
+  string username = 3;
 }
 
 // SignForDBResponse is a response for SignForDB.

--- a/proto/teleport/lib/vnet/v1/client_application_service.proto
+++ b/proto/teleport/lib/vnet/v1/client_application_service.proto
@@ -65,6 +65,14 @@ service ClientApplicationService {
   // ExchangeSSHKeys sends VNet's SSH host CA key to the client application and
   // returns the user public key.
   rpc ExchangeSSHKeys(ExchangeSSHKeysRequest) returns (ExchangeSSHKeysResponse);
+  // ReissueDBCert issues a new database cert.
+  rpc ReissueDBCert(ReissueDBCertRequest) returns (ReissueDBCertResponse);
+  // SignForDB issues a signature with the private key associated with an x509
+  // certificate previously issued for a requested database.
+  rpc SignForDB(SignForDBRequest) returns (SignForDBResponse);
+  // OnNewDBConnection gets called whenever a new database connection is about to
+  // be established through VNet for observability.
+  rpc OnNewDBConnection(OnNewDBConnectionRequest) returns (OnNewDBConnectionResponse);
 }
 
 // AuthenticateProcessRequest is a request for AuthenticateProcess.
@@ -123,6 +131,8 @@ message ResolveFQDNResponse {
     // match a subdomain of a proxy address. VNet will resolve the DNS query to
     // a handler that may later resolve the FQDN to an app or SSH server.
     MatchedCluster matched_cluster = 3;
+    // MatchedDatabase will be set when the query matched a database resource.
+    MatchedDatabase matched_database = 4;
   }
 }
 
@@ -394,3 +404,80 @@ message ExchangeSSHKeysResponse {
   // connections from SSH clients. It is encoded in OpenSSH wire format.
   bytes user_public_key = 1;
 }
+
+// MatchedDatabase holds info about a database that matched a query.
+message MatchedDatabase {
+  // DatabaseInfo holds all necessary info for making connections to the resolved database.
+  DatabaseInfo database_info = 1;
+}
+
+// DatabaseInfo holds all necessary info for making connections to VNet databases.
+message DatabaseInfo {
+  // DatabaseKey uniquely identifies a database.
+  DatabaseKey database_key = 1;
+  // Cluster is the name of the cluster in which the database is found.
+  // Iff the database is in a leaf cluster, this will match database_key.leaf_cluster.
+  string cluster = 2;
+  // Protocol is the database wire protocol (e.g. "postgres", "mysql", "mongodb").
+  string protocol = 3;
+  // Username is the database user parsed from the FQDN. May be empty when the
+  // user is auto-provisioned or when only one database user is allowed.
+  string username = 4;
+  // Ipv4CidrRange is the CIDR range from which an IPv4 address should be
+  // assigned to the database.
+  string ipv4_cidr_range = 5;
+  // DialOptions holds options that should be used when dialing the root cluster
+  // of the database.
+  DialOptions dial_options = 6;
+}
+
+// DatabaseKey uniquely identifies a database in a specific profile and cluster.
+message DatabaseKey {
+  // Profile is the profile in which the database is found.
+  string profile = 1;
+  // LeafCluster is the leaf cluster in which the database is found. If empty,
+  // the database is in the root cluster for the profile.
+  string leaf_cluster = 2;
+  // Name is the name of the database resource.
+  string name = 3;
+}
+
+// ReissueDBCertRequest is a request for ReissueDBCert.
+message ReissueDBCertRequest {
+  // DatabaseInfo contains info about the database, every ReissueDBCertRequest
+  // must include a database_info as returned from ResolveFQDN.
+  DatabaseInfo database_info = 1;
+}
+
+// ReissueDBCertResponse is a response for ReissueDBCert.
+message ReissueDBCertResponse {
+  // Cert is the issued database certificate in x509 DER format.
+  bytes cert = 1;
+}
+
+// SignForDBRequest is a request to sign data with a private key that the
+// server has cached for the database_key. The database_key must match a
+// previous successful call to ReissueDBCert. The private key used for the
+// signature will match the subject public key of the issued x509 certificate.
+message SignForDBRequest {
+  // DatabaseKey uniquely identifies a database, it must match the key of a
+  // database from a previous successful call to ReissueDBCert.
+  DatabaseKey database_key = 1;
+  // Sign holds signature request details.
+  SignRequest sign = 2;
+}
+
+// SignForDBResponse is a response for SignForDB.
+message SignForDBResponse {
+  // Signature is the signature.
+  bytes signature = 1;
+}
+
+// OnNewDBConnectionRequest is a request for OnNewDBConnection.
+message OnNewDBConnectionRequest {
+  // DatabaseKey identifies the database the connection is being made for.
+  DatabaseKey database_key = 1;
+}
+
+// OnNewDBConnectionResponse is a response for OnNewDBConnection.
+message OnNewDBConnectionResponse {}

--- a/tool/tsh/common/vnet_client_application.go
+++ b/tool/tsh/common/vnet_client_application.go
@@ -145,6 +145,63 @@ func (p *vnetClientApplication) OnNewAppConnection(_ context.Context, _ *vnetv1.
 	return nil
 }
 
+// ReissueDBCert returns a new database certificate for the given database.
+func (p *vnetClientApplication) ReissueDBCert(ctx context.Context, dbInfo *vnetv1.DatabaseInfo) (tls.Certificate, error) {
+	dbKey := dbInfo.GetDatabaseKey()
+	tc, err := p.newTeleportClient(ctx, dbKey.GetProfile(), dbKey.GetLeafCluster())
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+	routeToDatabase := vnet.RouteToDatabase(dbInfo)
+
+	var cert tls.Certificate
+	err = p.retryWithRelogin(ctx, tc, func() error {
+		var err error
+		cert, err = p.reissueDBCert(ctx, tc, dbKey.GetProfile(), dbKey.GetLeafCluster(), routeToDatabase)
+		return trace.Wrap(err, "reissuing database cert")
+	})
+	return cert, trace.Wrap(err)
+}
+
+func (p *vnetClientApplication) reissueDBCert(ctx context.Context, tc *client.TeleportClient, profileName, leafClusterName string, routeToDatabase *proto.RouteToDatabase) (tls.Certificate, error) {
+	slog.InfoContext(ctx, "Reissuing cert for database.", "db_name", routeToDatabase.ServiceName, "profile", profileName, "leaf_cluster", leafClusterName)
+
+	profile, err := tc.ProfileStatus()
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "loading client profile")
+	}
+
+	dbCertParams := client.ReissueParams{
+		RouteToCluster:  leafClusterName,
+		RouteToDatabase: *routeToDatabase,
+		AccessRequests:  profile.ActiveRequests,
+		RequesterName:   proto.UserCertsRequest_TSH_DB_LOCAL_PROXY_TUNNEL,
+	}
+
+	clusterClient, err := p.clientCache.Get(ctx, profileName, leafClusterName)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "getting cached cluster client")
+	}
+
+	result, err := clusterClient.IssueUserCertsWithMFA(ctx, dbCertParams)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "issuing database cert")
+	}
+
+	dbCert, err := result.KeyRing.DBTLSCert(routeToDatabase.ServiceName)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "getting TLS cert from key ring")
+	}
+
+	return dbCert, nil
+}
+
+// OnNewDBConnection gets called before each VNet database connection. It's a
+// noop as tsh doesn't need to do anything extra here.
+func (p *vnetClientApplication) OnNewDBConnection(_ context.Context, _ *vnetv1.DatabaseKey) error {
+	return nil
+}
+
 // OnInvalidLocalPort gets called before VNet refuses to handle a connection to a multi-port TCP app
 // because the provided port does not match any of the TCP ports in the app spec.
 func (p *vnetClientApplication) OnInvalidLocalPort(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16) {

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -286,7 +286,10 @@ const getTargetDesc = (reason: ClusterConnectReason): React.ReactNode => {
       }
     }
     case 'reason.vnet-cert-expired': {
-      return <strong>{publicAddrWithTargetPort(reason.routeToApp)}</strong>;
+      if (reason.routeToApp) {
+        return <strong>{publicAddrWithTargetPort(reason.routeToApp)}</strong>;
+      }
+      return <strong>{getTargetNameFromUri(reason.targetUri)}</strong>;
     }
     default: {
       reason satisfies never;

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -286,10 +286,7 @@ const getTargetDesc = (reason: ClusterConnectReason): React.ReactNode => {
       }
     }
     case 'reason.vnet-cert-expired': {
-      if (reason.routeToApp) {
-        return <strong>{publicAddrWithTargetPort(reason.routeToApp)}</strong>;
-      }
-      return <strong>{getTargetNameFromUri(reason.targetUri)}</strong>;
+      return <strong>{publicAddrWithTargetPort(reason.routeToApp)}</strong>;
     }
     default: {
       reason satisfies never;

--- a/web/packages/teleterm/src/ui/services/tshdNotifications/tshdNotificationService.ts
+++ b/web/packages/teleterm/src/ui/services/tshdNotifications/tshdNotificationService.ts
@@ -108,13 +108,10 @@ export class TshdNotificationsService {
               return;
             }
             const { error } = reason.certReissueError;
-            const targetName = routeToApp
-              ? publicAddrWithTargetPort(routeToApp)
-              : getTargetNameFromUri(targetUri);
 
             return {
-              title: `Cannot connect to ${targetName}`,
-              description: `A connection attempt to a resource in the cluster ${clusterName} failed due to an unexpected error: ${error}`,
+              title: `Cannot connect to ${publicAddrWithTargetPort(routeToApp)}`,
+              description: `A connection attempt to the app in the cluster ${clusterName} failed due to an unexpected error: ${error}`,
               key: [
                 'cannotProxyVnetConnection',
                 'certReissueError',
@@ -132,25 +129,16 @@ export class TshdNotificationsService {
               .map(portRange => formatPortRange(portRange))
               .join(', ');
 
-            let description: string;
-            if (routeToApp) {
-              description =
-                `A connection attempt on the port ${routeToApp.targetPort} was refused ` +
-                `as that port is not included in the target ports of the app ${routeToApp.clusterName} in the cluster ${clusterName}.`;
-            } else {
-              description = `A connection attempt was refused for a resource in the cluster ${clusterName}.`;
-            }
+            let description =
+              `A connection attempt on the port ${routeToApp.targetPort} was refused ` +
+              `as that port is not included in the target ports of the app ${routeToApp.clusterName} in the cluster ${clusterName}.`;
 
             if (ports) {
               description += ` Valid ports: ${ports}.`;
             }
 
-            const targetName = routeToApp
-              ? publicAddrWithTargetPort(routeToApp)
-              : getTargetNameFromUri(targetUri);
-
             return {
-              title: `Invalid port for ${targetName}`,
+              title: `Invalid port for ${publicAddrWithTargetPort(routeToApp)}`,
               description,
               // 3rd-party clients can potentially make dozens of attempts to connect to an invalid
               // port within a short time. As all notifications from this service go as errors, we

--- a/web/packages/teleterm/src/ui/services/tshdNotifications/tshdNotificationService.ts
+++ b/web/packages/teleterm/src/ui/services/tshdNotifications/tshdNotificationService.ts
@@ -108,10 +108,13 @@ export class TshdNotificationsService {
               return;
             }
             const { error } = reason.certReissueError;
+            const targetName = routeToApp
+              ? publicAddrWithTargetPort(routeToApp)
+              : getTargetNameFromUri(targetUri);
 
             return {
-              title: `Cannot connect to ${publicAddrWithTargetPort(routeToApp)}`,
-              description: `A connection attempt to the app in the cluster ${clusterName} failed due to an unexpected error: ${error}`,
+              title: `Cannot connect to ${targetName}`,
+              description: `A connection attempt to a resource in the cluster ${clusterName} failed due to an unexpected error: ${error}`,
               key: [
                 'cannotProxyVnetConnection',
                 'certReissueError',
@@ -129,16 +132,25 @@ export class TshdNotificationsService {
               .map(portRange => formatPortRange(portRange))
               .join(', ');
 
-            let description =
-              `A connection attempt on the port ${routeToApp.targetPort} was refused ` +
-              `as that port is not included in the target ports of the app ${routeToApp.clusterName} in the cluster ${clusterName}.`;
+            let description: string;
+            if (routeToApp) {
+              description =
+                `A connection attempt on the port ${routeToApp.targetPort} was refused ` +
+                `as that port is not included in the target ports of the app ${routeToApp.clusterName} in the cluster ${clusterName}.`;
+            } else {
+              description = `A connection attempt was refused for a resource in the cluster ${clusterName}.`;
+            }
 
             if (ports) {
               description += ` Valid ports: ${ports}.`;
             }
 
+            const targetName = routeToApp
+              ? publicAddrWithTargetPort(routeToApp)
+              : getTargetNameFromUri(targetUri);
+
             return {
-              title: `Invalid port for ${publicAddrWithTargetPort(routeToApp)}`,
+              title: `Invalid port for ${targetName}`,
               description,
               // 3rd-party clients can potentially make dozens of attempts to connect to an invalid
               // port within a short time. As all notifications from this service go as errors, we


### PR DESCRIPTION
## Changes
This adds db access support through vnet using Teleport Connect. This is a follow up from the previous PR which added the core logic to add vnet support for db here: https://github.com/gravitational/teleport/pull/65298

RFD: https://github.com/gravitational/teleport.e/pull/8432

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Teleport cluster with at least one database resource registered (e.g., Postgres in Docker)
- tsh login --proxy=<proxy-addr> completed
- tsh db ls shows the database

### Prerequisites
- Spin up a postgres container called `postgres-test`
- Register a tcp-app to validate tcp apps via vnet is not broken
- Start vnet by running `tsh vnet`

### Test Cases
- [x] VNet does not break existing TCP app access
  - `psql "postgresql://postgres@tcp-app.teleport.localhost/postgres" -c "SELECT 1;" 2>&1`
- [x] Teleport Connect: database via VNet
  - Click on vnet button in teleport connect and redo the basic database connection via vnet to validate db access works with vnet through Connect
- [x]  Session expiry and re-authentication
  - start vnet through connect
  - logout from tsh
  - Validate in connect it shows a message to `Connect a Cluster`

changelog: Added database access support via vnet using teleport connect