### PR TITLE
[v17] Update CODEOWNERS to reflect tools team changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Merge rules are governed by logic in the Workflow Bot. Protect the
 # .github/workflows directory (and the merge logic) using CODEOWNERS.
-/.github/workflows/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @doggydogworld @rosstimothy
-/.github/actions/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @doggydogworld @rosstimothy
+/.github/workflows/ @klizhentas @russjones @r0mant @zmb3 @mjsmithnh @doggydogworld @rosstimothy
+/.github/actions/ @klizhentas @russjones @r0mant @zmb3 @mjsmithnh @doggydogworld @rosstimothy
 /build.assets/tooling/cmd/difftest/ @klizhentas @russjones @r0mant @zmb3 @rosstimothy
 
 # Owners for JS dependency updates.
@@ -13,7 +13,7 @@
 /api/go.mod @russjones @r0mant @zmb3 @rosstimothy
 /assets/aws/go.mod @russjones @r0mant @zmb3 @rosstimothy
 /assets/backport/go.mod @russjones @r0mant @zmb3 @rosstimothy
-/build.assets/tooling/go.mod @russjones @r0mant @zmb3 @rosstimothy @fheinecke @camscale @doggydogworld
+/build.assets/tooling/go.mod @russjones @r0mant @zmb3 @rosstimothy @mjsmithnh @doggydogworld
 /integrations/terraform/go.mod @russjones @r0mant @zmb3 @rosstimothy @hugoShaka @tigrato
 /integrations/terraform-mwi/go.mod @russjones @r0mant @zmb3 @rosstimothy @hugoShaka @tigrato @strideynet
 /integrations/event-handler/go.mod @russjones @r0mant @zmb3 @rosstimothy @hugoShaka @tigrato


### PR DESCRIPTION

Backport: https://github.com/gravitational/teleport/pull/63990
