### PR TITLE
Migrate S3 upload/download to feature/s3/transfermanager

### DIFF
--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect

--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -132,6 +132,8 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeD
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 h1:uMC4oL6G3MNhodo358QEqSDjrgvzV3TUQ58nyQSGq2E=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13/go.mod h1:Cer86AE2686DvVUe57LPve3jUBmbujuaonSX8pNzGgw=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 h1:92MfpwB6KjsPIEq9g3DniRPxOe92ew5hUz1h8W8cX7E=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15/go.mod h1:7O129SmOn4acM++3oVfTLAeHmNOsj0y7AA7zmbgnGOk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=

--- a/e2e/runner/go.mod
+++ b/e2e/runner/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect

--- a/e2e/runner/go.sum
+++ b/e2e/runner/go.sum
@@ -117,6 +117,8 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeD
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 h1:uMC4oL6G3MNhodo358QEqSDjrgvzV3TUQ58nyQSGq2E=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13/go.mod h1:Cer86AE2686DvVUe57LPve3jUBmbujuaonSX8pNzGgw=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 h1:92MfpwB6KjsPIEq9g3DniRPxOe92ew5hUz1h8W8cX7E=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15/go.mod h1:7O129SmOn4acM++3oVfTLAeHmNOsj0y7AA7zmbgnGOk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=

--- a/examples/dynamoathenamigration/migration.go
+++ b/examples/dynamoathenamigration/migration.go
@@ -38,7 +38,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	dynamoTypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -151,7 +152,7 @@ type task struct {
 }
 
 type s3downloader interface {
-	Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (n int64, err error) //nolint:staticcheck // TODO(tigrato)
+	DownloadObject(ctx context.Context, input *transfermanager.DownloadObjectInput, opts ...func(*transfermanager.Options)) (*transfermanager.DownloadObjectOutput, error)
 }
 
 type eventsEmitter interface {
@@ -163,7 +164,7 @@ func newMigrateTask(ctx context.Context, cfg Config, awsCfg aws.Config) (*task, 
 	return &task{
 		Config:       cfg,
 		dynamoClient: dynamodb.NewFromConfig(awsCfg),
-		s3Downloader: manager.NewDownloader(s3Client), //nolint:staticcheck // TODO(tigrato)
+		s3Downloader: transfermanager.New(s3Client),
 		eventsEmitter: athena.NewPublisher(athena.PublisherConfig{
 			MessagePublisher: athena.SNSPublisherFunc(cfg.TopicARN, sns.NewFromConfig(awsCfg, func(o *sns.Options) {
 				o.Retryer = retry.NewStandard(func(so *retry.StandardOptions) {
@@ -173,7 +174,7 @@ func newMigrateTask(ctx context.Context, cfg Config, awsCfg aws.Config) (*task, 
 					so.RateLimiter = ratelimit.NewTokenRateLimit(1000000)
 				})
 			})),
-			Uploader:      manager.NewUploader(s3Client), //nolint:staticcheck // TODO(tigrato)
+			Uploader:      transfermanager.New(s3Client),
 			PayloadBucket: cfg.LargePayloadBucket,
 			PayloadPrefix: cfg.LargePayloadPrefix,
 		}),
@@ -334,12 +335,13 @@ type dataObjectInfo struct {
 // getDataObjectsInfo downloads manifest-files.json and get data object info from it.
 func (t *task) getDataObjectsInfo(ctx context.Context, manifestPath string) ([]dataObjectInfo, error) {
 	// summary file is small, we can use in-memory buffer.
-	writeAtBuf := manager.NewWriteAtBuffer([]byte{})
-	if _, err := t.s3Downloader.Download(ctx, writeAtBuf, &s3.GetObjectInput{
+	writeAtBuf := tmtypes.NewWriteAtBuffer([]byte{})
+	if _, err := t.s3Downloader.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
 		Bucket: aws.String(t.Bucket),
 		// AWS SDK returns manifest-summary.json path. We are interested in
 		// manifest-files.json because it's contains references about data export files.
-		Key: aws.String(path.Dir(manifestPath) + "/manifest-files.json"),
+		Key:      aws.String(path.Dir(manifestPath) + "/manifest-files.json"),
+		WriterAt: writeAtBuf,
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -506,9 +508,10 @@ func (t *task) downloadFromS3AndSort(ctx context.Context, dataObj dataObjectInfo
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if _, err := t.s3Downloader.Download(ctx, originalFile, &s3.GetObjectInput{
-		Bucket: aws.String(t.Bucket),
-		Key:    aws.String(dataObj.DataFileS3Key),
+	if _, err := t.s3Downloader.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
+		Bucket:   aws.String(t.Bucket),
+		Key:      aws.String(dataObj.DataFileS3Key),
+		WriterAt: originalFile,
 	}); err != nil {
 		return nil, trace.NewAggregate(err, originalFile.Close())
 	}

--- a/examples/dynamoathenamigration/migration_test.go
+++ b/examples/dynamoathenamigration/migration_test.go
@@ -32,8 +32,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -153,23 +152,27 @@ type fakeDownloader struct {
 	dataObjects map[string]string
 }
 
-func (f *fakeDownloader) Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (int64, error) { //nolint:staticcheck // TODO(tigrato)
+func (f *fakeDownloader) DownloadObject(ctx context.Context, input *transfermanager.DownloadObjectInput, opts ...func(*transfermanager.Options)) (*transfermanager.DownloadObjectOutput, error) {
 	data, ok := f.dataObjects[*input.Key]
 	if !ok {
-		return 0, errors.New("object does not exists")
+		return nil, errors.New("object does not exists")
 	}
 	var buf bytes.Buffer
 	zw := gzip.NewWriter(&buf)
 	_, err := zw.Write([]byte(data))
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	if err := zw.Close(); err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	n, err := w.WriteAt(buf.Bytes(), 0)
-	return int64(n), err
+	n, err := input.WriterAt.WriteAt(buf.Bytes(), 0)
+	if err != nil {
+		return nil, err
+	}
+	contentLength := int64(n)
+	return &transfermanager.DownloadObjectOutput{ContentLength: &contentLength}, nil
 }
 
 type mockEmitter struct {

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15
 	github.com/aws/aws-sdk-go-v2/service/account v1.30.5
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.14
 	github.com/aws/aws-sdk-go-v2/service/athena v1.57.4
@@ -650,9 +651,3 @@ replace (
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
 	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.4
 )
-
-// this package was included in google.golang.org/grpc but because it's still
-// referenced by some dependencies we should exclude it here to avoid problems
-// when evaluating versions; "go get -u ./..." succeeding is a good sign that
-// the problem has been resolved
-exclude google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3

--- a/go.sum
+++ b/go.sum
@@ -818,6 +818,8 @@ github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21 h1:HFn8sVT87KWnGs2Q2gO/brP
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21/go.mod h1:BGZ/K6gLGJt8K36j6gcsD7WVxmWt0MGBYtr57iLweio=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 h1:uMC4oL6G3MNhodo358QEqSDjrgvzV3TUQ58nyQSGq2E=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13/go.mod h1:Cer86AE2686DvVUe57LPve3jUBmbujuaonSX8pNzGgw=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 h1:92MfpwB6KjsPIEq9g3DniRPxOe92ew5hUz1h8W8cX7E=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15/go.mod h1:7O129SmOn4acM++3oVfTLAeHmNOsj0y7AA7zmbgnGOk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33/go.mod h1:7i0PF1ME/2eUPFcjkVIwq+DOygHEoK92t5cDqNgYbIw=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -144,6 +144,8 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeD
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 h1:uMC4oL6G3MNhodo358QEqSDjrgvzV3TUQ58nyQSGq2E=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13/go.mod h1:Cer86AE2686DvVUe57LPve3jUBmbujuaonSX8pNzGgw=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 h1:92MfpwB6KjsPIEq9g3DniRPxOe92ew5hUz1h8W8cX7E=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15/go.mod h1:7O129SmOn4acM++3oVfTLAeHmNOsj0y7AA7zmbgnGOk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -208,6 +208,8 @@ github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21 h1:HFn8sVT87KWnGs2Q2gO/brP
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21/go.mod h1:BGZ/K6gLGJt8K36j6gcsD7WVxmWt0MGBYtr57iLweio=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 h1:uMC4oL6G3MNhodo358QEqSDjrgvzV3TUQ58nyQSGq2E=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13/go.mod h1:Cer86AE2686DvVUe57LPve3jUBmbujuaonSX8pNzGgw=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 h1:92MfpwB6KjsPIEq9g3DniRPxOe92ew5hUz1h8W8cX7E=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15/go.mod h1:7O129SmOn4acM++3oVfTLAeHmNOsj0y7AA7zmbgnGOk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33/go.mod h1:7i0PF1ME/2eUPFcjkVIwq+DOygHEoK92t5cDqNgYbIw=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -258,6 +258,8 @@ github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21 h1:HFn8sVT87KWnGs2Q2gO/brP
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.21/go.mod h1:BGZ/K6gLGJt8K36j6gcsD7WVxmWt0MGBYtr57iLweio=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13 h1:uMC4oL6G3MNhodo358QEqSDjrgvzV3TUQ58nyQSGq2E=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.13/go.mod h1:Cer86AE2686DvVUe57LPve3jUBmbujuaonSX8pNzGgw=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15 h1:92MfpwB6KjsPIEq9g3DniRPxOe92ew5hUz1h8W8cX7E=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.15/go.mod h1:7O129SmOn4acM++3oVfTLAeHmNOsj0y7AA7zmbgnGOk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33/go.mod h1:7i0PF1ME/2eUPFcjkVIwq+DOygHEoK92t5cDqNgYbIw=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=

--- a/lib/events/athena/athena_test.go
+++ b/lib/events/athena/athena_test.go
@@ -30,8 +30,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -484,24 +483,25 @@ func newFakeS3manager() *fakeS3manager {
 	}
 }
 
-func (f *fakeS3manager) Upload(ctx context.Context, input *s3.PutObjectInput, opts ...func(*manager.Uploader)) (*manager.UploadOutput, error) { //nolint:staticcheck // TODO(tigrato)
+func (f *fakeS3manager) UploadObject(ctx context.Context, input *transfermanager.UploadObjectInput, opts ...func(*transfermanager.Options)) (*transfermanager.UploadObjectOutput, error) {
 	data, err := io.ReadAll(input.Body)
 	if err != nil {
 		return nil, err
 	}
 	f.objects[*input.Key] = data
 	f.uploadCount++
-	return &manager.UploadOutput{Key: input.Key}, nil
+	return &transfermanager.UploadObjectOutput{Key: input.Key}, nil
 }
 
-func (f *fakeS3manager) Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (int64, error) { //nolint:staticcheck // TODO(tigrato)
+func (f *fakeS3manager) DownloadObject(ctx context.Context, input *transfermanager.DownloadObjectInput, opts ...func(*transfermanager.Options)) (*transfermanager.DownloadObjectOutput, error) {
 	data, ok := f.objects[*input.Key]
 	if !ok {
-		return 0, errors.New("object not found")
+		return nil, errors.New("object not found")
 	}
-	n, err := w.WriteAt(data, 0)
+	n, err := input.WriterAt.WriteAt(data, 0)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return int64(n), nil
+	contentLength := int64(n)
+	return &transfermanager.DownloadObjectOutput{ContentLength: &contentLength}, nil
 }

--- a/lib/events/athena/consumer.go
+++ b/lib/events/athena/consumer.go
@@ -33,9 +33,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	tmtypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqsTypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/aws/smithy-go/tracing/smithyoteltracing"
@@ -113,7 +113,7 @@ type sqsDeleter interface {
 }
 
 type s3downloader interface {
-	Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (n int64, err error) //nolint:staticcheck // TODO(tigrato)
+	DownloadObject(ctx context.Context, input *transfermanager.DownloadObjectInput, opts ...func(*transfermanager.Options)) (*transfermanager.DownloadObjectOutput, error)
 }
 
 func newConsumer(cfg Config, cancelFn context.CancelFunc) (*consumer, error) {
@@ -148,7 +148,7 @@ func newConsumer(cfg Config, cancelFn context.CancelFunc) (*consumer, error) {
 		sqsReceiver: sqsClient,
 		queueURL:    cfg.QueueURL,
 		// TODO(nklaassen): use s3 manager from teleport observability.
-		payloadDownloader: manager.NewDownloader(publisherS3Client), //nolint:staticcheck // TODO(tigrato)
+		payloadDownloader: transfermanager.New(publisherS3Client),
 		payloadBucket:     cfg.largeEventsBucket,
 		visibilityTimeout: int32(cfg.BatchMaxInterval.Seconds()),
 		batchMaxItems:     cfg.BatchMaxItems,
@@ -185,9 +185,9 @@ func newConsumer(cfg Config, cancelFn context.CancelFunc) (*consumer, error) {
 				return nil, trace.Wrap(err)
 			}
 			key := fmt.Sprintf("%s/%s/%s.parquet", cfg.locationS3Prefix, date, id.String())
-			fw, err := awsutils.NewS3V2FileWriter(ctx, storerS3Client, cfg.locationS3Bucket, key, nil /* uploader options */, func(poi *s3.PutObjectInput) {
+			fw, err := awsutils.NewS3V2FileWriter(ctx, storerS3Client, cfg.locationS3Bucket, key, nil /* uploader options */, func(uoi *transfermanager.UploadObjectInput) {
 				// ChecksumAlgorithm is required for putting objects when object lock is enabled.
-				poi.ChecksumAlgorithm = s3Types.ChecksumAlgorithmSha256
+				uoi.ChecksumAlgorithm = tmtypes.ChecksumAlgorithmSha256
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -769,16 +769,17 @@ func (s *sqsMessagesCollector) downloadEventFromS3(ctx context.Context, payload 
 		versionIDPtr = aws.String(versionID)
 	}
 
-	buf := manager.NewWriteAtBuffer([]byte{})
-	written, err := s.cfg.payloadDownloader.Download(ctx, buf, &s3.GetObjectInput{
+	buf := tmtypes.NewWriteAtBuffer([]byte{})
+	out, err := s.cfg.payloadDownloader.DownloadObject(ctx, &transfermanager.DownloadObjectInput{
 		Bucket:    aws.String(s.cfg.payloadBucket),
 		Key:       aws.String(path),
-		VersionId: versionIDPtr,
+		VersionID: versionIDPtr,
+		WriterAt:  buf,
 	})
 	if err != nil {
 		return nil, awsutils.ConvertS3Error(err)
 	}
-	if written == 0 {
+	if aws.ToInt64(out.ContentLength) == 0 {
 		return nil, trace.NotFound("payload for %v is not found", path)
 	}
 	return buf.Bytes(), nil

--- a/lib/events/athena/publisher.go
+++ b/lib/events/athena/publisher.go
@@ -30,7 +30,7 @@ import (
 	awsratelimit "github.com/aws/aws-sdk-go-v2/aws/ratelimit"
 	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
-	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
@@ -146,7 +146,7 @@ func SQSPublisherFunc(queueURL string, sqsClient *sqs.Client) messagePublisherFu
 }
 
 type s3uploader interface {
-	Upload(ctx context.Context, input *s3.PutObjectInput, opts ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) //nolint:staticcheck // TODO(tigrato)
+	UploadObject(ctx context.Context, input *transfermanager.UploadObjectInput, opts ...func(*transfermanager.Options)) (*transfermanager.UploadObjectOutput, error)
 }
 
 type PublisherConfig struct {
@@ -197,7 +197,7 @@ func newPublisherFromAthenaConfig(cfg Config) *publisher {
 
 	return NewPublisher(PublisherConfig{
 		MessagePublisher: messagePublisher,
-		Uploader: s3manager.NewUploader(s3.NewFromConfig(*cfg.PublisherConsumerAWSConfig, func(o *s3.Options) { //nolint:staticcheck // TODO(tigrato)
+		Uploader: transfermanager.New(s3.NewFromConfig(*cfg.PublisherConsumerAWSConfig, func(o *s3.Options) {
 			o.TracerProvider = smithyoteltracing.Adapt(otel.GetTracerProvider())
 		})),
 		PayloadBucket: cfg.largeEventsBucket,
@@ -261,7 +261,7 @@ func (p *publisher) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent)
 
 func (p *publisher) emitViaS3(ctx context.Context, uid string, marshaledEvent []byte) error {
 	path := path.Join(p.PayloadPrefix, uid)
-	out, err := p.Uploader.Upload(ctx, &s3.PutObjectInput{
+	out, err := p.Uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
 		Bucket: &p.PayloadBucket,
 		Key:    &path,
 		Body:   bytes.NewBuffer(marshaledEvent),

--- a/lib/events/athena/publisher_test.go
+++ b/lib/events/athena/publisher_test.go
@@ -25,8 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
@@ -146,6 +145,6 @@ func Test_EmitAuditEvent(t *testing.T) {
 
 type mockUploader struct{}
 
-func (m mockUploader) Upload(ctx context.Context, input *s3.PutObjectInput, opts ...func(*manager.Uploader)) (*manager.UploadOutput, error) { //nolint:staticcheck // TODO(tigrato)
-	return &manager.UploadOutput{}, nil
+func (m mockUploader) UploadObject(ctx context.Context, input *transfermanager.UploadObjectInput, opts ...func(*transfermanager.Options)) (*transfermanager.UploadObjectOutput, error) {
+	return &transfermanager.UploadObjectOutput{}, nil
 }

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -35,7 +35,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	tmanagertypes "github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go/tracing/smithyoteltracing"
@@ -276,7 +277,7 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 	// Create S3 client with custom options
 	client := s3.NewFromConfig(awsConfig, s3Opts...)
 
-	uploader := manager.NewUploader(client) //nolint:staticcheck // TODO(tigrato)
+	uploader := transfermanager.New(client)
 
 	h := &Handler{
 		logger:   logger,
@@ -310,7 +311,7 @@ type Handler struct {
 	Config
 	// logger emits log messages
 	logger   *slog.Logger
-	uploader *manager.Uploader //nolint:staticcheck // TODO(tigrato)
+	uploader *transfermanager.Client
 	client   s3Client
 }
 
@@ -393,7 +394,7 @@ func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader,
 		opt(&cfg)
 	}
 
-	uploadInput := &s3.PutObjectInput{
+	uploadInput := &transfermanager.UploadObjectInput{
 		Bucket: aws.String(h.Bucket),
 		Key:    aws.String(path),
 		Body:   reader,
@@ -430,15 +431,15 @@ func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader,
 	}
 
 	if !h.Config.DisableServerSideEncryption {
-		uploadInput.ServerSideEncryption = awstypes.ServerSideEncryptionAwsKms
+		uploadInput.ServerSideEncryption = tmanagertypes.ServerSideEncryptionAwsKms
 		if h.Config.SSEKMSKey != "" {
-			uploadInput.SSEKMSKeyId = aws.String(h.Config.SSEKMSKey)
+			uploadInput.SSEKMSKeyID = aws.String(h.Config.SSEKMSKey)
 		}
 	}
 	if h.Config.ACL != "" {
-		uploadInput.ACL = awstypes.ObjectCannedACL(h.Config.ACL)
+		uploadInput.ACL = tmanagertypes.ObjectCannedACL(h.Config.ACL)
 	}
-	_, err := h.uploader.Upload(ctx, uploadInput) //nolint:staticcheck // TODO(tigrato)
+	_, err := h.uploader.UploadObject(ctx, uploadInput)
 	if err != nil {
 		return "", awsutils.ConvertS3Error(err)
 	}

--- a/lib/utils/aws/s3.go
+++ b/lib/utils/aws/s3.go
@@ -25,8 +25,7 @@ import (
 	"strings"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
-	managerv2 "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
-	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	"github.com/gravitational/trace"
@@ -83,11 +82,11 @@ type s3V2FileWriter struct {
 
 // NewS3V2FileWriter created s3V2FileWriter. Close method on writer should be called
 // to make sure that reader has finished.
-func NewS3V2FileWriter(ctx context.Context, s3Client managerv2.UploadAPIClient, bucket, key string, uploaderOptions []func(*managerv2.Uploader), putObjectInputOptions ...func(*s3v2.PutObjectInput)) (*s3V2FileWriter, error) { //nolint:staticcheck // TODO(tigrato)
-	uploader := managerv2.NewUploader(s3Client, uploaderOptions...) //nolint:staticcheck // TODO(tigrato)
+func NewS3V2FileWriter(ctx context.Context, s3Client transfermanager.S3APIClient, bucket, key string, uploaderOptions []func(*transfermanager.Options), putObjectInputOptions ...func(*transfermanager.UploadObjectInput)) (*s3V2FileWriter, error) {
+	client := transfermanager.New(s3Client, uploaderOptions...)
 	pr, pw := io.Pipe()
 
-	uploadParams := &s3v2.PutObjectInput{
+	uploadParams := &transfermanager.UploadObjectInput{
 		Bucket: awsv2.String(bucket),
 		Key:    awsv2.String(key),
 		Body:   pr,
@@ -99,7 +98,7 @@ func NewS3V2FileWriter(ctx context.Context, s3Client managerv2.UploadAPIClient, 
 	uploadFinisherErrChan := make(chan error)
 	go func() {
 		defer close(uploadFinisherErrChan)
-		_, err := uploader.Upload(ctx, uploadParams) //nolint:staticcheck // TODO(tigrato)
+		_, err := client.UploadObject(ctx, uploadParams)
 		if err != nil {
 			pr.CloseWithError(err)
 		}

--- a/lib/utils/aws/s3_test.go
+++ b/lib/utils/aws/s3_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/require"
@@ -70,7 +70,7 @@ func TestNewS3V2FileWriter(t *testing.T) {
 }
 
 type s3ClientMock struct {
-	manager.UploadAPIClient
+	transfermanager.S3APIClient
 
 	putObjectErr error
 


### PR DESCRIPTION
Replace deprecated github.com/aws/aws-sdk-go-v2/feature/s3/manager (Uploader/Downloader) with the new transfermanager package across all codebase. The old manager types were superceded per https://github.com/aws/aws-sdk-go-v2/discussions/3306.

## Manual Test Plan
### Test Environment
local

### Test Cases
- [x] Run `lib/events/athena` integration tests
- [x] Run `lib/events/s3sessions` integration tests

