### PR TITLE
docs: updated code block format

### DIFF
--- a/docs/pages/beams/beams.mdx
+++ b/docs/pages/beams/beams.mdx
@@ -232,7 +232,7 @@ Access control is enforced using owner labels on the beam's node and application
 resources (`teleport.internal/beam/owner: <username>`) and a `beam-user` role
 that restricts access to matching resources:
 
-```code
+```yaml
 kind: role
 version: v7
 metadata:


### PR DESCRIPTION
This PR updates the format of a yaml code block from `code` to `yaml` for readability.