### PR TITLE
Database service name validation for WebUI connections

### DIFF
--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -559,6 +559,13 @@ type DatabaseSessionRequest struct {
 	DatabaseRoles []string `json:"dbRoles"`
 }
 
+func (r *DatabaseSessionRequest) check() error {
+	if err := types.ValidateDatabaseName(r.ServiceName); err != nil {
+		return trace.Wrap(err, "database service name %q is invalid", r.ServiceName)
+	}
+	return nil
+}
+
 // databaseConnectionRequestWaitTimeout defines how long the server will wait
 // for the user to send the connection request.
 const databaseConnectionRequestWaitTimeout = defaults.HeadlessLoginTimeout
@@ -595,6 +602,10 @@ func readDatabaseSessionRequest(ws *websocket.Conn) (*DatabaseSessionRequest, er
 
 	var req DatabaseSessionRequest
 	if err := json.Unmarshal([]byte(envelope.Payload), &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := req.check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -663,15 +663,24 @@ func TestConnectDatabaseInteractiveSession(t *testing.T) {
 	_, err = s.server.Auth().UpsertDatabaseServer(ctx, mustCreateDatabaseServer(t, selfHosted))
 	require.NoError(t, err)
 	tests := []struct {
-		desc    string
-		replErr error
+		desc                     string
+		databaseServiceName      string
+		replErr                  error
+		expectRequestErrContains string
 	}{
 		{
-			desc: "success",
+			desc:                "success",
+			databaseServiceName: databaseName,
 		},
 		{
-			desc:    "errors are sent to the user",
-			replErr: trace.Errorf("database connection interrupted by unexpected llama crossing"),
+			desc:                "errors are sent to the user",
+			databaseServiceName: databaseName,
+			replErr:             trace.Errorf("database connection interrupted by unexpected llama crossing"),
+		},
+		{
+			desc:                     "invalid service name",
+			databaseServiceName:      "invalid service name",
+			expectRequestErrContains: "does not match regex",
 		},
 	}
 	for _, test := range tests {
@@ -715,7 +724,7 @@ func TestConnectDatabaseInteractiveSession(t *testing.T) {
 
 			req := DatabaseSessionRequest{
 				Protocol:      databaseProtocol,
-				ServiceName:   databaseName,
+				ServiceName:   test.databaseServiceName,
 				DatabaseName:  "postgres",
 				DatabaseUser:  "postgres",
 				DatabaseRoles: []string{"reader"},
@@ -729,6 +738,16 @@ func TestConnectDatabaseInteractiveSession(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NoError(t, ws.WriteMessage(websocket.BinaryMessage, reqWebSocketMessage))
+
+			if test.expectRequestErrContains != "" {
+				_, raw, err := ws.ReadMessage()
+				require.NoError(t, err)
+
+				var env terminal.Envelope
+				require.NoError(t, proto.Unmarshal(raw, &env))
+				require.Contains(t, env.Payload, test.expectRequestErrContains)
+				return
+			}
 
 			performMFACeremonyWS(t, ws, pack)
 


### PR DESCRIPTION
AI tool has found a potential issue at:
https://github.com/gravitational/teleport/blob/18598265065047f591c55cf7b9946deca11e0fb0/lib/web/databases.go#L498-L503
where the `req.ServiceName` coming from client can potentially be crafted to inject some special predicate. However, upon further investigation:
- `clt` here is scoped to the Teleport user so a crafted predicate like `my-postgres-auto\" || name == \"my-postgres` will NOT grant caller access to databases not allowed by their teleport roleset
- Even if a crafted predicate finds some other databases allowed by their teleport roleset, a later check at db proxy server will still fail
https://github.com/gravitational/teleport/blob/18598265065047f591c55cf7b9946deca11e0fb0/lib/srv/db/common/connect/connect.go#L65-L71

However, it may still worth it to validate the database service name earlier, thus this change

## Manual Test Plan

### Test Environment
steve-beams.cloud.gravitational.io

### Test Cases
- [x] Connect DB via browser still functions as normal
- [x] Run a [python tester](https://github.com/greedy52/teleport-database-test-setup/tree/main/teleport-db-via-ws) against the websocket API. 
  - Before this change, it has the following error showing the flow went a lot further
```
[error] Unable to connect to database: failed to connect to `host=repl user=teleport-admin database=test`: failed to write startup message (io: read/write on closed pipe)
```
   - After this change, it shows the new error
```
Server error: database service name "my-postgres-auto\" || name == \"my-postgres" is invalid
	"my-postgres-auto\" || name == \"my-postgres" does not match regex used for validation "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
```