### PR TITLE
[v17] Connect: Make menu bar action reliably show app window

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -237,7 +237,7 @@ async function initializeApp(): Promise<void> {
       windowsManager.createWindow();
 
       if (configService.get('runInBackground').value) {
-        setTray(settings, { show: () => windowsManager.showWindow() });
+        setTray(settings, { show: () => windowsManager.focusWindow() });
       }
     })
     .catch(error => {

--- a/web/packages/teleterm/src/mainProcess/windowsManager.test.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.test.ts
@@ -28,6 +28,9 @@ import { makeRuntimeSettings } from './fixtures/mocks';
 import { WindowsManager } from './windowsManager';
 
 jest.mock('electron', () => ({
+  app: {
+    focus: jest.fn(),
+  },
   Menu: {
     buildFromTemplate: jest.fn(),
   },
@@ -81,6 +84,9 @@ const makeWindowsManager = () => {
   let isFocused = false;
 
   const mockWindow = {
+    show: jest.fn().mockImplementation(() => {
+      isFocused = true;
+    }),
     focus: jest.fn().mockImplementation(() => {
       isFocused = true;
     }),

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -253,12 +253,8 @@ export class WindowsManager {
     );
   }
 
-  /** Shows the window when it's hidden or minimized. */
-  showWindow(): void {
-    if (!this.isWindowUsable()) {
-      return;
-    }
-
+  /** Shows the window when it's hidden or minimized. Also brings it out of background mode. */
+  private showWindow(): void {
     if (this.isInBackgroundMode) {
       this.window.webContents.send(RendererIpc.IsInBackgroundMode, {
         isInBackgroundMode: false,
@@ -271,7 +267,40 @@ export class WindowsManager {
       this.window.restore();
     }
 
-    // Menu bar clicks don't automatically make the app the active application on macOS.
+    // Menu bar clicks don't automatically make the app the active application on macOS, so let's
+    // steal focus first.
+    //
+    // On Windows, app.focus() doesn't work the same as on the other platforms.
+    // If the window is minimized, app.focus() will bring it to the front and give it focus.
+    // If the window is not minimized but simply covered by other another window, app.focus() will
+    // flash the icon of Connect in the task bar.
+    // To make things even more complicated, the app behaves like that only when it is packaged.
+    // When it is in dev mode, it seems to work correctly (it is brought to the front every time).
+    //
+    // Ideally, we'd like the not minimized window to receive focus too. We considered two
+    // workarounds to bring focus to a window that's not minimized:
+    //
+    // * win.minimized() followed by win.focus() – this reportedly doesn't work anymore (see the
+    // comment linked below) though it did work at the time of implementing forceFocusWindow.
+    // Admittedly, this seems like a hack and does cause the window to first minimize and then show
+    // up which feels weird.
+    // * win.setAlwaysOnTop(true) followed by win.show() – this does bring the window to the top
+    // but doesn't give it focus. Super awkward because Connect shows up over another app that you
+    // were using, you start typing to fill out whatever form Connect has shown you. But your
+    // keystrokes go to the app that the Connect window just covered.
+    //
+    // Since we cannot reliably steal focus, let's just not attempt to do it and instead defer to
+    // flashing the icon in the task bar.
+    //
+    // https://github.com/electron/electron/issues/2867#issuecomment-1080573240
+    //
+    // I don't understand why calling app.focus() on a minimized window gives it focus in the
+    // first place. In theory it shouldn't work, see the links below:
+    //
+    // https://stackoverflow.com/a/72620653/742872
+    // https://devblogs.microsoft.com/oldnewthing/20090220-00/?p=19083
+    // https://github.com/electron/electron/issues/2867#issuecomment-142480964
+    // https://github.com/electron/electron/issues/2867#issuecomment-142511956
     app.focus({ steal: true });
     // window.show() both makes the window visible and gives it focus.
     this.window.show();
@@ -305,9 +334,12 @@ export class WindowsManager {
   }
 
   /**
-   * focusWindow is for situations where the app has privileges to do so, for example in a scenario
-   * where the user attempts to launch a second instance of the app – the same process that the user
-   * interacted with asks for its window to receive focus.
+   * focusWindow is for situations where the user explicitly asks for the window to receive focus,
+   * for example they select "Open Teleport Connect" from the tray or they attempt to launch a
+   * second instance of the app.
+   *
+   * At the moment, the only difference is that forceFocusWindow does not bounce the dock icon on
+   * macOS.
    */
   focusWindow(): void {
     if (!this.isWindowUsable()) {
@@ -315,7 +347,6 @@ export class WindowsManager {
     }
 
     this.showWindow();
-    this.window.focus();
   }
 
   /**
@@ -330,47 +361,9 @@ export class WindowsManager {
       return;
     }
 
-    if (this.window.isFocused()) {
-      return;
-    }
-
-    // On Windows, app.focus() doesn't work the same as on the other platforms.
-    // If the window is minimized, app.focus() will bring it to the front and give it focus.
-    // If the window is not minimized but simply covered by other another window, app.focus() will
-    // flash the icon of Connect in the task bar.
-    // To make things even more complicated, the app behaves like that only when it is packaged.
-    // When it is in dev mode, it seems to work correctly (it is brought to the front every time).
-    //
-    // Ideally, we'd like the not minimized window to receive focus too. We considered two
-    // workarounds to bring focus to a window that's not minimized:
-    //
-    // * win.minimized() followed by win.focus() – this reportedly doesn't work anymore (see the
-    // comment linked below) though it did work at the time of implementing forceFocusWindow.
-    // Admittedly, this seems like a hack and does cause the window to first minimize and then show
-    // up which feels weird.
-    // * win.setAlwaysOnTop(true) followed by win.show() – this does bring the window to the top
-    // but doesn't give it focus. Super awkward because Connect shows up over another app that you
-    // were using, you start typing to fill out whatever form Connect has shown you. But your
-    // keystrokes go to the app that the Connect window just covered.
-    //
-    // Since we cannot reliably steal focus, let's just not attempt to do it and instead defer to
-    // flashing the icon in the task bar.
-    //
-    // https://github.com/electron/electron/issues/2867#issuecomment-1080573240
-    //
-    // I don't understand why calling app.focus() on a minimized window gives it focus in the
-    // first place. In theory it shouldn't work, see the links below:
-    //
-    // https://stackoverflow.com/a/72620653/742872
-    // https://devblogs.microsoft.com/oldnewthing/20090220-00/?p=19083
-    // https://github.com/electron/electron/issues/2867#issuecomment-142480964
-    // https://github.com/electron/electron/issues/2867#issuecomment-142511956
-
     this.showWindow();
 
     app.dock?.bounce('informational');
-
-    app.focus({ steal: true });
   }
 
   /**

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -259,16 +259,6 @@ export class WindowsManager {
       return;
     }
 
-    if (this.window.isMinimized()) {
-      this.window.restore();
-    }
-
-    if (this.window.isVisible()) {
-      this.window.focus();
-      return;
-    }
-
-    this.window.show();
     if (this.isInBackgroundMode) {
       this.window.webContents.send(RendererIpc.IsInBackgroundMode, {
         isInBackgroundMode: false,
@@ -276,6 +266,15 @@ export class WindowsManager {
       void app.dock?.show();
       this.isInBackgroundMode = false;
     }
+
+    if (this.window.isMinimized()) {
+      this.window.restore();
+    }
+
+    // Menu bar clicks don't automatically make the app the active application on macOS.
+    app.focus({ steal: true });
+    // window.show() both makes the window visible and gives it focus.
+    this.window.show();
   }
 
   /**


### PR DESCRIPTION
Backport #65705 to branch/v17

changelog: Fixed an issue in Teleport Connect on macOS where selecting "Open Teleport Connect" from the menu bar would not reliably open the app

## Manual Test Plan
### Test Environment

A locally built packaged app.

### Test Cases
- [x] Verify that the menu bar reliably opens the app, both when running and not running in background mode.
- [x] Verify that the change didn't introduce regressions on Linux and Windows, that is the following scenarios work as before:
  * Opening the app from the tray while it is/isn't in background mode.
  * Focusing on the app when attempting to use a local proxy with an expired cert.