### PR TITLE
Use libwtmpdb in session/uacc

### DIFF
--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -86,10 +86,29 @@ func checkUserInFile(t assert.TestingT, utmp *uacc.UtmpBackend, uaccFile, userna
 	assert.Equal(t, expectPresent, inFile)
 }
 
+func isUserLoggedInWtmpdb(wtmpdbPath, username string) (bool, error) {
+	db, err := sql.Open("sqlite", wtmpdbPath)
+	if err != nil {
+		return false, err
+	}
+	defer db.Close()
+	var count int
+	if err := db.QueryRow("SELECT COUNT(1) FROM wtmp WHERE User = ? AND Logout IS NULL", username).Scan(&count); err != nil {
+		return false, err
+	}
+	if err := db.Close(); err != nil {
+		return false, err
+	}
+	return count != 0, nil
+}
+
 // TestRootUTMPEntryExists verifies that user accounting is done on supported systems.
 func TestRootUTMPEntryExists(t *testing.T) {
 	if !isRoot() {
 		t.Skip("This test will be skipped because tests are not being run as root.")
+	}
+	if err := uacc.WtmpdbBackendAvailable(); err != nil {
+		t.Skipf("TestRootUTMPEntryExists requires linux, cgo and libwtmpdb installed: %v", err)
 	}
 
 	user, err := user.Current()
@@ -102,8 +121,6 @@ func TestRootUTMPEntryExists(t *testing.T) {
 	require.NoError(t, err)
 
 	utmp, err := uacc.NewUtmpBackend(s.utmpPath, s.wtmpPath, s.btmpPath)
-	require.NoError(t, err)
-	wtmpdb, err := uacc.NewWtmpdbBackend(s.wtmpdbPath)
 	require.NoError(t, err)
 
 	t.Run("successful login is logged in utmp and wtmp", func(t *testing.T) {
@@ -144,7 +161,7 @@ func TestRootUTMPEntryExists(t *testing.T) {
 			// Ensure than an entry was not written to btmp.
 			checkUserInFile(collect, utmp, s.btmpPath, teleportTestUser, false)
 
-			inWtmpdb, err := wtmpdb.IsUserLoggedIn(teleportTestUser)
+			inWtmpdb, err := isUserLoggedInWtmpdb(s.wtmpdbPath, teleportTestUser)
 			assert.NoError(collect, err)
 			assert.True(collect, inWtmpdb)
 		}, 5*time.Minute, time.Second, "did not detect utmp entry within 5 minutes")
@@ -188,7 +205,7 @@ func TestRootUTMPEntryExists(t *testing.T) {
 			checkUserInFile(t, utmp, s.utmpPath, teleportFakeUser, false)
 			checkUserInFile(t, utmp, s.wtmpPath, teleportFakeUser, false)
 
-			inWtmpdb, err := wtmpdb.IsUserLoggedIn(teleportFakeUser)
+			inWtmpdb, err := isUserLoggedInWtmpdb(s.wtmpdbPath, teleportFakeUser)
 			require.NoError(t, err)
 			require.False(t, inWtmpdb)
 		}, 5*time.Minute, time.Second, "did not detect btmp entry within 5 minutes")
@@ -310,9 +327,11 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 	// Initialize wtmpdb database.
 	db, err := sql.Open("sqlite", wtmpdbPath)
 	require.NoError(t, err)
+	defer db.Close()
 	// Schema: https://github.com/thkukuk/wtmpdb/blob/272b109f5b3bdfb3008604461b4ddbff03c28b77/lib/sqlite.c#L128
 	_, err = db.Exec("CREATE TABLE IF NOT EXISTS wtmp(ID INTEGER PRIMARY KEY, Type INTEGER, User TEXT NOT NULL, Login INTEGER, Logout INTEGER, TTY TEXT, RemoteHost TEXT, Service TEXT) STRICT;")
 	require.NoError(t, err)
+	require.NoError(t, db.Close())
 
 	lockWatcher, err := services.NewLockWatcher(ctx, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{

--- a/session/uacc/uacc.go
+++ b/session/uacc/uacc.go
@@ -30,17 +30,15 @@
 //
 // # wtmpdb
 //
-// [wtmpdb] is the Y2038-safe successor to utmp. Session history is logged in the
-// wtmp.db sqlite database. Teleport writes to wtmpdb with sqlite directly instead
-// of using libwtmpdb.
+// [wtmpdb] is the Y2038-safe successor to utmp. Session history is logged in
+// the wtmp.db sqlite database. Teleport lazily tries to dlopen libwtmpdb.so.0
+// on first use.
 //
 // [wtmpdb]: https://github.com/thkukuk/wtmpdb
 package uacc
 
 import (
 	"context"
-	"errors"
-	"io/fs"
 	"log/slog"
 	"net"
 	"os"
@@ -192,25 +190,4 @@ func (uacc *UserAccountHandler) FailedLogin(username string, remote net.Addr) er
 	}
 	// wtmpdb doesn't log failed logins.
 	return nil
-}
-
-// fileExists is an inlining of lib/utils.FileExists, to avoid importing
-// lib/utils
-func fileExists(fp string) bool {
-	_, err := os.Stat(fp)
-	return !errors.Is(err, fs.ErrNotExist)
-}
-
-// hostFromAddr is an inlining of lib/utils.FromAddr(a).Host(), to avoid
-// importing lib/utils
-func hostFromAddr(a net.Addr) string {
-	s := a.String()
-	host, _, err := net.SplitHostPort(s)
-	if err == nil {
-		return host
-	}
-	if ip := net.ParseIP(strings.Trim(s, "[]")); len(ip) != 0 {
-		return ip.String()
-	}
-	return s
 }

--- a/session/uacc/utmp_linux.go
+++ b/session/uacc/utmp_linux.go
@@ -28,7 +28,10 @@ import "C"
 
 import (
 	"encoding/binary"
+	"errors"
+	"io/fs"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -340,4 +343,25 @@ func decodeUnknownError(status int, rawUaccPathErr [uaccPathErrMaxLength]C.char)
 	}
 
 	return trace.Errorf("unknown error with code %d", status)
+}
+
+// fileExists is an inlining of lib/utils.FileExists, to avoid importing
+// lib/utils
+func fileExists(fp string) bool {
+	_, err := os.Stat(fp)
+	return !errors.Is(err, fs.ErrNotExist)
+}
+
+// hostFromAddr is an inlining of lib/utils.FromAddr(a).Host(), to avoid
+// importing lib/utils
+func hostFromAddr(a net.Addr) string {
+	s := a.String()
+	host, _, err := net.SplitHostPort(s)
+	if err == nil {
+		return host
+	}
+	if ip := net.ParseIP(strings.Trim(s, "[]")); len(ip) != 0 {
+		return ip.String()
+	}
+	return s
 }

--- a/session/uacc/wmptdb_dlopen.go
+++ b/session/uacc/wmptdb_dlopen.go
@@ -1,0 +1,184 @@
+//go:build linux && cgo
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package uacc
+
+/*
+#cgo LDFLAGS: -ldl
+
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+static int64_t (*teleport_wtmpdb_login_handle)(
+	const char *db_path,
+	int type,
+	const char *user,
+	uint64_t usec_login,
+	const char *tty,
+	const char *rhost,
+	const char *service,
+	char **error
+) = NULL;
+
+#cgo noescape teleport_wtmpdb_login
+#cgo nocallback teleport_wtmpdb_login
+
+static int64_t teleport_wtmpdb_login(
+	const char *db_path,
+	int type,
+	const char *user,
+	uint64_t usec_login,
+	const char *tty,
+	const char *rhost,
+	const char *service,
+	char **error
+) {
+	return teleport_wtmpdb_login_handle(db_path, type, user, usec_login, tty, rhost, service, error);
+}
+
+static int (*teleport_wtmpdb_logout_handle)(
+	const char *db_path,
+	int64_t id,
+	uint64_t usec_logout,
+	char **error
+) = NULL;
+
+#cgo noescape teleport_wtmpdb_logout
+#cgo nocallback teleport_wtmpdb_logout
+
+static int teleport_wtmpdb_logout(const char *db_path, int64_t id, uint64_t usec_logout, char **error) {
+	return teleport_wtmpdb_logout_handle(db_path, id, usec_logout, error);
+}
+
+#cgo noescape teleport_load_libwtmpdb
+#cgo nocallback teleport_load_libwtmpdb
+
+static int teleport_load_libwtmpdb() {
+	void *handle = dlopen("libwtmpdb.so.0", RTLD_LAZY);
+	if (!handle) {
+		return 1;
+	}
+	teleport_wtmpdb_login_handle = dlsym(handle, "wtmpdb_login");
+	if (!teleport_wtmpdb_login_handle) {
+		return 1;
+	}
+	teleport_wtmpdb_logout_handle = dlsym(handle, "wtmpdb_logout");
+	if (!teleport_wtmpdb_logout_handle) {
+		return 1;
+	}
+	return 0;
+}
+*/
+import "C"
+
+import (
+	"net"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/gravitational/trace"
+)
+
+var wtmpdbLoadOnce sync.Once
+var wtmpdbLoaded bool
+
+func wtmpdbBackendAvailable() error {
+	wtmpdbLoadOnce.Do(func() {
+		if C.teleport_load_libwtmpdb() == 0 {
+			wtmpdbLoaded = true
+		}
+	})
+	// TODO(espadolini): distinguish between a failure to dlopen (maybe it's not
+	// installed) and a failure to dlsym (something is very weird)
+	if !wtmpdbLoaded {
+		return trace.NotFound("libwtmpdb is not available")
+	}
+	return nil
+}
+
+type wtmpdbBackend struct {
+	dbPath string
+}
+
+func newWtmpdbBackend(dbPath string) (*WtmpdbBackend, error) {
+	if err := wtmpdbBackendAvailable(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &WtmpdbBackend{wtmpdbBackend: wtmpdbBackend{
+		dbPath: dbPath,
+	}}, nil
+}
+
+func (w *wtmpdbBackend) login(ttyName, username string, remote net.Addr, ts time.Time) (int64, error) {
+	if err := wtmpdbBackendAvailable(); err != nil {
+		return 0, trace.Wrap(err)
+	}
+	var dbPath *C.char
+	if w.dbPath != "" {
+		dbPath = constCString(w.dbPath)
+	}
+	var error *C.char
+	id := C.teleport_wtmpdb_login(
+		dbPath,
+		userProcess,
+		constCString(username),
+		C.uint64_t(ts.UnixMicro()),
+		constCString(ttyName),
+		constCString(hostFromAddr(remote)),
+		nil,
+		&error,
+	)
+	if id < 0 || error != nil {
+		errorStr := C.GoString(error)
+		C.free(unsafe.Pointer(error))
+		return 0, trace.Errorf("wtmpdb_login: (%d) %+q", id, errorStr)
+	}
+	return int64(id), nil
+}
+
+func (w *wtmpdbBackend) logout(id int64, ts time.Time) error {
+	if err := wtmpdbBackendAvailable(); err != nil {
+		return trace.Wrap(err)
+	}
+	var dbPath *C.char
+	if w.dbPath != "" {
+		dbPath = constCString(w.dbPath)
+	}
+	var error *C.char
+	r := C.teleport_wtmpdb_logout(
+		dbPath,
+		C.int64_t(id),
+		C.uint64_t(ts.UnixMicro()),
+		&error,
+	)
+	if r != 0 || error != nil {
+		errorStr := C.GoString(error)
+		C.free(unsafe.Pointer(error))
+		return trace.Errorf("wtmpdb_logout: (%d) %+q", r, errorStr)
+	}
+	return nil
+}
+
+func constCString(s string) *C.char {
+	if s == "" || s[len(s)-1] != 0 {
+		s += "\x00"
+	}
+	return (*C.char)(unsafe.Pointer(unsafe.StringData(s)))
+}

--- a/session/uacc/wmptdb_nop.go
+++ b/session/uacc/wmptdb_nop.go
@@ -1,0 +1,64 @@
+//go:build !linux || !cgo
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package uacc
+
+import (
+	"net"
+	"runtime"
+	"time"
+
+	"github.com/gravitational/trace"
+)
+
+func wtmpdbBackendAvailable() error {
+	if false {
+		// silence staticcheck SA4024
+		return nil
+	}
+	if runtime.GOOS == "linux" {
+		return trace.NotImplemented("wtmpdb is not available in this build")
+	}
+	return trace.NotImplemented("wtmpdb is not available on this platform")
+}
+
+type wtmpdbBackend struct{}
+
+func newWtmpdbBackend(dbPath string) (*WtmpdbBackend, error) {
+	if false {
+		// silence staticcheck SA4024
+		return &WtmpdbBackend{}, nil
+	}
+	return nil, wtmpdbBackendAvailable()
+}
+
+func (w *wtmpdbBackend) login(ttyName, username string, remote net.Addr, ts time.Time) (int64, error) {
+	if false {
+		// silence staticcheck SA4024
+		return 1, nil
+	}
+	return 0, wtmpdbBackendAvailable()
+}
+
+func (w *wtmpdbBackend) logout(id int64, ts time.Time) error {
+	if false {
+		// silence staticcheck SA4024
+		return nil
+	}
+	return wtmpdbBackendAvailable()
+}

--- a/session/uacc/wtmpdb.go
+++ b/session/uacc/wtmpdb.go
@@ -17,88 +17,33 @@
 package uacc
 
 import (
-	"database/sql"
-	"errors"
 	"net"
 	"time"
-
-	"github.com/gravitational/trace"
-	"modernc.org/sqlite"
-	sqlite3 "modernc.org/sqlite/lib"
 )
-
-// defaultWtmpdbPath is the default location of the wtmpdb db file.
-const defaultWtmpdbPath = "/var/lib/wtmpdb/wtmp.db"
 
 // userProcess is the wtmpdb entry type for user sessions.
 const userProcess = 3
 
 // WtmpdbBackend handles user accounting on systems with wtmpdb.
 type WtmpdbBackend struct {
-	db *sql.DB
+	wtmpdbBackend
+}
+
+func WtmpdbBackendAvailable() error {
+	return wtmpdbBackendAvailable()
 }
 
 // NewWtmpdbBackend creates a new wtmpdb backend.
 func NewWtmpdbBackend(dbPath string) (*WtmpdbBackend, error) {
-	if dbPath == "" {
-		dbPath = defaultWtmpdbPath
-	}
-	if !fileExists(dbPath) {
-		return nil, trace.NotFound("no wtmpdb at %q", dbPath)
-	}
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &WtmpdbBackend{db: db}, nil
+	return newWtmpdbBackend(dbPath)
 }
 
 // Login creates a new session entry for the given user.
 func (w *WtmpdbBackend) Login(ttyName, username string, remote net.Addr, ts time.Time) (int64, error) {
-	// Schema: https://github.com/thkukuk/wtmpdb?tab=readme-ov-file#database
-	stmt, err := w.db.Prepare("INSERT INTO wtmp(Type, User, Login, TTY, RemoteHost) VALUES(?,?,?,?,?)")
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-	defer stmt.Close()
-	result, err := stmt.Exec(userProcess, username, ts.UnixMicro(), ttyName, hostFromAddr(remote))
-	if err != nil {
-		var e *sqlite.Error
-		if ok := errors.As(err, &e); ok {
-			if e.Code() == sqlite3.SQLITE_READONLY {
-				return 0, trace.AccessDenied("cannot write to wtmpdb file, is Teleport running as root?")
-			}
-		}
-		return 0, trace.Wrap(err)
-	}
-	id, err := result.LastInsertId()
-	if err != nil {
-		return 0, trace.Wrap(err)
-	}
-	return id, nil
+	return w.login(ttyName, username, remote, ts)
 }
 
 // Logout marks the user corresponding to the given id (returned from Login) as logged out.
 func (w *WtmpdbBackend) Logout(id int64, ts time.Time) error {
-	stmt, err := w.db.Prepare("UPDATE wtmp SET Logout = ? WHERE ID = ?")
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer stmt.Close()
-	_, err = stmt.Exec(ts.UnixMicro(), id)
-	return trace.Wrap(err)
-}
-
-// IsUserLoggedIn checks if the given user has an active session.
-func (w *WtmpdbBackend) IsUserLoggedIn(username string) (bool, error) {
-	stmt, err := w.db.Prepare("SELECT COUNT(1) FROM wtmp WHERE User = ? AND Logout IS NULL")
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	defer stmt.Close()
-	var count int
-	if err := stmt.QueryRow(username).Scan(&count); err != nil {
-		return false, nil
-	}
-	return count != 0, nil
+	return w.logout(id, ts)
 }

--- a/session/uacc/wtmpdb_test.go
+++ b/session/uacc/wtmpdb_test.go
@@ -43,12 +43,26 @@ func assertDBEntry(t *testing.T, db *sql.DB, key int64, expectUsername, expectTT
 	assert.Equal(t, expectLogoutTime.UnixMicro(), logoutTs.Int64)
 }
 
+func isUserLoggedInWtmpdb(db *sql.DB, user string) (bool, error) {
+	var count int
+	if err := db.QueryRow("SELECT COUNT(1) FROM wtmp WHERE User = ? AND Logout IS NULL", user).Scan(&count); err != nil {
+		return false, err
+	}
+	return count != 0, nil
+}
+
 func TestWtmpdb(t *testing.T) {
 	t.Parallel()
+
+	if err := WtmpdbBackendAvailable(); err != nil {
+		t.Skipf("TestWtmpdb requires linux, cgo and libwtmpdb installed: %v", err)
+	}
+
 	// Create database.
 	dbFile := filepath.Join(t.TempDir(), "wtmp.db")
 	db, err := sql.Open("sqlite", dbFile)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
 	// Schema: https://github.com/thkukuk/wtmpdb/blob/272b109f5b3bdfb3008604461b4ddbff03c28b77/lib/sqlite.c#L128
 	_, err = db.Exec("CREATE TABLE IF NOT EXISTS wtmp(ID INTEGER PRIMARY KEY, Type INTEGER, User TEXT NOT NULL, Login INTEGER, Logout INTEGER, TTY TEXT, RemoteHost TEXT, Service TEXT) STRICT;")
 	require.NoError(t, err)
@@ -67,16 +81,16 @@ func TestWtmpdb(t *testing.T) {
 	require.NotEmpty(t, key)
 
 	// Check that user was logged.
-	assertDBEntry(t, wtmpdb.db, key, "testuser", "pts/99", remote.Addr, loginTime, time.Unix(0, 0))
-	isUserLoggedIn, err := wtmpdb.IsUserLoggedIn("testuser")
+	assertDBEntry(t, db, key, "testuser", "pts/99", remote.Addr, loginTime, time.Unix(0, 0))
+	isUserLoggedIn, err := isUserLoggedInWtmpdb(db, "testuser")
 	require.NoError(t, err)
 	require.True(t, isUserLoggedIn)
 
 	// Check that logout is logged.
 	logoutTime := loginTime.Add(time.Hour)
 	require.NoError(t, wtmpdb.Logout(key, logoutTime))
-	assertDBEntry(t, wtmpdb.db, key, "testuser", "pts/99", remote.Addr, loginTime, logoutTime)
-	isUserLoggedIn, err = wtmpdb.IsUserLoggedIn("testuser")
+	assertDBEntry(t, db, key, "testuser", "pts/99", remote.Addr, loginTime, logoutTime)
+	isUserLoggedIn, err = isUserLoggedInWtmpdb(db, "testuser")
 	require.NoError(t, err)
 	require.False(t, isUserLoggedIn)
 }


### PR DESCRIPTION
This PR removes the sqlite-based pure go implementation of the interaction with the wtmpdb database in favor of trying to dynamically load `libwtmpdb.so.0` (assuming that a system that is using wtmpdb will have the library available).

Part of #64945

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] TBD
