### PR TITLE
[v18] Update Go toolchain version to v1.25.9

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/api
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/charlievieth/strcase v0.0.5

--- a/assets/backport/go.mod
+++ b/assets/backport/go.mod
@@ -1,6 +1,6 @@
 module github.com/teleport/assets/backport
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/google/go-github/v41 v41.0.0

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.25.8
+FROM docker.io/golang:1.25.9
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.25.8
+go 1.25.9
 
 require (
 	buf.build/go/bufplugin v0.9.0

--- a/build.assets/tools/benchstat/go.mod
+++ b/build.assets/tools/benchstat/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tools/benchstat
 
-go 1.25.8
+go 1.25.9
 
 tool golang.org/x/perf/cmd/benchstat
 

--- a/build.assets/tools/gci/go.mod
+++ b/build.assets/tools/gci/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tools/gci
 
-go 1.25.8
+go 1.25.9
 
 tool github.com/daixiang0/gci
 

--- a/build.assets/tools/goda/go.mod
+++ b/build.assets/tools/goda/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tools/goda
 
-go 1.25.8
+go 1.25.9
 
 tool github.com/loov/goda
 

--- a/build.assets/tools/gotestsum/go.mod
+++ b/build.assets/tools/gotestsum/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tools/gotestsum
 
-go 1.25.8
+go 1.25.9
 
 tool gotest.tools/gotestsum
 

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.25.8
+GOLANG_VERSION ?= go1.25.9
 GOLANGCI_LINT_VERSION ?= v2.7.2
 
 # NOTE: Remember to update engines.node in package.json to match the major version.

--- a/docs/config.json
+++ b/docs/config.json
@@ -69,7 +69,7 @@
       "major_version": "18",
       "version": "18.7.3",
       "url": "teleport.example.com",
-      "golang": "1.25.8",
+      "golang": "1.25.9",
       "plugin": {
         "version": "18.7.3"
       },

--- a/examples/access-plugin-minimal/go.mod
+++ b/examples/access-plugin-minimal/go.mod
@@ -1,6 +1,6 @@
 module teleport-sheets
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707

--- a/examples/api-sync-roles/go.mod
+++ b/examples/api-sync-roles/go.mod
@@ -1,6 +1,6 @@
 module sync-roles
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707

--- a/examples/desktop-registration/go.mod
+++ b/examples/desktop-registration/go.mod
@@ -1,6 +1,6 @@
 module teleport-desktop-registration
 
-go 1.25.8
+go 1.25.9
 
 require github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707
 

--- a/examples/go-client/go.mod
+++ b/examples/go-client/go.mod
@@ -1,6 +1,6 @@
 module go-client
 
-go 1.25.8
+go 1.25.9
 
 require github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707
 

--- a/examples/mcp-servers/verify-teleport-jwt-mcp-go/go.mod
+++ b/examples/mcp-servers/verify-teleport-jwt-mcp-go/go.mod
@@ -1,6 +1,6 @@
 module verify-teleport-jwt-mcp-go
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/auth0/go-jwt-middleware/v2 v2.3.0

--- a/examples/service-discovery-api-client/go.mod
+++ b/examples/service-discovery-api-client/go.mod
@@ -1,6 +1,6 @@
 module register-app-service
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/examples/teleport-usage/go.mod
+++ b/examples/teleport-usage/go.mod
@@ -1,6 +1,6 @@
 module usage-script
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.25.8
+go 1.25.9
 
 ignore (
 	./build

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/alecthomas/kong v1.10.0

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform-mwi
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/gravitational/teleport v0.0.0-00010101000000-000000000000

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.25.8
+go 1.25.9
 
 // TF provider dependencies
 require (


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/65526 to branch/v18

Changelog: Update Go to v1.25.9.

>go1.25.9 (released 2026-04-07) includes security fixes to the go command, the compiler, and the archive/tar, crypto/tls, crypto/x509, html/template, and os packages, as well as bug fixes to the go command, the compiler, and the runtime. See the [Go 1.25.9 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.9+label%3ACherryPickApproved) on our issue tracker for details.