### PR TITLE
Add database-related resource reference docs

### DIFF
--- a/build.assets/tooling/cmd/resource-ref-generator/config.yaml
+++ b/build.assets/tooling/cmd/resource-ref-generator/config.yaml
@@ -53,10 +53,62 @@ resources:
       registered with your Teleport cluster. It is possible to read and list
       `bot_instance` resources with `tctl` but not to create, modify, or delete
       them.
+  - type: DatabaseV3
+    package: github.com/gravitational/teleport/api/types
+    yaml_kind: db
+    yaml_version: v3
+    introduction: |
+      The `db` resource represents a database that is dynamically registered
+      with Teleport.
+
+      If you configure the Teleport Database Service with **dynamic resource
+      watchers**, the service queries the Teleport backend for `db` resources
+      that match their configured filters. For each matching `db`, the Database
+      Service creates a `db_server` resource configured to proxy the target
+      database.
+
+      To learn more about using the `db` resource, see [Dynamic Database
+      Registration](../../../enroll-resources/database-access/guides/dynamic-registration.mdx).
+
+      To learn more about the `db_server` resource, see the [reference
+      guide](database-server-v3.mdx).
   - type: DatabaseServerV3
     package: github.com/gravitational/teleport/api/types
     yaml_kind: db_server
     yaml_version: v3
+    introduction: |
+      The `db_server` resource represents a database that has been registered
+      with Teleport.
+
+      The Teleport Database Service creates a `db_server` in two situations:
+
+        1. It reads information about the target database in its
+           configuration file when it first starts.
+        1. It fetches a dynamically registered `db` resource from the Teleport
+           backend that matches its dynamic resource watchers.
+
+      There can be multiple instances of a `db_server` for a single database,
+      each corresponding to a different Teleport Database Service instance that
+      proxies the database. Read more about [High
+      Availability](../../../installation/agents/high-availability.mdx) for
+      the Teleport Database Service. Read the [reference guide](./database-v3.mdx) for
+      the `db` resource.
+  - type: DatabaseServiceV1
+    package: github.com/gravitational/teleport/api/types
+    yaml_version: v1
+    yaml_kind: db_service
+    introduction: |
+      The `db_service` resource represents an instance of the Teleport Database
+      Service. When the Database Service starts, it registers a `db_service`
+      resource. You can query this resource to see a list of Database Service
+      instances and the dynamic resource matchers they are configured to use in
+      order to proxy databases configured via the dynamic `db` resource.
+
+      To learn more about using the `db_service` and `db` resources, see
+      [Dynamic Database
+      Registration](../../../enroll-resources/database-access/guides/dynamic-registration.mdx).
+
+      Read the [reference guide](./database-v3.mdx) for the `db` resource.
   - type: DiscoveryConfig
     package: github.com/gravitational/teleport/api/types/discoveryconfig
     yaml_kind: discovery_config

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/database-service-v1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/database-service-v1.mdx
@@ -1,0 +1,130 @@
+---
+title: Database Service V1 Reference
+description: Provides a reference of fields within the Database Service V1 resource, which you can manage with tctl.
+sidebar_label: Database Service V1
+---
+{/* vale 3rd-party-products.former-names = NO */}
+{/* vale messaging.capitalization = NO */}
+{/* Automatically generated from: types/types.pb.go */}
+{/* DO NOT EDIT */}
+
+**Kind**: `db_service`<br/>
+**Version**: `v1`
+
+The `db_service` resource represents an instance of the Teleport Database
+Service. When the Database Service starts, it registers a `db_service`
+resource. You can query this resource to see a list of Database Service
+instances and the dynamic resource matchers they are configured to use in
+order to proxy databases configured via the dynamic `db` resource.
+
+To learn more about using the `db_service` and `db` resources, see
+[Dynamic Database
+Registration](../../../enroll-resources/database-access/guides/dynamic-registration.mdx).
+
+Read the [reference guide](./database-v3.mdx) for the `db` resource.
+
+
+## Top-level fields
+
+Example:
+
+```yaml
+kind: "string"
+sub_kind: "string"
+version: "string"
+metadata: # [...]
+spec: # [...]
+```
+|Field Name|Description|Type|
+|---|---|---|
+|kind|A resource kind|string|
+|metadata|Resource metadata|[Metadata](#metadata)|
+|spec|The resource spec.|[Database Service Spec V1](#database-service-spec-v1)|
+|sub_kind|An optional resource sub kind, used in some resources|string|
+|version|The API version used to create the resource. It must be specified. Based on this version, Teleport will apply different defaults on resource creation or deletion. It must be an integer prefixed by "v". For example: `v1`|string|
+
+## Database Resource Matcher
+
+A set of properties that is used to match on resources.
+
+
+Example:
+
+```yaml
+labels: # [...]
+aws: # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|aws||[Resource Matcher AWS](#resource-matcher-aws)|
+|labels||[Labels](#labels)|
+
+## Database Service Spec V1
+
+The DatabaseService Spec.
+
+
+Example:
+
+```yaml
+resources: 
+  - # [...]
+  - # [...]
+  - # [...]
+hostname: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|hostname|The hostname where this service is running.|string|
+|resources|The configured match for Database resources.|[][Database Resource Matcher](#database-resource-matcher)|
+
+## Labels
+
+A wrapper around map that can marshal and unmarshal itself from scalar and list values
+
+
+## Metadata
+
+Resource metadata
+
+
+Example:
+
+```yaml
+name: "string"
+description: "string"
+labels: 
+  "string": "string"
+  "string": "string"
+  "string": "string"
+expires: # See description
+revision: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|description|Object description|string|
+|expires|A global expiry time header can be set on any resource in the system.||
+|labels|A set of labels|map[string]string|
+|name|An object name|string|
+|revision|An opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.|string|
+
+## Resource Matcher AWS
+
+Contains AWS specific settings for resource matcher.
+
+
+Example:
+
+```yaml
+assume_role_arn: "string"
+external_id: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|assume_role_arn|An optional AWS role ARN to assume when accessing a database.|string|
+|external_id|An optional AWS external ID used to enable assuming an AWS role across accounts.|string|
+

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/database-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/database-v3.mdx
@@ -1,32 +1,30 @@
 ---
-title: Database Server V3 Reference
-description: Provides a reference of fields within the Database Server V3 resource, which you can manage with tctl.
-sidebar_label: Database Server V3
+title: Database V3 Reference
+description: Provides a reference of fields within the Database V3 resource, which you can manage with tctl.
+sidebar_label: Database V3
 ---
 {/* vale 3rd-party-products.former-names = NO */}
 {/* vale messaging.capitalization = NO */}
 {/* Automatically generated from: types/types.pb.go */}
 {/* DO NOT EDIT */}
 
-**Kind**: `db_server`<br/>
+**Kind**: `db`<br/>
 **Version**: `v3`
 
-The `db_server` resource represents a database that has been registered
+The `db` resource represents a database that is dynamically registered
 with Teleport.
 
-The Teleport Database Service creates a `db_server` in two situations:
+If you configure the Teleport Database Service with **dynamic resource
+watchers**, the service queries the Teleport backend for `db` resources
+that match their configured filters. For each matching `db`, the Database
+Service creates a `db_server` resource configured to proxy the target
+database.
 
-  1. It reads information about the target database in its
-     configuration file when it first starts.
-  1. It fetches a dynamically registered `db` resource from the Teleport
-     backend that matches its dynamic resource watchers.
+To learn more about using the `db` resource, see [Dynamic Database
+Registration](../../../enroll-resources/database-access/guides/dynamic-registration.mdx).
 
-There can be multiple instances of a `db_server` for a single database,
-each corresponding to a different Teleport Database Service instance that
-proxies the database. Read more about [High
-Availability](../../../installation/agents/high-availability.mdx) for
-the Teleport Database Service. Read the [reference guide](./database-v3.mdx) for
-the `db` resource.
+To learn more about the `db_server` resource, see the [reference
+guide](database-server-v3.mdx).
 
 
 ## Top-level fields
@@ -40,17 +38,15 @@ version: "string"
 metadata: # [...]
 spec: # [...]
 status: # [...]
-scope: "string"
 ```
 |Field Name|Description|Type|
 |---|---|---|
-|kind|The database server resource kind.|string|
-|metadata|The database server metadata.|[Metadata](#metadata)|
-|scope|The advertized scope of the server which can not change once assigned.|string|
-|spec|The database server spec.|[Database Server Spec V3](#database-server-spec-v3)|
-|status|The database server status.|[Database Server Status V3](#database-server-status-v3)|
+|kind|The database resource kind.|string|
+|metadata|The database metadata.|[Metadata](#metadata)|
+|spec|The database spec.|[Database Spec V3](#database-spec-v3)|
+|status|The database runtime information.|[Database Status V3](#database-status-v3)|
 |sub_kind|An optional resource subkind.|string|
-|version|The resource version.|string|
+|version|The resource version. It must be specified. Supported values are: `v3`.|string|
 
 ## AD
 
@@ -221,56 +217,6 @@ default_database: "string"
 |default_database|The database that the privileged database user logs into by default.  Depending on the database type, this database may be used to store procedures or data for managing database users.|string|
 |name|The username of the privileged database user.|string|
 
-## Database Server Spec V3
-
-The database server spec.
-
-
-Example:
-
-```yaml
-version: "string"
-hostname: "string"
-host_id: "string"
-rotation: # [...]
-database: # [...]
-proxy_ids: 
-  - "string"
-  - "string"
-  - "string"
-relay_group: "string"
-relay_ids: 
-  - "string"
-  - "string"
-  - "string"
-```
-
-|Field Name|Description|Type|
-|---|---|---|
-|database|The database proxied by this database server.|[Database V3](#database-v3)|
-|host_id|The ID of the host the database server is running on.|string|
-|hostname|The database server hostname.|string|
-|proxy_ids|A list of proxy IDs this server is expected to be connected to.|[]string|
-|relay_group|The name of the Relay group that the server is connected to|string|
-|relay_ids|The list of Relay host IDs that the server is connected to|[]string|
-|rotation|Contains the server CA rotation information.|[Rotation](#rotation)|
-|version|The Teleport version that the server is running.|string|
-
-## Database Server Status V3
-
-The database server status.
-
-
-Example:
-
-```yaml
-target_health: # [...]
-```
-
-|Field Name|Description|Type|
-|---|---|---|
-|target_health|The health status of network connectivity between the agent and the database.|[Target Health](#target-health)|
-
 ## Database Spec V3
 
 The database spec.
@@ -366,31 +312,6 @@ trust_system_cert_pool: true
 
 Represents the level of TLS verification performed by DB agent when connecting to a database.
 
-
-## Database V3
-
-Represents a single proxied database.
-
-
-Example:
-
-```yaml
-kind: "string"
-sub_kind: "string"
-version: "string"
-metadata: # [...]
-spec: # [...]
-status: # [...]
-```
-
-|Field Name|Description|Type|
-|---|---|---|
-|kind|The database resource kind.|string|
-|metadata|The database metadata.|[Metadata](#metadata)|
-|spec|The database spec.|[Database Spec V3](#database-spec-v3)|
-|status|The database runtime information.|[Database Status V3](#database-status-v3)|
-|sub_kind|An optional resource subkind.|string|
-|version|The resource version. It must be specified. Supported values are: `v3`.|string|
 
 ## DocumentDB
 
@@ -680,54 +601,6 @@ workgroup_id: "string"
 |workgroup_id|The workgroup ID.|string|
 |workgroup_name|The workgroup name.|string|
 
-## Rotation
-
-A status of the rotation of the certificate authority
-
-
-Example:
-
-```yaml
-state: "string"
-phase: "string"
-mode: "string"
-current_id: "string"
-started: # See description
-grace_period: # [...]
-last_rotated: # See description
-schedule: # [...]
-```
-
-|Field Name|Description|Type|
-|---|---|---|
-|current_id|The ID of the rotation operation to differentiate between rotation attempts.|string|
-|grace_period|A period during which old and new CA are valid for checking purposes, but only new CA is issuing certificates.|[Duration](#duration)|
-|last_rotated|Specifies the last time of the completed rotation.||
-|mode|Sets manual or automatic rotation mode.|string|
-|phase|The current rotation phase.|string|
-|schedule|A rotation schedule - used in automatic mode to switch between phases.|[Rotation Schedule](#rotation-schedule)|
-|started|Set to the time when rotation has been started in case if the state of the rotation is "in_progress".||
-|state|Could be one of "init" or "in_progress".|string|
-
-## Rotation Schedule
-
-A rotation schedule setting time switches for different phases.
-
-
-Example:
-
-```yaml
-update_clients: # See description
-update_servers: # See description
-standby: # See description
-```
-
-|Field Name|Description|Type|
-|---|---|---|
-|standby|Specifies time to switch to the "Standby" phase.||
-|update_clients|Specifies time to switch to the "Update clients" phase||
-|update_servers|Specifies time to switch to the "Update servers" phase.||
-
 ## Secret Store
 
 Contains secret store configurations.
@@ -744,31 +617,4 @@ kms_key_id: "string"
 |---|---|---|
 |key_prefix|Specifies the secret key prefix.|string|
 |kms_key_id|Specifies the AWS KMS key for encryption.|string|
-
-## Target Health
-
-Describes the health status of network connectivity between an agent and a resource.
-
-
-Example:
-
-```yaml
-address: "string"
-protocol: "string"
-status: "string"
-transition_timestamp: # See description
-transition_reason: "string"
-transition_error: "string"
-message: "string"
-```
-
-|Field Name|Description|Type|
-|---|---|---|
-|address|The resource address.|string|
-|message|Additional information meant for a user.|string|
-|protocol|The health check protocol such as "tcp".|string|
-|status|The health status, one of "", "unknown", "healthy", "unhealthy".|string|
-|transition_error|Shows the health check error observed when the transition happened. Empty when transitioning to "healthy".|string|
-|transition_reason|A unique single word reason why the last transition occurred.|string|
-|transition_timestamp|The time that the last status transition occurred.||
 


### PR DESCRIPTION
Add a resource reference generator config for `db_service` and `db`, and generate pages for those resources.

Configure an introduction for the `db_server` page so that all database-related resource reference docs have introductions that point to related pages.