### PR TITLE
Small improvements to Browser MFA

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4359,12 +4359,14 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 	}
 
 	// If a BrowserMFARequestID is provided, look up the request and apply its challenge extensions.
+	var browserMFAReq *services.MFASessionData
 	if req.BrowserMFARequestID != "" {
 		if req.ChallengeExtensions != nil {
 			return nil, trace.BadParameter("challenge extensions must not be set when a browser MFA request ID is provided")
 		}
 
-		browserMFAReq, err := a.GetMFASession(ctx, req.BrowserMFARequestID)
+		var err error
+		browserMFAReq, err = a.GetMFASession(ctx, req.BrowserMFARequestID)
 		if err != nil {
 			a.logger.WarnContext(ctx, "Failed to read MFA session for browser MFA request", "error", err)
 			return nil, trace.AccessDenied("invalid browser MFA request")
@@ -4443,6 +4445,17 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+	}
+
+	if browserMFAReq != nil && browserMFAReq.Username != username {
+		a.logger.WarnContext(
+			ctx,
+			"Username stored in MFA session does not match requester's username",
+			"request_id", req.BrowserMFARequestID,
+			"session_username", browserMFAReq.Username,
+			"requestor_username", username,
+		)
+		return nil, trace.AccessDenied("invalid browser MFA request")
 	}
 
 	// When completing a Browser MFA flow, only a WebAuthn challenge is needed, so
@@ -8121,7 +8134,6 @@ func (a *Server) mfaAuthChallenge(ctx context.Context, user, clientRedirectURL, 
 			mfatypes.BeginBrowserMFAChallengeParams{
 				User:                     user,
 				BrowserMFATSHRedirectURL: clientRedirectURL,
-				ProxyAddress:             proxyAddress,
 				Ext:                      challengeExtensions,
 			},
 		); err != nil {

--- a/lib/auth/browser_mfa_test.go
+++ b/lib/auth/browser_mfa_test.go
@@ -523,6 +523,30 @@ func TestCreateAuthenticateChallenge_BrowserMFARequestID(t *testing.T) {
 				assert.ErrorContains(t, err, "stored session lacks challenge extensions")
 			},
 		},
+		{
+			name: "NOK username mismatch",
+			setup: func(t *testing.T) {
+				session := &services.MFASessionData{
+					RequestID:     "test-request-3",
+					Username:      "mismatch",
+					ConnectorID:   constants.BrowserMFA,
+					ConnectorType: constants.BrowserMFA,
+					ChallengeExtensions: &mfatypes.ChallengeExtensions{
+						Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_LOGIN,
+					},
+				}
+				err := a.UpsertMFASessionData(ctx, session)
+				require.NoError(t, err)
+			},
+			request: &proto.CreateAuthenticateChallengeRequest{
+				Request:             userCredsRequest,
+				BrowserMFARequestID: "test-request-3",
+			},
+			checkError: func(t *testing.T, err error) {
+				assert.ErrorAs(t, err, new(*trace.AccessDeniedError), "CreateAuthenticateChallenge error mismatch")
+				assert.ErrorContains(t, err, "invalid browser MFA request")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/auth/mfatypes/browser.go
+++ b/lib/auth/mfatypes/browser.go
@@ -27,7 +27,6 @@ import (
 type BeginBrowserMFAChallengeParams struct {
 	User                     string
 	BrowserMFATSHRedirectURL string
-	ProxyAddress             string
 	Ext                      *mfav1.ChallengeExtensions
 	SIP                      *mfav1.SessionIdentifyingPayload
 	SourceCluster            string

--- a/lib/client/sso/ceremony.go
+++ b/lib/client/sso/ceremony.go
@@ -132,6 +132,10 @@ func (m *MFACeremony) Run(ctx context.Context, chal *proto.MFAAuthenticateChalle
 	// this MFA ceremony. In which case, don't print the redirect URL and listen
 	// for either response to be returned.
 	case chal.SSOChallenge != nil && chal.BrowserMFAChallenge != nil:
+		if m.GetCallbackResponse == nil {
+			return nil, trace.BadParameter("GetCallbackResponse is required for combined SSO and Browser MFA challenges")
+		}
+
 		loginResp, err := m.GetCallbackResponse(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
This adds some small improvements to the Browser MFA flow:
1. When the user requests a MFA challenge in the browser, do a username check
2. Remove an unused `ProxyAddress` field
3. Add a nil check for `GetCallbackResponse`

## Manual Test Plan
### Test Environment
Running Teleport locally
### Test Cases
- [x] WebAuthn solve in the browser works
- [x] WebAuthn solve in the browser fails for username mismatch
- [x] Connect unaffected by nil check
- [x] tsh MFA ceremony unaffected by nil check