### PR TITLE
[v18] Bump rand from 0.9.2 to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,13 +2223,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.0",
- "zerocopy",
 ]
 
 [[package]]
@@ -2308,7 +2307,7 @@ dependencies = [
  "picky",
  "picky-asn1-der",
  "picky-asn1-x509",
- "rand 0.9.0",
+ "rand 0.9.3",
  "reqwest",
  "rsa",
  "rustls",

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -29,7 +29,7 @@ ironrdp-tokio.workspace = true
 iso7816 = "0.1.4"
 iso7816-tlv = "0.4.4"
 log = "0.4.27"
-rand = { version = "0.9.0", features = ["os_rng"] }
+rand = { version = "0.9.3", features = ["os_rng"] }
 rsa = "0.9.10"
 sspi = { version = "0.15.0", features = ["network_client"] }
 tokio = { version = "1.44", features = ["full"] }


### PR DESCRIPTION
Backport #65737 to branch/v18