### PR TITLE
[web] add azure discovery rules, user tasks to integrations api

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -905,6 +905,12 @@ const (
 	// to identify Azure VMs by resource group during auto-discovery.
 	// Preserved for backward compatibility; superseded by ResourceGroupLabel.
 	ResourceGroupLabelInternal = TeleportInternalLabelPrefix + "resource-group"
+	// AzureManagedIdentityRegionLabel is the label key for the Azure region for
+	// the managed identity created by the Azure discovery Terraform module.
+	AzureManagedIdentityRegionLabel = TeleportNamespace + "/azure-managed-identity-region"
+	// AzureManagedIdentityResourceGroupLabel is the label key for the Azure resource
+	// group for the managed identity created by the Azure discovery Terraform module.
+	AzureManagedIdentityResourceGroupLabel = TeleportNamespace + "/azure-managed-identity-resource-group"
 	// ZoneLabelDiscovery is used to identify virtual machines by GCP zone
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.

--- a/lib/usertasks/descriptions.go
+++ b/lib/usertasks/descriptions.go
@@ -70,3 +70,10 @@ func DescriptionForDiscoverEKSIssue(issueType string) (string, string) {
 func DescriptionForDiscoverRDSIssue(issueType string) (string, string) {
 	return loadIssueTitleDescription(issueType)
 }
+
+// DescriptionForDiscoverAzureVMIssue returns the description of the issue and fixing steps.
+// The returned string contains a markdown document.
+// If issue type is not recognized or doesn't have a specific description, an empty string is returned.
+func DescriptionForDiscoverAzureVMIssue(issueType string) (string, string) {
+	return loadIssueTitleDescription(issueType)
+}

--- a/lib/usertasks/urls.go
+++ b/lib/usertasks/urls.go
@@ -241,3 +241,51 @@ func RDSDatabasesWithURLs(ut *usertasksv1.UserTask) *UserTaskDiscoverRDSWithURLs
 		Databases:   databasesWithURLs,
 	}
 }
+
+// UserTaskDiscoverAzureVMWithURLs contains the instances that failed to auto-enroll into the cluster.
+type UserTaskDiscoverAzureVMWithURLs struct {
+	*usertasksv1.DiscoverAzureVM
+	// Instances maps the instance ID name to the result of enrolling that instance into teleport.
+	Instances map[string]*DiscoverAzureVMInstanceWithURLs `json:"instances,omitempty"`
+}
+
+// DiscoverAzureVMInstanceWithURLs contains the result of enrolling an Azure VM.
+type DiscoverAzureVMInstanceWithURLs struct {
+	*usertasksv1.DiscoverAzureVMInstance
+
+	// ResourceURL is the Azure Portal URL to access this VM.
+	// Always present.
+	// Format: https://portal.azure.com/#resource/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/virtualMachines/<vm-name>
+	ResourceURL string `json:"resourceUrl,omitempty"`
+}
+
+func withAzureVMInstanceIssueURL(instance *usertasksv1.DiscoverAzureVMInstance) *DiscoverAzureVMInstanceWithURLs {
+	ret := &DiscoverAzureVMInstanceWithURLs{
+		DiscoverAzureVMInstance: instance,
+	}
+
+	vmURL := url.URL{
+		Scheme:   "https",
+		Host:     "portal.azure.com",
+		Path:     "/",
+		Fragment: "resource" + instance.GetResourceId(),
+	}
+	ret.ResourceURL = vmURL.String()
+
+	return ret
+}
+
+// AzureVMInstancesWithURLs takes a UserTask and enriches the instance list with Azure Portal URLs.
+func AzureVMInstancesWithURLs(ut *usertasksv1.UserTask) *UserTaskDiscoverAzureVMWithURLs {
+	instances := ut.Spec.GetDiscoverAzureVm().GetInstances()
+	instancesWithURLs := make(map[string]*DiscoverAzureVMInstanceWithURLs, len(instances))
+
+	for instanceID, instance := range instances {
+		instancesWithURLs[instanceID] = withAzureVMInstanceIssueURL(instance)
+	}
+
+	return &UserTaskDiscoverAzureVMWithURLs{
+		DiscoverAzureVM: ut.Spec.GetDiscoverAzureVm(),
+		Instances:       instancesWithURLs,
+	}
+}

--- a/lib/usertasks/urls_test.go
+++ b/lib/usertasks/urls_test.go
@@ -195,3 +195,49 @@ func TestRDSURLs(t *testing.T) {
 		})
 	}
 }
+
+func TestAzureVMURLs(t *testing.T) {
+	resourceID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/my-vm"
+	dummyVM := &usertasksv1.DiscoverAzureVMInstance{
+		VmId:       "my-vm",
+		ResourceId: resourceID,
+	}
+	baseVMData := &usertasksv1.DiscoverAzureVM{
+		Instances: map[string]*usertasksv1.DiscoverAzureVMInstance{
+			resourceID: dummyVM,
+		},
+	}
+
+	for _, tt := range []struct {
+		name              string
+		issueType         string
+		expectedVMWithURL *DiscoverAzureVMInstanceWithURLs
+	}{
+		{
+			name:      "url for azure vm",
+			issueType: usertasksapi.AutoDiscoverAzureVMIssueVMNotRunning,
+			expectedVMWithURL: &DiscoverAzureVMInstanceWithURLs{
+				ResourceURL: "https://portal.azure.com/#resource" + resourceID,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			vmWithURL := tt.expectedVMWithURL
+			vmWithURL.DiscoverAzureVMInstance = dummyVM
+			expected := &UserTaskDiscoverAzureVMWithURLs{
+				DiscoverAzureVM: baseVMData,
+				Instances: map[string]*DiscoverAzureVMInstanceWithURLs{
+					resourceID: vmWithURL,
+				},
+			}
+
+			got := AzureVMInstancesWithURLs(&usertasksv1.UserTask{
+				Spec: &usertasksv1.UserTaskSpec{
+					IssueType:       tt.issueType,
+					DiscoverAzureVm: baseVMData,
+				},
+			})
+			require.Equal(t, expected, got)
+		})
+	}
+}

--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -363,6 +363,8 @@ func collectIntegrationStats(ctx context.Context, req collectIntegrationStatsReq
 			ret.AWSEKS.UnresolvedUserTasks++
 		case usertasks.TaskTypeDiscoverRDS:
 			ret.AWSRDS.UnresolvedUserTasks++
+		case usertasks.TaskTypeDiscoverAzureVM:
+			ret.AzureVM.UnresolvedUserTasks++
 		}
 	}
 	ret.UnresolvedUserTasks = len(ret.UserTasks)
@@ -390,6 +392,11 @@ func collectIntegrationStats(ctx context.Context, req collectIntegrationStatsReq
 		if matchers := rulesWithIntegration(cfg, types.AWSMatcherEKS, req.integration.GetName()); matchers != 0 {
 			ret.AWSEKS.RulesCount += matchers
 			mergeResourceTypeSummary(&ret.AWSEKS, cfg.Status.LastSyncTime, discoveredResources.AwsEks)
+		}
+
+		if matchers := rulesWithIntegration(cfg, types.AzureMatcherVM, req.integration.GetName()); matchers != 0 {
+			ret.AzureVM.RulesCount += matchers
+			mergeResourceTypeSummary(&ret.AzureVM, cfg.Status.LastSyncTime, discoveredResources.AzureVms)
 		}
 	}
 
@@ -527,6 +534,10 @@ func countAWSOIDCDeployedDatabaseServices(ctx context.Context, req collectIntegr
 }
 
 func mergeResourceTypeSummary(in *ui.ResourceTypeSummary, lastSyncTime time.Time, new *discoveryconfigv1.ResourcesDiscoveredSummary) {
+	if new == nil {
+		return
+	}
+
 	in.DiscoverLastSync = lastSync(in.DiscoverLastSync, lastSyncTime)
 	in.ResourcesFound += int(new.Found)
 	in.ResourcesEnrollmentSuccess += int(new.Enrolled)
@@ -552,6 +563,16 @@ func rulesWithIntegration(dc *discoveryconfig.DiscoveryConfig, matcherType strin
 	ret := 0
 
 	for _, matcher := range dc.Spec.AWS {
+		if matcher.Integration != integration {
+			continue
+		}
+		if !slices.Contains(matcher.Types, matcherType) {
+			continue
+		}
+		ret += len(matcher.Regions)
+	}
+
+	for _, matcher := range dc.Spec.Azure {
 		if matcher.Integration != integration {
 			continue
 		}
@@ -645,13 +666,18 @@ func collectAutoDiscoveryRules(
 }
 
 func collectAutoDiscoveryRulesFromDiscoveryConfig(dc *discoveryconfig.DiscoveryConfig, integrationName, resourceTypeFilter string, regionsFilter []string) []ui.IntegrationDiscoveryRule {
-	var ret []ui.IntegrationDiscoveryRule
-
 	lastSync := &dc.Status.LastSyncTime
 	if lastSync.IsZero() {
 		lastSync = nil
 	}
 
+	awsRules := collectAWSAutoDiscoveryRulesFromDiscoveryConfig(dc, integrationName, resourceTypeFilter, regionsFilter, lastSync)
+	azureRules := collectAzureAutoDiscoveryRulesFromDiscoveryConfig(dc, integrationName, resourceTypeFilter, regionsFilter, lastSync)
+
+	return append(awsRules, azureRules...)
+}
+
+func collectAWSAutoDiscoveryRulesFromDiscoveryConfig(dc *discoveryconfig.DiscoveryConfig, integrationName, resourceTypeFilter string, regionsFilter []string, lastSync *time.Time) (ret []ui.IntegrationDiscoveryRule) {
 	for _, matcher := range dc.Spec.AWS {
 		if matcher.Integration != integrationName {
 			continue
@@ -667,10 +693,10 @@ func collectAutoDiscoveryRulesFromDiscoveryConfig(dc *discoveryconfig.DiscoveryC
 					continue
 				}
 
-				uiLables := make([]libui.Label, 0, len(matcher.Tags))
+				uiLabels := make([]libui.Label, 0, len(matcher.Tags))
 				for labelKey, labelValues := range matcher.Tags {
 					for _, labelValue := range labelValues {
-						uiLables = append(uiLables, libui.Label{
+						uiLabels = append(uiLabels, libui.Label{
 							Name:  labelKey,
 							Value: labelValue,
 						})
@@ -679,7 +705,7 @@ func collectAutoDiscoveryRulesFromDiscoveryConfig(dc *discoveryconfig.DiscoveryC
 				rule := ui.IntegrationDiscoveryRule{
 					ResourceType:    resourceType,
 					Region:          region,
-					LabelMatcher:    uiLables,
+					LabelMatcher:    uiLabels,
 					DiscoveryConfig: dc.GetName(),
 					LastSync:        lastSync,
 				}
@@ -692,7 +718,49 @@ func collectAutoDiscoveryRulesFromDiscoveryConfig(dc *discoveryconfig.DiscoveryC
 		}
 	}
 
-	return ret
+	return
+}
+
+func collectAzureAutoDiscoveryRulesFromDiscoveryConfig(dc *discoveryconfig.DiscoveryConfig, integrationName, resourceTypeFilter string, regionsFilter []string, lastSync *time.Time) (ret []ui.IntegrationDiscoveryRule) {
+	for _, matcher := range dc.Spec.Azure {
+		if matcher.Integration != integrationName {
+			continue
+		}
+
+		for _, resourceType := range matcher.Types {
+			if resourceTypeFilter != "" && resourceType != resourceTypeFilter {
+				continue
+			}
+
+			for _, region := range matcher.Regions {
+				if len(regionsFilter) > 0 && !slices.Contains(regionsFilter, region) {
+					continue
+				}
+
+				uiLabels := make([]libui.Label, 0, len(matcher.ResourceTags))
+				for labelKey, labelValues := range matcher.ResourceTags {
+					for _, labelValue := range labelValues {
+						uiLabels = append(uiLabels, libui.Label{
+							Name:  labelKey,
+							Value: labelValue,
+						})
+					}
+				}
+
+				ret = append(ret, ui.IntegrationDiscoveryRule{
+					ResourceType:    resourceType,
+					Region:          region,
+					LabelMatcher:    uiLabels,
+					Subscriptions:   matcher.Subscriptions,
+					ResourceGroups:  matcher.ResourceGroups,
+					DiscoveryConfig: dc.GetName(),
+					LastSync:        lastSync,
+				})
+			}
+		}
+	}
+
+	return
 }
 
 // integrationsList returns a page of Integrations

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -672,6 +672,76 @@ func TestCollectIntegrationStats(t *testing.T) {
 		}
 		require.Equal(t, expectedSummary, gotSummary)
 	})
+
+	t.Run("collects Azure discovery configs", func(t *testing.T) {
+		mockInt := newMockAzureOIDCIntegration(t, integrationName)
+
+		syncTime := time.Now()
+		azureConfig := &discoveryconfig.DiscoveryConfig{
+			Spec: discoveryconfig.Spec{Azure: []types.AzureMatcher{{
+				Integration: integrationName,
+				Types:       []string{types.AzureMatcherVM},
+				Regions:     []string{"eastus", "westus"},
+			}}},
+			Status: discoveryconfig.Status{
+				LastSyncTime: syncTime,
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					integrationName: {
+						IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+							AzureVms: &discoveryconfigv1.ResourcesDiscoveredSummary{
+								Found:    5,
+								Enrolled: 3,
+								Failed:   1,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var userTasksList []*usertasksv1.UserTask
+		for range 10 {
+			userTasksList = append(userTasksList, &usertasksv1.UserTask{Spec: &usertasksv1.UserTaskSpec{State: usertasks.TaskStateOpen, TaskType: usertasks.TaskTypeDiscoverAzureVM}})
+		}
+
+		clt := &mockRelevantAWSRegionsClient{
+			discoveryConfigs: []*discoveryconfig.DiscoveryConfig{azureConfig},
+		}
+
+		req := collectIntegrationStatsRequest{
+			logger:                logger,
+			integration:           mockInt,
+			discoveryConfigLister: clt,
+			databaseGetter:        clt,
+			awsOIDCClient:         deployedDatabaseServicesClient,
+			userTasksClient:       &mockUserTasksLister{userTasks: userTasksList},
+		}
+
+		gotSummary, err := collectIntegrationStats(ctx, req)
+		require.NoError(t, err)
+
+		expectedSummary := &ui.IntegrationWithSummary{
+			Integration: &ui.Integration{
+				Name:    integrationName,
+				SubKind: "azure-oidc",
+				AzureOIDC: &ui.IntegrationAzureOIDCSpec{
+					TenantID: "00000000-0000-0000-0000-000000000000",
+					ClientID: "11111111-1111-1111-1111-111111111111",
+				},
+			},
+			UnresolvedUserTasks: 10,
+			UserTasks:           ui.MakeUserTasks(userTasksList),
+			AzureVM: ui.ResourceTypeSummary{
+				RulesCount:                 2,
+				ResourcesFound:             5,
+				ResourcesEnrollmentSuccess: 3,
+				ResourcesEnrollmentFailed:  1,
+				DiscoverLastSync:           &syncTime,
+				UnresolvedUserTasks:        10,
+			},
+		}
+		require.Equal(t, expectedSummary, gotSummary)
+	})
 }
 
 func TestCollectAutoDiscoveryRules(t *testing.T) {
@@ -805,6 +875,47 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 					{Name: "env", Value: "prod"},
 				},
 				DiscoveryConfig: dcForRDS.GetName(),
+				LastSync:        &syncTime,
+			},
+		}
+		require.Empty(t, got.NextKey)
+		require.ElementsMatch(t, expectedRules, got.Rules)
+	})
+
+	t.Run("collects azure discovery configs", func(t *testing.T) {
+		syncTime := time.Now()
+		dcForVM := &discoveryconfig.DiscoveryConfig{
+			ResourceHeader: header.ResourceHeader{Metadata: header.Metadata{
+				Name: uuid.NewString(),
+			}},
+			Spec: discoveryconfig.Spec{Azure: []types.AzureMatcher{{
+				Integration:    integrationName,
+				Types:          []string{types.AzureMatcherVM},
+				Regions:        []string{"eastus"},
+				Subscriptions:  []string{"sub-1"},
+				ResourceGroups: []string{"rg-1", "rg-2"},
+				ResourceTags:   types.Labels{"env": []string{"dev"}},
+			}}},
+			Status: discoveryconfig.Status{
+				LastSyncTime: syncTime,
+			},
+		}
+		clt := &mockRelevantAWSRegionsClient{
+			discoveryConfigs: []*discoveryconfig.DiscoveryConfig{dcForVM},
+		}
+
+		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", types.AzureMatcherVM, nil, clt)
+		require.NoError(t, err)
+		expectedRules := []ui.IntegrationDiscoveryRule{
+			{
+				ResourceType: types.AzureMatcherVM,
+				Region:       "eastus",
+				LabelMatcher: []libui.Label{
+					{Name: "env", Value: "dev"},
+				},
+				Subscriptions:   []string{"sub-1"},
+				ResourceGroups:  []string{"rg-1", "rg-2"},
+				DiscoveryConfig: dcForVM.GetName(),
 				LastSync:        &syncTime,
 			},
 		}
@@ -959,6 +1070,41 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 			}
 		}
 		require.Equal(t, totalRules, rulesCounter)
+	})
+
+	t.Run("collects Azure VM rules with subscriptions and resource groups", func(t *testing.T) {
+		syncTime := time.Now()
+		azureConfig := &discoveryconfig.DiscoveryConfig{
+			ResourceHeader: header.ResourceHeader{Metadata: header.Metadata{
+				Name: uuid.NewString(),
+			}},
+			Spec: discoveryconfig.Spec{Azure: []types.AzureMatcher{{
+				Integration:    integrationName,
+				Types:          []string{types.AzureMatcherVM},
+				Regions:        []string{"eastus", "westus"},
+				Subscriptions:  []string{"sub-1", "sub-2"},
+				ResourceGroups: []string{"rg-1"},
+				ResourceTags:   types.Labels{"env": []string{"prod"}},
+			}}},
+			Status: discoveryconfig.Status{
+				LastSyncTime: syncTime,
+			},
+		}
+		clt := &mockRelevantAWSRegionsClient{
+			discoveryConfigs: []*discoveryconfig.DiscoveryConfig{azureConfig},
+		}
+
+		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", nil, clt)
+		require.NoError(t, err)
+
+		require.Len(t, got.Rules, 2)
+		for _, rule := range got.Rules {
+			require.Equal(t, types.AzureMatcherVM, rule.ResourceType)
+			require.ElementsMatch(t, []string{"sub-1", "sub-2"}, rule.Subscriptions)
+			require.ElementsMatch(t, []string{"rg-1"}, rule.ResourceGroups)
+			require.Equal(t, []libui.Label{{Name: "env", Value: "prod"}}, rule.LabelMatcher)
+			require.Equal(t, &syncTime, rule.LastSync)
+		}
 	})
 }
 
@@ -1299,6 +1445,19 @@ func newMockGitHubIntegration(t *testing.T, name string) types.Integration {
 	ig, err := types.NewIntegrationGitHub(
 		types.Metadata{Name: name},
 		&types.GitHubIntegrationSpecV1{Organization: "test"},
+	)
+	require.NoError(t, err)
+	return ig
+}
+
+func newMockAzureOIDCIntegration(t *testing.T, name string) types.Integration {
+	t.Helper()
+	ig, err := types.NewIntegrationAzureOIDC(
+		types.Metadata{Name: name},
+		&types.AzureOIDCIntegrationSpecV1{
+			TenantID: "00000000-0000-0000-0000-000000000000",
+			ClientID: "11111111-1111-1111-1111-111111111111",
+		},
 	)
 	require.NoError(t, err)
 	return ig

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -58,6 +58,25 @@ type IntegrationAWSRASpec struct {
 	ProfileSyncConfig AWSRAProfileSync `json:"profileSyncConfig"`
 }
 
+// IntegrationAzureOIDCSpec contain the specific fields for the `azure-oidc` subkind integration.
+type IntegrationAzureOIDCSpec struct {
+	// TenantID specifies the ID of Entra Tenant (Directory) of this integration.
+	TenantID string `json:"tenantId"`
+	// ClientID specifies the ID of Azure enterprise application (client)
+	// associated with this integration.
+	ClientID string `json:"clientId"`
+	// ManagedIdentity contains the Azure managed identity details.
+	ManagedIdentity *IntegrationAzureManagedIdentitySpec `json:"managedIdentity,omitempty"`
+}
+
+// IntegrationAzureManagedIdentitySpec contains the Azure managed identity details.
+type IntegrationAzureManagedIdentitySpec struct {
+	// Region is the Azure region where the managed identity was created.
+	Region string `json:"region,omitempty"`
+	// ResourceGroup is the Azure resource group containing the managed identity.
+	ResourceGroup string `json:"resourceGroup,omitempty"`
+}
+
 // AWSRAProfileSync contains the configuration for the AWS Roles Anywhere Profile Sync.
 type AWSRAProfileSync struct {
 	// Enabled indicates if the Profile Sync is enabled.
@@ -126,6 +145,8 @@ type IntegrationWithSummary struct {
 	AWSRDS ResourceTypeSummary `json:"awsrds"`
 	// AWSEKS contains the summary for the AWS EKS resources for this integration.
 	AWSEKS ResourceTypeSummary `json:"awseks"`
+	// AzureVM contains the summary for the AzureVM resources for this integration.
+	AzureVM ResourceTypeSummary `json:"azurevm"`
 
 	// RolesAnywhereProfileSync contains the summary for the AWS Roles Anywhere Profile Sync.
 	RolesAnywhereProfileSync *RolesAnywhereProfileSync `json:"rolesAnywhereProfileSync,omitempty"`
@@ -200,13 +221,17 @@ type RolesAnywhereProfileSync struct {
 // IntegrationDiscoveryRule describes a discovery rule associated with an integration.
 type IntegrationDiscoveryRule struct {
 	// ResourceType indicates the type of resource that this rule targets.
-	// This is the same value that is set in DiscoveryConfig.AWS.<Matcher>.Types
-	// Example: ec2, rds, eks
+	// This is the same value that is set in DiscoveryConfig.[AWS|Azure].<Matcher>.Types
+	// Example: ec2, rds, eks, vm
 	ResourceType string `json:"resourceType,omitempty"`
 	// Region where this rule applies to.
 	Region string `json:"region,omitempty"`
 	// LabelMatcher is the set of labels that are used to filter the resources before trying to auto-enroll them.
 	LabelMatcher []ui.Label `json:"labelMatcher,omitempty"`
+	// ResourceGroups is the set of Azure resource group matchers
+	ResourceGroups []string `json:"resourceGroups,omitempty"`
+	// Subscriptions is the set of Azure subscription id matchers
+	Subscriptions []string `json:"subscriptions,omitempty"`
 	// DiscoveryConfig is the name of the DiscoveryConfig that created this rule.
 	DiscoveryConfig string `json:"discoveryConfig,omitempty"`
 	// LastSync contains the time when this rule was used.
@@ -235,6 +260,8 @@ type Integration struct {
 	AWSOIDC *IntegrationAWSOIDCSpec `json:"awsoidc,omitempty"`
 	// AWSRA contains the fields for `aws-ra` subkind integration.
 	AWSRA *IntegrationAWSRASpec `json:"awsra,omitempty"`
+	// AzureOIDC contains the fields for `azure-oidc` subkind integration.
+	AzureOIDC *IntegrationAzureOIDCSpec `json:"azureoidc,omitempty"`
 	// GitHub contains the fields for `github` subkind integration.
 	GitHub *IntegrationGitHub `json:"github,omitempty"`
 	// IsManagedByTerraform indicates if this integration was created by Terraform.
@@ -411,6 +438,26 @@ func MakeIntegration(ig types.Integration) (*Integration, error) {
 			IssuerS3Prefix: s3Prefix,
 			Audience:       ig.GetAWSOIDCIntegrationSpec().Audience,
 		}
+	case types.IntegrationSubKindAzureOIDC:
+		spec := ig.GetAzureOIDCIntegrationSpec()
+		if spec == nil {
+			return nil, trace.BadParameter("missing spec for Azure OIDC integrations")
+		}
+
+		azureSpec := &IntegrationAzureOIDCSpec{
+			TenantID: spec.TenantID,
+			ClientID: spec.ClientID,
+		}
+		region, _ := ig.GetLabel(types.AzureManagedIdentityRegionLabel)
+		resourceGroup, _ := ig.GetLabel(types.AzureManagedIdentityResourceGroupLabel)
+		if region != "" || resourceGroup != "" {
+			azureSpec.ManagedIdentity = &IntegrationAzureManagedIdentitySpec{
+				Region:        region,
+				ResourceGroup: resourceGroup,
+			}
+		}
+		ret.AzureOIDC = azureSpec
+
 	case types.IntegrationSubKindGitHub:
 		spec := ig.GetGitHubIntegrationSpec()
 		if spec == nil {

--- a/lib/web/ui/integration_test.go
+++ b/lib/web/ui/integration_test.go
@@ -47,15 +47,31 @@ func TestMakeIntegration(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	terraformManagedIntegration, err := types.NewIntegrationAWSOIDC(
+	terraformManagedAwsIntegration, err := types.NewIntegrationAWSOIDC(
 		types.Metadata{
-			Name: "terraform-managed",
+			Name: "terraform-managed-aws",
 			Labels: map[string]string{
 				types.CreatedByIaCLabel: IaCTerraformLabel,
 			},
 		},
 		&types.AWSOIDCIntegrationSpecV1{
 			RoleARN: "arn:aws:iam::123456789012:role/TerraformRole",
+		},
+	)
+	require.NoError(t, err)
+
+	terraformManagedAzureIntegration, err := types.NewIntegrationAzureOIDC(
+		types.Metadata{
+			Name: "terraform-managed-azure",
+			Labels: map[string]string{
+				types.CreatedByIaCLabel:                      IaCTerraformLabel,
+				types.AzureManagedIdentityRegionLabel:        "eastus",
+				types.AzureManagedIdentityResourceGroupLabel: "my-azure-resource-group",
+			},
+		},
+		&types.AzureOIDCIntegrationSpecV1{
+			TenantID: "foo",
+			ClientID: "bar",
 		},
 	)
 	require.NoError(t, err)
@@ -85,12 +101,28 @@ func TestMakeIntegration(t *testing.T) {
 			},
 		},
 		{
-			integration: terraformManagedIntegration,
+			integration: terraformManagedAwsIntegration,
 			want: Integration{
-				Name:    "terraform-managed",
+				Name:    "terraform-managed-aws",
 				SubKind: types.IntegrationSubKindAWSOIDC,
 				AWSOIDC: &IntegrationAWSOIDCSpec{
 					RoleARN: "arn:aws:iam::123456789012:role/TerraformRole",
+				},
+				IsManagedByTerraform: true,
+			},
+		},
+		{
+			integration: terraformManagedAzureIntegration,
+			want: Integration{
+				Name:    "terraform-managed-azure",
+				SubKind: types.IntegrationSubKindAzureOIDC,
+				AzureOIDC: &IntegrationAzureOIDCSpec{
+					TenantID: "foo",
+					ClientID: "bar",
+					ManagedIdentity: &IntegrationAzureManagedIdentitySpec{
+						Region:        "eastus",
+						ResourceGroup: "my-azure-resource-group",
+					},
 				},
 				IsManagedByTerraform: true,
 			},

--- a/lib/web/ui/usertask.go
+++ b/lib/web/ui/usertask.go
@@ -59,6 +59,8 @@ type UserTaskDetail struct {
 	DiscoverEKS *usertasks.UserTaskDiscoverEKSWithURLs `json:"discoverEks,omitempty"`
 	// DiscoverRDS contains the task details for the DiscoverRDS tasks.
 	DiscoverRDS *usertasks.UserTaskDiscoverRDSWithURLs `json:"discoverRds,omitempty"`
+	// DiscoverAzureVM contains the task details for the DiscoverAzureVM tasks.
+	DiscoverAzureVM *usertasks.UserTaskDiscoverAzureVMWithURLs `json:"discoverAzureVm,omitempty"`
 }
 
 // UpdateUserTaskStateRequest is a request to update a UserTask
@@ -102,6 +104,7 @@ func MakeDetailedUserTask(ut *usertasksv1.UserTask) UserTaskDetail {
 	var discoverEC2 *usertasks.UserTaskDiscoverEC2WithURLs
 	var discoverEKS *usertasks.UserTaskDiscoverEKSWithURLs
 	var discoverRDS *usertasks.UserTaskDiscoverRDSWithURLs
+	var discoverAzureVM *usertasks.UserTaskDiscoverAzureVMWithURLs
 
 	switch ut.GetSpec().GetTaskType() {
 	case apiusertasks.TaskTypeDiscoverEC2:
@@ -112,16 +115,20 @@ func MakeDetailedUserTask(ut *usertasksv1.UserTask) UserTaskDetail {
 
 	case apiusertasks.TaskTypeDiscoverRDS:
 		discoverRDS = usertasks.RDSDatabasesWithURLs(ut)
+
+	case apiusertasks.TaskTypeDiscoverAzureVM:
+		discoverAzureVM = usertasks.AzureVMInstancesWithURLs(ut)
 	}
 
 	_, description := userTaskTitleAndDescription(ut)
 
 	return UserTaskDetail{
-		UserTask:    MakeUserTask(ut),
-		Description: description,
-		DiscoverEC2: discoverEC2,
-		DiscoverEKS: discoverEKS,
-		DiscoverRDS: discoverRDS,
+		UserTask:        MakeUserTask(ut),
+		Description:     description,
+		DiscoverEC2:     discoverEC2,
+		DiscoverEKS:     discoverEKS,
+		DiscoverRDS:     discoverRDS,
+		DiscoverAzureVM: discoverAzureVM,
 	}
 }
 
@@ -135,6 +142,9 @@ func userTaskTitleAndDescription(ut *usertasksv1.UserTask) (string, string) {
 
 	case apiusertasks.TaskTypeDiscoverRDS:
 		return usertasks.DescriptionForDiscoverRDSIssue(ut.GetSpec().GetIssueType())
+
+	case apiusertasks.TaskTypeDiscoverAzureVM:
+		return usertasks.DescriptionForDiscoverAzureVMIssue(ut.GetSpec().GetIssueType())
 
 	default:
 		return "", ""


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/60816
Web UI PR: https://github.com/gravitational/teleport/pull/64644

Integrations API returns discovery rules and user tasks for Azure VM resource types

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- cloud (discover-dev-5, alexh)

This was tested with UI changes in https://github.com/gravitational/teleport/pull/64644

### Test Cases
- [x] Created Azure Integration, Discovery Config w/ Terraform
- [x] Integrations List reported integration name, discovered resources
- [x] Integration Overview shows discovered Azure VMs
- [x] Integration Settings page populated with rules from discoveryconfig
