### PR TITLE
Add token secret to helm chart

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -130,10 +130,14 @@ join the Teleport cluster.
 When `joinParams.method` is [a delegated join method](../../reference/deployment/join-methods.mdx#delegated-join-methods),
 the value is not sensitive.
 
-When `joinParams.method` is `token` (by default), `joinParams.tokenName`
-contains the secret token itself. In this case, the value is sensitive and
-is automatically stored in a Kubernetes Secret instead of being directly
+When `joinParams.method` is `token` (by default), and `joinParams.tokenName` refers to an
+unscoped token, the token name itself is considered secret. In this case, the value is
+sensitive and is automatically stored in a Kubernetes Secret instead of being directly
 included in the agent's configuration.
+
+When `joinParams.method` is `token` (by default), and `joinParams.tokenName` refers to a
+scoped token, the token name itself is not considered a secret. In this case, the
+`joinParams.tokenSecret` value must also be provided.
 
 If method is `token`, `joinParams.tokenName` can be empty if the token
 is provided through an existing Kubernetes Secret, see
@@ -147,15 +151,17 @@ If method is `kubernetes`, you must set [`teleportClusterName`](#teleportCluster
 |------|---------|
 | `string` | `""` |
 
-`joinParams.tokenSecret` is the secret value tied to the token identified
-by `joinparams.tokenName`. It is only valid when `joinParams.method` is `token` and
+`joinParams.tokenSecret` is the secret value tied to the scoped token identified
+by `joinparams.tokenName`. It should only be provided when `joinParams.method` is `token` and
 `joinParams.tokenName` refers to a scoped token.
 
-When `joinParams.method` is `token` and `joinParams.tokenName`  refers to a
-scoped token, this value is required.
-
 When `joinParams.method` is not `token` or when `joinParams.tokenName` refers to an
-unscoped token, this value is ignored.
+unscoped token, this value is ignored and should not be provided.
+
+When `joinParams.method` is `token` and `joinParams.tokenName` refers to a
+scoped token, this value is required. Unlike `joinParams.tokenName`, this value is always
+considered secret and will be automatically stored in a Kubernetes Secret instead of being
+directly included in the agent's configuration.
 
 ## `teleportClusterName`
 

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -141,6 +141,22 @@ is provided through an existing Kubernetes Secret, see
 
 If method is `kubernetes`, you must set [`teleportClusterName`](#teleportClusterName).
 
+### `joinParams.tokenSecret`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`joinParams.tokenSecret` is the secret value tied to the token identified
+by `joinparams.tokenName`. It is only valid when `joinParams.method` is `token` and
+`joinParams.tokenName` refers to a scoped token.
+
+When `joinParams.method` is `token` and `joinParams.tokenName`  refers to a
+scoped token, this value is required.
+
+When `joinParams.method` is not `token` or when `joinParams.tokenName` refers to an
+unscoped token, this value is ignored.
+
 ## `teleportClusterName`
 
 | Type | Default |

--- a/examples/chart/teleport-kube-agent/.lint/join-params-token-with-secret.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/join-params-token-with-secret.yaml
@@ -1,0 +1,6 @@
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster-name
+joinParams:
+  tokenName: non-secret-token
+  tokenSecret: xxxxxxx-secret-token-xxxxxxx
+  method: token

--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -9,7 +9,12 @@ version: v3
 teleport:
   join_params:
     method: "{{ .Values.joinParams.method }}"
+{{- if .Values.joinParams.tokenSecret }}
+    token_name: "{{ .Values.joinParams.tokenName }}"
+    token_secret: "/etc/teleport-secrets/auth-token"
+{{- else }}
     token_name: "/etc/teleport-secrets/auth-token"
+{{- end }}
   {{- if (ge (include "teleport-kube-agent.version" . | semver).Major 11) }}
   proxy_server: {{ required "proxyAddr is required in chart values" .Values.proxyAddr }}
   {{- else }}

--- a/examples/chart/teleport-kube-agent/templates/secret.yaml
+++ b/examples/chart/teleport-kube-agent/templates/secret.yaml
@@ -15,7 +15,7 @@ metadata:
 type: Opaque
 stringData:
   auth-token: |
-    {{ coalesce .Values.joinParams.tokenName .Values.authToken }}
+    {{ coalesce .Values.joinParams.tokenSecret .Values.joinParams.tokenName .Values.authToken }}
 {{- end}}
 
 {{- if and (contains "jamf" (.Values.roles | toString)) .Values.jamfCredentialsSecret.create }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -943,6 +943,49 @@ matches snapshot for join-params-iam.yaml:
     metadata:
       name: RELEASE-NAME
       namespace: NAMESPACE
+matches snapshot for join-params-token-with-secret.yaml:
+  1: |
+    apiVersion: v1
+    data:
+      teleport.yaml: |-
+        app_service:
+          enabled: false
+        auth_service:
+          enabled: false
+        db_service:
+          enabled: false
+        discovery_service:
+          enabled: false
+        jamf_service:
+          enabled: false
+        kubernetes_service:
+          enabled: true
+          kube_cluster_name: test-kube-cluster-name
+        proxy_service:
+          enabled: false
+        ssh_service:
+          enabled: false
+        teleport:
+          join_params:
+            method: token
+            token_name: non-secret-token
+            token_secret: /etc/teleport-secrets/auth-token
+          log:
+            format:
+              extra_fields:
+              - timestamp
+              - level
+              - component
+              - caller
+              output: text
+            output: stderr
+            severity: INFO
+          proxy_server: proxy.example.com:3080
+        version: v3
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME
+      namespace: NAMESPACE
 matches snapshot for join-params-token.yaml:
   1: |
     apiVersion: v1

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/secret_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/secret_test.yaml.snap
@@ -40,6 +40,17 @@ generates a secret when joinParams.tokenName is provided:
       auth-token: |
         sample-auth-token-dont-use-this
     type: Opaque
+generates a secret when joinParams.tokenSecret is provided:
+  1: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: teleport-kube-agent-join-token
+      namespace: NAMESPACE
+    stringData:
+      auth-token: |
+        sample-token-secret-dont-use-this
+    type: Opaque
 generates a secret with a custom name when authToken and joinTokenSecret.name are provided:
   1: |
     apiVersion: v1

--- a/examples/chart/teleport-kube-agent/tests/config_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/config_test.yaml
@@ -190,6 +190,16 @@ tests:
           of: ConfigMap
       - matchSnapshot: {}
 
+  - it: matches snapshot for join-params-token-with-secret.yaml
+    values:
+      - ../.lint/join-params-token-with-secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot: {}
+
   - it: matches snapshot for log-basic.yaml
     values:
       - ../.lint/log-basic.yaml

--- a/examples/chart/teleport-kube-agent/tests/secret_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/secret_test.yaml
@@ -36,6 +36,20 @@ tests:
           value: teleport-kube-agent-join-token
       - matchSnapshot: {}
 
+  - it: generates a secret when joinParams.tokenSecret is provided
+    set:
+      joinParams:
+        tokenSecret: sample-token-secret-dont-use-this
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: teleport-kube-agent-join-token
+      - matchSnapshot: {}
+
   - it: generates a secret with a custom name when authToken and secretName are provided
     set:
       authToken: sample-auth-token-dont-use-this

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -71,6 +71,11 @@
                     "type": "string",
                     "default": ""
                 },
+                "tokenName": {
+                    "$id": "#/properties/joinParams/tokenSecret",
+                    "type": "string",
+                    "default": ""
+                },
                 "method": {
                     "$id": "#/properties/joinParams/method",
                     "type": "string",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -105,6 +105,17 @@ joinParams:
   # If method is `kubernetes`, you must set [`teleportClusterName`](#teleportClusterName).
   tokenName: ""
 
+  # joinParams.tokenSecret(string) -- is the secret value tied to the token identified
+  # by `joinparams.tokenName`. It is only valid when `joinParams.method` is `token` and
+  # `joinParams.tokenName` refers to a scoped token.
+  #
+  # When `joinParams.method` is `token` and `joinParams.tokenName`  refers to a
+  # scoped token, this value is required.
+  #
+  # When `joinParams.method` is not `token` or when `joinParams.tokenName` refers to an
+  # unscoped token, this value is ignored.
+  tokenSecret: ""
+
 # teleportClusterName(string) -- is the name of the joined Teleport cluster.
 # Setting this value is required when joining via the
 # [Kubernetes JWKS or OIDC](../../reference/deployment/join-methods.mdx#kubernetes-jwks) join method.

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -93,10 +93,14 @@ joinParams:
   # When `joinParams.method` is [a delegated join method](../../reference/deployment/join-methods.mdx#delegated-join-methods),
   # the value is not sensitive.
   #
-  # When `joinParams.method` is `token` (by default), `joinParams.tokenName`
-  # contains the secret token itself. In this case, the value is sensitive and
-  # is automatically stored in a Kubernetes Secret instead of being directly
+  # When `joinParams.method` is `token` (by default), and `joinParams.tokenName` refers to an
+  # unscoped token, the token name itself is considered secret. In this case, the value is
+  # sensitive and is automatically stored in a Kubernetes Secret instead of being directly
   # included in the agent's configuration.
+  #
+  # When `joinParams.method` is `token` (by default), and `joinParams.tokenName` refers to a
+  # scoped token, the token name itself is not considered a secret. In this case, the
+  # `joinParams.tokenSecret` value must also be provided.
   #
   # If method is `token`, `joinParams.tokenName` can be empty if the token
   # is provided through an existing Kubernetes Secret, see
@@ -105,15 +109,17 @@ joinParams:
   # If method is `kubernetes`, you must set [`teleportClusterName`](#teleportClusterName).
   tokenName: ""
 
-  # joinParams.tokenSecret(string) -- is the secret value tied to the token identified
-  # by `joinparams.tokenName`. It is only valid when `joinParams.method` is `token` and
+  # joinParams.tokenSecret(string) -- is the secret value tied to the scoped token identified
+  # by `joinparams.tokenName`. It should only be provided when `joinParams.method` is `token` and
   # `joinParams.tokenName` refers to a scoped token.
   #
-  # When `joinParams.method` is `token` and `joinParams.tokenName`  refers to a
-  # scoped token, this value is required.
-  #
   # When `joinParams.method` is not `token` or when `joinParams.tokenName` refers to an
-  # unscoped token, this value is ignored.
+  # unscoped token, this value is ignored and should not be provided.
+  #
+  # When `joinParams.method` is `token` and `joinParams.tokenName` refers to a
+  # scoped token, this value is required. Unlike `joinParams.tokenName`, this value is always
+  # considered secret and will be automatically stored in a Kubernetes Secret instead of being
+  # directly included in the agent's configuration.
   tokenSecret: ""
 
 # teleportClusterName(string) -- is the name of the joined Teleport cluster.

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -135,8 +135,10 @@ helm repo update
 > helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=cluster ` + "`" + `# Change kubeClusterName variable to your preferred name.` + "`" + ` \
   --set roles="{{.set_roles}}" \
-  --set proxyAddr={{.proxy_server}} \
-  --set authToken={{.token}} \
+  --set proxyAddr={{.proxy_server}} \{{if .secret}}
+  --set "joinParams.tokenName={{.token}}" \
+  --set "joinParams.tokenSecret={{.secret}}" \{{else}}
+  --set authToken={{.token}} \{{end}}
   --set updater.enabled=true \
   --create-namespace \
   --namespace=teleport-agent \

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -137,7 +137,9 @@ helm repo update
   --set roles="{{.set_roles}}" \
   --set proxyAddr={{.proxy_server}} \{{if .secret}}
   --set "joinParams.tokenName={{.token}}" \
-  --set "joinParams.tokenSecret={{.secret}}" \{{else}}
+  --set "joinParams.tokenSecret={{.secret}}" \
+  --set "extraEnv[0].name=TELEPORT_UNSTABLE_SCOPES" \
+  --set "extraEnv[0].value=yes" \{{else}}
   --set authToken={{.token}} \{{end}}
   --set updater.enabled=true \
   --create-namespace \

--- a/tool/tctl/common/kube_command_test.go
+++ b/tool/tctl/common/kube_command_test.go
@@ -1,0 +1,123 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubeMessageTemplate(t *testing.T) {
+	tts := []struct {
+		name  string
+		input map[string]any
+		want  string
+	}{
+		{
+			name: "token without secret",
+			input: map[string]any{
+				"proxy_server": "proxy.example.com:443",
+				"token":        "token",
+				"minutes":      5,
+				"set_roles":    "kube",
+				"version":      "1.2.3",
+			},
+			want: `The invite token: token
+This token will expire in 5 minutes.
+
+To use with Helm installation follow these steps:
+
+# Retrieve the Teleport helm charts
+helm repo add teleport https://charts.releases.teleport.dev
+# Refresh the helm charts
+helm repo update
+
+> helm install teleport-agent teleport/teleport-kube-agent \
+  --set kubeClusterName=cluster ` + "`# Change kubeClusterName variable to your preferred name.`" + ` \
+  --set roles="kube" \
+  --set proxyAddr=proxy.example.com:443 \
+  --set authToken=token \
+  --set updater.enabled=true \
+  --create-namespace \
+  --namespace=teleport-agent \
+  --version=1.2.3
+
+Please note:
+
+  - This invitation token will expire in 5 minutes.
+  - proxy.example.com:443 must be reachable from Kubernetes cluster.
+  - The token is usable in a standalone Linux server with kubernetes_service.
+  - See https://goteleport.com/docs/kubernetes-access/ for detailed installation information.
+
+`,
+		},
+		{
+			name: "token with secret",
+			input: map[string]any{
+				"proxy_server": "proxy.example.com:443",
+				"token":        "token",
+				"secret":       "secret",
+				"minutes":      5,
+				"set_roles":    "kube",
+				"version":      "1.2.3",
+			},
+			want: `The invite token: token
+This token will expire in 5 minutes.
+
+To use with Helm installation follow these steps:
+
+# Retrieve the Teleport helm charts
+helm repo add teleport https://charts.releases.teleport.dev
+# Refresh the helm charts
+helm repo update
+
+> helm install teleport-agent teleport/teleport-kube-agent \
+  --set kubeClusterName=cluster ` + "`# Change kubeClusterName variable to your preferred name.`" + ` \
+  --set roles="kube" \
+  --set proxyAddr=proxy.example.com:443 \
+  --set "joinParams.tokenName=token" \
+  --set "joinParams.tokenSecret=secret" \
+  --set updater.enabled=true \
+  --create-namespace \
+  --namespace=teleport-agent \
+  --version=1.2.3
+
+Please note:
+
+  - This invitation token will expire in 5 minutes.
+  - proxy.example.com:443 must be reachable from Kubernetes cluster.
+  - The token is usable in a standalone Linux server with kubernetes_service.
+  - See https://goteleport.com/docs/kubernetes-access/ for detailed installation information.
+
+`,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			err := kubeMessageTemplate.Execute(buf, tt.input)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.want, buf.String())
+		})
+	}
+}

--- a/tool/tctl/common/kube_command_test.go
+++ b/tool/tctl/common/kube_command_test.go
@@ -95,6 +95,8 @@ helm repo update
   --set proxyAddr=proxy.example.com:443 \
   --set "joinParams.tokenName=token" \
   --set "joinParams.tokenSecret=secret" \
+  --set "extraEnv[0].name=TELEPORT_UNSTABLE_SCOPES" \
+  --set "extraEnv[0].value=yes" \
   --set updater.enabled=true \
   --create-namespace \
   --namespace=teleport-agent \

--- a/tool/tctl/common/kube_command_test.go
+++ b/tool/tctl/common/kube_command_test.go
@@ -1,0 +1,105 @@
+package common
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubeMessageTemplate(t *testing.T) {
+	tts := []struct {
+		name  string
+		input map[string]any
+		want  string
+	}{
+		{
+			name: "token without secret",
+			input: map[string]any{
+				"proxy_server": "proxy.example.com:443",
+				"token":        "token",
+				"minutes":      5,
+				"set_roles":    "kube",
+				"version":      "1.2.3",
+			},
+			want: `The invite token: token
+This token will expire in 5 minutes.
+
+To use with Helm installation follow these steps:
+
+# Retrieve the Teleport helm charts
+helm repo add teleport https://charts.releases.teleport.dev
+# Refresh the helm charts
+helm repo update
+
+> helm install teleport-agent teleport/teleport-kube-agent \
+  --set kubeClusterName=cluster ` + "`# Change kubeClusterName variable to your preferred name.`" + ` \
+  --set roles="kube" \
+  --set proxyAddr=proxy.example.com:443 \
+  --set authToken=token \
+  --set updater.enabled=true \
+  --create-namespace \
+  --namespace=teleport-agent \
+  --version=1.2.3
+
+Please note:
+
+  - This invitation token will expire in 5 minutes.
+  - proxy.example.com:443 must be reachable from Kubernetes cluster.
+  - The token is usable in a standalone Linux server with kubernetes_service.
+  - See https://goteleport.com/docs/kubernetes-access/ for detailed installation information.
+
+`,
+		},
+		{
+			name: "token with secret",
+			input: map[string]any{
+				"proxy_server": "proxy.example.com:443",
+				"token":        "token",
+				"secret":       "secret",
+				"minutes":      5,
+				"set_roles":    "kube",
+				"version":      "1.2.3",
+			},
+			want: `The invite token: token
+This token will expire in 5 minutes.
+
+To use with Helm installation follow these steps:
+
+# Retrieve the Teleport helm charts
+helm repo add teleport https://charts.releases.teleport.dev
+# Refresh the helm charts
+helm repo update
+
+> helm install teleport-agent teleport/teleport-kube-agent \
+  --set kubeClusterName=cluster ` + "`# Change kubeClusterName variable to your preferred name.`" + ` \
+  --set roles="kube" \
+  --set proxyAddr=proxy.example.com:443 \
+  --set "joinParams.tokenName=token" \
+  --set "joinParams.tokenSecret=secret" \
+  --set updater.enabled=true \
+  --create-namespace \
+  --namespace=teleport-agent \
+  --version=1.2.3
+
+Please note:
+
+  - This invitation token will expire in 5 minutes.
+  - proxy.example.com:443 must be reachable from Kubernetes cluster.
+  - The token is usable in a standalone Linux server with kubernetes_service.
+  - See https://goteleport.com/docs/kubernetes-access/ for detailed installation information.
+
+`,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			err := kubeMessageTemplate.Execute(buf, tt.input)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.want, buf.String())
+		})
+	}
+}

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -950,6 +950,7 @@ func showJoinInstructions(ctx context.Context, in joinInstructionsInput) error {
 			map[string]any{
 				"proxy_server": proxies[0].GetPublicAddr(),
 				"token":        in.tokenName,
+				"secret":       in.tokenSecret,
 				"minutes":      in.ttl.Minutes(),
 				"set_roles":    setRoles,
 				"version":      proxies[0].GetTeleportVersion(),


### PR DESCRIPTION
We added support for a `joinParams.tokenSecret` configuration a while ago for scoped tokens. That never made it into our helm chart for `teleport-kube-agent` or the instructions printed after the token is created for the `kube` role. This updates the instructions we print and updates our helm templates to handle the new field


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
A local teleport cluster with `TELEPORT_UNSTABLE_SCOPES` enabled.
### Test Cases
- [x] Create a scoped token for `kube`: 
```sh
tctl scoped tokens add --type=kube --scope=/kube --assign-scope=/kube --name=my-scoped-kube-token
```
- [x] Verify the helm command instructions include `joinParams.tokenName=my-scoped-kube-token` and the `joinParams.tokenSecret` is assigned the correct value (`tsh scoped tokens ls --with-secretes` to verify)
- [x] Create an unscoped token for `kube`: `tctl tokens add --type=kube --value=my-unscoped-kube-token`
- [x] Verify the instructions include `authToken=my-unscoped-kube-token` and nothing about `joinParams`.
- [x] Confirm the scoped instructions successfully deploy the `teleport-kube-agent` and it joins with the correct params