### PR TITLE
[Access Requests] Add Web UI support for Database Resource Constraints

### DIFF
--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
@@ -210,6 +210,42 @@ export const LoadedResourceRequestWithSSHConstraints = () => {
   );
 };
 
+export const LoadedResourceRequestWithDatabaseConstraints = () => {
+  const pendingAccessRequests = [
+    {
+      kind: 'db',
+      id: 'prod-postgres',
+      name: 'prod-postgres',
+      clusterName: 'localhost',
+    },
+  ] satisfies RequestCheckoutWithSliderProps['pendingAccessRequests'];
+  const addedResourceConstraints = {
+    [getResourceIDString({
+      kind: 'db',
+      name: 'prod-postgres',
+      cluster: 'localhost',
+    })]: {
+      database: {
+        users: ['readonly', 'admin'],
+        names: ['analytics', 'production'],
+      },
+    },
+  } satisfies ResourceConstraintsMap;
+
+  return (
+    <MemoryRouter>
+      <RequestCheckoutWithSlider
+        {...baseProps}
+        isResourceRequest={true}
+        fetchResourceRequestRolesAttempt={{ status: 'success' }}
+        pendingAccessRequests={pendingAccessRequests}
+        addedResourceConstraints={addedResourceConstraints}
+        setResourceConstraints={() => {}}
+      />
+    </MemoryRouter>
+  );
+};
+
 export const LoadedLongTermRequest = () => {
   const dryRunResponseWithLongTerm = {
     ...dryRunResponse,

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
@@ -266,6 +266,42 @@ export const LoadedResourceRequestWithSSHConstraints = () => {
   );
 };
 
+export const LoadedResourceRequestWithDatabaseConstraints = () => {
+  const pendingAccessRequests = [
+    {
+      kind: 'db',
+      id: 'prod-postgres',
+      name: 'prod-postgres',
+      clusterName: 'localhost',
+    },
+  ] satisfies RequestCheckoutWithSliderProps['pendingAccessRequests'];
+  const addedResourceConstraints = {
+    [getResourceIDString({
+      kind: 'db',
+      name: 'prod-postgres',
+      cluster: 'localhost',
+    })]: {
+      database: {
+        users: ['readonly', 'admin'],
+        names: ['analytics', 'production'],
+      },
+    },
+  } satisfies ResourceConstraintsMap;
+
+  return (
+    <MemoryRouter>
+      <RequestCheckoutWithSlider
+        {...baseProps}
+        isResourceRequest={true}
+        fetchResourceRequestRolesAttempt={{ status: 'success' }}
+        pendingAccessRequests={pendingAccessRequests}
+        addedResourceConstraints={addedResourceConstraints}
+        setResourceConstraints={() => {}}
+      />
+    </MemoryRouter>
+  );
+};
+
 export const LoadedLongTermRequest = () => {
   const dryRunResponseWithLongTerm = {
     ...dryRunResponse,

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -65,6 +65,7 @@ import { RequestableResourceKind } from 'shared/components/AccessRequests/NewReq
 import {
   formatAWSRoleARNForDisplay,
   toggleAWSConsoleConstraint,
+  toggleDatabaseConstraint,
   toggleSSHConstraint,
 } from 'shared/components/AccessRequests/Shared/utils';
 import { FieldCheckbox } from 'shared/components/FieldCheckbox';
@@ -277,6 +278,129 @@ const SSHConstraintsList = <T extends PendingListItem>({
   </Flex>
 );
 
+const DatabaseConstraintsList = <T extends PendingListItem>({
+  item,
+  createAttempt,
+  clearAttempt,
+  setResourceConstraints,
+}: {
+  item: WithResourceConstraints<'database', DisplayRow<T>>;
+  createAttempt: RequestCheckoutProps<T>['createAttempt'];
+  clearAttempt: RequestCheckoutProps<T>['clearAttempt'];
+  setResourceConstraints: RequestCheckoutProps<T>['setResourceConstraints'];
+}) => {
+  const db = item.constraints.database;
+  return (
+    <Flex flexDirection="column" gap={2} mt={1} width="100%">
+      {db.users && db.users.length > 0 && (
+        <Flex flexDirection="column" gap={1}>
+          <Text bold>Database Users</Text>
+          <Flex flexDirection="column" width="100%">
+            {db.users.map((user, idx) => (
+              <StyledAWSRoleARNDisplayRow
+                key={user}
+                $idx={idx}
+                $len={db.users.length}
+              >
+                <Text style={{ alignContent: 'center' }}>{user}</Text>
+                <ButtonIcon
+                  size={0}
+                  title="Remove Database User"
+                  onClick={() => {
+                    clearAttempt();
+                    toggleDatabaseConstraint(
+                      item,
+                      'users',
+                      user,
+                      setResourceConstraints
+                    );
+                  }}
+                  disabled={createAttempt.status === 'processing'}
+                  css={`
+                    border-radius: ${({ theme }) => theme.radii[2]}px;
+                  `}
+                >
+                  <Cross size="small" />
+                </ButtonIcon>
+              </StyledAWSRoleARNDisplayRow>
+            ))}
+          </Flex>
+        </Flex>
+      )}
+      {db.names && db.names.length > 0 && (
+        <Flex flexDirection="column" gap={1}>
+          <Text bold>Database Names</Text>
+          <Flex flexDirection="column" width="100%">
+            {db.names.map((name, idx) => (
+              <StyledAWSRoleARNDisplayRow
+                key={name}
+                $idx={idx}
+                $len={db.names.length}
+              >
+                <Text style={{ alignContent: 'center' }}>{name}</Text>
+                <ButtonIcon
+                  size={0}
+                  title="Remove Database Name"
+                  onClick={() => {
+                    clearAttempt();
+                    toggleDatabaseConstraint(
+                      item,
+                      'names',
+                      name,
+                      setResourceConstraints
+                    );
+                  }}
+                  disabled={createAttempt.status === 'processing'}
+                  css={`
+                    border-radius: ${({ theme }) => theme.radii[2]}px;
+                  `}
+                >
+                  <Cross size="small" />
+                </ButtonIcon>
+              </StyledAWSRoleARNDisplayRow>
+            ))}
+          </Flex>
+        </Flex>
+      )}
+      {db.roles && db.roles.length > 0 && (
+        <Flex flexDirection="column" gap={1}>
+          <Text bold>Database Roles</Text>
+          <Flex flexDirection="column" width="100%">
+            {db.roles.map((role, idx) => (
+              <StyledAWSRoleARNDisplayRow
+                key={role}
+                $idx={idx}
+                $len={db.roles.length}
+              >
+                <Text style={{ alignContent: 'center' }}>{role}</Text>
+                <ButtonIcon
+                  size={0}
+                  title="Remove Database Role"
+                  onClick={() => {
+                    clearAttempt();
+                    toggleDatabaseConstraint(
+                      item,
+                      'roles',
+                      role,
+                      setResourceConstraints
+                    );
+                  }}
+                  disabled={createAttempt.status === 'processing'}
+                  css={`
+                    border-radius: ${({ theme }) => theme.radii[2]}px;
+                  `}
+                >
+                  <Cross size="small" />
+                </ButtonIcon>
+              </StyledAWSRoleARNDisplayRow>
+            ))}
+          </Flex>
+        </Flex>
+      )}
+    </Flex>
+  );
+};
+
 export function RequestCheckout<T extends PendingListItem>({
   toggleResource,
   toggleResources,
@@ -483,6 +607,22 @@ export function RequestCheckout<T extends PendingListItem>({
           <td colSpan={showClusterNameColumn ? 4 : 3}>
             <Flex justifyContent="space-between" alignItems="center" mt={-2}>
               <SSHConstraintsList
+                item={item}
+                setResourceConstraints={setResourceConstraints}
+                clearAttempt={clearAttempt}
+                createAttempt={createAttempt}
+              />
+            </Flex>
+          </td>
+        </tr>
+      );
+    }
+    if (hasResourceConstraints(item, 'database')) {
+      return (
+        <tr style={{ borderTop: 'none' }} data-render-after-row>
+          <td colSpan={showClusterNameColumn ? 4 : 3}>
+            <Flex justifyContent="space-between" alignItems="center" mt={-2}>
+              <DatabaseConstraintsList
                 item={item}
                 setResourceConstraints={setResourceConstraints}
                 clearAttempt={clearAttempt}

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -65,6 +65,7 @@ import { RequestableResourceKind } from 'shared/components/AccessRequests/NewReq
 import {
   formatAWSRoleARNForDisplay,
   toggleAWSConsoleConstraint,
+  toggleDatabaseConstraint,
   toggleSSHConstraint,
 } from 'shared/components/AccessRequests/Shared/utils';
 import { FieldCheckbox } from 'shared/components/FieldCheckbox';
@@ -172,7 +173,7 @@ type DisplayRow<T extends PendingListItem> = T & {
   constraints?: ResourceConstraints;
 };
 
-const StyledAWSRoleARNDisplayRow = styled(Flex).attrs({
+const StyledResourceConstraintDisplayRow = styled(Flex).attrs({
   flexDirection: 'row',
   justifyContent: 'space-between',
   gap: 2,
@@ -208,7 +209,7 @@ const AWSConsoleConstraintsList = <T extends PendingListItem>({
     <Text bold>Role ARNs</Text>
     <Flex flexDirection="column" width="100%">
       {item.constraints.aws_console.role_arns.map((arn, idx) => (
-        <StyledAWSRoleARNDisplayRow
+        <StyledResourceConstraintDisplayRow
           key={arn}
           $idx={idx}
           $len={item.constraints.aws_console.role_arns.length}
@@ -230,7 +231,7 @@ const AWSConsoleConstraintsList = <T extends PendingListItem>({
           >
             <Cross size="small" />
           </ButtonIcon>
-        </StyledAWSRoleARNDisplayRow>
+        </StyledResourceConstraintDisplayRow>
       ))}
     </Flex>
   </Flex>
@@ -251,7 +252,7 @@ const SSHConstraintsList = <T extends PendingListItem>({
     <Text bold>SSH Logins</Text>
     <Flex flexDirection="column" width="100%">
       {item.constraints.ssh.logins.map((login, idx) => (
-        <StyledAWSRoleARNDisplayRow
+        <StyledResourceConstraintDisplayRow
           key={login}
           $idx={idx}
           $len={item.constraints.ssh.logins.length}
@@ -271,11 +272,134 @@ const SSHConstraintsList = <T extends PendingListItem>({
           >
             <Cross size="small" />
           </ButtonIcon>
-        </StyledAWSRoleARNDisplayRow>
+        </StyledResourceConstraintDisplayRow>
       ))}
     </Flex>
   </Flex>
 );
+
+const DatabaseConstraintsList = <T extends PendingListItem>({
+  item,
+  createAttempt,
+  clearAttempt,
+  setResourceConstraints,
+}: {
+  item: WithResourceConstraints<'database', DisplayRow<T>>;
+  createAttempt: RequestCheckoutProps<T>['createAttempt'];
+  clearAttempt: RequestCheckoutProps<T>['clearAttempt'];
+  setResourceConstraints: RequestCheckoutProps<T>['setResourceConstraints'];
+}) => {
+  const db = item.constraints.database;
+  return (
+    <Flex flexDirection="column" gap={2} mt={1} width="100%">
+      {!!db.names?.length && (
+        <Flex flexDirection="column" gap={1}>
+          <Text bold>Database Names</Text>
+          <Flex flexDirection="column" width="100%">
+            {db.names.map((name, idx) => (
+              <StyledResourceConstraintDisplayRow
+                key={name}
+                $idx={idx}
+                $len={db.names.length}
+              >
+                <Text style={{ alignContent: 'center' }}>{name}</Text>
+                <ButtonIcon
+                  size={0}
+                  title="Remove Database Name"
+                  onClick={() => {
+                    clearAttempt();
+                    toggleDatabaseConstraint(
+                      item,
+                      'names',
+                      name,
+                      setResourceConstraints
+                    );
+                  }}
+                  disabled={createAttempt.status === 'processing'}
+                  css={`
+                    border-radius: ${({ theme }) => theme.radii[2]}px;
+                  `}
+                >
+                  <Cross size="small" />
+                </ButtonIcon>
+              </StyledResourceConstraintDisplayRow>
+            ))}
+          </Flex>
+        </Flex>
+      )}
+      {!!db.users?.length && (
+        <Flex flexDirection="column" gap={1}>
+          <Text bold>Database Users</Text>
+          <Flex flexDirection="column" width="100%">
+            {db.users.map((user, idx) => (
+              <StyledResourceConstraintDisplayRow
+                key={user}
+                $idx={idx}
+                $len={db.users.length}
+              >
+                <Text style={{ alignContent: 'center' }}>{user}</Text>
+                <ButtonIcon
+                  size={0}
+                  title="Remove Database User"
+                  onClick={() => {
+                    clearAttempt();
+                    toggleDatabaseConstraint(
+                      item,
+                      'users',
+                      user,
+                      setResourceConstraints
+                    );
+                  }}
+                  disabled={createAttempt.status === 'processing'}
+                  css={`
+                    border-radius: ${({ theme }) => theme.radii[2]}px;
+                  `}
+                >
+                  <Cross size="small" />
+                </ButtonIcon>
+              </StyledResourceConstraintDisplayRow>
+            ))}
+          </Flex>
+        </Flex>
+      )}
+      {!!db.roles?.length && (
+        <Flex flexDirection="column" gap={1}>
+          <Text bold>Database Roles</Text>
+          <Flex flexDirection="column" width="100%">
+            {db.roles.map((role, idx) => (
+              <StyledResourceConstraintDisplayRow
+                key={role}
+                $idx={idx}
+                $len={db.roles.length}
+              >
+                <Text style={{ alignContent: 'center' }}>{role}</Text>
+                <ButtonIcon
+                  size={0}
+                  title="Remove Database Role"
+                  onClick={() => {
+                    clearAttempt();
+                    toggleDatabaseConstraint(
+                      item,
+                      'roles',
+                      role,
+                      setResourceConstraints
+                    );
+                  }}
+                  disabled={createAttempt.status === 'processing'}
+                  css={`
+                    border-radius: ${({ theme }) => theme.radii[2]}px;
+                  `}
+                >
+                  <Cross size="small" />
+                </ButtonIcon>
+              </StyledResourceConstraintDisplayRow>
+            ))}
+          </Flex>
+        </Flex>
+      )}
+    </Flex>
+  );
+};
 
 export function RequestCheckout<T extends PendingListItem>({
   toggleResource,
@@ -483,6 +607,22 @@ export function RequestCheckout<T extends PendingListItem>({
           <td colSpan={showClusterNameColumn ? 4 : 3}>
             <Flex justifyContent="space-between" alignItems="center" mt={-2}>
               <SSHConstraintsList
+                item={item}
+                setResourceConstraints={setResourceConstraints}
+                clearAttempt={clearAttempt}
+                createAttempt={createAttempt}
+              />
+            </Flex>
+          </td>
+        </tr>
+      );
+    }
+    if (hasResourceConstraints(item, 'database')) {
+      return (
+        <tr style={{ borderTop: 'none' }} data-render-after-row>
+          <td colSpan={showClusterNameColumn ? 4 : 3}>
+            <Flex justifyContent="space-between" alignItems="center" mt={-2}>
+              <DatabaseConstraintsList
                 item={item}
                 setResourceConstraints={setResourceConstraints}
                 clearAttempt={clearAttempt}

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.story.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.story.tsx
@@ -26,6 +26,7 @@ import {
 import {
   requestResourceApprovedWithConstraints,
   requestResourcePendingWithConstraints,
+  requestResourcePendingWithDatabaseConstraints,
   requestResourceWithConstraintsSuggestedAccessLists,
   requestRoleApproved,
   requestRoleApprovedWithStartTime,
@@ -123,6 +124,23 @@ export const LoadedResourcePendingWithConstraints = () => {
       )}
       fetchSuggestedAccessListsAttempt={makeSuccessAttempt(
         requestResourceWithConstraintsSuggestedAccessLists
+      )}
+      getFlags={() => flags}
+    />
+  );
+};
+
+export const LoadedResourcePendingWithDatabaseConstraints = () => {
+  const flags = {
+    ...sampleFlags,
+    canReview: true,
+    canDelete: true,
+  };
+  return (
+    <RequestView
+      {...sample}
+      fetchRequestAttempt={makeSuccessAttempt(
+        requestResourcePendingWithDatabaseConstraints
       )}
       getFlags={() => flags}
     />

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.story.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.story.tsx
@@ -31,6 +31,7 @@ import { AccessRequest, RequestKind } from 'shared/services/accessRequests';
 import {
   requestResourceApprovedWithConstraints,
   requestResourcePendingWithConstraints,
+  requestResourcePendingWithDatabaseConstraints,
   requestResourceWithConstraintsSuggestedAccessLists,
   requestRoleApproved,
   requestRoleApprovedWithStartTime,
@@ -51,6 +52,7 @@ type RequestState =
   | 'roleApproved'
   | 'roleApprovedWithStartTime'
   | 'resourcePendingWithConstraints'
+  | 'resourcePendingWithDatabaseConstraints'
   | 'resourceApprovedWithConstraints'
   | 'rolePromoted'
   | 'roleEmpty'
@@ -98,6 +100,8 @@ function requestAttempt(r: RequestState): Attempt<AccessRequest> {
       return makeSuccessAttempt(requestRoleApprovedWithStartTime);
     case 'resourcePendingWithConstraints':
       return makeSuccessAttempt(requestResourcePendingWithConstraints);
+    case 'resourcePendingWithDatabaseConstraints':
+      return makeSuccessAttempt(requestResourcePendingWithDatabaseConstraints);
     case 'resourceApprovedWithConstraints':
       return makeSuccessAttempt(requestResourceApprovedWithConstraints);
     case 'rolePromoted':
@@ -159,6 +163,7 @@ const meta = {
         'roleApproved',
         'roleApprovedWithStartTime',
         'resourcePendingWithConstraints',
+        'resourcePendingWithDatabaseConstraints',
         'resourceApprovedWithConstraints',
         'rolePromoted',
         'roleEmpty',
@@ -261,6 +266,14 @@ export const LoadedResourcePendingWithConstraints: Story = {
   args: {
     request: 'resourcePendingWithConstraints',
     suggestions: 'constraintLists',
+    canReview: true,
+    canDelete: true,
+  },
+};
+
+export const LoadedResourcePendingWithDatabaseConstraints: Story = {
+  args: {
+    request: 'resourcePendingWithDatabaseConstraints',
     canReview: true,
     canDelete: true,
   },

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -506,6 +506,48 @@ const SshConstraintsList = <R extends object>({
   );
 };
 
+const DatabaseConstraintsList = <R extends object>({
+  resource,
+}: {
+  resource: WithResourceConstraints<'database', R>;
+}) => {
+  const db = resource.constraints.database;
+  return (
+    <Flex flexDirection="column" gap={2} mt={2}>
+      {db.users && db.users.length > 0 && (
+        <>
+          <Text bold>Database Users</Text>
+          <Flex flexDirection="row" gap={2} flexWrap="wrap">
+            {db.users.map(user => (
+              <AWSConstraintChip key={user} label={user} />
+            ))}
+          </Flex>
+        </>
+      )}
+      {db.names && db.names.length > 0 && (
+        <>
+          <Text bold>Database Names</Text>
+          <Flex flexDirection="row" gap={2} flexWrap="wrap">
+            {db.names.map(name => (
+              <AWSConstraintChip key={name} label={name} />
+            ))}
+          </Flex>
+        </>
+      )}
+      {db.roles && db.roles.length > 0 && (
+        <>
+          <Text bold>Database Roles</Text>
+          <Flex flexDirection="row" gap={2} flexWrap="wrap">
+            {db.roles.map(role => (
+              <AWSConstraintChip key={role} label={role} />
+            ))}
+          </Flex>
+        </>
+      )}
+    </Flex>
+  );
+};
+
 function Comment({
   author,
   comment,
@@ -530,6 +572,9 @@ function Comment({
     }
     if (hasResourceConstraints(r, 'ssh')) {
       return <SshConstraintsList resource={r} />;
+    }
+    if (hasResourceConstraints(r, 'database')) {
+      return <DatabaseConstraintsList resource={r} />;
     }
     return null;
   };

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -520,6 +520,48 @@ const SshConstraintsList = <R extends object>({
   );
 };
 
+const DatabaseConstraintsList = <R extends object>({
+  resource,
+}: {
+  resource: WithResourceConstraints<'database', R>;
+}) => {
+  const db = resource.constraints.database;
+  return (
+    <Flex flexDirection="column" gap={2} mt={2}>
+      {db.users && db.users.length > 0 && (
+        <>
+          <Text bold>Database Users</Text>
+          <Flex flexDirection="row" gap={2} flexWrap="wrap">
+            {db.users.map(user => (
+              <AWSConstraintChip key={user} label={user} />
+            ))}
+          </Flex>
+        </>
+      )}
+      {db.names && db.names.length > 0 && (
+        <>
+          <Text bold>Database Names</Text>
+          <Flex flexDirection="row" gap={2} flexWrap="wrap">
+            {db.names.map(name => (
+              <AWSConstraintChip key={name} label={name} />
+            ))}
+          </Flex>
+        </>
+      )}
+      {db.roles && db.roles.length > 0 && (
+        <>
+          <Text bold>Database Roles</Text>
+          <Flex flexDirection="row" gap={2} flexWrap="wrap">
+            {db.roles.map(role => (
+              <AWSConstraintChip key={role} label={role} />
+            ))}
+          </Flex>
+        </>
+      )}
+    </Flex>
+  );
+};
+
 function Comment({
   author,
   display,
@@ -546,6 +588,9 @@ function Comment({
     }
     if (hasResourceConstraints(r, 'ssh')) {
       return <SshConstraintsList resource={r} />;
+    }
+    if (hasResourceConstraints(r, 'database')) {
+      return <DatabaseConstraintsList resource={r} />;
     }
     return null;
   };

--- a/web/packages/shared/components/AccessRequests/Shared/utils.ts
+++ b/web/packages/shared/components/AccessRequests/Shared/utils.ts
@@ -19,6 +19,7 @@
 import { formatDuration, intervalToDuration } from 'date-fns';
 
 import {
+  DatabaseConstraints,
   getResourceIDString,
   ResourceConstraints,
   ResourceIDString,
@@ -121,4 +122,46 @@ export const toggleSSHConstraint = <T extends PendingListItem>(
     },
   };
   set(key, newRc.ssh.logins.length ? newRc : undefined);
+};
+
+/**
+ * Toggles a database constraint by removing the specified value from the given
+ * dimension (users, names, or roles). If no values remain in any dimension
+ * after removal, it clears the constraint.
+ */
+export const toggleDatabaseConstraint = <T extends PendingListItem>(
+  item: WithResourceConstraints<
+    'database',
+    Pick<T, 'id' | 'kind' | 'clusterName'>
+  >,
+  dimension: keyof DatabaseConstraints,
+  value: string,
+  set: (
+    key: ResourceIDString,
+    constraints: ResourceConstraints | undefined
+  ) => void
+) => {
+  const key = getResourceIDString({
+    name: item.id,
+    kind: item.kind,
+    cluster: item.clusterName,
+  });
+  const db = item.constraints.database;
+  const newDb: DatabaseConstraints = {
+    users: db.users ? [...db.users] : undefined,
+    names: db.names ? [...db.names] : undefined,
+    roles: db.roles ? [...db.roles] : undefined,
+  };
+  if (newDb[dimension]) {
+    newDb[dimension] = newDb[dimension].filter(v => v !== value);
+    if (newDb[dimension].length === 0) {
+      newDb[dimension] = undefined;
+    }
+  }
+  const hasAny =
+    (newDb.users?.length ?? 0) +
+      (newDb.names?.length ?? 0) +
+      (newDb.roles?.length ?? 0) >
+    0;
+  set(key, hasAny ? { database: newDb } : undefined);
 };

--- a/web/packages/shared/components/AccessRequests/fixtures/index.ts
+++ b/web/packages/shared/components/AccessRequests/fixtures/index.ts
@@ -262,6 +262,70 @@ export const requestResourcePendingWithConstraints: AccessRequest = {
   reasonPrompts: [],
 };
 
+export const requestResourcePendingWithDatabaseConstraints: AccessRequest = {
+  id: '83ef0c01-15fd-6732-b66e-543eafe67fg3',
+  state: 'PENDING',
+  user: 'Sam',
+  expires: new Date('12-6-2026'),
+  expiresDuration: '1 hour',
+  created: new Date('12-5-2026'),
+  createdDuration: '1 day ago',
+  maxDuration: new Date('12-6-2026'),
+  maxDurationText: '',
+  requestTTL: new Date('12-6-2026'),
+  requestTTLDuration: '1 hour',
+  sessionTTL: new Date('12-6-2026'),
+  sessionTTLDuration: '',
+  roles: ['db-access'],
+  requestReason: 'Need to run queries on production database',
+  resolveReason: '',
+  reviews: [],
+  reviewers: [
+    {
+      name: 'Alice',
+      state: 'PENDING',
+    },
+    {
+      name: 'Bob',
+      state: 'PENDING',
+    },
+  ],
+  thresholdNames: ['Default', 'Admin'],
+  resources: [
+    {
+      id: {
+        kind: 'db',
+        name: 'prod-postgres',
+        clusterName: 'testing.com',
+      },
+      constraints: {
+        database: {
+          users: ['readonly'],
+          names: ['analytics'],
+        },
+      },
+    },
+    {
+      id: {
+        kind: 'db',
+        name: 'staging-mysql',
+        clusterName: 'testing.com',
+      },
+      constraints: {
+        database: {
+          users: ['admin', 'readonly'],
+          names: ['app_db', 'metrics_db'],
+          roles: ['reader', 'writer'],
+        },
+      },
+    },
+  ],
+  assumeStartTime: new Date('12-5-2026'),
+  assumeStartTimeDuration: '24 hours from now',
+  reasonMode: 'required',
+  reasonPrompts: [],
+};
+
 export const requestResourceWithConstraintsSuggestedAccessLists: SuggestedAccessList[] =
   [
     {

--- a/web/packages/shared/services/accessRequests/accessRequests.ts
+++ b/web/packages/shared/services/accessRequests/accessRequests.ts
@@ -153,6 +153,12 @@ type SshConstraints = {
   logins: string[];
 };
 
+export type DatabaseConstraints = {
+  users?: string[];
+  names?: string[];
+  roles?: string[];
+};
+
 type BaseResourceConstraints = {
   version?: 'v1';
 };
@@ -166,14 +172,22 @@ export type ResourceConstraints = BaseResourceConstraints &
     | {
         aws_console: AwsConsoleConstraints;
         ssh?: never;
+        database?: never;
       }
     | {
         aws_console?: never;
         ssh: SshConstraints;
+        database?: never;
       }
     | {
         aws_console?: never;
         ssh?: never;
+        database: DatabaseConstraints;
+      }
+    | {
+        aws_console?: never;
+        ssh?: never;
+        database?: never;
       }
   );
 

--- a/web/packages/shared/services/accessRequests/accessRequests.ts
+++ b/web/packages/shared/services/accessRequests/accessRequests.ts
@@ -161,6 +161,12 @@ type SshConstraints = {
   logins: string[];
 };
 
+export type DatabaseConstraints = {
+  users?: string[];
+  names?: string[];
+  roles?: string[];
+};
+
 type BaseResourceConstraints = {
   version?: 'v1';
 };
@@ -174,14 +180,22 @@ export type ResourceConstraints = BaseResourceConstraints &
     | {
         aws_console: AwsConsoleConstraints;
         ssh?: never;
+        database?: never;
       }
     | {
         aws_console?: never;
         ssh: SshConstraints;
+        database?: never;
       }
     | {
         aws_console?: never;
         ssh?: never;
+        database: DatabaseConstraints;
+      }
+    | {
+        aws_console?: never;
+        ssh?: never;
+        database?: never;
       }
   );
 

--- a/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
@@ -45,6 +45,9 @@ export function ConnectDialog(props: {
   serviceName: string;
   onClose(): void;
   onConnect(data: DbConnectData): void;
+  desiredDbUser?: string;
+  desiredDbName?: string;
+  desiredDbRole?: string;
 }) {
   // Fetch database information to pre-fill the connection parameters.
   const ctx = useTeleport();
@@ -95,6 +98,9 @@ export function ConnectDialog(props: {
           db={attempt.data}
           onConnect={props.onConnect}
           onClose={props.onClose}
+          desiredDbUser={props.desiredDbUser}
+          desiredDbName={props.desiredDbName}
+          desiredDbRole={props.desiredDbRole}
         />
       )}
     </Dialog>
@@ -105,6 +111,9 @@ function ConnectForm(props: {
   db: Database;
   onConnect(data: DbConnectData): void;
   onClose(): void;
+  desiredDbUser?: string;
+  desiredDbName?: string;
+  desiredDbRole?: string;
 }) {
   const { options: dbNamesOpts, hasWildcard: dbNameHasWildcard } =
     prepareOptions(props.db.names);
@@ -113,10 +122,15 @@ function ConnectForm(props: {
   const { options: dbRolesOpts, hasWildcard: dbRoleHasWildcard } =
     prepareOptions(props.db.roles);
 
-  const [selectedName, setSelectedName] = useState<Option>(dbNamesOpts?.[0]);
-  const [selectedUser, setSelectedUser] = useState<Option>(dbUserOpts?.[0]);
-  const [selectedRoles, setSelectedRoles] =
-    useState<readonly Option[]>(dbRolesOpts);
+  const [selectedName, setSelectedName] = useState<Option>(
+    toOption(props.desiredDbName) ?? dbNamesOpts?.[0]
+  );
+  const [selectedUser, setSelectedUser] = useState<Option>(
+    toOption(props.desiredDbUser) ?? dbUserOpts?.[0]
+  );
+  const [selectedRoles, setSelectedRoles] = useState<readonly Option[]>(
+    props.desiredDbRole ? [toOption(props.desiredDbRole)] : dbRolesOpts
+  );
 
   const dbConnect = () => {
     props.onConnect({
@@ -238,6 +252,13 @@ function ConnectionField({
   ) : (
     <FieldSelect {...commonOptions} />
   );
+}
+
+function toOption(value?: string): Option | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return { value, label: value };
 }
 
 function prepareOptions(rawOpts: string[]): {

--- a/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
@@ -45,13 +45,8 @@ export function ConnectDialog(props: {
   serviceName: string;
   onClose(): void;
   onConnect(data: DbConnectData): void;
-  desiredDbUser?: string;
-  desiredDbName?: string;
-  desiredDbRole?: string;
 }) {
   // Fetch database information to pre-fill the connection parameters.
-  // If desired principals all resolve to valid options, auto-connect
-  // directly from the fetch callback (bypassing the form entirely).
   const ctx = useTeleport();
   const [attempt, getDatabase] = useAsync(
     useCallback(async () => {
@@ -70,14 +65,7 @@ export function ConnectDialog(props: {
         throw new Error('Unable to retrieve database information.');
       }
 
-      const db = response.agents[0];
-      const autoConnectData = tryAutoConnect(db, props);
-      if (autoConnectData) {
-        props.onConnect(autoConnectData);
-        return null;
-      }
-
-      return db;
+      return response.agents[0];
     }, [props.clusterId, ctx.resourceService, props.serviceName])
   );
 
@@ -102,14 +90,11 @@ export function ConnectDialog(props: {
           <Indicator />
         </Box>
       )}
-      {attempt.status === 'success' && attempt.data && (
+      {attempt.status === 'success' && (
         <ConnectForm
           db={attempt.data}
           onConnect={props.onConnect}
           onClose={props.onClose}
-          desiredDbUser={props.desiredDbUser}
-          desiredDbName={props.desiredDbName}
-          desiredDbRole={props.desiredDbRole}
         />
       )}
     </Dialog>
@@ -120,9 +105,6 @@ function ConnectForm(props: {
   db: Database;
   onConnect(data: DbConnectData): void;
   onClose(): void;
-  desiredDbUser?: string;
-  desiredDbName?: string;
-  desiredDbRole?: string;
 }) {
   const { options: dbNamesOpts, hasWildcard: dbNameHasWildcard } =
     prepareOptions(props.db.names);
@@ -131,22 +113,10 @@ function ConnectForm(props: {
   const { options: dbRolesOpts, hasWildcard: dbRoleHasWildcard } =
     prepareOptions(props.db.roles);
 
-  const [selectedName, setSelectedName] = useState<Option>(() =>
-    findOptionOrCreate(dbNamesOpts, props.desiredDbName, dbNameHasWildcard) ??
-    dbNamesOpts?.[0]
-  );
-  const [selectedUser, setSelectedUser] = useState<Option>(() =>
-    findOptionOrCreate(dbUserOpts, props.desiredDbUser, dbUserHasWildcard) ??
-    dbUserOpts?.[0]
-  );
+  const [selectedName, setSelectedName] = useState<Option>(dbNamesOpts?.[0]);
+  const [selectedUser, setSelectedUser] = useState<Option>(dbUserOpts?.[0]);
   const [selectedRoles, setSelectedRoles] =
-    useState<readonly Option[]>(() => {
-      if (props.desiredDbRole) {
-        const match = findOptionOrCreate(dbRolesOpts, props.desiredDbRole, dbRoleHasWildcard);
-        if (match) return [match];
-      }
-      return dbRolesOpts;
-    });
+    useState<readonly Option[]>(dbRolesOpts);
 
   const dbConnect = () => {
     props.onConnect({
@@ -268,52 +238,6 @@ function ConnectionField({
   ) : (
     <FieldSelect {...commonOptions} />
   );
-}
-
-/**
- * Checks if desired principals all resolve to valid options for this DB.
- * If so, returns the DbConnectData to use; otherwise returns null.
- */
-function tryAutoConnect(
-  db: Database,
-  props: { desiredDbUser?: string; desiredDbName?: string; desiredDbRole?: string }
-): DbConnectData | null {
-  if (!props.desiredDbUser && !props.desiredDbRole) return null;
-
-  const { options: nameOpts, hasWildcard: nameWild } = prepareOptions(db.names);
-  const { options: userOpts, hasWildcard: userWild } = prepareOptions(db.users);
-  const { options: roleOpts, hasWildcard: roleWild } = prepareOptions(db.roles);
-
-  const dbNameReq = getDbNameRequirement(db.protocol);
-  const resolvedName = findOptionOrCreate(nameOpts, props.desiredDbName, nameWild);
-  const resolvedUser = findOptionOrCreate(userOpts, props.desiredDbUser, userWild);
-  const resolvedRole = findOptionOrCreate(roleOpts, props.desiredDbRole, roleWild);
-
-  const hasName = dbNameReq === 'unsupported' || !!resolvedName;
-  const hasUserOrRole = !!resolvedUser || !!resolvedRole;
-
-  if (!hasName || !hasUserOrRole) return null;
-
-  return {
-    serviceName: db.name,
-    protocol: db.protocol,
-    dbName: resolvedName?.value,
-    dbUser: resolvedUser?.value ?? userOpts?.[0]?.value,
-    dbRoles: resolvedRole ? [resolvedRole.value] : roleOpts?.map(o => o.value),
-  };
-}
-
-function findOptionOrCreate(
-  options: Option[],
-  desired: string | undefined,
-  hasWildcard: boolean
-): Option | undefined {
-  if (!desired) return undefined;
-  const match = options?.find(o => o.value === desired);
-  if (match) return match;
-  // If there's a wildcard, the user can use any value, so create an option.
-  if (hasWildcard) return { value: desired, label: desired };
-  return undefined;
 }
 
 function prepareOptions(rawOpts: string[]): {

--- a/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
@@ -45,8 +45,13 @@ export function ConnectDialog(props: {
   serviceName: string;
   onClose(): void;
   onConnect(data: DbConnectData): void;
+  desiredDbUser?: string;
+  desiredDbName?: string;
+  desiredDbRole?: string;
 }) {
   // Fetch database information to pre-fill the connection parameters.
+  // If desired principals all resolve to valid options, auto-connect
+  // directly from the fetch callback (bypassing the form entirely).
   const ctx = useTeleport();
   const [attempt, getDatabase] = useAsync(
     useCallback(async () => {
@@ -65,7 +70,14 @@ export function ConnectDialog(props: {
         throw new Error('Unable to retrieve database information.');
       }
 
-      return response.agents[0];
+      const db = response.agents[0];
+      const autoConnectData = tryAutoConnect(db, props);
+      if (autoConnectData) {
+        props.onConnect(autoConnectData);
+        return null;
+      }
+
+      return db;
     }, [props.clusterId, ctx.resourceService, props.serviceName])
   );
 
@@ -90,11 +102,14 @@ export function ConnectDialog(props: {
           <Indicator />
         </Box>
       )}
-      {attempt.status === 'success' && (
+      {attempt.status === 'success' && attempt.data && (
         <ConnectForm
           db={attempt.data}
           onConnect={props.onConnect}
           onClose={props.onClose}
+          desiredDbUser={props.desiredDbUser}
+          desiredDbName={props.desiredDbName}
+          desiredDbRole={props.desiredDbRole}
         />
       )}
     </Dialog>
@@ -105,6 +120,9 @@ function ConnectForm(props: {
   db: Database;
   onConnect(data: DbConnectData): void;
   onClose(): void;
+  desiredDbUser?: string;
+  desiredDbName?: string;
+  desiredDbRole?: string;
 }) {
   const { options: dbNamesOpts, hasWildcard: dbNameHasWildcard } =
     prepareOptions(props.db.names);
@@ -113,10 +131,22 @@ function ConnectForm(props: {
   const { options: dbRolesOpts, hasWildcard: dbRoleHasWildcard } =
     prepareOptions(props.db.roles);
 
-  const [selectedName, setSelectedName] = useState<Option>(dbNamesOpts?.[0]);
-  const [selectedUser, setSelectedUser] = useState<Option>(dbUserOpts?.[0]);
+  const [selectedName, setSelectedName] = useState<Option>(() =>
+    findOptionOrCreate(dbNamesOpts, props.desiredDbName, dbNameHasWildcard) ??
+    dbNamesOpts?.[0]
+  );
+  const [selectedUser, setSelectedUser] = useState<Option>(() =>
+    findOptionOrCreate(dbUserOpts, props.desiredDbUser, dbUserHasWildcard) ??
+    dbUserOpts?.[0]
+  );
   const [selectedRoles, setSelectedRoles] =
-    useState<readonly Option[]>(dbRolesOpts);
+    useState<readonly Option[]>(() => {
+      if (props.desiredDbRole) {
+        const match = findOptionOrCreate(dbRolesOpts, props.desiredDbRole, dbRoleHasWildcard);
+        if (match) return [match];
+      }
+      return dbRolesOpts;
+    });
 
   const dbConnect = () => {
     props.onConnect({
@@ -238,6 +268,52 @@ function ConnectionField({
   ) : (
     <FieldSelect {...commonOptions} />
   );
+}
+
+/**
+ * Checks if desired principals all resolve to valid options for this DB.
+ * If so, returns the DbConnectData to use; otherwise returns null.
+ */
+function tryAutoConnect(
+  db: Database,
+  props: { desiredDbUser?: string; desiredDbName?: string; desiredDbRole?: string }
+): DbConnectData | null {
+  if (!props.desiredDbUser && !props.desiredDbRole) return null;
+
+  const { options: nameOpts, hasWildcard: nameWild } = prepareOptions(db.names);
+  const { options: userOpts, hasWildcard: userWild } = prepareOptions(db.users);
+  const { options: roleOpts, hasWildcard: roleWild } = prepareOptions(db.roles);
+
+  const dbNameReq = getDbNameRequirement(db.protocol);
+  const resolvedName = findOptionOrCreate(nameOpts, props.desiredDbName, nameWild);
+  const resolvedUser = findOptionOrCreate(userOpts, props.desiredDbUser, userWild);
+  const resolvedRole = findOptionOrCreate(roleOpts, props.desiredDbRole, roleWild);
+
+  const hasName = dbNameReq === 'unsupported' || !!resolvedName;
+  const hasUserOrRole = !!resolvedUser || !!resolvedRole;
+
+  if (!hasName || !hasUserOrRole) return null;
+
+  return {
+    serviceName: db.name,
+    protocol: db.protocol,
+    dbName: resolvedName?.value,
+    dbUser: resolvedUser?.value ?? userOpts?.[0]?.value,
+    dbRoles: resolvedRole ? [resolvedRole.value] : roleOpts?.map(o => o.value),
+  };
+}
+
+function findOptionOrCreate(
+  options: Option[],
+  desired: string | undefined,
+  hasWildcard: boolean
+): Option | undefined {
+  if (!desired) return undefined;
+  const match = options?.find(o => o.value === desired);
+  if (match) return match;
+  // If there's a wildcard, the user can use any value, so create an option.
+  if (hasWildcard) return { value: desired, label: desired };
+  return undefined;
 }
 
 function prepareOptions(rawOpts: string[]): {

--- a/web/packages/teleport/src/Console/DocumentDb/DocumentDb.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/DocumentDb.tsx
@@ -59,6 +59,9 @@ export function DocumentDb({ doc, visible }: Props) {
           serviceName={doc.name}
           onConnect={sendDbConnectData}
           onClose={closeDocument}
+          desiredDbUser={doc.desiredDbUser}
+          desiredDbName={doc.desiredDbName}
+          desiredDbRole={doc.desiredDbRole}
         />
       )}
       {status !== 'loading' && (

--- a/web/packages/teleport/src/Console/DocumentDb/DocumentDb.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/DocumentDb.tsx
@@ -57,6 +57,9 @@ export function DocumentDb({ doc, visible }: Props) {
           serviceName={doc.name}
           onConnect={sendDbConnectData}
           onClose={closeDocument}
+          desiredDbUser={doc.desiredDbUser}
+          desiredDbName={doc.desiredDbName}
+          desiredDbRole={doc.desiredDbRole}
         />
       )}
       {status !== 'loading' && (

--- a/web/packages/teleport/src/Console/consoleContext.tsx
+++ b/web/packages/teleport/src/Console/consoleContext.tsx
@@ -164,9 +164,10 @@ export default class ConsoleContext {
     });
   }
 
-  addDbDocument(params: UrlDbConnectParams) {
+  addDbDocument(params: UrlDbConnectParams, search?: string) {
     const url = this.getDbDocumentUrl(params);
 
+    const searchParams = new URLSearchParams(search);
     return this.storeDocs.add({
       kind: 'db',
       clusterId: params.clusterId,
@@ -174,6 +175,9 @@ export default class ConsoleContext {
       url,
       created: new Date(),
       name: params.serviceName,
+      desiredDbUser: searchParams.get('dbUser') || undefined,
+      desiredDbName: searchParams.get('dbName') || undefined,
+      desiredDbRole: searchParams.get('dbRole') || undefined,
     });
   }
 

--- a/web/packages/teleport/src/Console/stores/types.ts
+++ b/web/packages/teleport/src/Console/stores/types.ts
@@ -65,6 +65,9 @@ export interface DocumentDb extends DocumentBase {
   kind: 'db';
   sid?: string;
   name: string;
+  desiredDbUser?: string;
+  desiredDbName?: string;
+  desiredDbRole?: string;
 }
 
 export type Document =

--- a/web/packages/teleport/src/Console/useTabRouting.ts
+++ b/web/packages/teleport/src/Console/useTabRouting.ts
@@ -62,7 +62,7 @@ export default function useRouting(ctx: ConsoleContext) {
         mode: participantMode,
       });
     } else if (dbConnectMatch) {
-      ctx.addDbDocument(dbConnectMatch.params);
+      ctx.addDbDocument(dbConnectMatch.params, search);
     }
   }, [ctx, pathname]);
 

--- a/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.tsx
@@ -51,7 +51,6 @@ export default function ConnectDialog({
   accessRequestId,
   dbProtocol,
   supportsInteractive,
-  desiredPrincipals,
 }: Props) {
   // For dynamodb and clickhouse-http protocols, the command is `tsh proxy db --tunnel` instead of `tsh db connect`.
   let connectCommand =
@@ -64,28 +63,20 @@ export default function ConnectDialog({
   let dbNameFlag: string;
   switch (dbNameReq) {
     case 'required':
-      dbNameFlag = ` --db-name=${desiredPrincipals?.dbName || '<name>'}`;
+      dbNameFlag = ' --db-name=<name>';
       break;
     case 'unsupported':
       dbNameFlag = '';
       break;
     case 'optional':
-      dbNameFlag = ` [--db-name=${desiredPrincipals?.dbName || '<name>'}]`;
+      dbNameFlag = ' [--db-name=<name>]';
       break;
     default:
       assertUnreachable(dbNameReq);
   }
 
   const onConnect = () => {
-    let url = cfg.getDbConnectRoute({ clusterId, serviceName: dbName });
-    if (desiredPrincipals) {
-      const qps = new URLSearchParams();
-      if (desiredPrincipals.dbUser) qps.set('dbUser', desiredPrincipals.dbUser);
-      if (desiredPrincipals.dbName) qps.set('dbName', desiredPrincipals.dbName);
-      if (desiredPrincipals.dbRole) qps.set('dbRole', desiredPrincipals.dbRole);
-      const qs = qps.toString();
-      if (qs) url += `?${qs}`;
-    }
+    const url = cfg.getDbConnectRoute({ clusterId, serviceName: dbName });
     openNewTab(url);
     onClose();
   };
@@ -155,7 +146,7 @@ export default function ConnectDialog({
           {' - Connect to the database'}
           <TextSelectCopy
             mt="2"
-            text={`tsh ${connectCommand} ${dbName} --db-user=${desiredPrincipals?.dbUser || desiredPrincipals?.dbRole || '<user>'}${dbNameFlag}`}
+            text={`tsh ${connectCommand} ${dbName} --db-user=<user>${dbNameFlag}`}
           />
         </Box>
         {accessRequestId && (
@@ -196,7 +187,4 @@ export type Props = {
   authType: AuthType;
   accessRequestId?: string;
   supportsInteractive?: boolean;
-  desiredPrincipals?:
-    | { dbName: string; dbUser: string; dbRole?: never }
-    | { dbName: string; dbUser?: never; dbRole: string };
 };

--- a/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.tsx
@@ -51,6 +51,7 @@ export default function ConnectDialog({
   accessRequestId,
   dbProtocol,
   supportsInteractive,
+  desiredPrincipals,
 }: Props) {
   // For dynamodb and clickhouse-http protocols, the command is `tsh proxy db --tunnel` instead of `tsh db connect`.
   let connectCommand =
@@ -63,20 +64,28 @@ export default function ConnectDialog({
   let dbNameFlag: string;
   switch (dbNameReq) {
     case 'required':
-      dbNameFlag = ' --db-name=<name>';
+      dbNameFlag = ` --db-name=${desiredPrincipals?.dbName || '<name>'}`;
       break;
     case 'unsupported':
       dbNameFlag = '';
       break;
     case 'optional':
-      dbNameFlag = ' [--db-name=<name>]';
+      dbNameFlag = ` [--db-name=${desiredPrincipals?.dbName || '<name>'}]`;
       break;
     default:
       assertUnreachable(dbNameReq);
   }
 
   const onConnect = () => {
-    const url = cfg.getDbConnectRoute({ clusterId, serviceName: dbName });
+    let url = cfg.getDbConnectRoute({ clusterId, serviceName: dbName });
+    if (desiredPrincipals) {
+      const qps = new URLSearchParams();
+      if (desiredPrincipals.dbUser) qps.set('dbUser', desiredPrincipals.dbUser);
+      if (desiredPrincipals.dbName) qps.set('dbName', desiredPrincipals.dbName);
+      if (desiredPrincipals.dbRole) qps.set('dbRole', desiredPrincipals.dbRole);
+      const qs = qps.toString();
+      if (qs) url += `?${qs}`;
+    }
     openNewTab(url);
     onClose();
   };
@@ -146,7 +155,7 @@ export default function ConnectDialog({
           {' - Connect to the database'}
           <TextSelectCopy
             mt="2"
-            text={`tsh ${connectCommand} ${dbName} --db-user=<user>${dbNameFlag}`}
+            text={`tsh ${connectCommand} ${dbName} --db-user=${desiredPrincipals?.dbUser || desiredPrincipals?.dbRole || '<user>'}${dbNameFlag}`}
           />
         </Box>
         {accessRequestId && (
@@ -187,4 +196,7 @@ export type Props = {
   authType: AuthType;
   accessRequestId?: string;
   supportsInteractive?: boolean;
+  desiredPrincipals?:
+    | { dbName: string; dbUser: string; dbRole?: never }
+    | { dbName: string; dbUser?: never; dbRole: string };
 };

--- a/web/packages/teleport/src/services/databases/index.ts
+++ b/web/packages/teleport/src/services/databases/index.ts
@@ -18,5 +18,6 @@
 
 import service from './databases';
 
+export * from './principals';
 export * from './types';
 export default service;

--- a/web/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/web/packages/teleport/src/services/databases/makeDatabase.ts
@@ -53,6 +53,7 @@ export function makeDatabase(json: any): Database {
     names: json.database_names || [],
     users: json.database_users || [],
     roles: json.database_roles || [],
+    databasePrincipalsByRole: json.databasePrincipalsByRole || {},
     hostname: json.hostname,
     aws: madeAws,
     requiresRequest,
@@ -63,6 +64,7 @@ export function makeDatabase(json: any): Database {
       error: targetHealth.transition_error,
       message: targetHealth.message,
     },
+    supportedFeatureIds: json.supportedFeatureIds || [],
   };
 }
 

--- a/web/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/web/packages/teleport/src/services/databases/makeDatabase.ts
@@ -66,7 +66,7 @@ export function makeDatabase(json: any): Database {
       error: targetHealth.transition_error,
       message: targetHealth.message,
     },
-    supportedFeatureIds: json.supportedFeatureIds,
+    supportedFeatureIds: json.supportedFeatureIds || [],
   };
 }
 

--- a/web/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/web/packages/teleport/src/services/databases/makeDatabase.ts
@@ -53,6 +53,9 @@ export function makeDatabase(json: any): Database {
     names: json.database_names || [],
     users: json.database_users || [],
     roles: json.database_roles || [],
+    databaseUserDetails: json.databaseUserDetails || [],
+    databaseNameDetails: json.databaseNameDetails || [],
+    databaseRoleDetails: json.databaseRoleDetails || [],
     hostname: json.hostname,
     aws: madeAws,
     requiresRequest,
@@ -63,6 +66,7 @@ export function makeDatabase(json: any): Database {
       error: targetHealth.transition_error,
       message: targetHealth.message,
     },
+    supportedFeatureIds: json.supportedFeatureIds,
   };
 }
 

--- a/web/packages/teleport/src/services/databases/principals.test.ts
+++ b/web/packages/teleport/src/services/databases/principals.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  isDatabasePrincipalSelectable,
+  type DatabasePrincipalSelection,
+} from './principals';
+
+const byRole = {
+  roleA: { users: ['alice'], names: ['sales'] },
+  roleB: { users: ['bob'], names: ['billing'] },
+  roleWild: { users: ['*'], names: ['reporting'], requiresRequest: true },
+  roleDbRoles: { roles: ['reader'], names: ['sales'] },
+};
+
+const sel = (
+  s?: Partial<DatabasePrincipalSelection>
+): DatabasePrincipalSelection => ({
+  users: [],
+  names: [],
+  roles: [],
+  ...s,
+});
+
+describe('isDatabasePrincipalSelectable', () => {
+  it('allows any granted value with no cross-dimension selection', () => {
+    expect(isDatabasePrincipalSelectable(byRole, sel(), 'users', 'alice')).toBe(
+      true
+    );
+    expect(isDatabasePrincipalSelectable(byRole, sel(), 'names', 'sales')).toBe(
+      true
+    );
+    expect(
+      isDatabasePrincipalSelectable(byRole, sel(), 'roles', 'reader')
+    ).toBe(true);
+  });
+
+  it('rejects values granted by no role', () => {
+    // Every literal user is covered by roleWild's wildcard grant, so use
+    // dimensions without one.
+    expect(
+      isDatabasePrincipalSelectable(byRole, sel(), 'names', 'nonexistent')
+    ).toBe(false);
+    expect(isDatabasePrincipalSelectable(byRole, sel(), 'roles', 'writer')).toBe(
+      false
+    );
+  });
+
+  it('enforces single-role (user, name) pairing', () => {
+    // alice pairs with sales via roleA.
+    expect(
+      isDatabasePrincipalSelectable(
+        byRole,
+        sel({ names: ['sales'] }),
+        'users',
+        'alice'
+      )
+    ).toBe(true);
+    // bob is granted, but no single role grants (bob, sales).
+    expect(
+      isDatabasePrincipalSelectable(
+        byRole,
+        sel({ names: ['sales'] }),
+        'users',
+        'bob'
+      )
+    ).toBe(false);
+    // A value pairs when any one selected value from the other dimension
+    // is co-granted.
+    expect(
+      isDatabasePrincipalSelectable(
+        byRole,
+        sel({ names: ['sales', 'billing'] }),
+        'users',
+        'bob'
+      )
+    ).toBe(true);
+    // Symmetric direction: names gated against selected users.
+    expect(
+      isDatabasePrincipalSelectable(
+        byRole,
+        sel({ users: ['alice'] }),
+        'names',
+        'billing'
+      )
+    ).toBe(false);
+  });
+
+  it('treats a wildcard grant as covering literals for pairing', () => {
+    // roleWild grants (any user, reporting).
+    expect(
+      isDatabasePrincipalSelectable(
+        byRole,
+        sel({ names: ['reporting'] }),
+        'users',
+        'dev1'
+      )
+    ).toBe(true);
+  });
+
+  it('covers a requested wildcard only via a wildcard grant', () => {
+    expect(isDatabasePrincipalSelectable(byRole, sel(), 'users', '*')).toBe(
+      true
+    );
+    expect(isDatabasePrincipalSelectable(byRole, sel(), 'names', '*')).toBe(
+      false
+    );
+    // The wildcard-granting role participates in pairing like any other:
+    // (*, sales) is not co-granted by one role.
+    expect(
+      isDatabasePrincipalSelectable(
+        byRole,
+        sel({ names: ['sales'] }),
+        'users',
+        '*'
+      )
+    ).toBe(false);
+    expect(
+      isDatabasePrincipalSelectable(
+        byRole,
+        sel({ names: ['reporting'] }),
+        'users',
+        '*'
+      )
+    ).toBe(true);
+  });
+
+  it('makes a wildcard mutually exclusive with the dimension literals', () => {
+    expect(
+      isDatabasePrincipalSelectable(
+        byRole,
+        sel({ users: ['alice'] }),
+        'users',
+        '*'
+      )
+    ).toBe(false);
+    expect(
+      isDatabasePrincipalSelectable(
+        byRole,
+        sel({ users: ['*'], names: ['reporting'] }),
+        'users',
+        'dev1'
+      )
+    ).toBe(false);
+  });
+});

--- a/web/packages/teleport/src/services/databases/principals.ts
+++ b/web/packages/teleport/src/services/databases/principals.ts
@@ -1,0 +1,103 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { DatabaseRolePrincipalGroup } from './types';
+
+/** The reserved wildcard principal value. */
+export const WildcardPrincipal = '*';
+
+export type DatabasePrincipalDimension = 'users' | 'names' | 'roles';
+
+/** A draft database constraint selection, flattened per dimension. */
+export type DatabasePrincipalSelection = {
+  users: string[];
+  names: string[];
+  roles: string[];
+};
+
+/**
+ * Returns whether a single role grants the given value for a dimension.
+ * A wildcard grant covers any literal for users/names, but a requested
+ * wildcard is only covered by a wildcard grant. db_roles have no wildcard
+ * matching.
+ */
+const groupGrants = (
+  group: DatabaseRolePrincipalGroup,
+  dimension: DatabasePrincipalDimension,
+  value: string
+): boolean => {
+  const values = group[dimension] ?? [];
+  if (value === WildcardPrincipal || dimension === 'roles') {
+    return values.includes(value);
+  }
+  return values.includes(value) || values.includes(WildcardPrincipal);
+};
+
+/**
+ * Returns whether adding the given value to the selection keeps it
+ * satisfiable, mirroring the backend's database constraint validation
+ * (ValidateDatabaseConstraintCoverage): a wildcard must be a dimension's
+ * only value, and when both users and names are requested, every value
+ * must pair with a value from the other dimension under a single granting
+ * role, since session-time matchers are evaluated per role.
+ *
+ * Selected values themselves are not gated; deselection is always allowed.
+ */
+export const isDatabasePrincipalSelectable = (
+  byRole: Record<string, DatabaseRolePrincipalGroup>,
+  selection: DatabasePrincipalSelection,
+  dimension: DatabasePrincipalDimension,
+  value: string
+): boolean => {
+  const groups = Object.values(byRole);
+  const selected = selection[dimension];
+
+  // A wildcard subsumes the dimension's literals: it must be the only
+  // value, in either selection order.
+  if (dimension !== 'roles') {
+    if (
+      value === WildcardPrincipal &&
+      selected.some(v => v !== WildcardPrincipal)
+    ) {
+      return false;
+    }
+    if (value !== WildcardPrincipal && selected.includes(WildcardPrincipal)) {
+      return false;
+    }
+  }
+
+  // The value must be granted by some role at all (a requested wildcard
+  // only by a wildcard grant).
+  if (!groups.some(g => groupGrants(g, dimension, value))) {
+    return false;
+  }
+
+  // Combination coverage applies between users and names only, and only
+  // once both dimensions would be non-empty: the value must pair with at
+  // least one selected value from the other dimension under one role.
+  const paired: DatabasePrincipalDimension | undefined =
+    dimension === 'users' ? 'names' : dimension === 'names' ? 'users' : undefined;
+  if (!paired || selection[paired].length === 0) {
+    return true;
+  }
+  return selection[paired].some(other =>
+    groups.some(
+      g => groupGrants(g, dimension, value) && groupGrants(g, paired, other)
+    )
+  );
+};

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -18,6 +18,7 @@
 
 import { ResourceTargetHealth } from 'shared/components/UnifiedResources';
 import { DbProtocol } from 'shared/services/databases';
+import { ComponentFeatureID } from 'shared/utils/componentFeatures';
 
 import { ResourceLabel } from 'teleport/services/agents';
 
@@ -50,6 +51,12 @@ export interface Database {
   names?: string[];
   users?: string[];
   roles?: string[];
+  /** Per-user metadata including whether an access request is required. */
+  databaseUserDetails?: DatabaseUserDetail[];
+  /** Per-name metadata including whether an access request is required. */
+  databaseNameDetails?: DatabaseNameDetail[];
+  /** Per-role metadata including whether an access request is required. */
+  databaseRoleDetails?: DatabaseRoleDetail[];
   hostname: string;
   aws?: Aws;
   requiresRequest?: boolean;
@@ -67,6 +74,11 @@ export interface Database {
    * - webapi/sites/:site/resources (unified resources)
    */
   targetHealth?: ResourceTargetHealth;
+  /**
+   * supportedFeatureIds contains component feature IDs supported by
+   * both the Database and all required back-end components.
+   */
+  supportedFeatureIds?: ComponentFeatureID[];
 }
 
 export type DatabasesResponse = {
@@ -121,4 +133,19 @@ export type DatabaseServer = {
   hostname: string;
   hostId: string;
   targetHealth?: ResourceTargetHealth;
+};
+
+export type DatabaseUserDetail = {
+  user: string;
+  requiresRequest?: boolean;
+};
+
+export type DatabaseNameDetail = {
+  name: string;
+  requiresRequest?: boolean;
+};
+
+export type DatabaseRoleDetail = {
+  role: string;
+  requiresRequest?: boolean;
 };

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -18,6 +18,7 @@
 
 import { ResourceTargetHealth } from 'shared/components/UnifiedResources';
 import { DbProtocol } from 'shared/services/databases';
+import { ComponentFeatureID } from 'shared/utils/componentFeatures';
 
 import { ResourceLabel } from 'teleport/services/agents';
 
@@ -50,6 +51,13 @@ export interface Database {
   names?: string[];
   users?: string[];
   roles?: string[];
+  /**
+   * databasePrincipalsByRole maps Teleport role names to the database
+   * principals each role grants, with requiresRequest metadata.
+   * Used by the frontend to show valid principal combinations and
+   * prevent selection of incompatible ones.
+   */
+  databasePrincipalsByRole?: Record<string, DatabaseRolePrincipalGroup>;
   hostname: string;
   aws?: Aws;
   requiresRequest?: boolean;
@@ -67,6 +75,11 @@ export interface Database {
    * - webapi/sites/:site/resources (unified resources)
    */
   targetHealth?: ResourceTargetHealth;
+  /**
+   * supportedFeatureIds contains component feature IDs supported by
+   * both the Database and all required back-end components.
+   */
+  supportedFeatureIds?: ComponentFeatureID[];
 }
 
 export type DatabasesResponse = {
@@ -121,4 +134,12 @@ export type DatabaseServer = {
   hostname: string;
   hostId: string;
   targetHealth?: ResourceTargetHealth;
+};
+
+/** Describes the database principals that a single Teleport role grants. */
+export type DatabaseRolePrincipalGroup = {
+  requiresRequest?: boolean;
+  users?: string[];
+  names?: string[];
+  roles?: string[];
 };

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -52,11 +52,11 @@ export interface Database {
   users?: string[];
   roles?: string[];
   /** Per-user metadata including whether an access request is required. */
-  databaseUserDetails?: DatabaseUserDetail[];
+  databaseUserDetails?: DatabasePrincipalDetail[];
   /** Per-name metadata including whether an access request is required. */
-  databaseNameDetails?: DatabaseNameDetail[];
+  databaseNameDetails?: DatabasePrincipalDetail[];
   /** Per-role metadata including whether an access request is required. */
-  databaseRoleDetails?: DatabaseRoleDetail[];
+  databaseRoleDetails?: DatabasePrincipalDetail[];
   hostname: string;
   aws?: Aws;
   requiresRequest?: boolean;
@@ -135,17 +135,7 @@ export type DatabaseServer = {
   targetHealth?: ResourceTargetHealth;
 };
 
-export type DatabaseUserDetail = {
-  user: string;
-  requiresRequest?: boolean;
-};
-
-export type DatabaseNameDetail = {
-  name: string;
-  requiresRequest?: boolean;
-};
-
-export type DatabaseRoleDetail = {
-  role: string;
+export type DatabasePrincipalDetail = {
+  value: string;
   requiresRequest?: boolean;
 };


### PR DESCRIPTION
## Context
Counterpart to https://github.com/gravitational/teleport/pull/65769. Adds Web UI support for displaying, selecting, and managing database constraints (users, names, roles) in the access request checkout and review flows.

## Changes
**Access Request Checkout/Review**
- Database constraints (users, names, roles) render under constrained database resources with per-value remove buttons
- Database constraints added to the access request review view

**Types**
- `ResourceConstraints` union extended with a `database` variant carrying optional `users`, `names`, `roles`
- Database response types updated to reflect per-principal detail objects with `requiresRequest` metadata and `supportedFeatureIds`

## Related
- Requires https://github.com/gravitational/teleport/pull/65769
- See https://github.com/gravitational/teleport/issues/58307

## Manual Test Plan
### Test Environment
- Teleport enterprise cluster built from the full branch stack (types + auth/proxy + this branch)
- Database resource with both granted and requestable principals configured via roles

### Test Cases
- [x] Request checkout renders database constraints (users, names, roles) with individual remove buttons when a constrained database is in the cart
- [x] Removing a single database user/name/role value updates the constraint correctly; removing all values clears the constraint
- [x] Request review view displays database constraints under each constrained database resource
- [x] Storybook stories render correctly: `LoadedResourceRequestWithDatabaseConstraints`, `LoadedResourcePendingWithDatabaseConstraints`
