### PR TITLE
[v17] pgx migration: use pgx v5 for postgres.MakeTestClient

### DIFF
--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -336,8 +336,9 @@ func connectPostgres(t *testing.T, ctx context.Context, info dbUserLogin, dbName
 
 	pool, err := pgxpool.NewWithConfig(ctx, pgCfg)
 	require.NoError(t, err)
-	require.NoError(t, pool.Ping(ctx))
 	t.Cleanup(pool.Close)
+
+	require.NoError(t, pool.Ping(ctx))
 	return &pgConn{
 		logger: utils.NewSlogLoggerForTests().With("test_name", t.Name()),
 		pool:   pool,

--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -36,10 +36,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	mysqlclient "github.com/go-mysql-org/go-mysql/client"
 	"github.com/gravitational/trace"
-	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
-	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool" // TODO(gavin): change this to v5 after updating other test packages to use v5 as well
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -334,8 +334,9 @@ func connectPostgres(t *testing.T, ctx context.Context, info dbUserLogin, dbName
 		RootCAs:    awsCertPool.Clone(),
 	}
 
-	pool, err := pgxpool.ConnectConfig(ctx, pgCfg)
+	pool, err := pgxpool.NewWithConfig(ctx, pgCfg)
 	require.NoError(t, err)
+	require.NoError(t, pool.Ping(ctx))
 	t.Cleanup(pool.Close)
 	return &pgConn{
 		logger: utils.NewSlogLoggerForTests().With("test_name", t.Name()),

--- a/go.mod
+++ b/go.mod
@@ -427,7 +427,6 @@ require (
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/puddle v1.3.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1698,7 +1698,6 @@ github.com/jackc/pgx/v5 v5.7.2/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsb
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=

--- a/integration/db/db_integration_test.go
+++ b/integration/db/db_integration_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -36,7 +36,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"

--- a/integration/proxy/proxy_tunnel_strategy_test.go
+++ b/integration/proxy/proxy_tunnel_strategy_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -40,7 +40,7 @@ import (
 	mysqllib "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jonboulle/clockwork"
 	mssql "github.com/microsoft/go-mssqldb"
 	opensearchclt "github.com/opensearch-project/opensearch-go/v2"

--- a/lib/srv/db/local_proxy_test.go
+++ b/lib/srv/db/local_proxy_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 

--- a/lib/srv/db/postgres/test.go
+++ b/lib/srv/db/postgres/test.go
@@ -33,10 +33,10 @@ import (
 	"sync/atomic"
 
 	"github.com/gravitational/trace"
-	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgproto3/v2"
 	"github.com/jackc/pgtype"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -410,9 +410,9 @@ func (s *TestServer) handleQuery(client *pgproto3.Backend, query string, pid uin
 	}
 
 	messages := []pgproto3.BackendMessage{
-		&pgproto3.RowDescription{Fields: TestQueryResponse.FieldDescriptions},
+		&pgproto3.RowDescription{Fields: legacyFieldDescriptions(TestQueryResponse.FieldDescriptions)},
 		&pgproto3.DataRow{Values: TestQueryResponse.Rows[0]},
-		&pgproto3.CommandComplete{CommandTag: TestQueryResponse.CommandTag},
+		&pgproto3.CommandComplete{CommandTag: []byte(TestQueryResponse.CommandTag.String())},
 		&pgproto3.ReadyForQuery{},
 	}
 	for _, message := range messages {
@@ -720,7 +720,7 @@ func (s *TestServer) handleDeactivateUser(client *pgproto3.Backend, sendDeleteRe
 	}
 	if sendDeleteResponse {
 		messages = append(messages,
-			&pgproto3.RowDescription{Fields: TestDeleteUserResponse.FieldDescriptions},
+			&pgproto3.RowDescription{Fields: legacyFieldDescriptions(TestDeleteUserResponse.FieldDescriptions)},
 			&pgproto3.DataRow{Values: TestDeleteUserResponse.Rows[0]},
 		)
 	} else {
@@ -1102,16 +1102,26 @@ func (s *TestServer) registerCancel(pid uint32, cancel context.CancelFunc) error
 // TestQueryResponse is the response test Postgres server sends to every success
 // query.
 var TestQueryResponse = &pgconn.Result{
-	FieldDescriptions: []pgproto3.FieldDescription{{Name: []byte("test-field")}},
+	FieldDescriptions: []pgconn.FieldDescription{{Name: "test-field"}},
 	Rows:              [][][]byte{{[]byte("test-value")}},
-	CommandTag:        pgconn.CommandTag("select 1"),
+	CommandTag:        pgconn.NewCommandTag("select 1"),
 }
 
 // TestDeleteUserResponse is the response test Postgres server sends to every
 // query that calls the auto user deletion procedure.
 var TestDeleteUserResponse = &pgconn.Result{
-	FieldDescriptions: []pgproto3.FieldDescription{{Name: []byte("state")}},
+	FieldDescriptions: []pgconn.FieldDescription{{Name: "state"}},
 	Rows:              [][][]byte{{[]byte("TP003")}},
+}
+
+// legacyFieldDescriptions converts pgconn.FieldDescriptions to legacy pgproto3.
+// TODO(greedy52): remove once the pgx is fully migrated.
+func legacyFieldDescriptions(fds []pgconn.FieldDescription) []pgproto3.FieldDescription {
+	out := make([]pgproto3.FieldDescription, len(fds))
+	for i, fd := range fds {
+		out[i] = pgproto3.FieldDescription{Name: []byte(fd.Name)}
+	}
+	return out
 }
 
 // TestLongRunningQuery is a stub SQL query clients can use to simulate a long

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
backport of #65476 to branch/v17

minor import conflicts

test only changes.