### PR TITLE
[v18] docs: adding new videos to docs pages

### DIFF
--- a/docs/pages/identity-security/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries.mdx
@@ -2,6 +2,8 @@
 title: Session Recording Summaries
 sidebar_label: Summarize Session Recordings with AI
 description: Describes how to use Teleport Identity security to summarize session recordings with a language model.
+# cspell:disable-next-line
+videoBanner: AW5DVLVNf6A
 tags:
   - session-recording
   - conceptual


### PR DESCRIPTION
Backports #65758 to branch/v18

Note, video for Beams page was removed as Beams page does not exist on v18. Session Summaries page change only.
