### PR TITLE
[v18] app: Fix context leak in handleConnection

### DIFF
--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -326,14 +326,18 @@ func (c *ConnectionsHandler) expireSessions() {
 // HandleConnection takes a connection and wraps it in a listener, so it can
 // be passed to http.Serve to process as a HTTP request.
 func (c *ConnectionsHandler) HandleConnection(conn net.Conn) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancelCause(c.closeContext)
+	// HandleConnection owns the context. handleConnection passes cancel
+	// to TrackingReadConn, which may call it first with io.EOF when the
+	// connection closes. The second cancel call is a no-op.
+	defer cancel(nil)
 
 	// Wrap conn in a CloserConn to detect when it is closed.
 	// Returning early will close conn before it has been serviced.
 	// httpServer will initiate the close call.
 	closerConn := utils.NewCloserConn(conn)
 
-	cleanup, err := c.handleConnection(closerConn)
+	cleanup, err := c.handleConnection(ctx, cancel, closerConn)
 	// Make sure that the cleanup function is run
 	if cleanup != nil {
 		defer cleanup()
@@ -349,7 +353,11 @@ func (c *ConnectionsHandler) HandleConnection(conn net.Conn) {
 		return
 	}
 
-	// Wait for connection to close.
+	// Wait for the connection to close. TCP and MCP handlers block until
+	// done, so closerConn is already closed by the time we get here. The
+	// HTTP handler returns immediately after handing the conn to
+	// http.Server, so this is where we block until the HTTP server
+	// closes it.
 	closerConn.Wait()
 }
 
@@ -584,8 +592,7 @@ func (c *ConnectionsHandler) authorizeContext(ctx context.Context) (*authz.Conte
 	return authContext, app, nil
 }
 
-func (c *ConnectionsHandler) handleConnection(conn net.Conn) (func(), error) {
-	ctx, cancel := context.WithCancelCause(c.closeContext)
+func (c *ConnectionsHandler) handleConnection(ctx context.Context, cancel context.CancelCauseFunc, conn net.Conn) (func(), error) {
 	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
 		Conn:    conn,
 		Clock:   c.cfg.Clock,
@@ -636,16 +643,17 @@ func (c *ConnectionsHandler) handleConnection(conn net.Conn) (func(), error) {
 	// initialization to ensure value is present on the context.
 	ctx = authz.ContextWithUserCertificate(ctx, leafCertFromConn(tlsConn))
 
-	// Application access supports plain TCP connections which are handled
-	// differently than HTTP requests from web apps.
+	// TCP and MCP handlers block until the session is done, so they return
+	// (nil, err) and the caller has nothing to clean up. The HTTP handler is
+	// asynchronous: handleHTTPApp hands the conn to http.Server.Serve and
+	// returns immediately, so it returns a cleanup function and the caller
+	// blocks on closerConn.Wait() until the HTTP server closes the conn.
 	switch {
 	case app.IsTCP():
 		identity := authCtx.Identity.GetIdentity()
-		defer cancel(nil)
 		return nil, trace.Wrap(c.handleTCPApp(ctx, tlsConn, &identity, app))
 
 	case app.IsMCP():
-		defer cancel(nil)
 		sessionCtx := mcp.SessionCtx{
 			ClientConn: tlsConn,
 			AuthCtx:    authCtx,
@@ -655,7 +663,6 @@ func (c *ConnectionsHandler) handleConnection(conn net.Conn) (func(), error) {
 
 	default:
 		cleanup := func() {
-			cancel(nil)
 			c.deleteConnAuth(tlsConn)
 		}
 		return cleanup, trace.Wrap(c.handleHTTPApp(ctx, tlsConn))


### PR DESCRIPTION
Move context creation from `handleConnection` to its caller
`HandleConnection`, which unconditionally defers `cancel(nil)`. Pass `ctx`
and `cancel` as parameters to `handleConnection` and remove the cancel
calls that were previously scattered across the TCP, MCP, and HTTP
branches.

Six error return paths in `handleConnection` created a child context via
`context.WithCancelCause` but returned without calling cancel, leaving the
child registered in the parent's children map until server shutdown. Under
connection churn (~5,000 concurrent TCP app connections), orphaned contexts
accumulate and agent memory climbs from ~1 GiB to ~3 GiB over 14 days
with no plateau. The heap profile shows 74-82% of agent memory in
`context.withCancel` trees under `handleConnection`.

Backport: https://github.com/gravitational/teleport/pull/65631

## Manual Test Plan

### Test Environment

macOS, single-process Teleport (auth + proxy + app service), enterprise
build. Three app types configured: TCP (socat echo server on port 9090),
HTTP (servedir on port 9080), MCP (npx filesystem server on `/tmp`).

```yaml
app_service:
  enabled: true
  apps:
    - name: tcp-test
      uri: tcp://127.0.0.1:9090
    - name: http-test
      uri: http://127.0.0.1:9080
    - name: mcp-test
      mcp:
        command: npx
        args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
        run_as_host_user: julia
```

### Test Cases

#### Test 1: HTTP app works

Open the HTTP app in the browser through the Teleport proxy.

- [x] HTTP app responds with the servedir directory listing.
- [x] No errors in logs.

#### Test 2: TCP app works

Connect to the TCP app through `tsh proxy app` and send data through the
tunnel.

- [x] socat echoes data back through the tunnel.
- [x] The connection closes cleanly, no errors in logs.

#### Test 3: MCP app works

Send a JSON-RPC initialize request through `tsh mcp connect`.

- [x] MCP server responds with a valid JSON-RPC initialize result
  (`serverInfo.name: "secure-filesystem-server"`).
- [x] No errors in logs.

#### Test 4: Connection churn

Generate 200 short-lived TCP app connections via `tsh proxy app`.

- [x] All 200 connections complete without errors.
- [x] No unexpected errors in logs.

#### Note on heap profile comparison

The context leak only affects error paths in `handleConnection` (limiter
exceeded, TLS failure, auth failure). Successful connections call `cancel()`
on both master and the fix, so heap profile diffs show no difference under
normal operation. The leak is verified by unit tests
(`TestHandleConnection_CancelsContextOnError`) which directly exercise the
error paths and assert that cancel is called.