### PR TITLE
Fix `TestIntegrations/ClientIdleConnection` flakiness

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1823,6 +1823,7 @@ type disconnectTestCase struct {
 // testClientIdleConnection validates that if a user is active beyond
 // the client idle timeout that the session is not terminated.
 func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
+	ctx := t.Context()
 	idleTimeout := 3 * time.Second
 	netConfig := types.DefaultClusterNetworkingConfig()
 	netConfig.SetClientIdleTimeout(idleTimeout)
@@ -1837,15 +1838,8 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 	term := NewTerminal(250)
 
 	sessionErr := make(chan error, 1)
-	t.Cleanup(func() {
-		require.Error(t, waitForError(sessionErr, 10*time.Second))
-	})
-
-	sessionCtx, cancelSession := context.WithCancel(t.Context())
-	defer cancelSession()
-
 	openSession := func() {
-		defer cancelSession()
+		defer close(sessionErr)
 		cl, err := instance.NewClient(helpers.ClientConfig{
 			Login:                suite.Me.Username,
 			Cluster:              helpers.Site,
@@ -1862,29 +1856,39 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 
 		// Print a ready marker, then echo bytes from stdin back to the client.
 		const clientIdleKeepaliveCommand = `sh -c 'echo __READY__; exec cat'`
-		sessionErr <- cl.SSH(sessionCtx, []string{clientIdleKeepaliveCommand})
+		sessionErr <- cl.SSH(ctx, []string{clientIdleKeepaliveCommand})
 	}
 
 	go openSession()
 
-	require.NoError(t, waitForTerminalOutput(sessionCtx, term, ".*__READY__.*"))
+	readyErr := make(chan error, 1)
+	go func() {
+		readyErr <- waitForTerminalOutput(ctx, term, ".*__READY__.*")
+	}()
+
+	select {
+	case err := <-readyErr:
+		require.NoError(t, err)
+	case err := <-sessionErr:
+		require.FailNowf(t, "timeout", "session ended before becoming ready: %v", err)
+	}
 
 	// Keep the session alive by writing/reading with the terminal within the idle timeout.
 	keepaliveTicker := time.NewTicker(idleTimeout / 3)
+	defer keepaliveTicker.Stop()
 	keepaliveEnd := time.After(10 * time.Second)
 
+	require.NoError(t, enterInput(ctx, term, "start\r\n", "start"))
 	for i := 0; ; i++ {
 		select {
 		case <-keepaliveTicker.C:
 			msg := "keepalive-" + strconv.Itoa(i)
-			require.NoError(t, enterInput(sessionCtx, term, msg+"\r\n", msg))
-
+			require.NoError(t, enterInput(ctx, term, msg+"\r\n", msg))
 		case <-keepaliveEnd:
 			// The session survived beyond the idle timeout, success.
 			return
-
-		case <-sessionCtx.Done():
-			require.FailNowf(t, "timeout", "session ended before exceeding idle timeout: %v", sessionCtx.Err())
+		case err := <-sessionErr:
+			require.FailNowf(t, "timeout", "session ended before exceeding idle timeout: %v", err)
 		}
 	}
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1820,55 +1820,12 @@ type disconnectTestCase struct {
 	verifyError errorVerifier
 }
 
-// repeatingReader is an [io.ReadCloser] that produces the
-// provided output at the configured interval until closed.
-// For example, all calls to Read on the following reader will
-// block for a minute and then return "hi" to the caller. Once
-// Closed an `io.EOF` will be returned from Read
-//
-// r := repeatingReader{output: hi, interval:time.Minute}
-// n, err := r.Read(out)
-type repeatingReader struct {
-	output   string
-	interval time.Duration
-	closed   chan struct{}
-}
-
-func newRepeatingReader(output string, interval time.Duration) repeatingReader {
-	return repeatingReader{
-		interval: interval,
-		output:   output,
-		closed:   make(chan struct{}),
-	}
-}
-
-func (r repeatingReader) Read(p []byte) (int, error) {
-	if len(p) == 0 {
-		return 0, nil
-	}
-
-	select {
-	case <-time.After(r.interval):
-	case <-r.closed:
-		return 0, io.EOF
-	}
-
-	end := min(len(r.output), len(p))
-
-	n := copy(p, r.output[:end])
-	return n, nil
-}
-
-func (r repeatingReader) Close() error {
-	close(r.closed)
-	return nil
-}
-
 // testClientIdleConnection validates that if a user is active beyond
 // the client idle timeout that the session is not terminated.
 func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
+	idleTimeout := 10 * time.Second
 	netConfig := types.DefaultClusterNetworkingConfig()
-	netConfig.SetClientIdleTimeout(3 * time.Second)
+	netConfig.SetClientIdleTimeout(idleTimeout)
 
 	tconf := suite.defaultServiceConfig()
 	tconf.SSH.Enabled = true
@@ -1877,48 +1834,59 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 	instance := suite.NewTeleportWithConfig(t, nil, nil, tconf)
 	t.Cleanup(func() { require.NoError(t, instance.StopAll()) })
 
-	var output bytes.Buffer
+	term := NewTerminal(100000)
+	sessionCtx, cancelSession := context.WithTimeout(t.Context(), 4*idleTimeout)
+	defer cancelSession()
 
-	// SSH into the server, and stay active for longer than
-	// the client idle timeout.
-	sessionErr := make(chan error)
+	sessionErr := make(chan error, 1)
 	openSession := func() {
 		cl, err := instance.NewClient(helpers.ClientConfig{
 			Login:                suite.Me.Username,
 			Cluster:              helpers.Site,
 			Host:                 Host,
+			Interactive:          true,
 			DisableSSHResumption: true,
 		})
 		if err != nil {
 			sessionErr <- trace.Wrap(err)
 			return
 		}
-		cl.Stdout = &output
-		// Execute a command faster than the idle timeout to stay active.
-		reader := newRepeatingReader("echo txlxport | sed 's/x/e/g'\n", 100*time.Millisecond)
-		defer func() { reader.Close() }()
-		cl.Stdin = reader
+		cl.Stdout = term
+		cl.Stdin = term
 
-		// Terminate the session after 2x the idle timeout
-		ctx, cancel := context.WithTimeout(t.Context(), netConfig.GetClientIdleTimeout()*2)
-		defer cancel()
-		sessionErr <- cl.SSH(ctx, nil)
+		sessionErr <- cl.SSH(sessionCtx, nil)
 	}
 
 	go openSession()
 
-	// Wait for the sessions to end - we expect an error
-	// since we are canceling the context.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.NoError(collect, enterInput(sessionCtx, term, "echo txlxport | sed 's/x/e/g' \r\n", "teleport"))
+	}, 10*time.Second, 2*time.Second)
+
+	var firstAckAt time.Time
+	var lastAckAt time.Time
+	for i := 0; ; i++ {
+		require.NoError(t, enterInput(sessionCtx, term, "echo txlxport"+strconv.Itoa(i)+" | sed 's/x/e/g' \r\n", "teleport"+strconv.Itoa(i)))
+		lastAckAt = time.Now()
+
+		if firstAckAt.IsZero() {
+			firstAckAt = lastAckAt
+		}
+
+		if lastAckAt.Sub(firstAckAt) > idleTimeout*3/2 {
+			break
+		}
+
+		select {
+		case <-time.After(idleTimeout / 3):
+		case <-sessionCtx.Done():
+			require.FailNowf(t, "timeout", "session ended before exceeding idle timeout: %v", sessionCtx.Err())
+		}
+	}
+
+	cancelSession()
 	err := waitForError(sessionErr, time.Second*15)
 	require.Error(t, err)
-
-	// Ensure that the session was alive beyond the idle timeout by
-	// counting the number of times "teleport" was output. If the session
-	// was alive past the idle timeout, then there should be at least 30 occurrences
-	// since the command is run more frequently the idle timeout.
-	require.NotEmpty(t, output)
-	count := strings.Count(output.String(), "teleport")
-	require.Greater(t, count, 30)
 }
 
 // TestDisconnectScenarios tests multiple scenarios with client disconnects
@@ -2159,20 +2127,16 @@ func timeNow() string {
 // the supplied regexp string.
 func enterInput(ctx context.Context, person *Terminal, command, pattern string) error {
 	person.Type(command)
-	abortTime := time.Now().Add(10 * time.Second)
-	var matched bool
-	var output string
+	abortTime := time.Now().Add(2 * time.Second)
 	for {
-		output = replaceNewlines(person.Output(1000))
-		matched, _ = regexp.MatchString(pattern, output)
+		output := replaceNewlines(person.Output(100000))
+		matched, _ := regexp.MatchString(pattern, output)
 		if matched {
 			return nil
 		}
 		select {
-		case <-time.After(time.Millisecond * 50):
+		case <-time.After(50 * time.Millisecond):
 		case <-ctx.Done():
-			// cancellation means that we don't care about the input being
-			// confirmed anymore; not equivalent to a timeout.
 			return nil
 		}
 		if time.Now().After(abortTime) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1823,8 +1823,7 @@ type disconnectTestCase struct {
 // testClientIdleConnection validates that if a user is active beyond
 // the client idle timeout that the session is not terminated.
 func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
-	ctx := t.Context()
-	idleTimeout := 3 * time.Second
+	const idleTimeout = 3 * time.Second
 	netConfig := types.DefaultClusterNetworkingConfig()
 	netConfig.SetClientIdleTimeout(idleTimeout)
 
@@ -1836,9 +1835,23 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 	t.Cleanup(func() { require.NoError(t, instance.StopAll()) })
 
 	term := NewTerminal(250)
-
 	sessionErr := make(chan error, 1)
-	openSession := func() {
+
+	waitForOutput := func(t *testing.T, pattern string) {
+		outputErr := make(chan error, 1)
+		go func() {
+			outputErr <- waitForTerminalOutput(t.Context(), term, pattern)
+		}()
+
+		select {
+		case err := <-outputErr:
+			require.NoError(t, err)
+		case err := <-sessionErr:
+			require.FailNowf(t, "session error", "session ended while waiting for output matching %q; err: %v", pattern, err)
+		}
+	}
+
+	go func() {
 		defer close(sessionErr)
 		cl, err := instance.NewClient(helpers.ClientConfig{
 			Login:                suite.Me.Username,
@@ -1856,39 +1869,34 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 
 		// Print a ready marker, then echo bytes from stdin back to the client.
 		const clientIdleKeepaliveCommand = `sh -c 'echo __READY__; exec cat'`
-		sessionErr <- cl.SSH(ctx, []string{clientIdleKeepaliveCommand})
-	}
-
-	go openSession()
-
-	readyErr := make(chan error, 1)
-	go func() {
-		readyErr <- waitForTerminalOutput(ctx, term, ".*__READY__.*")
+		sessionErr <- cl.SSH(t.Context(), []string{clientIdleKeepaliveCommand})
 	}()
+	waitForOutput(t, "__READY__")
 
-	select {
-	case err := <-readyErr:
-		require.NoError(t, err)
-	case err := <-sessionErr:
-		require.FailNowf(t, "timeout", "session ended before becoming ready: %v", err)
-	}
+	// With the session established, write to the terminal to refresh the client idle timeout
+	// before proceeding to the test below.
+	// TODO(Joerger): We can remove this once we address the issue causing the client idle timeout timer
+	// to start progressing during session establishment.
+	term.Type("start\r\n")
+	waitForOutput(t, "start")
 
 	// Keep the session alive by writing/reading with the terminal within the idle timeout.
-	keepaliveTicker := time.NewTicker(idleTimeout / 3)
+	keepaliveInterval := idleTimeout / 3
+	keepaliveTicker := time.NewTicker(keepaliveInterval)
 	defer keepaliveTicker.Stop()
-	keepaliveEnd := time.After(10 * time.Second)
+	keepaliveEnd := time.After(idleTimeout + keepaliveInterval)
 
-	require.NoError(t, enterInput(ctx, term, "start\r\n", "start"))
 	for i := 0; ; i++ {
 		select {
 		case <-keepaliveTicker.C:
 			msg := "keepalive-" + strconv.Itoa(i)
-			require.NoError(t, enterInput(ctx, term, msg+"\r\n", msg))
+			term.Type(msg + "\r\n")
+			waitForOutput(t, msg)
 		case <-keepaliveEnd:
 			// The session survived beyond the idle timeout, success.
 			return
 		case err := <-sessionErr:
-			require.FailNowf(t, "timeout", "session ended before exceeding idle timeout: %v", err)
+			require.FailNowf(t, "session error", "session ended before exceeding idle timeout: %v", err)
 		}
 	}
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1823,7 +1823,7 @@ type disconnectTestCase struct {
 // testClientIdleConnection validates that if a user is active beyond
 // the client idle timeout that the session is not terminated.
 func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
-	idleTimeout := 10 * time.Second
+	idleTimeout := 4 * time.Second
 	netConfig := types.DefaultClusterNetworkingConfig()
 	netConfig.SetClientIdleTimeout(idleTimeout)
 
@@ -1834,12 +1834,18 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 	instance := suite.NewTeleportWithConfig(t, nil, nil, tconf)
 	t.Cleanup(func() { require.NoError(t, instance.StopAll()) })
 
-	term := NewTerminal(100000)
-	sessionCtx, cancelSession := context.WithTimeout(t.Context(), 4*idleTimeout)
-	defer cancelSession()
+	term := NewTerminal(250)
 
 	sessionErr := make(chan error, 1)
+	t.Cleanup(func() {
+		require.Error(t, waitForError(sessionErr, 10*time.Second))
+	})
+
+	sessionCtx, cancelSession := context.WithCancel(t.Context())
+	defer cancelSession()
+
 	openSession := func() {
+		defer cancelSession()
 		cl, err := instance.NewClient(helpers.ClientConfig{
 			Login:                suite.Me.Username,
 			Cluster:              helpers.Site,
@@ -1854,27 +1860,24 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 		cl.Stdout = term
 		cl.Stdin = term
 
-		sessionErr <- cl.SSH(sessionCtx, nil)
+		// Print a ready marker, then echo each line of stdin back to the client.
+		const clientIdleKeepaliveCommand = `sh -c 'echo __READY__; exec cat'`
+		sessionErr <- cl.SSH(sessionCtx, []string{clientIdleKeepaliveCommand})
 	}
 
 	go openSession()
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.NoError(collect, enterInput(sessionCtx, term, "echo txlxport | sed 's/x/e/g' \r\n", "teleport"))
-	}, 10*time.Second, 2*time.Second)
+	require.NoError(t, waitForTerminalOutput(sessionCtx, term, ".*__READY__.*"))
 
-	var firstAckAt time.Time
-	var lastAckAt time.Time
+	// Keep the session alive by writing and reading from the terminal within the idle timeout.
+	start := time.Now()
 	for i := 0; ; i++ {
-		require.NoError(t, enterInput(sessionCtx, term, "echo txlxport"+strconv.Itoa(i)+" | sed 's/x/e/g' \r\n", "teleport"+strconv.Itoa(i)))
-		lastAckAt = time.Now()
+		msg := "keepalive-" + strconv.Itoa(i)
+		require.NoError(t, enterInput(sessionCtx, term, msg+"\r\n", msg))
 
-		if firstAckAt.IsZero() {
-			firstAckAt = lastAckAt
-		}
-
-		if lastAckAt.Sub(firstAckAt) > idleTimeout*3/2 {
-			break
+		if time.Since(start) > idleTimeout*2 {
+			// The session survived beyond the idle timeout, success.
+			return
 		}
 
 		select {
@@ -1883,10 +1886,6 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 			require.FailNowf(t, "timeout", "session ended before exceeding idle timeout: %v", sessionCtx.Err())
 		}
 	}
-
-	cancelSession()
-	err := waitForError(sessionErr, time.Second*15)
-	require.Error(t, err)
 }
 
 // TestDisconnectScenarios tests multiple scenarios with client disconnects
@@ -2127,9 +2126,13 @@ func timeNow() string {
 // the supplied regexp string.
 func enterInput(ctx context.Context, person *Terminal, command, pattern string) error {
 	person.Type(command)
-	abortTime := time.Now().Add(2 * time.Second)
+	return waitForTerminalOutput(ctx, person, pattern)
+}
+
+func waitForTerminalOutput(ctx context.Context, person *Terminal, pattern string) error {
+	abortTime := time.Now().Add(10 * time.Second)
 	for {
-		output := replaceNewlines(person.Output(100000))
+		output := replaceNewlines(person.Output(1000))
 		matched, _ := regexp.MatchString(pattern, output)
 		if matched {
 			return nil
@@ -2137,6 +2140,8 @@ func enterInput(ctx context.Context, person *Terminal, command, pattern string) 
 		select {
 		case <-time.After(50 * time.Millisecond):
 		case <-ctx.Done():
+			// cancellation means that we don't care about the input being
+			// confirmed anymore; not equivalent to a timeout.
 			return nil
 		}
 		if time.Now().After(abortTime) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1823,7 +1823,7 @@ type disconnectTestCase struct {
 // testClientIdleConnection validates that if a user is active beyond
 // the client idle timeout that the session is not terminated.
 func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
-	idleTimeout := 4 * time.Second
+	idleTimeout := 3 * time.Second
 	netConfig := types.DefaultClusterNetworkingConfig()
 	netConfig.SetClientIdleTimeout(idleTimeout)
 
@@ -1860,7 +1860,7 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 		cl.Stdout = term
 		cl.Stdin = term
 
-		// Print a ready marker, then echo each line of stdin back to the client.
+		// Print a ready marker, then echo bytes from stdin back to the client.
 		const clientIdleKeepaliveCommand = `sh -c 'echo __READY__; exec cat'`
 		sessionErr <- cl.SSH(sessionCtx, []string{clientIdleKeepaliveCommand})
 	}
@@ -1869,19 +1869,20 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 
 	require.NoError(t, waitForTerminalOutput(sessionCtx, term, ".*__READY__.*"))
 
-	// Keep the session alive by writing and reading from the terminal within the idle timeout.
-	start := time.Now()
-	for i := 0; ; i++ {
-		msg := "keepalive-" + strconv.Itoa(i)
-		require.NoError(t, enterInput(sessionCtx, term, msg+"\r\n", msg))
+	// Keep the session alive by writing/reading with the terminal within the idle timeout.
+	keepaliveTicker := time.NewTicker(idleTimeout / 3)
+	keepaliveEnd := time.After(10 * time.Second)
 
-		if time.Since(start) > idleTimeout*2 {
+	for i := 0; ; i++ {
+		select {
+		case <-keepaliveTicker.C:
+			msg := "keepalive-" + strconv.Itoa(i)
+			require.NoError(t, enterInput(sessionCtx, term, msg+"\r\n", msg))
+
+		case <-keepaliveEnd:
 			// The session survived beyond the idle timeout, success.
 			return
-		}
 
-		select {
-		case <-time.After(idleTimeout / 3):
 		case <-sessionCtx.Done():
 			require.FailNowf(t, "timeout", "session ended before exceeding idle timeout: %v", sessionCtx.Err())
 		}
@@ -2121,14 +2122,17 @@ func timeNow() string {
 	return time.Now().Format(time.StampMilli)
 }
 
-// enterInput simulates entering user input into a terminal and awaiting a
-// response. Returns an error if the given response text doesn't match
-// the supplied regexp string.
+// enterInput simulates typing command into the terminal and waits for output
+// matching pattern. Returns an error on timeout, nil on match or context
+// cancellation.
 func enterInput(ctx context.Context, person *Terminal, command, pattern string) error {
 	person.Type(command)
 	return waitForTerminalOutput(ctx, person, pattern)
 }
 
+// waitForTerminalOutput polls the terminal until output matches pattern,
+// 10 seconds elapse, or ctx is canceled.
+// Returns nil on match or cancellation, error on timeout.
 func waitForTerminalOutput(ctx context.Context, person *Terminal, pattern string) error {
 	abortTime := time.Now().Add(10 * time.Second)
 	for {


### PR DESCRIPTION
The issue with this test was that it was actually measuring throughput rather than idleness. If the session could not handle 30 echo commands in the span of 6 seconds, you'd get an error like `"9" is not greater than "30"` signaling that only 9 of the 30 echo commands were processed in time.

Since client idleness is measured by both client writes and reads, we don't need to write again until the current read is complete, so we can just send/receive keepalives instead. We also use `sh -c 'echo __READY__; exec cat'` instead of `echo txlxport | sed 's/x/e/g'` so that we can track readiness and simplify the command. `exec cat` just drops into an echo session where stdin echo is suppressed so we naturally only see stdout without the need for a `sed` trick.

Updates https://github.com/gravitational/teleport/issues/33252