### PR TITLE
Make fixes to database load testing scripts

### DIFF
--- a/assets/loadtest/Makefile
+++ b/assets/loadtest/Makefile
@@ -95,7 +95,7 @@ endif
 		-n database-agents \
 		--create-namespace \
 		teleport/teleport-kube-agent \
-		--set teleportVersionOverride="${TELEPORT_VERSION}" \
+		--version="${TELEPORT_VERSION}" \
 		--set highAvailability.replicaCount=${NODE_REPLICAS} \
 		--set roles=db \
 		--set proxyAddr=${PROXY_SERVER} \

--- a/assets/loadtest/cluster/aws/.gitignore
+++ b/assets/loadtest/cluster/aws/.gitignore
@@ -1,0 +1,1 @@
+.kuberlr

--- a/assets/loadtest/control-plane/monitoring/install-monitoring.sh
+++ b/assets/loadtest/control-plane/monitoring/install-monitoring.sh
@@ -23,6 +23,7 @@ prometheus:
       volumeClaimTemplate:
         spec:
           accessModes: ["ReadWriteOnce"]
+          storageClassName: gp2
           resources:
             requests:
               storage: 50Gi

--- a/assets/loadtest/control-plane/policies/gen-policies.sh
+++ b/assets/loadtest/control-plane/policies/gen-policies.sh
@@ -25,6 +25,7 @@ cat > "$dynamo_policy" <<EOF
             "Sid": "ClusterStateStorage",
             "Effect": "Allow",
             "Action": [
+                "dynamodb:ConditionCheckItem",
                 "dynamodb:BatchWriteItem",
                 "dynamodb:UpdateTimeToLive",
                 "dynamodb:PutItem",

--- a/assets/loadtest/databases/rds/versions.tf
+++ b/assets/loadtest/databases/rds/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 1.5.5"
+  required_version = ">= 1.5.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.12"
+      version = ">= 5.12"
     }
   }
 }


### PR DESCRIPTION
While going through the database load testing as part of the Q1 manual testing, I worked through a number of issues with the load testing scripts. This PR fixes the issues that are easy to fix.

## Manual Test Plan
### Test Environment

`teleport-dev` AWS account. Environment as specified by the scripts.

### Test Cases
- [x] Create the environment as specified in [the database load testing doc](https://www.notion.so/goteleport/Load-test-2fdc56339c5b4511b51d113dc6e1a3e1#a8ed42a7f97a401289eb07e81fe490d3). Everything is working as expected.
