### PR TITLE
Fix Shared Directory Folder Creation

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -1150,7 +1150,8 @@ func cgo_tdp_sd_create_request(handle C.uintptr_t, req *C.CGOSharedDirectoryCrea
 		DirectoryId:  uint32(req.directory_id),
 		Operation: &tdpbv1.SharedDirectoryRequest_Create_{
 			Create: &tdpbv1.SharedDirectoryRequest_Create{
-				Path: C.GoString(req.path),
+				Path:     C.GoString(req.path),
+				FileType: req.file_type,
 			},
 		},
 	})


### PR DESCRIPTION
Shared Directory create requests were missing the `FileType` member which caused creation of folders to fail.

closes #65027

No changelog since this is a TDPB related regression that has not been released.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster connecting to a Windows Desktop in EC2.
### Test Cases
- [x] Drag and drop a folder with at least one contained file into the shared directory. Validate that the folder is created and file contents copied.
- [x] Copy a folder within the shared directory and paste it into another folder also in the shared directory. Validate that the folder is created and file contents copied.
