### PR TITLE
[v18] Support verifying standard agent UUIDs for bound keypair joining (#64351)

### DIFF
--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -19,7 +19,6 @@
 package auth_test
 
 import (
-	"context"
 	"crypto"
 	"crypto/tls"
 	"strings"
@@ -105,7 +104,7 @@ func parseJoinState(t *testing.T, state []byte) *boundkeypair.JoinState {
 func TestServer_RegisterUsingBoundKeypairMethod(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, correctPublicKey := testBoundKeypair(t)
 	_, rotatedPublicKey := testBoundKeypair(t)
@@ -953,7 +952,7 @@ func testExtractBotParamsFromCerts(t require.TestingT, certs *proto.Certs) (stri
 func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sshPrivateKey, sshPublicKey, err := testauthority.GenerateKeyPair()
 	require.NoError(t, err)
@@ -1163,7 +1162,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {
 	// sequence.
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sshPrivateKey, sshPublicKey, err := testauthority.GenerateKeyPair()
 	require.NoError(t, err)
@@ -1322,7 +1321,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailureDuringRenewal(t 
 	// its own.
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sshPrivateKey, sshPublicKey, err := testauthority.GenerateKeyPair()
 	require.NoError(t, err)
@@ -1598,4 +1597,75 @@ func TestServer_CreateBoundKeypairToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TODO(timothyb89): DELETE IN 20 when the legacy join service is removed,
+// agents are allowed to join using the new join service.
+func TestServer_RegisterUsingBoundKeypairMethod_LegacyAgentJoinNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	sshPrivateKey, sshPublicKey, err := testauthority.GenerateKeyPair()
+	require.NoError(t, err)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	require.NoError(t, err)
+
+	_, correctPublicKey := testBoundKeypair(t)
+
+	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
+
+	srv := newTestTLSServer(t, withClock(clock))
+	authServer := srv.Auth()
+	authServer.SetCreateBoundKeypairValidator(func(subject, clusterName string, publicKey crypto.PublicKey) (joinboundkeypair.BoundKeypairValidator, error) {
+		return &mockBoundKeypairValidator{
+			subject:     subject,
+			clusterName: clusterName,
+			publicKey:   publicKey,
+		}, nil
+	})
+
+	_, err = authtest.CreateRole(ctx, authServer, "example", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	token, err := types.NewProvisionTokenFromSpecAndStatus(
+		"bound-keypair-test",
+		time.Now().Add(2*time.Hour),
+		types.ProvisionTokenSpecV2{
+			JoinMethod: types.JoinMethodBoundKeypair,
+			Roles:      []types.SystemRole{types.RoleNode, types.RoleKube},
+			BoundKeypair: &types.ProvisionTokenSpecV2BoundKeypair{
+				Onboarding: &types.ProvisionTokenSpecV2BoundKeypair_OnboardingSpec{
+					InitialPublicKey: correctPublicKey,
+				},
+				Recovery: &types.ProvisionTokenSpecV2BoundKeypair_RecoverySpec{
+					Limit: 1,
+				},
+			},
+		},
+		&types.ProvisionTokenStatusV2{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, authServer.CreateBoundKeypairToken(ctx, token))
+
+	makeInitReq := func(mutators ...func(r *proto.RegisterUsingBoundKeypairInitialRequest)) *proto.RegisterUsingBoundKeypairInitialRequest {
+		req := &proto.RegisterUsingBoundKeypairInitialRequest{
+			JoinRequest: &types.RegisterUsingTokenRequest{
+				HostID:       "host-id",
+				Role:         types.RoleNode,
+				PublicTLSKey: tlsPublicKey,
+				PublicSSHKey: sshPublicKey,
+				Token:        "bound-keypair-test",
+			},
+		}
+		for _, mutator := range mutators {
+			mutator(req)
+		}
+		return req
+	}
+
+	// Perform the initial registration.
+	solver := newMockSolver(t, correctPublicKey)
+	_, err = authServer.RegisterUsingBoundKeypairMethod(ctx, makeInitReq(), solver.solver())
+	require.ErrorContains(t, err, "bound keypair joining for agents requires use of the new join service")
 }

--- a/lib/boundkeypair/join_state.go
+++ b/lib/boundkeypair/join_state.go
@@ -41,8 +41,14 @@ type JoinState struct {
 	// process if the previous instance expired. The
 	// `(bot_instance_id, recovery_sequence)` tuple is considered functionally
 	// unique to each issued join state for verification purposes, and will
-	// remain unchanged until the next successful recovery.
+	// remain unchanged until the next successful recovery. Mutually exclusive
+	// with HostID.
 	BotInstanceID string `json:"bot_instance_id"`
+
+	// HostID is the unique identifier for standard Teleport (non-bot) agents.
+	// It is mutually exclusive with `bot_instance_id`, but otherwise behaves
+	// similarly.
+	HostID string `json:"host_id"`
 
 	// RecoverySequence is the recovery sequence number. This is incremented
 	// each time a recovery is performed, including on first join. This counter
@@ -70,6 +76,25 @@ type JoinStateParams struct {
 
 	ClusterName string
 	Token       *types.ProvisionTokenV2
+
+	// HostID is the ID if this JoinState is for a joining agent rather than
+	// bot, used as the JWT subject. This field is only required for newly
+	// joining agents; agents performing a hard rejoin (rare but possible) will
+	// have .status.bound_host_id set in their token resource.
+	HostID string
+}
+
+func (p *JoinStateParams) GetSubject() (string, error) {
+	switch {
+	case p.Token.Spec.BotName != "":
+		return p.Token.Spec.BotName, nil
+	case p.HostID != "":
+		return p.HostID, nil
+	case p.Token.Status.BoundKeypair.BoundHostID != "":
+		return p.Token.Status.BoundKeypair.BoundHostID, nil
+	default:
+		return "", trace.BadParameter("invalid join state parameters, one of [.Token.Spec.BotName, .HostID] is required")
+	}
 }
 
 // IssueJoinState generates a join state document from the provided token and
@@ -85,11 +110,12 @@ func IssueJoinState(signer crypto.Signer, params *JoinStateParams) (string, erro
 		return "", trace.BadParameter("status.bound_keypair: required field is missing")
 	}
 
-	status := params.Token.Status.BoundKeypair
-
-	if params.Token.Spec.BotName == "" {
-		return "", trace.BadParameter("spec.bot_name: required field is empty")
+	subject, err := params.GetSubject()
+	if err != nil {
+		return "", trace.Wrap(err)
 	}
+
+	status := params.Token.Status.BoundKeypair
 
 	state := &JoinState{
 		Claims: &jwt.Claims{
@@ -99,13 +125,14 @@ func IssueJoinState(signer crypto.Signer, params *JoinStateParams) (string, erro
 			IssuedAt:  jwt.NewNumericDate(params.Clock.Now()),
 			Issuer:    params.ClusterName,
 			Audience:  jwt.Audience{params.ClusterName},
-			Subject:   params.Token.Spec.BotName,
+			Subject:   subject,
 
 			// Note: These documents aren't meant to expire, so no expiration is
 			// included. We may opt to trust (or not) a given document during
 			// verification based on its `iat` in the future.
 		},
 		BotInstanceID:    status.BoundBotInstanceID,
+		HostID:           status.BoundHostID,
 		RecoverySequence: status.RecoveryCount,
 		RecoveryLimit:    spec.Recovery.Limit,
 		RecoveryMode:     spec.Recovery.Mode,
@@ -141,6 +168,11 @@ func verifyJoinStateInner(key crypto.PublicKey, parsed *jwt.JSONWebToken, params
 		return nil, trace.BadParameter("invalid token status")
 	}
 
+	subject, err := params.GetSubject()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var document JoinState
 	if err := parsed.Claims(key, &document); err != nil {
 		return nil, trace.Wrap(err)
@@ -155,7 +187,7 @@ func verifyJoinStateInner(key crypto.PublicKey, parsed *jwt.JSONWebToken, params
 	if err := document.Claims.ValidateWithLeeway(jwt.Expected{
 		Issuer:   params.ClusterName,
 		Audience: jwt.Audience{params.ClusterName},
-		Subject:  params.Token.Spec.BotName,
+		Subject:  subject,
 		Time:     params.Clock.Now(),
 	}, leeway); err != nil {
 		return nil, trace.Wrap(err, "validating join state claims")
@@ -169,6 +201,9 @@ func verifyJoinStateInner(key crypto.PublicKey, parsed *jwt.JSONWebToken, params
 	}
 	if document.BotInstanceID != params.Token.Status.BoundKeypair.BoundBotInstanceID {
 		errors = append(errors, trace.AccessDenied("bot instance mismatch"))
+	}
+	if document.HostID != params.Token.Status.BoundKeypair.BoundHostID {
+		errors = append(errors, trace.AccessDenied("host mismatch"))
 	}
 
 	if len(errors) > 0 {

--- a/lib/join/boundkeypair/boundkeypair.go
+++ b/lib/join/boundkeypair/boundkeypair.go
@@ -253,15 +253,42 @@ func mutateStatusBoundPublicKey(newPublicKey, expectPreviousKey string) boundKey
 }
 
 // mutateStatusBoundBotInstance updates the bot instance ID currently bound to
-// this token. It ensures the expected previous ID is still the bound value
-// before performing the update.
+// this token. It ensures the expected previous bot instance and host IDs are
+// still the bound value before performing the update. Note that bot instance
+// and host IDs are mutually exclusive, so `BoundHostID` on the token status
+// must be empty.
 func mutateStatusBoundBotInstance(newBotInstance, expectPreviousBotInstance string) boundKeypairStatusMutator {
 	return func(_ *types.ProvisionTokenSpecV2BoundKeypair, status *types.ProvisionTokenStatusV2BoundKeypair) error {
 		if status.BoundBotInstanceID != expectPreviousBotInstance {
 			return trace.AccessDenied("unexpected backend state")
 		}
 
+		if status.BoundHostID != "" {
+			return trace.AccessDenied("unexpected backend state")
+		}
+
 		status.BoundBotInstanceID = newBotInstance
+
+		return nil
+	}
+}
+
+// mutateStatusBoundHostID updates the host ID currently bound to this token. It
+// ensures the expected previous host and bot instance IDs are still the bound
+// values (or lack thereof) before performing the update. Note that bot instance
+// and host IDs are mutually exclusive, so an empty `BoundBotInstanceID` on the
+// token status is required.
+func mutateStatusBoundHostID(newHostID, expectPreviousHostID string) boundKeypairStatusMutator {
+	return func(_ *types.ProvisionTokenSpecV2BoundKeypair, status *types.ProvisionTokenStatusV2BoundKeypair) error {
+		if status.BoundHostID != expectPreviousHostID {
+			return trace.AccessDenied("unexpected backend state")
+		}
+
+		if status.BoundBotInstanceID != "" {
+			return trace.AccessDenied("unexpected backend state")
+		}
+
+		status.BoundHostID = newHostID
 
 		return nil
 	}
@@ -452,10 +479,10 @@ func verifyBoundKeypairJoinState(
 	params *JoinParams,
 	ptv2 *types.ProvisionTokenV2,
 	ca types.CertAuthority,
-) (previousBotInstnceID string, err error) {
+) (previousBotInstanceID, previousHostID string, err error) {
 	recoveryMode, err := boundkeypair.ParseRecoveryMode(ptv2.Spec.BoundKeypair.Recovery.Mode)
 	if err != nil {
-		return "", trace.Wrap(err, "parsing recovery mode")
+		return "", "", trace.Wrap(err, "parsing recovery mode")
 	}
 
 	// Join state is required after the initial join (first recovery), so long
@@ -473,13 +500,13 @@ func verifyBoundKeypairJoinState(
 			"recovery_count", ptv2.Status.BoundKeypair.RecoveryCount,
 			"recovery_mode", ptv2.Spec.BoundKeypair.Recovery.Mode,
 		)
-		return "", nil
+		return "", "", nil
 	}
 
 	// If join state is required but missing, raise an error.
 	hasIncomingJoinState := len(params.BoundKeypairInit.PreviousJoinState) > 0
 	if !hasIncomingJoinState {
-		return "", trace.AccessDenied("previous join state is required but was not provided")
+		return "", "", trace.AccessDenied("previous join state is required but was not provided")
 	}
 
 	params.Logger.DebugContext(ctx, "join state verification required, verifying")
@@ -490,18 +517,21 @@ func verifyBoundKeypairJoinState(
 			Clock:       params.Clock,
 			ClusterName: ca.GetClusterName(), // equivalent to clusterName but saves a method param
 			Token:       ptv2,
+
+			// Note: no HostID for agents specified, it will be extracted from
+			// the bound_host_id in the token status.
 		},
 	)
 	if err != nil {
 		params.Logger.ErrorContext(ctx, "bound keypair join state verification failed", "error", err)
 		tryLockBotInvalidJoinState(ctx, params, ptv2, err)
 
-		return "", trace.AccessDenied("join state verification failed")
+		return "", "", trace.AccessDenied("join state verification failed")
 	}
 
 	params.Logger.DebugContext(ctx, "join state verified successfully", "join_state", joinState)
-	// Now that we've verified it, return the previous bot instance ID.
-	return joinState.BotInstanceID, nil
+	// Now that we've verified it, return the previous bot instance / host ID.
+	return joinState.BotInstanceID, joinState.HostID, nil
 }
 
 // verifyLocksForBoundKeypairToken checks if any token-level locks are in place
@@ -546,6 +576,11 @@ type JoinParams struct {
 	CreateBoundKeypairValidator CreateBoundKeypairValidator
 	// GenerateBotCerts is a function that generates bot certificates.
 	GenerateBotCerts func(ctx context.Context, previousBotInstanceID string, claims any) (*messages.Certificates, string, error)
+	// GenerateHostCerts is a function that generates host certificates. Unlike
+	// bots, hosts do not maintain an ID lineage and are expected to retain
+	// their host IDs indefinitely (or else start over from a clean slate
+	// without tracking); therefore, no previous ID is expected.
+	GenerateHostCerts func(ctx context.Context, claims any) (certs *messages.Certificates, hostID string, err error)
 	// Clock is the clock.
 	Clock clockwork.Clock
 	// Logger is a logger.
@@ -614,11 +649,6 @@ func HandleBoundKeypairJoin(
 	if err := params.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// Only bot joining is supported at the moment - unique ID verification is
-	// required and this is currently only implemented for bots.
-	if types.SystemRole(params.ClientInit.SystemRole) != types.RoleBot {
-		return nil, trace.BadParameter("bound keypair joining is only supported for bots")
-	}
 
 	ptv2, ok := params.ProvisionToken.(*types.ProvisionTokenV2)
 	if !ok {
@@ -639,12 +669,37 @@ func HandleBoundKeypairJoin(
 		return nil, trace.Wrap(err)
 	}
 
+	systemRole := types.SystemRole(params.ClientInit.SystemRole)
 	spec := ptv2.Spec.BoundKeypair
 	status := ptv2.Status.BoundKeypair
 	hasBoundPublicKey := status.BoundPublicKey != ""
 	hasBoundBotInstance := status.BoundBotInstanceID != ""
+	hasBoundHostID := status.BoundHostID != ""
+	hasBoundUniqueID := hasBoundBotInstance || hasBoundHostID
 	hasIncomingBotInstance := params.AuthCtx.BotInstanceID != ""
+	hasIncomingHostID := params.AuthCtx.HostID != ""
+	hasIncomingUniqueID := hasIncomingBotInstance || hasIncomingHostID
 	hasJoinsRemaining := status.RecoveryCount < spec.Recovery.Limit
+
+	// Perform a few preflight checks to verify the incoming params are
+	// internally consistent
+	switch {
+	case hasIncomingBotInstance && hasIncomingHostID:
+		// Can't have both parameters set.
+		return nil, trace.AccessDenied("cannot join with invalid identity")
+	case systemRole == types.RoleBot && (hasIncomingHostID || hasBoundHostID):
+		// Note: this hasn't traditionally been enforced but bots have never
+		// self reported a host UUID. Given how new this join method is, it
+		// should be fairly safe to add this restriction.
+		fallthrough
+	case systemRole == types.RoleInstance && (hasIncomingBotInstance || hasBoundBotInstance):
+		fallthrough
+	case hasIncomingBotInstance && hasBoundHostID:
+		// Similarly, don't allow switching client types.
+		fallthrough
+	case hasIncomingHostID && hasBoundBotInstance:
+		return nil, trace.AccessDenied("cannot join with mismatched unique identifier")
+	}
 
 	recoveryMode, err := boundkeypair.ParseRecoveryMode(spec.Recovery.Mode)
 	if err != nil {
@@ -652,7 +707,7 @@ func HandleBoundKeypairJoin(
 	}
 
 	// if set, the bound bot instance will be updated in the backend
-	expectNewBotInstance := false
+	expectNewUniqueID := false
 
 	// the bound public key; may change during initial join or rotation. used to
 	// inform the returned public key value.
@@ -677,7 +732,7 @@ func HandleBoundKeypairJoin(
 
 	var verifiedPreviousBotInstanceID string
 	switch {
-	case !hasBoundPublicKey && !hasIncomingBotInstance:
+	case !hasBoundPublicKey && !hasIncomingUniqueID:
 		// Normal initial join attempt. No bound key, and no incoming bot
 		// instance. Consumes a recovery attempt.
 		if recoveryMode == boundkeypair.RecoveryModeStandard && !hasJoinsRemaining {
@@ -777,18 +832,18 @@ func HandleBoundKeypairJoin(
 		// Note: this is the initial join, so no join state to verify.
 
 		recoveryCount += 1
-		expectNewBotInstance = true
+		expectNewUniqueID = true
 		emitBoundKeypairRecoveryEvent(ctx, params, ptv2, boundPublicKey, recoveryCount, nil)
-	case !hasBoundPublicKey && hasIncomingBotInstance:
+	case !hasBoundPublicKey && hasIncomingUniqueID:
 		// Not allowed, at least at the moment. This would imply e.g. trying to
 		// change auth methods.
 		return nil, trace.BadParameter("cannot perform first bound keypair join with existing credentials")
-	case hasBoundPublicKey && !hasBoundBotInstance:
+	case hasBoundPublicKey && !hasBoundUniqueID:
 		// TODO: Bad backend state, or maybe an incomplete previous join
 		// attempt. This shouldn't be a possible state, but we should handle it
 		// sanely anyway.
 		return nil, trace.BadParameter("bad backend state, please recreate the join token")
-	case hasBoundPublicKey && hasBoundBotInstance && hasIncomingBotInstance:
+	case hasBoundPublicKey && hasBoundUniqueID && hasIncomingUniqueID:
 		// Standard rejoin case, does not consume a rejoin.
 		if err := issueBoundKeypairChallenge(
 			ctx,
@@ -810,7 +865,7 @@ func HandleBoundKeypairJoin(
 		// make sure an otherwise unauthorized client can't trigger a lockout.
 		// This also needs to be done before rotation to prevent an attacker
 		// from rotating the key.
-		verifiedPreviousBotInstanceID, err = verifyBoundKeypairJoinState(ctx, params, ptv2, ca)
+		verifiedPreviousBotInstanceID, _, err = verifyBoundKeypairJoinState(ctx, params, ptv2, ca)
 		if err != nil {
 			return nil, trace.AccessDenied("join state verification failed")
 		}
@@ -825,11 +880,13 @@ func HandleBoundKeypairJoin(
 		// keep this as a sanity check.
 		if status.BoundBotInstanceID != params.AuthCtx.BotInstanceID {
 			return nil, trace.AccessDenied("bot instance mismatch")
+		} else if status.BoundHostID != params.AuthCtx.HostID {
+			return nil, trace.AccessDenied("host ID mismatch")
 		}
 
 		// Nothing else to do, no key change, no additional audit event; regular
 		// bot join event will be emitted later.
-	case hasBoundPublicKey && hasBoundBotInstance && !hasIncomingBotInstance:
+	case hasBoundPublicKey && hasBoundUniqueID && !hasIncomingUniqueID:
 		if err := issueBoundKeypairChallenge(
 			ctx,
 			params,
@@ -843,7 +900,7 @@ func HandleBoundKeypairJoin(
 		// is required. Consumes a rejoin.
 		if recoveryMode == boundkeypair.RecoveryModeStandard && !hasJoinsRemaining {
 			// Recovery limit only applies in "standard" mode.
-			return nil, trace.AccessDenied("no rejoins remaining")
+			return nil, trace.AccessDenied("no recovery attempts remaining")
 		}
 
 		// Verify locks here now that we've verified private key ownership but
@@ -855,7 +912,7 @@ func HandleBoundKeypairJoin(
 
 		// As in the standard case above, once we've verified the client has the
 		// matching private key, validate the join state.
-		verifiedPreviousBotInstanceID, err = verifyBoundKeypairJoinState(ctx, params, ptv2, ca)
+		verifiedPreviousBotInstanceID, _, err = verifyBoundKeypairJoinState(ctx, params, ptv2, ca)
 		if err != nil {
 			return nil, trace.AccessDenied("join state verification failed")
 		}
@@ -866,14 +923,16 @@ func HandleBoundKeypairJoin(
 		)
 
 		recoveryCount += 1
-		expectNewBotInstance = true
+		expectNewUniqueID = true
 		emitBoundKeypairRecoveryEvent(ctx, params, ptv2, boundPublicKey, recoveryCount, nil)
 	default:
 		log.ErrorContext(
 			ctx, "unexpected state",
 			"has_bound_public_key", hasBoundPublicKey,
 			"has_bound_bot_instance", hasBoundBotInstance,
+			"has_bound_host_id", hasBoundHostID,
 			"has_incoming_bot_instance", hasIncomingBotInstance,
+			"has_incoming_host_id", hasIncomingHostID,
 			"spec", spec,
 			"status", status,
 		)
@@ -909,20 +968,48 @@ func HandleBoundKeypairJoin(
 		boundPublicKey = newPubKey
 	}
 
-	certs, botInstanceID, err := params.GenerateBotCerts(ctx, verifiedPreviousBotInstanceID, &boundkeypair.Claims{
-		PublicKey:     boundPublicKey,
-		RecoveryCount: recoveryCount,
-		RecoveryMode:  recoveryMode,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	var generatedHostID string
+	var certs *messages.Certificates
+	switch systemRole {
+	case types.RoleBot:
+		generatedCerts, botInstanceID, err := params.GenerateBotCerts(ctx, verifiedPreviousBotInstanceID, &boundkeypair.Claims{
+			PublicKey:     boundPublicKey,
+			RecoveryCount: recoveryCount,
+			RecoveryMode:  recoveryMode,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 
-	if expectNewBotInstance {
-		mutators = append(
-			mutators,
-			mutateStatusBoundBotInstance(botInstanceID, status.BoundBotInstanceID),
-		)
+		if expectNewUniqueID {
+			mutators = append(
+				mutators,
+				mutateStatusBoundBotInstance(botInstanceID, status.BoundBotInstanceID),
+			)
+		}
+
+		certs = generatedCerts
+	case types.RoleInstance:
+		generatedCerts, hostID, err := params.GenerateHostCerts(ctx, &boundkeypair.Claims{
+			PublicKey:     boundPublicKey,
+			RecoveryCount: recoveryCount,
+			RecoveryMode:  recoveryMode,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if expectNewUniqueID {
+			mutators = append(
+				mutators,
+				mutateStatusBoundHostID(hostID, status.BoundHostID),
+			)
+		}
+
+		certs = generatedCerts
+		generatedHostID = hostID
+	default:
+		return nil, trace.NotImplemented("bound keypair joining only supports Instance and Bot system roles, client requested %s", systemRole)
 	}
 
 	// A reference to the final provision token state; may be modified below via
@@ -968,6 +1055,7 @@ func HandleBoundKeypairJoin(
 		Clock:       params.Clock,
 		ClusterName: clusterName.GetClusterName(),
 		Token:       finalToken,
+		HostID:      generatedHostID,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "issuing join state document")

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -334,12 +334,23 @@ func TestJoinBoundKeypair(t *testing.T) {
 		return token
 	}
 
-	withRecovery := func(mode string, count, limit uint32, botInstanceID string) func(*types.ProvisionTokenV2) {
+	withRecovery := func(mode string, count, limit uint32) func(*types.ProvisionTokenV2) {
 		return func(v2 *types.ProvisionTokenV2) {
 			v2.Spec.BoundKeypair.Recovery.Mode = mode
 			v2.Spec.BoundKeypair.Recovery.Limit = limit
 			v2.Status.BoundKeypair.RecoveryCount = count
+		}
+	}
+
+	withBoundBotInstance := func(botInstanceID string) func(*types.ProvisionTokenV2) {
+		return func(v2 *types.ProvisionTokenV2) {
 			v2.Status.BoundKeypair.BoundBotInstanceID = botInstanceID
+		}
+	}
+
+	withBoundHostID := func(hostID string) func(*types.ProvisionTokenV2) {
+		return func(v2 *types.ProvisionTokenV2) {
+			v2.Status.BoundKeypair.BoundHostID = hostID
 		}
 	}
 
@@ -352,6 +363,13 @@ func TestJoinBoundKeypair(t *testing.T) {
 	withBoundKey := func(key string) func(*types.ProvisionTokenV2) {
 		return func(v2 *types.ProvisionTokenV2) {
 			v2.Status.BoundKeypair.BoundPublicKey = key
+		}
+	}
+
+	withNodeParams := func() func(*types.ProvisionTokenV2) {
+		return func(v2 *types.ProvisionTokenV2) {
+			v2.Spec.Roles = []types.SystemRole{types.RoleNode}
+			v2.Spec.BotName = ""
 		}
 	}
 
@@ -392,6 +410,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 		token             types.ProvisionTokenV2
 		initialJoinSecret string
 		state             *mockBoundKeypairState
+		joinAsInstance    bool
 
 		assertError       require.ErrorAssertionFunc
 		assertResponse    func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult)
@@ -460,7 +479,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 		},
 		{
 			name:        "standard-initial-recovery-success",
-			token:       makeToken(withRecovery("standard", 0, 1, ""), withInitialKey(correctPublicKey)),
+			token:       makeToken(withRecovery("standard", 0, 1), withInitialKey(correctPublicKey)),
 			state:       makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
@@ -471,11 +490,16 @@ func TestJoinBoundKeypair(t *testing.T) {
 			},
 		},
 		{
-			name:  "standard-success-second-recovery",
-			token: makeToken(withRecovery("standard", 1, 2, "id"), withInitialKey(correctPublicKey)),
+			name: "standard-success-second-recovery",
+			token: makeToken(
+				withRecovery("standard", 1, 2),
+				withBoundBotInstance("id"),
+				withInitialKey(correctPublicKey),
+			),
 			state: makeMockBoundKeypairState(signers,
 				withSigningKeys(correctPublicKey),
-				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 2, "id")))),
+				withPreviousJoinState(makeJoinState(jwtSigner,
+					withToken(withRecovery("standard", 1, 2), withBoundBotInstance("id")))),
 			),
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
@@ -487,7 +511,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 		},
 		{
 			name:  "standard-failure-missing-join-state",
-			token: makeToken(withRecovery("standard", 1, 2, "id"), withBoundKey(correctPublicKey)),
+			token: makeToken(withRecovery("standard", 1, 2), withBoundBotInstance("id"), withBoundKey(correctPublicKey)),
 			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
@@ -495,10 +519,11 @@ func TestJoinBoundKeypair(t *testing.T) {
 		},
 		{
 			name:  "standard-failure-limit-exhausted",
-			token: makeToken(withRecovery("standard", 2, 2, "id")),
+			token: makeToken(withRecovery("standard", 2, 2), withBoundBotInstance("id")),
 			state: makeMockBoundKeypairState(signers,
 				withSigningKeys(correctPublicKey),
-				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("standard", 2, 2, "id")))),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(
+					withRecovery("standard", 2, 2), withBoundBotInstance("id")))),
 			),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "no recovery attempts remaining")
@@ -507,10 +532,11 @@ func TestJoinBoundKeypair(t *testing.T) {
 		{
 			// Attempts to join with an outdated join state document should fail.
 			name:  "standard-failure-recovery-count-mismatch",
-			token: makeToken(withRecovery("standard", 2, 3, "id"), withBoundKey(correctPublicKey)),
+			token: makeToken(withRecovery("standard", 2, 3), withBoundBotInstance("id"), withBoundKey(correctPublicKey)),
 			state: makeMockBoundKeypairState(signers,
 				withSigningKeys(correctPublicKey),
-				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 3, "id")))),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(
+					withRecovery("standard", 1, 3), withBoundBotInstance("id")))),
 			),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
@@ -518,7 +544,7 @@ func TestJoinBoundKeypair(t *testing.T) {
 		},
 		{
 			name:  "standard-failure-invalid-jwt",
-			token: makeToken(withRecovery("standard", 1, 2, "id"), withBoundKey(correctPublicKey)),
+			token: makeToken(withRecovery("standard", 1, 2), withBoundBotInstance("id"), withBoundKey(correctPublicKey)),
 			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey), withPreviousJoinState([]byte("asdf"))),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
@@ -526,10 +552,11 @@ func TestJoinBoundKeypair(t *testing.T) {
 		},
 		{
 			name:  "standard-failure-invalid-jwt-signature",
-			token: makeToken(withRecovery("standard", 1, 2, "id"), withBoundKey(correctPublicKey)),
+			token: makeToken(withRecovery("standard", 1, 2), withBoundBotInstance("id"), withBoundKey(correctPublicKey)),
 			state: makeMockBoundKeypairState(signers,
 				withSigningKeys(correctPublicKey),
-				withPreviousJoinState(makeJoinState(invalidJWTSigner, withToken(withRecovery("standard", 1, 2, "id")))),
+				withPreviousJoinState(makeJoinState(invalidJWTSigner, withToken(
+					withRecovery("standard", 1, 2), withBoundBotInstance("id")))),
 			),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
@@ -537,10 +564,11 @@ func TestJoinBoundKeypair(t *testing.T) {
 		},
 		{
 			name:  "standard-failure-invalid-instance-id",
-			token: makeToken(withRecovery("standard", 1, 2, "foo"), withBoundKey(correctPublicKey)),
+			token: makeToken(withRecovery("standard", 1, 2), withBoundBotInstance("foo"), withBoundKey(correctPublicKey)),
 			state: makeMockBoundKeypairState(signers,
 				withSigningKeys(correctPublicKey),
-				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 2, "id")))),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(
+					withRecovery("standard", 1, 2), withBoundBotInstance("id")))),
 			),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
@@ -548,12 +576,14 @@ func TestJoinBoundKeypair(t *testing.T) {
 		},
 		{
 			name:  "standard-failure-invalid-cluster",
-			token: makeToken(withRecovery("standard", 1, 2, "foo"), withBoundKey(correctPublicKey)),
+			token: makeToken(withRecovery("standard", 1, 2), withBoundBotInstance("foo"), withBoundKey(correctPublicKey)),
 			state: makeMockBoundKeypairState(signers,
 				withSigningKeys(correctPublicKey),
-				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("standard", 1, 2, "id")), func(s *boundkeypair.JoinStateParams) {
-					s.ClusterName = "wrong-cluster"
-				})),
+				withPreviousJoinState(makeJoinState(jwtSigner,
+					withToken(withRecovery("standard", 1, 2), withBoundBotInstance("id")),
+					func(s *boundkeypair.JoinStateParams) {
+						s.ClusterName = "wrong-cluster"
+					})),
 			),
 			assertError: func(tt require.TestingT, err error, i ...any) {
 				require.ErrorContains(tt, err, "join state verification failed")
@@ -561,10 +591,11 @@ func TestJoinBoundKeypair(t *testing.T) {
 		},
 		{
 			name:  "relaxed-success-count-over-limit",
-			token: makeToken(withRecovery("relaxed", 1, 0, "id"), withBoundKey(correctPublicKey)),
+			token: makeToken(withRecovery("relaxed", 1, 0), withBoundBotInstance("id"), withBoundKey(correctPublicKey)),
 			state: makeMockBoundKeypairState(signers,
 				withSigningKeys(correctPublicKey),
-				withPreviousJoinState(makeJoinState(jwtSigner, withToken(withRecovery("relaxed", 1, 0, "id")))),
+				withPreviousJoinState(makeJoinState(jwtSigner,
+					withToken(withRecovery("relaxed", 1, 0), withBoundBotInstance("id")))),
 			),
 			assertError: require.NoError,
 			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
@@ -849,6 +880,117 @@ func TestJoinBoundKeypair(t *testing.T) {
 				require.Nil(t, res)
 			},
 		},
+		{
+			name:           "registration-success-node",
+			joinAsInstance: true,
+			token: makeToken(withNodeParams(), func(v2 *types.ProvisionTokenV2) {
+				v2.Spec.BoundKeypair.Onboarding.InitialPublicKey = ""
+				v2.Spec.BoundKeypair.Onboarding.RegistrationSecret = "secret"
+			}),
+			initialJoinSecret: "secret",
+			state:             makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey), withRotationKeys(correctPublicKey)),
+
+			assertError: require.NoError,
+			assertSolverState: func(t *testing.T, s *mockBoundKeypairState) {
+				require.EqualValues(t, 1, s.challengeCount.Load())
+				require.EqualValues(t, 1, s.rotationCount.Load())
+
+				// we'll only be asked for one challenge
+				require.Equal(t, []string{correctPublicKey}, s.solutionKeys)
+			},
+			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult) {
+				require.Empty(t, v2.Status.BoundKeypair.BoundBotInstanceID)
+				require.NotEmpty(t, v2.Status.BoundKeypair.BoundHostID)
+				require.Equal(t, correctPublicKey, v2.Status.BoundKeypair.BoundPublicKey)
+				require.Equal(t, correctPublicKey, res.BoundPublicKey)
+			},
+		},
+		{
+			// bound key but no valid incoming bot instance, i.e. the certs
+			// expired and triggered a hard rejoin
+			name:           "recovery-success-node",
+			joinAsInstance: true,
+			token:          makeToken(withNodeParams(), withBoundKey(correctPublicKey), withBoundHostID("asdf")),
+			state:          makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
+
+			assertError: require.NoError,
+			assertResponse: func(t *testing.T, v2 *types.ProvisionTokenV2, _ *joinclient.BoundKeypairResult) {
+				require.Equal(t, uint32(1), v2.Status.BoundKeypair.RecoveryCount)
+
+				// Should generate a new host ID (and no bot instance ID)
+				require.Empty(t, v2.Status.BoundKeypair.BoundBotInstanceID)
+				require.NotEmpty(t, v2.Status.BoundKeypair.BoundHostID)
+				require.NotEqual(t, "asdf", v2.Status.BoundKeypair.BoundHostID)
+			},
+		},
+		{
+			name:           "recovery-failure-node-limit-exhausted",
+			joinAsInstance: true,
+			token: makeToken(
+				withNodeParams(),
+				withRecovery("standard", 2, 2),
+				withBoundHostID("id"),
+				withBoundKey(correctPublicKey),
+			),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(
+					withRecovery("standard", 2, 2), withBoundHostID("id")))),
+			),
+			assertError: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "no recovery attempts remaining")
+			},
+		},
+		{
+			name:           "recovery-failure-node-with-bound-bot-id",
+			joinAsInstance: true,
+			token: makeToken(
+				withNodeParams(),
+				withRecovery("standard", 2, 3),
+				withBoundBotInstance("id"),
+				withBoundKey(correctPublicKey),
+			),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(
+					withRecovery("standard", 1, 3), withBoundBotInstance("id")))),
+			),
+			assertError: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "cannot join with mismatched unique identifier")
+			},
+		},
+		{
+			name: "recovery-failure-bot-with-bound-node-id",
+			token: makeToken(
+				withBoundKey(correctPublicKey),
+				withRecovery("standard", 2, 3),
+				withBoundHostID("id"),
+			),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(
+					withRecovery("standard", 2, 3), withBoundHostID("id")))),
+			),
+			assertError: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "cannot join with mismatched unique identifier")
+			},
+		},
+		{
+			name: "recovery-failure-bot-with-host-id-in-join-state",
+			token: makeToken(
+				withBoundKey(correctPublicKey),
+				withRecovery("standard", 2, 3),
+				withBoundBotInstance("id"),
+			),
+			state: makeMockBoundKeypairState(signers,
+				withSigningKeys(correctPublicKey),
+				withPreviousJoinState(makeJoinState(jwtSigner, withToken(
+					withRecovery("standard", 2, 3), withBoundHostID("id")))),
+			),
+			assertError: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "join state verification failed")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -863,11 +1005,16 @@ func TestJoinBoundKeypair(t *testing.T) {
 			// computed fields (i.e. registration secrets) are handled properly.
 			require.NoError(t, authServer.CreateBoundKeypairToken(ctx, token))
 
+			id := state.IdentityID{
+				Role: types.RoleBot,
+			}
+			if tt.joinAsInstance {
+				id.Role = types.RoleInstance
+			}
+
 			joinResult, err := joinclient.Join(t.Context(), joinclient.JoinParams{
-				Token: token.GetName(),
-				ID: state.IdentityID{
-					Role: types.RoleBot,
-				},
+				Token:                          token.GetName(),
+				ID:                             id,
 				AuthClient:                     nopClient,
 				BoundKeypairRegistrationSecret: tt.initialJoinSecret,
 				BoundKeypairState:              tt.state,
@@ -894,8 +1041,10 @@ func TestJoinBoundKeypair(t *testing.T) {
 	rejoinTests := []struct {
 		name string
 
-		mutateToken func(*types.ProvisionTokenV2)
-		state       *mockBoundKeypairState
+		mutateToken        func(*types.ProvisionTokenV2)
+		mutateInitialToken func(*types.ProvisionTokenV2)
+		state              *mockBoundKeypairState
+		joinAsInstance     bool
 
 		assertError    require.ErrorAssertionFunc
 		assertResponse func(t *testing.T, v2 *types.ProvisionTokenV2, res *joinclient.BoundKeypairResult)
@@ -940,19 +1089,52 @@ func TestJoinBoundKeypair(t *testing.T) {
 				require.ErrorContains(tt, err, "bot instance mismatch")
 			},
 		},
+		{
+			name: "bot-with-bound-host-id",
+			mutateToken: func(v2 *types.ProvisionTokenV2) {
+				v2.Status.BoundKeypair.BoundHostID = "qwerty"
+			},
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
+			assertError: func(tt require.TestingT, err error, i ...any) {
+				require.Error(tt, err)
+				require.ErrorContains(tt, err, "cannot join with mismatched unique identifier")
+			},
+		},
+		{
+			name:               "node-with-bound-bot-instance-id",
+			joinAsInstance:     true,
+			mutateInitialToken: withNodeParams(),
+			mutateToken: func(v2 *types.ProvisionTokenV2) {
+				v2.Status.BoundKeypair.BoundBotInstanceID = "qwerty"
+			},
+			state: makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey)),
+			assertError: func(tt require.TestingT, err error, i ...any) {
+				require.Error(tt, err)
+				require.ErrorContains(tt, err, "cannot join with mismatched unique identifier")
+			},
+		},
 	}
 	for _, tt := range rejoinTests {
 		t.Run(tt.name, func(t *testing.T) {
 			token := makeToken(withInitialKey(correctPublicKey))
+			if tt.mutateInitialToken != nil {
+				tt.mutateInitialToken(&token)
+			}
+
 			token.SetName(tt.name)
 			initialSolver := makeMockBoundKeypairState(signers, withSigningKeys(correctPublicKey))
 			require.NoError(t, authServer.CreateBoundKeypairToken(ctx, &token))
 
+			id := state.IdentityID{
+				Role: types.RoleBot,
+			}
+			if tt.joinAsInstance {
+				id.Role = types.RoleInstance
+			}
+
 			initialJoinResult, err := joinclient.Join(t.Context(), joinclient.JoinParams{
-				Token: token.GetName(),
-				ID: state.IdentityID{
-					Role: types.RoleBot,
-				},
+				Token:             token.GetName(),
+				ID:                id,
 				AuthClient:        nopClient,
 				BoundKeypairState: initialSolver,
 			})
@@ -969,10 +1151,8 @@ func TestJoinBoundKeypair(t *testing.T) {
 			}
 
 			rejoinResult, err := joinclient.Join(t.Context(), joinclient.JoinParams{
-				Token: token.GetName(),
-				ID: state.IdentityID{
-					Role: types.RoleBot,
-				},
+				Token:             token.GetName(),
+				ID:                id,
 				AuthClient:        botClient,
 				BoundKeypairState: tt.state,
 			})

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -63,11 +63,6 @@ func (s *Server) handleBoundKeypairJoin(
 ) (*messages.BotResult, error) {
 	ctx := stream.Context()
 	diag := stream.Diagnostic()
-	// Only bot joining is supported at the moment - unique ID verification is
-	// required and this is currently only implemented for bots.
-	if clientInit.SystemRole != types.RoleBot.String() {
-		return nil, trace.BadParameter("bound keypair joining is only supported for bots")
-	}
 
 	// Scoped tokens currently validate against being created with the bot role, but just in case
 	// we'll check and return a more helpful error message if one happens to make it through.
@@ -115,6 +110,30 @@ func (s *Server) handleBoundKeypairJoin(
 		}
 		return botCerts, botInstanceID, nil
 	}
+	generateHostCerts := func(ctx context.Context, claims any) (*messages.Certificates, string, error) {
+		certsParams, err := makeHostCertsParams(
+			ctx,
+			diag,
+			authCtx,
+			boundKeypairInit.ClientParams.HostParams,
+			configuredJoinMethod(token),
+			claims,
+		)
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+
+		certs, err := s.cfg.AuthService.GenerateHostCertsForJoin(ctx, token, certsParams)
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		certificates, err := convertCerts(certs)
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+
+		return certificates, certsParams.HostID, nil
+	}
 	return boundkeypair.HandleBoundKeypairJoin(ctx, &boundkeypair.JoinParams{
 		AuthService:          s.cfg.AuthService,
 		AuthCtx:              authCtx,
@@ -125,6 +144,7 @@ func (s *Server) handleBoundKeypairJoin(
 		IssueChallenge:       issueChallenge,
 		IssueRotationRequest: issueRotationRequest,
 		GenerateBotCerts:     generateBotCerts,
+		GenerateHostCerts:    generateHostCerts,
 		Clock:                s.cfg.AuthService.GetClock(),
 		Logger:               log,
 	})
@@ -167,12 +187,19 @@ func AdaptRegisterUsingBoundKeypairMethod(
 		// These are verified at the gRPC layer by the legacy join service.
 		BotInstanceID: req.JoinRequest.BotInstanceID,
 		BotGeneration: uint64(req.JoinRequest.BotGeneration),
+		HostID:        req.JoinRequest.HostID,
 	}
 
-	// Only bot joining is supported at the moment - unique ID verification is
-	// required and this is currently only implemented for bots.
+	// Only bot joining is supported through the legacy join service adapter.
+	// Bound keypair requires secure host UUIDs which are only available in the
+	// new join service.
 	if req.JoinRequest.Role != types.RoleBot {
-		return nil, trace.BadParameter("bound keypair joining is only supported for bots")
+		return nil, trace.BadParameter("bound keypair joining for agents requires use of the new join service")
+	} else {
+		// Bots cannot have a HostID, so clear any ID present on the request.
+		// The bound keypair implementation depends on having a trustworthy ID
+		// which this value is not.
+		authCtx.HostID = ""
 	}
 
 	provisionToken, err := a.ValidateToken(ctx, req.JoinRequest.Token)
@@ -230,6 +257,14 @@ func AdaptRegisterUsingBoundKeypairMethod(
 		return botCerts, botInstanceID, nil
 	}
 
+	generateHostCerts := func(ctx context.Context, claims any) (*messages.Certificates, string, error) {
+		// Bound keypair requires that a unique identifier is securely generated
+		// by the server. As the legacy join service allows joining agents to
+		// specify their own unique ID, we cannot allow agents to join with
+		// bound keypair via the legacy join service.
+		return nil, "", trace.NotImplemented("bound keypair joining for agents is not supported by the legacy join service")
+	}
+
 	botResult, err := boundkeypair.HandleBoundKeypairJoin(ctx, &boundkeypair.JoinParams{
 		AuthService:                 a,
 		AuthCtx:                     authCtx,
@@ -241,6 +276,7 @@ func AdaptRegisterUsingBoundKeypairMethod(
 		IssueRotationRequest:        adaptBoundKeypairRotationRequest(challengeResponse),
 		CreateBoundKeypairValidator: createBoundKeypairValidator,
 		GenerateBotCerts:            generateBotCerts,
+		GenerateHostCerts:           generateHostCerts,
 		Clock:                       a.GetClock(),
 		Logger:                      log,
 	})

--- a/lib/utils/hostid/hostid.go
+++ b/lib/utils/hostid/hostid.go
@@ -66,6 +66,7 @@ func Generate(ctx context.Context, joinMethod types.JoinMethod) (string, error) 
 		types.JoinMethodUnspecified,
 		types.JoinMethodAzureDevops,
 		types.JoinMethodBitbucket,
+		types.JoinMethodBoundKeypair,
 		types.JoinMethodIAM,
 		types.JoinMethodCircleCI,
 		types.JoinMethodKubernetes,


### PR DESCRIPTION
Backport of #64351 for branch/v18

---

This adds support for verifying host UUIDs (in addition to bot instance UUIDs) to the bound keypair join method.

Note that as hosts only have a trustworthy UUID when joining via the new join service, bound keypair joining for agents via the legacy join service is not allowed and will result in an error.

## Manual test plan

### Test environment

Verified on a self hosted homelab Teleport cluster (running this branch) with an x86_64 Linux agent run in Debian Docker container from a full tarball build (`make -C build.assets release-amd64`) on a Linux build machine.

Note that tests of agent joining must use the downstream branch in #63962 (`timothyb89/bound-keypair-for-agents`) as this branch does not include agent support for bound keypair joining.

### Test cases

- [x] Agents with node UUIDs can successfully join with a bound keypair token
- [x] Agents joining with standard tokens is unaffected
- [x] Bots can still successfully join via the new join service
- [x] Bots can still successfully join via the legacy join service
- [x] Agents cannot join via the legacy join service

### Test setup notes

1. Build Teleport (`make -C build.assets release-amd64` or similar)
2. Install the release on your Teleport cluster
3. Create a node join token:
   ```
   kind: token
   version: v2
   metadata:
     name: bk-agent
   spec:
     roles: [Node]
     join_method: bound_keypair
     bound_keypair:
       recovery:
         mode: standard
         limit: 1
   ```
   
   Create it and retrieve the registration secret:
   ```
   $ tctl create -f token-bk-agent.yaml
   $ tctl get token/bk-agent
   ```
4. Make a directory for node files, acquire/copy the `teleport` binary, and make config:
   ```
   $ mkdir bk-agent-test && cd bk-agent-test
   $ mkdir node
   $ tar zxvf teleport-ent-v19.0.0-prealpha.2-linux-amd64-bin.tar.gz # or otherwise copy the binary
   ```
5. Create the node config:
   ```yaml
   version: v3
   teleport:
     nodename: bk-agent-test
     data_dir: /var/lib/teleport
     join_params:
       token_name: bk-agent
       method: bound_keypair
       bound_keypair:
         registration_secret_value: <secret>
     proxy_server: example.teleport.sh:443
     log:
       output: stderr
       severity: INFO
       format:
         output: text
     ca_pin: ""
     diag_addr: ""
   auth_service:
     enabled: "no"
   ssh_service:
     enabled: "yes"
   proxy_service:
     enabled: "no"
     https_keypairs: []
     https_keypairs_reload_interval: 0s
     acme: {}
   ```
6. Run the container and start teleport:
   ```
   $ docker run --platform linux/amd64 --rm -v $(pwd):/mnt -v $(pwd)/node:/var/lib/teleport --entrypoint=bash -it debian:latest
   # ... inside the container ...
   $ apt update && apt install -y ca-certificates
   $ /path/to/teleport start -c /mnt/teleport.yaml
   ```

Note that you'll need an updated `tctl` build if you want to see the new `bound_host_id` field in the token (`tctl get token/bk-agent`).

Additionally, to verify that the legacy join service can't be used, I opted to hack `lib/join/joinclient/join.go` and force `Join()` to always use the legacy join branch.