### PR TITLE
Add  field to aws_matchers. Remove eks support from the legacy match_aws_* fields so we don't have to worry about compatibility.

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -71,6 +71,16 @@ module "aws_discovery" {
 }
 ```
 
+### `aws_matchers` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `types` | `list(string)` | (required) | AWS resource types to discover. Allowed values: `ec2`, `eks`. |
+| `regions` | `list(string)` | (required) | AWS regions to search. EC2 supports `"*"` for all regions. EKS requires explicit regions. |
+| `tags` | `map(list(string))` | `{ "*" : ["*"] }` | AWS resource tags to match. The default matches all resources. |
+| `setup_access_for_arn` | `string` | `""` | ARN to configure access for discovered EKS clusters. Only supported for EKS matchers. |
+| `kube_app_discovery` | `bool` | `true` | Teleport's Kubernetes App Discovery will automatically identify and enroll to Teleport HTTP applications running inside a Kubernetes cluster. |
+
 ## How to get help
 
 If you're having trouble, check out our [GitHub Discussions](https://github.com/gravitational/teleport/discussions).
@@ -85,7 +95,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | terraform | >= 1.5.7 |
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.5.1 |
+| teleport | >= 18.7.4 |
 | tls | >= 4.0 |
 
 ## Providers
@@ -94,7 +104,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 |------|---------|
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.5.1 |
+| teleport | >= 18.7.4 |
 | tls | >= 4.0 |
 
 ## Modules
@@ -130,7 +140,7 @@ No modules.
 | aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
-| aws\_matchers | AWS resource discovery matchers. | ```list(object({ types = list(string) regions = list(string) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") }))``` | `null` | no |
+| aws\_matchers | AWS resource discovery matchers. | ```list(object({ types = list(string) regions = list(string) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool, true) }))``` | `null` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
 | discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -57,6 +57,16 @@ module "aws_discovery" {
 }
 ```
 
+### `aws_matchers` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `types` | `list(string)` | (required) | AWS resource types to discover. Allowed values: `ec2`, `eks`. |
+| `regions` | `list(string)` | (required) | AWS regions to search. EC2 supports `"*"` for all regions. EKS requires explicit regions. |
+| `tags` | `map(list(string))` | `{ "*" : ["*"] }` | AWS resource tags to match. The default matches all resources. |
+| `setup_access_for_arn` | `string` | `""` | ARN to configure access for discovered EKS clusters. Only supported for EKS matchers. |
+| `kube_app_discovery` | `bool` | `true` | Teleport's Kubernetes App Discovery will automatically identify and enroll to Teleport HTTP applications running inside a Kubernetes cluster. |
+
 ## How to get help
 
 If you're having trouble, check out our [GitHub Discussions](https://github.com/gravitational/teleport/discussions).
@@ -71,7 +81,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | terraform | >= 1.5.7 |
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.5.1 |
+| teleport | >= 18.7.4 |
 | tls | >= 4.0 |
 
 ## Providers
@@ -80,7 +90,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 |------|---------|
 | aws | >= 5.0 |
 | http | >= 3.0 |
-| teleport | >= 18.5.1 |
+| teleport | >= 18.7.4 |
 | tls | >= 4.0 |
 
 ## Modules
@@ -116,7 +126,7 @@ No modules.
 | aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
-| aws\_matchers | AWS resource discovery matchers. | ```list(object({ types = list(string) regions = list(string) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") }))``` | `null` | no |
+| aws\_matchers | AWS resource discovery matchers. | ```list(object({ types = list(string) regions = list(string) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool, true) }))``` | `null` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
 | discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
@@ -19,6 +19,7 @@ locals {
       regions              = coalesce(var.match_aws_regions, ["*"])
       tags                 = coalesce(var.match_aws_tags, { "*" : ["*"] })
       setup_access_for_arn = ""
+      kube_app_discovery   = false
     }
   ]
 
@@ -56,6 +57,9 @@ locals {
       } : {},
       contains(matcher.types, "eks") && matcher.setup_access_for_arn != "" ? {
         setup_access_for_arn = matcher.setup_access_for_arn
+      } : {},
+      contains(matcher.types, "eks") ? {
+        kube_app_discovery = matcher.kube_app_discovery
       } : {}
     )
   ]

--- a/integrations/terraform-modules/teleport/discovery/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/variables.tf
@@ -34,11 +34,10 @@ variable "match_aws_resource_types" {
     condition = var.match_aws_resource_types == null || alltrue([
       for rt in var.match_aws_resource_types :
       contains([
-        "ec2",
-        "eks",
+        "ec2"
       ], rt)
     ])
-    error_message = "Allowed values for match_aws_resource_types are: ec2, eks."
+    error_message = "Allowed values for match_aws_resource_types are: ec2. Use the new aws_matchers field instead for all supported types."
   }
 }
 
@@ -49,6 +48,7 @@ variable "aws_matchers" {
     regions              = list(string)
     tags                 = optional(map(list(string)), { "*" : ["*"] })
     setup_access_for_arn = optional(string, "")
+    kube_app_discovery   = optional(bool, true)
   }))
   default  = null
   nullable = true

--- a/integrations/terraform-modules/teleport/discovery/aws/versions.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     teleport = {
       source  = "terraform.releases.teleport.dev/gravitational/teleport"
-      version = ">= 18.5.1"
+      version = ">= 18.7.4"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
Adds the kube_app_discovery option to EKS matchers, which was missed in #65002. It defaults to true to match the existing EKS discovery flow (the guided wizard).

Since EKS Terraform support hasn't been released yet, this PR also removes eks as a matcher option in the legacy fields. With the additional options (`setup_access_for_arn` and `kube_app_discovery`), adding more `match_aws_*` fields to maintain the singular matcher isn't practical. Users who want EKS matchers in their legacy setup should migrate to aws_matchers instead.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Cloud staging tenant with update dev build
### Test Cases
- [x] EKS matcher with empty options - gets default true value in underlying discovery_config
- [x] EKS matcher with `kube_app_discovery = false` - gets false in underlying discovery_config
- [x] EC2 matcher does not get option in underlying discovery_config.
- [x] EKS + EC2 matcher with `kube_app_discovery = true` works, discovery_config matches.

Not planning on testing discovery all the way through to access, since this is reusing the existing service functionality. Only the config produced by terraform is changing.
