### PR TITLE
Allow agents to re-upload session recordings

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2566,12 +2566,6 @@ func (a *Server) GetClock() clockwork.Clock {
 // reconstructs and emits one from the session start event if none is found.
 // It is the canonical OnUploadComplete callback used by the ProtoStreamer,
 // AuditLog, and recording encryption service.
-//
-// TODO(tigrato): this check is not 100% correct. Instead of streaming the file,
-// one should query the audit log to ensure the event exists. The file can contain
-// the session end event but for some reason the the audit log event was lost.
-// There are many reasons for that to happen such as audit queue in the agent being
-// full, audit backend being down, agent restarting after writing the session complete.
 func (a *Server) OnUploadComplete(ctx context.Context, sessionID libsession.ID) (apievents.AuditEvent, error) {
 	clusterName, err := a.GetClusterName(ctx)
 	if err != nil {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -448,7 +448,7 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 				return trace.Wrap(err)
 			}
 			if g.APIConfig.MetadataGetter != nil {
-				sessionData := g.APIConfig.MetadataGetter.GetUploadMetadata(sessionID)
+				sessionData := g.APIConfig.MetadataGetter.GetUploadMetadata(sessionID, "" /* upload ID */)
 				// TODO(zmb3): this may result in duplicate upload events, as the upload
 				// completer will emit its own session.upload
 				event := &apievents.SessionUpload{

--- a/lib/auth/recordingencryption/recordingencryptionv1/service_test.go
+++ b/lib/auth/recordingencryption/recordingencryptionv1/service_test.go
@@ -399,7 +399,8 @@ func TestCompleteUploadRecoversMissingSessionEnd(t *testing.T) {
 		},
 	}
 
-	auditLog := &eventstest.MockRecorderEmitter{}
+	emitter := &eventstest.MockRecorderEmitter{}
+	auditLog := &eventstest.MockAuditLog{Emitter: emitter}
 	streamer := eventstest.NewFakeStreamer(sessionEvents, 0)
 
 	slog := logtest.NewLogger()
@@ -437,7 +438,7 @@ func TestCompleteUploadRecoversMissingSessionEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	// The recovered session end event must have been emitted to the audit log.
-	emitted := auditLog.Events()
+	emitted := emitter.Events()
 	require.Len(t, emitted, 1)
 	sessionEnd, ok := emitted[0].(*apievents.SessionEnd)
 	require.True(t, ok, "expected *apievents.SessionEnd, got %T", emitted[0])

--- a/lib/auth/recordingencryption/recordingencryptionv1/service_test.go
+++ b/lib/auth/recordingencryption/recordingencryptionv1/service_test.go
@@ -211,7 +211,7 @@ type fakeUploader struct {
 	events.MultipartUploader
 }
 
-func (f fakeUploader) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+func (f fakeUploader) CreateUpload(ctx context.Context, sessionID session.ID, _ ...events.CreateUploadOption) (*events.StreamUpload, error) {
 	return &events.StreamUpload{ID: uuid.NewString(), SessionID: sessionID}, nil
 }
 

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -1174,7 +1174,7 @@ type StreamUpload struct {
 	// be eventually merged with the real recording.
 	Temporary bool `json:"temporary,omitempty"`
 	// ReplaceVersion indicates the recording version that this upload should
-	// replace. If empty, there should not be a preexisting version.
+	// replace. If empty, this upload must be the first.
 	ReplaceVersion string `json:"replace_version,omitempty"`
 }
 

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -1164,17 +1164,23 @@ type StreamPart struct {
 // StreamUpload represents stream multipart upload
 type StreamUpload struct {
 	// ID is unique upload ID
-	ID string
+	ID string `json:"id"`
 	// SessionID is a session ID of the upload
-	SessionID session.ID
+	SessionID session.ID `json:"session_id"`
 	// Initiated contains the timestamp of when the upload
 	// was initiated, not always initialized
-	Initiated time.Time
+	Initiated time.Time `json:"-"`
+	// Temporary indicates that this upload will go to a temporary recording, to
+	// be eventually merged with the real recording.
+	Temporary bool `json:"temporary,omitempty"`
+	// ReplaceVersion indicates the recording version that this upload should
+	// replace. If empty, there should not be a preexisting version.
+	ReplaceVersion string `json:"replace_version,omitempty"`
 }
 
 // String returns user friendly representation of the upload
 func (u StreamUpload) String() string {
-	return fmt.Sprintf("Upload(session=%v, id=%v, initiated=%v)", u.SessionID, u.ID, u.Initiated)
+	return fmt.Sprintf("Upload(session=%v, id=%v, initiated=%v, temporary=%v, version=%v)", u.SessionID, u.ID, u.Initiated, u.Temporary, u.ReplaceVersion)
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -1188,11 +1194,44 @@ func (u *StreamUpload) CheckAndSetDefaults() error {
 	return nil
 }
 
+// CreateUploadOptions is a set of options for [MultipartUploader.CreateUpload].
+type CreateUploadOptions struct {
+	// Temporary indicates that the result of the upload should go to a temporary
+	// location, to be later merged with the real recording.
+	// [MultipartUploader.CompleteUpload] will not clean up the temporary recording
+	// unless no parts are passed.
+	Temporary bool
+	// ReplaceVersion indicates the version of the current recording, as returned
+	// by [MultipartUploader.GetRecordingVersion], for this upload to replace.
+	// If empty, this must be the first upload.
+	ReplaceVersion string
+}
+
+// CreateUploadOption is an option for [MultipartUploader.CreateUpload].
+type CreateUploadOption func(opts *CreateUploadOptions)
+
+// WithUploadTemporary indicates that this is a temporary upload to be eventually
+// merged with the current recording.
+func WithUploadTemporary() CreateUploadOption {
+	return func(opts *CreateUploadOptions) {
+		opts.Temporary = true
+	}
+}
+
+// WithUploadReplace allows the upload to replace the given recording version
+// upon completion.
+func WithUploadReplace(version string) CreateUploadOption {
+	return func(opts *CreateUploadOptions) {
+		opts.ReplaceVersion = version
+	}
+}
+
 // MultipartUploader handles multipart uploads and downloads for session streams
 type MultipartUploader interface {
-	// CreateUpload creates a multipart upload
-	CreateUpload(ctx context.Context, sessionID session.ID) (*StreamUpload, error)
-	// CompleteUpload completes the upload
+	// CreateUpload creates a multipart upload.
+	CreateUpload(ctx context.Context, sessionID session.ID, opts ...CreateUploadOption) (*StreamUpload, error)
+	// CompleteUpload completes the upload. As a special case, if parts is empty
+	// the upload will be canceled.
 	CompleteUpload(ctx context.Context, upload StreamUpload, parts []StreamPart) error
 	// ReserveUploadPart reserves an upload part. Reserve is used to identify
 	// upload errors beforehand.
@@ -1209,7 +1248,7 @@ type MultipartUploader interface {
 	// earlier uploads returned first
 	ListUploads(ctx context.Context) ([]StreamUpload, error)
 	// GetUploadMetadata gets the upload metadata
-	GetUploadMetadata(sessionID session.ID) UploadMetadata
+	GetUploadMetadata(sessionID session.ID, uploadID string) UploadMetadata
 }
 
 // UploadMetadata contains data about the session upload
@@ -1217,13 +1256,12 @@ type UploadMetadata struct {
 	// URL is the url at which the session recording is located
 	// it is free-form and uploader-specific
 	URL string
-	// SessionID is the event session ID
-	SessionID session.ID
+	StreamUpload
 }
 
 // UploadMetadataGetter gets the metadata for session upload
 type UploadMetadataGetter interface {
-	GetUploadMetadata(sid session.ID) UploadMetadata
+	GetUploadMetadata(sid session.ID, uploadID string) UploadMetadata
 }
 
 // SessionEventPreparer will set necessary event fields for session-related

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -278,7 +278,7 @@ func (a *AuditLogConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing parameter ServerID")
 	}
 	if a.UploadHandler == nil {
-		return trace.BadParameter("missing parameter DownloadHandler")
+		return trace.BadParameter("missing parameter UploadHandler")
 	}
 	if a.Clock == nil {
 		a.Clock = clockwork.NewRealClock()
@@ -550,6 +550,16 @@ func (l *AuditLog) GetEventExportChunks(ctx context.Context, req *auditlogpb.Get
 // StreamSessionEvents implements [SessionStreamer].
 func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
 	l.log.DebugContext(ctx, "StreamSessionEvents", "session_id", string(sessionID))
+	return l.streamEvents(ctx, sessionID, "", startIndex)
+}
+
+// StreamTempSessionEvents streams events from a temporary recording associated with the uploadID.
+func (l *AuditLog) StreamTempSessionEvents(ctx context.Context, sessionID session.ID, uploadID string, startIndex int64) (chan apievents.AuditEvent, chan error) {
+	l.log.DebugContext(ctx, "StreamTempSessionEvents", "session_id", string(sessionID), "upload_id", uploadID)
+	return l.streamEvents(ctx, sessionID, uploadID, startIndex)
+}
+
+func (l *AuditLog) streamEvents(ctx context.Context, sessionID session.ID, uploadID string, startIndex int64) (chan apievents.AuditEvent, chan error) {
 	e := make(chan error, 1)
 	c := make(chan apievents.AuditEvent)
 
@@ -565,7 +575,7 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 			startCb(evt, nil)
 		}()
 	}
-	reader, err := l.UploadHandler.StreamSessionRecording(ctx, sessionID)
+	reader, err := l.UploadHandler.StreamSessionRecording(ctx, sessionID, uploadID)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) || trace.IsNotFound(err) {
 			err = trace.NotFound("a recording for session %v was not found", sessionID)

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -550,7 +550,7 @@ func (l *AuditLog) GetEventExportChunks(ctx context.Context, req *auditlogpb.Get
 // StreamSessionEvents implements [SessionStreamer].
 func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
 	l.log.DebugContext(ctx, "StreamSessionEvents", "session_id", string(sessionID))
-	return l.streamEvents(ctx, sessionID, "", startIndex)
+	return l.streamEvents(ctx, sessionID, "" /* upload ID */, startIndex)
 }
 
 // StreamTempSessionEvents streams events from a temporary recording associated with the uploadID.

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -383,7 +383,10 @@ func (h *Handler) uploadBlob(
 }
 
 // StreamSessionRecording implements [events.UploadHandler] and downloads a session recording.
-func (h *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
+func (h *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
+	if uploadID != "" {
+		return nil, trace.NotImplemented("")
+	}
 	return h.blobRetrier(ctx, sessionID, h.sessionBlob(sessionID))
 }
 
@@ -472,8 +475,12 @@ func (h *Handler) blobRetrier(ctx context.Context, sessionID session.ID, blobCli
 	}), nil
 }
 
+func (h *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
+	return "", trace.NotImplemented("")
+}
+
 // CreateUpload implements [events.MultipartUploader].
-func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID, opts ...events.CreateUploadOption) (*events.StreamUpload, error) {
 	upload := events.StreamUpload{
 		ID:        uuid.NewString(),
 		SessionID: sessionID,
@@ -741,9 +748,12 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 }
 
 // GetUploadMetadata implements [events.MultipartUploader].
-func (h *Handler) GetUploadMetadata(sessionID session.ID) events.UploadMetadata {
+func (h *Handler) GetUploadMetadata(sessionID session.ID, uploadID string) events.UploadMetadata {
 	return events.UploadMetadata{
-		URL:       h.sessionBlob(sessionID).URL(),
-		SessionID: sessionID,
+		URL: h.sessionBlob(sessionID).URL(),
+		StreamUpload: events.StreamUpload{
+			ID:        uploadID,
+			SessionID: sessionID,
+		},
 	}
 }

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -385,7 +385,7 @@ func (h *Handler) uploadBlob(
 // StreamSessionRecording implements [events.UploadHandler] and downloads a session recording.
 func (h *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
 	if uploadID != "" {
-		return nil, trace.NotImplemented("")
+		return nil, trace.NotImplemented("streaming temporary session recordings not supported for Azure Blob Storage")
 	}
 	return h.blobRetrier(ctx, sessionID, h.sessionBlob(sessionID))
 }
@@ -476,7 +476,7 @@ func (h *Handler) blobRetrier(ctx context.Context, sessionID session.ID, blobCli
 }
 
 func (h *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
-	return "", trace.NotImplemented("")
+	return "", trace.NotImplemented("GetRecordingVersion not implemented for Azure Blob Storage")
 }
 
 // CreateUpload implements [events.MultipartUploader].

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -476,7 +476,7 @@ func (h *Handler) blobRetrier(ctx context.Context, sessionID session.ID, blobCli
 }
 
 func (h *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
-	return "", trace.NotImplemented("GetRecordingVersion not implemented for Azure Blob Storage")
+	return "", nil
 }
 
 // CreateUpload implements [events.MultipartUploader].

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -22,7 +22,6 @@ import (
 	"cmp"
 	"context"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -467,76 +466,47 @@ func MergeUpload(
 	currentStream, currentErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, "" /* upload ID */, 0)
 	incomingStream, incomingErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, upload.ID, 0)
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	type fetchedEvents struct {
-		current  apievents.AuditEvent
-		incoming apievents.AuditEvent
-	}
-	fetchEvents := func(previous fetchedEvents) chan fetchedEvents {
-		// Fetch event from one or both streams concurrently.
-		events := make(chan fetchedEvents, 1)
-		go func() {
-			defer close(events)
-			wg := &sync.WaitGroup{}
-			fetched := previous
-			if previous.current == nil {
-				wg.Go(func() {
-					select {
-					case fetched.current = <-currentStream:
-					case <-ctx.Done():
-					}
-				})
-			}
-			if previous.incoming == nil {
-				wg.Go(func() {
-					select {
-					case fetched.incoming = <-incomingStream:
-					case <-ctx.Done():
-					}
-				})
-			}
-			wg.Wait()
-			events <- fetched
-		}()
-		return events
-	}
-
 	nopPreparer := NoOpPreparer{}
-	var nextEvents fetchedEvents
+	var current, incoming apievents.AuditEvent
 	for {
-		select {
-		case nextEvents = <-fetchEvents(nextEvents):
-		case err := <-currentErr:
-			if err != nil && !trace.IsNotFound(err) {
+		if current == nil {
+			select {
+			case current = <-currentStream:
+			case err := <-currentErr:
 				return trace.Wrap(err)
+			case <-ctx.Done():
+				return trace.Wrap(ctx.Err())
 			}
-		case err := <-incomingErr:
-			if err != nil && !trace.IsNotFound(err) {
+		}
+		if incoming == nil {
+			select {
+			case incoming = <-incomingStream:
+			case err := <-incomingErr:
 				return trace.Wrap(err)
+			case <-ctx.Done():
+				return trace.Wrap(ctx.Err())
 			}
-		case <-ctx.Done():
-			return trace.Wrap(ctx.Err())
 		}
 		// Both streams are exhausted, we are done.
-		if nextEvents.current == nil && nextEvents.incoming == nil {
+		if current == nil && incoming == nil {
 			return trace.Wrap(stream.Complete(ctx))
 		}
 
 		var nextEvent apievents.AuditEvent
 		switch {
 		// There are no incoming events, or the current event is next by index.
-		case nextEvents.incoming == nil || (nextEvents.current != nil && nextEvents.current.GetIndex() < nextEvents.incoming.GetIndex()):
-			nextEvent = nextEvents.current
-			nextEvents.current = nil
+		case incoming == nil || (current != nil && current.GetIndex() < incoming.GetIndex()):
+			nextEvent = current
+			current = nil
 			// There are no current events, or the incoming event is next by index.
-		case nextEvents.current == nil || (nextEvents.incoming != nil && nextEvents.incoming.GetIndex() < nextEvents.current.GetIndex()):
-			nextEvent = nextEvents.incoming
-			nextEvents.incoming = nil
+		case current == nil || (incoming != nil && incoming.GetIndex() < current.GetIndex()):
+			nextEvent = incoming
+			incoming = nil
 			// Duplicate event. Send the current event, replace both.
-		case nextEvents.current.GetIndex() == nextEvents.incoming.GetIndex():
-			nextEvent = nextEvents.current
-			nextEvents = fetchedEvents{}
+		case current.GetIndex() == incoming.GetIndex():
+			nextEvent = current
+			current = nil
+			incoming = nil
 		}
 
 		preparedEvent, _ := nopPreparer.PrepareSessionEvent(nextEvent)

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -45,7 +45,7 @@ type UploadCompleterConfig struct {
 	// AuditLog is used for storing logs
 	AuditLog AuditLogSessionStreamer
 	// Uploader allows the completer to list and complete uploads
-	Uploader MultipartUploader
+	Uploader MultipartHandler
 	// SessionTracker is used to discover the current state of a
 	// sesssions with active uploads.
 	SessionTracker services.SessionTrackerService
@@ -123,13 +123,25 @@ func NewUploadCompleter(cfg UploadCompleterConfig) (*UploadCompleter, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	u := &UploadCompleter{
-		cfg:    cfg,
-		log:    slog.With(teleport.ComponentKey, teleport.Component(cfg.Component, "completer")),
-		closeC: make(chan struct{}),
+
+	reuploadStreamer, err := NewProtoStreamer(ProtoStreamerConfig{
+		Uploader:                  cfg.Uploader,
+		MinUploadBytes:            MinUploadPartSizeBytes,
+		SessionSummarizerProvider: cfg.SessionSummarizerProvider,
+		RecordingMetadataProvider: cfg.RecordingMetadataProvider,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	err := metrics.RegisterPrometheusCollectors(incompleteSessionUploads)
+	u := &UploadCompleter{
+		cfg:              cfg,
+		log:              slog.With(teleport.ComponentKey, teleport.Component(cfg.Component, "completer")),
+		reuploadStreamer: reuploadStreamer,
+		closeC:           make(chan struct{}),
+	}
+
+	err = metrics.RegisterPrometheusCollectors(incompleteSessionUploads)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -151,9 +163,10 @@ func StartNewUploadCompleter(ctx context.Context, cfg UploadCompleterConfig) err
 // UploadCompleter periodically scans uploads that have not been completed
 // and completes them
 type UploadCompleter struct {
-	cfg    UploadCompleterConfig
-	log    *slog.Logger
-	closeC chan struct{}
+	cfg              UploadCompleterConfig
+	log              *slog.Logger
+	reuploadStreamer Streamer
+	closeC           chan struct{}
 }
 
 // Close stops the UploadCompleter
@@ -176,11 +189,26 @@ func (u *UploadCompleter) Serve(ctx context.Context) error {
 	})
 	defer periodic.Stop()
 	u.log.InfoContext(ctx, "upload completer starting", "check_interval", u.cfg.CheckPeriod.String())
+	var reuploadCh <-chan time.Time
+	if _, ok := u.cfg.AuditLog.(TempSessionStreamer); ok {
+		reuploadPeriodic := interval.New(interval.Config{
+			Clock:         u.cfg.Clock,
+			Duration:      u.cfg.CheckPeriod,
+			FirstDuration: retryutils.HalfJitter(u.cfg.CheckPeriod),
+			Jitter:        retryutils.SeventhJitter,
+		})
+		defer reuploadPeriodic.Stop()
+		reuploadCh = reuploadPeriodic.Next()
+	}
 
 	for {
 		select {
 		case <-periodic.Next():
 			u.PerformPeriodicCheck(ctx)
+		case <-reuploadCh:
+			if err := u.CheckReuploads(ctx); err != nil {
+				u.log.WarnContext(ctx, "Failed to check reuploads.", "error", err)
+			}
 		case <-u.closeC:
 			return nil
 		case <-ctx.Done():
@@ -249,6 +277,18 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 			break
 		}
 
+		if upload.Temporary {
+			// Skip complete temporary uploads. The upload won't be removed until
+			// the temporary recording is merged with the real one.
+			version, err := u.cfg.Uploader.GetRecordingVersion(ctx, upload.SessionID, upload.ID)
+			if err != nil {
+				log.WarnContext(ctx, "could not check recording version", "error", err)
+			}
+			if version != "" {
+				continue
+			}
+		}
+
 		switch _, err := u.cfg.SessionTracker.GetSessionTracker(ctx, upload.SessionID.String()); {
 		case err == nil: // session is still in progress, continue to other uploads
 			log.DebugContext(ctx, "session has active tracker and is not ready to be uploaded")
@@ -297,7 +337,7 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 			continue
 		}
 
-		uploadData := u.cfg.Uploader.GetUploadMetadata(upload.SessionID)
+		uploadData := u.cfg.Uploader.GetUploadMetadata(upload.SessionID, upload.ID)
 
 		// It's possible that we don't have a session ID here. For example,
 		// an S3 multipart upload may have been completed by another auth
@@ -345,6 +385,40 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 		err = u.cfg.AuditLog.EmitAuditEvent(ctx, session)
 		if err != nil {
 			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// CheckReuploads checks and merges temporary recordings that can be merged with
+// the real one.
+func (u *UploadCompleter) CheckReuploads(ctx context.Context) error {
+	sessionStreamer, ok := u.cfg.AuditLog.(TempSessionStreamer)
+	if !ok {
+		return trace.BadParameter("audit log does not implement UploadStreamer")
+	}
+	uploads, err := u.cfg.Uploader.ListUploads(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for _, upload := range uploads {
+		log := u.log.With("upload_id", upload.ID, "session_id", upload.SessionID)
+		if !upload.Temporary {
+			continue
+		}
+		version, err := u.cfg.Uploader.GetRecordingVersion(ctx, upload.SessionID, upload.ID)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if version == "" {
+			continue
+		}
+		if err := MergeUpload(ctx, sessionStreamer, u.reuploadStreamer, upload); err != nil {
+			log.ErrorContext(ctx, "failed to merge recordings", "error", err)
+			continue
+		}
+		if err := u.cfg.Uploader.CompleteUpload(ctx, upload, nil); err != nil {
+			log.WarnContext(ctx, "failed to clean up temporary upload", "error", err)
 		}
 	}
 	return nil

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -167,7 +167,7 @@ func StartNewUploadCompleter(ctx context.Context, cfg UploadCompleterConfig) err
 type UploadCompleter struct {
 	cfg              UploadCompleterConfig
 	log              *slog.Logger
-	reuploadStreamer Streamer
+	reuploadStreamer *ProtoStreamer
 	closeC           chan struct{}
 }
 
@@ -412,7 +412,8 @@ func (u *UploadCompleter) CheckReuploads(ctx context.Context) error {
 		}
 		version, err := u.cfg.Uploader.GetRecordingVersion(ctx, upload.SessionID, upload.ID)
 		if err != nil {
-			return trace.Wrap(err)
+			log.ErrorContext(ctx, "failed to check recording version", "error", err)
+			continue
 		}
 		if version == "" {
 			continue
@@ -441,10 +442,10 @@ type TempSessionStreamer interface {
 func MergeUpload(
 	ctx context.Context,
 	uploadStreamer TempSessionStreamer,
-	streamer Streamer,
+	streamer *ProtoStreamer,
 	upload StreamUpload,
 ) (err error) {
-	stream, err := streamer.ResumeAuditStream(ctx, upload.SessionID, upload.ID)
+	stream, err := streamer.CreateOverwriteAuditStream(ctx, upload.SessionID)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -209,9 +209,11 @@ func (u *UploadCompleter) Serve(ctx context.Context) error {
 		case <-periodic.Next():
 			u.PerformPeriodicCheck(ctx)
 		case <-reuploadCh:
-			if err := u.CheckReuploads(ctx); err != nil {
-				u.log.WarnContext(ctx, "Failed to check reuploads.", "error", err)
-			}
+			u.withSemaphore(ctx, func() {
+				if err := u.CheckReuploads(ctx); err != nil {
+					u.log.WarnContext(ctx, "Failed to check reuploads.", "error", err)
+				}
+			})
 		case <-u.closeC:
 			return nil
 		case <-ctx.Done():
@@ -220,7 +222,7 @@ func (u *UploadCompleter) Serve(ctx context.Context) error {
 	}
 }
 
-func (u *UploadCompleter) PerformPeriodicCheck(ctx context.Context) {
+func (u *UploadCompleter) withSemaphore(ctx context.Context, f func()) {
 	// If configured with a server ID, then acquire a semaphore prior to completing uploads.
 	// This is used for auth's upload completer and ensures that multiple auth servers do not
 	// attempt to complete the same uploads at the same time.
@@ -244,11 +246,17 @@ func (u *UploadCompleter) PerformPeriodicCheck(ctx context.Context) {
 			return
 		}
 	}
-	if err := u.CheckUploads(ctx); trace.IsAccessDenied(err) {
-		u.log.WarnContext(ctx, "Teleport does not have permission to list uploads. The upload completer will be unable to complete uploads of partial session recordings.")
-	} else if err != nil {
-		u.log.WarnContext(ctx, "Failed to check uploads.", "error", err)
-	}
+	f()
+}
+
+func (u *UploadCompleter) PerformPeriodicCheck(ctx context.Context) {
+	u.withSemaphore(ctx, func() {
+		if err := u.CheckUploads(ctx); trace.IsAccessDenied(err) {
+			u.log.WarnContext(ctx, "Teleport does not have permission to list uploads. The upload completer will be unable to complete uploads of partial session recordings.")
+		} else if err != nil {
+			u.log.WarnContext(ctx, "Failed to check uploads.", "error", err)
+		}
+	})
 }
 
 // CheckUploads fetches uploads and completes any abandoned uploads
@@ -358,7 +366,7 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 		// This is necessary because we'll need to download the session in order to
 		// enumerate its events, and the S3 API takes a little while after the upload
 		// is completed before version metadata becomes available.
-		if u.cfg.EnsureSessionEndEvent {
+		if u.cfg.EnsureSessionEndEvent && !upload.Temporary {
 			go func() {
 				select {
 				case <-ctx.Done():

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -293,6 +293,7 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 			version, err := u.cfg.Uploader.GetRecordingVersion(ctx, upload.SessionID, upload.ID)
 			if err != nil {
 				log.WarnContext(ctx, "could not check recording version", "error", err)
+				continue
 			}
 			if version != "" {
 				continue

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -298,6 +298,19 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 			if version != "" {
 				continue
 			}
+		} else {
+			// Delete abandoned append uploads, they will be recreated if needed.
+			version, err := u.cfg.Uploader.GetRecordingVersion(ctx, upload.SessionID, "")
+			if err != nil {
+				log.WarnContext(ctx, "could not check recording version", "error", err)
+				continue
+			}
+			if version != "" {
+				if err := u.cfg.Uploader.CompleteUpload(ctx, upload, nil); err != nil {
+					log.WarnContext(ctx, "could not clean up abandoned append upload", "error", err)
+				}
+				continue
+			}
 		}
 
 		switch _, err := u.cfg.SessionTracker.GetSessionTracker(ctx, upload.SessionID.String()); {
@@ -404,10 +417,6 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 // CheckReuploads checks and merges temporary recordings that can be merged with
 // the real one.
 func (u *UploadCompleter) CheckReuploads(ctx context.Context) error {
-	sessionStreamer, ok := u.cfg.AuditLog.(TempSessionStreamer)
-	if !ok {
-		return trace.BadParameter("audit log does not implement UploadStreamer")
-	}
 	uploads, err := u.cfg.Uploader.ListUploads(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -426,7 +435,7 @@ func (u *UploadCompleter) CheckReuploads(ctx context.Context) error {
 		if version == "" {
 			continue
 		}
-		if err := AppendUpload(ctx, sessionStreamer, u.reuploadStreamer, upload); err != nil {
+		if err := u.AppendUpload(ctx, upload); err != nil {
 			log.ErrorContext(ctx, "failed to merge recordings", "error", err)
 			continue
 		}
@@ -446,23 +455,48 @@ type TempSessionStreamer interface {
 
 // AppendUpload appends a temporary recording to an existing session recording
 // and replaces the current recording with the new one.
-func AppendUpload(
+func (u *UploadCompleter) AppendUpload(
 	ctx context.Context,
-	uploadStreamer TempSessionStreamer,
-	streamer *ProtoStreamer,
 	upload StreamUpload,
 ) (err error) {
-	stream, err := streamer.CreateOverwriteAuditStream(ctx, upload.SessionID)
+	uploadStreamer, ok := u.cfg.AuditLog.(TempSessionStreamer)
+	if !ok {
+		return trace.BadParameter("audit log does not implement UploadStreamer")
+	}
+	stream, err := u.reuploadStreamer.CreateOverwriteAuditStream(ctx, upload.SessionID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	uploadID := ""
+	select {
+	case status := <-stream.Status():
+		uploadID = status.UploadID
+	case <-ctx.Done():
+		_ = stream.Close(ctx)
+		return trace.Wrap(ctx.Err())
+	}
+
+	abortUpload := func() {
+		if closeErr := stream.Close(ctx); closeErr != nil {
+			slog.WarnContext(ctx, "Failed to close steam.", "error", closeErr)
+		}
+		if uploadID == "" {
+			return
+		}
+		// If this upload fails, delete it; it will be re-created on the next go around.
+		if err := u.cfg.Uploader.CompleteUpload(ctx, StreamUpload{
+			ID:        uploadID,
+			SessionID: upload.SessionID,
+		}, nil); err != nil {
+			u.log.WarnContext(ctx, "Failed to clean up upload.", "error", err)
+		}
+	}
 	defer func() {
 		if err != nil {
-			if closeErr := stream.Close(ctx); closeErr != nil {
-				slog.WarnContext(ctx, "Failed to close steam.", "error", closeErr)
-			}
+			abortUpload()
 		}
 	}()
+
 	// Record all existing events first.
 	currentStream, currentErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, "" /* upload ID */, 0)
 	nopPreparer := NoOpPreparer{}
@@ -488,6 +522,7 @@ func AppendUpload(
 
 	// Record new events from incoming.
 	incomingStream, incomingErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, upload.ID, 0)
+	appendedEvent := false
 	for {
 		var event apievents.AuditEvent
 		select {
@@ -507,6 +542,12 @@ func AppendUpload(
 		if err := stream.RecordEvent(ctx, preparedEvent); err != nil {
 			return trace.Wrap(err)
 		}
+		appendedEvent = true
+	}
+	if !appendedEvent {
+		// Recording is unchanged, nothing to do.
+		abortUpload()
+		return nil
 	}
 	return trace.Wrap(stream.Complete(ctx))
 }

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -22,6 +22,7 @@ import (
 	"cmp"
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -37,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/summarizer"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils/interval"
 )
 
@@ -190,6 +192,7 @@ func (u *UploadCompleter) Serve(ctx context.Context) error {
 	defer periodic.Stop()
 	u.log.InfoContext(ctx, "upload completer starting", "check_interval", u.cfg.CheckPeriod.String())
 	var reuploadCh <-chan time.Time
+	// Only the local audit log on the auth server can perform reuploads.
 	if _, ok := u.cfg.AuditLog.(TempSessionStreamer); ok {
 		reuploadPeriodic := interval.New(interval.Config{
 			Clock:         u.cfg.Clock,
@@ -403,6 +406,7 @@ func (u *UploadCompleter) CheckReuploads(ctx context.Context) error {
 	}
 	for _, upload := range uploads {
 		log := u.log.With("upload_id", upload.ID, "session_id", upload.SessionID)
+		// Merge any complete temporary recordings.
 		if !upload.Temporary {
 			continue
 		}
@@ -417,11 +421,120 @@ func (u *UploadCompleter) CheckReuploads(ctx context.Context) error {
 			log.ErrorContext(ctx, "failed to merge recordings", "error", err)
 			continue
 		}
+		// Clean up temporary recording.
 		if err := u.cfg.Uploader.CompleteUpload(ctx, upload, nil); err != nil {
 			log.WarnContext(ctx, "failed to clean up temporary upload", "error", err)
 		}
 	}
 	return nil
+}
+
+// TempSessionStreamer is an alternate version of [SessionStreamer] that can stream
+// events from temporary recordings.
+type TempSessionStreamer interface {
+	StreamTempSessionEvents(ctx context.Context, sessionID session.ID, uploadID string, startIndex int64) (chan apievents.AuditEvent, chan error)
+}
+
+// MergeUpload merges the current recording for a session with a temporary
+// recording, replacing the current recording with one that includes all
+// events from both.
+func MergeUpload(
+	ctx context.Context,
+	uploadStreamer TempSessionStreamer,
+	streamer Streamer,
+	upload StreamUpload,
+) (err error) {
+	stream, err := streamer.ResumeAuditStream(ctx, upload.SessionID, upload.ID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer func() {
+		if err != nil {
+			if closeErr := stream.Close(ctx); closeErr != nil {
+				slog.WarnContext(ctx, "Failed to close steam.", "error", closeErr)
+			}
+		}
+	}()
+	currentStream, currentErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, "" /* upload ID */, 0)
+	incomingStream, incomingErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, upload.ID, 0)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	type fetchedEvents struct {
+		current  apievents.AuditEvent
+		incoming apievents.AuditEvent
+	}
+	fetchEvents := func(previous fetchedEvents) chan fetchedEvents {
+		// Fetch event from one or both streams concurrently.
+		events := make(chan fetchedEvents, 1)
+		go func() {
+			defer close(events)
+			wg := &sync.WaitGroup{}
+			fetched := previous
+			if previous.current == nil {
+				wg.Go(func() {
+					select {
+					case fetched.current = <-currentStream:
+					case <-ctx.Done():
+					}
+				})
+			}
+			if previous.incoming == nil {
+				wg.Go(func() {
+					select {
+					case fetched.incoming = <-incomingStream:
+					case <-ctx.Done():
+					}
+				})
+			}
+			wg.Wait()
+			events <- fetched
+		}()
+		return events
+	}
+
+	nopPreparer := NoOpPreparer{}
+	var nextEvents fetchedEvents
+	for {
+		select {
+		case nextEvents = <-fetchEvents(nextEvents):
+		case err := <-currentErr:
+			if err != nil && !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
+		case err := <-incomingErr:
+			if err != nil && !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		}
+		// Both streams are exhausted, we are done.
+		if nextEvents.current == nil && nextEvents.incoming == nil {
+			return trace.Wrap(stream.Complete(ctx))
+		}
+
+		var nextEvent apievents.AuditEvent
+		switch {
+		// There are no incoming events, or the current event is next by index.
+		case nextEvents.incoming == nil || (nextEvents.current != nil && nextEvents.current.GetIndex() < nextEvents.incoming.GetIndex()):
+			nextEvent = nextEvents.current
+			nextEvents.current = nil
+			// There are no current events, or the incoming event is next by index.
+		case nextEvents.current == nil || (nextEvents.incoming != nil && nextEvents.incoming.GetIndex() < nextEvents.current.GetIndex()):
+			nextEvent = nextEvents.incoming
+			nextEvents.incoming = nil
+			// Duplicate event. Send the current event, replace both.
+		case nextEvents.current.GetIndex() == nextEvents.incoming.GetIndex():
+			nextEvent = nextEvents.current
+			nextEvents = fetchedEvents{}
+		}
+
+		preparedEvent, _ := nopPreparer.PrepareSessionEvent(nextEvent)
+		if err := stream.RecordEvent(ctx, preparedEvent); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 }
 
 func (u *UploadCompleter) ensureSessionEndEvent(ctx context.Context, uploadData UploadMetadata) error {

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/events"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth/recordingmetadata"
@@ -469,7 +468,7 @@ func AppendUpload(
 	nopPreparer := NoOpPreparer{}
 	var lastEventIndex int64 = -1
 	for {
-		var event events.AuditEvent
+		var event apievents.AuditEvent
 		select {
 		case event = <-currentStream:
 		case err := <-currentErr:

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/events"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth/recordingmetadata"
@@ -426,7 +427,7 @@ func (u *UploadCompleter) CheckReuploads(ctx context.Context) error {
 		if version == "" {
 			continue
 		}
-		if err := MergeUpload(ctx, sessionStreamer, u.reuploadStreamer, upload); err != nil {
+		if err := AppendUpload(ctx, sessionStreamer, u.reuploadStreamer, upload); err != nil {
 			log.ErrorContext(ctx, "failed to merge recordings", "error", err)
 			continue
 		}
@@ -444,10 +445,9 @@ type TempSessionStreamer interface {
 	StreamTempSessionEvents(ctx context.Context, sessionID session.ID, uploadID string, startIndex int64) (chan apievents.AuditEvent, chan error)
 }
 
-// MergeUpload merges the current recording for a session with a temporary
-// recording, replacing the current recording with one that includes all
-// events from both.
-func MergeUpload(
+// AppendUpload appends a temporary recording to an existing session recording
+// and replaces the current recording with the new one.
+func AppendUpload(
 	ctx context.Context,
 	uploadStreamer TempSessionStreamer,
 	streamer *ProtoStreamer,
@@ -464,57 +464,52 @@ func MergeUpload(
 			}
 		}
 	}()
+	// Record all existing events first.
 	currentStream, currentErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, "" /* upload ID */, 0)
-	incomingStream, incomingErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, upload.ID, 0)
-
 	nopPreparer := NoOpPreparer{}
-	var current, incoming apievents.AuditEvent
+	var lastEventIndex int64 = -1
 	for {
-		if current == nil {
-			select {
-			case current = <-currentStream:
-			case err := <-currentErr:
-				return trace.Wrap(err)
-			case <-ctx.Done():
-				return trace.Wrap(ctx.Err())
-			}
+		var event events.AuditEvent
+		select {
+		case event = <-currentStream:
+		case err := <-currentErr:
+			return trace.Wrap(err)
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
 		}
-		if incoming == nil {
-			select {
-			case incoming = <-incomingStream:
-			case err := <-incomingErr:
-				return trace.Wrap(err)
-			case <-ctx.Done():
-				return trace.Wrap(ctx.Err())
-			}
+		if event == nil {
+			break
 		}
-		// Both streams are exhausted, we are done.
-		if current == nil && incoming == nil {
-			return trace.Wrap(stream.Complete(ctx))
-		}
-
-		var nextEvent apievents.AuditEvent
-		switch {
-		// There are no incoming events, or the current event is next by index.
-		case incoming == nil || (current != nil && current.GetIndex() < incoming.GetIndex()):
-			nextEvent = current
-			current = nil
-			// There are no current events, or the incoming event is next by index.
-		case current == nil || (incoming != nil && incoming.GetIndex() < current.GetIndex()):
-			nextEvent = incoming
-			incoming = nil
-			// Duplicate event. Send the current event, replace both.
-		case current.GetIndex() == incoming.GetIndex():
-			nextEvent = current
-			current = nil
-			incoming = nil
-		}
-
-		preparedEvent, _ := nopPreparer.PrepareSessionEvent(nextEvent)
+		lastEventIndex = event.GetIndex()
+		preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
 		if err := stream.RecordEvent(ctx, preparedEvent); err != nil {
 			return trace.Wrap(err)
 		}
 	}
+
+	// Record new events from incoming.
+	incomingStream, incomingErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, upload.ID, 0)
+	for {
+		var event apievents.AuditEvent
+		select {
+		case event = <-incomingStream:
+		case err := <-incomingErr:
+			return trace.Wrap(err)
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		}
+		if event == nil {
+			break
+		}
+		if event.GetIndex() <= lastEventIndex {
+			continue
+		}
+		preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
+		if err := stream.RecordEvent(ctx, preparedEvent); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return trace.Wrap(stream.Complete(ctx))
 }
 
 func (u *UploadCompleter) ensureSessionEndEvent(ctx context.Context, uploadData UploadMetadata) error {

--- a/lib/events/complete_test.go
+++ b/lib/events/complete_test.go
@@ -467,7 +467,13 @@ func TestAppendUpload(t *testing.T) {
 				Context:       t.Context(),
 			})
 			require.NoError(t, err)
-			tc.assert(t, events.AppendUpload(t.Context(), log, streamer, events.StreamUpload{
+			completer, err := events.NewUploadCompleter(events.UploadCompleterConfig{
+				AuditLog:       log,
+				Uploader:       uploader,
+				SessionTracker: &mockSessionTrackerService{},
+				ClusterName:    "teleport-cluster",
+			})
+			tc.assert(t, completer.AppendUpload(t.Context(), events.StreamUpload{
 				ID:        secondUploadID,
 				SessionID: sessionID,
 			}))
@@ -484,7 +490,7 @@ func TestAppendUpload(t *testing.T) {
 	}
 }
 
-func TestUploadCompleterMergesRecordings(t *testing.T) {
+func TestUploadCompleterAppendsRecordings(t *testing.T) {
 	t.Parallel()
 	mkEvent := func(index int64, data string) apievents.AuditEvent {
 		return &apievents.SessionPrint{
@@ -625,6 +631,20 @@ func TestUploadCompleterMergesRecordings(t *testing.T) {
 		finalRecording := downloadEvents("")
 		require.Equal(t, sessionEvents, finalRecording)
 		require.NotEqual(t, initialVersion, finalVersion)
+
+		// Check that abandoned append uploads are aborted.
+		extraStream, err := streamer.CreateOverwriteAuditStream(t.Context(), sessionID)
+		require.NoError(t, err)
+		for _, event := range sessionEvents[:4] {
+			preparedEvent, _ := prep.PrepareSessionEvent(event)
+			require.NoError(t, extraStream.RecordEvent(t.Context(), preparedEvent))
+		}
+		require.NoError(t, extraStream.Close(t.Context()))
+
+		time.Sleep(gracePeriod + checkPeriod)
+		synctest.Wait()
+		extraVersion := assertRecordingExists(sessionID, "")
+		require.Equal(t, finalVersion, extraVersion)
 	})
 }
 

--- a/lib/events/complete_test.go
+++ b/lib/events/complete_test.go
@@ -36,6 +36,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/session"
 )
 
@@ -370,6 +371,152 @@ func TestCheckUploadsContinuesOnError(t *testing.T) {
 	clock.Advance(1 * time.Hour)
 	uc.CheckUploads(context.Background())
 	require.ElementsMatch(t, completedUploads, []session.ID{session.ID(sessionTrackers[1].GetSessionID())})
+}
+
+func TestUploadCompleterMergesRecordings(t *testing.T) {
+	t.Parallel()
+	mkEvent := func(index int64, data string) apievents.AuditEvent {
+		return &apievents.SessionPrint{
+			Metadata: apievents.Metadata{
+				Index: index,
+			},
+			Data: []byte(data),
+		}
+	}
+	// The upload initiation time is determined from the file modification time.
+	// The synctest time needs to be advanced so that upload grace periods can
+	// pass.
+	realNow := time.Now()
+	synctest.Test(t, func(t *testing.T) {
+		time.Sleep(time.Until(realNow))
+		handler, err := filesessions.NewHandler(filesessions.Config{
+			Directory: t.TempDir(),
+		})
+		require.NoError(t, err)
+
+		log, err := events.NewAuditLog(events.AuditLogConfig{
+			DataDir:       t.TempDir(),
+			ServerID:      "foo",
+			UploadHandler: handler,
+			Context:       t.Context(),
+		})
+		require.NoError(t, err)
+
+		const checkPeriod = time.Minute
+		const gracePeriod = 2 * time.Minute
+		err = events.StartNewUploadCompleter(t.Context(), events.UploadCompleterConfig{
+			Uploader:       handler,
+			AuditLog:       log,
+			SessionTracker: &mockSessionTrackerService{},
+			ClusterName:    "teleport-cluster",
+			GracePeriod:    gracePeriod,
+			CheckPeriod:    checkPeriod,
+		})
+		require.NoError(t, err)
+
+		streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
+			Uploader:       handler,
+			MinUploadBytes: events.MinUploadPartSizeBytes,
+		})
+		require.NoError(t, err)
+		sessionID := session.NewID()
+		downloadEvents := func(uploadID string) []apievents.AuditEvent {
+			reader, err := handler.StreamSessionRecording(t.Context(), sessionID, uploadID)
+			require.NoError(t, err)
+			recording, err := events.NewProtoReader(reader, nil).ReadAll(t.Context())
+			require.NoError(t, err)
+			return recording
+		}
+		sessionEvents := []apievents.AuditEvent{
+			&apievents.SessionStart{
+				Metadata: apievents.Metadata{
+					Index: 0,
+				},
+			},
+			mkEvent(1, "a"),
+			mkEvent(2, "b"),
+			mkEvent(3, "c"),
+			mkEvent(4, "d"),
+			mkEvent(5, "e"),
+			&apievents.SessionEnd{
+				Metadata: apievents.Metadata{
+					Index: 6,
+				},
+			},
+		}
+		prep := &events.NoOpPreparer{}
+		// Start event upload.
+		firstStream, err := streamer.CreateAuditStream(t.Context(), sessionID)
+		require.NoError(t, err)
+		status := <-firstStream.Status()
+		require.NotNil(t, status)
+		firstUploadID := status.UploadID
+
+		// Upload some events, then abandon the stream.
+		for _, event := range sessionEvents[:4] {
+			preparedEvent, _ := prep.PrepareSessionEvent(event)
+			require.NoError(t, firstStream.RecordEvent(t.Context(), preparedEvent))
+		}
+		require.NoError(t, firstStream.Close(t.Context()))
+
+		assertRecordingExists := func(sessionID session.ID, uploadID string) string {
+			version, err := handler.GetRecordingVersion(t.Context(), sessionID, uploadID)
+			require.NoError(t, err)
+			require.NotEmpty(t, version)
+			return version
+		}
+		assertRecordingNotExists := func(sessionID session.ID, uploadID string) {
+			version, err := handler.GetRecordingVersion(t.Context(), sessionID, uploadID)
+			require.NoError(t, err)
+			require.Empty(t, version)
+		}
+
+		// Let the upload completer complete the abandoned upload.
+		time.Sleep(gracePeriod + checkPeriod)
+		synctest.Wait()
+		initialVersion := assertRecordingExists(sessionID, "")
+		assertRecordingNotExists(sessionID, firstUploadID)
+
+		firstRecording := downloadEvents("")
+		require.Equal(t, sessionEvents[:4], firstRecording)
+		// log.SetSessionEvents(sessionEvents[:4])
+
+		// Resume the stream. Since the original upload was already completed, this
+		// will create a temporary upload.
+		secondStream, err := streamer.ResumeAuditStream(t.Context(), sessionID, firstUploadID)
+		require.NoError(t, err)
+		status = <-secondStream.Status()
+		secondUploadID := status.UploadID
+
+		// Upload remaining events.
+		for _, event := range sessionEvents[4:] {
+			preparedEvent, _ := prep.PrepareSessionEvent(event)
+			require.NoError(t, secondStream.RecordEvent(t.Context(), preparedEvent))
+		}
+		require.NoError(t, secondStream.Complete(t.Context()))
+
+		// Check that temporary recording was uploaded to the right place.
+		synctest.Wait()
+		assertRecordingNotExists(sessionID, firstUploadID)
+		_ = assertRecordingExists(sessionID, secondUploadID)
+		secondRecording := downloadEvents(secondUploadID)
+		require.Equal(t, sessionEvents[4:], secondRecording)
+		// log.SetTempSessionEvents(sessionEvents[4:])
+		// Final recording should be unchanged for now.
+		secondVersion := assertRecordingExists(sessionID, "")
+		require.Equal(t, initialVersion, secondVersion)
+		firstRecording = downloadEvents("")
+		require.Equal(t, sessionEvents[:4], firstRecording)
+
+		// Check that upload completer performs the merge.
+		time.Sleep(checkPeriod)
+		synctest.Wait()
+		assertRecordingNotExists(sessionID, secondUploadID)
+		finalVersion := assertRecordingExists(sessionID, "")
+		finalRecording := downloadEvents("")
+		require.Equal(t, sessionEvents, finalRecording)
+		require.NotEqual(t, initialVersion, finalVersion)
+	})
 }
 
 type mockSessionTrackerService struct {

--- a/lib/events/complete_test.go
+++ b/lib/events/complete_test.go
@@ -373,7 +373,7 @@ func TestCheckUploadsContinuesOnError(t *testing.T) {
 	require.ElementsMatch(t, completedUploads, []session.ID{session.ID(sessionTrackers[1].GetSessionID())})
 }
 
-func TestMergeStreams(t *testing.T) {
+func TestAppendUpload(t *testing.T) {
 	t.Parallel()
 	mkEvent := func(index int64, data string) apievents.AuditEvent {
 		return &apievents.SessionPrint{
@@ -383,68 +383,105 @@ func TestMergeStreams(t *testing.T) {
 			Data: []byte(data),
 		}
 	}
-	sessionID := session.NewID()
-	uploader, err := filesessions.NewHandler(filesessions.Config{
-		Directory: t.TempDir(),
-	})
-	require.NoError(t, err)
-	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
-		Uploader: uploader,
-	})
-	require.NoError(t, err)
-
-	currentEvents := []apievents.AuditEvent{mkEvent(2, "b"), mkEvent(3, "c"), mkEvent(6, "f"), mkEvent(7, "g"), mkEvent(9, "i")}
-
-	// Upload initial recording.
-	firstStream, err := streamer.CreateAuditStream(t.Context(), sessionID)
-	require.NoError(t, err)
-	firstUploadID := (<-firstStream.Status()).UploadID
-	nopPreparer := events.NoOpPreparer{}
-	for _, event := range currentEvents {
-		preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
-		require.NoError(t, firstStream.RecordEvent(t.Context(), preparedEvent))
+	tests := []struct {
+		name           string
+		currentEvents  []apievents.AuditEvent
+		incomingEvents []apievents.AuditEvent
+		assert         require.ErrorAssertionFunc
+		expectedEvents []apievents.AuditEvent
+	}{
+		{
+			name:          "current events only",
+			currentEvents: []apievents.AuditEvent{mkEvent(1, "a"), mkEvent(2, "b"), mkEvent(3, "c"), mkEvent(4, "d")},
+			assert:        require.Error,
+		},
+		{
+			name:           "incoming events only",
+			incomingEvents: []apievents.AuditEvent{mkEvent(1, "a"), mkEvent(2, "b"), mkEvent(3, "c"), mkEvent(4, "d")},
+			assert:         require.Error,
+		},
+		{
+			name:           "regular append",
+			currentEvents:  []apievents.AuditEvent{mkEvent(1, "a"), mkEvent(2, "b"), mkEvent(3, "c"), mkEvent(4, "d")},
+			incomingEvents: []apievents.AuditEvent{mkEvent(5, "e"), mkEvent(6, "f"), mkEvent(7, "g"), mkEvent(8, "h")},
+			assert:         require.NoError,
+			expectedEvents: []apievents.AuditEvent{
+				mkEvent(1, "a"), mkEvent(2, "b"), mkEvent(3, "c"), mkEvent(4, "d"),
+				mkEvent(5, "e"), mkEvent(6, "f"), mkEvent(7, "g"), mkEvent(8, "h"),
+			},
+		},
+		{
+			name:          "skip duplicate incoming events",
+			currentEvents: []apievents.AuditEvent{mkEvent(1, "a"), mkEvent(2, "b"), mkEvent(3, "c"), mkEvent(4, "d")},
+			incomingEvents: []apievents.AuditEvent{
+				mkEvent(1, "these"), mkEvent(2, "events"), mkEvent(3, "are"), mkEvent(4, "skipped"),
+				mkEvent(5, "e"), mkEvent(6, "f"), mkEvent(7, "g"), mkEvent(8, "h"),
+			},
+			assert: require.NoError,
+			expectedEvents: []apievents.AuditEvent{
+				mkEvent(1, "a"), mkEvent(2, "b"), mkEvent(3, "c"), mkEvent(4, "d"),
+				mkEvent(5, "e"), mkEvent(6, "f"), mkEvent(7, "g"), mkEvent(8, "h"),
+			},
+		},
 	}
-	require.NoError(t, firstStream.Complete(t.Context()))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sessionID := session.NewID()
+			uploader, err := filesessions.NewHandler(filesessions.Config{
+				Directory: t.TempDir(),
+			})
+			require.NoError(t, err)
+			streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
+				Uploader: uploader,
+			})
+			require.NoError(t, err)
 
-	incomingEvents := []apievents.AuditEvent{mkEvent(1, "a"), mkEvent(4, "d"), mkEvent(5, "e"), mkEvent(7, "this event will be overridden"), mkEvent(8, "h")}
+			// Upload initial recording.
+			firstStream, err := streamer.CreateAuditStream(t.Context(), sessionID)
+			require.NoError(t, err)
+			firstUploadID := (<-firstStream.Status()).UploadID
+			nopPreparer := events.NoOpPreparer{}
+			for _, event := range tc.currentEvents {
+				preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
+				require.NoError(t, firstStream.RecordEvent(t.Context(), preparedEvent))
+			}
+			require.NoError(t, firstStream.Complete(t.Context()))
 
-	// Upload updated recording. Node assumes it is resuming the original upload;
-	// it will be redirected to a new temporary upload.
-	secondStream, err := streamer.ResumeAuditStream(t.Context(), sessionID, firstUploadID)
-	require.NoError(t, err)
-	secondUploadID := (<-secondStream.Status()).UploadID
-	require.NotEqual(t, firstUploadID, secondUploadID, "temporary upload did not get a new upload ID")
-	for _, event := range incomingEvents {
-		preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
-		require.NoError(t, secondStream.RecordEvent(t.Context(), preparedEvent))
+			// Upload updated recording. Node assumes it is resuming the original upload;
+			// it will be redirected to a new temporary upload.
+			secondStream, err := streamer.ResumeAuditStream(t.Context(), sessionID, firstUploadID)
+			require.NoError(t, err)
+			secondUploadID := (<-secondStream.Status()).UploadID
+			require.NotEqual(t, firstUploadID, secondUploadID, "temporary upload did not get a new upload ID")
+			for _, event := range tc.incomingEvents {
+				preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
+				require.NoError(t, secondStream.RecordEvent(t.Context(), preparedEvent))
+			}
+			require.NoError(t, secondStream.Complete(t.Context()))
+
+			// Merge both recordings.
+			log, err := events.NewAuditLog(events.AuditLogConfig{
+				DataDir:       t.TempDir(),
+				ServerID:      "foo",
+				UploadHandler: uploader,
+				Context:       t.Context(),
+			})
+			require.NoError(t, err)
+			tc.assert(t, events.AppendUpload(t.Context(), log, streamer, events.StreamUpload{
+				ID:        secondUploadID,
+				SessionID: sessionID,
+			}))
+
+			if len(tc.expectedEvents) != 0 {
+				// Check the merged recording.
+				reader, err := uploader.StreamSessionRecording(t.Context(), sessionID, "")
+				require.NoError(t, err)
+				gotEvents, err := events.NewProtoReader(reader, nil).ReadAll(t.Context())
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedEvents, gotEvents)
+			}
+		})
 	}
-	require.NoError(t, secondStream.Complete(t.Context()))
-
-	// Merge both recordings.
-	log, err := events.NewAuditLog(events.AuditLogConfig{
-		DataDir:       t.TempDir(),
-		ServerID:      "foo",
-		UploadHandler: uploader,
-		Context:       t.Context(),
-	})
-	require.NoError(t, err)
-	require.NoError(t, events.MergeUpload(t.Context(), log, streamer, events.StreamUpload{
-		ID:        secondUploadID,
-		SessionID: sessionID,
-	}))
-
-	// Check the merged recording.
-	reader, err := uploader.StreamSessionRecording(t.Context(), sessionID, "")
-	require.NoError(t, err)
-	gotEvents, err := events.NewProtoReader(reader, nil).ReadAll(t.Context())
-	require.NoError(t, err)
-
-	expectedEvents := []apievents.AuditEvent{
-		mkEvent(1, "a"), mkEvent(2, "b"), mkEvent(3, "c"),
-		mkEvent(4, "d"), mkEvent(5, "e"), mkEvent(6, "f"),
-		mkEvent(7, "g"), mkEvent(8, "h"), mkEvent(9, "i"),
-	}
-	require.Equal(t, expectedEvents, gotEvents)
 }
 
 func TestUploadCompleterMergesRecordings(t *testing.T) {

--- a/lib/events/complete_test.go
+++ b/lib/events/complete_test.go
@@ -373,6 +373,80 @@ func TestCheckUploadsContinuesOnError(t *testing.T) {
 	require.ElementsMatch(t, completedUploads, []session.ID{session.ID(sessionTrackers[1].GetSessionID())})
 }
 
+func TestMergeStreams(t *testing.T) {
+	t.Parallel()
+	mkEvent := func(index int64, data string) apievents.AuditEvent {
+		return &apievents.SessionPrint{
+			Metadata: apievents.Metadata{
+				Index: index,
+			},
+			Data: []byte(data),
+		}
+	}
+	sessionID := session.NewID()
+	uploader, err := filesessions.NewHandler(filesessions.Config{
+		Directory: t.TempDir(),
+	})
+	require.NoError(t, err)
+	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
+		Uploader: uploader,
+	})
+	require.NoError(t, err)
+
+	currentEvents := []apievents.AuditEvent{mkEvent(2, "b"), mkEvent(3, "c"), mkEvent(6, "f"), mkEvent(7, "g"), mkEvent(9, "i")}
+
+	// Upload initial recording.
+	firstStream, err := streamer.CreateAuditStream(t.Context(), sessionID)
+	require.NoError(t, err)
+	firstUploadID := (<-firstStream.Status()).UploadID
+	nopPreparer := events.NoOpPreparer{}
+	for _, event := range currentEvents {
+		preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
+		require.NoError(t, firstStream.RecordEvent(t.Context(), preparedEvent))
+	}
+	require.NoError(t, firstStream.Complete(t.Context()))
+
+	incomingEvents := []apievents.AuditEvent{mkEvent(1, "a"), mkEvent(4, "d"), mkEvent(5, "e"), mkEvent(7, "this event will be overridden"), mkEvent(8, "h")}
+
+	// Upload updated recording. Node assumes it is resuming the original upload;
+	// it will be redirected to a new temporary upload.
+	secondStream, err := streamer.ResumeAuditStream(t.Context(), sessionID, firstUploadID)
+	require.NoError(t, err)
+	secondUploadID := (<-secondStream.Status()).UploadID
+	require.NotEqual(t, firstUploadID, secondUploadID, "temporary upload did not get a new upload ID")
+	for _, event := range incomingEvents {
+		preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
+		require.NoError(t, secondStream.RecordEvent(t.Context(), preparedEvent))
+	}
+	require.NoError(t, secondStream.Complete(t.Context()))
+
+	// Merge both recordings.
+	log, err := events.NewAuditLog(events.AuditLogConfig{
+		DataDir:       t.TempDir(),
+		ServerID:      "foo",
+		UploadHandler: uploader,
+		Context:       t.Context(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, events.MergeUpload(t.Context(), log, streamer, events.StreamUpload{
+		ID:        secondUploadID,
+		SessionID: sessionID,
+	}))
+
+	// Check the merged recording.
+	reader, err := uploader.StreamSessionRecording(t.Context(), sessionID, "")
+	require.NoError(t, err)
+	gotEvents, err := events.NewProtoReader(reader, nil).ReadAll(t.Context())
+	require.NoError(t, err)
+
+	expectedEvents := []apievents.AuditEvent{
+		mkEvent(1, "a"), mkEvent(2, "b"), mkEvent(3, "c"),
+		mkEvent(4, "d"), mkEvent(5, "e"), mkEvent(6, "f"),
+		mkEvent(7, "g"), mkEvent(8, "h"), mkEvent(9, "i"),
+	}
+	require.Equal(t, expectedEvents, gotEvents)
+}
+
 func TestUploadCompleterMergesRecordings(t *testing.T) {
 	t.Parallel()
 	mkEvent := func(index int64, data string) apievents.AuditEvent {
@@ -479,7 +553,6 @@ func TestUploadCompleterMergesRecordings(t *testing.T) {
 
 		firstRecording := downloadEvents("")
 		require.Equal(t, sessionEvents[:4], firstRecording)
-		// log.SetSessionEvents(sessionEvents[:4])
 
 		// Resume the stream. Since the original upload was already completed, this
 		// will create a temporary upload.
@@ -501,7 +574,6 @@ func TestUploadCompleterMergesRecordings(t *testing.T) {
 		_ = assertRecordingExists(sessionID, secondUploadID)
 		secondRecording := downloadEvents(secondUploadID)
 		require.Equal(t, sessionEvents[4:], secondRecording)
-		// log.SetTempSessionEvents(sessionEvents[4:])
 		// Final recording should be unchanged for now.
 		secondVersion := assertRecordingExists(sessionID, "")
 		require.Equal(t, initialVersion, secondVersion)

--- a/lib/events/complete_test.go
+++ b/lib/events/complete_test.go
@@ -473,6 +473,7 @@ func TestAppendUpload(t *testing.T) {
 				SessionTracker: &mockSessionTrackerService{},
 				ClusterName:    "teleport-cluster",
 			})
+			require.NoError(t, err)
 			tc.assert(t, completer.AppendUpload(t.Context(), events.StreamUpload{
 				ID:        secondUploadID,
 				SessionID: sessionID,

--- a/lib/events/eventstest/mock_auditlog.go
+++ b/lib/events/eventstest/mock_auditlog.go
@@ -55,3 +55,18 @@ func (m *MockAuditLog) StreamSessionEvents(ctx context.Context, sid session.ID, 
 func (m *MockAuditLog) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
 	return m.Emitter.EmitAuditEvent(ctx, event)
 }
+
+func (m *MockAuditLog) SearchSessionEvents(ctx context.Context, cfg events.SearchSessionEventsRequest) ([]apievents.AuditEvent, string, error) {
+	events := make([]apievents.AuditEvent, 0, len(m.SessionEvents))
+	for _, event := range m.SessionEvents {
+		if t := event.GetTime(); t.Before(cfg.From) || t.After(cfg.To) {
+			continue
+		}
+		switch e := event.(type) {
+		case *apievents.SessionEnd, *apievents.WindowsDesktopSessionEnd,
+			*apievents.DatabaseSessionEnd, *apievents.AppSessionEnd, *apievents.MCPSessionEnd:
+			events = append(events, e)
+		}
+	}
+	return events, "", nil
+}

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -123,7 +123,7 @@ func (m *MemoryUploader) Reset() {
 }
 
 // CreateUpload creates a multipart upload
-func (m *MemoryUploader) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+func (m *MemoryUploader) CreateUpload(ctx context.Context, sessionID session.ID, _ ...events.CreateUploadOption) (*events.StreamUpload, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	upload := &events.StreamUpload{
@@ -356,7 +356,7 @@ func (m *MemoryUploader) UploadThumbnail(ctx context.Context, sessionID session.
 }
 
 // StreamSessionRecording streams a session tarball and returns a ReadCloser for the content.
-func (m *MemoryUploader) StreamSessionRecording(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
+func (m *MemoryUploader) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -407,10 +407,13 @@ func (m *MemoryUploader) StreamSessionThumbnail(ctx context.Context, sessionID s
 }
 
 // GetUploadMetadata gets the session upload metadata
-func (m *MemoryUploader) GetUploadMetadata(sid session.ID) events.UploadMetadata {
+func (m *MemoryUploader) GetUploadMetadata(sid session.ID, uploadID string) events.UploadMetadata {
 	return events.UploadMetadata{
-		URL:       "memory",
-		SessionID: sid,
+		URL: "memory",
+		StreamUpload: events.StreamUpload{
+			ID:        uploadID,
+			SessionID: sid,
+		},
 	}
 }
 
@@ -496,21 +499,33 @@ func (m *MemoryUploader) DownloadSummary(ctx context.Context, sessionID session.
 	return nil
 }
 
+func (m *MemoryUploader) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
+	return "", nil
+}
+
 // MockUploader is a limited implementation of [events.MultipartUploader] that
 // allows injecting errors for testing purposes. [MemoryUploader] is a more
 // complete implementation and should be preferred for testing the happy path.
 type MockUploader struct {
-	events.MultipartUploader
+	events.MultipartHandler
 
 	CreateUploadError      error
 	ReserveUploadPartError error
 
+	MockCreateUpload   func(ctx context.Context, sessionID session.ID, opts ...events.CreateUploadOption) (*events.StreamUpload, error)
 	MockListParts      func(ctx context.Context, upload events.StreamUpload) ([]events.StreamPart, error)
 	MockListUploads    func(ctx context.Context) ([]events.StreamUpload, error)
 	MockCompleteUpload func(ctx context.Context, upload events.StreamUpload, parts []events.StreamPart) error
+
+	RecordingVersion     string
+	TempRecordingVersion string
+	ExistingUpload       events.StreamUpload
 }
 
-func (m *MockUploader) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+func (m *MockUploader) CreateUpload(ctx context.Context, sessionID session.ID, opts ...events.CreateUploadOption) (*events.StreamUpload, error) {
+	if m.MockCreateUpload != nil {
+		return m.MockCreateUpload(ctx, sessionID, opts...)
+	}
 	if m.CreateUploadError != nil {
 		return nil, m.CreateUploadError
 	}
@@ -547,4 +562,20 @@ func (m *MockUploader) CompleteUpload(ctx context.Context, upload events.StreamU
 	}
 
 	return nil
+}
+
+func (m *MockUploader) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
+	if uploadID != "" {
+		return m.TempRecordingVersion, nil
+	}
+	return m.RecordingVersion, nil
+}
+
+func (m *MockUploader) GetUploadMetadata(sessionID session.ID, uploadID string) events.UploadMetadata {
+	metadata := events.UploadMetadata{
+		StreamUpload: m.ExistingUpload,
+	}
+	metadata.StreamUpload.ID = uploadID
+	metadata.StreamUpload.SessionID = sessionID
+	return metadata
 }

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -356,7 +356,7 @@ func (m *MemoryUploader) UploadThumbnail(ctx context.Context, sessionID session.
 }
 
 // StreamSessionRecording streams a session tarball and returns a ReadCloser for the content.
-func (m *MemoryUploader) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
+func (m *MemoryUploader) StreamSessionRecording(ctx context.Context, sessionID session.ID, _ string) (io.ReadCloser, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -128,6 +128,7 @@ func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID, opts .
 	if err := os.MkdirAll(h.uploadsPath(), teleport.PrivateDirMode); err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
+
 	upload := events.StreamUpload{
 		SessionID:      sessionID,
 		ID:             uuid.New().String(),
@@ -373,11 +374,6 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 				continue
 			}
 			return nil, trace.Wrap(err)
-		}
-		// Expect two entries, the parts directory and the metadata file.
-		if len(files) != 2 {
-			h.logger.WarnContext(ctx, "Skipping upload, missing subdirectory or metadata file.", "upload_id", uploadID)
-			continue
 		}
 
 		info, err := dir.Info()

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -21,6 +21,7 @@ package filesessions
 import (
 	"cmp"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -119,20 +120,28 @@ func NewStreamer(cfg StreamerConfig) (*events.ProtoStreamer, error) {
 }
 
 // CreateUpload creates a multipart upload
-func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID, opts ...events.CreateUploadOption) (*events.StreamUpload, error) {
+	var options events.CreateUploadOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 	if err := os.MkdirAll(h.uploadsPath(), teleport.PrivateDirMode); err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
-
 	upload := events.StreamUpload{
-		SessionID: sessionID,
-		ID:        uuid.New().String(),
+		SessionID:      sessionID,
+		ID:             uuid.New().String(),
+		Temporary:      options.Temporary,
+		ReplaceVersion: options.ReplaceVersion,
 	}
 	if err := upload.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if err := os.MkdirAll(h.uploadPath(upload), teleport.PrivateDirMode); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := h.writeMetadata(upload); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -171,12 +180,33 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 		return trace.Wrap(err)
 	}
 
+	if err := h.Config.OnBeforeComplete(ctx, upload); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// If there are no parts to complete, move to cleanup
 	if len(parts) == 0 {
 		return h.cleanupUpload(ctx, upload)
 	}
 
-	uploadPath := h.recordingPath(upload.SessionID)
+	if !upload.Temporary {
+		// Check that we're replacing the version we expect to, or creating anew.
+		version, err := h.GetRecordingVersion(ctx, upload.SessionID, "")
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if upload.ReplaceVersion != version {
+			// Recording was updated out from under us, this upload must be abandoned
+			// to prevent overwrites.
+			cleanupErr := h.cleanupUpload(ctx, upload)
+			return trace.NewAggregate(trace.CompareFailed(
+				"Upload %q tried to replace version %q, but current version is %q. Create a new upload to proceed.",
+				upload.ID, upload.ReplaceVersion, version,
+			), cleanupErr)
+		}
+	}
+
+	uploadPath := h.recordingPath(upload)
 
 	// Prevent other processes from accessing this file until the write is completed
 	f, err := GetOpenFileFunc()(uploadPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
@@ -245,12 +275,12 @@ Loop:
 		return trace.Wrap(err)
 	}
 
-	err = h.Config.OnBeforeComplete(ctx, upload)
-	if err != nil {
-		return trace.Wrap(err)
+	deletePath := h.uploadRootPath(upload)
+	if upload.Temporary {
+		// Preserve the temporary recording.
+		deletePath = h.uploadPath(upload)
 	}
-
-	err = os.RemoveAll(h.uploadRootPath(upload))
+	err = os.RemoveAll(deletePath)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to remove upload", "upload_id", upload.ID)
 	}
@@ -258,7 +288,7 @@ Loop:
 }
 
 func (h *Handler) cleanupUpload(ctx context.Context, upload events.StreamUpload) error {
-	uploadKey := h.recordingPath(upload.SessionID)
+	uploadKey := h.recordingPath(upload)
 	log := h.logger.With(
 		"upload", upload.ID,
 		"session", upload.SessionID,
@@ -344,13 +374,9 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 			}
 			return nil, trace.Wrap(err)
 		}
-		// expect just one subdirectory - session ID
-		if len(files) != 1 {
-			h.logger.WarnContext(ctx, "Skipping upload, missing subdirectory.", "upload_id", uploadID)
-			continue
-		}
-		if !files[0].IsDir() {
-			h.logger.WarnContext(ctx, "Skipping upload, not a directory.", "upload_id", uploadID)
+		// Expect two entries, the parts directory and the metadata file.
+		if len(files) != 2 {
+			h.logger.WarnContext(ctx, "Skipping upload, missing subdirectory or metadata file.", "upload_id", uploadID)
 			continue
 		}
 
@@ -360,11 +386,28 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 			continue
 		}
 
-		uploads = append(uploads, events.StreamUpload{
-			SessionID: session.ID(filepath.Base(files[0].Name())),
-			ID:        uploadID,
-			Initiated: info.ModTime(),
-		})
+		upload, err := h.readMetadata(uploadID)
+		if err != nil {
+			// Look for session dir manually for backwards compatibility.
+			var sessionDir os.DirEntry
+			for _, ent := range files {
+				if ent.IsDir() {
+					sessionDir = ent
+					break
+				}
+			}
+			if sessionDir == nil {
+				h.logger.WarnContext(ctx, "Skipping upload, missing subdirectory.", "upload_id", uploadID)
+				continue
+			}
+
+			upload = events.StreamUpload{
+				SessionID: session.ID(filepath.Base(sessionDir.Name())),
+				ID:        uploadID,
+			}
+		}
+		upload.Initiated = info.ModTime()
+		uploads = append(uploads, upload)
 	}
 
 	sort.Slice(uploads, func(i, j int) bool {
@@ -375,11 +418,22 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 }
 
 // GetUploadMetadata gets the metadata for session upload
-func (h *Handler) GetUploadMetadata(s session.ID) events.UploadMetadata {
-	return events.UploadMetadata{
-		URL:       fmt.Sprintf("%v://%v/%v", teleport.SchemeFile, h.uploadsPath(), string(s)),
-		SessionID: s,
+func (h *Handler) GetUploadMetadata(s session.ID, uploadID string) events.UploadMetadata {
+	metadata := events.UploadMetadata{
+		URL: fmt.Sprintf("%v://%v/%v", teleport.SchemeFile, h.uploadsPath(), string(s)),
+		StreamUpload: events.StreamUpload{
+			ID:        uploadID,
+			SessionID: s,
+		},
 	}
+	if uploadID != "" {
+		upload, err := h.readMetadata(uploadID)
+		if err == nil {
+			metadata.StreamUpload.Temporary = upload.Temporary
+			metadata.StreamUpload.ReplaceVersion = upload.ReplaceVersion
+		}
+	}
+	return metadata
 }
 
 // ReserveUploadPart reserves an upload part.
@@ -410,6 +464,30 @@ func (h *Handler) partPath(upload events.StreamUpload, partNumber int64) string 
 
 func (h *Handler) reservationPath(upload events.StreamUpload, partNumber int64) string {
 	return filepath.Join(h.uploadPath(upload), reservationFileName(partNumber))
+}
+
+func (h *Handler) uploadMetadataPath(upload events.StreamUpload) string {
+	return filepath.Join(h.uploadRootPath(upload), upload.ID+uploadMetadataExt)
+}
+
+func (h *Handler) writeMetadata(upload events.StreamUpload) error {
+	data, err := json.Marshal(upload)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.ConvertSystemError(os.WriteFile(h.uploadMetadataPath(upload), data, teleport.PrivateDirMode))
+}
+
+func (h *Handler) readMetadata(uploadID string) (events.StreamUpload, error) {
+	data, err := os.ReadFile(h.uploadMetadataPath(events.StreamUpload{ID: uploadID}))
+	if err != nil {
+		return events.StreamUpload{}, trace.ConvertSystemError(err)
+	}
+	var upload events.StreamUpload
+	if err := json.Unmarshal(data, &upload); err != nil {
+		return events.StreamUpload{}, trace.Wrap(err)
+	}
+	return upload, nil
 }
 
 func partFileName(partNumber int64) string {
@@ -463,6 +541,8 @@ const (
 	partExt = ".part"
 	// tarExt is a suffix for file uploads
 	tarExt = ".tar"
+	// tempExt is a suffix for temporary file uploads
+	tempExt = ".temp" + tarExt
 	// summaryExt is a suffix for summary files
 	summaryExt = ".summary.json"
 	// metadataExt is a suffix for session metadata files
@@ -475,4 +555,6 @@ const (
 	errorExt = ".error"
 	// reservationExt is part reservation extension.
 	reservationExt = ".reservation"
+	// uploadMetadataExt is an upload metadata extension.
+	uploadMetadataExt = ".upload.json"
 )

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -292,8 +292,8 @@ func (h *Handler) cleanupUpload(ctx context.Context, upload events.StreamUpload)
 		"key", uploadKey,
 	)
 	log.DebugContext(ctx, "Aborting upload")
-	if err := os.RemoveAll(h.uploadRootPath(upload)); err != nil {
-		h.logger.ErrorContext(ctx, "Failed to remove upload", "upload_id", upload.ID)
+	if err := trace.ConvertSystemError(os.RemoveAll(h.uploadRootPath(upload))); err != nil && !trace.IsNotFound(err) {
+		h.logger.ErrorContext(ctx, "Failed to remove upload", "upload_id", upload.ID, "error", err)
 	}
 
 	log.InfoContext(ctx, "Aborted upload")

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -201,9 +201,7 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 	}
 	defer func() {
 		_ = tempFile.Close()
-		if err := os.Remove(tempFile.Name()); err != nil {
-			h.logger.ErrorContext(ctx, "Failed to remove temp file", "path", tempFile.Name(), "error", err)
-		}
+		_ = os.Remove(tempFile.Name())
 	}()
 
 	if err := h.fileRecorder.CombineParts(ctx, tempFile, func(yield func(string) bool) {

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -190,9 +190,70 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 		return h.cleanupUpload(ctx, upload)
 	}
 
+	// Parts must be sorted in PartNumber order.
+	slices.SortFunc(parts, func(a, b events.StreamPart) int {
+		return cmp.Compare(a.Number, b.Number)
+	})
+
+	tempFile, err := os.CreateTemp(h.Directory, string(upload.SessionID)+".tar.*")
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	defer func() {
+		_ = tempFile.Close()
+		if err := os.Remove(tempFile.Name()); err != nil {
+			h.logger.ErrorContext(ctx, "Failed to remove temp file", "path", tempFile.Name(), "error", err)
+		}
+	}()
+
+	if err := h.fileRecorder.CombineParts(ctx, tempFile, func(yield func(string) bool) {
+		for _, part := range parts {
+			if !yield(h.partPath(upload, part.Number)) {
+				break
+			}
+		}
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	uploadPath := h.recordingPath(upload)
+	// Prevent other processes from accessing this file until the write is completed
+	unlock, err := utils.FSTryWriteLock(uploadPath)
+Loop:
+	for range 3 {
+		switch {
+		case err == nil:
+			break Loop
+		case errors.Is(err, utils.ErrUnsuccessfulLockTry):
+			// If unable to lock the file, try again with some backoff
+			// to allow the UploadCompleter to finish and remove its
+			// file lock before giving up.
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(50 * time.Millisecond):
+				unlock, err = utils.FSTryWriteLock(uploadPath)
+				continue
+			}
+		default:
+			return trace.Wrap(err, "handler could not acquire file lock for %q", uploadPath)
+		}
+	}
+	if unlock == nil {
+		return trace.Wrap(err, "handler could not acquire file lock for %q", uploadPath)
+	}
+	defer func() {
+		if err := unlock(); err != nil {
+			h.logger.ErrorContext(ctx, "Failed to unlock filesystem lock.", "error", err)
+		}
+	}()
+
 	if !upload.Temporary {
 		// Check that we're replacing the version we expect to, or creating anew.
-		version, err := h.GetRecordingVersion(ctx, upload.SessionID, "")
+		version, err := h.GetRecordingVersion(ctx, upload.SessionID, "" /* upload ID */)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -207,72 +268,7 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 		}
 	}
 
-	uploadPath := h.recordingPath(upload)
-
-	// Prevent other processes from accessing this file until the write is completed
-	f, err := GetOpenFileFunc()(uploadPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	unlock, err := utils.FSTryWriteLock(uploadPath)
-Loop:
-	for range 3 {
-		switch {
-		case err == nil:
-			break Loop
-		case errors.Is(err, utils.ErrUnsuccessfulLockTry):
-			// If unable to lock the file, try again with some backoff
-			// to allow the UploadCompleter to finish and remove its
-			// file lock before giving up.
-			select {
-			case <-ctx.Done():
-				if err := f.Close(); err != nil {
-					h.logger.ErrorContext(ctx, "Failed to close upload file", "file", uploadPath, "error", err)
-				}
-
-				return nil
-			case <-time.After(50 * time.Millisecond):
-				unlock, err = utils.FSTryWriteLock(uploadPath)
-				continue
-			}
-		default:
-			if err := f.Close(); err != nil {
-				h.logger.ErrorContext(ctx, "Failed to close upload file", "file", uploadPath)
-			}
-
-			return trace.Wrap(err, "handler could not acquire file lock for %q", uploadPath)
-		}
-	}
-
-	if unlock == nil {
-		if err := f.Close(); err != nil {
-			h.logger.ErrorContext(ctx, "Failed to close upload file", "file", uploadPath, "error", err)
-		}
-
-		return trace.Wrap(err, "handler could not acquire file lock for %q", uploadPath)
-	}
-
-	defer func() {
-		if err := unlock(); err != nil {
-			h.logger.ErrorContext(ctx, "Failed to unlock filesystem lock.", "error", err)
-		}
-		if err := f.Close(); err != nil {
-			h.logger.ErrorContext(ctx, "Failed to close upload file", "file", uploadPath, "error", err)
-		}
-	}()
-
-	// Parts must be sorted in PartNumber order.
-	slices.SortFunc(parts, func(a, b events.StreamPart) int {
-		return cmp.Compare(a.Number, b.Number)
-	})
-
-	if err := h.fileRecorder.CombineParts(ctx, f, func(yield func(string) bool) {
-		for _, part := range parts {
-			if !yield(h.partPath(upload, part.Number)) {
-				break
-			}
-		}
-	}); err != nil {
+	if err := os.Rename(tempFile.Name(), uploadPath); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/events/filesessions/filestream_test.go
+++ b/lib/events/filesessions/filestream_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -147,9 +148,14 @@ func TestCompleteUpload(t *testing.T) {
 
 			err = handler.CompleteUpload(ctx, *upload, parts)
 			require.NoError(t, err)
+			version, err := handler.GetRecordingVersion(ctx, upload.SessionID, "")
+			require.NoError(t, err)
+			require.NotEmpty(t, version)
 
 			// Check upload contents
-			uploadPath := handler.recordingPath(upload.SessionID)
+			uploadPath := handler.recordingPath(events.StreamUpload{
+				SessionID: upload.SessionID,
+			})
 			f, err := os.Open(uploadPath)
 			require.NoError(t, err)
 
@@ -160,6 +166,90 @@ func TestCompleteUpload(t *testing.T) {
 			require.NoDirExists(t, handler.uploadRootPath(*upload))
 		})
 	}
+}
+
+func TestCompleteTemporaryUpload(t *testing.T) {
+	ctx := t.Context()
+	handler, err := NewHandler(Config{
+		Directory: t.TempDir(),
+		OpenFile:  os.OpenFile,
+	})
+	require.NoError(t, err)
+
+	// Create the upload.
+	upload, err := handler.CreateUpload(ctx, session.NewID(), events.WithUploadTemporary())
+	require.NoError(t, err)
+	uploads, err := handler.ListUploads(ctx)
+	require.NoError(t, err)
+	require.Len(t, uploads, 1)
+	upload.Initiated = uploads[0].Initiated
+	require.Equal(t, *upload, uploads[0])
+
+	// Create some upload parts using reserve + write.
+	createPart := func(partNumber int64, content []byte) events.StreamPart {
+		err := handler.ReserveUploadPart(ctx, *upload, partNumber)
+		require.NoError(t, err)
+
+		if len(content) > 0 {
+			part, err := handler.UploadPart(ctx, *upload, partNumber, bytes.NewReader(content))
+			require.NoError(t, err)
+			return *part
+		}
+
+		return events.StreamPart{Number: partNumber}
+	}
+	parts := []events.StreamPart{
+		createPart(0, []byte("hello ")),
+		createPart(1, []byte("world")),
+		createPart(2, []byte("!")),
+	}
+	// Complete the upload. Verify that the recording was written to the temporary
+	// upload location and not the final location.
+	require.NoError(t, handler.CompleteUpload(ctx, *upload, parts))
+	require.NoFileExists(t, handler.recordingPath(events.StreamUpload{
+		SessionID: upload.SessionID,
+	}))
+	require.FileExists(t, handler.recordingPath(*upload))
+	// Verify that completing the upload with no parts deletes the temp recording.
+	require.NoError(t, handler.CompleteUpload(ctx, *upload, nil))
+	require.NoFileExists(t, handler.recordingPath(*upload))
+}
+
+func TestRejectVersionMismatch(t *testing.T) {
+	t.Parallel()
+	handler, err := NewHandler(Config{Directory: t.TempDir()})
+	require.NoError(t, err)
+
+	createPart := func(upload events.StreamUpload, content string) events.StreamPart {
+		err := handler.ReserveUploadPart(t.Context(), upload, 1)
+		require.NoError(t, err)
+		part, err := handler.UploadPart(t.Context(), upload, 1, strings.NewReader(content))
+		require.NoError(t, err)
+		return *part
+	}
+
+	// Create initial upload.
+	sessionID := session.NewID()
+	initialUpload, err := handler.CreateUpload(t.Context(), sessionID)
+	require.NoError(t, err)
+	part := createPart(*initialUpload, "foo")
+	require.NoError(t, handler.CompleteUpload(t.Context(), *initialUpload, []events.StreamPart{part}))
+	version, err := handler.GetRecordingVersion(t.Context(), sessionID, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, version)
+
+	// Create two uploads targeting the same version.
+	firstReupload, err := handler.CreateUpload(t.Context(), sessionID, events.WithUploadReplace(version))
+	require.NoError(t, err)
+	secondReupload, err := handler.CreateUpload(t.Context(), sessionID, events.WithUploadReplace(version))
+	require.NoError(t, err)
+	firstPart := createPart(*firstReupload, "bar")
+	secondPart := createPart(*secondReupload, "baz")
+
+	// Verify that the first upload succeeds, but the second upload fails because
+	// the version has changed.
+	require.NoError(t, handler.CompleteUpload(t.Context(), *firstReupload, []events.StreamPart{firstPart}))
+	require.Error(t, handler.CompleteUpload(t.Context(), *secondReupload, []events.StreamPart{secondPart}))
 }
 
 func TestCleanupEmptyUpload(t *testing.T) {
@@ -195,7 +285,9 @@ func TestCleanupEmptyUpload(t *testing.T) {
 	require.NoError(t, err)
 
 	// The empty upload should be cleaned up without impacting the original completed upload.
-	uploadPath := handler.recordingPath(upload.SessionID)
+	uploadPath := handler.recordingPath(events.StreamUpload{
+		SessionID: upload.SessionID,
+	})
 	f, err := os.Open(uploadPath)
 	require.NoError(t, err)
 

--- a/lib/events/filesessions/filestream_test.go
+++ b/lib/events/filesessions/filestream_test.go
@@ -253,6 +253,7 @@ func TestRejectVersionMismatch(t *testing.T) {
 		"upload with target version %q tried to replace version %q", firstReupload.ReplaceVersion, version,
 	)
 	version, err = handler.GetRecordingVersion(t.Context(), sessionID, "")
+	require.NoError(t, err)
 	require.Error(
 		t, handler.CompleteUpload(t.Context(), *secondReupload, []events.StreamPart{secondPart}),
 		"upload with target version %q tried to replace version %q", secondReupload.ReplaceVersion, version,

--- a/lib/events/filesessions/filestream_test.go
+++ b/lib/events/filesessions/filestream_test.go
@@ -243,13 +243,20 @@ func TestRejectVersionMismatch(t *testing.T) {
 	require.NoError(t, err)
 	secondReupload, err := handler.CreateUpload(t.Context(), sessionID, events.WithUploadReplace(version))
 	require.NoError(t, err)
-	firstPart := createPart(*firstReupload, "bar")
-	secondPart := createPart(*secondReupload, "baz")
+	firstPart := createPart(*firstReupload, "foobar")
+	secondPart := createPart(*secondReupload, "foobaz")
 
 	// Verify that the first upload succeeds, but the second upload fails because
 	// the version has changed.
-	require.NoError(t, handler.CompleteUpload(t.Context(), *firstReupload, []events.StreamPart{firstPart}))
-	require.Error(t, handler.CompleteUpload(t.Context(), *secondReupload, []events.StreamPart{secondPart}))
+	require.NoError(
+		t, handler.CompleteUpload(t.Context(), *firstReupload, []events.StreamPart{firstPart}),
+		"upload with target version %q tried to replace version %q", firstReupload.ReplaceVersion, version,
+	)
+	version, err = handler.GetRecordingVersion(t.Context(), sessionID, "")
+	require.Error(
+		t, handler.CompleteUpload(t.Context(), *secondReupload, []events.StreamPart{secondPart}),
+		"upload with target version %q tried to replace version %q", secondReupload.ReplaceVersion, version,
+	)
 }
 
 func TestCleanupEmptyUpload(t *testing.T) {

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -170,10 +170,9 @@ func (l *Handler) UploadPendingSummary(ctx context.Context, sessionID session.ID
 }
 
 // UploadSummary writes a final version of session summary and removes the
-// pending one. This function can be called only once for a given sessionID;
-// subsequent calls will return an error.
+// pending one.
 func (l *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	name, err := uploadFile(l.summaryPath(sessionID), reader)
+	name, err := uploadFile(l.summaryPath(sessionID), reader, withOverwrite())
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -117,8 +117,12 @@ func (l *Handler) Close() error {
 }
 
 // StreamSessionRecording reads a session recording from a local directory.
-func (l *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
-	return openFile(l.recordingPath(sessionID))
+func (l *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
+	return openFile(l.recordingPath(events.StreamUpload{
+		ID:        uploadID,
+		SessionID: sessionID,
+		Temporary: uploadID != "",
+	}))
 }
 
 // StreamSessionSummary reads a session summary from a local directory.
@@ -154,7 +158,7 @@ func (l *Handler) StreamSessionThumbnail(ctx context.Context, sessionID session.
 
 // Upload writes a session recording to a local directory.
 func (l *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	s, err := uploadFile(l.recordingPath(sessionID), reader)
+	s, err := uploadFile(l.recordingPath(events.StreamUpload{SessionID: sessionID}), reader)
 	return s, trace.Wrap(err)
 }
 
@@ -184,12 +188,12 @@ func (l *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reade
 
 // UploadMetadata writes session metadata to a local directory.
 func (l *Handler) UploadMetadata(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return uploadFile(l.metadataPath(sessionID), reader)
+	return uploadFile(l.metadataPath(sessionID), reader, withOverwrite())
 }
 
 // UploadThumbnail writes a session thumbnail to a local directory.
 func (l *Handler) UploadThumbnail(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return uploadFile(l.thumbnailPath(sessionID), reader)
+	return uploadFile(l.thumbnailPath(sessionID), reader, withOverwrite())
 }
 
 func openFile(path string) (io.ReadCloser, error) {
@@ -198,6 +202,31 @@ func openFile(path string) (io.ReadCloser, error) {
 		return nil, trace.ConvertSystemError(err)
 	}
 	return f, nil
+}
+
+// GetRecordingVersion gets a string representing the current version of the
+// recording.
+//
+// The value of the version string should be considered opaque and
+// only used for comparisons. If uploadID is empty, this gets the current
+// recording version; otherwise, this gets the version of the temporary upload
+// associated with the upload ID, If there is no recording, the version is the
+// empty string.
+func (l *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
+	path := l.recordingPath(events.StreamUpload{
+		ID:        uploadID,
+		SessionID: sessionID,
+		Temporary: uploadID != "",
+	})
+	info, err := os.Stat(path)
+	if err != nil {
+		osErr := trace.ConvertSystemError(err)
+		if trace.IsNotFound(osErr) {
+			return "", nil
+		}
+		return "", osErr
+	}
+	return info.ModTime().String(), nil
 }
 
 type fileUploadConfig struct {
@@ -233,8 +262,11 @@ func uploadFile(path string, reader io.Reader, opts ...fileUploadOption) (string
 	return fmt.Sprintf("%v://%v", teleport.SchemeFile, path), nil
 }
 
-func (l *Handler) recordingPath(sessionID session.ID) string {
-	return filepath.Join(l.Directory, string(sessionID)+tarExt)
+func (l *Handler) recordingPath(upload events.StreamUpload) string {
+	if upload.Temporary {
+		return filepath.Join(l.uploadRootPath(upload), string(upload.SessionID)+tempExt)
+	}
+	return filepath.Join(l.Directory, string(upload.SessionID)+tarExt)
 }
 
 func (l *Handler) pendingSummariesPath() string {

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -225,6 +225,11 @@ func (l *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID,
 		}
 		return "", osErr
 	}
+	// Acquiring a file lock on a nonexistant session recording will create an
+	// empty file, treat that as not existing.
+	if info.Size() == 0 {
+		return "", nil
+	}
 	return info.ModTime().String(), nil
 }
 

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -20,6 +20,8 @@ package filesessions
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"iter"
@@ -217,7 +219,7 @@ func (l *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID,
 		SessionID: sessionID,
 		Temporary: uploadID != "",
 	})
-	info, err := os.Stat(path)
+	f, err := os.Open(path)
 	if err != nil {
 		osErr := trace.ConvertSystemError(err)
 		if trace.IsNotFound(osErr) {
@@ -225,12 +227,23 @@ func (l *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID,
 		}
 		return "", osErr
 	}
-	// Acquiring a file lock on a nonexistant session recording will create an
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return "", trace.ConvertSystemError(err)
+	}
+	// Acquiring a file lock on a nonexistent session recording will create an
 	// empty file, treat that as not existing.
 	if info.Size() == 0 {
 		return "", nil
 	}
-	return info.ModTime().String(), nil
+
+	h := sha256.New()
+	_, err = f.WriteTo(h)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 type fileUploadConfig struct {

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -211,7 +211,7 @@ func openFile(path string) (io.ReadCloser, error) {
 // The value of the version string should be considered opaque and
 // only used for comparisons. If uploadID is empty, this gets the current
 // recording version; otherwise, this gets the version of the temporary upload
-// associated with the upload ID, If there is no recording, the version is the
+// associated with the upload ID. If there is no recording, the version is the
 // empty string.
 func (l *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
 	path := l.recordingPath(events.StreamUpload{

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -21,7 +21,6 @@ package filesessions
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -235,12 +234,7 @@ func (l *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID,
 	}
 
 	h := sha256.New()
-	if err := binary.Write(h, binary.NativeEndian, info.ModTime().UnixMicro()); err != nil {
-		return "", trace.Wrap(err)
-	}
-	// In case mod time isn't high enough resolution. Recording files are append
-	// only, so if two files have the same size they should have the same contents.
-	if err := binary.Write(h, binary.NativeEndian, info.Size()); err != nil {
+	if err := computeVersion(path, info, h); err != nil {
 		return "", trace.Wrap(err)
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -21,6 +21,7 @@ package filesessions
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -219,18 +220,13 @@ func (l *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID,
 		SessionID: sessionID,
 		Temporary: uploadID != "",
 	})
-	f, err := os.Open(path)
+	info, err := os.Stat(path)
 	if err != nil {
 		osErr := trace.ConvertSystemError(err)
 		if trace.IsNotFound(osErr) {
 			return "", nil
 		}
 		return "", osErr
-	}
-	defer f.Close()
-	info, err := f.Stat()
-	if err != nil {
-		return "", trace.ConvertSystemError(err)
 	}
 	// Acquiring a file lock on a nonexistent session recording will create an
 	// empty file, treat that as not existing.
@@ -239,8 +235,12 @@ func (l *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID,
 	}
 
 	h := sha256.New()
-	_, err = f.WriteTo(h)
-	if err != nil {
+	if err := binary.Write(h, binary.NativeEndian, info.ModTime().UnixMicro()); err != nil {
+		return "", trace.Wrap(err)
+	}
+	// In case mod time isn't high enough resolution. Recording files are append
+	// only, so if two files have the same size they should have the same contents.
+	if err := binary.Write(h, binary.NativeEndian, info.Size()); err != nil {
 		return "", trace.Wrap(err)
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil

--- a/lib/events/filesessions/fileuploader_other.go
+++ b/lib/events/filesessions/fileuploader_other.go
@@ -1,0 +1,35 @@
+//go:build !unix
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package filesessions
+
+import (
+	"io"
+	"os"
+
+	"github.com/gravitational/trace"
+)
+
+func computeVersion(file string, _ os.FileInfo, hash io.Writer) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	_, err = f.WriteTo(hash)
+	return trace.ConvertSystemError(err)
+}

--- a/lib/events/filesessions/fileuploader_other.go
+++ b/lib/events/filesessions/fileuploader_other.go
@@ -30,6 +30,7 @@ func computeVersion(file string, _ os.FileInfo, hash io.Writer) error {
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
+	defer f.Close()
 	_, err = f.WriteTo(hash)
 	return trace.ConvertSystemError(err)
 }

--- a/lib/events/filesessions/fileuploader_unix.go
+++ b/lib/events/filesessions/fileuploader_unix.go
@@ -1,0 +1,46 @@
+//go:build unix
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package filesessions
+
+import (
+	"encoding/binary"
+	"io"
+	"os"
+	"syscall"
+
+	"github.com/gravitational/trace"
+)
+
+func computeVersion(_ string, info os.FileInfo, hash io.Writer) error {
+	if err := binary.Write(hash, binary.NativeEndian, info.ModTime().UnixMicro()); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := binary.Write(hash, binary.NativeEndian, info.Size()); err != nil {
+		return trace.Wrap(err)
+	}
+	sys := info.Sys()
+	if sys == nil {
+		return nil
+	}
+	sysInfo, ok := sys.(*syscall.Stat_t)
+	if !ok {
+		return trace.BadParameter("unexpected stat type %T", sys)
+	}
+	return trace.Wrap(binary.Write(hash, binary.NativeEndian, sysInfo.Ino))
+}

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -336,7 +336,7 @@ func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader,
 // is not found.
 func (h *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
 	if uploadID != "" {
-		return nil, trace.NotImplemented("")
+		return nil, trace.NotImplemented("streaming temporary session recordings not supported for GCS")
 	}
 	return h.gcsRetrier(ctx, h.recordingPath(sessionID))
 }
@@ -416,7 +416,7 @@ func (h *Handler) gcsRetrier(ctx context.Context, objectPath string) (io.ReadClo
 }
 
 func (h *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
-	return "", trace.NotImplemented("")
+	return "", trace.NotImplemented("GetRecordingVersion not implemented for GCS")
 }
 
 func (h *Handler) recordingPath(sessionID session.ID) string {

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -334,7 +334,10 @@ func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader,
 // StreamSessionRecording downloads a session recording from a GCS bucket and returns a
 // ReadCloser for the content. Returns trace.NotFound error if the recording
 // is not found.
-func (h *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
+func (h *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
+	if uploadID != "" {
+		return nil, trace.NotImplemented("")
+	}
 	return h.gcsRetrier(ctx, h.recordingPath(sessionID))
 }
 
@@ -410,6 +413,10 @@ func (h *Handler) gcsRetrier(ctx context.Context, objectPath string) (io.ReadClo
 		downloadLatencies.Observe(time.Since(start).Seconds())
 		return reader, nil
 	}), nil
+}
+
+func (h *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
+	return "", trace.NotImplemented("")
 }
 
 func (h *Handler) recordingPath(sessionID session.ID) string {

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -416,7 +416,7 @@ func (h *Handler) gcsRetrier(ctx context.Context, objectPath string) (io.ReadClo
 }
 
 func (h *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
-	return "", trace.NotImplemented("GetRecordingVersion not implemented for GCS")
+	return "", nil
 }
 
 func (h *Handler) recordingPath(sessionID session.ID) string {

--- a/lib/events/gcssessions/gcsstream.go
+++ b/lib/events/gcssessions/gcsstream.go
@@ -41,7 +41,7 @@ import (
 )
 
 // CreateUpload creates a multipart upload
-func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID, _ ...events.CreateUploadOption) (*events.StreamUpload, error) {
 	upload := events.StreamUpload{
 		ID:        uuid.New().String(),
 		SessionID: sessionID,
@@ -317,10 +317,13 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 }
 
 // GetUploadMetadata gets the metadata for session upload
-func (h *Handler) GetUploadMetadata(s session.ID) events.UploadMetadata {
+func (h *Handler) GetUploadMetadata(s session.ID, uploadID string) events.UploadMetadata {
 	return events.UploadMetadata{
-		URL:       fmt.Sprintf("%v://%v/%v", teleport.SchemeGCS, h.recordingPath(s), string(s)),
-		SessionID: s,
+		URL: fmt.Sprintf("%v://%v/%v", teleport.SchemeGCS, h.recordingPath(s), string(s)),
+		StreamUpload: events.StreamUpload{
+			ID:        uploadID,
+			SessionID: s,
+		},
 	}
 }
 

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -451,7 +451,7 @@ func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader,
 // is not found.
 func (h *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
 	if uploadID != "" {
-		return nil, trace.NotImplemented("")
+		return nil, trace.NotImplemented("streaming temporary session recordings not supported for S3")
 	}
 	return h.downloadOriginalFile(ctx, h.recordingPath(sessionID))
 }

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -449,7 +449,10 @@ func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader,
 // StreamSessionRecording downloads a session recording from an S3 bucket and returns a
 // ReadCloser for the content. Returns trace.NotFound error if the recording
 // is not found.
-func (h *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
+func (h *Handler) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
+	if uploadID != "" {
+		return nil, trace.NotImplemented("")
+	}
 	return h.downloadOriginalFile(ctx, h.recordingPath(sessionID))
 }
 

--- a/lib/events/s3sessions/s3handler_config_test.go
+++ b/lib/events/s3sessions/s3handler_config_test.go
@@ -182,7 +182,7 @@ func TestUploadMetadata(t *testing.T) {
 	require.NoError(t, err)
 	defer handler.Close()
 
-	meta := handler.GetUploadMetadata("test-session-id")
+	meta := handler.GetUploadMetadata("test-session-id", "" /* upload ID */)
 	require.Equal(t, "s3://teleport-unit-tests/test/test-session-id", meta.URL)
 }
 

--- a/lib/events/s3sessions/s3stream.go
+++ b/lib/events/s3sessions/s3stream.go
@@ -312,5 +312,5 @@ func (h *Handler) ReserveUploadPart(ctx context.Context, upload events.StreamUpl
 }
 
 func (h *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
-	return "", trace.NotImplemented("")
+	return "", trace.NotImplemented("GetRecordingVersion not implemented for S3")
 }

--- a/lib/events/s3sessions/s3stream.go
+++ b/lib/events/s3sessions/s3stream.go
@@ -43,7 +43,7 @@ import (
 )
 
 // CreateUpload creates a multipart upload
-func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID, _ ...events.CreateUploadOption) (*events.StreamUpload, error) {
 	start := time.Now()
 
 	input := &s3.CreateMultipartUploadInput{
@@ -289,7 +289,7 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 }
 
 // GetUploadMetadata gets the metadata for session upload
-func (h *Handler) GetUploadMetadata(sessionID session.ID) events.UploadMetadata {
+func (h *Handler) GetUploadMetadata(sessionID session.ID, uploadID string) events.UploadMetadata {
 	sessionURL, err := url.JoinPath(teleport.SchemeS3+"://"+h.Bucket, h.Path, sessionID.String())
 	if err != nil {
 		// this should never happen, but if it does revert to legacy behavior
@@ -298,12 +298,19 @@ func (h *Handler) GetUploadMetadata(sessionID session.ID) events.UploadMetadata 
 	}
 
 	return events.UploadMetadata{
-		URL:       sessionURL,
-		SessionID: sessionID,
+		URL: sessionURL,
+		StreamUpload: events.StreamUpload{
+			ID:        uploadID,
+			SessionID: sessionID,
+		},
 	}
 }
 
 // ReserveUploadPart reserves an upload part.
 func (h *Handler) ReserveUploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64) error {
 	return nil
+}
+
+func (h *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
+	return "", trace.NotImplemented("")
 }

--- a/lib/events/s3sessions/s3stream.go
+++ b/lib/events/s3sessions/s3stream.go
@@ -312,5 +312,5 @@ func (h *Handler) ReserveUploadPart(ctx context.Context, upload events.StreamUpl
 }
 
 func (h *Handler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
-	return "", trace.NotImplemented("GetRecordingVersion not implemented for S3")
+	return "", nil
 }

--- a/lib/events/sessionend.go
+++ b/lib/events/sessionend.go
@@ -88,7 +88,7 @@ type FindOrRecoverSessionEndConfig struct {
 	// SessionID is the ID of the session to recover.
 	SessionID session.ID
 	// AuditLog is the emitter used to emit the recovered session end event.
-	AuditLog apievents.Emitter
+	AuditLog AuditLogger
 	// Log is the logger.
 	Log *slog.Logger
 	// Clock is used to timestamp the recovered event.
@@ -131,6 +131,7 @@ func FindOrRecoverSessionEnd(ctx context.Context, cfg FindOrRecoverSessionEndCon
 	defer cancel()
 	evts, errors := cfg.Streamer.StreamSessionEvents(ctx, cfg.SessionID, 0)
 
+	foundRecordingEndEvent := false
 loop:
 	for {
 		select {
@@ -142,10 +143,10 @@ loop:
 			lastEvent = evt
 
 			switch e := evt.(type) {
-			// Return if session end event already exists
 			case *apievents.SessionEnd, *apievents.WindowsDesktopSessionEnd,
 				*apievents.DatabaseSessionEnd, *apievents.AppSessionEnd, *apievents.MCPSessionEnd:
-				return e, nil
+				foundRecordingEndEvent = true
+				break loop
 
 			case *apievents.WindowsDesktopSessionStart:
 				desktopSessionEnd.Type = WindowsDesktopSessionEndEvent
@@ -224,6 +225,34 @@ loop:
 		return nil, trace.Errorf("could not find any events for session %v", cfg.SessionID)
 	}
 
+	// Check audit log for session end event.
+	searchEndTime := lastEvent.GetTime()
+	if !foundRecordingEndEvent {
+		searchEndTime = cfg.Clock.Now()
+	}
+	var startKey string
+	for {
+		var evts []apievents.AuditEvent
+		var err error
+		evts, startKey, err = cfg.AuditLog.SearchSessionEvents(ctx, SearchSessionEventsRequest{
+			From:      lastEvent.GetTime(),
+			To:        searchEndTime,
+			Limit:     1,
+			StartKey:  startKey,
+			SessionID: cfg.SessionID.String(),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if len(evts) > 0 {
+			return evts[0], nil
+		}
+		if startKey == "" {
+			break
+		}
+	}
+
+	// We didn't find the end event, we have to recover it.
 	sshSessionEnd.Participants = apiutils.Deduplicate(sshSessionEnd.Participants)
 	sshSessionEnd.EndTime = lastEvent.GetTime()
 	desktopSessionEnd.EndTime = lastEvent.GetTime()

--- a/lib/events/sessionend.go
+++ b/lib/events/sessionend.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -229,6 +230,12 @@ loop:
 	searchEndTime := lastEvent.GetTime()
 	if !foundRecordingEndEvent {
 		searchEndTime = cfg.Clock.Now()
+		// In the unlikely event that the last event's time is in the future due to
+		// clock skew, add some extra buffer time so SearchSessionEvents doesn't
+		// fail outright.
+		if searchEndTime.Before(lastEvent.GetTime()) {
+			searchEndTime = searchEndTime.Add(time.Hour)
+		}
 	}
 	var startKey string
 	for {

--- a/lib/events/sessionend_test.go
+++ b/lib/events/sessionend_test.go
@@ -146,22 +146,22 @@ func TestFindOrRecoverSessionEnd(t *testing.T) {
 	dbMeta := apievents.DatabaseMetadata{DatabaseName: "mydb", DatabaseUser: "admin", DatabaseProtocol: "postgres"}
 	appMeta := apievents.AppMetadata{AppName: "myapp", AppURI: "http://app.local"}
 
-	startTime := clock.Now().UTC()
+	startTime := clock.Now().UTC().Add(-2 * time.Minute)
 	lastTime := startTime.Add(time.Minute)
 
-	makeConfig := func(streamer events.SessionStreamer, emitter apievents.Emitter) events.FindOrRecoverSessionEndConfig {
+	makeConfig := func(streamer events.SessionStreamer, auditLog events.AuditLogger) events.FindOrRecoverSessionEndConfig {
 		return events.FindOrRecoverSessionEndConfig{
 			ClusterName: clusterName,
 			Streamer:    streamer,
 			SessionID:   sessionID,
-			AuditLog:    emitter,
+			AuditLog:    auditLog,
 			Log:         slog.Default(),
 			Clock:       clock,
 		}
 	}
 
 	t.Run("validation", func(t *testing.T) {
-		base := makeConfig(eventstest.NewFakeStreamer(nil, 0), &eventstest.MockRecorderEmitter{})
+		base := makeConfig(eventstest.NewFakeStreamer(nil, 0), &eventstest.MockAuditLog{})
 		tests := []struct {
 			name   string
 			mutate func(*events.FindOrRecoverSessionEndConfig)
@@ -494,7 +494,11 @@ func TestFindOrRecoverSessionEnd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			emitter := &eventstest.MockRecorderEmitter{}
-			cfg := makeConfig(eventstest.NewFakeStreamer(tt.evts, 0), emitter)
+			auditLog := &eventstest.MockAuditLog{
+				Emitter:       emitter,
+				SessionEvents: tt.evts,
+			}
+			cfg := makeConfig(auditLog, auditLog)
 			gotEnd, err := events.FindOrRecoverSessionEnd(t.Context(), cfg)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -504,4 +508,72 @@ func TestFindOrRecoverSessionEnd(t *testing.T) {
 			tt.check(t, gotEnd, emitter.Events())
 		})
 	}
+
+	t.Run("end event in recording but not in audit log", func(t *testing.T) {
+		emitter := &eventstest.MockRecorderEmitter{}
+		sessionEvents := []apievents.AuditEvent{
+			&apievents.SessionStart{
+				Metadata:           apievents.Metadata{Type: events.SessionStartEvent, Time: startTime, ClusterName: clusterName},
+				UserMetadata:       userMeta,
+				SessionMetadata:    sessionMeta,
+				ServerMetadata:     serverMeta,
+				ConnectionMetadata: connMeta,
+				TerminalSize:       "80:25",
+			},
+			&apievents.SessionEnd{
+				Metadata:           apievents.Metadata{Type: events.SessionStartEvent, Time: lastTime, ClusterName: clusterName},
+				UserMetadata:       userMeta,
+				SessionMetadata:    sessionMeta,
+				ServerMetadata:     serverMeta,
+				ConnectionMetadata: connMeta,
+			},
+		}
+		auditLog := &eventstest.MockAuditLog{
+			Emitter:       emitter,
+			SessionEvents: sessionEvents[:1],
+		}
+		cfg := makeConfig(eventstest.NewFakeStreamer(sessionEvents, 0), auditLog)
+		gotEnd, err := events.FindOrRecoverSessionEnd(t.Context(), cfg)
+		assert.NoError(t, err)
+		recovered, ok := gotEnd.(*apievents.SessionEnd)
+		require.True(t, ok)
+		assert.Equal(t, events.SessionEndEvent, recovered.Type)
+		assert.Equal(t, events.SessionEndCode, recovered.Code)
+		assert.Equal(t, userMeta, recovered.UserMetadata)
+		assert.Equal(t, sessionMeta, recovered.SessionMetadata)
+		assert.Equal(t, serverMeta, recovered.ServerMetadata)
+		assert.Equal(t, connMeta, recovered.ConnectionMetadata)
+		assert.True(t, recovered.Interactive)
+		assert.Equal(t, lastTime, recovered.EndTime)
+		assert.Len(t, emitter.Events(), 1)
+	})
+
+	t.Run("end event in audit log but not in recording", func(t *testing.T) {
+		emitter := &eventstest.MockRecorderEmitter{}
+		sessionEvents := []apievents.AuditEvent{
+			&apievents.SessionStart{
+				Metadata:           apievents.Metadata{Type: events.SessionStartEvent, Time: startTime, ClusterName: clusterName},
+				UserMetadata:       userMeta,
+				SessionMetadata:    sessionMeta,
+				ServerMetadata:     serverMeta,
+				ConnectionMetadata: connMeta,
+				TerminalSize:       "80:25",
+			},
+			&apievents.SessionEnd{
+				Metadata:           apievents.Metadata{Type: events.SessionStartEvent, Time: lastTime, ClusterName: clusterName},
+				UserMetadata:       userMeta,
+				SessionMetadata:    sessionMeta,
+				ServerMetadata:     serverMeta,
+				ConnectionMetadata: connMeta,
+			},
+		}
+		auditLog := &eventstest.MockAuditLog{
+			Emitter:       emitter,
+			SessionEvents: sessionEvents,
+		}
+		cfg := makeConfig(eventstest.NewFakeStreamer(sessionEvents[:1], 0), auditLog)
+		gotEvent, err := events.FindOrRecoverSessionEnd(t.Context(), cfg)
+		assert.NoError(t, err)
+		alreadyExists(sessionEvents[1])(t, gotEvent, emitter.Events())
+	})
 }

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"sort"
@@ -225,9 +224,9 @@ func (s *ProtoStreamer) createAuditStream(ctx context.Context, sid session.ID, o
 
 // ResumeAuditStream resumes the stream that has not been completed yet
 func (s *ProtoStreamer) ResumeAuditStream(ctx context.Context, sid session.ID, uploadID string) (apievents.Stream, error) {
+	log := slog.With("session_id", sid, "upload_id", uploadID)
 	// Note, that if the session ID does not match the upload ID,
 	// the request will fail
-	fmt.Println("ResumeAuditStream", sid, uploadID)
 	upload := s.cfg.Uploader.GetUploadMetadata(sid, uploadID).StreamUpload
 	parts, err := s.cfg.Uploader.ListParts(ctx, upload)
 	if err == nil && len(parts) > 0 {
@@ -267,18 +266,16 @@ func (s *ProtoStreamer) ResumeAuditStream(ctx context.Context, sid session.ID, u
 		if tempRecordingExists {
 			// Both recordings exist, this stream is merging the two and overwriting
 			// the current recording.
+			log.DebugContext(ctx, "Found existing temporary recording. Creating upload to replace current recording.")
 			createOpts = append(createOpts, WithUploadReplace(currentRecordingVersion))
 		} else {
 			// Only current recording exists, we need to create the temporary recording.
+			log.DebugContext(ctx, "Found existing complete recording. Creating a new upload to merge with it.")
 			upload.Temporary = true
 			createOpts = append(createOpts, WithUploadTemporary())
 		}
-	}
-
-	if upload.Temporary {
-		slog.DebugContext(ctx, "Found existing complete recording. Creating a new upload to merge with it.", "session_id", sid)
 	} else {
-		slog.DebugContext(ctx, "Upload missing, creating a new one.", "session_id", sid, "upload_id", uploadID)
+		log.DebugContext(ctx, "Upload missing, creating a new one.")
 	}
 	return s.createAuditStream(ctx, sid, createOpts...)
 }
@@ -1560,116 +1557,4 @@ func (r *ProtoReader) ReadAll(ctx context.Context) ([]apievents.AuditEvent, erro
 // isReserveUploadPartError identifies uploader reserve part errors.
 func isReserveUploadPartError(err error) bool {
 	return strings.Contains(err.Error(), uploaderReservePartErrorMessage)
-}
-
-// TempSessionStreamer is an alternate version of [SessionStreamer] that can stream
-// events from temporary recordings.
-type TempSessionStreamer interface {
-	StreamTempSessionEvents(ctx context.Context, sessionID session.ID, uploadID string, startIndex int64) (chan apievents.AuditEvent, chan error)
-}
-
-// MergeUpload merges the current recording for a session with a temporary
-// recording, replacing the current recording with one that includes all
-// events from both.
-func MergeUpload(
-	ctx context.Context,
-	uploadStreamer TempSessionStreamer,
-	streamer Streamer,
-	upload StreamUpload,
-) (err error) {
-	stream, err := streamer.ResumeAuditStream(ctx, upload.SessionID, upload.ID)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer func() {
-		if err != nil {
-			if closeErr := stream.Close(ctx); closeErr != nil {
-				slog.WarnContext(ctx, "Failed to close steam.", "error", closeErr)
-			}
-		}
-	}()
-	currentStream, currentErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, "", 0)
-	incomingStream, incomingErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, upload.ID, 0)
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	var nextCurrentEvent apievents.AuditEvent
-	var nextIncomingEvent apievents.AuditEvent
-	fetchCurrent := true
-	fetchIncoming := true
-	fetchEvents := func() chan struct{} {
-		// Fetch event from one or both streams concurrently.
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			wg := &sync.WaitGroup{}
-			if fetchCurrent {
-				wg.Go(func() {
-					select {
-					case event := <-currentStream:
-						nextCurrentEvent = event
-						fetchCurrent = false
-					case <-ctx.Done():
-					}
-				})
-			}
-			if fetchIncoming {
-				wg.Go(func() {
-					select {
-					case event := <-incomingStream:
-						nextIncomingEvent = event
-						fetchIncoming = false
-					case <-ctx.Done():
-					}
-				})
-			}
-			wg.Wait()
-		}()
-		return done
-	}
-
-	nopPreparer := NoOpPreparer{}
-	for {
-		select {
-		case <-fetchEvents():
-		case err := <-currentErr:
-			if err != nil && !trace.IsNotFound(err) {
-				return trace.Wrap(err)
-			}
-		case err := <-incomingErr:
-			if err != nil && !trace.IsNotFound(err) {
-				return trace.Wrap(err)
-			}
-		case <-ctx.Done():
-			return trace.Wrap(ctx.Err())
-		}
-		// Both streams are exhausted, we are done.
-		if nextCurrentEvent == nil && nextIncomingEvent == nil {
-			return trace.Wrap(stream.Complete(ctx))
-		}
-
-		var nextEvent apievents.AuditEvent
-		switch {
-		// There are no incoming events, or the current event is next by index.
-		case nextIncomingEvent == nil || (nextCurrentEvent != nil && nextCurrentEvent.GetIndex() < nextIncomingEvent.GetIndex()):
-			nextEvent = nextCurrentEvent
-			fetchCurrent = true
-			// There are no current events, or the incoming event is next by index.
-		case nextCurrentEvent == nil || (nextIncomingEvent != nil && nextIncomingEvent.GetIndex() < nextCurrentEvent.GetIndex()):
-			nextEvent = nextIncomingEvent
-			fetchIncoming = true
-			// Duplicate event. Send the current event, replace both.
-		case nextCurrentEvent.GetIndex() == nextIncomingEvent.GetIndex():
-			nextEvent = nextCurrentEvent
-			fetchCurrent = true
-			fetchIncoming = true
-		}
-
-		if nextEvent != nil {
-			preparedEvent, _ := nopPreparer.PrepareSessionEvent(nextEvent)
-			if err := stream.RecordEvent(ctx, preparedEvent); err != nil {
-				return trace.Wrap(err)
-			}
-		}
-	}
 }

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"sort"
@@ -118,7 +119,7 @@ type DecryptionWrapper interface {
 
 // ProtoStreamerConfig specifies configuration for the part
 type ProtoStreamerConfig struct {
-	Uploader MultipartUploader
+	Uploader MultipartHandler
 	// MinUploadBytes submits upload when they have reached min bytes (could be more,
 	// but not less), due to the nature of gzip writer
 	MinUploadBytes int64
@@ -211,7 +212,11 @@ func (s *ProtoStreamer) SetOnUploadComplete(fn func(ctx context.Context, session
 
 // CreateAuditStream creates audit stream and upload
 func (s *ProtoStreamer) CreateAuditStream(ctx context.Context, sid session.ID) (apievents.Stream, error) {
-	upload, err := s.cfg.Uploader.CreateUpload(ctx, sid)
+	return s.createAuditStream(ctx, sid)
+}
+
+func (s *ProtoStreamer) createAuditStream(ctx context.Context, sid session.ID, opts ...CreateUploadOption) (apievents.Stream, error) {
+	upload, err := s.cfg.Uploader.CreateUpload(ctx, sid, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -222,24 +227,60 @@ func (s *ProtoStreamer) CreateAuditStream(ctx context.Context, sid session.ID) (
 func (s *ProtoStreamer) ResumeAuditStream(ctx context.Context, sid session.ID, uploadID string) (apievents.Stream, error) {
 	// Note, that if the session ID does not match the upload ID,
 	// the request will fail
-	upload := StreamUpload{SessionID: sid, ID: uploadID}
+	fmt.Println("ResumeAuditStream", sid, uploadID)
+	upload := s.cfg.Uploader.GetUploadMetadata(sid, uploadID).StreamUpload
 	parts, err := s.cfg.Uploader.ListParts(ctx, upload)
-	if err != nil {
+	if err == nil && len(parts) > 0 {
+		return NewProtoStream(ProtoStreamConfig{
+			Upload:                    upload,
+			BufferPool:                s.bufferPool,
+			SlicePool:                 s.slicePool,
+			Uploader:                  s.cfg.Uploader,
+			MinUploadBytes:            s.cfg.MinUploadBytes,
+			CompletedParts:            parts,
+			RetryConfig:               s.cfg.RetryConfig,
+			Encrypter:                 s.cfg.Encrypter,
+			SessionSummarizerProvider: s.cfg.SessionSummarizerProvider,
+			RecordingMetadataProvider: s.cfg.RecordingMetadataProvider,
+			OnUploadComplete:          s.onUploadComplete,
+		})
+	} else if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
-	return NewProtoStream(ProtoStreamConfig{
-		Upload:                    upload,
-		BufferPool:                s.bufferPool,
-		SlicePool:                 s.slicePool,
-		Uploader:                  s.cfg.Uploader,
-		MinUploadBytes:            s.cfg.MinUploadBytes,
-		CompletedParts:            parts,
-		RetryConfig:               s.cfg.RetryConfig,
-		Encrypter:                 s.cfg.Encrypter,
-		SessionSummarizerProvider: s.cfg.SessionSummarizerProvider,
-		RecordingMetadataProvider: s.cfg.RecordingMetadataProvider,
-		OnUploadComplete:          s.onUploadComplete,
-	})
+
+	var currentRecordingExists bool
+	currentRecordingVersion, err := s.cfg.Uploader.GetRecordingVersion(ctx, sid, "")
+	if err == nil {
+		currentRecordingExists = currentRecordingVersion != ""
+	}
+	var tempRecordingExists bool
+	tempRecordingVersion, err := s.cfg.Uploader.GetRecordingVersion(ctx, sid, uploadID)
+	if err == nil {
+		tempRecordingExists = tempRecordingVersion != ""
+	}
+	if tempRecordingExists && !currentRecordingExists {
+		// Should not be possible.
+		return nil, trace.Errorf("temporary recording for upload %v exists without an existing recording to merge into, this is a bug", uploadID)
+	}
+	var createOpts []CreateUploadOption
+	if currentRecordingExists {
+		if tempRecordingExists {
+			// Both recordings exist, this stream is merging the two and overwriting
+			// the current recording.
+			createOpts = append(createOpts, WithUploadReplace(currentRecordingVersion))
+		} else {
+			// Only current recording exists, we need to create the temporary recording.
+			upload.Temporary = true
+			createOpts = append(createOpts, WithUploadTemporary())
+		}
+	}
+
+	if upload.Temporary {
+		slog.DebugContext(ctx, "Found existing complete recording. Creating a new upload to merge with it.", "session_id", sid)
+	} else {
+		slog.DebugContext(ctx, "Upload missing, creating a new one.", "session_id", sid, "upload_id", uploadID)
+	}
+	return s.createAuditStream(ctx, sid, createOpts...)
 }
 
 // ProtoStreamConfig configures proto stream
@@ -889,6 +930,9 @@ func (w *sliceWriter) completeStream() {
 			slog.WarnContext(w.proto.cancelCtx, "Failed to complete upload", "error", err)
 			return
 		}
+		if w.proto.cfg.Upload.Temporary {
+			return
+		}
 
 		if !w.hasSessionEnd && w.proto.cfg.OnUploadComplete != nil {
 			sessionEndEvent, err := w.proto.cfg.OnUploadComplete(w.proto.cancelCtx, w.proto.cfg.Upload.SessionID)
@@ -1516,4 +1560,116 @@ func (r *ProtoReader) ReadAll(ctx context.Context) ([]apievents.AuditEvent, erro
 // isReserveUploadPartError identifies uploader reserve part errors.
 func isReserveUploadPartError(err error) bool {
 	return strings.Contains(err.Error(), uploaderReservePartErrorMessage)
+}
+
+// TempSessionStreamer is an alternate version of [SessionStreamer] that can stream
+// events from temporary recordings.
+type TempSessionStreamer interface {
+	StreamTempSessionEvents(ctx context.Context, sessionID session.ID, uploadID string, startIndex int64) (chan apievents.AuditEvent, chan error)
+}
+
+// MergeUpload merges the current recording for a session with a temporary
+// recording, replacing the current recording with one that includes all
+// events from both.
+func MergeUpload(
+	ctx context.Context,
+	uploadStreamer TempSessionStreamer,
+	streamer Streamer,
+	upload StreamUpload,
+) (err error) {
+	stream, err := streamer.ResumeAuditStream(ctx, upload.SessionID, upload.ID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer func() {
+		if err != nil {
+			if closeErr := stream.Close(ctx); closeErr != nil {
+				slog.WarnContext(ctx, "Failed to close steam.", "error", closeErr)
+			}
+		}
+	}()
+	currentStream, currentErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, "", 0)
+	incomingStream, incomingErr := uploadStreamer.StreamTempSessionEvents(ctx, upload.SessionID, upload.ID, 0)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var nextCurrentEvent apievents.AuditEvent
+	var nextIncomingEvent apievents.AuditEvent
+	fetchCurrent := true
+	fetchIncoming := true
+	fetchEvents := func() chan struct{} {
+		// Fetch event from one or both streams concurrently.
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			wg := &sync.WaitGroup{}
+			if fetchCurrent {
+				wg.Go(func() {
+					select {
+					case event := <-currentStream:
+						nextCurrentEvent = event
+						fetchCurrent = false
+					case <-ctx.Done():
+					}
+				})
+			}
+			if fetchIncoming {
+				wg.Go(func() {
+					select {
+					case event := <-incomingStream:
+						nextIncomingEvent = event
+						fetchIncoming = false
+					case <-ctx.Done():
+					}
+				})
+			}
+			wg.Wait()
+		}()
+		return done
+	}
+
+	nopPreparer := NoOpPreparer{}
+	for {
+		select {
+		case <-fetchEvents():
+		case err := <-currentErr:
+			if err != nil && !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
+		case err := <-incomingErr:
+			if err != nil && !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		}
+		// Both streams are exhausted, we are done.
+		if nextCurrentEvent == nil && nextIncomingEvent == nil {
+			return trace.Wrap(stream.Complete(ctx))
+		}
+
+		var nextEvent apievents.AuditEvent
+		switch {
+		// There are no incoming events, or the current event is next by index.
+		case nextIncomingEvent == nil || (nextCurrentEvent != nil && nextCurrentEvent.GetIndex() < nextIncomingEvent.GetIndex()):
+			nextEvent = nextCurrentEvent
+			fetchCurrent = true
+			// There are no current events, or the incoming event is next by index.
+		case nextCurrentEvent == nil || (nextIncomingEvent != nil && nextIncomingEvent.GetIndex() < nextCurrentEvent.GetIndex()):
+			nextEvent = nextIncomingEvent
+			fetchIncoming = true
+			// Duplicate event. Send the current event, replace both.
+		case nextCurrentEvent.GetIndex() == nextIncomingEvent.GetIndex():
+			nextEvent = nextCurrentEvent
+			fetchCurrent = true
+			fetchIncoming = true
+		}
+
+		if nextEvent != nil {
+			preparedEvent, _ := nopPreparer.PrepareSessionEvent(nextEvent)
+			if err := stream.RecordEvent(ctx, preparedEvent); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
 }

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -247,37 +247,38 @@ func (s *ProtoStreamer) ResumeAuditStream(ctx context.Context, sid session.ID, u
 		return nil, trace.Wrap(err)
 	}
 
-	var currentRecordingExists bool
-	currentRecordingVersion, err := s.cfg.Uploader.GetRecordingVersion(ctx, sid, "")
-	if err == nil {
-		currentRecordingExists = currentRecordingVersion != ""
+	version, err := s.cfg.Uploader.GetRecordingVersion(ctx, sid, "" /* upload ID */)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	var tempRecordingExists bool
-	tempRecordingVersion, err := s.cfg.Uploader.GetRecordingVersion(ctx, sid, uploadID)
-	if err == nil {
-		tempRecordingExists = tempRecordingVersion != ""
+	tempVersion, err := s.cfg.Uploader.GetRecordingVersion(ctx, sid, uploadID)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	if tempRecordingExists && !currentRecordingExists {
-		// Should not be possible.
-		return nil, trace.Errorf("temporary recording for upload %v exists without an existing recording to merge into, this is a bug", uploadID)
-	}
+
 	var createOpts []CreateUploadOption
-	if currentRecordingExists {
-		if tempRecordingExists {
-			// Both recordings exist, this stream is merging the two and overwriting
-			// the current recording.
-			log.DebugContext(ctx, "Found existing temporary recording. Creating upload to replace current recording.")
-			createOpts = append(createOpts, WithUploadReplace(currentRecordingVersion))
-		} else {
-			// Only current recording exists, we need to create the temporary recording.
-			log.DebugContext(ctx, "Found existing complete recording. Creating a new upload to merge with it.")
-			upload.Temporary = true
-			createOpts = append(createOpts, WithUploadTemporary())
+	if version != "" {
+		if tempVersion != "" {
+			return nil, trace.BadParameter("Both complete and temporary uploads exist for session %q, nothing to do.", sid)
 		}
+		// Only current recording exists, we need to create the temporary recording.
+		log.DebugContext(ctx, "Found existing complete recording. Creating a new temporary upload to merge with it.")
+		createOpts = append(createOpts, WithUploadTemporary())
 	} else {
 		log.DebugContext(ctx, "Upload missing, creating a new one.")
 	}
 	return s.createAuditStream(ctx, sid, createOpts...)
+}
+
+// CreateOverwriteAuditStream creates an audit stream that will overwrite the
+// recording that exists at call time.
+func (s *ProtoStreamer) CreateOverwriteAuditStream(ctx context.Context, sid session.ID) (apievents.Stream, error) {
+	version, err := s.cfg.Uploader.GetRecordingVersion(ctx, sid, "" /* upload ID */)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	slog.DebugContext(ctx, "Creating upload to overwrite existing recording.", "session_id", sid)
+	return s.createAuditStream(ctx, sid, WithUploadReplace(version))
 }
 
 // ProtoStreamConfig configures proto stream

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -29,10 +29,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
@@ -43,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/summarizer"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/session"
 )
 
@@ -363,7 +366,7 @@ func TestEncryptedRecordingIO(t *testing.T) {
 	case <-doneC:
 	}
 
-	rc, err := uploader.StreamSessionRecording(ctx, sid)
+	rc, err := uploader.StreamSessionRecording(ctx, sid, "")
 	require.NoError(t, err)
 	defer rc.Close()
 
@@ -1068,4 +1071,192 @@ func TestRecordingMetadataProcessing(t *testing.T) {
 			mockMetadata.AssertExpectations(t)
 		})
 	}
+}
+
+func TestResumeAuditStream(t *testing.T) {
+	t.Parallel()
+	assertUploadNotCreated := func(t *testing.T, _ session.ID, _ events.CreateUploadOptions) {
+		require.Fail(t, "CreateUpload should not be called")
+	}
+	sessionID := session.NewID()
+	uploadID := uuid.NewString()
+	tests := []struct {
+		name                 string
+		recordingVersion     string
+		tempRecordingVersion string
+		uploadMetadata       events.StreamUpload
+		existingParts        []events.StreamPart
+		assertCreateUpload   func(t *testing.T, sid session.ID, options events.CreateUploadOptions)
+	}{
+		{
+			name: "upload resumed",
+			existingParts: []events.StreamPart{
+				{Number: 1},
+				{Number: 2},
+				{Number: 3},
+			},
+			assertCreateUpload: assertUploadNotCreated,
+		},
+		{
+			name: "create upload with zero existing parts",
+			assertCreateUpload: func(t *testing.T, sid session.ID, options events.CreateUploadOptions) {
+				require.Equal(t, sessionID, sid)
+				require.Empty(t, options)
+			},
+		},
+		{
+			name:             "create temp upload for existing recording",
+			recordingVersion: "foo",
+			assertCreateUpload: func(t *testing.T, sid session.ID, options events.CreateUploadOptions) {
+				require.Equal(t, sessionID, sid)
+				require.True(t, options.Temporary)
+				require.Empty(t, options.ReplaceVersion)
+			},
+		},
+		{
+			name:             "resume temp upload",
+			recordingVersion: "foo",
+			existingParts: []events.StreamPart{
+				{Number: 1},
+				{Number: 2},
+				{Number: 3},
+			},
+			uploadMetadata: events.StreamUpload{
+				ID:        uploadID,
+				SessionID: sessionID,
+				Temporary: true,
+			},
+			assertCreateUpload: assertUploadNotCreated,
+		},
+		{
+			name:                 "create merge recording for existing temp recording",
+			recordingVersion:     "foo",
+			tempRecordingVersion: "bar",
+			assertCreateUpload: func(t *testing.T, sid session.ID, options events.CreateUploadOptions) {
+				require.Equal(t, sessionID, sid)
+				require.False(t, options.Temporary)
+				require.Equal(t, "foo", options.ReplaceVersion)
+			},
+		},
+		{
+			name:                 "resume merge upload",
+			recordingVersion:     "foo",
+			tempRecordingVersion: "bar",
+			existingParts: []events.StreamPart{
+				{Number: 1},
+				{Number: 2},
+				{Number: 3},
+			},
+			uploadMetadata: events.StreamUpload{
+				ID:             uploadID,
+				SessionID:      sessionID,
+				ReplaceVersion: "foo",
+			},
+			assertCreateUpload: assertUploadNotCreated,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
+				Uploader: &eventstest.MockUploader{
+					MockListParts: func(ctx context.Context, upload events.StreamUpload) ([]events.StreamPart, error) {
+						return tc.existingParts, nil
+					},
+					MockCreateUpload: func(ctx context.Context, sessionID session.ID, opts ...events.CreateUploadOption) (*events.StreamUpload, error) {
+						var options events.CreateUploadOptions
+						for _, opt := range opts {
+							opt(&options)
+						}
+						tc.assertCreateUpload(t, sessionID, options)
+						return &events.StreamUpload{
+							SessionID: sessionID,
+							ID:        uploadID,
+						}, nil
+					},
+					RecordingVersion:     tc.recordingVersion,
+					TempRecordingVersion: tc.tempRecordingVersion,
+					ExistingUpload:       tc.uploadMetadata,
+				},
+			})
+			require.NoError(t, err)
+
+			stream, err := streamer.ResumeAuditStream(t.Context(), sessionID, uploadID)
+			require.NoError(t, err)
+			require.NoError(t, stream.Close(t.Context()))
+		})
+	}
+}
+
+func TestMergeStreams(t *testing.T) {
+	t.Parallel()
+	mkEvent := func(index int64, data string) apievents.AuditEvent {
+		return &apievents.SessionPrint{
+			Metadata: apievents.Metadata{
+				Index: index,
+			},
+			Data: []byte(data),
+		}
+	}
+	sessionID := session.NewID()
+	uploader, err := filesessions.NewHandler(filesessions.Config{
+		Directory: t.TempDir(),
+	})
+	require.NoError(t, err)
+	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
+		Uploader: uploader,
+	})
+	require.NoError(t, err)
+
+	currentEvents := []apievents.AuditEvent{mkEvent(2, "b"), mkEvent(3, "c"), mkEvent(6, "f"), mkEvent(7, "g"), mkEvent(9, "i")}
+
+	// Upload initial recording.
+	firstStream, err := streamer.CreateAuditStream(t.Context(), sessionID)
+	require.NoError(t, err)
+	firstUploadID := (<-firstStream.Status()).UploadID
+	nopPreparer := events.NoOpPreparer{}
+	for _, event := range currentEvents {
+		preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
+		require.NoError(t, firstStream.RecordEvent(t.Context(), preparedEvent))
+	}
+	require.NoError(t, firstStream.Complete(t.Context()))
+
+	incomingEvents := []apievents.AuditEvent{mkEvent(1, "a"), mkEvent(4, "d"), mkEvent(5, "e"), mkEvent(7, "this event will be overridden"), mkEvent(8, "h")}
+
+	// Upload updated recording. Node assumes it is resuming the original upload;
+	// it will be redirected to a new temporary upload.
+	secondStream, err := streamer.ResumeAuditStream(t.Context(), sessionID, firstUploadID)
+	require.NoError(t, err)
+	secondUploadID := (<-secondStream.Status()).UploadID
+	require.NotEqual(t, firstUploadID, secondUploadID, "temporary upload did not get a new upload ID")
+	for _, event := range incomingEvents {
+		preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
+		require.NoError(t, secondStream.RecordEvent(t.Context(), preparedEvent))
+	}
+	require.NoError(t, secondStream.Complete(t.Context()))
+
+	// Merge both recordings.
+	log, err := events.NewAuditLog(events.AuditLogConfig{
+		DataDir:       t.TempDir(),
+		ServerID:      "foo",
+		UploadHandler: uploader,
+		Context:       t.Context(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, events.MergeUpload(t.Context(), log, streamer, events.StreamUpload{
+		ID:        secondUploadID,
+		SessionID: sessionID,
+	}))
+
+	// Check the merged recording.
+	reader, err := uploader.StreamSessionRecording(t.Context(), sessionID, "")
+	require.NoError(t, err)
+	gotEvents, err := events.NewProtoReader(reader, nil).ReadAll(t.Context())
+	require.NoError(t, err)
+
+	expectedEvents := []apievents.AuditEvent{
+		mkEvent(1, "a"), mkEvent(2, "b"), mkEvent(3, "c"),
+		mkEvent(4, "d"), mkEvent(5, "e"), mkEvent(6, "f"),
+		mkEvent(7, "g"), mkEvent(8, "h"), mkEvent(9, "i"),
+	}
+	require.Empty(t, cmp.Diff(expectedEvents, gotEvents, protocmp.Transform()))
 }

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -1126,16 +1126,6 @@ func TestResumeAuditStream(t *testing.T) {
 			assertCreateUpload: assertUploadNotCreated,
 		},
 		{
-			name:                 "create merge recording for existing temp recording",
-			recordingVersion:     "foo",
-			tempRecordingVersion: "bar",
-			assertCreateUpload: func(t *testing.T, sid session.ID, options events.CreateUploadOptions) {
-				require.Equal(t, sessionID, sid)
-				require.False(t, options.Temporary)
-				require.Equal(t, "foo", options.ReplaceVersion)
-			},
-		},
-		{
 			name:                 "resume merge upload",
 			recordingVersion:     "foo",
 			tempRecordingVersion: "bar",
@@ -1180,6 +1170,18 @@ func TestResumeAuditStream(t *testing.T) {
 			stream, err := streamer.ResumeAuditStream(t.Context(), sessionID, uploadID)
 			require.NoError(t, err)
 			require.NoError(t, stream.Close(t.Context()))
+		})
+		t.Run("don't create merge upload", func(t *testing.T) {
+			streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
+				Uploader: &eventstest.MockUploader{
+					RecordingVersion:     "foo",
+					TempRecordingVersion: "bar",
+				},
+			})
+			require.NoError(t, err)
+			stream, err := streamer.ResumeAuditStream(t.Context(), sessionID, uploadID)
+			require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+			require.Nil(t, stream)
 		})
 	}
 }

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -29,12 +29,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
@@ -45,7 +43,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/summarizer"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
-	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/session"
 )
 
@@ -366,7 +363,7 @@ func TestEncryptedRecordingIO(t *testing.T) {
 	case <-doneC:
 	}
 
-	rc, err := uploader.StreamSessionRecording(ctx, sid, "")
+	rc, err := uploader.StreamSessionRecording(ctx, sid, "" /* upload ID */)
 	require.NoError(t, err)
 	defer rc.Close()
 
@@ -1185,78 +1182,4 @@ func TestResumeAuditStream(t *testing.T) {
 			require.NoError(t, stream.Close(t.Context()))
 		})
 	}
-}
-
-func TestMergeStreams(t *testing.T) {
-	t.Parallel()
-	mkEvent := func(index int64, data string) apievents.AuditEvent {
-		return &apievents.SessionPrint{
-			Metadata: apievents.Metadata{
-				Index: index,
-			},
-			Data: []byte(data),
-		}
-	}
-	sessionID := session.NewID()
-	uploader, err := filesessions.NewHandler(filesessions.Config{
-		Directory: t.TempDir(),
-	})
-	require.NoError(t, err)
-	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
-		Uploader: uploader,
-	})
-	require.NoError(t, err)
-
-	currentEvents := []apievents.AuditEvent{mkEvent(2, "b"), mkEvent(3, "c"), mkEvent(6, "f"), mkEvent(7, "g"), mkEvent(9, "i")}
-
-	// Upload initial recording.
-	firstStream, err := streamer.CreateAuditStream(t.Context(), sessionID)
-	require.NoError(t, err)
-	firstUploadID := (<-firstStream.Status()).UploadID
-	nopPreparer := events.NoOpPreparer{}
-	for _, event := range currentEvents {
-		preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
-		require.NoError(t, firstStream.RecordEvent(t.Context(), preparedEvent))
-	}
-	require.NoError(t, firstStream.Complete(t.Context()))
-
-	incomingEvents := []apievents.AuditEvent{mkEvent(1, "a"), mkEvent(4, "d"), mkEvent(5, "e"), mkEvent(7, "this event will be overridden"), mkEvent(8, "h")}
-
-	// Upload updated recording. Node assumes it is resuming the original upload;
-	// it will be redirected to a new temporary upload.
-	secondStream, err := streamer.ResumeAuditStream(t.Context(), sessionID, firstUploadID)
-	require.NoError(t, err)
-	secondUploadID := (<-secondStream.Status()).UploadID
-	require.NotEqual(t, firstUploadID, secondUploadID, "temporary upload did not get a new upload ID")
-	for _, event := range incomingEvents {
-		preparedEvent, _ := nopPreparer.PrepareSessionEvent(event)
-		require.NoError(t, secondStream.RecordEvent(t.Context(), preparedEvent))
-	}
-	require.NoError(t, secondStream.Complete(t.Context()))
-
-	// Merge both recordings.
-	log, err := events.NewAuditLog(events.AuditLogConfig{
-		DataDir:       t.TempDir(),
-		ServerID:      "foo",
-		UploadHandler: uploader,
-		Context:       t.Context(),
-	})
-	require.NoError(t, err)
-	require.NoError(t, events.MergeUpload(t.Context(), log, streamer, events.StreamUpload{
-		ID:        secondUploadID,
-		SessionID: sessionID,
-	}))
-
-	// Check the merged recording.
-	reader, err := uploader.StreamSessionRecording(t.Context(), sessionID, "")
-	require.NoError(t, err)
-	gotEvents, err := events.NewProtoReader(reader, nil).ReadAll(t.Context())
-	require.NoError(t, err)
-
-	expectedEvents := []apievents.AuditEvent{
-		mkEvent(1, "a"), mkEvent(2, "b"), mkEvent(3, "c"),
-		mkEvent(4, "d"), mkEvent(5, "e"), mkEvent(6, "f"),
-		mkEvent(7, "g"), mkEvent(8, "h"), mkEvent(9, "i"),
-	}
-	require.Empty(t, cmp.Diff(expectedEvents, gotEvents, protocmp.Transform()))
 }

--- a/lib/events/test/streamsuite.go
+++ b/lib/events/test/streamsuite.go
@@ -181,7 +181,7 @@ func StreamEmpty(t *testing.T, handler events.MultipartHandler) {
 
 	require.NoError(t, stream.Complete(ctx))
 
-	_, err = handler.StreamSessionRecording(ctx, sid)
+	_, err = handler.StreamSessionRecording(ctx, sid, "" /* upload ID */)
 	require.True(t, trace.IsNotFound(err))
 }
 
@@ -240,7 +240,7 @@ func StreamWithParameters(t *testing.T, handler events.MultipartHandler, params 
 	err = stream.Complete(ctx)
 	require.NoError(t, err)
 
-	rc, err := handler.StreamSessionRecording(ctx, sid)
+	rc, err := handler.StreamSessionRecording(ctx, sid, "" /* upload ID */)
 	require.NoError(t, err)
 	defer rc.Close()
 
@@ -305,7 +305,7 @@ func StreamResumeWithParameters(t *testing.T, handler events.MultipartHandler, p
 	err = stream.Complete(ctx)
 	require.NoError(t, err, "Complete after resume should succeed")
 
-	rc, err := handler.StreamSessionRecording(ctx, sid)
+	rc, err := handler.StreamSessionRecording(ctx, sid, "" /* upload ID */)
 	require.NoError(t, err)
 	defer rc.Close()
 

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -57,7 +57,7 @@ func UploadDownload(t *testing.T, handler events.MultipartHandler) {
 	_, err = handler.Upload(ctx, id, strings.NewReader("impostor"))
 	require.Error(t, err)
 
-	rc, err := handler.StreamSessionRecording(ctx, id)
+	rc, err := handler.StreamSessionRecording(ctx, id, "" /* upload ID */)
 	require.NoError(t, err)
 	defer rc.Close()
 
@@ -160,7 +160,7 @@ func UploadDownloadThumbnail(t *testing.T, handler events.MultipartHandler) {
 func DownloadNotFound(t *testing.T, handler events.MultipartHandler) {
 	id := session.NewID()
 
-	_, err := handler.StreamSessionRecording(t.Context(), id)
+	_, err := handler.StreamSessionRecording(t.Context(), id, "" /* upload ID */)
 	require.True(t, trace.IsNotFound(err))
 }
 

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -97,10 +97,6 @@ func UploadDownloadSummary(t *testing.T, handler events.MultipartHandler) {
 	_, err = handler.UploadSummary(ctx, id, strings.NewReader("final summary"))
 	require.NoError(t, err)
 
-	// Attempt to overwrite an existing file. This should fail.
-	_, err = handler.UploadSummary(ctx, id, strings.NewReader("impostor"))
-	require.Error(t, err)
-
 	// Download the final version.
 	finalRC, err := handler.StreamSessionSummary(ctx, id)
 	require.NoError(t, err)

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -32,6 +32,7 @@ type UploadHandler interface {
 	// case of success.
 	Upload(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// StreamSessionRecording streams a session recording and returns a ReadCloser for the content.
+	// If uploadID is set, the temporary recording associated with it will be streamed.
 	StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error)
 	// UploadPendingSummary uploads a pending session summary and returns a URL
 	// with uploaded file in case of success. This function can be called

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -32,7 +32,7 @@ type UploadHandler interface {
 	// case of success.
 	Upload(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// StreamSessionRecording streams a session recording and returns a ReadCloser for the content.
-	StreamSessionRecording(ctx context.Context, sessionID session.ID) (io.ReadCloser, error)
+	StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error)
 	// UploadPendingSummary uploads a pending session summary and returns a URL
 	// with uploaded file in case of success. This function can be called
 	// multiple times for a given sessionID to update the state. A pending
@@ -61,6 +61,15 @@ type UploadHandler interface {
 	UploadThumbnail(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// StreamSessionThumbnail streams a session thumbnail and returns a ReadCloser for the content.
 	StreamSessionThumbnail(ctx context.Context, sessionID session.ID) (io.ReadCloser, error)
+	// GetRecordingVersion gets a string representing the current version of the
+	// recording.
+	//
+	// The value of the version string should be considered opaque and
+	// only used for comparisons. If uploadID is empty, this gets the current
+	// recording version; otherwise, this gets the version of the temporary upload
+	// associated with the upload ID, If there is no recording, the version is the
+	// empty string.
+	GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error)
 }
 
 // MultipartHandler handles both multipart and standalone uploads and

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -68,7 +68,7 @@ type UploadHandler interface {
 	// The value of the version string should be considered opaque and
 	// only used for comparisons. If uploadID is empty, this gets the current
 	// recording version; otherwise, this gets the version of the temporary upload
-	// associated with the upload ID, If there is no recording, the version is the
+	// associated with the upload ID. If there is no recording, the version is the
 	// empty string.
 	GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error)
 }

--- a/lib/integrations/externalauditstorage/error_counter.go
+++ b/lib/integrations/externalauditstorage/error_counter.go
@@ -410,8 +410,8 @@ func (c *ErrorCountingSessionHandler) UploadThumbnail(ctx context.Context, sessi
 }
 
 // StreamSessionRecording calls [c.wrapped.StreamSessionRecording] and counts the error or success.
-func (c *ErrorCountingSessionHandler) StreamSessionRecording(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
-	rc, err := c.wrapped.StreamSessionRecording(ctx, sessionID)
+func (c *ErrorCountingSessionHandler) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
+	rc, err := c.wrapped.StreamSessionRecording(ctx, sessionID, uploadID)
 	if err != nil {
 		c.downloads.observe(err)
 		return nil, err
@@ -449,9 +449,14 @@ func (c *ErrorCountingSessionHandler) StreamSessionThumbnail(ctx context.Context
 	return newErrorReportReader(rc, c.downloads), nil
 }
 
+func (c *ErrorCountingSessionHandler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
+	version, err := c.wrapped.GetRecordingVersion(ctx, sessionID, uploadID)
+	return version, trace.Wrap(err)
+}
+
 // CreateUpload calls [c.wrapped.CreateUpload] and counts the error or success.
-func (c *ErrorCountingSessionHandler) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
-	res, err := c.wrapped.CreateUpload(ctx, sessionID)
+func (c *ErrorCountingSessionHandler) CreateUpload(ctx context.Context, sessionID session.ID, opts ...events.CreateUploadOption) (*events.StreamUpload, error) {
+	res, err := c.wrapped.CreateUpload(ctx, sessionID, opts...)
 	c.uploads.observe(err)
 	return res, err
 }
@@ -492,8 +497,8 @@ func (c *ErrorCountingSessionHandler) ListUploads(ctx context.Context) ([]events
 }
 
 // GetUploadMetadata calls [c.wrapped.GetUploadMetadata] and counts the error or success.
-func (c *ErrorCountingSessionHandler) GetUploadMetadata(sessionID session.ID) events.UploadMetadata {
-	return c.wrapped.GetUploadMetadata(sessionID)
+func (c *ErrorCountingSessionHandler) GetUploadMetadata(sessionID session.ID, uploadID string) events.UploadMetadata {
+	return c.wrapped.GetUploadMetadata(sessionID, uploadID)
 }
 
 func sanitizeErrForAlert(err error) string {

--- a/lib/integrations/externalauditstorage/error_counter.go
+++ b/lib/integrations/externalauditstorage/error_counter.go
@@ -449,6 +449,14 @@ func (c *ErrorCountingSessionHandler) StreamSessionThumbnail(ctx context.Context
 	return newErrorReportReader(rc, c.downloads), nil
 }
 
+// GetRecordingVersion gets a string representing the current version of the
+// recording.
+//
+// The value of the version string should be considered opaque and
+// only used for comparisons. If uploadID is empty, this gets the current
+// recording version; otherwise, this gets the version of the temporary upload
+// associated with the upload ID. If there is no recording, the version is the
+// empty string.
 func (c *ErrorCountingSessionHandler) GetRecordingVersion(ctx context.Context, sessionID session.ID, uploadID string) (string, error) {
 	version, err := c.wrapped.GetRecordingVersion(ctx, sessionID, uploadID)
 	return version, trace.Wrap(err)

--- a/lib/integrations/externalauditstorage/error_counter_test.go
+++ b/lib/integrations/externalauditstorage/error_counter_test.go
@@ -71,8 +71,8 @@ func TestErrorCounter(t *testing.T) {
 			steps: []testStep{
 				{
 					action: func(pack *testPack) {
-						pack.errHandler.StreamSessionRecording(ctx, "")
-						pack.successHandler.StreamSessionRecording(ctx, "")
+						pack.errHandler.StreamSessionRecording(ctx, "", "")
+						pack.successHandler.StreamSessionRecording(ctx, "", "")
 					},
 					repeat: 10,
 				},
@@ -387,7 +387,7 @@ func (h *errorHandler) UploadThumbnail(ctx context.Context, sessionID session.ID
 	return "", h.err
 }
 
-func (h *errorHandler) StreamSessionRecording(ctx context.Context, sessionID session.ID) (io.ReadCloser, error) {
+func (h *errorHandler) StreamSessionRecording(ctx context.Context, sessionID session.ID, uploadID string) (io.ReadCloser, error) {
 	return nil, h.err
 }
 
@@ -410,7 +410,7 @@ type bodyErrorHandler struct {
 	events.MultipartHandler
 }
 
-func (h *bodyErrorHandler) StreamSessionRecording(_ context.Context, _ session.ID) (io.ReadCloser, error) {
+func (h *bodyErrorHandler) StreamSessionRecording(_ context.Context, _ session.ID, _ string) (io.ReadCloser, error) {
 	return io.NopCloser(errorReader{h.readErr}), nil
 }
 
@@ -432,7 +432,7 @@ func TestDownloadBodyReadError(t *testing.T) {
 	handler := counter.WrapSessionHandler(&bodyErrorHandler{readErr: readErr})
 
 	for range 4 {
-		rc, err := handler.StreamSessionRecording(ctx, "")
+		rc, err := handler.StreamSessionRecording(ctx, "", "")
 		assert.NoError(t, err, "Download call itself must succeed")
 		_, readErr := io.ReadAll(rc)
 		assert.Error(t, readErr, "reading the body must fail")

--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -699,7 +699,7 @@ func validateSessionRecordingEvents(t *testing.T, testCtx *TestContext, sessionI
 
 	// validate that session recording was correctly uploaded.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		rc, err := testCtx.UploadHandler.StreamSessionRecording(testCtx.Context, sessionpkg.ID(sessionID), "")
+		rc, err := testCtx.UploadHandler.StreamSessionRecording(testCtx.Context, sessionpkg.ID(sessionID), "" /* upload ID */)
 		if assert.NoError(t, err) {
 			rc.Close()
 		}

--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -699,7 +699,7 @@ func validateSessionRecordingEvents(t *testing.T, testCtx *TestContext, sessionI
 
 	// validate that session recording was correctly uploaded.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		rc, err := testCtx.UploadHandler.StreamSessionRecording(testCtx.Context, sessionpkg.ID(sessionID))
+		rc, err := testCtx.UploadHandler.StreamSessionRecording(testCtx.Context, sessionpkg.ID(sessionID), "")
 		if assert.NoError(t, err) {
 			rc.Close()
 		}


### PR DESCRIPTION
This change allows agents to re-upload session recordings if the original upload did not complete. This change only implements the file recording backend; cloud backends will be implemented in separate PRs.

Currently, if an agent goes down midway through uploading a session recording, the upload completer service will complete the upload after a grace period (24 hours). If the agent then comes back on line and tries to resume the upload, it will get an error saying the upload no longer exists (which is true).

With this change, the auth server can detect when an agent is trying to resume a completed upload. Instead of failing, the auth server will create a new temporary upload, which is identical to a regular upload except stored in a different location (for the file backend, `<data-dir>/multi/<upload-id>/<session-id>.temp.tar` instead of the final `<data-dir>/<session-id>.tar`.

In addition to completing abandoned uploads, the upload completer will now check for temporary uploads to be merged (uploads for which both a temporary and final recording exist). The upload completer will stream both recordings and merge the events (sorted by event index) into a new upload that will replace the current recording.

Related: #60981, gravitational/teleport-private#2219

Changelog: Fixed session recording uploads not resuming if an upload is interrupted for a long time

## Manual Test Plan
### Test Environment

Tested on a local cluster for the most part. No special configuration is needed outside of setting session recording mode/encryption for the appropriate cases. For the non-file test, I ran a cluster on a GCP VM with GCS as the session recording backend.

### Procedure

Sorry this one's a little complicated.

On the `atburke/experiment-session-tar` branch I've created a version of `tsh` that can recreate a session tar file from the JSON output of `tsh play -f json`. I've been aliasing it as `tsh-session` and will do so in the following procedure.

1. Set UPLOAD_DIR for convenience:
```sh
UPLOAD_DIR=/var/lib/teleport/log/upload/streaming/default
```
2. Start an ssh session to a node in another terminal or the web UI. Create some print data but DO NOT EXIT.
3. In the original terminal, write but DO NOT RUN:
```sh
mv $UPLOAD_DIR/*.tar ./
```
4. In quick succession, exit the ssh session and run the mv command. Ensure that `<session-id>.tar` made it into your working directory.
5. Run the following to create a "butchered" session and place it back in the upload directory:
```sh
SESSION_ID=$(basename *.tar .tar) && \
tsh-session play -f json $SESSION_ID.tar | head -n 50 > session_partial.json && \
tsh-session play -f tar session_partial.json > $UPLOAD_DIR/$SESSION_ID.tar
```
6. Wait for the uploader to run. Eventually you should be able to see and play back the truncated recording.
```
tsh play $SESSION_ID
```
7. Copy the original recording into the upload directory:
```sh
cp $SESSION_ID.tar $UPLOAD_DIR/
```
8. Wait for the uploader to run. Eventually you should be able to see and play back the complete recording.
```
tsh play $SESSION_ID
```

### Test Cases

- [x] Run the above procedure
  - [x] `node` recording mode
  - [x] `proxy` recording mode
  - [x] Verify that session metadata/thumbnails are updated when the recording is updated
  - [ ] Verify that session summaries are updated when the recording is updated
- [x] Run a session normally and ensure I didn't break anything
  - [x] `node-sync` recording mode
  - [x] `proxy-sync` recording mode
  - [x] encrypted session recordings
  - [x] Non-file recording backend
