### PR TITLE
docs: fix cert_authority resource name in CA rotation guide

### DIFF
--- a/docs/pages/zero-trust-access/management/security/ca-rotation.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-rotation.mdx
@@ -66,7 +66,7 @@ and lists any manual steps that need to be completed.
 - (!docs/pages/includes/tctl.mdx!)
 
 - Your user must have a role with permission to `create` and `update` the
-  `certificate_authority` resource.
+  `cert_authority` resource.
 
   ```yaml
   kind: role
@@ -76,7 +76,7 @@ and lists any manual steps that need to be completed.
   spec:
     allow:
       rules:
-      - resources: [ certificate_authority ]
+      - resources: [ cert_authority ]
         verbs: [ create, update ]
   ```
 


### PR DESCRIPTION
The CA rotation guide referenced `certificate_authority` as the resource name for RBAC rules, but the correct resource kind is `cert_authority`.

Fixes #65575




