### PR TITLE
Fix missing error in `tbot` logs

### DIFF
--- a/lib/tbot/workloadidentity/workloadattest/unix.go
+++ b/lib/tbot/workloadidentity/workloadattest/unix.go
@@ -198,7 +198,7 @@ func (a *UnixAttestor) hashBinary(ctx context.Context, proc *process.Process) st
 	select {
 	case res := <-resCh:
 		if res.err != nil {
-			a.log.ErrorContext(ctx, "Failed to hash workload executable", "error", err)
+			a.log.ErrorContext(ctx, "Failed to hash workload executable", "error", res.err)
 		}
 		return res.sum
 	case <-time.After(BinaryHashReadTimeout):


### PR DESCRIPTION
Sweeping `lib/tbot` for correctness with Claude, found this case where the wrong error variable was being included in the structured logs.

