### PR TITLE
docs: refactor aws roles anywhere guide

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -58,20 +58,18 @@ For CLI and SDK-based access, use `tsh` to obtain AWS credentials.
 
 ## Step 1/4. Configure AWS IAM Roles Anywhere integration
 
-In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
-
-The recommended approach is to use the guided flow in the Teleport Web UI. If you prefer to
-configure AWS resources manually, for example because you manage them with infrastructure as
-code, see [Manually configure the integration](#manually-configure-the-integration) below.
+In this section, you will configure AWS IAM resources to allow Teleport to issue
+AWS credentials. You can use the guided flow in the Teleport Web UI, or configure
+the AWS resources and Teleport integration manually. Once either path is complete,
+verify the integration is syncing profiles before moving on.
 
 ### Use the guided flow (recommended)
 
 Navigate to the Teleport Web UI, click **Enroll New Resource** on the Resources listing page,
 and follow the guide after clicking the **AWS CLI/Console Access via AWS Roles Anywhere** tile.
 
-When the guide completes, Teleport will start syncing AWS IAM Roles Anywhere profiles as AWS
-applications every 5 minutes. Skip ahead to the "Verify integration sync" checkpoint below to
-confirm the sync is working.
+When the guide completes, Teleport starts syncing AWS IAM Roles Anywhere profiles as AWS
+applications every 5 minutes.
 
 ### Manually configure the integration
 
@@ -221,20 +219,19 @@ Now that the required AWS resources are created, create the Teleport integration
    $ tctl create -f roles-anywhere-integration.yaml
    ```
 
-Teleport will now start syncing AWS IAM Roles Anywhere profiles as AWS applications every 5 minutes.
+### Verify the integration is syncing profiles
 
-<Checkpoint
-  title="Verify integration sync"
-  description="Confirm that Teleport has successfully connected to AWS IAM Roles Anywhere and imported your profiles as AWS applications."
->
+After either the guided flow or the manual configuration completes, Teleport
+begins syncing AWS IAM Roles Anywhere profiles as AWS applications. Sync runs
+every 5 minutes, so allow a few minutes after creation before checking.
 
-1. Confirm the integration status:
+1. Check the integration status from the command line:
 
    ```code
    $ tctl get integration/<Var name="Integration Name" />
    ```
 
-   Look for `status: SUCCESS` and a non-zero `synced_profiles` count in the output:
+   Look for the `status.aws_ra.last_profile_sync` block in the output:
 
    ```yaml
    status:
@@ -245,12 +242,24 @@ Teleport will now start syncing AWS IAM Roles Anywhere profiles as AWS applicati
          error_message: ""
    ```
 
-2. In the Teleport Web UI, navigate to the Resources page and confirm that an AWS application
-   appears for each Roles Anywhere profile.
+   A healthy integration shows `status: SUCCESS`, a non-zero `synced_profiles`
+   count that matches the number of profiles in your AWS account (or the subset
+   matching your `profile_name_filters`), and an empty `error_message`.
 
-Here are some troubleshooting tips:
-- If profiles are not appearing in the Web UI, confirm that `profile_name_filters` is set
-  to `*` to import all profiles, or that your filter matches the profile names in AWS:
+2. Confirm the synced profiles appear in the Web UI. Navigate to the Resources
+   page. Each Roles Anywhere profile should appear as an AWS application named
+   after the profile.
+
+<Checkpoint
+  title="The Roles Anywhere integration is syncing profiles"
+  description="The integration status reports SUCCESS with a non-zero synced_profiles count, and each Roles Anywhere profile appears as an AWS application on the Resources page."
+>
+
+If the integration is not syncing, try the following:
+
+- If `synced_profiles` is `0` or profiles are missing from the Web UI, confirm
+  that `profile_name_filters` is set to `*` to import all profiles, or that
+  your filter matches the profile names in AWS:
 
   ```yaml
   profile_sync_config:
@@ -259,16 +268,19 @@ Here are some troubleshooting tips:
     - '*'
   ```
 
-- If `error_message` is non-empty, check that the `TeleportRolesAnywhereProfileSync` IAM role has
-  the inline policy attached and that the trust anchor ARN and profile ARN in the integration match
-  what was created in AWS.
-- If you see a `Bad Request` error when trying to assume the role via the app in Teleport, the most
-  likely cause is that the Roles Anywhere trust policy JSON was pasted into the **Session policies**
-  field on the profile creation page instead of into the **Custom trust policy** editor on the
-  **Select trusted entity** page when creating the IAM role. Delete the misconfigured resource,
-  return to [Create role](https://console.aws.amazon.com/iam/home?#/roles/create), select
-  **Custom trust policy** on the first page, and paste the JSON there. Leave **Session policies**
-  empty when creating the profile.
+- If `error_message` is non-empty, check that the
+  `TeleportRolesAnywhereProfileSync` IAM role has the inline policy attached
+  and that the trust anchor ARN and profile ARN in the integration match what
+  was created in AWS.
+
+- If you see a `Bad Request` error when trying to assume a role via the app in
+  Teleport, the most likely cause is that the Roles Anywhere trust policy JSON
+  was pasted into the **Session policies** field on the profile creation page
+  instead of into the **Custom trust policy** editor on the **Select trusted
+  entity** page when creating the IAM role. Delete the misconfigured resource,
+  return to [Create role](https://console.aws.amazon.com/iam/home?#/roles/create),
+  select **Custom trust policy** on the first page, and paste the JSON there.
+  Leave **Session policies** empty when creating the profile.
 
 </Checkpoint>
 
@@ -389,33 +401,36 @@ Assign this role to the users you want to grant access. You can also assign it t
 [Access List](../../../identity-governance/access-lists/guide.mdx) or use it with
 [Access Requests](../../../identity-governance/access-requests/access-requests.mdx).
 
+After assigning the role, re-authenticate to pick up the new permissions.
+`<Var name="example.teleport.sh:443" />` is your Teleport Proxy address and
+`<Var name="Username" />` is your Teleport username:
+
+```code
+$ tsh logout
+$ tsh login --proxy=<Var name="example.teleport.sh:443" /> --user=<Var name="Username" />
+```
+
+Confirm the role appears in your session:
+
+```code
+$ tsh status
+```
+
+The `example-read-only-access` role should appear in the roles list.
+
 <Checkpoint
-  title="Confirm your user can use the new role"
-  description="After assigning the role, verify that your user's session reflects the new permissions before moving on to AWS access."
+  title="The new role is active in your Teleport session"
+  description="After logging out and back in, tsh status lists example-read-only-access among your active roles."
 >
 
-1. Re-authenticate to pick up the new permissions.
-   `<Var name="example.teleport.sh:443" />` is your Teleport Proxy address and
-   `<Var name="Username" />` is your Teleport username:
+If the new role is not active, try the following:
 
-   ```code
-   $ tsh logout
-   $ tsh login --proxy=<Var name="example.teleport.sh:443" /> --user=<Var name="Username" />
-   ```
-
-2. Confirm the role appears in your session:
-
-   ```code
-   $ tsh status
-   ```
-
-   The `example-read-only-access` role should appear in the roles list.
-
-Here are some troubleshooting tips:
-- If the AWS profile does not appear in a later step when running `tsh apps login`, the most
-  common cause is needing to log in again. Run `tsh logout` and `tsh login` again before continuing.
-- If the role is not listed in `tsh status`, confirm it was assigned to your user or Access List
-  and that you have logged out and back in since the assignment.
+- If the role is not listed in `tsh status`, confirm it was assigned to your
+  user or Access List and that you have logged out and back in since the
+  assignment.
+- If the AWS profile does not appear in the next step when running
+  `tsh apps login`, the most common cause is needing to log in again. Run
+  `tsh logout` and `tsh login` again before continuing.
 
 </Checkpoint>
 
@@ -476,39 +491,38 @@ provider "aws" {
 
 Setting the `AWS_PROFILE` environment variable is also an option.
 
+#### Confirm credentials are working
+
+Run a basic AWS CLI command to confirm the credentials are valid:
+
+```code
+$ aws --profile example-read-only-access sts get-caller-identity
+```
+
+The output should show the `ExampleReadOnlyAccess` role ARN and your Teleport
+username as the assumed-role session name.
+
+Confirm access is limited to read-only operations as expected:
+
+```code
+$ aws --profile example-read-only-access s3 ls
+```
+
 <Checkpoint
-  title="Verify AWS CLI and SDK access"
-  description="After obtaining credentials with tsh apps login, confirm that your AWS CLI and SDK-based tools can successfully call AWS APIs under the assumed role."
+  title="The AWS CLI can call AWS APIs under the assumed role"
+  description="sts get-caller-identity returns the ExampleReadOnlyAccess role ARN with your Teleport username as the session name, and read-only AWS commands succeed."
 >
 
-1. Confirm `tsh apps login` succeeds and shows the expected role ARN:
+If AWS CLI commands fail, try the following:
 
-   ```code
-   $ tsh apps login --aws-role <Var name="Read Only Role ARN" /> example-read-only-access
-   ```
-
-2. Run a basic AWS CLI command to confirm credentials are working:
-
-   ```code
-   $ aws --profile example-read-only-access sts get-caller-identity
-   ```
-
-   The output should show the `ExampleReadOnlyAccess` role ARN and your Teleport username as the
-   assumed-role session name.
-
-3. Confirm access is limited to read-only operations as expected:
-
-   ```code
-   $ aws --profile example-read-only-access s3 ls
-   ```
-
-Here are some troubleshooting tips:
-- If `tsh apps login` does not list the expected profile, run `tsh logout` and `tsh login`
-  to refresh your session, then try again.
-- If `sts get-caller-identity` returns an error, confirm that the profile ARN in your Teleport
-  role's `app_labels` exactly matches the ARN of the profile created in Step 2/4.
-- If you see an `AccessDenied` error from the AWS CLI, verify that the IAM role has the
-  `ReadOnlyAccess` policy attached and that the Roles Anywhere profile includes that role.
+- If `tsh apps login` does not list the expected profile, run `tsh logout` and
+  `tsh login` to refresh your session, then try again.
+- If `sts get-caller-identity` returns an error, confirm that the profile ARN
+  in your Teleport role's `app_labels` exactly matches the ARN of the profile
+  created in Step 2/4.
+- If you see an `AccessDenied` error from the AWS CLI, verify that the IAM
+  role has the `ReadOnlyAccess` policy attached and that the Roles Anywhere
+  profile includes that role.
 
 </Checkpoint>
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -61,8 +61,8 @@ For CLI and SDK-based access, use `tsh` to obtain AWS credentials.
 In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
 
 The recommended approach is to use the guided flow in the Teleport Web UI. If you prefer to
-configure AWS resources manually — for example, because you manage them with infrastructure as
-code — see [Manually configure the integration](#manually-configure-the-integration) below.
+configure AWS resources manually, for example because you manage them with infrastructure as
+code, see [Manually configure the integration](#manually-configure-the-integration) below.
 
 ### Use the guided flow (recommended)
 
@@ -141,7 +141,7 @@ Next, create the required AWS resources to enable profile sync.
    ```
 
    <Admonition type="warning" title="Trust policy placement">
-   Paste this JSON into the **Custom trust policy** editor on the **Select trusted entity** page —
+   Paste this JSON into the **Custom trust policy** editor on the **Select trusted entity** page,
    not into a permissions policy and not into the **Session policies** field on the profile creation
    page. Placing it in the wrong field will cause a `Bad Request` error when a user tries to assume
    the role.
@@ -303,7 +303,7 @@ If you are already using AWS IAM Roles Anywhere profiles, you can skip this step
    ```
 
    <Admonition type="warning" title="Trust policy placement">
-   Paste this JSON into the **Custom trust policy** editor on the **Select trusted entity** page —
+   Paste this JSON into the **Custom trust policy** editor on the **Select trusted entity** page,
    not into a permissions policy and not into the **Session policies** field on the profile creation
    page. Placing it in the wrong field will cause a `Bad Request` error.
    </Admonition>
@@ -413,7 +413,7 @@ Assign this role to the users you want to grant access. You can also assign it t
 
 Here are some troubleshooting tips:
 - If the AWS profile does not appear in a later step when running `tsh apps login`, the most
-  common cause is a missing re-login. Run `tsh logout` and `tsh login` again before continuing.
+  common cause is needing to log in again. Run `tsh logout` and `tsh login` again before continuing.
 - If the role is not listed in `tsh status`, confirm it was assigned to your user or Access List
   and that you have logged out and back in since the assignment.
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -57,7 +57,7 @@ For CLI and SDK-based access, use `tsh` to obtain AWS credentials.
 In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
 
 Navigate to the Teleport Web UI, click **Enroll New Resource** on the Resources listing page,
-and follow the guide after clicking the **AWS CLI/Console Access** tile.
+and follow the guide after clicking the **AWS CLI/Console Access via AWS Roles Anywhere** tile.
 
 <details>
   <summary>Manually configure the integration</summary>
@@ -208,6 +208,23 @@ and follow the guide after clicking the **AWS CLI/Console Access** tile.
      ```
 
   Teleport will now start syncing AWS IAM Roles Anywhere profiles as AWS applications every 5 minutes.
+  
+  1. Confirm the integration was created and is syncing profiles successfully.
+    
+     ```code
+     $ tctl get integration/<Var name="Integration Name" />
+     ```
+
+  Look for `status: SUCCESS` and a non-zero `synced_profiles` count in the output:
+
+     ```code
+     status:
+       aws_ra:
+         last_profile_sync:
+           status: SUCCESS
+           synced_profiles: 4
+           error_message: ""
+     ```
 
 </details>
 
@@ -217,24 +234,7 @@ and follow the guide after clicking the **AWS CLI/Console Access** tile.
 
 Confirm the integration was created and is syncing profiles successfully.
 
-1. Check the integration status:
-
-   ```code
-   $ tctl get integration/<Var name="Integration Name" />
-   ```
-
-   Look for `status: SUCCESS` and a non-zero `synced_profiles` count in the output:
-
-   ```code
-   status:
-     aws_ra:
-       last_profile_sync:
-         status: SUCCESS
-         synced_profiles: 4
-         error_message: ""
-   ```
-
-2. If profiles are not appearing in the Web UI, confirm that `profile_name_filters` is set
+1. If profiles are not appearing in the Web UI, confirm that `profile_name_filters` is set
    to `*` to import all profiles, or that your filter matches the profile names in AWS:
 
    ```code
@@ -251,7 +251,7 @@ Confirm the integration was created and is syncing profiles successfully.
 - If `error_message` is non-empty, check that the `TeleportRolesAnywhereProfileSync` IAM role has
   the inline policy attached and that the trust anchor ARN and profile ARN in the integration match
   what was created in AWS.
-- If you see a `Bad Request` error during profile or role creation in AWS, the most likely cause is
+- If you see a `Bad Request` error trying to assume the role via the app in Teleport, the most likely cause is
   that the Roles Anywhere trust policy JSON was pasted into the **Session policies** field on the
   profile creation page instead of into the **Custom trust policy** editor on the **Select trusted
   entity** page when creating the IAM role. Delete the misconfigured resource, return to
@@ -324,7 +324,7 @@ Grant your users access to the imported AWS profiles and roles by creating a Tel
 
   1. In the Teleport Web UI, navigate to **Zero Trust Access > Roles** and click **Create New Role**.
 
-  1. Set the role name to `aws-ro-access`.
+  1. Set the role name to `example-read-only-access`.
 
   1. In the **Resources** section, add an **Application Access** entry with the following values:
 
@@ -343,7 +343,7 @@ Grant your users access to the imported AWS profiles and roles by creating a Tel
      kind: role
      version: v8
      metadata:
-       name: aws-ro-access
+       name: example-read-only-access
      spec:
        allow:
          app_labels:
@@ -373,7 +373,7 @@ Assign this role to the users you want to grant access. You can also assign it t
 1. Confirm the role was created:
 
    ```code
-   $ tctl get role/aws-ro-access
+   $ tctl get role/example-read-only-access
    ```
 
    The output should show the role with the correct `app_labels` and `aws_role_arns` values.
@@ -392,7 +392,7 @@ Assign this role to the users you want to grant access. You can also assign it t
    $ tsh status
    ```
 
-   The `aws-ro-access` role should appear in the roles list.
+   The `example-read-only-access` role should appear in the roles list.
 
 - If the AWS profile does not appear in a later step when running `tsh apps login`, the most
   common cause is a missing re-login. Run `tsh logout` and `tsh login` again before continuing.

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -13,13 +13,17 @@ Teleport integrates with AWS IAM Roles Anywhere to provide AWS Console and CLI a
 This allows you to take advantage of Teleport role-based access controls, just-in-time Access Requests,
 and other Teleport Zero Trust Access and Identity Governance capabilities to manage access to your AWS infrastructure.
 
-If you're already using AWS IAM Roles Anywhere and looking to protect access to your AWS environment
-with Teleport while ensuring full compatibility with all AWS API-based tooling (such as CLI tools or
-Terraform), this guide provides a recommended way to do that.
+This guide describes the Roles Anywhere integration, which is the recommended approach when
+you are already using AWS IAM Roles Anywhere and want full compatibility with AWS API-based
+tooling such as the AWS CLI or Terraform. Because Roles Anywhere issues credentials directly
+to the client, AWS API traffic goes from the client to AWS without passing through a Teleport
+Agent or the Teleport Proxy Service at request time. Teleport still controls who can obtain
+credentials and enforces RBAC on every credential issuance, but it is not in the data path
+for subsequent AWS API calls.
 
-If you're looking to provide AWS CLI access to your users with audit capture by going through the
-Teleport Proxy, or if Roles Anywhere is not adopted at your organization, see the guide for
-[agent-based AWS access](aws-console.mdx) instead.
+If you instead want AWS CLI traffic to be proxied by Teleport so that every API call is captured
+in the Teleport audit log, or if Roles Anywhere is not adopted at your organization, see the
+guide for [agent-based AWS access](aws-console.mdx) instead.
 
 This guide will explain how to:
 
@@ -32,8 +36,8 @@ This guide will explain how to:
 
 Teleport uses AWS IAM Roles Anywhere to issue temporary credentials for assuming target IAM roles.
 Access is managed through Teleport's RBAC policies, ensuring credentials are only generated for
-authorized users and roles. No additional service is required, as it runs in the control plane
-(Proxy Service and Auth Service).
+authorized users and roles. No additional Teleport service is required: credential issuance and
+RBAC enforcement are handled by the Teleport control plane (the Auth Service and the Proxy Service).
 
 For web console access, navigate to the Resources page in the Teleport Web UI and click on the
 AWS application named after the Roles Anywhere profile.
@@ -56,206 +60,213 @@ For CLI and SDK-based access, use `tsh` to obtain AWS credentials.
 
 In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
 
+The recommended approach is to use the guided flow in the Teleport Web UI. If you prefer to
+configure AWS resources manually — for example, because you manage them with infrastructure as
+code — see [Manually configure the integration](#manually-configure-the-integration) below.
+
+### Use the guided flow (recommended)
+
 Navigate to the Teleport Web UI, click **Enroll New Resource** on the Resources listing page,
 and follow the guide after clicking the **AWS CLI/Console Access via AWS Roles Anywhere** tile.
 
-<details>
-  <summary>Manually configure the integration</summary>
+When the guide completes, Teleport will start syncing AWS IAM Roles Anywhere profiles as AWS
+applications every 5 minutes. Skip ahead to the "Verify integration sync" checkpoint below to
+confirm the sync is working.
 
-  You will create the following resources in AWS:
+### Manually configure the integration
 
-  | Name                                 | Resource                        | Function                                                                                  |
-  |--------------------------------------|---------------------------------|-------------------------------------------------------------------------------------------|
-  | `TeleportRolesAnywhereIntegrationCA` | IAM Roles Anywhere trust anchor | Allows access from Teleport into AWS.                                                     |
-  | `TeleportRolesAnywhereProfileSync`   | IAM role                        | Allows Teleport to iterate over AWS Roles Anywhere profiles and import them as resources. |
-  | `TeleportRolesAnywhereProfileSync`   | IAM Roles Anywhere profile      | Allows access to the `TeleportRolesAnywhereProfileSync` IAM role.                         |
+If you are not using the guided flow, create the following resources in AWS, then create the
+Teleport integration manually:
 
-  ### Create an IAM Roles Anywhere Trust Anchor
+| Name                                 | Resource                        | Function                                                                                  |
+|--------------------------------------|---------------------------------|-------------------------------------------------------------------------------------------|
+| `TeleportRolesAnywhereIntegrationCA` | IAM Roles Anywhere trust anchor | Allows access from Teleport into AWS.                                                     |
+| `TeleportRolesAnywhereProfileSync`   | IAM role                        | Allows Teleport to iterate over AWS Roles Anywhere profiles and import them as resources. |
+| `TeleportRolesAnywhereProfileSync`   | IAM Roles Anywhere profile      | Allows access to the `TeleportRolesAnywhereProfileSync` IAM role.                         |
 
-  First, create an IAM Roles Anywhere Trust Anchor that trusts Teleport's AWS Roles Anywhere CA.
-  You can reference the AWS Guide [Getting started with IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html).
+#### Create an IAM Roles Anywhere Trust Anchor
 
-  1. Obtain the Teleport certificate:
+First, create an IAM Roles Anywhere Trust Anchor that trusts Teleport's AWS Roles Anywhere CA.
+You can reference the AWS Guide [Getting started with IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html).
 
-     ```code
-     $ tctl auth export --type awsra
-     -----BEGIN CERTIFICATE-----
-     MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
-     ...
-     -----END CERTIFICATE-----
-     ```
+1. Obtain the Teleport certificate:
 
-  1. Navigate to the [Create a trust anchor](https://console.aws.amazon.com/rolesanywhere/home/trust-anchors/create) page in the AWS Console.
-     
-  1. Fill in the form:
+   ```code
+   $ tctl auth export --type awsra
+   -----BEGIN CERTIFICATE-----
+   MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
+   ...
+   -----END CERTIFICATE-----
+   ```
 
-     - **Trust anchor name**: `TeleportRolesAnywhereIntegrationCA`
-     - **Certificate bundle**: select **External certificate bundle**, then paste the full certificate
-       output from the previous step into the text field, including the `-----BEGIN CERTIFICATE-----`
-       and `-----END CERTIFICATE-----` lines.
+1. Navigate to the [Create a trust anchor](https://console.aws.amazon.com/rolesanywhere/home/trust-anchors/create) page in the AWS Console.
 
-  1. Click **Create trust anchor**.
+1. Fill in the form:
 
-  1. On the trust anchor detail page, copy the **Trust Anchor ARN** <Var name="Trust Anchor ARN" />.
+   - **Trust anchor name**: `TeleportRolesAnywhereIntegrationCA`
+   - **Certificate bundle**: select **External certificate bundle**, then paste the full certificate
+     output from the previous step into the text field, including the `-----BEGIN CERTIFICATE-----`
+     and `-----END CERTIFICATE-----` lines.
 
-  ### Set up Profile Sync
+1. Click **Create trust anchor**.
 
-  Next, create the required AWS resources to enable profile sync.
+1. On the trust anchor detail page, copy the **Trust Anchor ARN** <Var name="Trust Anchor ARN" />.
 
-  1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) in the AWS Console.
+#### Set up Profile Sync
 
-  1. On the **Select trusted entity** page, select **Custom trust policy** and replace the default
-     policy with the following:
+Next, create the required AWS resources to enable profile sync.
 
-     ```json
-     {
-         "Version": "2012-10-17",
-         "Statement": [
-             {
-                 "Effect": "Allow",
-                 "Principal": {
-                     "Service": "rolesanywhere.amazonaws.com"
-                 },
-                 "Action": [
-                     "sts:AssumeRole",
-                     "sts:SetSourceIdentity",
-                     "sts:TagSession"
-                 ]
-             }
-         ]
-     }
-     ```
+1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) in the AWS Console.
 
-     <Admonition type="warning" title="Trust policy placement">
-     Paste this JSON into the **Custom trust policy** editor on the **Select trusted entity** page —
-     not into a permissions policy and not into the **Session policies** field on the profile creation
-     page. Placing it in the wrong field will cause a `Bad Request` error. See the
-     "Verify integration sync" checkpoint below for details.
-     </Admonition>
+1. On the **Select trusted entity** page, select **Custom trust policy** and replace the default
+   policy with the following:
 
-  1. On the **Add permissions** page, do not attach any permissions policies yet. Click **Next**.
+   ```json
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Effect": "Allow",
+               "Principal": {
+                   "Service": "rolesanywhere.amazonaws.com"
+               },
+               "Action": [
+                   "sts:AssumeRole",
+                   "sts:SetSourceIdentity",
+                   "sts:TagSession"
+               ]
+           }
+       ]
+   }
+   ```
 
-  1. Name the role `TeleportRolesAnywhereProfileSync` and click **Create role**.
+   <Admonition type="warning" title="Trust policy placement">
+   Paste this JSON into the **Custom trust policy** editor on the **Select trusted entity** page —
+   not into a permissions policy and not into the **Session policies** field on the profile creation
+   page. Placing it in the wrong field will cause a `Bad Request` error when a user tries to assume
+   the role.
+   </Admonition>
 
-  1. On the role detail page, copy the **Role ARN** <Var name="Role ARN" />.
+1. On the **Add permissions** page, do not attach any permissions policies yet. Click **Next**.
 
-  1. On the same role detail page, select the **Permissions** tab and click
-     **Add permissions > Create inline policy**.
+1. Name the role `TeleportRolesAnywhereProfileSync` and click **Create role**.
 
-     Switch to the **JSON** view and enter the following:
+1. On the role detail page, copy the **Role ARN** <Var name="Role ARN" />.
 
-     ```json
-     {
-         "Version": "2012-10-17",
-         "Statement": [
-             {
-                 "Sid": "RolesAnywhereProfileSync",
-                 "Effect": "Allow",
-                 "Action": [
-                     "rolesanywhere:ListProfiles",
-                     "rolesanywhere:ListTagsForResource",
-                     "rolesanywhere:ImportCrl",
-                     "iam:GetRole"
-                 ],
-                 "Resource": [
-                     "*"
-                 ]
-             }
-         ]
-     }
-     ```
+1. On the same role detail page, select the **Permissions** tab and click
+   **Add permissions > Create inline policy**.
 
-     Name the policy and click **Create policy**.
+   Switch to the **JSON** view and enter the following:
 
-  1. Navigate to [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create)
-     in the AWS Console.
+   ```json
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Sid": "RolesAnywhereProfileSync",
+               "Effect": "Allow",
+               "Action": [
+                   "rolesanywhere:ListProfiles",
+                   "rolesanywhere:ListTagsForResource",
+                   "rolesanywhere:ImportCrl",
+                   "iam:GetRole"
+               ],
+               "Resource": [
+                   "*"
+               ]
+           }
+       ]
+   }
+   ```
 
-  1. Fill in the form:
+   Name the policy and click **Create policy**.
 
-     - **Profile name**: `TeleportRolesAnywhereProfileSync`
-     - **Roles**: add the `TeleportRolesAnywhereProfileSync` role you just created.
-     - Leave **Session policies** empty.
+1. Navigate to [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create)
+   in the AWS Console.
 
-     Click **Create profile**.
+1. Fill in the form:
 
-  1. On the profile detail page, copy the **Profile ARN** <Var name="Profile ARN" />.
+   - **Profile name**: `TeleportRolesAnywhereProfileSync`
+   - **Roles**: add the `TeleportRolesAnywhereProfileSync` role you just created.
+   - Leave **Session policies** empty.
 
-  ### Create a Teleport AWS IAM Roles Anywhere integration
+   Click **Create profile**.
 
-  Now that the required AWS resources are created, create the Teleport integration.
+1. On the profile detail page, copy the **Profile ARN** <Var name="Profile ARN" />.
 
-  1. Write the following contents to a file called `roles-anywhere-integration.yaml`:
+#### Create a Teleport AWS IAM Roles Anywhere integration
 
-     ```yaml
-     kind: integration
-     sub_kind: aws-ra
-     version: v1
-     metadata:
-       name: <Var name="Integration Name" />
-     spec:
-       aws_ra:
-         trust_anchor_arn: <Var name="Trust Anchor ARN" />
-         profile_sync_config:
-           enabled: true
-           profile_arn: <Var name="Profile ARN" />
-           role_arn: <Var name="Role ARN" />
-     ```
+Now that the required AWS resources are created, create the Teleport integration.
 
-  1. Create the integration:
+1. Write the following contents to a file called `roles-anywhere-integration.yaml`:
 
-     ```code
-     $ tctl create -f roles-anywhere-integration.yaml
-     ```
+   ```yaml
+   kind: integration
+   sub_kind: aws-ra
+   version: v1
+   metadata:
+     name: <Var name="Integration Name" />
+   spec:
+     aws_ra:
+       trust_anchor_arn: <Var name="Trust Anchor ARN" />
+       profile_sync_config:
+         enabled: true
+         profile_arn: <Var name="Profile ARN" />
+         role_arn: <Var name="Role ARN" />
+   ```
 
-  Teleport will now start syncing AWS IAM Roles Anywhere profiles as AWS applications every 5 minutes.
-  
-  1. Confirm the integration was created and is syncing profiles successfully.
-    
-     ```code
-     $ tctl get integration/<Var name="Integration Name" />
-     ```
+1. Create the integration:
 
-  Look for `status: SUCCESS` and a non-zero `synced_profiles` count in the output:
+   ```code
+   $ tctl create -f roles-anywhere-integration.yaml
+   ```
 
-     ```code
-     status:
-       aws_ra:
-         last_profile_sync:
-           status: SUCCESS
-           synced_profiles: 4
-           error_message: ""
-     ```
-
-</details>
+Teleport will now start syncing AWS IAM Roles Anywhere profiles as AWS applications every 5 minutes.
 
 <Checkpoint
   title="Verify integration sync"
+  description="Confirm that Teleport has successfully connected to AWS IAM Roles Anywhere and imported your profiles as AWS applications."
 >
 
-Confirm the integration was created and is syncing profiles successfully.
-
-1. If profiles are not appearing in the Web UI, confirm that `profile_name_filters` is set
-   to `*` to import all profiles, or that your filter matches the profile names in AWS:
+1. Confirm the integration status:
 
    ```code
    $ tctl get integration/<Var name="Integration Name" />
    ```
 
+   Look for `status: SUCCESS` and a non-zero `synced_profiles` count in the output:
+
    ```yaml
-   profile_sync_config:
-     enabled: true
-     profile_name_filters:
-     - '*'
+   status:
+     aws_ra:
+       last_profile_sync:
+         status: SUCCESS
+         synced_profiles: 4
+         error_message: ""
    ```
+
+2. In the Teleport Web UI, navigate to the Resources page and confirm that an AWS application
+   appears for each Roles Anywhere profile.
+
+Here are some troubleshooting tips:
+- If profiles are not appearing in the Web UI, confirm that `profile_name_filters` is set
+  to `*` to import all profiles, or that your filter matches the profile names in AWS:
+
+  ```yaml
+  profile_sync_config:
+    enabled: true
+    profile_name_filters:
+    - '*'
+  ```
 
 - If `error_message` is non-empty, check that the `TeleportRolesAnywhereProfileSync` IAM role has
   the inline policy attached and that the trust anchor ARN and profile ARN in the integration match
   what was created in AWS.
-- If you see a `Bad Request` error trying to assume the role via the app in Teleport, the most likely cause is
-  that the Roles Anywhere trust policy JSON was pasted into the **Session policies** field on the
-  profile creation page instead of into the **Custom trust policy** editor on the **Select trusted
-  entity** page when creating the IAM role. Delete the misconfigured resource, return to
-  [Create role](https://console.aws.amazon.com/iam/home?#/roles/create), select
+- If you see a `Bad Request` error when trying to assume the role via the app in Teleport, the most
+  likely cause is that the Roles Anywhere trust policy JSON was pasted into the **Session policies**
+  field on the profile creation page instead of into the **Custom trust policy** editor on the
+  **Select trusted entity** page when creating the IAM role. Delete the misconfigured resource,
+  return to [Create role](https://console.aws.amazon.com/iam/home?#/roles/create), select
   **Custom trust policy** on the first page, and paste the JSON there. Leave **Session policies**
   empty when creating the profile.
 
@@ -333,6 +344,10 @@ Grant your users access to the imported AWS profiles and roles by creating a Tel
 
   1. Click through the remaining steps and create the role.
 
+  1. Verify the role was created by navigating back to **Zero Trust Access > Roles**. The
+     `example-read-only-access` role should appear in the list with the labels and ARN values
+     you entered.
+
   </TabItem>
 
   <TabItem label="Via tctl">
@@ -359,6 +374,14 @@ Grant your users access to the imported AWS profiles and roles by creating a Tel
      $ tctl create -f example-read-only-access-role.yaml
      ```
 
+  1. Verify the role was created and contains the expected values:
+
+     ```code
+     $ tctl get role/example-read-only-access
+     ```
+
+     The output should show the role with the correct `app_labels` and `aws_role_arns` values.
+
   </TabItem>
 </Tabs>
 
@@ -367,26 +390,20 @@ Assign this role to the users you want to grant access. You can also assign it t
 [Access Requests](../../../identity-governance/access-requests/access-requests.mdx).
 
 <Checkpoint
-  title="Verify role creation and re-login"
+  title="Confirm your user can use the new role"
+  description="After assigning the role, verify that your user's session reflects the new permissions before moving on to AWS access."
 >
 
-1. Confirm the role was created:
-
-   ```code
-   $ tctl get role/example-read-only-access
-   ```
-
-   The output should show the role with the correct `app_labels` and `aws_role_arns` values.
-
-2. Assign the role to your user, then run the following to pick up the new permissions.
-   `<Var name="example.teleport.sh:443" />` is your Teleport Proxy address and `<Var name="Username" />` is your Teleport username:
+1. Re-authenticate to pick up the new permissions.
+   `<Var name="example.teleport.sh:443" />` is your Teleport Proxy address and
+   `<Var name="Username" />` is your Teleport username:
 
    ```code
    $ tsh logout
    $ tsh login --proxy=<Var name="example.teleport.sh:443" /> --user=<Var name="Username" />
    ```
 
-3. Confirm the role appears in your session:
+2. Confirm the role appears in your session:
 
    ```code
    $ tsh status
@@ -394,6 +411,7 @@ Assign this role to the users you want to grant access. You can also assign it t
 
    The `example-read-only-access` role should appear in the roles list.
 
+Here are some troubleshooting tips:
 - If the AWS profile does not appear in a later step when running `tsh apps login`, the most
   common cause is a missing re-login. Run `tsh logout` and `tsh login` again before continuing.
 - If the role is not listed in `tsh status`, confirm it was assigned to your user or Access List
@@ -403,18 +421,24 @@ Assign this role to the users you want to grant access. You can also assign it t
 
 ## Step 4/4. Access AWS resources
 
+In this step, you will access AWS under the role you granted yourself in Step 3/4. This section
+covers two workflows: signing into the AWS Management Console through the Teleport Web UI, and
+obtaining AWS credentials for the AWS CLI, SDKs, and tools like Terraform.
+
 ### Access AWS Management Console
 
 1. In the Teleport Web UI, click **Resources**. Each synced Roles Anywhere profile will appear
-   as an AWS application. If you don't see any profiles, return to the
-   "Verify integration sync" checkpoint in Step 1/4.
+   as an AWS application.
 1. Click **Launch** on the AWS Console application, then select the IAM role you want to assume.
 1. You will be redirected to the AWS Management Console, signed in under the selected role.
    Your Teleport username will appear as a federated login in the top-right corner of the console.
 
-### Access AWS using AWS CLI or other AWS SDK-based tools
+### Access AWS using the AWS CLI or AWS SDK-based tools
 
-### Obtain the credentials
+To use AWS CLI-based or SDK-based tools, first obtain credentials by logging into the AWS app,
+then point your tool at the resulting AWS profile.
+
+#### Obtain the credentials
 
 Log into the AWS app profile that was synced:
 
@@ -430,7 +454,7 @@ Logged into AWS app "example-read-only-access".
     AWS_PROFILE=example-read-only-access aws s3 ls
 ```
 
-### Access AWS using AWS CLI
+#### Access AWS using the AWS CLI
 
 Pass the `--profile` flag or export `AWS_PROFILE` with the profile name:
 
@@ -439,7 +463,7 @@ $ aws --profile example-read-only-access s3 ls
 ...
 ```
 
-### Access AWS from Terraform
+#### Access AWS from Terraform
 
 Set the profile in the provider block:
 
@@ -453,7 +477,8 @@ provider "aws" {
 Setting the `AWS_PROFILE` environment variable is also an option.
 
 <Checkpoint
-  title="Verify AWS access"
+  title="Verify AWS CLI and SDK access"
+  description="After obtaining credentials with tsh apps login, confirm that your AWS CLI and SDK-based tools can successfully call AWS APIs under the assumed role."
 >
 
 1. Confirm `tsh apps login` succeeds and shows the expected role ARN:
@@ -468,7 +493,8 @@ Setting the `AWS_PROFILE` environment variable is also an option.
    $ aws --profile example-read-only-access sts get-caller-identity
    ```
 
-   The output should show the `ExampleReadOnlyAccess` role ARN and your Teleport username as the assumed-role session name.
+   The output should show the `ExampleReadOnlyAccess` role ARN and your Teleport username as the
+   assumed-role session name.
 
 3. Confirm access is limited to read-only operations as expected:
 
@@ -476,6 +502,7 @@ Setting the `AWS_PROFILE` environment variable is also an option.
    $ aws --profile example-read-only-access s3 ls
    ```
 
+Here are some troubleshooting tips:
 - If `tsh apps login` does not list the expected profile, run `tsh logout` and `tsh login`
   to refresh your session, then try again.
 - If `sts get-caller-identity` returns an error, confirm that the profile ARN in your Teleport

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -458,7 +458,7 @@ then point your tool at the resulting AWS profile.
 Log into the AWS app profile that was synced:
 
 ```code
-$ tsh apps login --aws-role arn:aws:iam::278576220453:role/ExampleReadOnlyAccess example-read-only-access
+$ tsh apps login --aws-role arn:aws:iam::123456789012:role/ExampleReadOnlyAccess example-read-only-access
 Logged into AWS app "example-read-only-access".
 
 # Your IAM role:
@@ -539,8 +539,10 @@ a SAML attribute or OIDC claim called `aws_role_arns`, then reference it in a Te
     - {{external.aws_role_arns}}
 ```
 
-See the [Access Controls Reference](../../../reference/access-controls/roles.mdx) for all
-variables and functions available in the `aws_role_arns` field.
+See "Template expressions for access to infrastructure resources" in the
+[Access Controls Reference](../../../reference/access-controls/roles.mdx) for
+the traits (like `{{internal.aws_role_arns}}` and `{{external.xyz}}`) and
+functions available in the `aws_role_arns` field.
 
 ### Create roles to grant access to specific profiles and IAM roles
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -10,10 +10,16 @@ tags:
 ---
 
 Teleport integrates with AWS IAM Roles Anywhere to provide AWS Console and CLI access.
-This allows you to take advantage of Teleport role-based access controls, just-in-time Access Requests and other Teleport Zero Trust Access and Identity Governance capabilities to manage access to your AWS infrastructure.
+This allows you to take advantage of Teleport role-based access controls, just-in-time Access Requests,
+and other Teleport Zero Trust Access and Identity Governance capabilities to manage access to your AWS infrastructure.
 
-If you're already using AWS IAM Roles Anywhere and looking to protect access to your AWS environment with Teleport, while ensuring full compatibility with all AWS API based tooling (such as CLI tools or terraform), this guide provides a recommended way for you to do that.
-If you're looking to provide AWS CLI access to your users with audit capture by going through Teleport proxy, or Roles Anywhere are not adopted at your organization, take a look at the guide for [agent-based AWS access](aws-console.mdx) instead.
+If you're already using AWS IAM Roles Anywhere and looking to protect access to your AWS environment
+with Teleport while ensuring full compatibility with all AWS API-based tooling (such as CLI tools or
+Terraform), this guide provides a recommended way to do that.
+
+If you're looking to provide AWS CLI access to your users with audit capture by going through the
+Teleport Proxy, or if Roles Anywhere is not adopted at your organization, see the guide for
+[agent-based AWS access](aws-console.mdx) instead.
 
 This guide will explain how to:
 
@@ -25,13 +31,14 @@ This guide will explain how to:
 ## How it works
 
 Teleport uses AWS IAM Roles Anywhere to issue temporary credentials for assuming target IAM roles.
+Access is managed through Teleport's RBAC policies, ensuring credentials are only generated for
+authorized users and roles. No additional service is required, as it runs in the control plane
+(Proxy Service and Auth Service).
 
-Access is managed through Teleport's RBAC policies, ensuring credentials are only generated for authorized users and roles.
-No additional service is required, as it runs in the control plane (Proxy Service and Auth Service).
+For web console access, navigate to the Resources page in the Teleport Web UI and click on the
+AWS application named after the Roles Anywhere profile.
 
-For web console access, you can navigate to the resources page in Teleport Web UI and click on the AWS Application which is named after the Roles Anywhere profile.
-
-For CLI and SDK based access, you must use `tsh` to obtain AWS credentials.
+For CLI and SDK-based access, use `tsh` to obtain AWS credentials.
 
 ## Prerequisites
 
@@ -39,18 +46,18 @@ For CLI and SDK based access, you must use `tsh` to obtain AWS credentials.
 
 - (!docs/pages/includes/tctl.mdx!)
 - Permissions in AWS to:
-  - create IAM Roles Anywhere trust anchor
-  - create IAM Roles Anywhere profiles
-  - create IAM roles
-- `aws` command line interface (CLI) tool in PATH. Read the AWS documentation to
-  [install or update the latest version of the AWS
-  CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html).
+  - Create IAM Roles Anywhere trust anchors
+  - Create IAM Roles Anywhere profiles
+  - Create IAM roles
+- The `aws` CLI tool installed and in PATH. See the AWS documentation to
+  [install or update the latest version of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html).
 
 ## Step 1/4. Configure AWS IAM Roles Anywhere integration
 
 In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
 
-Navigate to the Teleport Web UI, click on Enroll New Resource in the Resources listing page, and follow the guide after clicking on AWS CLI/Console Access tile.
+Navigate to the Teleport Web UI, click **Enroll New Resource** on the Resources listing page,
+and follow the guide after clicking the **AWS CLI/Console Access** tile.
 
 <details>
   <summary>Manually configure the integration</summary>
@@ -59,15 +66,17 @@ Navigate to the Teleport Web UI, click on Enroll New Resource in the Resources l
 
   | Name                                 | Resource                        | Function                                                                                  |
   |--------------------------------------|---------------------------------|-------------------------------------------------------------------------------------------|
-  | `TeleportRolesAnywhereIntegrationCA` | IAM Roles Anywhere trust anchor | Allow access from Teleport into AWS.                                                      |
+  | `TeleportRolesAnywhereIntegrationCA` | IAM Roles Anywhere trust anchor | Allows access from Teleport into AWS.                                                     |
   | `TeleportRolesAnywhereProfileSync`   | IAM role                        | Allows Teleport to iterate over AWS Roles Anywhere profiles and import them as resources. |
-  | `TeleportRolesAnywhereProfileSync`   | IAM Roles Anywhere profile      | Allows access to `TeleportRolesAnywhereProfileSync` IAM role.                             |
+  | `TeleportRolesAnywhereProfileSync`   | IAM Roles Anywhere profile      | Allows access to the `TeleportRolesAnywhereProfileSync` IAM role.                         |
 
   ### Create an IAM Roles Anywhere Trust Anchor
 
-  First, you will create an IAM Roles Anywhere Trust Anchor which trusts the Teleport's AWS Roles Anywhere CA.
+  First, create an IAM Roles Anywhere Trust Anchor that trusts Teleport's AWS Roles Anywhere CA.
+  You can reference the AWS Guide [Getting started with IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html).
 
   1. Obtain the Teleport certificate:
+
      ```code
      $ tctl auth export --type awsra
      -----BEGIN CERTIFICATE-----
@@ -75,211 +84,365 @@ Navigate to the Teleport Web UI, click on Enroll New Resource in the Resources l
      ...
      -----END CERTIFICATE-----
      ```
-  1. Navigate to [Create a trust anchor](https://console.aws.amazon.com/rolesanywhere/home/trust-anchors/create) page.
-    Name the trust anchor `TeleportRolesAnywhereIntegrationCA` and add the Teleport's `awsra` CA certificate you obtained in the previous step as an External certificate bundle.
-  1. Copy the Trust Anchor ARN <Var name="Trust Anchor ARN" />
+
+  1. Navigate to the [Create a trust anchor](https://console.aws.amazon.com/rolesanywhere/home/trust-anchors/create) page in the AWS Console.
+     
+  1. Fill in the form:
+
+     - **Trust anchor name**: `TeleportRolesAnywhereIntegrationCA`
+     - **Certificate bundle**: select **External certificate bundle**, then paste the full certificate
+       output from the previous step into the text field, including the `-----BEGIN CERTIFICATE-----`
+       and `-----END CERTIFICATE-----` lines.
+
+  1. Click **Create trust anchor**.
+
+  1. On the trust anchor detail page, copy the **Trust Anchor ARN** <Var name="Trust Anchor ARN" />.
 
   ### Set up Profile Sync
 
-  Next, you will create the required AWS resources to enable the profile sync.
+  Next, create the required AWS resources to enable profile sync.
 
-  1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM role called `TeleportRolesAnywhereProfileSync`.
-    Trust policy must include the Roles Anywhere service principal:
-    ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Principal": {
-                    "Service": "rolesanywhere.amazonaws.com"
-                },
-                "Action": [
-                    "sts:AssumeRole",
-                    "sts:SetSourceIdentity",
-                    "sts:TagSession"
-                ]
-            }
-        ]
-    }
-    ```
-  1. Copy the IAM role ARN <Var name="Role ARN" />
-  1. Navigate to the [TeleportRolesAnywhereProfileSync Role](https://console.aws.amazon.com/iam/home?#/roles/details/TeleportRolesAnywhereProfileSync) and create a new inline policy:
-    ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Sid": "RolesAnywhereProfileSync",
-                "Effect": "Allow",
-                "Action": [
-                    "rolesanywhere:ListProfiles",
-                    "rolesanywhere:ListTagsForResource",
-                    "rolesanywhere:ImportCrl",
-                    "iam:GetRole"
-                ],
-                "Resource": [
-                    "*"
-                ]
-            }
-        ]
-    }
-    ```
+  1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) in the AWS Console.
 
-  1. Now, navigate to the [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `TeleportRolesAnywhereProfileSync`.
-    Add the role created in the last step (`TeleportRolesAnywhereProfileSync`) and create the Profile.
-  1. Copy the Profile ARN <Var name="Profile ARN" />
+  1. On the **Select trusted entity** page, select **Custom trust policy** and replace the default
+     policy with the following:
+
+     ```json
+     {
+         "Version": "2012-10-17",
+         "Statement": [
+             {
+                 "Effect": "Allow",
+                 "Principal": {
+                     "Service": "rolesanywhere.amazonaws.com"
+                 },
+                 "Action": [
+                     "sts:AssumeRole",
+                     "sts:SetSourceIdentity",
+                     "sts:TagSession"
+                 ]
+             }
+         ]
+     }
+     ```
+
+     <Admonition type="warning" title="Trust policy placement">
+     Paste this JSON into the **Custom trust policy** editor on the **Select trusted entity** page —
+     not into a permissions policy and not into the **Session policies** field on the profile creation
+     page. Placing it in the wrong field will cause a `Bad Request` error. See the
+     "Verify integration sync" checkpoint below for details.
+     </Admonition>
+
+  1. On the **Add permissions** page, do not attach any permissions policies yet. Click **Next**.
+
+  1. Name the role `TeleportRolesAnywhereProfileSync` and click **Create role**.
+
+  1. On the role detail page, copy the **Role ARN** <Var name="Role ARN" />.
+
+  1. On the same role detail page, select the **Permissions** tab and click
+     **Add permissions > Create inline policy**.
+
+     Switch to the **JSON** view and enter the following:
+
+     ```json
+     {
+         "Version": "2012-10-17",
+         "Statement": [
+             {
+                 "Sid": "RolesAnywhereProfileSync",
+                 "Effect": "Allow",
+                 "Action": [
+                     "rolesanywhere:ListProfiles",
+                     "rolesanywhere:ListTagsForResource",
+                     "rolesanywhere:ImportCrl",
+                     "iam:GetRole"
+                 ],
+                 "Resource": [
+                     "*"
+                 ]
+             }
+         ]
+     }
+     ```
+
+     Name the policy and click **Create policy**.
+
+  1. Navigate to [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create)
+     in the AWS Console.
+
+  1. Fill in the form:
+
+     - **Profile name**: `TeleportRolesAnywhereProfileSync`
+     - **Roles**: add the `TeleportRolesAnywhereProfileSync` role you just created.
+     - Leave **Session policies** empty.
+
+     Click **Create profile**.
+
+  1. On the profile detail page, copy the **Profile ARN** <Var name="Profile ARN" />.
 
   ### Create a Teleport AWS IAM Roles Anywhere integration
-  Now that the required AWS resources are created, you can create a Teleport AWS IAM Roles Anywhere integration.
+
+  Now that the required AWS resources are created, create the Teleport integration.
 
   1. Write the following contents to a file called `roles-anywhere-integration.yaml`:
-    ```yaml
-    kind: integration
-    sub_kind: aws-ra
-    version: v1
-    metadata:
-      name: <Var name="Integration Name" />
-    spec:
-      aws_ra:
-        trust_anchor_arn: <Var name="Trust Anchor ARN" />
-        profile_sync_config:
-          enabled: true
-          profile_arn: <Var name="Profile ARN" />
-          role_arn: <Var name="Role ARN" />
-    ```
 
-  1. Create the integration with the following command:
-    ```code
-    $ tctl create -f roles-anywhere-integration.yaml
-    ```
+     ```yaml
+     kind: integration
+     sub_kind: aws-ra
+     version: v1
+     metadata:
+       name: <Var name="Integration Name" />
+     spec:
+       aws_ra:
+         trust_anchor_arn: <Var name="Trust Anchor ARN" />
+         profile_sync_config:
+           enabled: true
+           profile_arn: <Var name="Profile ARN" />
+           role_arn: <Var name="Role ARN" />
+     ```
 
-  Teleport will now start syncing AWS IAM Roles Anywhere profiles as AWS applications, every 5 minutes.
+  1. Create the integration:
+
+     ```code
+     $ tctl create -f roles-anywhere-integration.yaml
+     ```
+
+  Teleport will now start syncing AWS IAM Roles Anywhere profiles as AWS applications every 5 minutes.
+
 </details>
+
+<Checkpoint
+  title="Verify integration sync"
+>
+
+Confirm the integration was created and is syncing profiles successfully.
+
+1. Check the integration status:
+
+   ```code
+   $ tctl get integration/<Var name="Integration Name" />
+   ```
+
+   Look for `status: SUCCESS` and a non-zero `synced_profiles` count in the output:
+
+   ```code
+   status:
+     aws_ra:
+       last_profile_sync:
+         status: SUCCESS
+         synced_profiles: 4
+         error_message: ""
+   ```
+
+2. If profiles are not appearing in the Web UI, confirm that `profile_name_filters` is set
+   to `*` to import all profiles, or that your filter matches the profile names in AWS:
+
+   ```code
+   $ tctl get integration/<Var name="Integration Name" />
+   ```
+
+   ```yaml
+   profile_sync_config:
+     enabled: true
+     profile_name_filters:
+     - '*'
+   ```
+
+- If `error_message` is non-empty, check that the `TeleportRolesAnywhereProfileSync` IAM role has
+  the inline policy attached and that the trust anchor ARN and profile ARN in the integration match
+  what was created in AWS.
+- If you see a `Bad Request` error during profile or role creation in AWS, the most likely cause is
+  that the Roles Anywhere trust policy JSON was pasted into the **Session policies** field on the
+  profile creation page instead of into the **Custom trust policy** editor on the **Select trusted
+  entity** page when creating the IAM role. Delete the misconfigured resource, return to
+  [Create role](https://console.aws.amazon.com/iam/home?#/roles/create), select
+  **Custom trust policy** on the first page, and paste the JSON there. Leave **Session policies**
+  empty when creating the profile.
+
+</Checkpoint>
 
 ## Step 2/4. Create an AWS IAM Roles Anywhere profile and assign IAM roles
 
-Now, you will create an example profile and role so that you can test the integration.
+Now you will create an example profile and role to test the integration.
 
-If you are already leveraging AWS IAM Roles Anywhere profiles, you can skip this step.
+If you are already using AWS IAM Roles Anywhere profiles, you can skip this step.
 
-1. Navigate to [Create role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM role called `ExampleReadOnlyAccess`.
-  Trust policy must include the Roles Anywhere service principal:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Principal": {
-                  "Service": "rolesanywhere.amazonaws.com"
-              },
-              "Action": [
-                  "sts:AssumeRole",
-                  "sts:SetSourceIdentity",
-                  "sts:TagSession"
-              ]
-          }
-      ]
-  }
-  ```
+1. Navigate to [Create role](https://console.aws.amazon.com/iam/home?#/roles/create) in the AWS Console.
 
-  Add the AWS-managed `ReadOnlyAccess` policy to the role.
-  Copy the role ARN <Var name="Read Only Role ARN" />.
+1. On the **Select trusted entity** page, select **Custom trust policy** and replace the default
+   policy with the following:
 
-1. Now, navigate to [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `ExampleReadOnlyAccess`.
-  Add the role created in the last step (`ExampleReadOnlyAccess`) and create the Profile.
-  
-  Copy the Profile ARN <Var name="Read Only Profile ARN" />.
+   ```json
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Effect": "Allow",
+               "Principal": {
+                   "Service": "rolesanywhere.amazonaws.com"
+               },
+               "Action": [
+                   "sts:AssumeRole",
+                   "sts:SetSourceIdentity",
+                   "sts:TagSession"
+               ]
+           }
+       ]
+   }
+   ```
+
+   <Admonition type="warning" title="Trust policy placement">
+   Paste this JSON into the **Custom trust policy** editor on the **Select trusted entity** page —
+   not into a permissions policy and not into the **Session policies** field on the profile creation
+   page. Placing it in the wrong field will cause a `Bad Request` error.
+   </Admonition>
+
+1. On the **Add permissions** page, search for and attach the AWS-managed `ReadOnlyAccess` policy.
+
+1. Name the role `ExampleReadOnlyAccess` and click **Create role**.
+
+1. On the role detail page, copy the **Role ARN** <Var name="Read Only Role ARN" />.
+
+1. Navigate to [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) in the AWS Console.
+
+1. Fill in the form:
+
+   - **Profile name**: `ExampleReadOnlyAccess`
+   - **Roles**: add the `ExampleReadOnlyAccess` role you just created.
+   - Leave **Session policies** empty, then click **Create profile**.
+
+1. On the profile detail page, copy the **Profile ARN** <Var name="Read Only Profile ARN" />.
 
 ## Step 3/4. Set up access
-Now you need to grant your users access to the imported AWS profiles/roles.
-You will create a Teleport role which will grant access to the `ExampleReadOnlyAccess` Profile and associated IAM role.
 
-  <Tabs>
-    <TabItem label="Web UI">
-    Open your Teleport cluster Web UI, select the "Zero Trust Access" and then "Roles".
+{/* vale messaging.protocol-products = NO */}
 
-    Click the "Create New Role" button, set the role name to `aws-ro-access`.
-    Next, add an Application Access entry, in the Resources section, with the following:
-    - Labels: `teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'`
-    - AWS Role ARNs: <Var name="Read Only Role ARN" />
+Grant your users access to the imported AWS profiles and roles by creating a Teleport role.
 
-    Proceed to the next steps and create the role.
-    </TabItem>
+<Tabs>
+  <TabItem label="Web UI">
 
-    <TabItem label="Via tctl">
-      1. Create a file named `example-read-only-access-role.yaml` with the following contents:
-        ```yaml
-        kind: role
-        version: v8
-        metadata:
-          name: aws-ro-access
-        spec:
-          allow:
-            app_labels:
-              'teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'
-            aws_role_arns:
-            - <Var name="Read Only Role ARN" />
-        ```
+  1. In the Teleport Web UI, navigate to **Zero Trust Access > Roles** and click **Create New Role**.
 
-      1. Create the role with the following command:
-        ```code
-        $ tctl create -f example-read-only-access-role.yaml
-        ```
-    </TabItem>
-  </Tabs>
+  1. Set the role name to `aws-ro-access`.
 
-Assign the Role to the users you want to allow access. You can also assign it to an [Access List](../../../identity-governance/access-lists/guide.mdx) or use it in conjunction with [Access Requests](../../../identity-governance/access-requests/access-requests.mdx).
+  1. In the **Resources** section, add an **Application Access** entry with the following values:
+
+     - **Labels**: `teleport.dev/aws-roles-anywhere-profile-arn: <Var name="Read Only Profile ARN" />`
+     - **AWS Role ARNs**: `<Var name="Read Only Role ARN" />`
+
+  1. Click through the remaining steps and create the role.
+
+  </TabItem>
+
+  <TabItem label="Via tctl">
+
+  1. Create a file named `example-read-only-access-role.yaml` with the following contents:
+
+     ```yaml
+     kind: role
+     version: v8
+     metadata:
+       name: aws-ro-access
+     spec:
+       allow:
+         app_labels:
+           'teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'
+         aws_role_arns:
+         - <Var name="Read Only Role ARN" />
+     ```
+{/* vale messaging.protocol-products = YES */}
+
+  1. Create the role:
+
+     ```code
+     $ tctl create -f example-read-only-access-role.yaml
+     ```
+
+  </TabItem>
+</Tabs>
+
+Assign this role to the users you want to grant access. You can also assign it to an
+[Access List](../../../identity-governance/access-lists/guide.mdx) or use it with
+[Access Requests](../../../identity-governance/access-requests/access-requests.mdx).
+
+<Checkpoint
+  title="Verify role creation and re-login"
+>
+
+1. Confirm the role was created:
+
+   ```code
+   $ tctl get role/aws-ro-access
+   ```
+
+   The output should show the role with the correct `app_labels` and `aws_role_arns` values.
+
+2. Assign the role to your user, then run the following to pick up the new permissions.
+   `<Var name="example.teleport.sh:443" />` is your Teleport Proxy address and `<Var name="Username" />` is your Teleport username:
+
+   ```code
+   $ tsh logout
+   $ tsh login --proxy=<Var name="example.teleport.sh:443" /> --user=<Var name="Username" />
+   ```
+
+3. Confirm the role appears in your session:
+
+   ```code
+   $ tsh status
+   ```
+
+   The `aws-ro-access` role should appear in the roles list.
+
+- If the AWS profile does not appear in a later step when running `tsh apps login`, the most
+  common cause is a missing re-login. Run `tsh logout` and `tsh login` again before continuing.
+- If the role is not listed in `tsh status`, confirm it was assigned to your user or Access List
+  and that you have logged out and back in since the assignment.
+
+</Checkpoint>
 
 ## Step 4/4. Access AWS resources
 
-Now that you have configured the Integration and set up the Role, users can access AWS resources through Teleport.
-
 ### Access AWS Management Console
 
-1. Visit the home page of the Teleport Web UI and click **Resources**.
-   If the Integration found any profiles as expected, the Web UI will display the name of the Profile.
-   If you don't see any profiles, see the [Troubleshooting](#troubleshooting) section.
+1. In the Teleport Web UI, click **Resources**. Each synced Roles Anywhere profile will appear
+   as an AWS application. If you don't see any profiles, return to the
+   "Verify integration sync" checkpoint in Step 1/4.
+1. Click **Launch** on the AWS Console application, then select the IAM role you want to assume.
+1. You will be redirected to the AWS Management Console, signed in under the selected role.
+   Your Teleport username will appear as a federated login in the top-right corner of the console.
 
-1. Click the **Launch** button for the AWS Console application, then click on the role you would like to assume when signing in to the AWS Console:
+### Access AWS using AWS CLI or other AWS SDK-based tools
 
-   ![IAM role selector](../../../../img/application-access/iam-role-selector.png)
+### Obtain the credentials
 
-1. You will get redirected to the AWS Management Console, signed in with the selected role.
-   You should see your Teleport user name as a federated login assigned to `ExampleReadOnlyRole` in the top-right corner of the AWS Console:
-
-   ![Federated login](../../../../img/application-access/federated-login@2x.png)
-
-### Access AWS using AWS CLI or other AWS SDK based tools
-
-#### Obtain the credentials
-On your desktop, log into the AWS App Profile that was synced:
+Log into the AWS app profile that was synced:
 
 ```code
 $ tsh apps login --aws-role arn:aws:iam::278576220453:role/ExampleReadOnlyAccess example-read-only-access
 Logged into AWS app "example-read-only-access".
 
-Your IAM role:
+# Your IAM role:
     arn:aws:iam::123456789012:role/ExampleReadOnlyAccess
 
-Example AWS CLI commands:
+# Example AWS CLI commands:
     aws --profile example-read-only-access s3 ls
     AWS_PROFILE=example-read-only-access aws s3 ls
 ```
 
-#### Access AWS using AWS CLI
-You can now access all your AWS resources from the command line using the `aws` command line tool.
+### Access AWS using AWS CLI
 
-You need to pass the `--profile` flag or export the `AWS_PROFILE` environment variable with the name of the profile you created earlier.
+Pass the `--profile` flag or export `AWS_PROFILE` with the profile name:
 
 ```code
 $ aws --profile example-read-only-access s3 ls
 ...
 ```
 
-#### Access AWS from Terraform
-Using Terraform requires you to set the profile in the provider.
+### Access AWS from Terraform
+
+Set the profile in the provider block:
+
 ```hcl
 provider "aws" {
   profile = "example-read-only-access"
@@ -289,78 +452,58 @@ provider "aws" {
 
 Setting the `AWS_PROFILE` environment variable is also an option.
 
-## Troubleshooting
+<Checkpoint
+  title="Verify AWS access"
+>
 
-Read this section if you run into issues while following this guide.
-
-### Missing Profiles in Resources page
-If you don't see the expected AWS profiles in the Teleport Web UI, check the following:
-
-1. Ensure the profile sync configuration is enabled and the `profile_name_filters` are set accordingly (set it to `*` if you want to import all the profiles):
+1. Confirm `tsh apps login` succeeds and shows the expected role ARN:
 
    ```code
-   $ tctl get integration/<Var name="Integration Name" />
-   ...
-   spec:
-     aws_ra:
-       profile_sync_config:
-         enabled: true
-         profile_arn: arn:aws:rolesanywhere:eu-west-2:123456789012:profile/5c659b8f-7ca3-48ef-a1aa-14c9c93506ee
-         profile_name_filters:
-         - MarcoRA-*
-         role_arn: arn:aws:iam::123456789012:role/TeleportRolesAnywhereProfileSync
-       trust_anchor_arn: arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/69a0c3f8-3157-49b2-85dd-75bdef828a68
+   $ tsh apps login --aws-role <Var name="Read Only Role ARN" /> example-read-only-access
    ```
 
-1. You can get the integration status summary by running the following command:
+2. Run a basic AWS CLI command to confirm credentials are working:
 
    ```code
-   $ tctl get integration/<Var name="Integration Name" />
-   ...
-   status:
-     aws_ra:
-       last_profile_sync:
-         end_time: "2025-07-23T15:46:27.475629Z"
-         error_message: ""
-         start_time: "2025-07-23T15:46:26.334536Z"
-         status: SUCCESS
-         synced_profiles: 4
+   $ aws --profile example-read-only-access sts get-caller-identity
    ```
 
-   Look for any error message you might have.
+   The output should show the `ExampleReadOnlyAccess` role ARN and your Teleport username as the assumed-role session name.
 
-1. Ensure that your Teleport role allows you access to all the expected profiles.
-   AWS app resources have a specific label which you can use to control access: `teleport.dev/aws-roles-anywhere-profile-arn`.
-   Set it to `*` to allow access to all profiles, like so:
+3. Confirm access is limited to read-only operations as expected:
 
-   ```yaml
-   kind: role
-   spec:
-     allow:
-       app_labels:
-         'teleport.dev/aws-roles-anywhere-profile-arn': '*'
+   ```code
+   $ aws --profile example-read-only-access s3 ls
    ```
+
+- If `tsh apps login` does not list the expected profile, run `tsh logout` and `tsh login`
+  to refresh your session, then try again.
+- If `sts get-caller-identity` returns an error, confirm that the profile ARN in your Teleport
+  role's `app_labels` exactly matches the ARN of the profile created in Step 2/4.
+- If you see an `AccessDenied` error from the AWS CLI, verify that the IAM role has the
+  `ReadOnlyAccess` policy attached and that the Roles Anywhere profile includes that role.
+
+</Checkpoint>
 
 ## Next steps
 
-Now that you know how to set up Teleport to protect access to the AWS Management Console and APIs, you can tailor your setup to the needs of your organization.
-
 ### Refine your AWS IAM role mapping
 
-The `aws_role_arns` field supports template variables so they can be populated dynamically when a user authenticates to Teleport.
-
-For example, you can configure your identity provider to define a SAML attribute or OIDC claim called `aws_role_arns`, then use this field to list each user's permitted AWS role ARNs on your IdP.
-If you define a Teleport role to mention the `{{external.aws_role_arns}}` variable, the Auth Service will fill in the user's permitted ARNs based on data from the IdP:
+The `aws_role_arns` field supports template variables that are populated dynamically
+at authentication time. For example, you can configure your identity provider to define
+a SAML attribute or OIDC claim called `aws_role_arns`, then reference it in a Teleport role:
 
 ```yaml
     aws_role_arns:
     - {{external.aws_role_arns}}
 ```
 
-See the [Access Controls Reference](../../../reference/access-controls/roles.mdx) for all of the variables and functions you can use in the `aws_role_arns` field.
+See the [Access Controls Reference](../../../reference/access-controls/roles.mdx) for all
+variables and functions available in the `aws_role_arns` field.
 
-### Create Roles to grant access to a specific profile and IAM roles
+### Create roles to grant access to specific profiles and IAM roles
 
-You can create multiple Teleport roles to grant access to the profiles and IAM roles for each Profile.
+You can create multiple Teleport roles to grant access to different profiles and IAM roles.
 
-See [Role Access Requests](../../../identity-governance/access-requests/role-requests.mdx) to learn more about creating Roles and how to access them using Access Requests.
+See [Role Access Requests](../../../identity-governance/access-requests/role-requests.mdx)
+to learn how to use Access Requests to manage access to these roles.


### PR DESCRIPTION
Resolves #64729

- Clearer policy placement throughout. Both the Step 1 manual setup and Step 2 role creation now walk through each AWS Console page by name ("Select trusted entity", "Add permissions", etc) so users know exactly where they are in the flow. The trust policy JSON steps now include explicit UI field names rather than just "configure the trust policy"

- I've tried making the steps more explicit and removed the 2 older images. If we determine updated ones should still be used, someone with aws access will need to provide them as the Docs team lost access, and I won't be able to create the Trust Anchor for my test cluster

- Provide warning about copying our "Role profile" example and putting it in the "Inline profile" instead, which has broken experiences for customers per Support + added a troubleshooting entry for this specific "Bad Request" error so if anyone else gets it, they know to check the Inline profile

- Add troubleshooting entry: "Profile not visible after role assignment". Explain that new role permissions aren't picked up until the user runs `tsh logout` + `tsh login`, with the exact commands. Also add a forward reference to this entry from the Step 4 CLI section so users hit it at the point they'd actually encounter the problem

- Checkpoint added to "Verify AWS access" after Step 4. Uses `sts get-caller-identity` as the definitive credential test since it returns the role ARN and session name, making it easy to confirm both that credentials work and that the right role was assumed. 

- Covers the three most likely failure modes at that stage; the standalone troubleshooting section is removed entirely. Everything is now inline at the point where a user would actually hit the issue.


