### PR TITLE
[v18] Prevent `DialogHeader` from shrinking, slightly refactor `HeadlessPrompt` in Connect

### DIFF
--- a/web/packages/design/src/Dialog/DialogHeader.jsx
+++ b/web/packages/design/src/Dialog/DialogHeader.jsx
@@ -28,6 +28,7 @@ export default function DialogHeader(props) {
       minHeight="32px"
       mb="3"
       alignItems="center"
+      flexShrink="0"
       {...props}
     />
   );

--- a/web/packages/design/src/Dialog/DialogHeader.tsx
+++ b/web/packages/design/src/Dialog/DialogHeader.tsx
@@ -22,18 +22,12 @@ import { typography } from 'design/system';
 
 import Flex from './../Flex';
 
-export default function DialogHeader(props) {
-  return (
-    <StyledDialogHeader
-      minHeight="32px"
-      mb="3"
-      alignItems="center"
-      flexShrink="0"
-      {...props}
-    />
-  );
-}
-
-const StyledDialogHeader = styled(Flex)`
+export const DialogHeader = styled(Flex).attrs(props => ({
+  minHeight: '32px',
+  mb: 3,
+  alignItems: 'center',
+  flexShrink: 0,
+  ...props,
+}))`
   ${typography}
 `;

--- a/web/packages/design/src/Dialog/index.ts
+++ b/web/packages/design/src/Dialog/index.ts
@@ -19,7 +19,7 @@
 import { Dialog } from './Dialog';
 import DialogContent from './DialogContent';
 import DialogFooter from './DialogFooter';
-import DialogHeader from './DialogHeader';
+import { DialogHeader } from './DialogHeader';
 import DialogTitle from './DialogTitle';
 
 export default Dialog;

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/Finish.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/Finish.tsx
@@ -21,20 +21,22 @@ import { useMemo, useState } from 'react';
 import { useHistory } from 'react-router';
 import { styled } from 'styled-components';
 
-import { Warning } from 'design/Alert/Alert';
-import Box from 'design/Box/Box';
 import {
+  Box,
   ButtonPrimary,
   ButtonSecondary,
   ButtonWarning,
-} from 'design/Button/Button';
-import { Dialog } from 'design/Dialog/Dialog';
-import DialogContent from 'design/Dialog/DialogContent';
-import DialogHeader from 'design/Dialog/DialogHeader';
-import DialogTitle from 'design/Dialog/DialogTitle';
-import Flex from 'design/Flex/Flex';
-import Link from 'design/Link/Link';
-import { H2, P2 } from 'design/Text/Text';
+  Flex,
+  H2,
+  Link,
+  P2,
+} from 'design';
+import { Warning } from 'design/Alert';
+import Dialog, {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from 'design/Dialog';
 import { FieldSelectCreatableAsync } from 'shared/components/FieldSelect/FieldSelectCreatable';
 import { Rule } from 'shared/components/Validation/rules';
 import Validator, { Validation } from 'shared/components/Validation/Validation';

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/KubernetesLabelsSelect.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/KubernetesLabelsSelect.tsx
@@ -24,11 +24,12 @@ import { Alert } from 'design/Alert/Alert';
 import Box, { BoxProps } from 'design/Box/Box';
 import { ButtonPrimary, ButtonSecondary } from 'design/Button/Button';
 import ButtonIcon from 'design/ButtonIcon/ButtonIcon';
-import { Dialog } from 'design/Dialog/Dialog';
-import DialogContent from 'design/Dialog/DialogContent';
-import DialogFooter from 'design/Dialog/DialogFooter';
-import DialogHeader from 'design/Dialog/DialogHeader';
-import DialogTitle from 'design/Dialog/DialogTitle';
+import Dialog, {
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'design/Dialog';
 import Flex from 'design/Flex/Flex';
 import { CheckThick } from 'design/Icon/Icons/CheckThick';
 import { Cross } from 'design/Icon/Icons/Cross';

--- a/web/packages/teleport/src/Bots/Delete/DeleteDialog.tsx
+++ b/web/packages/teleport/src/Bots/Delete/DeleteDialog.tsx
@@ -24,11 +24,12 @@ import {
   ButtonWarning,
   ButtonWarningBorder,
 } from 'design/Button/Button';
-import { Dialog } from 'design/Dialog/Dialog';
-import DialogContent from 'design/Dialog/DialogContent';
-import DialogFooter from 'design/Dialog/DialogFooter';
-import DialogHeader from 'design/Dialog/DialogHeader';
-import DialogTitle from 'design/Dialog/DialogTitle';
+import Dialog, {
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'design/Dialog';
 import Flex from 'design/Flex';
 import { P } from 'design/Text/Text';
 import { wait } from 'shared/utils/wait';

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.story.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.story.tsx
@@ -16,26 +16,82 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { makeEmptyAttempt } from 'shared/hooks/useAsync';
+import { Meta } from '@storybook/react-vite';
+import { useState } from 'react';
 
-import { rootClusterUri } from 'teleterm/services/tshd/testHelpers';
+import {
+  makeEmptyAttempt,
+  makeErrorAttempt,
+  makeSuccessAttempt,
+} from 'shared/hooks/useAsync';
+
+import { routing } from 'teleterm/ui/uri';
 
 import { HeadlessPrompt } from './HeadlessPrompt';
 
-export default {
-  title: 'Teleterm/ModalsHost/HeadlessPrompt',
+type StoryProps = {
+  clusterName: string;
+  approve: 'succeed' | 'throw-error' | 'processing';
+  reject: 'succeed' | 'throw-error' | 'processing';
 };
 
-export const Story = () => (
-  <HeadlessPrompt
-    rootClusterUri={rootClusterUri}
-    clientIp="localhost"
-    skipConfirm={false}
-    onApprove={async () => {}}
-    abortApproval={() => {}}
-    onReject={async () => {}}
-    updateHeadlessStateAttempt={makeEmptyAttempt<void>()}
-    onCancel={() => {}}
-    headlessAuthenticationId="85fa45fa-57f4-5a9d-9ba8-b3cbf76d5ea2"
-  />
+const meta: Meta<StoryProps> = {
+  title: 'Teleterm/ModalsHost/HeadlessPrompt',
+  argTypes: {
+    approve: {
+      control: { type: 'radio' },
+      options: ['succeed', 'throw-error', 'processing'],
+    },
+    reject: {
+      control: { type: 'radio' },
+      options: ['succeed', 'throw-error', 'processing'],
+    },
+  },
+  args: {
+    clusterName: 'teleport-local',
+    approve: 'succeed',
+    reject: 'succeed',
+  },
+};
+export default meta;
+
+export const Story = (props: StoryProps) => {
+  const [attempt, setAttempt] = useState(makeEmptyAttempt<void>());
+  const [key, setKey] = useState(crypto.randomUUID());
+
+  return (
+    <HeadlessPrompt
+      key={key}
+      rootClusterUri={routing.ensureRootClusterUri(
+        `/clusters/${props.clusterName}`
+      )}
+      clientIp="localhost"
+      skipConfirm={false}
+      onApprove={async () => {
+        if (props.approve === 'succeed') {
+          setAttempt(makeSuccessAttempt(undefined));
+        } else if (props.approve === 'throw-error') {
+          setAttempt(makeErrorAttempt(error));
+        }
+      }}
+      abortApproval={() => {}}
+      onReject={async () => {
+        if (props.reject === 'succeed') {
+          setAttempt(makeSuccessAttempt(undefined));
+        } else if (props.reject === 'throw-error') {
+          setAttempt(makeErrorAttempt(error));
+        }
+      }}
+      updateHeadlessStateAttempt={attempt}
+      onCancel={() => {
+        setAttempt(makeEmptyAttempt());
+        setKey(crypto.randomUUID());
+      }}
+      headlessAuthenticationId="85fa45fa-57f4-5a9d-9ba8-b3cbf76d5ea2"
+    />
+  );
+};
+
+const error = new Error(
+  'failed to authenticate using available MFA devices\n    Webauthn authentication failed\n    failed to get assertion: rx invalid cbor, rpc error: code = Aborted desc = MFA modal closed by user'
 );

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
@@ -101,12 +101,13 @@ export function HeadlessPrompt({
           <Icons.Cross size="medium" />
         </ButtonIcon>
       </DialogHeader>
-      {updateHeadlessStateAttempt.status === 'error' && (
-        <Alerts.Danger mb={0} details={updateHeadlessStateAttempt.statusText}>
-          Could not update the headless command state
-        </Alerts.Danger>
-      )}
-      <DialogContent>
+      <DialogContent mb={1}>
+        {updateHeadlessStateAttempt.status === 'error' && (
+          <Alerts.Danger mb={0} details={updateHeadlessStateAttempt.statusText}>
+            Could not update the headless command state
+          </Alerts.Danger>
+        )}
+
         <P>
           Someone initiated a headless command from <b>{clientIp}</b>.
         </P>
@@ -114,44 +115,44 @@ export function HeadlessPrompt({
         <P3 color="text.slightlyMuted">
           Request ID: {headlessAuthenticationId}
         </P3>
+        {waitForMfa && (
+          <>
+            <P>Complete MFA verification to approve the Headless Login.</P>
+
+            <Image mt={4} mb={4} width="200px" src={svgHardwareKey} mx="auto" />
+            <Box textAlign="center" style={{ position: 'relative' }}>
+              <Text bold>Insert your security key and tap it</Text>
+              <LinearProgress />
+            </Box>
+
+            <Flex justifyContent="flex-end" mt={4} gap={3}>
+              {/*
+                The Reject button is there so that if skipping confirmation is enabled (see
+                HeadlessAuthenticationService) then the user still has the ability to reject the
+                request from the screen that prompts for key touch.
+              */}
+              <ButtonSecondary
+                type="button"
+                onClick={() => {
+                  abortApproval();
+                  onReject();
+                }}
+              >
+                Reject
+              </ButtonSecondary>
+              <ButtonSecondary
+                type="button"
+                onClick={() => {
+                  abortApproval();
+                  onCancel();
+                }}
+              >
+                Cancel
+              </ButtonSecondary>
+            </Flex>
+          </>
+        )}
       </DialogContent>
-      {waitForMfa && (
-        <DialogContent mb={2}>
-          <P>Complete MFA verification to approve the Headless Login.</P>
-
-          <Image mt={4} mb={4} width="200px" src={svgHardwareKey} mx="auto" />
-          <Box textAlign="center" style={{ position: 'relative' }}>
-            <Text bold>Insert your security key and tap it</Text>
-            <LinearProgress />
-          </Box>
-
-          <Flex justifyContent="flex-end" mt={4} gap={3}>
-            {/*
-              The Reject button is there so that if skipping confirmation is enabled (see
-              HeadlessAuthenticationService) then the user still has the ability to reject the
-              request from the screen that prompts for key touch.
-            */}
-            <ButtonSecondary
-              type="button"
-              onClick={() => {
-                abortApproval();
-                onReject();
-              }}
-            >
-              Reject
-            </ButtonSecondary>
-            <ButtonSecondary
-              type="button"
-              onClick={() => {
-                abortApproval();
-                onCancel();
-              }}
-            >
-              Cancel
-            </ButtonSecondary>
-          </Flex>
-        </DialogContent>
-      )}
       {!waitForMfa && (
         <DialogFooter>
           <ButtonSecondary

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.story.tsx
@@ -159,7 +159,8 @@ export const MultilineTitle = () => (
         ...loginMfaRequest,
         webauthn: true,
         totp: true,
-        clusterUri: '/clusters/lorem.cloud.gravitational.io',
+        clusterUri:
+          '/clusters/ipsum.cloud.gravitational.io/leaves/lorem.cloud.gravitational.io',
       }}
       onSsoContinue={() => {}}
       onCancel={() => {}}


### PR DESCRIPTION
Backport #64354 to branch/v18

## Manual Test Plan
### Test Environment

Storybook.

### Test Cases
- [x] Opening https://localhost:9002/?path=/story/teleterm-modalshost-headlessprompt--story&args=clusterName:awsic-dev3cloudgravitationalio;approve:throw-error and clicking "Approve" does not make the modal layout run into modal body.
- [x] Other modals in Connect look fine.
- [x] Apps and DB dialogs in Web UI look fine.