### PR TITLE
Add `description` to Agentic Identity Framework

### DIFF
--- a/docs/pages/agentic-identity-framework.mdx
+++ b/docs/pages/agentic-identity-framework.mdx
@@ -1,6 +1,7 @@
 ---
 title: Teleport Agentic Identity Framework
 template: landing-page
+description: Describes a design and reference implementation for the secure deployment of agents on infrastructure. 
 ---
 
 {/* cspell:disable */}


### PR DESCRIPTION
Currently, Docusaurus auto-populates the description based on the first element of the page, which is a comment that ignores cSpell.
