### PR TITLE
Fix issues in Get Started Part 1

### DIFF
--- a/docs/pages/get-started/deploy-cloud.mdx
+++ b/docs/pages/get-started/deploy-cloud.mdx
@@ -51,10 +51,18 @@ relying on it for day-to-day usage:
    Tools](https://goteleport.com/download/client-tools/), select your platform,
    and choose "CLI Client Tools" in the **Download Type** menu.
 
+1. Sign in to your Teleport cluster from the command line so you can perform
+   administrative actions in your shell. Replace 
+   <Var name="example.teleport.sh" /> with the address of your Teleport cluster:
+
+   ```code
+   $ tsh login --proxy=<Var name="example.teleport.sh" /> --user=teleport-admin
+   ```
+
 1. On your workstation, run the following command:
 
    ```code
-   $ sudo tctl users add teleport-admin-backup --roles=editor,access,auditor --logins=root,ubuntu,ec2-user
+   $ tctl users add teleport-admin-backup --roles=editor,access,auditor --logins=root,ubuntu,ec2-user
    ```
 
    The command prints a message similar to the following:

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -300,7 +300,8 @@ allowed to log into SSH hosts as any of the principals `root`, `ubuntu`, or
 
 1. Visit the provided URL in order to create your Teleport user.
 
-   The signup flow creates a local Teleport user with the following preset roles:
+   The `tctl` command you ran earlier created a local Teleport user with the
+   following preset roles:
    
    |Role|Permissions|
    |---|---|
@@ -362,7 +363,7 @@ $ tsh login --proxy=<Var name="teleport.example.com" /> --user=teleport-admin
 > Profile URL:        https://teleport.example.com:443
   Logged in as:       teleport-admin
   Cluster:            teleport.example.com
-  Roles:              access, editor
+  Roles:              access, auditor, editor
   Logins:             root, ubuntu, ec2-user
   Kubernetes:         enabled
   Valid until:        2022-04-26 03:04:46 -0400 EDT [valid for 12h0m0s]


### PR DESCRIPTION
- Remove an unnecessary `sudo` from a local `tctl` command example.
- Add `tsh login` in the Part 1 guide showing the user their first `tctl` command.