### PR TITLE
feat: added long db name support using vnet & tsh vnet ls support

### DIFF
--- a/lib/vnet/db_fqdn.go
+++ b/lib/vnet/db_fqdn.go
@@ -90,7 +90,7 @@ func parseDatabaseFQDN(fqdn string, zone string) (dbUser, dbName string, err err
 	return dbUser, dbName, nil
 }
 
-// hashDBName returns a DNS-safe label for a database resource name. Names that
+// HashDBName returns a DNS-safe label for a database resource name. Names that
 // fit within a single DNS label (<=63 chars) are returned unchanged. Longer
 // names are truncated and suffixed with a hash to stay within DNS limits while
 // remaining deterministic and human-readable.
@@ -98,7 +98,7 @@ func parseDatabaseFQDN(fqdn string, zone string) (dbUser, dbName string, err err
 // Format for hashed names: <prefix>-vnethash-<hash12>
 // where <prefix> is the first portion of the original name and <hash12> is
 // 12 lowercase base32 characters of the SHA1 hash of the full name.
-func hashDBName(name string) string {
+func HashDBName(name string) string {
 	if len(name) <= maxDNSLabelLength {
 		return name
 	}

--- a/lib/vnet/db_fqdn.go
+++ b/lib/vnet/db_fqdn.go
@@ -17,9 +17,25 @@
 package vnet
 
 import (
+	"crypto/sha1"
+	"encoding/base32"
 	"strings"
 
 	"github.com/gravitational/teleport/api/types"
+)
+
+const (
+	// maxDNSLabelLength is the maximum length of a single DNS label (the part
+	// between dots in a FQDN)
+	maxDNSLabelLength = 63
+
+	// dbNameHashInfix separates the human-readable prefix from the hash suffix
+	dbNameHashInfix = "-vnethash-"
+
+	// dbNameHashLen is the number of base32 characters used from the SHA1 hash.
+	// 12 base32 chars = 60 bits of entropy, which provides negligible collision
+	// probability for database name sets
+	dbNameHashLen = 12
 )
 
 // dbFQDNInfix is the DNS label that separates the database-specific prefix
@@ -59,6 +75,12 @@ func parseDatabaseFQDN(fqdn string, zone string) (dbUser, dbName string, err err
 		return "", "", errNoMatch
 	}
 
+	// For hashed names, skip ValidateDatabaseName since the hashed label
+	// won't match the original database name regex.
+	if isHashedDBName(dbName) {
+		return dbUser, dbName, nil
+	}
+
 	// Validate that dbName looks like a valid database resource name. This
 	// avoids unnecessary cluster API calls for invalid names
 	if err := types.ValidateDatabaseName(dbName); err != nil {
@@ -66,4 +88,39 @@ func parseDatabaseFQDN(fqdn string, zone string) (dbUser, dbName string, err err
 	}
 
 	return dbUser, dbName, nil
+}
+
+// hashDBName returns a DNS-safe label for a database resource name. Names that
+// fit within a single DNS label (<=63 chars) are returned unchanged. Longer
+// names are truncated and suffixed with a hash to stay within DNS limits while
+// remaining deterministic and human-readable.
+//
+// Format for hashed names: <prefix>-vnethash-<hash12>
+// where <prefix> is the first portion of the original name and <hash12> is
+// 12 lowercase base32 characters of the SHA1 hash of the full name.
+func hashDBName(name string) string {
+	if len(name) <= maxDNSLabelLength {
+		return name
+	}
+
+	h := sha1.New()
+	h.Write([]byte(name))
+	hash := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(h.Sum(nil))
+
+	maxPrefix := maxDNSLabelLength - len(dbNameHashInfix) - dbNameHashLen
+	prefix := name[:maxPrefix]
+	// Ensure prefix doesn't end with a hyphen (invalid DNS label ending).
+	prefix = strings.TrimRight(prefix, "-")
+	return prefix + dbNameHashInfix + strings.ToLower(hash[:dbNameHashLen])
+}
+
+func isHashedDBName(name string) bool {
+	return strings.Contains(name, dbNameHashInfix)
+}
+
+func extractPrefixFromHashedDBName(name string) string {
+	if idx := strings.Index(name, dbNameHashInfix); idx >= 0 {
+		return name[:idx]
+	}
+	return name
 }

--- a/lib/vnet/db_fqdn_test.go
+++ b/lib/vnet/db_fqdn_test.go
@@ -201,19 +201,19 @@ func TestValidateDBUserForProtocol(t *testing.T) {
 func TestHashDBName(t *testing.T) {
 	t.Run("short name unchanged", func(t *testing.T) {
 		name := "my-postgres"
-		require.Equal(t, name, hashDBName(name))
+		require.Equal(t, name, HashDBName(name))
 	})
 
 	t.Run("exactly 63 chars unchanged", func(t *testing.T) {
 		name := "a" + strings.Repeat("b", 61) + "c"
 		require.Len(t, name, 63)
-		require.Equal(t, name, hashDBName(name))
+		require.Equal(t, name, HashDBName(name))
 	})
 
 	t.Run("64 chars gets hashed", func(t *testing.T) {
 		name := "a" + strings.Repeat("b", 62) + "c"
 		require.Len(t, name, 64)
-		hashed := hashDBName(name)
+		hashed := HashDBName(name)
 		require.NotEqual(t, name, hashed)
 		require.LessOrEqual(t, len(hashed), 63)
 		require.Contains(t, hashed, "-vnethash-")
@@ -222,31 +222,31 @@ func TestHashDBName(t *testing.T) {
 	t.Run("very long name fits in 63 chars", func(t *testing.T) {
 		name := "foo-rds-us-west-1-111111111111-some-very-long-extra-description-that-exceeds-dns-label-limit"
 		require.Greater(t, len(name), 63)
-		hashed := hashDBName(name)
+		hashed := HashDBName(name)
 		require.LessOrEqual(t, len(hashed), 63)
 	})
 
 	t.Run("deterministic", func(t *testing.T) {
 		name := "foo-rds-us-west-1-111111111111-some-very-long-extra-description-that-exceeds-dns-label-limit"
-		require.Equal(t, hashDBName(name), hashDBName(name))
+		require.Equal(t, HashDBName(name), HashDBName(name))
 	})
 
 	t.Run("preserves readable prefix", func(t *testing.T) {
 		name := "foo-rds-us-west-1-111111111111-some-very-long-extra-description-that-exceeds-dns-label-limit"
-		hashed := hashDBName(name)
+		hashed := HashDBName(name)
 		require.True(t, strings.HasPrefix(hashed, "foo-rds-us-west-1"))
 	})
 
 	t.Run("different long names produce different hashes", func(t *testing.T) {
 		name1 := "foo-rds-us-west-1-111111111111-some-very-long-extra-description-variant-a"
 		name2 := "foo-rds-us-west-1-111111111111-some-very-long-extra-description-variant-b"
-		require.NotEqual(t, hashDBName(name1), hashDBName(name2))
+		require.NotEqual(t, HashDBName(name1), HashDBName(name2))
 	})
 
 	t.Run("prefix does not end with hyphen", func(t *testing.T) {
 		// Craft a name where character at position 41 boundary falls on a hyphen
 		name := strings.Repeat("a", 40) + "-" + strings.Repeat("b", 30)
-		hashed := hashDBName(name)
+		hashed := HashDBName(name)
 		prefix := extractPrefixFromHashedDBName(hashed)
 		require.False(t, strings.HasSuffix(prefix, "-"))
 	})

--- a/lib/vnet/db_fqdn_test.go
+++ b/lib/vnet/db_fqdn_test.go
@@ -17,6 +17,7 @@
 package vnet
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -195,4 +196,64 @@ func TestValidateDBUserForProtocol(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHashDBName(t *testing.T) {
+	t.Run("short name unchanged", func(t *testing.T) {
+		name := "my-postgres"
+		require.Equal(t, name, hashDBName(name))
+	})
+
+	t.Run("exactly 63 chars unchanged", func(t *testing.T) {
+		name := "a" + strings.Repeat("b", 61) + "c"
+		require.Len(t, name, 63)
+		require.Equal(t, name, hashDBName(name))
+	})
+
+	t.Run("64 chars gets hashed", func(t *testing.T) {
+		name := "a" + strings.Repeat("b", 62) + "c"
+		require.Len(t, name, 64)
+		hashed := hashDBName(name)
+		require.NotEqual(t, name, hashed)
+		require.LessOrEqual(t, len(hashed), 63)
+		require.Contains(t, hashed, "-vnethash-")
+	})
+
+	t.Run("very long name fits in 63 chars", func(t *testing.T) {
+		name := "foo-rds-us-west-1-111111111111-some-very-long-extra-description-that-exceeds-dns-label-limit"
+		require.Greater(t, len(name), 63)
+		hashed := hashDBName(name)
+		require.LessOrEqual(t, len(hashed), 63)
+	})
+
+	t.Run("deterministic", func(t *testing.T) {
+		name := "foo-rds-us-west-1-111111111111-some-very-long-extra-description-that-exceeds-dns-label-limit"
+		require.Equal(t, hashDBName(name), hashDBName(name))
+	})
+
+	t.Run("preserves readable prefix", func(t *testing.T) {
+		name := "foo-rds-us-west-1-111111111111-some-very-long-extra-description-that-exceeds-dns-label-limit"
+		hashed := hashDBName(name)
+		require.True(t, strings.HasPrefix(hashed, "foo-rds-us-west-1"))
+	})
+
+	t.Run("different long names produce different hashes", func(t *testing.T) {
+		name1 := "foo-rds-us-west-1-111111111111-some-very-long-extra-description-variant-a"
+		name2 := "foo-rds-us-west-1-111111111111-some-very-long-extra-description-variant-b"
+		require.NotEqual(t, hashDBName(name1), hashDBName(name2))
+	})
+
+	t.Run("prefix does not end with hyphen", func(t *testing.T) {
+		// Craft a name where character at position 41 boundary falls on a hyphen
+		name := strings.Repeat("a", 40) + "-" + strings.Repeat("b", 30)
+		hashed := hashDBName(name)
+		prefix := extractPrefixFromHashedDBName(hashed)
+		require.False(t, strings.HasSuffix(prefix, "-"))
+	})
+}
+
+func TestIsHashedDBName(t *testing.T) {
+	require.True(t, isHashedDBName("foo-vnethash-abc123abc123"))
+	require.False(t, isHashedDBName("my-postgres"))
+	require.False(t, isHashedDBName(""))
 }

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -508,7 +508,7 @@ func (r *fqdnResolver) findDatabaseByHashedName(ctx context.Context, candidate c
 	}
 	for _, server := range resp.Resources {
 		db := server.GetDatabase()
-		if hashDBName(db.GetName()) == hashedName {
+		if HashDBName(db.GetName()) == hashedName {
 			return db, nil
 		}
 	}
@@ -590,7 +590,7 @@ func rootProxyHostFromProfile(profileName string) string {
 // validateDBUserForProtocol checks that the db-user parsed from the FQDN is
 // appropriate for the database protocol
 func validateDBUserForProtocol(dbUser, dbName, protocol string) error {
-	if dbProtocolExtractsUsernameFromWire(protocol) {
+	if DBProtocolExtractsUsernameFromWire(protocol) {
 		if dbUser != "" {
 			return trace.BadParameter("database protocol %q does not support username in domain name, specify the user in the client connection string instead", protocol)
 		}
@@ -602,9 +602,11 @@ func validateDBUserForProtocol(dbUser, dbName, protocol string) error {
 	return nil
 }
 
-// dbProtocolExtractsUsernameFromWire returns true for database protocols where
+// DBProtocolExtractsUsernameFromWire returns true for database protocols where
 // the db_service extracts the database username from the wire protocol
-func dbProtocolExtractsUsernameFromWire(protocol string) bool {
+// (e.g. from the Postgres StartupMessage or MySQL HandshakeResponse), meaning
+// the username should NOT be included in the FQDN.
+func DBProtocolExtractsUsernameFromWire(protocol string) bool {
 	switch protocol {
 	case defaults.ProtocolPostgres, defaults.ProtocolCockroachDB,
 		defaults.ProtocolMySQL, defaults.ProtocolSQLServer:

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -422,25 +422,18 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 	}
 
 	// Query the cluster for a database server matching the parsed name.
-	expr := fmt.Sprintf(`name == "%s"`, dbName)
-	resp, err := apiclient.GetResourcePage[types.DatabaseServer](ctx, candidate.client.CurrentCluster(), &proto.ListResourcesRequest{
-		ResourceType:        types.KindDatabaseServer,
-		PredicateExpression: expr,
-		Limit:               1,
-	})
+	db, err := r.findDatabaseByName(ctx, candidate, dbName)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil, trace.Wrap(err)
 		}
-		log.InfoContext(ctx, "Failed to list database servers", "error", err)
+		log.DebugContext(ctx, "Failed to find matching database server", "error", err)
 		return nil, errNoMatch
 	}
-	if len(resp.Resources) == 0 {
+	if db == nil {
 		log.DebugContext(ctx, "Found no matching database servers")
 		return nil, errNoMatch
 	}
-
-	db := resp.Resources[0].GetDatabase()
 	protocol := db.GetProtocol()
 
 	if err := validateDBUserForProtocol(dbUser, dbName, protocol); err != nil {
@@ -475,6 +468,51 @@ func (r *fqdnResolver) resolveDBInfoForCluster(
 			},
 		},
 	}, nil
+}
+
+// findDatabaseByName looks up a database server by name in the given cluster.
+func (r *fqdnResolver) findDatabaseByName(ctx context.Context, candidate clusterResolutionCandidate, dbName string) (types.Database, error) {
+	if isHashedDBName(dbName) {
+		return r.findDatabaseByHashedName(ctx, candidate, dbName)
+	}
+
+	expr := fmt.Sprintf(`name == "%s"`, dbName)
+	resp, err := apiclient.GetResourcePage[types.DatabaseServer](ctx, candidate.client.CurrentCluster(), &proto.ListResourcesRequest{
+		ResourceType:        types.KindDatabaseServer,
+		PredicateExpression: expr,
+		Limit:               1,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if len(resp.Resources) == 0 {
+		return nil, nil
+	}
+	return resp.Resources[0].GetDatabase(), nil
+}
+
+// findDatabaseByHashedName resolves a hashed database FQDN label back to the
+// original database resource. It uses the prefix portion of the hashed name to
+// narrow the search with a server-side hasPrefix predicate, then hashes each
+// candidate to find an exact match.
+func (r *fqdnResolver) findDatabaseByHashedName(ctx context.Context, candidate clusterResolutionCandidate, hashedName string) (types.Database, error) {
+	prefix := extractPrefixFromHashedDBName(hashedName)
+	expr := fmt.Sprintf(`hasPrefix(resource.metadata.name, "%s")`, prefix)
+	resp, err := apiclient.GetResourcePage[types.DatabaseServer](ctx, candidate.client.CurrentCluster(), &proto.ListResourcesRequest{
+		ResourceType:        types.KindDatabaseServer,
+		PredicateExpression: expr,
+		Limit:               100,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, server := range resp.Resources {
+		db := server.GetDatabase()
+		if hashDBName(db.GetName()) == hashedName {
+			return db, nil
+		}
+	}
+	return nil, nil
 }
 
 // VNet SSH handles SSH hostnames matching "<hostname>.<cluster_name>.", where

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -1321,7 +1321,7 @@ func TestDialFakeDatabase(t *testing.T) {
 		},
 		{
 			name:       "long database name resolved via hash",
-			fqdn:       hashDBName("a-very-long-database-name-that-exceeds-the-sixty-three-character-dns-label-limit") + ".db.root1.example.com",
+			fqdn:       HashDBName("a-very-long-database-name-that-exceeds-the-sixty-three-character-dns-label-limit") + ".db.root1.example.com",
 			expectCIDR: "192.168.2.0/24",
 			expectRouteToDatabase: proto.RouteToDatabase{
 				ServiceName: "a-very-long-database-name-that-exceeds-the-sixty-three-character-dns-label-limit",

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -1252,6 +1252,7 @@ func TestDialFakeDatabase(t *testing.T) {
 					{name: "my-postgres", protocol: "postgres"},
 					{name: "my-mysql", protocol: "mysql"},
 					{name: "my-mongo", protocol: "mongodb"},
+					{name: "a-very-long-database-name-that-exceeds-the-sixty-three-character-dns-label-limit", protocol: "postgres"},
 				},
 				cidrRange: "192.168.2.0/24",
 				leafClusters: map[string]testClusterSpec{
@@ -1316,6 +1317,16 @@ func TestDialFakeDatabase(t *testing.T) {
 				ServiceName: "my-mongo",
 				Protocol:    "mongodb",
 				Username:    "admin", // mongodb requires user in cert
+			},
+		},
+		{
+			name:       "long database name resolved via hash",
+			fqdn:       hashDBName("a-very-long-database-name-that-exceeds-the-sixty-three-character-dns-label-limit") + ".db.root1.example.com",
+			expectCIDR: "192.168.2.0/24",
+			expectRouteToDatabase: proto.RouteToDatabase{
+				ServiceName: "a-very-long-database-name-that-exceeds-the-sixty-three-character-dns-label-limit",
+				Protocol:    "postgres",
+				Username:    "",
 			},
 		},
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1510,7 +1510,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	workloadIdentityCmd := newWorkloadIdentityCommands(app)
 
-	vnetCommand := newVnetCommand(app)
+	vnetCmds := newVnetCommands(app)
 	vnetSSHAutoConfigCommand := newVnetSSHAutoConfigCommand(app)
 	vnetAdminSetupCommand := newVnetAdminSetupCommand(app)
 	vnetDaemonCommand := newVnetDaemonCommand(app)
@@ -1954,8 +1954,10 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = onHeadlessApprove(&cf)
 	case workloadIdentityCmd.issueX509.FullCommand():
 		err = workloadIdentityCmd.issueX509.run(&cf)
-	case vnetCommand.FullCommand():
-		err = vnetCommand.run(&cf)
+	case vnetCmds.start.FullCommand():
+		err = vnetCmds.start.run(&cf)
+	case vnetCmds.ls.FullCommand():
+		err = vnetCmds.ls.run(&cf)
 	case vnetSSHAutoConfigCommand.FullCommand():
 		err = vnetSSHAutoConfigCommand.run(&cf)
 	case vnetAdminSetupCommand.FullCommand():

--- a/tool/tsh/common/vnet.go
+++ b/tool/tsh/common/vnet.go
@@ -35,23 +35,37 @@ type vnetCLICommand interface {
 	run(cf *CLIConf) error
 }
 
-// vnetCommand implements the `tsh vnet` command to run VNet.
-type vnetCommand struct {
+// vnetCommands holds all `tsh vnet` subcommands.
+type vnetCommands struct {
+	start *vnetStartCommand
+	ls    *vnetLSCommand
+}
+
+func newVnetCommands(app *kingpin.Application) vnetCommands {
+	parent := app.Command("vnet", "Teleport VNet commands. Run without a subcommand to start VNet.")
+	return vnetCommands{
+		start: newVnetStartCommand(parent),
+		ls:    newVnetLSCommand(parent),
+	}
+}
+
+// vnetStartCommand implements the `tsh vnet` / `tsh vnet start` command to run VNet.
+type vnetStartCommand struct {
 	*kingpin.CmdClause
 	// runDiag determines whether to run diagnostics after VNet starts or not. Intended as a "feature
 	// flag" before we start running diagnostics on each start of VNet.
 	runDiag bool
 }
 
-func newVnetCommand(app *kingpin.Application) *vnetCommand {
-	cmd := &vnetCommand{
-		CmdClause: app.Command("vnet", "Start Teleport VNet, a virtual network for TCP application access."),
+func newVnetStartCommand(parent *kingpin.CmdClause) *vnetStartCommand {
+	cmd := &vnetStartCommand{
+		CmdClause: parent.Command("start", "Start Teleport VNet.").Default(),
 	}
 	cmd.Flag("diag", "Run diagnostics after starting VNet.").Hidden().BoolVar(&cmd.runDiag)
 	return cmd
 }
 
-func (c *vnetCommand) run(cf *CLIConf) error {
+func (c *vnetStartCommand) run(cf *CLIConf) error {
 	clientApp, err := newVnetClientApplication(cf)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tsh/common/vnet_ls.go
+++ b/tool/tsh/common/vnet_ls.go
@@ -1,0 +1,167 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/vnet"
+)
+
+var vnetSupportedKinds = []string{
+	types.KindApp,
+	types.KindDatabase,
+	types.KindNode,
+}
+
+// vnetLSCommand implements the `tsh vnet ls` command to list resources
+// accessible via VNet
+type vnetLSCommand struct {
+	*kingpin.CmdClause
+	kinds               []string
+	labels              string
+	searchKeywords      string
+	predicateExpression string
+}
+
+func newVnetLSCommand(parent *kingpin.CmdClause) *vnetLSCommand {
+	cmd := &vnetLSCommand{
+		CmdClause: parent.Command("ls", "List resources accessible via VNet."),
+	}
+	cmd.Flag("kind", fmt.Sprintf("Filter by resource kind. Supported: %s.", strings.Join(vnetSupportedKinds, ", "))).
+		StringsVar(&cmd.kinds)
+	cmd.Flag("search", searchHelp).StringVar(&cmd.searchKeywords)
+	cmd.Flag("query", queryHelp).StringVar(&cmd.predicateExpression)
+	cmd.Arg("labels", labelHelp).StringVar(&cmd.labels)
+	return cmd
+}
+
+func (c *vnetLSCommand) run(cf *CLIConf) error {
+	kinds := c.kinds
+	if len(kinds) == 0 {
+		kinds = vnetSupportedKinds
+	}
+	for _, kind := range kinds {
+		if !slices.Contains(vnetSupportedKinds, kind) {
+			return trace.BadParameter("unsupported kind %q, supported kinds: %s", kind, strings.Join(vnetSupportedKinds, ", "))
+		}
+	}
+
+	cf.Labels = c.labels
+	cf.SearchKeywords = c.searchKeywords
+	cf.PredicateExpression = c.predicateExpression
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var rows [][]string
+	var hasDB, hasNode bool
+
+	err = client.RetryWithRelogin(cf.Context, tc, func() error {
+		// Reset state between retries to avoid duplicate rows.
+		rows = nil
+		hasDB = false
+		hasNode = false
+
+		clusterClient, err := tc.ConnectToCluster(cf.Context)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		resources, err := apiclient.GetAllUnifiedResources(cf.Context, clusterClient.AuthClient, &proto.ListUnifiedResourcesRequest{
+			Kinds:               kinds,
+			SortBy:              types.SortBy{Field: types.ResourceKind},
+			SearchKeywords:      tc.SearchKeywords,
+			PredicateExpression: tc.PredicateExpression,
+			Labels:              tc.Labels,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		proxyHost := tc.WebProxyHost()
+
+		for _, r := range resources {
+			switch res := r.ResourceWithLabels.(type) {
+			case types.AppServer:
+				app := res.GetApp()
+				if app.IsTCP() {
+					rows = append(rows, []string{"app/tcp", app.GetName(), app.GetPublicAddr()})
+				} else {
+					rows = append(rows, []string{"app/http", app.GetName(), app.GetPublicAddr()})
+				}
+			case types.DatabaseServer:
+				db := res.GetDatabase()
+				dbName := db.GetName()
+				protocol := db.GetProtocol()
+				fqdnLabel := vnet.HashDBName(dbName)
+				var addr string
+				if vnet.DBProtocolExtractsUsernameFromWire(protocol) {
+					addr = fmt.Sprintf("%s.db.%s", fqdnLabel, proxyHost)
+				} else {
+					addr = fmt.Sprintf("<db-user>.%s.db.%s", fqdnLabel, proxyHost)
+				}
+				rows = append(rows, []string{"db", dbName, addr})
+				hasDB = true
+			case types.Server:
+				hostname := res.GetHostname()
+				clusterName := tc.SiteName
+				addr := fmt.Sprintf("%s.%s", hostname, clusterName)
+				rows = append(rows, []string{"node", hostname, addr})
+				hasNode = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if len(rows) == 0 {
+		fmt.Fprintln(cf.Stdout(), "No resources found accessible via VNet.")
+		return nil
+	}
+
+	t := asciitable.MakeTable([]string{"Type", "Name", "Address"}, rows...)
+	if _, err := fmt.Fprintln(cf.Stdout(), t.AsBuffer().String()); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if hasDB {
+		fmt.Fprintln(cf.Stdout(), "(*) For databases that show <db-user>, replace it with your database username.")
+		fmt.Fprintln(cf.Stdout(), "    For postgres, mysql, and sqlserver databases, specify the user in your client connection string instead.")
+	}
+	if hasNode {
+		fmt.Fprintln(cf.Stdout(), "(**) To connect to SSH nodes via VNet, run: ssh <os-username>@<address>")
+		fmt.Fprintln(cf.Stdout(), "     VNet must be configured in your SSH client. Run `tsh vnet-ssh-autoconfig` to set it up.")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Changes
- Hashed name resolution uses server-side hasPrefix predicate for efficient matching without fetching all databases
- Exports HashDBName and DBProtocolExtractsUsernameFromWire from the vnet package for use by tsh vnet ls
- Added tsh vnet ls command to list all resources accessible via VNet (apps, databases, SSH nodes) with their VNet FQDNs
- Supports --kind flag for filtering (tsh vnet ls --kind db), plus --search, --query, and label filters (can omit the other options if not interesting)
- Added DNS-safe hashing for database names exceeding the 63-character DNS label limit, using a <prefix>-vnethash-<hash> format


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] tsh vnet ls lists all resource types
- [ ] tsh vnet ls --kind db --kind app test for multiple kinds
- [ ] Invalid kind rejected
- [ ] Protocol-aware address formatting
- [ ] Connect via hashed FQDN
- [ ] tsh vnet backward compatibility
- [ ] tsh vnet start explicit alias
- [ ] No login required for tsh vnet ls
