### PR TITLE
docs: adding new videos to docs pages

### DIFF
--- a/docs/pages/beams/beams.mdx
+++ b/docs/pages/beams/beams.mdx
@@ -2,6 +2,7 @@
 title: Beams
 sidebar_label: Beams
 description: Trusted Runtimes for Infrastructure Agents
+videoBanner: NNczZTIFido
 tags:
   - conceptual
   - ai

--- a/docs/pages/identity-security/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries.mdx
@@ -2,6 +2,8 @@
 title: Session Recording Summaries
 sidebar_label: Summarize Session Recordings with AI
 description: Describes how to use Teleport Identity security to summarize session recordings with a language model.
+# cspell:disable-next-line
+videoBanner: AW5DVLVNf6A
 tags:
   - session-recording
   - conceptual


### PR DESCRIPTION
This commit adds accompanying videos to the Beams page (`/beams`) and the Session Summaries (`/identity-security/session-summaries/`) page.
