### PR TITLE
Cover all binaries in the bloat check

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -1,5 +1,8 @@
 name: Bloat Check
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/bloat.yaml'
   push:
     paths:
       - '.github/workflows/bloat.yaml'
@@ -65,7 +68,7 @@ jobs:
         id: build_base
         run: |
           make WEBASSETS_SKIP_BUILD=1 BUILDDIR=base_build binaries
-          cd .github/shared-workflows/bot && go run main.go -workflow=binary-sizes --artifacts="tbot,tctl,teleport,tsh" --builddir="../../../base_build" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"  >> ~/teleport_base_build_stats
+          cd .github/shared-workflows/bot && go run main.go -workflow=binary-sizes --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport" --builddir="../../../base_build" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"  >> ~/teleport_base_build_stats
           echo "base_stats_file=~/teleport_base_build_stats" >> $GITHUB_OUTPUT
           echo "base_stats=$(cat ~/teleport_base_build_stats)" >> $GITHUB_ENV
 
@@ -116,4 +119,4 @@ jobs:
         id: check_branch_bloat
         run: |
           current=$(pwd)/build
-          cd .github/shared-workflows/bot && go run main.go -workflow=bloat --artifacts="tbot,tctl,teleport,tsh" --base="${base_stats}" --builddir="${current}" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}" > $GITHUB_STEP_SUMMARY
+          cd .github/shared-workflows/bot && go run main.go -workflow=bloat --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport" --base="${base_stats}" --builddir="${current}" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}" > $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The check was not updated with fdpass-teleport and teleport-update when they were introduced.
