### PR TITLE
[v18] discover cloud iac integration hook (#64770)

### DIFF
--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.story.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.story.tsx
@@ -17,17 +17,13 @@
  */
 
 import { http, HttpResponse } from 'msw';
-import { MemoryRouter } from 'react-router';
-import { Route } from 'react-router-dom';
 
-import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
-import {
-  ToastNotificationProvider,
-  ToastNotifications,
-} from 'shared/components/ToastNotification';
+import { ToastNotifications } from 'shared/components/ToastNotification';
 
+import { Route } from 'teleport/components/Router';
 import cfg from 'teleport/config';
 import { ContentMinWidth } from 'teleport/Main/Main';
+import { TeleportProviderBasic } from 'teleport/mocks/providers';
 import { IntegrationKind } from 'teleport/services/integrations';
 
 import { IaCIntegrationOverview } from './IaCIntegrationOverview';
@@ -44,18 +40,14 @@ const path = cfg.routes.integrationOverview;
 
 function Component() {
   return (
-    <MemoryRouter initialEntries={initialEntries}>
-      <ToastNotificationProvider>
-        <ToastNotifications />
-        <InfoGuidePanelProvider>
-          <ContentMinWidth>
-            <Route path={path}>
-              <IaCIntegrationOverview />
-            </Route>
-          </ContentMinWidth>
-        </InfoGuidePanelProvider>
-      </ToastNotificationProvider>
-    </MemoryRouter>
+    <TeleportProviderBasic initialEntries={initialEntries}>
+      <ToastNotifications />
+      <ContentMinWidth>
+        <Route path={path}>
+          <IaCIntegrationOverview />
+        </Route>
+      </ContentMinWidth>
+    </TeleportProviderBasic>
   );
 }
 

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
@@ -16,8 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link as InternalLink } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -29,7 +28,6 @@ import {
   Subtitle1,
   Text,
 } from 'design';
-import { copyToClipboard } from 'design/utils/copyToClipboard';
 import FieldInput from 'shared/components/FieldInput';
 import { InfoGuideContainer } from 'shared/components/SlidingSidePanel/InfoGuide';
 import Validation from 'shared/components/Validation';
@@ -40,22 +38,14 @@ import cfg from 'teleport/config';
 import { Header } from 'teleport/Discover/Shared';
 import { useNoMinWidth } from 'teleport/Main';
 import { zIndexMap } from 'teleport/Navigation/zIndexMap';
-import { ApiError } from 'teleport/services/api/parseError';
 import {
   Regions as AwsRegion,
   IntegrationKind,
-  integrationService,
 } from 'teleport/services/integrations';
-import { userEventService } from 'teleport/services/userEvent';
-import {
-  IntegrationEnrollCodeType,
-  IntegrationEnrollEvent,
-  IntegrationEnrollEventData,
-  IntegrationEnrollKind,
-  IntegrationEnrollStep,
-} from 'teleport/services/userEvent/types';
+import { IntegrationEnrollKind } from 'teleport/services/userEvent/types';
 import { useClusterVersion } from 'teleport/useClusterVersion';
 
+import { useEnrollCloudIntegration } from '../Shared';
 import { DeploymentMethodSection } from './DeploymentMethodSection';
 import {
   ContentWithSidePanel,
@@ -72,42 +62,21 @@ import { ResourcesSection } from './ResourcesSection';
 import { buildTerraformConfig } from './tf_module';
 import { Ec2Config, WildcardRegion } from './types';
 
-const INTEGRATION_CHECK_RETRIES = 6;
-const INTEGRATION_CHECK_RETRY_DELAY = 5000;
-
 export function EnrollAws() {
   useNoMinWidth();
 
-  const [eventId] = useState(() => crypto.randomUUID());
-
-  function emitEvent(
-    event: IntegrationEnrollEvent,
-    extra?: Partial<IntegrationEnrollEventData>
-  ) {
-    userEventService.captureIntegrationEnrollEvent({
-      event,
-      eventData: {
-        id: eventId,
-        kind: IntegrationEnrollKind.AwsCloud,
-        ...extra,
-      },
-    });
-  }
-
-  useEffect(() => {
-    emitEvent(IntegrationEnrollEvent.Started);
-    // Only send once on init.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const { clusterVersion } = useClusterVersion();
 
-  const [integrationName, setIntegrationName] = useState(() => {
-    const randomHex = Array.from(crypto.getRandomValues(new Uint8Array(4)))
-      .map(b => b.toString(16).padStart(2, '0'))
-      .join('');
-    return `aws-integration-${randomHex}`;
-  });
+  const {
+    integrationName,
+    setIntegrationName,
+    copyTerraformConfig,
+    integrationExists,
+    isFetching,
+    isError,
+    checkIntegration,
+    cancelCheckIntegration,
+  } = useEnrollCloudIntegration(IntegrationEnrollKind.AwsCloud);
 
   const [regions, setRegions] = useState<WildcardRegion | AwsRegion[]>([
     '*',
@@ -132,44 +101,6 @@ export function EnrollAws() {
   const [isPanelOpen, setIsPanelOpen] = useState(true);
   const [activeInfoGuideTab, setActiveInfoGuideTab] =
     useState<InfoGuideTab>('terraform');
-
-  const integrationQueryKey = ['integration', integrationName];
-
-  const {
-    data: integrationData,
-    isFetching,
-    isError,
-    refetch,
-  } = useQuery({
-    queryKey: integrationQueryKey,
-    queryFn: ({ signal }) =>
-      integrationService.fetchIntegration(integrationName, signal),
-    enabled: false,
-    retry: (failureCount, error: unknown) => {
-      const shouldRetry =
-        failureCount < INTEGRATION_CHECK_RETRIES &&
-        error instanceof ApiError &&
-        error.response.status === 404;
-      return shouldRetry;
-    },
-    retryDelay: INTEGRATION_CHECK_RETRY_DELAY,
-    gcTime: 0,
-  });
-
-  const queryClient = useQueryClient();
-
-  const checkIntegration = () => {
-    emitEvent(IntegrationEnrollEvent.Step, {
-      step: IntegrationEnrollStep.VerifyIntegration,
-    });
-    refetch().then(result => {
-      if (result.isSuccess) {
-        emitEvent(IntegrationEnrollEvent.Complete);
-      }
-    });
-  };
-
-  const integrationExists = !!integrationData;
 
   const onInfoGuideClick = (section: InfoGuideTab) => {
     if (isPanelOpen && activeInfoGuideTab === section) {
@@ -223,10 +154,7 @@ export function EnrollAws() {
                 terraformConfig={terraformConfig}
                 handleCopy={() => {
                   if (validator.validate() && terraformConfig) {
-                    copyToClipboard(terraformConfig);
-                    emitEvent(IntegrationEnrollEvent.CodeCopy, {
-                      codeType: IntegrationEnrollCodeType.Terraform,
-                    });
+                    copyTerraformConfig(terraformConfig);
                   }
                 }}
                 integrationExists={integrationExists}
@@ -236,10 +164,7 @@ export function EnrollAws() {
                     checkIntegration();
                   }
                 }}
-                handleCancelCheckIntegration={() => {
-                  queryClient.cancelQueries({ queryKey: integrationQueryKey });
-                  queryClient.resetQueries({ queryKey: integrationQueryKey });
-                }}
+                handleCancelCheckIntegration={cancelCheckIntegration}
                 isCheckingIntegration={isFetching}
                 checkIntegrationError={isError}
               />
@@ -295,10 +220,7 @@ export function EnrollAws() {
                   terraformConfig={terraformConfig}
                   handleCopy={() => {
                     if (validator.validate() && terraformConfig) {
-                      copyToClipboard(terraformConfig);
-                      emitEvent(IntegrationEnrollEvent.CodeCopy, {
-                        codeType: IntegrationEnrollCodeType.Terraform,
-                      });
+                      copyTerraformConfig(terraformConfig);
                     }
                   }}
                 />

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/hooks.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/hooks.ts
@@ -1,0 +1,137 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+
+import { copyToClipboard } from 'design/utils/copyToClipboard';
+
+import { ApiError } from 'teleport/services/api/parseError';
+import { integrationService } from 'teleport/services/integrations';
+import { userEventService } from 'teleport/services/userEvent';
+import {
+  IntegrationEnrollCodeType,
+  IntegrationEnrollEvent,
+  IntegrationEnrollEventData,
+  IntegrationEnrollKind,
+  IntegrationEnrollStep,
+} from 'teleport/services/userEvent/types';
+
+const INTEGRATION_CHECK_RETRIES = 6;
+const INTEGRATION_CHECK_RETRY_DELAY = 5000;
+
+type CloudIntegrationKind =
+  | IntegrationEnrollKind.AwsCloud
+  | IntegrationEnrollKind.AzureCloud;
+
+function generateIntegrationName(kind: CloudIntegrationKind): string {
+  const prefix = kind === IntegrationEnrollKind.AwsCloud ? 'aws' : 'azure';
+
+  const randomHex = Array.from(crypto.getRandomValues(new Uint8Array(4)))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `${prefix}-integration-${randomHex}`;
+}
+
+// useEnrollCloudIntegration returns common steps and state of the IaC Enroll
+// flows (AWS, Azure, etc) and handles event tracking for each step
+export function useEnrollCloudIntegration(kind: CloudIntegrationKind) {
+  const [eventId] = useState(() => crypto.randomUUID());
+  const [integrationName, setIntegrationName] = useState(() =>
+    generateIntegrationName(kind)
+  );
+
+  const integrationQueryKey = ['integration', integrationName];
+
+  function emitEvent(
+    event: IntegrationEnrollEvent,
+    extra?: Partial<IntegrationEnrollEventData>
+  ) {
+    userEventService.captureIntegrationEnrollEvent({
+      event,
+      eventData: {
+        id: eventId,
+        kind: kind,
+        ...extra,
+      },
+    });
+  }
+
+  useEffect(() => {
+    emitEvent(IntegrationEnrollEvent.Started);
+    // Only send once on init.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const {
+    data: integrationData,
+    isFetching,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: integrationQueryKey,
+    queryFn: ({ signal }) =>
+      integrationService.fetchIntegration(integrationName, signal),
+    enabled: false,
+    retry: (failureCount, error: unknown) => {
+      const shouldRetry =
+        failureCount < INTEGRATION_CHECK_RETRIES &&
+        error instanceof ApiError &&
+        error.response.status === 404;
+      return shouldRetry;
+    },
+    retryDelay: INTEGRATION_CHECK_RETRY_DELAY,
+    gcTime: 0,
+  });
+
+  const queryClient = useQueryClient();
+
+  const checkIntegration = () => {
+    emitEvent(IntegrationEnrollEvent.Step, {
+      step: IntegrationEnrollStep.VerifyIntegration,
+    });
+    refetch().then(result => {
+      if (result.isSuccess) {
+        emitEvent(IntegrationEnrollEvent.Complete);
+      }
+    });
+  };
+
+  const cancelCheckIntegration = () => {
+    queryClient.cancelQueries({ queryKey: integrationQueryKey });
+    queryClient.resetQueries({ queryKey: integrationQueryKey });
+  };
+
+  const copyTerraformConfig = (config: string) => {
+    copyToClipboard(config);
+    emitEvent(IntegrationEnrollEvent.CodeCopy, {
+      codeType: IntegrationEnrollCodeType.Terraform,
+    });
+  };
+
+  return {
+    integrationName,
+    setIntegrationName,
+    copyTerraformConfig,
+    integrationExists: !!integrationData,
+    isFetching,
+    isError,
+    checkIntegration,
+    cancelCheckIntegration,
+  };
+}

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/index.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Shared/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from './hooks';


### PR DESCRIPTION
backport of https://github.com/gravitational/teleport/pull/64770

- Fixed react router issues with storybook changes

## Manual Test Plan

### Test Environment
- Local (enterprise)

### Test Cases
- [x] Visit `/web/integrations/new/aws-cloud`
- [x] Complete flow or enter an existing AWS integration name in form
- [x] Verify `Copy Terraform Module` copies example module in info guide to clipboard
- [x] Verify `Copy Terraform Module` button works in form + Info guide panel
- [x] Click "Check Integration" 
- [x] Verify integration found, `Check Integration` button  becomes `View Integration` and links to integration entered
- [x] Refresh page, use generated / non-existing integration name. 
- [x] Click "Check Integration"
- [x]  Verify you can cancel polling for integration (click Cancel button)
- [x] Click "Check Integration" again. After 30 seconds, verify an error is shown
- [x] IaCIntegrationOverview storybook still works

