### PR TITLE
Correct Enhanced Session Recording distro list

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
@@ -95,6 +95,7 @@ Teleport supports enhanced session recording with BPF on `amd64` and `arm64` arc
 | Arch Linux              | 2020.09.01     | 5.8.5+         |
 | Flatcar                 | 2765.2.2       | 5.10.25+       |
 | Amazon Linux            | 2 and 2023     | 5.10+          |
+| RHEL/CentOS             | 7+             | 5.8+           |
 
 - (!docs/pages/includes/tctl.mdx!)
 


### PR DESCRIPTION
Fixes #65212

Add RHEL and CentOS 7+. If a user installs these distros with kernel version 5.8+, they can use the BPF ring buffer for Enhanced Session Recording.