### PR TITLE
Fix flakey authentication in webkit e2e tests

### DIFF
--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -47,8 +47,6 @@ export async function login(
     .getByRole('button', { name: 'Sign In' })
     .click();
 
-  await page.waitForLoadState('networkidle');
-
   await expect(page.getByText(/^Resources$/).first()).toBeVisible();
 }
 

--- a/e2e/runner/instance.go
+++ b/e2e/runner/instance.go
@@ -41,23 +41,31 @@ type testInstance struct {
 // start starts the Teleport instance and SSH node for this test instance.
 // Called lazily from the playwright runner so that at most 2 instances run concurrently.
 func (inst *testInstance) start(ctx context.Context) error {
+	var err error
+
+	defer func() {
+		if err != nil {
+			inst.stop()
+		}
+	}()
+
 	if inst.teleport != nil {
-		if err := inst.teleport.start(ctx); err != nil {
+		if err = inst.teleport.start(ctx); err != nil {
 			return fmt.Errorf("failed to start Teleport for %s: %w", inst.browser, err)
 		}
-		if err := inst.teleport.waitReady(ctx, 30*time.Second); err != nil {
+		if err = inst.teleport.waitReady(ctx, 30*time.Second); err != nil {
 			return fmt.Errorf("teleport for %s failed to become ready: %w", inst.browser, err)
 		}
-		if err := seedRecordings(ctx, inst.e2eDir, inst.dataDir); err != nil {
+		if err = seedRecordings(ctx, inst.e2eDir, inst.dataDir); err != nil {
 			return fmt.Errorf("failed to seed session recordings for %s: %w", inst.browser, err)
 		}
 	}
 
 	if inst.node != nil {
-		if err := inst.node.start(ctx); err != nil {
+		if err = inst.node.start(ctx); err != nil {
 			return fmt.Errorf("failed to start docker node for %s: %w", inst.browser, err)
 		}
-		if err := inst.node.waitJoined(ctx, 30*time.Second); err != nil {
+		if err = inst.node.waitJoined(ctx, 30*time.Second); err != nil {
 			return fmt.Errorf("docker node for %s failed to join cluster: %w", inst.browser, err)
 		}
 	}

--- a/e2e/runner/instance.go
+++ b/e2e/runner/instance.go
@@ -22,18 +22,57 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 )
 
-type browserInstance struct {
+type testInstance struct {
 	browser            string
 	log                *slog.Logger
 	proxyPort          int
 	authPort           int
 	sshPort            int
+	e2eDir             string
 	dataDir            string
 	teleportConfigPath string
 	teleport           *teleportInstance
 	node               *dockerNode
+}
+
+// start starts the Teleport instance and SSH node for this test instance.
+// Called lazily from the playwright runner so that at most 2 instances run concurrently.
+func (inst *testInstance) start(ctx context.Context) error {
+	if inst.teleport != nil {
+		if err := inst.teleport.start(ctx); err != nil {
+			return fmt.Errorf("failed to start Teleport for %s: %w", inst.browser, err)
+		}
+		if err := inst.teleport.waitReady(ctx, 30*time.Second); err != nil {
+			return fmt.Errorf("teleport for %s failed to become ready: %w", inst.browser, err)
+		}
+		if err := seedRecordings(ctx, inst.e2eDir, inst.dataDir); err != nil {
+			return fmt.Errorf("failed to seed session recordings for %s: %w", inst.browser, err)
+		}
+	}
+
+	if inst.node != nil {
+		if err := inst.node.start(ctx); err != nil {
+			return fmt.Errorf("failed to start docker node for %s: %w", inst.browser, err)
+		}
+		if err := inst.node.waitJoined(ctx, 30*time.Second); err != nil {
+			return fmt.Errorf("docker node for %s failed to join cluster: %w", inst.browser, err)
+		}
+	}
+
+	return nil
+}
+
+func (inst *testInstance) stop() {
+	if inst.node != nil {
+		inst.node.stop(context.Background())
+	}
+
+	if inst.teleport != nil {
+		inst.teleport.stop()
+	}
 }
 
 var browserColors = map[string]string{

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	"github.com/lmittmann/tint"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport/e2e/runner/fixtures"
 )
@@ -143,8 +142,8 @@ type e2eConfig struct {
 
 	creds *credentials
 
-	instances       []*browserInstance
-	connectInstance *browserInstance
+	instances       []*testInstance
+	connectInstance *testInstance
 }
 
 // run sets up the test environment (ports, certs, credentials, teleport instance)
@@ -203,18 +202,20 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 	}
 
 	for _, browser := range config.browsers {
-		inst := &browserInstance{
+		inst := &testInstance{
 			browser: browser,
 			log:     newBrowserLogger(browser),
+			e2eDir:  e2eDir,
 			dataDir: filepath.Join(e2eDir, "data", browser),
 		}
 		config.instances = append(config.instances, inst)
 	}
 
 	if fixtures.Connect.Enabled {
-		config.connectInstance = &browserInstance{
+		config.connectInstance = &testInstance{
 			browser: "connect",
 			log:     newBrowserLogger("connect"),
+			e2eDir:  e2eDir,
 			dataDir: filepath.Join(e2eDir, "data", "connect"),
 		}
 	}
@@ -303,7 +304,7 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 			inst.log.Debug("generated Teleport config", "path", tcfg)
 		}
 
-		g, gctx := errgroup.WithContext(ctx)
+		// Create teleport instances (started lazily by the playwright runner so that at most 2 run concurrently).
 		for _, inst := range allInstances {
 			teleport := &teleportInstance{
 				log:         inst.log,
@@ -312,46 +313,14 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 				configPath:  inst.teleportConfigPath,
 				stateFile:   stateFile,
 			}
+
 			if config.isCI || config.quiet {
 				teleport.logFile = filepath.Join(config.e2eDir, "teleport-"+inst.browser+".log")
 				inst.log.Debug("redirecting Teleport logs to file", "path", teleport.logFile)
 			}
+
 			inst.teleport = teleport
-
-			g.Go(func() error {
-				if err := teleport.start(ctx); err != nil {
-					return fmt.Errorf("failed to start Teleport for %s: %w", inst.browser, err)
-				}
-				if err := teleport.waitReady(gctx, 30*time.Second); err != nil {
-					return fmt.Errorf("teleport for %s failed to become ready: %w", inst.browser, err)
-				}
-				if err := seedRecordings(gctx, config.e2eDir, inst.dataDir); err != nil {
-					return fmt.Errorf("failed to seed session recordings for %s: %w", inst.browser, err)
-				}
-				return nil
-			})
 		}
-		if err := g.Wait(); err != nil {
-			for _, inst := range allInstances {
-				if inst.teleport != nil {
-					inst.teleport.stop()
-				}
-			}
-			return err
-		}
-
-		defer func() {
-			for _, inst := range allInstances {
-				if inst.node != nil {
-					inst.node.stop(context.Background())
-				}
-			}
-			for _, inst := range allInstances {
-				if inst.teleport != nil {
-					inst.teleport.stop()
-				}
-			}
-		}()
 
 		if fixtures.SSHNode.Enabled {
 			slog.Info("running with SSH node fixture enabled")
@@ -397,22 +366,6 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 
 			if err := pullImage(ctx, nodeImage); err != nil {
 				return fmt.Errorf("pulling docker image: %w", err)
-			}
-
-			g, gctx := errgroup.WithContext(ctx)
-			for _, inst := range config.instances {
-				g.Go(func() error {
-					if err := inst.node.start(gctx); err != nil {
-						return fmt.Errorf("failed to start docker node for %s: %w", inst.browser, err)
-					}
-					if err := inst.node.waitJoined(gctx, 30*time.Second); err != nil {
-						return fmt.Errorf("docker node for %s failed to join cluster: %w", inst.browser, err)
-					}
-					return nil
-				})
-			}
-			if err := g.Wait(); err != nil {
-				return err
 			}
 		}
 	}

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -37,7 +37,7 @@ type playwrightRunner struct {
 	config *e2eConfig
 }
 
-func (p *playwrightRunner) startURL(inst *browserInstance) string {
+func (p *playwrightRunner) startURL(inst *testInstance) string {
 	if p.config.teleportURL != "" {
 		return p.config.teleportURL + "/web"
 	}
@@ -98,8 +98,16 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 	}
 
 	var g errgroup.Group
+
+	g.SetLimit(2)
+
 	for _, inst := range p.config.instances {
 		g.Go(func() error {
+			if err := inst.start(ctx); err != nil {
+				return err
+			}
+			defer inst.stop()
+
 			env, err := p.startEnv(inst)
 			if err != nil {
 				return fmt.Errorf("building env for %s: %w", inst.browser, err)
@@ -137,6 +145,11 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 
 	if ci := p.config.connectInstance; ci != nil {
 		g.Go(func() error {
+			if err := ci.start(ctx); err != nil {
+				return err
+			}
+			defer ci.stop()
+
 			env, err := p.startEnv(ci)
 			if err != nil {
 				return fmt.Errorf("building env for connect: %w", err)
@@ -187,7 +200,16 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 func (p *playwrightRunner) ui(ctx context.Context) error {
 	slog.Info("starting playwright in UI mode")
 
+	if len(p.config.instances) == 0 {
+		return fmt.Errorf("no test instances configured")
+	}
+
 	inst := p.config.instances[0]
+	if err := inst.start(ctx); err != nil {
+		return err
+	}
+	defer inst.stop()
+
 	env, err := p.startEnv(inst)
 	if err != nil {
 		return err
@@ -209,7 +231,16 @@ func (p *playwrightRunner) codegen(ctx context.Context) error {
 // a Chromium browser with a virtual WebAuthn authenticator pre-loaded so that
 // MFA challenges resolve automatically.
 func (p *playwrightRunner) openWebAuthenticated(ctx context.Context, playwrightCmd string) error {
+	if len(p.config.instances) == 0 {
+		return fmt.Errorf("no test instances configured")
+	}
+
 	inst := p.config.instances[0]
+	if err := inst.start(ctx); err != nil {
+		return err
+	}
+	defer inst.stop()
+
 	env, err := p.startEnv(inst)
 	if err != nil {
 		return err
@@ -232,8 +263,14 @@ func (p *playwrightRunner) openWebAuthenticated(ctx context.Context, playwrightC
 func (p *playwrightRunner) openConnectAuthenticated(ctx context.Context) error {
 	inst := p.config.connectInstance
 	if inst == nil {
-		return fmt.Errorf("connect instance not configured (use --with-connect)")
+		return fmt.Errorf("connect instance not configured (run Connect specific tests or use --with-connect)")
 	}
+
+	if err := inst.start(ctx); err != nil {
+		return err
+	}
+	defer inst.stop()
+
 	env, err := p.startEnv(inst)
 	if err != nil {
 		return err
@@ -246,7 +283,7 @@ func (p *playwrightRunner) openConnectAuthenticated(ctx context.Context) error {
 
 // startEnv builds the environment variables that Playwright tests need,
 // including START_URL, credentials, and tctl paths for invite URL generation.
-func (p *playwrightRunner) startEnv(inst *browserInstance) ([]string, error) {
+func (p *playwrightRunner) startEnv(inst *testInstance) ([]string, error) {
 	env := os.Environ()
 	// Force color output since Playwright's TTY detection won't work
 	// when stdout/stderr are wrapped by the rewrite writer.


### PR DESCRIPTION
This changes the running of e2e tests in CI to run at maximum two instances of teleport/tests at any one time. Before, we'd run all 4 (webkit/chromium/firefox/connect) Teleport instances and test suites at once, which would cause the webkit authentication setup test to sometimes take longer than 20 seconds and fail. By limiting the number of things running at a time, this test should run much more quickly.

Also removes the `networkidle` assertion from the login helper, as we assert on seeing "Resources" in the UI after that anyway. `networkidle` can also be something that Safari takes a while to fully resolve, further making the test take longer.

Closes #65563 

## Manual Test Plan
### Test Environment
CI

### Test Cases
- [x] Verified that the webkit authentication setup takes much less time than 20 seconds
- [x] Verified tests run against all browsers and connect as expected
