### PR TITLE
Fix node not taking over existing unmanaged host users

### DIFF
--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -201,7 +201,7 @@ func TestRootHostUsersBackend(t *testing.T) {
 		t.Cleanup(func() {
 			os.RemoveAll(testHome)
 		})
-		require.ErrorIs(t, err, os.ErrExist)
+		require.True(t, trace.IsAlreadyExists(err), "expected AlreadyExists, got %v", err)
 		require.NoFileExists(t, "/tmp/ignoreme")
 	})
 }

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"log/slog"
 	"maps"
-	"os"
 	"os/user"
 	"regexp"
 	"slices"
@@ -311,7 +310,7 @@ func (u *HostUserManagement) updateUser(hostUser HostUser, ui *decisionpb.HostUs
 
 			log.DebugContext(ctx, "Creating home directory", "home_path", home)
 			err = u.backend.CreateHomeDirectory(home, hostUser.UID, hostUser.GID)
-			if err != nil && !os.IsExist(err) {
+			if err != nil && !trace.IsAlreadyExists(err) {
 				return trace.Wrap(err)
 			}
 		}
@@ -399,7 +398,7 @@ func (u *HostUserManagement) createUser(name string, ui *decisionpb.HostUsersInf
 		if userOpts.Home != "" {
 			log.InfoContext(u.ctx, "Attempting to create home directory", "home", userOpts.Home, "gid", userOpts.GID)
 			if err := u.backend.CreateHomeDirectory(userOpts.Home, user.Uid, user.Gid); err != nil {
-				if !os.IsExist(err) {
+				if !trace.IsAlreadyExists(err) {
 					return trace.Wrap(err)
 				}
 				log.InfoContext(u.ctx, "Home directory already exists", "home", userOpts.Home, "gid", userOpts.GID)

--- a/lib/srv/usermgmt_linux.go
+++ b/lib/srv/usermgmt_linux.go
@@ -266,7 +266,7 @@ func (u *HostUsersProvisioningBackend) CreateHomeDirectory(userHome, uidS, gidS 
 
 	err = os.Mkdir(userHome, 0o700)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.ConvertSystemError(err)
 	}
 
 	skelDir, err := readDefaultSkel()
@@ -276,7 +276,7 @@ func (u *HostUsersProvisioningBackend) CreateHomeDirectory(userHome, uidS, gidS 
 
 	_, err = os.Stat(skelDir)
 	if err != nil && !os.IsNotExist(err) {
-		return trace.Wrap(err)
+		return trace.ConvertSystemError(err)
 	}
 
 	if !os.IsNotExist(err) {

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -180,6 +180,9 @@ func (tm *testHostUserBackend) DeleteUser(user string) error {
 
 func (tm *testHostUserBackend) CreateHomeDirectory(user, uid, gid string) error {
 	tm.createHomeDirectoryCalls++
+	if _, err := tm.Lookup(user); err == nil {
+		return trace.AlreadyExists("home directory for user %q already exists", user)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This change fixes nodes not taking over existing unmanaged host users when configured, due to incorrect error propagation.

Resolves #65349.

Changelog: Fixed Teleport not taking over an existing unmanaged host user when configured to

## Manual Test Plan
### Test Environment

Teleport cluster running as root, on a Linux host. No specific config needed.

### Test Cases
- Create unmanaged host user
```
sudo useradd -m unmanageduser
```
- Create role `host-user-test`:
```
# host-user-test.yaml
kind: role
version: v5
metadata:
  name: host-user-test
spec:
  options:
    create_host_user_mode: keep
  allow:
    logins: ["unmanageduser"]
    host_groups: [teleport-keep, testgroup1]
    node_labels:
      "*": "*"
```
- Create a user with `host-user-test` as the sole role. Log in as that user.
- Start an ssh session with `unmanageduser` as the login. Within the session, verify that the host user has gained the groups set in `host-user-test`:
```
groups unmanageduser
```
- [x] unmanageduser gains the expected roles
