### PR TITLE
Add codeowners for go.mod files in examples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 /integrations/terraform/go.mod @russjones @r0mant @zmb3 @rosstimothy @hugoShaka @tigrato
 /integrations/terraform-mwi/go.mod @russjones @r0mant @zmb3 @rosstimothy @hugoShaka @tigrato @strideynet
 /integrations/event-handler/go.mod @russjones @r0mant @zmb3 @rosstimothy @hugoShaka @tigrato
+/examples/**/go.mod @russjones @r0mant @zmb3 @rosstimothy
 
 # Owners for Rust dependency updates.
 /Cargo.toml @russjones @r0mant @zmb3 @rosstimothy @fspmarshall @espadolini


### PR DESCRIPTION
Dependabot reviewers are determined by codeowners. Since there were no owners defined for the examples modules Dependabot PRs created for security alerts were going unnoticed because nobody got assigned to review them.