### PR TITLE
`DocumentCluster`: Don't fetch user prefs until cluster is connected

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.test.tsx
@@ -38,6 +38,8 @@ import {
 
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import {
+  leafClusterUri,
+  makeLeafCluster,
   makeRootCluster,
   makeServer,
   rootClusterUri,
@@ -272,7 +274,7 @@ test.each([
   {
     name: 'refreshes resources when the document cluster URI matches the requested cluster URI',
     conditions: {
-      documentClusterUri: '/clusters/teleport-local',
+      documentClusterUri: rootClusterUri,
     },
     expect: {
       resourcesRefreshed: true,
@@ -281,7 +283,7 @@ test.each([
   {
     name: 'refreshes resources when the document cluster URI is a leaf of the requested cluster URI',
     conditions: {
-      documentClusterUri: '/clusters/teleport-local/leaves/leaf',
+      documentClusterUri: leafClusterUri,
     },
     expect: {
       resourcesRefreshed: true,
@@ -297,6 +299,9 @@ test.each([
   const serverResource = makeServer();
   const appContext = new MockAppContext();
   appContext.addRootClusterWithDoc(rootCluster, doc);
+  appContext.clustersService.setState(draft => {
+    draft.clusters.set(leafClusterUri, makeLeafCluster());
+  });
 
   jest
     .spyOn(appContext.resourcesService, 'listUnifiedResources')

--- a/web/packages/teleterm/src/ui/DocumentCluster/useUserPreferences.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/useUserPreferences.test.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import {
   AvailableResourceMode,
@@ -50,6 +50,7 @@ const preferences: UserPreferences = {
 
 test('user preferences are fetched', async () => {
   const appContext = new MockAppContext();
+  appContext.addRootCluster(cluster);
   const getUserPreferencesPromise = new MockedUnaryCall({
     userPreferences: preferences,
   });
@@ -83,8 +84,56 @@ test('user preferences are fetched', async () => {
   ).toHaveBeenCalledWith(cluster.uri, preferences.unifiedResourcePreferences);
 });
 
+test('user preferences are not fetched until cluster is connected', async () => {
+  const appContext = new MockAppContext();
+  const offlineCluster = makeRootCluster({ connected: false });
+  appContext.addRootCluster(offlineCluster);
+  const getUserPreferencesPromise = new MockedUnaryCall({
+    userPreferences: preferences,
+  });
+
+  jest
+    .spyOn(appContext.tshd, 'getUserPreferences')
+    .mockImplementation(() => getUserPreferencesPromise);
+  jest
+    .spyOn(appContext.workspacesService, 'getUnifiedResourcePreferences')
+    .mockReturnValue(undefined);
+  jest
+    .spyOn(appContext.workspacesService, 'setUnifiedResourcePreferences')
+    .mockImplementation();
+
+  const { result } = renderHook(() => useUserPreferences(offlineCluster.uri), {
+    wrapper: ({ children }) => (
+      <MockAppContextProvider appContext={appContext}>
+        {children}
+      </MockAppContextProvider>
+    ),
+  });
+
+  // Initial render while the cluster is offline.
+  await waitFor(() => {
+    expect(result.current.userPreferencesAttempt.status).toBe('');
+  });
+  expect(appContext.tshd.getUserPreferences).not.toHaveBeenCalled();
+
+  // Flip the cluster to connected state.
+  await act(async () => {
+    appContext.clustersService.setState(draft => {
+      draft.clusters.get(offlineCluster.uri).connected = true;
+    });
+  });
+
+  // Verify that the preferences were fetched.
+  await waitFor(() => {
+    expect(result.current.userPreferencesAttempt.status).toBe('success');
+  });
+  expect(result.current.userPreferences).toEqual(preferences);
+  expect(appContext.tshd.getUserPreferences).toHaveBeenCalled();
+});
+
 test('unified resources fallback preferences are taken from a workspace', async () => {
   const appContext = new MockAppContext();
+  appContext.addRootCluster(cluster);
   let resolveGetUserPreferencesPromise: (u: GetUserPreferencesResponse) => void;
   const getUserPreferencesPromise = new Promise<GetUserPreferencesResponse>(
     resolve => {
@@ -122,6 +171,7 @@ test('unified resources fallback preferences are taken from a workspace', async 
 
 describe('updating preferences', () => {
   const appContext = new MockAppContext();
+  appContext.addRootCluster(cluster);
   beforeEach(() => {
     jest
       .spyOn(appContext.workspacesService, 'getUnifiedResourcePreferences')

--- a/web/packages/teleterm/src/ui/DocumentCluster/useUserPreferences.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/useUserPreferences.ts
@@ -34,6 +34,7 @@ import {
 import { cloneAbortSignal } from 'teleterm/services/tshd/cloneableClient';
 import { UserPreferences } from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
 import { ClusterUri, routing } from 'teleterm/ui/uri';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 
@@ -59,6 +60,13 @@ export function useUserPreferences(clusterUri: ClusterUri): {
     // we pass an empty array, so pinning is enabled by default
     pinnedResources: { resourceIds: [] },
   });
+  const isClusterConnected = useStoreSelector(
+    'clustersService',
+    useCallback(
+      state => state.clusters.get(clusterUri)?.connected || false,
+      [clusterUri]
+    )
+  );
 
   const [initialFetchAttempt, runInitialFetchAttempt] = useAsync(
     useCallback(
@@ -114,7 +122,10 @@ export function useUserPreferences(clusterUri: ClusterUri): {
     const fetchPreferences = async () => {
       if (
         initialFetchAttempt.status === '' &&
-        supersededInitialFetchAttempt.status === ''
+        supersededInitialFetchAttempt.status === '' &&
+        // DocumentCluster is rendered by default for every workspace. isClusterConnected prevents
+        // the doc from attempting to fetch user prefs when the cluster is offline.
+        isClusterConnected
       ) {
         const [prefs, error] = await runInitialFetchAttempt();
         if (!error) {
@@ -132,6 +143,7 @@ export function useUserPreferences(clusterUri: ClusterUri): {
     runInitialFetchAttempt,
     updateUnifiedResourcePreferencesStateAndWorkspace,
     initialFetchAttempt.status,
+    isClusterConnected,
   ]);
 
   const hasUpdateSupersededInitialFetch =


### PR DESCRIPTION
In #63268, we removed one of the states of `DocumentCluster` that rendered "Cluster is offline" screen when `cluster.connected === false`. This solved an annoying issue where Connect would blank out the resources list with this screen after a cert for the cluster expired and the list of root clusters was refreshed by the profile watcher detecting changes in `~/.tsh`. Overall a good change.

However, it had a side effect we didn't foresee. `DocumentCluster` is a doc rendered by default for every workspace available in the app. When you launch the app and there's a cluster with an expired cert, there's an invisible `DocumentCluster` rendered for it. When you add a new cluster but you're yet to log in to it, there's `DocumentCluster` rendered for it too.

Before #63268, in both of those cases that `DocumentCluster` rendered in the background would do nothing since it would fall into that `cluster.connected === false` branch and render a "Cluster is offline" screen. But after we've removed that screen in #63268, `DocumentCluster` would attempt to fetch user prefs and error out because, well, there was no active client for that cluster. Unified resources were not fetched yet because they're triggered by the intersection observer.

This PR adds a simple check for `cluster.connected` before making the initial user prefs fetch attempt. This works for both root and leaf clusters.

Of course, this is just a band-aid because if someone makes changes to the shared unified resources component they might accidentally reintroduce a similar bug. A proper fix would be to avoid rendering `DocumentCluster` by default for every workspace, see #65695.

## Manual Test Plan
### Test Environment

A locally built app.

### Test Cases
- [x] `DocumentCluster` does not fetch user prefs for a newly added workspace until the user logs in.
- [x] `DocumentCluster` does not fetch user prefs for clusters that are already not connected when launching the app (since those clusters have expired certs).

This needs to be backported into https://github.com/gravitational/teleport/pull/65512.