### PR TITLE
tfgen: add support for depends_on meta argument

### DIFF
--- a/lib/tfgen/options.go
+++ b/lib/tfgen/options.go
@@ -73,15 +73,17 @@ func WithResourceBlockComment(comment string) GenerateOpt {
 // in the form "resource_type.resource_name".
 // E.g. "teleport_access_list.acl-UID1234" means the generated resource will
 // wait for "teleport_access_list.acl-UID1234" to be created first.
-func WithDependsOn(ref string) GenerateOpt {
-	return func(o *generateOpts) { o.dependsOn = ref }
+//
+// May be called multiple times to add multiple references.
+func WithDependsOn(reference string) GenerateOpt {
+	return func(o *generateOpts) { o.dependsOn = append(o.dependsOn, reference) }
 }
 
 type generateOpts struct {
 	resourceType         string
 	resourceName         string
 	resourceBlockComment string
-	dependsOn            string
+	dependsOn            []string
 
 	fieldTransforms map[string]Transform
 	fieldComments   map[string]string

--- a/lib/tfgen/options.go
+++ b/lib/tfgen/options.go
@@ -68,10 +68,20 @@ func WithResourceBlockComment(comment string) GenerateOpt {
 	return func(o *generateOpts) { o.resourceBlockComment = comment }
 }
 
+// WithDependsOn adds a terraform depends_on meta-argument to the generated
+// resource block. The value should be a reference to another Terraform resource
+// in the form "resource_type.resource_name".
+// E.g. "teleport_access_list.acl-UID1234" means the generated resource will
+// wait for "teleport_access_list.acl-UID1234" to be created first.
+func WithDependsOn(ref string) GenerateOpt {
+	return func(o *generateOpts) { o.dependsOn = ref }
+}
+
 type generateOpts struct {
 	resourceType         string
 	resourceName         string
 	resourceBlockComment string
+	dependsOn            string
 
 	fieldTransforms map[string]Transform
 	fieldComments   map[string]string

--- a/lib/tfgen/testdata/TestGenerate_DependsOn.golden
+++ b/lib/tfgen/testdata/TestGenerate_DependsOn.golden
@@ -1,0 +1,15 @@
+resource "teleport_role" "example-role" {
+  depends_on = [teleport_role.role-some-role-id]
+
+  version = "v7"
+
+  metadata = {
+    name = "example-role"
+  }
+
+  spec = {
+    allow = {
+      kubernetes_groups = ["system:masters"]
+    }
+  }
+}

--- a/lib/tfgen/testdata/TestGenerate_DependsOn_Multiple.golden
+++ b/lib/tfgen/testdata/TestGenerate_DependsOn_Multiple.golden
@@ -1,5 +1,5 @@
 resource "teleport_role" "example-role" {
-  depends_on = [teleport_role.role-some-role-id]
+  depends_on = [teleport_role.some-role-id-1, teleport_role.some-role-id-2, teleport_role.some-role-id-3]
 
   version = "v7"
 

--- a/lib/tfgen/testdata/TestGenerate_DependsOn_Single.golden
+++ b/lib/tfgen/testdata/TestGenerate_DependsOn_Single.golden
@@ -1,0 +1,15 @@
+resource "teleport_role" "example-role" {
+  depends_on = [teleport_role.some-role-id]
+
+  version = "v7"
+
+  metadata = {
+    name = "example-role"
+  }
+
+  spec = {
+    allow = {
+      kubernetes_groups = ["system:masters"]
+    }
+  }
+}

--- a/lib/tfgen/tfgen.go
+++ b/lib/tfgen/tfgen.go
@@ -162,6 +162,16 @@ func generateResource(
 		[]string{resourceType, resourceName},
 	)
 
+	// Add the terraform depends_on meta-argument to the resource block.
+	if opts.dependsOn != "" {
+		resourceBlock.Body().SetAttributeRaw("depends_on", hclwrite.Tokens{
+			{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(opts.dependsOn)},
+			{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")},
+		})
+		resourceBlock.Body().AppendNewline()
+	}
+
 	msg, err := reflectMessage(resource)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/tfgen/tfgen.go
+++ b/lib/tfgen/tfgen.go
@@ -163,10 +163,10 @@ func generateResource(
 	)
 
 	// Add the terraform depends_on meta-argument to the resource block.
-	if opts.dependsOn != "" {
+	if len(opts.dependsOn) > 0 {
 		resourceBlock.Body().SetAttributeRaw("depends_on", hclwrite.Tokens{
 			{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")},
-			{Type: hclsyntax.TokenIdent, Bytes: []byte(opts.dependsOn)},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(strings.Join(opts.dependsOn, ", "))},
 			{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")},
 		})
 		resourceBlock.Body().AppendNewline()

--- a/lib/tfgen/tfgen.go
+++ b/lib/tfgen/tfgen.go
@@ -164,11 +164,11 @@ func generateResource(
 
 	// Add the terraform depends_on meta-argument to the resource block.
 	if len(opts.dependsOn) > 0 {
-		resourceBlock.Body().SetAttributeRaw("depends_on", hclwrite.Tokens{
-			{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")},
-			{Type: hclsyntax.TokenIdent, Bytes: []byte(strings.Join(opts.dependsOn, ", "))},
-			{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")},
-		})
+		dependsOnTokens := make([]hclwrite.Tokens, 0, len(opts.dependsOn))
+		for _, d := range opts.dependsOn {
+			dependsOnTokens = append(dependsOnTokens, hclwrite.TokensForIdentifier(d))
+		}
+		resourceBlock.Body().SetAttributeRaw("depends_on", hclwrite.TokensForTuple(dependsOnTokens))
 		resourceBlock.Body().AppendNewline()
 	}
 

--- a/lib/tfgen/tfgen_test.go
+++ b/lib/tfgen/tfgen_test.go
@@ -256,7 +256,7 @@ func TestGenerate_AccessListMember(t *testing.T) {
 	)
 }
 
-func TestGenerate_DependsOn(t *testing.T) {
+func TestGenerate_DependsOn_Single(t *testing.T) {
 	t.Parallel()
 
 	goldenTest(t, &types.RoleV6{
@@ -267,7 +267,24 @@ func TestGenerate_DependsOn(t *testing.T) {
 		},
 		Spec: types.RoleSpecV6{Allow: types.RoleConditions{KubeGroups: []string{"system:masters"}}},
 	},
-		tfgen.WithDependsOn("teleport_role.role-some-role-id"),
+		tfgen.WithDependsOn("teleport_role.some-role-id"),
+	)
+}
+
+func TestGenerate_DependsOn_Multiple(t *testing.T) {
+	t.Parallel()
+
+	goldenTest(t, &types.RoleV6{
+		Kind:    types.KindRole,
+		Version: types.V7,
+		Metadata: types.Metadata{
+			Name: "example-role",
+		},
+		Spec: types.RoleSpecV6{Allow: types.RoleConditions{KubeGroups: []string{"system:masters"}}},
+	},
+		tfgen.WithDependsOn("teleport_role.some-role-id-1"),
+		tfgen.WithDependsOn("teleport_role.some-role-id-2"),
+		tfgen.WithDependsOn("teleport_role.some-role-id-3"),
 	)
 }
 

--- a/lib/tfgen/tfgen_test.go
+++ b/lib/tfgen/tfgen_test.go
@@ -256,6 +256,21 @@ func TestGenerate_AccessListMember(t *testing.T) {
 	)
 }
 
+func TestGenerate_DependsOn(t *testing.T) {
+	t.Parallel()
+
+	goldenTest(t, &types.RoleV6{
+		Kind:    types.KindRole,
+		Version: types.V7,
+		Metadata: types.Metadata{
+			Name: "example-role",
+		},
+		Spec: types.RoleSpecV6{Allow: types.RoleConditions{KubeGroups: []string{"system:masters"}}},
+	},
+		tfgen.WithDependsOn("teleport_role.role-some-role-id"),
+	)
+}
+
 func TestGenerate_ResourceComment(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/7183

Adds support for terraform meta-argument `depends_on`.

Why:
The web UI access list terraform builder for presets have all resources (roles, access list, access list member) defined in one .tf file. The access list member resource references the access list it belongs to, and access list needs to exist before creating the member resource, and the meta-argument `depends_on` resolves that.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

local

### Test Cases
- [x] i `terraform apply` a .tf file with an access list and access list member and it succeeds without error about access list not existing 
