### PR TITLE
Invert crdgen kindInVersion option

### DIFF
--- a/integrations/operator/crdgen/handlerequest.go
+++ b/integrations/operator/crdgen/handlerequest.go
@@ -167,22 +167,22 @@ func generateSchema(file *File, groupName string, format crdFormatFunc, resp *go
 	generator := NewSchemaGenerator(groupName)
 
 	resources := []resource{
-		{name: "UserV2", opts: []resourceSchemaOption{withAdditionalColumns(userColumns)}},
+		{name: "UserV2", opts: []resourceSchemaOption{withAdditionalColumns(userColumns), legacyWithoutVersionInKindOverride()}},
 		// Role V5 is using the RoleV6 message
-		{name: "RoleV6", opts: []resourceSchemaOption{withVersionOverride(types.V5)}},
+		{name: "RoleV6", opts: []resourceSchemaOption{withVersionOverride(types.V5), legacyWithoutVersionInKindOverride()}},
 		// For backward compatibility in v15, it actually creates v5 roles though.
-		{name: "RoleV6"},
+		{name: "RoleV6", opts: []resourceSchemaOption{legacyWithoutVersionInKindOverride()}},
 		// Role V6 and V7 have their own Kubernetes kind
-		{name: "RoleV6", opts: []resourceSchemaOption{withVersionInKindOverride()}},
+		{name: "RoleV6"},
 		// Role V7 and V8 is using the RoleV6 message
-		{name: "RoleV6", opts: []resourceSchemaOption{withVersionOverride(types.V7), withVersionInKindOverride()}},
-		{name: "RoleV6", opts: []resourceSchemaOption{withVersionOverride(types.V8), withVersionInKindOverride()}},
-		{name: "AppV3", opts: []resourceSchemaOption{withVersionOverride(types.V3), withVersionInKindOverride()}},
-		{name: "DatabaseV3", opts: []resourceSchemaOption{withVersionOverride(types.V3), withVersionInKindOverride()}},
-		{name: "SAMLConnectorV2"},
-		{name: "SAMLIdPServiceProviderV1", opts: []resourceSchemaOption{withVersionOverride(types.V1), withVersionInKindOverride()}},
-		{name: "OIDCConnectorV3"},
-		{name: "GithubConnectorV3"},
+		{name: "RoleV6", opts: []resourceSchemaOption{withVersionOverride(types.V7)}},
+		{name: "RoleV6", opts: []resourceSchemaOption{withVersionOverride(types.V8)}},
+		{name: "AppV3", opts: []resourceSchemaOption{withVersionOverride(types.V3)}},
+		{name: "DatabaseV3", opts: []resourceSchemaOption{withVersionOverride(types.V3)}},
+		{name: "SAMLConnectorV2", opts: []resourceSchemaOption{legacyWithoutVersionInKindOverride()}},
+		{name: "SAMLIdPServiceProviderV1", opts: []resourceSchemaOption{withVersionOverride(types.V1)}},
+		{name: "OIDCConnectorV3", opts: []resourceSchemaOption{legacyWithoutVersionInKindOverride()}},
+		{name: "GithubConnectorV3", opts: []resourceSchemaOption{legacyWithoutVersionInKindOverride()}},
 		{
 			name: "LoginRule",
 			opts: []resourceSchemaOption{
@@ -191,20 +191,21 @@ func generateSchema(file *File, groupName string, format crdFormatFunc, resp *go
 				// The LoginRule proto does not have a "spec" field, so force
 				// the CRD spec to include these fields from the root.
 				withCustomSpecFields([]string{"priority", "traits_expression", "traits_map"}),
+				legacyWithoutVersionInKindOverride(),
 			},
 		},
-		{name: "ProvisionTokenV2", opts: []resourceSchemaOption{withAdditionalColumns(tokenColumns)}},
-		{name: "OktaImportRuleV1"},
+		{name: "ProvisionTokenV2", opts: []resourceSchemaOption{withAdditionalColumns(tokenColumns), legacyWithoutVersionInKindOverride()}},
+		{name: "OktaImportRuleV1", opts: []resourceSchemaOption{legacyWithoutVersionInKindOverride()}},
 		{
 			name: "AccessList",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
+				legacyWithoutVersionInKindOverride(),
 			},
 		},
 		{
 			name: "ServerV2",
 			opts: []resourceSchemaOption{
-				withVersionInKindOverride(),
 				withNameOverride("OpenSSHServer"),
 				withAdditionalColumns(serverColumns),
 			},
@@ -212,25 +213,22 @@ func generateSchema(file *File, groupName string, format crdFormatFunc, resp *go
 		{
 			name: "ServerV2",
 			opts: []resourceSchemaOption{
-				withVersionInKindOverride(),
 				withNameOverride("OpenSSHEICEServer"),
 				withAdditionalColumns(serverColumns),
 			},
 		},
-		{name: "TrustedClusterV2", opts: []resourceSchemaOption{withVersionInKindOverride()}},
-		{name: "Bot", opts: []resourceSchemaOption{withVersionOverride(types.V1), withVersionInKindOverride()}},
+		{name: "TrustedClusterV2"},
+		{name: "Bot", opts: []resourceSchemaOption{withVersionOverride(types.V1)}},
 		{
 			name: "WorkloadIdentity",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
-				withVersionInKindOverride(),
 			},
 		},
 		{
 			name: "AutoUpdateConfig",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
-				withVersionInKindOverride(),
 				withNameOverride("AutoupdateConfig"),
 			},
 		},
@@ -238,7 +236,6 @@ func generateSchema(file *File, groupName string, format crdFormatFunc, resp *go
 			name: "AutoUpdateVersion",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
-				withVersionInKindOverride(),
 				withNameOverride("AutoupdateVersion"),
 			},
 		},
@@ -246,32 +243,33 @@ func generateSchema(file *File, groupName string, format crdFormatFunc, resp *go
 			name: "InferenceModel",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
+				legacyWithoutVersionInKindOverride(),
 			},
 		},
 		{
 			name: "InferencePolicy",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
+				legacyWithoutVersionInKindOverride(),
 			},
 		},
 		{
 			name: "InferenceSecret",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
+				legacyWithoutVersionInKindOverride(),
 			},
 		},
 		{
 			name: "AccessMonitoringRule",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
-				withVersionInKindOverride(),
 			},
 		},
 		{
 			name: "ScopedToken",
 			opts: []resourceSchemaOption{
 				withVersionOverride(types.V1),
-				withVersionInKindOverride(),
 				withAdditionalRootFields([]string{"scope"}),
 			},
 		},

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -115,7 +115,7 @@ type resourceSchemaConfig struct {
 	versionOverride      string
 	customSpecFields     []string
 	additionalRootFields []string
-	kindContainsVersion  bool
+	kindWithoutVersion   bool
 	additionalColumns    []apiextv1.CustomResourceColumnDefinition
 }
 
@@ -133,10 +133,11 @@ func withNameOverride(name string) resourceSchemaOption {
 	}
 }
 
-// set this only on new multi-version resources
-func withVersionInKindOverride() resourceSchemaOption {
+// Here for backward compatibility-only.
+// DO NOT SET on new resources. See RFD 169 for more details.
+func legacyWithoutVersionInKindOverride() resourceSchemaOption {
 	return func(cfg *resourceSchemaConfig) {
-		cfg.kindContainsVersion = true
+		cfg.kindWithoutVersion = true
 	}
 }
 
@@ -233,7 +234,7 @@ func (generator *SchemaGenerator) addResource(file *File, name string, opts ...r
 		resourceKind = cfg.nameOverride
 	}
 	kubernetesKind := resourceKind
-	if cfg.kindContainsVersion {
+	if !cfg.kindWithoutVersion {
 		kubernetesKind = resourceKind + strings.ToUpper(resourceVersion)
 	}
 	schema.Description = fmt.Sprintf("%s resource definition %s from Teleport", resourceKind, resourceVersion)
@@ -241,7 +242,7 @@ func (generator *SchemaGenerator) addResource(file *File, name string, opts ...r
 	root, ok := generator.roots[kubernetesKind]
 	if !ok {
 		pluralName := strings.ToLower(english.PluralWord(2, resourceKind, ""))
-		if cfg.kindContainsVersion {
+		if !cfg.kindWithoutVersion {
 			pluralName = pluralName + resourceVersion
 		}
 		root = &RootSchema{
@@ -257,7 +258,7 @@ func (generator *SchemaGenerator) addResource(file *File, name string, opts ...r
 	// For legacy CRs with a single version, we use the Teleport version as the
 	// Kubernetes API version
 	kubernetesVersion := resourceVersion
-	if cfg.kindContainsVersion {
+	if !cfg.kindWithoutVersion {
 		// For new multi-version resources we always set the version to "v1" as
 		// the Teleport version is also in the CR kind.
 		kubernetesVersion = "v1"


### PR DESCRIPTION
We introduced `kindInVersion` option to implement RFD 160 but we recently forgot to add it on a couple of resources. To prevent this to happen again, this PR inverts the option (legacy resources have to specify it).

The resourceSchemaConfig was also changed so its zero value does the right thing by default.

This has no functional effect, CRDs are identical before and after the change.

