### PR TITLE
Adding scope access checking to kube service

### DIFF
--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -606,6 +606,11 @@ type KubernetesAccessPoint interface {
 
 	// accessPoint provides common access point functionality
 	accessPoint
+
+	// ScopedRoleReader returns a read-only scoped role client.
+	// TODO(fspmarshall/scopes): remove the need for this. this is only here to satisfy the common
+	// interface used by lib/srv components. scoped access is not support for cross-cluster operations.
+	ScopedRoleReader() services.ScopedRoleReader
 }
 
 // ReadAppsAccessPoint is a read only API interface implemented by a certificate authority (CA) to be
@@ -1617,6 +1622,12 @@ func (w *KubernetesWrapper) Close() error {
 	err := w.NoCache.Close()
 	err2 := w.ReadKubernetesAccessPoint.Close()
 	return trace.NewAggregate(err, err2)
+}
+
+func (w *KubernetesWrapper) ScopedRoleReader() services.ScopedRoleReader {
+	// TODO(fspmarshall/scopes): implement caching for scoped roles
+	// on kube agents.
+	return w.NoCache.ScopedRoleReader()
 }
 
 type DatabaseWrapper struct {

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -774,6 +774,7 @@ func generateCertificate(authServer *auth.Server, identity TestIdentity) ([]byte
 				PublicSSHKey: sshPublicKeyPEM,
 				SystemRoles:  id.AdditionalSystemRoles,
 			},
+			AgentScope: identity.Scope,
 		})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
@@ -1113,7 +1114,8 @@ func TestUser(username string) TestIdentity {
 	return TestUserWithRoles(username, nil)
 }
 
-type TestIdentityOpt func(i *tlsca.Identity)
+// TestIdentityOpt applies custom options to a tlsca.Identity.
+type TestIdentityOpt func(*tlsca.Identity)
 
 // TestScopedUser returns a TestIdentity for a local user with a scoped identity
 // pinned to the given scope.
@@ -1243,6 +1245,7 @@ func TestScopedBuiltin(role types.SystemRole, scope string) TestIdentity {
 				AgentScope: scope,
 			},
 		},
+		Scope: scope,
 	}
 }
 
@@ -1275,6 +1278,22 @@ func TestServerID(role types.SystemRole, serverID string) TestIdentity {
 				Username: serverID,
 			},
 		},
+	}
+}
+
+// TestScopedServerID returns a TestIdentity for a scoped node with the passed in serverID.
+func TestScopedServerID(role types.SystemRole, serverID, scope string) TestIdentity {
+	return TestIdentity{
+		I: authz.BuiltinRole{
+			Role:                  types.RoleInstance,
+			Username:              serverID,
+			AdditionalSystemRoles: types.SystemRoles{role},
+			Identity: tlsca.Identity{
+				Username:   serverID,
+				AgentScope: scope,
+			},
+		},
+		Scope: scope,
 	}
 }
 
@@ -1509,8 +1528,10 @@ func (s FakeTeleportVersion) DeleteTeleportVersion(_ context.Context) error {
 	return nil
 }
 
+type HostCertsParamsOpt func(req *auth.HostCertsParams)
+
 // NewServerIdentity generates new server identity, used in tests
-func NewServerIdentity(clt *auth.Server, hostID string, role types.SystemRole) (*state.Identity, error) {
+func NewServerIdentity(clt *auth.Server, hostID string, role types.SystemRole, opts ...HostCertsParamsOpt) (*state.Identity, error) {
 	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1531,7 +1552,7 @@ func NewServerIdentity(clt *auth.Server, hostID string, role types.SystemRole) (
 		return nil, trace.Wrap(err)
 	}
 
-	certs, err := clt.GenerateHostCerts(context.Background(), auth.HostCertsParams{
+	params := auth.HostCertsParams{
 		Req: &proto.HostCertsRequest{
 			HostID:       hostID,
 			NodeName:     hostID,
@@ -1539,7 +1560,12 @@ func NewServerIdentity(clt *auth.Server, hostID string, role types.SystemRole) (
 			PublicSSHKey: ssh.MarshalAuthorizedKey(sshPubKey),
 			PublicTLSKey: tlsPubKey,
 		},
-	})
+	}
+	for _, op := range opts {
+		op(&params)
+	}
+
+	certs, err := clt.GenerateHostCerts(context.Background(), params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1236,6 +1236,11 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindKubernetesCluster, services.RO()),
 						types.NewRule(types.KindSemaphore, services.RW()),
 						types.NewRule(types.KindHealthCheckConfig, services.RO()),
+						// TODO(fspmarshall/scopes): we eventually want to remove blanket scoped role
+						// access in favor of nodes only being able to read scoped roles that may affect
+						// access decisions for the given node specifically. this verb grant will need to
+						// be revisited as part of that work.
+						types.NewRule(scopedaccess.KindScopedRole, services.RO()),
 					},
 				},
 			})

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -952,6 +952,7 @@ func roleSpecForProxy(clusterName string) types.RoleSpecV6 {
 				types.NewRule(types.KindAccessList, services.RO()),
 				types.NewRule(types.KindHealthCheckConfig, services.RO()),
 				types.NewRule(types.KindAppAuthConfig, services.RO()),
+				types.NewRule(scopedaccess.KindScopedRole, services.RO()),
 				// this rule allows cloud proxies to read
 				// plugins of `openai` type, since Assist uses the OpenAI API and runs in Proxy.
 				{

--- a/lib/authz/scoped.go
+++ b/lib/authz/scoped.go
@@ -200,6 +200,7 @@ func (s *ScopedContext) GetDisconnectCertExpiry(authPref readonly.AuthPreference
 	return identity.Expires
 }
 
+// GetAccessState is equivalent to [Context.GetAccessState], but will defer to defaults
 func (c *ScopedContext) GetAccessState(authPref readonly.AuthPreference) (services.AccessState, error) {
 	if c.unscopedContext != nil {
 		return c.unscopedContext.GetAccessState(authPref), nil

--- a/lib/authz/scoped.go
+++ b/lib/authz/scoped.go
@@ -199,3 +199,57 @@ func (s *ScopedContext) GetDisconnectCertExpiry(authPref readonly.AuthPreference
 	// Otherwise, return the current certificates expiration
 	return identity.Expires
 }
+
+func (c *ScopedContext) GetAccessState(authPref readonly.AuthPreference) (services.AccessState, error) {
+	if c.unscopedContext != nil {
+		return c.unscopedContext.GetAccessState(authPref), nil
+	}
+
+	if authPref.GetRequireMFAType().IsSessionMFARequired() {
+		// TODO(fspmarshall/scopes): implement scoped MFA
+		// NOTE: this will require additional refactoring of relevant access-checking logic. currently, we often
+		// check MFA requirements *before* we determine access to the underlying resource, but a scoped MFA model
+		// will need to first determine the scope of access *before* we can determine whether MFA is required for that scope.
+		return services.AccessState{}, trace.AccessDenied("cannot perform scoped access when cluster-level MFA is required (scoped MFA is not implemented)")
+	}
+	return services.AccessState{
+		MFARequired: services.MFARequiredNever,
+		MFAVerified: false,
+	}, nil
+}
+
+// LockTargets returns a list of LockTargets inferred from the context's
+// Identity
+func (c *ScopedContext) LockTargets() []types.LockTarget {
+	if c.unscopedContext != nil {
+		return c.unscopedContext.LockTargets()
+	}
+
+	lockTargets := services.LockTargetsFromTLSIdentity(c.Identity.GetIdentity())
+	if r, ok := c.Identity.(BuiltinRole); ok {
+		switch r.Role {
+		// Node role is a special case because it was previously suported as a
+		// lock target that only locked the `ssh_service`. If the same Teleport server
+		// had multiple roles, Node lock would only lock the `ssh_service` while
+		// other roles would be able to authenticate into Teleport without a problem.
+		// To remove the ambiguity, we now lock the entire Teleport server for
+		// all roles using the LockTarget.ServerID field and `Node` field is
+		// deprecated.
+		// In order to support legacy behavior, we need fill in both `ServerID`
+		// and `Node` fields if the role is `Node` so that the previous behavior
+		// is preserved.
+		// This is a legacy behavior that we need to support for backwards compatibility.
+		case types.RoleNode:
+			lockTargets = append(lockTargets,
+				types.LockTarget{ServerID: r.GetServerID()},
+				types.LockTarget{ServerID: r.Identity.Username},
+			)
+		default:
+			lockTargets = append(lockTargets,
+				types.LockTarget{ServerID: r.GetServerID()},
+				types.LockTarget{ServerID: r.Identity.Username},
+			)
+		}
+	}
+	return lockTargets
+}

--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -193,6 +193,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		LockWatcher:      testCtx.lockWatcher,
 	}
 	testCtx.Authz, err = authz.NewAuthorizer(authOpts)
+	require.NoError(t, err)
 	testCtx.ScopedAuthz, err = authz.NewScopedAuthorizer(authOpts)
 	require.NoError(t, err)
 

--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -80,6 +80,7 @@ type TestContext struct {
 	AuthServer           *auth.Server
 	AuthClient           *authclient.Client
 	Authz                authz.Authorizer
+	ScopedAuthz          authz.ScopedAuthorizer
 	KubeServer           *proxy.TLSServer
 	KubeProxy            *proxy.TLSServer
 	Emitter              *eventstest.ChannelEmitter
@@ -185,11 +186,14 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	t.Cleanup(func() {
 		testCtx.lockWatcher.Close()
 	})
-	testCtx.Authz, err = authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName: testCtx.ClusterName,
-		AccessPoint: proxyAuthClient,
-		LockWatcher: testCtx.lockWatcher,
-	})
+	authOpts := authz.AuthorizerOpts{
+		ClusterName:      testCtx.ClusterName,
+		AccessPoint:      proxyAuthClient,
+		ScopedRoleReader: proxyAuthClient.ScopedRoleReader(),
+		LockWatcher:      testCtx.lockWatcher,
+	}
+	testCtx.Authz, err = authz.NewAuthorizer(authOpts)
+	testCtx.ScopedAuthz, err = authz.NewScopedAuthorizer(authOpts)
 	require.NoError(t, err)
 
 	// TLS config for kube proxy and Kube service.
@@ -264,7 +268,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			Namespace:   apidefaults.Namespace,
 			Keygen:      keyGen,
 			ClusterName: testCtx.ClusterName,
-			Authz:       testCtx.Authz,
+			ScopedAuthz: testCtx.ScopedAuthz,
 			// fileStreamer continues to write events after the server is shutdown and
 			// races against os.RemoveAll leading the test to fail.
 			// Using "node-sync" mode to write the events and session recordings
@@ -348,7 +352,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			Namespace:   apidefaults.Namespace,
 			Keygen:      keyGen,
 			ClusterName: testCtx.ClusterName,
-			Authz:       testCtx.Authz,
+			ScopedAuthz: testCtx.ScopedAuthz,
 			// fileStreamer continues to write events after the server is shutdown and
 			// races against os.RemoveAll leading the test to fail.
 			// Using "node-sync" mode to write the events and session recordings

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -25,11 +25,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,9 +42,14 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 
 	"github.com/gravitational/teleport"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 var (
@@ -65,12 +72,15 @@ func TestExecKubeService(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { kubeMock.Close() })
 
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "1")
+	scope := "/test"
 	// creates a Kubernetes service with a configured cluster pointing to mock api server
 	testCtx := SetupTestContext(
 		context.Background(),
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
 		},
 	)
 
@@ -93,7 +103,6 @@ func TestExecKubeService(t *testing.T) {
 		userWithSingleKubeUser.GetName(),
 		kubeCluster,
 	)
-	require.NoError(t, err)
 
 	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
 	userMultiKubeUsers, _ := testCtx.CreateUserAndRole(
@@ -102,7 +111,7 @@ func TestExecKubeService(t *testing.T) {
 		usernameMultiUsers,
 		RoleSpec{
 			Name:       roleNameMultiUsers,
-			KubeUsers:  append(roleKubeUsers, "admin"),
+			KubeUsers:  append(slices.Clone(roleKubeUsers), "admin"),
 			KubeGroups: roleKubeGroups,
 		})
 
@@ -112,12 +121,67 @@ func TestExecKubeService(t *testing.T) {
 		userMultiKubeUsers.GetName(),
 		kubeCluster,
 	)
-	require.NoError(t, err)
+
+	scopedWithSingleKubeUser, scopedSingleKubeUserRole := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+username,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
+	scopedMultiKubeUsers, scopedMultiKubeUserRole := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameMultiUsers,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  append(slices.Clone(roleKubeUsers), "admin"),
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		},
+	)
+
+	waitForSRACache(t, testCtx.TLSServer, scopedSingleKubeUserRole, scopedMultiKubeUserRole)
+	_, configScopedWithSingleKubeUser := testCtx.GenTestKubeClientTLSCert(
+		t,
+		scopedWithSingleKubeUser.GetName(),
+		kubeCluster,
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedWithSingleKubeUser.GetName(), scope)
+		},
+	)
+	_, configScopedMultiKubeUsers := testCtx.GenTestKubeClientTLSCert(
+		t,
+		scopedMultiKubeUsers.GetName(),
+		kubeCluster,
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedMultiKubeUsers.GetName(), scope)
+		},
+	)
 
 	type args struct {
 		executorBuilder func(*rest.Config, string, *url.URL) (remotecommand.Executor, error)
 		impersonateUser string
 		config          *rest.Config
+		scopedConfig    *rest.Config
 	}
 	tests := []struct {
 		name    string
@@ -129,6 +193,14 @@ func TestExecKubeService(t *testing.T) {
 			args: args{
 				executorBuilder: remotecommand.NewSPDYExecutor,
 				config:          configWithSingleKubeUser,
+				scopedConfig:    configScopedWithSingleKubeUser,
+			},
+		},
+		{
+			name: "SPDY protocol - scoped",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          configScopedWithSingleKubeUser,
 			},
 		},
 		{
@@ -140,7 +212,20 @@ func TestExecKubeService(t *testing.T) {
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return newWebSocketClient(c, s, u)
 				},
-				config: configWithSingleKubeUser,
+				config:       configWithSingleKubeUser,
+				scopedConfig: configScopedWithSingleKubeUser,
+			},
+		},
+		{
+			name: "Websocket protocol v4 - scoped",
+			args: args{
+				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
+				// is merged into k8s go-client.
+				// For now go-client does not support connections over websockets.
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return newWebSocketClient(c, s, u)
+				},
+				config: configScopedWithSingleKubeUser,
 			},
 		},
 		{
@@ -153,10 +238,27 @@ func TestExecKubeService(t *testing.T) {
 			},
 		},
 		{
+			name: "Websocket protocol v5 - scoped",
+			args: args{
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return remotecommand.NewWebSocketExecutor(c, s, u.String())
+				},
+				config: configScopedWithSingleKubeUser,
+			},
+		},
+		{
 			name: "SPDY protocol for user with multiple kubernetes users",
 			args: args{
 				executorBuilder: remotecommand.NewSPDYExecutor,
 				config:          configMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
+			name: "SPDY protocol for user with multiple kubernetes users - scoped",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          configScopedMultiKubeUsers,
 				impersonateUser: "admin",
 			},
 		},
@@ -174,12 +276,36 @@ func TestExecKubeService(t *testing.T) {
 			},
 		},
 		{
+			name: "Websocket protocol v4 for user with multiple kubernetes users - scoped",
+			args: args{
+				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
+				// is merged into k8s go-client.
+				// For now go-client does not support connections over websockets.
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return newWebSocketClient(c, s, u)
+				},
+				config:          configScopedMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
 			name: "Websocket protocol v5 for user with multiple kubernetes users",
 			args: args{
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return remotecommand.NewWebSocketExecutor(c, s, u.String())
 				},
 				config:          configMultiKubeUsers,
+				scopedConfig:    configScopedMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
+			name: "Websocket protocol v5 for user with multiple kubernetes users - scoped",
+			args: args{
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return remotecommand.NewWebSocketExecutor(c, s, u.String())
+				},
+				config:          configScopedMultiKubeUsers,
 				impersonateUser: "admin",
 			},
 		},
@@ -188,6 +314,15 @@ func TestExecKubeService(t *testing.T) {
 			args: args{
 				executorBuilder: remotecommand.NewSPDYExecutor,
 				config:          configMultiKubeUsers,
+				scopedConfig:    configScopedMultiKubeUsers,
+			},
+			wantErr: true,
+		},
+		{
+			name: "SPDY protocol for user with multiple kubernetes users without specifying impersonate user - scoped",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          configScopedMultiKubeUsers,
 			},
 			wantErr: true,
 		},
@@ -197,7 +332,18 @@ func TestExecKubeService(t *testing.T) {
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return remotecommand.NewWebSocketExecutor(c, s, u.String())
 				},
-				config: configMultiKubeUsers,
+				config:       configMultiKubeUsers,
+				scopedConfig: configScopedMultiKubeUsers,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Websocket protocol v5 for user with multiple kubernetes users without specifying impersonate user - scoped",
+			args: args{
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return remotecommand.NewWebSocketExecutor(c, s, u.String())
+				},
+				config: configScopedMultiKubeUsers,
 			},
 			wantErr: true,
 		},
@@ -595,4 +741,18 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 			eventsLock.Unlock()
 		})
 	}
+}
+
+func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*accessv1.CreateScopedRoleAssignmentResponse) {
+	t.Helper()
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, resp := range resps {
+			_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, &accessv1.GetScopedRoleAssignmentRequest{
+				Name:    resp.GetAssignment().GetMetadata().GetName(),
+				SubKind: resp.GetAssignment().GetSubKind(),
+			})
+			require.NoError(t, err)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1097,6 +1097,12 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		f.log.DebugContext(ctx, "Skipping authorization for a remote kubernetes cluster name",
 			"auth_context", logutils.StringerAttr(actx),
 		)
+		unscopedCtx, isUnscoped := actx.ScopedContext.UnscopedContext()
+		if !isUnscoped {
+			return trace.AccessDenied("scoped identities do not support remote clusters")
+		}
+		actx.sessionTTL = unscopedCtx.Checker.AdjustSessionTTL(actx.sessionTTL)
+		actx.clientIdleTimeout = unscopedCtx.Checker.AdjustClientIdleTimeout(actx.sessionTTL)
 		return nil
 	}
 	if actx.kubeClusterName == "" {
@@ -1105,6 +1111,12 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		f.log.DebugContext(ctx, "Skipping authorization due to unknown kubernetes cluster name",
 			"auth_context", logutils.StringerAttr(actx),
 		)
+		unscopedCtx, isUnscoped := actx.ScopedContext.UnscopedContext()
+		if !isUnscoped {
+			return trace.AccessDenied("scoped identities do not support remote clusters")
+		}
+		actx.sessionTTL = unscopedCtx.Checker.AdjustSessionTTL(actx.sessionTTL)
+		actx.clientIdleTimeout = unscopedCtx.Checker.AdjustClientIdleTimeout(actx.sessionTTL)
 		return nil
 	}
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1046,7 +1046,7 @@ func (f *Forwarder) getKubeAccessDetails(
 		if err := checkerCtx.Decision(ctx, s.GetScope(), func(checker *services.ScopedAccessChecker) error {
 			var err error
 			overrideTTL := false
-			groups, users, err = checker.Kube().GetGroupsAndUsers(sessionTTL, overrideTTL, matchers...)
+			groups, users, err = checker.Kube().GetGroupsAndUsers(checker.AdjustSessionTTL(sessionTTL), overrideTTL, matchers...)
 			if err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -117,8 +117,6 @@ type ForwarderConfig struct {
 	ClusterName string
 	// Keygen points to a key generator implementation
 	Keygen sshca.Authority
-	// Authz authenticates user
-	Authz authz.Authorizer
 	// ScopedAuthz authenticates a scoped user
 	ScopedAuthz authz.ScopedAuthorizer
 	// AuthClient is a auth server client.
@@ -212,8 +210,8 @@ func (f *ForwarderConfig) CheckAndSetDefaults() error {
 	if f.CachingAuthClient == nil {
 		return trace.BadParameter("missing parameter CachingAuthClient")
 	}
-	if f.Authz == nil {
-		return trace.BadParameter("missing parameter Authz")
+	if f.ScopedAuthz == nil {
+		return trace.BadParameter("missing parameter ScopedAuthz")
 	}
 	if f.Emitter == nil {
 		return trace.BadParameter("missing parameter Emitter")

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1180,7 +1180,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		// once we find a scoped checker that grants access, that's the checker we should use for all subsequent
 		// checks
 		err := actx.CheckerContext.Decision(ctx, ks.GetScope(), func(check *services.ScopedAccessChecker) error {
-			if err := check.Kube().CheckAccessToCluster(ks, state); err != nil {
+			if err := check.Kube().CheckAccessToCluster(ks, state, roleMatchers...); err != nil {
 				return trace.Wrap(err)
 			}
 			actx.checker = check

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -86,6 +86,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/sshca"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/lib/utils/set"
@@ -118,6 +119,8 @@ type ForwarderConfig struct {
 	Keygen sshca.Authority
 	// Authz authenticates user
 	Authz authz.Authorizer
+	// ScopedAuthz authenticates a scoped user
+	ScopedAuthz authz.ScopedAuthorizer
 	// AuthClient is a auth server client.
 	AuthClient authclient.ClientI
 	// CachingAuthClient is a caching auth server client for read-only access.
@@ -430,7 +433,10 @@ func (f *Forwarder) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 // authContext is a context of authenticated user,
 // contains information about user, target cluster and authenticated groups
 type authContext struct {
-	authz.Context
+	*authz.ScopedContext
+	// checker is the scoped access checker that granted access to the cluster
+	// authContext provides access to.
+	checker           *services.ScopedAccessChecker
 	kubeGroups        map[string]struct{}
 	kubeUsers         map[string]struct{}
 	kubeClusterLabels map[string]string
@@ -568,12 +574,12 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 		return nil, trace.AccessDenied("%s", accessDeniedMsg)
 	}
 
-	userContext, err := f.cfg.Authz.Authorize(ctx)
+	scopedCtx, err := f.cfg.ScopedAuthz.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	authContext, err := f.setupContext(ctx, *userContext, req, isRemoteUser)
+	authContext, err := f.setupContext(ctx, scopedCtx, req, isRemoteUser)
 	if err != nil {
 		f.log.WarnContext(ctx, "Unable to setup context", "error", err)
 		if trace.IsAccessDenied(err) {
@@ -611,7 +617,7 @@ func (f *Forwarder) withAuthStd(handler handlerWithAuthFuncStd) http.HandlerFunc
 }
 
 // acquireConnectionLockWithIdentity acquires a connection lock under a given identity.
-func (f *Forwarder) acquireConnectionLockWithIdentity(ctx context.Context, identity *authContext) error {
+func (f *Forwarder) acquireConnectionLockWithIdentity(ctx context.Context, identity tlsca.Identity) error {
 	ctx, span := f.cfg.tracer.Start(
 		ctx,
 		"kube.Forwarder/acquireConnectionLockWithIdentity",
@@ -622,8 +628,8 @@ func (f *Forwarder) acquireConnectionLockWithIdentity(ctx context.Context, ident
 		),
 	)
 	defer span.End()
-	user := identity.Identity.GetIdentity().Username
-	roles, err := getRolesByName(f, identity.Identity.GetIdentity().Groups)
+	user := identity.Username
+	roles, err := getRolesByName(f, identity.Groups)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -677,7 +683,7 @@ func (f *Forwarder) withAuth(handler handlerWithAuthFunc, opts ...authOption) ht
 		if err := f.authorize(ctx, authContext); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		err = f.acquireConnectionLockWithIdentity(ctx, authContext)
+		err = f.acquireConnectionLockWithIdentity(ctx, authContext.Identity.GetIdentity())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -705,7 +711,7 @@ func (f *Forwarder) withAuthPassthrough(handler handlerWithAuthFunc) httprouter.
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		err = f.acquireConnectionLockWithIdentity(req.Context(), authContext)
+		err = f.acquireConnectionLockWithIdentity(req.Context(), authContext.Identity.GetIdentity())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -783,7 +789,7 @@ func (f *Forwarder) formatStatusResponseError(rw http.ResponseWriter, respErr er
 
 func (f *Forwarder) setupContext(
 	ctx context.Context,
-	authCtx authz.Context,
+	scopedCtx *authz.ScopedContext,
 	req *http.Request,
 	isRemoteUser bool,
 ) (*authContext, error) {
@@ -798,13 +804,7 @@ func (f *Forwarder) setupContext(
 	)
 	defer span.End()
 
-	roles := authCtx.Checker
-
-	// adjust session ttl to the smaller of two values: the session
-	// ttl requested in tsh or the session ttl for the role.
-	sessionTTL := roles.AdjustSessionTTL(time.Hour)
-
-	identity := authCtx.Identity.GetIdentity()
+	identity := scopedCtx.Identity.GetIdentity()
 	teleportClusterName := identity.RouteToCluster
 	if teleportClusterName == "" {
 		teleportClusterName = f.cfg.ClusterName
@@ -858,14 +858,14 @@ func (f *Forwarder) setupContext(
 	}
 
 	return &authContext{
-		clientIdleTimeout:        roles.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout()),
+		ScopedContext:            scopedCtx,
+		clientIdleTimeout:        netConfig.GetClientIdleTimeout(),
 		clientIdleTimeoutMessage: netConfig.GetClientIdleTimeoutMessage(),
-		sessionTTL:               sessionTTL,
-		Context:                  authCtx,
 		recordingConfig:          recordingConfig,
 		kubeClusterName:          kubeCluster,
 		certExpires:              identity.Expires,
-		disconnectExpiredCert:    authCtx.GetDisconnectCertExpiry(authPref),
+		disconnectExpiredCert:    scopedCtx.GetDisconnectCertExpiry(authPref),
+		sessionTTL:               time.Hour,
 		teleportCluster: teleportClusterClient{
 			name:       teleportClusterName,
 			remoteAddr: utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
@@ -994,8 +994,9 @@ type kubeAccessDetails struct {
 
 // getKubeAccessDetails returns the allowed kube groups/users names and the cluster labels for a local kube cluster.
 func (f *Forwarder) getKubeAccessDetails(
+	ctx context.Context,
 	kubeServers []types.KubeServer,
-	accessChecker services.AccessChecker,
+	checkerCtx *services.ScopedAccessCheckerContext,
 	kubeClusterName string,
 	sessionTTL time.Duration,
 	mr metaResource,
@@ -1014,7 +1015,7 @@ func (f *Forwarder) getKubeAccessDetails(
 		// Creates a matcher that matches the cluster labels against `kubernetes_labels`
 		// defined for each user's role.
 		matchers = append(matchers,
-			services.NewKubernetesClusterLabelMatcher(labels, accessChecker.Traits()),
+			services.NewKubernetesClusterLabelMatcher(labels, checkerCtx.Traits()),
 		)
 
 		// If the kubeResource is available, append an extra matcher that validates
@@ -1036,15 +1037,26 @@ func (f *Forwarder) getKubeAccessDetails(
 			}
 		}
 		// accessChecker.CheckKubeGroupsAndUsers returns the accumulated kubernetes_groups
-		// and kubernetes_users that satisfy te provided matchers.
-		// When a KubernetesResourceMatcher, it will gather the Kubernetes principals
+		// and kubernetes_users that satisfy the provided matchers for unscoped identities.
+		// For scoped identities, only the groups and users for the role permitting access
+		// are returned.
+		// When a KubernetesResourceMatcher is used, it will gather the Kubernetes principals
 		// whose role satisfy the desired Kubernetes Resource.
 		// The users/groups will be forwarded to Kubernetes Cluster as Impersonation
 		// headers.
-		groups, users, err := accessChecker.CheckKubeGroupsAndUsers(sessionTTL, false /* overrideTTL */, matchers...)
-		if err != nil {
+		var groups, users []string
+		if err := checkerCtx.Decision(ctx, s.GetScope(), func(checker *services.ScopedAccessChecker) error {
+			var err error
+			overrideTTL := false
+			groups, users, err = checker.Kube().GetGroupsAndUsers(sessionTTL, overrideTTL, matchers...)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			return nil
+		}); err != nil {
 			return kubeAccessDetails{}, trace.Wrap(err)
 		}
+
 		return kubeAccessDetails{
 			kubeGroups:    groups,
 			kubeUsers:     users,
@@ -1094,7 +1106,10 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		return trace.Wrap(err)
 	}
 
-	state := actx.GetAccessState(authPref)
+	state, err := actx.GetAccessState(authPref)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	notFoundMessage := fmt.Sprintf("kubernetes cluster %q not found", actx.kubeClusterName)
 	var roleMatchers services.RoleMatchers
@@ -1120,8 +1135,9 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 	if !actx.teleportCluster.isRemote {
 		// check signing TTL and return a list of allowed logins for local cluster based on Kubernetes service labels.
 		kubeAccessDetails, err := f.getKubeAccessDetails(
+			ctx,
 			actx.kubeServers,
-			actx.Checker,
+			actx.CheckerContext,
 			actx.kubeClusterName,
 			actx.sessionTTL,
 			actx.metaResource,
@@ -1161,7 +1177,17 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			continue
 		}
 
-		switch err := actx.Checker.CheckAccess(ks, state, roleMatchers...); {
+		// once we find a scoped checker that grants access, that's the checker we should use for all subsequent
+		// checks
+		err := actx.CheckerContext.Decision(ctx, ks.GetScope(), func(check *services.ScopedAccessChecker) error {
+			if err := check.Kube().CheckAccessToCluster(ks, state); err != nil {
+				return trace.Wrap(err)
+			}
+			actx.checker = check
+			return nil
+		})
+
+		switch {
 		case errors.Is(err, services.ErrTrustedDeviceRequired):
 			return trace.Wrap(err)
 		case err != nil:
@@ -1172,7 +1198,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		// the kubeResource.
 		// This is required because CheckAccess does not validate the subresource type.
 		if !actx.metaResource.isList {
-			if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil && len(actx.Checker.GetAllowedResourceAccessIDs()) > 0 {
+			if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil && len(actx.checker.GetAllowedResourceAccessIDs()) > 0 {
 				// GetKubeResources returns the allowed and denied Kubernetes resources
 				// for the user. Since we have active access requests, the allowed
 				// resources will be the list of pods that the user requested access to if he
@@ -1180,7 +1206,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 				// allow if the user requested access a kubernetes cluster. If the user
 				// did not request access to any Kubernetes resource type, the allowed
 				// list will be empty.
-				allowed, denied := actx.Checker.GetKubeResources(ks)
+				allowed, denied := actx.checker.Kube().GetResources(ks)
 				if result, err := matchKubernetesResource(*rbacResource, actx.metaResource.isClusterWideResource(), allowed, denied); err != nil || !result {
 					return trace.AccessDenied("%s", notFoundMessage)
 				}
@@ -1188,6 +1214,14 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		}
 		// store a copy of the Kubernetes Cluster.
 		actx.kubeCluster = ks
+		// set session TTL and client idle timeout now that we know which
+		// checker permits access
+		actx.sessionTTL = actx.checker.AdjustSessionTTL(time.Hour)
+		netConfig, err := f.cfg.CachingAuthClient.GetClusterNetworkingConfig(f.ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		actx.clientIdleTimeout = actx.checker.Kube().AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
 		return nil
 	}
 	if actx.kubeClusterName == f.cfg.ClusterName {
@@ -1626,7 +1660,12 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, req *http.Request, _ ht
 // canStartSessionAlone returns true if the user associated with authCtx
 // is allowed to start a session without moderation.
 func (f *Forwarder) canStartSessionAlone(authCtx *authContext) (bool, error) {
-	policySets := authCtx.Checker.SessionPolicySets()
+	unscopedCtx, ok := authCtx.UnscopedContext()
+	if !ok {
+		// scoped identities do not support session moderation
+		return true, nil
+	}
+	policySets := unscopedCtx.Checker.SessionPolicySets()
 	authorizer := moderation.NewSessionAccessEvaluator(policySets, types.KubernetesSessionKind, authCtx.User.GetName())
 	canStart, _, err := authorizer.FulfilledFor(nil)
 	if err != nil {
@@ -1992,7 +2031,7 @@ func setupImpersonationHeaders(sess *clusterSession, headers http.Header) error 
 		return nil
 	}
 
-	impersonateUser, impersonateGroups, err := computeAndValidateImpersonatedPrincipals(sess.kubeUsers, sess.kubeGroups, sess.User.GetName(), headers)
+	impersonateUser, impersonateGroups, err := computeAndValidateImpersonatedPrincipals(sess.kubeUsers, sess.kubeGroups, sess.authContext.User.GetName(), headers)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -2460,7 +2499,7 @@ func (s *clusterSession) monitorConn(conn net.Conn, err error, hostID string) (n
 		connCancel(err)
 		return nil, trace.Wrap(err)
 	}
-	lockTargets := s.LockTargets()
+	lockTargets := s.authContext.LockTargets()
 	// when the target is not a kubernetes_service instance, we don't need to lock it.
 	// the target could be a remote cluster or a local Kubernetes API server. In both cases,
 	// hostID is empty.

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -991,83 +991,92 @@ type kubeAccessDetails struct {
 }
 
 // getKubeAccessDetails returns the allowed kube groups/users names and the cluster labels for a local kube cluster.
-func (f *Forwarder) getKubeAccessDetails(
-	ctx context.Context,
-	kubeServers []types.KubeServer,
-	checkerCtx *services.ScopedAccessCheckerContext,
-	kubeClusterName string,
-	sessionTTL time.Duration,
-	mr metaResource,
-) (kubeAccessDetails, error) {
-	// Find requested kubernetes cluster name and get allowed kube users/groups names.
-	for _, s := range kubeServers {
-		c := s.GetCluster()
-		if c.GetName() != kubeClusterName {
+func (f *Forwarder) getKubeAccessDetails(actx *authContext) (kubeAccessDetails, error) {
+	// Get list of allowed kube user/groups based on kubernetes service labels.
+	labels := types.CombineLabels(nil, actx.kubeCluster.GetStaticLabels(), types.LabelsToV2(actx.kubeCluster.GetDynamicLabels()))
+
+	matchers := make([]services.RoleMatcher, 0, 2)
+	// Creates a matcher that matches the cluster labels against `kubernetes_labels`
+	// defined for each user's role.
+	matchers = append(matchers,
+		services.NewKubernetesClusterLabelMatcher(labels, actx.CheckerContext.Traits()),
+	)
+
+	// If the kubeResource is available, append an extra matcher that validates
+	// if the kubernetes resource is allowed by the user roles that satisfy the
+	// target cluster labels.
+	// Each role defines `kubernetes_resources` and when kubeResource is available,
+	// KubernetesResourceMatcher will match roles that statisfy the resources at the
+	// same time that ClusterLabelMatcher matches the role's "kubernetes_labels".
+	// The call to roles.CheckKubeGroupsAndUsers when both matchers are provided
+	// results in the intersection of roles that match the "kubernetes_labels" and
+	// roles that allow access to the desired "kubernetes_resource".
+	// If from the intersection results an empty set, the request is denied.
+	if !actx.metaResource.isList {
+		if kubeResource := actx.metaResource.rbacResource(); kubeResource != nil {
+			matchers = append(
+				matchers,
+				services.NewKubernetesResourceMatcher(*kubeResource, actx.metaResource.isClusterWideResource()),
+			)
+		}
+	}
+
+	// An unscoped checker returns the accumulated kubernetes_groups and kubernetes_users that satisfy the
+	// provided matchers. For scoped identities, only the groups and users for the role permitting access
+	// are returned. When a KubernetesResourceMatcher is used, it will gather the Kubernetes principals
+	// whose role satisfy the desired Kubernetes Resource. The users/groups will be forwarded to Kubernetes
+	// Cluster as Impersonation  headers.
+	const overrideTTL = false
+	groups, users, err := actx.checker.Kube().GetGroupsAndUsers(actx.checker.AdjustSessionTTL(actx.sessionTTL), overrideTTL, matchers...)
+	if err != nil {
+		return kubeAccessDetails{}, trace.Wrap(err)
+	}
+
+	return kubeAccessDetails{
+		kubeGroups:    groups,
+		kubeUsers:     users,
+		clusterLabels: labels,
+	}, nil
+}
+
+// authorizeWithCluster attempts to authorize against the first kube server matching the expected kube cluster name.
+// It sets both the authContext.checker and authContext.kubeCluster to be used in later checks.
+func (f *Forwarder) authorizeWithCluster(ctx context.Context, actx *authContext, state services.AccessState, matchers services.RoleMatchers) error {
+	// Check authz against the first match.
+	//
+	// We assume that users won't register two identically-named clusters with
+	// mis-matched labels. If they do, expect weirdness.
+	var kubeServer types.KubeServer
+	for _, kubeServer = range actx.kubeServers {
+		kc := kubeServer.GetCluster()
+		if kc.GetName() != actx.kubeClusterName {
 			continue
 		}
 
-		// Get list of allowed kube user/groups based on kubernetes service labels.
-		labels := types.CombineLabels(nil, c.GetStaticLabels(), types.LabelsToV2(c.GetDynamicLabels()))
-
-		matchers := make([]services.RoleMatcher, 0, 2)
-		// Creates a matcher that matches the cluster labels against `kubernetes_labels`
-		// defined for each user's role.
-		matchers = append(matchers,
-			services.NewKubernetesClusterLabelMatcher(labels, checkerCtx.Traits()),
-		)
-
-		// If the kubeResource is available, append an extra matcher that validates
-		// if the kubernetes resource is allowed by the user roles that satisfy the
-		// target cluster labels.
-		// Each role defines `kubernetes_resources` and when kubeResource is available,
-		// KubernetesResourceMatcher will match roles that statisfy the resources at the
-		// same time that ClusterLabelMatcher matches the role's "kubernetes_labels".
-		// The call to roles.CheckKubeGroupsAndUsers when both matchers are provided
-		// results in the intersection of roles that match the "kubernetes_labels" and
-		// roles that allow access to the desired "kubernetes_resource".
-		// If from the intersection results an empty set, the request is denied.
-		if !mr.isList {
-			if kubeResource := mr.rbacResource(); kubeResource != nil {
-				matchers = append(
-					matchers,
-					services.NewKubernetesResourceMatcher(*kubeResource, mr.isClusterWideResource()),
-				)
-			}
-		}
-		// accessChecker.CheckKubeGroupsAndUsers returns the accumulated kubernetes_groups
-		// and kubernetes_users that satisfy the provided matchers for unscoped identities.
-		// For scoped identities, only the groups and users for the role permitting access
-		// are returned.
-		// When a KubernetesResourceMatcher is used, it will gather the Kubernetes principals
-		// whose role satisfy the desired Kubernetes Resource.
-		// The users/groups will be forwarded to Kubernetes Cluster as Impersonation
-		// headers.
-		var groups, users []string
-		if err := checkerCtx.Decision(ctx, s.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			var err error
-			overrideTTL := false
-			groups, users, err = checker.Kube().GetGroupsAndUsers(checker.AdjustSessionTTL(sessionTTL), overrideTTL, matchers...)
-			if err != nil {
+		if err := actx.CheckerContext.Decision(ctx, kc.GetScope(), func(check *services.ScopedAccessChecker) error {
+			if err := check.Kube().CheckAccessToCluster(kc, state, matchers...); err != nil {
 				return trace.Wrap(err)
 			}
+			// whichever checker grants access should be used for all subsequent actions
+			actx.checker = check
 			return nil
 		}); err != nil {
-			return kubeAccessDetails{}, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
-		return kubeAccessDetails{
-			kubeGroups:    groups,
-			kubeUsers:     users,
-			clusterLabels: labels,
-		}, nil
-
+		// store a copy of the Kubernetes Cluster.
+		actx.kubeCluster = kc
+		return nil
 	}
-	// kubeClusterName not found. Empty list of allowed kube users/groups is returned.
-	return kubeAccessDetails{
-		kubeGroups:    []string{},
-		kubeUsers:     []string{},
-		clusterLabels: map[string]string{},
-	}, nil
+
+	if actx.kubeClusterName == f.cfg.ClusterName {
+		f.log.DebugContext(ctx, "Skipping authorization for proxy-based kubernetes cluster",
+			"auth_context", logutils.StringerAttr(actx),
+		)
+		return nil
+	}
+
+	return trace.NotFound("no matching kube server found")
 }
 
 func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
@@ -1125,110 +1134,68 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			}
 		}
 	}
+
+	if err := f.authorizeWithCluster(ctx, actx, state, roleMatchers); err != nil {
+		if errors.Is(err, services.ErrTrustedDeviceRequired) {
+			return trace.Wrap(err)
+		}
+		return trace.AccessDenied("%s", notFoundMessage)
+	}
+
 	var kubeUsers, kubeGroups []string
-	// Only check k8s principals for local clusters.
-	//
-	// For remote clusters, everything will be remapped to new roles on the
-	// leaf and checked there.
-	if !actx.teleportCluster.isRemote {
-		// check signing TTL and return a list of allowed logins for local cluster based on Kubernetes service labels.
-		kubeAccessDetails, err := f.getKubeAccessDetails(
-			ctx,
-			actx.kubeServers,
-			actx.CheckerContext,
-			actx.kubeClusterName,
-			actx.sessionTTL,
-			actx.metaResource,
-		)
-		if err != nil && !trace.IsNotFound(err) {
-			if actx.metaResource.resourceDefinition != nil {
-				return trace.AccessDenied("%s", notFoundMessage)
-			}
-			// TODO (tigrato): should return another message here.
-			return trace.AccessDenied("%s", accessDeniedMsg)
+	// check signing TTL and return a list of allowed logins for local cluster based on Kubernetes service labels.
+	kubeAccessDetails, err := f.getKubeAccessDetails(actx)
+	if err != nil {
+		if trace.IsNotFound(err) {
 			// roles.CheckKubeGroupsAndUsers returns trace.NotFound if the user does
-			// does not have at least one configured kubernetes_users or kubernetes_groups.
-		} else if trace.IsNotFound(err) {
+			// not have at least one configured kubernetes_users or kubernetes_groups.
 			const errMsg = "Your user's Teleport role does not allow Kubernetes access." +
 				" Please ask cluster administrator to ensure your role has appropriate kubernetes_groups and kubernetes_users set."
 			return trace.NotFound("%s", errMsg)
 		}
 
-		kubeUsers = kubeAccessDetails.kubeUsers
-		kubeGroups = kubeAccessDetails.kubeGroups
-		actx.kubeClusterLabels = kubeAccessDetails.clusterLabels
+		if actx.metaResource.resourceDefinition != nil {
+			return trace.AccessDenied("%s", notFoundMessage)
+		}
+
+		// TODO (tigrato): should return another message here.
+		return trace.AccessDenied(accessDeniedMsg)
 	}
 
 	// fillDefaultKubePrincipalDetails fills the default details in order to keep
 	// the correct behavior when forwarding the request to the Kubernetes API.
-	kubeUsers, kubeGroups = fillDefaultKubePrincipalDetails(kubeUsers, kubeGroups, actx.User.GetName())
+	kubeUsers, kubeGroups = fillDefaultKubePrincipalDetails(kubeAccessDetails.kubeUsers, kubeAccessDetails.kubeGroups, actx.User.GetName())
 	actx.kubeUsers = set.New(kubeUsers...)
 	actx.kubeGroups = set.New(kubeGroups...)
+	actx.kubeClusterLabels = kubeAccessDetails.clusterLabels
 
-	// Check authz against the first match.
-	//
-	// We assume that users won't register two identically-named clusters with
-	// mis-matched labels. If they do, expect weirdness.
-	for _, s := range actx.kubeServers {
-		ks := s.GetCluster()
-		if ks.GetName() != actx.kubeClusterName {
-			continue
-		}
-
-		// once we find a scoped checker that grants access, that's the checker we should use for all subsequent
-		// checks
-		err := actx.CheckerContext.Decision(ctx, ks.GetScope(), func(check *services.ScopedAccessChecker) error {
-			if err := check.Kube().CheckAccessToCluster(ks, state, roleMatchers...); err != nil {
-				return trace.Wrap(err)
-			}
-			actx.checker = check
-			return nil
-		})
-
-		switch {
-		case errors.Is(err, services.ErrTrustedDeviceRequired):
-			return trace.Wrap(err)
-		case err != nil:
-			return trace.AccessDenied("%s", notFoundMessage)
-		}
-
-		// If the user has active Access requests we need to validate that they allow
-		// the kubeResource.
-		// This is required because CheckAccess does not validate the subresource type.
-		if !actx.metaResource.isList {
-			if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil && len(actx.checker.GetAllowedResourceAccessIDs()) > 0 {
-				// GetKubeResources returns the allowed and denied Kubernetes resources
-				// for the user. Since we have active access requests, the allowed
-				// resources will be the list of pods that the user requested access to if he
-				// requested access to specific pods or the list of pods that his roles
-				// allow if the user requested access a kubernetes cluster. If the user
-				// did not request access to any Kubernetes resource type, the allowed
-				// list will be empty.
-				allowed, denied := actx.checker.Kube().GetResources(ks)
-				if result, err := matchKubernetesResource(*rbacResource, actx.metaResource.isClusterWideResource(), allowed, denied); err != nil || !result {
-					return trace.AccessDenied("%s", notFoundMessage)
-				}
+	// If the user has active Access requests we need to validate that they allow
+	// the kubeResource.
+	// This is required because CheckAccess does not validate the subresource type.
+	if !actx.metaResource.isList {
+		if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil && len(actx.checker.GetAllowedResourceAccessIDs()) > 0 {
+			// GetKubeResources returns the allowed and denied Kubernetes resources
+			// for the user. Since we have active access requests, the allowed
+			// resources will be the list of pods that the user requested access to if he
+			// requested access to specific pods or the list of pods that his roles
+			// allow if the user requested access a kubernetes cluster. If the user
+			// did not request access to any Kubernetes resource type, the allowed
+			// list will be empty.
+			allowed, denied := actx.checker.Kube().GetResources(actx.kubeCluster)
+			if result, err := matchKubernetesResource(*rbacResource, actx.metaResource.isClusterWideResource(), allowed, denied); err != nil || !result {
+				return trace.AccessDenied("%s", notFoundMessage)
 			}
 		}
-		// store a copy of the Kubernetes Cluster.
-		actx.kubeCluster = ks
-		// set session TTL and client idle timeout now that we know which
-		// checker permits access
-		actx.sessionTTL = actx.checker.AdjustSessionTTL(time.Hour)
-		netConfig, err := f.cfg.CachingAuthClient.GetClusterNetworkingConfig(f.ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		actx.clientIdleTimeout = actx.checker.Kube().AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
-		return nil
 	}
-	if actx.kubeClusterName == f.cfg.ClusterName {
-		f.log.DebugContext(ctx, "Skipping authorization for proxy-based kubernetes cluster",
-			"auth_context", logutils.StringerAttr(actx),
-		)
-		return nil
+	// set session TTL and client idle timeout now that we know which
+	// checker permits access
+	actx.sessionTTL = actx.checker.AdjustSessionTTL(time.Hour)
+	netConfig, err := f.cfg.CachingAuthClient.GetClusterNetworkingConfig(f.ctx)
+	if err != nil {
+		return trace.Wrap(err)
 	}
-	return trace.AccessDenied("%s", notFoundMessage)
+	actx.clientIdleTimeout = actx.checker.Kube().AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
+	return nil
 }
 
 // matchKubernetesResource checks if the Kubernetes Resource does not match any

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -35,6 +36,7 @@ import (
 	"os"
 	"slices"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -56,6 +58,10 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/tlsutils"
@@ -68,6 +74,8 @@ import (
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -124,6 +132,7 @@ func TestAuthenticate(t *testing.T) {
 		netConfig:       nc,
 		recordingConfig: types.DefaultSessionRecordingConfig(),
 		authPref:        authPref,
+		scopedRoles:     make(map[string]*accessv1.ScopedRole),
 	}
 
 	const (
@@ -170,6 +179,7 @@ func TestAuthenticate(t *testing.T) {
 	tests := []struct {
 		desc              string
 		user              authz.IdentityGetter
+		scope             string
 		authzErr          bool
 		roleKubeUsers     []string
 		roleKubeGroups    []string
@@ -180,9 +190,10 @@ func TestAuthenticate(t *testing.T) {
 		kubeServers       []types.KubeServer
 		activeRequests    []string
 
-		wantCtx     *authContext
-		wantErr     bool
-		wantAuthErr bool
+		wantCtx      *authContext
+		wantErr      bool
+		wantAuthErr  bool
+		wantAuthzErr bool
 	}{
 		{
 			desc:              "local user and cluster with active access request",
@@ -703,6 +714,115 @@ func TestAuthenticate(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:              "local scoped user and scoped cluster",
+			user:              authz.LocalUser{},
+			scope:             "/local",
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+					Scope: "/local",
+				},
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "foo",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+					Scope: "/local",
+				},
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "bar",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+					Scope: "/local",
+				},
+			),
+			wantCtx: &authContext{
+				kubeUsers:       set.New("user-a"),
+				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterName: "local",
+				kubeClusterLabels: map[string]string{
+					"static_label1": "static_value1",
+					"static_label2": "static_value2",
+				},
+				certExpires: certExpiration,
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+				kubeServers: newKubeServersFromKubeClusters(
+					t,
+					&types.KubernetesClusterV3{
+						Scope: "/local",
+						Metadata: types.Metadata{
+							Name: "local",
+							Labels: map[string]string{
+								"static_label1": "static_value1",
+								"static_label2": "static_value2",
+							},
+						},
+						Spec: types.KubernetesClusterSpecV3{
+							DynamicLabels: map[string]types.CommandLabelV2{},
+						},
+					},
+				),
+			},
+		},
+		{
+			desc:              "local scoped user and scoped cluster - mismatched scope",
+			user:              authz.LocalUser{},
+			scope:             "/local",
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+					Scope: "/other",
+				},
+			),
+			wantAuthzErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
@@ -728,10 +848,37 @@ func TestAuthenticate(t *testing.T) {
 					Expires:           certExpiration,
 				}),
 			}
+
 			authorizer := mockAuthorizer{ctx: &authCtx}
+			if tt.scope != "" {
+				scopePin := setupScopedKubeRoleWithAssignment(
+					t,
+					ap,
+					tt.roleKubeGroups,
+					tt.roleKubeUsers,
+					nil,
+					tt.scope,
+				)
+				checkerCtx, err := services.NewScopedAccessCheckerContext(f.ctx, &services.AccessInfo{ScopePin: scopePin}, "local", ap)
+				require.NoError(t, err)
+				authorizer.scopedCtx = &authz.ScopedContext{
+					User: user,
+					Identity: authz.WrapIdentity(
+						tlsca.Identity{
+							RouteToCluster:    tt.routeToCluster,
+							KubernetesCluster: tt.kubernetesCluster,
+							ActiveRequests:    tt.activeRequests,
+							Expires:           certExpiration,
+							ScopePin:          scopePin,
+						},
+					),
+					CheckerContext: checkerCtx,
+				}
+			}
 			if tt.authzErr {
 				authorizer.err = trace.AccessDenied("denied!")
 			}
+
 			f.cfg.ScopedAuthz = authorizer
 
 			req := &http.Request{
@@ -759,13 +906,17 @@ func TestAuthenticate(t *testing.T) {
 			}
 
 			gotCtx, err := f.authenticate(req)
-			if tt.wantErr {
+			if tt.wantErr || tt.wantAuthErr {
 				require.Error(t, err)
 				require.Equal(t, tt.wantAuthErr, trace.IsAccessDenied(err))
 				return
 			}
 			require.NoError(t, err)
 			err = f.authorize(context.Background(), gotCtx)
+			if tt.wantAuthzErr {
+				require.Equal(t, tt.wantAuthzErr, trace.IsAccessDenied(err))
+				return
+			}
 			require.NoError(t, err)
 
 			require.Empty(t, cmp.Diff(gotCtx, tt.wantCtx,
@@ -787,6 +938,58 @@ func TestAuthenticate(t *testing.T) {
 			)
 			require.Equal(t, ctxKey, gotCtx.key())
 		})
+	}
+}
+
+func setupScopedKubeRoleWithAssignment(t *testing.T, ap *mockAccessPoint, groups, users []string, labels []*labelsv1.Label, scope string) *scopesv1.Pin {
+	t.Helper()
+
+	scopeAsName := strings.ReplaceAll(strings.Trim(scope, "/"), "/", "-")
+
+	ap.scopedRoles[scopeAsName+"-role"] = &accessv1.ScopedRole{
+		Kind:    access.KindScopedRole,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: scopeAsName + "-role",
+		},
+		Scope: scope,
+		Spec: &accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  users,
+				Groups: groups,
+				Labels: []*labelsv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		},
+	}
+
+	// ap.scopedRoleAssignments[scopeAsName+"-assignment"] = &accessv1.ScopedRoleAssignment{
+	// 	Kind:    access.KindScopedRoleAssignment,
+	// 	SubKind: access.SubKindDynamic,
+	// 	Version: types.V1,
+	// 	Scope:   scope,
+	// 	Metadata: &headerv1.Metadata{
+	// 		Name: scopeAsName + "-assignment",
+	// 	},
+	// 	Spec: &accessv1.ScopedRoleAssignmentSpec{
+	// 		User: username,
+	// 		Assignments: []*accessv1.Assignment{
+	// 			{Role: scopeAsName + "-role", Scope: scope},
+	// 		},
+	// 	},
+	// }
+	return &scopesv1.Pin{
+		Scope: scope,
+		AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+			scope: {
+				scope: {scopeAsName + "-role"},
+			},
+		}),
 	}
 }
 
@@ -1251,6 +1454,8 @@ type mockAccessPoint struct {
 	authPref        types.AuthPreference
 	kubeServers     []types.KubeServer
 	cas             map[string]types.CertAuthority
+	scopedRoles     map[string]*accessv1.ScopedRole
+	// scopedRoleAssignments map[string]*accessv1.ScopedRoleAssignment
 }
 
 func (ap mockAccessPoint) GetClusterNetworkingConfig(context.Context) (types.ClusterNetworkingConfig, error) {
@@ -1280,6 +1485,18 @@ func (ap mockAccessPoint) GetCertAuthorities(ctx context.Context, caType types.C
 func (ap mockAccessPoint) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
 	return ap.cas[id.DomainName], nil
 }
+
+func (ap mockAccessPoint) GetScopedRole(ctx context.Context, req *accessv1.GetScopedRoleRequest) (*accessv1.GetScopedRoleResponse, error) {
+	return &accessv1.GetScopedRoleResponse{Role: ap.scopedRoles[req.GetName()]}, nil
+}
+
+func (ap mockAccessPoint) ListScopedRoles(ctx context.Context, req *accessv1.ListScopedRolesRequest) (*accessv1.ListScopedRolesResponse, error) {
+	return &accessv1.ListScopedRolesResponse{Roles: slices.Collect(maps.Values(ap.scopedRoles))}, nil
+}
+
+// func (ap mockAccessPoint) GetScopedRoleAssignment(ctx context.Context, req *accessv1.GetScopedRoleAssignmentRequest) (*accessv1.GetScopedRoleAssignmentResponse, error) {
+// 	return &accessv1.GetScopedRoleAssignmentResponse{Assignment: ap.scopedRoleAssignments[req.GetName()]}, nil
+// }
 
 type mockRevTunnel struct {
 	reversetunnelclient.Server
@@ -1476,6 +1693,7 @@ func newKubeServersFromKubeClusters(t *testing.T, kubeClusters ...*types.Kuberne
 	for _, kubeCluster := range kubeClusters {
 		kubeServer, err := types.NewKubernetesServerV3FromCluster(kubeCluster, "", kubeCluster.Metadata.Name)
 		require.NoError(t, err)
+		kubeServer.Scope = kubeCluster.GetScope()
 		kubeServers = append(kubeServers, kubeServer)
 	}
 	return kubeServers

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -732,7 +732,7 @@ func TestAuthenticate(t *testing.T) {
 			if tt.authzErr {
 				authorizer.err = trace.AccessDenied("denied!")
 			}
-			f.cfg.Authz = authorizer
+			f.cfg.ScopedAuthz = authorizer
 
 			req := &http.Request{
 				Host:       "example.com",
@@ -770,7 +770,7 @@ func TestAuthenticate(t *testing.T) {
 
 			require.Empty(t, cmp.Diff(gotCtx, tt.wantCtx,
 				cmp.AllowUnexported(authContext{}, teleportClusterClient{}, metaResource{}, apiResource{}),
-				cmpopts.IgnoreFields(authContext{}, "clientIdleTimeout", "sessionTTL", "Context", "recordingConfig", "disconnectExpiredCert", "kubeCluster"),
+				cmpopts.IgnoreFields(authContext{}, "clientIdleTimeout", "sessionTTL", "ScopedContext", "recordingConfig", "disconnectExpiredCert", "kubeCluster", "checker"),
 			))
 
 			// validate authCtx.key() to make sure it includes certExpires timestamp.
@@ -1006,11 +1006,11 @@ func TestSetupImpersonationHeaders(t *testing.T) {
 				&clusterSession{
 					kubeAPICreds: kubeCreds,
 					authContext: authContext{
-						Context: authz.Context{
+						ScopedContext: authz.ScopedContextFromUnscopedContext(&authz.Context{
 							User: &types.UserV2{
 								Metadata: types.Metadata{Name: tt.username},
 							},
-						},
+						}),
 						kubeUsers:       set.New(tt.kubeUsers...),
 						kubeGroups:      set.New(tt.kubeGroups...),
 						teleportCluster: teleportClusterClient{isRemote: tt.remoteCluster},
@@ -1038,11 +1038,11 @@ func mockAuthCtx(t *testing.T, kubeCluster string, isRemote bool) authContext {
 	require.NoError(t, err)
 
 	return authContext{
-		Context: authz.Context{
+		ScopedContext: authz.ScopedContextFromUnscopedContext(&authz.Context{
 			User:             user,
 			Identity:         identity,
 			UnmappedIdentity: unmappedIdentity,
-		},
+		}),
 		teleportCluster: teleportClusterClient{
 			name:     "kube-cluster",
 			isRemote: isRemote,
@@ -1304,12 +1304,20 @@ func (t mockRevTunnel) Clusters(context.Context) ([]reversetunnelclient.Cluster,
 }
 
 type mockAuthorizer struct {
-	ctx *authz.Context
-	err error
+	ctx       *authz.Context
+	scopedCtx *authz.ScopedContext
+	err       error
 }
 
 func (a mockAuthorizer) Authorize(context.Context) (*authz.Context, error) {
 	return a.ctx, a.err
+}
+
+func (a mockAuthorizer) AuthorizeScoped(context.Context) (*authz.ScopedContext, error) {
+	if a.scopedCtx != nil {
+		return a.scopedCtx, a.err
+	}
+	return authz.ScopedContextFromUnscopedContext(a.ctx), a.err
 }
 
 type mockEventClient struct {
@@ -1444,17 +1452,17 @@ func TestKubernetesConnectionLimit(t *testing.T) {
 			})
 
 			identity := &authContext{
-				Context: authz.Context{
+				ScopedContext: authz.ScopedContextFromUnscopedContext(&authz.Context{
 					User: user,
 					Identity: authz.WrapIdentity(tlsca.Identity{
 						Username: user.GetName(),
 						Groups:   []string{testCase.role.GetName()},
 					}),
-				},
+				}),
 			}
 
 			for i := 0; i < testCase.connections; i++ {
-				err = forwarder.acquireConnectionLockWithIdentity(ctx, identity)
+				err = forwarder.acquireConnectionLockWithIdentity(ctx, identity.Identity.GetIdentity())
 				if i == testCase.connections-1 {
 					testCase.assert(t, err)
 				}
@@ -1651,7 +1659,7 @@ func Test_authContext_eventClusterMeta(t *testing.T) {
 					Header: http.Header{},
 				},
 				ctx: &authContext{
-					Context:           baseAuthCtx,
+					ScopedContext:     authz.ScopedContextFromUnscopedContext(&baseAuthCtx),
 					kubeClusterName:   "clusterName",
 					kubeClusterLabels: kubeClusterLabels,
 					kubeGroups:        map[string]struct{}{"kube-group-a": {}, "kube-group-b": {}},
@@ -1675,7 +1683,7 @@ func Test_authContext_eventClusterMeta(t *testing.T) {
 					},
 				},
 				ctx: &authContext{
-					Context:           baseAuthCtx,
+					ScopedContext:     authz.ScopedContextFromUnscopedContext(&baseAuthCtx),
 					kubeClusterName:   "clusterName",
 					kubeClusterLabels: kubeClusterLabels,
 					kubeGroups:        map[string]struct{}{"kube-group-a": {}, "kube-group-b": {}, "kube-group-c": {}},
@@ -1696,7 +1704,7 @@ func Test_authContext_eventClusterMeta(t *testing.T) {
 					Header: http.Header{},
 				},
 				ctx: &authContext{
-					Context:           baseAuthCtx,
+					ScopedContext:     authz.ScopedContextFromUnscopedContext(&baseAuthCtx),
 					kubeClusterName:   "clusterName",
 					kubeClusterLabels: kubeClusterLabels,
 					kubeGroups:        map[string]struct{}{"kube-group-a": {}, "kube-group-b": {}, "kube-group-c": {}},

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -738,22 +738,51 @@ func TestAuthenticate(t *testing.T) {
 					},
 					Scope: "/local",
 				},
-				&types.KubernetesClusterV3{
-					Metadata: types.Metadata{
-						Name: "foo",
-						Labels: map[string]string{
-							"static_label1": "static_value1",
-							"static_label2": "static_value2",
+			),
+			wantCtx: &authContext{
+				kubeUsers:       set.New("user-a"),
+				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterName: "local",
+				kubeClusterLabels: map[string]string{
+					"static_label1": "static_value1",
+					"static_label2": "static_value2",
+				},
+				certExpires: certExpiration,
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+				kubeServers: newKubeServersFromKubeClusters(
+					t,
+					&types.KubernetesClusterV3{
+						Scope: "/local",
+						Metadata: types.Metadata{
+							Name: "local",
+							Labels: map[string]string{
+								"static_label1": "static_value1",
+								"static_label2": "static_value2",
+							},
+						},
+						Spec: types.KubernetesClusterSpecV3{
+							DynamicLabels: map[string]types.CommandLabelV2{},
 						},
 					},
-					Spec: types.KubernetesClusterSpecV3{
-						DynamicLabels: map[string]types.CommandLabelV2{},
-					},
-					Scope: "/local",
-				},
+				),
+			},
+		},
+		{
+			desc:              "local unscoped user and scoped cluster",
+			user:              authz.LocalUser{},
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
 				&types.KubernetesClusterV3{
 					Metadata: types.Metadata{
-						Name: "bar",
+						Name: "local",
 						Labels: map[string]string{
 							"static_label1": "static_value1",
 							"static_label2": "static_value2",
@@ -819,6 +848,32 @@ func TestAuthenticate(t *testing.T) {
 						DynamicLabels: map[string]types.CommandLabelV2{},
 					},
 					Scope: "/other",
+				},
+			),
+			wantAuthzErr: true,
+		},
+		{
+			desc:              "local scoped user and unscoped cluster",
+			user:              authz.LocalUser{},
+			scope:             "/local",
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
 				},
 			),
 			wantAuthzErr: true,
@@ -968,21 +1023,6 @@ func setupScopedKubeRoleWithAssignment(t *testing.T, ap *mockAccessPoint, groups
 		},
 	}
 
-	// ap.scopedRoleAssignments[scopeAsName+"-assignment"] = &accessv1.ScopedRoleAssignment{
-	// 	Kind:    access.KindScopedRoleAssignment,
-	// 	SubKind: access.SubKindDynamic,
-	// 	Version: types.V1,
-	// 	Scope:   scope,
-	// 	Metadata: &headerv1.Metadata{
-	// 		Name: scopeAsName + "-assignment",
-	// 	},
-	// 	Spec: &accessv1.ScopedRoleAssignmentSpec{
-	// 		User: username,
-	// 		Assignments: []*accessv1.Assignment{
-	// 			{Role: scopeAsName + "-role", Scope: scope},
-	// 		},
-	// 	},
-	// }
 	return &scopesv1.Pin{
 		Scope: scope,
 		AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -911,7 +911,6 @@ func TestAuthenticate(t *testing.T) {
 					ap,
 					tt.roleKubeGroups,
 					tt.roleKubeUsers,
-					nil,
 					tt.scope,
 				)
 				checkerCtx, err := services.NewScopedAccessCheckerContext(f.ctx, &services.AccessInfo{ScopePin: scopePin}, "local", ap)
@@ -996,7 +995,7 @@ func TestAuthenticate(t *testing.T) {
 	}
 }
 
-func setupScopedKubeRoleWithAssignment(t *testing.T, ap *mockAccessPoint, groups, users []string, labels []*labelsv1.Label, scope string) *scopesv1.Pin {
+func setupScopedKubeRoleWithAssignment(t *testing.T, ap *mockAccessPoint, groups, users []string, scope string) *scopesv1.Pin {
 	t.Helper()
 
 	scopeAsName := strings.ReplaceAll(strings.Trim(scope, "/"), "/", "-")

--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -338,12 +338,12 @@ func deleteResources[T kubeObjectInterface](
 	for _, item := range items {
 		// Compute users and groups from available roles that match the
 		// cluster labels and kubernetes resources.
-		allowedKubeGroups, allowedKubeUsers, err := params.authCtx.Checker.CheckKubeGroupsAndUsers(
+		allowedKubeGroups, allowedKubeUsers, err := params.authCtx.checker.Kube().GetGroupsAndUsers(
 			params.authCtx.sessionTTL,
 			false,
 			services.NewKubernetesClusterLabelMatcher(
 				params.authCtx.kubeClusterLabels,
-				params.authCtx.Checker.Traits(),
+				params.authCtx.CheckerContext.Traits(),
 			),
 			services.NewKubernetesResourceMatcher(
 				getKubeResource(kind, group, types.KubeVerbDeleteCollection, item),

--- a/lib/kube/proxy/resource_list.go
+++ b/lib/kube/proxy/resource_list.go
@@ -70,7 +70,7 @@ func (f *Forwarder) listResources(sess *clusterSession, w http.ResponseWriter, r
 		sess.forwarder.ServeHTTP(rw, req)
 		status = rw.Status()
 	} else {
-		allowedResources, deniedResources := sess.Checker.GetKubeResources(sess.kubeCluster)
+		allowedResources, deniedResources := sess.checker.Kube().GetResources(sess.kubeCluster)
 
 		shouldBeAllowed, err := matchListRequestShouldBeAllowed(sess.metaResource, allowedResources, deniedResources)
 		if err != nil {

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -50,13 +50,17 @@ import (
 	restclientwatch "k8s.io/client-go/rest/watch"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	tkm "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestListPodRBAC(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "1")
 	const (
 		usernameWithFullAccess        = "full_user"
 		usernameWithNamespaceAccess   = "default_user"
@@ -65,6 +69,7 @@ func TestListPodRBAC(t *testing.T) {
 		usernameWithoutListVerbAccess = "no_list_user"
 		usernameWithTraits            = "trait_user"
 		testPodName                   = "test"
+		scope                         = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -80,6 +85,7 @@ func TestListPodRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
 		},
 	)
 	// close tests
@@ -109,6 +115,25 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
 	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
@@ -278,10 +303,50 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 		{
+			name: "list default namespace pods for user with full access - scoped",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceDefault,
+				opts: []GenTestKubeClientTLSCertOptions{
+					func(i *tlsca.Identity) {
+						i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+					},
+				},
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+					"default/test",
+				},
+			},
+		},
+		{
 			name: "list pods in every namespace for user with full access",
 			args: args{
 				user:      userWithFullAccess,
 				namespace: metav1.NamespaceAll,
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+					"default/test",
+					"dev/nginx-1",
+					"dev/nginx-2",
+				},
+			},
+		},
+		{
+			name: "list pods in every namespace for user with full access - scoped",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceAll,
+				opts: []GenTestKubeClientTLSCertOptions{
+					func(i *tlsca.Identity) {
+						i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+					},
+				},
 			},
 			want: want{
 				listPodsResult: []string{
@@ -889,10 +954,14 @@ func (f *fakeResponseWriter) Write(b []byte) (int, error) {
 }
 
 func TestDeletePodCollectionRBAC(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "1")
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES_SESSION_TTL", "5m")
+
 	const (
 		usernameWithFullAccess      = "full_user"
 		usernameWithNamespaceAccess = "default_user"
 		usernameWithLimitedAccess   = "limited_user"
+		scope                       = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -908,6 +977,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
 		},
 	)
 	// close tests
@@ -937,6 +1007,25 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
 	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
@@ -991,6 +1080,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 	type args struct {
 		user      types.User
 		namespace string
+		opts      []GenTestKubeClientTLSCertOptions
 	}
 	tests := []struct {
 		name        string
@@ -1003,6 +1093,24 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 			args: args{
 				user:      userWithFullAccess,
 				namespace: metav1.NamespaceDefault,
+			},
+
+			deletedPods: []string{
+				"default/nginx-1",
+				"default/nginx-2",
+				"default/test",
+			},
+		},
+		{
+			name: "delete pods in default namespace for user with full access - scoped",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceDefault,
+				opts: []GenTestKubeClientTLSCertOptions{
+					func(i *tlsca.Identity) {
+						i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+					},
+				},
 			},
 
 			deletedPods: []string{
@@ -1055,6 +1163,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 				t,
 				tt.args.user.GetName(),
 				kubeCluster,
+				tt.args.opts...,
 			)
 			err := client.CoreV1().Pods(tt.args.namespace).DeleteCollection(
 				testCtx.Context,
@@ -1080,10 +1189,13 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 }
 
 func TestDeleteCRDCollectionRBAC(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "1")
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES_SESSION_TTL", "5m")
 	const (
 		usernameWithFullAccess      = "full_user"
 		usernameWithNamespaceAccess = "default_user"
 		usernameWithLimitedAccess   = "limited_user"
+		scope                       = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -1099,6 +1211,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
 		},
 	)
 	// close tests
@@ -1128,6 +1241,25 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
 	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
@@ -1182,6 +1314,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 	type args struct {
 		user      types.User
 		namespace string
+		opts      []GenTestKubeClientTLSCertOptions
 	}
 	tests := []struct {
 		name        string
@@ -1194,6 +1327,25 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 			args: args{
 				user:      userWithFullAccess,
 				namespace: metav1.NamespaceDefault,
+			},
+
+			deletedCRDs: []string{
+				"default/telerole-1",
+				"default/telerole-1",
+				"default/telerole-2",
+				"default/telerole-test",
+			},
+		},
+		{
+			name: "delete teleportroles in default namespace for user with full access - scoped",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceDefault,
+				opts: []GenTestKubeClientTLSCertOptions{
+					func(i *tlsca.Identity) {
+						i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+					},
+				},
 			},
 
 			deletedCRDs: []string{
@@ -1247,6 +1399,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 				t,
 				tt.args.user.GetName(),
 				kubeCluster,
+				tt.args.opts...,
 			)
 			err := client.Resource(schema.GroupVersionResource{
 				Group:    "resources.teleport.dev",
@@ -1276,12 +1429,14 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 }
 
 func TestListClusterRoleRBAC(t *testing.T) {
-	t.Parallel()
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "1")
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES_SESSION_TTL", "5m")
 
 	const (
 		usernameWithFullAccess    = "full_user"
 		usernameWithLimitedAccess = "limited_user"
 		testClusterRoleName       = "cr-test"
+		scope                     = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -1297,6 +1452,7 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
 		},
 	)
 	// close tests
@@ -1325,6 +1481,24 @@ func TestListClusterRoleRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
 
 	// Create a moderator user with access to kubernetes
 	// (kubernetes_user and kubernetes_groups specified).
@@ -1369,6 +1543,24 @@ func TestListClusterRoleRBAC(t *testing.T) {
 			name: "list cluster roles for user with full access",
 			args: args{
 				user: userWithFullAccess,
+			},
+			want: want{
+				listClusterRolesResult: []string{
+					"cr-nginx-1",
+					"cr-nginx-2",
+					"cr-test",
+				},
+			},
+		},
+		{
+			name: "list cluster roles for user with full access - scoped",
+			args: args{
+				user: scopedUserWithFullAccess,
+				opts: []GenTestKubeClientTLSCertOptions{
+					func(i *tlsca.Identity) {
+						i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+					},
+				},
 			},
 			want: want{
 				listClusterRolesResult: []string{
@@ -1486,7 +1678,8 @@ func TestListClusterRoleRBAC(t *testing.T) {
 }
 
 func TestGenericCustomResourcesRBAC(t *testing.T) {
-	t.Parallel()
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "1")
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES_SESSION_TTL", "5m")
 
 	const (
 		usernameWithFullAccess     = "full_user"
@@ -1494,9 +1687,10 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		usernameWithSpecificAccess = "specific_user"
 		testTeleportRoleName       = "telerole-test"
 		testTeleportRoleNamespace  = "default"
+		scope                      = "/test"
 	)
 
-	kubeScheme, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	kubeScheme, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
 	// create a user with full access to all namespaces.
 	// (kubernetes_user and kubernetes_groups specified)
@@ -1523,6 +1717,24 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
 
 	// create a user with limited access to kubernetes namespaces.
 	userWithLimitedAccess, _ := testCtx.CreateUserAndRoleVersion(
@@ -1600,6 +1812,27 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 			name: "list teleport roles for user with full access",
 			args: args{
 				user: userWithFullAccess,
+			},
+			want: want{
+				listTeleportRolesResult: []string{
+					"default/telerole-1",
+					"default/telerole-1",
+					"default/telerole-2",
+					"default/telerole-test",
+					"dev/telerole-1",
+					"dev/telerole-2",
+				},
+			},
+		},
+		{
+			name: "list teleport roles for user with full access - scoped",
+			args: args{
+				user: scopedUserWithFullAccess,
+				opts: []GenTestKubeClientTLSCertOptions{
+					func(i *tlsca.Identity) {
+						i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+					},
+				},
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -1817,7 +2050,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 func TestV8JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "", types.V8)
 
@@ -2140,7 +2373,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 func TestV7JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "", types.V7)
 
@@ -2365,7 +2598,7 @@ func TestV7JailedNamespaceListRBAC(t *testing.T) {
 func TestV7V8Match(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	// Create a factory to generate users in various role versions.
 	newV7TestUser := newTestUserFactory(t, testCtx, "v7v8", types.V7)
@@ -2725,7 +2958,7 @@ func TestV7V8Match(t *testing.T) {
 func TestNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "nslist", types.V8)
 
@@ -3008,7 +3241,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 func TestDenyClusterWideResources(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "deny-cw", types.V8)
 
@@ -3162,7 +3395,7 @@ func TestDenyClusterWideResources(t *testing.T) {
 func TestDeleteNamespace(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "delete-ns", types.V8)
 
@@ -3271,7 +3504,7 @@ func TestDeleteNamespace(t *testing.T) {
 func TestFullNamespaceNoDeleteRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "fullnsnodelete", types.V8)
 
@@ -3377,7 +3610,7 @@ func TestFullNamespaceNoDeleteRBAC(t *testing.T) {
 	}
 }
 
-func newTestKubeCRDMock(t *testing.T, opts ...tkm.Option) (*runtime.Scheme, *TestContext) {
+func newTestKubeCRDMock(t *testing.T, scope string, opts ...tkm.Option) (*runtime.Scheme, *TestContext) {
 	t.Helper()
 
 	// kubeMock is a Kubernetes API mock for the session tests.
@@ -3398,6 +3631,7 @@ func newTestKubeCRDMock(t *testing.T, opts ...tkm.Option) (*runtime.Scheme, *Tes
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
 		},
 	)
 	// Close tests.
@@ -3492,6 +3726,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 	clusterswagv0 := tkm.NewCRD("resources.teleport.dev", "v0", "clusterswags", "ClusterSwag", "ClusterSwagList", false)
 
 	kubeScheme, testCtx := newTestKubeCRDMock(t,
+		"",
 		tkm.WithTeleportRoleCRD,
 		tkm.WithCRD(telerolev8,
 			tkm.NewObject("default", "telerole-1"),

--- a/lib/kube/proxy/response_rewriter.go
+++ b/lib/kube/proxy/response_rewriter.go
@@ -129,13 +129,13 @@ func collectSystemMastersTeleportRoles(s *clusterSession) []string {
 	const (
 		systemMastersGroup = "system:masters"
 	)
-	accessChecker := s.authContext.Checker
+	checkerCtx := s.authContext.CheckerContext
 	matchers := make([]services.RoleMatcher, 0, 3)
 	// Creates a matcher that matches the cluster labels against `kubernetes_labels`
 	// defined for each user's role.
 	matchers = append(
 		matchers,
-		services.NewKubernetesClusterLabelMatcher(s.kubeClusterLabels, accessChecker.Traits()),
+		services.NewKubernetesClusterLabelMatcher(s.kubeClusterLabels, checkerCtx.Traits()),
 	)
 
 	// If the kubeResource is available, append an extra matcher that validates
@@ -171,6 +171,8 @@ func collectSystemMastersTeleportRoles(s *clusterSession) []string {
 		}),
 	)
 
-	_, _, _ = accessChecker.CheckKubeGroupsAndUsers(s.sessionTTL, false /* overrideTTL */, matchers...)
+	overrideTTL := false
+	_, _, _ = s.authContext.checker.Kube().GetGroupsAndUsers(s.sessionTTL, overrideTTL, matchers...)
+
 	return rolesWithSystemMasters
 }

--- a/lib/kube/proxy/self_subject_reviews.go
+++ b/lib/kube/proxy/self_subject_reviews.go
@@ -136,8 +136,14 @@ func (f *Forwarder) validateSelfSubjectAccessReview(sess *clusterSession, w http
 	}
 
 	actx := sess.authContext
-	state := actx.GetAccessState(authPref)
-	switch err := actx.Checker.CheckAccess(
+	unscopedCtx, ok := actx.UnscopedContext()
+	if !ok {
+		// TODO (eriktate): remove this limitation
+		return trace.AccessDenied("scoped identities do not support self subject access reviews")
+	}
+
+	state := unscopedCtx.GetAccessState(authPref)
+	switch err := unscopedCtx.Checker.CheckAccess(
 		actx.kubeCluster,
 		state,
 		services.RoleMatchers{

--- a/lib/kube/proxy/self_subject_reviews_test.go
+++ b/lib/kube/proxy/self_subject_reviews_test.go
@@ -437,7 +437,7 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 func TestSelfSubjectAccessReviewsAllowed(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, testingkubemock.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", testingkubemock.WithTeleportRoleCRD)
 
 	newTestUserV7 := newTestUserFactory(t, testCtx, "", types.V7)
 	newTestUserV8 := newTestUserFactory(t, testCtx, "", types.V8)

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -547,7 +547,10 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	srv.Scope = t.Scope
+	if t.Scope != "" {
+		srv.Scope = t.Scope
+		srv.Spec.Cluster.SetScope(t.Scope)
+	}
 	srv.SetExpiry(t.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL))
 
 	// Get the kube cluster health and send it to the auth server.
@@ -771,7 +774,7 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			if t.scope != "" {
+			if t.Scope != "" {
 				srv.Scope = t.scope
 				srv.Spec.Cluster.SetScope(t.scope)
 			}
@@ -800,7 +803,7 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			if t.scope != "" {
+			if t.Scope != "" {
 				srv.Scope = t.scope
 				srv.Spec.Cluster.SetScope(t.scope)
 			}

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -973,11 +973,11 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, eventPodMeta 
 
 // join attempts to connect a party to the session.
 func (s *session) join(p *party, emitJoinEvent bool) error {
-	unscopedCtx, ok := p.Ctx.UnscopedContext()
-	if !ok {
-		return trace.AccessDenied("scoped identities do not support session moderation")
-	}
 	if p.Ctx.User.GetName() != s.ctx.User.GetName() {
+		unscopedCtx, ok := p.Ctx.UnscopedContext()
+		if !ok {
+			return trace.AccessDenied("scoped identities do not support session moderation")
+		}
 		roles := unscopedCtx.Checker.Roles()
 
 		accessContext := moderation.SessionAccessContext{

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -446,10 +446,14 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 	log.DebugContext(req.Context(), "Creating session")
 
 	var policySets []*types.SessionTrackerPolicySet
-	roles := ctx.Checker.Roles()
-	for _, role := range roles {
-		policySet := role.GetSessionPolicySet()
-		policySets = append(policySets, &policySet)
+	unscopedCtx, ok := ctx.UnscopedContext()
+	if ok {
+		// only unscoped identities issue policy sets
+		roles := unscopedCtx.Checker.Roles()
+		for _, role := range roles {
+			policySet := role.GetSessionPolicySet()
+			policySets = append(policySets, &policySet)
+		}
 	}
 
 	q := req.URL.Query()
@@ -969,8 +973,12 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, eventPodMeta 
 
 // join attempts to connect a party to the session.
 func (s *session) join(p *party, emitJoinEvent bool) error {
+	unscopedCtx, ok := p.Ctx.UnscopedContext()
+	if !ok {
+		return trace.AccessDenied("scoped identities do not support session moderation")
+	}
 	if p.Ctx.User.GetName() != s.ctx.User.GetName() {
-		roles := p.Ctx.Checker.Roles()
+		roles := unscopedCtx.Checker.Roles()
 
 		accessContext := moderation.SessionAccessContext{
 			Username: p.Ctx.User.GetName(),

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -293,13 +293,13 @@ func Test_session_trackSession(t *testing.T) {
 				podNamespace:    "podNamespace",
 				accessEvaluator: moderation.NewSessionAccessEvaluator(tt.args.policies, types.KubernetesSessionKind, "username"),
 				ctx: authContext{
-					Context: authz.Context{
+					ScopedContext: authz.ScopedContextFromUnscopedContext(&authz.Context{
 						User: &types.UserV2{
 							Metadata: types.Metadata{
 								Name: "username",
 							},
 						},
-					},
+					}),
 					teleportCluster: teleportClusterClient{
 						name: "name",
 					},

--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -341,11 +341,12 @@ func (f *Forwarder) localClusterDialer(kubeClusterName string, opts ...contextDi
 				// different users.
 				// IP Pinning is based on the source IP address of the connection that
 				// we transport over HTTP headers so it's not affected.
-				From:     &utils.NetAddr{AddrNetwork: "tcp", Addr: "0.0.0.0:0"},
-				To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: server.GetHostname()},
-				ConnType: types.KubeTunnel,
-				ServerID: serverID,
-				ProxyIDs: server.GetProxyIDs(),
+				From:        &utils.NetAddr{AddrNetwork: "tcp", Addr: "0.0.0.0:0"},
+				To:          &utils.NetAddr{AddrNetwork: "tcp", Addr: server.GetHostname()},
+				ConnType:    types.KubeTunnel,
+				ServerID:    serverID,
+				ProxyIDs:    server.GetProxyIDs(),
+				TargetScope: server.GetScope(),
 			})
 			if err == nil {
 				opt.collect(server.GetHostID())

--- a/lib/kube/proxy/transport_test.go
+++ b/lib/kube/proxy/transport_test.go
@@ -19,6 +19,7 @@
 package proxy
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 
@@ -41,11 +43,13 @@ import (
 func TestForwarderClusterDialer(t *testing.T) {
 	t.Parallel()
 	var (
-		hostname    = "localhost:8080"
-		hostId      = "hostId"
-		proxyIds    = []string{"proxyId"}
-		clusterName = "cluster"
-		health      = types.TargetHealthStatusHealthy
+		hostname          = "localhost:8080"
+		hostId            = "hostId"
+		proxyIds          = []string{"proxyId"}
+		clusterName       = "cluster"
+		scopedClusterName = "scoped-cluster"
+		health            = types.TargetHealthStatusHealthy
+		scope             = "/test"
 	)
 	f := &Forwarder{
 		cfg: ForwarderConfig{
@@ -53,15 +57,23 @@ func TestForwarderClusterDialer(t *testing.T) {
 			ClusterName: clusterName,
 		},
 		getKubernetesServersForKubeCluster: func(_ context.Context, kubeClusterName string) ([]types.KubeServer, error) {
+			if kubeClusterName == clusterName {
+				return []types.KubeServer{
+					newKubeServer(t, clusterName, hostname, hostId, proxyIds, health),
+				}, nil
+			}
+			scopedKubeServer := newKubeServer(t, scopedClusterName, hostname, hostId, proxyIds, health)
+			scopedKubeServer.Scope = scope
 			return []types.KubeServer{
-				newKubeServer(t, hostname, hostId, proxyIds, health),
+				scopedKubeServer,
 			}, nil
 		},
 	}
 	tests := []struct {
-		name          string
-		dialerCreator func(kubeClusterName string) dialContextFunc
-		want          reversetunnelclient.DialParams
+		name            string
+		kubeClusterName string
+		dialerCreator   func(kubeClusterName string) dialContextFunc
+		want            reversetunnelclient.DialParams
 	}{
 		{
 			name: "local site",
@@ -80,6 +92,27 @@ func TestForwarderClusterDialer(t *testing.T) {
 				ServerID: hostId + "." + clusterName,
 				ConnType: types.KubeTunnel,
 				ProxyIDs: proxyIds,
+			},
+		},
+		{
+			name:            "local site scoped",
+			kubeClusterName: scopedClusterName,
+			dialerCreator: func(kubeClusterName string) dialContextFunc {
+				return f.localClusterDialer(kubeClusterName)
+			},
+			want: reversetunnelclient.DialParams{
+				From: &utils.NetAddr{
+					Addr:        "0.0.0.0:0",
+					AddrNetwork: "tcp",
+				},
+				To: &utils.NetAddr{
+					Addr:        hostname,
+					AddrNetwork: "tcp",
+				},
+				ServerID:    hostId + "." + clusterName,
+				ConnType:    types.KubeTunnel,
+				ProxyIDs:    proxyIds,
+				TargetScope: scope,
 			},
 		},
 		{
@@ -104,7 +137,8 @@ func TestForwarderClusterDialer(t *testing.T) {
 				t:    t,
 				want: tt.want,
 			}
-			_, _ = tt.dialerCreator("")(context.Background(), "tcp", "")
+			_, err := tt.dialerCreator(cmp.Or(tt.kubeClusterName, clusterName))(context.Background(), "tcp", "")
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -133,9 +167,9 @@ func (f *fakeRemoteSiteTunnel) DialTCP(p reversetunnelclient.DialParams) (net.Co
 	return nil, nil
 }
 
-func newKubeServer(t *testing.T, hostname, hostID string, proxyIds []string, health types.TargetHealthStatus) types.KubeServer {
+func newKubeServer(t *testing.T, name, hostname, hostID string, proxyIds []string, health types.TargetHealthStatus) *types.KubernetesServerV3 {
 	k, err := types.NewKubernetesClusterV3(types.Metadata{
-		Name: "cluster",
+		Name: name,
 	}, types.KubernetesClusterSpecV3{})
 	require.NoError(t, err)
 
@@ -207,73 +241,73 @@ func TestLocalClusterDialsByHealth(t *testing.T) {
 		{
 			name: "one",
 			servers: []types.KubeServer{
-				newKubeServer(t, hostname, "healthy-1", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-1", proxyIds, types.TargetHealthStatusHealthy),
 			},
 		},
 		{
 			name: "healthy",
 			servers: []types.KubeServer{
-				newKubeServer(t, hostname, "healthy-1", proxyIds, types.TargetHealthStatusHealthy),
-				newKubeServer(t, hostname, "healthy-2", proxyIds, types.TargetHealthStatusHealthy),
-				newKubeServer(t, hostname, "healthy-3", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-1", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-2", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-3", proxyIds, types.TargetHealthStatusHealthy),
 			},
 		},
 		{
 			name: "unknown",
 			servers: []types.KubeServer{
-				newKubeServer(t, hostname, "unknown-1", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "unknown-2", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "unknown-3", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "unknown-1", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "unknown-2", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "unknown-3", proxyIds, types.TargetHealthStatusUnknown),
 			},
 		},
 		{
 			name: "unhealthy",
 			servers: []types.KubeServer{
-				newKubeServer(t, hostname, "unhealthy-1", proxyIds, types.TargetHealthStatusUnhealthy),
-				newKubeServer(t, hostname, "unhealthy-2", proxyIds, types.TargetHealthStatusUnhealthy),
-				newKubeServer(t, hostname, "unhealthy-3", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "unhealthy-1", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "unhealthy-2", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "unhealthy-3", proxyIds, types.TargetHealthStatusUnhealthy),
 			},
 		},
 		{
 			name: "random",
 			servers: []types.KubeServer{
-				newKubeServer(t, hostname, "unhealthy-1", proxyIds, types.TargetHealthStatusUnhealthy),
-				newKubeServer(t, hostname, "healthy-3", proxyIds, types.TargetHealthStatusHealthy),
-				newKubeServer(t, hostname, "unknown-2", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "healthy-2", proxyIds, types.TargetHealthStatusHealthy),
-				newKubeServer(t, hostname, "unknown-1", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "unhealthy-3", proxyIds, types.TargetHealthStatusUnhealthy),
-				newKubeServer(t, hostname, "unknown-3", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "unhealthy-2", proxyIds, types.TargetHealthStatusUnhealthy),
-				newKubeServer(t, hostname, "healthy-1", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "unhealthy-1", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-3", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "unknown-2", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "healthy-2", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "unknown-1", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "unhealthy-3", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "unknown-3", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "unhealthy-2", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-1", proxyIds, types.TargetHealthStatusHealthy),
 			},
 		},
 		{
 			name: "reversed",
 			servers: []types.KubeServer{
-				newKubeServer(t, hostname, "unhealthy-3", proxyIds, types.TargetHealthStatusUnhealthy),
-				newKubeServer(t, hostname, "unhealthy-2", proxyIds, types.TargetHealthStatusUnhealthy),
-				newKubeServer(t, hostname, "unhealthy-1", proxyIds, types.TargetHealthStatusUnhealthy),
-				newKubeServer(t, hostname, "unknown-3", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "unknown-2", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "unknown-1", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "healthy-3", proxyIds, types.TargetHealthStatusHealthy),
-				newKubeServer(t, hostname, "healthy-2", proxyIds, types.TargetHealthStatusHealthy),
-				newKubeServer(t, hostname, "healthy-1", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "unhealthy-3", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "unhealthy-2", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "unhealthy-1", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "unknown-3", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "unknown-2", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "unknown-1", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "healthy-3", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-2", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-1", proxyIds, types.TargetHealthStatusHealthy),
 			},
 		},
 		{
 			name: "sorted",
 			servers: []types.KubeServer{
-				newKubeServer(t, hostname, "healthy-1", proxyIds, types.TargetHealthStatusHealthy),
-				newKubeServer(t, hostname, "healthy-2", proxyIds, types.TargetHealthStatusHealthy),
-				newKubeServer(t, hostname, "healthy-3", proxyIds, types.TargetHealthStatusHealthy),
-				newKubeServer(t, hostname, "unknown-1", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "unknown-2", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "unknown-3", proxyIds, types.TargetHealthStatusUnknown),
-				newKubeServer(t, hostname, "unhealthy-1", proxyIds, types.TargetHealthStatusUnhealthy),
-				newKubeServer(t, hostname, "unhealthy-2", proxyIds, types.TargetHealthStatusUnhealthy),
-				newKubeServer(t, hostname, "unhealthy-3", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-1", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-2", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "healthy-3", proxyIds, types.TargetHealthStatusHealthy),
+				newKubeServer(t, clusterName, hostname, "unknown-1", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "unknown-2", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "unknown-3", proxyIds, types.TargetHealthStatusUnknown),
+				newKubeServer(t, clusterName, hostname, "unhealthy-1", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "unhealthy-2", proxyIds, types.TargetHealthStatusUnhealthy),
+				newKubeServer(t, clusterName, hostname, "unhealthy-3", proxyIds, types.TargetHealthStatusUnhealthy),
 			},
 		},
 	}

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -79,7 +79,7 @@ type TestContext struct {
 	TLSServer          *authtest.TLSServer
 	AuthServer         *auth.Server
 	AuthClient         *authclient.Client
-	Authz              authz.Authorizer
+	ScopedAuthz        authz.ScopedAuthorizer
 	KubeServer         *TLSServer
 	KubeProxy          *TLSServer
 	Emitter            *eventstest.ChannelEmitter
@@ -195,10 +195,11 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	t.Cleanup(func() {
 		testCtx.lockWatcher.Close()
 	})
-	testCtx.Authz, err = authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName: testCtx.ClusterName,
-		AccessPoint: proxyAuthClient,
-		LockWatcher: testCtx.lockWatcher,
+	testCtx.ScopedAuthz, err = authz.NewScopedAuthorizer(authz.AuthorizerOpts{
+		ClusterName:      testCtx.ClusterName,
+		AccessPoint:      proxyAuthClient,
+		ScopedRoleReader: proxyAuthClient.ScopedRoleReader(),
+		LockWatcher:      testCtx.lockWatcher,
 	})
 	require.NoError(t, err)
 
@@ -279,7 +280,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			Namespace:   apidefaults.Namespace,
 			Keygen:      keyGen,
 			ClusterName: testCtx.ClusterName,
-			Authz:       testCtx.Authz,
+			ScopedAuthz: testCtx.ScopedAuthz,
 			// fileStreamer continues to write events after the server is shutdown and
 			// races against os.RemoveAll leading the test to fail.
 			// Using "node-sync" mode to write the events and session recordings
@@ -363,7 +364,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			Namespace:   apidefaults.Namespace,
 			Keygen:      keyGen,
 			ClusterName: testCtx.ClusterName,
-			Authz:       testCtx.Authz,
+			ScopedAuthz: testCtx.ScopedAuthz,
 			// fileStreamer continues to write events after the server is shutdown and
 			// races against os.RemoveAll leading the test to fail.
 			// Using "node-sync" mode to write the events and session recordings

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -47,6 +47,9 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -67,6 +70,7 @@ import (
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	sessPkg "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -110,6 +114,7 @@ type TestConfig struct {
 	ClusterFeatures      func() proto.Features
 	CreateAuditStreamErr error
 	WrapAuthClient       func(authclient.ClientI) authclient.ClientI
+	Scope                string
 }
 
 // SetupTestContext creates a kube service with clusters configured.
@@ -176,12 +181,12 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	require.NoError(t, err)
 
 	// Auth client for Kube service.
-	testCtx.AuthClient, err = testCtx.TLSServer.NewClient(authtest.TestServerID(types.RoleKube, testCtx.HostID))
+	testCtx.AuthClient, err = testCtx.TLSServer.NewClient(authtest.TestScopedServerID(types.RoleKube, testCtx.HostID, cfg.Scope))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, testCtx.AuthClient.Close()) })
 
 	// Auth client, lock watcher and authorizer for Kube proxy.
-	proxyAuthClient, err := testCtx.TLSServer.NewClient(authtest.TestBuiltin(types.RoleProxy))
+	proxyAuthClient, err := testCtx.TLSServer.NewClient(authtest.TestScopedBuiltin(types.RoleProxy, cfg.Scope))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, proxyAuthClient.Close()) })
 
@@ -204,7 +209,9 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	require.NoError(t, err)
 
 	// TLS config for kube proxy and Kube service.
-	serverIdentity, err := authtest.NewServerIdentity(authServer.AuthServer, testCtx.HostID, types.RoleKube)
+	serverIdentity, err := authtest.NewServerIdentity(authServer.AuthServer, testCtx.HostID, types.RoleKube, func(p *auth.HostCertsParams) {
+		p.AgentScope = cfg.Scope
+	})
 	require.NoError(t, err)
 	kubeServiceTLSConfig, err := serverIdentity.TLSConfig(nil)
 	require.NoError(t, err)
@@ -251,6 +258,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 				Version:  teleport.Version,
 				Services: types.SystemRoles{types.RoleKube}.StringSlice(),
 				Hostname: "test",
+				Scope:    cfg.Scope,
 			}, nil
 		})
 	require.NoError(t, err)
@@ -323,6 +331,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		InventoryHandle:      inventoryHandle,
 		ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
 		HealthCheckManager:   healthCheckManager,
+		Scope:                cfg.Scope,
 	})
 	require.NoError(t, err)
 
@@ -529,6 +538,51 @@ func (c *TestContext) CreateUserAndRoleVersion(ctx context.Context, t *testing.T
 	return c.CreateUserWithTraitsAndRoleVersion(ctx, t, username, nil, roleVersion, roleSpec)
 }
 
+// CreateUserAndRoleVersion creates a Teleport user and a scoped role assigned
+// to them
+func (c *TestContext) CreateUserAndScopedRole(t *testing.T, username, scope string, roleSpec *accessv1.ScopedRoleSpec) (types.User, *accessv1.CreateScopedRoleAssignmentResponse) {
+	user, err := authtest.CreateUser(t.Context(), c.TLSServer.Auth(), username)
+	require.NoError(t, err)
+
+	scopedAccess := c.TLSServer.Auth().ScopedAccess()
+	role, err := scopedAccess.CreateScopedRole(t.Context(), &accessv1.CreateScopedRoleRequest{
+		Role: &accessv1.ScopedRole{
+			Kind:    access.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: username,
+			},
+			Scope: scope,
+			Spec:  roleSpec,
+		},
+	})
+	require.NoError(t, err)
+
+	assignment, err := scopedAccess.CreateScopedRoleAssignment(t.Context(), &accessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &accessv1.ScopedRoleAssignment{
+			Kind:    access.KindScopedRoleAssignment,
+			Version: types.V1,
+			SubKind: access.SubKindDynamic,
+			Scope:   scope,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.New().String(),
+			},
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: username,
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  role.GetRole().GetMetadata().GetName(),
+						Scope: scope,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	return user, assignment
+}
+
 func newKubeConfigFile(t *testing.T, clusters ...KubeClusterConfig) string {
 	tmpDir := t.TempDir()
 
@@ -583,6 +637,16 @@ func WithMFAVerified() GenTestKubeClientTLSCertOptions {
 func (c *TestContext) GenTestKubeClientTLSCert(t *testing.T, userName, kubeCluster string, opts ...GenTestKubeClientTLSCertOptions) (*kubernetes.Clientset, *rest.Config) {
 	client, _, cfg := c.GenTestKubeClientsTLSCert(t, userName, kubeCluster, opts...)
 	return client, cfg
+}
+
+func (c *TestContext) GetScopePinForUser(t *testing.T, username, scope string) *scopesv1.Pin {
+	pin := &scopesv1.Pin{
+		Scope: scope,
+	}
+	err := c.AuthServer.ScopedAccessCache.PopulatePinnedAssignmentsForUser(t.Context(), username, pin)
+	require.NoError(t, err)
+
+	return pin
 }
 
 // GenTestKubeClientsTLSCert generates a "regular" kube client and a dynamic one to access kube service

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -227,12 +227,18 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 	}
 
 	// Create the kube server to service listener.
-	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName: teleportClusterName,
-		AccessPoint: accessPoint,
-		LockWatcher: lockWatcher,
-		Logger:      process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id)),
-	})
+	authOpts := authz.AuthorizerOpts{
+		ClusterName:      teleportClusterName,
+		AccessPoint:      accessPoint,
+		ScopedRoleReader: accessPoint.ScopedRoleReader(),
+		LockWatcher:      lockWatcher,
+		Logger:           process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id)),
+	}
+	authorizer, err := authz.NewAuthorizer(authOpts)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	scopedAuthorizer, err := authz.NewScopedAuthorizer(authOpts)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -275,6 +281,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			Keygen:                        cfg.Keygen,
 			ClusterName:                   teleportClusterName,
 			Authz:                         authorizer,
+			ScopedAuthz:                   scopedAuthorizer,
 			AuthClient:                    conn.Client,
 			Emitter:                       asyncEmitter,
 			DataDir:                       cfg.DataDir,

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -234,10 +234,6 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		LockWatcher:      lockWatcher,
 		Logger:           process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id)),
 	}
-	authorizer, err := authz.NewAuthorizer(authOpts)
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	scopedAuthorizer, err := authz.NewScopedAuthorizer(authOpts)
 	if err != nil {
 		return trace.Wrap(err)
@@ -280,7 +276,6 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			Namespace:                     apidefaults.Namespace,
 			Keygen:                        cfg.Keygen,
 			ClusterName:                   teleportClusterName,
-			Authz:                         authorizer,
 			ScopedAuthz:                   scopedAuthorizer,
 			AuthClient:                    conn.Client,
 			Emitter:                       asyncEmitter,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5922,13 +5922,19 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	})
 
 	if listeners.kube != nil && !process.Config.Proxy.DisableReverseTunnel {
-		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-			ClusterName:   clusterName,
-			AccessPoint:   accessPoint,
-			LockWatcher:   lockWatcher,
-			Logger:        process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
-			PermitCaching: process.Config.CachePolicy.Enabled,
-		})
+		authOpts := authz.AuthorizerOpts{
+			ClusterName:      clusterName,
+			AccessPoint:      accessPoint,
+			ScopedRoleReader: accessPoint.ScopedRoleReader(),
+			LockWatcher:      lockWatcher,
+			Logger:           process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+			PermitCaching:    process.Config.CachePolicy.Enabled,
+		}
+		authorizer, err := authz.NewAuthorizer(authOpts)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		scopedAuthorizer, err := authz.NewScopedAuthorizer(authOpts)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -5979,6 +5985,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				ClusterName:                   clusterName,
 				ReverseTunnelSrv:              tsrv,
 				Authz:                         authorizer,
+				ScopedAuthz:                   scopedAuthorizer,
 				AuthClient:                    conn.Client,
 				Emitter:                       asyncEmitter,
 				DataDir:                       cfg.DataDir,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5930,10 +5930,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Logger:           process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
 			PermitCaching:    process.Config.CachePolicy.Enabled,
 		}
-		authorizer, err := authz.NewAuthorizer(authOpts)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		scopedAuthorizer, err := authz.NewScopedAuthorizer(authOpts)
 		if err != nil {
 			return trace.Wrap(err)
@@ -5984,7 +5980,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				Keygen:                        cfg.Keygen,
 				ClusterName:                   clusterName,
 				ReverseTunnelSrv:              tsrv,
-				Authz:                         authorizer,
 				ScopedAuthz:                   scopedAuthorizer,
 				AuthClient:                    conn.Client,
 				Emitter:                       asyncEmitter,

--- a/lib/services/kube_access_checker.go
+++ b/lib/services/kube_access_checker.go
@@ -74,3 +74,32 @@ func (c *KubeAccessChecker) GetGroupsAndUsers(ttl time.Duration, overrideTTL boo
 	}
 	return c.checker.scopedCompatChecker.CheckKubeGroupsAndUsers(ttl, overrideTTL, matchers...)
 }
+
+// GetGroupsAndUsers returns the kube groups and users that are permitted for
+// impersonation.
+func (c *KubeAccessChecker) GetResources(cluster types.KubeCluster) (allowed []types.KubernetesResource, denied []types.KubernetesResource) {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.GetKubeResources(cluster)
+	}
+	// resources are not yet supported for scoped identities
+	return nil, nil
+}
+
+func (c *KubeAccessChecker) AdjustClientIdleTimeout(timeout time.Duration) time.Duration {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.AdjustClientIdleTimeout(timeout)
+	}
+	// kube block takes precedence over defaults block.
+	idleStr := c.checker.role.GetSpec().GetKube().GetClientIdleTimeout()
+	if idleStr == "" {
+		idleStr = c.checker.role.GetSpec().GetDefaults().GetClientIdleTimeout()
+	}
+	if idleStr != "" {
+		if d, err := time.ParseDuration(idleStr); err == nil && d > 0 {
+			if timeout == 0 || d < timeout {
+				return d
+			}
+		}
+	}
+	return timeout
+}

--- a/lib/services/kube_access_checker.go
+++ b/lib/services/kube_access_checker.go
@@ -50,11 +50,11 @@ func (c *KubeAccessChecker) CanAccessServer(target types.KubeServer) error {
 }
 
 // CheckAccessToCluster checks access to a kube cluster.
-func (c *KubeAccessChecker) CheckAccessToCluster(target types.KubeCluster, state AccessState) error {
+func (c *KubeAccessChecker) CheckAccessToCluster(target types.KubeCluster, state AccessState, matchers ...RoleMatcher) error {
 	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.CheckAccess(target, state)
+		return c.checker.unscopedChecker.CheckAccess(target, state, matchers...)
 	}
-	return c.checker.scopedCompatChecker.CheckAccess(target, state)
+	return c.checker.scopedCompatChecker.CheckAccess(target, state, matchers...)
 }
 
 // CanAccessCluster checks whether read access to the specified kube server is possible without

--- a/lib/services/kube_access_checker.go
+++ b/lib/services/kube_access_checker.go
@@ -75,14 +75,14 @@ func (c *KubeAccessChecker) GetGroupsAndUsers(ttl time.Duration, overrideTTL boo
 	return c.checker.scopedCompatChecker.CheckKubeGroupsAndUsers(ttl, overrideTTL, matchers...)
 }
 
-// GetGroupsAndUsers returns the kube groups and users that are permitted for
-// impersonation.
+// GetResources returns the kube resources that are permitted to be accessed. Scoped identities do not yet
+// support resources and will always return wildcards to prevent denying access that would oteherwise be granted.
 func (c *KubeAccessChecker) GetResources(cluster types.KubeCluster) (allowed []types.KubernetesResource, denied []types.KubernetesResource) {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.GetKubeResources(cluster)
 	}
-	// resources are not yet supported for scoped identities
-	return nil, nil
+
+	return c.checker.scopedCompatChecker.GetKubeResources(cluster)
 }
 
 func (c *KubeAccessChecker) AdjustClientIdleTimeout(timeout time.Duration) time.Duration {

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -290,6 +290,15 @@ func (c *ScopedAccessChecker) GetAllowedLoginsForResource(resource AccessCheckab
 	return c.scopedCompatChecker.GetAllowedLoginsForResource(resource)
 }
 
+func (c *ScopedAccessChecker) GetAllowedResourceAccessIDs() []types.ResourceAccessID {
+	if !c.isScoped() {
+		return c.unscopedChecker.GetAllowedResourceAccessIDs()
+	}
+
+	// scoped identities do not support checking active resource IDs.
+	return nil
+}
+
 // checkAccessToRulesImpl verifies that *all* of a series of verbs are permitted for the specified resource. This
 // function differs from AccessChecker.CheckAccessToRule in that it does not support advanced context-based features
 // or namespacing, and accepts a set of verbs all of which must evaluate to allow for the check to succeed.

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7615,7 +7615,7 @@ func TestDiagnoseKubeConnection(t *testing.T) {
 					Type:    types.ConnectionDiagnosticTrace_RBAC_KUBE,
 					Status:  types.ConnectionDiagnosticTrace_FAILED,
 					Details: "You are not authorized to access this Kubernetes Cluster. Ensure your role grants access by adding it to the 'kubernetes_labels' property.",
-					Error:   "[00] access denied",
+					Error:   "kubernetes cluster \"kube_cluster\" not found",
 				},
 			},
 		},
@@ -9915,11 +9915,13 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 		},
 	})
 	require.NoError(t, err)
-	proxyAuthorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName: cfg.authServer.ClusterName(),
-		AccessPoint: proxyAuthClient,
-		LockWatcher: proxyLockWatcher,
-	})
+	authOpts := authz.AuthorizerOpts{
+		ClusterName:      cfg.authServer.ClusterName(),
+		AccessPoint:      proxyAuthClient,
+		ScopedRoleReader: proxyAuthClient.ScopedRoleReader(),
+		LockWatcher:      proxyLockWatcher,
+	}
+	scopedProxyAuthorizer, err := authz.NewScopedAuthorizer(authOpts)
 	require.NoError(t, err)
 
 	// TLS config for kube proxy and Kube service.
@@ -9989,7 +9991,7 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 			Namespace:         apidefaults.Namespace,
 			Keygen:            keyGen,
 			ClusterName:       cfg.authServer.ClusterName(),
-			Authz:             proxyAuthorizer,
+			ScopedAuthz:       scopedProxyAuthorizer,
 			AuthClient:        client,
 			Emitter:           client,
 			DataDir:           t.TempDir(),


### PR DESCRIPTION
Apologies for the large diff! This sort of exploded in size over the last 3 days, but roughly ~500 lines of it is just copying existing test cases and replacing unscoped identities with scoped ones.

This converts the kube proxy forwarder to use a scoped access checker and adds support for checking scoped identities. The kube proxy server will assign its scope (pulled from its issued host cert) to the `KubeServer` and `KubeCluster` they heartbeat for, much like we currently do for SSH. In the case of the forwarder that runs in the proxy, it will not receive a scope and instead relies on the scope maintained by the inventory control stream.

You'll need to set `TELEPORT_UNSTABLE_SCOPES_SESSION_TTL` in order to get kube groups and users from your scoped roles.

## Manual Test Plan
### Test Environment
A cluster with the following resources:
- Scoped kubernetes cluster assigned to `/test` scope.
- Scoped kubernetes cluster assigned to `/other` scope.
- Unscoped kubernetes cluster.

A user with:
- An unscoped role that permits access to all kubernetes clusters.
- A scoped role assigned at `/test` assigning at least one kube user and group

### Test Cases
- [x] Unscoped credentials permit access to unscoped kube cluster (no regressions)
  - [x] `tsh login --proxy=<proxy-addr`, `tsh kube login`
  - [x] `tsh kubectl get namespaces` should return the namespaces present on the cluster
  - [x] `tsh kubectl -n <namespace> get pods` should return the pods within the given namespace
- [x] Repeat for unscoped credentials accessing scoped kube clusters (`/test` and `/other`)
- [x] Repeat for `/test` scoped credentials accessing `/test` scoped cluster
- [x] Repeat for `/test` scoped credentials accessing `/other` scoped cluster and confirm auth failure
- [x] Repeat for `/test` scoped credentials accessing unscoped cluster and confirm auth failure
- [x] Confirm that impersonation of user and/or group not present in the role is not possible (`tsh kubectl --as=<disallowed-user> get namespaces`)