### PR TITLE
app: Fix context leak in handleConnection and MonitorConn

### DIFF
--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -341,14 +341,14 @@ func (c *ConnectionsHandler) expireSessions() {
 // HandleConnection takes a connection and wraps it in a listener, so it can
 // be passed to http.Serve to process as a HTTP request.
 func (c *ConnectionsHandler) HandleConnection(conn net.Conn) {
-	ctx := context.Background()
-
 	// Wrap conn to detect when it is closed.
 	// Returning early will close conn before it has been serviced.
 	// httpServer will initiate the close call.
 	waitConn := utils.NewWaitConn(conn)
 
-	cleanup, err := c.handleConnection(waitConn)
+	ctx, cancel := context.WithCancelCause(c.closeContext)
+
+	cleanup, err := c.handleConnection(ctx, cancel, waitConn)
 	// Make sure that the cleanup function is run
 	if cleanup != nil {
 		defer cleanup()
@@ -599,8 +599,7 @@ func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*authz.Conte
 	return authContext, app, nil
 }
 
-func (c *ConnectionsHandler) handleConnection(conn net.Conn) (func(), error) {
-	ctx, cancel := context.WithCancelCause(c.closeContext)
+func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel context.CancelCauseFunc, conn net.Conn) (func(), error) {
 	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
 		Conn:    conn,
 		Clock:   c.cfg.Clock,
@@ -673,11 +672,9 @@ func (c *ConnectionsHandler) handleConnection(conn net.Conn) (func(), error) {
 	switch {
 	case app.IsTCP():
 		identity := authCtx.Identity.GetIdentity()
-		defer cancel(nil)
 		return nil, trace.Wrap(c.handleTCPApp(ctx, tlsConn, &identity, app))
 
 	case app.IsMCP():
-		defer cancel(nil)
 		sessionCtx := mcp.SessionCtx{
 			ClientConn: tlsConn,
 			AuthCtx:    authCtx,
@@ -694,7 +691,6 @@ func (c *ConnectionsHandler) handleConnection(conn net.Conn) (func(), error) {
 			if releaseConn != nil {
 				releaseConn()
 			}
-			cancel(nil)
 			c.deleteConnAuth(tlsConn)
 		}
 		return cleanup, trace.Wrap(c.handleHTTPApp(ctx, tlsConn))

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -658,7 +658,7 @@ func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel contex
 		case app.IsTCP():
 			return nil, trace.Wrap(err)
 		case app.IsMCP():
-			return nil, trace.Wrap(c.mcpServer.HandleUnauthorizedConnection(ctx, conn, app, err))
+			return nil, trace.Wrap(c.mcpServer.HandleUnauthorizedConnection(ctx, tlsConn, app, err))
 		default:
 			c.setConnAuth(tlsConn, err)
 		}

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -347,6 +347,7 @@ func (c *ConnectionsHandler) HandleConnection(conn net.Conn) {
 	waitConn := utils.NewWaitConn(conn)
 
 	ctx, cancel := context.WithCancelCause(c.closeContext)
+	defer cancel(nil)
 
 	cleanup, err := c.handleConnection(ctx, cancel, waitConn)
 	// Make sure that the cleanup function is run
@@ -600,6 +601,12 @@ func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*authz.Conte
 }
 
 func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel context.CancelCauseFunc, conn net.Conn) (func(), error) {
+	defer func() {
+		if cancel != nil {
+			cancel(nil)
+		}
+	}()
+
 	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
 		Conn:    conn,
 		Clock:   c.cfg.Clock,
@@ -684,9 +691,12 @@ func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel contex
 
 	default:
 		// Transfer release ownership to the cleanup function so
-		// the deferred release above becomes a no-op.
+		// the deferred calls above become no-ops. The caller
+		// (HandleConnection) cancels the context after the
+		// connection closes.
 		releaseConn := release
 		release = nil
+		cancel = nil
 		cleanup := func() {
 			if releaseConn != nil {
 				releaseConn()

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -636,7 +636,7 @@ func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel contex
 
 	// Proxy sends a X.509 client certificate to pass identity information,
 	// extract it and run authorization checks on it.
-	tlsConn, user, app, err := c.getConnectionInfo(c.closeContext, tc)
+	tlsConn, user, app, err := c.getConnectionInfo(ctx, tc)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/app/connections_handler_test.go
+++ b/lib/srv/app/connections_handler_test.go
@@ -19,6 +19,7 @@
 package app
 
 import (
+	"context"
 	"log/slog"
 	"net"
 	"net/http"
@@ -91,6 +92,45 @@ func newConnWithIP(t *testing.T, ip string, port int) (server, client net.Conn) 
 	return server, client
 }
 
+func TestHandleConnection_CancelsContextOnError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("limiter exceeded", func(t *testing.T) {
+		c := newTestHandler(t, limiter.Config{MaxConnections: 1})
+
+		// Pre-fill the limiter so handleConnection hits the
+		// "max connections exceeded" error path.
+		release, err := c.limiter.RegisterRequestAndConnection("10.0.0.1")
+		require.NoError(t, err)
+		defer release()
+
+		ctx, cancel := context.WithCancelCause(t.Context())
+		called := false
+		wrapped := func(cause error) { called = true; cancel(cause) }
+		conn, _ := newConnWithIP(t, "10.0.0.1", 10001)
+		_, err = c.handleConnection(ctx, wrapped, conn)
+		require.True(t, trace.IsLimitExceeded(err))
+		require.True(t, called, "cancel should be called on limiter error path")
+	})
+
+	t.Run("TLS handshake failure", func(t *testing.T) {
+		c := newTestHandler(t, limiter.Config{})
+
+		// Close the client side so the TLS handshake in
+		// getConnectionInfo fails immediately.
+		conn, client := net.Pipe()
+		t.Cleanup(func() { conn.Close() })
+		client.Close()
+
+		ctx, cancel := context.WithCancelCause(t.Context())
+		called := false
+		wrapped := func(cause error) { called = true; cancel(cause) }
+		_, err := c.handleConnection(ctx, wrapped, conn)
+		require.Error(t, err)
+		require.True(t, called, "cancel should be called on TLS handshake error path")
+	})
+}
+
 func TestHandleConnection_MaxConnections(t *testing.T) {
 	t.Parallel()
 
@@ -107,7 +147,9 @@ func TestHandleConnection_MaxConnections(t *testing.T) {
 	conn, client := newConnWithIP(t, clientIP, 10001)
 	client.Close() // prevent blocking on TLS handshake
 
-	_, err = c.handleConnection(conn)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	defer cancel(nil)
+	_, err = c.handleConnection(ctx, cancel, conn)
 	require.True(t, trace.IsLimitExceeded(err), "expected LimitExceeded error, got: %v", err)
 }
 
@@ -129,7 +171,9 @@ func TestHandleConnection_MaxConnectionsRelease(t *testing.T) {
 
 	// handleConnection should pass the limiter and fail later
 	// (at TLS handshake). The error must not be about limits.
-	_, err = c.handleConnection(conn)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	defer cancel(nil)
+	_, err = c.handleConnection(ctx, cancel, conn)
 	require.Error(t, err)
 	require.False(t, trace.IsLimitExceeded(err), "unexpected LimitExceeded error: %v", err)
 }
@@ -153,7 +197,9 @@ func TestHandleConnection_RateLimiting(t *testing.T) {
 	conn, client := newConnWithIP(t, clientIP, 10001)
 	client.Close()
 
-	_, err := c.handleConnection(conn)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	defer cancel(nil)
+	_, err := c.handleConnection(ctx, cancel, conn)
 	require.True(t, trace.IsLimitExceeded(err), "expected LimitExceeded error, got: %v", err)
 }
 
@@ -175,7 +221,9 @@ func TestHandleConnection_PipeSkipsLimiter(t *testing.T) {
 
 	// handleConnection should bypass the limiter (which is full)
 	// and fail later at TLS instead.
-	_, err = c.handleConnection(server)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	defer cancel(nil)
+	_, err = c.handleConnection(ctx, cancel, server)
 	require.Error(t, err)
 	require.False(t, trace.IsLimitExceeded(err), "unexpected LimitExceeded error: %v", err)
 }

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -167,9 +167,11 @@ func (c *ConnectionMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Con
 
 	idleTimeout := checker.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
 
+	var cancel context.CancelCauseFunc
 	tconn, ok := getTrackingReadConn(conn)
 	if !ok {
-		tctx, cancel := context.WithCancelCause(ctx)
+		var tctx context.Context
+		tctx, cancel = context.WithCancelCause(ctx)
 		tconn, err = NewTrackingReadConn(TrackingReadConnConfig{
 			Conn:    conn,
 			Clock:   c.cfg.Clock,
@@ -177,6 +179,7 @@ func (c *ConnectionMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Con
 			Cancel:  cancel,
 		})
 		if err != nil {
+			cancel(nil)
 			return ctx, conn, trace.Wrap(err)
 		}
 	}
@@ -201,6 +204,9 @@ func (c *ConnectionMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Con
 		IdleTimeoutMessage:    netConfig.GetClientIdleTimeoutMessage(),
 		MonitorCloseChannel:   c.cfg.MonitorCloseChannel,
 	}); err != nil {
+		if cancel != nil {
+			cancel(nil)
+		}
 		return ctx, conn, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Cancel child contexts on all error paths in `handleConnection` and
`MonitorConn` to prevent monotonic memory growth under connection churn.

Both functions create child contexts via `context.WithCancelCause` but omit
the cancel call on several error return paths. Go's context implementation
registers each child in the parent's internal children map for cancellation
propagation. Without cancel, the child stays in the map until the parent is
cancelled at server shutdown, holding everything the context references.

In `handleConnection`, six error return paths leak. Under connection churn
(~5,000 concurrent TCP app connections), orphaned contexts accumulate and
agent memory climbs from ~1 GiB to ~3 GiB over 14 days with no plateau.
The fix moves context creation from `handleConnection` to its caller
`HandleConnection`, passing `ctx` and `cancel` as parameters. This lets
`handleConnection` call `cancel(nil)` explicitly on each error return and
after the synchronous TCP and MCP handlers complete. The HTTP branch does
not call cancel because the HTTP server runs asynchronously - the caller
cancels after the connection closes.

In `MonitorConn`, the child context created for non-`TrackingReadConn`
connections leaks if `NewTrackingReadConn` or `StartMonitor` fails. The fix
lifts the cancel variable out of the if-block scope and calls `cancel(nil)`
on both error paths.

The regression test wraps the cancel function in a counter and asserts that
cancel is called for every connection that hits an error path.

Issue: https://github.com/gravitational/customer-sensitive-requests/issues/572