### PR TITLE
Fix Azure integration desc for Access Graph Synch

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -9316,7 +9316,7 @@ message AccessGraphAWSSync {
 message AccessGraphAzureSync {
   // SubscriptionID Is the ID of the Azure subscription to sync resources from
   string SubscriptionID = 1 [(gogoproto.jsontag) = "subscription_id,omitempty"];
-  // Integration is the integration name used to generate credentials to interact with AWS APIs.
+  // Integration is the integration name used to generate credentials to interact with Azure APIs.
   string Integration = 2 [(gogoproto.jsontag) = "integration,omitempty"];
 }
 

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -24665,7 +24665,7 @@ var xxx_messageInfo_AccessGraphAWSSync proto.InternalMessageInfo
 type AccessGraphAzureSync struct {
 	// SubscriptionID Is the ID of the Azure subscription to sync resources from
 	SubscriptionID string `protobuf:"bytes,1,opt,name=SubscriptionID,proto3" json:"subscription_id,omitempty"`
-	// Integration is the integration name used to generate credentials to interact with AWS APIs.
+	// Integration is the integration name used to generate credentials to interact with Azure APIs.
 	Integration          string   `protobuf:"bytes,2,opt,name=Integration,proto3" json:"integration,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
@@ -410,7 +410,7 @@ integration: "string"
 
 |Field Name|Description|Type|
 |---|---|---|
-|integration|The integration name used to generate credentials to interact with AWS APIs.|string|
+|integration|The integration name used to generate credentials to interact with Azure APIs.|string|
 |subscription_id|Is the ID of the Azure subscription to sync resources from|string|
 
 ## Access Graph Sync

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/discovery_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/discovery_config.mdx
@@ -112,7 +112,7 @@ Optional:
 
 Optional:
 
-- `integration` (String) Integration is the integration name used to generate credentials to interact with AWS APIs.
+- `integration` (String) Integration is the integration name used to generate credentials to interact with Azure APIs.
 - `subscription_id` (String) SubscriptionID Is the ID of the Azure subscription to sync resources from
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx
@@ -188,7 +188,7 @@ Optional:
 
 Optional:
 
-- `integration` (String) Integration is the integration name used to generate credentials to interact with AWS APIs.
+- `integration` (String) Integration is the integration name used to generate credentials to interact with Azure APIs.
 - `subscription_id` (String) SubscriptionID Is the ID of the Azure subscription to sync resources from
 
 

--- a/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
+++ b/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
@@ -191,7 +191,7 @@ func GenSchemaDiscoveryConfig(ctx context.Context) (github_com_hashicorp_terrafo
 						"azure": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"integration": {
-									Description: "Integration is the integration name used to generate credentials to interact with AWS APIs.",
+									Description: "Integration is the integration name used to generate credentials to interact with Azure APIs.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},


### PR DESCRIPTION
The Azure integration field was incorrectly described for AWS APIs usage.
