### PR TITLE
docs: updates to helm deployments

### DIFF
--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/azure.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/azure.mdx
@@ -5,7 +5,7 @@ description: Install and configure an HA Teleport cluster using a Microsoft Azur
 tags:
  - how-to
  - platform-wide
- - aws
+ - azure
 ---
 
 In this guide, we'll go through how to set up a High Availability Teleport

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/ibm.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/ibm.mdx
@@ -247,7 +247,7 @@ $ helm repo update
 
 Create a release from the chart:
 ```code
-$ helm upgrade --install -n teleport-cluster teleport teleport/teleport-cluster --version "TODO REPLACE ME" -f values.yaml
+$ helm upgrade --install -n teleport-cluster teleport teleport/teleport-cluster -f values.yaml
 
 Release "teleport" does not exist. Installing it now.
 NAME: teleport
@@ -319,4 +319,4 @@ As next steps you can:
   [applications](../../../enroll-resources/application-access/getting-started.mdx),
   or [Windows desktops](../../../enroll-resources/desktop-access/desktop-access.mdx) into your Teleport cluster
 - check the [`teleport-cluster` Helm reference](../../../reference/helm-reference/teleport-cluster.mdx) for a list of supported values
-- use [the Teleport Kubernetes operator(../../admin-guides/infrastructure-as-code/teleport-operator/teleport-operator.mdx) to control Teleport resources
+- use [the Teleport Kubernetes operator](../../admin-guides/infrastructure-as-code/teleport-operator/teleport-operator.mdx) to control Teleport resources

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/ibm.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/ibm.mdx
@@ -319,4 +319,4 @@ As next steps you can:
   [applications](../../../enroll-resources/application-access/getting-started.mdx),
   or [Windows desktops](../../../enroll-resources/desktop-access/desktop-access.mdx) into your Teleport cluster
 - check the [`teleport-cluster` Helm reference](../../../reference/helm-reference/teleport-cluster.mdx) for a list of supported values
-- use [the Teleport Kubernetes operator](../../admin-guides/infrastructure-as-code/teleport-operator/teleport-operator.mdx) to control Teleport resources
+- use [the Teleport Kubernetes operator](../../infrastructure-as-code/teleport-operator/teleport-operator.mdx) to control Teleport resources

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/ibm.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/ibm.mdx
@@ -247,7 +247,7 @@ $ helm repo update
 
 Create a release from the chart:
 ```code
-$ helm upgrade --install -n teleport-cluster teleport teleport/teleport-cluster -f values.yaml
+$ helm upgrade --install -n teleport-cluster teleport teleport/teleport-cluster --version=(=teleport.version=) -f values.yaml
 
 Release "teleport" does not exist. Installing it now.
 NAME: teleport


### PR DESCRIPTION


docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/azure.mdx:
- Tagged as aws originally, fixed to azure

docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/ibm.mdx:
- removed version parameter for `helm upgrade --install` that had a "TODO REPLACE". This will use the latest version from the repo. 
- Fixed link in next steps
