### PR TITLE
[v18] bump fastmcp to 3.2.0 for mcp server example

### DIFF
--- a/examples/mcp-servers/verify-teleport-jwt-fastmcp/pyproject.toml
+++ b/examples/mcp-servers/verify-teleport-jwt-fastmcp/pyproject.toml
@@ -5,5 +5,5 @@ description = "MCP server that verifies Teleport's JWT"
 readme = "README.md"
 requires-python = ">=3.13,<3.15"
 dependencies = [
-    "fastmcp>=2.12.4,<3.0",
+    "fastmcp>=3.2.0,<4",
 ]


### PR DESCRIPTION
Backport #65423 to branch/v18

did not redo the full manual test plan as the example only affects the example python MCP server, not Teleport services.

i did verify `uv run main.py` does run on this branch and verified the sever started successfully with `FastMCP 3.2.0`
```bash
$ git checkout bot/backport-65423-branch/v18
$ rm uv.lock
$ uv run main.py
Uninstalled 2 packages in 28ms
Installed 2 packages in 28ms
☕ Teleport cluster: steve-beams.cloud.gravitational.io
````