### PR TITLE
Fix `tctl get scoped_token` panic when handling tokens with nil status

### DIFF
--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -570,6 +570,27 @@ spec:
   usage_mode: "unlimited"
 `
 
+	const gcpScopedTokenYAML = `kind: scoped_token
+version: v1
+metadata:
+  name: gcp-test-token
+scope: "/"
+spec:
+  roles:
+    - Node
+  assigned_scope: "/foo"
+  join_method: "gcp"
+  usage_mode: "unlimited"
+  gcp:
+    allow:
+      - project_ids:
+          - example-project-123456
+        locations:
+          - us-west1
+        service_accounts:
+          - 123456789-compute@developer.gserviceaccount.com
+`
+
 	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 
 	dynAddr := helpers.NewDynamicServiceAddr(t)
@@ -627,8 +648,8 @@ spec:
 	require.Equal(t, "/foo", token.GetSpec().GetAssignedScope())
 	require.Equal(t, "token", token.GetSpec().GetJoinMethod())
 	require.Equal(t, "unlimited", token.GetSpec().GetUsageMode())
-	// Secret should be populated
-	require.Equal(t, "******", token.GetStatus().GetSecret())
+	// Secret is stripped server-side when not requested with --with-secrets.
+	require.Empty(t, token.GetStatus().GetSecret())
 
 	// Get all scoped tokens
 	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "--format=json", "--with-secrets"})
@@ -683,6 +704,30 @@ spec:
 		_, err = runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
 		require.True(ct, trace.IsNotFound(err))
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
+
+	// Create a GCP scoped token and verify it appears in listings.
+	gcpScopedTokenYAMLPath := filepath.Join(t.TempDir(), "gcp-test-token.yaml")
+	require.NoError(t, os.WriteFile(gcpScopedTokenYAMLPath, []byte(gcpScopedTokenYAML), 0644))
+
+	_, err = runResourceCommand(t, clt, []string{"create", gcpScopedTokenYAMLPath})
+	require.NoError(t, err)
+
+	// Wait for cache propagation.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		_, err := runResourceCommand(t, clt, []string{"get", "scoped_token/gcp-test-token", "--format=json"})
+		require.NoError(ct, err)
+	}, time.Second*30, time.Millisecond*100, "Timed out waiting for GCP scoped token cache propagation")
+
+	// Verify GCP token fields outside the retry loop.
+	buff, err = runResourceCommand(t, clt, []string{"get", "scoped_token", "--format=json"})
+	require.NoError(t, err)
+	gcpTokens, err := services.UnmarshalProtoResourceArray[*joiningv1.ScopedToken](buff.Bytes(), services.DisallowUnknown())
+	require.NoError(t, err)
+	require.Len(t, gcpTokens, 1)
+	require.Equal(t, "gcp-test-token", gcpTokens[0].GetMetadata().GetName())
+	require.Equal(t, "gcp", gcpTokens[0].GetSpec().GetJoinMethod())
+	require.Len(t, gcpTokens[0].GetSpec().GetGcp().GetAllow(), 1)
+	require.Equal(t, []string{"example-project-123456"}, gcpTokens[0].GetSpec().GetGcp().GetAllow()[0].GetProjectIds())
 }
 
 // TestIntegrationResource tests tctl integration commands.

--- a/tool/tctl/common/resources/scoped_token.go
+++ b/tool/tctl/common/resources/scoped_token.go
@@ -117,7 +117,7 @@ func getScopedToken(ctx context.Context, client *authclient.Client, ref services
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if !opts.WithSecrets {
+		if !opts.WithSecrets && token.GetStatus().GetSecret() != "" {
 			token.GetStatus().Secret = "******"
 		}
 		return &scopedTokenCollection{[]*joiningv1.ScopedToken{token}}, nil
@@ -134,7 +134,9 @@ func getScopedToken(ctx context.Context, client *authclient.Client, ref services
 		}
 		if !opts.WithSecrets {
 			for _, token := range res.GetTokens() {
-				token.GetStatus().Secret = "******"
+				if token.GetStatus().GetSecret() != "" {
+					token.GetStatus().Secret = "******"
+				}
 			}
 		}
 
@@ -166,7 +168,10 @@ func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *b
 		if withSecrets {
 			return t.GetStatus().GetSecret()
 		}
-		return "******"
+		if t.GetStatus().GetSecret() != "" {
+			return "******"
+		}
+		return ""
 	}
 
 	now := time.Now()

--- a/tool/tctl/common/resources/scoped_token.go
+++ b/tool/tctl/common/resources/scoped_token.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"time"
 
@@ -162,17 +163,18 @@ func deleteScopedToken(ctx context.Context, client *authclient.Client, ref servi
 }
 
 func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *bytes.Buffer {
-	table := asciitable.MakeTable([]string{"Token", "Secret", "Type", "Scope", "Assigns Scope", "Labels", "Expiry Time (UTC)"})
-
-	secretFunc := func(t *joiningv1.ScopedToken) string {
-		if withSecrets {
-			return t.GetStatus().GetSecret()
-		}
-		if t.GetStatus().GetSecret() != "" {
-			return "******"
-		}
-		return ""
+	headers := []string{
+		"Token",
+		"Type",
+		"Scope",
+		"Assigns Scope",
+		"Labels",
+		"Expiry Time (UTC)",
 	}
+	if withSecrets {
+		headers = slices.Insert(headers, 1, "Secret")
+	}
+	table := asciitable.MakeTable(headers)
 
 	now := time.Now()
 	for _, t := range tokens {
@@ -183,7 +185,18 @@ func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *b
 			expdur := expiresAt.Sub(now).Round(time.Second)
 			expiry = fmt.Sprintf("%s (%s)", exptime, expdur.String())
 		}
-		table.AddRow([]string{t.GetMetadata().GetName(), secretFunc(t), strings.Join(t.GetSpec().GetRoles(), ","), t.GetScope(), t.GetSpec().GetAssignedScope(), PrintMetadataLabels(t.GetMetadata().Labels), expiry})
+		row := []string{
+			t.GetMetadata().GetName(),
+			strings.Join(t.GetSpec().GetRoles(), ","),
+			t.GetScope(),
+			t.GetSpec().GetAssignedScope(),
+			PrintMetadataLabels(t.GetMetadata().Labels),
+			expiry,
+		}
+		if withSecrets {
+			row = slices.Insert(row, 1, t.GetStatus().GetSecret())
+		}
+		table.AddRow(row)
 	}
 	return table.AsBuffer()
 }

--- a/tool/tctl/common/scoped_token_command_test.go
+++ b/tool/tctl/common/scoped_token_command_test.go
@@ -26,6 +26,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/config"
@@ -106,25 +108,51 @@ func TestScopedTokens(t *testing.T) {
 	require.NoError(t, err)
 	out = mustDecodeJSON[addedToken](t, buf)
 
+	// Create a GCP scoped token to verify it appears in listings.
+	_, err = clt.CreateScopedToken(t.Context(), &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: "gcp-test-token",
+		},
+		Scope: "/aa",
+		Spec: &joiningv1.ScopedTokenSpec{
+			Roles:         []string{types.KindNode},
+			AssignedScope: "/aa/bb",
+			JoinMethod:    "gcp",
+			UsageMode:     "unlimited",
+			Gcp: &joiningv1.GCP{
+				Allow: []*joiningv1.GCP_Rule{
+					{
+						ProjectIds:      []string{"example-project-123456"},
+						Locations:       []string{"us-west1"},
+						ServiceAccounts: []string{"123456789-compute@developer.gserviceaccount.com"},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
 	// Test all output formats of "tokens ls".
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls"})
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(buf.String(), "Token "))
-	require.Equal(t, 7, strings.Count(buf.String(), "\n")) // account for header lines
+	require.Equal(t, 8, strings.Count(buf.String(), "\n")) // account for header lines
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.Text})
 	require.NoError(t, err)
-	require.Equal(t, 5, strings.Count(buf.String(), "\n"))
+	require.Equal(t, 6, strings.Count(buf.String(), "\n"))
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.JSON})
 	require.NoError(t, err)
 	jsonOut := mustDecodeJSON[[]listedScopedToken](t, buf)
-	require.Len(t, jsonOut, 5)
+	require.Len(t, jsonOut, 6)
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.YAML})
 	require.NoError(t, err)
 	yamlOut := []listedScopedToken{}
 	mustDecodeYAMLDocuments(t, buf, &yamlOut)
-	require.Len(t, yamlOut, 5)
+	require.Len(t, yamlOut, 6)
 	require.Equal(t, jsonOut, yamlOut)
 }


### PR DESCRIPTION
Previously `tctl get scoped_token` and `tctl get scoped_token/foo` would panic when the results included a scoped token that was a non-`token` join method. This panic occurred because `status` would be nil and the code would attempt to set `status.secret` to an obfuscated value.

This PR updates the obfuscation logic used by `tctl get scoped_token` to only obfuscate where there is a value to be obfuscated. This resolves the panic.

I also noticed that the `tctl scoped token ls` command produced confusing output with an obfuscated secret where there is actually no secret. I modified the behaviour here so that the secret column is only included when `--with-secrets` is specified. 


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed panic in `tctl get scoped_token` when non-`token` join method scoped tokens were present.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local environment with a mixture of `token` and `gcp` scoped tokens.

### Test Cases

- [x] `tctl get scoped_tokens`
  - [x] `--with-secrets` 
- [x] `tctl get scoped_token/token`
  - [x] `--with-secrets`
- [x] `tctl get scoped_token/gcp`
  - [x] `--with-secrets`
- [x] `tctl scoped tokens ls`
  - [x] `--with-secrets`
