### PR TITLE
Adjust ping endpoint

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -423,9 +423,15 @@ type PingResponse struct {
 	Edition string `json:"edition"`
 	// FIPS represents if Teleport is using FIPS-compliant cryptography.
 	FIPS bool `json:"fips"`
-	// AuthServerScopesStatus reports whether the scopes feature is enabled or not on the auth server.
+	// AuthSrv displays stasuses for the auth server.
+	AuthSrv AuthServer `json:"auth_server,omitempty"`
+}
+
+// AuthServer displays statuses from the ping endpoint from the auth server.
+type AuthServer struct {
+	// ScopesEnabled reports whether the scopes feature is enabled or not on the auth server.
 	// Possible values: "enabled", "disabled", "unknown".
-	AuthServerScopesStatus string `json:"auth_server_scopes_status,omitempty"`
+	ScopesEnabled string `json:"scopes_enabled,omitempty"`
 }
 
 // PingErrorResponse contains the error from /webapi/ping.

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -423,15 +423,6 @@ type PingResponse struct {
 	Edition string `json:"edition"`
 	// FIPS represents if Teleport is using FIPS-compliant cryptography.
 	FIPS bool `json:"fips"`
-	// AuthSrv displays stasuses for the auth server.
-	AuthSrv AuthServer `json:"auth_server,omitempty"`
-}
-
-// AuthServer displays statuses from the ping endpoint from the auth server.
-type AuthServer struct {
-	// ScopesEnabled reports whether the scopes feature is enabled or not on the auth server.
-	// Possible values: "enabled", "disabled", "unknown".
-	ScopesEnabled string `json:"scopes_enabled,omitempty"`
 }
 
 // PingErrorResponse contains the error from /webapi/ping.
@@ -573,6 +564,10 @@ type AuthenticationSettings struct {
 	// SignatureAlgorithmSuite is the configured signature algorithm suite for
 	// the cluster.
 	SignatureAlgorithmSuite types.SignatureAlgorithmSuite `json:"signature_algorithm_suite,omitempty"`
+	// Scopes reports whether the scopes feature is enabled or not on the auth server.
+	// Possible values: "enabled", "disabled", "unknown".
+	// This value is populated from the auth server's ping endpoint.
+	Scopes string `json:"scopes,omitempty"`
 }
 
 // LocalSettings holds settings for local authentication.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1810,16 +1810,18 @@ func (h *Handler) ping(w http.ResponseWriter, r *http.Request, p httprouter.Para
 	updaterID := r.URL.Query().Get(webclient.AgentUpdateIDParameter)
 
 	return webclient.PingResponse{
-		Auth:                   authSettings,
-		Proxy:                  *proxyConfig,
-		ServerVersion:          teleport.Version,
-		MinClientVersion:       teleport.MinClientSemVer().String(),
-		ClusterName:            h.auth.clusterName,
-		AutomaticUpgrades:      pr.ServerFeatures.GetAutomaticUpgrades(),
-		AutoUpdate:             h.automaticUpdateSettings184(r.Context(), group, updaterID),
-		Edition:                h.cfg.Modules.BuildType(),
-		FIPS:                   h.cfg.Modules.IsBoringBinary(),
-		AuthServerScopesStatus: scopes.ScopesStatusToString(pr.ScopesStatus),
+		Auth:              authSettings,
+		Proxy:             *proxyConfig,
+		ServerVersion:     teleport.Version,
+		MinClientVersion:  teleport.MinClientSemVer().String(),
+		ClusterName:       h.auth.clusterName,
+		AutomaticUpgrades: pr.ServerFeatures.GetAutomaticUpgrades(),
+		AutoUpdate:        h.automaticUpdateSettings184(r.Context(), group, updaterID),
+		Edition:           modules.GetModules().BuildType(),
+		FIPS:              modules.IsBoringBinary(),
+		AuthSrv: webclient.AuthServer{
+			ScopesEnabled: scopes.ScopesStatusToString(pr.ScopesStatus),
+		},
 	}, nil
 }
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1809,6 +1809,8 @@ func (h *Handler) ping(w http.ResponseWriter, r *http.Request, p httprouter.Para
 	group := r.URL.Query().Get(webclient.AgentUpdateGroupParameter)
 	updaterID := r.URL.Query().Get(webclient.AgentUpdateIDParameter)
 
+	authSettings.Scopes = scopes.ScopesStatusToString(pr.ScopesStatus)
+
 	return webclient.PingResponse{
 		Auth:              authSettings,
 		Proxy:             *proxyConfig,
@@ -1817,11 +1819,8 @@ func (h *Handler) ping(w http.ResponseWriter, r *http.Request, p httprouter.Para
 		ClusterName:       h.auth.clusterName,
 		AutomaticUpgrades: pr.ServerFeatures.GetAutomaticUpgrades(),
 		AutoUpdate:        h.automaticUpdateSettings184(r.Context(), group, updaterID),
-		Edition:           modules.GetModules().BuildType(),
-		FIPS:              modules.IsBoringBinary(),
-		AuthSrv: webclient.AuthServer{
-			ScopesEnabled: scopes.ScopesStatusToString(pr.ScopesStatus),
-		},
+		Edition:           h.cfg.Modules.BuildType(),
+		FIPS:              h.cfg.Modules.IsBoringBinary(),
 	}, nil
 }
 

--- a/lib/web/apiserver_ping_test.go
+++ b/lib/web/apiserver_ping_test.go
@@ -267,7 +267,7 @@ func TestPing_scopesEnabled(t *testing.T) {
 			require.NoError(t, json.Unmarshal(resp.Bytes(), &pingResp))
 
 			assert.Equal(t, test.expectProxyEnabled, pingResp.Proxy.ScopesEnabled)
-			assert.Equal(t, test.expectAuthServerScopesField, pingResp.AuthServerScopesStatus)
+			assert.Equal(t, test.expectAuthServerScopesField, pingResp.AuthSrv.ScopesEnabled)
 		})
 	}
 }

--- a/lib/web/apiserver_ping_test.go
+++ b/lib/web/apiserver_ping_test.go
@@ -267,7 +267,7 @@ func TestPing_scopesEnabled(t *testing.T) {
 			require.NoError(t, json.Unmarshal(resp.Bytes(), &pingResp))
 
 			assert.Equal(t, test.expectProxyEnabled, pingResp.Proxy.ScopesEnabled)
-			assert.Equal(t, test.expectAuthServerScopesField, pingResp.AuthSrv.ScopesEnabled)
+			assert.Equal(t, test.expectAuthServerScopesField, pingResp.Auth.Scopes)
 		})
 	}
 }


### PR DESCRIPTION
Adjust ping endpoint to nest the scopes enabled field under `auth`.
<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases
- [x] run curl /ping endpoint with scopes disabled and verified:
```
  "auth": {
    "scopes": "disabled"
  }
```
- [x] run curl /ping endpoint with scopes enabled and verified:
```
  "auth": {
    "scopes": "enabled"
  }
```