### PR TITLE
docs: remove Team references and update access request plugins

### DIFF
--- a/docs/pages/identity-governance/access-requests/plugins/plugins.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/plugins.mdx
@@ -43,11 +43,10 @@ The following Access Request plugins are hosted on Teleport Cloud:
 
 ## Self-hosting Access Request plugins
 
-You can host Teleport Access Request plugins yourself. Self-hosted Access
-Request plugins are the only way to manage Access Requests through a third-party
-communication platform if you are self-hosting Teleport. If you use Teleport
-Team or Teleport Enterprise Cloud, you can run self-hosted Access Request
-plugins for more control over configuration and architecture.
+You can host Teleport Access Request plugins yourself. Teleport Enterprise Cloud
+offers a greater number of managed Access Request plugins than self-hosted Teleport
+deployments. Self-hosted Access Request plugins typically give you more configuration
+options then managed ones.
 
 Access Request plugins can run within private networks that are isolated from
 the Teleport Auth Service. To access the Auth Service API, they connect to the

--- a/docs/pages/reference/deployment/join-methods.mdx
+++ b/docs/pages/reference/deployment/join-methods.mdx
@@ -325,7 +325,7 @@ joining the cluster.
 
 <Admonition type="warning">
 
-The EC2 join method is not available in Teleport Enterprise Cloud. 
+The EC2 join method is not available in Teleport Enterprise Cloud.
 Teleport Enterprise Cloud customers can use the [IAM join
 method](#aws-iam-role-iam) or [ephemeral secret tokens](#ephemeral-tokens).
 

--- a/docs/pages/reference/deployment/join-methods.mdx
+++ b/docs/pages/reference/deployment/join-methods.mdx
@@ -325,8 +325,8 @@ joining the cluster.
 
 <Admonition type="warning">
 
-The EC2 join method is not available in Teleport Enterprise Cloud and Teleport
-Team. Teleport Enterprise Cloud and Team customers can use the [IAM join
+The EC2 join method is not available in Teleport Enterprise Cloud. 
+Teleport Enterprise Cloud customers can use the [IAM join
 method](#aws-iam-role-iam) or [ephemeral secret tokens](#ephemeral-tokens).
 
 </Admonition>


### PR DESCRIPTION
Updates:
- Remove Teleport Team references
- Access request plugins are available as managed in self-hosted. This has been reworded to represent that more are available in Teleport ent cloud.
