### PR TITLE
Fix unsafe type assertion panic in TLS CA AgentScope parsing.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - depguard
     - errorlint
     - forbidigo
+    - forcetypeassert
     - govet
     - ineffassign
     - misspell
@@ -561,6 +562,13 @@ linters:
           - forbidigo
         path: ^api/ssh/
         text: tracessh.NewClientConnWithTimeout
+
+      # TODO: Fix forced type assertions in the rest of the codebase and remove this exclusion so that the linter can
+      # enforce this rule everywhere.
+      - linters:
+          - forcetypeassert
+        path-except: lib/tlsca/ca\.go
+
     paths:
       - (^|/)node_modules/
       - ^api/gen/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -567,7 +567,7 @@ linters:
       # enforce this rule everywhere.
       - linters:
           - forcetypeassert
-        path-except: lib/tlsca/ca\.go
+        path-except: ^lib/tlsca/ca\.go$
 
     paths:
       - (^|/)node_modules/

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1366,8 +1366,10 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 				id.ScopePin = pin
 			}
 		case attr.Type.Equal(AgentScopeASN1ExtensionOID):
-			id.AgentScope = attr.Value.(string)
-
+			val, ok := attr.Value.(string)
+			if ok {
+				id.AgentScope = val
+			}
 		case attr.Type.Equal(AllowedResourcesASN1ExtensionOID):
 			allowedResourcesStr, ok := attr.Value.(string)
 			if ok {


### PR DESCRIPTION
Resolves https://github.com/gravitational/teleport-private/issues/2457

Fixes the immediate problem and adds a linter scoped to that file to prevent reintroducing the problem going forward.

Intentionally left out fixing forced type assertions throughout the rest of the codebase to minimize scope.