### PR TITLE
Update error messages to remove duplicate strings

### DIFF
--- a/lib/auth/join/boundkeypair/boundkeypair.go
+++ b/lib/auth/join/boundkeypair/boundkeypair.go
@@ -446,7 +446,7 @@ func (c *FSClientState) Store(ctx context.Context) error {
 			Entries: c.KeyHistory,
 		})
 		if err != nil {
-			return trace.Wrap(err, "marshaling key key history")
+			return trace.Wrap(err, "marshaling key history")
 		}
 
 		if err := c.fs.Write(ctx, KeyHistoryPath, bytes); err != nil {

--- a/lib/jwt/jwk.go
+++ b/lib/jwt/jwk.go
@@ -107,7 +107,7 @@ func MarshalJWK(bytes []byte) (JWK, error) {
 	case *ecdsa.PublicKey:
 		return marshalECDSAJWK(p)
 	default:
-		return JWK{}, trace.BadParameter("unsupported public type type %T", pub)
+		return JWK{}, trace.BadParameter("unsupported public type %T", pub)
 	}
 }
 

--- a/lib/services/headlessauthn.go
+++ b/lib/services/headlessauthn.go
@@ -46,7 +46,7 @@ func ValidateHeadlessAuthentication(h *types.HeadlessAuthentication) error {
 	case len(h.SshPublicKey) == 0:
 		return trace.BadParameter("headless authentication resource must have non-empty SSH public key")
 	case h.Metadata.Name != NewHeadlessAuthenticationID(h.SshPublicKey):
-		return trace.BadParameter("headless authentication authentication resource name must be derived from public key")
+		return trace.BadParameter("headless authentication resource name must be derived from public key")
 	}
 
 	return nil

--- a/lib/services/headlessauthn_test.go
+++ b/lib/services/headlessauthn_test.go
@@ -77,7 +77,7 @@ func TestValidateHeadlessAuthentication(t *testing.T) {
 				// use a random UUID instead of the uuid.NewHash of the public key used above.
 				ha.SetName(uuid.NewString())
 			}),
-			wantErr: "headless authentication authentication resource name must be derived from public key",
+			wantErr: "headless authentication resource name must be derived from public key",
 		}, {
 			name: "NOK expires missing",
 			ha: newHA(func(ha *types.HeadlessAuthentication) {

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -151,7 +151,7 @@ type tdpHandshaker struct {
 func (t *tdpHandshaker) sendError(ctx context.Context, log *slog.Logger, err error) error {
 	if err == nil {
 		log.WarnContext(ctx, "SendError called with empty message")
-		err = errors.New("an an unknown error has occurred")
+		err = errors.New("an unknown error has occurred")
 	}
 
 	return trace.Wrap(t.connection.WriteMessage((&legacy.Alert{


### PR DESCRIPTION
Error messages had duplicate words, fixed.
