### PR TITLE
Relax uuid requirement for scoped role assignments

### DIFF
--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -410,6 +410,10 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		return trace.BadParameter("scoped role assignment %q has invalid sub_kind %q", assignment.GetMetadata().GetName(), assignment.GetSubKind())
 	}
 
+	if err := scopes.StrongValidateSegment(assignment.GetMetadata().GetName()); err != nil {
+		return trace.BadParameter("scoped role assignment name %q does not conform to segment naming rules: %v", assignment.GetMetadata().GetName(), err)
+	}
+
 	if err := scopes.StrongValidate(assignment.GetScope()); err != nil {
 		return trace.BadParameter("scoped role assignment %q has invalid scope: %v", assignment.GetMetadata().GetName(), err)
 	}

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
@@ -409,10 +408,6 @@ func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) e
 		return trace.BadParameter("scoped role assignment %q has empty sub_kind", assignment.GetMetadata().GetName())
 	default:
 		return trace.BadParameter("scoped role assignment %q has invalid sub_kind %q", assignment.GetMetadata().GetName(), assignment.GetSubKind())
-	}
-
-	if _, err := uuid.Parse(assignment.GetMetadata().GetName()); err != nil {
-		return trace.BadParameter("scoped role assignment %q has invalid name (must be uuid): %v", assignment.GetMetadata().GetName(), err)
 	}
 
 	if err := scopes.StrongValidate(assignment.GetScope()); err != nil {

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -597,7 +597,7 @@ func TestValidateAsssignment(t *testing.T) {
 				},
 				Version: types.V1,
 			},
-			strongOk: false,
+			strongOk: true,
 			weakOk:   true,
 		},
 		{

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -578,12 +578,12 @@ func TestValidateAsssignment(t *testing.T) {
 			weakOk:   false,
 		},
 		{
-			name: "malformed name",
+			name: "malformed name - long name",
 			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: SubKindDynamic,
 				Metadata: &headerv1.Metadata{
-					Name: "not-a-uuid",
+					Name: "thisiswaytoolongofanameaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 				Scope: "/",
 				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
@@ -597,7 +597,7 @@ func TestValidateAsssignment(t *testing.T) {
 				},
 				Version: types.V1,
 			},
-			strongOk: true,
+			strongOk: false,
 			weakOk:   true,
 		},
 		{

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -50,7 +50,8 @@ const (
 	maxScopeSize = 64
 
 	// maxSegmentSize is the maximum size of a segment, excluding separators.
-	maxSegmentSize = 32
+	// The max size is 36 to take into account UUIDs.
+	maxSegmentSize = 36
 
 	// minSegmentSize is the minimum size of a segment, excluding separators.
 	minSegmentSize = 2

--- a/lib/scopes/scopes_test.go
+++ b/lib/scopes/scopes_test.go
@@ -216,12 +216,12 @@ func TestStrongValidate(t *testing.T) {
 		},
 		{
 			name:  "long but ok segment",
-			scope: "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			scope: "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			ok:    true,
 		},
 		{
 			name:  "segment too long",
-			scope: "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			scope: "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			ok:    false,
 		},
 	}


### PR DESCRIPTION
Relax the uuid name requirement for scoped role assignments. 

IAC (k8s and Terraform) requires a name be present when creating a resource, having the name be a uuid is very inconvenient.


<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases
- [x] Create a sra without a name - uuid name generated
- [x] Create a sra with a random name - ensure non uuid names are ok
- [x] Ensure we can still edit and delete the sra
- [x] sra with too long of a name is rejected
