### PR TITLE
Implement SubCAServiceGetter in lib/auth/authclient.ClientI

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -6282,7 +6282,7 @@ func (c *Client) GetCertAuthorityOverride(
 
 	// TODO(codingllama): Consider adding ClusterName to requests so the server
 	//  can handle them appropriately/uniformly.
-	if id.ClusterName != "" && resp.CaOverride.GetMetadata().GetName() != id.ClusterName {
+	if id.ClusterName != "" && resp.GetCaOverride().GetMetadata().GetName() != id.ClusterName {
 		return nil, trace.NotFound("%s %s/%s not found", types.KindCertAuthorityOverride, id.CAType, id.ClusterName)
 	}
 

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -6260,6 +6260,53 @@ func (c *Client) SubCAClient() subcav1.SubCAServiceClient {
 	return subcav1.NewSubCAServiceClient(c.conn)
 }
 
+// GetCertAuthorityOverride reads a CA override resource by ID.
+//
+// It's equivalent to `c.SubCAClient().GetCertAuthorityOverride(ctx, req)`.
+//
+// If the cluster name is empty it's assumed that the default cluster is being
+// queried (like its namesake RPC). If the cluster name is non-empty, then it's
+// checked against the RPC response.
+func (c *Client) GetCertAuthorityOverride(
+	ctx context.Context,
+	id types.CertAuthorityOverrideID,
+) (*subcav1.CertAuthorityOverride, error) {
+	resp, err := c.SubCAClient().GetCertAuthorityOverride(ctx, &subcav1.GetCertAuthorityOverrideRequest{
+		CaId: &subcav1.CertAuthorityOverrideID{
+			CaType: id.CAType,
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// TODO(codingllama): Consider adding ClusterName to requests so the server
+	//  can handle them appropriately/uniformly.
+	if id.ClusterName != "" && resp.CaOverride.GetMetadata().GetName() != id.ClusterName {
+		return nil, trace.NotFound("%s %s/%s not found", types.KindCertAuthorityOverride, id.CAType, id.ClusterName)
+	}
+
+	return resp.CaOverride, nil
+}
+
+// ListCertAuthorityOverrides lists all CA overrides.
+//
+// It's equivalent to `c.SubCAClient().ListCertAuthorityOverrides(ctx, req)`.
+func (c *Client) ListCertAuthorityOverrides(
+	ctx context.Context,
+	pageSize int,
+	pageToken string,
+) (_ []*subcav1.CertAuthorityOverride, nextPageToken string, _ error) {
+	resp, err := c.SubCAClient().ListCertAuthorityOverride(ctx, &subcav1.ListCertAuthorityOverrideRequest{
+		PageSize:  int32(pageSize),
+		PageToken: pageToken,
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return resp.CaOverrides, resp.NextPageToken, nil
+}
+
 // IssuanceClient returns an [issuancev1pb.IssuanceServiceClient].
 func (c *Client) IssuanceClient() issuancev1pb.IssuanceServiceClient {
 	return issuancev1pb.NewIssuanceServiceClient(c.conn)

--- a/api/client/client_subca_test.go
+++ b/api/client/client_subca_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
+)
+
+func TestClient_GetCertAuthorityOverride(t *testing.T) {
+	t.Parallel()
+
+	client := newClientForSubCATesting(t)
+
+	override := caOverrides[0]
+	overrideID := types.CertAuthorityOverrideID{
+		ClusterName: override.Metadata.Name,
+		CAType:      override.SubKind,
+	}
+
+	tests := []struct {
+		name    string
+		id      types.CertAuthorityOverrideID
+		want    *subcav1.CertAuthorityOverride
+		wantErr bool // always a NotFoundError
+	}{
+		{
+			name: "ok",
+			id:   overrideID,
+			want: override,
+		},
+		{
+			name: "default cluster",
+			id: types.CertAuthorityOverrideID{
+				ClusterName: "", // aka default
+				CAType:      overrideID.CAType,
+			},
+			want: override,
+		},
+		{
+			name: "wrong cluster",
+			id: types.CertAuthorityOverrideID{
+				ClusterName: "llama", // wrong
+				CAType:      overrideID.CAType,
+			},
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := client.GetCertAuthorityOverride(t.Context(), test.id)
+			if test.wantErr {
+				assert.ErrorAs(t, err, new(*trace.NotFoundError), "GetCertAuthorityOverride error mismatch")
+				return
+			}
+			require.NoError(t, err)
+
+			if diff := cmp.Diff(test.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("GetCertAuthorityOverride mismatch (-want +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClient_ListCertAuthorityOverride(t *testing.T) {
+	t.Parallel()
+
+	client := newClientForSubCATesting(t)
+
+	t.Run("ok", func(t *testing.T) {
+		const pageSize = 0
+		const pageToken = ""
+		got, nextPageToken, err := client.ListCertAuthorityOverrides(t.Context(), pageSize, pageToken)
+		require.NoError(t, err)
+		assert.Empty(t, nextPageToken, "ListCertAuthorityOverrides returned unexpected nextPageToken")
+
+		want := caOverrides
+		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+			t.Errorf("ListCertAuthorityOverrides mismatch (-want +got)\n%s", diff)
+		}
+	})
+}
+
+func newClientForSubCATesting(t *testing.T) *Client {
+	// Use a bufconn as the gRPC listener.
+	const bufSize = 10 // arbitrary
+	lis := bufconn.Listen(bufSize)
+	t.Cleanup(func() {
+		assert.NoError(t, lis.Close(), "bufconn.Listener.Close()")
+	})
+
+	// Create the gRPC server.
+	s := grpc.NewServer(
+		// Options below are similar to auth.GRPCServer.
+		grpc.ChainStreamInterceptor(interceptors.GRPCServerStreamErrorInterceptor),
+		grpc.ChainUnaryInterceptor(interceptors.GRPCServerUnaryErrorInterceptor),
+	)
+
+	// Take a defensive copy of overrides.
+	overrides := make([]*subcav1.CertAuthorityOverride, len(caOverrides))
+	copy(overrides, caOverrides)
+
+	// Register services.
+	subcav1.RegisterSubCAServiceServer(s, &fakeSubCAService{
+		overrides: overrides,
+	})
+
+	// Start the gRPC server.
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		assert.NoError(t, s.Serve(lis), "grpc.Server.Serve()")
+	})
+	t.Cleanup(func() {
+		s.GracefulStop()
+		wg.Wait()
+	})
+
+	// Dial to the gRPC server using the bufconn.
+	cc, err := grpc.NewClient("passthrough:///bufconn",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithStreamInterceptor(interceptors.GRPCClientStreamErrorInterceptor),
+		grpc.WithUnaryInterceptor(interceptors.GRPCClientUnaryErrorInterceptor),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, cc.Close(), "grpc.ClientConn.Close()")
+	})
+
+	// Create the Client. We only set the fields required for SubCA testing.
+	return &Client{
+		conn: cc,
+	}
+}
+
+var caOverrides = []*subcav1.CertAuthorityOverride{
+	{
+		Kind:    types.KindCertAuthorityOverride,
+		SubKind: string(types.DatabaseClientCA),
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name:     "zarquon",
+			Revision: "1774a27d-977e-45a1-ac6a-dd8b7a8e0d8d",
+		},
+		Spec: &subcav1.CertAuthorityOverrideSpec{},
+	},
+	{
+		Kind:    types.KindCertAuthorityOverride,
+		SubKind: string(types.WindowsCA),
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name:     "zarquon",
+			Revision: "511c8c23-03ea-44b2-81e5-62ddcd4d3445",
+		},
+		Spec: &subcav1.CertAuthorityOverrideSpec{},
+	},
+}
+
+// fakeSubCAService is a fake SubCAService implementation that returns
+// hard-coded data.
+type fakeSubCAService struct {
+	subcav1.UnimplementedSubCAServiceServer
+
+	overrides []*subcav1.CertAuthorityOverride
+}
+
+func (s *fakeSubCAService) GetCertAuthorityOverride(
+	ctx context.Context,
+	req *subcav1.GetCertAuthorityOverrideRequest,
+) (*subcav1.GetCertAuthorityOverrideResponse, error) {
+	// Implement a simplistic Get. Input validation not performed.
+	for _, o := range s.overrides {
+		if o.SubKind == req.GetCaId().GetCaType() {
+			return &subcav1.GetCertAuthorityOverrideResponse{
+				CaOverride: o,
+			}, nil
+		}
+	}
+	return nil, trace.NotFound("ca override not found")
+}
+
+func (s *fakeSubCAService) ListCertAuthorityOverride(
+	ctx context.Context,
+	req *subcav1.ListCertAuthorityOverrideRequest,
+) (*subcav1.ListCertAuthorityOverrideResponse, error) {
+	// Input filters are completely disregarded.
+	return &subcav1.ListCertAuthorityOverrideResponse{
+		CaOverrides: s.overrides,
+	}, nil
+}

--- a/api/types/cert_authority_override.go
+++ b/api/types/cert_authority_override.go
@@ -20,8 +20,8 @@ type CertAuthorityOverrideID struct {
 	CAType      string
 }
 
-// DisplayName returns a user-friendly representation of the ID.
-func (id *CertAuthorityOverrideID) DisplayName() string {
+// FullName returns the "full name" of the resource, "{CAType}/{ClusterName}".
+func (id *CertAuthorityOverrideID) FullName() string {
 	if id == nil || (id.CAType == "" && id.ClusterName == "") {
 		return ""
 	}

--- a/api/types/cert_authority_override.go
+++ b/api/types/cert_authority_override.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// CertAuthorityOverrideID uniquely identifies a CertAuthorityOverride resource.
+type CertAuthorityOverrideID struct {
+	ClusterName string
+	CAType      string
+}
+
+// DisplayName returns a user-friendly representation of the ID.
+func (id *CertAuthorityOverrideID) DisplayName() string {
+	if id == nil || (id.CAType == "" && id.ClusterName == "") {
+		return ""
+	}
+	return id.CAType + "/" + id.ClusterName
+}

--- a/api/types/cert_authority_override_test.go
+++ b/api/types/cert_authority_override_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCertAuthorityOverrideID_DisplayName(t *testing.T) {
+func TestCertAuthorityOverrideID_FullName(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -65,7 +65,7 @@ func TestCertAuthorityOverrideID_DisplayName(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, test.want, test.id.DisplayName(), "DisplayName mismatch")
+			assert.Equal(t, test.want, test.id.FullName(), "DisplayName mismatch")
 		})
 	}
 }

--- a/api/types/cert_authority_override_test.go
+++ b/api/types/cert_authority_override_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCertAuthorityOverrideID_DisplayName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		id   *CertAuthorityOverrideID
+		want string
+	}{
+		{
+			name: "nil ID",
+			id:   nil,
+			want: "",
+		},
+		{
+			name: "empty ID",
+			id:   &CertAuthorityOverrideID{},
+			want: "",
+		},
+		{
+			name: "ClusterName only",
+			id: &CertAuthorityOverrideID{
+				ClusterName: "zarquon",
+			},
+			want: "/zarquon",
+		},
+		{
+			name: "CAType only",
+			id: &CertAuthorityOverrideID{
+				CAType: string(UserCA),
+			},
+			want: "user/",
+		},
+		{
+			name: "ok",
+			id: &CertAuthorityOverrideID{
+				ClusterName: "zarquon",
+				CAType:      string(DatabaseClientCA),
+			},
+			want: "db_client/zarquon",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.want, test.id.DisplayName(), "DisplayName mismatch")
+		})
+	}
+}

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -1629,6 +1629,7 @@ type ClientI interface {
 	types.Events
 	services.ScopedAccessClientGetter
 	services.WorkloadClusterService
+	services.SubCAServiceGetter
 
 	// ListUnifiedInstances returns a paginated list of unified instances (teleport instances and bot instances).
 	ListUnifiedInstances(ctx context.Context, req *inventoryv1.ListUnifiedInstancesRequest) (*inventoryv1.ListUnifiedInstancesResponse, error)

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -154,7 +154,7 @@ func (s *SubCAService) GetCertAuthorityOverride(
 
 	// Name has no effect on the query, it's only used for errors.
 	// See serviceForClusterAndType() / generic.Service.WithNameKeyFunc().
-	name := id.DisplayName()
+	name := id.FullName()
 
 	resource, err := service.GetResource(ctx, name)
 	return resource, trace.Wrap(err)
@@ -186,7 +186,7 @@ func (s *SubCAService) DeleteCertAuthorityOverride(
 
 	// Name has no effect on the query, it's only used for errors.
 	// See serviceForClusterAndType() / generic.Service.WithNameKeyFunc().
-	name := id.DisplayName()
+	name := id.FullName()
 
 	return trace.Wrap(service.DeleteResource(ctx, name))
 }

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -42,15 +42,7 @@ func newCAOverridesPrefix() backend.Key {
 }
 
 // CertAuthorityOverrideID uniquely identifies a CertAuthorityOverride resource.
-type CertAuthorityOverrideID struct {
-	ClusterName string
-	CAType      string
-}
-
-// displayName returns a user-friendly string for the ID.
-func (id *CertAuthorityOverrideID) displayName() string {
-	return id.CAType + "/" + id.ClusterName
-}
+type CertAuthorityOverrideID = types.CertAuthorityOverrideID
 
 // CertAuthorityOverrideIDFromResource returns the id of the specified resource.
 //
@@ -80,6 +72,9 @@ type SubCAServiceParams struct {
 type SubCAService struct {
 	service *generic.ServiceWrapper[*subcav1.CertAuthorityOverride]
 }
+
+// Keep interface in-sync with implementation.
+var _ services.SubCAService = (*SubCAService)(nil)
 
 // NewSubCAService creates a new service using the provided params.
 func NewSubCAService(p SubCAServiceParams) (*SubCAService, error) {
@@ -159,7 +154,7 @@ func (s *SubCAService) GetCertAuthorityOverride(
 
 	// Name has no effect on the query, it's only used for errors.
 	// See serviceForClusterAndType() / generic.Service.WithNameKeyFunc().
-	name := id.displayName()
+	name := id.DisplayName()
 
 	resource, err := service.GetResource(ctx, name)
 	return resource, trace.Wrap(err)
@@ -191,7 +186,7 @@ func (s *SubCAService) DeleteCertAuthorityOverride(
 
 	// Name has no effect on the query, it's only used for errors.
 	// See serviceForClusterAndType() / generic.Service.WithNameKeyFunc().
-	name := id.displayName()
+	name := id.DisplayName()
 
 	return trace.Wrap(service.DeleteResource(ctx, name))
 }

--- a/lib/services/subca.go
+++ b/lib/services/subca.go
@@ -16,7 +16,42 @@
 
 package services
 
-import subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+import (
+	"context"
+
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// SubCAServiceGetter is the read-only SubCAService interface.
+//
+// See lib/services/local.SubCAService.
+type SubCAServiceGetter interface {
+	// GetCertAuthorityOverride reads a CA override resource by ID.
+	GetCertAuthorityOverride(ctx context.Context, id types.CertAuthorityOverrideID) (*subcav1.CertAuthorityOverride, error)
+
+	// ListCertAuthorityOverrides lists all CA overrides.
+	ListCertAuthorityOverrides(ctx context.Context, pageSize int, pageToken string) (_ []*subcav1.CertAuthorityOverride, nextPageToken string, _ error)
+}
+
+// SubCAService manages CertAuthorityOverride resources.
+//
+// See lib/services/local.SubCAService.
+type SubCAService interface {
+	SubCAServiceGetter
+
+	// CreateCertAuthorityOverride creates a CA override.
+	CreateCertAuthorityOverride(ctx context.Context, resource *subcav1.CertAuthorityOverride) (*subcav1.CertAuthorityOverride, error)
+
+	// DeleteCertAuthorityOverride hard-deletes a CA override.
+	DeleteCertAuthorityOverride(ctx context.Context, id types.CertAuthorityOverrideID) error
+
+	// UpdateCertAuthorityOverride conditionally updates a CA override.
+	UpdateCertAuthorityOverride(ctx context.Context, resource *subcav1.CertAuthorityOverride) (*subcav1.CertAuthorityOverride, error)
+
+	// UpsertCertAuthorityOverride unconditionally creates or updates a CA override.
+	UpsertCertAuthorityOverride(ctx context.Context, resource *subcav1.CertAuthorityOverride) (*subcav1.CertAuthorityOverride, error)
+}
 
 // MarshalCertAuthorityOverride marshals a CA override resource.
 func MarshalCertAuthorityOverride(resource *subcav1.CertAuthorityOverride, opts ...MarshalOption) ([]byte, error) {


### PR DESCRIPTION
Define lib/services.SubCAService and lib/services.SubCAServiceGetter, and implement the latter in lib/auth/authclient.ClientI (and, consequently, api/client.Client).

The ClientI methods are necessary for Desktop Service instances to be able to query (and later watch) CA overrides from a remote Auth.

This PR also acts as a precursor to adding cache support for CA overrides, particularly by adding the services interface definitions.

https://github.com/gravitational/teleport.e/issues/7675