### PR TITLE
Prevent races in TestRefreshRemoteCluster

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -756,6 +756,8 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		recordingMetadataProvider:    cfg.RecordingMetadataProvider,
 		awsOrganizationsClientGetter: cfg.AWSOrganizationsClientGetter,
 		insecureMode:                 cfg.InsecureMode,
+		remoteClusterRefreshLimit:    cmp.Or(cfg.RemoteClusterRefreshLimit, defaultRemoteClusterRefreshLimit),
+		remoteClusterRefreshBuckets:  cmp.Or(cfg.RemoteClusterRefreshBuckets, defaultRemoteClusterRefreshBuckets),
 	}
 	as.inventory = inventory.NewController(as, services,
 		inventory.WithAuthServerID(cfg.HostUUID),
@@ -1503,6 +1505,13 @@ type Server struct {
 	// anonymizationKey is used to anonymize sensitive data in a consistent way for
 	// use in telemetry and logging without exposing the original values.
 	anonymizationKey []byte
+
+	// RemoteClusterRefreshLimit is the maximum number of backend updates that will be performed
+	// during periodic remote cluster connection status refresh.
+	remoteClusterRefreshLimit int
+	// RemoteClusterRefreshBuckets is the maximum number of refresh cycles that should guarantee the status update
+	// of all remote clusters if their number exceeds RemoteClusterRefreshLimit × RemoteClusterRefreshBuckets.
+	remoteClusterRefreshBuckets int
 }
 
 // SetSAMLService registers svc as the SAMLService that provides the SAML
@@ -2393,14 +2402,14 @@ func (a *Server) updateBotInstanceMetrics() {
 	}
 }
 
-var (
-	// remoteClusterRefreshLimit is the maximum number of backend updates that will be performed
+const (
+	// defaultRemoteClusterRefreshLimit is the maximum number of backend updates that will be performed
 	// during periodic remote cluster connection status refresh.
-	remoteClusterRefreshLimit = 50
+	defaultRemoteClusterRefreshLimit = 50
 
-	// remoteClusterRefreshBuckets is the maximum number of refresh cycles that should guarantee the status update
+	// defaultRemoteClusterRefreshBuckets is the maximum number of refresh cycles that should guarantee the status update
 	// of all remote clusters if their number exceeds remoteClusterRefreshLimit × remoteClusterRefreshBuckets.
-	remoteClusterRefreshBuckets = 12
+	defaultRemoteClusterRefreshBuckets = 12
 )
 
 // refreshRemoteClusters updates connection status of all remote clusters.
@@ -2418,8 +2427,8 @@ func (a *Server) refreshRemoteClusters(ctx context.Context) {
 	}
 
 	// we want to limit the number of backend updates performed on each refresh to avoid overwhelming the backend.
-	updateLimit := remoteClusterRefreshLimit
-	if dynamicLimit := (len(remoteClusters) / remoteClusterRefreshBuckets) + 1; dynamicLimit > updateLimit {
+	updateLimit := a.remoteClusterRefreshLimit
+	if dynamicLimit := (len(remoteClusters) / a.remoteClusterRefreshBuckets) + 1; dynamicLimit > updateLimit {
 		// if the number of remote clusters is larger than remoteClusterRefreshLimit × remoteClusterRefreshBuckets,
 		// bump the limit to make sure all remote clusters will be updated within reasonable time.
 		updateLimit = dynamicLimit

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -83,14 +83,6 @@ var (
 	CreateAuditStreamAcceptedTotalMetric = createAuditStreamAcceptedTotalMetric
 )
 
-func (a *Server) SetRemoteClusterRefreshLimit(limit int) {
-	remoteClusterRefreshLimit = limit
-}
-
-func (a *Server) RemoteClusterRefreshBuckets(buckets int) {
-	remoteClusterRefreshBuckets = buckets
-}
-
 func (a *Server) VerifyRecoveryCode(ctx context.Context, username string, recoveryCode []byte) (errResult error) {
 	return a.verifyRecoveryCode(ctx, username, recoveryCode)
 }

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -455,6 +455,13 @@ type InitConfig struct {
 	FakeRecoveryCodeHash []byte
 	// Modules defines build time constraints and licensed features.
 	Modules modules.Modules
+
+	// RemoteClusterRefreshLimit is the maximum number of backend updates that will be performed
+	// during periodic remote cluster connection status refresh.
+	RemoteClusterRefreshLimit int
+	// RemoteClusterRefreshBuckets is the maximum number of refresh cycles that should guarantee the status update
+	// of all remote clusters if their number exceeds RemoteClusterRefreshLimit × RemoteClusterRefreshBuckets.
+	RemoteClusterRefreshBuckets int
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -164,8 +164,6 @@ func TestRefreshRemoteClusters(t *testing.T) {
 			require.LessOrEqual(t, tt.clustersNeedUpdate, tt.clustersTotal)
 
 			a := newTestAuthServer(ctx, t)
-			a.SetRemoteClusterRefreshLimit(10)
-			a.RemoteClusterRefreshBuckets(5)
 
 			allClusters := make(map[string]types.RemoteCluster)
 			for i := range tt.clustersTotal {
@@ -454,12 +452,14 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *auth.
 	require.NoError(t, err)
 
 	authConfig := &auth.InitConfig{
-		ClusterName:            clusterNameRes,
-		Backend:                bk,
-		VersionStorage:         authtest.NewFakeTeleportVersion(),
-		Authority:              keygen,
-		SkipPeriodicOperations: true,
-		HostUUID:               uuid.NewString(),
+		ClusterName:                 clusterNameRes,
+		Backend:                     bk,
+		VersionStorage:              authtest.NewFakeTeleportVersion(),
+		Authority:                   keygen,
+		SkipPeriodicOperations:      true,
+		HostUUID:                    uuid.NewString(),
+		RemoteClusterRefreshLimit:   10,
+		RemoteClusterRefreshBuckets: 5,
 	}
 	a, err := auth.NewServer(authConfig)
 	require.NoError(t, err)


### PR DESCRIPTION
Replaces global variable with struct fields on the auth.Server which can be injected. The newTestAuthServer helper used by trusted cluster tests specifies the limits directly so tests no longer have to modify the globals causing races.

Closes https://github.com/gravitational/teleport/issues/65564.