### PR TITLE
[docs] correct bench command

### DIFF
--- a/docs/pages/reference/deployment/scaling.mdx
+++ b/docs/pages/reference/deployment/scaling.mdx
@@ -216,9 +216,9 @@ For example to spawn 32 requests per second for 2 minutes against a specific age
 tsh bench ssh --rate=32 --duration=2m user@node-agent -- ls
 ```
 
-Similarly to test 64 concurrent sessions against a single agent:
+Similarly to test 64 concurrent sessions against a single agent using a unique label:
 ```sh
-tsh bench web ssh --max=64 --duration=2m user@node-agent ls
+tsh bench web sessions --max=64 --duration=2m user@UNIQUE=example ls
 ```
 
 The payload can be customized to represent a typical use case.


### PR DESCRIPTION
This is a correction for changes merged in #62485

The correct command is `tsh bench web sessions`

In addition, this command does not respect a singular host which is ignored when no label is given. As a workaround use a unique label on the target. 





