### PR TITLE
Fix race condition in moderated session closure

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -800,6 +800,8 @@ type session struct {
 
 	// started is true after the session start.
 	started atomic.Bool
+	// started is true after the session is being closed.
+	closing atomic.Bool
 }
 
 type sessionType bool
@@ -1013,6 +1015,11 @@ func (s *session) haltTerminal() {
 // prematurely can result in missing audit events, session recordings, and other
 // unexpected errors.
 func (s *session) Close() error {
+	if s.closing.Swap(true) {
+		s.logger.DebugContext(s.serverCtx, "Session is already closing.")
+		return nil
+	}
+
 	s.BroadcastMessage("Closing session...")
 	s.logger.InfoContext(s.serverCtx, "Closing session.")
 
@@ -1742,6 +1749,20 @@ func (s *session) removePartyUnderLock(p *party) error {
 	// Emit session leave event to both the Audit Log and over the
 	// "x-teleport-event" channel in the SSH connection.
 	s.emitSessionLeaveEventUnderLock(p.ctx)
+
+	return s.handlePartyLeavePolicyUnderLock(p)
+}
+
+// handlePartyLeavePolicyUnderLock applies any session state changes caused by a
+// party leaving, such as terminating or pausing the session when required
+// participants are no longer present.
+func (s *session) handlePartyLeavePolicyUnderLock(p *party) error {
+	// Skip leave policy handling during normal session teardown to avoid
+	// retriggering forced termination while the session is already closing.
+	if s.closing.Load() {
+		s.logger.DebugContext(s.serverCtx, "Session is already closing, skipping forced termination.")
+		return nil
+	}
 
 	canRun, policyOptions, err := s.checkIfStartUnderLock()
 	if err != nil {


### PR DESCRIPTION
Changelog: Ensure consistent client output when a moderated session ends by fixing a race condition between participant closure and forced termination due to session leave policies.

Fix a race condition in session closure that looks like this: `session close -> eject parties -> check each party's leave policy -> force terminate session -> stop session before all parties are ejected`.

Exiting a moderated session now consistently results in the following output:
```
$ exit
Teleport > Closing session...
Teleport > User dev left the session.
the connection was closed on the remote side at  02 Apr 26 15:56 PDT
```

Before this fix, ending a moderated session could result in any of the following outputs, depending on which parties are ejected from the session first:
```
$ exit
Teleport > Closing session...
Teleport > User dev left the session.
the connection was closed on the remote side at  02 Apr 26 15:56 PDT

$ exit
Teleport > Closing session...
Teleport > User dev2 left the session.
Teleport > User dev left the session.
Teleport > Forcefully terminating session...
the connection was closed on the remote side at  02 Apr 26 15:56 PDT

$ exit
Teleport > Closing session...
Teleport > User dev2 left the session.
Teleport > User dev left the session.
Teleport > Forcefully terminating session...
Teleport > Stopping session...
Teleport > Closing session...
ERROR: Process exited with status 255
```

TODO: add regression test and manual test plan

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
