### PR TITLE
[v18] feat(integrations/terraform): support polling state changes

### DIFF
--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -24,6 +24,9 @@ import (
     "encoding/hex"
 {{- end }}
 	"fmt"
+{{- if .StatePoll }}
+	"time"
+{{- end }}
 {{- range $i, $a := .ExtraImports }}
 	{{$a}}
 {{- end }}
@@ -40,6 +43,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+{{- if .StatePoll }}
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+{{- end }}
 	"github.com/jonboulle/clockwork"
 {{- if .Namespaced }}
 	"github.com/gravitational/teleport/api/defaults"
@@ -239,6 +245,55 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+{{- if .StatePoll }}
+
+	stateConf := resource.StateChangeConf{
+		Pending: []string{
+		{{- range $state := .StatePoll.PendingStates }}
+			"{{ $state }}",
+		{{- end }}
+		},
+		Target:  []string{
+		{{- range $state := .StatePoll.TargetStates }}
+			"{{ $state }}",
+		{{- end }}
+		},
+		Timeout:      {{ .StatePoll.StateTimeoutSeconds }} * time.Second,
+		PollInterval: {{ .StatePoll.StatePollIntervalSeconds }} * time.Second,
+		Refresh: func() (any, string, error) {
+			{{ .VarName }}, err := r.p.Client.{{ .GetMethod }}(ctx, id)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			if {{ .VarName }} == nil {
+				return nil, "", trace.Errorf("response from {{ .GetMethod }} was nil")
+			}
+
+			{{- $root := . }}
+			{{- $lastIndex := -1 }}
+			{{- range $i, $p := .StatePoll.StatePath }}
+				{{- $lastIndex = $i }}
+			{{- end }}
+			{{- $currentPath := "" }}
+			{{- range $i, $p := .StatePoll.StatePath }}
+				{{- if eq $i $lastIndex }}
+					{{- break }}
+				{{- end }}
+				{{- $currentPath = print $currentPath "." $p }}
+			if {{ $root.VarName }}{{ $currentPath }} == nil {
+				return nil, "", trace.Errorf("response from {{ $root.GetMethod }} at {{ $currentPath }} was nil")
+			}
+			{{- end }}
+
+			return {{ .VarName }}, {{ .VarName }}{{ range $p := .StatePoll.StatePath }}. {{- $p }}{{ end }}, nil
+		},
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error waiting for {{ .TypeName }}", trace.Wrap(err), "{{ .Kind }}"))
+	}
+{{- end }}
 }
 
 // Read reads teleport {{.Name}}
@@ -417,6 +472,55 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+{{- if .StatePoll }}
+
+	stateConf := resource.StateChangeConf{
+		Pending: []string{
+		{{- range $state := .StatePoll.PendingStates }}
+			"{{ $state }}",
+		{{- end }}
+		},
+		Target:  []string{
+		{{- range $state := .StatePoll.TargetStates }}
+			"{{ $state }}",
+		{{- end }}
+		},
+		Timeout:      {{ .StatePoll.StateTimeoutSeconds }} * time.Second,
+		PollInterval: {{ .StatePoll.StatePollIntervalSeconds }} * time.Second,
+		Refresh: func() (any, string, error) {
+			{{ .VarName }}, err := r.p.Client.{{ .GetMethod }}(ctx, name)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			if {{ .VarName }} == nil {
+				return nil, "", trace.Errorf("response from {{ .GetMethod }} was nil")
+			}
+
+			{{- $root := . }}
+			{{- $lastIndex := -1 }}
+			{{- range $i, $p := .StatePoll.StatePath }}
+				{{- $lastIndex = $i }}
+			{{- end }}
+			{{- $currentPath := "" }}
+			{{- range $i, $p := .StatePoll.StatePath }}
+				{{- if eq $i $lastIndex }}
+					{{- break }}
+				{{- end }}
+				{{- $currentPath = print $currentPath "." $p }}
+			if {{ $root.VarName }}{{ $currentPath }} == nil {
+				return nil, "", trace.Errorf("response from {{ $root.GetMethod }} at {{ $currentPath }} was nil")
+			}
+			{{- end }}
+
+			return {{ .VarName }}, {{ .VarName }}{{ range $p := .StatePoll.StatePath }}. {{- $p }}{{ end }}, nil
+		},
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error waiting for {{ .TypeName }}", trace.Wrap(err), "{{ .Kind }}"))
+	}
+{{- end }}
 }
 
 // Delete deletes Teleport {{.Name}}


### PR DESCRIPTION
This backports #63520 to v18. I had to manually cherry-pick 44ed0e11c78a923b2ea83b740ac0f997a3b6c10c to resolve conflict with the new import in `integrations/terraform/gen/plural_resource.go.tpl`.

Goal: https://github.com/gravitational/cloud/issues/15870

No test cases since this doesn't impact any existing resources. Test cases will exist for the backport of #63535, which does use this new functionality.