### PR TITLE
[v18] Add visible labels for Azure and GCP VM auto-discovery

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -845,14 +845,14 @@ const (
 	AWSInstanceRegion = TeleportNamespace + "/aws-region"
 	// AWSSSORegionLabel is the AWS Identity Center SSO region label.
 	AWSSSORegionLabel = TeleportNamespace + "/sso-region"
-	// SubscriptionIDLabel is used to identify virtual machines by Azure
-	// subscription ID found via automatic discovery, to avoid re-running
-	// installation commands on the node.
-	SubscriptionIDLabel = TeleportInternalLabelPrefix + "subscription-id"
-	// VMIDLabel is used to identify virtual machines by ID found
-	// via automatic discovery, to avoid re-running installation commands
-	// on the node.
-	VMIDLabel = TeleportInternalLabelPrefix + "vm-id"
+	// SubscriptionIDLabelInternal is a hidden label (teleport.internal/) used
+	// to identify Azure VMs by subscription ID during auto-discovery.
+	// Preserved for backward compatibility; superseded by SubscriptionIDLabel.
+	SubscriptionIDLabelInternal = TeleportInternalLabelPrefix + "subscription-id"
+	// VMIDLabelInternal is a hidden label (teleport.internal/) used to identify
+	// Azure VMs by VM ID during auto-discovery.
+	// Preserved for backward compatibility; superseded by VMIDLabel.
+	VMIDLabelInternal = TeleportInternalLabelPrefix + "vm-id"
 	// projectIDLabelSuffix is the identifier for adding the GCE ProjectID to an instance.
 	projectIDLabelSuffix = "project-id"
 	// ProjectIDLabelDiscovery is used to identify virtual machines by GCP project
@@ -863,14 +863,14 @@ const (
 	// The difference between this and ProjectIDLabelDiscovery, is that this one will be visible to the user
 	// and can be used in RBAC checks.
 	ProjectIDLabel = TeleportNamespace + "/" + projectIDLabelSuffix
-	// RegionLabel is used to identify virtual machines by region found
-	// via automatic discovery, to avoid re-running installation commands
-	// on the node.
-	RegionLabel = TeleportInternalLabelPrefix + "region"
-	// ResourceGroupLabel is used to identify virtual machines by resource-group found
-	// via automatic discovery, to avoid re-running installation commands
-	// on the node.
-	ResourceGroupLabel = TeleportInternalLabelPrefix + "resource-group"
+	// RegionLabelInternal is a hidden label (teleport.internal/) used to
+	// identify Azure VMs by region during auto-discovery.
+	// Preserved for backward compatibility; superseded by RegionLabel.
+	RegionLabelInternal = TeleportInternalLabelPrefix + "region"
+	// ResourceGroupLabelInternal is a hidden label (teleport.internal/) used
+	// to identify Azure VMs by resource group during auto-discovery.
+	// Preserved for backward compatibility; superseded by ResourceGroupLabel.
+	ResourceGroupLabelInternal = TeleportInternalLabelPrefix + "resource-group"
 	// ZoneLabelDiscovery is used to identify virtual machines by GCP zone
 	// found via automatic discovery, to avoid re-running installation
 	// commands on the node.
@@ -880,17 +880,17 @@ const (
 	// commands on the node.
 	NameLabelDiscovery = TeleportInternalLabelPrefix + "name"
 
-	// Azure VM visible labels (teleport.dev/ prefix, visible in UI and CLI).
+	// Azure VM labels (teleport.dev/ prefix, visible in UI and CLI).
 	// Used for RBAC and resource filtering.
 
-	// SubscriptionIDLabelVisible is the visible version of SubscriptionIDLabel.
-	SubscriptionIDLabelVisible = TeleportNamespace + "/subscription-id"
-	// VMIDLabelVisible is the visible version of VMIDLabel.
-	VMIDLabelVisible = TeleportNamespace + "/vm-id"
-	// RegionLabelVisible is the visible version of RegionLabel.
-	RegionLabelVisible = TeleportNamespace + "/region"
-	// ResourceGroupLabelVisible is the visible version of ResourceGroupLabel.
-	ResourceGroupLabelVisible = TeleportNamespace + "/resource-group"
+	// SubscriptionIDLabel identifies Azure VMs by subscription ID.
+	SubscriptionIDLabel = TeleportNamespace + "/subscription-id"
+	// VMIDLabel identifies Azure VMs by VM ID.
+	VMIDLabel = TeleportNamespace + "/vm-id"
+	// RegionLabel identifies Azure VMs by region.
+	RegionLabel = TeleportNamespace + "/region"
+	// ResourceGroupLabel identifies Azure VMs by resource group.
+	ResourceGroupLabel = TeleportNamespace + "/resource-group"
 
 	// GCP VM visible labels (teleport.dev/ prefix, visible in UI and CLI).
 	// Used for RBAC and resource filtering.

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -880,6 +880,26 @@ const (
 	// commands on the node.
 	NameLabelDiscovery = TeleportInternalLabelPrefix + "name"
 
+	// Azure VM visible labels (teleport.dev/ prefix, visible in UI and CLI).
+	// Used for RBAC and resource filtering.
+
+	// SubscriptionIDLabelVisible is the visible version of SubscriptionIDLabel.
+	SubscriptionIDLabelVisible = TeleportNamespace + "/subscription-id"
+	// VMIDLabelVisible is the visible version of VMIDLabel.
+	VMIDLabelVisible = TeleportNamespace + "/vm-id"
+	// RegionLabelVisible is the visible version of RegionLabel.
+	RegionLabelVisible = TeleportNamespace + "/region"
+	// ResourceGroupLabelVisible is the visible version of ResourceGroupLabel.
+	ResourceGroupLabelVisible = TeleportNamespace + "/resource-group"
+
+	// GCP VM visible labels (teleport.dev/ prefix, visible in UI and CLI).
+	// Used for RBAC and resource filtering.
+
+	// ZoneLabel is the visible version of ZoneLabelDiscovery.
+	ZoneLabel = TeleportNamespace + "/zone"
+	// NameLabel is the visible version of NameLabelDiscovery.
+	NameLabel = TeleportNamespace + "/name"
+
 	// CloudLabel is used to identify the cloud where the resource was discovered.
 	CloudLabel = TeleportNamespace + "/cloud"
 

--- a/docs/pages/enroll-resources/auto-discovery/reference/labels.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/reference/labels.mdx
@@ -17,7 +17,8 @@ See the AWS EC2 auto-discovery [guide](../../../enroll-resources/auto-discovery/
 
 | Label                      | Description                                          |
 |----------------------------|------------------------------------------------------|
-| `teleport.dev/account-id`  | AWS account ID where the EC2 instance is running |
+| `teleport.dev/account-id`  | AWS account ID where the EC2 instance is running     |
+| `teleport.dev/aws-region`  | AWS region where the EC2 instance is running         |
 | `teleport.dev/instance-id` | AWS EC2 instance ID                                  |
 
 ### Databases
@@ -65,12 +66,12 @@ See the AWS EKS auto-discovery [guide](../../../enroll-resources/auto-discovery/
 
 See the Azure VM auto-discovery [guide](../../../enroll-resources/auto-discovery/servers/azure-discovery.mdx).
 
-| Label                               | Description                                   |
-|-------------------------------------|-----------------------------------------------|
-| `teleport.internal/region`          | Azure region where the VM is running          |
-| `teleport.internal/resource-group`  | Azure resource group the VM belongs to        |
-| `teleport.internal/subscription-id` | Azure subscription ID where the VM is running |
-| `teleport.internal/vm-id`           | Azure VM ID                                   |
+| Label                          | Description                                   |
+|--------------------------------|-----------------------------------------------|
+| `teleport.dev/region`          | Azure region where the VM is running          |
+| `teleport.dev/resource-group`  | Azure resource group the VM belongs to        |
+| `teleport.dev/subscription-id` | Azure subscription ID where the VM is running |
+| `teleport.dev/vm-id`           | Azure VM ID                                   |
 
 
 ### Databases
@@ -116,16 +117,15 @@ See the Azure AKS auto-discovery [guide](../../../enroll-resources/auto-discover
 
 See the GCP VM auto-discovery [guide](../../../enroll-resources/auto-discovery/servers/gcp-discovery.mdx).
 
-| Label                          | Description                         |
-|--------------------------------|-------------------------------------|
-| `teleport.dev/project-id`      | GCP project ID the VM is running in |
-| `teleport.internal/name`       | GCP VM name                         |
-| `teleport.internal/project-id` | GCP project ID the VM is running in |
-| `teleport.internal/zone`       | GCP zone where the VM is running    |
+| Label                     | Description                         |
+|---------------------------|-------------------------------------|
+| `teleport.dev/name`       | GCP VM name                         |
+| `teleport.dev/project-id` | GCP project ID the VM is running in |
+| `teleport.dev/zone`       | GCP zone where the VM is running    |
 
 ### Kubernetes clusters
 
-See the Azure AKS auto-discovery [guide](../../../enroll-resources/auto-discovery/kubernetes/google-cloud.mdx).
+See the GCP GKE auto-discovery [guide](../../../enroll-resources/auto-discovery/kubernetes/google-cloud.mdx).
 
 | Label                                     | Description                                                                                               |
 |-------------------------------------------|-----------------------------------------------------------------------------------------------------------|

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -93,11 +93,11 @@ func (instances *AzureInstances) FilterExistingNodes(existingNodes []types.Serve
 	vmIDs := make(map[string]struct{})
 	for _, node := range existingNodes {
 		labels := node.GetAllLabels()
-		subscriptionID := labels[types.SubscriptionIDLabel]
+		subscriptionID := labels[types.SubscriptionIDLabelInternal]
 		if subscriptionID != instances.SubscriptionID {
 			continue
 		}
-		vmID := labels[types.VMIDLabel]
+		vmID := labels[types.VMIDLabelInternal]
 		if vmID != "" {
 			vmIDs[vmID] = struct{}{}
 		}

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -431,10 +431,10 @@ func makeAzureNode(t *testing.T, name, subscriptionID, vmID string) types.Server
 	t.Helper()
 
 	labels := map[string]string{
-		types.SubscriptionIDLabel: subscriptionID,
+		types.SubscriptionIDLabelInternal: subscriptionID,
 	}
 	if vmID != "" {
-		labels[types.VMIDLabel] = vmID
+		labels[types.VMIDLabelInternal] = vmID
 	}
 
 	node, err := types.NewServerWithLabels(name, types.KindNode, types.ServerSpecV2{}, labels)

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -543,6 +543,10 @@ func fetchNodeAutoDiscoverLabels(ctx context.Context, imdsClient imds.Client) (m
 		nodeLabels[types.VMIDLabel] = instanceInfo.VMID
 		nodeLabels[types.RegionLabel] = instanceInfo.Location
 		nodeLabels[types.ResourceGroupLabel] = instanceInfo.ResourceGroupName
+		nodeLabels[types.SubscriptionIDLabelVisible] = instanceInfo.SubscriptionID
+		nodeLabels[types.VMIDLabelVisible] = instanceInfo.VMID
+		nodeLabels[types.RegionLabelVisible] = instanceInfo.Location
+		nodeLabels[types.ResourceGroupLabelVisible] = instanceInfo.ResourceGroupName
 
 	case types.InstanceMetadataTypeEC2:
 		awsIMDSClient, ok := imdsClient.(*awsimds.InstanceMetadataClient)
@@ -587,6 +591,8 @@ func fetchNodeAutoDiscoverLabels(ctx context.Context, imdsClient imds.Client) (m
 		nodeLabels[types.ZoneLabelDiscovery] = zone
 		nodeLabels[types.ProjectIDLabelDiscovery] = projectID
 		nodeLabels[types.ProjectIDLabel] = projectID
+		nodeLabels[types.NameLabel] = name
+		nodeLabels[types.ZoneLabel] = zone
 
 	default:
 		return nil, trace.BadParameter("Unsupported cloud provider: %v", imdsClient.GetType())

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -539,14 +539,16 @@ func fetchNodeAutoDiscoverLabels(ctx context.Context, imdsClient imds.Client) (m
 			return nil, trace.Wrap(err)
 		}
 
+		// XXXInternal are hidden labels (teleport.internal/) that are preserved for backward
+		// compatibility with nodes enrolled before visible labels were introduced.
+		nodeLabels[types.SubscriptionIDLabelInternal] = instanceInfo.SubscriptionID
+		nodeLabels[types.VMIDLabelInternal] = instanceInfo.VMID
+		nodeLabels[types.RegionLabelInternal] = instanceInfo.Location
+		nodeLabels[types.ResourceGroupLabelInternal] = instanceInfo.ResourceGroupName
 		nodeLabels[types.SubscriptionIDLabel] = instanceInfo.SubscriptionID
 		nodeLabels[types.VMIDLabel] = instanceInfo.VMID
 		nodeLabels[types.RegionLabel] = instanceInfo.Location
 		nodeLabels[types.ResourceGroupLabel] = instanceInfo.ResourceGroupName
-		nodeLabels[types.SubscriptionIDLabelVisible] = instanceInfo.SubscriptionID
-		nodeLabels[types.VMIDLabelVisible] = instanceInfo.VMID
-		nodeLabels[types.RegionLabelVisible] = instanceInfo.Location
-		nodeLabels[types.ResourceGroupLabelVisible] = instanceInfo.ResourceGroupName
 
 	case types.InstanceMetadataTypeEC2:
 		awsIMDSClient, ok := imdsClient.(*awsimds.InstanceMetadataClient)
@@ -587,9 +589,12 @@ func fetchNodeAutoDiscoverLabels(ctx context.Context, imdsClient imds.Client) (m
 			return nil, trace.Wrap(err)
 		}
 
+		// XXXDiscovery are hidden labels (teleport.internal/) that are preserved for backward
+		// compatibility with nodes enrolled before visible labels were introduced.
 		nodeLabels[types.NameLabelDiscovery] = name
 		nodeLabels[types.ZoneLabelDiscovery] = zone
 		nodeLabels[types.ProjectIDLabelDiscovery] = projectID
+
 		nodeLabels[types.ProjectIDLabel] = projectID
 		nodeLabels[types.NameLabel] = name
 		nodeLabels[types.ZoneLabel] = zone

--- a/lib/srv/server/installer/autodiscover_test.go
+++ b/lib/srv/server/installer/autodiscover_test.go
@@ -306,7 +306,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 						"--proxy=proxy.example.com",
 						"--join-method=azure",
 						"--token=my-token",
-						"--labels=teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
+						"--labels=teleport.dev/region=eastus,teleport.dev/resource-group=TestGroup,teleport.dev/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.dev/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4,teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
 						"--azure-client-id=azure-client-id",
 					).AndCallFunc(func(c *bintest.Call) {
 						// create a teleport.yaml configuration file
@@ -380,7 +380,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 			"--proxy="+proxyPublicAddr,
 			"--join-method=azure",
 			"--token=my-token",
-			"--labels=teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
+			"--labels=teleport.dev/region=eastus,teleport.dev/resource-group=TestGroup,teleport.dev/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.dev/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4,teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
 			"--azure-client-id=azure-client-id",
 		).AndCallFunc(func(c *bintest.Call) {
 			// create a teleport.yaml configuration file
@@ -456,7 +456,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 			"--proxy="+proxyPublicAddr,
 			"--join-method=azure",
 			"--token=my-token",
-			"--labels=teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
+			"--labels=teleport.dev/region=eastus,teleport.dev/resource-group=TestGroup,teleport.dev/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.dev/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4,teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
 			"--azure-client-id=azure-client-id",
 		).AndCallFunc(func(c *bintest.Call) {
 			// create a teleport.yaml configuration file
@@ -538,7 +538,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 			"--proxy=proxy.example.com",
 			"--join-method=gcp",
 			"--token=my-token",
-			"--labels=teleport.dev/project-id=my-project,teleport.internal/name=my-name,teleport.internal/project-id=my-project,teleport.internal/zone=my-zone",
+			"--labels=teleport.dev/name=my-name,teleport.dev/project-id=my-project,teleport.dev/zone=my-zone,teleport.internal/name=my-name,teleport.internal/project-id=my-project,teleport.internal/zone=my-zone",
 		).AndCallFunc(func(c *bintest.Call) {
 			// create a teleport.yaml configuration file
 			require.NoError(t, os.WriteFile(testTempDir+"/etc/teleport.yaml.new", []byte("teleport.yaml configuration bytes"), 0o644))
@@ -643,7 +643,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 			"--proxy=proxy.example.com",
 			"--join-method=azure",
 			"--token=my-token",
-			"--labels=teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
+			"--labels=teleport.dev/region=eastus,teleport.dev/resource-group=TestGroup,teleport.dev/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.dev/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4,teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
 			"--azure-client-id=azure-client-id",
 		).AndCallFunc(func(c *bintest.Call) {
 			// create a teleport.yaml configuration file
@@ -708,7 +708,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 			"--proxy=proxy.example.com",
 			"--join-method=azure",
 			"--token=my-token",
-			"--labels=teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
+			"--labels=teleport.dev/region=eastus,teleport.dev/resource-group=TestGroup,teleport.dev/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.dev/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4,teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
 			"--azure-client-id=azure-client-id",
 		).AndCallFunc(func(c *bintest.Call) {
 			// create a teleport.yaml configuration file
@@ -771,7 +771,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 			"--proxy=proxy.example.com",
 			"--join-method=azure",
 			"--token=my-token",
-			"--labels=teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
+			"--labels=teleport.dev/region=eastus,teleport.dev/resource-group=TestGroup,teleport.dev/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.dev/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4,teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
 			"--azure-client-id=azure-client-id",
 		).AndCallFunc(func(c *bintest.Call) {
 			// create a teleport.yaml configuration file
@@ -834,7 +834,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 			"--proxy=proxy.example.com",
 			"--join-method=azure",
 			"--token=my-token",
-			"--labels=teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
+			"--labels=teleport.dev/region=eastus,teleport.dev/resource-group=TestGroup,teleport.dev/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.dev/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4,teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
 			"--azure-client-id=azure-client-id",
 		).AndCallFunc(func(c *bintest.Call) {
 			// create a teleport.yaml configuration file
@@ -863,7 +863,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 				"--proxy=proxy.example.com",
 				"--join-method=azure",
 				"--token=my-token",
-				"--labels=teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
+				"--labels=teleport.dev/region=eastus,teleport.dev/resource-group=TestGroup,teleport.dev/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.dev/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4,teleport.internal/region=eastus,teleport.internal/resource-group=TestGroup,teleport.internal/subscription-id=5187AF11-3581-4AB6-A654-59405CD40C44,teleport.internal/vm-id=ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
 				"--azure-client-id=azure-client-id",
 			).AndCallFunc(func(c *bintest.Call) {
 				// create a teleport.yaml configuration file


### PR DESCRIPTION
Backport #65400 to branch/v18

changelog: Added visible `teleport.dev/` labels for Azure and GCP auto-discovered VMs, making subscription ID, VM ID, region, resource group, VM name, and zone available in the web UI, CLI output, and RBAC rules.

## Manual Test Plan
### Test Environment
https://carlisia-4.cloud.gravitational.io/

### Test Cases

- [x] GCP VM auto-discovery labels are visible
    - [x] Deploy with GCP VM discovery enabled, verify `tsh ls -v` shows `teleport.dev/name`, `teleport.dev/zone`, `teleport.dev/project-id` on discovered VMs
    - [x] Verify the same labels appear in the web UI resource list
    - [x] Verify `teleport.internal/` labels still present in `tsh ls -v --format=json`
