### PR TITLE
Don't resolve symlinks or allow relative paths for moderated file transfers

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7971,32 +7971,17 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Create and approve a file download request
-			tempDir := t.TempDir()
-			reqFile := filepath.Join(tempDir, "req-file")
-			err = os.WriteFile(reqFile, []byte("contents"), 0o666)
-			require.NoError(t, err)
-
-			err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
-				Download: true,
-				Location: reqFile,
-			})
-			require.NoError(t, err)
-
-			sshReq = sshRquestIgnoringKeepalives(t, modSSHReqs)
+		createAndApproveTransferRequest := func(t *testing.T, req tracessh.FileTransferReq) {
+			require.NoError(t, tc.sess.RequestFileTransfer(ctx, req))
+			sshReq := sshRquestIgnoringKeepalives(t, modSSHReqs)
 			var fileReq apievents.FileTransferRequestEvent
-			err = json.Unmarshal(sshReq.Payload, &fileReq)
-			require.NoError(t, err)
-
-			err = modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID)
-			require.NoError(t, err)
-
+			require.NoError(t, json.Unmarshal(sshReq.Payload, &fileReq))
+			require.NoError(t, modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID))
 			// Ignore file transfer request approve event
 			sshRquestIgnoringKeepalives(t, modSSHReqs)
+		}
 
-			// Test that only operations needed to complete the download
-			// are allowed
+		openSFTPClient := func(t *testing.T) *sftp.Client {
 			transferSess, err := tc.sshClient.NewSession(ctx)
 			require.NoError(t, err)
 			t.Cleanup(func() {
@@ -8014,92 +7999,105 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 			require.NoError(t, err)
 			sftpClient, err := sftp.NewClientPipe(r, w)
 			require.NoError(t, err)
-
-			// A file not in the request shouldn't be allowed
-			badFile := filepath.Join(tempDir, "bad-file")
-			_, err = sftpClient.Open(badFile)
-			require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
-			// Since this is a download no files should be allowed to be written to
-			_, err = sftpClient.OpenFile(reqFile, os.O_WRONLY)
-			require.ErrorContains(t, err, `writing is not allowed`)
-			// Only stats and reads should be allowed
-			err = sftpClient.Mkdir(reqFile)
-			require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
-			// Since this is a download no files should be allowed to have
-			// their permissions changed
-			err = sftpClient.Chmod(reqFile, 0o777)
-			require.ErrorContains(t, err, `writing is not allowed`)
-
-			// Only necessary operations should be allowed
-			_, err = sftpClient.Stat(reqFile)
-			require.NoError(t, err)
-			_, err = sftpClient.Lstat(reqFile)
-			require.NoError(t, err)
-			rf, err := sftpClient.Open(reqFile)
-			require.NoError(t, err)
-			require.NoError(t, rf.Close())
-
-			require.NoError(t, sftpClient.Close())
-
-			// Create and approve a file upload request
-			err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
-				Download: false,
-				Filename: "upload-file",
-				Location: reqFile,
-			})
-			require.NoError(t, err)
-
-			sshReq = sshRquestIgnoringKeepalives(t, modSSHReqs)
-			err = json.Unmarshal(sshReq.Payload, &fileReq)
-			require.NoError(t, err)
-
-			err = modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID)
-			require.NoError(t, err)
-
-			// Ignore file transfer request approve event
-			sshRquestIgnoringKeepalives(t, modSSHReqs)
-
-			isNilOrEOFErr(t, transferSess.Close())
-			transferSess, err = tc.sshClient.NewSession(ctx)
-			require.NoError(t, err)
 			t.Cleanup(func() {
-				require.NoError(t, transferSess.Close())
+				isNilOrEOFErr(t, sftpClient.Close())
 			})
 
-			err = transferSess.Setenv(ctx, telesftp.EnvModeratedSessionID, sessTracker.GetSessionID())
-			require.NoError(t, err)
+			return sftpClient
+		}
 
-			// Test that only operations needed to complete the download
-			// are allowed
-			err = transferSess.RequestSubsystem(ctx, teleport.SFTPSubsystem)
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			// Create needed files.
+			reqFile := filepath.Join(tempDir, "req-file")
+			err = os.WriteFile(reqFile, []byte("contents"), 0o666)
 			require.NoError(t, err)
-			w, err = transferSess.StdinPipe()
+			// On MacOS temp dirs are symlinked, we need the real path so the symlink
+			// check works.
+			reqFile, err := filepath.EvalSymlinks(reqFile)
 			require.NoError(t, err)
-			r, err = transferSess.StdoutPipe()
-			require.NoError(t, err)
-			sftpClient, err = sftp.NewClientPipe(r, w)
-			require.NoError(t, err)
+			symlinkFile := filepath.Join(tempDir, "symlink")
+			require.NoError(t, os.Symlink(reqFile, symlinkFile))
+			badFile := filepath.Join(tempDir, "bad-file")
 
-			// A file not in the request shouldn't be allowed
-			_, err = sftpClient.Open(badFile)
-			require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
-			// Since this is an upload no files should be allowed to be read from
-			_, err = sftpClient.OpenFile(reqFile, os.O_RDONLY)
-			require.ErrorContains(t, err, `reading is not allowed`)
-			// Only stats, writes, and chmods should be allowed
-			err = sftpClient.Mkdir(reqFile)
-			require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
+			t.Run("download", func(t *testing.T) {
+				// Create and approve a file download request
+				createAndApproveTransferRequest(t, tracessh.FileTransferReq{
+					Download: true,
+					Location: reqFile,
+				})
 
-			// Only necessary operations should be allowed
-			_, err = sftpClient.Stat(reqFile)
-			require.NoError(t, err)
-			_, err = sftpClient.Lstat(reqFile)
-			require.NoError(t, err)
-			err = sftpClient.Chmod(reqFile, 0o777)
-			require.NoError(t, err)
-			wf, err := sftpClient.OpenFile(reqFile, os.O_WRONLY)
-			require.NoError(t, err)
-			require.NoError(t, wf.Close())
+				// Test that only operations needed to complete the download
+				// are allowed
+				sftpClient := openSFTPClient(t)
+
+				// A file not in the request shouldn't be allowed
+				_, err = sftpClient.Open(badFile)
+				require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
+				// Since this is a download no files should be allowed to be written to
+				_, err = sftpClient.OpenFile(reqFile, os.O_WRONLY)
+				require.ErrorContains(t, err, `writing is not allowed`)
+				// Only stats and reads should be allowed
+				err = sftpClient.Mkdir(reqFile)
+				require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
+				// Since this is a download no files should be allowed to have
+				// their permissions changed
+				err = sftpClient.Chmod(reqFile, 0o777)
+				require.ErrorContains(t, err, `writing is not allowed`)
+
+				// Only necessary operations should be allowed
+				_, err = sftpClient.Stat(reqFile)
+				require.NoError(t, err)
+				_, err = sftpClient.Lstat(reqFile)
+				require.NoError(t, err)
+				rf, err := sftpClient.Open(reqFile)
+				require.NoError(t, err)
+				require.NoError(t, rf.Close())
+			})
+
+			t.Run("upload", func(t *testing.T) {
+				// Create and approve a file upload request
+				createAndApproveTransferRequest(t, tracessh.FileTransferReq{
+					Download: false,
+					Filename: "upload-file",
+					Location: reqFile,
+				})
+
+				sftpClient := openSFTPClient(t)
+
+				// A file not in the request shouldn't be allowed
+				_, err = sftpClient.Open(badFile)
+				require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
+				// Since this is an upload no files should be allowed to be read from
+				_, err = sftpClient.OpenFile(reqFile, os.O_RDONLY)
+				require.ErrorContains(t, err, `reading is not allowed`)
+				// Only stats, writes, and chmods should be allowed
+				err = sftpClient.Mkdir(reqFile)
+				require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
+
+				// Only necessary operations should be allowed
+				_, err = sftpClient.Stat(reqFile)
+				require.NoError(t, err)
+				_, err = sftpClient.Lstat(reqFile)
+				require.NoError(t, err)
+				err = sftpClient.Chmod(reqFile, 0o777)
+				require.NoError(t, err)
+				wf, err := sftpClient.OpenFile(reqFile, os.O_WRONLY)
+				require.NoError(t, err)
+				require.NoError(t, wf.Close())
+
+				require.NoError(t, sftpClient.Close())
+			})
+
+			t.Run("don't evaluate symlinks", func(t *testing.T) {
+				createAndApproveTransferRequest(t, tracessh.FileTransferReq{
+					Download: true,
+					Location: symlinkFile,
+				})
+				sftpClient := openSFTPClient(t)
+				_, err = sftpClient.Open(symlinkFile)
+				require.ErrorContains(t, err, "following symlinks is not allowed")
+			})
 		})
 	}
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7898,32 +7898,17 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Create and approve a file download request
-			tempDir := t.TempDir()
-			reqFile := filepath.Join(tempDir, "req-file")
-			err = os.WriteFile(reqFile, []byte("contents"), 0o666)
-			require.NoError(t, err)
-
-			err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
-				Download: true,
-				Location: reqFile,
-			})
-			require.NoError(t, err)
-
-			sshReq = sshRquestIgnoringKeepalives(t, modSSHReqs)
+		createAndApproveTransferRequest := func(t *testing.T, req tracessh.FileTransferReq) {
+			require.NoError(t, tc.sess.RequestFileTransfer(ctx, req))
+			sshReq := sshRquestIgnoringKeepalives(t, modSSHReqs)
 			var fileReq apievents.FileTransferRequestEvent
-			err = json.Unmarshal(sshReq.Payload, &fileReq)
-			require.NoError(t, err)
-
-			err = modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID)
-			require.NoError(t, err)
-
+			require.NoError(t, json.Unmarshal(sshReq.Payload, &fileReq))
+			require.NoError(t, modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID))
 			// Ignore file transfer request approve event
 			sshRquestIgnoringKeepalives(t, modSSHReqs)
+		}
 
-			// Test that only operations needed to complete the download
-			// are allowed
+		openSFTPClient := func(t *testing.T) *sftp.Client {
 			transferSess, err := tc.sshClient.NewSession(ctx)
 			require.NoError(t, err)
 			t.Cleanup(func() {
@@ -7941,92 +7926,105 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 			require.NoError(t, err)
 			sftpClient, err := sftp.NewClientPipe(r, w)
 			require.NoError(t, err)
-
-			// A file not in the request shouldn't be allowed
-			badFile := filepath.Join(tempDir, "bad-file")
-			_, err = sftpClient.Open(badFile)
-			require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
-			// Since this is a download no files should be allowed to be written to
-			_, err = sftpClient.OpenFile(reqFile, os.O_WRONLY)
-			require.ErrorContains(t, err, `writing is not allowed`)
-			// Only stats and reads should be allowed
-			err = sftpClient.Mkdir(reqFile)
-			require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
-			// Since this is a download no files should be allowed to have
-			// their permissions changed
-			err = sftpClient.Chmod(reqFile, 0o777)
-			require.ErrorContains(t, err, `writing is not allowed`)
-
-			// Only necessary operations should be allowed
-			_, err = sftpClient.Stat(reqFile)
-			require.NoError(t, err)
-			_, err = sftpClient.Lstat(reqFile)
-			require.NoError(t, err)
-			rf, err := sftpClient.Open(reqFile)
-			require.NoError(t, err)
-			require.NoError(t, rf.Close())
-
-			require.NoError(t, sftpClient.Close())
-
-			// Create and approve a file upload request
-			err = tc.sess.RequestFileTransfer(ctx, tracessh.FileTransferReq{
-				Download: false,
-				Filename: "upload-file",
-				Location: reqFile,
-			})
-			require.NoError(t, err)
-
-			sshReq = sshRquestIgnoringKeepalives(t, modSSHReqs)
-			err = json.Unmarshal(sshReq.Payload, &fileReq)
-			require.NoError(t, err)
-
-			err = modSess.ApproveFileTransferRequest(ctx, fileReq.RequestID)
-			require.NoError(t, err)
-
-			// Ignore file transfer request approve event
-			sshRquestIgnoringKeepalives(t, modSSHReqs)
-
-			isNilOrEOFErr(t, transferSess.Close())
-			transferSess, err = tc.sshClient.NewSession(ctx)
-			require.NoError(t, err)
 			t.Cleanup(func() {
-				require.NoError(t, transferSess.Close())
+				isNilOrEOFErr(t, sftpClient.Close())
 			})
 
-			err = transferSess.Setenv(ctx, telesftp.EnvModeratedSessionID, sessTracker.GetSessionID())
-			require.NoError(t, err)
+			return sftpClient
+		}
 
-			// Test that only operations needed to complete the download
-			// are allowed
-			err = transferSess.RequestSubsystem(ctx, teleport.SFTPSubsystem)
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			// Create needed files.
+			reqFile := filepath.Join(tempDir, "req-file")
+			err = os.WriteFile(reqFile, []byte("contents"), 0o666)
 			require.NoError(t, err)
-			w, err = transferSess.StdinPipe()
+			// On MacOS temp dirs are symlinked, we need the real path so the symlink
+			// check works.
+			reqFile, err := filepath.EvalSymlinks(reqFile)
 			require.NoError(t, err)
-			r, err = transferSess.StdoutPipe()
-			require.NoError(t, err)
-			sftpClient, err = sftp.NewClientPipe(r, w)
-			require.NoError(t, err)
+			symlinkFile := filepath.Join(tempDir, "symlink")
+			require.NoError(t, os.Symlink(reqFile, symlinkFile))
+			badFile := filepath.Join(tempDir, "bad-file")
 
-			// A file not in the request shouldn't be allowed
-			_, err = sftpClient.Open(badFile)
-			require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
-			// Since this is an upload no files should be allowed to be read from
-			_, err = sftpClient.OpenFile(reqFile, os.O_RDONLY)
-			require.ErrorContains(t, err, `reading is not allowed`)
-			// Only stats, writes, and chmods should be allowed
-			err = sftpClient.Mkdir(reqFile)
-			require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
+			t.Run("download", func(t *testing.T) {
+				// Create and approve a file download request
+				createAndApproveTransferRequest(t, tracessh.FileTransferReq{
+					Download: true,
+					Location: reqFile,
+				})
 
-			// Only necessary operations should be allowed
-			_, err = sftpClient.Stat(reqFile)
-			require.NoError(t, err)
-			_, err = sftpClient.Lstat(reqFile)
-			require.NoError(t, err)
-			err = sftpClient.Chmod(reqFile, 0o777)
-			require.NoError(t, err)
-			wf, err := sftpClient.OpenFile(reqFile, os.O_WRONLY)
-			require.NoError(t, err)
-			require.NoError(t, wf.Close())
+				// Test that only operations needed to complete the download
+				// are allowed
+				sftpClient := openSFTPClient(t)
+
+				// A file not in the request shouldn't be allowed
+				_, err = sftpClient.Open(badFile)
+				require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
+				// Since this is a download no files should be allowed to be written to
+				_, err = sftpClient.OpenFile(reqFile, os.O_WRONLY)
+				require.ErrorContains(t, err, `writing is not allowed`)
+				// Only stats and reads should be allowed
+				err = sftpClient.Mkdir(reqFile)
+				require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
+				// Since this is a download no files should be allowed to have
+				// their permissions changed
+				err = sftpClient.Chmod(reqFile, 0o777)
+				require.ErrorContains(t, err, `writing is not allowed`)
+
+				// Only necessary operations should be allowed
+				_, err = sftpClient.Stat(reqFile)
+				require.NoError(t, err)
+				_, err = sftpClient.Lstat(reqFile)
+				require.NoError(t, err)
+				rf, err := sftpClient.Open(reqFile)
+				require.NoError(t, err)
+				require.NoError(t, rf.Close())
+			})
+
+			t.Run("upload", func(t *testing.T) {
+				// Create and approve a file upload request
+				createAndApproveTransferRequest(t, tracessh.FileTransferReq{
+					Download: false,
+					Filename: "upload-file",
+					Location: reqFile,
+				})
+
+				sftpClient := openSFTPClient(t)
+
+				// A file not in the request shouldn't be allowed
+				_, err = sftpClient.Open(badFile)
+				require.ErrorContains(t, err, fmt.Sprintf("operations are only allowed on %s, not %s", reqFile, badFile))
+				// Since this is an upload no files should be allowed to be read from
+				_, err = sftpClient.OpenFile(reqFile, os.O_RDONLY)
+				require.ErrorContains(t, err, `reading is not allowed`)
+				// Only stats, writes, and chmods should be allowed
+				err = sftpClient.Mkdir(reqFile)
+				require.ErrorContains(t, err, `method mkdir is not allowed on `+reqFile)
+
+				// Only necessary operations should be allowed
+				_, err = sftpClient.Stat(reqFile)
+				require.NoError(t, err)
+				_, err = sftpClient.Lstat(reqFile)
+				require.NoError(t, err)
+				err = sftpClient.Chmod(reqFile, 0o777)
+				require.NoError(t, err)
+				wf, err := sftpClient.OpenFile(reqFile, os.O_WRONLY)
+				require.NoError(t, err)
+				require.NoError(t, wf.Close())
+
+				require.NoError(t, sftpClient.Close())
+			})
+
+			t.Run("don't evaluate symlinks", func(t *testing.T) {
+				createAndApproveTransferRequest(t, tracessh.FileTransferReq{
+					Download: true,
+					Location: symlinkFile,
+				})
+				sftpClient := openSFTPClient(t)
+				_, err = sftpClient.Open(symlinkFile)
+				require.ErrorContains(t, err, "following symlinks is not allowed")
+			})
 		})
 	}
 }

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"sync"
@@ -1898,6 +1899,9 @@ func (s *session) addFileTransferRequest(params *rsession.FileTransferRequestPar
 	}
 	if !params.Download && params.Filename == "" {
 		return trace.BadParameter("no source file is set for the upload")
+	}
+	if !filepath.IsAbs(params.Location) {
+		return trace.BadParameter("request path must be absolute")
 	}
 
 	s.fileTransferReq = &fileTransferRequestWithApprovers{

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1925,7 +1925,7 @@ func TestFileTransferEvents(t *testing.T) {
 	// Create file transfer event
 	data, err := json.Marshal(events.EventFields{
 		"download": true,
-		"location": "~/myfile.txt",
+		"location": "/home/alice/myfile.txt",
 	})
 
 	require.NoError(t, err)

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -28,8 +28,10 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -79,22 +81,12 @@ func newSFTPHandler(logger *slog.Logger, req *FileTransferRequest, events chan<-
 		allowed = &allowedOps{
 			write: !req.Download,
 		}
-		// TODO(capnspacehook): reject relative paths and symlinks
-		// make filepaths consistent by ensuring all separators use backslashes
-		allowedPath, err := sftputils.ExpandHomeDir(req.Location)
+		allowedPath, err := sftputils.ExpandHomeDir(filepath.ToSlash(req.Location))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		if !path.IsAbs(allowedPath) {
-			currentUser, err := user.Current()
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			if currentUser.HomeDir != "" {
-				allowedPath = path.Join(currentUser.HomeDir, allowedPath)
-			} else {
-				allowedPath = path.Join(string(os.PathSeparator), allowedPath)
-			}
+			return nil, trace.BadParameter("allowed path must be absolute")
 		}
 		allowed.path = path.Clean(allowedPath)
 	}
@@ -114,7 +106,7 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 		return nil
 	}
 
-	cleaned := path.Clean(req.Filepath)
+	cleaned := path.Clean(filepath.ToSlash(req.Filepath))
 	if s.allowed.path != cleaned {
 		return trace.Errorf("operations are only allowed on %s, not %s", s.allowed.path, cleaned)
 	}
@@ -185,11 +177,23 @@ func (s *sftpHandler) openFile(req *sftp.Request) (sftp.WriterAtReaderAt, error)
 	if err := s.ensureReqIsAllowed(req); err != nil {
 		return nil, err
 	}
-
-	f, err := os.OpenFile(req.Filepath, sftputils.ParseFlags(req), 0o644)
+	flags := sftputils.ParseFlags(req)
+	var f *os.File
+	var err error
+	if s.allowed != nil {
+		// Files in moderated sessions may not include symlinks.
+		f, err = openFileNoFollow(req.Filepath, flags, 0o644)
+	} else {
+		f, err = os.OpenFile(req.Filepath, flags, 0o644)
+	}
 	if err != nil {
+		// Symlink traversal is not allowed for moderated file transfers.
+		if s.allowed != nil && errors.Is(err, syscall.ELOOP) {
+			return nil, trace.Errorf("following symlinks is not allowed for moderated file transfers, request the resolved path instead")
+		}
 		return nil, err
 	}
+
 	trackFile := &sftputils.TrackedFile{File: f}
 	s.mtx.Lock()
 	s.files = append(s.files, trackFile)
@@ -212,6 +216,12 @@ func (s *sftpHandler) Filecmd(req *sftp.Request) (retErr error) {
 	}
 	if err := s.ensureReqIsAllowed(req); err != nil {
 		return err
+	}
+
+	if s.allowed != nil && req.Method == sftputils.MethodSetStat {
+		// Setstat can be called during moderated file transfers, don't follow
+		// symlinks if that's the case.
+		return setstatNoFollow(req.Filepath, req.AttrFlags(), req.Attributes())
 	}
 
 	return sftputils.HandleFilecmd(req, nil /* local filesystem */)
@@ -380,4 +390,132 @@ func openFD(fd uintptr, name string) (*os.File, error) {
 	}
 
 	return file, nil
+}
+
+// openAtAndClose opens a file under the parent directory without following
+// symlinks, then closes the parent file. The parent file will be
+// closed even if this function returns an error.
+func openAtAndClose(parent *os.File, name string, flags int, mode os.FileMode) (*os.File, error) {
+	defer parent.Close()
+	syscallConn, err := parent.SyscallConn()
+	if err != nil {
+		return nil, err
+	}
+	var childFd int
+	var openAtErr error
+	ctrlErr := syscallConn.Control(func(fd uintptr) {
+		for {
+			childFd, openAtErr = unix.Openat(int(fd), name, flags|unix.O_NOFOLLOW|unix.O_CLOEXEC, uint32(mode))
+			if !errors.Is(openAtErr, syscall.EINTR) {
+				return
+			}
+		}
+	})
+	if ctrlErr != nil {
+		return nil, ctrlErr
+	} else if openAtErr != nil {
+		return nil, openAtErr
+	}
+	return os.NewFile(uintptr(childFd), filepath.Join(parent.Name(), name)), nil
+}
+
+// openFileNoFollow opens a file without following symlinks in any part of the path.
+func openFileNoFollow(file string, flags int, mode os.FileMode) (*os.File, error) {
+	if !filepath.IsAbs(file) {
+		return nil, trace.BadParameter("file path must be absolute")
+	}
+	dir, filename := filepath.Split(file)
+	relDir, err := filepath.Rel(string(os.PathSeparator), dir)
+	if err != nil {
+		return nil, err
+	}
+	parent, err := os.OpenFile(string(os.PathSeparator), readOnlyPath, 0)
+	if err != nil {
+		return nil, err
+	}
+	// Open each directory one at a time to ensure no symlinks are followed.
+	for relDir != "" {
+		var part string
+		part, relDir, _ = strings.Cut(relDir, string(os.PathSeparator))
+		parent, err = openAtAndClose(parent, part, unix.O_DIRECTORY|readOnlyPath, 0)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Set nonblock so we don't hang in case file is a pipe.
+	f, err := openAtAndClose(parent, filename, flags|unix.O_NONBLOCK, mode)
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, trace.BadParameter("path does not point to a regular file")
+	}
+	return f, nil
+}
+
+func chtimes(file *os.File, atime, mtime time.Time) error {
+	syscallConn, err := file.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var modifyErr error
+	ctrlErr := syscallConn.Control(func(fd uintptr) {
+		for {
+			modifyErr = unix.Futimes(int(fd), []unix.Timeval{
+				unix.NsecToTimeval(atime.UnixNano()),
+				unix.NsecToTimeval(mtime.UnixNano()),
+			})
+			if !errors.Is(modifyErr, syscall.EINTR) {
+				return
+			}
+		}
+	})
+	if ctrlErr != nil {
+		return ctrlErr
+	}
+	return modifyErr
+}
+
+// setstatNoFollow sets file attributes on a file without following any symlinks.
+func setstatNoFollow(file string, attrFlags sftp.FileAttrFlags, attrs *sftp.FileStat) error {
+	if !attrFlags.Acmodtime && !attrFlags.Permissions && !attrFlags.Size && !attrFlags.UidGid {
+		return nil
+	}
+	mode := os.O_RDONLY
+	if attrFlags.Size {
+		// Only open in write mode if needed to truncate.
+		mode = os.O_WRONLY
+	}
+	f, err := openFileNoFollow(file, mode, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if attrFlags.Size {
+		if err := f.Truncate(int64(attrs.Size)); err != nil {
+			return err
+		}
+	}
+	if attrFlags.Acmodtime {
+		if err := chtimes(f, time.Unix(int64(attrs.Atime), 0), time.Unix(int64(attrs.Mtime), 0)); err != nil {
+			return err
+		}
+	}
+	if attrFlags.Permissions {
+		if err := f.Chmod(attrs.FileMode()); err != nil {
+			return err
+		}
+	}
+	if attrFlags.UidGid {
+		if err := f.Chown(int(attrs.UID), int(attrs.GID)); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -108,43 +107,6 @@ func newSFTPHandler(logger *slog.Logger, req *FileTransferRequest, events chan<-
 	}, nil
 }
 
-// evalSymlinks evaluates symlinks in a path. Unlike [filepath.EvalSymlinks],
-// it is okay if the file at the end does not exist, as it may be created soon.
-// The returned path is not localized.
-func evalSymlinks(p string) (string, error) {
-	p = filepath.ToSlash(p)
-	dir, file := path.Split(p)
-	resolvedDir, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		return "", trace.ConvertSystemError(err)
-	}
-	// Work with path package compatible paths as much as possible.
-	resolvedDir = filepath.ToSlash(resolvedDir)
-	linkInfo, err := os.Lstat(p)
-	if err != nil {
-		osErr := trace.ConvertSystemError(err)
-		if trace.IsNotFound(err) {
-			// File does not exist and is not a symlink, but the path is valid.
-			return path.Join(resolvedDir, file), nil
-		}
-		return "", osErr
-	}
-	if linkInfo.Mode()&os.ModeSymlink == 0 {
-		// File is not a symlink, return the resolved parent + file.
-		return path.Join(resolvedDir, file), nil
-	}
-	// File is a symlink, resolve its target.
-	linkTarget, err := os.Readlink(p)
-	if err != nil {
-		return "", trace.ConvertSystemError(err)
-	}
-	linkTarget = filepath.ToSlash(linkTarget)
-	if path.IsAbs(linkTarget) {
-		return linkTarget, nil
-	}
-	return path.Join(resolvedDir, linkTarget), nil
-}
-
 // ensureReqIsAllowed returns an error if the SFTP request isn't
 // allowed based on the approved file transfer request for this session.
 func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
@@ -156,13 +118,6 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	cleaned := path.Clean(req.Filepath)
 	if s.allowed.path != cleaned {
 		return trace.Errorf("operations are only allowed on %s, not %s", s.allowed.path, cleaned)
-	}
-	resolvedPath, err := evalSymlinks(cleaned)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if s.allowed.path != resolvedPath {
-		return trace.Errorf("following symlinks is not allowed for moderated file transfers, request the resolved path instead")
 	}
 
 	switch req.Method {
@@ -238,6 +193,10 @@ func (s *sftpHandler) openFile(req *sftp.Request) (sftp.WriterAtReaderAt, error)
 	}
 	f, err := os.OpenFile(req.Filepath, flags, 0o644)
 	if err != nil {
+		// Symlink traversal is not allowed for moderated file transfers.
+		if s.allowed != nil && strings.Contains(err.Error(), "too many levels of symbolic links") {
+			return nil, trace.Errorf("following symlinks is not allowed for moderated file transfers, request the resolved path instead")
+		}
 		return nil, err
 	}
 

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -231,7 +231,13 @@ func (s *sftpHandler) openFile(req *sftp.Request) (sftp.WriterAtReaderAt, error)
 		return nil, err
 	}
 
-	f, err := os.OpenFile(req.Filepath, sftputils.ParseFlags(req), 0o644)
+	dir, filename := path.Split(req.Filepath)
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	f, err := root.OpenFile(filename, sftputils.ParseFlags(req), 0o644)
 	if err != nil {
 		return nil, err
 	}

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -231,16 +231,28 @@ func (s *sftpHandler) openFile(req *sftp.Request) (sftp.WriterAtReaderAt, error)
 		return nil, err
 	}
 
-	dir, filename := path.Split(req.Filepath)
-	root, err := os.OpenRoot(dir)
-	if err != nil {
-		return nil, err
+	var f *os.File
+	if s.allowed != nil {
+		// For moderated sessions, open in a root to minimize unexpected symlink
+		// traversals.
+		dir, filename := path.Split(req.Filepath)
+		root, err := os.OpenRoot(dir)
+		if err != nil {
+			return nil, err
+		}
+		defer root.Close()
+		f, err = root.OpenFile(filename, sftputils.ParseFlags(req), 0o644)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		f, err = os.OpenFile(req.Filepath, sftputils.ParseFlags(req), 0o644)
+		if err != nil {
+			return nil, err
+		}
 	}
-	defer root.Close()
-	f, err := root.OpenFile(filename, sftputils.ParseFlags(req), 0o644)
-	if err != nil {
-		return nil, err
-	}
+
 	trackFile := &sftputils.TrackedFile{File: f}
 	s.mtx.Lock()
 	s.files = append(s.files, trackFile)

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -230,27 +231,14 @@ func (s *sftpHandler) openFile(req *sftp.Request) (sftp.WriterAtReaderAt, error)
 	if err := s.ensureReqIsAllowed(req); err != nil {
 		return nil, err
 	}
-
-	var f *os.File
+	flags := sftputils.ParseFlags(req)
+	// Files in moderated sessions may not include symlinks.
 	if s.allowed != nil {
-		// For moderated sessions, open in a root to minimize unexpected symlink
-		// traversals.
-		dir, filename := path.Split(req.Filepath)
-		root, err := os.OpenRoot(dir)
-		if err != nil {
-			return nil, err
-		}
-		defer root.Close()
-		f, err = root.OpenFile(filename, sftputils.ParseFlags(req), 0o644)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		var err error
-		f, err = os.OpenFile(req.Filepath, sftputils.ParseFlags(req), 0o644)
-		if err != nil {
-			return nil, err
-		}
+		flags |= syscall.O_NOFOLLOW
+	}
+	f, err := os.OpenFile(req.Filepath, flags, 0o644)
+	if err != nil {
+		return nil, err
 	}
 
 	trackFile := &sftputils.TrackedFile{File: f}

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -107,6 +107,38 @@ func newSFTPHandler(logger *slog.Logger, req *FileTransferRequest, events chan<-
 	}, nil
 }
 
+// evalSymlinks evaluates symlinks in a path. Unlike [filepath.EvalSymlinks],
+// it is okay if the file at the end does not exist, as it may be created soon.
+func evalSymlinks(p string) (string, error) {
+	dir, file := filepath.Split(p)
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", trace.ConvertSystemError(err)
+	}
+	linkInfo, err := os.Lstat(p)
+	if err != nil {
+		osErr := trace.ConvertSystemError(err)
+		if trace.IsNotFound(err) {
+			// File does not exist and is not a symlink, but the path is valid.
+			return filepath.Join(resolvedDir, file), nil
+		}
+		return "", osErr
+	}
+	if linkInfo.Mode()&os.ModeSymlink == 0 {
+		// File is not a symlink, return the resolved parent + file.
+		return filepath.Join(resolvedDir, file), nil
+	}
+	// File is a symlink, resolve its target.
+	linkTarget, err := os.Readlink(p)
+	if err != nil {
+		return "", trace.ConvertSystemError(err)
+	}
+	if filepath.IsAbs(linkTarget) {
+		return linkTarget, nil
+	}
+	return filepath.Join(resolvedDir, linkTarget), nil
+}
+
 // ensureReqIsAllowed returns an error if the SFTP request isn't
 // allowed based on the approved file transfer request for this session.
 func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
@@ -119,21 +151,9 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	if s.allowed.path != cleaned {
 		return trace.Errorf("operations are only allowed on %s, not %s", s.allowed.path, cleaned)
 	}
-	resolvedPath, err := sftputils.Realpath(cleaned)
+	resolvedPath, err := evalSymlinks(cleaned)
 	if err != nil {
-		// Check if newly created file could exist.
-		if !s.allowed.write {
-			return trace.Wrap(err)
-		}
-		osErr := trace.ConvertSystemError(err)
-		if !trace.IsNotFound(osErr) {
-			return trace.Wrap(err)
-		}
-		resolvedDir, dirErr := sftputils.Realpath(filepath.Dir(cleaned))
-		if dirErr != nil {
-			return trace.Wrap(err)
-		}
-		resolvedPath = filepath.Join(resolvedDir, filepath.Base(cleaned))
+		return trace.Wrap(err)
 	}
 	if s.allowed.path != filepath.ToSlash(resolvedPath) {
 		return trace.Errorf("following symlinks is not allowed for moderated file transfers, request the resolved path instead")

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -111,6 +111,7 @@ func newSFTPHandler(logger *slog.Logger, req *FileTransferRequest, events chan<-
 // it is okay if the file at the end does not exist, as it may be created soon.
 // The returned path is not localized.
 func evalSymlinks(p string) (string, error) {
+	p = filepath.ToSlash(p)
 	dir, file := path.Split(p)
 	resolvedDir, err := filepath.EvalSymlinks(dir)
 	if err != nil {

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -118,6 +118,13 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	if s.allowed.path != cleaned {
 		return trace.Errorf("operations are only allowed on %s, not %s", s.allowed.path, cleaned)
 	}
+	resolvedPath, err := sftputils.Realpath(cleaned)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if s.allowed.path != resolvedPath {
+		return trace.Errorf("following symlinks is not allowed for moderated file transfers, request the resolved path instead")
+	}
 
 	switch req.Method {
 	case sftputils.MethodLstat, sftputils.MethodStat:

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -120,9 +121,21 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	}
 	resolvedPath, err := sftputils.Realpath(cleaned)
 	if err != nil {
-		return trace.Wrap(err)
+		// Check if newly created file could exist.
+		if !s.allowed.write {
+			return trace.Wrap(err)
+		}
+		osErr := trace.ConvertSystemError(err)
+		if !trace.IsNotFound(osErr) {
+			return trace.Wrap(err)
+		}
+		resolvedDir, dirErr := sftputils.Realpath(filepath.Dir(cleaned))
+		if dirErr != nil {
+			return trace.Wrap(err)
+		}
+		resolvedPath = filepath.Join(resolvedDir, filepath.Base(cleaned))
 	}
-	if s.allowed.path != resolvedPath {
+	if s.allowed.path != filepath.ToSlash(resolvedPath) {
 		return trace.Errorf("following symlinks is not allowed for moderated file transfers, request the resolved path instead")
 	}
 

--- a/session/reexec/reexecsftp/sftp.go
+++ b/session/reexec/reexecsftp/sftp.go
@@ -109,34 +109,38 @@ func newSFTPHandler(logger *slog.Logger, req *FileTransferRequest, events chan<-
 
 // evalSymlinks evaluates symlinks in a path. Unlike [filepath.EvalSymlinks],
 // it is okay if the file at the end does not exist, as it may be created soon.
+// The returned path is not localized.
 func evalSymlinks(p string) (string, error) {
-	dir, file := filepath.Split(p)
+	dir, file := path.Split(p)
 	resolvedDir, err := filepath.EvalSymlinks(dir)
 	if err != nil {
 		return "", trace.ConvertSystemError(err)
 	}
+	// Work with path package compatible paths as much as possible.
+	resolvedDir = filepath.ToSlash(resolvedDir)
 	linkInfo, err := os.Lstat(p)
 	if err != nil {
 		osErr := trace.ConvertSystemError(err)
 		if trace.IsNotFound(err) {
 			// File does not exist and is not a symlink, but the path is valid.
-			return filepath.Join(resolvedDir, file), nil
+			return path.Join(resolvedDir, file), nil
 		}
 		return "", osErr
 	}
 	if linkInfo.Mode()&os.ModeSymlink == 0 {
 		// File is not a symlink, return the resolved parent + file.
-		return filepath.Join(resolvedDir, file), nil
+		return path.Join(resolvedDir, file), nil
 	}
 	// File is a symlink, resolve its target.
 	linkTarget, err := os.Readlink(p)
 	if err != nil {
 		return "", trace.ConvertSystemError(err)
 	}
-	if filepath.IsAbs(linkTarget) {
+	linkTarget = filepath.ToSlash(linkTarget)
+	if path.IsAbs(linkTarget) {
 		return linkTarget, nil
 	}
-	return filepath.Join(resolvedDir, linkTarget), nil
+	return path.Join(resolvedDir, linkTarget), nil
 }
 
 // ensureReqIsAllowed returns an error if the SFTP request isn't
@@ -155,7 +159,7 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if s.allowed.path != filepath.ToSlash(resolvedPath) {
+	if s.allowed.path != resolvedPath {
 		return trace.Errorf("following symlinks is not allowed for moderated file transfers, request the resolved path instead")
 	}
 

--- a/session/reexec/reexecsftp/sftp_darwin.go
+++ b/session/reexec/reexecsftp/sftp_darwin.go
@@ -1,0 +1,26 @@
+//go:build darwin
+
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package reexecsftp
+
+import "golang.org/x/sys/unix"
+
+// readOnlyPath holds platform-specific flags for opening a directory for openat().
+const readOnlyPath = unix.O_RDONLY

--- a/session/reexec/reexecsftp/sftp_linux.go
+++ b/session/reexec/reexecsftp/sftp_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package reexecsftp
+
+import "golang.org/x/sys/unix"
+
+// readOnlyPath holds platform-specific flags for opening a directory for openat().
+const readOnlyPath = unix.O_PATH | unix.O_RDONLY

--- a/session/reexec/reexecsftp/sftp_test.go
+++ b/session/reexec/reexecsftp/sftp_test.go
@@ -1,0 +1,248 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package reexecsftp
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/session/sftputils"
+)
+
+func TestEnsureReqIsAllowed(t *testing.T) {
+	t.Parallel()
+	const filePath = "/foo/bar/baz.txt"
+	passTests := []struct {
+		name    string
+		allowed *allowedOps
+		req     *sftp.Request
+	}{
+		{
+			name: "no restrictions",
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "read",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "write",
+			allowed: &allowedOps{path: filePath, write: true},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodPut,
+			},
+		},
+		{
+			name:    "chmod",
+			allowed: &allowedOps{path: filePath, write: true},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodSetStat,
+			},
+		},
+		{
+			name:    "stat in read mode",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodStat,
+			},
+		},
+		{
+			name:    "lstat in read mode",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodLstat,
+			},
+		},
+		{
+			name:    "stat in write mode",
+			allowed: &allowedOps{path: filePath, write: true},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodStat,
+			},
+		},
+		{
+			name:    "lstat in write mode",
+			allowed: &allowedOps{path: filePath, write: true},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodLstat,
+			},
+		},
+	}
+	for _, tc := range passTests {
+		t.Run("allow "+tc.name, func(t *testing.T) {
+			tc.req.Filepath = filePath
+			if tc.allowed != nil {
+				tc.allowed.path = filePath
+			}
+			handler := &sftpHandler{allowed: tc.allowed}
+			require.NoError(t, handler.ensureReqIsAllowed(tc.req))
+		})
+	}
+
+	const convolutedPath = "/foo/bar/../bar/baz.txt"
+	failTests := []struct {
+		name    string
+		allowed *allowedOps
+		req     *sftp.Request
+	}{
+		{
+			name:    "uncleaned path",
+			allowed: &allowedOps{path: convolutedPath},
+			req: &sftp.Request{
+				Filepath: convolutedPath,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "get in write mode",
+			allowed: &allowedOps{path: filePath, write: true},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "write in read mode",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodPut,
+			},
+		},
+		{
+			name:    "chmod in read mode",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodSetStat,
+			},
+		},
+		{
+			name:    "unknown method",
+			allowed: &allowedOps{path: filePath},
+			req: &sftp.Request{
+				Filepath: filePath,
+				Method:   sftputils.MethodRename,
+			},
+		},
+	}
+	for _, tc := range failTests {
+		t.Run("deny "+tc.name, func(t *testing.T) {
+			handler := &sftpHandler{allowed: tc.allowed}
+			require.Error(t, handler.ensureReqIsAllowed(tc.req))
+		})
+	}
+}
+
+func newTempDir(t *testing.T) string {
+	tempDir := t.TempDir()
+	tempRoot, err := filepath.EvalSymlinks(tempDir)
+	require.NoError(t, err)
+	return tempRoot
+}
+
+func TestNoFollowFileOperations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful on path with no symlinks", func(t *testing.T) {
+		targetFile := filepath.Join(newTempDir(t), "myfile.txt")
+
+		f, err := openFileNoFollow(targetFile, os.O_WRONLY|os.O_CREATE, 0o600)
+		require.NoError(t, err)
+		const fileData = "foo bar baz"
+		_, err = f.WriteString(fileData)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		info, err := os.Stat(targetFile)
+		require.NoError(t, err)
+		require.Equal(t, int64(len(fileData)), info.Size())
+		require.Equal(t, os.FileMode(0o600), info.Mode())
+
+		f, err = openFileNoFollow(targetFile, os.O_RDONLY, 0)
+		require.NoError(t, err)
+		data, err := io.ReadAll(f)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		require.Equal(t, []byte(fileData), data)
+
+		updatedTime := info.ModTime().Add(time.Hour).Truncate(time.Second)
+		err = setstatNoFollow(targetFile, sftp.FileAttrFlags{
+			Size:        true,
+			Permissions: true,
+			Acmodtime:   true,
+		}, &sftp.FileStat{
+			Size:  uint64(len(fileData) / 2),
+			Mode:  0o604,
+			Atime: uint32(updatedTime.Unix()),
+			Mtime: uint32(updatedTime.Unix()),
+		})
+		require.NoError(t, err)
+		newInfo, err := os.Stat(targetFile)
+		require.NoError(t, err)
+		require.Equal(t, int64(len(fileData)/2), newInfo.Size())
+		require.Equal(t, os.FileMode(0o604), newInfo.Mode())
+		require.Equal(t, updatedTime, newInfo.ModTime())
+	})
+
+	t.Run("block symlink in parent dir", func(t *testing.T) {
+		tempDir := newTempDir(t)
+		targetFile := filepath.Join(tempDir, "foo.txt")
+		require.NoError(t, os.WriteFile(targetFile, []byte("foo"), 0o644))
+		link := filepath.Join(tempDir, "link")
+		require.NoError(t, os.Symlink(tempDir, link))
+		linkTarget := filepath.Join(link, "foo.txt")
+
+		_, err := openFileNoFollow(linkTarget, os.O_WRONLY|os.O_CREATE, 0o644)
+		require.ErrorIs(t, err, syscall.ENOTDIR)
+		err = setstatNoFollow(linkTarget, sftp.FileAttrFlags{Permissions: true}, &sftp.FileStat{Mode: 0o600})
+		require.ErrorIs(t, err, syscall.ENOTDIR)
+	})
+
+	t.Run("block symlink at end of path", func(t *testing.T) {
+		tempDir := newTempDir(t)
+		targetFile := filepath.Join(tempDir, "foo.txt")
+		require.NoError(t, os.WriteFile(targetFile, []byte("foo"), 0o644))
+		link := filepath.Join(tempDir, "link")
+		require.NoError(t, os.Symlink(targetFile, link))
+
+		_, err := openFileNoFollow(link, os.O_WRONLY|os.O_CREATE, 0o644)
+		require.ErrorIs(t, err, syscall.ELOOP)
+		err = setstatNoFollow(link, sftp.FileAttrFlags{Permissions: true}, &sftp.FileStat{Mode: 0o600})
+		require.ErrorIs(t, err, syscall.ELOOP)
+	})
+}

--- a/session/reexec/reexecsftp/sftp_test.go
+++ b/session/reexec/reexecsftp/sftp_test.go
@@ -17,6 +17,7 @@
 package reexecsftp
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,86 +29,9 @@ import (
 	"github.com/gravitational/teleport/session/sftputils"
 )
 
-func TestEvalSymlinks(t *testing.T) {
-	t.Parallel()
-	tempDir := t.TempDir()
-	tempRoot, err := filepath.EvalSymlinks(tempDir)
-	require.NoError(t, err)
-	subDir := filepath.Join(tempRoot, "foo")
-	require.NoError(t, os.Mkdir(subDir, 0o700))
-	realFile := filepath.Join(subDir, "bar.txt")
-	require.NoError(t, os.WriteFile(realFile, []byte("test data"), 0o600))
-	nonexistentFile := filepath.Join(subDir, "idontexist.txt")
-
-	dirLink := filepath.Join(tempRoot, "dirLink")
-	require.NoError(t, os.Symlink(subDir, dirLink))
-	fileLink := filepath.Join(tempRoot, "filelink")
-	require.NoError(t, os.Symlink(realFile, fileLink))
-	absLinkToNonexistentFile := filepath.Join(tempRoot, "abs")
-	require.NoError(t, os.Symlink(nonexistentFile, absLinkToNonexistentFile))
-	relLinkToNonexistentFile := filepath.Join(tempRoot, "rel")
-	require.NoError(t, os.Symlink("foo/idontexist.txt", relLinkToNonexistentFile))
-
-	tests := []struct {
-		name         string
-		path         string
-		expectedPath string
-	}{
-		{
-			name:         "real path",
-			path:         realFile,
-			expectedPath: realFile,
-		},
-		{
-			name:         "real path to nonexistent file",
-			path:         nonexistentFile,
-			expectedPath: nonexistentFile,
-		},
-		{
-			name:         "symlink in parent",
-			path:         filepath.Join(dirLink, "bar.txt"),
-			expectedPath: realFile,
-		},
-		{
-			name:         "link to file",
-			path:         fileLink,
-			expectedPath: realFile,
-		},
-		{
-			name:         "absolute link to nonexistent file",
-			path:         absLinkToNonexistentFile,
-			expectedPath: nonexistentFile,
-		},
-		{
-			name:         "relative link to nonexistent file",
-			path:         relLinkToNonexistentFile,
-			expectedPath: nonexistentFile,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			out, err := evalSymlinks(tc.path)
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedPath, out)
-		})
-	}
-
-	t.Run("don't eval with bad path", func(t *testing.T) {
-		_, err := evalSymlinks(filepath.Join(tempRoot, "this/does/not/exist.txt"))
-		require.Error(t, err)
-	})
-}
-
 func TestEnsureReqIsAllowed(t *testing.T) {
 	t.Parallel()
-	tempDir := t.TempDir()
-	tempRoot, err := filepath.EvalSymlinks(tempDir)
-	require.NoError(t, err)
-	file := filepath.Join(tempRoot, "foo.txt")
-	require.NoError(t, os.WriteFile(file, []byte("foo"), 0o600))
-	link := filepath.Join(tempRoot, "link")
-	require.NoError(t, os.Symlink(file, link))
-
+	const filePath = "/foo/bar/baz.txt"
 	passTests := []struct {
 		name    string
 		allowed *allowedOps
@@ -116,75 +40,79 @@ func TestEnsureReqIsAllowed(t *testing.T) {
 		{
 			name: "no restrictions",
 			req: &sftp.Request{
-				Filepath: "/foo/bar/baz.txt",
+				Filepath: filePath,
 				Method:   sftputils.MethodGet,
 			},
 		},
 		{
 			name:    "read",
-			allowed: &allowedOps{path: file},
+			allowed: &allowedOps{path: filePath},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodGet,
 			},
 		},
 		{
 			name:    "write",
-			allowed: &allowedOps{path: file, write: true},
+			allowed: &allowedOps{path: filePath, write: true},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodPut,
 			},
 		},
 		{
 			name:    "chmod",
-			allowed: &allowedOps{path: file, write: true},
+			allowed: &allowedOps{path: filePath, write: true},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodSetStat,
 			},
 		},
 		{
 			name:    "stat in read mode",
-			allowed: &allowedOps{path: file},
+			allowed: &allowedOps{path: filePath},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodStat,
 			},
 		},
 		{
 			name:    "lstat in read mode",
-			allowed: &allowedOps{path: file},
+			allowed: &allowedOps{path: filePath},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodLstat,
 			},
 		},
 		{
 			name:    "stat in write mode",
-			allowed: &allowedOps{path: file, write: true},
+			allowed: &allowedOps{path: filePath, write: true},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodStat,
 			},
 		},
 		{
 			name:    "lstat in write mode",
-			allowed: &allowedOps{path: file, write: true},
+			allowed: &allowedOps{path: filePath, write: true},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodLstat,
 			},
 		},
 	}
 	for _, tc := range passTests {
 		t.Run("allow "+tc.name, func(t *testing.T) {
+			tc.req.Filepath = filePath
+			if tc.allowed != nil {
+				tc.allowed.path = filePath
+			}
 			handler := &sftpHandler{allowed: tc.allowed}
 			require.NoError(t, handler.ensureReqIsAllowed(tc.req))
 		})
 	}
 
-	convolutedPath := tempRoot + "/../" + filepath.Base(tempRoot) + "/foo.txt"
+	const convolutedPath = "/foo/bar/../bar/baz.txt"
 	failTests := []struct {
 		name    string
 		allowed *allowedOps
@@ -199,42 +127,34 @@ func TestEnsureReqIsAllowed(t *testing.T) {
 			},
 		},
 		{
-			name:    "symlink",
-			allowed: &allowedOps{path: file},
-			req: &sftp.Request{
-				Filepath: link,
-				Method:   sftputils.MethodGet,
-			},
-		},
-		{
 			name:    "get in write mode",
-			allowed: &allowedOps{path: file, write: true},
+			allowed: &allowedOps{path: filePath, write: true},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodGet,
 			},
 		},
 		{
 			name:    "write in read mode",
-			allowed: &allowedOps{path: file},
+			allowed: &allowedOps{path: filePath},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodPut,
 			},
 		},
 		{
 			name:    "chmod in read mode",
-			allowed: &allowedOps{path: file},
+			allowed: &allowedOps{path: filePath},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodSetStat,
 			},
 		},
 		{
 			name:    "unknown method",
-			allowed: &allowedOps{path: file},
+			allowed: &allowedOps{path: filePath},
 			req: &sftp.Request{
-				Filepath: file,
+				Filepath: filePath,
 				Method:   sftputils.MethodRename,
 			},
 		},
@@ -243,6 +163,64 @@ func TestEnsureReqIsAllowed(t *testing.T) {
 		t.Run("deny "+tc.name, func(t *testing.T) {
 			handler := &sftpHandler{allowed: tc.allowed}
 			require.Error(t, handler.ensureReqIsAllowed(tc.req))
+		})
+	}
+}
+
+func TestOpenFile(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	tempRoot, err := filepath.EvalSymlinks(tempDir)
+	require.NoError(t, err)
+
+	file := filepath.Join(tempRoot, "foo.txt")
+	require.NoError(t, os.WriteFile(file, []byte("data"), 0o644))
+	link := filepath.Join(tempRoot, "link")
+	require.NoError(t, os.Symlink(file, link))
+
+	tests := []struct {
+		name    string
+		path    string
+		allowed *allowedOps
+		assert  assert.ErrorAssertionFunc
+	}{
+		{
+			name:   "regular read",
+			path:   file,
+			assert: assert.NoError,
+		},
+		{
+			name:    "moderated read",
+			path:    file,
+			allowed: &allowedOps{path: file},
+			assert:  assert.NoError,
+		},
+		{
+			name:   "symlink read",
+			path:   link,
+			assert: assert.NoError,
+		},
+		{
+			name:    "moderated symlink read",
+			path:    link,
+			allowed: &allowedOps{path: link},
+			assert:  assert.Error,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := sftp.NewRequest(sftputils.MethodGet, tc.path)
+			handler := &sftpHandler{
+				allowed: tc.allowed,
+			}
+			file, err := handler.openFile(req)
+			tc.assert(t, err)
+			if file == nil {
+				return
+			}
+			if closer, ok := file.(io.Closer); ok {
+				assert.NoError(t, closer.Close())
+			}
 		})
 	}
 }

--- a/session/reexec/reexecsftp/sftp_test.go
+++ b/session/reexec/reexecsftp/sftp_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package common
+package reexecsftp
 
 import (
 	"os"
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	sftputils "github.com/gravitational/teleport/lib/sshutils/sftp"
+	"github.com/gravitational/teleport/session/sftputils"
 )
 
 func TestEvalSymlinks(t *testing.T) {

--- a/session/sftputils/sftp.go
+++ b/session/sftputils/sftp.go
@@ -193,7 +193,6 @@ func (n *NonRecursiveDirectoryTransferError) Error() string {
 func setstat(req *sftp.Request, fs FileSystem) error {
 	attrFlags := req.AttrFlags()
 	attrs := req.Attributes()
-
 	if attrFlags.Acmodtime {
 		atime := time.Unix(int64(attrs.Atime), 0)
 		mtime := time.Unix(int64(attrs.Mtime), 0)

--- a/tool/teleport/common/sftp_test.go
+++ b/tool/teleport/common/sftp_test.go
@@ -1,0 +1,248 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sftputils "github.com/gravitational/teleport/lib/sshutils/sftp"
+)
+
+func TestEvalSymlinks(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	tempRoot, err := filepath.EvalSymlinks(tempDir)
+	require.NoError(t, err)
+	subDir := filepath.Join(tempRoot, "foo")
+	require.NoError(t, os.Mkdir(subDir, 0o700))
+	realFile := filepath.Join(subDir, "bar.txt")
+	require.NoError(t, os.WriteFile(realFile, []byte("test data"), 0o600))
+	nonexistentFile := filepath.Join(subDir, "idontexist.txt")
+
+	dirLink := filepath.Join(tempRoot, "dirLink")
+	require.NoError(t, os.Symlink(subDir, dirLink))
+	fileLink := filepath.Join(tempRoot, "filelink")
+	require.NoError(t, os.Symlink(realFile, fileLink))
+	absLinkToNonexistentFile := filepath.Join(tempRoot, "abs")
+	require.NoError(t, os.Symlink(nonexistentFile, absLinkToNonexistentFile))
+	relLinkToNonexistentFile := filepath.Join(tempRoot, "rel")
+	require.NoError(t, os.Symlink("foo/idontexist.txt", relLinkToNonexistentFile))
+
+	tests := []struct {
+		name         string
+		path         string
+		expectedPath string
+	}{
+		{
+			name:         "real path",
+			path:         realFile,
+			expectedPath: realFile,
+		},
+		{
+			name:         "real path to nonexistent file",
+			path:         nonexistentFile,
+			expectedPath: nonexistentFile,
+		},
+		{
+			name:         "symlink in parent",
+			path:         filepath.Join(dirLink, "bar.txt"),
+			expectedPath: realFile,
+		},
+		{
+			name:         "link to file",
+			path:         fileLink,
+			expectedPath: realFile,
+		},
+		{
+			name:         "absolute link to nonexistent file",
+			path:         absLinkToNonexistentFile,
+			expectedPath: nonexistentFile,
+		},
+		{
+			name:         "relative link to nonexistent file",
+			path:         relLinkToNonexistentFile,
+			expectedPath: nonexistentFile,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := evalSymlinks(tc.path)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedPath, out)
+		})
+	}
+
+	t.Run("don't eval with bad path", func(t *testing.T) {
+		_, err := evalSymlinks(filepath.Join(tempRoot, "this/does/not/exist.txt"))
+		require.Error(t, err)
+	})
+}
+
+func TestEnsureReqIsAllowed(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	tempRoot, err := filepath.EvalSymlinks(tempDir)
+	require.NoError(t, err)
+	file := filepath.Join(tempRoot, "foo.txt")
+	require.NoError(t, os.WriteFile(file, []byte("foo"), 0o600))
+	link := filepath.Join(tempRoot, "link")
+	require.NoError(t, os.Symlink(file, link))
+
+	passTests := []struct {
+		name    string
+		allowed *allowedOps
+		req     *sftp.Request
+	}{
+		{
+			name: "no restrictions",
+			req: &sftp.Request{
+				Filepath: "/foo/bar/baz.txt",
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "read",
+			allowed: &allowedOps{path: file},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "write",
+			allowed: &allowedOps{path: file, write: true},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodPut,
+			},
+		},
+		{
+			name:    "chmod",
+			allowed: &allowedOps{path: file, write: true},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodSetStat,
+			},
+		},
+		{
+			name:    "stat in read mode",
+			allowed: &allowedOps{path: file},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodStat,
+			},
+		},
+		{
+			name:    "lstat in read mode",
+			allowed: &allowedOps{path: file},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodLstat,
+			},
+		},
+		{
+			name:    "stat in write mode",
+			allowed: &allowedOps{path: file, write: true},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodStat,
+			},
+		},
+		{
+			name:    "lstat in write mode",
+			allowed: &allowedOps{path: file, write: true},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodLstat,
+			},
+		},
+	}
+	for _, tc := range passTests {
+		t.Run("allow "+tc.name, func(t *testing.T) {
+			handler := &sftpHandler{allowed: tc.allowed}
+			require.NoError(t, handler.ensureReqIsAllowed(tc.req))
+		})
+	}
+
+	convolutedPath := tempRoot + "/../" + filepath.Base(tempRoot) + "/foo.txt"
+	failTests := []struct {
+		name    string
+		allowed *allowedOps
+		req     *sftp.Request
+	}{
+		{
+			name:    "uncleaned path",
+			allowed: &allowedOps{path: convolutedPath},
+			req: &sftp.Request{
+				Filepath: convolutedPath,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "symlink",
+			allowed: &allowedOps{path: file},
+			req: &sftp.Request{
+				Filepath: link,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "get in write mode",
+			allowed: &allowedOps{path: file, write: true},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodGet,
+			},
+		},
+		{
+			name:    "write in read mode",
+			allowed: &allowedOps{path: file},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodPut,
+			},
+		},
+		{
+			name:    "chmod in read mode",
+			allowed: &allowedOps{path: file},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodSetStat,
+			},
+		},
+		{
+			name:    "unknown method",
+			allowed: &allowedOps{path: file},
+			req: &sftp.Request{
+				Filepath: file,
+				Method:   sftputils.MethodRename,
+			},
+		},
+	}
+	for _, tc := range failTests {
+		t.Run("deny "+tc.name, func(t *testing.T) {
+			handler := &sftpHandler{allowed: tc.allowed}
+			require.Error(t, handler.ensureReqIsAllowed(tc.req))
+		})
+	}
+}


### PR DESCRIPTION
This change updates moderated file transfers to not allow symlink traversal or relative paths.

Resolves gravitational/teleport-private#2343.

Changelog: Stopped traversing symlinks and allowing relative paths in moderated file transfers

## Manual Test Plan
### Test Environment
Enterprise cluster with two users, one that requires a moderator and one that can moderate sessions.
### Test Cases
- [x] Start a moderated session. As the peer, request to download a path that includes a symlink. As the moderator, approve the request. Verify that the peer sees an error message stating that symlinks are not allowed.
- [x] Start a moderated session. Verify that requesting a relative path returns an error.
