### PR TITLE
app: Consolidate app name and public_addr validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ other services. The limit is aggregated across all apps on the
 `connection_limits` configured, those values apply to app access
 connections after upgrading to v19.
 
+#### Stricter `public_addr` validation
+
+App `name`, `public_addr`, and `required_apps` are now validated as
+lowercase DNS-1123 hostnames on every write path, including agent
+heartbeats. The change is backwards compatible for most existing
+records: heartbeats from older agents are first normalized (URL
+schemes and ports stripped, value lowercased) so URL-shaped or
+mixed-case legacy values keep working after upgrade.
+
+The exception is `public_addr` values that are not a valid DNS-1123
+hostname even after normalization -- for example, IP addresses, IDN
+Unicode (non-ASCII), trailing dots, or underscores. Such records
+are rejected on the next heartbeat and drop from the app registry
+until the `public_addr` is fixed.
+
 #### CLI --help Output Improvements
 
 In the past, Teleport CLI programs printed all subcommands, subcommands'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,33 +23,29 @@ connections after upgrading to v19.
 
 #### Stricter application validation
 
-The application service now applies stricter naming rules at every
-write path (`teleport.yaml`, dynamic `tctl create`, and agent
-heartbeats). The rules differ slightly by field.
+The application service now applies stricter naming rules on every
+write path (static config in `teleport.yaml`, the dynamic API via
+`tctl create`, the Terraform provider, the Kubernetes operator,
+direct API calls, and apps registered by existing agents). The
+change is backwards compatible apart from three cases:
 
-App `name` in `teleport.yaml` is a lowercase DNS label:
+- Names in `teleport.yaml` static config must now be a valid DNS
+  label (lowercase alphanumeric and `-`, max 63 chars). Update the
+  config before upgrading.
+- `public_addr` values that remain unroutable after normalization
+  (IP addresses, IDN Unicode, trailing dots, underscores) are
+  rejected. The affected app drops from the registry until
+  corrected.
+- Duplicate `name` entries in the `app_service.apps` block of a
+  single agent's `teleport.yaml` now fail validation at startup.
+  Previously, the second entry silently overwrote the first, so
+  only one of the two apps was actually served. Deduplicate the
+  config before upgrading. The check is per-agent; multiple agents
+  heartbeating the same app name remain supported for load
+  balancing.
 
-- only letters `a-z`, digits `0-9`, and dashes (`-`),
-- starts and ends with a letter or digit,
-- up to 63 characters.
-
-App `name` written through the dynamic API, `public_addr`, and
-`required_apps` entries are lowercase DNS hostnames. The same
-rules apply, with dots (`.`) allowed as label separators for
-AWS OIDC integration compatibility, up to 253 characters in
-total, and no trailing dot or IDN Unicode (use punycode for
-non-ASCII).
-
-The change is backwards compatible for most existing records.
-Heartbeats from older agents are first normalized (URL schemes and
-ports stripped, value lowercased) so URL-shaped or mixed-case
-legacy values keep working after upgrade.
-
-The exception is `public_addr` values that are still invalid after
-normalization, for example IP addresses, IDN Unicode, trailing
-dots, or underscores. Such records are rejected on the next
-heartbeat and drop from the app registry until the `public_addr`
-is corrected.
+Rolling upgrades are supported: older-agent heartbeats are
+normalized so previously valid names still pass.
 
 #### CLI --help Output Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,20 +21,35 @@ other services. The limit is aggregated across all apps on the
 `connection_limits` configured, those values apply to app access
 connections after upgrading to v19.
 
-#### Stricter `public_addr` validation
+#### Stricter application validation
 
-App `name`, `public_addr`, and `required_apps` are now validated as
-lowercase DNS-1123 hostnames on every write path, including agent
-heartbeats. The change is backwards compatible for most existing
-records: heartbeats from older agents are first normalized (URL
-schemes and ports stripped, value lowercased) so URL-shaped or
-mixed-case legacy values keep working after upgrade.
+The application service now applies stricter naming rules at every
+write path (`teleport.yaml`, dynamic `tctl create`, and agent
+heartbeats). The rules differ slightly by field.
 
-The exception is `public_addr` values that are not a valid DNS-1123
-hostname even after normalization -- for example, IP addresses, IDN
-Unicode (non-ASCII), trailing dots, or underscores. Such records
-are rejected on the next heartbeat and drop from the app registry
-until the `public_addr` is fixed.
+App `name` in `teleport.yaml` is a lowercase DNS label:
+
+- only letters `a-z`, digits `0-9`, and dashes (`-`),
+- starts and ends with a letter or digit,
+- up to 63 characters.
+
+App `name` written through the dynamic API, `public_addr`, and
+`required_apps` entries are lowercase DNS hostnames. The same
+rules apply, with dots (`.`) allowed as label separators for
+AWS OIDC integration compatibility, up to 253 characters in
+total, and no trailing dot or IDN Unicode (use punycode for
+non-ASCII).
+
+The change is backwards compatible for most existing records.
+Heartbeats from older agents are first normalized (URL schemes and
+ports stripped, value lowercased) so URL-shaped or mixed-case
+legacy values keep working after upgrade.
+
+The exception is `public_addr` values that are still invalid after
+normalization, for example IP addresses, IDN Unicode, trailing
+dots, or underscores. Such records are rejected on the next
+heartbeat and drop from the app registry until the `public_addr`
+is corrected.
 
 #### CLI --help Output Improvements
 

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -207,8 +207,8 @@ is registered:
 
 - **Static config (`app_service.apps` in YAML)**: lowercase
   alphanumeric and `-`, max 63 characters, no dots, must start and end
-  with alphanumeric. Mixed-case names are rejected at startup, as is
-  a duplicate name.
+  with alphanumeric. Mixed-case names are rejected at startup, as are
+  duplicate names.
 - **Dynamic resources (`tctl create app`, integrations, Kubernetes
   operator)**: lowercase alphanumeric, `-`, or `.`, max 253
   characters.

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -210,11 +210,14 @@ is registered:
   with alphanumeric. Mixed-case names are rejected at startup, as are
   duplicate names.
 - **Dynamic resources (`tctl create app`, integrations, Kubernetes
-  operator)**: lowercase alphanumeric, `-`, or `.`, max 253
+  operator)**: lowercase alphanumeric, `-`, `_`, or `.`, max 253
   characters. On Teleport Cloud, avoid `.` in app names: the tenant
   wildcard certificate only covers one subdomain level
   (`*.<tenant>.teleport.sh`), so dotted names will fail TLS
-  validation.
+  validation. Underscores are accepted by the Auth Service and the
+  cluster's wildcard cert, but strict TLS clients
+  (OpenSSL with `verify_hostname`) and proxies like NGINX (with
+  `underscores_in_headers off`) may reject them at access time.
 
 `public_addr` (if set) must be a bare, lowercase DNS hostname. URI
 schemes, ports, IP addresses, and uppercase letters are rejected.

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -211,7 +211,10 @@ is registered:
   duplicate names.
 - **Dynamic resources (`tctl create app`, integrations, Kubernetes
   operator)**: lowercase alphanumeric, `-`, or `.`, max 253
-  characters.
+  characters. On Teleport Cloud, avoid `.` in app names: the tenant
+  wildcard certificate only covers one subdomain level
+  (`*.<tenant>.teleport.sh`), so dotted names will fail TLS
+  validation.
 
 `public_addr` (if set) must be a bare, lowercase DNS hostname. URI
 schemes, ports, IP addresses, and uppercase letters are rejected.

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -197,12 +197,24 @@ Application Service:
 
 {/*
 Note: this section of the docs is linked to from error messages in the product.
-Please make sure to update lib/srv/servicecfg/app.go if you change this section
-header or move this page.
+Please make sure to update lib/service/servicecfg/app.go and lib/services/app.go
+if you change this section header or move this page.
 */}
 
-An application name should make a valid sub-domain (\<=63 characters, no spaces, only `a-z 0-9 -` allowed).
-It should also be unique across root and leaf clusters if you are deploying in a trusted clusters environment.
+An application name must be unique across root and leaf clusters in a
+trusted clusters environment. Validation rules depend on where the app
+is registered:
+
+- **Static config (`app_service.apps` in YAML)**: lowercase
+  alphanumeric and `-`, max 63 characters, no dots, must start and end
+  with alphanumeric. Mixed-case names are rejected at startup, as is
+  a duplicate name.
+- **Dynamic resources (`tctl create app`, integrations, Kubernetes
+  operator)**: lowercase alphanumeric, `-`, or `.`, max 253
+  characters.
+
+`public_addr` (if set) must be a bare, lowercase DNS hostname. URI
+schemes, ports, IP addresses, and uppercase letters are rejected.
 
 After Teleport is running, users can access the app at `app-name.proxy_public_addr.com`
 e.g. `grafana.teleport.example.com`. You can also override `public_addr` e.g

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6738,6 +6738,11 @@ func (a *Server) UpsertKubernetesServer(ctx context.Context, server types.KubeSe
 // UpsertApplicationServer implements [services.Presence] by delegating to
 // [Server.Services] and then potentially emitting a [usagereporter] event.
 func (a *Server) UpsertApplicationServer(ctx context.Context, server types.AppServer) (*types.KeepAlive, error) {
+	// Choke point: every app-write path converges here.
+	// Keepalives skip via UnconditionalUpdateApplicationServer.
+	if err := services.ValidateAppServer(server, a); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	lease, err := a.Services.UpsertApplicationServer(ctx, server)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -6756,6 +6761,7 @@ func (a *Server) UpsertApplicationServer(ctx context.Context, server types.AppSe
 // by delegating to [Server.Services] and then potentially emitting a
 // [usagereporter] event.
 func (a *Server) UnconditionalUpdateApplicationServer(ctx context.Context, server types.AppServer) (types.AppServer, error) {
+	// Skip validation: callers must have already passed through UpsertApplicationServer.
 	server, err := a.Services.UnconditionalUpdateApplicationServer(ctx, server)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -7425,6 +7431,9 @@ func (a *Server) IterateResources(ctx context.Context, req proto.ListResourcesRe
 
 // CreateApp creates a new application resource.
 func (a *Server) CreateApp(ctx context.Context, app types.Application) error {
+	if err := services.ValidateApp(app, a); err != nil {
+		return trace.Wrap(err)
+	}
 	if err := a.Services.CreateApp(ctx, app); err != nil {
 		return trace.Wrap(err)
 	}
@@ -7451,6 +7460,9 @@ func (a *Server) CreateApp(ctx context.Context, app types.Application) error {
 
 // UpdateApp updates an existing application resource.
 func (a *Server) UpdateApp(ctx context.Context, app types.Application) error {
+	if err := services.ValidateApp(app, a); err != nil {
+		return trace.Wrap(err)
+	}
 	if err := a.Services.UpdateApp(ctx, app); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -6925,6 +6925,12 @@ func (a *ServerWithRoles) CreateApp(ctx context.Context, app types.Application) 
 	if err := a.authorizeAction(types.KindApp, types.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
+	// Validate before the label-matching access check so callers with
+	// the correct role see input errors rather than access-denied from
+	// a label mismatch on a malformed app.
+	if err := services.ValidateApp(app, a.authServer); err != nil {
+		return trace.Wrap(err)
+	}
 	// Don't allow users create apps they wouldn't have access to (e.g.
 	// non-matching labels).
 	if err := a.checkAccessToApp(app); err != nil {
@@ -6936,6 +6942,11 @@ func (a *ServerWithRoles) CreateApp(ctx context.Context, app types.Application) 
 // UpdateApp updates existing application resource.
 func (a *ServerWithRoles) UpdateApp(ctx context.Context, app types.Application) error {
 	if err := a.authorizeAction(types.KindApp, types.VerbUpdate); err != nil {
+		return trace.Wrap(err)
+	}
+	// Validate before the GetApp existence check so a malformed name
+	// returns the input error rather than "doesn't exist".
+	if err := services.ValidateApp(app, a.authServer); err != nil {
 		return trace.Wrap(err)
 	}
 	// Don't allow users update apps they don't have access to (e.g.

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7308,14 +7308,14 @@ func TestListUnifiedResources_search_as_roles_oktaReadOnly(t *testing.T) {
 	// 1. Create app resources
 
 	searchableGenericApp := createTestAppServerV3(t, srv.Auth(),
-		"test_generic_app",
+		"test-generic-app",
 		map[string]string{
 			"find_me": "please",
 		},
 	)
 
 	searchableOktaApp := createTestAppServerV3(t, srv.Auth(),
-		"test_searchable_okta_app",
+		"test-searchable-okta-app",
 		map[string]string{
 			"find_me":         "please",
 			types.OriginLabel: types.OriginOkta,
@@ -7323,7 +7323,7 @@ func TestListUnifiedResources_search_as_roles_oktaReadOnly(t *testing.T) {
 	)
 
 	assignedOktaApp := createTestAppServerV3(t, srv.Auth(),
-		"test_assigned_okta_app",
+		"test-assigned-okta-app",
 		map[string]string{
 			"owner":           "alice",
 			types.OriginLabel: types.OriginOkta,

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -1673,7 +1673,7 @@ func (g *GRPCServer) UpsertApplicationServer(ctx context.Context, req *authpb.Up
 	//      names or URL-shaped public_addr; normalize so the heartbeat
 	//      passes validation and the apps keep showing up in the
 	//      cluster.
-	//   2. Admin users uploading an app_server YAML (no builtin role).
+	//   2. Admin users creating an app_server YAML (no builtin role).
 	//      Do NOT normalize - admin writes follow strict validation;
 	//      reject malformed input rather than silently rewriting it.
 	if authz.HasBuiltinRole(auth.context, string(types.RoleApp)) ||

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -1667,8 +1667,18 @@ func (g *GRPCServer) UpsertApplicationServer(ctx context.Context, req *authpb.Up
 		}
 	}
 
-	if err := services.ValidateApp(app, auth); err != nil {
-		return nil, trace.Wrap(err)
+	// Two callers reach this RPC:
+	//   1. App-service agents heartbeating (have builtin role RoleApp
+	//      or RoleInstance). Legacy agents may still send mixed-case
+	//      names or URL-shaped public_addr; normalize so the heartbeat
+	//      passes validation and the apps keep showing up in the
+	//      cluster.
+	//   2. Admin users uploading an app_server YAML (no builtin role).
+	//      Do NOT normalize - admin writes follow strict validation;
+	//      reject malformed input rather than silently rewriting it.
+	if authz.HasBuiltinRole(auth.context, string(types.RoleApp)) ||
+		authz.HasBuiltinRole(auth.context, string(types.RoleInstance)) {
+		services.NormalizeAppServerForHeartbeat(server)
 	}
 
 	keepAlive, err := auth.UpsertApplicationServer(ctx, server)
@@ -4285,9 +4295,6 @@ func (g *GRPCServer) CreateApp(ctx context.Context, app *types.AppV3) (*emptypb.
 	if app.Origin() == "" {
 		app.SetOrigin(types.OriginDynamic)
 	}
-	if err := services.ValidateApp(app, auth); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	if err := auth.CreateApp(ctx, app); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4302,9 +4309,6 @@ func (g *GRPCServer) UpdateApp(ctx context.Context, app *types.AppV3) (*emptypb.
 	}
 	if app.Origin() == "" {
 		app.SetOrigin(types.OriginDynamic)
-	}
-	if err := services.ValidateApp(app, auth); err != nil {
-		return nil, trace.Wrap(err)
 	}
 	if err := auth.UpdateApp(ctx, app); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -5768,11 +5768,12 @@ func TestUpsertApplicationServerOrigin(t *testing.T) {
 func TestApplicationServerHeartbeatLowercase(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	server := newTestTLSServer(t)
 	agent := authtest.TestBuiltin(types.RoleApp)
 	client, err := server.NewClient(agent)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
 
 	app, err := types.NewAppV3(types.Metadata{Name: "MixedCaseApp"}, types.AppSpecV3{
 		URI: "http://localhost:8080",
@@ -5798,7 +5799,7 @@ func TestApplicationServerHeartbeatLowercase(t *testing.T) {
 func TestServerUpsertApplicationServerValidates(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	srv := newTestTLSServer(t)
 
 	bad, err := types.NewAppV3(types.Metadata{Name: "MixedCase"}, types.AppSpecV3{
@@ -5819,11 +5820,12 @@ func TestServerUpsertApplicationServerValidates(t *testing.T) {
 func TestApplicationAdminPathsRejectMixedCase(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	server := newTestTLSServer(t)
 	admin := authtest.TestAdmin()
 	client, err := server.NewClient(admin)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
 
 	t.Run("CreateApp", func(t *testing.T) {
 		app, err := types.NewAppV3(types.Metadata{Name: "MyApp"}, types.AppSpecV3{

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -5762,6 +5762,105 @@ func TestUpsertApplicationServerOrigin(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestApplicationServerHeartbeatLowercase asserts the gRPC handler
+// plumbs NormalizeAppServerForHeartbeat through to the backend write
+// for a legacy agent's mixed-case heartbeat.
+func TestApplicationServerHeartbeatLowercase(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server := newTestTLSServer(t)
+	agent := authtest.TestBuiltin(types.RoleApp)
+	client, err := server.NewClient(agent)
+	require.NoError(t, err)
+
+	app, err := types.NewAppV3(types.Metadata{Name: "MixedCaseApp"}, types.AppSpecV3{
+		URI: "http://localhost:8080",
+	})
+	require.NoError(t, err)
+	appServer, err := types.NewAppServerV3FromApp(app, "localhost", "host-id")
+	require.NoError(t, err)
+
+	_, err = client.UpsertApplicationServer(ctx, appServer)
+	require.NoError(t, err)
+
+	stored, err := client.GetApplicationServers(ctx, apidefaults.Namespace)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	require.Equal(t, "mixedcaseapp", stored[0].GetApp().GetName())
+	require.Equal(t, "mixedcaseapp", stored[0].GetName())
+}
+
+// TestServerUpsertApplicationServerValidates asserts
+// (*Server).UpsertApplicationServer validates rather than relying on
+// the gRPC handler. Moving validation up would re-open the
+// inventory-stream bypass.
+func TestServerUpsertApplicationServerValidates(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	srv := newTestTLSServer(t)
+
+	bad, err := types.NewAppV3(types.Metadata{Name: "MixedCase"}, types.AppSpecV3{
+		URI: "http://localhost:8080",
+	})
+	require.NoError(t, err)
+	badServer, err := types.NewAppServerV3FromApp(bad, "localhost", "host-id-direct")
+	require.NoError(t, err)
+
+	_, err = srv.Auth().UpsertApplicationServer(ctx, badServer)
+	require.ErrorContains(t, err, "must be a valid DNS name")
+}
+
+// TestApplicationAdminPathsRejectMixedCase asserts CreateApp,
+// UpdateApp, and UpsertApplicationServer all reject mixed-case names
+// for admin callers (the heartbeat-role normalize gate does not
+// apply).
+func TestApplicationAdminPathsRejectMixedCase(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server := newTestTLSServer(t)
+	admin := authtest.TestAdmin()
+	client, err := server.NewClient(admin)
+	require.NoError(t, err)
+
+	t.Run("CreateApp", func(t *testing.T) {
+		app, err := types.NewAppV3(types.Metadata{Name: "MyApp"}, types.AppSpecV3{
+			URI: "http://localhost:8080",
+		})
+		require.NoError(t, err)
+		err = client.CreateApp(ctx, app)
+		require.ErrorContains(t, err, "must be a valid DNS name")
+	})
+
+	t.Run("UpdateApp", func(t *testing.T) {
+		seeded, err := types.NewAppV3(types.Metadata{Name: "myapp"}, types.AppSpecV3{
+			URI: "http://localhost:8080",
+		})
+		require.NoError(t, err)
+		require.NoError(t, client.CreateApp(ctx, seeded))
+
+		bad, err := types.NewAppV3(types.Metadata{Name: "MyApp"}, types.AppSpecV3{
+			URI: "http://localhost:8080",
+		})
+		require.NoError(t, err)
+		err = client.UpdateApp(ctx, bad)
+		require.ErrorContains(t, err, "must be a valid DNS name")
+	})
+
+	t.Run("UpsertApplicationServer", func(t *testing.T) {
+		app, err := types.NewAppV3(types.Metadata{Name: "MyApp"}, types.AppSpecV3{
+			URI: "http://localhost:8080",
+		})
+		require.NoError(t, err)
+		appServer, err := types.NewAppServerV3FromApp(app, "localhost", "host-id-admin")
+		require.NoError(t, err)
+		_, err = client.UpsertApplicationServer(ctx, appServer)
+		require.ErrorContains(t, err, "must be a valid DNS name")
+	})
+}
+
 func TestGetAccessGraphConfig(t *testing.T) {
 	t.Parallel()
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2192,6 +2192,17 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		cfg.Apps.Apps = append(cfg.Apps.Apps, app)
 	}
 
+	// Reject literal duplicates: at registration two entries with the
+	// same name would write to the same backend key (host_id + name)
+	// and the second would silently overwrite the first.
+	seenNames := make(map[string]bool, len(cfg.Apps.Apps))
+	for _, app := range cfg.Apps.Apps {
+		if seenNames[app.Name] {
+			return trace.BadParameter("duplicate application name %q in static config", app.Name)
+		}
+		seenNames[app.Name] = true
+	}
+
 	return nil
 }
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2195,12 +2195,12 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	// Reject literal duplicates: at registration two entries with the
 	// same name would write to the same backend key (host_id + name)
 	// and the second would silently overwrite the first.
-	seenNames := make(map[string]bool, len(cfg.Apps.Apps))
+	seenNames := make(map[string]struct{}, len(cfg.Apps.Apps))
 	for _, app := range cfg.Apps.Apps {
-		if seenNames[app.Name] {
+		if _, ok := seenNames[app.Name]; ok {
 			return trace.BadParameter("duplicate application name %q in static config", app.Name)
 		}
-		seenNames[app.Name] = true
+		seenNames[app.Name] = struct{}{}
 	}
 
 	return nil

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2756,6 +2756,34 @@ app_service:
 			name:   "App TLS configuration fails to read file",
 			outErr: require.Error,
 		},
+		{
+			inConfigString: `
+app_service:
+  enabled: true
+  apps:
+    - name: Foo
+      uri: "http://127.0.0.1:8080"
+`,
+			name: "uppercase app name is rejected",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "must be a valid DNS label")
+			},
+		},
+		{
+			inConfigString: `
+app_service:
+  enabled: true
+  apps:
+    - name: foo
+      uri: "http://127.0.0.1:8080"
+    - name: foo
+      uri: "http://127.0.0.1:8081"
+`,
+			name: "duplicate app names rejected",
+			outErr: func(t require.TestingT, err error, _ ...any) {
+				require.ErrorContains(t, err, "duplicate application name")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2907,7 +2935,7 @@ func TestAppsCLF(t *testing.T) {
 			outApps:   nil,
 			requireError: func(t require.TestingT, err error, i ...any) {
 				require.True(t, trace.IsBadParameter(err))
-				require.ErrorContains(t, err, "application name \"-foo\" must be a lower case valid DNS subdomain: https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name")
+				require.ErrorContains(t, err, "application name \"-foo\" must be a valid DNS label (lowercase alphanumeric or '-', must start and end with alphanumeric, max 63 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name")
 			},
 		},
 		{

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2811,7 +2811,7 @@ func TestAppsCLF(t *testing.T) {
 			outApps:   nil,
 			requireError: func(t require.TestingT, err error, i ...any) {
 				require.True(t, trace.IsBadParameter(err))
-				require.ErrorContains(t, err, "application name \"-foo\" must be a lower case valid DNS subdomain: https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name")
+				require.ErrorContains(t, err, "application name \"-foo\" must be a valid DNS label (lowercase alphanumeric or '-', must start and end with alphanumeric, max 63 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name")
 			},
 		},
 		{

--- a/lib/integrations/awscommon/validations.go
+++ b/lib/integrations/awscommon/validations.go
@@ -29,8 +29,8 @@ func ValidIntegrationName(name string) error {
 	// For OIDC, this creates a new AppServer whose endpoint is <integrationName>.<proxyURL>, which can fail if integrationName is not a valid DNS Label.
 	// For Roles Anywhere, this creates a AppServers for each Roles Anywhere Profile whose endpoint is <profileName>-<integrationName>.<proxyURL>, which can fail if integrationName is not a valid DNS Label.
 	// Instead of failing when the integration is already created, it fails at creation time.
-	if errs := validation.IsDNS1035Label(name); len(errs) > 0 {
-		return trace.BadParameter("integration name %q must be a lower case valid DNS subdomain so that it can be used to allow Web/CLI access", name)
+	if errs := validation.IsDNS1123Label(name); len(errs) > 0 {
+		return trace.BadParameter("integration name %q must be a valid DNS label (lowercase alphanumeric or '-', must start and end with alphanumeric, max 63 chars) so that it can be used to allow Web/CLI access", name)
 	}
 
 	return nil

--- a/lib/integrations/awscommon/validations_test.go
+++ b/lib/integrations/awscommon/validations_test.go
@@ -1,0 +1,50 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awscommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidIntegrationName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{name: "lowercase alphanumeric", input: "myintegration"},
+		{name: "with hyphen", input: "my-integration"},
+		{name: "leading digit", input: "1integration"},
+		{name: "uppercase rejected", input: "Integration", wantErr: "must be a valid DNS label"},
+		{name: "trailing hyphen rejected", input: "INVALID-", wantErr: "must be a valid DNS label"},
+		{name: "empty rejected", input: "", wantErr: "must be a valid DNS label"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidIntegrationName(tt.input)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/lib/integrations/awscommon/validations_test.go
+++ b/lib/integrations/awscommon/validations_test.go
@@ -33,6 +33,7 @@ func TestValidIntegrationName(t *testing.T) {
 		{name: "lowercase alphanumeric", input: "myintegration"},
 		{name: "with hyphen", input: "my-integration"},
 		{name: "leading digit", input: "1integration"},
+		{name: "aws account id", input: "123456789012"},
 		{name: "uppercase rejected", input: "Integration", wantErr: "must be a valid DNS label"},
 		{name: "trailing hyphen rejected", input: "INVALID-", wantErr: "must be a valid DNS label"},
 		{name: "empty rejected", input: "", wantErr: "must be a valid DNS label"},

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -552,21 +552,17 @@ func awsConsoleURLForARN(parsedARN arn.ARN) string {
 	}
 }
 
-var (
-	// invalidAppNameChar matches any char not valid in a DNS-1123
-	// subdomain after lowercasing. Dots are kept as label separators.
-	invalidAppNameChar = regexp.MustCompile(`[^a-z0-9.\-]`)
-	// multiHyphen matches two or more consecutive hyphens.
-	multiHyphen = regexp.MustCompile(`-{2,}`)
-)
+// invalidAppNameChar matches any char not valid in a DNS-1123
+// subdomain after lowercasing. Dots are kept as label separators.
+var invalidAppNameChar = regexp.MustCompile(`[^a-z0-9.\-]`)
 
 // sanitizeProfileName rewrites a raw AWS profile name to satisfy
 // DNS-1123 subdomain: lowercase, hyphen-substitute invalid chars,
-// collapse runs of hyphens, and trim hyphens from each label.
+// and trim hyphens from each label. Runs of hyphens are kept;
+// DNS-1123 allows them and preserving them avoids extra collisions.
 func sanitizeProfileName(name string) string {
 	name = strings.ToLower(name)
 	name = invalidAppNameChar.ReplaceAllString(name, "-")
-	name = multiHyphen.ReplaceAllString(name, "-")
 	parts := strings.Split(name, ".")
 	out := make([]string, 0, len(parts))
 	for _, p := range parts {

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -446,6 +447,10 @@ func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywhereProfi
 	profileNameFilters := integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.ProfileNameFilters
 	profileUsedForProfileSync := integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.ProfileARN
 
+	// Declared outside the page loop so collisions are detected
+	// across pages, not just within one.
+	seenAppNames := map[string]string{}
+
 	var nextPage *string
 	for {
 		listReq := listRolesAnywhereProfilesRequest{
@@ -463,9 +468,9 @@ func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywhereProfi
 			err := processProfile(ctx, processProfileRequest{
 				Params:          params,
 				Profile:         profile,
-				RAClient:        raClient,
 				Integration:     integration,
 				ProxyPublicAddr: proxyPublicAddr,
+				SeenAppNames:    seenAppNames,
 			})
 			if err != nil {
 				if errors.Is(err, errDisabledProfile) {
@@ -497,9 +502,13 @@ var (
 type processProfileRequest struct {
 	Params          AWSRolesAnywhereProfileSyncerParams
 	Profile         *integrationv1.RolesAnywhereProfile
-	RAClient        RolesAnywhereClient
 	Integration     types.Integration
 	ProxyPublicAddr string
+	// SeenAppNames maps sanitized app name -> raw profile name.
+	// Two profile names can sanitize to the same app name (e.g.
+	// "prod_ops" and "prod-ops"); the second must error rather than
+	// silently overwrite the first.
+	SeenAppNames map[string]string
 }
 
 func processProfile(ctx context.Context, req processProfileRequest) error {
@@ -509,13 +518,21 @@ func processProfile(ctx context.Context, req processProfileRequest) error {
 
 	appServer, err := convertProfile(req.Params, req.Profile, req.Integration.GetName(), req.ProxyPublicAddr)
 	if err != nil {
-		return trace.BadParameter("failed to convert Profile to AppServer: %v", err)
+		return trace.Wrap(err, "failed to convert Profile to AppServer")
+	}
+
+	appName := appServer.GetApp().GetName()
+	if existing, ok := req.SeenAppNames[appName]; ok {
+		return trace.BadParameter(
+			"app name %q for profile %q conflicts with profile %q which was upserted first. Rename either profile or set %q on one of them to a unique value.",
+			appName, req.Profile.Name, existing, types.AWSRolesAnywhereProfileNameOverrideLabel)
 	}
 
 	if _, err := req.Params.AppServerUpserter.UpsertApplicationServer(ctx, appServer); err != nil {
-		return trace.BadParameter("failed to upsert application server from Profile: %v", err)
+		return trace.Wrap(err, "failed to upsert application server from profile %q", req.Profile.Name)
 	}
 
+	req.SeenAppNames[appName] = req.Profile.Name
 	return nil
 }
 
@@ -535,13 +552,38 @@ func awsConsoleURLForARN(parsedARN arn.ARN) string {
 	}
 }
 
+var (
+	// invalidAppNameChar matches any char not valid in a DNS-1123
+	// subdomain after lowercasing. Dots are kept as label separators.
+	invalidAppNameChar = regexp.MustCompile(`[^a-z0-9.\-]`)
+	// multiHyphen matches two or more consecutive hyphens.
+	multiHyphen = regexp.MustCompile(`-{2,}`)
+)
+
+// sanitizeProfileName rewrites a raw AWS profile name to satisfy
+// DNS-1123 subdomain: lowercase, hyphen-substitute invalid chars,
+// collapse runs of hyphens, and trim hyphens from each label.
+func sanitizeProfileName(name string) string {
+	name = strings.ToLower(name)
+	name = invalidAppNameChar.ReplaceAllString(name, "-")
+	name = multiHyphen.ReplaceAllString(name, "-")
+	parts := strings.Split(name, ".")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.Trim(p, "-"); p != "" {
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, ".")
+}
+
 func convertProfile(params AWSRolesAnywhereProfileSyncerParams, profile *integrationv1.RolesAnywhereProfile, integrationName string, proxyPublicAddr string) (types.AppServer, error) {
 	parsedProfileARN, err := arn.Parse(profile.Arn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	applicationName := profile.Name + "-" + integrationName
+	applicationName := profile.Name
 
 	labels := make(map[string]string, len(profile.Tags))
 	for tagKey, tagValue := range profile.Tags {
@@ -552,7 +594,20 @@ func convertProfile(params AWSRolesAnywhereProfileSyncerParams, profile *integra
 		}
 	}
 
-	appURL := utils.DefaultAppPublicAddr(strings.ToLower(applicationName), proxyPublicAddr)
+	// Sanitize the user-supplied portion first so all-invalid inputs
+	// (e.g. "___") error out instead of silently collapsing to the
+	// integration name and colliding with sibling profiles.
+	applicationName = sanitizeProfileName(applicationName)
+	if applicationName == "" {
+		return nil, trace.BadParameter(
+			"profile %q has no DNS-safe characters in its name; set the %q tag to override",
+			profile.Name, types.AWSRolesAnywhereProfileNameOverrideLabel)
+	}
+	// Append the integration suffix so a tagger with iam:TagResource
+	// on one profile cannot pick a name that collides with another
+	// integration or a static-config app.
+	applicationName = applicationName + "-" + integrationName
+	appURL := utils.DefaultAppPublicAddr(applicationName, proxyPublicAddr)
 
 	labels[types.AWSAccountIDLabel] = parsedProfileARN.AccountID
 	labels[constants.AWSAccountIDLabel] = parsedProfileARN.AccountID

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"regexp"
 	"strings"
 	"time"
 
@@ -524,7 +523,7 @@ func processProfile(ctx context.Context, req processProfileRequest) error {
 	appName := appServer.GetApp().GetName()
 	if existing, ok := req.SeenAppNames[appName]; ok {
 		return trace.BadParameter(
-			"app name %q for profile %q conflicts with profile %q which was upserted first. Rename either profile or set %q on one of them to a unique value.",
+			"app name %q for profile %q conflicts with profile %q which was upserted first. Rename either profile or set the %q tag on one of them to a unique value.",
 			appName, req.Profile.Name, existing, types.AWSRolesAnywhereProfileNameOverrideLabel)
 	}
 
@@ -552,17 +551,17 @@ func awsConsoleURLForARN(parsedARN arn.ARN) string {
 	}
 }
 
-// invalidAppNameChar matches any char not valid in a DNS-1123
-// subdomain after lowercasing. Dots are kept as label separators.
-var invalidAppNameChar = regexp.MustCompile(`[^a-z0-9.\-]`)
-
 // sanitizeProfileName rewrites a raw AWS profile name to satisfy
 // DNS-1123 subdomain: lowercase, hyphen-substitute invalid chars,
 // and trim hyphens from each label. Runs of hyphens are kept;
 // DNS-1123 allows them and preserving them avoids extra collisions.
+// AWS IAM Roles Anywhere profile names allow `[ a-zA-Z0-9-_]*`, so
+// after lowercasing the only DNS-1123-invalid chars are space and
+// underscore.
 func sanitizeProfileName(name string) string {
 	name = strings.ToLower(name)
-	name = invalidAppNameChar.ReplaceAllString(name, "-")
+	name = strings.ReplaceAll(name, " ", "-")
+	name = strings.ReplaceAll(name, "_", "-")
 	parts := strings.Split(name, ".")
 	out := make([]string, 0, len(parts))
 	for _, p := range parts {

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -552,7 +552,8 @@ func convertProfile(params AWSRolesAnywhereProfileSyncerParams, profile *integra
 		}
 	}
 
-	appURL := utils.DefaultAppPublicAddr(strings.ToLower(applicationName), proxyPublicAddr)
+	applicationName = strings.ToLower(applicationName)
+	appURL := utils.DefaultAppPublicAddr(applicationName, proxyPublicAddr)
 
 	labels[types.AWSAccountIDLabel] = parsedProfileARN.AccountID
 	labels[constants.AWSAccountIDLabel] = parsedProfileARN.AccountID

--- a/lib/integrations/awsra/profile_syncer_test.go
+++ b/lib/integrations/awsra/profile_syncer_test.go
@@ -231,10 +231,10 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 
 		params := baseParams(serverClient)
 		params.rolesAnywhereClient = &mockRolesAnywhereClient{
-			profiles: []ratypes.ProfileDetail{
+			pages: [][]ratypes.ProfileDetail{{
 				syncProfile,
 				disabledProfile,
-			},
+			}},
 			tags: exampleProfileTags,
 		}
 
@@ -256,11 +256,11 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 
 		params := baseParams(serverClient)
 		params.rolesAnywhereClient = &mockRolesAnywhereClient{
-			profiles: []ratypes.ProfileDetail{
+			pages: [][]ratypes.ProfileDetail{{
 				syncProfile,
 				disabledProfile,
 				exampleProfile,
-			},
+			}},
 			tags: exampleProfileTags,
 		}
 
@@ -308,9 +308,9 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 			},
 		}
 		params.rolesAnywhereClient = &mockRolesAnywhereClient{
-			profiles: []ratypes.ProfileDetail{
+			pages: [][]ratypes.ProfileDetail{{
 				exampleProfile,
-			},
+			}},
 			tags: tags,
 		}
 
@@ -349,9 +349,9 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 			},
 		}
 		params.rolesAnywhereClient = &mockRolesAnywhereClient{
-			profiles: []ratypes.ProfileDetail{
+			pages: [][]ratypes.ProfileDetail{{
 				exampleProfile,
-			},
+			}},
 			tags: tags,
 		}
 
@@ -395,8 +395,8 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 
 		params := baseParams(serverClient)
 		params.rolesAnywhereClient = &mockRolesAnywhereClient{
-			profiles: []ratypes.ProfileDetail{profileA, profileB},
-			tags:     map[string][]ratypes.Tag{},
+			pages: [][]ratypes.ProfileDetail{{profileA, profileB}},
+			tags:  map[string][]ratypes.Tag{},
 		}
 
 		synctest.Test(t, func(t *testing.T) {
@@ -538,10 +538,10 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 
 				params := baseParams(serverClient)
 				params.rolesAnywhereClient = &mockRolesAnywhereClient{
-					profiles: []ratypes.ProfileDetail{
+					pages: [][]ratypes.ProfileDetail{{
 						syncProfile,
 						appProfile,
-					},
+					}},
 					tags: map[string][]ratypes.Tag{},
 				}
 
@@ -584,10 +584,10 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 
 		params := baseParams(serverClient)
 		params.rolesAnywhereClient = &mockRolesAnywhereClient{
-			profiles: []ratypes.ProfileDetail{
+			pages: [][]ratypes.ProfileDetail{{
 				syncProfile,
 				invalidProfile,
-			},
+			}},
 			tags: map[string][]ratypes.Tag{},
 		}
 
@@ -647,9 +647,9 @@ func TestSanitizeProfileName(t *testing.T) {
 			want:  "foo",
 		},
 		{
-			name:  "consecutive invalid chars collapsed",
+			name:  "consecutive invalid chars become consecutive hyphens",
 			input: "foo__bar",
-			want:  "foo-bar",
+			want:  "foo--bar",
 		},
 		{
 			name:  "dotted name preserved",
@@ -785,22 +785,14 @@ func TestAWSConsoleURLForARN(t *testing.T) {
 }
 
 type mockRolesAnywhereClient struct {
-	profiles []ratypes.ProfileDetail
-	// pages, when non-nil, takes precedence over profiles and returns
-	// one element per ListProfiles call along with a NextToken pointing
-	// at the following index, exercising the page loop in
-	// syncProfileForIntegration.
+	// pages returns one element per ListProfiles call with a NextToken
+	// pointing at the following index. Single-page tests set one entry.
 	pages [][]ratypes.ProfileDetail
 	tags  map[string][]ratypes.Tag
 }
 
 // Lists all profiles in the authenticated account and Amazon Web Services Region.
 func (m *mockRolesAnywhereClient) ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error) {
-	if len(m.pages) == 0 {
-		return &rolesanywhere.ListProfilesOutput{
-			Profiles: m.profiles,
-		}, nil
-	}
 	idx := 0
 	if params.NextToken != nil {
 		n, err := strconv.Atoi(aws.ToString(params.NextToken))

--- a/lib/integrations/awsra/profile_syncer_test.go
+++ b/lib/integrations/awsra/profile_syncer_test.go
@@ -20,6 +20,8 @@ package awsra
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -28,15 +30,19 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
 	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
+	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -269,7 +275,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 
 			require.Len(t, serverClient.appServers, 1)
 			appServer := serverClient.appServers[0]
-			require.Equal(t, "ExampleProfile-test-integration", appServer.GetName())
+			require.Equal(t, "exampleprofile-test-integration", appServer.GetName())
 			require.Equal(t, "123456789012", appServer.GetApp().GetAWSAccountID())
 			require.True(t, appServer.GetApp().GetAWSRolesAnywhereAcceptRoleSessionName())
 			require.Equal(t, "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1", appServer.GetApp().GetAWSRolesAnywhereProfileARN())
@@ -319,7 +325,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 
 			require.Len(t, serverClient.appServers, 1)
 			appServer := serverClient.appServers[0]
-			require.Equal(t, "ProfileCustomName", appServer.GetName())
+			require.Equal(t, "profilecustomname-test-integration", appServer.GetName())
 			require.Equal(t, "123456789012", appServer.GetApp().GetAWSAccountID())
 			require.True(t, appServer.GetApp().GetAWSRolesAnywhereAcceptRoleSessionName())
 			require.Equal(t, "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1", appServer.GetApp().GetAWSRolesAnywhereProfileARN())
@@ -339,7 +345,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 		params := baseParams(serverClient)
 		tags := map[string][]ratypes.Tag{
 			aws.ToString(exampleProfile.ProfileArn): {
-				{Key: aws.String("TeleportApplicationName"), Value: aws.String("``invalid host $ name")},
+				{Key: aws.String("TeleportApplicationName"), Value: aws.String("___")},
 			},
 		}
 		params.rolesAnywhereClient = &mockRolesAnywhereClient{
@@ -369,6 +375,99 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 		})
 	})
 
+	t.Run("colliding sanitized names report an error", func(t *testing.T) {
+		serverClient := baseServerClient(t)
+
+		// prod_ops and prod-ops sanitize to the same name; the second
+		// must error rather than overwrite the first.
+		profileA := ratypes.ProfileDetail{
+			Name:                  aws.String("prod_ops"),
+			ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid-a"),
+			Enabled:               aws.Bool(true),
+			AcceptRoleSessionName: aws.Bool(true),
+		}
+		profileB := ratypes.ProfileDetail{
+			Name:                  aws.String("prod-ops"),
+			ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid-b"),
+			Enabled:               aws.Bool(true),
+			AcceptRoleSessionName: aws.Bool(true),
+		}
+
+		params := baseParams(serverClient)
+		params.rolesAnywhereClient = &mockRolesAnywhereClient{
+			profiles: []ratypes.ProfileDetail{profileA, profileB},
+			tags:     map[string][]ratypes.Tag{},
+		}
+
+		synctest.Test(t, func(t *testing.T) {
+			go func() {
+				err := RunAWSRolesAnywhereProfileSyncerWhileLocked(t.Context(), params)
+				assert.NoError(t, err)
+			}()
+
+			synctest.Wait()
+
+			require.Len(t, serverClient.appServers, 1)
+			require.Equal(t, "prod-ops-test-integration", serverClient.appServers[0].GetName())
+			require.Equal(t, aws.ToString(profileA.ProfileArn), serverClient.appServers[0].GetApp().GetAWSRolesAnywhereProfileARN())
+
+			status := serverClient.integrations[integrationWithProfileSync.GetName()].GetStatus()
+			require.NotNil(t, status)
+			lastSyncSummary := status.AWSRolesAnywhere.LastProfileSync
+			require.Equal(t, types.IntegrationAWSRolesAnywhereProfileSyncStatusError, lastSyncSummary.Status)
+			require.Equal(t, int32(1), lastSyncSummary.SyncedProfiles)
+			require.Contains(t, lastSyncSummary.ErrorMessage, "prod-ops-test-integration")
+			require.Contains(t, lastSyncSummary.ErrorMessage, "prod_ops")
+		})
+	})
+
+	t.Run("colliding sanitized names across pages report an error", func(t *testing.T) {
+		// Returns the collision across two pages, exercising the
+		// cross-page detection path (seenAppNames declared outside
+		// the page loop).
+		serverClient := baseServerClient(t)
+
+		profileA := ratypes.ProfileDetail{
+			Name:                  aws.String("prod_ops"),
+			ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid-a"),
+			Enabled:               aws.Bool(true),
+			AcceptRoleSessionName: aws.Bool(true),
+		}
+		profileB := ratypes.ProfileDetail{
+			Name:                  aws.String("prod-ops"),
+			ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid-b"),
+			Enabled:               aws.Bool(true),
+			AcceptRoleSessionName: aws.Bool(true),
+		}
+
+		params := baseParams(serverClient)
+		params.rolesAnywhereClient = &mockRolesAnywhereClient{
+			pages: [][]ratypes.ProfileDetail{{profileA}, {profileB}},
+			tags:  map[string][]ratypes.Tag{},
+		}
+
+		synctest.Test(t, func(t *testing.T) {
+			go func() {
+				err := RunAWSRolesAnywhereProfileSyncerWhileLocked(t.Context(), params)
+				assert.NoError(t, err)
+			}()
+
+			synctest.Wait()
+
+			require.Len(t, serverClient.appServers, 1)
+			require.Equal(t, "prod-ops-test-integration", serverClient.appServers[0].GetName())
+			require.Equal(t, aws.ToString(profileA.ProfileArn), serverClient.appServers[0].GetApp().GetAWSRolesAnywhereProfileARN())
+
+			status := serverClient.integrations[integrationWithProfileSync.GetName()].GetStatus()
+			require.NotNil(t, status)
+			lastSyncSummary := status.AWSRolesAnywhere.LastProfileSync
+			require.Equal(t, types.IntegrationAWSRolesAnywhereProfileSyncStatusError, lastSyncSummary.Status)
+			require.Equal(t, int32(1), lastSyncSummary.SyncedProfiles)
+			require.Contains(t, lastSyncSummary.ErrorMessage, "prod-ops-test-integration")
+			require.Contains(t, lastSyncSummary.ErrorMessage, "prod_ops")
+		})
+	})
+
 	t.Run("app server console URL is partition-specific", func(t *testing.T) {
 		for _, tt := range []struct {
 			name          string
@@ -390,7 +489,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 				trustAnchor:   "arn:aws-us-gov:rolesanywhere:us-gov-west-1:123456789012:trust-anchor/ExampleTrustAnchor",
 				roleARN:       "arn:aws-us-gov:iam::123456789012:role/SyncRole",
 				expectedURI:   constants.AWSUSGovConsoleURL,
-				expectedAppID: "GovProfile-govcloud-integration",
+				expectedAppID: "govprofile-govcloud-integration",
 			},
 			{
 				name:          "china",
@@ -401,7 +500,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 				trustAnchor:   "arn:aws-cn:rolesanywhere:cn-north-1:123456789012:trust-anchor/ExampleTrustAnchor",
 				roleARN:       "arn:aws-cn:iam::123456789012:role/SyncRole",
 				expectedURI:   constants.AWSCNConsoleURL,
-				expectedAppID: "ChinaProfile-china-integration",
+				expectedAppID: "chinaprofile-china-integration",
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
@@ -514,6 +613,140 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 	})
 }
 
+func TestSanitizeProfileName(t *testing.T) {
+	// Inputs and wants are raw profile.Name; the integration suffix
+	// is appended later by convertProfile.
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "already valid",
+			input: "prod-ops",
+			want:  "prod-ops",
+		},
+		{
+			name:  "underscore replaced",
+			input: "prod_ops",
+			want:  "prod-ops",
+		},
+		{
+			name:  "space replaced",
+			input: "my profile",
+			want:  "my-profile",
+		},
+		{
+			name:  "uppercase lowercased",
+			input: "ProdOps",
+			want:  "prodops",
+		},
+		{
+			name:  "leading underscore stripped",
+			input: "_foo",
+			want:  "foo",
+		},
+		{
+			name:  "consecutive invalid chars collapsed",
+			input: "foo__bar",
+			want:  "foo-bar",
+		},
+		{
+			name:  "dotted name preserved",
+			input: "env.prod",
+			want:  "env.prod",
+		},
+		{
+			name:  "underscore adjacent to dot",
+			input: "env_.prod_",
+			want:  "env.prod",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, sanitizeProfileName(tt.input))
+		})
+	}
+}
+
+func TestConvertProfile(t *testing.T) {
+	tests := []struct {
+		name        string
+		profileName string
+		tags        map[string]string
+		wantAppName string
+	}{
+		{
+			name:        "valid name unchanged",
+			profileName: "ExampleProfile",
+			wantAppName: "exampleprofile-test-integration",
+		},
+		{
+			name:        "underscores in profile name replaced with hyphens",
+			profileName: "prod_ops",
+			wantAppName: "prod-ops-test-integration",
+		},
+		{
+			name:        "spaces in profile name replaced with hyphens",
+			profileName: "my profile",
+			wantAppName: "my-profile-test-integration",
+		},
+		{
+			name:        "override tag sanitized",
+			profileName: "ExampleProfile",
+			tags:        map[string]string{types.AWSRolesAnywhereProfileNameOverrideLabel: "custom_override name"},
+			// The integration suffix is preserved on override to
+			// prevent a single-profile tagger from picking a name
+			// that collides with a different integration.
+			wantAppName: "custom-override-name-test-integration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := &integrationv1.RolesAnywhereProfile{
+				Name:    tt.profileName,
+				Arn:     "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1",
+				Enabled: true,
+				Tags:    tt.tags,
+			}
+
+			appServer, err := convertProfile(AWSRolesAnywhereProfileSyncerParams{
+				Clock:    clockwork.NewFakeClock(),
+				HostUUID: "test-host-uuid",
+			}, profile, "test-integration", "proxy.example.com")
+			require.NoError(t, err)
+			require.Equal(t, tt.wantAppName, appServer.GetApp().GetName())
+			require.Equal(t, tt.wantAppName, appServer.GetName())
+			// Round-trip through ValidateApp so a runtime heartbeat
+			// rejection surfaces here at sync time.
+			proxyGetter := &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}
+			require.NoError(t, services.ValidateApp(appServer.GetApp(), proxyGetter))
+		})
+	}
+}
+
+// mockProxyGetter is a test implementation of services.ProxyGetter.
+type mockProxyGetter struct {
+	addrs []string
+}
+
+func (m *mockProxyGetter) GetProxies() ([]types.Server, error) {
+	servers := make([]types.Server, 0, len(m.addrs))
+	for _, addr := range m.addrs {
+		servers = append(servers, &types.ServerV2{
+			Spec: types.ServerSpecV2{PublicAddrs: []string{addr}},
+		})
+	}
+	return servers, nil
+}
+
+func (m *mockProxyGetter) ListProxyServers(_ context.Context, _ int, _ string) ([]types.Server, string, error) {
+	servers, _ := m.GetProxies()
+	return servers, "", nil
+}
+
 func TestAWSConsoleURLForARN(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -553,13 +786,39 @@ func TestAWSConsoleURLForARN(t *testing.T) {
 
 type mockRolesAnywhereClient struct {
 	profiles []ratypes.ProfileDetail
-	tags     map[string][]ratypes.Tag
+	// pages, when non-nil, takes precedence over profiles and returns
+	// one element per ListProfiles call along with a NextToken pointing
+	// at the following index, exercising the page loop in
+	// syncProfileForIntegration.
+	pages [][]ratypes.ProfileDetail
+	tags  map[string][]ratypes.Tag
 }
 
 // Lists all profiles in the authenticated account and Amazon Web Services Region.
 func (m *mockRolesAnywhereClient) ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error) {
+	if len(m.pages) == 0 {
+		return &rolesanywhere.ListProfilesOutput{
+			Profiles: m.profiles,
+		}, nil
+	}
+	idx := 0
+	if params.NextToken != nil {
+		n, err := strconv.Atoi(aws.ToString(params.NextToken))
+		if err != nil {
+			return nil, trace.Wrap(err, "malformed page token %q", aws.ToString(params.NextToken))
+		}
+		idx = n
+	}
+	if idx >= len(m.pages) {
+		return &rolesanywhere.ListProfilesOutput{}, nil
+	}
+	var nextToken *string
+	if idx+1 < len(m.pages) {
+		nextToken = aws.String(fmt.Sprintf("%d", idx+1))
+	}
 	return &rolesanywhere.ListProfilesOutput{
-		Profiles: m.profiles,
+		Profiles:  m.pages[idx],
+		NextToken: nextToken,
 	}, nil
 }
 

--- a/lib/integrations/awsra/profile_syncer_test.go
+++ b/lib/integrations/awsra/profile_syncer_test.go
@@ -269,7 +269,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 
 			require.Len(t, serverClient.appServers, 1)
 			appServer := serverClient.appServers[0]
-			require.Equal(t, "ExampleProfile-test-integration", appServer.GetName())
+			require.Equal(t, "exampleprofile-test-integration", appServer.GetName())
 			require.Equal(t, "123456789012", appServer.GetApp().GetAWSAccountID())
 			require.True(t, appServer.GetApp().GetAWSRolesAnywhereAcceptRoleSessionName())
 			require.Equal(t, "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1", appServer.GetApp().GetAWSRolesAnywhereProfileARN())
@@ -319,7 +319,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 
 			require.Len(t, serverClient.appServers, 1)
 			appServer := serverClient.appServers[0]
-			require.Equal(t, "ProfileCustomName", appServer.GetName())
+			require.Equal(t, "profilecustomname", appServer.GetName())
 			require.Equal(t, "123456789012", appServer.GetApp().GetAWSAccountID())
 			require.True(t, appServer.GetApp().GetAWSRolesAnywhereAcceptRoleSessionName())
 			require.Equal(t, "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1", appServer.GetApp().GetAWSRolesAnywhereProfileARN())
@@ -390,7 +390,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 				trustAnchor:   "arn:aws-us-gov:rolesanywhere:us-gov-west-1:123456789012:trust-anchor/ExampleTrustAnchor",
 				roleARN:       "arn:aws-us-gov:iam::123456789012:role/SyncRole",
 				expectedURI:   constants.AWSUSGovConsoleURL,
-				expectedAppID: "GovProfile-govcloud-integration",
+				expectedAppID: "govprofile-govcloud-integration",
 			},
 			{
 				name:          "china",
@@ -401,7 +401,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 				trustAnchor:   "arn:aws-cn:rolesanywhere:cn-north-1:123456789012:trust-anchor/ExampleTrustAnchor",
 				roleARN:       "arn:aws-cn:iam::123456789012:role/SyncRole",
 				expectedURI:   constants.AWSCNConsoleURL,
-				expectedAppID: "ChinaProfile-china-integration",
+				expectedAppID: "chinaprofile-china-integration",
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -1067,6 +1067,11 @@ func (c *Controller) handleAppServerHB(handle *upstreamHandle, appServer *types.
 		return trace.AccessDenied("incorrect app server scope (expected %q, got %q)", handle.Hello().GetScope(), appServer.Scope)
 	}
 
+	// Older agents send mixed-case names and URL-shaped public_addr;
+	// normalize before deriving the cache key so it matches the
+	// backend write.
+	services.NormalizeAppServerForHeartbeat(appServer)
+
 	if handle.appServers == nil {
 		handle.appServers = make(map[resourceKey]*heartBeatInfo[*types.AppServerV3])
 	}
@@ -1290,7 +1295,19 @@ func (c *Controller) keepAliveAppServer(handle *upstreamHandle, now time.Time, n
 	}
 
 	srv.resource.SetExpiry(now.Add(c.serverTTL).UTC())
-	if _, err := c.auth.UnconditionalUpdateApplicationServer(c.closeContext, srv.resource); err == nil {
+	// retryUpsert is set when the previous UpsertApplicationServer call
+	// failed. Route the retry back through UpsertApplicationServer so
+	// ValidateApp re-runs - UnconditionalUpdate would let an unvalidated
+	// app_server record slip through. Steady-state keepalives skip
+	// ValidateApp via UnconditionalUpdate; the record was already
+	// validated on its first successful upsert.
+	var err error
+	if srv.retryUpsert {
+		_, err = c.auth.UpsertApplicationServer(c.closeContext, srv.resource)
+	} else {
+		_, err = c.auth.UnconditionalUpdateApplicationServer(c.closeContext, srv.resource)
+	}
+	if err == nil {
 		if srv.retryUpsert {
 			c.testEvent(appUpsertRetryOk)
 		} else {

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -939,13 +939,11 @@ func testAppServerHeartbeatNormalization(t *testing.T) {
 		withServerKeepAlive(time.Millisecond*200),
 		withTestEventsChannel(events),
 	)
-	defer controller.Close()
-
 	upstream, downstream := client.InventoryControlStreamPipe()
 	t.Cleanup(func() {
-		controller.Close()
 		upstream.Close()
 		downstream.Close()
+		controller.Close()
 	})
 
 	go func() {
@@ -1029,13 +1027,11 @@ func testAppKeepAliveRetryRoutesThroughUpsert(t *testing.T) {
 		withServerKeepAlive(time.Millisecond*200),
 		withTestEventsChannel(events),
 	)
-	defer controller.Close()
-
 	upstream, downstream := client.InventoryControlStreamPipe()
 	t.Cleanup(func() {
-		controller.Close()
 		upstream.Close()
 		downstream.Close()
+		controller.Close()
 	})
 
 	go func() {

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -916,6 +916,199 @@ func testAppServerBasics(t *testing.T) {
 	require.Zero(t, rc.count())
 }
 
+// TestAppServerHeartbeatNormalization verifies handleAppServerHB calls
+// services.NormalizeAppServerForHeartbeat on the inventory control
+// stream path so an older agent that heartbeats a mixed-case name and
+// URL-shaped public_addr lands the same lowercased, bare-hostname
+// resource as the gRPC handler would. A regression that dropped the
+// normalize call would still leave the gRPC test passing.
+func TestAppServerHeartbeatNormalization(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, testAppServerHeartbeatNormalization)
+}
+
+func testAppServerHeartbeatNormalization(t *testing.T) {
+	const serverID = "test-server"
+	ctx := t.Context()
+	events := make(chan testEvent, 1024)
+
+	auth := &fakeAuth{}
+	controller := NewController(
+		auth,
+		usagereporter.DiscardUsageReporter{},
+		withServerKeepAlive(time.Millisecond*200),
+		withTestEventsChannel(events),
+	)
+	defer controller.Close()
+
+	upstream, downstream := client.InventoryControlStreamPipe()
+	t.Cleanup(func() {
+		controller.Close()
+		upstream.Close()
+		downstream.Close()
+	})
+
+	go func() {
+		for {
+			select {
+			case msg := <-downstream.Recv():
+				downstream.Send(ctx, &proto.UpstreamInventoryPong{
+					ID: msg.(*proto.DownstreamInventoryPing).GetID(),
+				})
+			case <-downstream.Done():
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	controller.RegisterControlStream(upstream, &proto.UpstreamInventoryHello{
+		ServerID: serverID,
+		Version:  teleport.Version,
+		Services: types.SystemRoles{types.RoleApp}.StringSlice(),
+	})
+
+	h, ok := controller.GetControlStream(serverID)
+	require.True(t, ok)
+	handle := h.(*upstreamHandle)
+
+	err := downstream.Send(ctx, &proto.InventoryHeartbeat{
+		AppServer: &types.AppServerV3{
+			Metadata: types.Metadata{
+				Name: "MixedCaseApp",
+			},
+			Spec: types.AppServerSpecV3{
+				HostID: serverID,
+				App: &types.AppV3{
+					Kind:    types.KindApp,
+					Version: types.V3,
+					Metadata: types.Metadata{
+						Name: "MixedCaseApp",
+					},
+					Spec: types.AppSpecV3{
+						URI:        "http://localhost:8080",
+						PublicAddr: "https://mixedcaseapp.example.com:8443/start",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	awaitEvents(t, events,
+		expect(appUpsertOk),
+		deny(appUpsertErr, handlerClose),
+	)
+	synctest.Wait()
+
+	expectedKey := resourceKey{hostID: serverID, name: "mixedcaseapp"}
+	srv, ok := handle.appServers[expectedKey]
+	require.True(t, ok, "expected handle.appServers key %+v; got %+v", expectedKey, handle.appServers)
+	require.Equal(t, "mixedcaseapp", srv.resource.GetApp().GetName())
+	require.Equal(t, "mixedcaseapp", srv.resource.GetName())
+	require.Equal(t, "mixedcaseapp.example.com", srv.resource.GetApp().GetPublicAddr())
+}
+
+// TestAppKeepAliveRetryRoutesThroughUpsert asserts a retry tick
+// re-runs Upsert while steady-state uses UnconditionalUpdate.
+func TestAppKeepAliveRetryRoutesThroughUpsert(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, testAppKeepAliveRetryRoutesThroughUpsert)
+}
+
+func testAppKeepAliveRetryRoutesThroughUpsert(t *testing.T) {
+	const serverID = "test-server"
+	ctx := t.Context()
+	events := make(chan testEvent, 1024)
+
+	auth := &fakeAuth{}
+	controller := NewController(
+		auth,
+		usagereporter.DiscardUsageReporter{},
+		withServerKeepAlive(time.Millisecond*200),
+		withTestEventsChannel(events),
+	)
+	defer controller.Close()
+
+	upstream, downstream := client.InventoryControlStreamPipe()
+	t.Cleanup(func() {
+		controller.Close()
+		upstream.Close()
+		downstream.Close()
+	})
+
+	go func() {
+		for {
+			select {
+			case msg := <-downstream.Recv():
+				downstream.Send(ctx, &proto.UpstreamInventoryPong{
+					ID: msg.(*proto.DownstreamInventoryPing).GetID(),
+				})
+			case <-downstream.Done():
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	controller.RegisterControlStream(upstream, &proto.UpstreamInventoryHello{
+		ServerID: serverID,
+		Version:  teleport.Version,
+		Services: types.SystemRoles{types.RoleApp}.StringSlice(),
+	})
+
+	auth.mu.Lock()
+	auth.failUpserts = 1
+	auth.mu.Unlock()
+
+	err := downstream.Send(ctx, &proto.InventoryHeartbeat{
+		AppServer: &types.AppServerV3{
+			Metadata: types.Metadata{Name: "app-retry"},
+			Spec: types.AppServerSpecV3{
+				HostID: serverID,
+				App: &types.AppV3{
+					Kind:    types.KindApp,
+					Version: types.V3,
+					Metadata: types.Metadata{
+						Name:   "app-retry",
+						Labels: map[string]string{"foo": uuid.NewString()},
+					},
+					Spec: types.AppSpecV3{},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	awaitEvents(t, events,
+		expect(appUpsertErr, appUpsertRetryOk),
+		deny(appKeepAliveErr, handlerClose),
+	)
+
+	auth.mu.Lock()
+	upserts := auth.upserts
+	keepalives := auth.keepalives
+	auth.mu.Unlock()
+
+	require.Equal(t, 2, upserts, "retry tick must route through Upsert")
+	require.Zero(t, keepalives, "retry tick must not use UnconditionalUpdate")
+
+	awaitEvents(t, events,
+		expect(appKeepAliveOk),
+		deny(appKeepAliveErr, handlerClose),
+	)
+
+	auth.mu.Lock()
+	upsertsAfter := auth.upserts
+	keepalivesAfter := auth.keepalives
+	auth.mu.Unlock()
+
+	require.Equal(t, 2, upsertsAfter, "steady-state keepalive must not call Upsert")
+	require.Positive(t, keepalivesAfter, "steady-state keepalive must call UnconditionalUpdate")
+}
+
 // TestDatabaseServerBasics verifies basic expected behaviors for a single control stream heartbeating
 // a database server.
 func TestDatabaseServerBasics(t *testing.T) {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2990,7 +2990,7 @@ func (process *TeleportProcess) initAuthService() error {
 			Cache:             authServer.Cache,
 			StatusReporter:    authServer.Services,
 			Backend:           process.backend,
-			AppServerUpserter: authServer.Services,
+			AppServerUpserter: authServer,
 			HostUUID:          hostUUID,
 		}))
 	})

--- a/lib/service/servicecfg/app.go
+++ b/lib/service/servicecfg/app.go
@@ -20,7 +20,6 @@ package servicecfg
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -186,25 +185,17 @@ func (a *App) CheckAndSetDefaults() error {
 			return trace.BadParameter("missing application %q URI", a.Name)
 		}
 	}
-	// Check if the application name is a valid subdomain. Don't allow names that
-	// are invalid subdomains because for trusted clusters the name is used to
-	// construct the domain that the application will be available at.
-	if errs := validation.IsDNS1035Label(a.Name); len(errs) > 0 {
-		return trace.BadParameter("application name %q must be a lower case valid DNS subdomain: https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", a.Name)
+	// Stricter than the dynamic write path: label (no dots), max 63.
+	// Dynamic resources allow subdomain because integrations produce
+	// dotted names.
+	if errs := validation.IsDNS1123Label(a.Name); len(errs) > 0 {
+		return trace.BadParameter("application name %q must be a valid DNS label (lowercase alphanumeric or '-', must start and end with alphanumeric, max 63 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", a.Name)
 	}
-	// Parse and validate URL.
 	if _, err := url.Parse(a.URI); err != nil {
 		return trace.BadParameter("application %q URI invalid: %v", a.Name, err)
 	}
-	// If a port was specified or an IP address was provided for the public
-	// address, return an error.
-	if a.PublicAddr != "" {
-		if _, _, err := net.SplitHostPort(a.PublicAddr); err == nil {
-			return trace.BadParameter("application %q public_addr %q can not contain a port, applications will be available on the same port as the web proxy", a.Name, a.PublicAddr)
-		}
-		if net.ParseIP(a.PublicAddr) != nil {
-			return trace.BadParameter("application %q public_addr %q can not be an IP address, Teleport Application Access uses DNS names for routing", a.Name, a.PublicAddr)
-		}
+	if err := services.ValidatePublicAddr(a.Name, a.PublicAddr); err != nil {
+		return trace.Wrap(err)
 	}
 	// Mark the app as coming from the static configuration.
 	if a.StaticLabels == nil {

--- a/lib/service/servicecfg/app.go
+++ b/lib/service/servicecfg/app.go
@@ -19,7 +19,9 @@
 package servicecfg
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -175,24 +177,33 @@ func (a *App) CheckAndSetDefaults() error {
 			return trace.BadParameter("missing application %q URI", a.Name)
 		}
 	}
-	// Check if the application name is a valid subdomain. Don't allow names that
-	// are invalid subdomains because for trusted clusters the name is used to
-	// construct the domain that the application will be available at.
-	if errs := validation.IsDNS1035Label(a.Name); len(errs) > 0 {
-		return trace.BadParameter("application name %q must be a lower case valid DNS subdomain: https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", a.Name)
+	// Auto-lowercase the app name to avoid crashing on uppercase names.
+	// Log a warning so operators know to update their config.
+	// CheckAndSetDefaults has no context parameter, so context.TODO is used.
+	if name := strings.ToLower(a.Name); name != a.Name {
+		slog.WarnContext(context.TODO(), "Application name contains uppercase letters, using lowercase instead. Update your configuration to use the lowercase name.", "original", a.Name, "lowercase", name)
+		a.Name = name
+	}
+	// Check if the application name is a valid subdomain (RFC 1123). App names
+	// become subdomains (appName.proxyHost), so they must comply.
+	if errs := validation.IsDNS1123Label(a.Name); len(errs) > 0 {
+		return trace.BadParameter("application name %q must be a valid DNS label (lowercase alphanumeric or '-', must start and end with alphanumeric, max 63 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", a.Name)
 	}
 	// Parse and validate URL.
 	if _, err := url.Parse(a.URI); err != nil {
 		return trace.BadParameter("application %q URI invalid: %v", a.Name, err)
 	}
-	// If a port was specified or an IP address was provided for the public
-	// address, return an error.
+	// Validate public_addr is a bare DNS hostname - no scheme, port, or IP.
 	if a.PublicAddr != "" {
-		if _, _, err := net.SplitHostPort(a.PublicAddr); err == nil {
-			return trace.BadParameter("application %q public_addr %q can not contain a port, applications will be available on the same port as the web proxy", a.Name, a.PublicAddr)
+		if strings.Contains(a.PublicAddr, "://") {
+			return trace.BadParameter("application %q public_addr %q must not contain a URI scheme; use a bare hostname", a.Name, a.PublicAddr)
 		}
-		if net.ParseIP(a.PublicAddr) != nil {
-			return trace.BadParameter("application %q public_addr %q can not be an IP address, Teleport Application Access uses DNS names for routing", a.Name, a.PublicAddr)
+		if _, _, err := net.SplitHostPort(a.PublicAddr); err == nil {
+			return trace.BadParameter("application %q public_addr %q must not contain a port, applications will be available on the same port as the web proxy", a.Name, a.PublicAddr)
+		}
+		stripped := strings.TrimPrefix(strings.TrimSuffix(a.PublicAddr, "]"), "[")
+		if net.ParseIP(stripped) != nil {
+			return trace.BadParameter("application %q public_addr %q must not be an IP address, Teleport Application Access uses DNS names for routing", a.Name, a.PublicAddr)
 		}
 	}
 	// Mark the app as coming from the static configuration.

--- a/lib/service/servicecfg/app.go
+++ b/lib/service/servicecfg/app.go
@@ -184,6 +184,11 @@ func (a *App) CheckAndSetDefaults() error {
 		slog.WarnContext(context.TODO(), "Application name contains uppercase letters, using lowercase instead. Update your configuration to use the lowercase name.", "original", a.Name, "lowercase", name)
 		a.Name = name
 	}
+	// Also lowercase RequiredAppNames entries so they match their
+	// referents after those apps are also lowercased.
+	for i, n := range a.RequiredAppNames {
+		a.RequiredAppNames[i] = strings.ToLower(n)
+	}
 	// Check if the application name is a valid subdomain (RFC 1123). App names
 	// become subdomains (appName.proxyHost), so they must comply.
 	if errs := validation.IsDNS1123Label(a.Name); len(errs) > 0 {

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -136,7 +136,7 @@ func TestCheckApp(t *testing.T) {
 				Name: "-foo",
 				URI:  "http://localhost",
 			},
-			err: "must be a lower case valid DNS subdomain",
+			err: "must be a valid DNS label",
 		},
 		{
 			desc: `subdomain cannot contain the exclamation mark character "!"`,
@@ -144,7 +144,7 @@ func TestCheckApp(t *testing.T) {
 				Name: "foo!bar",
 				URI:  "http://localhost",
 			},
-			err: "must be a lower case valid DNS subdomain",
+			err: "must be a valid DNS label",
 		},
 		{
 			desc: "subdomain of length 63 characters is valid (maximum length)",
@@ -159,7 +159,121 @@ func TestCheckApp(t *testing.T) {
 				Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				URI:  "http://localhost",
 			},
-			err: "must be a lower case valid DNS subdomain",
+			err: "must be a valid DNS label",
+		},
+		{
+			desc: "leading digit is accepted (RFC 1123)",
+			inApp: App{
+				Name: "1stapp",
+				URI:  "http://localhost",
+			},
+		},
+		{
+			desc: "uppercase is rejected",
+			inApp: App{
+				Name: "MyApp",
+				URI:  "http://localhost",
+			},
+			err: "must be a valid DNS label",
+		},
+		{
+			desc: "public_addr with scheme is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "https://foo.example.com",
+			},
+			err: "must be a valid DNS name",
+		},
+		{
+			desc: "public_addr with mixed case is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "MyApp.example.com",
+			},
+			err: "must be a valid DNS name",
+		},
+		{
+			desc: "public_addr with port is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "foo.example.com:443",
+			},
+			err: "must be a valid DNS name",
+		},
+		{
+			desc: "public_addr with path is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "foo.example.com/path",
+			},
+			err: "must be a valid DNS name",
+		},
+		{
+			desc: "public_addr with bracketed IPv6 is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "[::1]",
+			},
+			err: "must be a valid DNS name",
+		},
+		{
+			desc: "public_addr with single trailing FQDN dot is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "foo.example.com.",
+			},
+			err: "must be a valid DNS name",
+		},
+		{
+			desc: "public_addr with two trailing dots is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "foo.example.com..",
+			},
+			err: "must be a valid DNS name",
+		},
+		{
+			desc: "public_addr with query string is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "foo.example.com?x=y",
+			},
+			err: "must be a valid DNS name",
+		},
+		{
+			desc: "public_addr with fragment is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "foo.example.com#frag",
+			},
+			err: "must be a valid DNS name",
+		},
+		{
+			desc: "public_addr with userinfo is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "user@foo.example.com",
+			},
+			err: "must be a valid DNS name",
+		},
+		{
+			desc: "public_addr with empty label is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "foo..bar",
+			},
+			err: "must be a valid DNS name",
 		},
 	}
 	for _, h := range common.ReservedHeaders {
@@ -185,9 +299,9 @@ func TestCheckApp(t *testing.T) {
 			err := tt.inApp.CheckAndSetDefaults()
 			if tt.err != "" {
 				require.Contains(t, err.Error(), tt.err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -230,6 +230,17 @@ func TestCheckAppAutoLowercase(t *testing.T) {
 	require.Equal(t, "myapp", app.Name)
 }
 
+func TestCheckAppAutoLowercaseRequiredApps(t *testing.T) {
+	app := App{
+		Name:             "MyApp",
+		URI:              "http://localhost",
+		RequiredAppNames: []string{"AnotherApp", "already-lower"},
+	}
+	require.NoError(t, app.CheckAndSetDefaults())
+	require.Equal(t, "myapp", app.Name)
+	require.Equal(t, []string{"anotherapp", "already-lower"}, app.RequiredAppNames)
+}
+
 func TestCheckAppTCPPorts(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -136,7 +136,7 @@ func TestCheckApp(t *testing.T) {
 				Name: "-foo",
 				URI:  "http://localhost",
 			},
-			err: "must be a lower case valid DNS subdomain",
+			err: "must be a valid DNS label",
 		},
 		{
 			desc: `subdomain cannot contain the exclamation mark character "!"`,
@@ -144,7 +144,7 @@ func TestCheckApp(t *testing.T) {
 				Name: "foo!bar",
 				URI:  "http://localhost",
 			},
-			err: "must be a lower case valid DNS subdomain",
+			err: "must be a valid DNS label",
 		},
 		{
 			desc: "subdomain of length 63 characters is valid (maximum length)",
@@ -159,7 +159,39 @@ func TestCheckApp(t *testing.T) {
 				Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				URI:  "http://localhost",
 			},
-			err: "must be a lower case valid DNS subdomain",
+			err: "must be a valid DNS label",
+		},
+		{
+			desc: "leading digit is accepted (RFC 1123)",
+			inApp: App{
+				Name: "1stapp",
+				URI:  "http://localhost",
+			},
+		},
+		{
+			desc: "uppercase is auto-lowercased",
+			inApp: App{
+				Name: "MyApp",
+				URI:  "http://localhost",
+			},
+		},
+		{
+			desc: "public_addr with scheme is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "https://foo.example.com",
+			},
+			err: "must not contain a URI scheme",
+		},
+		{
+			desc: "public_addr with bracketed IPv6 is rejected",
+			inApp: App{
+				Name:       "foo",
+				URI:        "http://localhost",
+				PublicAddr: "[::1]",
+			},
+			err: "must not be an IP address",
 		},
 	}
 	for _, h := range common.ReservedHeaders {
@@ -190,6 +222,12 @@ func TestCheckApp(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckAppAutoLowercase(t *testing.T) {
+	app := App{Name: "MyApp", URI: "http://localhost"}
+	require.NoError(t, app.CheckAndSetDefaults())
+	require.Equal(t, "myapp", app.Name)
 }
 
 func TestCheckAppTCPPorts(t *testing.T) {

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -283,8 +283,9 @@ func validateAppTLS(a types.Application) error {
 
 // ValidateAppServer checks the outer AppServer name (the backend
 // storage key) and delegates to ValidateApp for the inner app. The
-// outer name can differ from the inner name on admin uploads, so it
-// needs its own DNS-1123 check.
+// outer name can differ from the inner name when an admin creates
+// an app_server resource directly (for example, via `tctl create`),
+// so it needs its own DNS-1123 check.
 func ValidateAppServer(server types.AppServer, proxyGetter ProxyGetter) error {
 	if server == nil {
 		return trace.BadParameter("nil app server")

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -104,14 +104,18 @@ func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {
 		return trace.BadParameter("nil application")
 	}
 	// Subdomain (not label) so integrations can produce dotted names.
-	if errs := validation.IsDNS1123Subdomain(app.GetName()); len(errs) > 0 {
-		return trace.BadParameter("application name %q must be a valid DNS name (lowercase alphanumeric, '-', or '.', must start and end with alphanumeric, max 253 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", app.GetName())
+	// Allow underscores: Cloud and self-hosted both already accept
+	// underscored app names, and curl/Go-based clients route them via
+	// the wildcard cert. Stricter rejection would break callers like
+	// the Terraform provider whose test fixtures use snake_case.
+	if errs := validation.IsDNS1123SubdomainWithUnderscore(app.GetName()); len(errs) > 0 {
+		return trace.BadParameter("application name %q must be a valid DNS name (lowercase alphanumeric, '-', '_', or '.', must start and end with alphanumeric, max 253 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", app.GetName())
 	}
 	// required_apps lookup is exact-string; a mixed-case entry would
 	// never match a lowercased primary name.
 	for _, required := range app.GetRequiredAppNames() {
-		if errs := validation.IsDNS1123Subdomain(required); len(errs) > 0 {
-			return trace.BadParameter("application %q references required_apps entry %q which must be a valid DNS name (lowercase alphanumeric, '-', or '.', start and end alphanumeric, max 253 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", app.GetName(), required)
+		if errs := validation.IsDNS1123SubdomainWithUnderscore(required); len(errs) > 0 {
+			return trace.BadParameter("application %q references required_apps entry %q which must be a valid DNS name (lowercase alphanumeric, '-', '_', or '.', start and end alphanumeric, max 253 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", app.GetName(), required)
 		}
 	}
 
@@ -290,8 +294,8 @@ func ValidateAppServer(server types.AppServer, proxyGetter ProxyGetter) error {
 	if server == nil {
 		return trace.BadParameter("nil app server")
 	}
-	if errs := validation.IsDNS1123Subdomain(server.GetName()); len(errs) > 0 {
-		return trace.BadParameter("app server name %q must be a valid DNS name (lowercase alphanumeric, '-', or '.', must start and end with alphanumeric, max 253 chars): %s", server.GetName(), strings.Join(errs, ", "))
+	if errs := validation.IsDNS1123SubdomainWithUnderscore(server.GetName()); len(errs) > 0 {
+		return trace.BadParameter("app server name %q must be a valid DNS name (lowercase alphanumeric, '-', '_', or '.', must start and end with alphanumeric, max 253 chars): %s", server.GetName(), strings.Join(errs, ", "))
 	}
 	return trace.Wrap(ValidateApp(server.GetApp(), proxyGetter))
 }

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -97,29 +97,44 @@ type ApplicationsInternal interface {
 	) ([]backend.ConditionalAction, error)
 }
 
-// ValidateApp validates the Application resource.
+// ValidateApp checks an Application's name, public_addr, and
+// required_apps.
 func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {
+	if app == nil {
+		return trace.BadParameter("nil application")
+	}
+	// Subdomain (not label) so integrations can produce dotted names.
+	if errs := validation.IsDNS1123Subdomain(app.GetName()); len(errs) > 0 {
+		return trace.BadParameter("application name %q must be a valid DNS name (lowercase alphanumeric, '-', or '.', must start and end with alphanumeric, max 253 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", app.GetName())
+	}
+	// required_apps lookup is exact-string; a mixed-case entry would
+	// never match a lowercased primary name.
+	for _, required := range app.GetRequiredAppNames() {
+		if errs := validation.IsDNS1123Subdomain(required); len(errs) > 0 {
+			return trace.BadParameter("application %q references required_apps entry %q which must be a valid DNS name (lowercase alphanumeric, '-', or '.', start and end alphanumeric, max 253 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", app.GetName(), required)
+		}
+	}
+
 	if app.GetTLS() != nil {
 		if err := validateAppTLS(app); err != nil {
 			return trace.Wrap(err)
 		}
 	}
 
-	// If no public address is set, there's nothing to validate.
 	if app.GetPublicAddr() == "" {
 		return nil
 	}
 
-	// The app's spec has already been validated in CheckAndSetDefaults, so we can assume the public address is a valid
-	// address. The remainder of this function focuses on detecting conflicts with proxy public addresses because the
-	// proxy addresses are not part of the app spec and need to be fetched separately.
+	if err := ValidatePublicAddr(app.GetName(), app.GetPublicAddr()); err != nil {
+		return trace.Wrap(err)
+	}
 	appAddr, err := utils.ParseAddr(app.GetPublicAddr())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	// Convert the application's public address hostname to its ASCII representation for comparison. Strip any trailing
-	// dots to ensure consistent comparison.
+	// Normalize to ASCII for the proxy-collision compare below; the
+	// proxy public_addr is not run through ValidatePublicAddr.
 	asciiAppHostname, err := idna.ToASCII(strings.TrimRight(appAddr.Host(), "."))
 	if err != nil {
 		return trace.Wrap(err, "app %q has an invalid IDN hostname %q", app.GetName(), appAddr.Host())
@@ -264,6 +279,84 @@ func validateAppTLS(a types.Application) error {
 	}
 
 	return nil
+}
+
+// ValidateAppServer checks the outer AppServer name (the backend
+// storage key) and delegates to ValidateApp for the inner app. The
+// outer name can differ from the inner name on admin uploads, so it
+// needs its own DNS-1123 check.
+func ValidateAppServer(server types.AppServer, proxyGetter ProxyGetter) error {
+	if server == nil {
+		return trace.BadParameter("nil app server")
+	}
+	if errs := validation.IsDNS1123Subdomain(server.GetName()); len(errs) > 0 {
+		return trace.BadParameter("app server name %q must be a valid DNS name (lowercase alphanumeric, '-', or '.', must start and end with alphanumeric, max 253 chars): %s", server.GetName(), strings.Join(errs, ", "))
+	}
+	return trace.Wrap(ValidateApp(server.GetApp(), proxyGetter))
+}
+
+// ValidatePublicAddr requires a lowercase DNS-1123 hostname. An
+// empty addr is treated as unset.
+func ValidatePublicAddr(appName, addr string) error {
+	if addr == "" {
+		return nil
+	}
+	// IPv4 literals satisfy IsDNS1123Subdomain (digits + dots);
+	// reject explicitly so routing-by-hostname holds.
+	if net.ParseIP(addr) != nil {
+		return trace.BadParameter("application %q public_addr %q must not be an IP address, Teleport Application Access uses DNS names for routing", appName, addr)
+	}
+	if errs := validation.IsDNS1123Subdomain(addr); len(errs) > 0 {
+		return trace.BadParameter("application %q public_addr %q must be a valid DNS name (lowercase alphanumeric, '-', or '.', no trailing dot, no IDN Unicode -- use punycode): %s", appName, addr, strings.Join(errs, ", "))
+	}
+	return nil
+}
+
+// NormalizeAppServerForHeartbeat case-folds a legacy agent's name and
+// strips a scheme/port from its public_addr. Heartbeat-only; admin
+// paths must not call it.
+func NormalizeAppServerForHeartbeat(server types.AppServer) {
+	app := server.GetApp()
+	if app == nil {
+		return
+	}
+	appName := strings.ToLower(app.GetName())
+	if appName != app.GetName() {
+		app.SetName(appName)
+	}
+	serverName := server.GetName()
+	if strings.EqualFold(serverName, appName) && serverName != appName {
+		server.SetName(appName)
+	}
+	normalizedPublicAddr := normalizeHeartbeatPublicAddr(app.GetPublicAddr())
+	if normalizedPublicAddr != app.GetPublicAddr() {
+		app.SetPublicAddr(normalizedPublicAddr)
+	}
+	// required_apps go through the same DNS-1123 check in ValidateApp;
+	// lowercase legacy mixed-case entries so older agents keep working.
+	if appV3, ok := app.(*types.AppV3); ok {
+		for i, required := range appV3.Spec.RequiredAppNames {
+			appV3.Spec.RequiredAppNames[i] = strings.ToLower(required)
+		}
+	}
+}
+
+// normalizeHeartbeatPublicAddr strips a URL scheme, path, or port
+// from a legacy public_addr and lowercases the result.
+func normalizeHeartbeatPublicAddr(addr string) string {
+	if addr == "" {
+		return addr
+	}
+	if strings.Contains(addr, "://") {
+		if u, err := url.Parse(addr); err == nil && u.Hostname() != "" {
+			return strings.ToLower(u.Hostname())
+		}
+		return addr
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return strings.ToLower(host)
+	}
+	return strings.ToLower(addr)
 }
 
 // MarshalApp marshals Application resource to JSON.
@@ -470,15 +563,16 @@ func getAppName(serviceName, namespace, clusterName, portName, nameAnnotation st
 			name = fmt.Sprintf("%s-%s", name, portName)
 		}
 
-		if len(validation.IsDNS1035Label(name)) > 0 {
+		if len(validation.IsDNS1123Label(name)) > 0 {
 			return "", trace.BadParameter(
-				"application name %q must be a lower case valid DNS subdomain: https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", name)
+				"application name %q must be a valid DNS label (lowercase alphanumeric or '-', must start and end with alphanumeric, max 63 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", name)
 		}
 
 		return name, nil
 	}
 
-	clusterName = strings.ReplaceAll(clusterName, ".", "-")
+	// Lowercase + dot-replace so the composed name passes ValidateApp.
+	clusterName = strings.ToLower(strings.ReplaceAll(clusterName, ".", "-"))
 	if portName != "" {
 		return fmt.Sprintf("%s-%s-%s-%s", serviceName, portName, namespace, clusterName), nil
 	}

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -102,6 +102,11 @@ func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {
 	if lowered := strings.ToLower(app.GetName()); lowered != app.GetName() {
 		app.SetName(lowered)
 	}
+	// Also lowercase RequiredAppNames so references to other apps stay
+	// consistent after those apps are also lowercased.
+	for i, n := range app.GetRequiredAppNames() {
+		app.GetRequiredAppNames()[i] = strings.ToLower(n)
+	}
 
 	// Validate that the app name is a valid DNS subdomain (RFC 1123). App
 	// names become subdomains (appName.proxyHost), so each label must be

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -95,14 +95,46 @@ type ApplicationsInternal interface {
 
 // ValidateApp validates the Application resource.
 func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {
-	// If no public address is set, there's nothing to validate.
+	// TODO(julia): Remove auto-lowercase once all agents include the
+	// lowercase fix in convertProfile and IdentityCenterAccountToAppServer.
+	// This exists to avoid breaking rolling upgrades where auth upgrades
+	// before agents - old agents may still send mixed-case app names.
+	if lowered := strings.ToLower(app.GetName()); lowered != app.GetName() {
+		app.SetName(lowered)
+	}
+
+	// Validate that the app name is a valid DNS subdomain (RFC 1123). App
+	// names become subdomains (appName.proxyHost), so each label must be
+	// lowercase alphanumeric or hyphens. Dots are allowed because some
+	// integrations (e.g. AWS OIDC) use dotted names like "env.prod".
+	if errs := validation.IsDNS1123Subdomain(app.GetName()); len(errs) > 0 {
+		return trace.BadParameter("application name %q must be a valid DNS name (lowercase alphanumeric, '-', or '.', must start and end with alphanumeric, max 253 chars)", app.GetName())
+	}
+
+	// If no public address is set, there's nothing else to validate.
 	if app.GetPublicAddr() == "" {
 		return nil
 	}
 
-	// The app's spec has already been validated in CheckAndSetDefaults, so we can assume the public address is a valid
-	// address. The remainder of this function focuses on detecting conflicts with proxy public addresses because the
-	// proxy addresses are not part of the app spec and need to be fetched separately.
+	addr := app.GetPublicAddr()
+	// Reject public_addr values that contain a URI scheme.
+	if strings.Contains(addr, "://") {
+		return trace.BadParameter("application %q public_addr %q must not contain a URI scheme; use a bare hostname", app.GetName(), addr)
+	}
+	// Reject public_addr values that contain a port.
+	if _, _, err := net.SplitHostPort(addr); err == nil {
+		return trace.BadParameter("application %q public_addr %q must not contain a port, applications will be available on the same port as the web proxy", app.GetName(), addr)
+	}
+	// Reject public_addr values that are IP addresses, including bracketed
+	// IPv6 like [::1].
+	stripped := strings.TrimPrefix(strings.TrimSuffix(addr, "]"), "[")
+	if net.ParseIP(stripped) != nil {
+		return trace.BadParameter("application %q public_addr %q must not be an IP address, Teleport Application Access uses DNS names for routing", app.GetName(), addr)
+	}
+
+	// The checks above have rejected public addresses with URI schemes, ports,
+	// and IP addresses. The remainder of this function detects conflicts with
+	// proxy public addresses, which require fetching proxy state separately.
 	appAddr, err := utils.ParseAddr(app.GetPublicAddr())
 	if err != nil {
 		return trace.Wrap(err)
@@ -360,9 +392,9 @@ func getAppName(serviceName, namespace, clusterName, portName, nameAnnotation st
 			name = fmt.Sprintf("%s-%s", name, portName)
 		}
 
-		if len(validation.IsDNS1035Label(name)) > 0 {
+		if len(validation.IsDNS1123Label(name)) > 0 {
 			return "", trace.BadParameter(
-				"application name %q must be a lower case valid DNS subdomain: https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", name)
+				"application name %q must be a valid DNS label (lowercase alphanumeric or '-', must start and end with alphanumeric, max 63 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", name)
 		}
 
 		return name, nil

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -76,34 +77,64 @@ func TestValidateApp(t *testing.T) {
 			wantErr:    "conflicts with the Teleport Proxy public address",
 		},
 		{
-			name: "public addr with trailing dot matches proxy host",
+			name: "public addr with trailing dot is rejected, with colliding proxy",
 			app: func() types.Application {
 				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "web.example.com."})
 				require.NoError(t, err)
 				return app
 			}(),
 			proxyAddrs: []string{"web.example.com:443"},
-			wantErr:    "conflicts with the Teleport Proxy public address",
+			wantErr:    "must be a valid DNS name",
 		},
 		{
-			name: "public addr with multiple trailing dots matches proxy host",
+			name: "public addr with trailing dot is rejected, no proxy",
+			app: func() types.Application {
+				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "web.example.com."})
+				require.NoError(t, err)
+				return app
+			}(),
+			proxyAddrs: []string{},
+			wantErr:    "must be a valid DNS name",
+		},
+		{
+			name: "public addr with multiple trailing dots is rejected, with colliding proxy",
 			app: func() types.Application {
 				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "web.example.com..."})
 				require.NoError(t, err)
 				return app
 			}(),
 			proxyAddrs: []string{"web.example.com:443"},
-			wantErr:    "conflicts with the Teleport Proxy public address",
+			wantErr:    "must be a valid DNS name",
 		},
 		{
-			name: "public addr with mixed casing matches proxy host",
+			name: "public addr with multiple trailing dots is rejected, no proxy",
+			app: func() types.Application {
+				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "web.example.com..."})
+				require.NoError(t, err)
+				return app
+			}(),
+			proxyAddrs: []string{},
+			wantErr:    "must be a valid DNS name",
+		},
+		{
+			name: "public addr with mixed casing is rejected, with colliding proxy",
 			app: func() types.Application {
 				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "WeB.ExAmPle.CoM"})
 				require.NoError(t, err)
 				return app
 			}(),
 			proxyAddrs: []string{"web.example.com:443"},
-			wantErr:    "conflicts with the Teleport Proxy public address",
+			wantErr:    "must be a valid DNS name",
+		},
+		{
+			name: "public addr with mixed casing is rejected, no proxy",
+			app: func() types.Application {
+				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "WeB.ExAmPle.CoM"})
+				require.NoError(t, err)
+				return app
+			}(),
+			proxyAddrs: []string{},
+			wantErr:    "must be a valid DNS name",
 		},
 		{
 			name: "multiple proxy addrs, one matches",
@@ -116,42 +147,33 @@ func TestValidateApp(t *testing.T) {
 			wantErr:    "conflicts with the Teleport Proxy public address",
 		},
 		{
-			name: "public addr with IDN matches proxy host",
+			name: "public addr IDN Unicode is rejected, with colliding proxy",
 			app: func() types.Application {
 				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "例.cn"})
 				require.NoError(t, err)
 				return app
 			}(),
 			proxyAddrs: []string{"xn--fsq.cn:443"},
-			wantErr:    "conflicts with the Teleport Proxy public address",
+			wantErr:    "must be a valid DNS name",
 		},
 		{
-			name: "public addr with IDN does not conflict with non-IDN proxy host",
+			name: "public addr IDN Unicode is rejected, no proxy",
 			app: func() types.Application {
-				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "münchen.de"})
+				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "例.cn"})
 				require.NoError(t, err)
 				return app
 			}(),
-			proxyAddrs: []string{"example.com:443"},
+			proxyAddrs: []string{},
+			wantErr:    "must be a valid DNS name",
 		},
 		{
-			name: "IDN with mixed case matches proxy host",
+			name: "punycode IDN matches proxy host",
 			app: func() types.Application {
-				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "MünchEn.de"})
+				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "xn--fsq.cn"})
 				require.NoError(t, err)
 				return app
 			}(),
-			proxyAddrs: []string{"münchen.de:443"},
-			wantErr:    "conflicts with the Teleport Proxy public address",
-		},
-		{
-			name: "IDN with subdomains matches proxy host",
-			app: func() types.Application {
-				app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: "sub.münchen.de"})
-				require.NoError(t, err)
-				return app
-			}(),
-			proxyAddrs: []string{"sub.xn--mnchen-3ya.de:443"},
+			proxyAddrs: []string{"xn--fsq.cn:443"},
 			wantErr:    "conflicts with the Teleport Proxy public address",
 		},
 		{
@@ -183,6 +205,253 @@ func TestValidateApp(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestValidateAppServer(t *testing.T) {
+	proxyGetter := &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}
+
+	makeServer := func(t *testing.T, outerName, innerName string) types.AppServer {
+		t.Helper()
+		app, err := types.NewAppV3(types.Metadata{Name: innerName}, types.AppSpecV3{URI: "http://localhost:8080"})
+		require.NoError(t, err)
+		srv, err := types.NewAppServerV3FromApp(app, "localhost", "host-id")
+		require.NoError(t, err)
+		srv.Metadata.Name = outerName
+		return srv
+	}
+
+	t.Run("nil server rejected", func(t *testing.T) {
+		require.ErrorContains(t, ValidateAppServer(nil, proxyGetter), "nil app server")
+	})
+	t.Run("valid outer and inner", func(t *testing.T) {
+		require.NoError(t, ValidateAppServer(makeServer(t, "myapp", "myapp"), proxyGetter))
+	})
+	t.Run("mixed-case outer rejected", func(t *testing.T) {
+		err := ValidateAppServer(makeServer(t, "MyApp", "myapp"), proxyGetter)
+		require.ErrorContains(t, err, "app server name")
+		require.ErrorContains(t, err, "MyApp")
+	})
+	t.Run("underscore in outer rejected", func(t *testing.T) {
+		err := ValidateAppServer(makeServer(t, "bad_name", "good-name"), proxyGetter)
+		require.ErrorContains(t, err, "app server name")
+		require.ErrorContains(t, err, "bad_name")
+	})
+	t.Run("mixed-case inner rejected", func(t *testing.T) {
+		err := ValidateAppServer(makeServer(t, "myapp", "MyApp"), proxyGetter)
+		require.ErrorContains(t, err, "application name")
+	})
+}
+
+func TestValidateAppName(t *testing.T) {
+	proxyGetter := &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}
+
+	t.Run("nil app rejected", func(t *testing.T) {
+		err := ValidateApp(nil, proxyGetter)
+		require.ErrorContains(t, err, "nil application")
+	})
+
+	t.Run("required_apps mixed case rejected", func(t *testing.T) {
+		app, err := types.NewAppV3(types.Metadata{Name: "main"}, types.AppSpecV3{
+			URI:              "http://localhost:8080",
+			RequiredAppNames: []string{"MixedCase"},
+		})
+		require.NoError(t, err)
+		err = ValidateApp(app, proxyGetter)
+		require.ErrorContains(t, err, `references required_apps entry "MixedCase"`)
+	})
+
+	t.Run("required_apps valid entries accepted", func(t *testing.T) {
+		app, err := types.NewAppV3(types.Metadata{Name: "main"}, types.AppSpecV3{
+			URI:              "http://localhost:8080",
+			RequiredAppNames: []string{"other-app", "another.app"},
+		})
+		require.NoError(t, err)
+		require.NoError(t, ValidateApp(app, proxyGetter))
+	})
+
+	makeApp := func(t *testing.T, name string) types.Application {
+		t.Helper()
+		app, err := types.NewAppV3(types.Metadata{Name: name}, types.AppSpecV3{URI: "http://localhost:8080"})
+		require.NoError(t, err)
+		return app
+	}
+
+	tests := []struct {
+		name    string
+		appName string
+		wantErr string
+	}{
+		{name: "valid lowercase", appName: "myapp"},
+		{name: "valid with hyphen", appName: "my-app"},
+		{name: "valid leading digit", appName: "1stapp"},
+		{name: "valid all digits", appName: "123"},
+		{name: "valid dotted name", appName: "env.prod"},
+		{name: "reject uppercase", appName: "MyApp", wantErr: "must be a valid DNS name"},
+		{name: "reject underscore", appName: "my_app", wantErr: "must be a valid DNS name"},
+		{name: "reject trailing hyphen", appName: "foo-", wantErr: "must be a valid DNS name"},
+		{name: "accept 63-char label", appName: strings.Repeat("a", 63)},
+		{name: "reject too long", appName: strings.Repeat("a", 254), wantErr: "must be a valid DNS name"},
+		{name: "accept single char", appName: "a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := makeApp(t, tt.appName)
+			err := ValidateApp(app, proxyGetter)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			// ValidateApp must not rewrite GetName; UpdateApp would
+			// retarget the wrong record.
+			require.Equal(t, tt.appName, app.GetName())
+		})
+	}
+}
+
+func TestValidateAppPublicAddr(t *testing.T) {
+	proxyGetter := &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}
+
+	makeApp := func(t *testing.T, publicAddr string) types.Application {
+		t.Helper()
+		app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: publicAddr})
+		require.NoError(t, err)
+		return app
+	}
+
+	tests := []struct {
+		name    string
+		addr    string
+		wantErr string
+	}{
+		{name: "bare hostname", addr: "app.example.com"},
+		{name: "reject mixed case", addr: "MyApp.example.com", wantErr: "must be a valid DNS name"},
+		{name: "reject all-upper", addr: "APP.EXAMPLE.COM", wantErr: "must be a valid DNS name"},
+		{name: "reject scheme http", addr: "http://foo.bar", wantErr: "must be a valid DNS name"},
+		{name: "reject scheme https with port", addr: "https://foo.bar:443", wantErr: "must be a valid DNS name"},
+		{name: "reject port", addr: "foo.bar:443", wantErr: "must be a valid DNS name"},
+		{name: "reject IPv4", addr: "192.168.1.1", wantErr: "must not be an IP address"},
+		{name: "reject bare IPv6", addr: "::1", wantErr: "must not be an IP address"},
+		{name: "reject bracketed IPv6", addr: "[::1]", wantErr: "must be a valid DNS name"},
+		{name: "reject bracketed IPv6 with port", addr: "[::1]:443", wantErr: "must be a valid DNS name"},
+		{name: "reject mailto opaque", addr: "mailto:victim@example.com", wantErr: "must be a valid DNS name"},
+		{name: "reject path", addr: "app.example.com/path", wantErr: "must be a valid DNS name"},
+		{name: "reject query", addr: "app.example.com?x=y", wantErr: "must be a valid DNS name"},
+		{name: "reject fragment", addr: "app.example.com#frag", wantErr: "must be a valid DNS name"},
+		{name: "reject userinfo", addr: "user@app.example.com", wantErr: "must be a valid DNS name"},
+		{name: "reject single trailing dot", addr: "app.example.com.", wantErr: "must be a valid DNS name"},
+		{name: "reject double trailing dot", addr: "app.example.com..", wantErr: "must be a valid DNS name"},
+		{name: "reject only dots", addr: "...", wantErr: "must be a valid DNS name"},
+		{name: "reject IDN unicode", addr: "münchen.de", wantErr: "must be a valid DNS name"},
+		{name: "accept punycode", addr: "xn--mnchen-3ya.de"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := makeApp(t, tt.addr)
+			err := ValidateApp(app, proxyGetter)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNormalizeAppServerForHeartbeat(t *testing.T) {
+	makeServer := func(t *testing.T, outerName, innerName string) *types.AppServerV3 {
+		t.Helper()
+		app, err := types.NewAppV3(types.Metadata{Name: innerName}, types.AppSpecV3{
+			URI: "http://localhost:8080",
+		})
+		require.NoError(t, err)
+		srv, err := types.NewAppServerV3FromApp(app, "localhost", "host-id")
+		require.NoError(t, err)
+		srv.Metadata.Name = outerName
+		return srv
+	}
+
+	tests := []struct {
+		name          string
+		outerName     string
+		innerName     string
+		wantOuterName string
+		wantInnerName string
+	}{
+		{
+			name:          "both lowercase unchanged",
+			outerName:     "myapp",
+			innerName:     "myapp",
+			wantOuterName: "myapp",
+			wantInnerName: "myapp",
+		},
+		{
+			name:          "both mixed-case lowercased together",
+			outerName:     "MyApp",
+			innerName:     "MyApp",
+			wantOuterName: "myapp",
+			wantInnerName: "myapp",
+		},
+		{
+			name:          "outer mixed-case inner lowercase",
+			outerName:     "MyApp",
+			innerName:     "myapp",
+			wantOuterName: "myapp",
+			wantInnerName: "myapp",
+		},
+		{
+			name:          "true mismatch left unchanged",
+			outerName:     "different",
+			innerName:     "myapp",
+			wantOuterName: "different",
+			wantInnerName: "myapp",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := makeServer(t, tt.outerName, tt.innerName)
+			NormalizeAppServerForHeartbeat(srv)
+			require.Equal(t, tt.wantOuterName, srv.GetName())
+			require.Equal(t, tt.wantInnerName, srv.GetApp().GetName())
+		})
+	}
+
+	t.Run("required_apps lowercased", func(t *testing.T) {
+		app, err := types.NewAppV3(types.Metadata{Name: "main"}, types.AppSpecV3{
+			URI:              "http://localhost:8080",
+			RequiredAppNames: []string{"MixedCase", "Other.App"},
+		})
+		require.NoError(t, err)
+		srv, err := types.NewAppServerV3FromApp(app, "localhost", "host-id")
+		require.NoError(t, err)
+		NormalizeAppServerForHeartbeat(srv)
+		require.Equal(t, []string{"mixedcase", "other.app"}, srv.GetApp().GetRequiredAppNames())
+	})
+}
+
+func TestNormalizeHeartbeatPublicAddr(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty unchanged", input: "", want: ""},
+		{name: "bare hostname unchanged", input: "app.example.com", want: "app.example.com"},
+		{name: "scheme and path stripped", input: "https://app.example.com/start", want: "app.example.com"},
+		{name: "scheme path and port stripped", input: "https://app.example.com:443/path", want: "app.example.com"},
+		{name: "trailing port stripped", input: "app.example.com:443", want: "app.example.com"},
+		{name: "mixed case lowercased", input: "MyApp.Example.Com", want: "myapp.example.com"},
+		{name: "mixed case with scheme lowercased", input: "https://MyApp.Example.Com/start", want: "myapp.example.com"},
+		{name: "mixed case with port lowercased", input: "MyApp.Example.Com:443", want: "myapp.example.com"},
+		{name: "bare IPv6 returned as-is", input: "::1", want: "::1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, normalizeHeartbeatPublicAddr(tt.input))
 		})
 	}
 }
@@ -338,6 +607,19 @@ func TestGetAppName(t *testing.T) {
 			portName:    "http",
 			annotation:  "overridden*name",
 			wantErr:     "s",
+		},
+		{
+			serviceName: "service4",
+			namespace:   "ns4",
+			clusterName: "cluster4",
+			annotation:  "1stapp",
+			expected:    "1stapp",
+		},
+		{
+			serviceName: "service5",
+			namespace:   "ns5",
+			clusterName: "MyGroup",
+			expected:    "service5-ns5-mygroup",
 		},
 	}
 

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -233,10 +233,8 @@ func TestValidateAppServer(t *testing.T) {
 		require.ErrorContains(t, err, "app server name")
 		require.ErrorContains(t, err, "MyApp")
 	})
-	t.Run("underscore in outer rejected", func(t *testing.T) {
-		err := ValidateAppServer(makeServer(t, "bad_name", "good-name"), proxyGetter)
-		require.ErrorContains(t, err, "app server name")
-		require.ErrorContains(t, err, "bad_name")
+	t.Run("underscore in outer accepted", func(t *testing.T) {
+		require.NoError(t, ValidateAppServer(makeServer(t, "ok_name", "good-name"), proxyGetter))
 	})
 	t.Run("mixed-case inner rejected", func(t *testing.T) {
 		err := ValidateAppServer(makeServer(t, "myapp", "MyApp"), proxyGetter)
@@ -289,7 +287,7 @@ func TestValidateAppName(t *testing.T) {
 		{name: "valid all digits", appName: "123"},
 		{name: "valid dotted name", appName: "env.prod"},
 		{name: "reject uppercase", appName: "MyApp", wantErr: "must be a valid DNS name"},
-		{name: "reject underscore", appName: "my_app", wantErr: "must be a valid DNS name"},
+		{name: "accept underscore", appName: "my_app"},
 		{name: "reject trailing hyphen", appName: "foo-", wantErr: "must be a valid DNS name"},
 		{name: "accept 63-char label", appName: strings.Repeat("a", 63)},
 		{name: "reject too long", appName: strings.Repeat("a", 254), wantErr: "must be a valid DNS name"},

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -182,6 +183,89 @@ func TestValidateApp(t *testing.T) {
 	}
 }
 
+func TestValidateAppName(t *testing.T) {
+	proxyGetter := &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}
+
+	makeApp := func(t *testing.T, name, publicAddr string) types.Application {
+		t.Helper()
+		spec := types.AppSpecV3{URI: "http://localhost:8080"}
+		if publicAddr != "" {
+			spec.PublicAddr = publicAddr
+		}
+		app, err := types.NewAppV3(types.Metadata{Name: name}, spec)
+		require.NoError(t, err)
+		return app
+	}
+
+	tests := []struct {
+		name       string
+		appName    string
+		publicAddr string
+		wantErr    string
+	}{
+		{name: "valid lowercase", appName: "myapp"},
+		{name: "valid with hyphen", appName: "my-app"},
+		{name: "valid leading digit", appName: "1stapp"},
+		{name: "valid all digits", appName: "123"},
+		{name: "valid dotted name", appName: "env.prod"},
+		{name: "auto-lowercase uppercase", appName: "MyApp"},
+		{name: "reject underscore", appName: "my_app", wantErr: "must be a valid DNS name"},
+		{name: "accept 63-char label", appName: strings.Repeat("a", 63)},
+		{name: "reject too long", appName: strings.Repeat("a", 254), wantErr: "must be a valid DNS name"},
+		{name: "auto-lowercase without public_addr", appName: "MyApp", publicAddr: ""},
+		{name: "accept single char", appName: "a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := makeApp(t, tt.appName, tt.publicAddr)
+			err := ValidateApp(app, proxyGetter)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAppPublicAddr(t *testing.T) {
+	proxyGetter := &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}
+
+	makeApp := func(t *testing.T, publicAddr string) types.Application {
+		t.Helper()
+		app, err := types.NewAppV3(types.Metadata{Name: "app"}, types.AppSpecV3{URI: "http://localhost:8080", PublicAddr: publicAddr})
+		require.NoError(t, err)
+		return app
+	}
+
+	tests := []struct {
+		name    string
+		addr    string
+		wantErr string
+	}{
+		{name: "bare hostname", addr: "app.example.com"},
+		{name: "reject scheme http", addr: "http://foo.bar", wantErr: "must not contain a URI scheme"},
+		{name: "reject scheme https with port", addr: "https://foo.bar:443", wantErr: "must not contain a URI scheme"},
+		{name: "reject port", addr: "foo.bar:443", wantErr: "must not contain a port"},
+		{name: "reject IPv4", addr: "192.168.1.1", wantErr: "must not be an IP address"},
+		{name: "reject IPv6", addr: "::1", wantErr: "must not be an IP address"},
+		{name: "reject bracketed IPv6", addr: "[::1]", wantErr: "must not be an IP address"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := makeApp(t, tt.addr)
+			err := ValidateApp(app, proxyGetter)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 // mockProxyGetter is a test implementation of ProxyGetter.
 type mockProxyGetter struct {
 	addrs []string
@@ -316,6 +400,13 @@ func TestGetAppName(t *testing.T) {
 			portName:    "http",
 			annotation:  "overridden*name",
 			wantErr:     "s",
+		},
+		{
+			serviceName: "service4",
+			namespace:   "ns4",
+			clusterName: "cluster4",
+			annotation:  "1stapp",
+			expected:    "1stapp",
 		},
 	}
 

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -229,6 +229,17 @@ func TestValidateAppName(t *testing.T) {
 	}
 }
 
+func TestValidateAppLowercasesRequiredAppNames(t *testing.T) {
+	proxyGetter := &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}
+	app, err := types.NewAppV3(types.Metadata{Name: "myapp"}, types.AppSpecV3{
+		URI:              "http://localhost:8080",
+		RequiredAppNames: []string{"AnotherApp", "already-lower"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, ValidateApp(app, proxyGetter))
+	require.Equal(t, []string{"anotherapp", "already-lower"}, app.GetRequiredAppNames())
+}
+
 func TestValidateAppPublicAddr(t *testing.T) {
 	proxyGetter := &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}
 

--- a/lib/services/fuzz_test.go
+++ b/lib/services/fuzz_test.go
@@ -131,12 +131,12 @@ func FuzzValidateApp(f *testing.F) {
 	f.Add("proxy.example.com:443", "")                      // valid: empty app address
 	f.Add("example.com", "app.example.com")                 // valid: proxy without port
 	f.Add("web.example.com:443", "web.example.com")         // conflict: same as proxy
-	f.Add("web.example.com:443", "web.example.com.")        // conflict: trailing dot
-	f.Add("web.example.com:443", "web.example.com..")       // conflict: multiple trailing dots
-	f.Add("web.example.com:443", "WeB.ExAmPle.CoM")         // conflict: case insensitive
+	f.Add("web.example.com:443", "web.example.com.")        // conflict: trailing dot stripped before compare
+	f.Add("web.example.com:443", "web.example.com..")       // rejected by shape check: multiple trailing dots
+	f.Add("web.example.com:443", "WeB.ExAmPle.CoM")         // rejected by shape check: mixed case
 	f.Add("web.example.com:443,other.com:443", "other.com") // conflict: matches second proxy
-	f.Add("xn--mnchen-3ya.de:443", "münchen.de")            // conflict: IDN
-	f.Add("münchen.de:443", "MünchEn.de")                   // conflict: IDN case insensitive
+	f.Add("xn--mnchen-3ya.de:443", "münchen.de")            // rejected by shape check: IDN Unicode
+	f.Add("münchen.de:443", "MünchEn.de")                   // rejected by shape check: mixed case + IDN
 	f.Add("example.com:443,example.com:80", "example.com")  // conflict: multiple proxy ports
 
 	f.Fuzz(func(t *testing.T, proxyPublicAddrs string, appPublicAddr string) {

--- a/lib/services/identitycenter.go
+++ b/lib/services/identitycenter.go
@@ -19,8 +19,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -245,19 +243,13 @@ func IdentityCenterAccountToAppServer(acct *identitycenterv1.Account) *types.App
 		}
 	}
 
-	// StartUrl is usually a full URL; reduce to a bare hostname.
-	publicAddr := acct.GetSpec().GetStartUrl()
-	if u, err := url.Parse(publicAddr); err == nil && u.Hostname() != "" {
-		publicAddr = u.Hostname()
-	}
-	// ValidatePublicAddr requires lowercase.
-	publicAddr = strings.ToLower(publicAddr)
-
-	// Identity Center accounts can be mixed-case; lowercase so the
-	// resource passes ValidateApp. Applies to both outer and inner
-	// metadata so storage key and routing identity stay aligned.
+	// Identity Center accounts surface in the unified-resource cache as
+	// synthetic AppServers; they never traverse the app write paths
+	// (ValidateApp / ValidateAppServer), so no DNS-1123 normalization
+	// here. The web Launch button (ResourceActionButton.tsx) builds the
+	// SSO launch URL as `${publicAddr}&role_name=...`, which requires
+	// the full StartUrl - scheme, path, and case preserved.
 	metadata := types.Metadata153ToLegacy(acct.Metadata)
-	metadata.Name = strings.ToLower(metadata.Name)
 	metadata.Description = acct.GetSpec().GetName()
 
 	return &types.AppServerV3{
@@ -272,10 +264,8 @@ func IdentityCenterAccountToAppServer(acct *identitycenterv1.Account) *types.App
 				Version:  types.V3,
 				Metadata: metadata,
 				Spec: types.AppSpecV3{
-					// URI keeps the original StartUrl as the SSO
-					// redirect target; only PublicAddr is normalized.
 					URI:        acct.GetSpec().GetStartUrl(),
-					PublicAddr: publicAddr,
+					PublicAddr: acct.GetSpec().GetStartUrl(),
 					AWS: &types.AppAWS{
 						ExternalID: acct.GetSpec().GetId(),
 					},

--- a/lib/services/identitycenter.go
+++ b/lib/services/identitycenter.go
@@ -246,7 +246,7 @@ func IdentityCenterAccountToAppServer(acct *identitycenterv1.Account) *types.App
 	}
 
 	// StartUrl is usually a full URL; reduce to a bare hostname.
-	publicAddr := acct.Spec.StartUrl
+	publicAddr := acct.GetSpec().GetStartUrl()
 	if u, err := url.Parse(publicAddr); err == nil && u.Hostname() != "" {
 		publicAddr = u.Hostname()
 	}
@@ -258,7 +258,7 @@ func IdentityCenterAccountToAppServer(acct *identitycenterv1.Account) *types.App
 	// metadata so storage key and routing identity stay aligned.
 	metadata := types.Metadata153ToLegacy(acct.Metadata)
 	metadata.Name = strings.ToLower(metadata.Name)
-	metadata.Description = acct.Spec.Name
+	metadata.Description = acct.GetSpec().GetName()
 
 	return &types.AppServerV3{
 		Kind:     types.KindAppServer,

--- a/lib/services/identitycenter.go
+++ b/lib/services/identitycenter.go
@@ -19,6 +19,8 @@ package services
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -243,20 +245,37 @@ func IdentityCenterAccountToAppServer(acct *identitycenterv1.Account) *types.App
 		}
 	}
 
-	appServer := &types.AppServerV3{
+	// StartUrl is usually a full URL; reduce to a bare hostname.
+	publicAddr := acct.Spec.StartUrl
+	if u, err := url.Parse(publicAddr); err == nil && u.Hostname() != "" {
+		publicAddr = u.Hostname()
+	}
+	// ValidatePublicAddr requires lowercase.
+	publicAddr = strings.ToLower(publicAddr)
+
+	// Identity Center accounts can be mixed-case; lowercase so the
+	// resource passes ValidateApp. Applies to both outer and inner
+	// metadata so storage key and routing identity stay aligned.
+	metadata := types.Metadata153ToLegacy(acct.Metadata)
+	metadata.Name = strings.ToLower(metadata.Name)
+	metadata.Description = acct.Spec.Name
+
+	return &types.AppServerV3{
 		Kind:     types.KindAppServer,
 		SubKind:  types.KindIdentityCenterAccount,
 		Version:  types.V3,
-		Metadata: types.Metadata153ToLegacy(acct.Metadata),
+		Metadata: metadata,
 		Spec: types.AppServerSpecV3{
 			App: &types.AppV3{
 				Kind:     types.KindApp,
 				SubKind:  types.KindIdentityCenterAccount,
 				Version:  types.V3,
-				Metadata: types.Metadata153ToLegacy(acct.Metadata),
+				Metadata: metadata,
 				Spec: types.AppSpecV3{
+					// URI keeps the original StartUrl as the SSO
+					// redirect target; only PublicAddr is normalized.
 					URI:        acct.Spec.StartUrl,
-					PublicAddr: acct.Spec.StartUrl,
+					PublicAddr: publicAddr,
 					AWS: &types.AppAWS{
 						ExternalID: acct.Spec.Id,
 					},
@@ -268,8 +287,6 @@ func IdentityCenterAccountToAppServer(acct *identitycenterv1.Account) *types.App
 			},
 		},
 	}
-	appServer.Metadata.Description = acct.Spec.Name
-	return appServer
 }
 
 // NewIdentityCenterAppMatcher creates a new [RoleMatcher] configured to

--- a/lib/services/identitycenter.go
+++ b/lib/services/identitycenter.go
@@ -274,13 +274,13 @@ func IdentityCenterAccountToAppServer(acct *identitycenterv1.Account) *types.App
 				Spec: types.AppSpecV3{
 					// URI keeps the original StartUrl as the SSO
 					// redirect target; only PublicAddr is normalized.
-					URI:        acct.Spec.StartUrl,
+					URI:        acct.GetSpec().GetStartUrl(),
 					PublicAddr: publicAddr,
 					AWS: &types.AppAWS{
-						ExternalID: acct.Spec.Id,
+						ExternalID: acct.GetSpec().GetId(),
 					},
 					IdentityCenter: &types.AppIdentityCenter{
-						AccountID:      acct.Spec.Id,
+						AccountID:      acct.GetSpec().GetId(),
 						PermissionSets: pss,
 					},
 				},

--- a/lib/services/identitycenter.go
+++ b/lib/services/identitycenter.go
@@ -247,8 +247,8 @@ func IdentityCenterAccountToAppServer(acct *identitycenterv1.Account) *types.App
 	// StartUrl contains a scheme (e.g. "https://start.example.com/start").
 	// PublicAddr must be a bare hostname, so strip the scheme and path.
 	publicAddr := acct.Spec.StartUrl
-	if u, err := url.Parse(publicAddr); err == nil && u.Host != "" {
-		publicAddr = u.Host
+	if u, err := url.Parse(publicAddr); err == nil && u.Hostname() != "" {
+		publicAddr = u.Hostname()
 	}
 
 	appServer := &types.AppServerV3{

--- a/lib/services/identitycenter.go
+++ b/lib/services/identitycenter.go
@@ -19,6 +19,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/gravitational/trace"
 
@@ -243,6 +244,13 @@ func IdentityCenterAccountToAppServer(acct *identitycenterv1.Account) *types.App
 		}
 	}
 
+	// StartUrl contains a scheme (e.g. "https://start.example.com/start").
+	// PublicAddr must be a bare hostname, so strip the scheme and path.
+	publicAddr := acct.Spec.StartUrl
+	if u, err := url.Parse(publicAddr); err == nil && u.Host != "" {
+		publicAddr = u.Host
+	}
+
 	appServer := &types.AppServerV3{
 		Kind:     types.KindAppServer,
 		SubKind:  types.KindIdentityCenterAccount,
@@ -256,7 +264,7 @@ func IdentityCenterAccountToAppServer(acct *identitycenterv1.Account) *types.App
 				Metadata: types.Metadata153ToLegacy(acct.Metadata),
 				Spec: types.AppSpecV3{
 					URI:        acct.Spec.StartUrl,
-					PublicAddr: acct.Spec.StartUrl,
+					PublicAddr: publicAddr,
 					AWS: &types.AppAWS{
 						ExternalID: acct.Spec.Id,
 					},

--- a/lib/services/identitycenter_test.go
+++ b/lib/services/identitycenter_test.go
@@ -320,41 +320,36 @@ func TestIdentityCenterAccountAssignmentMatcher(t *testing.T) {
 	}
 }
 
+// TestIdentityCenterAccountToAppServer asserts the converter passes
+// StartUrl through to both URI and PublicAddr verbatim. The web
+// Launch button builds the SSO launch href as
+// `${publicAddr}&role_name=...`, so any normalization of scheme,
+// path, port, or case breaks Identity Center app launches.
 func TestIdentityCenterAccountToAppServer(t *testing.T) {
 	tests := []struct {
-		name           string
-		acctName       string
-		startURL       string
-		wantAppName    string
-		wantPublicAddr string
+		name     string
+		acctName string
+		startURL string
 	}{
 		{
-			name:           "strips scheme and path",
-			acctName:       "test-account",
-			startURL:       "https://start.example.com/start",
-			wantAppName:    "test-account",
-			wantPublicAddr: "start.example.com",
+			name:     "full launch URL preserved",
+			acctName: "test-account",
+			startURL: "https://start.example.com/start",
 		},
 		{
-			name:           "strips scheme and port",
-			acctName:       "test-account",
-			startURL:       "https://start.example.com:8443/start",
-			wantAppName:    "test-account",
-			wantPublicAddr: "start.example.com",
+			name:     "URL with port preserved",
+			acctName: "test-account",
+			startURL: "https://start.example.com:8443/start",
 		},
 		{
-			name:           "bare hostname unchanged",
-			acctName:       "test-account",
-			startURL:       "start.example.com",
-			wantAppName:    "test-account",
-			wantPublicAddr: "start.example.com",
+			name:     "bare hostname preserved",
+			acctName: "test-account",
+			startURL: "start.example.com",
 		},
 		{
-			name:           "lowercases mixed-case name and host",
-			acctName:       "Mixed-Case-Account",
-			startURL:       "https://Start.Example.COM/start",
-			wantAppName:    "mixed-case-account",
-			wantPublicAddr: "start.example.com",
+			name:     "mixed-case name and URL preserved",
+			acctName: "Mixed-Case-Account",
+			startURL: "https://Start.Example.COM/start",
 		},
 	}
 
@@ -373,13 +368,10 @@ func TestIdentityCenterAccountToAppServer(t *testing.T) {
 			}
 
 			srv := IdentityCenterAccountToAppServer(acct)
-			require.Equal(t, tt.wantAppName, srv.GetApp().GetName())
-			require.Equal(t, tt.wantAppName, srv.GetName())
-			require.Equal(t, tt.wantPublicAddr, srv.GetApp().GetPublicAddr())
+			require.Equal(t, tt.acctName, srv.GetApp().GetName())
+			require.Equal(t, tt.acctName, srv.GetName())
 			require.Equal(t, tt.startURL, srv.GetApp().GetURI())
-			// Round-trip through ValidateApp catches future write-path
-			// tightening.
-			require.NoError(t, ValidateApp(srv.GetApp(), &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}))
+			require.Equal(t, tt.startURL, srv.GetApp().GetPublicAddr())
 		})
 	}
 }

--- a/lib/services/identitycenter_test.go
+++ b/lib/services/identitycenter_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -314,6 +316,70 @@ func TestIdentityCenterAccountAssignmentMatcher(t *testing.T) {
 			require.NoError(t, err)
 
 			testCase.expectMatch(t, match)
+		})
+	}
+}
+
+func TestIdentityCenterAccountToAppServer(t *testing.T) {
+	tests := []struct {
+		name           string
+		acctName       string
+		startURL       string
+		wantAppName    string
+		wantPublicAddr string
+	}{
+		{
+			name:           "strips scheme and path",
+			acctName:       "test-account",
+			startURL:       "https://start.example.com/start",
+			wantAppName:    "test-account",
+			wantPublicAddr: "start.example.com",
+		},
+		{
+			name:           "strips scheme and port",
+			acctName:       "test-account",
+			startURL:       "https://start.example.com:8443/start",
+			wantAppName:    "test-account",
+			wantPublicAddr: "start.example.com",
+		},
+		{
+			name:           "bare hostname unchanged",
+			acctName:       "test-account",
+			startURL:       "start.example.com",
+			wantAppName:    "test-account",
+			wantPublicAddr: "start.example.com",
+		},
+		{
+			name:           "lowercases mixed-case name and host",
+			acctName:       "Mixed-Case-Account",
+			startURL:       "https://Start.Example.COM/start",
+			wantAppName:    "mixed-case-account",
+			wantPublicAddr: "start.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acct := &identitycenterv1.Account{
+				Kind:    types.KindIdentityCenterAccount,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: tt.acctName,
+				},
+				Spec: &identitycenterv1.AccountSpec{
+					Id:       "123456789012",
+					StartUrl: tt.startURL,
+				},
+			}
+
+			srv := IdentityCenterAccountToAppServer(acct)
+			require.Equal(t, tt.wantAppName, srv.GetApp().GetName())
+			require.Equal(t, tt.wantAppName, srv.GetName())
+			require.Equal(t, tt.wantPublicAddr, srv.GetApp().GetPublicAddr())
+			require.Equal(t, tt.startURL, srv.GetApp().GetURI())
+			// Round-trip through ValidateApp catches future write-path
+			// tightening.
+			require.NoError(t, ValidateApp(srv.GetApp(), &mockProxyGetter{addrs: []string{"proxy.example.com:443"}}))
 		})
 	}
 }

--- a/lib/services/identitycenter_test.go
+++ b/lib/services/identitycenter_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -314,6 +316,50 @@ func TestIdentityCenterAccountAssignmentMatcher(t *testing.T) {
 			require.NoError(t, err)
 
 			testCase.expectMatch(t, match)
+		})
+	}
+}
+
+func TestIdentityCenterAccountToAppServer(t *testing.T) {
+	tests := []struct {
+		name           string
+		startURL       string
+		wantPublicAddr string
+	}{
+		{
+			name:           "strips scheme and path",
+			startURL:       "https://start.example.com/start",
+			wantPublicAddr: "start.example.com",
+		},
+		{
+			name:           "strips scheme and port",
+			startURL:       "https://start.example.com:8443/start",
+			wantPublicAddr: "start.example.com",
+		},
+		{
+			name:           "bare hostname unchanged",
+			startURL:       "start.example.com",
+			wantPublicAddr: "start.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acct := &identitycenterv1.Account{
+				Kind:    types.KindIdentityCenterAccount,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "test-account",
+				},
+				Spec: &identitycenterv1.AccountSpec{
+					Id:       "123456789012",
+					StartUrl: tt.startURL,
+				},
+			}
+
+			srv := IdentityCenterAccountToAppServer(acct)
+			require.Equal(t, tt.wantPublicAddr, srv.GetApp().GetPublicAddr())
+			require.Equal(t, tt.startURL, srv.GetApp().GetURI())
 		})
 	}
 }

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -894,12 +894,13 @@ func (c *UnifiedResourceCache) processEventsAndUpdateCurrent(ctx context.Context
 		case types.OpDelete:
 			switch event.Resource.GetKind() {
 			case types.KindIdentityCenterAccount:
-				// Match the lowercased name IdentityCenterAccountToAppServer
-				// uses on insert; otherwise the delete misses the key.
+				// IdentityCenterAccountToAppServer stores the entry under
+				// KindAppServer with the IC account's name; rebuild that
+				// header so the delete matches the cache key.
 				c.deleteLocked(&types.ResourceHeader{
 					Kind: types.KindAppServer,
 					Metadata: types.Metadata{
-						Name: strings.ToLower(event.Resource.GetName()),
+						Name: event.Resource.GetName(),
 					},
 				})
 			default:

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -894,10 +894,12 @@ func (c *UnifiedResourceCache) processEventsAndUpdateCurrent(ctx context.Context
 		case types.OpDelete:
 			switch event.Resource.GetKind() {
 			case types.KindIdentityCenterAccount:
+				// Match the lowercased name IdentityCenterAccountToAppServer
+				// uses on insert; otherwise the delete misses the key.
 				c.deleteLocked(&types.ResourceHeader{
 					Kind: types.KindAppServer,
 					Metadata: types.Metadata{
-						Name: event.Resource.GetName(),
+						Name: strings.ToLower(event.Resource.GetName()),
 					},
 				})
 			default:

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -20,7 +20,6 @@ package app
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gravitational/trace"
 
@@ -170,7 +169,7 @@ func FindPublicAddr(ctx context.Context, client FindPublicAddrClient, appPublicA
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	return fmt.Sprintf("%v.%v", appName, cn.GetClusterName()), nil
+	return utils.DefaultAppPublicAddr(appName, cn.GetClusterName()), nil
 }
 
 func (s *Server) getResources() map[string]types.Application {

--- a/lib/srv/app/watcher_test.go
+++ b/lib/srv/app/watcher_test.go
@@ -58,7 +58,7 @@ func TestCloudHostedAppServiceRejectsDynamicLabels(t *testing.T) {
 	}
 
 	// Create app with label group=a and dynamic labels.
-	app, err := makeDynamicApp("app_with_dynamic_labels", map[string]string{"group": "a"})
+	app, err := makeDynamicApp("app-with-dynamic-labels", map[string]string{"group": "a"})
 	require.NoError(t, err)
 	app.SetDynamicLabels(map[string]types.CommandLabel{
 		"foo": &types.CommandLabelV2{

--- a/lib/utils/app.go
+++ b/lib/utils/app.go
@@ -18,6 +18,8 @@ package utils
 
 import (
 	"fmt"
+	"net"
+	"strings"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -38,8 +40,12 @@ func AssembleAppFQDN(localClusterName string, localProxyDNSName string, appClust
 	return DefaultAppPublicAddr(app.GetName(), localProxyDNSName)
 }
 
-// DefaultAppPublicAddr returns the default publicAddr for an app.
-// Format: <appName>.<localProxyDNSName>
+// DefaultAppPublicAddr returns "<appName>.<localProxyDNSName>",
+// stripping a trailing port and lowercasing the host so the result
+// satisfies ValidatePublicAddr.
 func DefaultAppPublicAddr(appName, localProxyDNSName string) string {
-	return fmt.Sprintf("%v.%v", appName, localProxyDNSName)
+	if host, _, err := net.SplitHostPort(localProxyDNSName); err == nil {
+		localProxyDNSName = host
+	}
+	return fmt.Sprintf("%s.%s", appName, strings.ToLower(localProxyDNSName))
 }

--- a/lib/utils/app.go
+++ b/lib/utils/app.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -40,6 +41,12 @@ func AssembleAppFQDN(localClusterName string, localProxyDNSName string, appClust
 
 // DefaultAppPublicAddr returns the default publicAddr for an app.
 // Format: <appName>.<localProxyDNSName>
+//
+// If localProxyDNSName contains a port (e.g. "proxy.example.com:443"),
+// the port is stripped because public addresses are bare hostnames.
 func DefaultAppPublicAddr(appName, localProxyDNSName string) string {
+	if host, _, err := net.SplitHostPort(localProxyDNSName); err == nil {
+		localProxyDNSName = host
+	}
 	return fmt.Sprintf("%v.%v", appName, localProxyDNSName)
 }

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -1103,6 +1103,12 @@ func (h *Handler) awsOIDCCreateAWSAppAccess(w http.ResponseWriter, r *http.Reque
 
 	getUserGroupLookup := h.getUserGroupLookup(r.Context(), clt)
 
+	// Reject mixed-case integration names; do not silently lowercase.
+	// The backend lookup is case-sensitive, so a stored record from
+	// before ValidIntegrationName enforced lowercase would be missed.
+	if strings.ToLower(integrationName) != integrationName {
+		return nil, trace.BadParameter("integration name %q contains uppercase characters which are no longer supported; recreate the integration with a lowercase name", integrationName)
+	}
 	publicAddr := libutils.DefaultAppPublicAddr(integrationName, h.PublicProxyAddr())
 
 	parsedRoleARN, err := awsutils.ParseRoleARN(ig.GetAWSOIDCIntegrationSpec().RoleARN)

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -1106,6 +1107,8 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 	proxy := env.proxies[0]
 	proxy.handler.handler.cfg.PublicProxyAddr = strings.TrimPrefix(proxy.handler.handler.cfg.PublicProxyAddr, "https://")
 	proxyPublicAddr := proxy.handler.handler.cfg.PublicProxyAddr
+	proxyPublicHost, _, err := net.SplitHostPort(proxyPublicAddr)
+	require.NoError(t, err)
 	pack := proxy.authPack(t, "foo@example.com", []types.Role{roleTokenCRD})
 
 	myIntegration, err := types.NewIntegrationAWSOIDC(types.Metadata{
@@ -1155,7 +1158,7 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 					URI:         "https://console.aws.amazon.com",
 					Integration: "my-integration",
 					Cloud:       "AWS",
-					PublicAddr:  "my-integration." + proxyPublicAddr,
+					PublicAddr:  "my-integration." + proxyPublicHost,
 				},
 			},
 		},
@@ -1207,6 +1210,22 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 		_, err = pack.clt.PostJSON(ctx, endpoint, nil)
 		require.Error(t, err)
 		require.ErrorContains(t, err, `Invalid integration name ("env.prod") for enabling AWS Access.`)
+	})
+
+	t.Run("mixed-case integration name is rejected", func(t *testing.T) {
+		mixedCaseIntegration, err := types.NewIntegrationAWSOIDC(types.Metadata{
+			Name: "MixedCase",
+		}, &types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "arn:aws:iam::123456789012:role/teleport",
+		})
+		require.NoError(t, err)
+
+		_, err = env.server.Auth().CreateIntegration(ctx, mixedCaseIntegration)
+		require.NoError(t, err)
+		endpoint = pack.clt.Endpoint("webapi", "sites", "localhost", "integrations", "aws-oidc", "MixedCase", "aws-app-access")
+		_, err = pack.clt.PostJSON(ctx, endpoint, nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "contains uppercase characters")
 	})
 }
 

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -1106,6 +1107,8 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 	proxy := env.proxies[0]
 	proxy.handler.handler.cfg.PublicProxyAddr = strings.TrimPrefix(proxy.handler.handler.cfg.PublicProxyAddr, "https://")
 	proxyPublicAddr := proxy.handler.handler.cfg.PublicProxyAddr
+	proxyPublicHost, _, err := net.SplitHostPort(proxyPublicAddr)
+	require.NoError(t, err)
 	pack := proxy.authPack(t, "foo@example.com", []types.Role{roleTokenCRD})
 
 	myIntegration, err := types.NewIntegrationAWSOIDC(types.Metadata{
@@ -1155,7 +1158,7 @@ func TestAWSOIDCAppAccessAppServerCreationDeletion(t *testing.T) {
 					URI:         "https://console.aws.amazon.com",
 					Integration: "my-integration",
 					Cloud:       "AWS",
-					PublicAddr:  "my-integration." + proxyPublicAddr,
+					PublicAddr:  "my-integration." + proxyPublicHost,
 				},
 			},
 		},

--- a/lib/web/integrations_awsra_test.go
+++ b/lib/web/integrations_awsra_test.go
@@ -160,7 +160,7 @@ func TestValidateAWSRolesAnywhereIntegration(t *testing.T) {
 			integrationName: "INVALID-",
 			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
 				require.Error(tt, err)
-				require.ErrorContains(tt, err, "must be a lower case valid DNS subdomain")
+				require.ErrorContains(tt, err, "must be a valid DNS label")
 			},
 		},
 		{

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -133,8 +133,8 @@ func GetNodeInstallScript(ctx context.Context, opts InstallNodeScriptOptions) (s
 	var appServerResourceLabels []string
 
 	if opts.AppServiceEnabled {
-		if errs := validation.IsDNS1035Label(opts.AppName); len(errs) > 0 {
-			return "", trace.BadParameter("appName %q must be a lower case valid DNS subdomain: https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", opts.AppName)
+		if errs := validation.IsDNS1123Label(opts.AppName); len(errs) > 0 {
+			return "", trace.BadParameter("appName %q must be a valid DNS label (lowercase alphanumeric or '-', must start and end with alphanumeric, max 63 chars): https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#application-name", opts.AppName)
 		}
 		if !appURIPattern.MatchString(opts.AppURI) {
 			return "", trace.BadParameter("appURI %q contains invalid characters", opts.AppURI)

--- a/tool/tctl/common/resources/resource_test.go
+++ b/tool/tctl/common/resources/resource_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -139,6 +140,8 @@ func TestHandlers(t *testing.T) {
 			kind: types.KindAppServer,
 			makeResource: func(t *testing.T, name string) types.Resource {
 				t.Helper()
+				// Shared name generator emits underscores; DNS-1123 rejects.
+				name = strings.ReplaceAll(name, "_", "-")
 				app, err := types.NewAppV3(
 					types.Metadata{
 						Name: name,
@@ -343,6 +346,43 @@ func TestHandlers(t *testing.T) {
 			})
 		})
 	}
+
+	// Shared kind table above generates DNS-1123 valid names; the
+	// two cases below cover the admin-path rejection of mixed-case.
+	t.Run("KindApp/rejects mixed-case name on Create", func(t *testing.T) {
+		handler := Handlers()[types.KindApp]
+		require.NotNil(t, handler)
+
+		app, err := types.NewAppV3(
+			types.Metadata{Name: "MyApp"},
+			types.AppSpecV3{URI: "http://localhost:12345"},
+		)
+		require.NoError(t, err)
+		raw := mustMakeUnknownResource(t, app)
+		err = handler.Create(t.Context(), clt, raw, CreateOpts{})
+		require.ErrorContains(t, err, "must be a valid DNS name")
+	})
+
+	t.Run("KindApp/rejects mixed-case name on Update", func(t *testing.T) {
+		handler := Handlers()[types.KindApp]
+		require.NotNil(t, handler)
+
+		// Seed a valid record so Update has something to target.
+		seeded, err := types.NewAppV3(
+			types.Metadata{Name: "valid-app-for-update"},
+			types.AppSpecV3{URI: "http://localhost:12345"},
+		)
+		require.NoError(t, err)
+		require.NoError(t, handler.Create(t.Context(), clt, mustMakeUnknownResource(t, seeded), CreateOpts{}))
+
+		bad, err := types.NewAppV3(
+			types.Metadata{Name: "MyApp"},
+			types.AppSpecV3{URI: "http://localhost:12345"},
+		)
+		require.NoError(t, err)
+		err = handler.Update(t.Context(), clt, mustMakeUnknownResource(t, bad), CreateOpts{})
+		require.ErrorContains(t, err, "must be a valid DNS name")
+	})
 }
 
 func mustMakeUnknownResource(t *testing.T, r types.Resource) services.UnknownResource {

--- a/tool/tctl/common/resources/resource_test.go
+++ b/tool/tctl/common/resources/resource_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -140,8 +139,6 @@ func TestHandlers(t *testing.T) {
 			kind: types.KindAppServer,
 			makeResource: func(t *testing.T, name string) types.Resource {
 				t.Helper()
-				// Shared name generator emits underscores; DNS-1123 rejects.
-				name = strings.ReplaceAll(name, "_", "-")
 				app, err := types.NewAppV3(
 					types.Metadata{
 						Name: name,

--- a/tool/tctl/common/resources/resource_test.go
+++ b/tool/tctl/common/resources/resource_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -139,6 +140,7 @@ func TestHandlers(t *testing.T) {
 			kind: types.KindAppServer,
 			makeResource: func(t *testing.T, name string) types.Resource {
 				t.Helper()
+				name = strings.ReplaceAll(name, "_", "-")
 				app, err := types.NewAppV3(
 					types.Metadata{
 						Name: name,


### PR DESCRIPTION
Consolidate app `name` and `public_addr` validation to fix six issues where
Teleport rejects valid app names, accepts invalid ones, or crashes on startup.
Preserve backwards compatibility for dynamic and heartbeat paths: clusters with
mixed-case records already in the backend keep working.

**Strict write validation** (admin writes + static config):

- App name, static: `IsDNS1123Label` - no dots, max 63 chars.
- App name, dynamic: `IsDNS1123SubdomainWithUnderscore` - dots OK for AWS-OIDC, `_` OK for snake_case identifiers (e.g. terraform), max 253 chars.
- `public_addr`: `IsDNS1123Subdomain` - dots OK (it is a hostname), max 253 chars.

All three k8s validators also enforce lowercase. RFC 1123 itself does not -
lowercase is a Teleport convention for interop with [k8s object
names][k8s-names].

`ValidateApp` is the single write-time validator, called from `CreateApp`,
`UpdateApp`, `UpsertApplicationServer`, the inventory control stream, and app
service startup. Heartbeats run `NormalizeAppServerForHeartbeat` first, which
lowercases both `name` and `public_addr` and strips URL schemes and ports, so
heartbeats from older agents end up stored lowercase.

**Backport note.** Older agents with truly malformed stored `public_addr`
values - e.g. a trailing dash on a label like `foo-.example.com`, a label
longer than 63 characters, or a total length over 253 characters - will fail
the new DNS-1123 check on the next heartbeat and drop from the registry.
Master had no DNS-1123 check at all (only port and IP-address rejections in
static config), so any of these values could have been stored. Most clusters
will not have them in practice, but the risk is not zero, so do not backport.

**Reviewer note:** the diff is big but the essence is small; splitting it
would leave app name creation and usage in an inconsistent state. An attempt
to support mixed-case `public_addr` end-to-end
([#66694][pr-66694]) surfaced multiple existing bugs, future-footgun potential, 
and the need for predicate language additions; rejecting mixed-case at write 
seemed the better choice.

Issue: https://github.com/gravitational/teleport/issues/22626
Issue: https://github.com/gravitational/teleport/issues/30160
Issue: https://github.com/gravitational/teleport/issues/7750
Issue: https://github.com/gravitational/teleport/issues/45010
Issue: https://github.com/gravitational/teleport/issues/58751
Issue: https://github.com/gravitational/teleport/issues/4838
Related-RFD: https://github.com/gravitational/teleport/blob/master/rfd/0153-resource-guidelines.md

## Manual Test Plan

### Test Environment

macOS, single-node Teleport (auth + proxy + app service), enterprise build
from the PR branch.

### Test Cases

#### Test 1: Mixed-case app name rejected (static config)

```yaml
app_service:
  enabled: true
  apps:
    - name: "MyApp"
      uri: http://localhost:9080
```

- [x] Teleport refuses to start with an error containing `must be a valid DNS label`.

#### Test 2: Leading-digit app name accepted (RFC 1123)

```yaml
app_service:
  enabled: true
  apps:
    - name: "1stapp"
      uri: http://localhost:9080
```

- [x] Teleport starts and registers the app without error.

#### Test 3: public_addr with URI scheme rejected

```yaml
app_service:
  enabled: true
  apps:
    - name: "myapp"
      uri: http://localhost:9080
      public_addr: "https://myapp.example.com"
```

- [x] Teleport refuses to start with an error containing `must not contain a URI scheme`.

#### Test 4: public_addr with port rejected

```yaml
app_service:
  enabled: true
  apps:
    - name: "myapp"
      uri: http://localhost:9080
      public_addr: "myapp.example.com:443"
```

- [x] Teleport refuses to start with an error containing `must not contain a port`.

#### Test 5: public_addr with malformed label rejected (closes #4838)

```yaml
app_service:
  enabled: true
  apps:
    - name: "myapp"
      uri: http://localhost:9080
      public_addr: "myapp-.example.com"
```

- [x] Teleport refuses to start with an error containing `must be a valid DNS name`.

#### Test 6: trailing FQDN dot and IDN Unicode rejected; punycode accepted

Static config with a trailing-dot `public_addr`:

```yaml
app_service:
  enabled: true
  apps:
    - name: "fqdn"
      uri: http://localhost:9080
      public_addr: "fqdn.example.com."
```

Then with Unicode IDN:

```yaml
app_service:
  enabled: true
  apps:
    - name: "idn"
      uri: http://localhost:9080
      public_addr: "münchen.de"
```

Then with the punycode form:

```yaml
app_service:
  enabled: true
  apps:
    - name: "puny"
      uri: http://localhost:9080
      public_addr: "xn--mnchen-3ya.de"
```

- [x] Trailing-dot config refuses to start with `must be a valid DNS name`.
- [x] IDN Unicode config refuses to start with `must be a valid DNS name`.
- [x] Punycode config starts and registers without error.

#### Test 7: tctl create rejects mixed-case app name (dynamic write)

```yaml
kind: app
version: v3
metadata:
  name: MyApp
spec:
  uri: http://localhost:9080
```

- [x] `tctl create` returns an error containing `must be a valid DNS name`.

#### Test 8: tctl create rejects public_addr with IP

```yaml
kind: app
version: v3
metadata:
  name: badapp
spec:
  uri: http://localhost:9080
  public_addr: "192.168.1.1"
```

- [x] `tctl create` returns an error containing `must not be an IP address`.

#### Test 9: Apps with hyphens or embedded digits launch without cert errors

```yaml
app_service:
  enabled: true
  apps:
    - name: "nginx-demo"
      uri: http://localhost:9080
    - name: "nginxdemo1"
      uri: http://localhost:9080
```

- [x] Both apps appear in `tsh apps ls`.
- [x] Launching each from the web UI loads the app without `NET::ERR_CERT_COMMON_NAME_INVALID`.

#### Test 10: Older agent heartbeat with mixed-case auto-normalises

Run a new auth/proxy from this PR alongside an older app service
(pre-PR) configured with `name: "Mixed"` and
`public_addr: "https://Mixed.example.com:8443"`.

- [x] The older agent registers successfully.
- [x] `tctl get app_servers` shows the app with lowercase `name: mixed` and `public_addr: mixed.example.com` (scheme and port stripped).

#### Test 11: Regression baseline (without fix)

Build from master (before the fix) and repeat Test 5
(`public_addr: "myapp-.example.com"`).

- [x] Master starts without rejecting the malformed `public_addr`, confirming the bug this PR fixes.

[k8s-names]:
  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
[pr-66694]:
  https://github.com/gravitational/teleport/pull/66694


