### PR TITLE
kube: add streaming JSON list filter package

### DIFF
--- a/lib/kube/proxy/streamfilter/streamfilter.go
+++ b/lib/kube/proxy/streamfilter/streamfilter.go
@@ -1,0 +1,299 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package streamfilter implements streaming RBAC filtering for Kubernetes
+// list responses. It uses json.Decoder with json.RawMessage to decode
+// individual items incrementally, apply a matcher to each item, and write
+// matching items to the output without buffering the entire response.
+package streamfilter
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+)
+
+// Matcher matches a Kubernetes resource by name and namespace.
+type Matcher interface {
+	Match(name, namespace string) (bool, error)
+}
+
+// Filter filters a Kubernetes list response by reading from src and
+// writing filtered output to dst, without buffering the entire response.
+type Filter interface {
+	Filter(src io.Reader, dst io.Writer) error
+}
+
+// NewJSONFilter returns a streaming filter for Kubernetes JSON list responses.
+// Callers are responsible for ensuring the upstream response is JSON
+// (e.g. by forcing Accept: application/json on the upstream request).
+// If log is nil, slog.Default() is used.
+func NewJSONFilter(matcher Matcher, log *slog.Logger) *JSONFilter {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &JSONFilter{matcher: matcher, log: log}
+}
+
+// JSONFilter performs streaming RBAC filtering on a Kubernetes JSON list response.
+// It parses the top-level JSON object incrementally using json.Decoder,
+// writes non-items fields through unchanged,
+// and filters the items/rows array one element at a time using the matcher.
+// This avoids buffering the entire response in memory.
+//
+// Supports both regular list responses ("items" array)
+// and server-side Table format ("rows" array with nested object.metadata).
+type JSONFilter struct {
+	matcher Matcher
+	log     *slog.Logger
+}
+
+func (f *JSONFilter) Filter(src io.Reader, dst io.Writer) error {
+	decoder := json.NewDecoder(src)
+	w := &jsonStreamWriter{dst: dst, firstField: true}
+	scratch := make(json.RawMessage, 0, 2048)
+
+	// Read opening { of the list object.
+	if err := expectDelim(decoder, '{'); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := w.writeRaw("{"); err != nil {
+		return trace.Wrap(err)
+	}
+
+	for decoder.More() {
+		key, err := decodeStringToken(decoder)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		switch key {
+		case "items":
+			if err := w.writeKey(key); err != nil {
+				return trace.Wrap(err)
+			}
+			scratch, err = f.filterArray(decoder, w, scratch, extractItemMeta)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+		case "rows":
+			if err := w.writeKey(key); err != nil {
+				return trace.Wrap(err)
+			}
+			scratch, err = f.filterArray(decoder, w, scratch, extractTableRowMeta)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+		default:
+			scratch = scratch[:0]
+			if err := decoder.Decode(&scratch); err != nil {
+				return trace.Wrap(err)
+			}
+			if err := w.writeKeyValue(key, scratch); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+
+	if err := expectDelim(decoder, '}'); err != nil {
+		return trace.Wrap(err)
+	}
+	return w.writeRaw("}")
+}
+
+// metaExtractor extracts name and namespace from a JSON item for RBAC matching.
+type metaExtractor func(item json.RawMessage) (name, namespace string, err error)
+
+// filterArray reads a JSON array from the decoder, applies RBAC filtering
+// to each element, and writes the filtered array to the writer.
+// The scratch buffer is reused across calls to reduce allocations.
+// Returns the (possibly grown) scratch buffer for reuse.
+func (f *JSONFilter) filterArray(
+	decoder *json.Decoder,
+	w *jsonStreamWriter,
+	scratch json.RawMessage,
+	extract metaExtractor,
+) (json.RawMessage, error) {
+	// Check if the next token is null (items: null).
+	token, err := decoder.Token()
+	if err != nil {
+		return scratch, trace.Wrap(err)
+	}
+	if token == nil {
+		return scratch, w.writeRaw("null")
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '[' {
+		return scratch, trace.BadParameter("expected [ or null, got %v", token)
+	}
+
+	if err := w.writeRaw("["); err != nil {
+		return scratch, trace.Wrap(err)
+	}
+
+	firstItem := true
+	for decoder.More() {
+		scratch = scratch[:0]
+		if err := decoder.Decode(&scratch); err != nil {
+			return scratch, trace.Wrap(err)
+		}
+
+		name, namespace, err := extract(scratch)
+		if err != nil {
+			// Can't extract metadata — fail closed (deny).
+			f.log.WarnContext(context.Background(), "Unable to extract name/namespace from list item", "error", err)
+			continue
+		}
+
+		allowed, err := f.matcher.Match(name, namespace)
+		if err != nil {
+			f.log.WarnContext(context.Background(), "Unable to compile regex expressions within kubernetes_resources", "error", err)
+			continue
+		}
+		if !allowed {
+			continue
+		}
+
+		if !firstItem {
+			if err := w.writeRaw(","); err != nil {
+				return scratch, trace.Wrap(err)
+			}
+		}
+		firstItem = false
+
+		if _, err := w.dst.Write(scratch); err != nil {
+			return scratch, trace.Wrap(err)
+		}
+	}
+
+	if err := expectDelim(decoder, ']'); err != nil {
+		return scratch, trace.Wrap(err)
+	}
+	return scratch, trace.Wrap(w.writeRaw("]"))
+}
+
+// kubeItemEnvelope is the minimal struct needed to extract name and namespace
+// from a regular Kubernetes list item for RBAC filtering.
+type kubeItemEnvelope struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+}
+
+// kubeTableRowEnvelope is the minimal struct needed to extract name and namespace
+// from a Kubernetes Table row for RBAC filtering.
+type kubeTableRowEnvelope struct {
+	Object *struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	} `json:"object"`
+}
+
+func extractItemMeta(item json.RawMessage) (name, namespace string, err error) {
+	var env kubeItemEnvelope
+	if err := json.Unmarshal(item, &env); err != nil {
+		return "", "", trace.Wrap(err)
+	}
+	if env.Metadata.Name == "" {
+		return "", "", trace.BadParameter("item has no name")
+	}
+	return env.Metadata.Name, env.Metadata.Namespace, nil
+}
+
+func extractTableRowMeta(item json.RawMessage) (name, namespace string, err error) {
+	var env kubeTableRowEnvelope
+	if err := json.Unmarshal(item, &env); err != nil {
+		return "", "", trace.Wrap(err)
+	}
+	if env.Object == nil {
+		return "", "", trace.BadParameter("table row has no embedded object")
+	}
+	if env.Object.Metadata.Name == "" {
+		return "", "", trace.BadParameter("table row embedded object has no name")
+	}
+	return env.Object.Metadata.Name, env.Object.Metadata.Namespace, nil
+}
+
+// jsonStreamWriter handles JSON output formatting with comma tracking.
+type jsonStreamWriter struct {
+	dst        io.Writer
+	firstField bool // tracks whether the next top-level field is the first
+}
+
+func (w *jsonStreamWriter) writeRaw(s string) error {
+	_, err := io.WriteString(w.dst, s)
+	return trace.Wrap(err)
+}
+
+func (w *jsonStreamWriter) writeKey(key string) error {
+	if !w.firstField {
+		if err := w.writeRaw(","); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	w.firstField = false
+
+	keyBytes, err := json.Marshal(key)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if _, err := w.dst.Write(keyBytes); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(w.writeRaw(":"))
+}
+
+func (w *jsonStreamWriter) writeKeyValue(key string, value json.RawMessage) error {
+	if err := w.writeKey(key); err != nil {
+		return trace.Wrap(err)
+	}
+	_, err := w.dst.Write(value)
+	return trace.Wrap(err)
+}
+
+func expectDelim(decoder *json.Decoder, expected rune) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != json.Delim(expected) {
+		return trace.BadParameter("expected %c, got %v", expected, token)
+	}
+	return nil
+}
+
+func decodeStringToken(decoder *json.Decoder) (string, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	s, ok := token.(string)
+	if !ok {
+		return "", trace.BadParameter("expected string key, got %v", token)
+	}
+	return s, nil
+}

--- a/lib/kube/proxy/streamfilter/streamfilter.go
+++ b/lib/kube/proxy/streamfilter/streamfilter.go
@@ -1,0 +1,292 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package streamfilter implements streaming RBAC filtering for Kubernetes
+// list responses. It uses json.Decoder with json.RawMessage to decode
+// individual items incrementally, apply a matcher to each item, and write
+// matching items to the output without buffering the entire response.
+package streamfilter
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// Matcher matches a Kubernetes resource by name and namespace.
+type Matcher interface {
+	Match(name, namespace string) (bool, error)
+}
+
+// Filter filters a Kubernetes list response by reading from src and
+// writing filtered output to dst, without buffering the entire response.
+type Filter interface {
+	Filter(src io.Reader, dst io.Writer) error
+}
+
+// New returns a streaming filter for the given content type,
+// or nil if no streaming implementation is available for that type.
+func New(contentType string, matcher Matcher) Filter {
+	switch {
+	case strings.Contains(contentType, "application/json"):
+		return &jsonFilter{matcher: matcher}
+	default:
+		return nil
+	}
+}
+
+// jsonFilter performs streaming RBAC filtering on a Kubernetes JSON list response.
+// It parses the top-level JSON object incrementally using json.Decoder,
+// writes non-items fields through unchanged,
+// and filters the items/rows array one element at a time using the matcher.
+// This avoids buffering the entire response in memory.
+//
+// Supports both regular list responses ("items" array)
+// and server-side Table format ("rows" array with nested object.metadata).
+type jsonFilter struct {
+	matcher Matcher
+}
+
+func (f *jsonFilter) Filter(src io.Reader, dst io.Writer) error {
+	decoder := json.NewDecoder(src)
+	w := &jsonStreamWriter{dst: dst, firstField: true}
+	scratch := make(json.RawMessage, 0, 2048)
+
+	// Read opening { of the list object.
+	if err := expectDelim(decoder, '{'); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := w.writeRaw("{"); err != nil {
+		return trace.Wrap(err)
+	}
+
+	for decoder.More() {
+		key, err := decodeStringToken(decoder)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		switch key {
+		case "items":
+			if err := w.writeKey(key); err != nil {
+				return trace.Wrap(err)
+			}
+			scratch, err = f.filterArray(decoder, w, scratch, extractItemMeta)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+		case "rows":
+			if err := w.writeKey(key); err != nil {
+				return trace.Wrap(err)
+			}
+			scratch, err = f.filterArray(decoder, w, scratch, extractTableRowMeta)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+		default:
+			scratch = scratch[:0]
+			if err := decoder.Decode(&scratch); err != nil {
+				return trace.Wrap(err)
+			}
+			if err := w.writeKeyValue(key, scratch); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+
+	if err := expectDelim(decoder, '}'); err != nil {
+		return trace.Wrap(err)
+	}
+	return w.writeRaw("}")
+}
+
+// metaExtractor extracts name and namespace from a JSON item for RBAC matching.
+type metaExtractor func(item json.RawMessage) (name, namespace string, err error)
+
+// filterArray reads a JSON array from the decoder, applies RBAC filtering
+// to each element, and writes the filtered array to the writer.
+// The scratch buffer is reused across calls to reduce allocations.
+// Returns the (possibly grown) scratch buffer for reuse.
+func (f *jsonFilter) filterArray(
+	decoder *json.Decoder,
+	w *jsonStreamWriter,
+	scratch json.RawMessage,
+	extract metaExtractor,
+) (json.RawMessage, error) {
+	// Check if the next token is null (items: null).
+	token, err := decoder.Token()
+	if err != nil {
+		return scratch, trace.Wrap(err)
+	}
+	if token == nil {
+		return scratch, w.writeRaw("null")
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '[' {
+		return scratch, trace.BadParameter("expected [ or null, got %v", token)
+	}
+
+	if err := w.writeRaw("["); err != nil {
+		return scratch, trace.Wrap(err)
+	}
+
+	firstItem := true
+	for decoder.More() {
+		scratch = scratch[:0]
+		if err := decoder.Decode(&scratch); err != nil {
+			return scratch, trace.Wrap(err)
+		}
+
+		name, namespace, err := extract(scratch)
+		if err != nil {
+			// Can't extract metadata — fail closed (deny).
+			continue
+		}
+
+		allowed, err := f.matcher.Match(name, namespace)
+		if err != nil || !allowed {
+			continue
+		}
+
+		if !firstItem {
+			if err := w.writeRaw(","); err != nil {
+				return scratch, trace.Wrap(err)
+			}
+		}
+		firstItem = false
+
+		if _, err := w.dst.Write(scratch); err != nil {
+			return scratch, trace.Wrap(err)
+		}
+	}
+
+	if err := expectDelim(decoder, ']'); err != nil {
+		return scratch, trace.Wrap(err)
+	}
+	return scratch, w.writeRaw("]")
+}
+
+// kubeItemEnvelope is the minimal struct needed to extract name and namespace
+// from a regular Kubernetes list item for RBAC filtering.
+type kubeItemEnvelope struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+}
+
+// kubeTableRowEnvelope is the minimal struct needed to extract name and namespace
+// from a Kubernetes Table row for RBAC filtering.
+type kubeTableRowEnvelope struct {
+	Object *struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	} `json:"object"`
+}
+
+func extractItemMeta(item json.RawMessage) (name, namespace string, err error) {
+	var env kubeItemEnvelope
+	if err := json.Unmarshal(item, &env); err != nil {
+		return "", "", trace.Wrap(err)
+	}
+	if env.Metadata.Name == "" {
+		return "", "", trace.BadParameter("item has no name")
+	}
+	return env.Metadata.Name, env.Metadata.Namespace, nil
+}
+
+func extractTableRowMeta(item json.RawMessage) (name, namespace string, err error) {
+	var env kubeTableRowEnvelope
+	if err := json.Unmarshal(item, &env); err != nil {
+		return "", "", trace.Wrap(err)
+	}
+	if env.Object == nil {
+		return "", "", trace.BadParameter("table row has no embedded object")
+	}
+	if env.Object.Metadata.Name == "" {
+		return "", "", trace.BadParameter("table row embedded object has no name")
+	}
+	return env.Object.Metadata.Name, env.Object.Metadata.Namespace, nil
+}
+
+// jsonStreamWriter handles JSON output formatting with comma tracking.
+type jsonStreamWriter struct {
+	dst        io.Writer
+	firstField bool // tracks whether the next top-level field is the first
+}
+
+func (w *jsonStreamWriter) writeRaw(s string) error {
+	_, err := io.WriteString(w.dst, s)
+	return trace.Wrap(err)
+}
+
+func (w *jsonStreamWriter) writeKey(key string) error {
+	if !w.firstField {
+		if err := w.writeRaw(","); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	w.firstField = false
+
+	keyBytes, err := json.Marshal(key)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if _, err := w.dst.Write(keyBytes); err != nil {
+		return trace.Wrap(err)
+	}
+	return w.writeRaw(":")
+}
+
+func (w *jsonStreamWriter) writeKeyValue(key string, value json.RawMessage) error {
+	if err := w.writeKey(key); err != nil {
+		return trace.Wrap(err)
+	}
+	_, err := w.dst.Write(value)
+	return trace.Wrap(err)
+}
+
+func expectDelim(decoder *json.Decoder, expected rune) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != json.Delim(expected) {
+		return trace.BadParameter("expected %c, got %v", expected, token)
+	}
+	return nil
+}
+
+func decodeStringToken(decoder *json.Decoder) (string, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	s, ok := token.(string)
+	if !ok {
+		return "", trace.BadParameter("expected string key, got %v", token)
+	}
+	return s, nil
+}

--- a/lib/kube/proxy/streamfilter/streamfilter_test.go
+++ b/lib/kube/proxy/streamfilter/streamfilter_test.go
@@ -1,0 +1,476 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package streamfilter
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"slices"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testMatcher is a mock Matcher for testing.
+type testMatcher struct {
+	allowFn func(name, namespace string) (bool, error)
+}
+
+func (m *testMatcher) Match(name, ns string) (bool, error) { return m.allowFn(name, ns) }
+
+func matcherAllowAll() *testMatcher {
+	return &testMatcher{allowFn: func(_, _ string) (bool, error) { return true, nil }}
+}
+
+func matcherDenyAll() *testMatcher {
+	return &testMatcher{allowFn: func(_, _ string) (bool, error) { return false, nil }}
+}
+
+func matcherAllowNamespace(ns string) *testMatcher {
+	return &testMatcher{allowFn: func(_, namespace string) (bool, error) { return namespace == ns, nil }}
+}
+
+func matcherAllowNames(names ...string) *testMatcher {
+	return &testMatcher{allowFn: func(name, _ string) (bool, error) { return slices.Contains(names, name), nil }}
+}
+
+// testItem represents a Kubernetes resource for building test JSON.
+type testItem struct {
+	Name      string
+	Namespace string
+}
+
+func buildListJSON(t *testing.T, apiVersion, kind string, items []testItem) []byte {
+	t.Helper()
+	list := map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   map[string]any{"resourceVersion": "12345"},
+	}
+	jsonItems := make([]map[string]any, len(items))
+	for i, item := range items {
+		jsonItems[i] = map[string]any{
+			"apiVersion": apiVersion,
+			"kind":       kind[:len(kind)-len("List")],
+			"metadata": map[string]any{
+				"name":      item.Name,
+				"namespace": item.Namespace,
+			},
+		}
+	}
+	list["items"] = jsonItems
+	data, err := json.Marshal(list)
+	require.NoError(t, err)
+	return data
+}
+
+func buildTableJSON(t *testing.T, rows []testItem) []byte {
+	t.Helper()
+	tableRows := make([]map[string]any, len(rows))
+	for i, item := range rows {
+		tableRows[i] = map[string]any{
+			"cells": []any{item.Name, "ClusterIP", "10.0.0.1"},
+			"object": map[string]any{
+				"kind":       "PartialObjectMetadata",
+				"apiVersion": "meta.k8s.io/v1",
+				"metadata": map[string]any{
+					"name":      item.Name,
+					"namespace": item.Namespace,
+				},
+			},
+		}
+	}
+	table := map[string]any{
+		"kind":       "Table",
+		"apiVersion": "meta.k8s.io/v1",
+		"metadata":   map[string]any{"resourceVersion": "99999"},
+		"columnDefinitions": []map[string]any{
+			{"name": "Name", "type": "string"},
+			{"name": "Type", "type": "string"},
+			{"name": "Cluster-IP", "type": "string"},
+		},
+		"rows": tableRows,
+	}
+	data, err := json.Marshal(table)
+	require.NoError(t, err)
+	return data
+}
+
+func filterJSON(t *testing.T, input []byte, matcher Matcher) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	sf := NewJSONFilter(matcher, nil)
+	err := sf.Filter(bytes.NewReader(input), &buf)
+	require.NoError(t, err)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "output is not valid JSON: %s", buf.String())
+	return result
+}
+
+func itemNames(t *testing.T, parsed map[string]any, key string) []string {
+	t.Helper()
+	arr, ok := parsed[key].([]any)
+	if !ok {
+		return nil
+	}
+	var names []string
+	for _, raw := range arr {
+		item, ok := raw.(map[string]any)
+		require.True(t, ok)
+		var name string
+		switch key {
+		case "items":
+			meta := item["metadata"].(map[string]any)
+			name = meta["namespace"].(string) + "/" + meta["name"].(string)
+		case "rows":
+			obj := item["object"].(map[string]any)
+			meta := obj["metadata"].(map[string]any)
+			name = meta["namespace"].(string) + "/" + meta["name"].(string)
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+func TestFilter_items(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		items   []testItem
+		matcher Matcher
+		want    []string
+	}{
+		{
+			name:    "all allowed",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherAllowAll(),
+			want:    []string{"default/nginx-1", "default/nginx-2", "kube-system/redis-1", "kube-system/postgres-1"},
+		},
+		{
+			name:    "filter by namespace",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherAllowNamespace("default"),
+			want:    []string{"default/nginx-1", "default/nginx-2"},
+		},
+		{
+			name:    "filter by name",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherAllowNames("nginx-1", "postgres-1"),
+			want:    []string{"default/nginx-1", "kube-system/postgres-1"},
+		},
+		{
+			name:    "all denied",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherDenyAll(),
+			want:    nil,
+		},
+		{
+			name:    "single item allowed",
+			items:   []testItem{{"nginx", "default"}},
+			matcher: matcherAllowAll(),
+			want:    []string{"default/nginx"},
+		},
+		{
+			name:    "single item denied",
+			items:   []testItem{{"nginx", "default"}},
+			matcher: matcherDenyAll(),
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := buildListJSON(t, "v1", "PodList", tt.items)
+			result := filterJSON(t, input, tt.matcher)
+			got := itemNames(t, result, "items")
+			require.ElementsMatch(t, tt.want, got)
+
+			require.Equal(t, "v1", result["apiVersion"])
+			require.Equal(t, "PodList", result["kind"])
+			meta, ok := result["metadata"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "12345", meta["resourceVersion"])
+		})
+	}
+}
+
+func TestFilter_table(t *testing.T) {
+	t.Parallel()
+
+	rows := []testItem{
+		{"kubernetes", "default"},
+		{"kube-dns", "kube-system"},
+		{"metrics-server", "kube-system"},
+	}
+
+	tests := []struct {
+		name    string
+		matcher Matcher
+		want    []string
+	}{
+		{
+			name:    "all rows allowed",
+			matcher: matcherAllowAll(),
+			want:    []string{"default/kubernetes", "kube-system/kube-dns", "kube-system/metrics-server"},
+		},
+		{
+			name:    "filter by namespace",
+			matcher: matcherAllowNamespace("default"),
+			want:    []string{"default/kubernetes"},
+		},
+		{
+			name:    "all rows denied",
+			matcher: matcherDenyAll(),
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := buildTableJSON(t, rows)
+			result := filterJSON(t, input, tt.matcher)
+			got := itemNames(t, result, "rows")
+			require.ElementsMatch(t, tt.want, got)
+
+			require.Equal(t, "Table", result["kind"])
+			require.Equal(t, "meta.k8s.io/v1", result["apiVersion"])
+			colDefs, ok := result["columnDefinitions"].([]any)
+			require.True(t, ok)
+			require.Len(t, colDefs, 3)
+		})
+	}
+}
+
+func TestFilter_edgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   []byte
+		matcher Matcher
+		wantErr string
+		check   func(t *testing.T, result map[string]any)
+	}{
+		{
+			name:    "null items array",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":null}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				require.Nil(t, result["items"])
+			},
+		},
+		{
+			name:    "empty items array",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[]}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				arr, ok := result["items"].([]any)
+				require.True(t, ok)
+				require.Empty(t, arr)
+			},
+		},
+		{
+			name:    "item with missing metadata denied",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"kind":"Pod"},{"metadata":{"name":"good","namespace":"default"}}]}`),
+			matcher: matcherAllowNamespace("default"),
+			check: func(t *testing.T, result map[string]any) {
+				got := itemNames(t, result, "items")
+				require.Equal(t, []string{"default/good"}, got)
+			},
+		},
+		{
+			name:    "malformed item metadata skipped",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":"broken"},{"metadata":{"name":"good","namespace":"ns"}}]}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				got := itemNames(t, result, "items")
+				require.Equal(t, []string{"ns/good"}, got)
+			},
+		},
+		{
+			name:    "extra top-level fields preserved",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"extraField":"hello","count":42,"items":[]}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				require.Equal(t, "hello", result["extraField"])
+				require.InDelta(t, float64(42), result["count"], 0)
+			},
+		},
+		{
+			name:    "matcher error denies item",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"x","namespace":"y"}}]}`),
+			matcher: &testMatcher{allowFn: func(_, _ string) (bool, error) { return false, errors.New("boom") }},
+			check: func(t *testing.T, result map[string]any) {
+				arr, ok := result["items"].([]any)
+				require.True(t, ok)
+				require.Empty(t, arr)
+			},
+		},
+		{
+			name:    "empty JSON object",
+			input:   []byte(`{}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				require.Empty(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			sf := NewJSONFilter(tt.matcher, nil)
+			err := sf.Filter(bytes.NewReader(tt.input), &buf)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			var result map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "output is not valid JSON: %s", buf.String())
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+func TestExtractItemMeta(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     string
+		wantName  string
+		wantNS    string
+		wantError bool
+	}{
+		{"valid", `{"metadata":{"name":"nginx","namespace":"default"}}`, "nginx", "default", false},
+		{"missing namespace", `{"metadata":{"name":"nginx"}}`, "nginx", "", false},
+		{"missing metadata", `{"kind":"Pod"}`, "", "", true},
+		{"empty object", `{}`, "", "", true},
+		{"invalid JSON", `not-json`, "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, ns, err := extractItemMeta(json.RawMessage(tt.input))
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantName, name)
+				require.Equal(t, tt.wantNS, ns)
+			}
+		})
+	}
+}
+
+func TestExtractTableRowMeta(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     string
+		wantName  string
+		wantNS    string
+		wantError bool
+	}{
+		{"valid", `{"object":{"metadata":{"name":"svc","namespace":"default"}}}`, "svc", "default", false},
+		{"missing object", `{"cells":["a"]}`, "", "", true},
+		{"missing metadata in object", `{"object":{"kind":"Pod"}}`, "", "", true},
+		{"empty object", `{}`, "", "", true},
+		{"invalid JSON", `{broken`, "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, ns, err := extractTableRowMeta(json.RawMessage(tt.input))
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantName, name)
+				require.Equal(t, tt.wantNS, ns)
+			}
+		})
+	}
+}
+
+// TestFilter_streaming verifies that items are written to the output incrementally
+// as they arrive from the upstream, not buffered until the entire response is received.
+// It also verifies that denied items never appear in the output.
+func TestFilter_streaming(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		matcher := matcherAllowNamespace("default")
+		sf := NewJSONFilter(matcher, nil)
+
+		// src pipe: test writes upstream JSON, filter reads.
+		// dst: plain buffer is safe because synctest.Wait() guarantees the
+		// filter goroutine is idle (blocked on pipe read) before we inspect output.
+		srcR, srcW := io.Pipe()
+		var dst bytes.Buffer
+
+		filterErr := make(chan error, 1)
+		go func() {
+			filterErr <- sf.Filter(srcR, &dst)
+		}()
+
+		// Write preamble + first item (allowed).
+		io.WriteString(srcW, `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"1"},"items":[`)
+		io.WriteString(srcW, `{"metadata":{"name":"nginx","namespace":"default"}}`)
+		synctest.Wait()
+
+		out := dst.String()
+		require.Contains(t, out, `"apiVersion"`, "preamble should be written before all items arrive")
+		require.Contains(t, out, `"nginx"`, "first allowed item should arrive incrementally")
+
+		// Write denied item.
+		io.WriteString(srcW, `,{"metadata":{"name":"coredns","namespace":"kube-system"}}`)
+		synctest.Wait()
+
+		out = dst.String()
+		require.NotContains(t, out, `"coredns"`, "denied item must not appear in output")
+
+		// Write second allowed item.
+		io.WriteString(srcW, `,{"metadata":{"name":"redis","namespace":"default"}}`)
+		synctest.Wait()
+
+		out = dst.String()
+		require.Contains(t, out, `"redis"`, "second allowed item should arrive incrementally")
+
+		// Close the JSON list and upstream pipe.
+		io.WriteString(srcW, `]}`)
+		srcW.Close()
+		synctest.Wait()
+
+		require.NoError(t, <-filterErr)
+
+		// Final output should be valid JSON with exactly the allowed items.
+		var result map[string]any
+		require.NoError(t, json.Unmarshal(dst.Bytes(), &result), "output should be valid JSON: %s", dst.String())
+		names := itemNames(t, result, "items")
+		require.Equal(t, []string{"default/nginx", "default/redis"}, names)
+	})
+}

--- a/lib/kube/proxy/streamfilter/streamfilter_test.go
+++ b/lib/kube/proxy/streamfilter/streamfilter_test.go
@@ -1,0 +1,505 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package streamfilter
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"slices"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testMatcher is a mock Matcher for testing.
+type testMatcher struct {
+	allowFn func(name, namespace string) (bool, error)
+}
+
+func (m *testMatcher) Match(name, ns string) (bool, error) { return m.allowFn(name, ns) }
+
+func matcherAllowAll() *testMatcher {
+	return &testMatcher{allowFn: func(_, _ string) (bool, error) { return true, nil }}
+}
+
+func matcherDenyAll() *testMatcher {
+	return &testMatcher{allowFn: func(_, _ string) (bool, error) { return false, nil }}
+}
+
+func matcherAllowNamespace(ns string) *testMatcher {
+	return &testMatcher{allowFn: func(_, namespace string) (bool, error) { return namespace == ns, nil }}
+}
+
+func matcherAllowNames(names ...string) *testMatcher {
+	return &testMatcher{allowFn: func(name, _ string) (bool, error) { return slices.Contains(names, name), nil }}
+}
+
+// testItem represents a Kubernetes resource for building test JSON.
+type testItem struct {
+	Name      string
+	Namespace string
+}
+
+func buildListJSON(t *testing.T, apiVersion, kind string, items []testItem) []byte {
+	t.Helper()
+	list := map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   map[string]any{"resourceVersion": "12345"},
+	}
+	jsonItems := make([]map[string]any, len(items))
+	for i, item := range items {
+		jsonItems[i] = map[string]any{
+			"apiVersion": apiVersion,
+			"kind":       kind[:len(kind)-len("List")],
+			"metadata": map[string]any{
+				"name":      item.Name,
+				"namespace": item.Namespace,
+			},
+		}
+	}
+	list["items"] = jsonItems
+	data, err := json.Marshal(list)
+	require.NoError(t, err)
+	return data
+}
+
+func buildTableJSON(t *testing.T, rows []testItem) []byte {
+	t.Helper()
+	tableRows := make([]map[string]any, len(rows))
+	for i, item := range rows {
+		tableRows[i] = map[string]any{
+			"cells": []any{item.Name, "ClusterIP", "10.0.0.1"},
+			"object": map[string]any{
+				"kind":       "PartialObjectMetadata",
+				"apiVersion": "meta.k8s.io/v1",
+				"metadata": map[string]any{
+					"name":      item.Name,
+					"namespace": item.Namespace,
+				},
+			},
+		}
+	}
+	table := map[string]any{
+		"kind":       "Table",
+		"apiVersion": "meta.k8s.io/v1",
+		"metadata":   map[string]any{"resourceVersion": "99999"},
+		"columnDefinitions": []map[string]any{
+			{"name": "Name", "type": "string"},
+			{"name": "Type", "type": "string"},
+			{"name": "Cluster-IP", "type": "string"},
+		},
+		"rows": tableRows,
+	}
+	data, err := json.Marshal(table)
+	require.NoError(t, err)
+	return data
+}
+
+func filterJSON(t *testing.T, input []byte, matcher Matcher) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	sf := &jsonFilter{matcher: matcher}
+	err := sf.Filter(bytes.NewReader(input), &buf)
+	require.NoError(t, err)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "output is not valid JSON: %s", buf.String())
+	return result
+}
+
+func itemNames(t *testing.T, parsed map[string]any, key string) []string {
+	t.Helper()
+	arr, ok := parsed[key].([]any)
+	if !ok {
+		return nil
+	}
+	var names []string
+	for _, raw := range arr {
+		item, ok := raw.(map[string]any)
+		require.True(t, ok)
+		var name string
+		switch key {
+		case "items":
+			meta := item["metadata"].(map[string]any)
+			name = meta["namespace"].(string) + "/" + meta["name"].(string)
+		case "rows":
+			obj := item["object"].(map[string]any)
+			meta := obj["metadata"].(map[string]any)
+			name = meta["namespace"].(string) + "/" + meta["name"].(string)
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		contentType string
+		wantNil     bool
+	}{
+		{"json", "application/json", false},
+		{"json with charset", "application/json; charset=utf-8", false},
+		{"json table params", "application/json;as=Table;g=meta.k8s.io;v=v1", false},
+		{"protobuf", "application/vnd.kubernetes.protobuf", true},
+		{"empty", "", true},
+		{"text html", "text/html", true},
+		{"yaml", "application/yaml", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sf := New(tt.contentType, matcherAllowAll())
+			if tt.wantNil {
+				require.Nil(t, sf)
+			} else {
+				require.NotNil(t, sf)
+			}
+		})
+	}
+}
+
+func TestFilter_items(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		items   []testItem
+		matcher Matcher
+		want    []string
+	}{
+		{
+			name:    "all allowed",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherAllowAll(),
+			want:    []string{"default/nginx-1", "default/nginx-2", "kube-system/redis-1", "kube-system/postgres-1"},
+		},
+		{
+			name:    "filter by namespace",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherAllowNamespace("default"),
+			want:    []string{"default/nginx-1", "default/nginx-2"},
+		},
+		{
+			name:    "filter by name",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherAllowNames("nginx-1", "postgres-1"),
+			want:    []string{"default/nginx-1", "kube-system/postgres-1"},
+		},
+		{
+			name:    "all denied",
+			items:   []testItem{{"nginx-1", "default"}, {"nginx-2", "default"}, {"redis-1", "kube-system"}, {"postgres-1", "kube-system"}},
+			matcher: matcherDenyAll(),
+			want:    nil,
+		},
+		{
+			name:    "single item allowed",
+			items:   []testItem{{"nginx", "default"}},
+			matcher: matcherAllowAll(),
+			want:    []string{"default/nginx"},
+		},
+		{
+			name:    "single item denied",
+			items:   []testItem{{"nginx", "default"}},
+			matcher: matcherDenyAll(),
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := buildListJSON(t, "v1", "PodList", tt.items)
+			result := filterJSON(t, input, tt.matcher)
+			got := itemNames(t, result, "items")
+			require.ElementsMatch(t, tt.want, got)
+
+			require.Equal(t, "v1", result["apiVersion"])
+			require.Equal(t, "PodList", result["kind"])
+			meta, ok := result["metadata"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "12345", meta["resourceVersion"])
+		})
+	}
+}
+
+func TestFilter_table(t *testing.T) {
+	t.Parallel()
+
+	rows := []testItem{
+		{"kubernetes", "default"},
+		{"kube-dns", "kube-system"},
+		{"metrics-server", "kube-system"},
+	}
+
+	tests := []struct {
+		name    string
+		matcher Matcher
+		want    []string
+	}{
+		{
+			name:    "all rows allowed",
+			matcher: matcherAllowAll(),
+			want:    []string{"default/kubernetes", "kube-system/kube-dns", "kube-system/metrics-server"},
+		},
+		{
+			name:    "filter by namespace",
+			matcher: matcherAllowNamespace("default"),
+			want:    []string{"default/kubernetes"},
+		},
+		{
+			name:    "all rows denied",
+			matcher: matcherDenyAll(),
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := buildTableJSON(t, rows)
+			result := filterJSON(t, input, tt.matcher)
+			got := itemNames(t, result, "rows")
+			require.ElementsMatch(t, tt.want, got)
+
+			require.Equal(t, "Table", result["kind"])
+			require.Equal(t, "meta.k8s.io/v1", result["apiVersion"])
+			colDefs, ok := result["columnDefinitions"].([]any)
+			require.True(t, ok)
+			require.Len(t, colDefs, 3)
+		})
+	}
+}
+
+func TestFilter_edgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   []byte
+		matcher Matcher
+		wantErr string
+		check   func(t *testing.T, result map[string]any)
+	}{
+		{
+			name:    "null items array",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":null}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				require.Nil(t, result["items"])
+			},
+		},
+		{
+			name:    "empty items array",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[]}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				arr, ok := result["items"].([]any)
+				require.True(t, ok)
+				require.Empty(t, arr)
+			},
+		},
+		{
+			name:    "item with missing metadata denied",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"kind":"Pod"},{"metadata":{"name":"good","namespace":"default"}}]}`),
+			matcher: matcherAllowNamespace("default"),
+			check: func(t *testing.T, result map[string]any) {
+				got := itemNames(t, result, "items")
+				require.Equal(t, []string{"default/good"}, got)
+			},
+		},
+		{
+			name:    "malformed item metadata skipped",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":"broken"},{"metadata":{"name":"good","namespace":"ns"}}]}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				got := itemNames(t, result, "items")
+				require.Equal(t, []string{"ns/good"}, got)
+			},
+		},
+		{
+			name:    "extra top-level fields preserved",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"extraField":"hello","count":42,"items":[]}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				require.Equal(t, "hello", result["extraField"])
+				require.InDelta(t, float64(42), result["count"], 0)
+			},
+		},
+		{
+			name:    "matcher error denies item",
+			input:   []byte(`{"apiVersion":"v1","kind":"PodList","metadata":{},"items":[{"metadata":{"name":"x","namespace":"y"}}]}`),
+			matcher: &testMatcher{allowFn: func(_, _ string) (bool, error) { return false, errors.New("boom") }},
+			check: func(t *testing.T, result map[string]any) {
+				arr, ok := result["items"].([]any)
+				require.True(t, ok)
+				require.Empty(t, arr)
+			},
+		},
+		{
+			name:    "empty JSON object",
+			input:   []byte(`{}`),
+			matcher: matcherAllowAll(),
+			check: func(t *testing.T, result map[string]any) {
+				require.Empty(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			sf := &jsonFilter{matcher: tt.matcher}
+			err := sf.Filter(bytes.NewReader(tt.input), &buf)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			var result map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "output is not valid JSON: %s", buf.String())
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+func TestExtractItemMeta(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     string
+		wantName  string
+		wantNS    string
+		wantError bool
+	}{
+		{"valid", `{"metadata":{"name":"nginx","namespace":"default"}}`, "nginx", "default", false},
+		{"missing namespace", `{"metadata":{"name":"nginx"}}`, "nginx", "", false},
+		{"missing metadata", `{"kind":"Pod"}`, "", "", true},
+		{"empty object", `{}`, "", "", true},
+		{"invalid JSON", `not-json`, "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, ns, err := extractItemMeta(json.RawMessage(tt.input))
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantName, name)
+				require.Equal(t, tt.wantNS, ns)
+			}
+		})
+	}
+}
+
+func TestExtractTableRowMeta(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     string
+		wantName  string
+		wantNS    string
+		wantError bool
+	}{
+		{"valid", `{"object":{"metadata":{"name":"svc","namespace":"default"}}}`, "svc", "default", false},
+		{"missing object", `{"cells":["a"]}`, "", "", true},
+		{"missing metadata in object", `{"object":{"kind":"Pod"}}`, "", "", true},
+		{"empty object", `{}`, "", "", true},
+		{"invalid JSON", `{broken`, "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, ns, err := extractTableRowMeta(json.RawMessage(tt.input))
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantName, name)
+				require.Equal(t, tt.wantNS, ns)
+			}
+		})
+	}
+}
+
+// TestFilter_streaming verifies that items are written to the output incrementally
+// as they arrive from the upstream, not buffered until the entire response is received.
+// It also verifies that denied items never appear in the output.
+func TestFilter_streaming(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		matcher := matcherAllowNamespace("default")
+		sf := New("application/json", matcher)
+		require.NotNil(t, sf)
+
+		// src pipe: test writes upstream JSON, filter reads.
+		// dst: plain buffer is safe because synctest.Wait() guarantees the
+		// filter goroutine is idle (blocked on pipe read) before we inspect output.
+		srcR, srcW := io.Pipe()
+		var dst bytes.Buffer
+
+		filterErr := make(chan error, 1)
+		go func() {
+			filterErr <- sf.Filter(srcR, &dst)
+		}()
+
+		// Write preamble + first item (allowed).
+		io.WriteString(srcW, `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"1"},"items":[`)
+		io.WriteString(srcW, `{"metadata":{"name":"nginx","namespace":"default"}}`)
+		synctest.Wait()
+
+		out := dst.String()
+		require.Contains(t, out, `"apiVersion"`, "preamble should be written before all items arrive")
+		require.Contains(t, out, `"nginx"`, "first allowed item should arrive incrementally")
+
+		// Write denied item.
+		io.WriteString(srcW, `,{"metadata":{"name":"coredns","namespace":"kube-system"}}`)
+		synctest.Wait()
+
+		out = dst.String()
+		require.NotContains(t, out, `"coredns"`, "denied item must not appear in output")
+
+		// Write second allowed item.
+		io.WriteString(srcW, `,{"metadata":{"name":"redis","namespace":"default"}}`)
+		synctest.Wait()
+
+		out = dst.String()
+		require.Contains(t, out, `"redis"`, "second allowed item should arrive incrementally")
+
+		// Close the JSON list and upstream pipe.
+		io.WriteString(srcW, `]}`)
+		srcW.Close()
+		synctest.Wait()
+
+		require.NoError(t, <-filterErr)
+
+		// Final output should be valid JSON with exactly the allowed items.
+		var result map[string]any
+		require.NoError(t, json.Unmarshal(dst.Bytes(), &result), "output should be valid JSON: %s", dst.String())
+		names := itemNames(t, result, "items")
+		require.Equal(t, []string{"default/nginx", "default/redis"}, names)
+	})
+}


### PR DESCRIPTION
Add a streaming JSON filter path for Kubernetes list responses that need RBAC filtering. Instead of buffering the entire response, items are decoded, filtered, and written incrementally using `json.Decoder` + `json.RawMessage`.

When the upstream response is JSON, the streaming filter activates and writes items incrementally without buffering. For non-JSON responses (e.g. protobuf), it falls back to the existing buffered filter path.

## Manual Test Plan
### Test Environment
EKS cluster with RBAC rules that require filtering. Measure with `hyperfine`.

### Test Cases
- [x] `kubectl get configmaps` through `tsh proxy kube` with namespace-scoped RBAC returns correct filtered results (4700/5001 configmaps)
- [x] `kubectl get configmaps -o json` returns valid JSON that can be piped to `jq`
- [x] `kubectl get configmaps` with table output (default) returns correct filtered rows
- [x] `hyperfine` in-cluster comparison (4700 configmaps): table ~17% faster (949ms vs 1.108s), JSON ~10% faster (1.614s vs 1.784s); microbenchmarks show ~16-20% latency reduction and ~94% memory reduction in the filter path
- [x] Protobuf clients (`client-go`) fall back to buffered path correctly
- [x] Non-200 responses (e.g. 403 on kube-system namespace) pass through unchanged

Part 1 of 2: streaming filter package and tests. Part 2 wires it into the kube proxy list path.