### PR TITLE
Correct node name validation notes

### DIFF
--- a/docs/pages/enroll-resources/server-access/troubleshooting-server.mdx
+++ b/docs/pages/enroll-resources/server-access/troubleshooting-server.mdx
@@ -181,9 +181,10 @@ Service validates the name of the server against the following pattern:
 ^[a-zA-Z0-9]+[a-zA-Z0-9\.-]*$
 ```
 
-In other words, each server's name must begin with an alphanumeric character and
-contain only alphanumeric characters, dots, and hyphens. If a node name violates
-this pattern, the Auth Service replaces it with a UUID.
+Each server's name must begin with an alphanumeric character and contain only
+alphanumeric characters, dots, and hyphens. If a node name violates this
+pattern, or exceeds 256 characters in length, the Auth Service replaces it with
+a UUID (the server's Teleport resource ID).
 
 You can check whether any host names are invalid by adding the `-v` flag when
 listing servers:

--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -10,8 +10,11 @@ teleport:
   # reached by. By default it's equal to hostname.
   #
   # For Teleport-protected SSH servers, nodename must begin with an alphanumeric
-  # character and contain only alphanumeric characters, dots, and hyphens.
-  # Teleport replaces servers with invalid hostnames with random UUIDs.
+  # character, contain only alphanumeric characters, dots, and hyphens, and be
+  # no more than 256 characters in length.
+  #
+  # If a Teleport-protected server has an invalid nodename, Teleport replaces
+  # the nodename with the resource ID.
   nodename: graviton
 
   # Data directory where Teleport daemon keeps its data.


### PR DESCRIPTION
Edit the `ssh_service` configuration reference partial and troubleshooting guide for enrolling servers to address feedback that came up after we merged #64632.
