### PR TITLE
[v17] docs: fix cert_authority resource name in CA rotation guide

### DIFF
--- a/docs/pages/zero-trust-access/management/operations/ca-rotation.mdx
+++ b/docs/pages/zero-trust-access/management/operations/ca-rotation.mdx
@@ -65,7 +65,7 @@ and lists any manual steps that need to be completed.
 - (!docs/pages/includes/tctl.mdx!)
 
 - Your user must have a role with permission to `create` and `update` the
-  `certificate_authority` resource.
+  `cert_authority` resource.
 
   ```yaml
   kind: role
@@ -75,7 +75,7 @@ and lists any manual steps that need to be completed.
   spec:
     allow:
       rules:
-      - resources: [ certificate_authority ]
+      - resources: [ cert_authority ]
         verbs: [ create, update ]
   ```
 


### PR DESCRIPTION
Backport #65576 to branch/v17