### PR TITLE
Bump gravitational/ci-etcd to 3.3.27

### DIFF
--- a/.github/services/Dockerfile.etcd
+++ b/.github/services/Dockerfile.etcd
@@ -1,7 +1,6 @@
-ARG BUILDARCH
 ARG ETCD_VERSION
 
-FROM bitnami/etcd:${ETCD_VERSION}
+FROM quay.io/coreos/etcd:v${ETCD_VERSION}
 
 COPY fixtures/etcdcerts /certs
 
@@ -14,11 +13,14 @@ RUN mkdir teleportstorage.etcd
 RUN chown 1001 teleportstorage.etcd
 USER 1001
 
-ENTRYPOINT /opt/bitnami/etcd/bin/etcd --name teleportstorage \
-    --initial-cluster-state new \
-    --cert-file /certs/server-cert.pem \
-    --key-file /certs/server-key.pem \
-    --trusted-ca-file /certs/ca-cert.pem \
-    --advertise-client-urls=https://127.0.0.1:2379 \
-    --listen-client-urls=https://0.0.0.0:2379 \
-    --client-cert-auth
+CMD [ \
+    "/usr/local/bin/etcd", \
+    "--name", "teleportstorage", \
+    "--initial-cluster-state", "new", \
+    "--cert-file", "/certs/server-cert.pem", \
+    "--key-file", "/certs/server-key.pem", \
+    "--trusted-ca-file", "/certs/ca-cert.pem", \
+    "--advertise-client-urls=https://127.0.0.1:2379", \
+    "--listen-client-urls=https://0.0.0.0:2379", \
+    "--client-cert-auth" \
+]

--- a/.github/workflows/build-ci-service-images.yaml
+++ b/.github/workflows/build-ci-service-images.yaml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: gravitational/ci-etcd
-  ETCD_VERSION: 3.3.9
+  ETCD_VERSION: 3.3.27
 
 jobs:
   build:


### PR DESCRIPTION
This PR changes the `gravitational/ci-etcd` image base to `quay.io/coreos/etcd` (which seems to be the official image published by the etcd project) to bump its version to 3.3.27, since the bitnami images are no longer available.

Once the image is pushed to ghcr, a followup PR will change the image version in the CI workflows.

Updates #65600