### PR TITLE
Fix flaky test `TestModeratedSessionWithMFA`

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2420,7 +2420,7 @@ func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipan
 	if mode == types.SessionModeratorMode {
 		beforeStart = func(out io.Writer) {
 			nc.OnMFA = func() {
-				RunPresenceTask(presenceCtx, out, clt.AuthClient, session.GetSessionID(), tc.NewMFACeremony())
+				RunDefaultPresenceTask(presenceCtx, out, clt.AuthClient, session.GetSessionID(), tc.NewMFACeremony())
 			}
 		}
 	}

--- a/lib/client/kubesession.go
+++ b/lib/client/kubesession.go
@@ -216,7 +216,7 @@ func (s *KubeSession) handleMFA(ctx context.Context, authFn func(context.Context
 
 		go func() {
 			defer auth.Close()
-			if err := RunPresenceTask(ctx, stdout, auth, s.meta.GetSessionID(), ceremony); err != nil {
+			if err := RunDefaultPresenceTask(ctx, stdout, auth, s.meta.GetSessionID(), ceremony); err != nil {
 				slog.DebugContext(ctx, "Presence check terminated unexpectedly", "error", err)
 			}
 		}()

--- a/lib/client/presence.go
+++ b/lib/client/presence.go
@@ -25,10 +25,15 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/mfa"
+)
+
+const (
+	// DefaultPresenceMaxDuration is the default max duration that a moderated session
+	// can continue between presence verifications.
+	DefaultPresenceMaxDuration = time.Minute
 )
 
 // PresenceMaintainer allows maintaining presence with the Auth service.
@@ -36,38 +41,18 @@ type PresenceMaintainer interface {
 	MaintainSessionPresence(ctx context.Context) (proto.AuthService_MaintainSessionPresenceClient, error)
 }
 
-const mfaChallengeInterval = time.Second * 30
-
-// presenceOptions allows passing optional overrides
-// to RunPresenceTask. Mainly used by tests.
-type presenceOptions struct {
-	Clock clockwork.Clock
-}
-
-// PresenceOption a functional option for RunPresenceTask.
-type PresenceOption func(p *presenceOptions)
-
-// WithPresenceClock sets the clock to be used by RunPresenceTask.
-func WithPresenceClock(clock clockwork.Clock) PresenceOption {
-	return func(p *presenceOptions) {
-		p.Clock = clock
-	}
+// RunDefaultPresenceTask performs an MFA ceremony every 30 seconds to detect that a user is
+// still present and attentive.
+func RunDefaultPresenceTask(ctx context.Context, term io.Writer, maintainer PresenceMaintainer, sessionID string, baseCeremony *mfa.Ceremony) error {
+	return RunPresenceTask(ctx, term, maintainer, sessionID, baseCeremony, DefaultPresenceMaxDuration/2)
 }
 
 // RunPresenceTask periodically performs and MFA ceremony to detect that a user is
 // still present and attentive.
-func RunPresenceTask(ctx context.Context, term io.Writer, maintainer PresenceMaintainer, sessionID string, baseCeremony *mfa.Ceremony, opts ...PresenceOption) error {
+func RunPresenceTask(ctx context.Context, term io.Writer, maintainer PresenceMaintainer, sessionID string, baseCeremony *mfa.Ceremony, interval time.Duration) error {
 	fmt.Fprintf(term, "\r\nTeleport > MFA presence enabled\r\n")
 
-	o := &presenceOptions{
-		Clock: clockwork.NewRealClock(),
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
-
-	ticker := o.Clock.NewTicker(mfaChallengeInterval)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	stream, err := maintainer.MaintainSessionPresence(ctx)
@@ -126,7 +111,7 @@ func RunPresenceTask(ctx context.Context, term io.Writer, maintainer PresenceMai
 
 	for {
 		select {
-		case <-ticker.Chan():
+		case <-ticker.C:
 			mfaResp, err := presenceCeremony.Run(ctx, &proto.CreateAuthenticateChallengeRequest{})
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -203,6 +203,10 @@ type Server interface {
 	// ChildLogConfig returns the log configuration for handling logs from
 	// child processes.
 	ChildLogConfig() ChildLogConfig
+
+	// GetPresenceMaxDuration returns the max duration that a moderated session
+	// can continue between presence verifications.
+	GetPresenceMaxDuration() time.Duration
 }
 
 // ChildLogConfig is the log configuration for handling logs from child processes.

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/moderation"
 	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
@@ -570,6 +571,12 @@ func (s *Server) ChildLogConfig() srv.ChildLogConfig {
 		ExecLogConfig: srv.ExecLogConfig{},
 		Writer:        io.Discard,
 	}
+}
+
+// GetPresenceMaxDuration returns the max duration that a moderated session
+// can continue between presence verifications.
+func (s *Server) GetPresenceMaxDuration() time.Duration {
+	return client.DefaultPresenceMaxDuration
 }
 
 func (s *Server) Serve() {

--- a/lib/srv/git/forward.go
+++ b/lib/srv/git/forward.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"net"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -37,6 +38,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
@@ -765,6 +767,12 @@ func (s *ForwardServer) ChildLogConfig() srv.ChildLogConfig {
 		ExecLogConfig: srv.ExecLogConfig{},
 		Writer:        io.Discard,
 	}
+}
+
+// GetPresenceMaxDuration returns the max duration that a moderated session
+// can continue between presence verifications.
+func (s *ForwardServer) GetPresenceMaxDuration() time.Duration {
+	return client.DefaultPresenceMaxDuration
 }
 
 type serverContextKey struct{}

--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/user"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -44,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/modules"
@@ -354,6 +356,10 @@ func (m *mockServer) ChildLogConfig() ChildLogConfig {
 		},
 		Writer: os.Stdout,
 	}
+}
+
+func (m *mockServer) GetPresenceMaxDuration() time.Duration {
+	return client.DefaultPresenceMaxDuration
 }
 
 // Implementation of ssh.Conn interface.

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -54,6 +54,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/componentfeatures"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -264,6 +265,10 @@ type Server struct {
 
 	// immutableLabels are the immutable labels assigned to the server's host certificate
 	immutableLabels map[string]string
+
+	// presenceMaxDuration is the max duration that a moderated session
+	// can continue between presence verifications.
+	presenceMaxDuration time.Duration
 }
 
 // EventMetadata returns metadata about the server.
@@ -373,6 +378,12 @@ func (s *Server) ChildLogConfig() srv.ChildLogConfig {
 		ExecLogConfig: srv.ExecLogConfig{},
 		Writer:        io.Discard,
 	}
+}
+
+// GetPresenceMaxDuration returns the max duration that a moderated session
+// can continue between presence verifications.
+func (s *Server) GetPresenceMaxDuration() time.Duration {
+	return s.presenceMaxDuration
 }
 
 // ServerOption is a functional option passed to the server
@@ -837,6 +848,15 @@ func SetChildLogConfig(cfg *servicecfg.Config) ServerOption {
 	}
 }
 
+// SetPresenceMaxDuration sets the max duration that a moderated session
+// can continue between presence verifications.
+func SetPresenceMaxDuration(maxDuration time.Duration) ServerOption {
+	return func(s *Server) error {
+		s.presenceMaxDuration = maxDuration
+		return nil
+	}
+}
+
 // New returns an unstarted server
 func New(
 	ctx context.Context,
@@ -907,6 +927,10 @@ func New(
 
 	if s.tracerProvider == nil {
 		s.tracerProvider = tracing.DefaultProvider()
+	}
+
+	if s.presenceMaxDuration == 0 {
+		s.presenceMaxDuration = client.DefaultPresenceMaxDuration
 	}
 
 	var component string

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -61,11 +61,6 @@ import (
 const sessionRecorderID = "session-recorder"
 
 const (
-	PresenceVerifyInterval = time.Second * 15
-	PresenceMaxDifference  = time.Minute
-)
-
-const (
 	// sessionRecordingWarningMessage is sent when the session recording is
 	// going to be disabled.
 	sessionRecordingWarningMessage = "Warning: node error. This might cause some functionalities not to work correctly."
@@ -1336,7 +1331,8 @@ func (s *session) launch() {
 	// If the identity is verified with an MFA device, we enabled MFA-based presence for the session.
 	if s.presenceEnabled {
 		go func() {
-			ticker := s.registry.clock.NewTicker(PresenceVerifyInterval)
+			checkPresenceInterval := s.scx.srv.GetPresenceMaxDuration() / 4
+			ticker := s.registry.clock.NewTicker(checkPresenceInterval)
 			defer ticker.Stop()
 			for {
 				select {
@@ -1836,7 +1832,7 @@ func (s *session) checkPresence(ctx context.Context) error {
 			continue
 		}
 
-		if participant.Mode == string(types.SessionModeratorMode) && s.registry.clock.Now().UTC().After(participant.LastActive.Add(PresenceMaxDifference)) {
+		if participant.Mode == string(types.SessionModeratorMode) && s.registry.clock.Now().UTC().After(participant.LastActive.Add(s.scx.srv.GetPresenceMaxDuration())) {
 			s.logger.WarnContext(
 				ctx, "Participant is not active, kicking.",
 				"participant", participant.ID,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -212,10 +212,6 @@ type ProxySettingsGetter interface {
 	GetProxySettings(ctx context.Context) (*webclient.ProxySettings, error)
 }
 
-// PresenceChecker is a function that executes an MFA prompt to enforce
-// that a user is present.
-type PresenceChecker = func(ctx context.Context, term io.Writer, maintainer client.PresenceMaintainer, sessionID string, mfaCeremony *mfa.Ceremony, opts ...client.PresenceOption) error
-
 // Config represents web handler configuration parameters
 type Config struct {
 	// PluginRegistry handles plugin registration
@@ -325,9 +321,9 @@ type Config struct {
 	// AppServerWatcher ia a app server watcher to speed up app look up.
 	AppServerWatcher *services.GenericWatcher[types.AppServer, readonly.AppServer]
 
-	// PresenceChecker periodically runs the mfa ceremony for moderated
-	// sessions.
-	PresenceChecker PresenceChecker
+	// PresenceMaxDuration is the max duration that a moderated session
+	// can continue between presence verifications.
+	PresenceMaxDuration time.Duration
 
 	// AccessGraphAddr is the address of the Access Graph service GRPC API
 	AccessGraphAddr utils.NetAddr
@@ -357,8 +353,8 @@ func (c *Config) SetDefaults() {
 		c.TracerProvider = tracing.NoopProvider()
 	}
 
-	if c.PresenceChecker == nil {
-		c.PresenceChecker = client.RunPresenceTask
+	if c.PresenceMaxDuration == 0 {
+		c.PresenceMaxDuration = client.DefaultPresenceMaxDuration
 	}
 
 	if c.AutomaticUpgradesChannels == nil {
@@ -4124,26 +4120,26 @@ func (h *Handler) siteNodeConnect(
 	}
 
 	term, err := NewTerminal(ctx, TerminalHandlerConfig{
-		Logger:             h.logger,
-		Term:               req.Term,
-		SessionCtx:         sessionCtx,
-		UserAuthClient:     clt,
-		LocalAccessPoint:   h.auth.accessPoint,
-		DisplayLogin:       displayLogin,
-		SessionData:        sessionData,
-		KeepAliveInterval:  keepAliveInterval,
-		ProxyHostPort:      h.ProxyHostPort(),
-		ProxyPublicAddr:    h.PublicProxyAddr(),
-		InteractiveCommand: req.InteractiveCommand,
-		Router:             h.cfg.Router,
-		TracerProvider:     h.cfg.TracerProvider,
-		ParticipantMode:    req.ParticipantMode,
-		PROXYSigner:        h.cfg.PROXYSigner,
-		Tracker:            tracker,
-		PresenceChecker:    h.cfg.PresenceChecker,
-		WebsocketConn:      ws,
-		SSHDialTimeout:     dialTimeout,
-		FIPSBuild:          h.cfg.Modules.IsBoringBinary(),
+		Logger:              h.logger,
+		Term:                req.Term,
+		SessionCtx:          sessionCtx,
+		UserAuthClient:      clt,
+		LocalAccessPoint:    h.auth.accessPoint,
+		DisplayLogin:        displayLogin,
+		SessionData:         sessionData,
+		KeepAliveInterval:   keepAliveInterval,
+		ProxyHostPort:       h.ProxyHostPort(),
+		ProxyPublicAddr:     h.PublicProxyAddr(),
+		InteractiveCommand:  req.InteractiveCommand,
+		Router:              h.cfg.Router,
+		TracerProvider:      h.cfg.TracerProvider,
+		ParticipantMode:     req.ParticipantMode,
+		PROXYSigner:         h.cfg.PROXYSigner,
+		Tracker:             tracker,
+		PresenceMaxDuration: h.cfg.PresenceMaxDuration,
+		WebsocketConn:       ws,
+		SSHDialTimeout:      dialTimeout,
+		FIPSBuild:           h.cfg.Modules.IsBoringBinary(),
 		HostNameResolver: func(serverID string) (string, error) {
 			matches, err := nw.CurrentResourcesWithFilter(r.Context(), func(n readonly.Server) bool {
 				return n.GetName() == serverID

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -8272,7 +8272,8 @@ func (mock authProviderMock) GetRole(_ context.Context, _ string) (types.Role, e
 	return nil, nil
 }
 
-func waitForOutputWithDuration(r ReaderWithDeadline, substr string, timeout time.Duration) error {
+func waitForOutput(r ReaderWithDeadline, substr string) error {
+	const timeout = 10 * time.Second
 	timeoutCh := time.After(timeout)
 
 	var prev string
@@ -8317,10 +8318,6 @@ type ReadWriterWithDeadline interface {
 	io.Writer
 	SetReadDeadline(time.Time) error
 	SetWriteDeadline(time.Time) error
-}
-
-func waitForOutput(r ReaderWithDeadline, substr string) error {
-	return waitForOutputWithDuration(r, substr, 10*time.Second)
 }
 
 func (s *WebSuite) client(t *testing.T, opts ...roundtrip.ClientParam) *TestWebClient {
@@ -10774,12 +10771,22 @@ func TestModeratedSessionWithMFA(t *testing.T) {
 
 	// Advance the clock far enough in the future to make the moderator stale
 	// which will terminate the session - because the clock is used by ALL server
-	// components, it's not practical to use BlockUntil here, so we use EventuallyWithT instead.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
+	// components, it's not practical to use BlockUntil here, so we advance the
+	// clock in a loop to ensure it is caught by the stale presence goroutine.
+	go func() {
 		s.clock.Advance(3 * time.Minute)
-		require.NoError(t, waitForOutputWithDuration(moderatorTerm, "wait: remote command exited without exit status or exit signal", 3*time.Second))
-		require.NoError(t, waitForOutputWithDuration(peerTerm, "Process exited with status 255", 3*time.Second))
-	}, 15*time.Second, 500*time.Millisecond)
+		for {
+			select {
+			case <-time.After(100 * time.Millisecond):
+				s.clock.Advance(3 * time.Minute)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	require.NoError(t, waitForOutput(moderatorTerm, "wait: remote command exited without exit status or exit signal"))
+	require.NoError(t, waitForOutput(peerTerm, "Process exited with status 255"))
 }
 
 type proxyClientMock struct {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -91,7 +91,6 @@ import (
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	transportpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
-	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -179,7 +178,7 @@ type WebSuite struct {
 	mockU2F     *mocku2f.Key
 	server      *authtest.Server
 	proxyClient *authclient.Client
-	clock       *clockwork.FakeClock
+	clock       clockwork.Clock
 }
 
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
@@ -224,11 +223,12 @@ type webSuiteConfig struct {
 	// ClusterFeatures allows overriding default auth server features
 	ClusterFeatures *authproto.Features
 
-	// presenceChecker executes presence prompts for tests
-	presenceChecker PresenceChecker
+	// presenceMaxDuration is the max duration that a moderated session
+	// can continue between presence verifications.
+	presenceMaxDuration time.Duration
 
 	// clock to use for all server components
-	clock *clockwork.FakeClock
+	clock clockwork.Clock
 
 	// databaseREPLGetter allows setting custom database REPLs.
 	databaseREPLGetter dbrepl.REPLRegistry
@@ -253,7 +253,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	require.NoError(t, err)
 
 	if cfg.clock == nil {
-		cfg.clock = clockwork.NewFakeClock()
+		cfg.clock = clockwork.NewRealClock()
 	}
 
 	if cfg.modules == nil {
@@ -403,6 +403,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		regular.SetLockWatcher(nodeLockWatcher),
 		regular.SetSessionController(nodeSessionController),
 		regular.SetConnectedProxyGetter(reversetunnel.NewConnectedProxyGetter()),
+		regular.SetPresenceMaxDuration(cfg.presenceMaxDuration),
 	)
 	require.NoError(t, err)
 	s.node = node
@@ -599,7 +600,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		Router:                    router,
 		HealthCheckAppServer:      cfg.HealthCheckAppServer,
 		UI:                        cfg.uiConfig,
-		PresenceChecker:           cfg.presenceChecker,
+		PresenceMaxDuration:       cfg.presenceMaxDuration,
 		GetProxyClientCertificate: getProxyClientCert,
 		IntegrationAppHandler:     &mockIntegrationAppHandler{},
 		DatabaseREPLRegistry:      cfg.databaseREPLGetter,
@@ -1074,12 +1075,14 @@ func TestCSRF(t *testing.T) {
 
 func TestPasswordChange(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+
+	clock := clockwork.NewFakeClock()
+	s := newWebSuiteWithConfig(t, webSuiteConfig{clock: clock})
 	pack := s.authPack(t, "foo")
 
 	// invalidate the token
-	s.clock.Advance(1 * time.Minute)
-	validToken, err := totp.GenerateCode(pack.otpSecret, s.clock.Now())
+	clock.Advance(1 * time.Minute)
+	validToken, err := totp.GenerateCode(pack.otpSecret, clock.Now())
 	require.NoError(t, err)
 
 	req := changePasswordReq{
@@ -1116,10 +1119,11 @@ func TestValidateBearerToken(t *testing.T) {
 
 func TestWebSessionsBadInput(t *testing.T) {
 	t.Parallel()
-	s := newWebSuite(t)
+
+	clock := clockwork.NewFakeClock()
+	s := newWebSuiteWithConfig(t, webSuiteConfig{clock: clock})
 
 	authServer := s.server.Auth()
-	clock := s.clock
 	ctx := context.Background()
 
 	authPref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
@@ -8273,7 +8277,7 @@ func (mock authProviderMock) GetRole(_ context.Context, _ string) (types.Role, e
 }
 
 func waitForOutput(r ReaderWithDeadline, substr string) error {
-	const timeout = 10 * time.Second
+	const timeout = 30 * time.Second
 	timeoutCh := time.After(timeout)
 
 	var prev string
@@ -10622,9 +10626,8 @@ func TestModeratedSession(t *testing.T) {
 func TestModeratedSessionWithMFA(t *testing.T) {
 	const RPID = "localhost"
 
-	presenceClock := clockwork.NewFakeClock()
 	s := newWebSuiteWithConfig(t, webSuiteConfig{
-		clock:                     clockwork.NewFakeClockAt(presenceClock.Now()),
+		clock:                     clockwork.NewRealClock(),
 		disableDiskBasedRecording: true,
 		authPreferenceSpec: &types.AuthPreferenceSpecV2{
 			Type:           constants.Local,
@@ -10635,10 +10638,11 @@ func TestModeratedSessionWithMFA(t *testing.T) {
 				RPID: RPID,
 			},
 		},
-		presenceChecker: func(ctx context.Context, term io.Writer, maintainer client.PresenceMaintainer, sessionID string, mfaCeremony *mfa.Ceremony, opts ...client.PresenceOption) error {
-			return trace.Wrap(client.RunPresenceTask(ctx, term, maintainer, sessionID, mfaCeremony, client.WithPresenceClock(presenceClock)))
-		},
-		modules: modulestest.EnterpriseModules(),
+		// TODO(Joerger): This test relies on a real timer to drive the presence task, which can inherently
+		// introduce a test flake if the test runner is sufficiently slow. This isn't a problem for now, but
+		// ideally this test would be replaced with a thinner synctest closer to the session logic.
+		presenceMaxDuration: 10 * time.Second,
+		modules:             modulestest.EnterpriseModules(),
 	})
 
 	peerRole, err := types.NewRole("moderated", types.RoleSpecV6{
@@ -10745,8 +10749,6 @@ func TestModeratedSessionWithMFA(t *testing.T) {
 
 	// run the presence check a few times
 	for range 3 {
-		presenceClock.BlockUntil(1)
-		presenceClock.Advance(30 * time.Second)
 		require.NoError(t, waitForOutput(moderatorTerm, "Teleport > Please tap your MFA key"), "waiting for moderator mfa prompt")
 
 		challenge, err := moderatorTerm.stream.ReadChallenge(protobufMFACodec{})
@@ -10768,22 +10770,6 @@ func TestModeratedSessionWithMFA(t *testing.T) {
 
 		require.NoError(t, moderatorTerm.ws.WriteMessage(websocket.BinaryMessage, envelopeBytes))
 	}
-
-	// Advance the clock far enough in the future to make the moderator stale
-	// which will terminate the session - because the clock is used by ALL server
-	// components, it's not practical to use BlockUntil here, so we advance the
-	// clock in a loop to ensure it is caught by the stale presence goroutine.
-	go func() {
-		s.clock.Advance(3 * time.Minute)
-		for {
-			select {
-			case <-time.After(100 * time.Millisecond):
-				s.clock.Advance(3 * time.Minute)
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
 
 	require.NoError(t, waitForOutput(moderatorTerm, "wait: remote command exited without exit status or exit signal"))
 	require.NoError(t, waitForOutput(peerTerm, "Process exited with status 255"))

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -140,13 +140,13 @@ func NewTerminal(ctx context.Context, cfg TerminalHandlerConfig) (*TerminalHandl
 			sshDialTimeout:     cfg.SSHDialTimeout,
 			fipsBuild:          cfg.FIPSBuild,
 		},
-		displayLogin:    cfg.DisplayLogin,
-		term:            cfg.Term,
-		proxySigner:     cfg.PROXYSigner,
-		participantMode: cfg.ParticipantMode,
-		tracker:         cfg.Tracker,
-		presenceChecker: cfg.PresenceChecker,
-		websocketConn:   cfg.WebsocketConn,
+		displayLogin:        cfg.DisplayLogin,
+		term:                cfg.Term,
+		proxySigner:         cfg.PROXYSigner,
+		participantMode:     cfg.ParticipantMode,
+		tracker:             cfg.Tracker,
+		presenceMaxDuration: cfg.PresenceMaxDuration,
+		websocketConn:       cfg.WebsocketConn,
 	}, nil
 }
 
@@ -197,8 +197,9 @@ type TerminalHandlerConfig struct {
 	// Tracker is the session tracker of the session being joined. May be nil
 	// if the user is not joining a session.
 	Tracker types.SessionTracker
-	// PresenceChecker used for presence checking.
-	PresenceChecker PresenceChecker
+	// PresenceMaxDuration is the max duration that a moderated session
+	// can continue between presence verifications.
+	PresenceMaxDuration time.Duration
 	// Clock allows interaction with time.
 	Clock clockwork.Clock
 	// WebsocketConn is the active websocket connection
@@ -256,6 +257,10 @@ func (t *TerminalHandlerConfig) CheckAndSetDefaults() error {
 
 	if t.Clock == nil {
 		t.Clock = clockwork.NewRealClock()
+	}
+
+	if t.PresenceMaxDuration == 0 {
+		t.PresenceMaxDuration = client.DefaultPresenceMaxDuration
 	}
 
 	t.tracer = t.TracerProvider.Tracer("webterminal")
@@ -335,8 +340,9 @@ type TerminalHandler struct {
 	// if the user is not joining a session.
 	tracker types.SessionTracker
 
-	// presenceChecker to use for presence checking
-	presenceChecker PresenceChecker
+	// PresenceMaxDuration is the max duration that a moderated session
+	// can continue between presence verifications.
+	presenceMaxDuration time.Duration
 
 	// closedByClient indicates if the websocket connection was closed by the
 	// user (closing the browser tab, exiting the session, etc).
@@ -803,7 +809,8 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 		beforeStart = func(out io.Writer) {
 			nc.OnMFA = func() {
 				baseCeremony := newMFACeremony(t.stream.WSStream, nil, t.proxyPublicAddr)
-				if err := t.presenceChecker(ctx, out, t.userAuthClient, t.sessionData.ID.String(), baseCeremony); err != nil {
+				mfaInterval := t.presenceMaxDuration / 2
+				if err := client.RunPresenceTask(ctx, out, t.userAuthClient, t.sessionData.ID.String(), baseCeremony, mfaInterval); err != nil {
 					t.logger.WarnContext(ctx, "Unable to stream terminal - failure performing presence checks", "error", err)
 					return
 				}


### PR DESCRIPTION
Fix `TestModeratedSessionWithMFA` by using a real clock and setting the presence max duration on the server/client instead of only using default values. This replaces the short, repeated `waitForOutput` calls in the Eventually loop which exacerbated the issue described in https://github.com/gravitational/teleport/pull/65358.

Unfortunately, changing to a real clock increases the runtime of the test to 30s up from 5s, so I've left a todo to replace this test with a more focused unit test in the future.

Under stress, this test may flake due to the real 10s max presence duration timeout. I ran this with `stress -p 30 -count 1000` without any flakes, but if necessary we can increase the max presence duration timeout. Any change to this timeout has a 1:1 impact on the actual test length.

This just fixes one observed flake. https://github.com/gravitational/teleport/pull/65358 is needed to fix the other flake.

Updates https://github.com/gravitational/teleport/issues/36061