### PR TITLE
unset XAUTHORITY env var for the networking command

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1020,7 +1020,6 @@ func testSessionRecordingModes(t *testing.T, suite *integrationTestSuite) {
 				term.Type("exit\n\r")
 				waitSessionTermination(t, errCh, require.NoError)
 			})
-
 		})
 	}
 }
@@ -4637,6 +4636,11 @@ func testX11Forwarding(t *testing.T, suite *integrationTestSuite) {
 	if _, err := exec.LookPath("ssh"); err != nil {
 		t.Skip("Skipping TestX11Forwarding, no external SSH binary found.")
 	}
+
+	// Set XAUTHORITY to a non-existent path to ensure that XAUTHORITY
+	// is unset for the networking command, if it isn't xauth will attempt
+	// to read /does/not/exist and fail, causing X11 forwarding to fail.
+	t.Setenv(x11.XAuthFileEnvVar, "/does/not/exist")
 
 	// Create a fake client XServer listener.
 	clientXServer, clientDisplay, err := x11.OpenNewXServerListener(x11.DefaultDisplayOffset, x11.DefaultMaxDisplays, 0)

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -715,10 +715,7 @@ func ConfigureCommand(ctx *ServerContext, extraFiles ...*os.File) (*exec.Cmd, er
 		// Unset XAUTHORITY for the networking command as the SSH session
 		// process given to the user will not have it set which can cause
 		// issues with the X11 forwarding.
-		xauthorityPrefix := x11.XAuthFileEnvVar + "="
-		*env = slices.DeleteFunc(*env, func(s string) bool {
-			return strings.HasPrefix(s, xauthorityPrefix)
-		})
+		env.Remove(x11.XAuthFileEnvVar)
 	default:
 		subCommand = reexecconstants.ExecSubCommand
 	}

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/sshutils/reexec"
 	"github.com/gravitational/teleport/session/envutils"
+	"github.com/gravitational/teleport/session/networking/x11"
 	sessionreexec "github.com/gravitational/teleport/session/reexec"
 	"github.com/gravitational/teleport/session/reexec/reexecconstants"
 )
@@ -701,11 +702,23 @@ func ConfigureCommand(ctx *ServerContext, extraFiles ...*os.File) (*exec.Cmd, er
 		return nil, trace.Wrap(err)
 	}
 
+	// Build env for `teleport exec`.
+	env := &envutils.SafeEnv{}
+	env.AddExecEnvironment()
+
 	// The channel/request type determines the subcommand to execute.
 	var subCommand string
 	switch ctx.ExecType {
 	case reexecconstants.NetworkingSubCommand:
 		subCommand = reexecconstants.NetworkingSubCommand
+
+		// Unset XAUTHORITY for the networking command as the SSH session
+		// process given to the user will not have it set which can cause
+		// issues with the X11 forwarding.
+		xauthorityPrefix := x11.XAuthFileEnvVar + "="
+		*env = slices.DeleteFunc(*env, func(s string) bool {
+			return strings.HasPrefix(s, xauthorityPrefix)
+		})
 	default:
 		subCommand = reexecconstants.ExecSubCommand
 	}
@@ -713,10 +726,6 @@ func ConfigureCommand(ctx *ServerContext, extraFiles ...*os.File) (*exec.Cmd, er
 	// Build the list of arguments to have Teleport re-exec itself. The "-d" flag
 	// is appended if Teleport is running in debug mode.
 	args := []string{executable, subCommand}
-
-	// build env for `teleport exec`
-	env := &envutils.SafeEnv{}
-	env.AddExecEnvironment()
 
 	// Build the "teleport exec" command.
 	cmd := &exec.Cmd{

--- a/session/envutils/environment.go
+++ b/session/envutils/environment.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -173,4 +174,12 @@ func (e *SafeEnv) isUnsafeKey(preventDuplicates bool, key string) bool {
 // AddExecEnvironment will add safe values from [os.Environ], ignoring any duplicates that may have already been added.
 func (e *SafeEnv) AddExecEnvironment() {
 	e.addFull(true, os.Environ())
+}
+
+// Remove deletes the key and value from the environment if it exists.
+func (e *SafeEnv) Remove(key string) {
+	keyPrefix := key + "="
+	*e = slices.DeleteFunc(*e, func(s string) bool {
+		return strings.HasPrefix(s, keyPrefix)
+	})
 }

--- a/session/networking/x11/auth.go
+++ b/session/networking/x11/auth.go
@@ -33,6 +33,10 @@ import (
 )
 
 const (
+	// XAuthFileEnvVar is the environment variable used to specify the path to the
+	// X11 authorization file.
+	XAuthFileEnvVar = "XAUTHORITY"
+
 	// mitMagicCookieProto is the default xauth protocol used for X11 forwarding.
 	mitMagicCookieProto = "MIT-MAGIC-COOKIE-1"
 	// mitMagicCookieSize is the number of bytes in an mit magic cookie.


### PR DESCRIPTION
When Teleport passes almost all the environment variables to the child processes that are born of a reexec. This is an issue when XAUTHORITY is set as it will be passed to the networking process, causing `xauth` to use a different file than the one that the SSH session process will use. This is because the SSH session process only inherits a small subset of the environment variables from the parent process, and XAUTHORITY is not one of them. This causes X11 forwarding to fail.

I found this because I often test Teleport locally by running Auth/Proxy/SSH from a terminal on a host with a GUI, so XAUTHORITY was set and passed to Teleport SSH. This is very unlikely to happen when Teleport is running as a service.

Fixes #65030 

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fix rare issue forwarding X11 requests over SSH when Teleport SSH isn't run as a service


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Ubuntu 22.04, RHEL 9

### Test Cases
- [x] Successfully X11 forward as both root and non-root user
  - [x] tsh ssh -X user@node xeyes
  - [x] tsh ssh -X root@node xeyes
- [x] Test untrusted vs trusted forwarding
  - [x] tsh ssh -Y server01 "echo Hello World | xclip -sel c && xclip -sel c -o" should print "Hello World"
  - [x] tsh ssh -X server01 "echo Hello World | xclip -sel c && xclip -sel c -o" should fail with "BadAccess" X error
