### PR TITLE
Fix input swallowing race condition in moderated session resumption

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1312,9 +1312,8 @@ func (s *session) setHasEnhancedRecording(val bool) {
 	s.hasEnhancedRecording = val
 }
 
-// launch launches the session.
-// Must be called under session Lock.
-func (s *session) launch() {
+// launchUnderLock launches the session. Must be called under session Lock.
+func (s *session) launchUnderLock() {
 	// Mark the session as started here, as we want to avoid double initialization.
 	if s.started.Swap(true) {
 		s.logger.DebugContext(s.serverCtx, "Session has already started.")
@@ -1322,17 +1321,6 @@ func (s *session) launch() {
 	}
 
 	s.logger.DebugContext(s.serverCtx, "Launching session.")
-	s.BroadcastMessage("Connecting to %v over SSH", s.serverMeta.ServerHostname)
-
-	s.io.On()
-
-	if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStateRunning); err != nil {
-		s.logger.WarnContext(
-			s.serverCtx, "Failed to set tracker state.",
-			"error", err,
-			"state", types.SessionState_SessionStateRunning,
-		)
-	}
 
 	// If the identity is verified with an MFA device, we enabled MFA-based presence for the session.
 	if s.presenceEnabled {
@@ -1388,6 +1376,45 @@ func (s *session) launch() {
 			"error", err,
 		)
 	}()
+
+	// Start the session IO, broadcast an update to participants, and update tracker state in that order.
+	// We do this after starting the PTY goroutines to ensure no input is lost due to limited buffering.
+	s.io.On()
+	s.BroadcastMessage("Connecting to %v over SSH", s.serverMeta.ServerHostname)
+	if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStateRunning); err != nil {
+		s.logger.WarnContext(
+			s.serverCtx, "Failed to set tracker state.",
+			"error", err,
+			"state", types.SessionState_SessionStateRunning,
+		)
+	}
+}
+
+// pauseUnderLock pauses the session. Must be called under session Lock.
+func (s *session) pauseUnderLock() {
+	// pause the session IO, broadcast an update to participants, and update tracker state in that order.
+	s.io.Off()
+	s.BroadcastMessage("Session paused, Waiting for required participants...")
+	if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStatePending); err != nil {
+		s.logger.WarnContext(
+			s.serverCtx, "Failed to set tracker state.",
+			"error", err,
+			"state", types.SessionState_SessionStatePending,
+		)
+	}
+}
+
+// resumeUnderLock resumes the session. Must be called under session Lock.
+func (s *session) resumeUnderLock() {
+	// resume the session IO, broadcast an update to participants, and update tracker state in that order.
+	s.io.On()
+	s.BroadcastMessage("Resuming session...")
+	if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStateRunning); err != nil {
+		s.logger.WarnContext(
+			s.serverCtx, "Failed to set tracker state.",
+			"state", types.SessionState_SessionStateRunning,
+		)
+	}
 }
 
 // startInteractive starts a new interactive process (or a shell) in the
@@ -1743,22 +1770,7 @@ func (s *session) removePartyUnderLock(p *party) error {
 		}
 
 		// pause session and wait for another party to resume
-		s.io.Off()
-		s.BroadcastMessage("Session paused, Waiting for required participants...")
-		if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStatePending); err != nil {
-			s.logger.WarnContext(
-				s.serverCtx, "Failed to set tracker state.",
-				"error", err,
-				"state", types.SessionState_SessionStatePending,
-			)
-		}
-
-		go func() {
-			if state := s.tracker.WaitForStateUpdate(types.SessionState_SessionStatePending); state == types.SessionState_SessionStateRunning {
-				s.BroadcastMessage("Resuming session...")
-				s.io.On()
-			}
-		}()
+		s.pauseUnderLock()
 	}
 
 	// If the leaving party was the last one in the session, start the lingerAndDie
@@ -2102,33 +2114,20 @@ func (s *session) addParty(p *party, mode types.SessionParticipantMode) error {
 			return trace.Wrap(err)
 		}
 
-		switch {
-		case canStart && !s.started.Load():
-			s.launch()
-
-			return nil
-		case canStart:
-			// If the session is already running, but the party is a moderator that leaved
-			// a session with onLeave=pause and then rejoined, we need to unpause the session.
-			// When the moderator leaved the session, the session was paused, and we spawn
-			// a goroutine to wait for the moderator to rejoin. If the moderator rejoins
-			// before the session ends, we need to unpause the session by updating its state and
-			// the goroutine will unblock the s.io terminal.
-			// types.SessionState_SessionStatePending marks a session that is waiting for
-			// a moderator to rejoin.
-			if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStateRunning); err != nil {
-				s.logger.WarnContext(
-					s.serverCtx, "Failed to set tracker state.",
-					"state", types.SessionState_SessionStateRunning,
-				)
-			}
-		default:
+		if !canStart {
 			const base = "Waiting for required participants..."
 			if s.displayParticipantRequirements {
 				s.BroadcastMessage(base+"\r\n%v", s.access.PrettyRequirementsList())
 			} else {
 				s.BroadcastMessage(base)
 			}
+			return nil
+		}
+
+		if s.started.Load() {
+			s.resumeUnderLock()
+		} else {
+			s.launchUnderLock()
 		}
 	}
 


### PR DESCRIPTION
Changelog: Fixed a rare input swallowing bug when resuming a moderated Node session.

When transitioning to started/paused/resumed/stopped, Node sessions now consistently perform the following actions in the following order:
- enable/disable session IO
- broadcast state change message to connected parties
- update session tracker state

This ordering ensures that client input is allowed before they get the broadcast so that client's don't start typing and getting their input swallowed.

Supporting changes:
- starting/resuming session IO is handled directly, rather than indirectly in a goroutine waiting for tracker state changes.
- Add helper functions to guarantee correct ordering.

Also fixes this test flake, which was caused by the `Connecting to node over SSH` message being broadcasted before session IO was turned on.
```
    apiserver_test.go:10615: 
        	Error Trace:	/Users/bjoerger/src/gravitational/teleport.worktree/joerger/fix-flake-TestModeratedSession/lib/web/apiserver_test.go:8314
        	            				/Users/bjoerger/src/gravitational/teleport.worktree/joerger/fix-flake-TestModeratedSession/lib/web/apiserver_test.go:10615
        	Error:      	Received unexpected error:
        	            	timeout waiting on terminal for output: llama
        	Test:       	TestModeratedSession
        	Messages:   	[waiting for output on peer terminal]
```

Updates https://github.com/gravitational/teleport/issues/30892
Updates https://github.com/gravitational/teleport/issues/36061

Changelog:

## Manual Test Plan
### Test Environment

Create a role that requires another user with the same role to join in order for the session to proceed, with `on_leave: pause` so that it pauses/resumes when the joiner leaves/re-joins.
```
kind: role
metadata: 
  name: dev
spec:
  allow:
    join_sessions:
      - name: Auditor oversight
        roles : ['*']
        kinds: ['k8s','ssh']
        modes: ['moderator', 'observer', 'peer']
        count: 1
    require_session_join:
      - name: Auditor oversight
        filter: 'contains(user.spec.roles, "dev")'
        roles : ['*']
        kinds: ['k8s','ssh']
        modes: ['moderator', 'observer', 'peer']
        count: 1
        on_leave: 'pause'
```

### Test Cases
- [x] Start a moderated session. 
  - [x] `Teleport > Waiting for required participants...`
- [x] Join as observer to launch session.
  - [x] Historical output is printed
  - [x] `Teleport > Connecting to server01 over SSH`
  - [x] Leave as observer to pause session (ctrl+C).
    - [x] `Teleport > Session paused, Waiting for required participants...`
- [x] Join as moderator to resume session.
  - [x] Historical output is printed
  - [x] `Teleport > Resuming session...`
  - [x] Leave as moderator to pause session (ctrl+C).
    - [x] `Teleport > Session paused, Waiting for required participants...`
- [x] Leave as host to stop session (ctrl+C).
  - [x] `Teleport > Stopping session...`