### PR TITLE
[vnet] fix: use correct SSH login when checking MFA requirement

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -127,6 +127,7 @@ func RouteToDatabaseToProto(dbRoute tlsca.RouteToDatabase) proto.RouteToDatabase
 type ReissueParams struct {
 	RouteToCluster    string
 	NodeName          string
+	SSHLogin          string
 	KubernetesCluster string
 	AccessRequests    []string
 	// See [proto.UserCertsRequest.DropAccessRequests].

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -19,6 +19,7 @@
 package client
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -353,6 +354,7 @@ func (c *ClusterClient) SessionSSHKeyRing(ctx context.Context, user string, targ
 		mfaClt,
 		ReissueParams{
 			NodeName:       nodeName(TargetNode{Addr: target.Addr}),
+			SSHLogin:       user,
 			RouteToCluster: target.Cluster,
 			MFACheck:       target.MFACheck,
 		},
@@ -453,6 +455,8 @@ func (c *ClusterClient) prepareUserCertsRequest(ctx context.Context, params Reis
 		purpose = proto.UserCertsRequest_CERT_PURPOSE_SINGLE_USE_CERTS
 	}
 
+	sshLogin := cmp.Or(params.SSHLogin, c.tc.HostLogin)
+
 	return newUserKeys, &proto.UserCertsRequest{
 		SSHPublicKey:                     sshPub,
 		TLSPublicKey:                     tlsPub,
@@ -469,7 +473,7 @@ func (c *ClusterClient) prepareUserCertsRequest(ctx context.Context, params Reis
 		Usage:                            params.usage(),
 		Format:                           c.tc.CertificateFormat,
 		RequesterName:                    params.RequesterName,
-		SSHLogin:                         c.tc.HostLogin,
+		SSHLogin:                         sshLogin,
 		SSHPublicKeyAttestationStatement: sshAttestationStatement.ToProto(),
 		TLSPublicKeyAttestationStatement: tlsAttestationStatement.ToProto(),
 		Purpose:                          purpose,
@@ -485,7 +489,8 @@ func (c *ClusterClient) performSessionMFACeremony(ctx context.Context, rootClien
 		return nil, trace.Wrap(err)
 	}
 
-	mfaRequiredReq, err := params.isMFARequiredRequest(c.tc.HostLogin)
+	sshLogin := cmp.Or(params.SSHLogin, c.tc.HostLogin)
+	mfaRequiredReq, err := params.isMFARequiredRequest(sshLogin)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -568,7 +573,8 @@ func (c *ClusterClient) IssueUserCertsWithMFA(ctx context.Context, params Reissu
 			}
 		}
 
-		mfaRequiredReq, err := params.isMFARequiredRequest(c.tc.HostLogin)
+		sshLogin := cmp.Or(params.SSHLogin, c.tc.HostLogin)
+		mfaRequiredReq, err := params.isMFARequiredRequest(sshLogin)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -215,6 +215,57 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 			},
 		},
 		{
+			name: "ssh login falls back to host login",
+			params: ReissueParams{
+				NodeName: "test",
+				AuthClient: fakeAuthClient{
+					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
+						nodeReq, ok := req.Target.(*proto.IsMFARequiredRequest_Node)
+						require.True(t, ok)
+						require.Equal(t, "default-login", nodeReq.Node.Login)
+						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
+					},
+					generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+						require.Equal(t, "default-login", req.SSHLogin)
+						return defaultGenerateUserCerts(ctx, req)
+					},
+				},
+			},
+			assertion: func(t *testing.T, result *IssueUserCertsWithMFAResult, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, result.MFARequired)
+				require.NotNil(t, result.KeyRing)
+				require.NotEmpty(t, result.KeyRing.Cert)
+			},
+		},
+		{
+			name: "ssh login override used",
+			params: ReissueParams{
+				NodeName: "test",
+				SSHLogin: "override-login",
+				AuthClient: fakeAuthClient{
+					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
+						nodeReq, ok := req.Target.(*proto.IsMFARequiredRequest_Node)
+						require.True(t, ok)
+						require.Equal(t, "override-login", nodeReq.Node.Login)
+						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
+					},
+					generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+						require.Equal(t, "override-login", req.SSHLogin)
+						return defaultGenerateUserCerts(ctx, req)
+					},
+				},
+			},
+			assertion: func(t *testing.T, result *IssueUserCertsWithMFAResult, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, result.MFARequired)
+				require.NotNil(t, result.KeyRing)
+				require.NotEmpty(t, result.KeyRing.Cert)
+			},
+		},
+		{
 			name:        "kube no mfa",
 			mfaRequired: proto.MFARequired_MFA_REQUIRED_NO,
 			params:      ReissueParams{KubernetesCluster: "test"},
@@ -518,6 +569,7 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 					Config: Config{
 						WebProxyAddr: "proxy.example.com",
 						SiteName:     "test",
+						HostLogin:    "default-login",
 						Tracer:       tracing.NoopTracer("test"),
 						MFAPromptConstructor: func(cfg *libmfa.PromptConfig) mfa.Prompt {
 							return test.prompt


### PR DESCRIPTION
Fixes #65301
## Summary

VNet SSH can request a per-session SSH login that differs from the profile's default `HostLogin`.
Before this change, the SSH single-use cert flow used the requested login for the connection, but the MFA pre-check still used the client's default host login. When the requested login was granted by an MFA-protected role and the default login was not, the MFA pre-check could incorrectly conclude that MFA was not required. The node would then reject the connection because the issued credentials had not been MFA-verified for the requested login.

This change carries the requested SSH login through `ReissueParams` and uses the same effective login for both:

- `IsMFARequired` requests for SSH targets
- `UserCertsRequest.SSHLogin` during cert issuance

This keeps the MFA decision and the issued SSH credentials aligned with the actual login the user requested.

## Testing

- Added unit coverage for SSH login fallback and explicit SSH login override in `lib/client/cluster_client_test.go`
- Ran `go test ./lib/client -run TestIssueUserCertsWithMFA`

Changelog: Fix VNet SSH per-session MFA checks to use the requested SSH login instead of the profile default login

## Manual Test Plan
### Test Environment

- macOS or Windows client machine with OpenSSH installed
- `tsh` built from this branch and available on `PATH`
- Teleport cluster with WebAuthn per-session MFA already working
- One enrolled MFA device for the test user
- One Linux node enrolled in the cluster
- Root cluster name used below as `<cluster-name>`
- Proxy address used below as `<proxy>`

Cluster setup:

1. On the test node, create two local Unix users:
   ```bash
   sudo useradd -m nic || true
   sudo useradd -m additional-login || true
   ```

2. Ensure the Teleport node has a static label that can be targeted by the test roles.
   Example `teleport.yaml` fragment on the node:
   ```yaml
   ssh_service:
     enabled: yes
     labels:
       test_case: vnet-ssh-mfa-login
   ```
   Restart the node after updating the config.

3. Create the test roles:
   ```yaml
   # role-vnet-default.yaml
   kind: role
   version: v7
   metadata:
     name: vnet-default-login
   spec:
     options:
       require_session_mfa: false
     allow:
       logins: ["nic"]
       node_labels:
         test_case: ["vnet-ssh-mfa-login"]
   ---
   # role-vnet-mfa.yaml
   kind: role
   version: v7
   metadata:
     name: vnet-alt-login-mfa
   spec:
     options:
       require_session_mfa: true
     allow:
       logins: ["additional-login"]
       node_labels:
         test_case: ["vnet-ssh-mfa-login"]
   ```
   Apply them:
   ```bash
   tctl create -f role-vnet-default.yaml
   tctl create -f role-vnet-mfa.yaml
   ```

4. Create a test user with both roles:
   ```bash
   tctl users add vnet-tester --roles=vnet-default-login,vnet-alt-login-mfa
   ```
   Complete user signup and enroll a WebAuthn MFA device.

5. Confirm the target node is visible and note its hostname:
   ```bash
   tsh ls
   ```
   Use the hostname shown there below as `<node-hostname>`.

### Test Cases

- [x] Verify VNet SSH works with the default profile login
  1. Log in with default SSH login `nic`:
     ```bash
     tsh login --proxy=<proxy> --user=vnet-tester --login=nic
     ```
  2. Start VNet in one terminal:
     ```bash
     tsh vnet
     ```
  3. In a second terminal, install the VNet SSH config if needed:
     ```bash
     tsh vnet-ssh-autoconfig
     ```
  4. Connect over VNet using the default login:
     ```bash
     ssh nic@<node-hostname>.<cluster-name> whoami
     ```
  5. Confirm the command succeeds and prints:
     ```text
     nic
     ```

- [x] Verify VNet SSH with a different login triggers per-session MFA and succeeds
  1. Keep the same `tsh login` session from the previous test, still using profile default SSH login `nic`.
  2. Keep `tsh vnet` running.
  3. Connect over VNet using the other login that is only granted by the MFA-required role:
     ```bash
     ssh additional-login@<node-hostname>.<cluster-name> whoami
     ```
  4. Confirm a per-session MFA prompt appears.
  5. Complete the MFA check.
  6. Confirm the command succeeds and prints:
     ```text
     additional-login
     ```

- [x] Verify the selected login, not the profile default login, controls MFA behavior
  1. With the same profile still logged in as default SSH login `nic`, run:
     ```bash
     ssh nic@<node-hostname>.<cluster-name> whoami
     ```
  2. Confirm this does not require the MFA-only `additional-login` behavior and still succeeds as:
     ```text
     nic
     ```
  3. Run again:
     ```bash
     ssh additional-login@<node-hostname>.<cluster-name> whoami
     ```
  4. Confirm this path requires MFA and succeeds as:
     ```text
     additional-login
     ```

- [x] Regression check against the original bug
  1. Verify the profile default SSH login is still `nic`:
     ```bash
     tsh status
     ```
  2. While logged in with default SSH login `nic`, connect to VNet SSH as `additional-login`:
     ```bash
     ssh additional-login@<node-hostname>.<cluster-name> whoami
     ```
  3. Confirm the connection is not rejected with an error like:
     ```text
     access to resource requires MFA
     ```
  4. Confirm instead that MFA is performed and the command succeeds.

Expected result:

- VNet SSH uses the requested SSH login for MFA checks and single-use cert issuance.
- A profile logged in with default SSH login `nic` can still connect as `additional-login` when that login is the one requiring per-session MFA.

