### PR TITLE
[v18] app: Broadcast ready events for unconfigured services

### DIFF
--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -55,6 +55,10 @@ func (process *TeleportProcess) initKubernetes() {
 		k8s := modules.GetProtoEntitlement(&features, entitlements.K8s)
 		if !k8s.Enabled {
 			logger.WarnContext(process.ExitContext(), "Warning: Kubernetes service not initialized because Teleport Auth Server is not licensed for Kubernetes Access. Please contact the cluster administrator to enable it.")
+			// Do not close conn: it is stored in process.connectors
+			// by RegisterWithAuthServer and rotation code reads it.
+			process.BroadcastEvent(Event{Name: KubernetesReady, Payload: nil})
+			process.OnHeartbeat(teleport.ComponentKube)(nil)
 			return nil
 		}
 		if err := process.initKubernetesService(logger, conn); err != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6572,13 +6572,18 @@ var appDependEvents = []string{
 }
 
 func (process *TeleportProcess) initApps() {
-	// If no applications are specified, exit early. This is due to the strange
-	// behavior in reading file configuration. If the user does not specify an
-	// "app_service" section, that is considered enabling "app_service".
+	// If no applications are specified, broadcast AppsReady so the
+	// process readiness gate is not blocked, then return. This is due
+	// to the strange behavior in reading file configuration. If the
+	// user does not specify an "app_service" section, that is
+	// considered enabling "app_service".
 	if len(process.Config.Apps.Apps) == 0 &&
 		!process.Config.Apps.DebugApp &&
 		!process.Config.Apps.MCPDemoServer &&
 		len(process.Config.Apps.ResourceMatchers) == 0 {
+		process.logger.InfoContext(process.ExitContext(),
+			"App service is enabled but has no static apps, debug app, MCP demo server, or resource matchers configured, it will not proxy anything.")
+		process.BroadcastEvent(Event{Name: AppsReady, Payload: nil})
 		return
 	}
 

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -2480,6 +2480,7 @@ func TestInitAppsEmptyConfig(t *testing.T) {
 	log := logtest.NewLogger()
 	supervisor, err := NewSupervisor("test-initApps", log, clock)
 	require.NoError(t, err)
+	t.Cleanup(func() { supervisor.Wait() })
 	process := &TeleportProcess{
 		Supervisor: supervisor,
 		Clock:      clock,
@@ -2504,7 +2505,7 @@ func TestInitKubernetesUnlicensed(t *testing.T) {
 	stor, err := storage.NewProcessStorage(context.Background(), dataDir)
 	require.NoError(t, err)
 	t.Cleanup(func() { stor.Close() })
-	t.Cleanup(func() { supervisor.signalExit() })
+	t.Cleanup(func() { supervisor.signalExit(); supervisor.Wait() })
 
 	process := &TeleportProcess{
 		Supervisor:    supervisor,

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -60,6 +60,7 @@ import (
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -2471,4 +2472,69 @@ func basicDirCopy(src string, dst string) error {
 	}
 
 	return nil
+}
+
+func TestInitAppsEmptyConfig(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+	log := logtest.NewLogger()
+	supervisor, err := NewSupervisor("test-initApps", log, clock)
+	require.NoError(t, err)
+	process := &TeleportProcess{
+		Supervisor: supervisor,
+		Clock:      clock,
+		Config:     &servicecfg.Config{Apps: servicecfg.AppsConfig{Enabled: true}},
+		logger:     log,
+	}
+
+	process.initApps()
+
+	event, err := process.WaitForEventTimeout(5*time.Second, AppsReady)
+	require.NoError(t, err)
+	require.Equal(t, AppsReady, event.Name)
+}
+
+func TestInitKubernetesUnlicensed(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+	log := logtest.NewLogger()
+	supervisor, err := NewSupervisor("test-initKube", log, clock)
+	require.NoError(t, err)
+	t.Cleanup(func() { supervisor.signalExit() })
+
+	dataDir := t.TempDir()
+	stor, err := storage.NewProcessStorage(context.Background(), dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { stor.Close() })
+
+	process := &TeleportProcess{
+		Supervisor: supervisor,
+		Clock:      clock,
+		Config:     servicecfg.MakeDefaultConfig(),
+		logger:     log,
+		storage:    stor,
+	}
+	// clusterFeatures is zero-valued so K8s entitlement is
+	// disabled, matching the unlicensed early-return path.
+	process.Config.Kube.Enabled = true
+	process.Config.DataDir = dataDir
+
+	process.initKubernetes()
+
+	// Broadcast a fake connector to unblock WaitForConnector
+	// inside the registered critical func.
+	process.BroadcastEvent(Event{Name: KubeIdentityEvent, Payload: &Connector{ReusedClient: true}})
+
+	err = supervisor.Start()
+	require.NoError(t, err)
+
+	event, err := process.WaitForEventTimeout(5*time.Second, KubernetesReady)
+	require.NoError(t, err)
+	require.Equal(t, KubernetesReady, event.Name)
+
+	// Verify OnHeartbeat transitioned the component to stateOK
+	// so that /readyz returns HTTP 200.
+	okEvent, err := process.WaitForEventTimeout(5*time.Second, TeleportOKEvent)
+	require.NoError(t, err)
+	require.Equal(t, teleport.ComponentKube, okEvent.Payload)
 }

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -2500,19 +2500,19 @@ func TestInitKubernetesUnlicensed(t *testing.T) {
 	log := logtest.NewLogger()
 	supervisor, err := NewSupervisor("test-initKube", log, clock)
 	require.NoError(t, err)
-	t.Cleanup(func() { supervisor.signalExit() })
-
 	dataDir := t.TempDir()
 	stor, err := storage.NewProcessStorage(context.Background(), dataDir)
 	require.NoError(t, err)
 	t.Cleanup(func() { stor.Close() })
+	t.Cleanup(func() { supervisor.signalExit() })
 
 	process := &TeleportProcess{
-		Supervisor: supervisor,
-		Clock:      clock,
-		Config:     servicecfg.MakeDefaultConfig(),
-		logger:     log,
-		storage:    stor,
+		Supervisor:    supervisor,
+		Clock:         clock,
+		Config:        servicecfg.MakeDefaultConfig(),
+		logger:        log,
+		storage:       stor,
+		instanceRoles: map[types.SystemRole]string{types.RoleKube: KubeIdentityEvent},
 	}
 	// clusterFeatures is zero-valued so K8s entitlement is
 	// disabled, matching the unlicensed early-return path.


### PR DESCRIPTION
Broadcast `AppsReady` when `app_service` is enabled but has no
static apps, debug app, MCP demo server, or resource matchers
configured. Without the broadcast, `TeleportReadyEvent` is never
emitted, which blocks internal operations that wait on it
(rotation sync, AWS OIDC deploy service updater, OpenSSH rotation
state sync). Note that `/readyz` is unaffected because the app
component is never registered with the process state tracker
(`ExpectService` is after the early return).

Apply the same fix to `initKubernetes`: broadcast
`KubernetesReady` and transition the component to `stateOK` via
`OnHeartbeat` when the kube service is enabled but the cluster
license does not include Kubernetes access. Without `OnHeartbeat`,
`/readyz` would return HTTP 400 indefinitely because
`ExpectService` is called before the license check.

Use `Info` level instead of `Warn` for the apps log message
because `app_service` is implicitly enabled when the config
section is omitted, which is the common case for deployments
that do not use app access.

Issue: https://github.com/gravitational/teleport/issues/12256
Backport: https://github.com/gravitational/teleport/pull/63628

## Manual Test Plan

### Test Cases

#### Test 1: Explicit empty app_service (with fix)

Local macOS, single-process Teleport (auth + proxy) with
`app_service: { enabled: true }` and no apps or resource matchers.

```yaml
app_service:
  enabled: true
```

- [x] Teleport starts without hanging.
- [x] Log contains: `App service is enabled but has no static apps, debug app, MCP demo server, or resource matchers configured, it will not proxy anything.`
- [x] Log contains: `The new service has started successfully. Starting syncing rotation status.` (confirms `TeleportReadyEvent` fired).

#### Test 2: Regression baseline (without fix)

Build from a commit before the fix and run Test 1.

- [x] The app service info message is absent.
- [x] `Starting syncing rotation status` never appears (confirms `TeleportReadyEvent` is blocked).