### PR TITLE
Add rough reference for `tbot-spiffe-daemon-set` chart

### DIFF
--- a/docs/pages/reference/helm-reference/helm-reference.mdx
+++ b/docs/pages/reference/helm-reference/helm-reference.mdx
@@ -20,7 +20,7 @@ tags:
   Teleport Identity Security Access Graph service.
 - [tbot](tbot.mdx): Deploy an instance of TBot, the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx) agent.
 - [tbot-spiffe-daemon-set](tbot-spiffe-daemon-set.mdx):
-  Deploy a daemon set of TBot, the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx)
+  Deploy a daemon set of tbot, the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx)
   agent to provide the SPIFFE Workload API to Kubernetes workloads.
 - [teleport-plugin-event-handler](teleport-plugin-event-handler.mdx):
   Deploy the Teleport Event Handler plugin which sends events and session logs

--- a/docs/pages/reference/helm-reference/helm-reference.mdx
+++ b/docs/pages/reference/helm-reference/helm-reference.mdx
@@ -19,6 +19,9 @@ tags:
 - [teleport-access-graph](teleport-access-graph.mdx): Deploy the
   Teleport Identity Security Access Graph service.
 - [tbot](tbot.mdx): Deploy an instance of TBot, the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx) agent.
+- [tbot-spiffe-daemon-set](tbot-spiffe-daemon-set.mdx):
+  Deploy a daemon set of TBot, the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx)
+  agent to provide the SPIFFE Workload API to Kubernetes workloads.
 - [teleport-plugin-event-handler](teleport-plugin-event-handler.mdx):
   Deploy the Teleport Event Handler plugin which sends events and session logs
   to Fluentd.

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -9,7 +9,7 @@ tags:
 ---
 
 This chart deploys an daemon set of the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx) agent,
-TBot, into your Kubernetes cluster for the purposes of providing SPIFFE
+TBot, into your Kubernetes cluster to provide SPIFFE
 identities to workloads in the cluster. This is the recommended way of deploying
 MWI for SPIFFE into Kubernetes Clusters.
 

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -68,6 +68,11 @@ workloadIdentitySelector:
   name: example-workload-identity
 ```
 
+Once this chart is deployed, you may then manually mount the SPIFFE Workload API
+into your workload pods or deploy the
+[SPIFFE CSI Driver](https://github.com/spiffe/spiffe-csi) to simplify this
+process.
+
 ## Full reference
 
 (!docs/pages/includes/helm-reference/zz_generated.tbot-spiffe-daemon-set.mdx!)

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -9,7 +9,7 @@ tags:
 ---
 
 This chart deploys a daemon set of the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx) agent,
-TBot, into your Kubernetes cluster to provide SPIFFE identities to workloads in
+tbot, into your Kubernetes cluster to provide SPIFFE identities to workloads in
 the cluster. This is the recommended way of deploying MWI for SPIFFE into
 Kubernetes Clusters.
 

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -11,7 +11,7 @@ tags:
 This chart deploys a daemon set of the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx) agent,
 tbot, into your Kubernetes cluster to provide SPIFFE identities to workloads in
 the cluster. This is the recommended way of deploying MWI for SPIFFE into
-Kubernetes Clusters.
+Kubernetes clusters.
 
 To use it, you will need to know:
 

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -9,9 +9,9 @@ tags:
 ---
 
 This chart deploys a daemon set of the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx) agent,
-TBot, into your Kubernetes cluster to provide SPIFFE
-identities to workloads in the cluster. This is the recommended way of deploying
-MWI for SPIFFE into Kubernetes Clusters.
+TBot, into your Kubernetes cluster to provide SPIFFE identities to workloads in
+the cluster. This is the recommended way of deploying MWI for SPIFFE into
+Kubernetes Clusters.
 
 To use it, you will need to know:
 
@@ -23,7 +23,8 @@ as described in the [Machine & Workload Identity on Kubernetes guide](../../mach
 
 By default, this chart is designed to use the `kubernetes` join method but it
 can be customized to use any delegated join method. We do not recommend that
-you use the `token` join method with this chart.
+you use the `token` join method with this chart. Visit the
+[join method reference](../deployment/join-methods.mdx) for more information.
 
 ## Minimal configuration
 
@@ -68,8 +69,9 @@ workloadIdentitySelector:
   name: example-workload-identity
 ```
 
-Once this chart is deployed, you may then manually mount the SPIFFE Workload API
-into your workload pods or deploy the
+After deploying the chart, you will need to make the SPIFFE Workload API
+available to your workloads. You can manually mount the SPIFFE Workload API into
+your pods via hostPath, or you can deploy the
 [SPIFFE CSI Driver](https://github.com/spiffe/spiffe-csi) to simplify this
 process.
 

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -49,10 +49,9 @@ spec:
 ```
 
 Ensure that your Bot has been granted access to issue this WorkloadIdentity
-via a role.
-
-See the [WorkloadIdentity reference](../machine-workload-identity/workload-identity/workload-identity-resource.mdx)
-for more information.
+via a role. See the [WorkloadIdentity reference](../machine-workload-identity/workload-identity/workload-identity-resource.mdx)
+to learn more about customizing the structure of the SPIFFE IDs issued to your
+workloads.
 
 The following are the minimal values you must set on the chart for it to
 function correctly:

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -8,7 +8,7 @@ tags:
  - infrastructure-identity
 ---
 
-This chart deploys an daemon set of the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx) agent,
+This chart deploys a daemon set of the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx) agent,
 TBot, into your Kubernetes cluster to provide SPIFFE
 identities to workloads in the cluster. This is the recommended way of deploying
 MWI for SPIFFE into Kubernetes Clusters.

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -24,7 +24,8 @@ as described in the [Machine & Workload Identity on Kubernetes guide](../../mach
 By default, this chart is designed to use the `kubernetes` join method but it
 can be customized to use any delegated join method. We do not recommend that
 you use the `token` join method with this chart. Visit the
-[join method reference](../deployment/join-methods.mdx) for more information.
+[join method reference](../deployment/join-methods.mdx) for more information
+about alternatives to the `kubernetes` join method.
 
 ## Minimal configuration
 

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -1,0 +1,73 @@
+---
+title: tbot-spiffe-daemon-set Chart Reference
+sidebar_label: tbot-spiffe-daemon-set
+description: Values that can be set using the tbot-spiffe-daemon-set Helm chart
+tags:
+ - reference
+ - mwi
+ - infrastructure-identity
+---
+
+This chart deploys an daemon set of the [Machine & Workload Identity](../../machine-workload-identity/introduction.mdx) agent,
+TBot, into your Kubernetes cluster for the purposes of providing SPIFFE
+identities to workloads in the cluster. This is the recommended way of deploying
+MWI for SPIFFE into Kubernetes Clusters.
+
+To use it, you will need to know:
+
+- The address of your Teleport Proxy Service or Auth Service
+- The name of your Teleport cluster
+- The name of a join token configured for Machine & Workload Identity and your Kubernetes cluster
+as described in the [Machine & Workload Identity on Kubernetes guide](../../machine-workload-identity/deployment/kubernetes.mdx)
+- A configured WorkloadIdentity resource for your cluster.
+
+By default, this chart is designed to use the `kubernetes` join method but it
+can be customized to use any delegated join method. We do not recommend that
+you use the `token` join method with this chart.
+
+## Minimal configuration
+
+Follow steps 1 and 2 from the
+[Deploying `tbot` on Kubernetes guide](https://goteleport.com/docs/machine-workload-identity/deployment/kubernetes/)
+to create a Bot and Join Token for your `tbot` daemon set to use for
+authentication.
+
+You must have also created a WorkloadIdentity resource to be used when issuing
+a SPIFFE SVID. For example, the following configuration would produce a SPIFFE
+ID including the namespace and service account of the pod:
+
+```yaml
+kind: workload_identity
+version: v1
+metadata:
+  name: example-workload-identity
+spec:
+  spiffe:
+    id: /k8s/{{ workload.kubernetes.namespace }}/{{ workload.kubernetes.service_account }}
+```
+
+Ensure that your Bot has been granted access to issue this WorkloadIdentity
+via a role.
+
+See the [WorkloadIdentity reference](../machine-workload-identity/workload-identity/workload-identity-resource.mdx)
+for more information.
+
+The following are the minimal values you must set on the chart for it to
+function correctly:
+
+```yaml
+# Set to the name of your Teleport cluster.
+clusterName: example.teleport.sh
+# Set to the name of the token you created.
+token: example-token
+# Set to the address of your Teleport Proxy Service.
+teleportProxyAddress: example.teleport.sh:443
+workloadIdentitySelector:
+  # Set to the name of the WorkloadIdentity resource you'd like to use when
+  # issuing SVIDs.
+  name: example-workload-identity
+```
+
+## Full reference
+
+(!docs/pages/includes/helm-reference/zz_generated.tbot-spiffe-daemon-set.mdx!)

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -28,7 +28,7 @@ you use the `token` join method with this chart.
 ## Minimal configuration
 
 Follow steps 1 and 2 from the
-[Deploying `tbot` on Kubernetes guide](https://goteleport.com/docs/machine-workload-identity/deployment/kubernetes/)
+[Deploying `tbot` on Kubernetes guide](../../machine-workload-identity/deployment/kubernetes.mdx)
 to create a Bot and Join Token for your `tbot` daemon set to use for
 authentication.
 

--- a/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/reference/helm-reference/tbot-spiffe-daemon-set.mdx
@@ -19,7 +19,7 @@ To use it, you will need to know:
 - The name of your Teleport cluster
 - The name of a join token configured for Machine & Workload Identity and your Kubernetes cluster
 as described in the [Machine & Workload Identity on Kubernetes guide](../../machine-workload-identity/deployment/kubernetes.mdx)
-- A configured WorkloadIdentity resource for your cluster.
+- A configured WorkloadIdentity resource for your cluster
 
 By default, this chart is designed to use the `kubernetes` join method but it
 can be customized to use any delegated join method. We do not recommend that


### PR DESCRIPTION
Adds an initial pass at a reference page for the `tbot-spiffe-daemon-set` chart to the documentation. We are beginning to recommend this chart over the manual creation of Kubernetes manifests.

A future PR will revisit this content, and either add more detail in regards to deploying MWI/SPIFFE on Kubernetes, or introduce a guide page for this content and strip the content within this reference back.
