### PR TITLE
session-helper: fix operator and kube-agent-updater builds

### DIFF
--- a/integrations/kube-agent-updater/Dockerfile
+++ b/integrations/kube-agent-updater/Dockerfile
@@ -17,6 +17,7 @@ RUN go mod download
 
 # Copy in code
 COPY lib/ lib/
+COPY session/ session/
 COPY entitlements/ entitlements/
 COPY *.go ./
 COPY integrations/kube-agent-updater/ integrations/kube-agent-updater/

--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -57,6 +57,7 @@ RUN go mod download
 
 COPY *.go ./
 COPY lib/ lib/
+COPY session/ session/
 COPY gen/ gen/
 COPY entitlements/ entitlements/
 COPY integrations/lib/embeddedtbot/ integrations/lib/embeddedtbot/

--- a/integrations/operator/Dockerfile.gha
+++ b/integrations/operator/Dockerfile.gha
@@ -74,6 +74,7 @@ RUN go mod download
 
 COPY *.go ./
 COPY lib/ lib/
+COPY session/ session/
 COPY gen/ gen/
 COPY entitlements/ entitlements/
 COPY integrations/lib/embeddedtbot/ integrations/lib/embeddedtbot/


### PR DESCRIPTION
This PR fixes the dockerfiles used for building the operator and kube-agent-updater images after the addition of another directory with source code broke the nightly builds. This PR should be included when backporting #65145.

Part of #64945