### PR TITLE
Connect: Bypass HTTP proxies for local JS gRPC clients

### DIFF
--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -930,6 +930,9 @@ async function setUpTshdClients({
     host: tshdAddress,
     channelCredentials: creds,
     interceptors: [loggingInterceptor(new Logger('tshd'))],
+    // This gRPC client talks to a localhost endpoint on Windows.
+    // Do not route it through HTTP proxies.
+    clientOptions: { 'grpc.enable_http_proxy': 0 },
   });
   return {
     terminalService: new TerminalServiceClient(transport),

--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -70,6 +70,9 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
     host: addresses.tsh,
     channelCredentials: credentials.tshd,
     interceptors: [loggingInterceptor(new Logger('tshd'))],
+    // This gRPC client talks to a localhost endpoint on Windows.
+    // Do not route it through HTTP proxies.
+    clientOptions: { 'grpc.enable_http_proxy': 0 },
   });
   const tshClient = withoutInsecureTshdMethods(createTshdClient(tshdTransport));
   const vnetClient = createVnetClient(tshdTransport);

--- a/web/packages/teleterm/src/services/pty/ptyHost/ptyHostClient.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/ptyHostClient.ts
@@ -33,6 +33,9 @@ export function createPtyHostClient(
   const transport = new GrpcTransport({
     host: address,
     channelCredentials: credentials,
+    // This gRPC client talks to a localhost endpoint on Windows.
+    // Do not route it through HTTP proxies.
+    clientOptions: { 'grpc.enable_http_proxy': 0 },
   });
   const client = new GrpcClient(transport);
 


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/63113

>We should be able to address this by manually setting no_grpc_proxy to localhost when initializing local gRPC clients on Windows. The problem appears to be that [this option is set only through an env var](https://github.com/grpc/grpc-node/blob/61208ea8557bdfa2d9ff5ce64e15943ae493c3e7/packages/grpc-js/src/http_proxy.ts#L118-L132). We'd like to set it only for clients of our gRPC servers listening on localhost, but we should not set it for the client used in tshd which actually connects to a remote server.

It looks like the simplest fix is to disable HTTP proxy for all localhost gRPC clients in the JS code.
I initially expected we would need the same change for the Go `TshdEvents` client, but Go already bypasses proxies for `localhost` by default: https://cs.opensource.google/go/go/+/refs/tags/go1.26.2:src/net/http/transport.go;drc=0921e1db83d3e67032999b5a2f54f5ede8ba39b5;l=505

Changelog: Fixed a Teleport Connect issue on Windows where startup could fail when `HTTPS_PROXY` is set

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
* Built and ran the app locally.
* Added two clusters.
* Set `HTTPS_PROXY=http://127.0.0.1:9` (no proxy is running on that port).
* Set `NO_PROXY=<address of one cluster>` so I could test the `TshdEvents` path.

### Test Cases
- [x] The app launches correctly on Windows, the terminal works. 
- [x] The app receives tshd events, like headless auth.
- [x] The remote connection to the cluster is routed through the proxy (and it fails as expected).
