### PR TITLE
Edit the enrolling apps getting started guide

### DIFF
--- a/docs/pages/enroll-resources/application-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/application-access/getting-started.mdx
@@ -231,6 +231,8 @@ Teleport Web UI.
 
 There are a couple of ways to access the proxied application.
 
+### Using a browser
+
 Sign in to the Teleport Web UI using your Teleport cluster address. 
 All available applications are displayed on the Applications tab. 
 Click **Launch** on the Grafana application tile to access it.
@@ -238,6 +240,30 @@ Click **Launch** on the Grafana application tile to access it.
 Alternatively, you can call the application directly with its name as the subdomain, for example, 
 `https://grafana.teleport.example.com` or `https://grafana.mytenant.teleport.sh`. 
 You are prompted to sign in if you haven't already been authenticated.
+
+### Using CLI clients
+
+You can access Teleport-protected web applications using command-line tools and
+scripts. To do so, retrieve a short-lived X.509 certificate for the application.
+Teleport uses this certificate to authenticate requests. Run the following
+command:
+
+```code
+$ tsh apps login grafana
+```
+
+The output shows an example `curl` command you can run to call the target
+application's API, similar to the example below. The `curl` command shows the
+file paths of your certificate and private key. These contain the Proxy Service
+URL, your Teleport username, and cluster URL (which happen to be the same
+below):
+
+```text
+curl \
+  --cert ~/.tsh/keys/teleport.example.com/alice-app/teleport.example.com/grafana.crt \
+  --key ~/.tsh/keys/teleport.example.com/alice-app/teleport.example.com/grafana.key \
+  https://grafana.teleport.example.com
+```
 
 ## Next steps
 

--- a/docs/pages/enroll-resources/application-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/application-access/getting-started.mdx
@@ -253,17 +253,8 @@ $ tsh apps login grafana
 ```
 
 The output shows an example `curl` command you can run to call the target
-application's API, similar to the example below. The `curl` command shows the
-file paths of your certificate and private key. These contain the Proxy Service
-URL, your Teleport username, and cluster URL (which happen to be the same
-below):
-
-```text
-curl \
-  --cert ~/.tsh/keys/teleport.example.com/alice-app/teleport.example.com/grafana.crt \
-  --key ~/.tsh/keys/teleport.example.com/alice-app/teleport.example.com/grafana.key \
-  https://grafana.teleport.example.com
-```
+application's API. The `curl` command shows the file paths of the certificate
+and private key to use to authenticate your API calls.
 
 ## Next steps
 


### PR DESCRIPTION
Add a noninteractive alternative to using a browser to access the application. This allows an agent without browser access to complete the entirety of the guide as long as it has tctl privileges, and helps us begin to standardize how-to guides on including CLI alternatives to browser-only steps.

This is also helpful for humans who are interested in access to APIs, since the instructions are mostly the same as enrolling browser-based apps. (Note that there is also a link to the API Access guide in the "Next steps" section of the Getting Started guide.)