### PR TITLE
Implement Azure wildcard subscription join rule

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -874,7 +874,9 @@ type Azure struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// A list of Rules for allowing use of this token. A node must match at least one
 	// allow rule in order to use this token.
-	Allow         []*Azure_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	Allow []*Azure_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// Integration name which provides credentials for validating join attempts.
+	Integration   string `protobuf:"bytes,2,opt,name=integration,proto3" json:"integration,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -914,6 +916,13 @@ func (x *Azure) GetAllow() []*Azure_Rule {
 		return x.Allow
 	}
 	return nil
+}
+
+func (x *Azure) GetIntegration() string {
+	if x != nil {
+		return x.Integration
+	}
+	return ""
 }
 
 // The Azure Devops-specific configuration used with the "azure_devops" join method.
@@ -1741,9 +1750,10 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\vproject_ids\x18\x01 \x03(\tR\n" +
 	"projectIds\x12\x1c\n" +
 	"\tlocations\x18\x02 \x03(\tR\tlocations\x12)\n" +
-	"\x10service_accounts\x18\x03 \x03(\tR\x0fserviceAccounts\"\x9a\x01\n" +
+	"\x10service_accounts\x18\x03 \x03(\tR\x0fserviceAccounts\"\xbc\x01\n" +
 	"\x05Azure\x12<\n" +
-	"\x05allow\x18\x01 \x03(\v2&.teleport.scopes.joining.v1.Azure.RuleR\x05allow\x1aS\n" +
+	"\x05allow\x18\x01 \x03(\v2&.teleport.scopes.joining.v1.Azure.RuleR\x05allow\x12 \n" +
+	"\vintegration\x18\x02 \x01(\tR\vintegration\x1aS\n" +
 	"\x04Rule\x12\"\n" +
 	"\fsubscription\x18\x01 \x01(\tR\fsubscription\x12'\n" +
 	"\x0fresource_groups\x18\x02 \x03(\tR\x0eresourceGroups\"\x9e\x03\n" +

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -1265,6 +1265,8 @@ func (x *GCP_Rule) GetServiceAccounts() []string {
 type Azure_Rule struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The Azure subscription.
+	// It supports wildcard "*", which will allow all Azure subscriptions that
+	// the Auth Service can list (Microsoft.Resources/subscriptions/read permission).
 	Subscription string `protobuf:"bytes,1,opt,name=subscription,proto3" json:"subscription,omitempty"`
 	// A list of Azure resource groups the node is allowed to join from.
 	ResourceGroups []string `protobuf:"bytes,2,rep,name=resource_groups,json=resourceGroups,proto3" json:"resource_groups,omitempty"`

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -1897,6 +1897,8 @@ message ProvisionTokenSpecV2Azure {
   // allowed to use this ProvisionToken.
   message Rule {
     // Subscription is the Azure subscription.
+    // It supports wildcard "*", which will allow all Azure subscriptions that
+    // the Auth Service can list (Microsoft.Resources/subscriptions/read permission).
     string Subscription = 1 [(gogoproto.jsontag) = "subscription,omitempty"];
     // ResourceGroups is a list of Azure resource groups the node is allowed
     // to join from.
@@ -9193,6 +9195,8 @@ message AzureInstallerParams {
 // It defines which resource types, filters and some configuration params.
 message AzureMatcher {
   // Subscriptions are Azure subscriptions to query for resources.
+  // It supports wildcard "*", which will discover resources in all Azure
+  // subscriptions that the Discovery Service can list (Microsoft.Resources/subscriptions/read permission).
   repeated string Subscriptions = 1 [(gogoproto.jsontag) = "subscriptions,omitempty"];
   // ResourceGroups are Azure resource groups to query for resources.
   repeated string ResourceGroups = 2 [(gogoproto.jsontag) = "resource_groups,omitempty"];

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -240,6 +240,9 @@ message Azure {
   // A list of Rules for allowing use of this token. A node must match at least one
   // allow rule in order to use this token.
   repeated Rule allow = 1;
+
+  // Integration name which provides credentials for validating join attempts.
+  string integration = 2;
 }
 
 // The Azure Devops-specific configuration used with the "azure_devops" join method.

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -233,6 +233,8 @@ message Azure {
   // with the "azure" join method.
   message Rule {
     // The Azure subscription.
+    // It supports wildcard "*", which will allow all Azure subscriptions that
+    // the Auth Service can list (Microsoft.Resources/subscriptions/read permission).
     string subscription = 1;
     // A list of Azure resource groups the node is allowed to join from.
     repeated string resource_groups = 2;

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -151,7 +151,7 @@ type ProvisionToken interface {
 	// SetAllowRules sets the allow rules
 	SetAllowRules([]*TokenRule)
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.
-	// Currently, this is only used to validate the AWS Organization.
+	// Currently, this is only used to validate the AWS Organization and Azure subscriptions.
 	GetIntegration() string
 	// GetGCPRules will return the GCP rules within this token.
 	GetGCPRules() *ProvisionTokenSpecV2GCP
@@ -653,7 +653,7 @@ func (p *ProvisionTokenV2) GetSuggestedAgentMatcherLabels() Labels {
 }
 
 // GetIntegration returns the integration name that provides credentials to validate allow rules.
-// Currently, this is only used to validate the AWS Organization.
+// Currently, this is only used to validate the AWS Organization and Azure subscriptions.
 func (p *ProvisionTokenV2) GetIntegration() string {
 	return p.Spec.Integration
 }

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -6073,6 +6073,8 @@ var xxx_messageInfo_ProvisionTokenSpecV2Azure proto.InternalMessageInfo
 // allowed to use this ProvisionToken.
 type ProvisionTokenSpecV2Azure_Rule struct {
 	// Subscription is the Azure subscription.
+	// It supports wildcard "*", which will allow all Azure subscriptions that
+	// the Auth Service can list (Microsoft.Resources/subscriptions/read permission).
 	Subscription string `protobuf:"bytes,1,opt,name=Subscription,proto3" json:"subscription,omitempty"`
 	// ResourceGroups is a list of Azure resource groups the node is allowed
 	// to join from.
@@ -24282,6 +24284,8 @@ var xxx_messageInfo_AzureInstallerParams proto.InternalMessageInfo
 // It defines which resource types, filters and some configuration params.
 type AzureMatcher struct {
 	// Subscriptions are Azure subscriptions to query for resources.
+	// It supports wildcard "*", which will discover resources in all Azure
+	// subscriptions that the Discovery Service can list (Microsoft.Resources/subscriptions/read permission).
 	Subscriptions []string `protobuf:"bytes,1,rep,name=Subscriptions,proto3" json:"subscriptions,omitempty"`
 	// ResourceGroups are Azure resource groups to query for resources.
 	ResourceGroups []string `protobuf:"bytes,2,rep,name=ResourceGroups,proto3" json:"resource_groups,omitempty"`

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
@@ -65,6 +65,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |allow|[][object](#specazureallow-items)|A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token.|
+|integration|string|Integration name which provides credentials for validating join attempts.|
 
 ### spec.azure.allow items
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
@@ -507,7 +507,7 @@ integration: "string"
 |integration|The integration name used to generate credentials to interact with Azure APIs. Environment credentials will not be used when this value is set.|string|
 |regions|Azure locations to match for databases.|[]string|
 |resource_groups|Azure resource groups to query for resources.|[]string|
-|subscriptions|Azure subscriptions to query for resources.|[]string|
+|subscriptions|Azure subscriptions to query for resources. It supports wildcard "*", which will discover resources in all Azure subscriptions that the Discovery Service can list (Microsoft.Resources/subscriptions/read permission).|[]string|
 |tags|Azure tags on resources to match.|[Labels](#labels)|
 |types|Azure types to match: "mysql", "postgres", "aks", "vm"|[]string|
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/discovery_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/discovery_config.mdx
@@ -206,7 +206,7 @@ Optional:
 - `integration` (String) Integration is the integration name used to generate credentials to interact with Azure APIs. Environment credentials will not be used when this value is set.
 - `regions` (List of String) Regions are Azure locations to match for databases.
 - `resource_groups` (List of String) ResourceGroups are Azure resource groups to query for resources.
-- `subscriptions` (List of String) Subscriptions are Azure subscriptions to query for resources.
+- `subscriptions` (List of String) Subscriptions are Azure subscriptions to query for resources. It supports wildcard "*", which will discover resources in all Azure subscriptions that the Discovery Service can list (Microsoft.Resources/subscriptions/read permission).
 - `tags` (Map of List of String) ResourceTags are Azure tags on resources to match.
 - `types` (List of String) Types are Azure types to match: "mysql", "postgres", "aks", "vm"
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
@@ -84,7 +84,7 @@ Optional:
 Optional:
 
 - `resource_groups` (List of String) ResourceGroups is a list of Azure resource groups the node is allowed to join from.
-- `subscription` (String) Subscription is the Azure subscription.
+- `subscription` (String) Subscription is the Azure subscription. It supports wildcard "*", which will allow all Azure subscriptions that the Auth Service can list (Microsoft.Resources/subscriptions/read permission).
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -89,6 +89,7 @@ Optional:
 Optional:
 
 - `allow` (Attributes List) A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token. (see [below for nested schema](#nested-schema-for-specazureallow))
+- `integration` (String) Integration name which provides credentials for validating join attempts.
 
 ### Nested Schema for `spec.azure.allow`
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -96,7 +96,7 @@ Optional:
 Optional:
 
 - `resource_groups` (List of String) A list of Azure resource groups the node is allowed to join from.
-- `subscription` (String) The Azure subscription.
+- `subscription` (String) The Azure subscription. It supports wildcard "*", which will allow all Azure subscriptions that the Auth Service can list (Microsoft.Resources/subscriptions/read permission).
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx
@@ -282,7 +282,7 @@ Optional:
 - `integration` (String) Integration is the integration name used to generate credentials to interact with Azure APIs. Environment credentials will not be used when this value is set.
 - `regions` (List of String) Regions are Azure locations to match for databases.
 - `resource_groups` (List of String) ResourceGroups are Azure resource groups to query for resources.
-- `subscriptions` (List of String) Subscriptions are Azure subscriptions to query for resources.
+- `subscriptions` (List of String) Subscriptions are Azure subscriptions to query for resources. It supports wildcard "*", which will discover resources in all Azure subscriptions that the Discovery Service can list (Microsoft.Resources/subscriptions/read permission).
 - `tags` (Map of List of String) ResourceTags are Azure tags on resources to match.
 - `types` (List of String) Types are Azure types to match: "mysql", "postgres", "aks", "vm"
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
@@ -120,7 +120,7 @@ Optional:
 Optional:
 
 - `resource_groups` (List of String) ResourceGroups is a list of Azure resource groups the node is allowed to join from.
-- `subscription` (String) Subscription is the Azure subscription.
+- `subscription` (String) Subscription is the Azure subscription. It supports wildcard "*", which will allow all Azure subscriptions that the Auth Service can list (Microsoft.Resources/subscriptions/read permission).
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -133,6 +133,7 @@ Optional:
 Optional:
 
 - `allow` (Attributes List) A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token. (see [below for nested schema](#nested-schema-for-specazureallow))
+- `integration` (String) Integration name which provides credentials for validating join attempts.
 
 ### Nested Schema for `spec.azure.allow`
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -140,7 +140,7 @@ Optional:
 Optional:
 
 - `resource_groups` (List of String) A list of Azure resource groups the node is allowed to join from.
-- `subscription` (String) The Azure subscription.
+- `subscription` (String) The Azure subscription. It supports wildcard "*", which will allow all Azure subscriptions that the Auth Service can list (Microsoft.Resources/subscriptions/read permission).
 
 
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -100,6 +100,10 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  integration:
+                    description: Integration name which provides credentials for validating
+                      join attempts.
+                    type: string
                 type: object
               azure_devops:
                 description: The Azure Devops-specific configuration used with the

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -100,6 +100,10 @@ spec:
                       type: object
                     nullable: true
                     type: array
+                  integration:
+                    description: Integration name which provides credentials for validating
+                      join attempts.
+                    type: string
                 type: object
               azure_devops:
                 description: The Azure Devops-specific configuration used with the

--- a/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
+++ b/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
@@ -491,7 +491,7 @@ func GenSchemaDiscoveryConfig(ctx context.Context) (github_com_hashicorp_terrafo
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},
 						"subscriptions": {
-							Description: "Subscriptions are Azure subscriptions to query for resources.",
+							Description: "Subscriptions are Azure subscriptions to query for resources. It supports wildcard \"*\", which will discover resources in all Azure subscriptions that the Discovery Service can list (Microsoft.Resources/subscriptions/read permission).",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 						},

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -161,22 +161,29 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 					Optional:    true,
 				},
 				"azure": {
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"allow": {
-						Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-							"resource_groups": {
-								Description: "A list of Azure resource groups the node is allowed to join from.",
-								Optional:    true,
-								Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
-							},
-							"subscription": {
-								Description: "The Azure subscription.",
-								Optional:    true,
-								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-							},
-						}),
-						Description: "A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token.",
-						Optional:    true,
-					}}),
+					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"allow": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"resource_groups": {
+									Description: "A list of Azure resource groups the node is allowed to join from.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+								},
+								"subscription": {
+									Description: "The Azure subscription.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+							}),
+							Description: "A list of Rules for allowing use of this token. A node must match at least one allow rule in order to use this token.",
+							Optional:    true,
+						},
+						"integration": {
+							Description: "Integration name which provides credentials for validating join attempts.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+					}),
 					Description: "The Azure-specific configuration used with the \"azure\" join method.",
 					Optional:    true,
 				},
@@ -1094,6 +1101,23 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 														}
 													}
 												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["integration"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.azure.integration"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.azure.integration", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.Integration = t
 											}
 										}
 									}
@@ -2804,6 +2828,28 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 												c.Unknown = false
 												tf.Attrs["allow"] = c
 											}
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["integration"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.azure.integration"})
+										} else {
+											v, ok := tf.Attrs["integration"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedToken.spec.azure.integration", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.azure.integration", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.Integration) == ""
+											}
+											v.Value = string(obj.Integration)
+											v.Unknown = false
+											tf.Attrs["integration"] = v
 										}
 									}
 								}

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -170,7 +170,7 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 								},
 								"subscription": {
-									Description: "The Azure subscription.",
+									Description: "The Azure subscription. It supports wildcard \"*\", which will allow all Azure subscriptions that the Auth Service can list (Microsoft.Resources/subscriptions/read permission).",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -1261,7 +1261,7 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 								Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 							},
 							"subscription": {
-								Description: "Subscription is the Azure subscription.",
+								Description: "Subscription is the Azure subscription. It supports wildcard \"*\", which will allow all Azure subscriptions that the Auth Service can list (Microsoft.Resources/subscriptions/read permission).",
 								Optional:    true,
 								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 							},

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -108,6 +108,7 @@ import (
 	"github.com/gravitational/teleport/lib/cache"
 	inventorycache "github.com/gravitational/teleport/lib/cache/inventory"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/decision"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -116,6 +117,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
+	"github.com/gravitational/teleport/lib/integrations/azureoidc"
 	"github.com/gravitational/teleport/lib/inventory"
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/join"
@@ -889,6 +891,41 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		as.env0IDTokenValidator = validator
 	}
 
+	if as.azureJoinConfig == nil {
+		azureClientCache, err := utils.NewFnCache(utils.FnCacheConfig{
+			TTL:   time.Minute * 15,
+			Clock: as.clock,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		as.azureJoinConfig = &azurejoin.AzureJoinConfig{
+			GetSubscriptionClient: func(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
+				// For Azure join flow, the join token might allow wildcard
+				// subscriptions which requires listing the Azure subscriptions
+				// to check that a VM is allowed to join the cluster.
+				// This requires Azure credentials to be accessible to Auth.
+				// The credentials can come from an integration or from ambient
+				// credentials, when an integration is not specified in the join
+				// token.
+				//
+				// Using ambient credentials when the Auth Service is running
+				// within Teleport Cloud is not supported.
+				// In that scenario a NotImplemented error is returned.
+				if integration == "" && modules.GetModules().Features().Cloud {
+					return nil, trace.NotImplemented("Azure subscriptions cannot be listed on Teleport Cloud without an Azure OIDC integration included in the join token spec")
+				}
+				azureClients, err := as.getAzureClients(ctx, azureClientCache, integration)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+				subClient, err := azureClients.GetSubscriptionClient(ctx)
+				return subClient, trace.Wrap(err)
+			},
+		}
+	}
+
 	// Add in a login hook for generating state during user login.
 	as.ulsGenerator, err = userloginstate.NewGenerator(userloginstate.GeneratorConfig{
 		Log:         as.logger,
@@ -1023,11 +1060,13 @@ func (r *Services) GetWebSession(ctx context.Context, req types.GetWebSessionReq
 }
 
 // GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
+// TODO(gavin): this function appears to be unused and should be removed.
 func (r *Services) GenerateAWSOIDCToken(ctx context.Context, integration string) (string, error) {
 	return r.IntegrationsTokenGenerator.GenerateAWSOIDCToken(ctx, integration)
 }
 
 // GenerateAzureOIDCToken generates a token to be used to execute an Azure OIDC Integration action.
+// TODO(gavin): this function appears to be unused and should be removed.
 func (r *Services) GenerateAzureOIDCToken(ctx context.Context, integration string) (string, error) {
 	return r.IntegrationsTokenGenerator.GenerateAzureOIDCToken(ctx, integration)
 }
@@ -1731,6 +1770,15 @@ func (a *Server) GenerateAWSOIDCToken(ctx context.Context, integration string) (
 		Subject:     types.IntegrationAWSOIDCSubjectAuth,
 		Clock:       a.clock,
 	})
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return token, nil
+}
+
+// GenerateAzureOIDCToken generates a token to be used to execute an Azure OIDC Integration action.
+func (a *Server) GenerateAzureOIDCToken(ctx context.Context, integration string) (string, error) {
+	token, err := azureoidc.GenerateEntraOIDCToken(ctx, a, a.GetKeyStore(), a.clock)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -8814,4 +8862,20 @@ func (s *Server) DownloadSummary(ctx context.Context, sessionID session.ID, writ
 	defer reader.Close()
 	_, err = io.Copy(writer, reader)
 	return trace.Wrap(err)
+}
+
+func (s *Server) getAzureClients(ctx context.Context, cache *utils.FnCache, integration string) (azure.Clients, error) {
+	clients, err := utils.FnCacheGet(ctx, cache, integration,
+		func(ctx context.Context) (azure.Clients, error) {
+			var opts []azure.ClientsOption
+			if integration != "" {
+				opts = append(opts, azure.WithIntegrationCredentials(integration, s))
+			}
+			clients, err := azure.NewClients(opts...)
+			return clients, trace.Wrap(err)
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return clients, nil
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -892,8 +892,9 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 
 	if as.azureClientCache == nil {
 		azureClientCache, err := utils.NewFnCache(utils.FnCacheConfig{
-			TTL:   1 * time.Minute,
-			Clock: as.clock,
+			TTL:         1 * time.Minute,
+			Clock:       as.clock,
+			ReloadOnErr: true,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -108,7 +108,6 @@ import (
 	"github.com/gravitational/teleport/lib/cache"
 	inventorycache "github.com/gravitational/teleport/lib/cache/inventory"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
-	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/decision"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -891,39 +890,15 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		as.env0IDTokenValidator = validator
 	}
 
-	if as.azureJoinConfig == nil {
+	if as.azureClientCache == nil {
 		azureClientCache, err := utils.NewFnCache(utils.FnCacheConfig{
-			TTL:   time.Minute * 15,
+			TTL:   1 * time.Minute,
 			Clock: as.clock,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		as.azureJoinConfig = &azurejoin.AzureJoinConfig{
-			GetSubscriptionClient: func(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
-				// For Azure join flow, the join token might allow wildcard
-				// subscriptions which requires listing the Azure subscriptions
-				// to check that a VM is allowed to join the cluster.
-				// This requires Azure credentials to be accessible to Auth.
-				// The credentials can come from an integration or from ambient
-				// credentials, when an integration is not specified in the join
-				// token.
-				//
-				// Using ambient credentials when the Auth Service is running
-				// within Teleport Cloud is not supported.
-				// In that scenario a NotImplemented error is returned.
-				if integration == "" && modules.GetModules().Features().Cloud {
-					return nil, trace.NotImplemented("Azure subscriptions cannot be listed on Teleport Cloud without an Azure OIDC integration included in the join token spec")
-				}
-				azureClients, err := as.getAzureClients(ctx, azureClientCache, integration)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				subClient, err := azureClients.GetSubscriptionClient(ctx)
-				return subClient, trace.Wrap(err)
-			},
-		}
+		as.azureClientCache = azureClientCache
 	}
 
 	// Add in a login hook for generating state during user login.
@@ -1450,8 +1425,12 @@ type Server struct {
 	// override the implementation used in tests.
 	env0IDTokenValidator join.Env0TokenValidator
 
-	// azureJoinConfig holds configuration for the Azure join method.
-	azureJoinConfig *azurejoin.AzureJoinConfig
+	// azureJoinConfigOverride holds configuration for the Azure join method.
+	// Only used for overriding Azure join config in tests.
+	azureJoinConfigOverride *azurejoin.AzureJoinConfig
+
+	// azureClientCache is used to cache Azure clients.
+	azureClientCache *utils.FnCache
 
 	// loadAllCAs tells tsh to load the host CAs for all clusters when trying to ssh into a node.
 	loadAllCAs bool
@@ -8862,20 +8841,4 @@ func (s *Server) DownloadSummary(ctx context.Context, sessionID session.ID, writ
 	defer reader.Close()
 	_, err = io.Copy(writer, reader)
 	return trace.Wrap(err)
-}
-
-func (s *Server) getAzureClients(ctx context.Context, cache *utils.FnCache, integration string) (azure.Clients, error) {
-	clients, err := utils.FnCacheGet(ctx, cache, integration,
-		func(ctx context.Context) (azure.Clients, error) {
-			var opts []azure.ClientsOption
-			if integration != "" {
-				opts = append(opts, azure.WithIntegrationCredentials(integration, s))
-			}
-			clients, err := azure.NewClients(opts...)
-			return clients, trace.Wrap(err)
-		})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return clients, nil
 }

--- a/lib/auth/join_azure_legacy.go
+++ b/lib/auth/join_azure_legacy.go
@@ -20,7 +20,6 @@ package auth
 
 import (
 	"context"
-	"sync"
 
 	"github.com/gravitational/trace"
 
@@ -135,11 +134,9 @@ func (a *Server) GetAzureJoinConfig() *azurejoin.AzureJoinConfig {
 			if integration == "" && modules.GetModules().Features().Cloud {
 				return nil, trace.NotImplemented("Azure subscriptions cannot be listed on Teleport Cloud without an Azure OIDC integration included in the join token spec")
 			}
-			subClient, err := a.getAzureSubscriptionClient(ctx, integration)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return subClient, nil
+			return azureSubscriptionClientFunc(func(ctx context.Context) ([]string, error) {
+				return a.listAzureSubscriptionIDs(ctx, integration)
+			}), nil
 		},
 	}
 }
@@ -151,9 +148,27 @@ func (a *Server) SetAzureJoinConfig(c *azurejoin.AzureJoinConfig) {
 	a.azureJoinConfigOverride = c
 }
 
-func (a *Server) getAzureSubscriptionClient(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
-	subClient, err := utils.FnCacheGet(ctx, a.azureClientCache, integration,
-		func(ctx context.Context) (azure.SubscriptionClient, error) {
+type azureSubscriptionClientFunc func(ctx context.Context) ([]string, error)
+
+func (fn azureSubscriptionClientFunc) ListSubscriptionIDs(ctx context.Context) ([]string, error) {
+	return fn(ctx)
+}
+
+type azureClientCacheKey struct {
+	// api is the name of the Azure API call that is being cached.
+	api string
+	// integration is the name of the Teleport integration that is used for
+	// credentials. It is empty if using ambient credentials.
+	integration string
+}
+
+func newListAzureSubscriptionIDsCacheKey(integration string) azureClientCacheKey {
+	return azureClientCacheKey{api: "ListSubscriptionIDs", integration: integration}
+}
+
+func (a *Server) listAzureSubscriptionIDs(ctx context.Context, integration string) ([]string, error) {
+	subscriptions, err := utils.FnCacheGet(ctx, a.azureClientCache, newListAzureSubscriptionIDsCacheKey(integration),
+		func(ctx context.Context) ([]string, error) {
 			var opts []azure.ClientsOption
 			if integration != "" {
 				opts = append(opts, azure.WithIntegrationCredentials(integration, a))
@@ -166,29 +181,8 @@ func (a *Server) getAzureSubscriptionClient(ctx context.Context, integration str
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			return &listSubscriptionsOnceClient{subClient: subClient}, nil
+			subscriptions, err := subClient.ListSubscriptionIDs(ctx)
+			return subscriptions, trace.Wrap(err)
 		})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return subClient, nil
-}
-
-// listSubscriptionsOnceClient performs ListSubscriptionIDs only once and caches
-// the result for all future calls. It can be returned from a TTL cache to
-// provide Azure API response caching with a TTL.
-type listSubscriptionsOnceClient struct {
-	subClient azure.SubscriptionClient
-
-	listOnce      sync.Once
-	subscriptions []string
-	err           error
-}
-
-func (c *listSubscriptionsOnceClient) ListSubscriptionIDs(ctx context.Context) ([]string, error) {
-	c.listOnce.Do(func() {
-		subs, err := c.subClient.ListSubscriptionIDs(ctx)
-		c.subscriptions, c.err = subs, trace.Wrap(err)
-	})
-	return c.subscriptions, c.err
+	return subscriptions, trace.Wrap(err)
 }

--- a/lib/auth/join_azure_legacy.go
+++ b/lib/auth/join_azure_legacy.go
@@ -113,8 +113,8 @@ func (a *Server) RegisterUsingAzureMethod(
 
 // GetAzureJoinConfig gets configuration options for azure joining.
 func (a *Server) GetAzureJoinConfig() *azurejoin.AzureJoinConfig {
-	a.lock.Lock()
-	defer a.lock.Unlock()
+	a.lock.RLock()
+	defer a.lock.RUnlock()
 	if a.azureJoinConfigOverride != nil {
 		return a.azureJoinConfigOverride
 	}

--- a/lib/auth/join_azure_legacy.go
+++ b/lib/auth/join_azure_legacy.go
@@ -20,6 +20,7 @@ package auth
 
 import (
 	"context"
+	"sync"
 
 	"github.com/gravitational/trace"
 
@@ -27,8 +28,11 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/join/azurejoin"
 	"github.com/gravitational/teleport/lib/join/legacyjoin"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // RegisterUsingAzureMethod registers the caller using the Azure join method
@@ -110,10 +114,81 @@ func (a *Server) RegisterUsingAzureMethod(
 
 // GetAzureJoinConfig gets configuration options for azure joining.
 func (a *Server) GetAzureJoinConfig() *azurejoin.AzureJoinConfig {
-	return a.azureJoinConfig
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	if a.azureJoinConfigOverride != nil {
+		return a.azureJoinConfigOverride
+	}
+	return &azurejoin.AzureJoinConfig{
+		GetSubscriptionClient: func(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
+			// For Azure join flow, the join token might allow wildcard
+			// subscriptions which requires listing the Azure subscriptions
+			// to check that a VM is allowed to join the cluster.
+			// This requires Azure credentials to be accessible to Auth.
+			// The credentials can come from an integration or from ambient
+			// credentials, when an integration is not specified in the join
+			// token.
+			//
+			// Using ambient credentials when the Auth Service is running
+			// within Teleport Cloud is not supported.
+			// In that scenario a NotImplemented error is returned.
+			if integration == "" && modules.GetModules().Features().Cloud {
+				return nil, trace.NotImplemented("Azure subscriptions cannot be listed on Teleport Cloud without an Azure OIDC integration included in the join token spec")
+			}
+			subClient, err := a.getAzureSubscriptionClient(ctx, integration)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return subClient, nil
+		},
+	}
 }
 
 // SetAzureJoinConfig sets configuration options for azure joining.
 func (a *Server) SetAzureJoinConfig(c *azurejoin.AzureJoinConfig) {
-	a.azureJoinConfig = c
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	a.azureJoinConfigOverride = c
+}
+
+func (a *Server) getAzureSubscriptionClient(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
+	subClient, err := utils.FnCacheGet(ctx, a.azureClientCache, integration,
+		func(ctx context.Context) (azure.SubscriptionClient, error) {
+			var opts []azure.ClientsOption
+			if integration != "" {
+				opts = append(opts, azure.WithIntegrationCredentials(integration, a))
+			}
+			clients, err := azure.NewClients(opts...)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			subClient, err := clients.GetSubscriptionClient(ctx)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &listSubscriptionsOnceClient{subClient: subClient}, nil
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return subClient, nil
+}
+
+// listSubscriptionsOnceClient performs ListSubscriptionIDs only once and caches
+// the result for all future calls. It can be returned from a TTL cache to
+// provide Azure API response caching with a TTL.
+type listSubscriptionsOnceClient struct {
+	subClient azure.SubscriptionClient
+
+	listOnce      sync.Once
+	subscriptions []string
+	err           error
+}
+
+func (c *listSubscriptionsOnceClient) ListSubscriptionIDs(ctx context.Context) ([]string, error) {
+	c.listOnce.Do(func() {
+		subs, err := c.subClient.ListSubscriptionIDs(ctx)
+		c.subscriptions, c.err = subs, trace.Wrap(err)
+	})
+	return c.subscriptions, c.err
 }

--- a/lib/auth/services.go
+++ b/lib/auth/services.go
@@ -52,7 +52,7 @@ type Services struct {
 	services.ConnectionsDiagnostic
 	services.Status
 	services.Integrations
-	services.IntegrationsTokenGenerator
+	services.IntegrationsTokenGenerator // TODO(gavin): remove this field, it is only set in tests and does not appear to do anything
 	services.UserTasks
 	services.DiscoveryConfigs
 	services.Okta

--- a/lib/cloud/azure/azuretest/azure.go
+++ b/lib/cloud/azure/azuretest/azure.go
@@ -30,7 +30,7 @@ type Clients struct {
 	AzureMySQLPerSub        map[string]azure.DBServersClient
 	AzurePostgres           azure.DBServersClient
 	AzurePostgresPerSub     map[string]azure.DBServersClient
-	AzureSubscriptionClient *azure.SubscriptionClient
+	AzureSubscriptionClient azure.SubscriptionClient
 	AzureRedis              azure.RedisClient
 	AzureRedisEnterprise    azure.RedisEnterpriseClient
 	AzureAKSClientPerSub    map[string]azure.AKSClient
@@ -75,7 +75,7 @@ func (c *Clients) GetKubernetesClient(ctx context.Context, subscription string) 
 }
 
 // GetSubscriptionClient returns an Azure SubscriptionClient
-func (c *Clients) GetSubscriptionClient(ctx context.Context) (*azure.SubscriptionClient, error) {
+func (c *Clients) GetSubscriptionClient(ctx context.Context) (azure.SubscriptionClient, error) {
 	return c.AzureSubscriptionClient, nil
 }
 

--- a/lib/cloud/azure/clients.go
+++ b/lib/cloud/azure/clients.go
@@ -43,7 +43,7 @@ type Clients interface {
 	// GetPostgresClient returns Azure Postgres client for the specified subscription.
 	GetPostgresClient(ctx context.Context, subscription string) (DBServersClient, error)
 	// GetSubscriptionClient returns an Azure Subscriptions client
-	GetSubscriptionClient(ctx context.Context) (*SubscriptionClient, error)
+	GetSubscriptionClient(ctx context.Context) (SubscriptionClient, error)
 	// GetRedisClient returns an Azure Redis client for the given subscription.
 	GetRedisClient(ctx context.Context, subscription string) (RedisClient, error)
 	// GetRedisEnterpriseClient returns an Azure Redis Enterprise client for the given subscription.
@@ -164,7 +164,7 @@ type clients struct {
 
 	mySQLClients               map[string]DBServersClient
 	postgresClients            map[string]DBServersClient
-	subscriptionsClient        *SubscriptionClient
+	subscriptionsClient        SubscriptionClient
 	redisClients               ClientMap[RedisClient]
 	redisEnterpriseClients     ClientMap[RedisEnterpriseClient]
 	kubernetesClient           map[string]AKSClient
@@ -210,7 +210,7 @@ func (c *clients) GetPostgresClient(ctx context.Context, subscription string) (D
 }
 
 // GetSubscriptionClient returns an Azure client for listing subscriptions.
-func (c *clients) GetSubscriptionClient(ctx context.Context) (*SubscriptionClient, error) {
+func (c *clients) GetSubscriptionClient(ctx context.Context) (SubscriptionClient, error) {
 	c.mtx.RLock()
 	if c.subscriptionsClient != nil {
 		defer c.mtx.RUnlock()
@@ -334,7 +334,7 @@ func (c *clients) initPostgresClient(ctx context.Context, subscription string) (
 	return client, nil
 }
 
-func (c *clients) initSubscriptionsClient(ctx context.Context) (*SubscriptionClient, error) {
+func (c *clients) initSubscriptionsClient(ctx context.Context) (SubscriptionClient, error) {
 	cred, err := c.GetCredential(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/cloud/azure/subscriptions.go
+++ b/lib/cloud/azure/subscriptions.go
@@ -34,18 +34,24 @@ type ARMSubscriptions interface {
 
 var _ ARMSubscriptions = (*armsubscription.SubscriptionsClient)(nil)
 
-// SubscriptionClient wraps the Azure SubscriptionsAPI to fetch subscription IDs.
-type SubscriptionClient struct {
+// subscriptionClient wraps the Azure SubscriptionsAPI to fetch subscription IDs.
+type subscriptionClient struct {
 	api ARMSubscriptions
 }
 
+// SubscriptionClient is an Azure subscriptions client.
+type SubscriptionClient interface {
+	// ListSubscriptionIDs lists all subscription IDs using the Azure Subscription API.
+	ListSubscriptionIDs(ctx context.Context) ([]string, error)
+}
+
 // NewSubscriptionClient returns a SubscriptionsClient.
-func NewSubscriptionClient(api ARMSubscriptions) *SubscriptionClient {
-	return &SubscriptionClient{api: api}
+func NewSubscriptionClient(api ARMSubscriptions) SubscriptionClient {
+	return &subscriptionClient{api: api}
 }
 
 // ListSubscriptionIDs lists all subscription IDs using the Azure Subscription API.
-func (c *SubscriptionClient) ListSubscriptionIDs(ctx context.Context) ([]string, error) {
+func (c *subscriptionClient) ListSubscriptionIDs(ctx context.Context) ([]string, error) {
 	pagerOpts := &armsubscription.SubscriptionsClientListOptions{}
 	pager := c.api.NewListPager(pagerOpts)
 	subIDs := []string{}

--- a/lib/join/azurejoin/azure.go
+++ b/lib/join/azurejoin/azure.go
@@ -38,6 +38,7 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/join/joinutils"
@@ -129,6 +130,15 @@ type AzureVerifyTokenFunc func(ctx context.Context, rawIDToken string) (*AccessT
 // given subscription authenticated with a given static token credential.
 type VMClientGetter func(subscriptionID string, token *azure.StaticCredential) (azure.VirtualMachinesClient, error)
 
+// SubscriptionClient is an Azure subscriptions client.
+type SubscriptionClient interface {
+	// ListSubscriptionIDs lists all subscription IDs using the Azure Subscription API.
+	ListSubscriptionIDs(ctx context.Context) ([]string, error)
+}
+
+// SubscriptionClientGetter returns an Azure subscription client.
+type SubscriptionClientGetter func(ctx context.Context, integration string) (azure.SubscriptionClient, error)
+
 // AzureJoinConfig holds configurable options for Azure joining.
 type AzureJoinConfig struct {
 	// CertificateAuthorities, if set, overrides the root certificate
@@ -142,6 +152,9 @@ type AzureJoinConfig struct {
 	// fetch the intermediate CA which issued the attested data document
 	// signing certificate.
 	IssuerHTTPClient utils.HTTPDoClient
+	// GetAzureClients returns [AzureClients] for the given integration name.
+	// If the integration name is the empty string, then ambient credentials will be used instead.
+	GetSubscriptionClient SubscriptionClientGetter
 }
 
 func azureVerifyFuncFromOIDCVerifier(clientID string) AzureVerifyTokenFunc {
@@ -164,6 +177,10 @@ func azureVerifyFuncFromOIDCVerifier(clientID string) AzureVerifyTokenFunc {
 }
 
 func (cfg *AzureJoinConfig) checkAndSetDefaults() error {
+	if cfg.GetSubscriptionClient == nil {
+		return trace.BadParameter("GetSubscriptionClient is required")
+	}
+
 	if cfg.Verify == nil {
 		cfg.Verify = azureVerifyFuncFromOIDCVerifier(AzureAccessTokenAudience)
 	}
@@ -404,9 +421,45 @@ func claimsToIdentifiers(tokenClaims *AccessTokenClaims) (subscriptionID, resour
 	return "", "", trace.BadParameter("unexpected resource type: %q", resourceID.ResourceType.Type)
 }
 
-func checkAzureAllowRules(vmID string, attrs *workloadidentityv1pb.JoinAttrsAzure, token provision.Token) error {
-	for _, rule := range token.GetAzure().Allow {
-		if rule.Subscription != attrs.Subscription {
+func checkAzureAllowRules(
+	ctx context.Context,
+	vmID string,
+	attrs *workloadidentityv1pb.JoinAttrsAzure,
+	token provision.Token,
+	subscriptionClientGetter SubscriptionClientGetter,
+	logger *slog.Logger,
+) error {
+	rules := token.GetAzure().Allow
+	var checkedWildcard bool
+	var wildcardMatched bool
+	for _, rule := range rules {
+		if rule.Subscription == types.Wildcard {
+			if !checkedWildcard {
+				// only check wildcard subscription once, even if it appears in
+				// multiple rules
+				checkedWildcard = true
+				subClient, err := subscriptionClientGetter(ctx, token.GetIntegration())
+				if err != nil {
+					logger.WarnContext(ctx, "Failed to get Azure subscription client, unable to expand wildcard Azure subscription in join token",
+						"error", err,
+						"token_name", token.GetSafeName(),
+					)
+					continue
+				}
+				subscriptions, err := subClient.ListSubscriptionIDs(ctx)
+				if err != nil {
+					logger.WarnContext(ctx, "Failed to list Azure subscriptions, unable to expand wildcard Azure subscription in join token",
+						"error", err,
+						"token_name", token.GetSafeName(),
+					)
+					continue
+				}
+				wildcardMatched = slices.Contains(subscriptions, attrs.Subscription)
+			}
+			if !wildcardMatched {
+				continue
+			}
+		} else if rule.Subscription != attrs.Subscription {
 			continue
 		}
 		if !azureResourceGroupIsAllowed(rule.ResourceGroups, attrs.ResourceGroup) {
@@ -466,13 +519,12 @@ type CheckAzureRequestParams struct {
 }
 
 func (p *CheckAzureRequestParams) checkAndSetDefaults() error {
-	if p.AzureJoinConfig == nil {
-		p.AzureJoinConfig = &AzureJoinConfig{}
-	}
 	if p.Clock == nil {
 		p.Clock = clockwork.NewRealClock()
 	}
 	switch {
+	case p.AzureJoinConfig == nil:
+		return trace.BadParameter("AzureJoinConfig is required")
 	case p.Token == nil:
 		return trace.BadParameter("Token is required")
 	case len(p.Challenge) == 0:
@@ -510,7 +562,7 @@ func CheckAzureRequest(ctx context.Context, params CheckAzureRequestParams) (*wo
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := checkAzureAllowRules(vmID, attrs, params.Token); err != nil {
+	if err := checkAzureAllowRules(ctx, vmID, attrs, params.Token, params.AzureJoinConfig.GetSubscriptionClient, params.Logger); err != nil {
 		return attrs, trace.Wrap(err)
 	}
 

--- a/lib/join/azurejoin/azure.go
+++ b/lib/join/azurejoin/azure.go
@@ -466,9 +466,13 @@ type CheckAzureRequestParams struct {
 }
 
 func (p *CheckAzureRequestParams) checkAndSetDefaults() error {
-	switch {
-	case p.AzureJoinConfig == nil:
+	if p.AzureJoinConfig == nil {
 		p.AzureJoinConfig = &AzureJoinConfig{}
+	}
+	if p.Clock == nil {
+		p.Clock = clockwork.NewRealClock()
+	}
+	switch {
 	case p.Token == nil:
 		return trace.BadParameter("Token is required")
 	case len(p.Challenge) == 0:
@@ -479,8 +483,6 @@ func (p *CheckAzureRequestParams) checkAndSetDefaults() error {
 		return trace.BadParameter("AccessToken is required")
 	case p.Logger == nil:
 		return trace.BadParameter("Logger is required")
-	case p.Clock == nil:
-		p.Clock = clockwork.NewRealClock()
 	}
 	return trace.Wrap(p.AzureJoinConfig.checkAndSetDefaults())
 }

--- a/lib/join/azurejoin/azure.go
+++ b/lib/join/azurejoin/azure.go
@@ -130,7 +130,8 @@ type AzureVerifyTokenFunc func(ctx context.Context, rawIDToken string) (*AccessT
 // given subscription authenticated with a given static token credential.
 type VMClientGetter func(subscriptionID string, token *azure.StaticCredential) (azure.VirtualMachinesClient, error)
 
-// SubscriptionClientGetter returns an Azure subscription client.
+// SubscriptionClientGetter returns an Azure subscription client for the given Teleport integration name.
+// If the integration name is the empty string, then ambient credentials will be used instead.
 type SubscriptionClientGetter func(ctx context.Context, integration string) (azure.SubscriptionClient, error)
 
 // AzureJoinConfig holds configurable options for Azure joining.
@@ -146,7 +147,7 @@ type AzureJoinConfig struct {
 	// fetch the intermediate CA which issued the attested data document
 	// signing certificate.
 	IssuerHTTPClient utils.HTTPDoClient
-	// GetSubscriptionClient returns [SubscriptionClientGetter] for the given integration name.
+	// GetSubscriptionClient returns an Azure subscription client for the given Teleport integration name.
 	// If the integration name is the empty string, then ambient credentials will be used instead.
 	GetSubscriptionClient SubscriptionClientGetter
 }

--- a/lib/join/azurejoin/azure.go
+++ b/lib/join/azurejoin/azure.go
@@ -130,12 +130,6 @@ type AzureVerifyTokenFunc func(ctx context.Context, rawIDToken string) (*AccessT
 // given subscription authenticated with a given static token credential.
 type VMClientGetter func(subscriptionID string, token *azure.StaticCredential) (azure.VirtualMachinesClient, error)
 
-// SubscriptionClient is an Azure subscriptions client.
-type SubscriptionClient interface {
-	// ListSubscriptionIDs lists all subscription IDs using the Azure Subscription API.
-	ListSubscriptionIDs(ctx context.Context) ([]string, error)
-}
-
 // SubscriptionClientGetter returns an Azure subscription client.
 type SubscriptionClientGetter func(ctx context.Context, integration string) (azure.SubscriptionClient, error)
 

--- a/lib/join/azurejoin/azure.go
+++ b/lib/join/azurejoin/azure.go
@@ -146,7 +146,7 @@ type AzureJoinConfig struct {
 	// fetch the intermediate CA which issued the attested data document
 	// signing certificate.
 	IssuerHTTPClient utils.HTTPDoClient
-	// GetAzureClients returns [AzureClients] for the given integration name.
+	// GetSubscriptionClient returns [SubscriptionClientGetter] for the given integration name.
 	// If the integration name is the empty string, then ambient credentials will be used instead.
 	GetSubscriptionClient SubscriptionClientGetter
 }

--- a/lib/join/azurejoin/check_azure_request_params_test.go
+++ b/lib/join/azurejoin/check_azure_request_params_test.go
@@ -1,0 +1,161 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package azurejoin
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/join/provision"
+)
+
+func TestCheckAzureRequestParamsCheckAndSetDefaults(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	tests := []struct {
+		name        string
+		params      CheckAzureRequestParams
+		setup       func(*testing.T)
+		assertError require.ErrorAssertionFunc
+		errorText   string
+		assert      func(*testing.T, *CheckAzureRequestParams)
+	}{
+		{
+			name: "sets defaults when config and clock are nil",
+			params: CheckAzureRequestParams{
+				Token:        fakeProvisionToken{},
+				Challenge:    "challenge",
+				AttestedData: []byte("attested-data"),
+				AccessToken:  "access-token",
+				Logger:       logger,
+			},
+			assertError: require.NoError,
+			assert: func(t *testing.T, params *CheckAzureRequestParams) {
+				require.NotNil(t, params.AzureJoinConfig)
+				require.NotNil(t, params.Clock)
+				require.NotNil(t, params.AzureJoinConfig.Verify)
+				require.NotEmpty(t, params.AzureJoinConfig.CertificateAuthorities)
+				require.NotNil(t, params.AzureJoinConfig.GetVMClient)
+				require.NotNil(t, params.AzureJoinConfig.IssuerHTTPClient)
+			},
+		},
+		{
+			name: "missing token",
+			params: CheckAzureRequestParams{
+				Challenge:    "challenge",
+				AttestedData: []byte("attested-data"),
+				AccessToken:  "access-token",
+				Logger:       logger,
+			},
+			assertError: require.Error,
+			errorText:   "Token is required",
+			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+		},
+		{
+			name: "missing challenge",
+			params: CheckAzureRequestParams{
+				Token:        fakeProvisionToken{},
+				AttestedData: []byte("attested-data"),
+				AccessToken:  "access-token",
+				Logger:       logger,
+			},
+			assertError: require.Error,
+			errorText:   "Challenge is required",
+			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+		},
+		{
+			name: "missing attested data",
+			params: CheckAzureRequestParams{
+				Token:       fakeProvisionToken{},
+				Challenge:   "challenge",
+				AccessToken: "access-token",
+				Logger:      logger,
+			},
+			assertError: require.Error,
+			errorText:   "AttestedData is required",
+			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+		},
+		{
+			name: "missing access token",
+			params: CheckAzureRequestParams{
+				Token:        fakeProvisionToken{},
+				Challenge:    "challenge",
+				AttestedData: []byte("attested-data"),
+				Logger:       logger,
+			},
+			assertError: require.Error,
+			errorText:   "AccessToken is required",
+			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+		},
+		{
+			name: "missing logger",
+			params: CheckAzureRequestParams{
+				Token:        fakeProvisionToken{},
+				Challenge:    "challenge",
+				AttestedData: []byte("attested-data"),
+				AccessToken:  "access-token",
+			},
+			assertError: require.Error,
+			errorText:   "Logger is required",
+			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+		},
+		{
+			name: "returns config validation error",
+			setup: func(t *testing.T) {
+				original := rawAzureCerts
+				rawAzureCerts = [][]byte{[]byte("-----BEGIN CERTIFICATE-----\nZm9v\n-----END CERTIFICATE-----\n")}
+				t.Cleanup(func() {
+					rawAzureCerts = original
+				})
+			},
+			params: CheckAzureRequestParams{
+				Token:        fakeProvisionToken{},
+				Challenge:    "challenge",
+				AttestedData: []byte("attested-data"),
+				AccessToken:  "access-token",
+				Logger:       logger,
+			},
+			assertError: require.Error,
+			errorText:   "x509",
+			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+
+			params := tc.params
+			err := params.checkAndSetDefaults()
+			tc.assertError(t, err)
+			if tc.errorText != "" {
+				require.ErrorContains(t, err, tc.errorText)
+			}
+			tc.assert(t, &params)
+		})
+	}
+}
+
+type fakeProvisionToken struct {
+	provision.Token
+}

--- a/lib/join/azurejoin/check_azure_request_params_test.go
+++ b/lib/join/azurejoin/check_azure_request_params_test.go
@@ -19,27 +19,39 @@
 package azurejoin
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 func TestCheckAzureRequestParamsCheckAndSetDefaults(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	nopGetSubscriptionClient := func(context.Context, string) (azure.SubscriptionClient, error) { return nil, nil }
 	tests := []struct {
-		name        string
-		params      CheckAzureRequestParams
-		setup       func(*testing.T)
-		assertError require.ErrorAssertionFunc
-		errorText   string
-		assert      func(*testing.T, *CheckAzureRequestParams)
+		name          string
+		params        CheckAzureRequestParams
+		setup         func(*testing.T)
+		errorContains string
 	}{
 		{
-			name: "sets defaults when config and clock are nil",
+			name: "sets defaults",
+			params: CheckAzureRequestParams{
+				AzureJoinConfig: &AzureJoinConfig{GetSubscriptionClient: nopGetSubscriptionClient},
+				Token:           fakeProvisionToken{},
+				Challenge:       "challenge",
+				AttestedData:    []byte("attested-data"),
+				AccessToken:     "access-token",
+				Logger:          logger,
+			},
+		},
+		{
+			name: "missing join config",
 			params: CheckAzureRequestParams{
 				Token:        fakeProvisionToken{},
 				Challenge:    "challenge",
@@ -47,75 +59,62 @@ func TestCheckAzureRequestParamsCheckAndSetDefaults(t *testing.T) {
 				AccessToken:  "access-token",
 				Logger:       logger,
 			},
-			assertError: require.NoError,
-			assert: func(t *testing.T, params *CheckAzureRequestParams) {
-				require.NotNil(t, params.AzureJoinConfig)
-				require.NotNil(t, params.Clock)
-				require.NotNil(t, params.AzureJoinConfig.Verify)
-				require.NotEmpty(t, params.AzureJoinConfig.CertificateAuthorities)
-				require.NotNil(t, params.AzureJoinConfig.GetVMClient)
-				require.NotNil(t, params.AzureJoinConfig.IssuerHTTPClient)
-			},
+			errorContains: "AzureJoinConfig is required",
 		},
 		{
 			name: "missing token",
 			params: CheckAzureRequestParams{
-				Challenge:    "challenge",
-				AttestedData: []byte("attested-data"),
-				AccessToken:  "access-token",
-				Logger:       logger,
+				AzureJoinConfig: &AzureJoinConfig{GetSubscriptionClient: nopGetSubscriptionClient},
+				Challenge:       "challenge",
+				AttestedData:    []byte("attested-data"),
+				AccessToken:     "access-token",
+				Logger:          logger,
 			},
-			assertError: require.Error,
-			errorText:   "Token is required",
-			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+			errorContains: "Token is required",
 		},
 		{
 			name: "missing challenge",
 			params: CheckAzureRequestParams{
-				Token:        fakeProvisionToken{},
-				AttestedData: []byte("attested-data"),
-				AccessToken:  "access-token",
-				Logger:       logger,
+				AzureJoinConfig: &AzureJoinConfig{GetSubscriptionClient: nopGetSubscriptionClient},
+				Token:           fakeProvisionToken{},
+				AttestedData:    []byte("attested-data"),
+				AccessToken:     "access-token",
+				Logger:          logger,
 			},
-			assertError: require.Error,
-			errorText:   "Challenge is required",
-			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+			errorContains: "Challenge is required",
 		},
 		{
 			name: "missing attested data",
 			params: CheckAzureRequestParams{
-				Token:       fakeProvisionToken{},
-				Challenge:   "challenge",
-				AccessToken: "access-token",
-				Logger:      logger,
+				AzureJoinConfig: &AzureJoinConfig{GetSubscriptionClient: nopGetSubscriptionClient},
+				Token:           fakeProvisionToken{},
+				Challenge:       "challenge",
+				AccessToken:     "access-token",
+				Logger:          logger,
 			},
-			assertError: require.Error,
-			errorText:   "AttestedData is required",
-			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+			errorContains: "AttestedData is required",
 		},
 		{
 			name: "missing access token",
 			params: CheckAzureRequestParams{
-				Token:        fakeProvisionToken{},
-				Challenge:    "challenge",
-				AttestedData: []byte("attested-data"),
-				Logger:       logger,
+				AzureJoinConfig: &AzureJoinConfig{GetSubscriptionClient: nopGetSubscriptionClient},
+				Token:           fakeProvisionToken{},
+				Challenge:       "challenge",
+				AttestedData:    []byte("attested-data"),
+				Logger:          logger,
 			},
-			assertError: require.Error,
-			errorText:   "AccessToken is required",
-			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+			errorContains: "AccessToken is required",
 		},
 		{
 			name: "missing logger",
 			params: CheckAzureRequestParams{
-				Token:        fakeProvisionToken{},
-				Challenge:    "challenge",
-				AttestedData: []byte("attested-data"),
-				AccessToken:  "access-token",
+				AzureJoinConfig: &AzureJoinConfig{GetSubscriptionClient: nopGetSubscriptionClient},
+				Token:           fakeProvisionToken{},
+				Challenge:       "challenge",
+				AttestedData:    []byte("attested-data"),
+				AccessToken:     "access-token",
 			},
-			assertError: require.Error,
-			errorText:   "Logger is required",
-			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+			errorContains: "Logger is required",
 		},
 		{
 			name: "returns config validation error",
@@ -127,15 +126,14 @@ func TestCheckAzureRequestParamsCheckAndSetDefaults(t *testing.T) {
 				})
 			},
 			params: CheckAzureRequestParams{
-				Token:        fakeProvisionToken{},
-				Challenge:    "challenge",
-				AttestedData: []byte("attested-data"),
-				AccessToken:  "access-token",
-				Logger:       logger,
+				AzureJoinConfig: &AzureJoinConfig{GetSubscriptionClient: nopGetSubscriptionClient},
+				Token:           fakeProvisionToken{},
+				Challenge:       "challenge",
+				AttestedData:    []byte("attested-data"),
+				AccessToken:     "access-token",
+				Logger:          logger,
 			},
-			assertError: require.Error,
-			errorText:   "x509",
-			assert:      func(*testing.T, *CheckAzureRequestParams) {},
+			errorContains: "x509",
 		},
 	}
 
@@ -147,11 +145,18 @@ func TestCheckAzureRequestParamsCheckAndSetDefaults(t *testing.T) {
 
 			params := tc.params
 			err := params.checkAndSetDefaults()
-			tc.assertError(t, err)
-			if tc.errorText != "" {
-				require.ErrorContains(t, err, tc.errorText)
+			if tc.errorContains != "" {
+				require.ErrorContains(t, err, tc.errorContains)
+				return
 			}
-			tc.assert(t, &params)
+			require.NoError(t, err)
+			// ensure default params are set
+			require.NotNil(t, params.Clock)
+			require.NotNil(t, params.AzureJoinConfig)
+			require.NotNil(t, params.AzureJoinConfig.Verify)
+			require.NotEmpty(t, params.AzureJoinConfig.CertificateAuthorities)
+			require.NotNil(t, params.AzureJoinConfig.GetVMClient)
+			require.NotNil(t, params.AzureJoinConfig.IssuerHTTPClient)
 		})
 	}
 }

--- a/lib/join/azurejoin/check_azure_request_params_test.go
+++ b/lib/join/azurejoin/check_azure_request_params_test.go
@@ -20,7 +20,6 @@ package azurejoin
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"testing"
 
@@ -31,7 +30,7 @@ import (
 )
 
 func TestCheckAzureRequestParamsCheckAndSetDefaults(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	nopGetSubscriptionClient := func(context.Context, string) (azure.SubscriptionClient, error) { return nil, nil }
 	tests := []struct {
 		name          string

--- a/lib/join/azurejoin/join_azure_test.go
+++ b/lib/join/azurejoin/join_azure_test.go
@@ -193,6 +193,10 @@ func TestJoinAzure(t *testing.T) {
 	defaultVMID := "my-vm-id"
 	defaultVMResourceID := vmResourceID(defaultSubscription, defaultResourceGroup, defaultVMName)
 	defaultIdentityResourceID := identityResourceID(defaultSubscription, defaultResourceGroup, defaultIdentityName)
+	defaultSubscriptionClientGetter := func(_ context.Context, _ string) (azure.SubscriptionClient, error) {
+		return &fakeAzureSubscriptionsClient{}, nil
+	}
+	azureIntegrationName := "an-azure-oidc-integration"
 
 	tests := []struct {
 		name                           string
@@ -202,6 +206,7 @@ func TestJoinAzure(t *testing.T) {
 		tokenVMID                      string
 		requestTokenName               string
 		tokenSpec                      types.ProvisionTokenSpecV2
+		subscriptionClientGetter       azurejoin.SubscriptionClientGetter
 		overrideReturnedChallenge      string
 		challengeResponseErr           error
 		certs                          []*x509.Certificate
@@ -245,6 +250,147 @@ func TestJoinAzure(t *testing.T) {
 					},
 				},
 				JoinMethod: types.JoinMethodAzure,
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{caChain.rootCert},
+			assertError: require.NoError,
+		},
+		{
+			name:              "wildcard subscription matches using ambient credentials",
+			requestTokenName:  "test-token",
+			tokenSubscription: defaultSubscription,
+			tokenVMID:         defaultVMID,
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   types.Wildcard,
+							ResourceGroups: []string{defaultResourceGroup},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			subscriptionClientGetter: func(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
+				if integration != "" {
+					return nil, trace.NotFound("expected ambient credentials with empty integration, but got %q integration", integration)
+				}
+				return &fakeAzureSubscriptionsClient{
+					subscriptions: []string{defaultSubscription},
+				}, nil
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{caChain.rootCert},
+			assertError: require.NoError,
+		},
+		{
+			name:              "wildcard subscription matches using integration credentials",
+			requestTokenName:  "test-token",
+			tokenSubscription: defaultSubscription,
+			tokenVMID:         defaultVMID,
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   types.Wildcard,
+							ResourceGroups: []string{defaultResourceGroup},
+						},
+					},
+				},
+				JoinMethod:  types.JoinMethodAzure,
+				Integration: azureIntegrationName,
+			},
+			subscriptionClientGetter: func(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
+				if integration != azureIntegrationName {
+					return nil, trace.NotFound("test integration %q not found", integration)
+				}
+				return &fakeAzureSubscriptionsClient{
+					subscriptions: []string{defaultSubscription},
+				}, nil
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{caChain.rootCert},
+			assertError: require.NoError,
+		},
+		{
+			name:              "wildcard subscription does not match",
+			requestTokenName:  "test-token",
+			tokenSubscription: defaultSubscription,
+			tokenVMID:         defaultVMID,
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   types.Wildcard,
+							ResourceGroups: []string{defaultResourceGroup},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			subscriptionClientGetter: func(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
+				return &fakeAzureSubscriptionsClient{
+					subscriptions: []string{"aaa"},
+				}, nil
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{caChain.rootCert},
+			assertError: isAccessDenied,
+		},
+		{
+			name:              "get subscription client error",
+			requestTokenName:  "test-token",
+			tokenSubscription: defaultSubscription,
+			tokenVMID:         defaultVMID,
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   types.Wildcard,
+							ResourceGroups: []string{defaultResourceGroup},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			subscriptionClientGetter: func(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
+				return nil, trace.Errorf("failed to get subscription client")
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{caChain.rootCert},
+			assertError: isAccessDenied,
+		},
+		{
+			name:              "get subscription client error does not prevent explicit match",
+			requestTokenName:  "test-token",
+			tokenSubscription: defaultSubscription,
+			tokenVMID:         defaultVMID,
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   types.Wildcard,
+							ResourceGroups: []string{defaultResourceGroup},
+						},
+						{
+							Subscription:   defaultSubscription,
+							ResourceGroups: []string{defaultResourceGroup},
+						},
+						{
+							Subscription:   types.Wildcard,
+							ResourceGroups: []string{defaultResourceGroup},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			subscriptionClientGetter: func(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
+				return nil, trace.Errorf("failed to get subscription client")
 			},
 			verify:      mockVerifyToken(nil),
 			certs:       []*x509.Certificate{caChain.rootCert},
@@ -481,6 +627,12 @@ func TestJoinAzure(t *testing.T) {
 				Verify:                 tc.verify,
 				GetVMClient:            getVMClient,
 				IssuerHTTPClient:       httpClient,
+				GetSubscriptionClient: func(ctx context.Context, integration string) (azure.SubscriptionClient, error) {
+					if tc.subscriptionClientGetter != nil {
+						return tc.subscriptionClientGetter(ctx, integration)
+					}
+					return defaultSubscriptionClientGetter(ctx, integration)
+				},
 			})
 
 			token, err := types.NewProvisionTokenFromSpec(
@@ -899,6 +1051,9 @@ func TestJoinAzureClaims(t *testing.T) {
 				Verify:                 tc.verify,
 				GetVMClient:            getVMClient,
 				IssuerHTTPClient:       httpClient,
+				GetSubscriptionClient: func(_ context.Context, _ string) (azure.SubscriptionClient, error) {
+					return nil, trace.NotImplemented("GetSubscriptionClient not implemented")
+				},
 			})
 
 			imdsClient := &fakeIMDSClient{
@@ -1135,6 +1290,9 @@ func TestAzureIssuerCert(t *testing.T) {
 				Verify:                 mockVerifyToken(nil),
 				GetVMClient:            getVMClient,
 				IssuerHTTPClient:       httpClient,
+				GetSubscriptionClient: func(_ context.Context, _ string) (azure.SubscriptionClient, error) {
+					return nil, trace.NotImplemented("GetSubscriptionClient not implemented")
+				},
 			})
 
 			// Join via the legacy join service.
@@ -1301,4 +1459,20 @@ func (c *fakeAzureIssuerHTTPClient) Do(req *http.Request) (*http.Response, error
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(bytes.NewReader(c.issuerCertDER)),
 	}, nil
+}
+
+type fakeAzureSubscriptionsClient struct {
+	// subscriptions can be set to fake a ListSubscriptionIDs response
+	subscriptions []string
+	// listSubscriptionIDsErr can be set to fake a ListSubscriptionIDs error
+	listSubscriptionIDsErr error
+	called                 int
+}
+
+func (c *fakeAzureSubscriptionsClient) ListSubscriptionIDs(ctx context.Context) ([]string, error) {
+	c.called++
+	if c.listSubscriptionIDsErr != nil {
+		return nil, c.listSubscriptionIDsErr
+	}
+	return c.subscriptions, nil
 }

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -108,7 +108,8 @@ func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override
 			}
 		}
 		scopedToken.Spec.Azure = &joiningv1.Azure{
-			Allow: allow,
+			Allow:       allow,
+			Integration: base.Integration,
 		}
 	case types.JoinMethodAzureDevops:
 		allow := make([]*joiningv1.AzureDevops_Rule, len(base.AzureDevops.Allow))

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -56,7 +56,7 @@ type Token interface {
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() types.Duration
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.
-	// Currently, this is only used to validate the AWS Organization.
+	// Currently, this is only used to validate the AWS Organization and Azure subscriptions.
 	GetIntegration() string
 	// GetGCPRules returns the GCP-specific configuration for this token.
 	GetGCPRules() *types.ProvisionTokenSpecV2GCP

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -437,9 +437,18 @@ func (t *Token) GetAWSIIDTTL() types.Duration {
 }
 
 // GetIntegration returns the Integration field which is used to provide
-// credentials that will be used when validating the AWS Organization if required by an IAM Token.
+// cloud credentials when validating cloud join tokens that require API calls to
+// check the allow rules, e.g., AWS organization rules or Azure wildcard
+// subscription rules.
 func (t *Token) GetIntegration() string {
-	return t.scoped.GetSpec().GetAws().GetIntegration()
+	switch t.GetJoinMethod() {
+	case types.JoinMethodIAM:
+		return t.scoped.GetSpec().GetAws().GetIntegration()
+	case types.JoinMethodAzure:
+		return t.scoped.GetSpec().GetAzure().GetIntegration()
+	default:
+		return ""
+	}
 }
 
 // GetGCPRules returns the GCP-specific configuration for this token.

--- a/lib/services/integration.go
+++ b/lib/services/integration.go
@@ -49,6 +49,7 @@ type IntegrationsGetter interface {
 }
 
 // IntegrationsTokenGenerator defines methods to generate tokens for Integrations.
+// TODO(gavin): remove this type, it is not actually used anywhere
 type IntegrationsTokenGenerator interface {
 	// GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
 	GenerateAWSOIDCToken(ctx context.Context, integration string) (string, error)

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -1102,9 +1102,11 @@ func TestSortAzureRules(t *testing.T) {
 			rules: []*types.ProvisionTokenSpecV2Azure_Rule{
 				{Subscription: "200000000000"},
 				{Subscription: "300000000000"},
+				{Subscription: "*"},
 				{Subscription: "100000000000"},
 			},
 			expected: []*types.ProvisionTokenSpecV2Azure_Rule{
+				{Subscription: "*"},
 				{Subscription: "100000000000"},
 				{Subscription: "200000000000"},
 				{Subscription: "300000000000"},
@@ -1113,11 +1115,13 @@ func TestSortAzureRules(t *testing.T) {
 		{
 			name: "already ordered",
 			rules: []*types.ProvisionTokenSpecV2Azure_Rule{
+				{Subscription: "*"},
 				{Subscription: "100000000000"},
 				{Subscription: "200000000000"},
 				{Subscription: "300000000000"},
 			},
 			expected: []*types.ProvisionTokenSpecV2Azure_Rule{
+				{Subscription: "*"},
 				{Subscription: "100000000000"},
 				{Subscription: "200000000000"},
 				{Subscription: "300000000000"},
@@ -2184,10 +2188,16 @@ func TestIsSameAzureRuleSet(t *testing.T) {
 					Subscription: "456456456456",
 				},
 				{
+					Subscription: "*",
+				},
+				{
 					Subscription: "123123123123",
 				},
 			},
 			r2: []*types.ProvisionTokenSpecV2Azure_Rule{
+				{
+					Subscription: "*",
+				},
 				{
 					Subscription: "123123123123",
 				},


### PR DESCRIPTION
Related recent PR:
- https://github.com/gravitational/teleport/pull/64596

Relevant issue:
- https://github.com/gravitational/customer-sensitive-requests/issues/557

Docs will be updated in a separate PR.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added support for wildcard Azure subscription rules in Azure join tokens.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Create multiple Azure subscriptions
- Create VMs in each subscription
- Create an Azure join token that allows joining from wildcard subscription `*`
- Create an Azure OIDC integration and corresponding Azure role with permissions to list subscriptions
- Create a discovery config to auto discover VMs in each subscription

### Test Cases

- [X] Verify that all discovered VMs are able to join the cluster with the Azure join token
- [X] Modify the Azure OIDC role permissions such that it cannot list one of the VM subscriptions and verify that VMs are not allowed to join from that subscription, but the other VMs can still join