### PR TITLE
Add access client in terraform module

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -839,11 +839,6 @@ func (c *Client) ScopedAccessServiceClient() *scopedaccess.Client {
 	return scopedaccess.NewClient(scopedaccessv1.NewScopedAccessServiceClient(c.conn))
 }
 
-// ScopedAccessTerraformClient returns a terraform specific scoped access client.
-func (c *Client) ScopedAccessTerraformClient() *scopedaccess.TerraformClient {
-	return scopedaccess.NewTerraformClient(c.ScopedAccessServiceClient())
-}
-
 // LoginRuleClient returns an unadorned Login Rule client, using the underlying
 // Auth gRPC connection.
 // Clients connecting to non-Enterprise clusters, or older Teleport versions,

--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -133,6 +133,8 @@ type payload struct {
 	WithoutImportState bool
 	// StatePoll optionally configures polling for state changes when creating or updating resources.
 	StatePoll *statePoll
+	// ClientOverride sets a different client from main client to use for the resource.
+	ClientOverride string
 }
 
 // statePoll configures polling for state changes when creating or updating resources.
@@ -957,11 +959,11 @@ var (
 		Name:                  "ScopedRole",
 		TypeName:              "ScopedRole",
 		VarName:               "scopedRole",
-		GetMethod:             "ScopedAccessTerraformClient().GetScopedRole",
-		CreateMethod:          "ScopedAccessTerraformClient().CreateScopedRole",
-		UpdateMethod:          "ScopedAccessTerraformClient().UpsertScopedRole",
+		GetMethod:             "GetScopedRole",
+		CreateMethod:          "CreateScopedRole",
+		UpdateMethod:          "UpsertScopedRole",
 		UpsertMethodArity:     2,
-		DeleteMethod:          "ScopedAccessTerraformClient().DeleteScopedRole",
+		DeleteMethod:          "DeleteScopedRole",
 		ID:                    "scopedRole.Metadata.Name",
 		Kind:                  "scoped_role",
 		HasStaticID:           false,

--- a/integrations/terraform/provider/client/scopedaccessclient.go
+++ b/integrations/terraform/provider/client/scopedaccessclient.go
@@ -12,27 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package access
+package client
 
 import (
 	"context"
 
+	"github.com/gravitational/teleport/api/client/scopes/access"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 )
 
-// TerraformClient is a wrapper around the scoped access Client that unwraps gRPC
+// AccessClient is a wrapper around the scoped access Client that unwraps gRPC
 // request/response types into the simple signatures expected by terraform provider code generation.
-type TerraformClient struct {
-	client *Client
+type AccessClient struct {
+	client *access.Client
 }
 
-// NewTerraformClient creates a new TerraformClient wrapping the given scoped access Client.
-func NewTerraformClient(client *Client) *TerraformClient {
-	return &TerraformClient{client: client}
+// NewAccessClient creates a new AccessClient wrapping the given scoped access Client.
+func NewAccessClient(client *access.Client) *AccessClient {
+	return &AccessClient{client: client}
 }
 
 // GetScopedRole gets a scoped role by name.
-func (t *TerraformClient) GetScopedRole(ctx context.Context, name string) (*scopedaccessv1.ScopedRole, error) {
+func (t *AccessClient) GetScopedRole(ctx context.Context, name string) (*scopedaccessv1.ScopedRole, error) {
 	res, err := t.client.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
 		Name: name,
 	})
@@ -43,7 +44,7 @@ func (t *TerraformClient) GetScopedRole(ctx context.Context, name string) (*scop
 }
 
 // CreateScopedRole creates a new scoped role.
-func (t *TerraformClient) CreateScopedRole(ctx context.Context, role *scopedaccessv1.ScopedRole) (*scopedaccessv1.ScopedRole, error) {
+func (t *AccessClient) CreateScopedRole(ctx context.Context, role *scopedaccessv1.ScopedRole) (*scopedaccessv1.ScopedRole, error) {
 	res, err := t.client.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
 		Role: role,
 	})
@@ -54,7 +55,7 @@ func (t *TerraformClient) CreateScopedRole(ctx context.Context, role *scopedacce
 }
 
 // UpsertScopedRole creates or updates a scoped role.
-func (t *TerraformClient) UpsertScopedRole(ctx context.Context, role *scopedaccessv1.ScopedRole) (*scopedaccessv1.ScopedRole, error) {
+func (t *AccessClient) UpsertScopedRole(ctx context.Context, role *scopedaccessv1.ScopedRole) (*scopedaccessv1.ScopedRole, error) {
 	res, err := t.client.UpsertScopedRole(ctx, &scopedaccessv1.UpsertScopedRoleRequest{
 		Role: role,
 	})
@@ -65,7 +66,7 @@ func (t *TerraformClient) UpsertScopedRole(ctx context.Context, role *scopedacce
 }
 
 // DeleteScopedRole deletes a scoped role by name.
-func (t *TerraformClient) DeleteScopedRole(ctx context.Context, name string) error {
+func (t *AccessClient) DeleteScopedRole(ctx context.Context, name string) error {
 	_, err := t.client.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
 		Name: name,
 	})

--- a/integrations/terraform/provider/data_source_teleport_scoped_role.go
+++ b/integrations/terraform/provider/data_source_teleport_scoped_role.go
@@ -59,7 +59,7 @@ func (r dataSourceTeleportScopedRole) Read(ctx context.Context, req tfsdk.ReadDa
 		return
 	}
 
-	scopedRoleI, err := r.p.Client.ScopedAccessTerraformClient().GetScopedRole(ctx, id.Value)
+	scopedRoleI, err := r.p.Client.GetScopedRole(ctx, id.Value)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ScopedRole", trace.Wrap(err), "scoped_role"))
 		return

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/constants"
+	terraformclient "github.com/gravitational/teleport/integrations/terraform/provider/client"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -43,6 +44,11 @@ const (
 	// minServerVersion is the minimal teleport version the plugin supports.
 	minServerVersion = "15.0.0-0"
 )
+
+type TerraformClient struct {
+	*terraformclient.AccessClient
+	*client.Client
+}
 
 const (
 	// attributeTerraformAddress is the attribute configuring the Teleport address the Terraform provider connects to.
@@ -109,10 +115,11 @@ type RetryConfig struct {
 
 // Provider Teleport Provider
 type Provider struct {
-	configured  bool
-	Client      *client.Client
-	RetryConfig RetryConfig
-	cancel      context.CancelFunc
+	configured         bool
+	Client             *TerraformClient
+	ScopedAccessClient *terraformclient.AccessClient
+	RetryConfig        RetryConfig
+	cancel             context.CancelFunc
 }
 
 // providerData provider schema struct
@@ -427,8 +434,12 @@ func (p *Provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 		Cap:      retryCapDuration,
 		MaxTries: int(maxTries),
 	}
-	p.Client = clt
+	p.Client = &TerraformClient{
+		Client:       clt,
+		AccessClient: terraformclient.NewAccessClient(clt.ScopedAccessServiceClient()),
+	}
 	p.configured = true
+
 }
 
 // checkTeleportVersion ensures that Teleport version is at least minServerVersion

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -115,11 +115,10 @@ type RetryConfig struct {
 
 // Provider Teleport Provider
 type Provider struct {
-	configured         bool
-	Client             *TerraformClient
-	ScopedAccessClient *terraformclient.AccessClient
-	RetryConfig        RetryConfig
-	cancel             context.CancelFunc
+	configured  bool
+	Client      *TerraformClient
+	RetryConfig RetryConfig
+	cancel      context.CancelFunc
 }
 
 // providerData provider schema struct

--- a/integrations/terraform/provider/resource_teleport_scoped_role.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_role.go
@@ -82,7 +82,7 @@ func (r resourceTeleportScopedRole) Create(ctx context.Context, req tfsdk.Create
 
 	id := scopedRoleResource.Metadata.Name
 
-	_, err = r.p.Client.ScopedAccessTerraformClient().GetScopedRole(ctx, id)
+	_, err = r.p.Client.GetScopedRole(ctx, id)
 	if !trace.IsNotFound(err) {
 		if err == nil {
 			existErr := fmt.Sprintf("ScopedRole exists in Teleport. Either remove it (tctl rm scoped_role/%v)"+
@@ -96,7 +96,7 @@ func (r resourceTeleportScopedRole) Create(ctx context.Context, req tfsdk.Create
 		return
 	}
 
-	_, err = r.p.Client.ScopedAccessTerraformClient().CreateScopedRole(ctx, scopedRoleResource)
+	_, err = r.p.Client.CreateScopedRole(ctx, scopedRoleResource)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error creating ScopedRole", trace.Wrap(err), "scoped_role"))
 		return
@@ -115,7 +115,7 @@ func (r resourceTeleportScopedRole) Create(ctx context.Context, req tfsdk.Create
 	}
 	for {
 		tries = tries + 1
-		scopedRoleI, err = r.p.Client.ScopedAccessTerraformClient().GetScopedRole(ctx, id)
+		scopedRoleI, err = r.p.Client.GetScopedRole(ctx, id)
 		if trace.IsNotFound(err) {
 		    select {
 			case <-ctx.Done():
@@ -173,7 +173,7 @@ func (r resourceTeleportScopedRole) Read(ctx context.Context, req tfsdk.ReadReso
 		return
 	}
 
-	scopedRoleI, err := r.p.Client.ScopedAccessTerraformClient().GetScopedRole(ctx, id.Value)
+	scopedRoleI, err := r.p.Client.GetScopedRole(ctx, id.Value)
 	if trace.IsNotFound(err) {
 		resp.State.RemoveResource(ctx)
 		return
@@ -224,13 +224,13 @@ func (r resourceTeleportScopedRole) Update(ctx context.Context, req tfsdk.Update
 	
 	name := scopedRoleResource.Metadata.Name
 
-	scopedRoleBefore, err := r.p.Client.ScopedAccessTerraformClient().GetScopedRole(ctx, name)
+	scopedRoleBefore, err := r.p.Client.GetScopedRole(ctx, name)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ScopedRole", err, "scoped_role"))
 		return
 	}
 
-	_, err = r.p.Client.ScopedAccessTerraformClient().UpsertScopedRole(ctx, scopedRoleResource)
+	_, err = r.p.Client.UpsertScopedRole(ctx, scopedRoleResource)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating ScopedRole", err, "scoped_role"))
 		return
@@ -249,7 +249,7 @@ func (r resourceTeleportScopedRole) Update(ctx context.Context, req tfsdk.Update
 	}
 	for {
 		tries = tries + 1
-		scopedRoleI, err = r.p.Client.ScopedAccessTerraformClient().GetScopedRole(ctx, name)
+		scopedRoleI, err = r.p.Client.GetScopedRole(ctx, name)
 		if err != nil {
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ScopedRole", err, "scoped_role"))
 			return
@@ -295,7 +295,7 @@ func (r resourceTeleportScopedRole) Delete(ctx context.Context, req tfsdk.Delete
 		return
 	}
 
-	err := r.p.Client.ScopedAccessTerraformClient().DeleteScopedRole(ctx, id.Value)
+	err := r.p.Client.DeleteScopedRole(ctx, id.Value)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting ScopedRole", trace.Wrap(err), "scoped_role"))
 		return
@@ -306,7 +306,7 @@ func (r resourceTeleportScopedRole) Delete(ctx context.Context, req tfsdk.Delete
 
 // ImportState imports ScopedRole state
 func (r resourceTeleportScopedRole) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	scopedRole, err := r.p.Client.ScopedAccessTerraformClient().GetScopedRole(ctx, req.ID)
+	scopedRole, err := r.p.Client.GetScopedRole(ctx, req.ID)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ScopedRole", trace.Wrap(err), "scoped_role"))
 		return

--- a/integrations/terraform/testlib/scoped_role_test.go
+++ b/integrations/terraform/testlib/scoped_role_test.go
@@ -29,6 +29,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
+	client "github.com/gravitational/teleport/integrations/terraform/provider/client"
 )
 
 func (s *TerraformSuiteOSS) TestScopedRole() {
@@ -37,7 +38,8 @@ func (s *TerraformSuiteOSS) TestScopedRole() {
 	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 
 	checkDestroyed := func(state *terraform.State) error {
-		_, err := s.client.ScopedAccessTerraformClient().GetScopedRole(ctx, "test-scoped-role")
+		accessClient := client.NewAccessClient(s.client.ScopedAccessServiceClient())
+		_, err := accessClient.GetScopedRole(ctx, "test-scoped-role")
 		if !trace.IsNotFound(err) {
 			return trace.Errorf("expected not found, actual: %v", err)
 		}
@@ -88,6 +90,7 @@ func (s *TerraformSuiteOSS) TestImportScopedRole() {
 	t := s.T()
 	ctx := t.Context()
 	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	accessClient := client.NewAccessClient(s.client.ScopedAccessServiceClient())
 
 	r := "teleport_scoped_role"
 	id := "test_import_scoped_role"
@@ -111,11 +114,11 @@ func (s *TerraformSuiteOSS) TestImportScopedRole() {
 		},
 	}
 
-	_, err := s.client.ScopedAccessTerraformClient().CreateScopedRole(ctx, role)
+	_, err := accessClient.CreateScopedRole(ctx, role)
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		_, err := s.client.ScopedAccessTerraformClient().GetScopedRole(ctx, id)
+		_, err := accessClient.GetScopedRole(ctx, id)
 		require.NoError(t, err)
 	}, 5*time.Second, time.Second)
 


### PR DESCRIPTION
Moved scoped access client into the terraform module.

Added a wrapper that allows the terraform client to be extensible with terraform only clients.

<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [x] Added a scoped role with terraform
- [x] Update scoped role with terraform
- [x] Delete scoped role with terraform
- [x]  Retrieved the scoped role created with tctl (verified before and after delete) 
- [x] Ensure other resources did not break - edited and destroyed a scoped token and role