### PR TITLE
GitHub joining wildcard support

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -1657,19 +1657,47 @@ message ProvisionTokenSpecV2GitHub {
     // Sub also known as Subject is a string that roughly uniquely identifies
     // the workload. The format of this varies depending on the type of
     // github action run.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string Sub = 1 [(gogoproto.jsontag) = "sub,omitempty"];
     // The repository from where the workflow is running.
     // This includes the name of the owner e.g `gravitational/teleport`
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string Repository = 2 [(gogoproto.jsontag) = "repository,omitempty"];
     // The name of the organization in which the repository is stored.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string RepositoryOwner = 3 [(gogoproto.jsontag) = "repository_owner,omitempty"];
     // The name of the workflow.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string Workflow = 4 [(gogoproto.jsontag) = "workflow,omitempty"];
     // The name of the environment used by the job.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string Environment = 5 [(gogoproto.jsontag) = "environment,omitempty"];
     // The personal account that initiated the workflow run.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string Actor = 6 [(gogoproto.jsontag) = "actor,omitempty"];
     // The git ref that triggered the workflow run.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
     string Ref = 7 [(gogoproto.jsontag) = "ref,omitempty"];
     // The type of ref, for example: "branch".
     string RefType = 8 [(gogoproto.jsontag) = "ref_type,omitempty"];

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -5423,19 +5423,47 @@ type ProvisionTokenSpecV2GitHub_Rule struct {
 	// Sub also known as Subject is a string that roughly uniquely identifies
 	// the workload. The format of this varies depending on the type of
 	// github action run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
 	Sub string `protobuf:"bytes,1,opt,name=Sub,proto3" json:"sub,omitempty"`
 	// The repository from where the workflow is running.
 	// This includes the name of the owner e.g `gravitational/teleport`
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
 	Repository string `protobuf:"bytes,2,opt,name=Repository,proto3" json:"repository,omitempty"`
 	// The name of the organization in which the repository is stored.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
 	RepositoryOwner string `protobuf:"bytes,3,opt,name=RepositoryOwner,proto3" json:"repository_owner,omitempty"`
 	// The name of the workflow.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
 	Workflow string `protobuf:"bytes,4,opt,name=Workflow,proto3" json:"workflow,omitempty"`
 	// The name of the environment used by the job.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
 	Environment string `protobuf:"bytes,5,opt,name=Environment,proto3" json:"environment,omitempty"`
 	// The personal account that initiated the workflow run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
 	Actor string `protobuf:"bytes,6,opt,name=Actor,proto3" json:"actor,omitempty"`
 	// The git ref that triggered the workflow run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
 	Ref string `protobuf:"bytes,7,opt,name=Ref,proto3" json:"ref,omitempty"`
 	// The type of ref, for example: "branch".
 	RefType              string   `protobuf:"bytes,8,opt,name=RefType,proto3" json:"ref_type,omitempty"`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
@@ -224,14 +224,14 @@ Optional:
 
 Optional:
 
-- `actor` (String) The personal account that initiated the workflow run.
-- `environment` (String) The name of the environment used by the job.
-- `ref` (String) The git ref that triggered the workflow run.
+- `actor` (String) The personal account that initiated the workflow run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `environment` (String) The name of the environment used by the job.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `ref` (String) The git ref that triggered the workflow run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
 - `ref_type` (String) The type of ref, for example: "branch".
-- `repository` (String) The repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`
-- `repository_owner` (String) The name of the organization in which the repository is stored.
-- `sub` (String) Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.
-- `workflow` (String) The name of the workflow.
+- `repository` (String) The repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `repository_owner` (String) The name of the organization in which the repository is stored.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `sub` (String) Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `workflow` (String) The name of the workflow.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
@@ -260,14 +260,14 @@ Optional:
 
 Optional:
 
-- `actor` (String) The personal account that initiated the workflow run.
-- `environment` (String) The name of the environment used by the job.
-- `ref` (String) The git ref that triggered the workflow run.
+- `actor` (String) The personal account that initiated the workflow run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `environment` (String) The name of the environment used by the job.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `ref` (String) The git ref that triggered the workflow run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
 - `ref_type` (String) The type of ref, for example: "branch".
-- `repository` (String) The repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`
-- `repository_owner` (String) The name of the organization in which the repository is stored.
-- `sub` (String) Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.
-- `workflow` (String) The name of the workflow.
+- `repository` (String) The repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `repository_owner` (String) The name of the organization in which the repository is stored.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `sub` (String) Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `workflow` (String) The name of the workflow.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
 
 
 

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -1546,17 +1546,17 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 						"allow": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"actor": {
-									Description: "The personal account that initiated the workflow run.",
+									Description: "The personal account that initiated the workflow run.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"environment": {
-									Description: "The name of the environment used by the job.",
+									Description: "The name of the environment used by the job.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"ref": {
-									Description: "The git ref that triggered the workflow run.",
+									Description: "The git ref that triggered the workflow run.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
@@ -1566,22 +1566,22 @@ func GenSchemaProvisionTokenV2(ctx context.Context) (github_com_hashicorp_terraf
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"repository": {
-									Description: "The repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`",
+									Description: "The repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"repository_owner": {
-									Description: "The name of the organization in which the repository is stored.",
+									Description: "The name of the organization in which the repository is stored.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"sub": {
-									Description: "Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.",
+									Description: "Sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"workflow": {
-									Description: "The name of the workflow.",
+									Description: "The name of the workflow.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
 									Optional:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},

--- a/lib/join/githubactions/githubactions.go
+++ b/lib/join/githubactions/githubactions.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
@@ -231,28 +232,56 @@ func CheckGithubIDToken(ctx context.Context, params *CheckGithubIDTokenParams) (
 
 func checkGithubAllowRules(token *types.ProvisionTokenV2, claims *IDTokenClaims) error {
 	// If a single rule passes, accept the IDToken
-	for _, rule := range token.Spec.GitHub.Allow {
+	for i, rule := range token.Spec.GitHub.Allow {
 		// Please consider keeping these field validators in the same order they
 		// are defined within the ProvisionTokenSpecV2Github proto spec.
-		if rule.Sub != "" && claims.Sub != rule.Sub {
+		subMatches, err := joinutils.GlobMatchAllowEmptyPattern(rule.Sub, claims.Sub)
+		if err != nil {
+			return trace.Wrap(err, "evaluating rule (%d) sub match", i)
+		}
+		if !subMatches {
 			continue
 		}
-		if rule.Repository != "" && claims.Repository != rule.Repository {
+		repoMatches, err := joinutils.GlobMatchAllowEmptyPattern(rule.Repository, claims.Repository)
+		if err != nil {
+			return trace.Wrap(err, "evaluating rule (%d) repository match", i)
+		}
+		if !repoMatches {
 			continue
 		}
-		if rule.RepositoryOwner != "" && claims.RepositoryOwner != rule.RepositoryOwner {
+		repoOwnerMatches, err := joinutils.GlobMatchAllowEmptyPattern(rule.RepositoryOwner, claims.RepositoryOwner)
+		if err != nil {
+			return trace.Wrap(err, "evaluating rule (%d) repository owner match", i)
+		}
+		if !repoOwnerMatches {
 			continue
 		}
-		if rule.Workflow != "" && claims.Workflow != rule.Workflow {
+		workflowMatches, err := joinutils.GlobMatchAllowEmptyPattern(rule.Workflow, claims.Workflow)
+		if err != nil {
+			return trace.Wrap(err, "evaluating rule (%d) workflow match", i)
+		}
+		if !workflowMatches {
 			continue
 		}
-		if rule.Environment != "" && claims.Environment != rule.Environment {
+		environmentMatches, err := joinutils.GlobMatchAllowEmptyPattern(rule.Environment, claims.Environment)
+		if err != nil {
+			return trace.Wrap(err, "evaluating rule (%d) environment match", i)
+		}
+		if !environmentMatches {
 			continue
 		}
-		if rule.Actor != "" && claims.Actor != rule.Actor {
+		actorMatches, err := joinutils.GlobMatchAllowEmptyPattern(rule.Actor, claims.Actor)
+		if err != nil {
+			return trace.Wrap(err, "evaluating rule (%d) actor match", i)
+		}
+		if !actorMatches {
 			continue
 		}
-		if rule.Ref != "" && claims.Ref != rule.Ref {
+		refMatches, err := joinutils.GlobMatchAllowEmptyPattern(rule.Ref, claims.Ref)
+		if err != nil {
+			return trace.Wrap(err, "evaluating rule (%d) ref match", i)
+		}
+		if !refMatches {
 			continue
 		}
 		if rule.RefType != "" && claims.RefType != rule.RefType {

--- a/lib/join/join_github_test.go
+++ b/lib/join/join_github_test.go
@@ -300,6 +300,38 @@ func TestJoinGHA(t *testing.T) {
 			assertError: require.NoError,
 		},
 		{
+			name: "sub-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Sub = "repo:octo-org/octo-repo:environment:*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: require.NoError,
+		},
+		{
+			name: "incorrect-sub-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Sub = "repo:octo-org/octo-repo:environment:dev*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: allowRulesNotMatched,
+		},
+		{
 			name: "incorrect-sub",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				JoinMethod: types.JoinMethodGitHub,
@@ -308,6 +340,38 @@ func TestJoinGHA(t *testing.T) {
 					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
 						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
 							rule.Sub = "not matching"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: allowRulesNotMatched,
+		},
+		{
+			name: "repository-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Repository = "octo-org/octo-*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: require.NoError,
+		},
+		{
+			name: "incorrect-repository-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Repository = "octo-org/octoo-*"
 						}),
 					},
 				},
@@ -332,6 +396,38 @@ func TestJoinGHA(t *testing.T) {
 			assertError: allowRulesNotMatched,
 		},
 		{
+			name: "repository-owner-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.RepositoryOwner = "octo-*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: require.NoError,
+		},
+		{
+			name: "incorrect-repository-owner-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.RepositoryOwner = "octoo-*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: allowRulesNotMatched,
+		},
+		{
 			name: "incorrect-repository-owner",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				JoinMethod: types.JoinMethodGitHub,
@@ -340,6 +436,38 @@ func TestJoinGHA(t *testing.T) {
 					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
 						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
 							rule.RepositoryOwner = "not matching"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: allowRulesNotMatched,
+		},
+		{
+			name: "workflow-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Workflow = "example-*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: require.NoError,
+		},
+		{
+			name: "incorrect-workflow-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Workflow = "examplee-*"
 						}),
 					},
 				},
@@ -364,6 +492,38 @@ func TestJoinGHA(t *testing.T) {
 			assertError: allowRulesNotMatched,
 		},
 		{
+			name: "environment-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Environment = "pr*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: require.NoError,
+		},
+		{
+			name: "incorrect-environment-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Environment = "prr*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: allowRulesNotMatched,
+		},
+		{
 			name: "incorrect-environment",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				JoinMethod: types.JoinMethodGitHub,
@@ -380,6 +540,38 @@ func TestJoinGHA(t *testing.T) {
 			assertError: allowRulesNotMatched,
 		},
 		{
+			name: "actor-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Actor = "octo*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: require.NoError,
+		},
+		{
+			name: "incorrect-actor-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Actor = "octoo*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: allowRulesNotMatched,
+		},
+		{
 			name: "incorrect-actor",
 			tokenSpec: types.ProvisionTokenSpecV2{
 				JoinMethod: types.JoinMethodGitHub,
@@ -388,6 +580,38 @@ func TestJoinGHA(t *testing.T) {
 					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
 						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
 							rule.Actor = "not matching"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: allowRulesNotMatched,
+		},
+		{
+			name: "ref-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Ref = "refs/heads/*"
+						}),
+					},
+				},
+			},
+			request:     newRequest(validIDToken),
+			assertError: require.NoError,
+		},
+		{
+			name: "incorrect-ref-with-wildcard",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodGitHub,
+				Roles:      []types.SystemRole{types.RoleNode},
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						allowRule(func(rule *types.ProvisionTokenSpecV2GitHub_Rule) {
+							rule.Ref = "refs/tags/*"
 						}),
 					},
 				},


### PR DESCRIPTION
Changelog: Added support for `*` and `$` globbing to the GitHub Actions token rules.

## Manual Test Plan
### Test Environment

- personal cloud staging tenant

### Test Cases
- [x] No glob, respoitory matching rule should join
- [x] No glob, respoitory not matching rule should not join
- [x] Glob, respoitory matching rule should join
- [x] Glob, respoitory not matching rule should not join