### PR TITLE
[v18] Show AWS Identity Center-Specific Guidance for Unauthorized Status

### DIFF
--- a/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import { createMemoryHistory } from 'history';
-import { Router } from 'react-router';
+import { MemoryRouter, Router } from 'react-router';
 
 import { render, screen, userEvent } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
@@ -25,6 +25,7 @@ import { IntegrationList } from 'teleport/Integrations/IntegrationList';
 import {
   IntegrationKind,
   IntegrationStatusCode,
+  type Plugin,
 } from 'teleport/services/integrations';
 
 test('integration list does not display action menu for aws-oidc, row click navigates', async () => {
@@ -54,4 +55,28 @@ test('integration list does not display action menu for aws-oidc, row click navi
   expect(history.push).toHaveBeenCalledWith(
     '/web/integrations/status/aws-oidc/aws-integration'
   );
+});
+
+test('integration list details prefer plugin status error message over details', () => {
+  const plugin: Plugin = {
+    resourceType: 'plugin',
+    name: 'okta-plugin',
+    kind: 'okta',
+    details: 'fallback details',
+    statusCode: IntegrationStatusCode.OtherError,
+    status: {
+      code: IntegrationStatusCode.OtherError,
+      lastRun: new Date('2026-03-31T00:00:00Z'),
+      errorMessage: 'sync failed',
+    },
+  };
+
+  render(
+    <MemoryRouter>
+      <IntegrationList list={[plugin]} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText('sync failed')).toBeInTheDocument();
+  expect(screen.queryByText('fallback details')).not.toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -492,7 +492,9 @@ export function percent(n: number, d: number): string {
 }
 
 const DetailsCell = ({ integration }: { integration: IntegrationLike }) => {
-  let content = <Text>{integration.details}</Text>;
+  let content = (
+    <Text>{integration.status?.errorMessage || integration.details}</Text>
+  );
   switch (integration.kind) {
     case IntegrationKind.AwsOidc:
     case IntegrationKind.AzureOidc:


### PR DESCRIPTION
Backport #64906 to branch/v18


## Manual Test Plan

### Test Environment
- Follow the setup laid out in https://github.com/gravitational/teleport.e/pull/8510
### Test Cases

- [x] Follow the steps laid out in https://github.com/gravitational/teleport.e/pull/8510

changelog: AWS Identity Center-specific guidance is now given when the integration encounters an unauthorized error, suggesting SCIM API token rotation
