### PR TITLE
[v18] Scoped role options (#65340)

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -278,8 +278,25 @@ type ScopedRoleSSH struct {
 	// Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
 	// (or global default) applies.
 	ClientIdleTimeout string `protobuf:"bytes,3,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions.
+	// If not set, X11 forwarding is not permitted.
+	PermitX11Forwarding *bool `protobuf:"varint,4,opt,name=permit_x11_forwarding,json=permitX11Forwarding,proto3,oneof" json:"permit_x11_forwarding,omitempty"`
+	// ForwardAgent enables SSH agent forwarding.
+	ForwardAgent *bool `protobuf:"varint,6,opt,name=forward_agent,json=forwardAgent,proto3,oneof" json:"forward_agent,omitempty"`
+	// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
+	PortForwarding *SSHPortForwarding `protobuf:"bytes,7,opt,name=port_forwarding,json=portForwarding,proto3" json:"port_forwarding,omitempty"`
+	// HostUserCreation configures the creation of host users.
+	HostUserCreation *CreateHostUser `protobuf:"bytes,8,opt,name=host_user_creation,json=hostUserCreation,proto3" json:"host_user_creation,omitempty"`
+	// MaxSessions defines the maximum number of
+	// concurrent sessions per connection.
+	MaxSessions *int64 `protobuf:"varint,9,opt,name=max_sessions,json=maxSessions,proto3,oneof" json:"max_sessions,omitempty"`
+	// Sudoers is a list of entries to include in a users sudoer file
+	HostSudoers []string `protobuf:"bytes,10,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
+	// FileCopy indicates whether remote file operations via SCP or SFTP are allowed
+	// over an SSH session. It defaults to allowing the user to download and upload files by default.
+	FileCopy      *bool `protobuf:"varint,11,opt,name=file_copy,json=fileCopy,proto3,oneof" json:"file_copy,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSSH) Reset() {
@@ -331,6 +348,55 @@ func (x *ScopedRoleSSH) GetClientIdleTimeout() string {
 		return x.ClientIdleTimeout
 	}
 	return ""
+}
+
+func (x *ScopedRoleSSH) GetPermitX11Forwarding() bool {
+	if x != nil && x.PermitX11Forwarding != nil {
+		return *x.PermitX11Forwarding
+	}
+	return false
+}
+
+func (x *ScopedRoleSSH) GetForwardAgent() bool {
+	if x != nil && x.ForwardAgent != nil {
+		return *x.ForwardAgent
+	}
+	return false
+}
+
+func (x *ScopedRoleSSH) GetPortForwarding() *SSHPortForwarding {
+	if x != nil {
+		return x.PortForwarding
+	}
+	return nil
+}
+
+func (x *ScopedRoleSSH) GetHostUserCreation() *CreateHostUser {
+	if x != nil {
+		return x.HostUserCreation
+	}
+	return nil
+}
+
+func (x *ScopedRoleSSH) GetMaxSessions() int64 {
+	if x != nil && x.MaxSessions != nil {
+		return *x.MaxSessions
+	}
+	return 0
+}
+
+func (x *ScopedRoleSSH) GetHostSudoers() []string {
+	if x != nil {
+		return x.HostSudoers
+	}
+	return nil
+}
+
+func (x *ScopedRoleSSH) GetFileCopy() bool {
+	if x != nil && x.FileCopy != nil {
+		return *x.FileCopy
+	}
+	return false
 }
 
 // ScopedRule maps resources to verbs. This is the underlying type used to describe
@@ -389,6 +455,215 @@ func (x *ScopedRule) GetVerbs() []string {
 	return nil
 }
 
+// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
+type SSHPortForwarding struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Allow for local port forwarding.
+	Local *SSHLocalPortForwarding `protobuf:"bytes,1,opt,name=local,proto3" json:"local,omitempty"`
+	// Allow for remote port forwarding.
+	Remote        *SSHRemotePortForwarding `protobuf:"bytes,2,opt,name=remote,proto3" json:"remote,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SSHPortForwarding) Reset() {
+	*x = SSHPortForwarding{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SSHPortForwarding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SSHPortForwarding) ProtoMessage() {}
+
+func (x *SSHPortForwarding) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SSHPortForwarding.ProtoReflect.Descriptor instead.
+func (*SSHPortForwarding) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SSHPortForwarding) GetLocal() *SSHLocalPortForwarding {
+	if x != nil {
+		return x.Local
+	}
+	return nil
+}
+
+func (x *SSHPortForwarding) GetRemote() *SSHRemotePortForwarding {
+	if x != nil {
+		return x.Remote
+	}
+	return nil
+}
+
+// SSHLocalPortForwarding configures access controls for local SSH port forwarding.
+type SSHLocalPortForwarding struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       *bool                  `protobuf:"varint,1,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SSHLocalPortForwarding) Reset() {
+	*x = SSHLocalPortForwarding{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SSHLocalPortForwarding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SSHLocalPortForwarding) ProtoMessage() {}
+
+func (x *SSHLocalPortForwarding) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SSHLocalPortForwarding.ProtoReflect.Descriptor instead.
+func (*SSHLocalPortForwarding) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SSHLocalPortForwarding) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
+	}
+	return false
+}
+
+// SSHRemotePortForwarding configures access controls for remote SSH port forwarding.
+type SSHRemotePortForwarding struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       *bool                  `protobuf:"varint,1,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SSHRemotePortForwarding) Reset() {
+	*x = SSHRemotePortForwarding{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SSHRemotePortForwarding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SSHRemotePortForwarding) ProtoMessage() {}
+
+func (x *SSHRemotePortForwarding) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SSHRemotePortForwarding.ProtoReflect.Descriptor instead.
+func (*SSHRemotePortForwarding) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *SSHRemotePortForwarding) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
+	}
+	return false
+}
+
+// CreateHostUser configures what types of host user creation are allowed by a role.
+type CreateHostUser struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Mode specifies how the host user should be created.
+	Mode string `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
+	// Groups is a list of host groups to add the user to.
+	Groups []string `protobuf:"bytes,2,rep,name=groups,proto3" json:"groups,omitempty"`
+	// Shell is the shell to set for the user.
+	Shell         string `protobuf:"bytes,3,opt,name=shell,proto3" json:"shell,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateHostUser) Reset() {
+	*x = CreateHostUser{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateHostUser) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateHostUser) ProtoMessage() {}
+
+func (x *CreateHostUser) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateHostUser.ProtoReflect.Descriptor instead.
+func (*CreateHostUser) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *CreateHostUser) GetMode() string {
+	if x != nil {
+		return x.Mode
+	}
+	return ""
+}
+
+func (x *CreateHostUser) GetGroups() []string {
+	if x != nil {
+		return x.Groups
+	}
+	return nil
+}
+
+func (x *CreateHostUser) GetShell() string {
+	if x != nil {
+		return x.Shell
+	}
+	return ""
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -408,15 +683,43 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03sshJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\x89\x01\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xd4\x04\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
-	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\"@\n" +
+	"\x13client_idle_timeout\x18\x03 \x01(\tR\x11clientIdleTimeout\x127\n" +
+	"\x15permit_x11_forwarding\x18\x04 \x01(\bH\x00R\x13permitX11Forwarding\x88\x01\x01\x12(\n" +
+	"\rforward_agent\x18\x06 \x01(\bH\x01R\fforwardAgent\x88\x01\x01\x12U\n" +
+	"\x0fport_forwarding\x18\a \x01(\v2,.teleport.scopes.access.v1.SSHPortForwardingR\x0eportForwarding\x12W\n" +
+	"\x12host_user_creation\x18\b \x01(\v2).teleport.scopes.access.v1.CreateHostUserR\x10hostUserCreation\x12&\n" +
+	"\fmax_sessions\x18\t \x01(\x03H\x02R\vmaxSessions\x88\x01\x01\x12!\n" +
+	"\fhost_sudoers\x18\n" +
+	" \x03(\tR\vhostSudoers\x12 \n" +
+	"\tfile_copy\x18\v \x01(\bH\x03R\bfileCopy\x88\x01\x01B\x18\n" +
+	"\x16_permit_x11_forwardingB\x10\n" +
+	"\x0e_forward_agentB\x0f\n" +
+	"\r_max_sessionsB\f\n" +
+	"\n" +
+	"_file_copy\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
-	"\x05verbs\x18\x02 \x03(\tR\x05verbsBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x05verbs\x18\x02 \x03(\tR\x05verbs\"\xa8\x01\n" +
+	"\x11SSHPortForwarding\x12G\n" +
+	"\x05local\x18\x01 \x01(\v21.teleport.scopes.access.v1.SSHLocalPortForwardingR\x05local\x12J\n" +
+	"\x06remote\x18\x02 \x01(\v22.teleport.scopes.access.v1.SSHRemotePortForwardingR\x06remote\"C\n" +
+	"\x16SSHLocalPortForwarding\x12\x1d\n" +
+	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01B\n" +
+	"\n" +
+	"\b_enabled\"D\n" +
+	"\x17SSHRemotePortForwarding\x12\x1d\n" +
+	"\aenabled\x18\x01 \x01(\bH\x00R\aenabled\x88\x01\x01B\n" +
+	"\n" +
+	"\b_enabled\"R\n" +
+	"\x0eCreateHostUser\x12\x12\n" +
+	"\x04mode\x18\x01 \x01(\tR\x04mode\x12\x16\n" +
+	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
+	"\x05shell\x18\x03 \x01(\tR\x05shellBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
 var (
 	file_teleport_scopes_access_v1_role_proto_rawDescOnce sync.Once
@@ -430,28 +733,36 @@ func file_teleport_scopes_access_v1_role_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_role_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
-	(*ScopedRole)(nil),         // 0: teleport.scopes.access.v1.ScopedRole
-	(*ScopedRoleSpec)(nil),     // 1: teleport.scopes.access.v1.ScopedRoleSpec
-	(*ScopedRoleDefaults)(nil), // 2: teleport.scopes.access.v1.ScopedRoleDefaults
-	(*ScopedRoleSSH)(nil),      // 3: teleport.scopes.access.v1.ScopedRoleSSH
-	(*ScopedRule)(nil),         // 4: teleport.scopes.access.v1.ScopedRule
-	(*v1.Metadata)(nil),        // 5: teleport.header.v1.Metadata
-	(*v11.Label)(nil),          // 6: teleport.label.v1.Label
+	(*ScopedRole)(nil),              // 0: teleport.scopes.access.v1.ScopedRole
+	(*ScopedRoleSpec)(nil),          // 1: teleport.scopes.access.v1.ScopedRoleSpec
+	(*ScopedRoleDefaults)(nil),      // 2: teleport.scopes.access.v1.ScopedRoleDefaults
+	(*ScopedRoleSSH)(nil),           // 3: teleport.scopes.access.v1.ScopedRoleSSH
+	(*ScopedRule)(nil),              // 4: teleport.scopes.access.v1.ScopedRule
+	(*SSHPortForwarding)(nil),       // 5: teleport.scopes.access.v1.SSHPortForwarding
+	(*SSHLocalPortForwarding)(nil),  // 6: teleport.scopes.access.v1.SSHLocalPortForwarding
+	(*SSHRemotePortForwarding)(nil), // 7: teleport.scopes.access.v1.SSHRemotePortForwarding
+	(*CreateHostUser)(nil),          // 8: teleport.scopes.access.v1.CreateHostUser
+	(*v1.Metadata)(nil),             // 9: teleport.header.v1.Metadata
+	(*v11.Label)(nil),               // 10: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	5, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
-	1, // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
-	2, // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
-	4, // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
-	3, // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
-	6, // 5: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	9,  // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
+	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
+	4,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
+	3,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
+	10, // 5: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	5,  // 6: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	8,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
+	6,  // 8: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	7,  // 9: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -459,13 +770,16 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	if File_teleport_scopes_access_v1_role_proto != nil {
 		return
 	}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[6].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[7].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -100,6 +100,30 @@ message ScopedRoleSSH {
   // Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value
   // (or global default) applies.
   string client_idle_timeout = 3;
+
+  // PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions.
+  // If not set, X11 forwarding is not permitted.
+  optional bool permit_x11_forwarding = 4;
+
+  // ForwardAgent enables SSH agent forwarding.
+  optional bool forward_agent = 6;
+
+  // SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
+  SSHPortForwarding port_forwarding = 7;
+
+  // HostUserCreation configures the creation of host users.
+  CreateHostUser host_user_creation = 8;
+
+  // MaxSessions defines the maximum number of
+  // concurrent sessions per connection.
+  optional int64 max_sessions = 9;
+
+  // Sudoers is a list of entries to include in a users sudoer file
+  repeated string host_sudoers = 10;
+
+  // FileCopy indicates whether remote file operations via SCP or SFTP are allowed
+  // over an SSH session. It defaults to allowing the user to download and upload files by default.
+  optional bool file_copy = 11;
 }
 
 // ScopedRule maps resources to verbs. This is the underlying type used to describe
@@ -109,4 +133,34 @@ message ScopedRule {
   repeated string resources = 1;
   // Verbs is the list of action verbs (e.g. 'read') that apply to the above resources.
   repeated string verbs = 2;
+}
+
+// SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.
+message SSHPortForwarding {
+  // Allow for local port forwarding.
+  SSHLocalPortForwarding local = 1;
+  // Allow for remote port forwarding.
+  SSHRemotePortForwarding remote = 2;
+}
+
+// SSHLocalPortForwarding configures access controls for local SSH port forwarding.
+message SSHLocalPortForwarding {
+  optional bool enabled = 1;
+}
+
+// SSHRemotePortForwarding configures access controls for remote SSH port forwarding.
+message SSHRemotePortForwarding {
+  optional bool enabled = 1;
+}
+
+// CreateHostUser configures what types of host user creation are allowed by a role.
+message CreateHostUser {
+  // Mode specifies how the host user should be created.
+  string mode = 1;
+
+  // Groups is a list of host groups to add the user to.
+  repeated string groups = 2;
+
+  // Shell is the shell to set for the user.
+  string shell = 3;
 }

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -2539,6 +2539,16 @@ func (h *CreateHostUserMode) UnmarshalJSON(data []byte) error {
 	return trace.Wrap(err)
 }
 
+// UnmarshalText supports parsing CreateHostUserMode from string.
+//
+// The JSON and YAML unmarshaller will not call this method because CreateHostUserMode
+// also implements yaml/json.Unmarshaler, which takes precedence.
+// Callers that have a plain string should call UnmarshalText directly.
+func (h *CreateHostUserMode) UnmarshalText(text []byte) error {
+	err := h.decode(string(text))
+	return trace.Wrap(err)
+}
+
 const (
 	createDatabaseUserModeOffString            = "off"
 	createDatabaseUserModeKeepString           = "keep"

--- a/api/types/role_test.go
+++ b/api/types/role_test.go
@@ -990,6 +990,23 @@ func TestUnmarshallCreateHostUserModeYAML(t *testing.T) {
 	}
 }
 
+func TestUnmarshalCreateHostUserModeText(t *testing.T) {
+	for _, tc := range []struct {
+		input    string
+		expected CreateHostUserMode
+	}{
+		{input: "off", expected: CreateHostUserMode_HOST_USER_MODE_OFF},
+		{input: "", expected: CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED},
+		{input: "keep", expected: CreateHostUserMode_HOST_USER_MODE_KEEP},
+		{input: "insecure-drop", expected: CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP},
+	} {
+		var got CreateHostUserMode
+		err := got.UnmarshalText([]byte(tc.input))
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, got)
+	}
+}
+
 func TestUnmarshallCreateDatabaseUserModeJSON(t *testing.T) {
 	for _, tc := range []struct {
 		input    any

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -235,6 +235,19 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 		}
 	}
 
+	// verify that create_host_user_mode is a recognized value
+	if mode := role.GetSpec().GetSsh().GetHostUserCreation().GetMode(); mode != "" {
+		var hostUserMode types.CreateHostUserMode
+		if err := hostUserMode.UnmarshalText([]byte(mode)); err != nil {
+			return trace.BadParameter("scoped role %q has invalid ssh.host_user_creation.create_host_user_mode %q", role.GetMetadata().GetName(), mode)
+		}
+	}
+
+	// verify that max_sessions is non-negative
+	if ms := role.GetSpec().GetSsh().GetMaxSessions(); ms < 0 {
+		return trace.BadParameter("scoped role %q has invalid ssh.max_sessions %d: must be non-negative", role.GetMetadata().GetName(), ms)
+	}
+
 	// verify that scoped role converts to a valid unscoped role
 	if _, err := ScopedRoleToRole(role, role.GetScope()); err != nil {
 		return trace.BadParameter("scoped role %q is malformed: %v", role.GetMetadata().GetName(), err)

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -314,6 +314,86 @@ func TestValidateRole(t *testing.T) {
 			strongOk: false,
 			weakOk:   true,
 		},
+		{
+			name: "invalid create_host_user_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						HostUserCreation: &scopedaccessv1.CreateHostUser{
+							Mode: "invalid-mode",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "valid create_host_user_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						HostUserCreation: &scopedaccessv1.CreateHostUser{
+							Mode: "keep",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "negative max_sessions",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						MaxSessions: proto.Int64(-1),
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "positive max_sessions",
+			role: &scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						MaxSessions: proto.Int64(1),
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
 	}
 
 	for _, tt := range tts {
@@ -999,7 +1079,21 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			Labels: []*labelv1.Label{
 				{Name: "env", Values: []string{"prod"}},
 			},
-			ClientIdleTimeout: "1h",
+			ClientIdleTimeout:   "1h",
+			PermitX11Forwarding: proto.Bool(true),
+			FileCopy:            proto.Bool(true),
+			ForwardAgent:        proto.Bool(true),
+			PortForwarding: &scopedaccessv1.SSHPortForwarding{
+				Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(true)},
+				Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(true)},
+			},
+			HostUserCreation: &scopedaccessv1.CreateHostUser{
+				Mode:   "keep",
+				Groups: []string{"wheel"},
+				Shell:  "/bin/bash",
+			},
+			HostSudoers: []string{"ALL=(ALL) NOPASSWD:ALL"},
+			MaxSessions: proto.Int64(10),
 		},
 	}
 

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -221,29 +221,108 @@ func TestRulesConversion(t *testing.T) {
 	}
 }
 
+func baseScopedRole() *scopedaccessv1.ScopedRole {
+	return &scopedaccessv1.ScopedRole{
+		Kind:     KindScopedRole,
+		Metadata: &headerv1.Metadata{Name: "test"},
+		Scope:    "/foo",
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{"/foo/bar"},
+			Ssh:              &scopedaccessv1.ScopedRoleSSH{},
+		},
+		Version: types.V1,
+	}
+}
+
 // TestClientIdleTimeoutNotInClassicRole verifies that ScopedRoleToRole does not populate ClientIdleTimeout
 // in the classic role options. Per the scoped role design, client_idle_timeout is read directly from the
 // appropriate protocol block on the scoped role, which does not have a direct classic role equivalent.
 func TestClientIdleTimeoutNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	role, err := ScopedRoleToRole(&scopedaccessv1.ScopedRole{
-		Kind: KindScopedRole,
-		Metadata: &headerv1.Metadata{
-			Name: "test",
-		},
-		Scope: "/foo",
-		Spec: &scopedaccessv1.ScopedRoleSpec{
-			AssignableScopes: []string{"/foo/bar"},
-			Ssh: &scopedaccessv1.ScopedRoleSSH{
-				ClientIdleTimeout: "30m",
-			},
-		},
-		Version: types.V1,
-	}, "/foo/bar")
+	sr := baseScopedRole()
+	sr.Spec.Ssh.ClientIdleTimeout = "30m"
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
 	require.NotNil(t, role)
 	// ClientIdleTimeout must be zero in the converted role; it is evaluated at access-check time
 	// via SSHAccessChecker.AdjustClientIdleTimeout reading directly from the scoped role proto.
 	require.Zero(t, role.GetOptions().ClientIdleTimeout.Duration())
+}
+
+func TestX11ForwardingNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(v bool) *bool { return &v }
+	sr := baseScopedRole()
+	sr.Spec.Ssh.PermitX11Forwarding = boolPtr(true)
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, types.NewBool(false), role.GetOptions().PermitX11Forwarding)
+}
+
+func TestForwardAgentNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(v bool) *bool { return &v }
+	sr := baseScopedRole()
+	sr.Spec.Ssh.ForwardAgent = boolPtr(true)
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, types.NewBool(UnstableGetScopedForwardAgent()), role.GetOptions().ForwardAgent)
+}
+
+func TestMaxSessionsNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	int64Ptr := func(v int64) *int64 { return &v }
+	sr := baseScopedRole()
+	sr.Spec.Ssh.MaxSessions = int64Ptr(10)
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), role.GetOptions().MaxSessions)
+}
+
+func TestSSHPortForwardingNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(v bool) *bool { return &v }
+	sr := baseScopedRole()
+	sr.Spec.Ssh.PortForwarding = &scopedaccessv1.SSHPortForwarding{
+		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
+		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(getScopedPortForwardingConfig(), role.GetOptions().SSHPortForwarding))
+}
+
+func TestHostUserCreationNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	sr := baseScopedRole()
+	sr.Spec.Ssh.HostUserCreation = &scopedaccessv1.CreateHostUser{
+		Mode: "keep",
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, types.CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED, role.GetOptions().CreateHostUserMode)
+}
+
+func TestSSHFileCopyNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(v bool) *bool { return &v }
+	sr := baseScopedRole()
+	sr.Spec.Ssh.FileCopy = boolPtr(false)
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	require.Equal(t, types.NewBoolOption(true), role.GetOptions().SSHFileCopy)
 }

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -116,7 +116,7 @@ func (c *SSHAccessChecker) PermitX11Forwarding() bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.PermitX11Forwarding()
 	}
-	return c.checker.scopedCompatChecker.PermitX11Forwarding()
+	return c.checker.role.GetSpec().GetSsh().GetPermitX11Forwarding()
 }
 
 // SSHPortForwardMode returns the SSH port forwarding mode.
@@ -124,7 +124,29 @@ func (c *SSHAccessChecker) SSHPortForwardMode() decisionpb.SSHPortForwardMode {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.SSHPortForwardMode()
 	}
-	return c.checker.scopedCompatChecker.SSHPortForwardMode()
+
+	remote := c.checker.role.GetSpec().GetSsh().GetPortForwarding().GetRemote()
+	local := c.checker.role.GetSpec().GetSsh().GetPortForwarding().GetLocal()
+
+	var denyRemote, denyLocal bool
+	if remote != nil && remote.Enabled != nil && !*remote.Enabled {
+		denyRemote = true
+	}
+	if local != nil && local.Enabled != nil && !*local.Enabled {
+		denyLocal = true
+	}
+
+	// enforcing implicit allow and preferring allow over explicit deny
+	switch {
+	case denyRemote && denyLocal:
+		return decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_OFF
+	case denyRemote:
+		return decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_LOCAL
+	case denyLocal:
+		return decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_REMOTE
+	default:
+		return decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON
+	}
 }
 
 // HostSudoers returns the sudoers rules for the host.
@@ -132,7 +154,7 @@ func (c *SSHAccessChecker) HostSudoers(srv types.Server) ([]string, error) {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.HostSudoers(srv)
 	}
-	return c.checker.scopedCompatChecker.HostSudoers(srv)
+	return c.checker.role.GetSpec().GetSsh().GetHostSudoers(), nil
 }
 
 // EnhancedRecordingSet returns the set of enhanced session recording events to capture.
@@ -148,7 +170,59 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*decisionpb.HostUsersInf
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.HostUsers(srv)
 	}
-	return c.checker.scopedCompatChecker.HostUsers(srv)
+
+	createHostUser := c.checker.role.GetSpec().GetSsh().GetHostUserCreation()
+
+	var hostUserMode types.CreateHostUserMode
+	if err := hostUserMode.UnmarshalText([]byte(createHostUser.GetMode())); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// If no create_host_user block, or mode is OFF/UNSPECIFIED, host user creation is disabled.
+	if hostUserMode == types.CreateHostUserMode_HOST_USER_MODE_OFF ||
+		hostUserMode == types.CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED {
+		return &HostUsersDecision{
+			Info: nil,
+			DeniedBy: []*decisionpb.Determinant{{
+				Kind: c.checker.role.GetKind(),
+				Name: c.checker.role.GetMetadata().GetName(),
+			}},
+		}, nil
+	}
+
+	// Convert to decision
+	var decisionMode decisionpb.HostUserMode
+	switch hostUserMode {
+	case types.CreateHostUserMode_HOST_USER_MODE_KEEP:
+		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_KEEP
+	case types.CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP:
+		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_DROP
+	default:
+		decisionMode = decisionpb.HostUserMode_HOST_USER_MODE_UNSPECIFIED
+	}
+
+	traits := c.checker.Traits()
+	var uid, gid string
+	if uidL := traits[constants.TraitHostUserUID]; len(uidL) >= 1 {
+		uid = uidL[0]
+	}
+	if gidL := traits[constants.TraitHostUserGID]; len(gidL) >= 1 {
+		gid = gidL[0]
+	}
+
+	return &HostUsersDecision{
+		Info: &decisionpb.HostUsersInfo{
+			Groups: createHostUser.GetGroups(),
+			Mode:   decisionMode,
+			Uid:    uid,
+			Gid:    gid,
+			Shell:  createHostUser.GetShell(),
+		},
+		AllowedBy: []*decisionpb.Determinant{{
+			Kind: c.checker.role.GetKind(),
+			Name: c.checker.role.GetMetadata().GetName(),
+		}},
+	}, nil
 }
 
 // CheckAgentForward checks whether SSH agent forwarding is permitted for the given login.
@@ -156,7 +230,11 @@ func (c *SSHAccessChecker) CheckAgentForward(login string) error {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.CheckAgentForward(login)
 	}
-	return c.checker.scopedCompatChecker.CheckAgentForward(login)
+	if !c.checker.role.GetSpec().GetSsh().GetForwardAgent() {
+		return trace.AccessDenied("agent forwarding is not permitted for scoped role %q",
+			c.checker.role.GetMetadata().GetName())
+	}
+	return nil
 }
 
 // MaxConnections returns the maximum number of concurrent SSH connections permitted.
@@ -174,7 +252,7 @@ func (c *SSHAccessChecker) MaxSessions() int64 {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.MaxSessions()
 	}
-	return c.checker.scopedCompatChecker.MaxSessions()
+	return c.checker.role.GetSpec().GetSsh().GetMaxSessions()
 }
 
 // getScopedLogins returns the OS logins permitted by this scoped role. Returns nil for unscoped
@@ -188,9 +266,16 @@ func (c *SSHAccessChecker) getScopedLogins() []string {
 }
 
 // CanCopyFiles returns true if remote file operations via SCP or SFTP are permitted.
+// If GetSshFileCopy is nil, then we default to true.
 func (c *SSHAccessChecker) CanCopyFiles() bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.CanCopyFiles()
 	}
-	return c.checker.scopedCompatChecker.CanCopyFiles()
+
+	ssh := c.checker.role.GetSpec().GetSsh()
+	if ssh == nil || ssh.FileCopy == nil {
+		return true
+	}
+	return ssh.GetFileCopy()
+
 }

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -178,16 +178,10 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*decisionpb.HostUsersInf
 		return nil, trace.Wrap(err)
 	}
 
-	// If no create_host_user block, or mode is OFF/UNSPECIFIED, host user creation is disabled.
+	// If mode is OFF or UNSPECIFIED, host user creation is disabled.
 	if hostUserMode == types.CreateHostUserMode_HOST_USER_MODE_OFF ||
 		hostUserMode == types.CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED {
-		return &HostUsersDecision{
-			Info: nil,
-			DeniedBy: []*decisionpb.Determinant{{
-				Kind: c.checker.role.GetKind(),
-				Name: c.checker.role.GetMetadata().GetName(),
-			}},
-		}, nil
+		return nil, trace.AccessDenied("role %q prevents creating host users", c.checker.role.GetMetadata().GetName())
 	}
 
 	// Convert to decision
@@ -210,18 +204,12 @@ func (c *SSHAccessChecker) HostUsers(srv types.Server) (*decisionpb.HostUsersInf
 		gid = gidL[0]
 	}
 
-	return &HostUsersDecision{
-		Info: &decisionpb.HostUsersInfo{
-			Groups: createHostUser.GetGroups(),
-			Mode:   decisionMode,
-			Uid:    uid,
-			Gid:    gid,
-			Shell:  createHostUser.GetShell(),
-		},
-		AllowedBy: []*decisionpb.Determinant{{
-			Kind: c.checker.role.GetKind(),
-			Name: c.checker.role.GetMetadata().GetName(),
-		}},
+	return &decisionpb.HostUsersInfo{
+		Groups: createHostUser.GetGroups(),
+		Mode:   decisionMode,
+		Uid:    uid,
+		Gid:    gid,
+		Shell:  createHostUser.GetShell(),
 	}, nil
 }
 

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -24,9 +24,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
+	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
 )
 
 // newScopedCheckerWithRole is a test helper that builds a minimal ScopedAccessChecker
@@ -185,6 +188,463 @@ func TestSSHAccessCheckerAdjustClientIdleTimeout(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestSSHAccessCheckerPermitX11Forwarding(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect bool
+	}{
+		{
+			name: "nil ssh block defaults to false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{},
+			},
+			expect: false,
+		},
+		{
+			name: "set true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					PermitX11Forwarding: ptr(true),
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "set false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					PermitX11Forwarding: ptr(false),
+				},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.PermitX11Forwarding())
+		})
+	}
+}
+
+func TestSSHAccessCheckerCheckAgentForward(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name      string
+		spec      *scopedaccessv1.ScopedRoleSpec
+		expectErr bool
+	}{
+		{
+			name: "nil agent forwarding denies",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{},
+			},
+			expectErr: true,
+		},
+		{
+			name: "set true allows",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					ForwardAgent: ptr(true),
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "set false denies",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					ForwardAgent: ptr(false),
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			err := checker.CheckAgentForward("testuser")
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSSHAccessCheckerCanCopyFiles(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect bool
+	}{
+		{
+			name: "nil file_copy defaults to true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					FileCopy: nil,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "true",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					FileCopy: ptr(true),
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "false",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					FileCopy: ptr(false),
+				},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.CanCopyFiles())
+		})
+	}
+}
+
+func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect decisionpb.SSHPortForwardMode
+	}{
+		{
+			name: "nil port forwarding defaults to ON",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					PortForwarding: nil,
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON,
+		},
+		{
+			name: "both enabled",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					PortForwarding: &scopedaccessv1.SSHPortForwarding{
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: ptr(true)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: ptr(true)},
+					},
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON,
+		},
+		{
+			name: "both disabled",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					PortForwarding: &scopedaccessv1.SSHPortForwarding{
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: ptr(false)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: ptr(false)},
+					},
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_OFF,
+		},
+		{
+			name: "local enabled remote disabled",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					PortForwarding: &scopedaccessv1.SSHPortForwarding{
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: ptr(true)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: ptr(false)},
+					},
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_LOCAL,
+		},
+		{
+			name: "local disabled remote enabled",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					PortForwarding: &scopedaccessv1.SSHPortForwarding{
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: ptr(false)},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: ptr(true)},
+					},
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_REMOTE,
+		},
+		{
+			name: "local and remote enabled not set defaults to ON",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					PortForwarding: &scopedaccessv1.SSHPortForwarding{
+						Local:  &scopedaccessv1.SSHLocalPortForwarding{},
+						Remote: &scopedaccessv1.SSHRemotePortForwarding{},
+					},
+				},
+			},
+			expect: decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.SSHPortForwardMode())
+		})
+	}
+}
+
+func TestSSHAccessCheckerMaxSessions(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect int64
+	}{
+		{
+			name: "not set defaults to 0",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{},
+			},
+			expect: 0,
+		},
+		{
+			name: "set to 5",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					MaxSessions: ptr(int64(5)),
+				},
+			},
+			expect: 5,
+		},
+		{
+			name: "set to 0",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					MaxSessions: ptr(int64(0)),
+				},
+			},
+			expect: 0,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.MaxSessions())
+		})
+	}
+}
+
+func TestSSHAccessCheckerHostSudoers(t *testing.T) {
+	t.Parallel()
+
+	srv := &types.ServerV2{}
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect []string
+	}{
+		{
+			name: "no sudoers",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostSudoers: nil,
+				},
+			},
+			expect: nil,
+		},
+		{
+			name: "has sudoers",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostSudoers: []string{"ALL=(ALL) NOPASSWD: ALL"},
+				},
+			},
+			expect: []string{"ALL=(ALL) NOPASSWD: ALL"},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			sudoers, err := checker.HostSudoers(srv)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, sudoers)
+		})
+	}
+}
+
+func TestSSHAccessCheckerHostUsers(t *testing.T) {
+	t.Parallel()
+
+	srv := &types.ServerV2{}
+
+	tts := []struct {
+		name         string
+		spec         *scopedaccessv1.ScopedRoleSpec
+		traits       wrappers.Traits
+		expectNil    bool
+		expectErr    bool
+		expectMode   decisionpb.HostUserMode
+		expectGroups []string
+		expectShell  string
+		expectUID    string
+		expectGID    string
+	}{
+		{
+			name: "nil host_user_creation - denied",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: nil,
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "empty mode string - denied",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						Mode: "",
+					},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "mode off - denied",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						Mode: "off",
+					},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "mode keep",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						Mode:   "keep",
+						Groups: []string{"test"},
+						Shell:  "/bin/bash",
+					},
+				},
+			},
+			expectNil:    false,
+			expectMode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
+			expectGroups: []string{"test"},
+			expectShell:  "/bin/bash",
+		},
+		{
+			name: "mode insecure-drop",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						Mode:   "insecure-drop",
+						Groups: []string{"test"},
+					},
+				},
+			},
+			expectNil:    false,
+			expectMode:   decisionpb.HostUserMode_HOST_USER_MODE_DROP,
+			expectGroups: []string{"test"},
+		},
+		{
+			name: "uid and gid from traits",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						Mode: "keep",
+					},
+				},
+			},
+			traits: wrappers.Traits{
+				constants.TraitHostUserUID: []string{"1001"},
+				constants.TraitHostUserGID: []string{"1001"},
+			},
+			expectNil:  false,
+			expectMode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
+			expectUID:  "1001",
+			expectGID:  "1001",
+		},
+		{
+			name: "invalid mode returns error",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					HostUserCreation: &scopedaccessv1.CreateHostUser{
+						Mode: "invalid",
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			checker.checker.scopedCompatChecker = newAccessChecker(&AccessInfo{
+				Traits: tt.traits,
+			}, "local", NewRoleSet())
+
+			decision, err := checker.HostUsers(srv)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, decision)
+
+			if tt.expectNil {
+				require.Nil(t, decision.Info)
+				require.NotEmpty(t, decision.DeniedBy)
+				return
+			}
+
+			require.NotNil(t, decision.Info, "expected Info to be non-nil (allowed)")
+			require.NotEmpty(t, decision.AllowedBy, "expected AllowedBy to be populated")
+			require.Equal(t, tt.expectMode, decision.Info.Mode)
+			require.Equal(t, tt.expectGroups, decision.Info.Groups)
+			require.Equal(t, tt.expectShell, decision.Info.Shell)
+			require.Equal(t, tt.expectUID, decision.Info.Uid)
+			require.Equal(t, tt.expectGID, decision.Info.Gid)
 		})
 	}
 }

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -30,6 +30,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/trace"
 )
 
 // newScopedCheckerWithRole is a test helper that builds a minimal ScopedAccessChecker
@@ -515,7 +516,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 		name         string
 		spec         *scopedaccessv1.ScopedRoleSpec
 		traits       wrappers.Traits
-		expectNil    bool
+		expectDenied bool
 		expectErr    bool
 		expectMode   decisionpb.HostUserMode
 		expectGroups []string
@@ -530,7 +531,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 					HostUserCreation: nil,
 				},
 			},
-			expectNil: true,
+			expectDenied: true,
 		},
 		{
 			name: "empty mode string - denied",
@@ -541,7 +542,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 					},
 				},
 			},
-			expectNil: true,
+			expectDenied: true,
 		},
 		{
 			name: "mode off - denied",
@@ -552,7 +553,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 					},
 				},
 			},
-			expectNil: true,
+			expectDenied: true,
 		},
 		{
 			name: "mode keep",
@@ -565,7 +566,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 					},
 				},
 			},
-			expectNil:    false,
+			expectDenied: false,
 			expectMode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
 			expectGroups: []string{"test"},
 			expectShell:  "/bin/bash",
@@ -580,7 +581,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 					},
 				},
 			},
-			expectNil:    false,
+			expectDenied: false,
 			expectMode:   decisionpb.HostUserMode_HOST_USER_MODE_DROP,
 			expectGroups: []string{"test"},
 		},
@@ -597,10 +598,10 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 				constants.TraitHostUserUID: []string{"1001"},
 				constants.TraitHostUserGID: []string{"1001"},
 			},
-			expectNil:  false,
-			expectMode: decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
-			expectUID:  "1001",
-			expectGID:  "1001",
+			expectDenied: false,
+			expectMode:   decisionpb.HostUserMode_HOST_USER_MODE_KEEP,
+			expectUID:    "1001",
+			expectGID:    "1001",
 		},
 		{
 			name: "invalid mode returns error",
@@ -629,22 +630,18 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
+			if tt.expectDenied {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+				return
+			}
 			require.NoError(t, err)
 			require.NotNil(t, decision)
 
-			if tt.expectNil {
-				require.Nil(t, decision.Info)
-				require.NotEmpty(t, decision.DeniedBy)
-				return
-			}
-
-			require.NotNil(t, decision.Info, "expected Info to be non-nil (allowed)")
-			require.NotEmpty(t, decision.AllowedBy, "expected AllowedBy to be populated")
-			require.Equal(t, tt.expectMode, decision.Info.Mode)
-			require.Equal(t, tt.expectGroups, decision.Info.Groups)
-			require.Equal(t, tt.expectShell, decision.Info.Shell)
-			require.Equal(t, tt.expectUID, decision.Info.Uid)
-			require.Equal(t, tt.expectGID, decision.Info.Gid)
+			require.Equal(t, tt.expectMode, decision.Mode)
+			require.Equal(t, tt.expectGroups, decision.Groups)
+			require.Equal(t, tt.expectShell, decision.Shell)
+			require.Equal(t, tt.expectUID, decision.Uid)
+			require.Equal(t, tt.expectGID, decision.Gid)
 		})
 	}
 }

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -30,7 +31,6 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
-	"github.com/gravitational/trace"
 )
 
 // newScopedCheckerWithRole is a test helper that builds a minimal ScopedAccessChecker

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
@@ -1522,6 +1523,306 @@ func TestScopedClientIdleTimeout(t *testing.T) {
 			actualTimeout := permit.ClientIdleTimeout.AsDuration()
 			require.Equal(t, tt.expectTimeout, actualTimeout,
 				"ClientIdleTimeout should be %v but got %v", tt.expectTimeout, actualTimeout)
+		})
+	}
+}
+
+// newScopedSSHPermitTestPack is a helper to create newScopedAccessAuthzPack
+func newScopedSSHPermitTestPack(t *testing.T, roles []*scopedaccessv1.ScopedRole) *scopedAccessAuthzPack {
+	t.Helper()
+
+	node, err := types.NewNode("testnode", types.SubKindTeleportNode, types.ServerSpecV2{
+		Addr:     "1.2.3.4:22",
+		Hostname: "testnode",
+	}, map[string]string{
+		"env": "test",
+	})
+	require.NoError(t, err)
+
+	serverV2 := node.(*types.ServerV2)
+	serverV2.Scope = "/staging/west"
+
+	// add standard logins and labels to each role so they match the test node
+	for _, role := range roles {
+		if role.Spec.Ssh.Logins == nil {
+			role.Spec.Ssh.Logins = []string{"testuser"}
+		}
+		if role.Spec.Ssh.Labels == nil {
+			role.Spec.Ssh.Labels = []*labelv1.Label{
+				{Name: "env", Values: []string{"test"}},
+			}
+		}
+	}
+
+	return newScopedAccessAuthzPack(t, serverV2, roles, types.DefaultClusterNetworkingConfig())
+}
+
+func pinForRole(roleName string) *scopesv1.Pin {
+	return &scopesv1.Pin{
+		Scope: "/staging",
+		AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+			"/staging/west": {"/staging/west": {roleName}},
+		}),
+	}
+}
+
+func baseScopedRoleForAuthz(name string) *scopedaccessv1.ScopedRole {
+	return &scopedaccessv1.ScopedRole{
+		Kind:     scopedaccess.KindScopedRole,
+		Metadata: &headerv1.Metadata{Name: name},
+		Scope:    "/staging/west",
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{"/staging/west"},
+			Ssh:              &scopedaccessv1.ScopedRoleSSH{},
+		},
+		Version: types.V1,
+	}
+}
+
+func TestScopedX11Forwarding(t *testing.T) {
+	const x11enabled = "x11-enabled"
+	const x11disabled = "x11-disabled"
+	const x11unset = "x11-unset"
+	enabled := baseScopedRoleForAuthz(x11enabled)
+	enabled.Spec.Ssh.PermitX11Forwarding = proto.Bool(true)
+
+	disabled := baseScopedRoleForAuthz(x11disabled)
+	disabled.Spec.Ssh.PermitX11Forwarding = proto.Bool(false)
+
+	unset := baseScopedRoleForAuthz(x11unset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{enabled, disabled, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect bool
+	}{
+		{"enabled", pinForRole(x11enabled), true},
+		{"disabled", pinForRole(x11disabled), false},
+		{"unset defaults to false", pinForRole(x11unset), false},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.X11Forwarding)
+		})
+	}
+}
+
+func TestScopedForwardAgent(t *testing.T) {
+	const agentEnabled = "agent-enabled"
+	const agentDisabled = "agent-disabled"
+	const agentUnset = "agent-unset"
+
+	enabled := baseScopedRoleForAuthz(agentEnabled)
+	enabled.Spec.Ssh.ForwardAgent = proto.Bool(true)
+
+	disabled := baseScopedRoleForAuthz(agentDisabled)
+	disabled.Spec.Ssh.ForwardAgent = proto.Bool(false)
+
+	unset := baseScopedRoleForAuthz(agentUnset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{enabled, disabled, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect bool
+	}{
+		{"enabled", pinForRole(agentEnabled), true},
+		{"disabled", pinForRole(agentDisabled), false},
+		{"unset defaults to false", pinForRole(agentUnset), false},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.ForwardAgent)
+		})
+	}
+}
+
+func TestScopedSSHFileCopy(t *testing.T) {
+	const copyEnabled = "copy-enabled"
+	const copyDisabled = "copy-disabled"
+	const copyUnset = "copy-unset"
+
+	enabled := baseScopedRoleForAuthz(copyEnabled)
+	enabled.Spec.Ssh.FileCopy = proto.Bool(true)
+
+	disabled := baseScopedRoleForAuthz(copyDisabled)
+	disabled.Spec.Ssh.FileCopy = proto.Bool(false)
+
+	unset := baseScopedRoleForAuthz(copyUnset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{enabled, disabled, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect bool
+	}{
+		{"enabled", pinForRole(copyEnabled), true},
+		{"disabled", pinForRole(copyDisabled), false},
+		{"unset defaults to true", pinForRole(copyUnset), true},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.SshFileCopy)
+		})
+	}
+}
+
+func TestScopedSSHPortForwarding(t *testing.T) {
+	const pfBothOn = "pf-both-on"
+	const pfBothOff = "pf-both-off"
+	const pfLocalOnly = "pf-local-only"
+	const pfUnset = "pf-unset"
+
+	bothOn := baseScopedRoleForAuthz(pfBothOn)
+	bothOn.Spec.Ssh.PortForwarding = &scopedaccessv1.SSHPortForwarding{
+		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(true)},
+		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(true)},
+	}
+
+	bothOff := baseScopedRoleForAuthz(pfBothOff)
+	bothOff.Spec.Ssh.PortForwarding = &scopedaccessv1.SSHPortForwarding{
+		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(false)},
+		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(false)},
+	}
+
+	localOnly := baseScopedRoleForAuthz(pfLocalOnly)
+	localOnly.Spec.Ssh.PortForwarding = &scopedaccessv1.SSHPortForwarding{
+		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: proto.Bool(true)},
+		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: proto.Bool(false)},
+	}
+
+	unset := baseScopedRoleForAuthz(pfUnset)
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{bothOn, bothOff, localOnly, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect decisionpb.SSHPortForwardMode
+	}{
+		{"both on", pinForRole(pfBothOn), decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON},
+		{"both off", pinForRole(pfBothOff), decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_OFF},
+		{"local only", pinForRole(pfLocalOnly), decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_LOCAL},
+		{"unset defaults to on", pinForRole(pfUnset), decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_ON},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.PortForwardMode)
+		})
+	}
+}
+
+func TestScopedMaxSessions(t *testing.T) {
+	const sessions5 = "sessions-5"
+	const sessions1 = "sessions-1"
+	const sessionsUnset = "sessions-unset"
+
+	five := baseScopedRoleForAuthz(sessions5)
+	five.Spec.Ssh.MaxSessions = proto.Int64(5)
+
+	one := baseScopedRoleForAuthz(sessions1)
+	one.Spec.Ssh.MaxSessions = proto.Int64(1)
+
+	unset := baseScopedRoleForAuthz(sessionsUnset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{five, one, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect int64
+	}{
+		{"set to 5", pinForRole(sessions5), 5},
+		{"set to 1", pinForRole(sessions1), 1},
+		{"unset defaults to 0", pinForRole(sessionsUnset), 0},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.MaxSessions)
+		})
+	}
+}
+
+func TestScopedHostUserCreation(t *testing.T) {
+	const hostUserKeep = "host-user-keep"
+	const hostUserOff = "host-user-off"
+	const hostUserUnset = "host-user-unset"
+
+	keep := baseScopedRoleForAuthz(hostUserKeep)
+	keep.Spec.Ssh.HostUserCreation = &scopedaccessv1.CreateHostUser{
+		Mode:   "keep",
+		Groups: []string{"wheel"},
+		Shell:  "/bin/bash",
+	}
+
+	off := baseScopedRoleForAuthz(hostUserOff)
+	off.Spec.Ssh.HostUserCreation = &scopedaccessv1.CreateHostUser{
+		Mode: "off",
+	}
+
+	unset := baseScopedRoleForAuthz(hostUserUnset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{keep, off, unset})
+
+	tts := []struct {
+		name      string
+		pin       *scopesv1.Pin
+		expectNil bool
+	}{
+		{"mode keep", pinForRole(hostUserKeep), false},
+		{"mode off", pinForRole(hostUserOff), true},
+		{"unset defaults to denied", pinForRole(hostUserUnset), true},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			if tt.expectNil {
+				require.Nil(t, permit.HostUsersInfo)
+			} else {
+				require.NotNil(t, permit.HostUsersInfo)
+			}
+		})
+	}
+}
+
+func TestHostSudoers(t *testing.T) {
+	const sudoersPresent = "sudoers-present"
+	const sudoersUnset = "sudoers-unset"
+
+	present := baseScopedRoleForAuthz(sudoersPresent)
+	expectedSudoers := []string{"ALL=(ALL) NOPASSWD:ALL"}
+	present.Spec.Ssh.HostSudoers = expectedSudoers
+	unset := baseScopedRoleForAuthz(sudoersUnset)
+
+	pack := newScopedSSHPermitTestPack(t, []*scopedaccessv1.ScopedRole{present, unset})
+
+	tts := []struct {
+		name   string
+		pin    *scopesv1.Pin
+		expect []string
+	}{
+		{"enabled", pinForRole(sudoersPresent), expectedSudoers},
+		{"unset defaults to false", pinForRole(sudoersUnset), nil},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			permit, err := pack.UserKeyAuthFromPin(t, tt.pin)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, permit.HostSudoers)
 		})
 	}
 }


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/65340

Manually deleted some included kube updates and reran `make grpc`


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Add x11 forwarding, SSH File Copying, Agent Forwarding, SSH Port Forwarding, Create Host User, Max Sessions, and host sudoers to scoped ssh role options


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local teleport cluster + ssh into docker nodes running ubuntu

### Test Cases
X11 Forwarding
- [x] When enabled, can run xeyes in the node
- [x] When disabled, cannot run xeyes in the node

SSH File Copying
- [x] When enabled, can copy file to node
- [x] When enabled, can copy file from node
- [x] When disabled, both directions are rejected

Forward Agent
- [x] When enabled, devtsh ssh -A, then ssh-add -l shows forwarded keys
- [x] When disabled, devtsh ssh -A, then ssh-add -l doesn't show keys

SSH Port Forwarding
- [x] When local=true, devtsh ssh -L 8080:localhost:80 + curl localhost:8080 returns response
- [x] When local=false, devtsh ssh -L 8080:localhost:80 + curl localhost:8080 is rejected
- [x] When remote=true, devtsh ssh -R 9090:localhost:9090 + curl localhost:9090 from node returns response
- [x] When remote=false, devtsh ssh -R 9090:localhost:9090 + curl localhost:9090 from node is rejected

Create Host User
- [x] When mode="keep"(2), SSH as nonexistent user creates OS user that persists after logout
- [x] When mode="drop"(3), SSH as nonexistent user creates OS user that is deleted after logout
- [x] When mode="off"(1), SSH as nonexistent user is rejected
- [x] host_groups: created user is added to specified groups
- [x] host_sudoers: sudo whoami returns root without password prompt `- 'ALL=(ALL) NOPASSWD: ALL'`
- [x] host_shell: echo $SHELL shows /bin/bash

Max Sessions
- [x] With max_sessions=3, opening 3 sessions over one connection succeeds and the 4th one is rejected - repeat by changing the values and making sure that the xth+1 connection fails toconnect.
