### PR TITLE
Remove discover and app from support scoped token roles

### DIFF
--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -37,8 +37,6 @@ import (
 var rolesSupportingScopes = types.SystemRoles{
 	types.RoleNode,
 	types.RoleKube,
-	types.RoleApp,
-	types.RoleDiscovery,
 }
 
 // TokenUsageMode represents the possible usage modes of a scoped token.

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -538,7 +538,7 @@ func TestValidateScopedToken(t *testing.T) {
 		{
 			name: "valid scoped token",
 			modFn: func(tok *joiningv1.ScopedToken) {
-				tok.Spec.Roles = types.SystemRoles{types.RoleNode, types.RoleKube, types.RoleApp, types.RoleDiscovery}.StringSlice()
+				tok.Spec.Roles = types.SystemRoles{types.RoleNode, types.RoleKube}.StringSlice()
 			},
 		},
 		{

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -163,11 +163,14 @@ func (c *ScopedTokensCommand) Add(ctx context.Context, client *authclient.Client
 		return trace.Wrap(err)
 	}
 
+	// NOTE (eriktate): we want to prevent this behavior until discovery and app
+	// services properly support scopes
+	//
 	// If it's Kube, then enable App and Discovery roles automatically so users
 	// don't have problems with running Kubernetes App Discovery by default.
-	if len(roles) == 1 && roles[0] == types.RoleKube {
-		roles = append(roles, types.RoleApp, types.RoleDiscovery)
-	}
+	// if len(roles) == 1 && roles[0] == types.RoleKube {
+	// 	roles = append(roles, types.RoleApp, types.RoleDiscovery)
+	// }
 
 	tokenName := c.name
 


### PR DESCRIPTION
We originally replicated the unscoped behavior of  enforcing `discovery` and `app` roles are included with `kube`. This actually creates scope isolation issues until these services are updated to support scopes, so this PR prevents them from being automatically added and prevents scoped tokens from being created with them.


## Manual Test Plan
### Test Environment
Local cluster

### Test Cases
- [x] Create a scoped `kube` token
```sh
tctl scoped tokens add --type=kube --scope=/kube --assign-scope=/kube --name=scoped-kube-token
```
- [x] Verify the token does not have `discovery` or `app` in the `roles` list:
```sh
tctl scoped tokens ls
```
- [x] Confirm creating a scoped token with `discovery` and/or `app` fails
```sh
tctl scoped tokens add --type=kube,discovery,app --scope=/kube --assign-scope=/kube
```