### PR TITLE
[v18] Address flaky tests due to scoped role assignment cache delay (#65407)

### DIFF
--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1496,7 +1496,7 @@ func TestAuthPreferenceSettings_ScopedIdentity(t *testing.T) {
 	user, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-reader")
 	require.NoError(t, err)
 
-	_, err = scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+	createResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: &scopedaccessv1.ScopedRoleAssignment{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			Version: types.V1,
@@ -1513,6 +1513,14 @@ func TestAuthPreferenceSettings_ScopedIdentity(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := srv.AuthServer.AuthServer.ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name:    createResp.GetAssignment().GetMetadata().GetName(),
+			SubKind: createResp.GetAssignment().GetSubKind(),
+		})
+		require.NoError(t, err)
+	}, 10*time.Second, 100*time.Millisecond)
 
 	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
 	require.NoError(t, err)
@@ -2574,7 +2582,7 @@ func TestGetCertAuthority_ScopedIdentity(t *testing.T) {
 	user, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-reader")
 	require.NoError(t, err)
 
-	_, err = scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+	createResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: &scopedaccessv1.ScopedRoleAssignment{
 			Kind:    scopedaccess.KindScopedRoleAssignment,
 			Version: types.V1,
@@ -2591,6 +2599,14 @@ func TestGetCertAuthority_ScopedIdentity(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := srv.AuthServer.AuthServer.ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name:    createResp.GetAssignment().GetMetadata().GetName(),
+			SubKind: createResp.GetAssignment().GetSubKind(),
+		})
+		require.NoError(t, err)
+	}, 10*time.Second, 100*time.Millisecond)
 
 	scopedClt, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), "/test/scope"))
 	require.NoError(t, err)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1516,8 +1516,7 @@ func TestAuthPreferenceSettings_ScopedIdentity(t *testing.T) {
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		_, err := srv.AuthServer.AuthServer.ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
-			Name:    createResp.GetAssignment().GetMetadata().GetName(),
-			SubKind: createResp.GetAssignment().GetSubKind(),
+			Name: createResp.GetAssignment().GetMetadata().GetName(),
 		})
 		require.NoError(t, err)
 	}, 10*time.Second, 100*time.Millisecond)
@@ -2602,8 +2601,7 @@ func TestGetCertAuthority_ScopedIdentity(t *testing.T) {
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		_, err := srv.AuthServer.AuthServer.ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
-			Name:    createResp.GetAssignment().GetMetadata().GetName(),
-			SubKind: createResp.GetAssignment().GetSubKind(),
+			Name: createResp.GetAssignment().GetMetadata().GetName(),
 		})
 		require.NoError(t, err)
 	}, 10*time.Second, 100*time.Millisecond)


### PR DESCRIPTION
Backports #65407
