### PR TITLE
[v17] Fix double start check in bot.Bot

### DIFF
--- a/lib/tbot/bot/bot.go
+++ b/lib/tbot/bot/bot.go
@@ -65,7 +65,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 	ctx, span := tracer.Start(ctx, "Bot/Run")
 	defer func() { apitracing.EndSpan(span, err) }()
 
-	if b.checkStarted(); err != nil {
+	if err := b.checkStarted(); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -118,7 +118,7 @@ func (b *Bot) OneShot(ctx context.Context) (err error) {
 	ctx, span := tracer.Start(ctx, "Bot/OneShot")
 	defer func() { apitracing.EndSpan(span, err) }()
 
-	if b.checkStarted(); err != nil {
+	if err := b.checkStarted(); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/tbot/bot/bot_test.go
+++ b/lib/tbot/bot/bot_test.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2025  Gravitational, Inc.
+ * Copyright (C) 2026  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,20 +16,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bot_test
+package bot
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 )
 
 func TestBot_RejectsDoubleStart(t *testing.T) {
-	b, err := bot.New(bot.Config{
+	b, err := New(Config{
 		Connection: connection.Config{
 			Address:            "localhost:3025",
 			AddressKind:        connection.AddressKindProxy,
@@ -38,7 +36,7 @@ func TestBot_RejectsDoubleStart(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_ = b.OneShot(ctx)
 

--- a/lib/tbot/bot/bot_test.go
+++ b/lib/tbot/bot/bot_test.go
@@ -1,0 +1,50 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bot_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+)
+
+func TestBot_RejectsDoubleStart(t *testing.T) {
+	b, err := bot.New(bot.Config{
+		Connection: connection.Config{
+			Address:            "localhost:3025",
+			AddressKind:        connection.AddressKindProxy,
+			StaticProxyAddress: true,
+		},
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_ = b.OneShot(ctx)
+
+	err = b.OneShot(ctx)
+	require.ErrorContains(t, err, "already been started")
+
+	err = b.Run(ctx)
+	require.ErrorContains(t, err, "already been started")
+}


### PR DESCRIPTION
Backport #65384 to branch/v17

## Manual Test Plan
### Test Environment

 Local environment

### Test Cases

- [x] Start tbot in one shot mode
- [x] Start tbot in daemon mode