### PR TITLE
Stop using text/template and html/template to enable DCE

### DIFF
--- a/build.assets/tooling/cmd/apiversion/main.go
+++ b/build.assets/tooling/cmd/apiversion/main.go
@@ -19,8 +19,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/coreos/go-semver/semver"
 )
 

--- a/build.assets/tooling/cmd/gen-athena-docs/main.go
+++ b/build.assets/tooling/cmd/gen-athena-docs/main.go
@@ -23,9 +23,10 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"text/template"
 	"unicode"
 	"unicode/utf8"
+
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 
 	"github.com/gravitational/teleport/gen/go/eventschema"
 )
@@ -81,6 +82,7 @@ func main() {
 		template.FuncMap{
 			"ColNameList":        colNameList,
 			"PrepareDescription": prepareDescription,
+			"NameSQL":            func(c *eventschema.ColumnSchemaDetails) string { return c.NameSQL() },
 		},
 	).Parse(docTempl)).Execute(os.Stdout, data)
 }

--- a/build.assets/tooling/cmd/gen-athena-docs/schema-reference.mdx.tmpl
+++ b/build.assets/tooling/cmd/gen-athena-docs/schema-reference.mdx.tmpl
@@ -20,7 +20,7 @@ Columns:
 |SQL Name|Type|Description|
 |---|---|---|
 {{- range .Columns }}
-|{{ .NameSQL }}|{{ .Type }}|{{ PrepareDescription . }}|
+|{{ NameSQL . }}|{{ .Type }}|{{ PrepareDescription . }}|
 {{- end }}
 
 {{ end }}

--- a/build.assets/tooling/cmd/render-helm-ref/template.go
+++ b/build.assets/tooling/cmd/render-helm-ref/template.go
@@ -20,8 +20,8 @@ package main
 
 import (
 	"bytes"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/Masterminds/sprig/v3"
 	"github.com/gravitational/trace"
 )

--- a/build.assets/tooling/cmd/resource-ref-generator/main.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/main.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/teleport/build.assets/tooling/cmd/resource-ref-generator/reference"

--- a/build.assets/tooling/cmd/resource-ref-generator/reference/reference.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/reference/reference.go
@@ -22,7 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"text/template"
+
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 
 	"github.com/gravitational/teleport/build.assets/tooling/cmd/resource-ref-generator/resource"
 )

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -4,6 +4,7 @@ go 1.25.9
 
 require (
 	buf.build/go/bufplugin v0.9.0
+	github.com/DataDog/datadog-agent/pkg/template v0.77.2
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/awalterschulze/goderive v0.5.1

--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -96,6 +96,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgv
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2 h1:jykra+J/uDkVr/LfnNvHLT7YY51Q8RcH7GnCh01rnKA=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2/go.mod h1:ZUjICHSlN0of0cmWrYk9Pof0DV0eqHSpTUK1NTnN26Y=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/build.assets/tooling/lib/eventschema/dump.go
+++ b/build.assets/tooling/lib/eventschema/dump.go
@@ -24,8 +24,8 @@ import (
 	"go/format"
 	"sort"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/Masterminds/sprig/v3"
 	"github.com/gravitational/trace"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"

--- a/e2e/runner/cmd/gen-ts-fixtures/main.go
+++ b/e2e/runner/cmd/gen-ts-fixtures/main.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"text/template"
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 
 	"github.com/gravitational/teleport/e2e/runner/fixtures"
 )

--- a/e2e/runner/go.mod
+++ b/e2e/runner/go.mod
@@ -3,6 +3,7 @@ module github.com/gravitational/teleport/e2e/runner
 go 1.25.9
 
 require (
+	github.com/DataDog/datadog-agent/pkg/template v0.77.2
 	github.com/docker/go-sdk/container v0.1.0-alpha013
 	github.com/google/go-github/v84 v84.0.0
 	github.com/gravitational/teleport v0.0.0-00010101000000-000000000000

--- a/e2e/runner/go.sum
+++ b/e2e/runner/go.sum
@@ -82,6 +82,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgv
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2 h1:jykra+J/uDkVr/LfnNvHLT7YY51Q8RcH7GnCh01rnKA=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2/go.mod h1:ZUjICHSlN0of0cmWrYk9Pof0DV0eqHSpTUK1NTnN26Y=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/e2e/runner/teleport.go
+++ b/e2e/runner/teleport.go
@@ -31,8 +31,9 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"text/template"
 	"time"
+
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 )
 
 // clusterName is the name of the Teleport cluster used for E2E testing.

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/ClickHouse/ch-go v0.69.0
 	github.com/ClickHouse/clickhouse-go/v2 v2.37.2
 	github.com/DanielTitkov/go-adaptive-cards v0.2.2
+	github.com/DataDog/datadog-agent/pkg/template v0.77.2
 	github.com/HdrHistogram/hdrhistogram-go v1.2.0
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/Microsoft/go-winio v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2 h1:tBFExyvsbCcrBJEvPaV3FW4gcAkwQjXFKiKEBrE7Yuw=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2/go.mod h1:RtCzt65p/zEos6+zhiCFQmiaHmro6M63l9NP7xXx/Lg=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2 h1:jykra+J/uDkVr/LfnNvHLT7YY51Q8RcH7GnCh01rnKA=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2/go.mod h1:ZUjICHSlN0of0cmWrYk9Pof0DV0eqHSpTUK1NTnN26Y=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.6.0 h1:BzsL0qE7LvtTEtXG7Dt5NS1EP0CQwI21HZfj9aGghhw=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.6.0/go.mod h1:I7kE2kM3qCr9QPT4cU4cCFYkEpVyVr16YOGUHzy+nR0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=

--- a/integrations/access/accessrequest/message.go
+++ b/integrations/access/accessrequest/message.go
@@ -23,9 +23,9 @@ import (
 	"net/url"
 	"slices"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
@@ -44,7 +44,7 @@ const (
 )
 
 var reviewReplyTemplate = template.Must(template.New("review reply").Parse(
-	`{{.Author}} reviewed the request at {{.Created.Format .TimeFormat}}.
+	`{{.Author}} reviewed the request at {{.CreatedTime}}.
 Resolution: {{.ProposedStateEmoji}} {{.ProposedState}}.
 {{if .Reason}}Reason: {{.Reason}}{{end}}`,
 ))
@@ -138,12 +138,12 @@ func MsgReview(review types.AccessReview) (string, error) {
 		types.AccessReview
 		ProposedState      string
 		ProposedStateEmoji string
-		TimeFormat         string
+		CreatedTime        string
 	}{
 		review,
 		review.ProposedState.String(),
 		proposedStateEmoji,
-		time.RFC822,
+		review.Created.Format(time.RFC822),
 	})
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/integrations/access/datadog/bot.go
+++ b/integrations/access/datadog/bot.go
@@ -24,8 +24,8 @@ import (
 	"net/url"
 	"slices"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"

--- a/integrations/access/email/client.go
+++ b/integrations/access/email/client.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
@@ -33,7 +33,7 @@ import (
 )
 
 var reviewReplyTemplate = template.Must(template.New("review reply").Parse(
-	`{{.Author}} reviewed the request at {{.Created.Format .TimeFormat}}.
+	`{{.Author}} reviewed the request at {{.CreatedTime}}.
 Resolution: {{.ProposedStateEmoji}} {{.ProposedState}}.
 {{if .Reason}}Reason: {{.Reason}}.{{end}}`,
 ))
@@ -122,12 +122,12 @@ func (c *Client) SendReview(ctx context.Context, threads []EmailThread, reqID st
 		types.AccessReview
 		ProposedState      string
 		ProposedStateEmoji string
-		TimeFormat         string
+		CreatedTime        string
 	}{
 		review,
 		review.ProposedState.String(),
 		proposedStateEmoji,
-		time.RFC822,
+		review.Created.Format(time.RFC822),
 	})
 	if err != nil {
 		return threadsSent, trace.Wrap(err)

--- a/integrations/access/jira/client.go
+++ b/integrations/access/jira/client.go
@@ -24,9 +24,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/go-resty/resty/v2"
 	"github.com/google/go-querystring/query"
 	"github.com/gravitational/trace"
@@ -62,7 +62,7 @@ type Jira struct {
 }
 
 var descriptionTemplate = template.Must(template.New("description").Parse(
-	`User *{{.User}}* requested an access on *{{.Created.Format .TimeFormat}}* with the following roles:
+	`User *{{.User}}* requested an access on *{{.CreatedTime}}* with the following roles:
 {{range .Roles}}
 * {{ . }}
 {{end}}
@@ -73,7 +73,7 @@ Request ID: *{{.ID}}*
 {{if .RequestLink}}To approve or deny the request, proceed to {{.RequestLink}}{{end}}`,
 ))
 var reviewCommentTemplate = template.Must(template.New("review comment").Parse(
-	`*{{.Author}}* reviewed the request at *{{.Created.Format .TimeFormat}}*.
+	`*{{.Author}}* reviewed the request at *{{.CreatedTime}}*.
 Resolution: *{{.ProposedState}}*.
 {{if .Reason}}Reason: {{.Reason}}.{{end}}`,
 ))
@@ -291,12 +291,12 @@ func (j *Jira) buildIssueDescription(reqID string, reqData RequestData) (string,
 	var builder strings.Builder
 	err := descriptionTemplate.Execute(&builder, struct {
 		ID          string
-		TimeFormat  string
+		CreatedTime string
 		RequestLink string
 		RequestData
 	}{
 		reqID,
-		time.RFC822,
+		reqData.Created.Format(time.RFC822),
 		requestLink,
 		reqData,
 	})
@@ -336,11 +336,11 @@ func (j *Jira) AddIssueReviewComment(ctx context.Context, id string, review type
 	err := reviewCommentTemplate.Execute(&builder, struct {
 		types.AccessReview
 		ProposedState string
-		TimeFormat    string
+		CreatedTime   string
 	}{
 		review,
 		review.ProposedState.String(),
-		time.RFC822,
+		review.Created.Format(time.RFC822),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -24,9 +24,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/go-resty/resty/v2"
 	"github.com/gravitational/trace"
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -61,7 +61,7 @@ var postTextTemplate = template.Must(template.New("description").Parse(
 ))
 
 var reviewCommentTemplate = template.Must(template.New("review comment").Parse(
-	`{{.Author}} reviewed the request at {{.Created.Format .TimeFormat}}.
+	`{{.Author}} reviewed the request at {{.CreatedTime}}.
 Resolution: {{.ProposedStateEmoji}} {{.ProposedState}}.
 {{if .Reason}}Reason: {{.Reason}}.{{end}}`,
 ))
@@ -297,12 +297,12 @@ func (b Bot) PostReviewReply(ctx context.Context, channelID, rootID string, revi
 		types.AccessReview
 		ProposedState      string
 		ProposedStateEmoji string
-		TimeFormat         string
+		CreatedTime        string
 	}{
 		review,
 		review.ProposedState.String(),
 		proposedStateEmoji,
-		time.RFC822,
+		review.Created.Format(time.RFC822),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/integrations/access/msteams/configure.go
+++ b/integrations/access/msteams/configure.go
@@ -18,12 +18,12 @@ import (
 	"archive/zip"
 	"embed"
 	"fmt"
-	"html/template"
 	"io"
 	"os"
 	"path/filepath"
 	"slices"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/html"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 )

--- a/integrations/access/opsgenie/client.go
+++ b/integrations/access/opsgenie/client.go
@@ -25,9 +25,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/go-resty/resty/v2"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -52,13 +52,13 @@ const (
 )
 
 var alertBodyTemplate = template.Must(template.New("alert body").Parse(
-	`{{.User}} requested permissions for roles {{range $index, $element := .Roles}}{{if $index}}, {{end}}{{ . }}{{end}} on Teleport at {{.Created.Format .TimeFormat}}.
+	`{{.User}} requested permissions for roles {{range $index, $element := .Roles}}{{if $index}}, {{end}}{{ . }}{{end}} on Teleport at {{.CreatedTime}}.
 {{if .RequestReason}}Reason: {{.RequestReason}}{{end}}
 {{if .RequestLink}}To approve or deny the request, proceed to {{.RequestLink}}{{end}}
 `,
 ))
 var reviewNoteTemplate = template.Must(template.New("review note").Parse(
-	`{{.Author}} reviewed the request at {{.Created.Format .TimeFormat}}.
+	`{{.Author}} reviewed the request at {{.CreatedTime}}.
 Resolution: {{.ProposedState}}.
 {{if .Reason}}Reason: {{.Reason}}.{{end}}`,
 ))
@@ -356,12 +356,12 @@ func buildAlertBody(webProxyURL *url.URL, reqID string, reqData RequestData) (st
 	var builder strings.Builder
 	err := alertBodyTemplate.Execute(&builder, struct {
 		ID          string
-		TimeFormat  string
+		CreatedTime string
 		RequestLink string
 		RequestData
 	}{
 		ID:          reqID,
-		TimeFormat:  time.RFC822,
+		CreatedTime: reqData.Created.Format(time.RFC822),
 		RequestLink: requestLink,
 		RequestData: reqData,
 	})
@@ -376,11 +376,11 @@ func buildReviewNoteBody(review types.AccessReview) (string, error) {
 	err := reviewNoteTemplate.Execute(&builder, struct {
 		types.AccessReview
 		ProposedState string
-		TimeFormat    string
+		CreatedTime   string
 	}{
 		review,
 		review.ProposedState.String(),
-		time.RFC822,
+		review.Created.Format(time.RFC822),
 	})
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/integrations/access/pagerduty/client.go
+++ b/integrations/access/pagerduty/client.go
@@ -24,9 +24,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/go-resty/resty/v2"
 	"github.com/google/go-querystring/query"
 	"github.com/gravitational/trace"
@@ -49,13 +49,13 @@ const (
 )
 
 var incidentBodyTemplate = template.Must(template.New("incident body").Parse(
-	`{{.User}} requested permissions for roles {{range $index, $element := .Roles}}{{if $index}}, {{end}}{{ . }}{{end}} on Teleport at {{.Created.Format .TimeFormat}}.
+	`{{.User}} requested permissions for roles {{range $index, $element := .Roles}}{{if $index}}, {{end}}{{ . }}{{end}} on Teleport at {{.CreatedTime}}.
 {{if .RequestReason}}Reason: {{.RequestReason}}{{end}}
 {{if .RequestLink}}To approve or deny the request, proceed to {{.RequestLink}}{{end}}
 `,
 ))
 var reviewNoteTemplate = template.Must(template.New("review note").Parse(
-	`{{.Author}} reviewed the request at {{.Created.Format .TimeFormat}}.
+	`{{.Author}} reviewed the request at {{.CreatedTime}}.
 Resolution: {{.ProposedState}}.
 {{if .Reason}}Reason: {{.Reason}}.{{end}}`,
 ))
@@ -411,12 +411,12 @@ func (p Pagerduty) buildIncidentBody(reqID string, reqData RequestData) (string,
 	var builder strings.Builder
 	err := incidentBodyTemplate.Execute(&builder, struct {
 		ID          string
-		TimeFormat  string
+		CreatedTime string
 		RequestLink string
 		RequestData
 	}{
 		reqID,
-		time.RFC822,
+		reqData.Created.Format(time.RFC822),
 		requestLink,
 		reqData,
 	})
@@ -431,11 +431,11 @@ func (p Pagerduty) buildReviewNoteBody(review types.AccessReview) (string, error
 	err := reviewNoteTemplate.Execute(&builder, struct {
 		types.AccessReview
 		ProposedState string
-		TimeFormat    string
+		CreatedTime   string
 	}{
 		review,
 		review.ProposedState.String(),
-		time.RFC822,
+		review.Created.Format(time.RFC822),
 	})
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/integrations/access/servicenow/client.go
+++ b/integrations/access/servicenow/client.go
@@ -25,9 +25,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/go-resty/resty/v2"
 	"github.com/gravitational/trace"
 
@@ -315,7 +315,7 @@ var (
 `,
 	))
 	reviewNoteTemplate = template.Must(template.New("review note").Parse(
-		`{{.Author}} reviewed the request at {{.Created.Format .TimeFormat}}.
+		`{{.Author}} reviewed the request at {{.CreatedTime}}.
 Resolution: {{.ProposedState}}.
 {{if .Reason}}Reason: {{.Reason}}.{{end}}`,
 	))
@@ -340,13 +340,13 @@ func buildIncidentBody(webProxyURL *url.URL, reqID string, reqData RequestData, 
 	}
 	err := template.Execute(&builder, struct {
 		ID          string
-		TimeFormat  string
+		CreatedTime string
 		RequestLink string
 		ClusterName string
 		RequestData
 	}{
 		ID:          reqID,
-		TimeFormat:  time.RFC822,
+		CreatedTime: reqData.Created.Format(time.RFC822),
 		RequestLink: requestLink,
 		ClusterName: clusterName,
 		RequestData: reqData,
@@ -362,11 +362,11 @@ func buildReviewNoteBody(review types.AccessReview) (string, error) {
 	err := reviewNoteTemplate.Execute(&builder, struct {
 		types.AccessReview
 		ProposedState string
-		TimeFormat    string
+		CreatedTime   string
 	}{
 		review,
 		review.ProposedState.String(),
-		time.RFC822,
+		review.Created.Format(time.RFC822),
 	})
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -3,6 +3,7 @@ module github.com/gravitational/teleport/integrations/event-handler
 go 1.25.9
 
 require (
+	github.com/DataDog/datadog-agent/pkg/template v0.77.2
 	github.com/alecthomas/kong v1.14.0
 	github.com/google/uuid v1.6.0
 	github.com/gravitational/teleport v0.0.0-00010101000000-000000000000

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -95,6 +95,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2 h1:tBFExyvsbCcrBJEvPaV3FW4gcAkwQjXFKiKEBrE7Yuw=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2/go.mod h1:RtCzt65p/zEos6+zhiCFQmiaHmro6M63l9NP7xXx/Lg=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2 h1:jykra+J/uDkVr/LfnNvHLT7YY51Q8RcH7GnCh01rnKA=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2/go.mod h1:ZUjICHSlN0of0cmWrYk9Pof0DV0eqHSpTUK1NTnN26Y=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/integrations/event-handler/lib/templates.go
+++ b/integrations/event-handler/lib/templates.go
@@ -18,8 +18,8 @@ package lib
 
 import (
 	"io"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 )
 

--- a/integrations/kube-agent-updater/hack/cosign-fixtures.go
+++ b/integrations/kube-agent-updater/hack/cosign-fixtures.go
@@ -31,8 +31,8 @@ import (
 	"log"
 	"maps"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/Masterminds/sprig/v3"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"

--- a/integrations/operator/crdgen/format.go
+++ b/integrations/operator/crdgen/format.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/yaml"

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/ClickHouse/ch-go v0.69.0 // indirect
 	github.com/ClickHouse/clickhouse-go/v2 v2.37.2 // indirect
 	github.com/DanielTitkov/go-adaptive-cards v0.2.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/template v0.77.2 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -130,6 +130,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2 h1:tBFExyvsbCcrBJEvPaV3FW4gcAkwQjXFKiKEBrE7Yuw=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2/go.mod h1:RtCzt65p/zEos6+zhiCFQmiaHmro6M63l9NP7xXx/Lg=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2 h1:jykra+J/uDkVr/LfnNvHLT7YY51Q8RcH7GnCh01rnKA=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2/go.mod h1:ZUjICHSlN0of0cmWrYk9Pof0DV0eqHSpTUK1NTnN26Y=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.6.0 h1:BzsL0qE7LvtTEtXG7Dt5NS1EP0CQwI21HZfj9aGghhw=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.6.0/go.mod h1:I7kE2kM3qCr9QPT4cU4cCFYkEpVyVr16YOGUHzy+nR0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=

--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -23,7 +23,8 @@ import (
 	"os"
 	"path"
 	"strings"
-	"text/template"
+
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 
 	"github.com/gravitational/teleport/integrations/terraform/gen/strcase"
 )

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -4,6 +4,7 @@ go 1.25.9
 
 // TF provider dependencies
 require (
+	github.com/DataDog/datadog-agent/pkg/template v0.77.2
 	github.com/beevik/etree v1.6.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.7.0

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -162,6 +162,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2 h1:tBFExyvsbCcrBJEvPaV3FW4gcAkwQjXFKiKEBrE7Yuw=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2/go.mod h1:RtCzt65p/zEos6+zhiCFQmiaHmro6M63l9NP7xXx/Lg=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2 h1:jykra+J/uDkVr/LfnNvHLT7YY51Q8RcH7GnCh01rnKA=
+github.com/DataDog/datadog-agent/pkg/template v0.77.2/go.mod h1:ZUjICHSlN0of0cmWrYk9Pof0DV0eqHSpTUK1NTnN26Y=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.6.0 h1:BzsL0qE7LvtTEtXG7Dt5NS1EP0CQwI21HZfj9aGghhw=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.6.0/go.mod h1:I7kE2kM3qCr9QPT4cU4cCFYkEpVyVr16YOGUHzy+nR0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -29,9 +29,9 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"

--- a/lib/auth/desktop.go
+++ b/lib/auth/desktop.go
@@ -29,8 +29,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"strconv"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -31,8 +31,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
 

--- a/lib/autoupdate/package_url.go
+++ b/lib/autoupdate/package_url.go
@@ -22,8 +22,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"runtime"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
 )

--- a/lib/client/db/oracle/config.go
+++ b/lib/client/db/oracle/config.go
@@ -22,8 +22,8 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"

--- a/lib/cloud/provisioning/operations.go
+++ b/lib/cloud/provisioning/operations.go
@@ -26,8 +26,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/utils/prompt"
@@ -204,15 +204,18 @@ func writeOperationPlan(config OperationConfig) error {
 var operationPlanTemplate = template.Must(template.New("plan").
 	Funcs(template.FuncMap{
 		// used to enumerate the action steps starting from 1 instead of 0.
-		"addOne": func(x int) int { return x + 1 },
+		"addOne":     func(x int) int { return x + 1 },
+		"getSummary": func(a *Action) string { return a.GetSummary() },
+		"getName":    func(a *Action) string { return a.GetName() },
+		"getDetails": func(a *Action) string { return a.GetDetails() },
 	}).
 	Parse(`
 {{- printf "%q" .config.Name }} will perform the following {{ if .showStepNumbers }}actions{{ else }}action{{ end }}:
 
 {{ $global := . }}
 {{- range $index, $action := .config.Actions }}
-{{- if $global.showStepNumbers }}{{ addOne $index }}. {{ end -}}{{$action.GetSummary}}.
-{{$action.GetName}}: {{$action.GetDetails}}
+{{- if $global.showStepNumbers }}{{ addOne $index }}. {{ end -}}{{getSummary $action}}.
+{{getName $action}}: {{getDetails $action}}
 
 {{end -}}
 `))

--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -22,8 +22,9 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"text/template"
+	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
@@ -36,8 +37,9 @@ import (
 // databaseConfigTemplateFunc list of template functions used on the database
 // config template.
 var databaseConfigTemplateFuncs = template.FuncMap{
-	"quote": quote,
-	"join":  strings.Join,
+	"quote":    quote,
+	"join":     strings.Join,
+	"duration": func(d types.Duration) time.Duration { return d.Duration() },
 }
 
 // databaseAgentConfigurationTemplate database configuration template.
@@ -457,7 +459,7 @@ db_service:
     dynamic_labels:
     {{- range $name, $label := .StaticDatabaseDynamicLabels }}
     - name: "{{ $name }}"
-      period: "{{ $label.Period.Duration }}"
+      period: "{{ duration $label.Period }}"
       command:
       {{- range $command := $label.Command }}
       - {{ $command | quote }}

--- a/lib/config/openssh/openssh.go
+++ b/lib/config/openssh/openssh.go
@@ -21,8 +21,8 @@ package openssh
 import (
 	"io"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"

--- a/lib/config/systemd/systemd.go
+++ b/lib/config/systemd/systemd.go
@@ -21,8 +21,8 @@ package systemd
 import (
 	"io"
 	"os"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/defaults"

--- a/lib/join/join_iam_test.go
+++ b/lib/join/join_iam_test.go
@@ -26,9 +26,9 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	organizationstypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"

--- a/lib/kube/kubeconfig/context_overwrite.go
+++ b/lib/kube/kubeconfig/context_overwrite.go
@@ -21,8 +21,8 @@ package kubeconfig
 
 import (
 	"bytes"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 )
 

--- a/lib/kube/proxy/resource_filters_test.go
+++ b/lib/kube/proxy/resource_filters_test.go
@@ -27,8 +27,8 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"

--- a/lib/kube/proxy/resource_list_test.go
+++ b/lib/kube/proxy/resource_list_test.go
@@ -25,8 +25,8 @@ import (
 	"io"
 	"log/slog"
 	"testing"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/lib/openssh/sshd.go
+++ b/lib/openssh/sshd.go
@@ -27,8 +27,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"

--- a/lib/puttyhosts/puttyhosts.go
+++ b/lib/puttyhosts/puttyhosts.go
@@ -25,8 +25,8 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 

--- a/lib/saml/request.go
+++ b/lib/saml/request.go
@@ -20,9 +20,9 @@ package saml
 
 import (
 	"bytes"
-	"html/template"
 	"net/http"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/html"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/httplib"

--- a/lib/srv/db/common/kerberos/kinit/kinit.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit.go
@@ -28,9 +28,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	"github.com/jcmturner/gokrb5/v8/client"
 	"github.com/jcmturner/gokrb5/v8/config"

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -21,8 +21,8 @@ package installer_test
 import (
 	"bytes"
 	"testing"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/installers"

--- a/lib/tbot/config/systemd/template.go
+++ b/lib/tbot/config/systemd/template.go
@@ -20,7 +20,8 @@ package systemd
 
 import (
 	_ "embed"
-	"text/template"
+
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 )
 
 var (

--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -29,9 +29,9 @@ import (
 	"maps"
 	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"

--- a/lib/utils/aws/region/internal/codegen.go
+++ b/lib/utils/aws/region/internal/codegen.go
@@ -26,8 +26,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 )
 

--- a/lib/vnet/opensshconfig.go
+++ b/lib/vnet/opensshconfig.go
@@ -29,9 +29,9 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	renameio "github.com/google/renameio/v2/maybe" // Writes aren't guaranteed to be atomic on Windows.
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -28,7 +28,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
 	"log/slog"
 	"math/rand/v2"
@@ -44,6 +43,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/html"
 	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/google/safetext/shsprintf"
 	"github.com/google/uuid"

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -20,12 +20,12 @@ package app
 
 import (
 	"fmt"
-	"html/template"
 	"io"
 	"net/http"
 	"slices"
 	"strings"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/html"
 	"github.com/gravitational/trace"
 	"golang.org/x/net/html"
 

--- a/lib/web/mwi_wizards.go
+++ b/lib/web/mwi_wizards.go
@@ -24,8 +24,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 

--- a/lib/web/scripts/database.go
+++ b/lib/web/scripts/database.go
@@ -20,7 +20,8 @@ package scripts
 
 import (
 	_ "embed"
-	"text/template"
+
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 )
 
 //go:embed database/sqlserver/configure-ad.ps1

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -27,8 +27,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"

--- a/lib/web/scripts/oneoff/oneoff.go
+++ b/lib/web/scripts/oneoff/oneoff.go
@@ -23,8 +23,8 @@ import (
 	_ "embed"
 	"slices"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api"

--- a/session/selinux/selinux_linux.go
+++ b/session/selinux/selinux_linux.go
@@ -28,8 +28,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	ocselinux "github.com/opencontainers/selinux/go-selinux"
 )

--- a/session/selinux/selinux_test.go
+++ b/session/selinux/selinux_test.go
@@ -22,8 +22,8 @@ import (
 	"io"
 	"os"
 	"testing"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tool/tbot/keypair.go
+++ b/tool/tbot/keypair.go
@@ -27,8 +27,8 @@ import (
 	"io"
 	"os"
 	"strings"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 

--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -21,8 +21,8 @@ package common
 import (
 	"context"
 	"os"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -28,9 +28,9 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -31,9 +31,9 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/google/uuid"

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -21,8 +21,8 @@ package common
 import (
 	"context"
 	"os"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 

--- a/tool/tctl/common/desktop_command.go
+++ b/tool/tctl/common/desktop_command.go
@@ -21,8 +21,8 @@ package common
 import (
 	"context"
 	"os"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -21,8 +21,8 @@ package common
 import (
 	"context"
 	"os"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -24,9 +24,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -30,9 +30,9 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/gravitational/trace"

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -28,8 +28,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/ghodss/yaml"
 	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -30,9 +30,9 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel/attribute"

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -28,9 +28,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 	"k8s.io/client-go/tools/clientcmd"

--- a/tool/tsh/common/mcp_db.go
+++ b/tool/tsh/common/mcp_db.go
@@ -23,8 +23,8 @@ import (
 	"log/slog"
 	"maps"
 	"net"
-	"text/template"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -30,9 +30,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"text/template"
 	"unicode"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -40,9 +40,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
All existing template usage was converted to make use of github.com/DataDog/datadog-agent/pkg/template. The DataDog package is a fork of the stdlib template packages with method calling removed so that reflect.MethodByName does not prevent DCE.

The only templates that made use of method calling were the ones used by access plugins. They were formatting the created at time in the template. This was changed to format the time when the template was created so that the template only needed to render a string.

A future change will add linter rules to prevent new text/template or html/imports from landing. They have not been included here so as to not to break enterprise code while it is migrated.