### PR TITLE
Bump Date for Identity Activity Center

### DIFF
--- a/docs/pages/identity-security/usage/alerts.mdx
+++ b/docs/pages/identity-security/usage/alerts.mdx
@@ -24,7 +24,7 @@ To view active alerts, navigate to **Identity Security** > **Alerts** in the Tel
 
 <Admonition type="tip">
 
-Teleport Identity Security Alerts and the Investigate view are currently only available in self-hosted AWS Teleport Enterprise deployments.  They will be coming to Teleport Enterprise Cloud in Q4 2025.
+Teleport Identity Security Alerts and the Investigate view are currently only available in self-hosted AWS Teleport Enterprise deployments.  They will be coming to Teleport Enterprise Cloud in Q2 2026.
 
 </Admonition>
 


### PR DESCRIPTION
Alerts / Identity Activity Center is aimed for Q1, but to be safe bumping date for Q2. Once deployed I'll remove this notice. 