### PR TITLE
Improving validation errors for scoped kube tokens

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -1031,7 +1031,6 @@ type Kubernetes struct {
 	// - `in_cluster`
 	// - `static_jwks`
 	// - `oidc`
-	// If unset, this defaults to `in_cluster`.
 	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
 	// The configuration specific to the `static_jwks` type.
 	StaticJwks *Kubernetes_StaticJWKSConfig `protobuf:"bytes,3,opt,name=static_jwks,json=staticJwks,proto3" json:"static_jwks,omitempty"`
@@ -1560,7 +1559,7 @@ func (x *Kubernetes_StaticJWKSConfig) GetJwks() string {
 // The configuration specific to the `oidc` type.
 type Kubernetes_OIDCConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/oidc-configuration`
+	// The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/openid-configuration`
 	// endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT.
 	// For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...
 	Issuer string `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -321,7 +321,7 @@ message Kubernetes {
   }
   // The configuration specific to the `oidc` type.
   message OIDCConfig {
-    // The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/oidc-configuration`
+    // The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/openid-configuration`
     // endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT.
     // For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...
     string issuer = 1;
@@ -342,7 +342,6 @@ message Kubernetes {
   // - `in_cluster`
   // - `static_jwks`
   // - `oidc`
-  // If unset, this defaults to `in_cluster`.
   string type = 2;
   // The configuration specific to the `static_jwks` type.
   StaticJWKSConfig static_jwks = 3;

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
@@ -127,7 +127,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |allow|[][object](#speckubernetesallow-items)|A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token.|
 |oidc|[object](#speckubernetesoidc)|The configuration specific to the `oidc` type.|
 |static_jwks|[object](#speckubernetesstatic_jwks)|The configuration specific to the `static_jwks` type.|
-|type|string|Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.|
+|type|string|Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc`|
 
 ### spec.kubernetes.allow items
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -151,7 +151,7 @@ Optional:
 - `allow` (Attributes List) A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token. (see [below for nested schema](#nested-schema-for-speckubernetesallow))
 - `oidc` (Attributes) The configuration specific to the `oidc` type. (see [below for nested schema](#nested-schema-for-speckubernetesoidc))
 - `static_jwks` (Attributes) The configuration specific to the `static_jwks` type. (see [below for nested schema](#nested-schema-for-speckubernetesstatic_jwks))
-- `type` (String) Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.
+- `type` (String) Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc`
 
 ### Nested Schema for `spec.kubernetes.allow`
 
@@ -165,7 +165,7 @@ Optional:
 Optional:
 
 - `insecure_allow_http_issuer` (Boolean) If set, disables the requirement that the issuer must use HTTPS.
-- `issuer` (String) The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/oidc-configuration` endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT. For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...
+- `issuer` (String) The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/openid-configuration` endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT. For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...
 
 
 ### Nested Schema for `spec.kubernetes.static_jwks`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -195,7 +195,7 @@ Optional:
 - `allow` (Attributes List) A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token. (see [below for nested schema](#nested-schema-for-speckubernetesallow))
 - `oidc` (Attributes) The configuration specific to the `oidc` type. (see [below for nested schema](#nested-schema-for-speckubernetesoidc))
 - `static_jwks` (Attributes) The configuration specific to the `static_jwks` type. (see [below for nested schema](#nested-schema-for-speckubernetesstatic_jwks))
-- `type` (String) Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.
+- `type` (String) Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc`
 
 ### Nested Schema for `spec.kubernetes.allow`
 
@@ -209,7 +209,7 @@ Optional:
 Optional:
 
 - `insecure_allow_http_issuer` (Boolean) If set, disables the requirement that the issuer must use HTTPS.
-- `issuer` (String) The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/oidc-configuration` endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT. For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...
+- `issuer` (String) The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/openid-configuration` endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT. For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...
 
 
 ### Nested Schema for `spec.kubernetes.static_jwks`

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -219,7 +219,7 @@ spec:
                   type:
                     description: 'Controls which behavior should be used for validating
                       the Kubernetes Service Account token. Supported values: - `in_cluster`
-                      - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.'
+                      - `static_jwks` - `oidc`'
                     type: string
                 type: object
               oracle:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -219,7 +219,7 @@ spec:
                   type:
                     description: 'Controls which behavior should be used for validating
                       the Kubernetes Service Account token. Supported values: - `in_cluster`
-                      - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.'
+                      - `static_jwks` - `oidc`'
                     type: string
                 type: object
               oracle:

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -295,7 +295,7 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 								},
 								"issuer": {
-									Description: "The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/oidc-configuration` endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT. For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...",
+									Description: "The URI of the OIDC issuer. It must have an accessible and OIDC-compliant `/.well-known/openid-configuration` endpoint. This should be a valid URL and must exactly match the `issuer` field in a service account JWT. For example: https://oidc.eks.us-west-2.amazonaws.com/id/12345...",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -313,7 +313,7 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 							Optional:    true,
 						},
 						"type": {
-							Description: "Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc` If unset, this defaults to `in_cluster`.",
+							Description: "Controls which behavior should be used for validating the Kubernetes Service Account token. Supported values: - `in_cluster` - `static_jwks` - `oidc`",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -87,7 +87,7 @@ func validateKubernetes(kube *joiningv1.Kubernetes) error {
 		}
 	case types.KubernetesJoinTypeOIDC:
 		if kube.GetOidc().GetIssuer() == "" {
-			return trace.BadParameter("oidc.issuer issuer must be set when type is %q", kube.GetType())
+			return trace.BadParameter("oidc.issuer must be set when type is %q", kube.GetType())
 		}
 		if kube.GetStaticJwks() != nil {
 			return trace.BadParameter("static_jwks must not be set when type is %q", kube.GetType())
@@ -105,9 +105,11 @@ func validateKubernetes(kube *joiningv1.Kubernetes) error {
 		} else if parsed.Scheme != "https" {
 			return trace.BadParameter("invalid oidc.issuer URL scheme, must be https://")
 		}
+	case types.KubernetesJoinTypeUnspecified:
+		return trace.BadParameter("type must be specified")
 	default:
 		return trace.BadParameter(
-			"unrecognized join type %q, must be one of (%s)",
+			"unrecognized type %q, must be one of (%s)",
 			kube.GetType(),
 			strings.Join([]string{
 				string(types.KubernetesJoinTypeInCluster),

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -381,8 +381,23 @@ func TestValidateScopedToken(t *testing.T) {
 					},
 				}
 			},
-			expectedStrongErr: "unrecognized join type \"unknown\"",
-			expectedWeakErr:   "unrecognized join type \"unknown\"",
+			expectedStrongErr: "unrecognized type \"unknown\"",
+			expectedWeakErr:   "unrecognized type \"unknown\"",
+		},
+		{
+			name: "kubernetes token with no join type",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodKubernetes)
+				tok.Spec.Kubernetes = &joiningv1.Kubernetes{
+					Allow: []*joiningv1.Kubernetes_Rule{
+						{
+							ServiceAccount: "test:test",
+						},
+					},
+				}
+			},
+			expectedStrongErr: "type must be specified",
+			expectedWeakErr:   "type must be specified",
 		},
 		{
 			name: "kubernetes static_jwks token without configuration",
@@ -465,8 +480,8 @@ func TestValidateScopedToken(t *testing.T) {
 					},
 				}
 			},
-			expectedStrongErr: "oidc.issuer issuer must be set when type is \"oidc\"",
-			expectedWeakErr:   "oidc.issuer issuer must be set when type is \"oidc\"",
+			expectedStrongErr: "oidc.issuer must be set when type is \"oidc\"",
+			expectedWeakErr:   "oidc.issuer must be set when type is \"oidc\"",
 		},
 		{
 			name: "kubernetes oidc token with static_jwks configuration",

--- a/lib/services/local/scoped_tokens.go
+++ b/lib/services/local/scoped_tokens.go
@@ -518,7 +518,6 @@ func (p *staticScopedTokenParser) parse(event backend.Event) (types.Resource, er
 
 // maybeSetTokenSecret sets a random secret if not provided.
 func maybeSetTokenSecret(token *joiningv1.ScopedToken) error {
-
 	if token.GetSpec().GetJoinMethod() == string(types.JoinMethodToken) {
 		if token.Status == nil {
 			token.Status = &joiningv1.ScopedTokenStatus{}

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -913,3 +913,52 @@ func TestScopedTokenUpsert(t *testing.T) {
 		require.Contains(t, []string{"user-0", "user-1", "user-2", "user-3"}, label)
 	})
 }
+
+func TestScopedTokenCreate(t *testing.T) {
+	t.Parallel()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	service, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	cmpOpts := []gocmp.Option{
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		protocmp.Transform(),
+	}
+
+	t.Run("create a new scoped token", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+
+		created, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+
+		fetched, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name:       created.GetToken().GetMetadata().GetName(),
+			WithSecret: true,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, gocmp.Diff(created.GetToken(), fetched.GetToken(), cmpOpts...))
+	})
+
+	t.Run("create a token with no secret", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+		token.Status.Secret = ""
+		created, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+
+		fetched, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name:       created.GetToken().GetMetadata().GetName(),
+			WithSecret: true,
+		})
+		require.NoError(t, err)
+
+		opts := append(slices.Clone(cmpOpts), protocmp.IgnoreFields(&joiningv1.ScopedTokenStatus{}, "secret"))
+		assert.Empty(t, gocmp.Diff(created.GetToken(), fetched.GetToken(), opts...))
+		// token should be assigned a random secret
+		assert.NotEmpty(t, created.GetToken().GetStatus().GetSecret())
+	})
+}


### PR DESCRIPTION
Improves some error message when the kube join type is left unspecified and fixes some other small issues found by claude in #65386
