### PR TITLE
[v18][scopes] backport scoped role assignment status, observability, and inherited grants fixes

### DIFF
--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -23,7 +23,6 @@ import (
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	conv "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
-	traitv1 "github.com/gravitational/teleport/api/types/trait/convert/v1"
 )
 
 // Client is an access list client that conforms to the following lib/services interfaces:
@@ -144,10 +143,8 @@ func (c *Client) GetInheritedGrants(ctx context.Context, accessListID string) (*
 		return nil, trace.Wrap(err)
 	}
 
-	return &accesslist.Grants{
-		Roles:  resp.Grants.Roles,
-		Traits: traitv1.FromProto(resp.Grants.Traits),
-	}, nil
+	grants := conv.ConvertGrantsFromProto(resp.GetGrants())
+	return &grants, nil
 }
 
 // UpsertAccessList creates or updates an access list resource.

--- a/api/gen/proto/go/teleport/scopes/access/v1/assignment.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/assignment.pb.go
@@ -53,7 +53,9 @@ type ScopedRoleAssignment struct {
 	// Scope is the scope of the role assignment resource.
 	Scope string `protobuf:"bytes,5,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Spec is the role assignment specification.
-	Spec          *ScopedRoleAssignmentSpec `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	Spec *ScopedRoleAssignmentSpec `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	// Status is the status of the role assignment.
+	Status        *ScopedRoleAssignmentStatus `protobuf:"bytes,7,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -130,7 +132,14 @@ func (x *ScopedRoleAssignment) GetSpec() *ScopedRoleAssignmentSpec {
 	return nil
 }
 
-// ScopedRoleAssignmentSpec is the specification of a scoped role.
+func (x *ScopedRoleAssignment) GetStatus() *ScopedRoleAssignmentStatus {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+// ScopedRoleAssignmentSpec is the specification of a scoped role assignment.
 type ScopedRoleAssignmentSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// User is the user to whom all contained assignments apply.
@@ -263,18 +272,120 @@ func (x *Assignment) GetScope() string {
 	return ""
 }
 
+// ScopedRoleAssignmentStatus is the status of a scoped role assignment.
+type ScopedRoleAssignmentStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Origin describes the origin of the scoped role assignment.
+	Origin        *ScopedRoleAssignmentStatus_Origin `protobuf:"bytes,1,opt,name=origin,proto3" json:"origin,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScopedRoleAssignmentStatus) Reset() {
+	*x = ScopedRoleAssignmentStatus{}
+	mi := &file_teleport_scopes_access_v1_assignment_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRoleAssignmentStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRoleAssignmentStatus) ProtoMessage() {}
+
+func (x *ScopedRoleAssignmentStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_assignment_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedRoleAssignmentStatus.ProtoReflect.Descriptor instead.
+func (*ScopedRoleAssignmentStatus) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_assignment_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ScopedRoleAssignmentStatus) GetOrigin() *ScopedRoleAssignmentStatus_Origin {
+	if x != nil {
+		return x.Origin
+	}
+	return nil
+}
+
+// Origin describes the origin of a scoped role assignment.
+type ScopedRoleAssignmentStatus_Origin struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// CreatorKind is the kind of the scoped role assignment creator.
+	CreatorKind string `protobuf:"bytes,1,opt,name=creator_kind,json=creatorKind,proto3" json:"creator_kind,omitempty"`
+	// CreatorName is the name of the scoped role assignment creator.
+	CreatorName   string `protobuf:"bytes,2,opt,name=creator_name,json=creatorName,proto3" json:"creator_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScopedRoleAssignmentStatus_Origin) Reset() {
+	*x = ScopedRoleAssignmentStatus_Origin{}
+	mi := &file_teleport_scopes_access_v1_assignment_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRoleAssignmentStatus_Origin) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRoleAssignmentStatus_Origin) ProtoMessage() {}
+
+func (x *ScopedRoleAssignmentStatus_Origin) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_assignment_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedRoleAssignmentStatus_Origin.ProtoReflect.Descriptor instead.
+func (*ScopedRoleAssignmentStatus_Origin) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_assignment_proto_rawDescGZIP(), []int{3, 0}
+}
+
+func (x *ScopedRoleAssignmentStatus_Origin) GetCreatorKind() string {
+	if x != nil {
+		return x.CreatorKind
+	}
+	return ""
+}
+
+func (x *ScopedRoleAssignmentStatus_Origin) GetCreatorName() string {
+	if x != nil {
+		return x.CreatorName
+	}
+	return ""
+}
+
 var File_teleport_scopes_access_v1_assignment_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_assignment_proto_rawDesc = "" +
 	"\n" +
-	"*teleport/scopes/access/v1/assignment.proto\x12\x19teleport.scopes.access.v1\x1a!teleport/header/v1/metadata.proto\"\xf8\x01\n" +
+	"*teleport/scopes/access/v1/assignment.proto\x12\x19teleport.scopes.access.v1\x1a!teleport/header/v1/metadata.proto\"\xc7\x02\n" +
 	"\x14ScopedRoleAssignment\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12G\n" +
-	"\x04spec\x18\x06 \x01(\v23.teleport.scopes.access.v1.ScopedRoleAssignmentSpecR\x04spec\"\xaf\x01\n" +
+	"\x04spec\x18\x06 \x01(\v23.teleport.scopes.access.v1.ScopedRoleAssignmentSpecR\x04spec\x12M\n" +
+	"\x06status\x18\a \x01(\v25.teleport.scopes.access.v1.ScopedRoleAssignmentStatusR\x06status\"\xaf\x01\n" +
 	"\x18ScopedRoleAssignmentSpec\x12\x12\n" +
 	"\x04user\x18\x01 \x01(\tR\x04user\x12G\n" +
 	"\vassignments\x18\x02 \x03(\v2%.teleport.scopes.access.v1.AssignmentR\vassignments\x12\x19\n" +
@@ -283,7 +394,12 @@ const file_teleport_scopes_access_v1_assignment_proto_rawDesc = "" +
 	"\n" +
 	"Assignment\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x14\n" +
-	"\x05scope\x18\x02 \x01(\tR\x05scopeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\xc2\x01\n" +
+	"\x1aScopedRoleAssignmentStatus\x12T\n" +
+	"\x06origin\x18\x01 \x01(\v2<.teleport.scopes.access.v1.ScopedRoleAssignmentStatus.OriginR\x06origin\x1aN\n" +
+	"\x06Origin\x12!\n" +
+	"\fcreator_kind\x18\x01 \x01(\tR\vcreatorKind\x12!\n" +
+	"\fcreator_name\x18\x02 \x01(\tR\vcreatorNameBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
 var (
 	file_teleport_scopes_access_v1_assignment_proto_rawDescOnce sync.Once
@@ -297,22 +413,26 @@ func file_teleport_scopes_access_v1_assignment_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_assignment_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_assignment_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_teleport_scopes_access_v1_assignment_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_teleport_scopes_access_v1_assignment_proto_goTypes = []any{
-	(*ScopedRoleAssignment)(nil),     // 0: teleport.scopes.access.v1.ScopedRoleAssignment
-	(*ScopedRoleAssignmentSpec)(nil), // 1: teleport.scopes.access.v1.ScopedRoleAssignmentSpec
-	(*Assignment)(nil),               // 2: teleport.scopes.access.v1.Assignment
-	(*v1.Metadata)(nil),              // 3: teleport.header.v1.Metadata
+	(*ScopedRoleAssignment)(nil),              // 0: teleport.scopes.access.v1.ScopedRoleAssignment
+	(*ScopedRoleAssignmentSpec)(nil),          // 1: teleport.scopes.access.v1.ScopedRoleAssignmentSpec
+	(*Assignment)(nil),                        // 2: teleport.scopes.access.v1.Assignment
+	(*ScopedRoleAssignmentStatus)(nil),        // 3: teleport.scopes.access.v1.ScopedRoleAssignmentStatus
+	(*ScopedRoleAssignmentStatus_Origin)(nil), // 4: teleport.scopes.access.v1.ScopedRoleAssignmentStatus.Origin
+	(*v1.Metadata)(nil),                       // 5: teleport.header.v1.Metadata
 }
 var file_teleport_scopes_access_v1_assignment_proto_depIdxs = []int32{
-	3, // 0: teleport.scopes.access.v1.ScopedRoleAssignment.metadata:type_name -> teleport.header.v1.Metadata
+	5, // 0: teleport.scopes.access.v1.ScopedRoleAssignment.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.scopes.access.v1.ScopedRoleAssignment.spec:type_name -> teleport.scopes.access.v1.ScopedRoleAssignmentSpec
-	2, // 2: teleport.scopes.access.v1.ScopedRoleAssignmentSpec.assignments:type_name -> teleport.scopes.access.v1.Assignment
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	3, // 2: teleport.scopes.access.v1.ScopedRoleAssignment.status:type_name -> teleport.scopes.access.v1.ScopedRoleAssignmentStatus
+	2, // 3: teleport.scopes.access.v1.ScopedRoleAssignmentSpec.assignments:type_name -> teleport.scopes.access.v1.Assignment
+	4, // 4: teleport.scopes.access.v1.ScopedRoleAssignmentStatus.origin:type_name -> teleport.scopes.access.v1.ScopedRoleAssignmentStatus.Origin
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_assignment_proto_init() }
@@ -326,7 +446,7 @@ func file_teleport_scopes_access_v1_assignment_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_assignment_proto_rawDesc), len(file_teleport_scopes_access_v1_assignment_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/access/v1/assignment.proto
+++ b/api/proto/teleport/scopes/access/v1/assignment.proto
@@ -42,9 +42,12 @@ message ScopedRoleAssignment {
 
   // Spec is the role assignment specification.
   ScopedRoleAssignmentSpec spec = 6;
+
+  // Status is the status of the role assignment.
+  ScopedRoleAssignmentStatus status = 7;
 }
 
-// ScopedRoleAssignmentSpec is the specification of a scoped role.
+// ScopedRoleAssignmentSpec is the specification of a scoped role assignment.
 message ScopedRoleAssignmentSpec {
   // User is the user to whom all contained assignments apply.
   // Mutually exclusive with `bot_name`.
@@ -71,4 +74,19 @@ message Assignment {
   // Scope is the scope to which the role is assigned. This must be a member/child
   // of the scope of the [ScopedRoleAssignment] in which this assignment is contained.
   string scope = 2;
+}
+
+// ScopedRoleAssignmentStatus is the status of a scoped role assignment.
+message ScopedRoleAssignmentStatus {
+  // Origin describes the origin of a scoped role assignment.
+  message Origin {
+    // CreatorKind is the kind of the scoped role assignment creator.
+    string creator_kind = 1;
+
+    // CreatorName is the name of the scoped role assignment creator.
+    string creator_name = 2;
+  }
+
+  // Origin describes the origin of the scoped role assignment.
+  Origin origin = 1;
 }

--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -48,8 +48,8 @@ func FromProto(msg *accesslistv1.AccessList, opts ...AccessListOption) (*accessl
 		Audit:              convertAuditFromProto(spec.GetAudit()),
 		MembershipRequires: convertRequiresFromProto(spec.GetMembershipRequires()),
 		OwnershipRequires:  convertRequiresFromProto(spec.GetOwnershipRequires()),
-		Grants:             convertGrantsFromProto(spec.GetGrants()),
-		OwnerGrants:        convertGrantsFromProto(spec.GetOwnerGrants()),
+		Grants:             ConvertGrantsFromProto(spec.GetGrants()),
+		OwnerGrants:        ConvertGrantsFromProto(spec.GetOwnerGrants()),
 	}
 
 	accessList, err := accesslist.NewAccessList(metadata, accessListSpec)
@@ -84,8 +84,8 @@ func ToProto(accessList *accesslist.AccessList) *accesslistv1.AccessList {
 			Audit:              convertAuditToProto(accessList.Spec.Audit),
 			MembershipRequires: convertRequiresToProto(accessList.Spec.MembershipRequires),
 			OwnershipRequires:  convertRequiresToProto(accessList.Spec.OwnershipRequires),
-			Grants:             convertGrantsToProto(accessList.Spec.Grants),
-			OwnerGrants:        convertGrantsToProto(accessList.Spec.OwnerGrants),
+			Grants:             ConvertGrantsToProto(accessList.Spec.Grants),
+			OwnerGrants:        ConvertGrantsToProto(accessList.Spec.OwnerGrants),
 		},
 		Status: convertStatusToProto(&accessList.Status),
 	}
@@ -139,7 +139,7 @@ func convertOwnersFromProto(protoOwners []*accesslistv1.AccessListOwner) []acces
 	return owners
 }
 
-func convertGrantsFromProto(protoGrants *accesslistv1.AccessListGrants) accesslist.Grants {
+func ConvertGrantsFromProto(protoGrants *accesslistv1.AccessListGrants) accesslist.Grants {
 	if protoGrants == nil {
 		return accesslist.Grants{}
 	}
@@ -313,7 +313,7 @@ func convertOwnersToProto(owners []accesslist.Owner) []*accesslistv1.AccessListO
 	return protoOwners
 }
 
-func convertGrantsToProto(grants accesslist.Grants) *accesslistv1.AccessListGrants {
+func ConvertGrantsToProto(grants accesslist.Grants) *accesslistv1.AccessListGrants {
 	return &accesslistv1.AccessListGrants{
 		Roles:       grants.Roles,
 		Traits:      traitv1.ToProto(grants.Traits),

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -502,5 +502,5 @@ func Test_convertGrantsToProto_never_nil(t *testing.T) {
 	//
 	// See https://github.com/gravitational/teleport/issues/58948
 	emptyGrants := accesslist.Grants{}
-	require.NotNil(t, convertGrantsToProto(emptyGrants))
+	require.NotNil(t, ConvertGrantsToProto(emptyGrants))
 }

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -19,6 +19,7 @@
 package accesslists
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"maps"
@@ -803,16 +804,23 @@ func GetInheritedGrants(ctx context.Context, accessList *accesslist.AccessList, 
 	}
 
 	collectedRoles := make(map[string]struct{})
+	collectedScopedRoles := make(map[accesslist.ScopedRoleGrant]struct{})
 	collectedTraits := make(map[string]map[string]struct{})
 
-	addGrants := func(grantRoles []string, grantTraits trait.Traits) {
-		for _, role := range grantRoles {
+	addGrants := func(grantsToAdd accesslist.Grants) {
+		for _, role := range grantsToAdd.Roles {
 			if _, exists := collectedRoles[role]; !exists {
 				grants.Roles = append(grants.Roles, role)
 				collectedRoles[role] = struct{}{}
 			}
 		}
-		for traitKey, traitValues := range grantTraits {
+		for _, scopedRoleGrant := range grantsToAdd.ScopedRoles {
+			if _, exists := collectedScopedRoles[scopedRoleGrant]; !exists {
+				grants.ScopedRoles = append(grants.ScopedRoles, scopedRoleGrant)
+				collectedScopedRoles[scopedRoleGrant] = struct{}{}
+			}
+		}
+		for traitKey, traitValues := range grantsToAdd.Traits {
 			if _, exists := collectedTraits[traitKey]; !exists {
 				collectedTraits[traitKey] = make(map[string]struct{})
 			}
@@ -831,8 +839,7 @@ func GetInheritedGrants(ctx context.Context, accessList *accesslist.AccessList, 
 		return nil, trace.Wrap(err)
 	}
 	for _, ancestor := range ancestorLists {
-		memberGrants := ancestor.GetGrants()
-		addGrants(memberGrants.Roles, memberGrants.Traits)
+		addGrants(ancestor.GetGrants())
 	}
 
 	// Get ancestors via owner relationship
@@ -841,16 +848,20 @@ func GetInheritedGrants(ctx context.Context, accessList *accesslist.AccessList, 
 		return nil, trace.Wrap(err)
 	}
 	for _, ancestorOwner := range ancestorOwnerLists {
-		ownerGrants := ancestorOwner.GetOwnerGrants()
-		addGrants(ownerGrants.Roles, ownerGrants.Traits)
+		addGrants(ancestorOwner.GetOwnerGrants())
 	}
 
 	slices.Sort(grants.Roles)
-	grants.Roles = slices.Compact(grants.Roles)
 
-	for k, v := range grants.Traits {
-		slices.Sort(v)
-		grants.Traits[k] = slices.Compact(v)
+	slices.SortFunc(grants.ScopedRoles, func(a, b accesslist.ScopedRoleGrant) int {
+		if c := cmp.Compare(a.Role, b.Role); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Scope, b.Scope)
+	})
+
+	for _, values := range grants.Traits {
+		slices.Sort(values)
 	}
 
 	return &grants, nil

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -624,19 +624,41 @@ func TestGetInheritedGrants(t *testing.T) {
 	acl2 := newAccessList(t, "2", clock)
 
 	// aclroot has a trait for owners - "root-owner-trait", and a role for owners - "root-owner-role"
+	// and 2 scoped roles for owners
 	aclroot.Spec.OwnerGrants = accesslist.Grants{
 		Traits: map[string][]string{
 			"root-owner-trait": {"root-owner-value"},
 		},
 		Roles: []string{"root-owner-role"},
+		ScopedRoles: []accesslist.ScopedRoleGrant{
+			{
+				Role:  "root-scoped-role",
+				Scope: "/root/bb",
+			},
+			{
+				Role:  "root-scoped-role",
+				Scope: "/root/aa",
+			},
+		},
 	}
 
 	// acl1 has a trait for members - "1-member-trait", and a role for members - "1-member-role"
+	// and 2 scoped roles for members
 	acl1.Spec.Grants = accesslist.Grants{
 		Traits: map[string][]string{
 			"1-member-trait": {"1-member-value"},
 		},
 		Roles: []string{"1-member-role"},
+		ScopedRoles: []accesslist.ScopedRoleGrant{
+			{
+				Role:  "1-scoped-role",
+				Scope: "/1/bb",
+			},
+			{
+				Role:  "1-scoped-role",
+				Scope: "/1/aa",
+			},
+		},
 	}
 
 	// acl2 has no traits or roles
@@ -668,6 +690,24 @@ func TestGetInheritedGrants(t *testing.T) {
 			"root-owner-trait": {"root-owner-value"},
 		},
 		Roles: []string{"1-member-role", "root-owner-role"},
+		ScopedRoles: []accesslist.ScopedRoleGrant{
+			{
+				Role:  "1-scoped-role",
+				Scope: "/1/aa",
+			},
+			{
+				Role:  "1-scoped-role",
+				Scope: "/1/bb",
+			},
+			{
+				Role:  "root-scoped-role",
+				Scope: "/root/aa",
+			},
+			{
+				Role:  "root-scoped-role",
+				Scope: "/root/bb",
+			},
+		},
 	}
 
 	grants, err := GetInheritedGrants(ctx, acl2, accessListAndMembersGetter)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -776,6 +776,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		Reader:           cfg.ScopedAccess,
 		AccessListEvents: as.Cache,
 		AccessListReader: as.Cache,
+		Tracer:           cfg.Tracer,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -143,6 +143,10 @@ func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedacce
 	if req.GetAssignment().GetMetadata().GetName() == "" {
 		req.GetAssignment().GetMetadata().Name = uuid.New().String()
 	}
+	// Currently, don't allow assignments created via the API to have a status,
+	// as they could impersonate an access-list-materialized assignment.
+	// TODO(nklaassen): set assignment status based on authenticated identity.
+	req.GetAssignment().Status = nil
 
 	if err := scopedaccess.StrongValidateAssignment(req.GetAssignment()); err != nil {
 		return nil, trace.Wrap(err)
@@ -492,6 +496,11 @@ func (s *Server) UpdateScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return nil, trace.Wrap(err)
 	}
 
+	// Currently, don't allow assignments created via the API to have a status,
+	// as they could impersonate an access-list-materialized assignment.
+	// TODO(nklaassen): set assignment status based on authenticated identity.
+	req.GetAssignment().Status = nil
+
 	return s.cfg.Writer.UpdateScopedRoleAssignment(ctx, req)
 }
 
@@ -541,6 +550,11 @@ func (s *Server) UpsertScopedRoleAssignment(ctx context.Context, req *scopedacce
 			"scope", req.GetAssignment().GetScope())
 		return nil, trace.Wrap(err)
 	}
+
+	// Currently, don't allow assignments created via the API to have a status,
+	// as they could impersonate an access-list-materialized assignment.
+	// TODO(nklaassen): set assignment status based on authenticated identity.
+	req.GetAssignment().Status = nil
 
 	return s.cfg.Writer.UpsertScopedRoleAssignment(ctx, req)
 }

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -499,7 +499,9 @@ func (s *Server) UpdateScopedRoleAssignment(ctx context.Context, req *scopedacce
 	// Currently, don't allow assignments created via the API to have a status,
 	// as they could impersonate an access-list-materialized assignment.
 	// TODO(nklaassen): set assignment status based on authenticated identity.
-	req.GetAssignment().Status = nil
+	if req.GetAssignment().GetStatus() != nil {
+		req.GetAssignment().Status = nil
+	}
 
 	return s.cfg.Writer.UpdateScopedRoleAssignment(ctx, req)
 }
@@ -554,7 +556,9 @@ func (s *Server) UpsertScopedRoleAssignment(ctx context.Context, req *scopedacce
 	// Currently, don't allow assignments created via the API to have a status,
 	// as they could impersonate an access-list-materialized assignment.
 	// TODO(nklaassen): set assignment status based on authenticated identity.
-	req.GetAssignment().Status = nil
+	if req.GetAssignment().GetStatus() != nil {
+		req.GetAssignment().Status = nil
+	}
 
 	return s.cfg.Writer.UpsertScopedRoleAssignment(ctx, req)
 }

--- a/lib/auth/scopes/access/service_test.go
+++ b/lib/auth/scopes/access/service_test.go
@@ -478,6 +478,14 @@ func TestAssignmentBasics(t *testing.T) {
 	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 
 	ctx := t.Context()
+	newForgedStatus := func() *scopedaccessv1.ScopedRoleAssignmentStatus {
+		return &scopedaccessv1.ScopedRoleAssignmentStatus{
+			Origin: &scopedaccessv1.ScopedRoleAssignmentStatus_Origin{
+				CreatorKind: scopedaccess.CreatorKindAccessList,
+				CreatorName: "forged-access-list",
+			},
+		}
+	}
 
 	bk := newBackendPack(t)
 	defer bk.Close()
@@ -588,11 +596,13 @@ func TestAssignmentBasics(t *testing.T) {
 
 	// verify expected successful create
 	a1 := newScopedRoleAssignmentAtScope("staging-admin", "/staging")
+	a1.Status = newForgedStatus()
 	carsp, err := srv.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: a1,
 	})
 	require.NoError(t, err)
 	require.Equal(t, a1.GetMetadata().GetName(), carsp.GetAssignment().GetMetadata().GetName())
+	require.Nil(t, carsp.GetAssignment().GetStatus())
 
 	// wait for assignments to be populated into cache
 	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
@@ -673,12 +683,14 @@ func TestAssignmentBasics(t *testing.T) {
 
 	// add a label and update
 	ca3rsp.Assignment.Metadata.Labels = map[string]string{"key": "val"}
+	ca3rsp.Assignment.Status = newForgedStatus()
 	ua3rsp, err := srv.UpdateScopedRoleAssignment(ctx, &scopedaccessv1.UpdateScopedRoleAssignmentRequest{
 		Assignment: ca3rsp.GetAssignment(),
 	})
 	require.NoError(t, err)
 	require.Equal(t, a3.GetMetadata().GetName(), ua3rsp.GetAssignment().GetMetadata().GetName())
 	require.NotEqual(t, ca3rsp.GetAssignment().GetMetadata().GetRevision(), ua3rsp.GetAssignment().GetMetadata().GetRevision())
+	require.Nil(t, ua3rsp.GetAssignment().GetStatus())
 
 	// observe change in cache
 	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
@@ -718,14 +730,17 @@ func TestAssignmentBasics(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Nil(t, garsp.GetAssignment().GetMetadata().GetLabels())
+	require.Nil(t, garsp.GetAssignment().GetStatus())
 
 	// verify expected successful upsert (creates new assignment)
 	a4 := newScopedRoleAssignmentAtScope("staging-admin", "/staging")
+	a4.Status = newForgedStatus()
 	ua4rsp, err := srv.UpsertScopedRoleAssignment(ctx, &scopedaccessv1.UpsertScopedRoleAssignmentRequest{
 		Assignment: a4,
 	})
 	require.NoError(t, err)
 	require.Equal(t, a4.GetMetadata().GetName(), ua4rsp.GetAssignment().GetMetadata().GetName())
+	require.Nil(t, ua4rsp.GetAssignment().GetStatus())
 
 	// wait for upserted assignment to appear in cache
 	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
@@ -739,12 +754,21 @@ func TestAssignmentBasics(t *testing.T) {
 
 	// verify expected successful upsert (updates existing assignment)
 	ua4rsp.Assignment.Metadata.Labels = map[string]string{"upserted": "true"}
+	ua4rsp.Assignment.Status = newForgedStatus()
 	ua4rsp2, err := srv.UpsertScopedRoleAssignment(ctx, &scopedaccessv1.UpsertScopedRoleAssignmentRequest{
 		Assignment: ua4rsp.GetAssignment(),
 	})
 	require.NoError(t, err)
 	require.Equal(t, a4.GetMetadata().GetName(), ua4rsp2.GetAssignment().GetMetadata().GetName())
 	require.Equal(t, "true", ua4rsp2.GetAssignment().GetMetadata().GetLabels()["upserted"])
+	require.Nil(t, ua4rsp2.GetAssignment().GetStatus())
+
+	garsp, err = bk.service.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+		Name:    a4.GetMetadata().GetName(),
+		SubKind: a4.GetSubKind(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, garsp.GetAssignment().GetStatus())
 
 	// verify expected denied upsert (out of scope)
 	a5 := newScopedRoleAssignmentAtScope("prod-admin", "/prod")

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -51,6 +51,10 @@ const (
 	// SubKindMaterialized is the sub kind of a scoped role assignment that has been materialized.
 	SubKindMaterialized = "materialized"
 
+	// CreatorKindAccessList indicates that the creator is an access list, for
+	// scoped role assignments materialized from access list membership.
+	CreatorKindAccessList = "access_list"
+
 	// maxAssignableScopes is the maximum number of assignable scopes that a given scoped role resource may contain. Note that
 	// unlike MaxRolesPerAssignment, this is a fairly arbitrary limit and there isn't a strong reason to keep it low other than
 	// to avoid excess resource size and to keep our options open for the future.

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -25,12 +25,17 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/prometheus/client_golang/prometheus"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
+	"github.com/gravitational/teleport"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+	"github.com/gravitational/teleport/lib/observability/tracing"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/cache/assignments"
 	"github.com/gravitational/teleport/lib/scopes/cache/roles"
@@ -46,10 +51,18 @@ type CacheConfig struct {
 
 	AccessListEvents types.Events
 	AccessListReader AccessListReader
+	Tracer           oteltrace.Tracer
 
 	MaxRetryPeriod    time.Duration
 	TTLCacheRetention time.Duration
 }
+
+var materializedAssignmentsMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: teleport.MetricNamespace,
+	Subsystem: "scoped_access_cache",
+	Name:      "materialized_assignments",
+	Help:      "Current number of materialized scoped role assignments tracked by the scoped access cache materializer.",
+})
 
 // CheckAndSetDefaults verifies required fields and sets default values as appropriate.
 func (c *CacheConfig) CheckAndSetDefaults() error {
@@ -75,6 +88,10 @@ func (c *CacheConfig) CheckAndSetDefaults() error {
 
 	if c.TTLCacheRetention <= 0 {
 		c.TTLCacheRetention = time.Second * 3
+	}
+
+	if c.Tracer == nil {
+		c.Tracer = tracing.NoopTracer("scoped_access_cache")
 	}
 
 	return nil
@@ -106,6 +123,9 @@ type Cache struct {
 // but performance may be suboptimal until watcher init has completed.
 func NewCache(cfg CacheConfig) (*Cache, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := metrics.RegisterPrometheusCollectors(materializedAssignmentsMetric); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -497,7 +517,7 @@ func (c *Cache) fetch(ctx context.Context) (state, *materializer, error) {
 		assignments: assignmentCache,
 	}
 
-	materializer := newMaterializer(c.cfg.AccessListReader)
+	materializer := newMaterializer(c.cfg.AccessListReader, c.cfg.Tracer)
 	if err := materializer.Init(ctx, s); err != nil {
 		return s, nil, trace.Wrap(err)
 	}

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -28,10 +28,13 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/gravitational/teleport"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -115,6 +118,7 @@ type materializer struct {
 	materializedAssignments map[materializedAssignmentKey]ancestorRelation
 
 	logger *slog.Logger
+	tracer oteltrace.Tracer
 
 	repairTimeMu                 sync.Mutex
 	repairEventC                 chan repairEvent
@@ -136,13 +140,14 @@ func (k materializedAssignmentKey) assignmentName() string {
 	return "acl-" + base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 }
 
-func newMaterializer(aclReader AccessListReader) *materializer {
+func newMaterializer(aclReader AccessListReader, tracer oteltrace.Tracer) *materializer {
 	now := time.Now()
 	return &materializer{
 		aclReader:                    aclReader,
 		ancestorCache:                newAncestorCache(),
 		materializedAssignments:      make(map[materializedAssignmentKey]ancestorRelation),
 		logger:                       slog.With(teleport.ComponentKey, "sra_materializer"),
+		tracer:                       tracer,
 		repairEventC:                 make(chan repairEvent),
 		wakeRepairLoop:               make(chan struct{}, 1),
 		nextExpiredMembersRepairTime: now.Add(century),
@@ -152,7 +157,11 @@ func newMaterializer(aclReader AccessListReader) *materializer {
 
 // Init materializes all necessary scoped role assignments into [state] based
 // on the current set of access list memberships.
-func (m *materializer) Init(ctx context.Context, state state) error {
+func (m *materializer) Init(ctx context.Context, state state) (err error) {
+	ctx, span := m.tracer.Start(ctx, "scoped_access_cache/materializer/init")
+	defer func() { tracing.EndSpan(span, err) }()
+	m.syncMaterializedAssignmentsMetric()
+
 	// First populate the ancestor cache with all list->list memberships and
 	// ownerships, it's critical for this to be up to date to process
 	// relationships and future changes. The ancestor cache should include even
@@ -175,6 +184,7 @@ func (m *materializer) Init(ctx context.Context, state state) error {
 		}
 	}
 	m.reportFutureMemberExpiry(ctx, nextExpiry)
+
 	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
 		if err != nil {
 			return trace.Wrap(err, "reading access lists")
@@ -204,7 +214,12 @@ func (m *materializer) Init(ctx context.Context, state state) error {
 
 // ProcessEvent is the entry point for all event-driven changes to materializer
 // state, driven by access list and access list member events.
-func (m *materializer) ProcessEvent(ctx context.Context, state state, event types.Event) error {
+func (m *materializer) ProcessEvent(ctx context.Context, state state, event types.Event) (err error) {
+	ctx, span := m.tracer.Start(ctx, "scoped_access_cache/materializer/process_event",
+		oteltrace.WithAttributes(materializerEventAttributes(event)...),
+	)
+	defer func() { tracing.EndSpan(span, err) }()
+
 	switch event.Type {
 	case types.OpPut:
 		switch item := event.Resource.(type) {
@@ -841,6 +856,7 @@ func (m *materializer) materializeAssignment(
 		return trace.Wrap(err, "putting materialized assignment into cache")
 	}
 	m.materializedAssignments[key] = relation
+	m.syncMaterializedAssignmentsMetric()
 	return nil
 }
 
@@ -851,8 +867,13 @@ func (m *materializer) deleteMaterializedAssignment(ctx context.Context, state s
 			"list", key.list)
 		state.assignments.Delete(key.assignmentName(), scopedaccess.SubKindMaterialized)
 		delete(m.materializedAssignments, key)
+		m.syncMaterializedAssignmentsMetric()
 
 	}
+}
+
+func (m *materializer) syncMaterializedAssignmentsMetric() {
+	materializedAssignmentsMetric.Set(float64(len(m.materializedAssignments)))
 }
 
 func (m *materializer) recheckAssignment(ctx context.Context, state state, key materializedAssignmentKey) error {
@@ -1387,6 +1408,11 @@ func (m *materializer) RepairEvents() <-chan repairEvent {
 // [materializer.RepairEvents]. It must not be called concurrently with
 // [materializer.ProcessEvent].
 func (m *materializer) ProcessRepairEvent(ctx context.Context, state state, event repairEvent) {
+	ctx, span := m.tracer.Start(ctx, "scoped_access_cache/materializer/process_repair_event",
+		oteltrace.WithAttributes(attribute.String("repair.type", event.String())),
+	)
+	defer span.End()
+
 	switch event {
 	case repairExpiredMembersEvent:
 		m.repairExpiredMembers(ctx, state)
@@ -1464,7 +1490,9 @@ func (m *materializer) repairExpiredMembers(ctx context.Context, state state) {
 	expiredMembersOf, nextExpiry := m.collectExpiredMembers(ctx)
 	m.reportFutureMemberExpiry(ctx, nextExpiry)
 
+	affected := 0
 	for key := range m.affectedAssignmentsForExpiredMembers(expiredMembersOf) {
+		affected++
 		if err := m.recheckAssignment(ctx, state, key); err != nil {
 			// Must pessimistically assume any assignment is invalid if we
 			// encountered an error trying to validate it.
@@ -1474,6 +1502,7 @@ func (m *materializer) repairExpiredMembers(ctx context.Context, state state) {
 			m.scheduleMissedMembersRepair(ctx)
 		}
 	}
+	oteltrace.SpanFromContext(ctx).SetAttributes(attribute.Int("assignments.affected", affected))
 }
 
 // collectExpiredMembers collects all expired access list members by parent
@@ -1488,6 +1517,7 @@ func (m *materializer) collectExpiredMembers(ctx context.Context) (expiredMember
 	nextExpiry = now.Add(century)
 
 	expiredMembersOf = make(map[string]expiredMembers)
+	expiredCount := 0
 
 	// Iterate all access list members to find any that are expired.
 	for member, err := range clientutils.Resources(ctx, m.aclReader.ListAllAccessListMembers) {
@@ -1520,7 +1550,9 @@ func (m *materializer) collectExpiredMembers(ctx context.Context) (expiredMember
 		knownExpiredMembers := expiredMembersOf[member.Spec.AccessList]
 		knownExpiredMembers.insert(member)
 		expiredMembersOf[member.Spec.AccessList] = knownExpiredMembers
+		expiredCount++
 	}
+	oteltrace.SpanFromContext(ctx).SetAttributes(attribute.Int("members.expired", expiredCount))
 
 	return expiredMembersOf, nextExpiry
 }
@@ -1626,16 +1658,20 @@ func (m *materializer) repairMissedMembers(ctx context.Context, state state) {
 
 	// Iterate all access lists to additively materialize assignments for all
 	// their members and owners.
+	repairedLists := 0
 	for list, err := range clientutils.Resources(ctx, m.aclReader.ListAccessLists) {
 		if err != nil {
 			m.logger.InfoContext(ctx, "Missed membership repair failed to read all access lists, scheduling another repair",
 				"error", err)
+			oteltrace.SpanFromContext(ctx).RecordError(err)
 			m.scheduleMissedMembersRepair(ctx)
 			return
 		}
+		repairedLists++
 		m.initAccessListMembers(ctx, state, list)
 		m.initAccessListOwners(ctx, state, list)
 	}
+	oteltrace.SpanFromContext(ctx).SetAttributes(attribute.Int("lists.repaired", repairedLists))
 }
 
 func hasMemberGrants(list *accesslist.AccessList) bool {
@@ -1652,4 +1688,29 @@ func hasMembershipRequires(list *accesslist.AccessList) bool {
 
 func hasOwnershipRequires(list *accesslist.AccessList) bool {
 	return !list.Spec.OwnershipRequires.IsEmpty()
+}
+
+func materializerEventAttributes(event types.Event) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String("event.type", event.Type.String()),
+	}
+	if event.Resource == nil {
+		return attrs
+	}
+	attrs = append(attrs,
+		attribute.String("resource.kind", event.Resource.GetKind()),
+		attribute.String("resource.name", event.Resource.GetName()),
+	)
+	return attrs
+}
+
+func (e repairEvent) String() string {
+	switch e {
+	case repairExpiredMembersEvent:
+		return "expired_members"
+	case repairMissedMembersEvent:
+		return "missed_members"
+	default:
+		return "unknown"
+	}
 }

--- a/lib/scopes/cache/access/materializer.go
+++ b/lib/scopes/cache/access/materializer.go
@@ -809,6 +809,12 @@ func (m *materializer) materializeAssignment(
 		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 			User: userName,
 		},
+		Status: &scopedaccessv1.ScopedRoleAssignmentStatus{
+			Origin: &scopedaccessv1.ScopedRoleAssignmentStatus_Origin{
+				CreatorKind: scopedaccess.CreatorKindAccessList,
+				CreatorName: list.GetName(),
+			},
+		},
 	}
 
 	if relation.isMember {

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -1408,6 +1408,12 @@ func expectedScopedRoleAssignment(userName, listName string, assignments []*scop
 			User:        userName,
 			Assignments: assignments,
 		},
+		Status: &scopedaccessv1.ScopedRoleAssignmentStatus{
+			Origin: &scopedaccessv1.ScopedRoleAssignmentStatus_Origin{
+				CreatorKind: scopedaccess.CreatorKindAccessList,
+				CreatorName: listName,
+			},
+		},
 	}
 }
 

--- a/lib/scopes/cache/access/materializer_test.go
+++ b/lib/scopes/cache/access/materializer_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	cachepkg "github.com/gravitational/teleport/lib/cache"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/observability/tracing"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/cache/assignments"
 	"github.com/gravitational/teleport/lib/scopes/utils"
@@ -1223,7 +1224,7 @@ initializing acl cache: %v`, t1.Sub(t0), t2.Sub(t1), t3.Sub(t2))
 				// for each benchmark loop.
 				for b.Loop() {
 					state.assignments = assignments.NewAssignmentCache(assignments.AssignmentCacheConfig{})
-					materializer := newMaterializer(aclCache)
+					materializer := newMaterializer(aclCache, tracing.NoopTracer("test"))
 					require.NoError(b, materializer.Init(b.Context(), state))
 				}
 			})

--- a/lib/services/local/scoped_access_test.go
+++ b/lib/services/local/scoped_access_test.go
@@ -501,6 +501,12 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 				},
 			},
 		},
+		Status: &scopedaccessv1.ScopedRoleAssignmentStatus{
+			Origin: &scopedaccessv1.ScopedRoleAssignmentStatus_Origin{
+				CreatorKind: scopedaccess.CreatorKindAccessList,
+				CreatorName: "test-list",
+			},
+		},
 		Version: types.V1,
 	}
 

--- a/rfd/cspell.json
+++ b/rfd/cspell.json
@@ -85,6 +85,7 @@
     "Backpressure",
     "barebones",
     "Bartosz",
+    "basicinfo",
     "bazel",
     "behaviour",
     "behaviours",


### PR DESCRIPTION
Backport #65247 to branch/v18
Backport #65352 to branch/v18
Backport #65354 to branch/v18

Backport three scoped-access changes from `master` to `branch/v18`:

- add status metadata to materialized scoped role assignments so the originating access list is visible
- add tracing and metrics for the scoped role assignment materializer
- fix inherited grant collection so inherited scoped role grants are returned correctly

merged testplan of the original PRs:

## Manual Test Plan

### Test Environment

Run Jaeger locally:

```bash
docker run --rm -it \
  -p 16686:16686 \
  -p 4317:4317 \
  -e COLLECTOR_OTLP_ENABLED=true \
  jaegertracing/all-in-one:latest
```

Configure the auth service to export traces to Jaeger:

```yaml
tracing_service:
  enabled: yes
  exporter_url: "grpc:127.0.0.1:4317"
  sampling_rate_per_million: 1000000
```

Run a local cluster from this branch with `TELEPORT_UNSTABLE_SCOPES=yes`.

### Setup

Create a scoped role:

```bash
cat >./test-scoped-role.yaml <<EOF
kind: scoped_role
version: v1
metadata:
  name: test-role
scope: /
spec:
  assignable_scopes:
    - /test/**
  ssh:
    logins: ["tester"]
    labels:
      - name: "*"
        values: ["*"]
EOF

tctl create ./test-scoped-role.yaml
```

Create an access list that grants the scoped role:

```bash
cat >./test-access-list.yaml <<EOF
kind: access_list
version: v1
metadata:
  name: test-list
spec:
  title: test-list
  owners:
    - name: owner@example.com
      membership_kind: MEMBERSHIP_KIND_USER
  grants:
    scoped_roles:
      - role: test-role
        scope: /test/test
EOF

tctl create ./test-access-list.yaml
```

Add a member to the access list:

```bash
tctl acl users add test-list tester
```

### Test Cases

- [x] Jaeger at `http://localhost:16686` shows a span for materializer init after auth startup.
- [x] Adding the access list member emits a materializer event-processing span.
- [x] the `teleport_scoped_access_cache_materialized_assignments` gauge is present at the metrics endpoint (tctl top seems broken in branch/v18)
- [x] `tctl get scoped_role_assignments` shows a materialized assignment for `tester` with origin status pointing to `test-list`, for example:

```yaml
status:
  origin:
    creator_kind: access_list
    creator_name: test-list
sub_kind: materialized
```

- [x] With the backport of https://github.com/gravitational/teleport.e/pull/8435, verify that inherited grants for an access list include inherited scoped role grants in the UI.
