### PR TITLE
Address flaky tests due to scoped role assignment cache delay

### DIFF
--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1513,7 +1513,7 @@ func TestAuthPreferenceSettings_ScopedIdentity(t *testing.T) {
 	user, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-reader")
 	require.NoError(t, err)
 
-	_, err = scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+	createResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: &scopedaccessv1.ScopedRoleAssignment{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			SubKind: scopedaccess.SubKindDynamic,
@@ -1531,6 +1531,14 @@ func TestAuthPreferenceSettings_ScopedIdentity(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := srv.AuthServer.AuthServer.ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name:    createResp.GetAssignment().GetMetadata().GetName(),
+			SubKind: createResp.GetAssignment().GetSubKind(),
+		})
+		require.NoError(t, err)
+	}, 10*time.Second, 100*time.Millisecond)
 
 	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
 	require.NoError(t, err)
@@ -2595,7 +2603,7 @@ func TestGetCertAuthority_ScopedIdentity(t *testing.T) {
 	user, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-reader")
 	require.NoError(t, err)
 
-	_, err = scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+	createResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: &scopedaccessv1.ScopedRoleAssignment{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			SubKind: scopedaccess.SubKindDynamic,
@@ -2613,6 +2621,14 @@ func TestGetCertAuthority_ScopedIdentity(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := srv.AuthServer.AuthServer.ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name:    createResp.GetAssignment().GetMetadata().GetName(),
+			SubKind: createResp.GetAssignment().GetSubKind(),
+		})
+		require.NoError(t, err)
+	}, 10*time.Second, 100*time.Millisecond)
 
 	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
 	require.NoError(t, err)
@@ -5002,7 +5018,7 @@ func TestWatchEvents_ScopedIdentity(t *testing.T) {
 	user, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-watcher")
 	require.NoError(t, err)
 
-	_, err = scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+	createResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: &scopedaccessv1.ScopedRoleAssignment{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			SubKind: scopedaccess.SubKindDynamic,
@@ -5020,6 +5036,14 @@ func TestWatchEvents_ScopedIdentity(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := srv.AuthServer.AuthServer.ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name:    createResp.GetAssignment().GetMetadata().GetName(),
+			SubKind: createResp.GetAssignment().GetSubKind(),
+		})
+		require.NoError(t, err)
+	}, 10*time.Second, 100*time.Millisecond)
 
 	scopedClient, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
 	require.NoError(t, err)


### PR DESCRIPTION
These tests were occasionally flaking in CI due to delays in propagation of the created SRA to the scoped role cache.

Closes https://github.com/gravitational/teleport/issues/65406