### PR TITLE
[v18] Refactor bound keypair join client interface (#64235)

### DIFF
--- a/lib/auth/join/boundkeypair/boundkeypair.go
+++ b/lib/auth/join/boundkeypair/boundkeypair.go
@@ -32,7 +32,6 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/auth/join"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/sshutils"
 )
@@ -67,13 +66,19 @@ type ClientParams struct {
 	// RegistrationSecret is a one-time secret used to authenticate an initial
 	// join when a public key has not been preregistered.
 	RegistrationSecret string
+
+	// PreviousJoinState is the join state from a previous auth attempt, if any.
+	// This is unset for first-time joins or when static keys are in use.
+	PreviousJoinState []byte
 }
 
 // ClientState is the minimal interface needed to generate joining parameters.
 type ClientState interface {
-	ToJoinParams(params ClientParams) *join.BoundKeypairParams
-	UpdateFromRegisterResult(result *join.RegisterResult) error
+	UpdateFromRegisterResult(boundPublicKey []byte, joinState []byte) error
 	Store(ctx context.Context) error
+	GetSigner(pubKey []byte) (crypto.Signer, error)
+	RequestNewKeypair(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error)
+	GetClientParams(registrationSecret string) *ClientParams
 }
 
 // FSClientState contains state parameters stored on disk needed to complete the
@@ -105,49 +110,38 @@ type FSClientState struct {
 	KeyHistory []KeyHistoryEntry
 }
 
-// ToJoinParams creates joining parameters for use with `join.Register()` from
-// this client state.
-func (c *FSClientState) ToJoinParams(params ClientParams) *join.BoundKeypairParams {
-	registrationSecret := params.RegistrationSecret
+func (c *FSClientState) RequestNewKeypair(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
+	signer, err := c.GenerateKeypair(ctx, getSuite)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Make sure to store the intermediate state. We don't want to risk
+	// losing a private key if an error occurs between here and the end
+	// of the join process, but also don't want to force
+	// `GenerateKeypair()` to trigger a `Store()` on every call, so it's
+	// reasonably done here.
+	if err := c.Store(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return signer, nil
+}
+
+func (c *FSClientState) GetClientParams(registrationSecret string) *ClientParams {
 	if len(c.JoinStateBytes) > 0 {
-		// This identity has been bound, so don't pass along the join secret (if
-		// any)
 		registrationSecret = ""
 	}
 
-	return &join.BoundKeypairParams{
-		PreviousJoinState:  c.JoinStateBytes,
+	return &ClientParams{
 		RegistrationSecret: registrationSecret,
-		GetSigner: func(pubKey string) (crypto.Signer, error) {
-			return c.SignerForPublicKey([]byte(pubKey))
-		},
-		RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-			signer, err := c.GenerateKeypair(ctx, getSuite)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			// Make sure to store the intermediate state. We don't want to risk
-			// losing a private key if an error occurs between here and the end
-			// of the join process, but also don't want to force
-			// `GenerateKeypair()` to trigger a `Store()` on every call, so it's
-			// reasonably done here.
-			if err := c.Store(ctx); err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			return signer, nil
-		},
+		PreviousJoinState:  c.JoinStateBytes,
 	}
 }
 
 // UpdateFromRegisterResult updates this client state from the register result.
-func (c *FSClientState) UpdateFromRegisterResult(result *join.RegisterResult) error {
-	if result.BoundKeypair == nil {
-		return trace.BadParameter("register result is missing bound keypair parameters")
-	}
-
-	signer, err := c.SignerForPublicKey([]byte(result.BoundKeypair.BoundPublicKey))
+func (c *FSClientState) UpdateFromRegisterResult(boundPublicKey []byte, joinState []byte) error {
+	signer, err := c.GetSigner(boundPublicKey)
 	if err != nil {
 		return trace.Wrap(err, "fetching key requested by auth")
 	}
@@ -161,7 +155,7 @@ func (c *FSClientState) UpdateFromRegisterResult(result *join.RegisterResult) er
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.JoinStateBytes = result.BoundKeypair.JoinState
+	c.JoinStateBytes = joinState
 
 	return nil
 }
@@ -188,9 +182,9 @@ func pubKeyEqual(a, b crypto.PublicKey) (bool, error) {
 	return aEq.Equal(b), nil
 }
 
-// SignerForPublicKey attempts to resolve a signer for the given public key
+// GetSigner attempts to resolve a signer for the given public key
 // encoded in authorized_keys format.
-func (c *FSClientState) SignerForPublicKey(authorizedKeysBytes []byte) (crypto.Signer, error) {
+func (c *FSClientState) GetSigner(authorizedKeysBytes []byte) (crypto.Signer, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -524,7 +518,7 @@ type StaticClientState struct {
 	privateKeyBytes []byte
 }
 
-func (s *StaticClientState) checkedSigner(expectPubKey []byte) (crypto.Signer, error) {
+func (s *StaticClientState) GetSigner(expectPubKey []byte) (crypto.Signer, error) {
 	desiredPubKey, err := sshutils.CryptoPublicKey(expectPubKey)
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing expected public key")
@@ -548,27 +542,7 @@ func (s *StaticClientState) checkedSigner(expectPubKey []byte) (crypto.Signer, e
 	return privateKey.Signer, nil
 }
 
-// ToJoinParams returns join parameters for this static client state. It does
-// not support registration secrets or key rotation, and will produce a warning
-// or error if unsupported operations are attempted.
-func (s *StaticClientState) ToJoinParams(params ClientParams) *join.BoundKeypairParams {
-	if params.RegistrationSecret != "" {
-		slog.WarnContext(context.Background(), "A registration secret was specified while using a static private key and will be ignored")
-	}
-
-	return &join.BoundKeypairParams{
-		// Note: no registration secret or previous join state.
-
-		GetSigner: func(pubKey string) (crypto.Signer, error) {
-			return s.checkedSigner([]byte(pubKey))
-		},
-		RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-			return nil, trace.BadParameter("static private keys do not support automatic rotation, `rotate_after` must be unset in the token to continue")
-		},
-	}
-}
-
-func (s *StaticClientState) UpdateFromRegisterResult(result *join.RegisterResult) error {
+func (s *StaticClientState) UpdateFromRegisterResult(boundPublicKey []byte, joinState []byte) error {
 	// TODO: We could parse the returned join state JWT and examine the recovery
 	// mode claim to log a warning if it is anything but `insecure`.
 
@@ -582,6 +556,19 @@ func (s *StaticClientState) Store(ctx context.Context) error {
 	// no-op. don't bother logging anything since there's nothing that can be
 	// done.
 	return nil
+}
+
+func (s *StaticClientState) RequestNewKeypair(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
+	return nil, trace.BadParameter("static private keys do not support automatic rotation, `rotate_after` must be unset in the token to continue")
+}
+
+func (s *StaticClientState) GetClientParams(registrationSecret string) *ClientParams {
+	if registrationSecret != "" {
+		slog.WarnContext(context.Background(), "A registration secret was specified while using a static private key and will be ignored")
+	}
+
+	// No client params for static keys.
+	return &ClientParams{}
 }
 
 // NewStaticClientState returns a client state implementation backed by a static

--- a/lib/auth/join/boundkeypair/boundkeypair_test.go
+++ b/lib/auth/join/boundkeypair/boundkeypair_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/auth/join"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 )
 
@@ -85,11 +84,11 @@ func TestClientState(t *testing.T) {
 	// Simulate writes up to the key history recording length.
 	for i := 0; i < KeyHistoryLength-1; i++ {
 		// We should still be able to load the original signer (< KeyHistoryLength)
-		_, err := state.SignerForPublicKey(firstKey)
+		_, err := state.GetSigner(firstKey)
 		require.NoError(t, err)
 
 		// Similarly, the previous key should still be accessible.
-		_, err = state.SignerForPublicKey(prevKey)
+		_, err = state.GetSigner(prevKey)
 		require.NoError(t, err)
 
 		prevKey = state.PrivateKey.MarshalSSHPublicKey()
@@ -127,7 +126,7 @@ func TestClientState(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to load the original key again; it should fail.
-	_, err = state.SignerForPublicKey(firstKey)
+	_, err = state.GetSigner(firstKey)
 	require.Error(t, err)
 }
 
@@ -160,22 +159,20 @@ func TestStaticClientState(t *testing.T) {
 
 	static := NewStaticClientState(privateKeyBytes)
 
-	params := static.ToJoinParams(ClientParams{
-		RegistrationSecret: "test",
-	})
+	params := static.GetClientParams("test")
 	require.Empty(t, params.RegistrationSecret, "registration secret must not be passed through")
 	require.Empty(t, params.PreviousJoinState, "previous join state must always be empty")
 
-	signer, err := params.GetSigner(publicKeyString)
+	signer, err := static.GetSigner([]byte(publicKeyString))
 	require.NoError(t, err)
 
 	// We should actually retrieve a signer for the public key we requested
 	require.True(t, keyEq.Equal(signer.Public()))
 
-	_, err = params.GetSigner(wrongPublicKeyString)
+	_, err = static.GetSigner([]byte(wrongPublicKeyString))
 	require.ErrorContains(t, err, "configured static private key does match the value requested by the server")
 
-	invalidSigner, err := params.RequestNewKeypair(t.Context(), getSuite)
+	invalidSigner, err := static.RequestNewKeypair(t.Context(), getSuite)
 	require.Nil(t, invalidSigner)
 	require.ErrorContains(t, err, "static private keys do not support automatic rotation")
 
@@ -183,5 +180,5 @@ func TestStaticClientState(t *testing.T) {
 	require.NoError(t, static.Store(t.Context()))
 
 	// no-op, but shouldn't return an error
-	require.NoError(t, static.UpdateFromRegisterResult(&join.RegisterResult{}))
+	require.NoError(t, static.UpdateFromRegisterResult(nil, nil))
 }

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/auth/join/iam"
 	"github.com/gravitational/teleport/lib/auth/join/oracle"
 	"github.com/gravitational/teleport/lib/auth/state"
@@ -99,36 +100,6 @@ type GitlabParams struct {
 	// EnvVarName is the name of the environment variable that contains the
 	// IDToken. If unset, this will default to "TBOT_GITLAB_JWT".
 	EnvVarName string
-}
-
-// GetSignerFunc is a function that fetches a keypair from bound keypair client
-// state.
-type GetSignerFunc func(pubKey string) (crypto.Signer, error)
-
-// KeygenFunc is a function to generate a new keypair for bound keypair joining.
-// Clients will generally need to store this for future use, so this function
-// should include some mechanism for storage and retrieval.
-type KeygenFunc func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error)
-
-// BoundKeypairParams are parameters specific to bound-keypair joining.
-type BoundKeypairParams struct {
-	// RegistrationSecret is a one-time-use joining token for use on first join.
-	// May be unset if a keypair was registered with Auth out of band.
-	RegistrationSecret string
-
-	// PreviousJoinState is the previous join state document provided by Auth
-	// alongside the previous set of certs. If this is initial registration, it
-	// can be empty.
-	PreviousJoinState []byte
-
-	// GetSigner is a function that fetches a signer from the client keystore.
-	GetSigner GetSignerFunc
-
-	// RequestNewKeypair is a callback function used to request a new keypair.
-	// This may be called at initial onboarding when `InitialJoinSecret` is set,
-	// or on any join (including the initial join) if `RotateAfter` is set on
-	// the backing token and its value has elapsed.
-	RequestNewKeypair KeygenFunc
 }
 
 // RegisterParams specifies parameters
@@ -204,8 +175,14 @@ type RegisterParams struct {
 	TerraformCloudAudienceTag string
 	// GitlabParams is the parameters specific to the gitlab join method.
 	GitlabParams GitlabParams
-	// BoundKeypairParams contains parameters specific to bound keypair joining.
-	BoundKeypairParams *BoundKeypairParams
+	// BoundKeypairState contains the bound keypair client state, which must
+	// always be present when joining with the bound keypair join method, even
+	// at first join.
+	BoundKeypairState boundkeypair.ClientState
+	// BoundKeypairRegistrationSecret contains an optional registration secret
+	// for bound keypair joining, used to authenticate the first join (and
+	// keypair registration) in lieu of a preregistered public key.
+	BoundKeypairRegistrationSecret string
 	// CreateSignedSTSIdentityRequestFunc overrides the function used to
 	// generate a signed AWs sts:GetCallerIdentity request.
 	CreateSignedSTSIdentityRequestFunc func(ctx context.Context, challenge string, opts ...iam.STSIdentityRequestOption) ([]byte, error)
@@ -418,8 +395,8 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 			}
 		}
 	case types.JoinMethodBoundKeypair:
-		if params.BoundKeypairParams == nil {
-			return nil, trace.BadParameter("bound keypair parameters are required")
+		if params.BoundKeypairState == nil {
+			return nil, trace.BadParameter("bound keypair state is required")
 		}
 	}
 
@@ -1051,13 +1028,14 @@ func registerUsingBoundKeypairMethod(
 	hostKeys *newHostKeys,
 	params RegisterParams,
 ) (*RegisterResult, error) {
-	bkParams := params.BoundKeypairParams
+	bkState := params.BoundKeypairState
 	log := params.Log
 
+	bkClientParams := bkState.GetClientParams(params.BoundKeypairRegistrationSecret)
 	initReq := &proto.RegisterUsingBoundKeypairInitialRequest{
 		JoinRequest:       registerUsingTokenRequestForParams(token, hostKeys, params),
-		InitialJoinSecret: bkParams.RegistrationSecret,
-		PreviousJoinState: bkParams.PreviousJoinState,
+		InitialJoinSecret: bkClientParams.RegistrationSecret,
+		PreviousJoinState: bkClientParams.PreviousJoinState,
 	}
 
 	regResponse, err := client.RegisterUsingBoundKeypairMethod(
@@ -1066,7 +1044,7 @@ func registerUsingBoundKeypairMethod(
 		func(resp *proto.RegisterUsingBoundKeypairMethodResponse) (*proto.RegisterUsingBoundKeypairMethodRequest, error) {
 			switch kind := resp.GetResponse().(type) {
 			case *proto.RegisterUsingBoundKeypairMethodResponse_Challenge:
-				signer, err := bkParams.GetSigner(kind.Challenge.PublicKey)
+				signer, err := bkState.GetSigner([]byte(kind.Challenge.PublicKey))
 				if err != nil {
 					return nil, trace.Wrap(err, "could not lookup signer for public key %+v", kind.Challenge.PublicKey)
 				}
@@ -1105,13 +1083,9 @@ func registerUsingBoundKeypairMethod(
 					},
 				}, nil
 			case *proto.RegisterUsingBoundKeypairMethodResponse_Rotation:
-				if bkParams.RequestNewKeypair == nil {
-					return nil, trace.BadParameter("RequestNewKeypair is required")
-				}
-
 				log.InfoContext(ctx, "Server has requested keypair rotation", "suite", kind.Rotation.SignatureAlgorithmSuite)
 
-				newSigner, err := bkParams.RequestNewKeypair(ctx, cryptosuites.StaticAlgorithmSuite(kind.Rotation.SignatureAlgorithmSuite))
+				newSigner, err := bkState.RequestNewKeypair(ctx, cryptosuites.StaticAlgorithmSuite(kind.Rotation.SignatureAlgorithmSuite))
 				if err != nil {
 					return nil, trace.Wrap(err, "requesting new keypair")
 				}
@@ -1135,6 +1109,14 @@ func registerUsingBoundKeypairMethod(
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	if err := bkState.UpdateFromRegisterResult([]byte(regResponse.BoundPublicKey), regResponse.JoinState); err != nil {
+		return nil, trace.Wrap(err, "updating bound keypair state after registration")
+	}
+
+	if err := bkState.Store(ctx); err != nil {
+		return nil, trace.Wrap(err, "storing updated bound keypair state")
 	}
 
 	// Implementation note, callers are expected to call

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -26,6 +26,8 @@ import (
 	"errors"
 	"net"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -41,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	libboundkeypair "github.com/gravitational/teleport/lib/auth/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/boundkeypair"
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -85,6 +88,174 @@ func newTestTLSServer(t *testing.T, clock clockwork.Clock) *authtest.TLSServer {
 		require.NoError(t, err)
 	})
 	return srv
+}
+
+type mockBoundKeypairState struct {
+	getSigner                func(pubKey []byte) (crypto.Signer, error)
+	requestNewKeypair        func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error)
+	getClientParams          func(registrationSecret string) *libboundkeypair.ClientParams
+	store                    func(ctx context.Context) error
+	updateFromRegisterResult func(boundPublicKey []byte, joinState []byte) error
+
+	signers map[string]crypto.Signer
+
+	rotationCount  atomic.Uint32
+	challengeCount atomic.Uint32
+
+	// single enables single signing mode, otherwise assumes one signing key per
+	// challenge
+	single       bool
+	signingKeys  []string
+	rotationKeys []string
+	solutionKeys []string
+
+	mu                sync.Mutex
+	boundPublicKey    []byte
+	previousJoinState []byte
+}
+
+func (m *mockBoundKeypairState) GetSigner(pubKey []byte) (crypto.Signer, error) {
+	challengeNum := m.challengeCount.Add(1)
+
+	if m.getSigner != nil {
+		return m.getSigner(pubKey)
+	}
+
+	if m.single && len(m.signingKeys) == 0 {
+		return nil, trace.Errorf("single signing mode but no signers found")
+	} else if m.single {
+		signerPubKey := m.signingKeys[0]
+		m.solutionKeys = append(m.solutionKeys, signerPubKey)
+		return m.signers[signerPubKey], nil
+	}
+
+	// the default impl will return signers in order from s.signingKeys, these
+	// may not match pubKey requested but that will test signatures
+	// using an incorrect key.
+	if int(challengeNum) > len(m.signingKeys) {
+		return nil, trace.Errorf("unable to sign (solver has %d signing keys, %d challenges requested)", len(m.signingKeys), challengeNum)
+	}
+
+	signerPubKey := m.signingKeys[challengeNum-1]
+	signer, ok := m.signers[signerPubKey]
+	if !ok {
+		return nil, trace.NotFound("key not found: %s", signerPubKey)
+	}
+
+	m.solutionKeys = append(m.solutionKeys, signerPubKey)
+	return signer, nil
+}
+
+func (m *mockBoundKeypairState) RequestNewKeypair(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
+	count := m.rotationCount.Add(1)
+
+	if m.requestNewKeypair != nil {
+		return m.requestNewKeypair(ctx, getSuite)
+	}
+
+	// requestNewKeypair will return signers in order from
+	// s.rotationKeys.
+	if int(count) > len(m.rotationKeys) {
+		return nil, trace.BadParameter("can't generate key")
+	}
+
+	nextPubKey := m.rotationKeys[count-1]
+	signer, ok := m.signers[nextPubKey]
+	if !ok {
+		return nil, trace.NotFound("signer for rotatedPubKey not found")
+	}
+
+	return signer, nil
+}
+
+func (m *mockBoundKeypairState) GetClientParams(registrationSecret string) *libboundkeypair.ClientParams {
+	if m.getClientParams != nil {
+		return m.getClientParams(registrationSecret)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	joinState := append([]byte(nil), m.previousJoinState...)
+	if len(joinState) > 0 {
+		registrationSecret = ""
+	}
+
+	return &libboundkeypair.ClientParams{
+		RegistrationSecret: registrationSecret,
+		PreviousJoinState:  joinState,
+	}
+}
+
+func (m *mockBoundKeypairState) Store(ctx context.Context) error {
+	if m.store != nil {
+		return m.store(ctx)
+	}
+
+	// mock impl; nothing to do
+	return nil
+}
+
+func (m *mockBoundKeypairState) UpdateFromRegisterResult(boundPublicKey []byte, joinState []byte) error {
+	if m.updateFromRegisterResult != nil {
+		return m.updateFromRegisterResult(boundPublicKey, joinState)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.boundPublicKey = boundPublicKey
+	m.previousJoinState = joinState
+
+	return nil
+}
+
+func withSigningKeys(pubKeys ...string) func(m *mockBoundKeypairState) {
+	return func(m *mockBoundKeypairState) {
+		m.signingKeys = pubKeys
+	}
+}
+
+func withSingleSigningKey(pubKey string) func(m *mockBoundKeypairState) {
+	return func(m *mockBoundKeypairState) {
+		m.single = true
+		m.signingKeys = []string{pubKey}
+	}
+}
+
+func withRotationKeys(pubKeys ...string) func(m *mockBoundKeypairState) {
+	return func(m *mockBoundKeypairState) {
+		m.rotationKeys = pubKeys
+	}
+}
+
+func withPreviousJoinState(data []byte) func(m *mockBoundKeypairState) {
+	return func(m *mockBoundKeypairState) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		m.previousJoinState = data
+	}
+}
+
+func withNoRotation() func(m *mockBoundKeypairState) {
+	return func(m *mockBoundKeypairState) {
+		m.requestNewKeypair = func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
+			return nil, trace.Errorf("no rotation expected")
+		}
+	}
+}
+
+func makeMockBoundKeypairState(signers map[string]crypto.Signer, mutators ...func(*mockBoundKeypairState)) *mockBoundKeypairState {
+	m := &mockBoundKeypairState{
+		signers: signers,
+	}
+
+	for _, mut := range mutators {
+		mut(m)
+	}
+
+	return m
 }
 
 func TestJoinBoundKeypair(t *testing.T) {
@@ -184,7 +355,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 		}
 	}
 
-	makeJoinState := func(signer crypto.Signer, mutators ...func(s *boundkeypair.JoinStateParams)) string {
+	makeJoinState := func(signer crypto.Signer, mutators ...func(s *boundkeypair.JoinStateParams)) []byte {
 		params := &boundkeypair.JoinStateParams{
 			Clock:       srv.Clock(),
 			ClusterName: srv.ClusterName(),
@@ -197,79 +368,13 @@ func TestJoinBoundKeypair(t *testing.T) {
 		state, err := boundkeypair.IssueJoinState(signer, params)
 		require.NoError(t, err)
 
-		return state
+		return []byte(state)
 	}
 
 	withToken := func(mutators ...func(v2 *types.ProvisionTokenV2)) func(*boundkeypair.JoinStateParams) {
 		return func(jsp *boundkeypair.JoinStateParams) {
 			token := makeToken(mutators...)
 			jsp.Token = &token
-		}
-	}
-
-	type solver struct {
-		signingKeys  []string
-		rotationKeys []string
-
-		rotationCount  int
-		challengeCount int
-		solutionKeys   []string
-
-		getSigner         joinclient.GetSignerFunc
-		requestNewKeypair joinclient.KeygenFunc
-	}
-
-	makeSolver := func(mutators ...func(s *solver)) *solver {
-		s := &solver{}
-		for _, mutator := range mutators {
-			mutator(s)
-		}
-
-		s.getSigner = func(pubKey string) (crypto.Signer, error) {
-			// getSigner will return signers in order from s.signingKeys, these
-			// may not match pubKey requested but that will test signatures
-			// using an incorrect key.
-			s.challengeCount++
-			challengeNum := s.challengeCount
-			if s.challengeCount > len(s.signingKeys) {
-				return nil, trace.Errorf("unabled to sign (solver has %d signing keys, %d challenges requested)", len(s.signingKeys), challengeNum)
-			}
-			signerPubKey := s.signingKeys[challengeNum-1]
-			signer, ok := signers[signerPubKey]
-			if !ok {
-				return nil, trace.NotFound("key not found: %s", signerPubKey)
-			}
-			s.solutionKeys = append(s.solutionKeys, signerPubKey)
-			return signer, nil
-		}
-
-		s.requestNewKeypair = func(_ context.Context, _ cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-			// requestNewKeypair will return signers in order from
-			// s.rotationKeys.
-			s.rotationCount++
-			if s.rotationCount > len(s.rotationKeys) {
-				return nil, trace.BadParameter("can't generate key")
-			}
-			nextPubKey := s.rotationKeys[s.rotationCount-1]
-			signer, ok := signers[nextPubKey]
-			if !ok {
-				return nil, trace.NotFound("signer for rotatedPubKey not found")
-			}
-			return signer, nil
-		}
-
-		return s
-	}
-
-	withSigningKeys := func(pubKeys ...string) func(s *solver) {
-		return func(s *solver) {
-			s.signingKeys = pubKeys
-		}
-	}
-
-	withRotationKeys := func(pubKeys ...string) func(s *solver) {
-		return func(s *solver) {
-			s.rotationKeys = pubKeys
 		}
 	}
 
@@ -286,20 +391,19 @@ func TestJoinBoundKeypair(t *testing.T) {
 
 		token             types.ProvisionTokenV2
 		initialJoinSecret string
-		previousJoinState string
-		solver            *solver
+		state             *mockBoundKeypairState
 
 		assertError       require.ErrorAssertionFunc
 		assertResponse    func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult)
-		assertSolverState func(t *testing.T, s *solver)
+		assertSolverState func(t *testing.T, s *mockBoundKeypairState)
 	}{
 		{
 			// an initial key but no bound key, and no bound bot instance. aka,
 			// initial join with preregistered key
 			name: "initial-join-success",
 
-			token:  makeToken(withInitialKey(correctPublicKey)),
-			solver: makeSolver(withSigningKeys(correctPublicKey)),
+			token: makeToken(withInitialKey(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
 
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, _ *joinclient.BoundKeypairResult) {
@@ -314,8 +418,8 @@ func TestJoinBoundKeypair(t *testing.T) {
 			// secret
 			name: "initial-join-with-wrong-key",
 
-			token:  makeToken(withInitialKey(correctPublicKey)),
-			solver: makeSolver(withSigningKeys(incorrectPublicKey)),
+			token: makeToken(withInitialKey(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(incorrectPublicKey)),
 
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.Error(tt, err)
@@ -330,7 +434,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 			token: makeToken(withBoundKey(correctPublicKey), func(v2 *types.ProvisionTokenV2) {
 				v2.Status.BoundKeypair.BoundBotInstanceID = "asdf"
 			}),
-			solver: makeSolver(withSigningKeys(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
 
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, _ *joinclient.BoundKeypairResult) {
@@ -346,8 +450,8 @@ func TestJoinBoundKeypair(t *testing.T) {
 			// This should fail and prompt the user to recreate the token.
 			name: "bound-key-no-instance",
 
-			token:  makeToken(withBoundKey(correctPublicKey)),
-			solver: makeSolver(withSigningKeys(correctPublicKey)),
+			token: makeToken(withBoundKey(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
 
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.Error(tt, err)
@@ -357,7 +461,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 		{
 			name:        "standard-initial-recovery-success",
 			token:       makeToken(withRecovery("standard", 0, 1, ""), withInitialKey(correctPublicKey)),
-			solver:      makeSolver(withSigningKeys(correctPublicKey)),
+			state:       makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
 				require.Equal(t, uint32(1), v2.Status.BoundKeypair.RecoveryCount)
@@ -367,11 +471,13 @@ func TestJoinBoundKeypair(t *testing.T) {
 			},
 		},
 		{
-			name:              "standard-success-second-recovery",
-			token:             makeToken(withRecovery("standard", 1, 2, "id"), withInitialKey(correctPublicKey)),
-			previousJoinState: makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 2, "id"))),
-			solver:            makeSolver(withSigningKeys(correctPublicKey)),
-			assertError:       require.NoError,
+			name:  "standard-success-second-recovery",
+			token: makeToken(withRecovery("standard", 1, 2, "id"), withInitialKey(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 2, "id")))),
+			),
+			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
 				require.Equal(t, uint32(2), v2.Status.BoundKeypair.RecoveryCount)
 				require.NotNil(t, res)
@@ -380,55 +486,62 @@ func TestJoinBoundKeypair(t *testing.T) {
 			},
 		},
 		{
-			name:   "standard-failure-missing-join-state",
-			token:  makeToken(withRecovery("standard", 1, 2, "id"), withBoundKey(correctPublicKey)),
-			solver: makeSolver(withSigningKeys(correctPublicKey)),
+			name:  "standard-failure-missing-join-state",
+			token: makeToken(withRecovery("standard", 1, 2, "id"), withBoundKey(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
 			},
 		},
 		{
-			name:              "standard-failure-limit-exhausted",
-			token:             makeToken(withRecovery("standard", 2, 2, "id")),
-			previousJoinState: makeJoinState(jwtSigner, withToken(withRecovery("standard", 2, 2, "id"))),
-			solver:            makeSolver(withSigningKeys(correctPublicKey)),
+			name:  "standard-failure-limit-exhausted",
+			token: makeToken(withRecovery("standard", 2, 2, "id")),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("standard", 2, 2, "id")))),
+			),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "no recovery attempts remaining")
 			},
 		},
 		{
 			// Attempts to join with an outdated join state document should fail.
-			name:              "standard-failure-recovery-count-mismatch",
-			token:             makeToken(withRecovery("standard", 2, 3, "id"), withBoundKey(correctPublicKey)),
-			previousJoinState: makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 3, "id"))),
-			solver:            makeSolver(withSigningKeys(correctPublicKey)),
+			name:  "standard-failure-recovery-count-mismatch",
+			token: makeToken(withRecovery("standard", 2, 3, "id"), withBoundKey(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 3, "id")))),
+			),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
 			},
 		},
 		{
-			name:              "standard-failure-invalid-jwt",
-			token:             makeToken(withRecovery("standard", 1, 2, "id"), withBoundKey(correctPublicKey)),
-			previousJoinState: "asdf",
-			solver:            makeSolver(withSigningKeys(correctPublicKey)),
+			name:  "standard-failure-invalid-jwt",
+			token: makeToken(withRecovery("standard", 1, 2, "id"), withBoundKey(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey), withPreviousJoinState([]byte("asdf"))),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
 			},
 		},
 		{
-			name:              "standard-failure-invalid-jwt-signature",
-			token:             makeToken(withRecovery("standard", 1, 2, "id"), withBoundKey(correctPublicKey)),
-			previousJoinState: makeJoinState(invalidJWTSigner, withToken(withRecovery("standard", 1, 2, "id"))),
-			solver:            makeSolver(withSigningKeys(correctPublicKey)),
+			name:  "standard-failure-invalid-jwt-signature",
+			token: makeToken(withRecovery("standard", 1, 2, "id"), withBoundKey(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(invalidJWTSigner, withToken(withRecovery("standard", 1, 2, "id")))),
+			),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
 			},
 		},
 		{
-			name:              "standard-failure-invalid-instance-id",
-			token:             makeToken(withRecovery("standard", 1, 2, "foo"), withBoundKey(correctPublicKey)),
-			previousJoinState: makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 2, "id"))),
-			solver:            makeSolver(withSigningKeys(correctPublicKey)),
+			name:  "standard-failure-invalid-instance-id",
+			token: makeToken(withRecovery("standard", 1, 2, "foo"), withBoundKey(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 2, "id")))),
+			),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
 			},
@@ -436,20 +549,24 @@ func TestJoinBoundKeypair(t *testing.T) {
 		{
 			name:  "standard-failure-invalid-cluster",
 			token: makeToken(withRecovery("standard", 1, 2, "foo"), withBoundKey(correctPublicKey)),
-			previousJoinState: makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 2, "id")), func(s *boundkeypair.JoinStateParams) {
-				s.ClusterName = "wrong-cluster"
-			}),
-			solver: makeSolver(withSigningKeys(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 2, "id")), func(s *boundkeypair.JoinStateParams) {
+					s.ClusterName = "wrong-cluster"
+				})),
+			),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
 			},
 		},
 		{
-			name:              "relaxed-success-count-over-limit",
-			token:             makeToken(withRecovery("relaxed", 1, 0, "id"), withBoundKey(correctPublicKey)),
-			previousJoinState: makeJoinState(jwtSigner, withToken(withRecovery("relaxed", 1, 0, "id"))),
-			solver:            makeSolver(withSigningKeys(correctPublicKey)),
-			assertError:       require.NoError,
+			name:  "relaxed-success-count-over-limit",
+			token: makeToken(withRecovery("relaxed", 1, 0, "id"), withBoundKey(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("relaxed", 1, 0, "id")))),
+			),
+			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
 				require.Equal(t, uint32(2), v2.Status.BoundKeypair.RecoveryCount)
 
@@ -471,16 +588,16 @@ func TestJoinBoundKeypair(t *testing.T) {
 				v2.Status.BoundKeypair.BoundPublicKey = correctPublicKey
 				v2.Status.BoundKeypair.BoundBotInstanceID = "asdf"
 			}),
-			solver: makeSolver(withSigningKeys(correctPublicKey, rotatedPublicKey), withRotationKeys(rotatedPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey, rotatedPublicKey), withRotationKeys(rotatedPublicKey)),
 
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
 				require.Equal(t, rotatedPublicKey, v2.Status.BoundKeypair.BoundPublicKey)
 				require.Equal(t, rotatedPublicKey, res.BoundPublicKey)
 			},
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 2, s.challengeCount)
-				require.EqualValues(t, 1, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 2, s.challengeCount.Load())
+				require.EqualValues(t, 1, s.rotationCount.Load())
 				require.Equal(t, []string{correctPublicKey, rotatedPublicKey}, s.solutionKeys)
 			},
 		},
@@ -495,16 +612,16 @@ func TestJoinBoundKeypair(t *testing.T) {
 				v2.Status.BoundKeypair.BoundPublicKey = correctPublicKey
 				v2.Status.BoundKeypair.BoundBotInstanceID = "asdf"
 			}),
-			solver: makeSolver(withSigningKeys(correctPublicKey), withRotationKeys(rotatedPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey), withRotationKeys(rotatedPublicKey)),
 
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
 				require.Equal(t, correctPublicKey, v2.Status.BoundKeypair.BoundPublicKey)
 				require.Equal(t, correctPublicKey, res.BoundPublicKey)
 			},
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 1, s.challengeCount)
-				require.EqualValues(t, 0, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 1, s.challengeCount.Load())
+				require.EqualValues(t, 0, s.rotationCount.Load())
 				require.Equal(t, []string{correctPublicKey}, s.solutionKeys)
 			},
 		},
@@ -521,16 +638,16 @@ func TestJoinBoundKeypair(t *testing.T) {
 				v2.Status.BoundKeypair.BoundBotInstanceID = "asdf"
 				v2.Status.BoundKeypair.LastRotatedAt = &startTime
 			}),
-			solver: makeSolver(withSigningKeys(correctPublicKey, rotatedPublicKey), withRotationKeys(rotatedPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey, rotatedPublicKey), withRotationKeys(rotatedPublicKey)),
 
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
 				require.Equal(t, rotatedPublicKey, v2.Status.BoundKeypair.BoundPublicKey)
 				require.Equal(t, rotatedPublicKey, res.BoundPublicKey)
 			},
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 2, s.challengeCount)
-				require.EqualValues(t, 1, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 2, s.challengeCount.Load())
+				require.EqualValues(t, 1, s.rotationCount.Load())
 				require.Equal(t, []string{correctPublicKey, rotatedPublicKey}, s.solutionKeys)
 			},
 		},
@@ -548,16 +665,16 @@ func TestJoinBoundKeypair(t *testing.T) {
 				rotatedAt := startTime.Add(10 * time.Minute)
 				v2.Status.BoundKeypair.LastRotatedAt = &rotatedAt
 			}),
-			solver: makeSolver(withSigningKeys(correctPublicKey), withRotationKeys(rotatedPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey), withRotationKeys(rotatedPublicKey)),
 
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
 				require.Equal(t, correctPublicKey, v2.Status.BoundKeypair.BoundPublicKey)
 				require.Equal(t, correctPublicKey, res.BoundPublicKey)
 			},
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 1, s.challengeCount)
-				require.EqualValues(t, 0, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 1, s.challengeCount.Load())
+				require.EqualValues(t, 0, s.rotationCount.Load())
 				require.Equal(t, []string{correctPublicKey}, s.solutionKeys)
 			},
 		},
@@ -572,14 +689,14 @@ func TestJoinBoundKeypair(t *testing.T) {
 				v2.Status.BoundKeypair.BoundPublicKey = correctPublicKey
 				v2.Status.BoundKeypair.BoundBotInstanceID = "asdf"
 			}),
-			solver: makeSolver(withSigningKeys(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
 
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "requesting new keypair")
 			},
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 1, s.challengeCount)
-				require.EqualValues(t, 1, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 1, s.challengeCount.Load())
+				require.EqualValues(t, 1, s.rotationCount.Load())
 				require.Equal(t, []string{correctPublicKey}, s.solutionKeys)
 			},
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
@@ -596,14 +713,14 @@ func TestJoinBoundKeypair(t *testing.T) {
 				v2.Status.BoundKeypair.BoundPublicKey = correctPublicKey
 				v2.Status.BoundKeypair.BoundBotInstanceID = "asdf"
 			}),
-			solver: makeSolver(withSigningKeys(correctPublicKey, correctPublicKey), withRotationKeys(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey, correctPublicKey), withRotationKeys(correctPublicKey)),
 
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "public key may not be reused after rotation")
 			},
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 2, s.challengeCount)
-				require.EqualValues(t, 1, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 2, s.challengeCount.Load())
+				require.EqualValues(t, 1, s.rotationCount.Load())
 
 				// note: the client does complete the challenge for the
 				// duplicate key, but the attempt will ultimately be rejected
@@ -622,12 +739,12 @@ func TestJoinBoundKeypair(t *testing.T) {
 				v2.Spec.BoundKeypair.Onboarding.RegistrationSecret = "secret"
 			}),
 			initialJoinSecret: "secret",
-			solver:            makeSolver(withSigningKeys(correctPublicKey), withRotationKeys(correctPublicKey)),
+			state:             makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey), withRotationKeys(correctPublicKey)),
 
 			assertError: require.NoError,
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 1, s.challengeCount)
-				require.EqualValues(t, 1, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 1, s.challengeCount.Load())
+				require.EqualValues(t, 1, s.rotationCount.Load())
 
 				// we'll only be asked for one challenge
 				require.Equal(t, []string{correctPublicKey}, s.solutionKeys)
@@ -644,14 +761,14 @@ func TestJoinBoundKeypair(t *testing.T) {
 				v2.Spec.BoundKeypair.Onboarding.RegistrationSecret = "secret"
 			}),
 			initialJoinSecret: "asdf",
-			solver:            makeSolver(),
+			state:             makeMockBoundKeypairState(signers),
 
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(t, err, "a valid registration secret is required")
 			},
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 0, s.challengeCount)
-				require.EqualValues(t, 0, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 0, s.challengeCount.Load())
+				require.EqualValues(t, 0, s.rotationCount.Load())
 				require.Empty(t, s.solutionKeys)
 			},
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
@@ -670,14 +787,14 @@ func TestJoinBoundKeypair(t *testing.T) {
 				v2.Spec.BoundKeypair.Onboarding.RegistrationSecret = ""
 			}),
 			initialJoinSecret: "asdf",
-			solver:            makeSolver(),
+			state:             makeMockBoundKeypairState(signers),
 
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "a valid registration secret is required")
 			},
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 0, s.challengeCount)
-				require.EqualValues(t, 0, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 0, s.challengeCount.Load())
+				require.EqualValues(t, 0, s.rotationCount.Load())
 				require.Empty(t, s.solutionKeys)
 			},
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
@@ -694,14 +811,14 @@ func TestJoinBoundKeypair(t *testing.T) {
 				v2.Spec.BoundKeypair.Onboarding.InitialPublicKey = correctPublicKey
 			}),
 			initialJoinSecret: "asdf",
-			solver:            makeSolver(withSigningKeys(rotatedPublicKey), withRotationKeys(rotatedPublicKey)),
+			state:             makeMockBoundKeypairState(signers, withSigningKeys(rotatedPublicKey), withRotationKeys(rotatedPublicKey)),
 
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "failed to complete challenge")
 			},
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 1, s.challengeCount)
-				require.EqualValues(t, 0, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 1, s.challengeCount.Load())
+				require.EqualValues(t, 0, s.rotationCount.Load())
 				require.Equal(t, []string{rotatedPublicKey}, s.solutionKeys)
 			},
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
@@ -717,14 +834,14 @@ func TestJoinBoundKeypair(t *testing.T) {
 				v2.Spec.BoundKeypair.Onboarding.MustRegisterBefore = &startTime
 			}),
 			initialJoinSecret: "secret",
-			solver:            makeSolver(),
+			state:             makeMockBoundKeypairState(signers),
 
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "a valid registration secret is required")
 			},
-			assertSolverState: func(t *testing.T, s *solver) {
-				require.EqualValues(t, 0, s.challengeCount)
-				require.EqualValues(t, 0, s.rotationCount)
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 0, s.challengeCount.Load())
+				require.EqualValues(t, 0, s.rotationCount.Load())
 				require.Empty(t, s.solutionKeys)
 			},
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
@@ -751,13 +868,9 @@ func TestJoinBoundKeypair(t *testing.T) {
 				ID: state.IdentityID{
 					Role: types.RoleBot,
 				},
-				AuthClient: nopClient,
-				BoundKeypairParams: &joinclient.BoundKeypairParams{
-					RegistrationSecret: tt.initialJoinSecret,
-					PreviousJoinState:  []byte(tt.previousJoinState),
-					GetSigner:          tt.solver.getSigner,
-					RequestNewKeypair:  tt.solver.requestNewKeypair,
-				},
+				AuthClient:                     nopClient,
+				BoundKeypairRegistrationSecret: tt.initialJoinSecret,
+				BoundKeypairState:              tt.state,
 			})
 			tt.assertError(t, err)
 
@@ -773,7 +886,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 			}
 
 			if tt.assertSolverState != nil {
-				tt.assertSolverState(t, tt.solver)
+				tt.assertSolverState(t, tt.state)
 			}
 		})
 	}
@@ -782,7 +895,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 		name string
 
 		mutateToken func(*types.ProvisionTokenV2)
-		solver      *solver
+		state       *mockBoundKeypairState
 
 		assertError    require.ErrorAssertionFunc
 		assertResponse func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult)
@@ -792,7 +905,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 			name: "reauth-success",
 
 			mutateToken: func(v2 *types.ProvisionTokenV2) {},
-			solver:      makeSolver(withSigningKeys(correctPublicKey)),
+			state:       makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
 
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, _ *joinclient.BoundKeypairResult) {
@@ -805,7 +918,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 			// (should be impossible, but should fail anyway)
 			name: "reauth-with-wrong-key",
 
-			solver: makeSolver(withSigningKeys(incorrectPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(incorrectPublicKey)),
 
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.Error(tt, err)
@@ -820,7 +933,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 			mutateToken: func(v2 *types.ProvisionTokenV2) {
 				v2.Status.BoundKeypair.BoundBotInstanceID = "qwerty"
 			},
-			solver: makeSolver(withSigningKeys(correctPublicKey)),
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
 
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.Error(tt, err)
@@ -832,7 +945,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			token := makeToken(withInitialKey(correctPublicKey))
 			token.SetName(tt.name)
-			initialSolver := makeSolver(withSigningKeys(correctPublicKey))
+			initialSolver := makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey))
 			require.NoError(t, authServer.CreateBoundKeypairToken(ctx, &token))
 
 			initialJoinResult, err := joinclient.Join(t.Context(), joinclient.JoinParams{
@@ -840,11 +953,8 @@ func TestJoinBoundKeypair(t *testing.T) {
 				ID: state.IdentityID{
 					Role: types.RoleBot,
 				},
-				AuthClient: nopClient,
-				BoundKeypairParams: &joinclient.BoundKeypairParams{
-					GetSigner:         initialSolver.getSigner,
-					RequestNewKeypair: initialSolver.requestNewKeypair,
-				},
+				AuthClient:        nopClient,
+				BoundKeypairState: initialSolver,
 			})
 			require.NoError(t, err)
 			botClient, err := clientFromJoinResult(srv, initialJoinResult)
@@ -863,11 +973,8 @@ func TestJoinBoundKeypair(t *testing.T) {
 				ID: state.IdentityID{
 					Role: types.RoleBot,
 				},
-				AuthClient: botClient,
-				BoundKeypairParams: &joinclient.BoundKeypairParams{
-					GetSigner:         tt.solver.getSigner,
-					RequestNewKeypair: tt.solver.requestNewKeypair,
-				},
+				AuthClient:        botClient,
+				BoundKeypairState: tt.state,
 			})
 			tt.assertError(t, err)
 
@@ -890,6 +997,9 @@ func TestJoinBoundKeypair_GenerationCounter(t *testing.T) {
 	ctx := t.Context()
 
 	correctSigner, correctPublicKey := testBoundKeypair(t)
+	signers := map[string]crypto.Signer{
+		correctPublicKey: correctSigner,
+	}
 
 	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
 
@@ -941,20 +1051,18 @@ func TestJoinBoundKeypair_GenerationCounter(t *testing.T) {
 	nopClient, err := srv.NewClient(authtest.TestNop())
 	require.NoError(t, err)
 
+	clientState := makeMockBoundKeypairState(signers,
+		withSingleSigningKey(correctPublicKey),
+		withNoRotation(),
+	)
+
 	joinResult, err := joinclient.Join(t.Context(), joinclient.JoinParams{
 		Token: token.GetName(),
 		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
-		AuthClient: nopClient,
-		BoundKeypairParams: &joinclient.BoundKeypairParams{
-			GetSigner: func(pubKey string) (crypto.Signer, error) {
-				return correctSigner, nil
-			},
-			RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-				return nil, trace.Errorf("no rotation expected")
-			},
-		},
+		AuthClient:        nopClient,
+		BoundKeypairState: clientState,
 	})
 	require.NoError(t, err)
 
@@ -972,15 +1080,10 @@ func TestJoinBoundKeypair_GenerationCounter(t *testing.T) {
 				Role: types.RoleBot,
 			},
 			AuthClient: botClient,
-			BoundKeypairParams: &joinclient.BoundKeypairParams{
-				PreviousJoinState: joinResult.BoundKeypair.JoinState,
-				GetSigner: func(pubKey string) (crypto.Signer, error) {
-					return correctSigner, nil
-				},
-				RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-					return nil, trace.Errorf("no rotation expected")
-				},
-			},
+
+			// Note: mock clientState handles join state updates internally in
+			// UpdateFromRegisterResult()
+			BoundKeypairState: clientState,
 		})
 		require.NoError(t, err)
 
@@ -997,16 +1100,8 @@ func TestJoinBoundKeypair_GenerationCounter(t *testing.T) {
 		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
-		AuthClient: nopClient,
-		BoundKeypairParams: &joinclient.BoundKeypairParams{
-			PreviousJoinState: joinResult.BoundKeypair.JoinState,
-			GetSigner: func(pubKey string) (crypto.Signer, error) {
-				return correctSigner, nil
-			},
-			RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-				return nil, trace.Errorf("no rotation expected")
-			},
-		},
+		AuthClient:        nopClient,
+		BoundKeypairState: clientState,
 	})
 	require.NoError(t, err)
 
@@ -1028,16 +1123,8 @@ func TestJoinBoundKeypair_GenerationCounter(t *testing.T) {
 			ID: state.IdentityID{
 				Role: types.RoleBot,
 			},
-			AuthClient: botClient,
-			BoundKeypairParams: &joinclient.BoundKeypairParams{
-				PreviousJoinState: joinResult.BoundKeypair.JoinState,
-				GetSigner: func(pubKey string) (crypto.Signer, error) {
-					return correctSigner, nil
-				},
-				RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-					return nil, trace.Errorf("no rotation expected")
-				},
-			},
+			AuthClient:        botClient,
+			BoundKeypairState: clientState,
 		})
 		require.NoError(t, err)
 
@@ -1058,16 +1145,8 @@ func TestJoinBoundKeypair_GenerationCounter(t *testing.T) {
 		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
-		AuthClient: oldClient,
-		BoundKeypairParams: &joinclient.BoundKeypairParams{
-			PreviousJoinState: joinResult.BoundKeypair.JoinState,
-			GetSigner: func(pubKey string) (crypto.Signer, error) {
-				return correctSigner, nil
-			},
-			RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-				return nil, trace.Errorf("no rotation expected")
-			},
-		},
+		AuthClient:        oldClient,
+		BoundKeypairState: clientState,
 	})
 	require.Error(t, err)
 
@@ -1091,16 +1170,8 @@ func TestJoinBoundKeypair_GenerationCounter(t *testing.T) {
 		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
-		AuthClient: botClient,
-		BoundKeypairParams: &joinclient.BoundKeypairParams{
-			PreviousJoinState: joinResult.BoundKeypair.JoinState,
-			GetSigner: func(pubKey string) (crypto.Signer, error) {
-				return correctSigner, nil
-			},
-			RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-				return nil, trace.Errorf("no rotation expected")
-			},
-		},
+		AuthClient:        botClient,
+		BoundKeypairState: clientState,
 	})
 	require.ErrorContains(t, err, "have been locked due to a certificate generation mismatch")
 }
@@ -1113,6 +1184,9 @@ func TestJoinBoundKeypair_JoinStateFailure(t *testing.T) {
 	ctx := t.Context()
 
 	correctSigner, correctPublicKey := testBoundKeypair(t)
+	signers := map[string]crypto.Signer{
+		correctPublicKey: correctSigner,
+	}
 
 	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
 
@@ -1164,20 +1238,18 @@ func TestJoinBoundKeypair_JoinStateFailure(t *testing.T) {
 	nopClient, err := srv.NewClient(authtest.TestNop())
 	require.NoError(t, err)
 
+	clientState := makeMockBoundKeypairState(signers,
+		withSingleSigningKey(correctPublicKey),
+		withNoRotation(),
+	)
+
 	originalJoinResult, err := joinclient.Join(t.Context(), joinclient.JoinParams{
 		Token: token.GetName(),
 		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
-		AuthClient: nopClient,
-		BoundKeypairParams: &joinclient.BoundKeypairParams{
-			GetSigner: func(pubKey string) (crypto.Signer, error) {
-				return correctSigner, nil
-			},
-			RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-				return nil, trace.Errorf("no rotation expected")
-			},
-		},
+		AuthClient:        nopClient,
+		BoundKeypairState: clientState,
 	})
 	require.NoError(t, err)
 
@@ -1188,15 +1260,9 @@ func TestJoinBoundKeypair_JoinStateFailure(t *testing.T) {
 			Role: types.RoleBot,
 		},
 		AuthClient: nopClient,
-		BoundKeypairParams: &joinclient.BoundKeypairParams{
-			PreviousJoinState: originalJoinResult.BoundKeypair.JoinState,
-			GetSigner: func(pubKey string) (crypto.Signer, error) {
-				return correctSigner, nil
-			},
-			RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-				return nil, trace.Errorf("no rotation expected")
-			},
-		},
+		// Note: the client state manages prev join state internally in
+		// UpdateFromRegisterResult().
+		BoundKeypairState: clientState,
 	})
 	require.NoError(t, err)
 
@@ -1208,21 +1274,18 @@ func TestJoinBoundKeypair_JoinStateFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to recover again, but with the original join state.
+	outdatedClientState := makeMockBoundKeypairState(signers,
+		withSingleSigningKey(correctPublicKey),
+		withPreviousJoinState(originalJoinResult.BoundKeypair.JoinState),
+		withNoRotation(),
+	)
 	_, err = joinclient.Join(ctx, joinclient.JoinParams{
 		Token: token.GetName(),
 		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
-		AuthClient: nopClient,
-		BoundKeypairParams: &joinclient.BoundKeypairParams{
-			PreviousJoinState: originalJoinResult.BoundKeypair.JoinState,
-			GetSigner: func(pubKey string) (crypto.Signer, error) {
-				return correctSigner, nil
-			},
-			RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-				return nil, trace.Errorf("no rotation expected")
-			},
-		},
+		AuthClient:        nopClient,
+		BoundKeypairState: outdatedClientState,
 	})
 	require.Error(t, err)
 
@@ -1245,21 +1308,18 @@ func TestJoinBoundKeypair_JoinStateFailure(t *testing.T) {
 	// etc the lock may or may not be in force, but we also need to be
 	// absolutely certain to try to generate at least 2 locking events.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		tempClientState := makeMockBoundKeypairState(signers,
+			withSingleSigningKey(correctPublicKey),
+			withPreviousJoinState(originalJoinResult.BoundKeypair.JoinState),
+			withNoRotation(),
+		)
 		_, err = joinclient.Join(ctx, joinclient.JoinParams{
 			Token: token.GetName(),
 			ID: state.IdentityID{
 				Role: types.RoleBot,
 			},
-			AuthClient: nopClient,
-			BoundKeypairParams: &joinclient.BoundKeypairParams{
-				PreviousJoinState: originalJoinResult.BoundKeypair.JoinState,
-				GetSigner: func(pubKey string) (crypto.Signer, error) {
-					return correctSigner, nil
-				},
-				RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-					return nil, trace.Errorf("no rotation expected")
-				},
-			},
+			AuthClient:        nopClient,
+			BoundKeypairState: tempClientState,
 		})
 		require.ErrorContains(t, err, "a client failed to verify its join state")
 	}, 5*time.Second, 100*time.Millisecond)
@@ -1273,6 +1333,14 @@ func TestJoinBoundKeypair_JoinStateFailureDuringRenewal(t *testing.T) {
 	ctx := t.Context()
 
 	correctSigner, correctPublicKey := testBoundKeypair(t)
+	signers := map[string]crypto.Signer{
+		correctPublicKey: correctSigner,
+	}
+
+	clientState := makeMockBoundKeypairState(signers,
+		withSingleSigningKey(correctPublicKey),
+		withNoRotation(),
+	)
 
 	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
 
@@ -1330,15 +1398,8 @@ func TestJoinBoundKeypair_JoinStateFailureDuringRenewal(t *testing.T) {
 		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
-		AuthClient: nopClient,
-		BoundKeypairParams: &joinclient.BoundKeypairParams{
-			GetSigner: func(pubKey string) (crypto.Signer, error) {
-				return correctSigner, nil
-			},
-			RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-				return nil, trace.Errorf("no rotation expected")
-			},
-		},
+		AuthClient:        nopClient,
+		BoundKeypairState: clientState,
 	})
 	require.NoError(t, err)
 	originalBotClient, err := clientFromJoinResult(srv, originalJoinResult)
@@ -1346,21 +1407,18 @@ func TestJoinBoundKeypair_JoinStateFailureDuringRenewal(t *testing.T) {
 
 	// Perform a recovery, this time with a join state, simulating an attacker
 	// that has copied the certs.
+	duplicateClientState := makeMockBoundKeypairState(signers,
+		withSingleSigningKey(correctPublicKey),
+		withPreviousJoinState(originalJoinResult.BoundKeypair.JoinState),
+		withNoRotation(),
+	)
 	attackerResult, err := joinclient.Join(t.Context(), joinclient.JoinParams{
 		Token: token.GetName(),
 		ID: state.IdentityID{
 			Role: types.RoleBot,
 		},
-		AuthClient: nopClient,
-		BoundKeypairParams: &joinclient.BoundKeypairParams{
-			PreviousJoinState: originalJoinResult.BoundKeypair.JoinState,
-			GetSigner: func(pubKey string) (crypto.Signer, error) {
-				return correctSigner, nil
-			},
-			RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-				return nil, trace.Errorf("no rotation expected")
-			},
-		},
+		AuthClient:        nopClient,
+		BoundKeypairState: duplicateClientState,
 	})
 	require.NoError(t, err)
 
@@ -1380,15 +1438,9 @@ func TestJoinBoundKeypair_JoinStateFailureDuringRenewal(t *testing.T) {
 			Role: types.RoleBot,
 		},
 		AuthClient: originalBotClient,
-		BoundKeypairParams: &joinclient.BoundKeypairParams{
-			PreviousJoinState: originalJoinResult.BoundKeypair.JoinState,
-			GetSigner: func(pubKey string) (crypto.Signer, error) {
-				return correctSigner, nil
-			},
-			RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-				return nil, trace.Errorf("no rotation expected")
-			},
-		},
+		// Note: the mock client state handles join state updates internally in
+		// UpdateFromRegisterResult()
+		BoundKeypairState: clientState,
 	})
 	require.Error(t, err)
 
@@ -1411,21 +1463,18 @@ func TestJoinBoundKeypair_JoinStateFailureDuringRenewal(t *testing.T) {
 	// propagation / etc the lock may or may not be in force, but we also need
 	// to be absolutely certain to try to generate at least 2 locking events.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		tempClientState := makeMockBoundKeypairState(signers,
+			withSingleSigningKey(correctPublicKey),
+			withPreviousJoinState(originalJoinResult.BoundKeypair.JoinState),
+			withNoRotation(),
+		)
 		_, err = joinclient.Join(ctx, joinclient.JoinParams{
 			Token: token.GetName(),
 			ID: state.IdentityID{
 				Role: types.RoleBot,
 			},
-			AuthClient: originalBotClient,
-			BoundKeypairParams: &joinclient.BoundKeypairParams{
-				PreviousJoinState: originalJoinResult.BoundKeypair.JoinState,
-				GetSigner: func(pubKey string) (crypto.Signer, error) {
-					return correctSigner, nil
-				},
-				RequestNewKeypair: func(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (crypto.Signer, error) {
-					return nil, trace.Errorf("no rotation expected")
-				},
-			},
+			AuthClient:        originalBotClient,
+			BoundKeypairState: tempClientState,
 		})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "a client failed to verify its join state")

--- a/lib/join/joinclient/join_boundkeypair.go
+++ b/lib/join/joinclient/join_boundkeypair.go
@@ -28,15 +28,13 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	authjoin "github.com/gravitational/teleport/lib/auth/join"
+	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/jwt"
 )
 
 type (
-	BoundKeypairParams = authjoin.BoundKeypairParams
-	GetSignerFunc      = authjoin.GetSignerFunc
-	KeygenFunc         = authjoin.KeygenFunc
 	BoundKeypairResult = authjoin.BoundKeypairRegisterResult
 )
 
@@ -64,16 +62,23 @@ func boundKeypairJoin(
 	// At this point the ServerInit message has already been received, this
 	// function needs to send the BoundKeyPairInit and then handle any
 	// challenges and rotation requests.
+
+	state := joinParams.BoundKeypairState
+	if state == nil {
+		return nil, trace.BadParameter("bound keypair state is required for bound keypair joining")
+	}
+
+	bkClientParams := state.GetClientParams(joinParams.BoundKeypairRegistrationSecret)
+
 	boundKeypairInit := &messages.BoundKeypairInit{
 		ClientParams:      clientParams,
-		InitialJoinSecret: joinParams.BoundKeypairParams.RegistrationSecret,
-		PreviousJoinState: joinParams.BoundKeypairParams.PreviousJoinState,
+		InitialJoinSecret: bkClientParams.RegistrationSecret,
+		PreviousJoinState: bkClientParams.PreviousJoinState,
 	}
 	if err := stream.Send(boundKeypairInit); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	bkParams := joinParams.BoundKeypairParams
 	for {
 		msg, err := stream.Recv()
 		if err != nil {
@@ -81,10 +86,25 @@ func boundKeypairJoin(
 		}
 		switch kind := msg.(type) {
 		case *messages.BotResult:
-			// Return the final result.
+			// Received join result, store and return.
+			if kind.BoundKeypairResult == nil {
+				return nil, trace.BadParameter("register result missing required bound keypair response")
+			}
+
+			if err := state.UpdateFromRegisterResult(
+				kind.BoundKeypairResult.PublicKey,
+				kind.BoundKeypairResult.JoinState,
+			); err != nil {
+				return nil, trace.Wrap(err, "updating local bound keypair state")
+			}
+
+			if err := state.Store(ctx); err != nil {
+				return nil, trace.Wrap(err, "storing updated bound keypair state")
+			}
+
 			return kind, nil
 		case *messages.BoundKeypairChallenge:
-			solution, err := solveBoundKeypairChallenge(bkParams, kind)
+			solution, err := solveBoundKeypairChallenge(state, kind)
 			if err != nil {
 				sendGivingUpErr := stream.Send(&messages.GivingUp{
 					Reason: messages.GivingUpReasonChallengeSolutionFailed,
@@ -102,7 +122,7 @@ func boundKeypairJoin(
 			}
 		case *messages.BoundKeypairRotationRequest:
 			newPubkey, err := handleBoundKeypairRotationRequest(
-				ctx, joinParams.Log, bkParams, kind,
+				ctx, joinParams.Log, state, kind,
 			)
 			if err != nil {
 				sendGivingUpErr := stream.Send(&messages.GivingUp{
@@ -125,8 +145,8 @@ func boundKeypairJoin(
 	}
 }
 
-func solveBoundKeypairChallenge(bkParams *BoundKeypairParams, challengeMsg *messages.BoundKeypairChallenge) ([]byte, error) {
-	signer, err := bkParams.GetSigner(string(challengeMsg.PublicKey))
+func solveBoundKeypairChallenge(state boundkeypair.ClientState, challengeMsg *messages.BoundKeypairChallenge) ([]byte, error) {
+	signer, err := state.GetSigner(challengeMsg.PublicKey)
 	if err != nil {
 		return nil, trace.Wrap(err, "could not lookup signer for public key %s", string(challengeMsg.PublicKey))
 	}
@@ -162,20 +182,16 @@ func solveBoundKeypairChallenge(bkParams *BoundKeypairParams, challengeMsg *mess
 func handleBoundKeypairRotationRequest(
 	ctx context.Context,
 	log *slog.Logger,
-	bkParams *BoundKeypairParams,
+	state boundkeypair.ClientState,
 	rotationRequest *messages.BoundKeypairRotationRequest,
 ) ([]byte, error) {
-	if bkParams.RequestNewKeypair == nil {
-		return nil, trace.BadParameter("RequestNewKeypair is required")
-	}
-
 	log.InfoContext(ctx, "Server has requested keypair rotation", "suite", rotationRequest.SignatureAlgorithmSuite)
 
 	suite, err := types.SignatureAlgorithmSuiteFromString(rotationRequest.SignatureAlgorithmSuite)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	newSigner, err := bkParams.RequestNewKeypair(ctx, cryptosuites.StaticAlgorithmSuite(suite))
+	newSigner, err := state.RequestNewKeypair(ctx, cryptosuites.StaticAlgorithmSuite(suite))
 	if err != nil {
 		return nil, trace.Wrap(err, "requesting new keypair")
 	}

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -766,9 +766,6 @@ func botIdentityFromToken(
 		return nil, trace.BadParameter("unsupported address kind: %v", cfg.Connection.AddressKind)
 	}
 
-	// Only set during bound keypair joining, but used both before and after.
-	var boundKeypairState boundkeypair.ClientState
-
 	switch params.JoinMethod {
 	case types.JoinMethodAzure:
 		params.AzureParams = joinclient.AzureParams{
@@ -785,30 +782,17 @@ func botIdentityFromToken(
 		if err != nil {
 			return nil, trace.Wrap(err, "loading registration secret from disk")
 		}
+		params.BoundKeypairRegistrationSecret = joinSecret
 
-		boundKeypairState, err = initBoundKeypairClientState(ctx, log, cfg, joinSecret)
+		params.BoundKeypairState, err = initBoundKeypairClientState(ctx, log, cfg, joinSecret)
 		if err != nil {
 			return nil, trace.Wrap(err, "initializing bound keypair client state")
 		}
-
-		params.BoundKeypairParams = boundKeypairState.ToJoinParams(boundkeypair.ClientParams{
-			RegistrationSecret: joinSecret,
-		})
 	}
 
 	result, err := joinclient.Join(ctx, params)
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	if boundKeypairState != nil {
-		if err := boundKeypairState.UpdateFromRegisterResult(result); err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		if err := boundKeypairState.Store(ctx); err != nil {
-			return nil, trace.Wrap(err)
-		}
 	}
 
 	privateKeyPEM, err := keys.MarshalPrivateKey(result.PrivateKey)


### PR DESCRIPTION
Backport of #64235 for branch/v18

---

This refactors the bound keypair join client interface to reduce the work needed for clients to manage local bound keypair state. Most state management, aside from the initial load (from storage, static keys, etc) is now handled internally by the join client.

The client state is now passed directly to the join client through its params, after which the joining client no longer needs to perform any join method-specific logic once joining completes.

This is part of adding support for bound keypair for standard agents (#59617). Agents make several different calls to the joinclient for different joining and rejoining scenarios. This would've required a lot of duplicate code to manage the update/store calls, and not all callsites lent well to additional post-join steps. This refactor eliminates that entirely and simplifies the interface for all clients, including `tbot`.

## Manual Test Plan

### Test Environment

Any v18+ Teleport instance with a `tbot` built from this branch.

### Test Cases

- [x] `tbot` can join with a standard bound keypair key
- [x] `tbot` can join with a static bound keypair key
