### PR TITLE
[v18][scopes] cross-resource write validation between access lists and scoped roles

### DIFF
--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -24,6 +24,8 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
 // ValidateAccessListWithMembers makes sure the given AccessList and it's members is valid before
@@ -77,6 +79,55 @@ func validateAccessList(a *accesslist.AccessList) error {
 		if a.Spec.Audit.Notifications.Start == 0 {
 			return trace.BadParameter("audit notifications start is not set")
 		}
+	}
+
+	if err := validateScopedRoleGrants(a); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func validateScopedRoleGrants(a *accesslist.AccessList) error {
+	// Access lists that assign scoped roles cannot contain membership_requires or ownership_requires.
+	hasScopedRoleGrants := len(a.Spec.Grants.ScopedRoles) > 0 || len(a.Spec.OwnerGrants.ScopedRoles) > 0
+	hasRequires := !a.Spec.MembershipRequires.IsEmpty() || !a.Spec.OwnershipRequires.IsEmpty()
+	if hasScopedRoleGrants && hasRequires {
+		return trace.BadParameter("access lists cannot contain both scoped_role grants and non-empty membership_requires or ownership_requires blocks")
+	}
+
+	uniqueScopedRoleGrants := make(map[accesslist.ScopedRoleGrant]struct{})
+	validateScopedRoleGrant := func(grant accesslist.ScopedRoleGrant) error {
+		if _, alreadyValidated := uniqueScopedRoleGrants[grant]; alreadyValidated {
+			return nil
+		}
+		switch {
+		case grant.Role == "":
+			return trace.BadParameter("role is empty")
+		case grant.Scope == "":
+			return trace.BadParameter("scope is empty")
+		}
+		if err := scopes.StrongValidate(grant.Scope); err != nil {
+			return trace.Wrap(err, "validating scope")
+		}
+		uniqueScopedRoleGrants[grant] = struct{}{}
+		return nil
+	}
+	for i, grant := range a.Spec.Grants.ScopedRoles {
+		if err := validateScopedRoleGrant(grant); err != nil {
+			return trace.Wrap(err, "validating grants.scoped_roles[%d]", i)
+		}
+	}
+	for i, grant := range a.Spec.OwnerGrants.ScopedRoles {
+		if err := validateScopedRoleGrant(grant); err != nil {
+			return trace.Wrap(err, "validating owner_grants.scoped_roles[%d]", i)
+		}
+	}
+	// Unique scoped role grants per access list have the same limit as role
+	// grants per scoped_role_assignment for the same reason: each role may
+	// require two backend.ConditionalActions to include in an AtomicWrite.
+	if len(uniqueScopedRoleGrants) > scopedaccess.MaxRolesPerAssignment {
+		return trace.BadParameter("access list contains too many unique scoped role grants (max %d)", scopedaccess.MaxRolesPerAssignment)
 	}
 
 	return nil

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/accesslist"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
 func TestAccessListHierarchyCircularRefsCheck(t *testing.T) {
@@ -266,6 +267,83 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("scoped role grants are validated", func(t *testing.T) {
+		newScopedAccessList := func(name string) *accesslist.AccessList {
+			accessList := newAccessList(t, name, clock)
+			accessList.Spec.MembershipRequires = accesslist.Requires{}
+			accessList.Spec.OwnershipRequires = accesslist.Requires{}
+			accessList.Spec.Grants.ScopedRoles = nil
+			accessList.Spec.OwnerGrants.ScopedRoles = nil
+			return accessList
+		}
+
+		t.Run("scoped roles conflict with membership requires", func(t *testing.T) {
+			accessList := newScopedAccessList("test_access_list_membership_requires")
+			accessList.Spec.MembershipRequires = accesslist.Requires{Roles: []string{"member-role"}}
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a", Scope: "/eng"}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "cannot contain both scoped_role grants")
+		})
+
+		t.Run("scoped roles conflict with ownership requires", func(t *testing.T) {
+			accessList := newScopedAccessList("test_access_list_ownership_requires")
+			accessList.Spec.OwnershipRequires = accesslist.Requires{Roles: []string{"owner-role"}}
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a", Scope: "/eng"}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "cannot contain both scoped_role grants")
+		})
+
+		t.Run("empty scoped role name is rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_access_list_empty_scoped_role")
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Scope: "/eng"}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "validating grants.scoped_roles[0]")
+			require.ErrorContains(t, err, "role is empty")
+		})
+
+		t.Run("empty scoped role scope is rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_access_list_empty_scope")
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a"}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "validating grants.scoped_roles[0]")
+			require.ErrorContains(t, err, "scope is empty")
+		})
+
+		t.Run("invalid scoped role scope syntax is rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_access_list_invalid_scope")
+			accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "role-a", Scope: "not-a-scope"}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "validating grants.scoped_roles[0]")
+			require.ErrorContains(t, err, "validating scope")
+		})
+
+		t.Run("too many unique scoped role grants are rejected", func(t *testing.T) {
+			accessList := newScopedAccessList("test_access_list_too_many_scoped_roles")
+			for i := range scopedaccess.MaxRolesPerAssignment + 1 {
+				accessList.Spec.Grants.ScopedRoles = append(accessList.Spec.Grants.ScopedRoles, accesslist.ScopedRoleGrant{
+					Role:  fmt.Sprintf("role-%02d", i),
+					Scope: "/eng",
+				})
+			}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "too many unique scoped role grants")
+		})
+
+		t.Run("valid owner grants scoped roles pass validation", func(t *testing.T) {
+			accessList := newScopedAccessList("test_access_list_valid_owner_scoped_roles")
+			accessList.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "owner-role", Scope: "/eng"}}
+
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.NoError(t, err)
+		})
+	})
 
 }
 

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"errors"
 	"iter"
 	"maps"
 	"slices"
@@ -31,6 +32,7 @@ import (
 	"github.com/gravitational/trace"
 
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/common"
@@ -40,9 +42,12 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/set"
 )
 
 const (
@@ -76,11 +81,12 @@ const (
 // consistent view to the rest of the Teleport application. It makes no decisions
 // about granting or withholding list membership.
 type AccessListService struct {
-	backend       backend.Backend
-	modules       modules.Modules
-	service       *generic.Service[*accesslist.AccessList]
-	memberService *generic.Service[*accesslist.AccessListMember]
-	reviewService *generic.Service[*accesslist.Review]
+	backend             backend.Backend
+	modules             modules.Modules
+	service             *generic.Service[*accesslist.AccessList]
+	memberService       *generic.Service[*accesslist.AccessListMember]
+	reviewService       *generic.Service[*accesslist.Review]
+	scopedAccessService *ScopedAccessService
 }
 
 type accessListAndMembersGetter struct {
@@ -163,12 +169,15 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 		return nil, trace.Wrap(err)
 	}
 
+	scopedAccessService := NewScopedAccessService(cfg.Backend)
+
 	return &AccessListService{
-		backend:       cfg.Backend,
-		modules:       cfg.Modules,
-		service:       service,
-		memberService: memberService,
-		reviewService: reviewService,
+		backend:             cfg.Backend,
+		modules:             cfg.Modules,
+		service:             service,
+		memberService:       memberService,
+		reviewService:       reviewService,
+		scopedAccessService: scopedAccessService,
 	}, nil
 }
 
@@ -236,11 +245,7 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 
 	var upserted *accesslist.AccessList
 	var existingAccessList *accesslist.AccessList
-
-	opFn := a.service.UpsertResource
-	if op == opTypeUpdate {
-		opFn = a.service.ConditionalUpdateResource
-	}
+	var scopedRoleConditions []backend.ConditionalAction
 
 	validateAccessList := func() error {
 		var err error
@@ -258,7 +263,18 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 			return trace.Wrap(err)
 		}
 
-		return accesslists.ValidateAccessListWithMembers(ctx, existingAccessList, accessList, listMembers, &accessListAndMembersGetter{a.service, a.memberService})
+		if err := accesslists.ValidateAccessListWithMembers(ctx, existingAccessList, accessList, listMembers, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
+			return trace.Wrap(err)
+		}
+
+		// TODO(nklaassen): make full cross-resource validation opt-in.
+		validatedRoles, err := a.validateScopedRoleGrants(ctx, existingAccessList, accessList)
+		if err != nil {
+			return trace.Wrap(err, "validating scoped role grants")
+		}
+		scopedRoleConditions = a.conditionalActionsForValidatedScopedRoles(validatedRoles)
+
+		return nil
 	}
 
 	reconcileOldOwners := func() error {
@@ -288,9 +304,8 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 		return nil
 	}
 
-	updateAccessList := func() error {
-		var err error
-		upserted, err = opFn(ctx, accessList)
+	updateAccessList := func() (err error) {
+		upserted, err = a.writeAccessListWithConditions(ctx, accessList, op, scopedRoleConditions)
 		return trace.Wrap(err)
 	}
 
@@ -691,29 +706,69 @@ func (a *AccessListService) DeleteAllAccessListMembers(ctx context.Context) erro
 	return trace.Wrap(a.memberService.DeleteAllResources(ctx))
 }
 
-type writeFn func(context.Context, *accesslist.AccessList) (*accesslist.AccessList, error)
-
-func (a *AccessListService) selectWriteFn(op opType) (writeFn, error) {
+func (a *AccessListService) writeAccessList(
+	ctx context.Context,
+	accessList *accesslist.AccessList,
+	op opType,
+) (*accesslist.AccessList, error) {
 	switch op {
 	case opTypeUpdate:
-		return a.service.ConditionalUpdateResource, nil
-
+		return a.service.ConditionalUpdateResource(ctx, accessList)
 	case opTypeUpsert:
-		return a.service.UpsertResource, nil
+		return a.service.UpsertResource(ctx, accessList)
+	default:
+		return nil, trace.BadParameter("Unknown Access List write operation: %d", op)
 	}
+}
 
-	return nil, trace.BadParameter("Unknown Access List write operation: %d", op)
+func (a *AccessListService) writeAccessListWithConditions(
+	ctx context.Context,
+	accessList *accesslist.AccessList,
+	op opType,
+	conditions []backend.ConditionalAction,
+) (*accesslist.AccessList, error) {
+	if len(conditions) == 0 {
+		return a.writeAccessList(ctx, accessList, op)
+	}
+	item, err := a.service.MakeBackendItem(accessList)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	writeCondition, err := a.selectWriteCondition(op, item.Revision)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	writeAction := backend.ConditionalAction{
+		Key:       item.Key,
+		Condition: writeCondition,
+		Action:    backend.Put(item),
+	}
+	conditionalActions := append(conditions, writeAction)
+	revision, err := a.backend.AtomicWrite(ctx, conditionalActions)
+	if err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return nil, trace.CompareFailed("access list %q or a related resource was concurrently modified", accessList.GetName())
+		}
+		return nil, trace.Wrap(err)
+	}
+	accessList.SetRevision(revision)
+	return accessList, nil
+}
+
+func (a *AccessListService) selectWriteCondition(op opType, revision string) (backend.Condition, error) {
+	switch op {
+	case opTypeUpdate:
+		return backend.Revision(revision), nil
+	case opTypeUpsert:
+		return backend.Whatever(), nil
+	}
+	return backend.Condition{}, trace.BadParameter("Unknown Access List write operation: %d", op)
 }
 
 // writeAccessListWithMembers holds all of the common logic for updating and
 // upserting an access list and it's collection of members.
 func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, accessList *accesslist.AccessList, membersIn []*accesslist.AccessListMember, op opType) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
 	if err := accessList.CheckAndSetDefaults(); err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	writeFn, err := a.selectWriteFn(op)
-	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
@@ -724,6 +779,7 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	}
 
 	var existingAccessList *accesslist.AccessList
+	var scopedRoleConditions []backend.ConditionalAction
 
 	validateAccessList := func() error {
 		var err error
@@ -747,6 +803,13 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 		if err := accesslists.ValidateAccessListWithMembers(ctx, existingAccessList, accessList, membersIn, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
 			return trace.Wrap(err)
 		}
+
+		// TODO(nklaassen): make full cross-resource validation opt-in.
+		validatedRoles, err := a.validateScopedRoleGrants(ctx, existingAccessList, accessList)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		scopedRoleConditions = a.conditionalActionsForValidatedScopedRoles(validatedRoles)
 
 		return nil
 	}
@@ -839,9 +902,8 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 		return nil
 	}
 
-	writeAccessList := func() error {
-		var err error
-		accessList, err = writeFn(ctx, accessList)
+	writeAccessList := func() (err error) {
+		accessList, err = a.writeAccessListWithConditions(ctx, accessList, op, scopedRoleConditions)
 		return trace.Wrap(err)
 	}
 
@@ -887,6 +949,83 @@ func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, acce
 	}
 
 	return accessList, membersIn, nil
+}
+
+// validateScopedRoleGrants asserts that:
+// - newList only assigns scoped roles that exist
+// - newList only assigns scoped roles defined in the root scope
+// - newList only assigns scoped roles to an assignable_scope of the role
+//
+// In case the access list is already in an invalid state (existingList grants
+// a scoped role violating any of the above invariants) we would prefer not to
+// break unrelated list updates, so the checks are only performed if a role is
+// newly granted at any scope.
+//
+// It returns a map of all validated scoped roles keyed by role name.
+func (a *AccessListService) validateScopedRoleGrants(ctx context.Context, existingList, newList *accesslist.AccessList) (map[string]*scopedaccessv1.ScopedRole, error) {
+	if len(newList.Spec.Grants.ScopedRoles) == 0 && len(newList.Spec.OwnerGrants.ScopedRoles) == 0 {
+		// The new list does not grant any scoped roles, so no checks are needed.
+		return nil, nil
+	}
+
+	var existingListGrants set.Set[accesslist.ScopedRoleGrant]
+	if existingList != nil {
+		existingListGrants = set.New(existingList.Spec.Grants.ScopedRoles...).Add(existingList.Spec.OwnerGrants.ScopedRoles...)
+	}
+	newListGrants := set.New(newList.Spec.Grants.ScopedRoles...).Add(newList.Spec.OwnerGrants.ScopedRoles...)
+	addedGrants := newListGrants.Subtract(existingListGrants)
+
+	if addedGrants.Len() == 0 {
+		// The new list does not grant any scoped roles at scopes not already
+		// granted by the existing list, no validation is necessary.
+		return nil, nil
+	}
+
+	// This list has new scoped role grants, the scopes feature must be enabled.
+	if err := scopes.AssertFeatureEnabled(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Deduplicate roles, which may be granted at multiple scopes.
+	validatedRoles := make(map[string]*scopedaccessv1.ScopedRole)
+	for grant := range addedGrants {
+		role, ok := validatedRoles[grant.Role]
+		if !ok {
+			rsp, err := a.scopedAccessService.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{Name: grant.Role})
+			if err != nil {
+				if trace.IsNotFound(err) {
+					return nil, trace.BadParameter("access_list %q has scoped role grant for non-existent role %q", newList.GetName(), grant.Role)
+				}
+				return nil, trace.Wrap(err)
+			}
+			role = rsp.GetRole()
+		}
+
+		if scopes.Compare(role.GetScope(), "/") != scopes.Equivalent {
+			return nil, trace.BadParameter("access_list %q has scoped role grant for role %q which is not defined in root scope", newList.GetName(), grant.Role)
+		}
+		if !scopedaccess.RoleIsAssignableToScopeOfEffect(role, grant.Scope) {
+			return nil, trace.BadParameter("access_list %q has scoped role grant for role %q at non-assignable scope %q", newList.GetName(), grant.Role, grant.Scope)
+		}
+
+		validatedRoles[grant.Role] = role
+	}
+
+	return validatedRoles, nil
+}
+
+// conditionalActionsForValidatedScopedRoles returns a set of
+// backend.ConditionalActions that must be used in an AtomicWrite to
+// prevent concurrent modifications granted scoped roles.
+func (a *AccessListService) conditionalActionsForValidatedScopedRoles(validatedRoles map[string]*scopedaccessv1.ScopedRole) []backend.ConditionalAction {
+	condacts := make([]backend.ConditionalAction, 0, 2*len(validatedRoles))
+	for roleName, role := range validatedRoles {
+		// Assert that the role has not changed since it was validated.
+		condacts = append(condacts, a.scopedAccessService.assertAssignedRoleStable(roleName, role.GetMetadata().GetRevision()))
+		// Prevent changes to the role concurrent with changes to the assignment.
+		condacts = append(condacts, a.scopedAccessService.touchRoleAssignmentLock(roleName))
+	}
+	return condacts
 }
 
 // UpsertAccessListWithMembers creates or updates an access list resource and its members.

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -47,7 +47,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/set"
 )
 
 const (
@@ -968,14 +967,14 @@ func (a *AccessListService) validateScopedRoleGrants(ctx context.Context, existi
 		return nil, nil
 	}
 
-	var existingListGrants set.Set[accesslist.ScopedRoleGrant]
+	var existingListGrants utils.Set[accesslist.ScopedRoleGrant]
 	if existingList != nil {
-		existingListGrants = set.New(existingList.Spec.Grants.ScopedRoles...).Add(existingList.Spec.OwnerGrants.ScopedRoles...)
+		existingListGrants = utils.NewSet(existingList.Spec.Grants.ScopedRoles...).Add(existingList.Spec.OwnerGrants.ScopedRoles...)
 	}
-	newListGrants := set.New(newList.Spec.Grants.ScopedRoles...).Add(newList.Spec.OwnerGrants.ScopedRoles...)
+	newListGrants := utils.NewSet(newList.Spec.Grants.ScopedRoles...).Add(newList.Spec.OwnerGrants.ScopedRoles...)
 	addedGrants := newListGrants.Subtract(existingListGrants)
 
-	if addedGrants.Len() == 0 {
+	if len(addedGrants) == 0 {
 		// The new list does not grant any scoped roles at scopes not already
 		// granted by the existing list, no validation is necessary.
 		return nil, nil

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -34,6 +34,9 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/common"
 	"github.com/gravitational/teleport/api/types/header"
@@ -47,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/utils"
 	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 )
@@ -153,6 +157,7 @@ func TestAccessListCRUD(t *testing.T) {
 }
 
 func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	ctx := t.Context()
 	clock := clockwork.NewFakeClock()
 
@@ -163,8 +168,26 @@ func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
 	require.NoError(t, err)
 
 	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+	scopedAccessService := NewScopedAccessService(mem)
 
-	accessList := newAccessList(t, "accessList-scoped", clock)
+	for _, role := range []string{"scoped-role-1", "scoped-role-2", "scoped-role-3"} {
+		_, err = scopedAccessService.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+			Role: &scopedaccessv1.ScopedRole{
+				Kind: scopedaccess.KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: role,
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/eng", "/platform", "/ops"},
+				},
+				Version: types.V1,
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	accessList := newAccessList(t, "accessList-scoped", clock, withOwnerRequires(accesslist.Requires{}), withMemberRequires(accesslist.Requires{}))
 	accessList.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
 		{
 			Role:  "scoped-role-1",
@@ -202,6 +225,117 @@ func TestAccessListCRUDScopedRoleGrants(t *testing.T) {
 	fetched, err = service.GetAccessList(ctx, accessList.GetName())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(updated, fetched, cmpOpts...))
+}
+
+func TestAccessListScopedRoleGrantInvariants(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+	scopedAccessService := NewScopedAccessService(mem)
+
+	for _, role := range []*scopedaccessv1.ScopedRole{
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "root-role",
+			},
+			Scope: "/",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/eng", "/ops"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "non-root-role",
+			},
+			Scope: "/eng",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/eng"},
+			},
+			Version: types.V1,
+		},
+	} {
+		_, err := scopedAccessService.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{Role: role})
+		require.NoError(t, err)
+	}
+
+	baseList := newAccessList(t, "testlist", clock,
+		withOwnerRequires(accesslist.Requires{}), withMemberRequires(accesslist.Requires{}))
+	baseList, err = service.UpsertAccessList(ctx, baseList)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		apply func(*accesslist.AccessList)
+		msg   string
+	}{
+		{
+			name: "missing role",
+			apply: func(al *accesslist.AccessList) {
+				al.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "does-not-exist", Scope: "/eng"}}
+			},
+			msg: "non-existent role",
+		},
+		{
+			name: "non root role",
+			apply: func(al *accesslist.AccessList) {
+				al.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "non-root-role", Scope: "/eng"}}
+			},
+			msg: "not defined in root scope",
+		},
+		{
+			name: "non assignable scope",
+			apply: func(al *accesslist.AccessList) {
+				al.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "root-role", Scope: "/db"}}
+			},
+			msg: "non-assignable scope",
+		},
+		{
+			name: "owner grants checked too",
+			apply: func(al *accesslist.AccessList) {
+				al.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{{Role: "root-role", Scope: "/db"}}
+			},
+			msg: "non-assignable scope",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			al := baseList.Clone()
+			tc.apply(al)
+
+			t.Run("upsert", func(t *testing.T) {
+				_, err := service.UpsertAccessList(ctx, al)
+				require.ErrorAs(t, err, new(*trace.BadParameterError))
+				require.ErrorContains(t, err, tc.msg)
+			})
+			t.Run("upsertWithMembers", func(t *testing.T) {
+				_, _, err := service.UpsertAccessListWithMembers(ctx, al, nil)
+				require.ErrorAs(t, err, new(*trace.BadParameterError))
+				require.ErrorContains(t, err, tc.msg)
+			})
+			t.Run("update", func(t *testing.T) {
+				_, err := service.UpdateAccessList(ctx, al)
+				require.ErrorAs(t, err, new(*trace.BadParameterError))
+				require.ErrorContains(t, err, tc.msg)
+			})
+			t.Run("updateAndOverwriteMembers", func(t *testing.T) {
+				_, _, err := service.UpdateAccessListAndOverwriteMembers(ctx, al, nil)
+				require.ErrorAs(t, err, new(*trace.BadParameterError))
+				require.ErrorContains(t, err, tc.msg)
+			})
+		})
+	}
 }
 
 func requireAccessDenied(t require.TestingT, err error, i ...any) {
@@ -1755,6 +1889,18 @@ func withType(typ accesslist.Type) newAccessListOpt {
 func withOwners(owners []accesslist.Owner) newAccessListOpt {
 	return func(o *newAccessListOptions) {
 		o.owners = owners
+	}
+}
+
+func withOwnerRequires(requires accesslist.Requires) newAccessListOpt {
+	return func(o *newAccessListOptions) {
+		o.ownerRequires = requires
+	}
+}
+
+func withMemberRequires(requires accesslist.Requires) newAccessListOpt {
+	return func(o *newAccessListOptions) {
+		o.memberRequires = requires
 	}
 }
 

--- a/lib/services/local/scoped_access.go
+++ b/lib/services/local/scoped_access.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/gravitational/trace"
@@ -29,11 +30,13 @@ import (
 
 	"github.com/gravitational/teleport"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -197,28 +200,23 @@ func (s *ScopedAccessService) CreateScopedRole(ctx context.Context, req *scopeda
 	lockCondition := backend.NotExists()
 	if lockItem != nil {
 		lockCondition = backend.Revision(lockItem.Revision)
-		for assignment, err := range s.StreamScopedRoleAssignments(ctx) {
+
+		for binding, err := range s.streamBindingsForRole(ctx, role.GetMetadata().GetName()) {
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 
-			for _, subAssignment := range assignment.GetSpec().GetAssignments() {
-				if subAssignment.GetRole() != role.GetMetadata().GetName() {
-					continue
+			// an assignment or access list already exists referencing this role, we need to check if that is because
+			// a role with this name exists, or because the assignment is dangling.
+			_, err = s.bk.Get(ctx, scopedRoleKey(role.GetMetadata().GetName()))
+			if err != nil {
+				if !trace.IsNotFound(err) {
+					return nil, trace.Wrap(err)
 				}
-
-				// an assignment already exists referencing this role, we need to check if that is because
-				// a role with this name exists, or because the assignment is dangling.
-				_, err = s.bk.Get(ctx, scopedRoleKey(role.GetMetadata().GetName()))
-				if err != nil {
-					if !trace.IsNotFound(err) {
-						return nil, trace.Wrap(err)
-					}
-					// this is a dangling assignment, we need to return an error
-					return nil, trace.CompareFailed("cannot create scoped role %q while extant assignment %q references it", role.GetMetadata().GetName(), assignment.GetMetadata().GetName())
-				}
-				return nil, trace.CompareFailed("scoped role %q already exists", role.GetMetadata().GetName())
+				// this is a dangling assignment, we need to return an error
+				return nil, trace.CompareFailed("cannot create scoped role %q while %s references it", role.GetMetadata().GetName(), binding.source)
 			}
+			return nil, trace.CompareFailed("scoped role %q already exists", role.GetMetadata().GetName())
 		}
 	}
 
@@ -291,27 +289,27 @@ func (s *ScopedAccessService) UpdateScopedRole(ctx context.Context, req *scopeda
 	lockCondition := backend.NotExists()
 	if lockItem != nil {
 		lockCondition = backend.Revision(lockItem.Revision)
-		for assignment, err := range s.StreamScopedRoleAssignments(ctx) {
+	}
+
+	// An update that modifies the assignable scopes of the role may invalidate
+	// any assignments or grants in another resource.
+	if !apiutils.ContainSameUniqueElements(extant.GetRole().GetSpec().GetAssignableScopes(), role.GetSpec().GetAssignableScopes()) {
+		// TODO(nklaassen): make full cross-resource validation opt-in.
+		for binding, err := range s.streamBindingsForRole(ctx, role.GetMetadata().GetName()) {
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 
-			for _, subAssignment := range assignment.GetSpec().GetAssignments() {
-				if subAssignment.GetRole() != role.GetMetadata().GetName() {
-					continue
-				}
+			if !scopedaccess.RoleIsAssignableToScopeOfEffect(extant.GetRole(), binding.scope) {
+				// theoretically, we prevent broken assignments. in practice, its best to
+				// assume they may exist and to not allow them to prevent an otherwsie
+				// valid update. We will still force all broken assignments to be
+				// removed at the time of role deletion.
+				continue
+			}
 
-				if !scopedaccess.RoleIsAssignableToScopeOfEffect(extant.GetRole(), subAssignment.GetScope()) {
-					// theoretically, we prevent broken assignments. in practice, its best to
-					// assume they may exist and to not allow them to prevent an otherwsie
-					// valid update. We will still force all broken assignments to be
-					// removed at the time of role deletion.
-					continue
-				}
-
-				if !scopedaccess.RoleIsAssignableToScopeOfEffect(role, subAssignment.GetScope()) {
-					return nil, trace.BadParameter("update of scoped role %q would invalidate assignment %q which assigns it to user %q at scope %q", role.GetMetadata().GetName(), assignment.GetMetadata().GetName(), assignment.GetSpec().GetUser(), subAssignment.GetScope())
-				}
+			if !scopedaccess.RoleIsAssignableToScopeOfEffect(role, binding.scope) {
+				return nil, trace.BadParameter("update of scoped role %q would invalidate %s which binds it to scope %q", role.GetMetadata().GetName(), binding.source, binding.scope)
 			}
 		}
 	}
@@ -364,18 +362,14 @@ func (s *ScopedAccessService) DeleteScopedRole(ctx context.Context, req *scopeda
 		lockCondition = backend.Revision(lockItem.Revision)
 	}
 
-	// now that we have a lock condition established, we can read all assignments with a "happens after" relationship
-	// to the current lock value and verify that no assignments target this role.
-	for assignment, err := range s.StreamScopedRoleAssignments(ctx) {
+	// now that we have a lock condition established, we can read all
+	// assignments and access lists with a "happens after" relationship to the
+	// current lock value and verify that no assignments or lists target this role.
+	for binding, err := range s.streamBindingsForRole(ctx, roleName) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		for _, subAssignment := range assignment.GetSpec().GetAssignments() {
-			if subAssignment.GetRole() == roleName {
-				return nil, trace.CompareFailed("cannot delete scoped role %q while assignment %q assigns it to a user", roleName, assignment.GetMetadata().GetName())
-			}
-		}
+		return nil, trace.CompareFailed("cannot delete scoped role %q while %s references it", roleName, binding.source)
 	}
 
 	roleCondition := backend.Exists()
@@ -715,6 +709,98 @@ func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, re
 	}
 
 	return &scopedaccessv1.DeleteScopedRoleAssignmentResponse{}, nil
+}
+
+func (s *ScopedAccessService) streamAccessLists(ctx context.Context) stream.Stream[*accesslist.AccessList] {
+	return func(yield func(*accesslist.AccessList, error) bool) {
+		startKey := backend.ExactKey(accessListPrefix)
+		params := backend.ItemsParams{
+			StartKey: startKey,
+			EndKey:   backend.RangeEnd(startKey),
+		}
+
+		for item, err := range s.bk.Items(ctx, params) {
+			if err != nil {
+				yield(nil, trace.Wrap(err))
+				return
+			}
+
+			accessList, err := services.UnmarshalAccessList(item.Value,
+				services.WithRevision(item.Revision),
+				services.WithExpires(item.Expires),
+			)
+			if err != nil {
+				s.logger.WarnContext(ctx, "skipping access list due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
+				continue
+			}
+
+			if !yield(accessList, nil) {
+				return
+			}
+		}
+	}
+}
+
+// scopeBinding describes a concrete scope that a scoped role is "bound" to. A
+// scoped role is "bound" to a scope if it is assigned at that scope by a
+// scoped role assignment or if it is granted at that scoped by an access list grant.
+type scopeBinding struct {
+	scope string
+	// source describes the resource that bound the role to this scope, useful
+	// for error messages.
+	source string
+}
+
+// streamBindingsForRole streams all bindings of the given role to a scope,
+// either by a scoped role assignment or an access list grant. This essentially
+// streams all cross-resource references to the role.
+func (s *ScopedAccessService) streamBindingsForRole(ctx context.Context, role string) stream.Stream[scopeBinding] {
+	return func(yield func(scopeBinding, error) bool) {
+		for assignment, err := range s.StreamScopedRoleAssignments(ctx) {
+			if err != nil {
+				yield(scopeBinding{}, trace.Wrap(err))
+				return
+			}
+
+			for i, subAssignment := range assignment.GetSpec().GetAssignments() {
+				if subAssignment.GetRole() != role {
+					continue
+				}
+				if !yield(scopeBinding{
+					scope:  subAssignment.GetScope(),
+					source: fmt.Sprintf("scoped role assignment %q spec.assignments[%d]", assignment.GetMetadata().GetName(), i),
+				}, nil) {
+					return
+				}
+			}
+		}
+		for acl, err := range s.streamAccessLists(ctx) {
+			if err != nil {
+				yield(scopeBinding{}, trace.Wrap(err))
+				return
+			}
+
+			for _, lense := range []struct {
+				field  string
+				grants []accesslist.ScopedRoleGrant
+			}{
+				{field: "grants", grants: acl.GetGrants().ScopedRoles},
+				{field: "owner_grants", grants: acl.GetOwnerGrants().ScopedRoles},
+			} {
+				for i, grant := range lense.grants {
+					if grant.Role != role {
+						continue
+					}
+					if !yield(scopeBinding{
+						scope:  grant.Scope,
+						source: fmt.Sprintf("access list %q spec.%s.scoped_roles[%d]", acl.GetName(), lense.field, i),
+					}, nil) {
+						return
+					}
+				}
+			}
+		}
+	}
 }
 
 // assertAssignedRoleStable returns a backend.ConditionalAction that asserts

--- a/lib/services/local/scoped_access.go
+++ b/lib/services/local/scoped_access.go
@@ -581,22 +581,12 @@ func (s *ScopedAccessService) CreateScopedRoleAssignment(ctx context.Context, re
 			continue
 		}
 
-		// assert that role is unchanged and modify associated role lock so that role modifications can
-		// detect concurrent modifications to their assignments.
-		condacts = append(condacts, []backend.ConditionalAction{
-			{
-				Key:       scopedRoleKey(subAssignment.GetRole()),
-				Condition: backend.Revision(roleRevision),
-				Action:    backend.Nop(),
-			},
-			{
-				Key:       roleAssignmentLockKey(subAssignment.GetRole()),
-				Condition: backend.Whatever(),
-				Action: backend.Put(backend.Item{
-					Value: newRoleAssignmentLockVal(subAssignment.GetRole()),
-				}),
-			},
-		}...)
+		condacts = append(condacts,
+			// assert that role is unchanged since it was checked.
+			s.assertAssignedRoleStable(subAssignment.GetRole(), roleRevision),
+			// touch role lock so that role modifications can detect concurrent
+			// modifications to their assignments.
+			s.touchRoleAssignmentLock(subAssignment.GetRole()))
 
 		assertedRoles[subAssignment.GetRole()] = struct{}{}
 	}
@@ -725,6 +715,32 @@ func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, re
 	}
 
 	return &scopedaccessv1.DeleteScopedRoleAssignmentResponse{}, nil
+}
+
+// assertAssignedRoleStable returns a backend.ConditionalAction that asserts
+// that a scoped role has not been modified since it was checked at a given
+// roleRevision.
+func (s *ScopedAccessService) assertAssignedRoleStable(roleName, roleRevision string) backend.ConditionalAction {
+	return backend.ConditionalAction{
+		Key:       scopedRoleKey(roleName),
+		Condition: backend.Revision(roleRevision),
+		Action:    backend.Nop(),
+	}
+}
+
+// touchRoleAssignmentLock returns a backend.ConditionalAction to be included
+// in the list of backend.ConditionalActions for an AtomicWrite that modifies a
+// resource that assigns a scoped role. This allows operations that create,
+// modify, or delete a scoped role to efficiently assert that no assignment of
+// that role has been concurrently created or modified.
+func (s *ScopedAccessService) touchRoleAssignmentLock(roleName string) backend.ConditionalAction {
+	return backend.ConditionalAction{
+		Key:       roleAssignmentLockKey(roleName),
+		Condition: backend.Whatever(),
+		Action: backend.Put(backend.Item{
+			Value: newRoleAssignmentLockVal(roleName),
+		}),
+	}
 }
 
 func scopedRoleKey(roleName string) backend.Key {

--- a/lib/services/local/scoped_access_test.go
+++ b/lib/services/local/scoped_access_test.go
@@ -26,14 +26,17 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
@@ -822,4 +825,98 @@ func TestScopedRoleAssignmentInteraction(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+}
+
+// TestScopedRoleInteractionWithAccessListGrants verifies the expected
+// interaction between access list grants and scoped role writes. Namely:
+//   - scoped roles cannot update their assignable scopes if that would
+//     invalidate an assignment from an access list
+//   - scoped roles cannot be deleted if they are assigned from an access list
+func TestScopedRoleInteractionWithAccessListGrants(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{Context: ctx, Clock: clock})
+	require.NoError(t, err)
+	defer bk.Close()
+
+	accessListService := newAccessListService(t, bk, modulestest.EnterpriseModules())
+	scopedAccessService := NewScopedAccessService(bk)
+
+	// Create a base scoped role to update.
+	role := &scopedaccessv1.ScopedRole{
+		Kind: scopedaccess.KindScopedRole,
+		Metadata: &headerv1.Metadata{
+			Name: "testrole",
+		},
+		Scope: "/",
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{
+				"/test/member",
+				"/test/owner",
+			},
+		},
+		Version: types.V1,
+	}
+	createRoleResp, err := scopedAccessService.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{Role: role})
+	require.NoError(t, err)
+
+	// Create an access list that grants the scoped role.
+	al := newAccessList(t, "testlist", clock, withOwnerRequires(accesslist.Requires{}), withMemberRequires(accesslist.Requires{}))
+	al.Spec.Grants.ScopedRoles = []accesslist.ScopedRoleGrant{
+		{
+			Role:  "testrole",
+			Scope: "/test/member",
+		},
+	}
+	al.Spec.OwnerGrants.ScopedRoles = []accesslist.ScopedRoleGrant{
+		{
+			Role:  "testrole",
+			Scope: "/test/owner",
+		},
+	}
+	_, err = accessListService.UpsertAccessList(ctx, al)
+	require.NoError(t, err)
+
+	alm := newAccessListMember(t, "testlist", "alice")
+	_, err = accessListService.UpsertAccessListMember(ctx, alm)
+	require.NoError(t, err)
+
+	// Cannot update the scoped role if it would invalidate the existing member grant.
+	updatedRole := apiutils.CloneProtoMsg(createRoleResp.GetRole())
+	updatedRole.Spec.AssignableScopes = []string{"/test/owner"}
+	_, err = scopedAccessService.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{Role: updatedRole})
+	require.Error(t, err)
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
+	require.ErrorContains(t, err, `would invalidate access list "testlist" spec.grants`)
+
+	// Cannot update the scoped role if it would invalidate the existing owner grant.
+	updatedRole = apiutils.CloneProtoMsg(createRoleResp.GetRole())
+	updatedRole.Spec.AssignableScopes = []string{"/test/member"}
+	_, err = scopedAccessService.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{Role: updatedRole})
+	require.Error(t, err)
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
+	require.ErrorContains(t, err, `would invalidate access list "testlist" spec.owner_grants`)
+
+	// Cannot delete a scoped role granted by an access list.
+	_, err = scopedAccessService.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
+		Name:     "testrole",
+		Revision: createRoleResp.GetRole().GetMetadata().GetRevision(),
+	})
+	require.Error(t, err)
+	require.ErrorAs(t, err, new(*trace.CompareFailedError))
+	require.ErrorContains(t, err, `while access list "testlist"`)
+
+	// After deleting the access list, the scoped role can be updated or deleted.
+	err = accessListService.DeleteAccessList(ctx, al.GetName())
+	require.NoError(t, err)
+	updateRoleResp, err := scopedAccessService.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{Role: updatedRole})
+	require.NoError(t, err)
+	_, err = scopedAccessService.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
+		Name:     "testrole",
+		Revision: updateRoleResp.GetRole().GetMetadata().GetRevision(),
+	})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Backport #64407 to branch/v18
Backport #64494 to branch/v18

Almost all of the code in here is about to be deleted by the backport of https://github.com/gravitational/teleport/pull/65333, backporting to get a little bit of added static validation and a clean base for Forrest's backports.

## Manual Test Plan
### Test Environment

A teleport cluster running with `TELEPORT_UNSTABLE_SCOPES=yes`

access_list_eng.yaml:
```version: v1
kind: access_list
metadata:
  name: eng-access
spec:
  title: "Scoped access for eng team"
  owners:
    - name: teleport-admin
      membership_kind: MEMBERSHIP_KIND_USER
  grants:
    scoped_roles:
      - role: eng-access
        scope: /eng
```

scoped_role_eng_access.yaml:
```
kind: scoped_role
version: v1
metadata:
  name: eng-access
scope: "/"
spec:
  assignable_scopes:
    - /eng
  allow:
    logins:
      - nic
    node_labels:
      - name: "*"
        values: ["*"]
```

### Test Cases

- [x] Access list granting scoped roles cannot be created without TELEPORT_UNSTABLE_SCOPES=yes
- [x] Access list can be created granting a scoped role in one of its assignable scopes `tctl create access_list_eng.yaml`