### PR TITLE
[scopes] tctl scoped role assignment UX improvements

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -294,7 +294,7 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindHealthCheckConfig, nil
 	case scopedaccess.KindScopedRole, scopedaccess.KindScopedRole + "s", "scopedrole", "scopedroles":
 		return scopedaccess.KindScopedRole, nil
-	case scopedaccess.KindScopedRoleAssignment, scopedaccess.KindScopedRoleAssignment + "s", "scopedroleassignment", "scopedroleassignments":
+	case scopedaccess.KindScopedRoleAssignment, scopedaccess.KindScopedRoleAssignment + "s", "scopedroleassignment", "scopedroleassignments", "sra":
 		return scopedaccess.KindScopedRoleAssignment, nil
 	case types.KindInferenceModel, "inference_models":
 		return types.KindInferenceModel, nil

--- a/lib/services/resource_test.go
+++ b/lib/services/resource_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/healthcheckconfig"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
 // TestParseShortcut will test parsing of shortcuts.
@@ -184,6 +185,12 @@ func TestParseShortcut(t *testing.T) {
 		"access_requests": {expectedOutput: types.KindAccessRequest},
 		"accessrequest":   {expectedOutput: types.KindAccessRequest},
 		"accessrequests":  {expectedOutput: types.KindAccessRequest},
+
+		"scoped_role_assignment":  {expectedOutput: scopedaccess.KindScopedRoleAssignment},
+		"scoped_role_assignments": {expectedOutput: scopedaccess.KindScopedRoleAssignment},
+		"scopedroleassignment":    {expectedOutput: scopedaccess.KindScopedRoleAssignment},
+		"scopedroleassignments":   {expectedOutput: scopedaccess.KindScopedRoleAssignment},
+		"sra":                     {expectedOutput: scopedaccess.KindScopedRoleAssignment},
 
 		"unknown_type": {expectedErr: true},
 	}

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -474,18 +474,14 @@ version: v1
 	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/materialized/" + assignmentName, "--format=json"})
 	require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
 
-	// Ensure that retrieving the scoped role assignment by name with default sub_kind works.
-	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/" + assignmentName, "--format=json"})
-	require.NoError(t, err)
-	var asByName []*scopedaccessv1.ScopedRoleAssignment
-	err = json.Unmarshal(buff.Bytes(), &asByName)
-	require.NoError(t, err)
-	require.Len(t, asByName, 1)
-	require.Equal(t, assignmentName, asByName[0].GetMetadata().GetName())
+	// Ensure that trying to retrieve the scoped role assignment without a subkind fails.
+	_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/" + assignmentName, "--format=json"})
+	require.ErrorContains(t, err, "requires an explicit subkind")
 
 	// Ensure that retrieving the scoped role assignment by name with explicit sub_kind works.
-	buff, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic/" + assignmentName, "--format=json"})
+	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic/" + assignmentName, "--format=json"})
 	require.NoError(t, err)
+	var asByName []*scopedaccessv1.ScopedRoleAssignment
 	err = json.Unmarshal(buff.Bytes(), &asByName)
 	require.NoError(t, err)
 	require.Len(t, asByName, 1)
@@ -513,6 +509,14 @@ version: v1
 
 	require.Empty(t, cmp.Diff(expectedAssignment, as[0], protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
 
+	// verify delete of assignment fails without subkind
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/" + assignmentName})
+	require.ErrorContains(t, err, "requires an explicit subkind")
+
+	// verify delete of assignment fails without materialized subkind.
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/materialized/" + assignmentName})
+	require.ErrorContains(t, err, "cannot be deleted")
+
 	// verify delete of assignment
 	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_role_assignment/dynamic/" + assignmentName})
 	require.NoError(t, err)
@@ -521,7 +525,7 @@ version: v1
 	timeout = time.After(time.Second * 30)
 	for {
 		// verify assignment is gone
-		_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/" + assignmentName, "--format=json"})
+		_, err = runResourceCommand(t, clt, []string{"get", "scoped_role_assignment/dynamic/" + assignmentName, "--format=json"})
 		if err != nil {
 			require.True(t, trace.IsNotFound(err), "expected a NotFound error, got %v", err)
 			break

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -16,7 +16,6 @@
 package resources
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -150,11 +149,12 @@ func updateScopedRoleAssignment(ctx context.Context, client *authclient.Client, 
 
 func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
 	if ref.Name != "" {
-		// Default to dynamic if the user didn't specify a subkind.
-		subKind := cmp.Or(ref.SubKind, scopedaccess.SubKindDynamic)
+		if ref.SubKind == "" {
+			return nil, trace.BadParameter("scoped_role_assignment requires an explicit subkind when getting a single resource, try: tctl get scoped_role_assignment/dynamic/%s", ref.Name)
+		}
 		rsp, err := client.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
 			Name:    ref.Name,
-			SubKind: subKind,
+			SubKind: ref.SubKind,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -171,6 +171,12 @@ func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref
 }
 
 func deleteScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if ref.SubKind == "" {
+		return trace.BadParameter("scoped_role_assignment requires an explicit subkind when deleting a resource, try: tctl rm scoped_role_assignment/%s/%s", scopedaccess.SubKindDynamic, ref.Name)
+	}
+	if ref.SubKind == scopedaccess.SubKindMaterialized {
+		return trace.BadParameter("%s scoped_role_assignments are derived from access lists and cannot be deleted directly", scopedaccess.SubKindMaterialized)
+	}
 	if _, err := client.ScopedAccessServiceClient().DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
 		Name:    ref.Name,
 		SubKind: ref.SubKind,


### PR DESCRIPTION
This PR makes a few UX improvements for tctl resource commands on scoped role assignments:

- `tctl get scoped_role_assignment/<name>` now requires an explicit subkind instead of implicitly treating it as dynamic
- `tctl rm scoped_role_assignment/<name>` now fails with an actionable error
- it now rejects deletes of materialized scoped role assignments up front with a clearer explanation
- `sra` is added as an alias of `scoped_role_assignment`

Why:

The previous UX was inconsistent: get silently normalized bare scoped role assignment references to dynamic, while rm did not. That made the same path mean different things across commands and obscured the fact that scoped role assignments have meaningful subkinds.

This change makes single-resource operations more explicit and predictable. And reduces typing by 19 chars per command.

Note: it's no longer possible to delete any lingering SRAs without a subkind. I think this tradeoff is fine, the subkind addition is a known breaking change, and nobody is running scopes yet that will upgrade a cluster with existing SRAs.

## Manual Test Plan
### Test Environment

A cluster on this branch with TELEPORT_UNSTABLE_SCOPES=yes

resources.yaml:
```yaml
kind: scoped_role
metadata:
  name: eng-access
  revision: 17ce670f-f672-4a97-843d-dcc9ef80c65a
scope: /
spec:
  assignable_scopes:
  - /eng
version: v1
---
kind: scoped_role_assignment
sub_kind: dynamic
scope: /
spec:
  user: nic
  assignments:
    - role: eng-access
      scope: /eng
version: v1
```

### Test Cases

- [x] `tctl create resources.yaml`
- [x] `tctl get scoped_role_assignment` lists the assignment
- [x] `tctl get scoped_role_assignment/dynamic/id` works
- [x] `tctl get scoped_role_assignment/id` fails with an actionable error
- [x] `tctl rm scoped_role_assignment/id` fails with an actionable error
- [x] `tctl rm scoped_role_assignment/materialized/id` fails with an informative error
- [x] `tctl rm scoped_role_assignment/unknown/id` fails with BadParameter
- [x] `tctl rm scoped_role_assignment/dynamic/id` works