### PR TITLE
docs: Add MDM token to "Token resource reference" and "Supported token types"

### DIFF
--- a/docs/pages/includes/token-types.mdx
+++ b/docs/pages/includes/token-types.mdx
@@ -9,4 +9,5 @@
 | `node`           | SSH Service                     |
 | `proxy`          | Proxy Service                   |
 | `windowsdesktop` | Windows Desktop Service         |
+| `mdm`            | Jamf Service                    |
 

--- a/docs/pages/reference/deployment/join-methods.mdx
+++ b/docs/pages/reference/deployment/join-methods.mdx
@@ -197,6 +197,7 @@ spec:
   # - "WindowsDesktop" for Windows Desktop Service
   # - "Discovery" for Discovery Service
   # - "Bot" for Machine & Workload Identity (when set, "spec.bot_name" must be set in the token)
+  # - "MDM" for Jamf Service
   roles:
     - Node
     - App


### PR DESCRIPTION
Closes #60419 as described in https://github.com/gravitational/teleport/issues/60419#issuecomment-3451786852.

Currently the only service using the MDM role is the Jamf service. The Intune integration runs as a plugin, not a service.

* https://maja-mdm-token-docs.d212ksyjt6y4yg.amplifyapp.com/docs/reference/deployment/join-methods/#token-resource-reference
* https://maja-mdm-token-docs.d212ksyjt6y4yg.amplifyapp.com/docs/enroll-resources/agents/join-token/#generate-a-token

https://github.com/gravitational/teleport/blob/b05a3a79864cc1e709025d183b8a3663f90f13ea/api/types/system_role.go#L78-L82

https://github.com/gravitational/teleport/blob/b05a3a79864cc1e709025d183b8a3663f90f13ea/api/types/system_role.go#L89-L113