### PR TITLE
Remove nested Oxlint config for teleterm

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -160,6 +160,12 @@
   },
   "overrides": [
     {
+      "files": ["web/packages/teleterm/**"],
+      "rules": {
+        "no-console": "off",
+      }
+    },
+    {
       "files": ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
       "rules": {
         "constructor-super": "off",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-coverage": "jest --coverage && web/scripts/print-coverage-link.sh",
     "test-update-snapshot": "pnpm run test --updateSnapshot",
     "tdd": "jest --watch",
-    "oxlint": "oxlint -c .oxlintrc.jsonc --quiet --report-unused-disable-directives-severity error web/ e/ e2e/",
+    "oxlint": "oxlint --quiet --report-unused-disable-directives-severity error web/ e/ e2e/",
     "lint": "pnpm oxlint && pnpm format-check",
     "lint-fix": "pnpm oxlint --fix && pnpm format",
     "type-check": "NODE_OPTIONS='--max-old-space-size=4096' tsc --build",

--- a/web/packages/teleterm/.oxlintrc.json
+++ b/web/packages/teleterm/.oxlintrc.json
@@ -1,3 +1,0 @@
-{
-  "rules": { "no-console": "off" }
-}


### PR DESCRIPTION
In #64616, we wondered why there's a difference in the number of warnings and errors when we explicitly pass the Oxlint config through the `-c` flag. The answer is that explicitly passing the config turns off nested configuration files:

> Oxlint automatically looks for a `.oxlintrc.json` or `oxlint.config.ts` in the current working directory. You can also pass a config explicitly (note that this will disable nested config lookup).

https://oxc.rs/docs/guide/usage/linter/config.html#create-a-config-file

What's more, nested config files don't get automatically merged with parents. This means that when running Oxlint without the `-c` flag, teleterm would have no rules applied besides `no-console` being off:

https://github.com/gravitational/teleport/blob/b05a3a79864cc1e709025d183b8a3663f90f13ea/web/packages/teleterm/.oxlintrc.json#L1-L3

The correct way to deal with this would be to add `extends`, see [Monorepo pattern: share a base config with extends](https://oxc.rs/docs/guide/usage/linter/nested-config.html#monorepo-pattern-share-a-base-config-with-extends). However, since it's just a single rule, I've decided to add an override instead.

This is something I've wanted to fix because my editor doesn't explicitly pass the `-c` flag, so in result I was getting no linter in my editor when editing teleterm files.

With this change, there's no difference between passing and not passing the config file:

```
$ pnpm oxlint

> teleport-ui@1.0.0 oxlint /Users/m/src/teleport-jj
> oxlint --quiet --report-unused-disable-directives-severity error web/ e/ e2e/


Found 606 warnings and 0 errors.
Finished in 2.9s on 3613 files with 95 rules using 14 threads.

$: pnpm exec oxlint --quiet --report-unused-disable-directives-severity error web/ e/ e2e/

Found 606 warnings and 0 errors.
Finished in 2.7s on 3613 files with 95 rules using 14 threads.

$: pnpm exec oxlint -c .oxlintrc.jsonc --quiet --report-unused-disable-directives-severity error web/ e/ e2e/

Found 606 warnings and 0 errors.
Finished in 2.7s on 3613 files with 95 rules using 14 threads.
```