### PR TITLE
Remove debug command timeout

### DIFF
--- a/lib/client/debug/debug.go
+++ b/lib/client/debug/debug.go
@@ -33,7 +33,6 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/gravitational/teleport"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 )
 
 // SupportedProfiles list of supported pprof profiles that can be collected.
@@ -61,7 +60,7 @@ func NewClient(dataDir string) *Client {
 	socketPath := filepath.Join(dataDir, teleport.DebugServiceSocketName)
 	return &Client{
 		clt: &http.Client{
-			Timeout: apidefaults.DefaultIOTimeout,
+			Timeout: 0, // Timeout has been deliberately removed, as some debug endpoints may take a long time to respond.
 			Transport: &http.Transport{
 				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 					var d net.Dialer


### PR DESCRIPTION
We have long running debug commands, such as `profile`, that support a user defined duration. Setting a timeout on the client means that if the user sets a duration longer than the timeout, the client will timeout before the command completes, which is not ideal.

This commit removes the timeout from the debug client, allowing long running debug commands to complete successfully.

Changelog: Removed timeout that was preventing `teleport debug` commands from being run with a duration of 30 seconds or longer.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Tested locally with dev build, `teleport start` with default config.

### Test Cases
- [x] Run `teleport debug profile` _with default duration_
- [x] Run `teleport debug profile -s 45` _with "long" duration (anything over the default timeout of 30s)_
