### PR TITLE
app: Preserve URL fragment through auth redirect

### DIFF
--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -103,39 +103,31 @@ const appRedirectHTML = `
     <title>Teleport Redirection Service</title>
     <script nonce="{{.}}">
       (function() {
-        var currentUrl = new URL(window.location);
-        var currentOrigin = currentUrl.origin;
-        var params = new URLSearchParams(currentUrl.search);
-        var stateValue = params.get('state');
-        var subjectValue = params.get('subject');
-        var path = params.get('path');
+        var currentUrl = new URL(window.location)
+        var currentOrigin = currentUrl.origin
+        var params = new URLSearchParams(currentUrl.search)
+        var stateValue = params.get('state')
+        var subjectValue = params.get('subject')
+        var path = params.get('path')
         if (!stateValue) {
-          return;
+          return
         }
-        // The URL fragment carries two named values: 'value' is the
-        // session cookie value, and 'fragment' (optional) is the
-        // user's original URL fragment. Browsers do not send the
-        // fragment to the server (RFC 9110 § 7.1), so values placed
-        // here stay client-side. The original fragment is
-        // reattached to the final navigation below.
-        //
-        // window.location.hash includes a leading '#' when
-        // non-empty, so slice(1) strips it before URLSearchParams
-        // parses the body.
-        var hashParams = new URLSearchParams(window.location.hash.slice(1));
-        var cookieValue = hashParams.get('value');
+        // The URL fragment encodes two URLSearchParams values:
+        // 'value' is the session cookie, and 'fragment' (optional)
+        // is the user's original fragment, reattached to the final
+        // navigation below.
+        var hashParams = new URLSearchParams(window.location.hash.slice(1))
+        var cookieValue = hashParams.get('value')
         if (!cookieValue) {
-          return;
+          return
         }
-        // fragment does not include a leading '#'; the URL.hash
-        // setter below adds it back.
-        var fragment = hashParams.get('fragment');
+        var fragment = hashParams.get('fragment')
         const data = {
           state_value: stateValue,
           cookie_value: cookieValue,
           subject_cookie_value: subjectValue,
           required_apps: params.get('required-apps'),
-        };
+        }
         fetch('/x-teleport-auth', {
           method: 'POST',
           mode: 'same-origin',
@@ -145,53 +137,37 @@ const appRedirectHTML = `
           },
           body: JSON.stringify(data),
         }).then(response => {
-          if (response.ok) {
-            const nextAppRedirectUrl = response.headers.get("X-Teleport-NextAppRedirectUrl")
-            if (nextAppRedirectUrl) {
-              // The required-app chain navigates to a different
-              // application's launcher. The launcher gates fragment
-              // forwarding on requiredApps.length <= 1, so on this
-              // branch fragment should already be empty. Drop
-              // it unconditionally as a defense-in-depth backstop:
-              // an intermediate app must not see values that were
-              // meant for the user's originally requested app
-              // (e.g. an OAuth implicit-flow access token or a
-              // password-reset token). As a consequence, chain-
-              // redirected apps lose the original fragment
-              // entirely; "final navigation" below means the final
-              // navigation of this hop, not the user's originally
-              // requested URL.
-              window.location.replace(nextAppRedirectUrl)
-              return;
-            }
+          if (!response.ok) {
+            return
+          }
+          var target = currentOrigin
+          const nextAppRedirectUrl = response.headers.get("X-Teleport-NextAppRedirectUrl")
+          if (nextAppRedirectUrl) {
+            // Drop the fragment on a chain hop: reattaching it
+            // here would leak it to an intermediate app's
+            // origin. The launcher already skips packing it on
+            // chain redirects.
+            target = nextAppRedirectUrl
+          } else {
             try {
-              // if a path parameter was passed through the redirect, append that path to the current origin
-              if (path) {
-                var redirectUrl = new URL(path, currentOrigin)
-                if (fragment) {
-                  redirectUrl.hash = fragment
-                }
-                if (redirectUrl.origin === currentOrigin) {
-                  window.location.replace(redirectUrl.toString())
-                } else {
-                  window.location.replace(currentOrigin)
-                }
-              } else if (fragment) {
-                // Match the path branch: assign via URL.hash so
-                // the browser handles encoding.
-                var rootUrl = new URL('/', currentOrigin)
-                rootUrl.hash = fragment
-                window.location.replace(rootUrl.toString())
-              } else {
-                window.location.replace(currentOrigin)
+              // Resolve path relative to currentOrigin; fall back
+              // to the origin root if the path crosses origins
+              // (e.g. "//attacker.com/foo").
+              var redirectUrl = new URL(path || '/', currentOrigin)
+              if (redirectUrl.origin !== currentOrigin) {
+                redirectUrl = new URL('/', currentOrigin)
               }
+              if (fragment) {
+                redirectUrl.hash = fragment
+              }
+              target = redirectUrl.toString()
             } catch (error) {
-              // in case of malformed url, return to current origin
-              window.location.replace(currentOrigin)
+              // Malformed URL: target stays as currentOrigin.
             }
           }
-        });
-      })();
+          window.location.replace(target)
+        })
+      })()
     </script>
   </head>
   <body></body>

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -112,13 +112,27 @@ const appRedirectHTML = `
         if (!stateValue) {
           return;
         }
-        var hashParts = window.location.hash.split('=');
-        if (hashParts.length !== 2 || hashParts[0] !== '#value') {
+        // The URL fragment carries two named values: 'value' is the
+        // session cookie value, and 'fragment' (optional) is the
+        // user's original URL fragment. Browsers do not send the
+        // fragment to the server (RFC 9110 § 7.1), so values placed
+        // here stay client-side. The original fragment is
+        // reattached to the final navigation below.
+        //
+        // window.location.hash includes a leading '#' when
+        // non-empty, so slice(1) strips it before URLSearchParams
+        // parses the body.
+        var hashParams = new URLSearchParams(window.location.hash.slice(1));
+        var cookieValue = hashParams.get('value');
+        if (!cookieValue) {
           return;
         }
+        // fragment does not include a leading '#'; the URL.hash
+        // setter below adds it back.
+        var fragment = hashParams.get('fragment');
         const data = {
           state_value: stateValue,
-          cookie_value: hashParts[1],
+          cookie_value: cookieValue,
           subject_cookie_value: subjectValue,
           required_apps: params.get('required-apps'),
         };
@@ -134,6 +148,19 @@ const appRedirectHTML = `
           if (response.ok) {
             const nextAppRedirectUrl = response.headers.get("X-Teleport-NextAppRedirectUrl")
             if (nextAppRedirectUrl) {
+              // The required-app chain navigates to a different
+              // application's launcher. The launcher gates fragment
+              // forwarding on requiredApps.length <= 1, so on this
+              // branch fragment should already be empty. Drop
+              // it unconditionally as a defense-in-depth backstop:
+              // an intermediate app must not see values that were
+              // meant for the user's originally requested app
+              // (e.g. an OAuth implicit-flow access token or a
+              // password-reset token). As a consequence, chain-
+              // redirected apps lose the original fragment
+              // entirely; "final navigation" below means the final
+              // navigation of this hop, not the user's originally
+              // requested URL.
               window.location.replace(nextAppRedirectUrl)
               return;
             }
@@ -141,11 +168,20 @@ const appRedirectHTML = `
               // if a path parameter was passed through the redirect, append that path to the current origin
               if (path) {
                 var redirectUrl = new URL(path, currentOrigin)
+                if (fragment) {
+                  redirectUrl.hash = fragment
+                }
                 if (redirectUrl.origin === currentOrigin) {
                   window.location.replace(redirectUrl.toString())
                 } else {
                   window.location.replace(currentOrigin)
                 }
+              } else if (fragment) {
+                // Match the path branch: assign via URL.hash so
+                // the browser handles encoding.
+                var rootUrl = new URL('/', currentOrigin)
+                rootUrl.hash = fragment
+                window.location.replace(rootUrl.toString())
               } else {
                 window.location.replace(currentOrigin)
               }

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -76,9 +76,8 @@ const launcherPathTestCases: {
       'x-teleport-auth?state=ABC&subject=subject-cookie-value&path=%2Ffoo%2Fbar#value=cookie-value',
   },
   {
-    // The fragment travels through the URL fragment of the
-    // auth-exchange URL, never the query string, so it stays out
-    // of proxy access logs.
+    // First leg: the auth-exchange URL hash carries the
+    // fragment, not the query string.
     name: 'no state with root path and fragment',
     path: '?path=%2F#my-section',
     expectedPath: 'x-teleport-auth?path=%2F#my-section',
@@ -94,44 +93,33 @@ const launcherPathTestCases: {
     expectedPath: 'x-teleport-auth?path=%2Ffoo%2Fbar%3Fq%3Dv#my-section',
   },
   {
-    // On the second leg the browser carries the original fragment
-    // forward via RFC 9110 § 15.4. The fragment is repacked
-    // alongside the session cookie value in the URL fragment of
-    // the redirect URL so the inline JS in
-    // lib/web/app/redirect.go can reattach it to the final
-    // navigation. The fragment is never serialised into the path
-    // query parameter.
+    // Second leg: fragment is repacked alongside the session
+    // cookie in the URL hash for the inline JS in
+    // lib/web/app/redirect.go to reattach.
     name: 'with state, path, and fragment',
     path: '?state=ABC&path=%2Ffoo%2Fbar#my-section',
     expectedPath:
       'x-teleport-auth?state=ABC&subject=subject-cookie-value&path=%2Ffoo%2Fbar#value=cookie-value&fragment=my-section',
   },
   {
-    // The new `else if (origFragment)` branch in the inline JS at
-    // lib/web/app/redirect.go is the only branch that handles a
-    // second-leg navigation with no `path` but with a fragment;
-    // pin the launcher's side of that branch.
+    // Second leg, no path: hits the inline-JS branch that
+    // navigates to the origin root with the fragment attached.
     name: 'with state and fragment, no path',
     path: '?state=ABC#my-section',
     expectedPath:
       'x-teleport-auth?state=ABC&subject=subject-cookie-value#value=cookie-value&fragment=my-section',
   },
   {
-    // OAuth implicit-flow tokens stay client-side: they only appear
-    // in the URL fragment, encoded as the `fragment` param.
+    // OAuth-style fragment: `=` and `&` round-trip through
+    // URLSearchParams encoding.
     name: 'with state, path, and OAuth implicit-flow fragment',
     path: '?state=ABC&path=%2Fcallback#access_token=secret&token_type=Bearer',
     expectedPath:
       'x-teleport-auth?state=ABC&subject=subject-cookie-value&path=%2Fcallback#value=cookie-value&fragment=access_token%3Dsecret%26token_type%3DBearer',
   },
   {
-    // Chain-redirect case: the launcher gates fragment forwarding
-    // on requiredApps.length <= 1 so the fragment never enters the
-    // chain. The inline JS in lib/web/app/redirect.go drops the
-    // fragment on the chain branch as a defense-in-depth backstop.
-    // The user's original fragment is intentionally lost when a
-    // required-apps chain is in play, to avoid exposing it to
-    // intermediate apps' origins.
+    // Chain redirect: launcher drops the fragment to avoid
+    // leaking it to intermediate apps' origins.
     name: 'with state, path, fragment, and required-apps chain',
     path: '?state=ABC&path=%2Ffoo&required-apps=app1,app2#secret',
     expectedPath:

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -23,6 +23,7 @@ import { render, screen, waitFor } from 'design/utils/testing';
 import cfg, { UrlLauncherParams } from 'teleport/config';
 import api from 'teleport/services/api';
 import service from 'teleport/services/apps';
+import { storageService } from 'teleport/services/storageService';
 
 import { AppLauncher } from './AppLauncher';
 
@@ -419,6 +420,166 @@ describe('fqdn is matched', () => {
     await screen.findByText(/access denied/i);
     expect(screen.getByText(/Failed to parse URL:/i)).toBeInTheDocument();
     expect(windowLocation.replace).not.toHaveBeenCalled();
+  });
+});
+
+// stashedFragmentTestCases cover the logged-out flow: the
+// Authenticated wrapper stashes the hash in sessionStorage before
+// redirecting to /web/login, and the launcher consumes it after
+// the post-login navigation. The launcher cannot read the original
+// hash from `useLocation()` at this point because goToLogin
+// dropped it from `redirect_uri` and the JS-driven navigation back
+// to the launcher does not inherit fragments.
+const stashedFragmentTestCases: {
+  name: string;
+  path: string;
+  stashedPath: string;
+  stashedHash: string;
+  expectedPath: string;
+}[] = [
+  {
+    // Stashed fragment threads through the first leg.
+    name: 'no state with stashed fragment',
+    path: '?path=%2Ffoo%2Fbar',
+    stashedPath: '/web/launch/grafana.localhost',
+    stashedHash: '#my-section',
+    expectedPath: 'x-teleport-auth?path=%2Ffoo%2Fbar#my-section',
+  },
+  {
+    // Stashed fragment threads through the second leg, packed
+    // alongside the session cookie.
+    name: 'with state and stashed fragment',
+    path: '?state=ABC&path=%2Ffoo%2Fbar',
+    stashedPath: '/web/launch/grafana.localhost',
+    stashedHash: '#my-section',
+    expectedPath:
+      'x-teleport-auth?state=ABC&subject=subject-cookie-value&path=%2Ffoo%2Fbar#value=cookie-value&fragment=my-section',
+  },
+  {
+    // Stash for a different launcher path is ignored.
+    name: 'stash for a different path is ignored',
+    path: '?path=%2Ffoo%2Fbar',
+    stashedPath: '/web/launch/other.localhost',
+    stashedHash: '#my-section',
+    expectedPath: 'x-teleport-auth?path=%2Ffoo%2Fbar',
+  },
+  {
+    // Required-apps chain drops the stashed fragment, same as for
+    // a URL fragment on the logged-in path.
+    name: 'required-apps chain drops stashed fragment',
+    path: '?state=ABC&path=%2Ffoo&required-apps=app1,app2',
+    stashedPath: '/web/launch/grafana.localhost',
+    stashedHash: '#secret',
+    expectedPath:
+      'x-teleport-auth?state=ABC&subject=subject-cookie-value&required-apps=app1%2Capp2&path=%2Ffoo#value=cookie-value',
+  },
+];
+
+describe('app launcher consumes a stashed fragment when the URL has none', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() => Promise.resolve({})) as jest.Mock;
+    jest.spyOn(api, 'get').mockResolvedValue({});
+    jest.spyOn(api, 'post').mockResolvedValue({});
+    jest.spyOn(service, 'getAppDetails').mockResolvedValue({
+      fqdn: 'grafana.localhost',
+    });
+    jest.spyOn(service, 'createAppSession').mockResolvedValue({
+      cookieValue: 'cookie-value',
+      subjectCookieValue: 'subject-cookie-value',
+      fqdn: '',
+    });
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  test.each(stashedFragmentTestCases)(
+    '$name',
+    async ({ path: query, stashedPath, stashedHash, expectedPath }) => {
+      storageService.setAppLauncherFragment(stashedPath, stashedHash);
+
+      const windowLocation = {
+        replace: jest.fn(),
+      };
+      render(
+        <MemoryRouter
+          initialEntries={[`/web/launch/grafana.localhost${query}`]}
+        >
+          <Routes>
+            <Route
+              path={appLauncherRoute}
+              element={<AppLauncher windowLocation={windowLocation} />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() =>
+        expect(windowLocation.replace).toHaveBeenCalledWith(
+          `https://grafana.localhost/${expectedPath}`
+        )
+      );
+      expect(screen.queryByText(/access denied/i)).not.toBeInTheDocument();
+    }
+  );
+
+  test('the URL fragment wins when both are present', async () => {
+    storageService.setAppLauncherFragment(
+      '/web/launch/grafana.localhost',
+      '#stashed'
+    );
+
+    const windowLocation = {
+      replace: jest.fn(),
+    };
+    render(
+      <MemoryRouter
+        initialEntries={[`/web/launch/grafana.localhost?path=%2Ffoo#fromurl`]}
+      >
+        <Routes>
+          <Route
+            path={appLauncherRoute}
+            element={<AppLauncher windowLocation={windowLocation} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(windowLocation.replace).toHaveBeenCalledWith(
+        `https://grafana.localhost/x-teleport-auth?path=%2Ffoo#fromurl`
+      )
+    );
+  });
+
+  test('the stash is cleared after the launcher reads it', async () => {
+    storageService.setAppLauncherFragment(
+      '/web/launch/grafana.localhost',
+      '#my-section'
+    );
+
+    const windowLocation = {
+      replace: jest.fn(),
+    };
+    render(
+      <MemoryRouter
+        initialEntries={[`/web/launch/grafana.localhost?path=%2Ffoo`]}
+      >
+        <Routes>
+          <Route
+            path={appLauncherRoute}
+            element={<AppLauncher windowLocation={windowLocation} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(windowLocation.replace).toHaveBeenCalled());
+    expect(
+      storageService.consumeAppLauncherFragment('/web/launch/grafana.localhost')
+    ).toBe('');
   });
 });
 

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -75,6 +75,68 @@ const launcherPathTestCases: {
     expectedPath:
       'x-teleport-auth?state=ABC&subject=subject-cookie-value&path=%2Ffoo%2Fbar#value=cookie-value',
   },
+  {
+    // The fragment travels through the URL fragment of the
+    // auth-exchange URL, never the query string, so it stays out
+    // of proxy access logs.
+    name: 'no state with root path and fragment',
+    path: '?path=%2F#my-section',
+    expectedPath: 'x-teleport-auth?path=%2F#my-section',
+  },
+  {
+    name: 'no state with path and fragment',
+    path: '?path=%2Ffoo%2Fbar#my-section',
+    expectedPath: 'x-teleport-auth?path=%2Ffoo%2Fbar#my-section',
+  },
+  {
+    name: 'no state with path, query, and fragment',
+    path: '?path=%2Ffoo%2Fbar&query=q%3Dv#my-section',
+    expectedPath: 'x-teleport-auth?path=%2Ffoo%2Fbar%3Fq%3Dv#my-section',
+  },
+  {
+    // On the second leg the browser carries the original fragment
+    // forward via RFC 9110 § 15.4. The fragment is repacked
+    // alongside the session cookie value in the URL fragment of
+    // the redirect URL so the inline JS in
+    // lib/web/app/redirect.go can reattach it to the final
+    // navigation. The fragment is never serialised into the path
+    // query parameter.
+    name: 'with state, path, and fragment',
+    path: '?state=ABC&path=%2Ffoo%2Fbar#my-section',
+    expectedPath:
+      'x-teleport-auth?state=ABC&subject=subject-cookie-value&path=%2Ffoo%2Fbar#value=cookie-value&fragment=my-section',
+  },
+  {
+    // The new `else if (origFragment)` branch in the inline JS at
+    // lib/web/app/redirect.go is the only branch that handles a
+    // second-leg navigation with no `path` but with a fragment;
+    // pin the launcher's side of that branch.
+    name: 'with state and fragment, no path',
+    path: '?state=ABC#my-section',
+    expectedPath:
+      'x-teleport-auth?state=ABC&subject=subject-cookie-value#value=cookie-value&fragment=my-section',
+  },
+  {
+    // OAuth implicit-flow tokens stay client-side: they only appear
+    // in the URL fragment, encoded as the `fragment` param.
+    name: 'with state, path, and OAuth implicit-flow fragment',
+    path: '?state=ABC&path=%2Fcallback#access_token=secret&token_type=Bearer',
+    expectedPath:
+      'x-teleport-auth?state=ABC&subject=subject-cookie-value&path=%2Fcallback#value=cookie-value&fragment=access_token%3Dsecret%26token_type%3DBearer',
+  },
+  {
+    // Chain-redirect case: the launcher gates fragment forwarding
+    // on requiredApps.length <= 1 so the fragment never enters the
+    // chain. The inline JS in lib/web/app/redirect.go drops the
+    // fragment on the chain branch as a defense-in-depth backstop.
+    // The user's original fragment is intentionally lost when a
+    // required-apps chain is in play, to avoid exposing it to
+    // intermediate apps' origins.
+    name: 'with state, path, fragment, and required-apps chain',
+    path: '?state=ABC&path=%2Ffoo&required-apps=app1,app2#secret',
+    expectedPath:
+      'x-teleport-auth?state=ABC&subject=subject-cookie-value&required-apps=app1%2Capp2&path=%2Ffoo#value=cookie-value',
+  },
 ];
 
 describe('app launcher path is properly formed', () => {

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -75,6 +75,27 @@ const launcherPathTestCases: {
     expectedPath:
       'x-teleport-auth?state=ABC&subject=subject-cookie-value&path=%2Ffoo%2Fbar#value=cookie-value',
   },
+  {
+    name: 'no state with root path and fragment',
+    path: '?path=%2F#my-section',
+    expectedPath: 'x-teleport-auth?path=%2F%23my-section',
+  },
+  {
+    name: 'no state with path and fragment',
+    path: '?path=%2Ffoo%2Fbar#my-section',
+    expectedPath: 'x-teleport-auth?path=%2Ffoo%2Fbar%23my-section',
+  },
+  {
+    name: 'no state with path, query, and fragment',
+    path: '?path=%2Ffoo%2Fbar&query=q%3Dv#my-section',
+    expectedPath: 'x-teleport-auth?path=%2Ffoo%2Fbar%3Fq%3Dv%23my-section',
+  },
+  {
+    name: 'with state, path, and fragment',
+    path: '?state=ABC&path=%2Ffoo%2Fbar%23my-section',
+    expectedPath:
+      'x-teleport-auth?state=ABC&subject=subject-cookie-value&path=%2Ffoo%2Fbar%23my-section#value=cookie-value',
+  },
 ];
 
 describe('app launcher path is properly formed', () => {

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useLocation, useParams } from 'react-router';
 
 import { Flex, Indicator } from 'design';
@@ -28,6 +28,7 @@ import { CreateAppSessionParams, UrlLauncherParams } from 'teleport/config';
 import { useMfa } from 'teleport/lib/useMfa';
 import service from 'teleport/services/apps';
 import { MfaChallengeScope } from 'teleport/services/auth/auth';
+import { storageService } from 'teleport/services/storageService';
 
 export function AppLauncher({
   windowLocation = window.location,
@@ -42,7 +43,23 @@ export function AppLauncher({
   const clusterId = pathParams.clusterId;
   const publicAddr = pathParams.publicAddr;
   const arn = pathParams.arn;
-  const { search, hash } = useLocation();
+  const { pathname, search, hash: urlHash } = useLocation();
+
+  // If the user reached the launcher while logged out, the
+  // Authenticated wrapper redirects to /web/login and drops the
+  // hash on the way (goToLogin builds redirect_uri from
+  // pathname+search only, and the JS-driven navigation does not
+  // inherit fragments). Authenticated stashes the hash in
+  // sessionStorage before that redirect; consume it here on the
+  // post-login launcher load so the existing fragment-forwarding
+  // logic below works for the logged-out case too.
+  //
+  // useState initializer runs once on mount, so the stash is read
+  // (and cleared) exactly once per launcher render.
+  const [stashedHash] = useState(() =>
+    urlHash ? '' : storageService.consumeAppLauncherFragment(pathname)
+  );
+  const hash = urlHash || stashedHash;
 
   const mfa = useMfa({
     req: {

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -126,23 +126,11 @@ export function AppLauncher({
             params,
             requiredApps,
           });
-          // Carry the original URL fragment through the auth flow as
-          // a URL fragment, not a query parameter. Browsers do not
-          // send fragments to the server (RFC 9110 § 7.1), so any
-          // sensitive values an app places in the fragment (for
-          // example an OAuth implicit-flow `#access_token=...` or a
-          // password-reset token) stay client-side. The browser will
-          // re-attach the fragment to the proxy's 302 response back
-          // to the launcher (RFC 9110 § 15.4), letting the second
-          // leg pick it up again from `useLocation().hash`.
-          //
-          // Skip the fragment when a required-apps chain is in
-          // play. In that case the proxy 302 to the next app's
-          // launcher would carry the fragment across origins via
-          // RFC 9110 § 15.4, exposing the originally requested
-          // app's fragment to intermediate apps. The trade-off is
-          // that chain-redirected apps lose the original fragment
-          // entirely.
+          // Pass the fragment to the second leg via the URL hash
+          // so it stays client-side. Skip on a required-apps chain
+          // to avoid leaking the originally requested app's
+          // fragment to intermediate apps' origins; chain-
+          // redirected apps lose the fragment as a result.
           if (hash && requiredApps.length <= 1) {
             url.hash = hash;
           }
@@ -176,18 +164,11 @@ export function AppLauncher({
           url.searchParams.set('required-apps', requiredApps.join(','));
         }
 
-        // Build the URL fragment used by the inline JS in
-        // `lib/web/app/redirect.go` to finish the auth exchange:
-        // `value` is the session cookie, and `fragment` is the
-        // user's original URL fragment, both kept in the URL hash
-        // so neither hits the proxy as a query parameter.
-        //
-        // Skip `fragment` on a required-apps chain so the original
-        // fragment never enters the chain in the first place. The
-        // inline JS in `redirect.go` also drops the fragment on
-        // the chain branch as a defense-in-depth backstop.
-        // `useLocation().hash` always has a leading `#` when
-        // non-empty, so `slice(1)` strips it before packing.
+        // Pack the session cookie and the original fragment into
+        // the URL hash for the inline JS in
+        // `lib/web/app/redirect.go` to consume. Skip `fragment` on
+        // a required-apps chain; the inline JS also drops it on
+        // the chain branch.
         const hashParams = new URLSearchParams();
         hashParams.set('value', session.cookieValue);
         if (hash && requiredApps.length <= 1) {

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -42,7 +42,7 @@ export function AppLauncher({
   const clusterId = pathParams.clusterId;
   const publicAddr = pathParams.publicAddr;
   const arn = pathParams.arn;
-  const { search } = useLocation();
+  const { search, hash } = useLocation();
 
   const mfa = useMfa({
     req: {
@@ -56,7 +56,7 @@ export function AppLauncher({
       },
     },
   });
-  const launchKey = `${fqdn}|${clusterId || ''}|${publicAddr || ''}|${arn || ''}|${search}`;
+  const launchKey = `${fqdn}|${clusterId || ''}|${publicAddr || ''}|${arn || ''}|${search}|${hash}`;
   const latestRunKeyRef = useRef<string>('');
 
   useEffect(() => {
@@ -126,6 +126,26 @@ export function AppLauncher({
             params,
             requiredApps,
           });
+          // Carry the original URL fragment through the auth flow as
+          // a URL fragment, not a query parameter. Browsers do not
+          // send fragments to the server (RFC 9110 § 7.1), so any
+          // sensitive values an app places in the fragment (for
+          // example an OAuth implicit-flow `#access_token=...` or a
+          // password-reset token) stay client-side. The browser will
+          // re-attach the fragment to the proxy's 302 response back
+          // to the launcher (RFC 9110 § 15.4), letting the second
+          // leg pick it up again from `useLocation().hash`.
+          //
+          // Skip the fragment when a required-apps chain is in
+          // play. In that case the proxy 302 to the next app's
+          // launcher would carry the fragment across origins via
+          // RFC 9110 § 15.4, exposing the originally requested
+          // app's fragment to intermediate apps. The trade-off is
+          // that chain-redirected apps lose the original fragment
+          // entirely.
+          if (hash && requiredApps.length <= 1) {
+            url.hash = hash;
+          }
           windowLocation.replace(url.toString());
           return;
         }
@@ -155,7 +175,25 @@ export function AppLauncher({
         if (requiredApps.length > 1) {
           url.searchParams.set('required-apps', requiredApps.join(','));
         }
-        url.hash = `#value=${session.cookieValue}`;
+
+        // Build the URL fragment used by the inline JS in
+        // `lib/web/app/redirect.go` to finish the auth exchange:
+        // `value` is the session cookie, and `fragment` is the
+        // user's original URL fragment, both kept in the URL hash
+        // so neither hits the proxy as a query parameter.
+        //
+        // Skip `fragment` on a required-apps chain so the original
+        // fragment never enters the chain in the first place. The
+        // inline JS in `redirect.go` also drops the fragment on
+        // the chain branch as a defense-in-depth backstop.
+        // `useLocation().hash` always has a leading `#` when
+        // non-empty, so `slice(1)` strips it before packing.
+        const hashParams = new URLSearchParams();
+        hashParams.set('value', session.cookieValue);
+        if (hash && requiredApps.length <= 1) {
+          hashParams.set('fragment', hash.slice(1));
+        }
+        url.hash = hashParams.toString();
 
         if (path) {
           url.searchParams.set('path', path);
@@ -193,6 +231,7 @@ export function AppLauncher({
     arn,
     clusterId,
     fqdn,
+    hash,
     launchKey,
     mfa,
     publicAddr,
@@ -280,7 +319,10 @@ function getNewAuthExchangeUrl({
   // path will only be defined, if a user hit the app endpoint
   // directly. This path is created in the server.
   // The path preserves both the path and query params of
-  // the original request.
+  // the original request. The caller is responsible for
+  // setting `url.hash` on the returned URL if a fragment
+  // must be preserved across the redirect; this function
+  // only builds the path and query parts.
   path: string;
   requiredApps: string[];
 }) {

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -42,7 +42,7 @@ export function AppLauncher({
   const clusterId = pathParams.clusterId;
   const publicAddr = pathParams.publicAddr;
   const arn = pathParams.arn;
-  const { search } = useLocation();
+  const { search, hash } = useLocation();
 
   const mfa = useMfa({
     req: {
@@ -56,7 +56,7 @@ export function AppLauncher({
       },
     },
   });
-  const launchKey = `${fqdn}|${clusterId || ''}|${publicAddr || ''}|${arn || ''}|${search}`;
+  const launchKey = `${fqdn}|${clusterId || ''}|${publicAddr || ''}|${arn || ''}|${search}|${hash}`;
   const latestRunKeyRef = useRef<string>('');
 
   useEffect(() => {
@@ -108,6 +108,10 @@ export function AppLauncher({
 
           if (queryParams.has('query')) {
             path += '?' + queryParams.get('query');
+          }
+
+          if (hash && !path.includes('#')) {
+            path += hash;
           }
         }
 
@@ -193,6 +197,7 @@ export function AppLauncher({
     arn,
     clusterId,
     fqdn,
+    hash,
     launchKey,
     mfa,
     publicAddr,

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -110,6 +110,14 @@ export function AppLauncher({
             path += '?' + queryParams.get('query');
           }
 
+          // Append the browser's fragment if one is present. On the first
+          // redirect leg the browser keeps the fragment in location.hash
+          // (fragments are never sent to the server), so hash is non-empty
+          // and we append it. On the second leg the fragment was already
+          // encoded as %23 inside the path query parameter, so hash is
+          // empty and the condition short-circuits without appending. The
+          // path.includes('#') check is a secondary guard for the unlikely
+          // case where a real fragment coexists with a decoded # in path.
           if (hash && !path.includes('#')) {
             path += hash;
           }

--- a/web/packages/teleport/src/components/Authenticated/Authenticated.test.tsx
+++ b/web/packages/teleport/src/components/Authenticated/Authenticated.test.tsx
@@ -21,6 +21,7 @@ import { render, screen, waitFor } from 'design/utils/testing';
 import api from 'teleport/services/api';
 import { ApiError } from 'teleport/services/api/parseError';
 import history from 'teleport/services/history';
+import { storageService } from 'teleport/services/storageService';
 import userService from 'teleport/services/user';
 import session from 'teleport/services/websession';
 
@@ -131,5 +132,128 @@ describe('session', () => {
     expect(screen.queryByText(/hello world/i)).not.toBeInTheDocument();
     expect(session.ensureSession).not.toHaveBeenCalled();
     expect(history.goToLogin).not.toHaveBeenCalled();
+  });
+});
+
+describe('app launcher fragment stash', () => {
+  function setLocation({ pathname, search = '', hash = '' }) {
+    window.history.replaceState({}, '', `${pathname}${search}${hash}`);
+  }
+
+  beforeEach(() => {
+    jest.spyOn(session, 'validateCookieAndSession').mockResolvedValue({});
+    jest.spyOn(session, 'ensureSession').mockImplementation();
+    jest.spyOn(session, 'getInactivityTimeout').mockImplementation(() => 0);
+    jest.spyOn(session, 'clearBrowserSession').mockImplementation();
+    jest.spyOn(api, 'get').mockResolvedValue({});
+    jest.spyOn(userService, 'fetchUserContext').mockResolvedValue(null);
+    jest.spyOn(history, 'goToLogin').mockImplementation();
+    jest.spyOn(storageService, 'setAppLauncherFragment');
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+    jest.clearAllMocks();
+  });
+
+  test('stashes the fragment when invalid session on launcher route', async () => {
+    jest.spyOn(session, 'isValid').mockImplementation(() => false);
+    setLocation({
+      pathname: '/web/launch/grafana.localhost',
+      search: '?path=%2Ffoo',
+      hash: '#my-section',
+    });
+
+    render(
+      <Authenticated>
+        <div>hello world</div>
+      </Authenticated>
+    );
+
+    await waitFor(() =>
+      expect(storageService.setAppLauncherFragment).toHaveBeenCalledWith(
+        '/web/launch/grafana.localhost',
+        '#my-section'
+      )
+    );
+  });
+
+  test('stashes the fragment when 403 on launcher route', async () => {
+    jest.spyOn(session, 'isValid').mockImplementation(() => true);
+    jest.spyOn(session, 'validateCookieAndSession').mockRejectedValue(
+      new ApiError({
+        message: 'forbidden',
+        response: { status: 403 } as Response,
+      })
+    );
+    setLocation({
+      pathname: '/web/launch/grafana.localhost',
+      hash: '#my-section',
+    });
+
+    render(
+      <Authenticated>
+        <div>hello world</div>
+      </Authenticated>
+    );
+
+    await waitFor(() =>
+      expect(storageService.setAppLauncherFragment).toHaveBeenCalledWith(
+        '/web/launch/grafana.localhost',
+        '#my-section'
+      )
+    );
+  });
+
+  test('does not stash on a non-launcher route', async () => {
+    jest.spyOn(session, 'isValid').mockImplementation(() => false);
+    setLocation({
+      pathname: '/web/cluster/test/resources',
+      hash: '#some-anchor',
+    });
+
+    render(
+      <Authenticated>
+        <div>hello world</div>
+      </Authenticated>
+    );
+
+    await waitFor(() => expect(session.clearBrowserSession).toHaveBeenCalled());
+    expect(storageService.setAppLauncherFragment).not.toHaveBeenCalled();
+  });
+
+  test('does not stash when no hash is present', async () => {
+    jest.spyOn(session, 'isValid').mockImplementation(() => false);
+    setLocation({
+      pathname: '/web/launch/grafana.localhost',
+      search: '?path=%2Ffoo',
+    });
+
+    render(
+      <Authenticated>
+        <div>hello world</div>
+      </Authenticated>
+    );
+
+    await waitFor(() => expect(session.clearBrowserSession).toHaveBeenCalled());
+    expect(storageService.setAppLauncherFragment).not.toHaveBeenCalled();
+  });
+
+  test('does not stash on a required-apps chain', async () => {
+    jest.spyOn(session, 'isValid').mockImplementation(() => false);
+    setLocation({
+      pathname: '/web/launch/grafana.localhost',
+      search: '?required-apps=app1,app2',
+      hash: '#secret',
+    });
+
+    render(
+      <Authenticated>
+        <div>hello world</div>
+      </Authenticated>
+    );
+
+    await waitFor(() => expect(session.clearBrowserSession).toHaveBeenCalled());
+    expect(storageService.setAppLauncherFragment).not.toHaveBeenCalled();
   });
 });

--- a/web/packages/teleport/src/components/Authenticated/Authenticated.tsx
+++ b/web/packages/teleport/src/components/Authenticated/Authenticated.tsx
@@ -17,6 +17,7 @@
  */
 
 import React, { PropsWithChildren, useEffect } from 'react';
+import { matchPath } from 'react-router';
 
 import { Box, Indicator } from 'design';
 import { TrustedDeviceRequirement } from 'gen-proto-ts/teleport/legacy/types/trusted_device_requirement_pb';
@@ -25,6 +26,7 @@ import Logger from 'shared/libs/logger';
 import { getErrMessage } from 'shared/utils/errorType';
 import { throttle } from 'shared/utils/highbar';
 
+import cfg from 'teleport/config';
 import { StyledIndicator } from 'teleport/Main';
 import { ApiError } from 'teleport/services/api/parseError';
 import { storageService } from 'teleport/services/storageService';
@@ -57,6 +59,7 @@ const Authenticated: React.FC<PropsWithChildren> = ({ children }) => {
     const checkIfUserIsAuthenticated = async () => {
       if (!session.isValid()) {
         logger.warn('invalid session');
+        stashAppLauncherFragmentIfPresent();
         session.clearBrowserSession(true /* rememberLocation */);
         return;
       }
@@ -83,6 +86,7 @@ const Authenticated: React.FC<PropsWithChildren> = ({ children }) => {
       } catch (e) {
         if (e instanceof ApiError && e.response?.status == 403) {
           logger.warn('invalid session');
+          stashAppLauncherFragmentIfPresent();
           session.clearBrowserSession(true /* rememberLocation */);
           // No need to update attempt, as `logout` will
           // redirect user to login page.
@@ -174,4 +178,39 @@ function startActivityChecker(ttl = 0) {
 function isInactive(ttl = 0) {
   const lastActive = storageService.getLastActive();
   return lastActive > 0 && Date.now() - lastActive > ttl;
+}
+
+// stashAppLauncherFragmentIfPresent persists the URL fragment to
+// sessionStorage when the user is about to be redirected to the
+// login page from the app launcher route. The launcher reads it
+// back after login and threads it through to the target app.
+//
+// goToLogin builds `redirect_uri` from `pathname + search` only,
+// dropping the hash, and the subsequent JS-driven navigation does
+// not inherit the fragment from the current location either, so
+// without this stash the fragment is lost before the login page
+// loads.
+//
+// Skip when the launcher request is part of a required-apps chain:
+// forwarding a fragment across origins would expose values meant
+// for the originally requested app to every intermediate app's
+// domain. The launcher itself enforces the same rule on the
+// logged-in path.
+function stashAppLauncherFragmentIfPresent() {
+  const { pathname, hash, search } = window.location;
+  if (!hash) {
+    return;
+  }
+  const matched = matchPath(
+    { path: cfg.routes.appLauncher, end: false },
+    pathname
+  );
+  if (!matched) {
+    return;
+  }
+  const requiredApps = new URLSearchParams(search).get('required-apps');
+  if (requiredApps && requiredApps.split(',').length > 1) {
+    return;
+  }
+  storageService.setAppLauncherFragment(pathname, hash);
 }

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -347,4 +347,34 @@ export const storageService = {
   clearRememberedSsoUsername() {
     window.localStorage.removeItem(KeysEnum.REMEMBERED_SSO_USERNAME);
   },
+
+  // setAppLauncherFragment stashes the URL fragment from a logged-out
+  // app-launcher request in sessionStorage so it can be reattached
+  // after the user completes the web login flow. sessionStorage is
+  // used (not localStorage or a query parameter) so the fragment
+  // value never reaches the server and never persists beyond the
+  // current tab.
+  setAppLauncherFragment(path: string, hash: string) {
+    window.sessionStorage.setItem(
+      KeysEnum.APP_LAUNCHER_FRAGMENT,
+      JSON.stringify({ path, hash })
+    );
+  },
+
+  // consumeAppLauncherFragment returns the previously stashed
+  // fragment if and only if it was stashed for the same launcher
+  // path. The entry is removed on read so a stale value cannot
+  // surface on a later launcher run.
+  consumeAppLauncherFragment(path: string): string {
+    const raw = window.sessionStorage.getItem(KeysEnum.APP_LAUNCHER_FRAGMENT);
+    if (!raw) {
+      return '';
+    }
+    window.sessionStorage.removeItem(KeysEnum.APP_LAUNCHER_FRAGMENT);
+    const parsed = JSON.parse(raw) as { path: string; hash: string };
+    if (parsed.path !== path) {
+      return '';
+    }
+    return parsed.hash;
+  },
 };

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -67,6 +67,7 @@ export const KeysEnum = {
 
   IDENTITY_SECURITY_RECOMMENDATIONS_UNIFIED_RESOURCES_CTA_SEEN:
     'grv_teleport_identity_security_recommendations_unified_resources_cta_seen',
+  APP_LAUNCHER_FRAGMENT: 'grv_teleport_app_launcher_fragment',
 };
 
 // SurveyRequest is the request for sending data to the back end


### PR DESCRIPTION
The app access auth redirect flow drops URL fragments (`#...`)
when a user accesses an app URL directly, so deep-link anchors
and tokens (e.g., `#access_token=...`) never reach the target
app. Thread the hash from `useLocation()` in the AppLauncher
through every hop of the auth exchange. For users without a Web
UI session, the launcher cannot read the hash because
`goToLogin` drops it from `redirect_uri` before login; stash it
in `sessionStorage` keyed by the launcher path before the
redirect, and consume it after login.

Use `sessionStorage` rather than `redirect_uri` so the fragment
value never reaches the server (otherwise it lands in
`/web/login` and SAML SSO access logs). Drop the fragment on a
required-apps chain because forwarding it across origins would
leak it to intermediate apps.

Changelog: Fixed app access dropping URL fragments through the auth redirect flow.

Issue: https://github.com/gravitational/teleport/issues/38653

## Manual Test Plan

### Test Environment

Single-process Teleport (auth + proxy + app service) running
locally on `t.tp` with the fragment echo Go server below as the
app backend. Run two batches: one with an existing web UI session
(verifies the AppLauncher hash forwarding), and one with no web UI
session (verifies the `sessionStorage` stash through the login
flow). Run each test in a fresh incognito window so neither the
app session cookie nor `sessionStorage` persists between cases.

<details>
<summary>Minimal Teleport config</summary>

```yaml
version: v3
teleport:
  nodename: fragment-test
  data_dir: data

auth_service:
  enabled: true
  cluster_name: t.tp
  authentication:
    type: local
    second_factor: "on"
    webauthn:
      rp_id: t.tp

proxy_service:
  enabled: true
  public_addr: t.tp:443
  web_listen_addr: 0.0.0.0:443
  https_keypairs:
    - key_file: /path/to/key.pem
      cert_file: /path/to/cert.pem

ssh_service:
  enabled: false

app_service:
  enabled: true
  apps:
    - name: app
      uri: http://127.0.0.1:9080
      public_addr: app.t.tp
```

</details>

<details>
<summary>Fragment echo server (test backend)</summary>

Save as `main.go`, run with `go run main.go`. The page shows a
green PASS box if the fragment survived, red if it was lost.

```go
package main

import (
	"fmt"
	"net/http"
	"os"
)

const page = `<!DOCTYPE html>
<html>
<head>
<title>Fragment Test</title>
<style>
  body { font-family: system-ui, sans-serif; max-width: 600px; margin: 40px auto; padding: 0 20px; }
  #result { font-size: 1.4em; padding: 16px; border-radius: 8px; margin: 20px 0; }
  .pass { background: #d4edda; color: #155724; }
  .fail { background: #f8d7da; color: #721c24; }
  code { background: #f0f0f0; padding: 2px 6px; border-radius: 3px; }
  .spacer { height: 2000px; }
</style>
</head>
<body>
<h1>Fragment Echo</h1>
<div id="result">Checking...</div>
<p><strong>Full URL:</strong> <code id="url"></code></p>
<p><strong>Fragment:</strong> <code id="hash"></code></p>
<div class="spacer"></div>
<h2 id="my-section">My Section</h2>
<p>Target anchor for fragment tests.</p>
<h2 id="deep-link">Deep Link</h2>
<p>Another anchor target.</p>
<script>
  var h = window.location.hash;
  document.getElementById('url').textContent = window.location.href;
  document.getElementById('hash').textContent = h || '(none)';
  var el = document.getElementById('result');
  if (h) {
    el.textContent = 'PASS — fragment preserved: ' + h;
    el.className = 'pass';
  } else {
    el.textContent = 'NO FRAGMENT in URL';
    el.className = 'fail';
  }
</script>
</body>
</html>`

func main() {
	port := "9080"
	if p := os.Getenv("PORT"); p != "" {
		port = p
	}
	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		w.Header().Set("Content-Type", "text/html; charset=utf-8")
		fmt.Fprint(w, page)
	})
	fmt.Printf("listening on :%s\n", port)
	if err := http.ListenAndServe(":"+port, nil); err != nil {
		fmt.Fprintln(os.Stderr, err)
		os.Exit(1)
	}
}
```

</details>

### Test Cases

#### Logged in to the Web UI

Sign into the Web UI first, then run each case in a fresh
incognito window with the web session present.

- [x] `https://app.t.tp/index.html#my-section` -> final URL has
  `#my-section`, page scrolls to "My Section".
- [x] `https://app.t.tp/index.html?q=value#deep-link` -> final URL
  preserves path, query, and `#deep-link`.
- [x] `https://app.t.tp/index.html` -> no fragment, page loads
  normally.
- [x] `https://app.t.tp/#my-section` -> root path with `#my-section`.
- [x] Build from `master` and repeat the first test: confirm the
  fragment is dropped, regression baseline.

#### Not logged in to the Web UI

Run each case in a fresh incognito window with no Teleport session
in either origin. Paste the URL into the address bar; the proxy
redirects to the Web UI login page; sign in; the launcher resumes
and lands on the app.

- [x] `https://app.t.tp/index.html#my-section` -> sign in, end on
  `https://app.t.tp/index.html#my-section`, page scrolls.
- [x] `https://app.t.tp/index.html?q=value#deep-link` -> end URL
  preserves path, query, and `#deep-link`.
- [x] `https://app.t.tp/#my-section` -> root with `#my-section`.
- [x] `https://app.t.tp/index.html` -> no fragment, page loads.
- [x] **Sensitive fragment never reaches the server.** Open
  `https://app.t.tp/callback#access_token=secret123&token_type=Bearer`,
  sign in, and verify all three of:
    - The final URL bar shows the full
      `#access_token=secret123&token_type=Bearer` fragment, page
      shows green PASS.
    - While the URL bar is on the Web UI login page, `redirect_uri`
      does NOT contain `secret123` or `access_token`. The value
      sits in `sessionStorage` instead, under the key
      `grv_teleport_app_launcher_fragment` (DevTools ->
      Application -> Session Storage -> `https://t.tp`). After the
      launcher resumes post-login, the entry is removed.
    - `grep -i 'secret123\|access_token\|Bearer' teleport.log`
      returns no matches: the fragment value never reached the
      proxy.
