### PR TITLE
Add override certificate validation

### DIFF
--- a/lib/subca/parsed.go
+++ b/lib/subca/parsed.go
@@ -29,6 +29,7 @@ import (
 
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 var (
@@ -92,12 +93,13 @@ func ValidateAndParseCAOverride(resource *subcav1.CertAuthorityOverride) (*Parse
 	case resource.Spec == nil:
 		return nil, trace.BadParameter("spec required")
 	}
+	clusterName := resource.Metadata.Name
 
 	overrides := resource.Spec.CertificateOverrides
 	parsedOverrides := make([]*ParsedCertificateOverride, len(overrides))
 	seenPublicKeys := make(map[string]struct{})
 	for i, co := range overrides {
-		parsedCO, fieldName, err := validateCertificateOverride(co)
+		parsedCO, fieldName, err := validateCertificateOverride(clusterName, co)
 		if err != nil {
 			if fieldName != "" {
 				fieldName = "." + fieldName
@@ -123,6 +125,7 @@ func ValidateAndParseCAOverride(resource *subcav1.CertAuthorityOverride) (*Parse
 }
 
 func validateCertificateOverride(
+	clusterName string,
 	co *subcav1.CertificateOverride,
 ) (_ *ParsedCertificateOverride, fieldName string, _ error) {
 	// Trace not used on purpose. Errors are trace-wrapped up in the chain.
@@ -137,6 +140,9 @@ func validateCertificateOverride(
 		var err error
 		cert, err = ParseCertificateOverrideCertificate(co.Certificate)
 		if err != nil {
+			return nil, "certificate", err
+		}
+		if err := validateOverrideCertificate(clusterName, cert); err != nil {
 			return nil, "certificate", err
 		}
 		wantPublicKey = HashCertificatePublicKey(cert)
@@ -225,4 +231,40 @@ func validateCertificateOverride(
 		Certificate:         cert,
 		Chain:               chain,
 	}, "", nil
+}
+
+func validateOverrideCertificate(
+	clusterName string,
+	cert *x509.Certificate,
+) error {
+	// Trace not used on purpose. Errors are trace-wrapped up in the chain.
+	certClusterName, err := tlsca.ClusterName(cert.Subject)
+	if err != nil {
+		return fmt.Errorf("cluster name: %w", err)
+	}
+	if certClusterName != clusterName {
+		return fmt.Errorf(
+			"incorrect cluster name %q (expected %q)",
+			certClusterName,
+			clusterName,
+		)
+	}
+
+	// Verify certificate constraints.
+	switch {
+	case !cert.IsCA:
+		return errors.New("not a CA certificate (IsCA=false)")
+	case !cert.BasicConstraintsValid:
+		return errors.New("basic constraints not valid (BasicConstraintsValid=false)")
+	case cert.KeyUsage&x509.KeyUsageCertSign == 0:
+		// Usage names per Go 1.26.1.
+		// https://cs.opensource.google/go/go/+/refs/tags/go1.26.1:src/crypto/x509/x509_string.go;l=23
+		return errors.New("missing KeyUsage keyCertSign")
+	case cert.KeyUsage&x509.KeyUsageCRLSign == 0:
+		return errors.New("missing KeyUsage cRLSign")
+	case cert.NotBefore.After(cert.NotAfter):
+		return errors.New("NotBefore > NotAfter")
+	}
+
+	return nil
 }

--- a/lib/subca/parsed_test.go
+++ b/lib/subca/parsed_test.go
@@ -18,8 +18,10 @@ package subca_test
 
 import (
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/subca"
 	subcaenv "github.com/gravitational/teleport/lib/subca/testenv"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 func TestValidateAndParseCAOverride(t *testing.T) {
@@ -67,6 +70,30 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Used for scenarios that test invalid certificate override certificates.
+	makeInvalidCertificateFn := func(modify func(template *x509.Certificate)) func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
+		return func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
+			co := ca.Spec.CertificateOverrides[0]
+			cert, err := tlsca.ParseCertificatePEM([]byte(co.Certificate))
+			require.NoError(t, err, "ParseCertificatePEM: override certificate")
+
+			intCA, err := env.ExternalRoot.NewIntermediateCA(&subcaenv.CAParams{
+				Clock: env.Clock,
+				Pub:   cert.PublicKey,
+				Template: &x509.Certificate{
+					Subject: pkix.Name{
+						Organization: []string{env.ClusterName},
+					},
+				},
+				ModifyCertificate: modify,
+			})
+			require.NoError(t, err, "NewIntermediateCA")
+
+			co.Certificate = string(intCA.CertPEM)
+			ca.Spec.CertificateOverrides = []*subcav1.CertificateOverride{co}
+		}
+	}
+
 	t.Run("nil", func(t *testing.T) {
 		t.Parallel()
 		_, err := subca.ValidateAndParseCAOverride(nil)
@@ -75,95 +102,95 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		modify  func(ca *subcav1.CertAuthorityOverride)
+		modify  func(t *testing.T, ca *subcav1.CertAuthorityOverride)
 		wantErr string
 	}{
 		{
 			name: "OK: Valid CA override",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				// Don't modify anything, take the default testenv override.
 			},
 		},
 		{
 			name: "OK: Minimal CA override",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Spec = &subcav1.CertAuthorityOverrideSpec{}
 			},
 		},
 
 		{
 			name: "empty kind",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Kind = ""
 			},
 			wantErr: "kind",
 		},
 		{
 			name: "invalid kind",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Kind = types.KindCertAuthority // wrong type
 			},
 			wantErr: "kind",
 		},
 		{
 			name: "empty sub_kind",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.SubKind = ""
 			},
 			wantErr: "sub_kind",
 		},
 		{
 			name: "invalid sub_kind",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.SubKind = string(types.DatabaseCA) // not allowed
 			},
 			wantErr: "sub_kind",
 		},
 		{
 			name: "empty version",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Version = ""
 			},
 			wantErr: "version",
 		},
 		{
 			name: "invalid version",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Version = types.V2
 			},
 			wantErr: "version",
 		},
 		{
 			name: "nil metadata",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Metadata = nil
 			},
 			wantErr: "metadata required",
 		},
 		{
 			name: "empty name",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Metadata.Name = ""
 			},
 			wantErr: "name/clusterName required",
 		},
 		{
 			name: "nil spec",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Spec = nil
 			},
 			wantErr: "spec required",
 		},
 		{
 			name: "nil certificate_override",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Spec.CertificateOverrides = append(ca.Spec.CertificateOverrides, nil)
 			},
 			wantErr: "nil certificate override",
 		},
 		{
 			name: "certificate_override: empty certificate and public key (enabled)",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Spec.CertificateOverrides[0].Certificate = ""
 				ca.Spec.CertificateOverrides[0].PublicKey = ""
 				ca.Spec.CertificateOverrides[0].Disabled = false
@@ -172,7 +199,7 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 		},
 		{
 			name: "certificate_override: empty certificate and public key (disabled)",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Spec.CertificateOverrides[0].Certificate = ""
 				ca.Spec.CertificateOverrides[0].PublicKey = ""
 				ca.Spec.CertificateOverrides[0].Disabled = true
@@ -181,21 +208,21 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 		},
 		{
 			name: "certificate_override: invalid certificate",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Spec.CertificateOverrides[0].Certificate = "ceci n'est pas a certificate"
 			},
 			wantErr: "expected PEM",
 		},
 		{
 			name: "certificate_override: invalid public key",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				ca.Spec.CertificateOverrides[0].PublicKey = "not a valid key"
 			},
 			wantErr: "invalid public key",
 		},
 		{
 			name: "certificate_override: certificate and public key mismatch",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				// Doesn't match the Certificate field.
 				ca.Spec.CertificateOverrides[0].PublicKey = unrelatedPublicKey
 			},
@@ -203,7 +230,7 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 		},
 		{
 			name: "certificate_override: chain without certificate",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.Chain = leafToRootChain
 				co.Certificate = ""
@@ -213,7 +240,7 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 		},
 		{
 			name: "certificate_override: chain certificate invalid",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.PublicKey = ""
 				co.Chain = []string{
@@ -227,7 +254,7 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 		},
 		{
 			name: "certificate_override: certificate included in chain",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.PublicKey = ""
 				co.Chain = append([]string{co.Certificate}, leafToRootChain...)
@@ -236,7 +263,7 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 		},
 		{
 			name: "certificate_override: chain out of order",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.PublicKey = ""
 				co.Chain = caChain.RootToLeafPEMs() // reverse order
@@ -245,7 +272,7 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 		},
 		{
 			name: "certificate_override: chain signature invalid (forged CA)",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.Chain = append(
 					[]string{string(forgedExternalRoot.CertPEM)},
@@ -256,7 +283,7 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 		},
 		{
 			name: "certificate_override: chain has too many entries",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.PublicKey = ""
 				co.Chain = slices.Repeat([]string{leafToRootChain[0]}, 20)
@@ -265,7 +292,7 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 		},
 		{
 			name: "certificate_override: duplicate public key",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				ca.Spec.CertificateOverrides = append(
 					ca.Spec.CertificateOverrides,
@@ -277,31 +304,98 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 
 		{
 			name: "OK: Enabled override",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.Disabled = false
 			},
 		},
 		{
 			name: "OK: Override without public key",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.PublicKey = ""
 			},
 		},
 		{
 			name: "OK: Disabled override with only public key",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.Certificate = ""
 			},
 		},
 		{
 			name: "OK: Override with chain",
-			modify: func(ca *subcav1.CertAuthorityOverride) {
+			modify: func(t *testing.T, ca *subcav1.CertAuthorityOverride) {
 				co := ca.Spec.CertificateOverrides[0]
 				co.Chain = leafToRootChain
 			},
+		},
+
+		// Override certificate validation.
+		{
+			name: "certificate_override: missing cluster name",
+			modify: makeInvalidCertificateFn(func(template *x509.Certificate) {
+				template.Subject = pkix.Name{
+					// Lacks "O=ClusterName" or "tlsca.CAClusterNameExtensionOID=ClusterName"
+					CommonName: "Llama CA",
+				}
+			}),
+			wantErr: "missing cluster name",
+		},
+		{
+			name: "certificate_override: invalid cluster name (1)",
+			modify: makeInvalidCertificateFn(func(template *x509.Certificate) {
+				template.Subject = pkix.Name{
+					Organization: []string{"not the cluster name"},
+				}
+			}),
+			wantErr: "incorrect cluster name",
+		},
+		{
+			name: "certificate_override: invalid cluster name (2)",
+			modify: makeInvalidCertificateFn(func(template *x509.Certificate) {
+				template.Subject = pkix.Name{
+					// Correct, but it doesn't matter. OID takes precedence.
+					Organization: []string{env.ClusterName},
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{
+							Type:  tlsca.CAClusterNameExtensionOID,
+							Value: "not the cluster name",
+						},
+					},
+				}
+			}),
+			wantErr: "incorrect cluster name",
+		},
+		{
+			name: "certificate_override: IsCA=false",
+			modify: makeInvalidCertificateFn(func(template *x509.Certificate) {
+				template.IsCA = false
+			}),
+			wantErr: "IsCA",
+		},
+		{
+			name: "certificate_override: KeyUsage missing keyCertSign",
+			modify: makeInvalidCertificateFn(func(template *x509.Certificate) {
+				template.KeyUsage = x509.KeyUsageCRLSign
+			}),
+			wantErr: "keyCertSign",
+		},
+		{
+			name: "certificate_override: KeyUsage missing cRLSign",
+			modify: makeInvalidCertificateFn(func(template *x509.Certificate) {
+				template.KeyUsage = x509.KeyUsageCertSign
+			}),
+			wantErr: "cRLSign",
+		},
+		{
+			name: "certificate_override: NotBefore>NotAfter",
+			modify: makeInvalidCertificateFn(func(template *x509.Certificate) {
+				now := env.Clock.Now()
+				template.NotBefore = now.Add(1 * time.Second)
+				template.NotAfter = now
+			}),
+			wantErr: "NotBefore",
 		},
 	}
 	for _, test := range tests {
@@ -309,7 +403,7 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 			t.Parallel()
 
 			caOverride := proto.Clone(sharedCAOverride).(*subcav1.CertAuthorityOverride)
-			test.modify(caOverride)
+			test.modify(t, caOverride)
 
 			_, err := subca.ValidateAndParseCAOverride(caOverride)
 			if test.wantErr == "" {
@@ -326,7 +420,7 @@ func TestValidateAndParseCAOverride(t *testing.T) {
 func TestValidateAndParseCAOverride_ParsedResource(t *testing.T) {
 	t.Parallel()
 
-	// Use a pre-made caOverride so we have predicatable certificates/public keys.
+	// Use a pre-made caOverride so we have predictable certificates/public keys.
 	caOverride := &subcav1.CertAuthorityOverride{
 		Kind:    "cert_authority_override",
 		SubKind: "windows",
@@ -337,12 +431,12 @@ func TestValidateAndParseCAOverride_ParsedResource(t *testing.T) {
 		Spec: &subcav1.CertAuthorityOverrideSpec{
 			CertificateOverrides: []*subcav1.CertificateOverride{
 				{
-					//PublicKey:   "b05b24e7c4b141d8a081f49242ad859218d95ab826f23cf823c4e07138c95a9f",
-					Certificate: "-----BEGIN CERTIFICATE-----\nMIIBtDCCAVqgAwIBAgIBBDAKBggqhkjOPQQDAjAxMSMwIQYDVQQDExpFWFRFUk5B\nTCBJTlRFUk1FRElBVEUgQ0EgMzEKMAgGA1UEBRMBMzAeFw0yNjAzMTIxMzA4MTZa\nFw0yNjAzMTIxNDA5MTZaMDExIzAhBgNVBAMTGkVYVEVSTkFMIElOVEVSTUVESUFU\nRSBDQSA0MQowCAYDVQQFEwE0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+quy\nog1ZSEDzXc3rGhRqQG98tbn2rnrf8ynmRCejQRCmfWA8fHQB1ObedzRGbnkyUvYa\nfKCJxhhHS6vhgM0xM6NjMGEwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMB\nAf8wHQYDVR0OBBYEFJFkotRmGwBC0gKTDIGqDcAKtdeJMB8GA1UdIwQYMBaAFNuI\nI2v0B+R00TyVP+uJ5wzUhrQoMAoGCCqGSM49BAMCA0gAMEUCIQCnugqmqxDg1JnJ\nwjT8MpDMPrwPO5+IVth5E67QAq9ZIAIgcvkIy0V+k3Q180AziL7ZrLtLY2h0FRqv\nyWt+1Lnx+EY=\n-----END CERTIFICATE-----\n",
+					//PublicKey: "e96aa5dc0b1c238bb2201191f381f91d7f2d27eca890591de14998e5e15ce417",
+					Certificate: "-----BEGIN CERTIFICATE-----\nMIIBxzCCAWygAwIBAgIBBzAKBggqhkjOPQQDAjAxMSMwIQYDVQQDExpFWFRFUk5B\nTCBJTlRFUk1FRElBVEUgQ0EgMzEKMAgGA1UEBRMBMzAeFw0yNjA0MDcyMDM0MzRa\nFw0yNjA0MDcyMTM1MzRaMEMxEDAOBgNVBAoTB3phcnF1b24xIzAhBgNVBAMTGkVY\nVEVSTkFMIElOVEVSTUVESUFURSBDQSA3MQowCAYDVQQFEwE3MFkwEwYHKoZIzj0C\nAQYIKoZIzj0DAQcDQgAE5xcb9chZRNgg/K/AXhMQ9GMUu1wBvPo97L107e4iQ/Dp\nc+RG8ywYGHbqSXIcJP+ONOgbDaLYeSg0Y+89k1Bgg6NjMGEwDgYDVR0PAQH/BAQD\nAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFHC7cgHrQtquasktOLXLZRt3\nQizJMB8GA1UdIwQYMBaAFKauhVOH7awfXqv4WkNmyzsP00ucMAoGCCqGSM49BAMC\nA0kAMEYCIQCLbjjjwvTxATYa5FQCtvE/sg0z5n6zLEPuDUapmZ2bswIhAM6mljTl\nldbZY/y+1kC52QRpOWCTNGLlEQwTY0JN966I\n-----END CERTIFICATE-----\n",
 					Chain: []string{
-						"-----BEGIN CERTIFICATE-----\nMIIBtTCCAVqgAwIBAgIBAzAKBggqhkjOPQQDAjAxMSMwIQYDVQQDExpFWFRFUk5B\nTCBJTlRFUk1FRElBVEUgQ0EgMjEKMAgGA1UEBRMBMjAeFw0yNjAzMTIxMzA4MTZa\nFw0yNjAzMTIxNDA5MTZaMDExIzAhBgNVBAMTGkVYVEVSTkFMIElOVEVSTUVESUFU\nRSBDQSAzMQowCAYDVQQFEwEzMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPBu0\nRewncuGV9LP2CUEW5U5JHRMbgcL4RUNkl+gYo3WYAxFYRdjqFGRD0d7wzo2t4I+s\niT/CwF1EfNO1AAtePKNjMGEwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMB\nAf8wHQYDVR0OBBYEFNuII2v0B+R00TyVP+uJ5wzUhrQoMB8GA1UdIwQYMBaAFKWp\nG0/k4iUwHJf1hjDBbOGgJIicMAoGCCqGSM49BAMCA0kAMEYCIQC/yLDWxElbkYJJ\nD7B7HnMNWabsJu0EDA408s+M0JcS9gIhAI1Cs+smAkb5f+UXQdBv7lqOlHFfR/3c\ni/ONL+HCRA1P\n-----END CERTIFICATE-----\n",
-						"-----BEGIN CERTIFICATE-----\nMIIBrzCCAVWgAwIBAgIBAjAKBggqhkjOPQQDAjApMRswGQYDVQQDExJFWFRFUk5B\nTCBST09UIENBIDExCjAIBgNVBAUTATEwHhcNMjYwMzEyMTMwODE2WhcNMjYwMzEy\nMTQwOTE2WjAxMSMwIQYDVQQDExpFWFRFUk5BTCBJTlRFUk1FRElBVEUgQ0EgMjEK\nMAgGA1UEBRMBMjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABHX5Lb4OjZG21k/7\nqAdDRPCNXn1G4XndwMoBL53Ni3xd+ovx4zIFajLq+8i6jg/rihxI74QBnR38j/D7\nlaPp48WjZjBkMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgEBMB0G\nA1UdDgQWBBSlqRtP5OIlMByX9YYwwWzhoCSInDAfBgNVHSMEGDAWgBSgEnGXl1ci\nDYWoRhm8uNXB5T3t8zAKBggqhkjOPQQDAgNIADBFAiBc1KqvASkx1PYuVjZEQr7b\nWCizRoOn3J/yLbi5DVo/TgIhAPHPm8ErDxl/AoZybbdT8QVwQYPeB1jsK+h9Kcm1\nAkDR\n-----END CERTIFICATE-----\n",
-						"-----BEGIN CERTIFICATE-----\nMIIBhjCCASygAwIBAgIBATAKBggqhkjOPQQDAjApMRswGQYDVQQDExJFWFRFUk5B\nTCBST09UIENBIDExCjAIBgNVBAUTATEwHhcNMjYwMzEyMTMwODE2WhcNMjYwMzEy\nMTQwOTE2WjApMRswGQYDVQQDExJFWFRFUk5BTCBST09UIENBIDExCjAIBgNVBAUT\nATEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASP68oeRXs8P10r2KMP0yx1zkTk\nyUDdy9PCMMQgdDl85jMwOLcEKeOR+rwqp4FvHJVkDebQdtU4mqIweyOW1u8to0Uw\nQzAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBAjAdBgNVHQ4EFgQU\noBJxl5dXIg2FqEYZvLjVweU97fMwCgYIKoZIzj0EAwIDSAAwRQIgWXfQuNOSTrY2\nEHG41FDbIY3kB5730M7NNLm09ZuecRICIQCXwm9EH13zx462z+6eahLAoYeUdtP6\nhBW0accYgMXnmQ==\n-----END CERTIFICATE-----\n",
+						"-----BEGIN CERTIFICATE-----\nMIIBtDCCAVqgAwIBAgIBAzAKBggqhkjOPQQDAjAxMSMwIQYDVQQDExpFWFRFUk5B\nTCBJTlRFUk1FRElBVEUgQ0EgMjEKMAgGA1UEBRMBMjAeFw0yNjA0MDcyMDM0MzRa\nFw0yNjA0MDcyMTM1MzRaMDExIzAhBgNVBAMTGkVYVEVSTkFMIElOVEVSTUVESUFU\nRSBDQSAzMQowCAYDVQQFEwEzMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYq0e\nBGPQYXZzo41zQOAOosID5Y/bDR0k8aQsjuWp+GVPzXFwd3i8xRDQVTv3B7b7G8CY\nZqrrR4knVcEMV9N+vaNjMGEwDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQFMAMB\nAf8wHQYDVR0OBBYEFKauhVOH7awfXqv4WkNmyzsP00ucMB8GA1UdIwQYMBaAFJn1\nQfodXtsY3vOFfZDazgamLir8MAoGCCqGSM49BAMCA0gAMEUCIQDsLHRY/go3anuQ\ncy/r/dG2X928Aer2r33Cx+Vi9kIoYAIgDEFkGM1xoznXoHM2P6+mhMXsUBuAcekt\no5Hzu+f8MH4=\n-----END CERTIFICATE-----\n",
+						"-----BEGIN CERTIFICATE-----\nMIIBrjCCAVWgAwIBAgIBAjAKBggqhkjOPQQDAjApMRswGQYDVQQDExJFWFRFUk5B\nTCBST09UIENBIDExCjAIBgNVBAUTATEwHhcNMjYwNDA3MjAzNDM0WhcNMjYwNDA3\nMjEzNTM0WjAxMSMwIQYDVQQDExpFWFRFUk5BTCBJTlRFUk1FRElBVEUgQ0EgMjEK\nMAgGA1UEBRMBMjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFsxbOWrOS86n597\nwSJ0Fn1kVza5rFsVtGbyrUG8Vw9gMkDAWya4jJGg6rus3ZK2Mpq0tfp23heKARAo\naJgWOIWjZjBkMA4GA1UdDwEB/wQEAwIBhjASBgNVHRMBAf8ECDAGAQH/AgEBMB0G\nA1UdDgQWBBSZ9UH6HV7bGN7zhX2Q2s4Gpi4q/DAfBgNVHSMEGDAWgBSsMuNnj6ZK\n3Cnx1+/GP/EHtVbF5zAKBggqhkjOPQQDAgNHADBEAiAKUfe9STknEx7BDIC2kPAM\nS1Buktg0sx1oFTXT5T1+kQIgDnpLGh1vpvj6uZXRbABG2Pp3XxeW5xxgZvL8vKE4\nCcU=\n-----END CERTIFICATE-----\n",
+						"-----BEGIN CERTIFICATE-----\nMIIBhjCCASygAwIBAgIBATAKBggqhkjOPQQDAjApMRswGQYDVQQDExJFWFRFUk5B\nTCBST09UIENBIDExCjAIBgNVBAUTATEwHhcNMjYwNDA3MjAzNDM0WhcNMjYwNDA3\nMjEzNTM0WjApMRswGQYDVQQDExJFWFRFUk5BTCBST09UIENBIDExCjAIBgNVBAUT\nATEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARfTXGAS719qco6RuW/i9PIymfI\nRCGU6qKVEGDjHaFK6nlPod0vHxBL0GbcKNoiEVO+8VGyHYyIvqpGOtnBZCMWo0Uw\nQzAOBgNVHQ8BAf8EBAMCAYYwEgYDVR0TAQH/BAgwBgEB/wIBAjAdBgNVHQ4EFgQU\nrDLjZ4+mStwp8dfvxj/xB7VWxecwCgYIKoZIzj0EAwIDSAAwRQIhALlT/cKaQV8c\nPCfbWdb2RP3TZseQDLEyUkPeqVgvwKnDAiAWjntSrPBwRpaf7K1rB/PZs+4gXIJw\n3bRU1xKbDLGzkw==\n-----END CERTIFICATE-----\n",
 					},
 					Disabled: true,
 				},
@@ -353,6 +447,11 @@ func TestValidateAndParseCAOverride_ParsedResource(t *testing.T) {
 			},
 		},
 	}
+	const publicKey0 = "e96aa5dc0b1c238bb2201191f381f91d7f2d27eca890591de14998e5e15ce417"
+	const chain0Key0 = "36b3cc3e289c286de54fa166ddc867058fe52f7bfc33ea04572c23b867fe2011"
+	const chain0Key1 = "8510a1fee7c494b6883a3d80ca8bee2d47535fb9b6b2650946c36845845adf40"
+	const chain0Key2 = "6dbe15f7e4774851894b7e7732ae5d5155cbb0a25cddb61ab7cb310e5c3afae7"
+	const publicKey1 = "89b32ef334d6fa94e2a7d9b3cc122115a3a9ed19907a7f25d3fe71bbc734619d" // lowercase!
 
 	// Verify ParsedCAOverride.
 	parsed, err := subca.ValidateAndParseCAOverride(caOverride)
@@ -361,7 +460,6 @@ func TestValidateAndParseCAOverride_ParsedResource(t *testing.T) {
 	require.Len(t, parsed.CertificateOverrides, 2, "CertificateOverrides mismatch")
 
 	// Verify CertificateOverride #0.
-	const publicKey0 = "b05b24e7c4b141d8a081f49242ad859218d95ab826f23cf823c4e07138c95a9f"
 	co0 := parsed.CertificateOverrides[0]
 	assert.Same(t, caOverride.Spec.CertificateOverrides[0], co0.CertificateOverride, "CertificateOverride changed")
 	assert.Equal(t, publicKey0, co0.PublicKey, "PublicKey mismatch")
@@ -370,9 +468,9 @@ func TestValidateAndParseCAOverride_ParsedResource(t *testing.T) {
 	assert.Len(t, co0.Chain, 3, "Chain mismatch")
 
 	chainPublicKeys := []string{
-		"6fe333ee9900316999fecc7b026b833fa97f301ed08ec545728a21c2ef04a7ba",
-		"76e4355c0493658b869450c097f233ed4017ccb8eb1f7f6d251e8745b33f4336",
-		"b14d63ec97168d52dee4de8f80be040441964e2b06443ce50786b60f0028ec42",
+		chain0Key0,
+		chain0Key1,
+		chain0Key2,
 	}
 	for i, chain := range co0.Chain {
 		assert.NotNil(t, chain, "Chain[%d] certificate expected", i)
@@ -381,7 +479,6 @@ func TestValidateAndParseCAOverride_ParsedResource(t *testing.T) {
 	}
 
 	// Verify CertificateOverride #1.
-	const publicKey1 = "89b32ef334d6fa94e2a7d9b3cc122115a3a9ed19907a7f25d3fe71bbc734619d" // lowercase!
 	co1 := parsed.CertificateOverrides[1]
 	assert.Same(t, caOverride.Spec.CertificateOverrides[1], co1.CertificateOverride, "CertificateOverride changed")
 	assert.Equal(t, publicKey1, co1.PublicKey, "PublicKey mismatch")

--- a/lib/subca/testenv/ca.go
+++ b/lib/subca/testenv/ca.go
@@ -48,6 +48,10 @@ type CAParams struct {
 	// Template for the CA certificate.
 	// Optional.
 	Template *x509.Certificate
+	// ModifyCertificate is called on the certificate template before issuance.
+	// Unlike Template it may be used to force otherwise "invalid" CA certificates
+	// (wrong KeyUsage, IsCA=false, BasicConstraintsValid=false, etc).
+	ModifyCertificate func(template *x509.Certificate)
 }
 
 // CA represents a CA external to Teleport.
@@ -112,6 +116,10 @@ func createCA(optionalParams *CAParams, parent *CA) (*CA, error) {
 	}
 
 	prepareCATemplate(template, clock, issuerName)
+
+	if optionalParams != nil && optionalParams.ModifyCertificate != nil {
+		optionalParams.ModifyCertificate(template)
+	}
 
 	certRaw, err := x509.CreateCertificate(rand.Reader, template, issuerCert, pub, issuerKey)
 	if err != nil {

--- a/lib/subca/testenv/env.go
+++ b/lib/subca/testenv/env.go
@@ -19,6 +19,7 @@ package testenv
 import (
 	"cmp"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"testing"
 
 	"github.com/jonboulle/clockwork"
@@ -230,6 +231,11 @@ func (env *Env) NewDisabledCertificateOverride(
 	overrideCA, err := externalRoot.NewIntermediateCA(&CAParams{
 		Clock: env.Clock,
 		Pub:   cert.PublicKey,
+		Template: &x509.Certificate{
+			Subject: pkix.Name{
+				Organization: cert.Subject.Organization, // ClusterName.
+			},
+		},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Add validation to CA override certificates to ensure they can function as CA certificates (IsCA=true, KeyUsage=keyCertSign|cRLSign, etc).

The cluster name requirement is also enforced, as per RFD 0237.

https://github.com/gravitational/teleport.e/issues/7675