### PR TITLE
[v18] Fix unsafe type assertion panic in TLS CA AgentScope parsing.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - depguard
     - errorlint
     - forbidigo
+    - forcetypeassert
     - govet
     - ineffassign
     - misspell
@@ -468,6 +469,13 @@ linters:
           - forbidigo
         path: lib/utils/aws/stsutils/stscreds_v1.go
         text: stscreds.NewCredentials
+
+      # TODO: Fix forced type assertions in the rest of the codebase and remove this exclusion so that the linter can
+      # enforce this rule everywhere.
+      - linters:
+          - forcetypeassert
+        path-except: ^lib/tlsca/ca\.go$
+
     paths:
       - (^|/)node_modules/
       - ^api/gen/

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1352,8 +1352,10 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 				id.ScopePin = pin
 			}
 		case attr.Type.Equal(AgentScopeASN1ExtensionOID):
-			id.AgentScope = attr.Value.(string)
-
+			val, ok := attr.Value.(string)
+			if ok {
+				id.AgentScope = val
+			}
 		case attr.Type.Equal(AllowedResourcesASN1ExtensionOID):
 			allowedResourcesStr, ok := attr.Value.(string)
 			if ok {


### PR DESCRIPTION
Resolves https://github.com/gravitational/teleport-private/issues/2457

Backports https://github.com/gravitational/teleport/pull/65661 to branch/v18
