### PR TITLE
[v18] Web: Improve navigation stepper when it gets too long (#65344)

### DIFF
--- a/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.tsx
+++ b/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.tsx
@@ -53,6 +53,7 @@ export function TextSelectCopyMulti({
 
   return (
     <Box
+      width="100%"
       bg="bgTerminal"
       pl={3}
       pt={2}

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
@@ -16,44 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
 import { Link as InternalLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Alert, Box, Button, ButtonText, Flex, Text } from 'design';
-import { Check, Copy, Notification, Spinner } from 'design/Icon';
+import { Alert, Box, ButtonText, Flex, Text } from 'design';
+import { Notification, Spinner } from 'design/Icon';
 import { rotate360 } from 'design/keyframes';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 import { useValidation } from 'shared/components/Validation';
 
+import { TerraformCopyButton } from 'teleport/components/TerraformCopyButton';
 import cfg from 'teleport/config';
 import { IntegrationKind } from 'teleport/services/integrations';
 
 import { CircleNumber } from './EnrollAws';
-
-export function CopyTerraformButton({
-  onClick,
-}: {
-  onClick: (e: React.SyntheticEvent) => void;
-}) {
-  const [configCopied, setConfigCopied] = useState(false);
-
-  const handleClick = (e: React.SyntheticEvent) => {
-    onClick(e);
-
-    if (!e.defaultPrevented) {
-      setConfigCopied(true);
-      setTimeout(() => setConfigCopied(false), 1000);
-    }
-  };
-
-  return (
-    <Button fill="border" intent="primary" onClick={handleClick} gap={2}>
-      {configCopied ? <Check size="small" /> : <Copy size="small" />}
-      Copy Terraform Module
-    </Button>
-  );
-}
 
 type DeploymentMethodSectionProps = {
   terraformConfig?: string;
@@ -111,7 +87,7 @@ export function DeploymentMethodSection({
             configuration.
           </Text>
           <Box>
-            <CopyTerraformButton
+            <TerraformCopyButton
               onClick={e => {
                 const isValid = validator.validate();
                 if (!isValid) {

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/InfoGuide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/InfoGuide.tsx
@@ -35,8 +35,9 @@ import {
 import { marginTransitionCss } from 'shared/components/SlidingSidePanel/InfoGuide/const';
 import { useValidation } from 'shared/components/Validation';
 
+import { TerraformCopyButton } from 'teleport/components/TerraformCopyButton';
+
 import LiveTextEditor from '../LiveTextEditor';
-import { CopyTerraformButton } from './DeploymentMethodSection';
 
 export const PANEL_WIDTH = 500;
 
@@ -80,7 +81,7 @@ export function TerraformInfoGuide({
         data={[{ content: terraformConfig, type: 'terraform' }]}
       />
       <Box p={3}>
-        <CopyTerraformButton
+        <TerraformCopyButton
           onClick={e => {
             const isValid = validator.validate();
             if (!isValid) {

--- a/web/packages/teleport/src/components/TerraformCopyButton.tsx
+++ b/web/packages/teleport/src/components/TerraformCopyButton.tsx
@@ -1,0 +1,54 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState, MouseEvent } from 'react';
+
+import { Button } from 'design';
+import { Check, Copy } from 'design/Icon';
+
+export function TerraformCopyButton({
+  onClick,
+  disabled = false,
+}: {
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
+}) {
+  const [configCopied, setConfigCopied] = useState(false);
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    onClick(e);
+
+    if (!e.defaultPrevented) {
+      setConfigCopied(true);
+      setTimeout(() => setConfigCopied(false), 1000);
+    }
+  };
+
+  return (
+    <Button
+      fill="border"
+      intent="primary"
+      onClick={handleClick}
+      gap={2}
+      disabled={disabled}
+    >
+      {configCopied ? <Check size="small" /> : <Copy size="small" />}
+      Copy Terraform Module
+    </Button>
+  );
+}

--- a/web/packages/teleport/src/components/Wizard/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/Navigation.tsx
@@ -167,7 +167,7 @@ export function Navigation<T>({
   startWithIcon,
 }: NavigationProps<T>) {
   return (
-    <Flex>
+    <Flex minWidth={0} width="100%">
       {startWithIcon && (
         <StepsContainer>
           <StepTitle css={{ fontWeight: 'bold' }}>
@@ -176,7 +176,9 @@ export function Navigation<T>({
           </StepTitle>
         </StepsContainer>
       )}
-      <StepList views={views} currentStep={currentStep} />
+      <Flex flex={1} css="overflow-x: auto;">
+        <StepList views={views} currentStep={currentStep} />
+      </Flex>
     </Flex>
   );
 }

--- a/web/packages/teleport/src/components/Wizard/Navigation/Shared.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/Shared.tsx
@@ -22,6 +22,7 @@ export const StepTitle = styled.div`
   display: flex;
   align-items: center;
   font-size: ${p => p.theme.fontSizes[1]}px;
+  white-space: nowrap;
 `;
 
 export const StepsContainer = styled.div<{ active?: boolean }>`


### PR DESCRIPTION
backport #65344 to branch/v18

manual due to conflicts


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

local

### Test Cases
- [x] CopyTerraformButton works as before
- [x] checked a few places with TextSelectCopyMulti
- [x] checked step navigation renders and when text overfills horizontal scrolling is possible
