### PR TITLE
Use a single desktop reconciler

### DIFF
--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -223,7 +223,7 @@ func (r *GenericReconciler[K, T]) Reconcile(ctx context.Context) error {
 }
 
 // processRegisteredResource checks the specified registered resource against the
-// new list of resources.
+// new list of resources, deleting the resource if should no longer exist.
 func (r *GenericReconciler[K, T]) processRegisteredResource(ctx context.Context, newResources map[K]T, key K, registered T) error {
 	// See if this registered resource is still present among "new" resources.
 	if _, ok := newResources[key]; ok {
@@ -268,7 +268,10 @@ func (r *GenericReconciler[K, T]) processRegisteredResource(ctx context.Context,
 }
 
 // processNewResource checks the provided new resource against currently
-// registered resources.
+// registered resources. It may:
+// - create a new resource if one does not already exist
+// - update an existing resource
+// - delete a resource that no longer matches the reconciler's matchers
 func (r *GenericReconciler[K, T]) processNewResource(ctx context.Context, currentResources map[K]T, key K, newT T) error {
 	// First see if the resource is already registered and if not, whether it
 	// matches the selector labels and should be registered.

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -414,6 +414,9 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 
 		// Only create the watcher when dynamic registration is enabled.
 		var dynamicDesktopUpdates chan []types.DynamicWindowsDesktop
+		var periodicUpdate <-chan time.Time
+		reset := func(time.Duration) {}
+		periodicInterval := retryutils.SeventhJitter(apidefaults.ServerAnnounceTTL / 2)
 		if len(s.cfg.ResourceMatchers) > 0 {
 			// Pre-populate dynamic desktops. This covers the case where
 			// the LDAP discovery happens before dynamic desktops are
@@ -424,7 +427,7 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 				s.cfg.AccessPoint.ListDynamicWindowsDesktops,
 			) {
 				if err != nil {
-					continue
+					break
 				}
 				if d, err := s.toWindowsDesktop(dynamicDesktop); err == nil {
 					dynamicDesktops[d.GetName()] = d
@@ -444,6 +447,11 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 			}
 			defer dynamicWatcher.Close()
 			dynamicDesktopUpdates = dynamicWatcher.ResourcesC
+
+			periodicReconcile := s.cfg.Clock.NewTicker(periodicInterval)
+			defer periodicReconcile.Stop()
+			periodicUpdate = periodicReconcile.Chan()
+			reset = periodicReconcile.Reset
 		}
 
 		// If we got here, the reconciler is running.
@@ -468,10 +476,6 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 			// before LDAP discovery and makes sure LDAP hosts don't get deleted.
 			ldapDesktops = s.getDesktopsFromLDAP()
 		}
-
-		interval := retryutils.SeventhJitter(apidefaults.ServerAnnounceTTL / 2)
-		periodicReconcile := s.cfg.Clock.NewTicker(interval)
-		defer periodicReconcile.Stop()
 
 		for {
 			select {
@@ -498,7 +502,7 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 					continue
 				}
 
-				periodicReconcile.Reset(interval)
+				reset(periodicInterval)
 
 			case <-ldapDiscoveryTimer:
 				s.cfg.Logger.DebugContext(ctx, "Performing LDAP discovery")
@@ -509,7 +513,7 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 
 			// Periodic reconcile, which serves to  push out the expiry of dynamic hosts if
 			// no other changes have triggered the watcher.
-			case <-periodicReconcile.Chan():
+			case <-periodicUpdate:
 				s.cfg.Logger.DebugContext(ctx, "Performing periodic reconciliation")
 				for _, desktop := range dynamicDesktops {
 					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -528,7 +528,7 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 				// watcher doesn't prevent LDAP discovery from running.
 				if len(s.cfg.ResourceMatchers) > 0 &&
 					!watcherNotificationReceived &&
-					s.cfg.Clock.Since(start) > 5*time.Minute {
+					s.cfg.Clock.Since(start) < 5*time.Minute {
 					continue
 				}
 				s.cfg.Logger.DebugContext(ctx, "Performing LDAP discovery")

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/interval"
 	"github.com/gravitational/teleport/lib/winpki"
 )
 
@@ -414,6 +415,22 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 		// Only create the watcher when dynamic registration is enabled.
 		var dynamicDesktopUpdates chan []types.DynamicWindowsDesktop
 		if len(s.cfg.ResourceMatchers) > 0 {
+			// Pre-populate dynamic desktops. This covers the case where
+			// the LDAP discovery happens before dynamic desktops are
+			// received from the watcher and ensures that dynamically
+			// registered hosts don't get deleted.
+			for dynamicDesktop, err := range clientutils.Resources(
+				ctx,
+				s.cfg.AccessPoint.ListDynamicWindowsDesktops,
+			) {
+				if err != nil {
+					continue
+				}
+				if d, err := s.toWindowsDesktop(dynamicDesktop); err == nil {
+					dynamicDesktops[d.GetName()] = d
+				}
+			}
+
 			dynamicWatcher, err := services.NewDynamicWindowsDesktopWatcher(ctx, services.DynamicWindowsDesktopWatcherConfig{
 				DynamicWindowsDesktopGetter: s.cfg.AccessPoint,
 				ResourceWatcherConfig: services.ResourceWatcherConfig{
@@ -432,20 +449,24 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 		// If we got here, the reconciler is running.
 		errCh <- nil
 
-		// Do periodic reconciliations, using the discovery interval if LDAP discovery
-		// is enabled, otherwise using the default interval.
 		var ldapDiscoveryTimer <-chan time.Time
 		if len(s.cfg.Discovery) > 0 {
-			timer := s.cfg.Clock.NewTicker(s.cfg.DiscoveryInterval)
-			defer timer.Stop()
-			ldapDiscoveryTimer = timer.Chan()
+			int := interval.New(interval.Config{
+				// Use a short FirstDuration so we don't have to wait a full
+				// discovery interval before hosts show up.
+				FirstDuration: retryutils.SeventhJitter(2 * time.Second),
+				Duration:      s.cfg.DiscoveryInterval,
+				Jitter:        retryutils.SeventhJitter,
+				Clock:         s.cfg.Clock,
+			})
+			defer int.Stop()
 
-			// perform one LDAP discovery right away so that we don't have to wait
-			// for a full discovery interval for hosts to show up
+			ldapDiscoveryTimer = int.Next()
+
+			// Pre-populate LDAP desktops but don't reconcile yet.
+			// This covers the case when the dynamic watcher triggers
+			// before LDAP discovery and makes sure LDAP hosts don't get deleted.
 			ldapDesktops = s.getDesktopsFromLDAP()
-			if err := reconciler.Reconcile(ctx); err != nil && !errors.Is(err, context.Canceled) {
-				s.cfg.Logger.ErrorContext(s.closeCtx, "Initial LDAP reconciliation failed", "error", err)
-			}
 		}
 
 		interval := retryutils.SeventhJitter(apidefaults.ServerAnnounceTTL / 2)
@@ -459,7 +480,7 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 
 			// Changes to dynamic desktops were detected.
 			case desktops := <-dynamicDesktopUpdates:
-				s.cfg.Logger.DebugContext(ctx, "Reconciling due to dynamic desktop change")
+				s.cfg.Logger.DebugContext(ctx, "Reconciling due to dynamic desktop change", "count", len(desktops))
 				clear(dynamicDesktops)
 				for _, dynamicDesktop := range desktops {
 					desktop, err := s.toWindowsDesktop(dynamicDesktop)

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -33,8 +33,10 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -129,7 +131,7 @@ func (s *WindowsService) startDesktopDiscovery() error {
 		OnCreate:            s.upsertDesktop,
 		OnUpdate:            s.updateDesktop,
 		OnDelete:            s.deleteDesktop,
-		Logger:              s.cfg.Logger.With("kind", types.KindWindowsDesktop),
+		Logger:              s.cfg.Logger.With("kind", types.KindWindowsDesktop).With("reconciler", "ldap"),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -450,6 +452,7 @@ func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
 			OnCreate:            s.upsertDesktop,
 			OnUpdate:            s.updateDesktop,
 			OnDelete:            s.deleteDesktop,
+			Logger:              s.cfg.Logger.With("kind", types.KindWindowsDesktop),
 		})
 		if err != nil {
 			errCh <- trace.Wrap(err)
@@ -458,12 +461,6 @@ func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
 
 		// If we got here, the reconciler is running.
 		errCh <- nil
-
-		tickDuration := 5 * time.Minute
-		expiryDuration := tickDuration + 2*time.Minute
-
-		tick := s.cfg.Clock.NewTicker(tickDuration)
-		defer tick.Stop()
 
 		for {
 			select {
@@ -476,7 +473,13 @@ func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
 						s.cfg.Logger.WarnContext(ctx, "Can't create desktop resource", "error", err)
 						continue
 					}
-					desktop.SetExpiry(s.cfg.Clock.Now().Add(expiryDuration))
+
+					// TODO: the reconciler's default comparison func is going to mark new resources
+					// different just because the expiry timestamp differs.
+					//
+					// Note: we can use a longer expiry here if/when we update the agent to remove
+					// resources on shutdown (like we already do for apps).
+					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
 					newResources[dynamicDesktop.GetName()] = desktop
 				}
 				if err := reconciler.Reconcile(ctx); err != nil {
@@ -485,19 +488,25 @@ func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
 				}
 				currentResources = newResources
 				s.cfg.Logger.DebugContext(ctx, "completed dynamic desktop reconciliation", "duration", s.cfg.Clock.Since(start), "count", len(newResources))
-			case <-tick.Chan():
+			case <-s.cfg.Clock.After(retryutils.SeventhJitter(apidefaults.ServerAnnounceTTL / 2)):
 				start := s.cfg.Clock.Now()
-				newResources = make(map[string]types.WindowsDesktop)
-				for k, v := range currentResources {
-					newResources[k] = v.Copy()
-					newResources[k].SetExpiry(s.cfg.Clock.Now().Add(expiryDuration))
+
+				// We currently use a relatively short expiration period so that desktops associated with
+				// an agent that terminates will expire shortly after the agent stops heartbeating them.
+				//
+				// As a result, we must also run the reconciler periodically to "renew" the desktop
+				// heartbeat and prevent it from expiring while the agent is healthy.
+				for _, desktop := range newResources {
+					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
 				}
+
 				if err := reconciler.Reconcile(ctx); err != nil {
 					s.cfg.Logger.WarnContext(ctx, "Reconciliation failed, will retry", "error", err)
 					continue
 				}
-				currentResources = newResources
+
 				s.cfg.Logger.DebugContext(ctx, "completed dynamic desktop reconciliation", "duration", s.cfg.Clock.Since(start), "count", len(newResources))
+
 			case <-watcher.Done():
 				return
 			case <-ctx.Done():

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -26,6 +26,7 @@ import (
 	"maps"
 	"net"
 	"net/netip"
+	"slices"
 	"strings"
 	"time"
 
@@ -114,52 +115,6 @@ func (s *WindowsService) currentDesktops(ctx context.Context) map[string]types.W
 	}
 
 	return result
-}
-
-// startDesktopDiscovery starts fetching desktops from LDAP, periodically
-// registering and unregistering them as necessary.
-func (s *WindowsService) startDesktopDiscovery() error {
-	reconciler, err := services.NewReconciler(services.ReconcilerConfig[types.WindowsDesktop]{
-		// Match all desktops with one of our LDAP labels.
-		// This ensures the desktop was discovered via LDAP and not created with dynamic registration.
-		Matcher: func(d types.WindowsDesktop) bool {
-			_, ok := d.GetLabel(types.DiscoveryLabelWindowsOS)
-			return ok
-		},
-		GetCurrentResources: func() map[string]types.WindowsDesktop { return s.currentDesktops(s.closeCtx) },
-		GetNewResources:     s.getDesktopsFromLDAP,
-		OnCreate:            s.upsertDesktop,
-		OnUpdate:            s.updateDesktop,
-		OnDelete:            s.deleteDesktop,
-		Logger:              s.cfg.Logger.With("kind", types.KindWindowsDesktop).With("reconciler", "ldap"),
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	go func() {
-		// reconcile once before starting the ticker, so that desktops show up immediately
-		// (we still have a small delay to give the LDAP client time to initialize)
-		s.cfg.Clock.Sleep(15 * time.Second)
-		if err := reconciler.Reconcile(s.closeCtx); err != nil && !errors.Is(err, context.Canceled) {
-			s.cfg.Logger.ErrorContext(s.closeCtx, "desktop reconciliation failed", "error", err)
-		}
-
-		t := s.cfg.Clock.NewTicker(s.cfg.DiscoveryInterval)
-		defer t.Stop()
-		for {
-			select {
-			case <-s.closeCtx.Done():
-				return
-			case <-t.Chan():
-				if err := reconciler.Reconcile(s.closeCtx); err != nil && !errors.Is(err, context.Canceled) {
-					s.cfg.Logger.ErrorContext(s.closeCtx, "desktop reconciliation failed", "error", err)
-				}
-			}
-		}
-	}()
-
-	return nil
 }
 
 func (s *WindowsService) ldapSearchFilter(additionalFilters []string) string {
@@ -411,21 +366,53 @@ func (s *WindowsService) ldapEntryToWindowsDesktop(
 	return desktop, nil
 }
 
-// startDynamicReconciler starts resource watcher and reconciler that registers/unregisters Windows desktops
-// according to the up-to-date list of dynamic Windows desktop resources. The reconciler runs until the
-// provided context expires.
-func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
-	if len(s.cfg.ResourceMatchers) == 0 {
-		s.cfg.Logger.DebugContext(ctx, "Not starting dynamic desktop resource watcher.")
-		return nil
-	}
+// startReconciler starts the service's reconciler, which is used to handle both LDAP discovery as well
+// as dynamic registration. The reconciler runs until the provided context expires.
+func (s *WindowsService) startReconciler(ctx context.Context) error {
+	s.cfg.Logger.DebugContext(ctx, "Starting reconciler")
+
 	// errCh is used to indicate whether the background reconciliation routine
 	// starts successfully
 	errCh := make(chan error)
 
 	go func() {
-		s.cfg.Logger.DebugContext(ctx, "Starting dynamic desktop resource watcher.")
-		watcher, err := services.NewDynamicWindowsDesktopWatcher(ctx, services.DynamicWindowsDesktopWatcherConfig{
+		dynamicDesktops := make(map[string]types.WindowsDesktop)
+
+		newDesktops := func() map[string]types.WindowsDesktop {
+			ldapDesktops := make(map[string]types.WindowsDesktop)
+			if len(s.cfg.Discovery) > 0 {
+				maps.Copy(ldapDesktops, s.getDesktopsFromLDAP())
+			}
+
+			// Combine the results from the last watcher update with the LDAP results
+			maps.Copy(ldapDesktops, dynamicDesktops)
+			return ldapDesktops
+		}
+
+		reconciler, err := services.NewReconciler(services.ReconcilerConfig[types.WindowsDesktop]{
+			Matcher: func(desktop types.WindowsDesktop) bool {
+				// Our matcher needs to match both dynamic desktops from the config's resources section
+				// and any LDAP-discovered hosts from this this service. To make sure we get any LDAP
+				// hosts, we add a matcher for one of the labels that we always use for LDAP discovery.
+				matchers := slices.Clone(s.cfg.ResourceMatchers)
+				matchers = append(matchers, services.ResourceMatcher{
+					Labels: types.Labels{types.DiscoveryLabelWindowsOS: []string{"*"}},
+				})
+				return services.MatchResourceLabels(matchers, desktop.GetAllLabels())
+			},
+			GetCurrentResources: func() map[string]types.WindowsDesktop { return s.currentDesktops(ctx) },
+			GetNewResources:     func() map[string]types.WindowsDesktop { return newDesktops() },
+			OnCreate:            s.upsertDesktop,
+			OnUpdate:            s.updateDesktop,
+			OnDelete:            s.deleteDesktop,
+			Logger:              s.cfg.Logger.With("kind", types.KindWindowsDesktop),
+		})
+		if err != nil {
+			errCh <- trace.Wrap(err, "creating reconciler")
+			return
+		}
+
+		dynamicWatcher, err := services.NewDynamicWindowsDesktopWatcher(ctx, services.DynamicWindowsDesktopWatcherConfig{
 			DynamicWindowsDesktopGetter: s.cfg.AccessPoint,
 			ResourceWatcherConfig: services.ResourceWatcherConfig{
 				Component: teleport.ComponentWindowsDesktop,
@@ -433,40 +420,37 @@ func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
 			},
 		})
 		if err != nil {
-			errCh <- trace.Wrap(err)
+			errCh <- trace.Wrap(err, "creating dynamic desktop watcher")
 			return
 		}
-
-		defer watcher.Close()
-		defer s.cfg.Logger.DebugContext(ctx, "DynamicWindowsDesktop resource watcher done.")
-
-		currentResources := make(map[string]types.WindowsDesktop)
-		var newResources map[string]types.WindowsDesktop
-
-		reconciler, err := services.NewReconciler(services.ReconcilerConfig[types.WindowsDesktop]{
-			Matcher: func(desktop types.WindowsDesktop) bool {
-				return services.MatchResourceLabels(s.cfg.ResourceMatchers, desktop.GetAllLabels())
-			},
-			GetCurrentResources: func() map[string]types.WindowsDesktop { return currentResources },
-			GetNewResources:     func() map[string]types.WindowsDesktop { return newResources },
-			OnCreate:            s.upsertDesktop,
-			OnUpdate:            s.updateDesktop,
-			OnDelete:            s.deleteDesktop,
-			Logger:              s.cfg.Logger.With("kind", types.KindWindowsDesktop),
-		})
-		if err != nil {
-			errCh <- trace.Wrap(err)
-			return
-		}
+		defer dynamicWatcher.Close()
 
 		// If we got here, the reconciler is running.
 		errCh <- nil
 
+		// Do periodic reconciliations, using the discovery interval if LDAP discovery
+		// is enabled, otherwise using the default interval.
+		interval := s.cfg.DiscoveryInterval
+		if len(s.cfg.Discovery) == 0 {
+			interval = apidefaults.ServerAnnounceTTL / 2
+		}
+		expiryDuration := interval * 2
+
+		// TODO: do one LDAP discovery before entering the loop so that desktops
+		// show up quickly after starting the service rather than waiting for the
+		// first full interval to pass.
+
 		for {
 			select {
-			case desktops := <-watcher.ResourcesC:
-				start := s.cfg.Clock.Now()
-				newResources = make(map[string]types.WindowsDesktop)
+			case <-ctx.Done():
+				return
+			case <-dynamicWatcher.Done():
+				return
+
+			// Changes to dynamic desktops were detected.
+			case desktops := <-dynamicWatcher.ResourcesC:
+				s.cfg.Logger.DebugContext(ctx, "Reconciling due to dynamic desktop change")
+				clear(dynamicDesktops)
 				for _, dynamicDesktop := range desktops {
 					desktop, err := s.toWindowsDesktop(dynamicDesktop)
 					if err != nil {
@@ -474,30 +458,8 @@ func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
 						continue
 					}
 
-					// TODO: the reconciler's default comparison func is going to mark new resources
-					// different just because the expiry timestamp differs.
-					//
-					// Note: we can use a longer expiry here if/when we update the agent to remove
-					// resources on shutdown (like we already do for apps).
-					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
-					newResources[dynamicDesktop.GetName()] = desktop
-				}
-				if err := reconciler.Reconcile(ctx); err != nil {
-					s.cfg.Logger.WarnContext(ctx, "Reconciliation failed, will retry", "error", err)
-					continue
-				}
-				currentResources = newResources
-				s.cfg.Logger.DebugContext(ctx, "completed dynamic desktop reconciliation", "duration", s.cfg.Clock.Since(start), "count", len(newResources))
-			case <-s.cfg.Clock.After(retryutils.SeventhJitter(apidefaults.ServerAnnounceTTL / 2)):
-				start := s.cfg.Clock.Now()
-
-				// We currently use a relatively short expiration period so that desktops associated with
-				// an agent that terminates will expire shortly after the agent stops heartbeating them.
-				//
-				// As a result, we must also run the reconciler periodically to "renew" the desktop
-				// heartbeat and prevent it from expiring while the agent is healthy.
-				for _, desktop := range newResources {
-					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
+					desktop.SetExpiry(s.cfg.Clock.Now().Add(expiryDuration))
+					dynamicDesktops[dynamicDesktop.GetName()] = desktop
 				}
 
 				if err := reconciler.Reconcile(ctx); err != nil {
@@ -505,17 +467,24 @@ func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
 					continue
 				}
 
-				s.cfg.Logger.DebugContext(ctx, "completed dynamic desktop reconciliation", "duration", s.cfg.Clock.Since(start), "count", len(newResources))
+			// Periodic reconcile, which serves to both perform LDAP discovery
+			// and to push out the expiry of dynamic hosts if no other changes
+			// have triggered the watcher.
+			case <-s.cfg.Clock.After(retryutils.SeventhJitter(interval)):
+				s.cfg.Logger.DebugContext(ctx, "Performing periodic reconciliation")
+				for _, desktop := range dynamicDesktops {
+					desktop.SetExpiry(s.cfg.Clock.Now().Add(expiryDuration))
+				}
 
-			case <-watcher.Done():
-				return
-			case <-ctx.Done():
-				return
+				if err := reconciler.Reconcile(ctx); err != nil && !errors.Is(err, context.Canceled) {
+					s.cfg.Logger.ErrorContext(s.closeCtx, "Periodic reconciliation failed", "error", err)
+				}
 			}
 		}
+
 	}()
 
-	return trace.Wrap(<-errCh, "could not start dynamic desktop reconciler")
+	return trace.Wrap(<-errCh, "starting reconciler")
 }
 
 func (s *WindowsService) toWindowsDesktop(dynamicDesktop types.DynamicWindowsDesktop) (*types.WindowsDesktopV3, error) {

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -377,16 +377,13 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 
 	go func() {
 		dynamicDesktops := make(map[string]types.WindowsDesktop)
+		ldapDesktops := make(map[string]types.WindowsDesktop)
 
 		newDesktops := func() map[string]types.WindowsDesktop {
-			ldapDesktops := make(map[string]types.WindowsDesktop)
-			if len(s.cfg.Discovery) > 0 {
-				maps.Copy(ldapDesktops, s.getDesktopsFromLDAP())
-			}
-
 			// Combine the results from the last watcher update with the LDAP results
-			maps.Copy(ldapDesktops, dynamicDesktops)
-			return ldapDesktops
+			result := maps.Clone(dynamicDesktops)
+			maps.Copy(result, ldapDesktops)
+			return result
 		}
 
 		reconciler, err := services.NewReconciler(services.ReconcilerConfig[types.WindowsDesktop]{
@@ -412,43 +409,54 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 			return
 		}
 
-		dynamicWatcher, err := services.NewDynamicWindowsDesktopWatcher(ctx, services.DynamicWindowsDesktopWatcherConfig{
-			DynamicWindowsDesktopGetter: s.cfg.AccessPoint,
-			ResourceWatcherConfig: services.ResourceWatcherConfig{
-				Component: teleport.ComponentWindowsDesktop,
-				Client:    s.cfg.AccessPoint,
-			},
-		})
-		if err != nil {
-			errCh <- trace.Wrap(err, "creating dynamic desktop watcher")
-			return
+		// Only create the watcher when dynamic registration is enabled.
+		var dynamicDesktopUpdates chan []types.DynamicWindowsDesktop
+		if len(s.cfg.ResourceMatchers) > 0 {
+			dynamicWatcher, err := services.NewDynamicWindowsDesktopWatcher(ctx, services.DynamicWindowsDesktopWatcherConfig{
+				DynamicWindowsDesktopGetter: s.cfg.AccessPoint,
+				ResourceWatcherConfig: services.ResourceWatcherConfig{
+					Component: teleport.ComponentWindowsDesktop,
+					Client:    s.cfg.AccessPoint,
+				},
+			})
+			if err != nil {
+				errCh <- trace.Wrap(err, "creating dynamic desktop watcher")
+				return
+			}
+			defer dynamicWatcher.Close()
+			dynamicDesktopUpdates = dynamicWatcher.ResourcesC
 		}
-		defer dynamicWatcher.Close()
 
 		// If we got here, the reconciler is running.
 		errCh <- nil
 
 		// Do periodic reconciliations, using the discovery interval if LDAP discovery
 		// is enabled, otherwise using the default interval.
-		interval := s.cfg.DiscoveryInterval
-		if len(s.cfg.Discovery) == 0 {
-			interval = apidefaults.ServerAnnounceTTL / 2
-		}
-		expiryDuration := interval * 2
+		var ldapDiscoveryTimer <-chan time.Time
+		if len(s.cfg.Discovery) > 0 {
+			timer := s.cfg.Clock.NewTicker(s.cfg.DiscoveryInterval)
+			defer timer.Stop()
+			ldapDiscoveryTimer = timer.Chan()
 
-		// TODO: do one LDAP discovery before entering the loop so that desktops
-		// show up quickly after starting the service rather than waiting for the
-		// first full interval to pass.
+			// perform one LDAP discovery right away so that we don't have to wait
+			// for a full discovery interval for hosts to show up
+			ldapDesktops = s.getDesktopsFromLDAP()
+			if err := reconciler.Reconcile(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				s.cfg.Logger.ErrorContext(s.closeCtx, "Initial LDAP reconciliation failed", "error", err)
+			}
+		}
+
+		interval := retryutils.SeventhJitter(apidefaults.ServerAnnounceTTL / 2)
+		periodicReconcile := s.cfg.Clock.NewTicker(interval)
+		defer periodicReconcile.Stop()
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-dynamicWatcher.Done():
-				return
 
 			// Changes to dynamic desktops were detected.
-			case desktops := <-dynamicWatcher.ResourcesC:
+			case desktops := <-dynamicDesktopUpdates:
 				s.cfg.Logger.DebugContext(ctx, "Reconciling due to dynamic desktop change")
 				clear(dynamicDesktops)
 				for _, dynamicDesktop := range desktops {
@@ -458,7 +466,7 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 						continue
 					}
 
-					desktop.SetExpiry(s.cfg.Clock.Now().Add(expiryDuration))
+					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
 					dynamicDesktops[dynamicDesktop.GetName()] = desktop
 				}
 
@@ -467,13 +475,23 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 					continue
 				}
 
-			// Periodic reconcile, which serves to both perform LDAP discovery
-			// and to push out the expiry of dynamic hosts if no other changes
-			// have triggered the watcher.
-			case <-s.cfg.Clock.After(retryutils.SeventhJitter(interval)):
+				periodicReconcile.Reset(interval)
+
+			case <-ldapDiscoveryTimer:
+				s.cfg.Logger.DebugContext(ctx, "Performing LDAP discovery")
+				ldapDesktops = s.getDesktopsFromLDAP()
+				if err := reconciler.Reconcile(ctx); err != nil && !errors.Is(err, context.Canceled) {
+					s.cfg.Logger.ErrorContext(s.closeCtx, "Periodic reconciliation failed", "error", err)
+				}
+
+				periodicReconcile.Reset(interval)
+
+			// Periodic reconcile, which serves to  push out the expiry of dynamic hosts if
+			// no other changes have triggered the watcher.
+			case <-periodicReconcile.Chan():
 				s.cfg.Logger.DebugContext(ctx, "Performing periodic reconciliation")
 				for _, desktop := range dynamicDesktops {
-					desktop.SetExpiry(s.cfg.Clock.Now().Add(expiryDuration))
+					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
 				}
 
 				if err := reconciler.Reconcile(ctx); err != nil && !errors.Is(err, context.Canceled) {
@@ -481,7 +499,6 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 				}
 			}
 		}
-
 	}()
 
 	return trace.Wrap(<-errCh, "starting reconciler")

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -485,7 +485,6 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 						continue
 					}
 
-					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
 					nextDynamicDesktops[dynamicDesktop.GetName()] = desktop
 				}
 

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -379,15 +379,9 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 	errCh := make(chan error)
 
 	go func() {
-		dynamicDesktops := make(map[string]types.WindowsDesktop)
-		ldapDesktops := make(map[string]types.WindowsDesktop)
-
-		newDesktops := func() map[string]types.WindowsDesktop {
-			// Combine the results from the last watcher update with the LDAP results
-			result := maps.Clone(dynamicDesktops)
-			maps.Copy(result, ldapDesktops)
-			return result
-		}
+		dynamicDesktopNames := make(map[string]struct{})
+		ldapDesktopNames := make(map[string]struct{})
+		allDesktops := make(map[string]types.WindowsDesktop)
 
 		reconciler, err := services.NewReconciler(services.ReconcilerConfig[types.WindowsDesktop]{
 			Matcher: func(desktop types.WindowsDesktop) bool {
@@ -407,7 +401,7 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 				return services.MatchResourceLabels(matchers, desktop.GetAllLabels())
 			},
 			GetCurrentResources: func() map[string]types.WindowsDesktop { return s.currentDesktops(ctx) },
-			GetNewResources:     func() map[string]types.WindowsDesktop { return newDesktops() },
+			GetNewResources:     func() map[string]types.WindowsDesktop { return allDesktops },
 			OnCreate:            s.upsertDesktop,
 			OnUpdate:            s.updateDesktop,
 			OnDelete:            s.deleteDesktop,
@@ -464,10 +458,15 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 			// Pre-populate LDAP desktops but don't reconcile yet.
 			// This covers the case when the dynamic watcher triggers
 			// before LDAP discovery and makes sure LDAP hosts don't get deleted.
-			ldapDesktops = s.getDesktopsFromLDAP()
+			ldapDesktops := s.getDesktopsFromLDAP()
+			maps.Copy(allDesktops, ldapDesktops)
+			for name := range ldapDesktops {
+				ldapDesktopNames[name] = struct{}{}
+			}
 		}
 
 		watcherNotificationReceived := false
+		start := s.cfg.Clock.Now()
 
 		for {
 			select {
@@ -476,8 +475,9 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 
 			// Changes to dynamic desktops were detected.
 			case desktops := <-dynamicDesktopUpdates:
+				watcherNotificationReceived = true
+				nextDynamicDesktops := make(map[string]types.WindowsDesktop, len(desktops))
 				s.cfg.Logger.DebugContext(ctx, "Reconciling due to dynamic desktop change", "count", len(desktops))
-				clear(dynamicDesktops)
 				for _, dynamicDesktop := range desktops {
 					desktop, err := s.toWindowsDesktop(dynamicDesktop)
 					if err != nil {
@@ -486,7 +486,20 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 					}
 
 					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
-					dynamicDesktops[dynamicDesktop.GetName()] = desktop
+					nextDynamicDesktops[dynamicDesktop.GetName()] = desktop
+				}
+
+				// Remove any dynamic desktops that didn't appear in this update.
+				for name := range dynamicDesktopNames {
+					if _, ok := nextDynamicDesktops[name]; !ok {
+						delete(dynamicDesktopNames, name)
+						delete(allDesktops, name)
+					}
+				}
+				// Add/update new dynamic desktops.
+				for name, desktop := range nextDynamicDesktops {
+					dynamicDesktopNames[name] = struct{}{}
+					allDesktops[name] = desktop
 				}
 
 				if err := reconciler.Reconcile(ctx); err != nil {
@@ -495,17 +508,36 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 				}
 
 				reset(periodicInterval)
-				watcherNotificationReceived = true
 
 			case <-ldapDiscoveryTimer:
-				// If dynamic registration is enabled, wait for the watcher's initial notification.
-				// This handles a rare condition where the first LDAP discovery tick happens before
-				// the first watcher notification, causing existing dynamic desktops to be deleted.
-				if len(s.cfg.ResourceMatchers) > 0 && !watcherNotificationReceived {
+				// If dynamic registration is enabled, wait (up to 5 minutes) for the watcher's
+				// initial notification. This handles a rare condition where the first LDAP
+				// discovery tick happens before the first watcher notification, causing existing
+				// dynamic desktops to be deleted.
+				//
+				// The 5-minute maximum wait period ensures that an unhealthy dynamic desktop
+				// watcher doesn't prevent LDAP discovery from running.
+				if len(s.cfg.ResourceMatchers) > 0 &&
+					!watcherNotificationReceived &&
+					s.cfg.Clock.Since(start) > 5*time.Minute {
 					continue
 				}
 				s.cfg.Logger.DebugContext(ctx, "Performing LDAP discovery")
-				ldapDesktops = s.getDesktopsFromLDAP()
+
+				ldapDesktops := s.getDesktopsFromLDAP()
+				// Remove any desktops that no longer show up in LDAP.
+				for currentDesktop := range ldapDesktopNames {
+					if _, ok := ldapDesktops[currentDesktop]; !ok {
+						delete(allDesktops, currentDesktop)
+						delete(ldapDesktopNames, currentDesktop)
+					}
+				}
+				// Add new LDAP desktops.
+				maps.Copy(allDesktops, ldapDesktops)
+				for name := range ldapDesktops {
+					ldapDesktopNames[name] = struct{}{}
+				}
+
 				if err := reconciler.Reconcile(ctx); err != nil && !errors.Is(err, context.Canceled) {
 					s.cfg.Logger.ErrorContext(s.closeCtx, "Periodic reconciliation failed", "error", err)
 				}
@@ -514,8 +546,10 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 			// no other changes have triggered the watcher.
 			case <-periodicUpdate:
 				s.cfg.Logger.DebugContext(ctx, "Performing periodic reconciliation")
-				for _, desktop := range dynamicDesktops {
-					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
+				for name := range dynamicDesktopNames {
+					if desktop, ok := allDesktops[name]; ok {
+						desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
+					}
 				}
 
 				if err := reconciler.Reconcile(ctx); err != nil && !errors.Is(err, context.Canceled) {

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -102,6 +102,8 @@ func (s *WindowsService) currentDesktops(ctx context.Context) map[string]types.W
 			resp, err := s.cfg.AccessPoint.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
 				WindowsDesktopFilter: types.WindowsDesktopFilter{HostID: s.cfg.Heartbeat.HostUUID},
 				Labels:               map[string]string{types.OriginLabel: types.OriginDynamic},
+				Limit:                pageSize,
+				StartKey:             pageToken,
 			})
 			if err != nil {
 				return nil, "", trace.Wrap(err)
@@ -483,8 +485,6 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 				if err := reconciler.Reconcile(ctx); err != nil && !errors.Is(err, context.Canceled) {
 					s.cfg.Logger.ErrorContext(s.closeCtx, "Periodic reconciliation failed", "error", err)
 				}
-
-				periodicReconcile.Reset(interval)
 
 			// Periodic reconcile, which serves to  push out the expiry of dynamic hosts if
 			// no other changes have triggered the watcher.

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -485,6 +485,16 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 						continue
 					}
 
+					// Preserve the expiry time if the desktop already exists.
+					// This avoids issuing backend writes for all the desktops we
+					// already know about, while making sure that new desktops get
+					// a reasonable expiry.
+					if previous, ok := allDesktops[desktop.GetName()]; ok {
+						desktop.SetExpiry(previous.Expiry())
+					} else {
+						desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
+					}
+
 					nextDynamicDesktops[dynamicDesktop.GetName()] = desktop
 				}
 

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -424,22 +424,6 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 		reset := func(time.Duration) {}
 		periodicInterval := retryutils.SeventhJitter(apidefaults.ServerAnnounceTTL / 2)
 		if len(s.cfg.ResourceMatchers) > 0 {
-			// Pre-populate dynamic desktops. This covers the case where
-			// the LDAP discovery happens before dynamic desktops are
-			// received from the watcher and ensures that dynamically
-			// registered hosts don't get deleted.
-			for dynamicDesktop, err := range clientutils.Resources(
-				ctx,
-				s.cfg.AccessPoint.ListDynamicWindowsDesktops,
-			) {
-				if err != nil {
-					break
-				}
-				if d, err := s.toWindowsDesktop(dynamicDesktop); err == nil {
-					dynamicDesktops[d.GetName()] = d
-				}
-			}
-
 			dynamicWatcher, err := services.NewDynamicWindowsDesktopWatcher(ctx, services.DynamicWindowsDesktopWatcherConfig{
 				DynamicWindowsDesktopGetter: s.cfg.AccessPoint,
 				ResourceWatcherConfig: services.ResourceWatcherConfig{
@@ -483,6 +467,8 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 			ldapDesktops = s.getDesktopsFromLDAP()
 		}
 
+		watcherNotificationReceived := false
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -509,8 +495,15 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 				}
 
 				reset(periodicInterval)
+				watcherNotificationReceived = true
 
 			case <-ldapDiscoveryTimer:
+				// If dynamic registration is enabled, wait for the watcher's initial notification.
+				// This handles a rare condition where the first LDAP discovery tick happens before
+				// the first watcher notification, causing existing dynamic desktops to be deleted.
+				if len(s.cfg.ResourceMatchers) > 0 && !watcherNotificationReceived {
+					continue
+				}
 				s.cfg.Logger.DebugContext(ctx, "Performing LDAP discovery")
 				ldapDesktops = s.getDesktopsFromLDAP()
 				if err := reconciler.Reconcile(ctx); err != nil && !errors.Is(err, context.Canceled) {

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -393,10 +393,16 @@ func (s *WindowsService) startReconciler(ctx context.Context) error {
 			Matcher: func(desktop types.WindowsDesktop) bool {
 				// Our matcher needs to match both dynamic desktops from the config's resources section
 				// and any LDAP-discovered hosts from this this service. To make sure we get any LDAP
-				// hosts, we add a matcher for one of the labels that we always use for LDAP discovery.
+				// hosts, we add a matcher for the labels that we always use for LDAP discovery.
 				matchers := slices.Clone(s.cfg.ResourceMatchers)
 				matchers = append(matchers, services.ResourceMatcher{
-					Labels: types.Labels{types.DiscoveryLabelWindowsOS: []string{"*"}},
+					Labels: types.Labels{
+						types.OriginLabel:                       []string{types.OriginDynamic},
+						types.DiscoveryLabelWindowsOS:           []string{"*"},
+						types.DiscoveryLabelWindowsOSVersion:    []string{"*"},
+						types.DiscoveryLabelWindowsDNSHostName:  []string{"*"},
+						types.DiscoveryLabelWindowsComputerName: []string{"*"},
+					},
 				})
 				return services.MatchResourceLabels(matchers, desktop.GetAllLabels())
 			},

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -766,11 +766,16 @@ func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, client.Close()) })
 
+		logger := slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{}))
+		if testing.Verbose() {
+			logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		}
+
 		s := &WindowsService{
 			closeCtx: t.Context(),
 			cfg: WindowsServiceConfig{
 				Heartbeat:         HeartbeatConfig{HostUUID: hostUUID},
-				Logger:            slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
+				Logger:            logger,
 				Clock:             clockwork.NewRealClock(),
 				AccessPoint:       client,
 				AuthClient:        client,
@@ -791,9 +796,11 @@ func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 		for i := 1; i <= 3; i++ {
 			name := "desktop-" + strconv.Itoa(i)
 			desktop, err := types.NewWindowsDesktopV3(name, map[string]string{
-				types.OriginLabel:                      types.OriginDynamic,
-				types.DiscoveryLabelWindowsDNSHostName: name + ".example.com",
-				types.DiscoveryLabelWindowsOS:          "Windows Server 2019",
+				types.OriginLabel:                       types.OriginDynamic,
+				types.DiscoveryLabelWindowsDNSHostName:  name + ".example.com",
+				types.DiscoveryLabelWindowsOS:           "Windows",
+				types.DiscoveryLabelWindowsOSVersion:    "Vista",
+				types.DiscoveryLabelWindowsComputerName: name,
 			}, types.WindowsDesktopSpecV3{
 				HostID: hostUUID,
 				Addr:   name + ".example.com:3389",

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -37,6 +37,7 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -610,33 +611,57 @@ func TestCurrentDesktops(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Call currentDesktops and verify results
-	result := s.currentDesktops(t.Context())
+	t.Run("single page", func(t *testing.T) {
+		// Call currentDesktops and verify results
+		result := s.currentDesktops(t.Context())
 
-	// Count expected desktops
-	var expectedCount int
-	for _, d := range desktops {
-		if d.expect {
-			expectedCount++
+		// Count expected desktops
+		var expectedCount int
+		for _, d := range desktops {
+			if d.expect {
+				expectedCount++
+			}
 		}
-	}
 
-	require.Len(t, result, expectedCount)
+		require.Len(t, result, expectedCount)
 
-	// Verify only the expected desktops are returned
-	for _, d := range desktops {
-		if d.expect {
-			desktop, ok := result[d.name]
-			require.True(t, ok, "expected desktop %s to be in results", d.name)
-			require.Equal(t, d.name, desktop.GetName())
-			require.Equal(t, d.hostID, desktop.GetHostID())
-			originLabel, _ := desktop.GetLabel(types.OriginLabel)
-			require.Equal(t, types.OriginDynamic, originLabel)
-		} else {
-			_, ok := result[d.name]
-			require.False(t, ok, "desktop %s should not be in results", d.name)
+		// Verify only the expected desktops are returned
+		for _, d := range desktops {
+			if d.expect {
+				desktop, ok := result[d.name]
+				require.True(t, ok, "expected desktop %s to be in results", d.name)
+				require.Equal(t, d.name, desktop.GetName())
+				require.Equal(t, d.hostID, desktop.GetHostID())
+				originLabel, _ := desktop.GetLabel(types.OriginLabel)
+				require.Equal(t, types.OriginDynamic, originLabel)
+			} else {
+				_, ok := result[d.name]
+				require.False(t, ok, "desktop %s should not be in results", d.name)
+			}
 		}
-	}
+	})
+
+	t.Run("paginated", func(t *testing.T) {
+		// forces a tiny page size so that  desktops span multiple pages
+		// without needing thousands of entries.
+		ap := &smallPageAccessPoint{WindowsDesktopAccessPoint: client, pageSize: 1}
+		s.cfg.AccessPoint = ap
+
+		result := s.currentDesktops(t.Context())
+		require.Len(t, result, 2)
+	})
+}
+
+// smallPageAccessPoint wraps a real access point and overrides ListWindowsDesktops
+// to enforce a small page size, exercising multi-page iteration in tests.
+type smallPageAccessPoint struct {
+	authclient.WindowsDesktopAccessPoint
+	pageSize int
+}
+
+func (a *smallPageAccessPoint) ListWindowsDesktops(ctx context.Context, req types.ListWindowsDesktopsRequest) (*types.ListWindowsDesktopsResponse, error) {
+	req.Limit = a.pageSize
+	return a.WindowsDesktopAccessPoint.ListWindowsDesktops(ctx, req)
 }
 
 func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -305,12 +305,17 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 			// note: we don't use t.Run() because we're already inside a synctest bubble
 			t.Logf("executing test case: %v", testCase.name)
 
+			logger := slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{}))
+			if testing.Verbose() {
+				logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			}
+
 			s := &WindowsService{
 				cfg: WindowsServiceConfig{
 					Heartbeat: HeartbeatConfig{
 						HostUUID: "1234",
 					},
-					Logger:               slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
+					Logger:               logger,
 					Clock:                clockwork.NewFakeClock(),
 					AuthClient:           client,
 					AccessPoint:          client,

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -169,9 +169,90 @@ func TestDNSErrors(t *testing.T) {
 	}
 
 	start := time.Now()
-	_, err := s.lookupDesktop(context.Background(), "$invalid hostname")
+	_, err := s.lookupDesktop(t.Context(), "")
 	require.Less(t, time.Since(start), dnsQueryTimeout-1*time.Second)
 	require.Error(t, err)
+}
+
+func TestFirstReconcile(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+			ClusterName: "test",
+			Dir:         t.TempDir(),
+			AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+
+		tlsServer, err := authServer.NewTestTLSServer(authtest.WithBufconnListener())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+		client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+		logger := slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{}))
+		if testing.Verbose() {
+			logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		}
+
+		s := &WindowsService{
+			cfg: WindowsServiceConfig{
+				Heartbeat: HeartbeatConfig{
+					HostUUID: "1234",
+				},
+				Logger:      logger,
+				Clock:       clockwork.NewRealClock(),
+				AuthClient:  client,
+				AccessPoint: client,
+
+				DiscoveryInterval: 5 * time.Minute,
+				Discovery: []servicecfg.LDAPDiscoveryConfig{
+					{BaseDN: "*"},
+				},
+				ResourceMatchers: []services.ResourceMatcher{{
+					Labels: types.Labels{"foo": {"bar"}},
+				}},
+			},
+
+			// pre-cache a TLS config so we don't ask auth to issue a real cert
+			// (there isn't a real LDAP server here to connect to)
+			ldapTLSConfig:          new(tls.Config),
+			ldapTLSConfigExpiresAt: time.Now().Add(24 * time.Hour),
+		}
+
+		// simulate a dynamically-registered desktop already existing
+		// in the backend while the service is starting up
+		dynamicDesktop, err := types.NewDynamicWindowsDesktopV1(
+			"test-desktop",
+			map[string]string{"foo": "bar"},
+			types.DynamicWindowsDesktopSpecV1{
+				NonAD: true,
+				Addr:  "192.168.1.103:3389",
+			},
+		)
+		require.NoError(t, err)
+		_, err = client.DynamicDesktopClient().UpsertDynamicWindowsDesktop(t.Context(), dynamicDesktop)
+		require.NoError(t, err)
+
+		desktop, err := s.toWindowsDesktop(dynamicDesktop)
+		require.NoError(t, err)
+		require.NoError(t, client.UpsertWindowsDesktop(t.Context(), desktop))
+
+		require.NoError(t, s.startReconciler(t.Context()))
+		synctest.Wait()
+
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+
+		// Make sure the dynamic desktop wasn't deleted
+		desktops, err := client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
+		require.NoError(t, err)
+		require.Len(t, desktops, 1)
+	})
 }
 
 func TestDynamicWindowsDiscovery(t *testing.T) {

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -28,11 +28,11 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -175,59 +175,54 @@ func TestDNSErrors(t *testing.T) {
 
 func TestDynamicWindowsDiscovery(t *testing.T) {
 	t.Parallel()
-	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		ClusterName: "test",
-		Dir:         t.TempDir(),
-		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, authServer.Close())
-	})
 
-	tlsServer, err := authServer.NewTestTLSServer()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, tlsServer.Close())
-	})
+	synctest.Test(t, func(t *testing.T) {
+		authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+			ClusterName: "test",
+			Dir:         t.TempDir(),
+			AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
-	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, client.Close())
-	})
+		tlsServer, err := authServer.NewTestTLSServer(authtest.WithBufconnListener())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
 
-	dynamicWindowsClient := client.DynamicDesktopClient()
+		client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close()) })
 
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
+		dynamicWindowsClient := client.DynamicDesktopClient()
 
-	for _, testCase := range []struct {
-		name     string
-		labels   map[string]string
-		expected int
-	}{
-		{
-			name:     "no labels",
-			expected: 0,
-		},
-		{
-			name:     "no matching labels",
-			labels:   map[string]string{"xyz": "abc"},
-			expected: 0,
-		},
-		{
-			name:     "matching labels",
-			labels:   map[string]string{"foo": "bar"},
-			expected: 1,
-		},
-		{
-			name:     "matching wildcard labels",
-			labels:   map[string]string{"abc": "abc"},
-			expected: 1,
-		},
-	} {
-		t.Run(testCase.name, func(t *testing.T) {
+		for _, testCase := range []struct {
+			name     string
+			labels   map[string]string
+			expected int
+		}{
+			{
+				name:     "no labels",
+				expected: 0,
+			},
+			{
+				name:     "no matching labels",
+				labels:   map[string]string{"xyz": "abc"},
+				expected: 0,
+			},
+			{
+				name:     "matching labels",
+				labels:   map[string]string{"foo": "bar"},
+				expected: 1,
+			},
+			{
+				name:     "matching wildcard labels",
+				labels:   map[string]string{"abc": "abc"},
+				expected: 1,
+			},
+		} {
+			// note: we don't use t.Run() because we're already inside a synctest bubble
+			t.Logf("executing test case: %v", testCase.name)
+
 			s := &WindowsService{
 				cfg: WindowsServiceConfig{
 					Heartbeat: HeartbeatConfig{
@@ -256,176 +251,171 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 				},
 			}
 
-			require.NoError(t, s.startReconciler(t.Context()))
-			t.Cleanup(func() {
-				require.NoError(t, authServer.AuthServer.DeleteAllWindowsDesktops(ctx))
-				var key string
-				for {
-					page, next, err := authServer.AuthServer.ListDynamicWindowsDesktops(ctx, 0, key)
-					require.NoError(t, err)
-					for _, dwd := range page {
-						require.NoError(t, authServer.AuthServer.DeleteDynamicWindowsDesktop(ctx, dwd.GetName()))
-					}
-					if next == "" {
-						break
-					}
-					key = next
+			// Clear all desktops to start each test case fresh.
+			require.NoError(t, authServer.AuthServer.DeleteAllWindowsDesktops(t.Context()))
+			var key string
+			for {
+				page, next, err := authServer.AuthServer.ListDynamicWindowsDesktops(t.Context(), 0, key)
+				require.NoError(t, err)
+				for _, dwd := range page {
+					require.NoError(t, authServer.AuthServer.DeleteDynamicWindowsDesktop(t.Context(), dwd.GetName()))
 				}
-			})
+				if next == "" {
+					break
+				}
+				key = next
+			}
+
+			require.NoError(t, s.startReconciler(t.Context()))
+			synctest.Wait()
 
 			desktop, err := types.NewDynamicWindowsDesktopV1("test", testCase.labels, types.DynamicWindowsDesktopSpecV1{
 				Addr: "addr",
 			})
 			require.NoError(t, err)
 
-			_, err = dynamicWindowsClient.CreateDynamicWindowsDesktop(ctx, desktop)
+			_, err = dynamicWindowsClient.CreateDynamicWindowsDesktop(t.Context(), desktop)
 			require.NoError(t, err)
 
-			require.EventuallyWithT(t, func(t *assert.CollectT) {
-				desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-				require.NoError(t, err)
-				require.Len(t, desktops, testCase.expected)
+			synctest.Wait()
 
-				if testCase.expected > 0 {
-					require.Equal(t, desktop.GetName(), desktops[0].GetName())
-					require.Equal(t, desktop.GetAddr(), desktops[0].GetAddr())
-				}
-			}, 5*time.Second, 50*time.Millisecond)
+			desktops, err := client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
+			require.NoError(t, err)
+			require.Len(t, desktops, testCase.expected)
+
+			if testCase.expected > 0 {
+				require.Equal(t, desktop.GetName(), desktops[0].GetName())
+				require.Equal(t, desktop.GetAddr(), desktops[0].GetAddr())
+			}
 
 			desktop.Spec.Addr = "addr2"
-			_, err = dynamicWindowsClient.UpsertDynamicWindowsDesktop(ctx, desktop)
+			_, err = dynamicWindowsClient.UpsertDynamicWindowsDesktop(t.Context(), desktop)
 			require.NoError(t, err)
 
-			require.EventuallyWithT(t, func(t *assert.CollectT) {
-				desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-				require.NoError(t, err)
-				require.Len(t, desktops, testCase.expected)
-				if testCase.expected > 0 {
-					require.Equal(t, desktop.GetName(), desktops[0].GetName())
-					require.Equal(t, desktop.GetAddr(), desktops[0].GetAddr())
-				}
-			}, 5*time.Second, 50*time.Millisecond)
+			synctest.Wait()
 
-			require.NoError(t, dynamicWindowsClient.DeleteDynamicWindowsDesktop(ctx, "test"))
+			desktops, err = client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
+			require.NoError(t, err)
+			require.Len(t, desktops, testCase.expected)
+			if testCase.expected > 0 {
+				require.Equal(t, desktop.GetName(), desktops[0].GetName())
+				require.Equal(t, desktop.GetAddr(), desktops[0].GetAddr())
+			}
 
-			require.EventuallyWithT(t, func(t *assert.CollectT) {
-				desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-				require.NoError(t, err)
-				require.Empty(t, desktops)
-			}, 5*time.Second, 50*time.Millisecond)
-		})
-	}
+			require.NoError(t, dynamicWindowsClient.DeleteDynamicWindowsDesktop(t.Context(), "test"))
+
+			synctest.Wait()
+
+			desktops, err = client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
+			require.NoError(t, err)
+			require.Empty(t, desktops)
+		}
+	})
 }
 
 func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
-	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		ClusterName: "test",
-		Dir:         t.TempDir(),
-		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+	t.Parallel()
 
-	tlsServer, err := authServer.NewTestTLSServer()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+	synctest.Test(t, func(t *testing.T) {
+		authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+			ClusterName: "test",
+			Dir:         t.TempDir(),
+			AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
-	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, client.Close()) })
+		tlsServer, err := authServer.NewTestTLSServer(authtest.WithBufconnListener())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
 
-	dynamicWindowsClient := client.DynamicDesktopClient()
+		client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close()) })
 
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
+		dynamicWindowsClient := client.DynamicDesktopClient()
 
-	logger := slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{}))
-	if testing.Verbose() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	}
+		logger := slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{}))
+		if testing.Verbose() {
+			logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		}
 
-	clock := clockwork.NewFakeClock()
-	s := &WindowsService{
-		cfg: WindowsServiceConfig{
-			Heartbeat: HeartbeatConfig{
-				HostUUID: "1234",
-			},
-			Logger:      logger,
-			Clock:       clock,
-			AuthClient:  client,
-			AccessPoint: client,
-			ResourceMatchers: []services.ResourceMatcher{{
-				Labels: types.Labels{
-					"foo": {"bar"},
+		s := &WindowsService{
+			cfg: WindowsServiceConfig{
+				Heartbeat: HeartbeatConfig{
+					HostUUID: "1234",
 				},
-			}},
-		},
-		dnsResolver: &net.Resolver{
-			PreferGo: true,
-			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-				return nil, errors.New("this resolver always fails")
+				Logger:      logger,
+				Clock:       clockwork.NewRealClock(),
+				AuthClient:  client,
+				AccessPoint: client,
+				ResourceMatchers: []services.ResourceMatcher{{
+					Labels: types.Labels{
+						"foo": {"bar"},
+					},
+				}},
 			},
-		},
-	}
+			dnsResolver: &net.Resolver{
+				PreferGo: true,
+				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+					return nil, errors.New("this resolver always fails")
+				},
+			},
+		}
 
-	require.NoError(t, s.startReconciler(t.Context()))
+		require.NoError(t, s.startReconciler(t.Context()))
+		synctest.Wait()
 
-	desktop, err := types.NewDynamicWindowsDesktopV1("test", map[string]string{
-		"foo": "bar",
-	}, types.DynamicWindowsDesktopSpecV1{
-		Addr: "addr",
-	})
-	require.NoError(t, err)
+		desktop, err := types.NewDynamicWindowsDesktopV1("test", map[string]string{
+			"foo": "bar",
+		}, types.DynamicWindowsDesktopSpecV1{
+			Addr: "addr",
+		})
+		require.NoError(t, err)
 
-	// Create the dynamic desktop and verify that a corresponding desktop
-	// resource is created.
-	_, err = dynamicWindowsClient.CreateDynamicWindowsDesktop(ctx, desktop)
-	require.NoError(t, err)
+		// Create the dynamic desktop and verify that a corresponding desktop
+		// resource is created.
+		_, err = dynamicWindowsClient.CreateDynamicWindowsDesktop(t.Context(), desktop)
+		require.NoError(t, err)
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+		synctest.Wait()
+
+		desktops, err := client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
 		require.NoError(t, err)
 		require.Len(t, desktops, 1)
 		require.Equal(t, "test", desktops[0].GetName())
-	}, 5*time.Second, 50*time.Millisecond)
 
-	// Delete the desktop resource, advance the clock, and verify that
-	// the reconciler re-created the desktop resource.
-	err = client.DeleteWindowsDesktop(ctx, s.cfg.Heartbeat.HostUUID, "test")
-	require.NoError(t, err)
+		// Delete the desktop resource, advance the clock, and verify that
+		// the reconciler re-created the desktop resource.
+		err = client.DeleteWindowsDesktop(t.Context(), s.cfg.Heartbeat.HostUUID, "test")
+		require.NoError(t, err)
 
-	desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-	require.NoError(t, err)
-	require.Empty(t, desktops)
+		desktops, err = client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
+		require.NoError(t, err)
+		require.Empty(t, desktops)
 
-	clock.Advance(apidefaults.ServerAnnounceTTL / 2)
+		synctest.Wait()
+		time.Sleep(apidefaults.ServerAnnounceTTL / 2)
+		synctest.Wait()
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+		desktops, err = client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
 		require.NoError(t, err)
 		require.Len(t, desktops, 1)
 		require.Equal(t, "test", desktops[0].GetName())
-	}, 5*time.Second, 50*time.Millisecond)
 
-	// Ensure that the reconciler is advancing the expiry.
-	desktops, err = client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-	require.NoError(t, err)
-	require.Len(t, desktops, 1)
+		// Ensure that the reconciler is advancing the expiry.
+		start := time.Now()
+		time.Sleep(apidefaults.ServerAnnounceTTL / 2)
+		synctest.Wait()
 
-	start := desktops[0].GetMetadata().Expires
-	require.NotNil(t, start)
-
-	clock.Advance(apidefaults.ServerAnnounceTTL / 2)
-
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+		desktops, err = client.GetWindowsDesktops(t.Context(), types.WindowsDesktopFilter{})
 		require.NoError(t, err)
-		require.Len(t, desktops, 1)
 
 		end := desktops[0].GetMetadata().Expires
 		require.NotNil(t, end)
-		require.Equal(t, start.Add(5*time.Minute), *end, "original expiry was %v", *start)
-	}, 5*time.Second, 50*time.Millisecond)
+
+		require.GreaterOrEqual(t, end.Sub(start), apidefaults.ServerAnnounceTTL)
+	})
 }
 
 // TestDynamicRegistrationAndLDAP verifies that a single desktop service
@@ -433,94 +423,98 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 // conflicts.
 func TestDynamicRegistrationAndLDAP(t *testing.T) {
 	t.Parallel()
-	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		ClusterName: "test",
-		Dir:         t.TempDir(),
-		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
-	tlsServer, err := authServer.NewTestTLSServer()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+	synctest.Test(t, func(t *testing.T) {
+		authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+			ClusterName: "test",
+			Dir:         t.TempDir(),
+			AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
-	hostUUID := "test-host-id"
-	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, client.Close()) })
+		tlsServer, err := authServer.NewTestTLSServer(authtest.WithBufconnListener())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
 
-	logger := slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{}))
-	if testing.Verbose() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	}
+		hostUUID := "test-host-id"
+		client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close()) })
 
-	clock := clockwork.NewFakeClock()
-	s := &WindowsService{
-		cfg: WindowsServiceConfig{
-			Heartbeat: HeartbeatConfig{
-				HostUUID: hostUUID,
-			},
-			Logger:      logger,
-			Clock:       clock,
-			AccessPoint: client,
-			AuthClient:  client,
+		logger := slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{}))
+		if testing.Verbose() {
+			logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		}
 
-			// Enable both LDAP discovery and dynamic registration.
-			DiscoveryInterval: 5 * time.Minute,
-			Discovery:         []servicecfg.LDAPDiscoveryConfig{{BaseDN: "*"}},
-			ResourceMatchers: []services.ResourceMatcher{{
-				Labels: types.Labels{
-					"foo": {"bar"},
+		s := &WindowsService{
+			cfg: WindowsServiceConfig{
+				Heartbeat: HeartbeatConfig{
+					HostUUID: hostUUID,
 				},
-			}},
-		},
+				Logger:      logger,
+				Clock:       clockwork.NewRealClock(),
+				AccessPoint: client,
+				AuthClient:  client,
 
-		// pre-cache a TLS config so we don't ask auth to issue a real cert
-		// (there isn't a real LDAP server here to connect to)
-		ldapTLSConfig:          new(tls.Config),
-		ldapTLSConfigExpiresAt: clock.Now().Add(24 * time.Hour),
-	}
+				// Enable both LDAP discovery and dynamic registration.
+				DiscoveryInterval: 5 * time.Minute,
+				Discovery:         []servicecfg.LDAPDiscoveryConfig{{BaseDN: "*"}},
+				ResourceMatchers: []services.ResourceMatcher{{
+					Labels: types.Labels{
+						"foo": {"bar"},
+					},
+				}},
+			},
 
-	// Seed a fake LDAP dekstop. Discovery will pick it up since
-	// it uses the last known results on error.
-	ldapDeskop, err := types.NewWindowsDesktopV3(
-		"ldap-desktop",
-		map[string]string{
-			"teleport.dev/computer_name":  "host-1",
-			"teleport.dev/dns_host_name":  "host-1.example.com",
-			"teleport.dev/origin":         "dynamic",
-			"teleport.dev/os":             "Windows Server 2025 Standard",
-			"teleport.dev/os_version":     "10.0 (26100)",
-			"teleport.dev/ou":             "OU=Windows,DC=example,DC=com",
-			"teleport.dev/windows_domain": "EXAMPLE.COM",
-		},
-		types.WindowsDesktopSpecV3{
-			Domain: "example.com",
-			Addr:   "192.168.1.100:3389",
-			HostID: hostUUID,
-		},
-	)
-	require.NoError(t, err)
-	s.lastDiscoveryResults = map[string]types.WindowsDesktop{
-		ldapDeskop.GetName(): ldapDeskop,
-	}
+			// pre-cache a TLS config so we don't ask auth to issue a real cert
+			// (there isn't a real LDAP server here to connect to)
+			ldapTLSConfig:          new(tls.Config),
+			ldapTLSConfigExpiresAt: time.Now().Add(24 * time.Hour),
+		}
 
-	ctx := t.Context()
-	require.NoError(t, s.startReconciler(ctx))
+		// Seed a fake LDAP dekstop. Discovery will pick it up since
+		// it uses the last known results on error.
+		ldapDeskop, err := types.NewWindowsDesktopV3(
+			"ldap-desktop",
+			map[string]string{
+				"teleport.dev/computer_name":  "host-1",
+				"teleport.dev/dns_host_name":  "host-1.example.com",
+				"teleport.dev/origin":         "dynamic",
+				"teleport.dev/os":             "Windows Server 2025 Standard",
+				"teleport.dev/os_version":     "10.0 (26100)",
+				"teleport.dev/ou":             "OU=Windows,DC=example,DC=com",
+				"teleport.dev/windows_domain": "EXAMPLE.COM",
+			},
+			types.WindowsDesktopSpecV3{
+				Domain: "example.com",
+				Addr:   "192.168.1.100:3389",
+				HostID: hostUUID,
+			},
+		)
+		require.NoError(t, err)
+		s.lastDiscoveryResults = map[string]types.WindowsDesktop{
+			ldapDeskop.GetName(): ldapDeskop,
+		}
 
-	// Create a dynamic desktop and wait for it to show up.
-	desktop, err := types.NewDynamicWindowsDesktopV1("test", map[string]string{
-		"foo": "bar",
-	}, types.DynamicWindowsDesktopSpecV1{
-		Addr: "addr",
-	})
-	require.NoError(t, err)
+		ctx := t.Context()
+		require.NoError(t, s.startReconciler(ctx))
 
-	_, err = client.DynamicDesktopClient().CreateDynamicWindowsDesktop(ctx, desktop)
-	require.NoError(t, err)
+		synctest.Wait()
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		// Create a dynamic desktop and wait for it to show up.
+		desktop, err := types.NewDynamicWindowsDesktopV1("test", map[string]string{
+			"foo": "bar",
+		}, types.DynamicWindowsDesktopSpecV1{
+			Addr: "addr",
+		})
+		require.NoError(t, err)
+
+		_, err = client.DynamicDesktopClient().CreateDynamicWindowsDesktop(ctx, desktop)
+		require.NoError(t, err)
+
+		synctest.Wait()
+
 		desktops, err := client.GetWindowsDesktops(
 			ctx,
 			types.WindowsDesktopFilter{Name: desktop.GetName()},
@@ -528,18 +522,18 @@ func TestDynamicRegistrationAndLDAP(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, desktops, 1)
 		require.Equal(t, desktop.GetName(), desktops[0].GetName())
-	}, 5*time.Second, 50*time.Millisecond)
 
-	// Force the reconciler to run.
-	clock.BlockUntilContext(t.Context(), 1)
-	clock.Advance(s.cfg.DiscoveryInterval)
-	clock.BlockUntilContext(t.Context(), 1)
+		// Force the reconciler to run.
+		synctest.Wait()
+		time.Sleep(s.cfg.DiscoveryInterval)
+		synctest.Wait()
 
-	// Expect that the reconciler created the new LDAP desktop,
-	// and also kept the existing dynamic desktop.
-	desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-	require.NoError(t, err)
-	require.Len(t, desktops, 2)
+		// Expect that the reconciler created the new LDAP desktop,
+		// and also kept the existing dynamic desktop.
+		desktops, err = client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+		require.NoError(t, err)
+		require.Len(t, desktops, 2)
+	})
 }
 
 func TestCurrentDesktops(t *testing.T) {
@@ -648,72 +642,72 @@ func TestCurrentDesktops(t *testing.T) {
 func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 	t.Parallel()
 
-	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		ClusterName: "test",
-		Dir:         t.TempDir(),
-		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
-
-	tlsServer, err := authServer.NewTestTLSServer()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
-
-	const hostUUID = "test-host-uuid"
-	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, client.Close()) })
-
-	clock := clockwork.NewFakeClock()
-
-	s := &WindowsService{
-		closeCtx: t.Context(),
-		cfg: WindowsServiceConfig{
-			Heartbeat:         HeartbeatConfig{HostUUID: hostUUID},
-			Logger:            slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
-			Clock:             clock,
-			AccessPoint:       client,
-			AuthClient:        client,
-			DiscoveryInterval: 5 * time.Minute,
-			Discovery:         []servicecfg.LDAPDiscoveryConfig{{BaseDN: "*"}},
-		},
-
-		// pre-cache a TLS config so we don't ask auth to issue a real cert
-		// (there isn't a real LDAP server here to connect to)
-		ldapTLSConfig:          new(tls.Config),
-		ldapTLSConfigExpiresAt: clock.Now().Add(24 * time.Hour),
-	}
-
-	originalExpiry := clock.Now().Add(s.cfg.DiscoveryInterval * 3)
-
-	// Populate last discovery results with some desktops
-	lastDiscoveryResults := map[string]types.WindowsDesktop{}
-	for i := 1; i <= 3; i++ {
-		name := "desktop-" + strconv.Itoa(i)
-		desktop, err := types.NewWindowsDesktopV3(name, map[string]string{
-			types.OriginLabel:                      types.OriginDynamic,
-			types.DiscoveryLabelWindowsDNSHostName: name + ".example.com",
-			types.DiscoveryLabelWindowsOS:          "Windows Server 2019",
-		}, types.WindowsDesktopSpecV3{
-			HostID: hostUUID,
-			Addr:   name + ".example.com:3389",
+	synctest.Test(t, func(t *testing.T) {
+		authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+			ClusterName: "test",
+			Dir:         t.TempDir(),
+			AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 		})
 		require.NoError(t, err)
-		desktop.SetExpiry(originalExpiry)
-		lastDiscoveryResults[name] = desktop
+		t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
-		require.NoError(t, tlsServer.Auth().UpsertWindowsDesktop(t.Context(), desktop))
-	}
-	s.lastDiscoveryResults = lastDiscoveryResults
+		tlsServer, err := authServer.NewTestTLSServer(authtest.WithBufconnListener())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
 
-	// Force the reconciler to run.
-	// It will fail because we aren't running a real LDAP server in the test.
-	require.NoError(t, s.startReconciler(t.Context()))
+		const hostUUID = "test-host-uuid"
+		client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close()) })
 
-	clock.Advance(s.cfg.DiscoveryInterval)
+		s := &WindowsService{
+			closeCtx: t.Context(),
+			cfg: WindowsServiceConfig{
+				Heartbeat:         HeartbeatConfig{HostUUID: hostUUID},
+				Logger:            slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
+				Clock:             clockwork.NewRealClock(),
+				AccessPoint:       client,
+				AuthClient:        client,
+				DiscoveryInterval: 5 * time.Minute,
+				Discovery:         []servicecfg.LDAPDiscoveryConfig{{BaseDN: "*"}},
+			},
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// pre-cache a TLS config so we don't ask auth to issue a real cert
+			// (there isn't a real LDAP server here to connect to)
+			ldapTLSConfig:          new(tls.Config),
+			ldapTLSConfigExpiresAt: time.Now().Add(24 * time.Hour),
+		}
+
+		originalExpiry := time.Now().Add(s.cfg.DiscoveryInterval * 3)
+
+		// Populate last discovery results with some desktops
+		lastDiscoveryResults := map[string]types.WindowsDesktop{}
+		for i := 1; i <= 3; i++ {
+			name := "desktop-" + strconv.Itoa(i)
+			desktop, err := types.NewWindowsDesktopV3(name, map[string]string{
+				types.OriginLabel:                      types.OriginDynamic,
+				types.DiscoveryLabelWindowsDNSHostName: name + ".example.com",
+				types.DiscoveryLabelWindowsOS:          "Windows Server 2019",
+			}, types.WindowsDesktopSpecV3{
+				HostID: hostUUID,
+				Addr:   name + ".example.com:3389",
+			})
+			require.NoError(t, err)
+			desktop.SetExpiry(originalExpiry)
+			lastDiscoveryResults[name] = desktop
+
+			require.NoError(t, tlsServer.Auth().UpsertWindowsDesktop(t.Context(), desktop))
+		}
+		s.lastDiscoveryResults = lastDiscoveryResults
+
+		// Force the reconciler to run.
+		// It will fail because we aren't running a real LDAP server in the test.
+		require.NoError(t, s.startReconciler(t.Context()))
+
+		synctest.Wait()
+		time.Sleep(s.cfg.DiscoveryInterval)
+		synctest.Wait()
+
 		// Verify that the reconciler failure did not delete desktops and that
 		// their expiry times were updated.
 		for i := 1; i <= 3; i++ {
@@ -730,5 +724,5 @@ func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 			actualExpiry := desktops[0].Expiry()
 			require.GreaterOrEqual(t, actualExpiry, originalExpiry)
 		}
-	}, 10*time.Second, 50*time.Millisecond)
+	})
 }

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -256,7 +256,7 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 				},
 			}
 
-			require.NoError(t, s.startDynamicReconciler(t.Context()))
+			require.NoError(t, s.startReconciler(t.Context()))
 			t.Cleanup(func() {
 				require.NoError(t, authServer.AuthServer.DeleteAllWindowsDesktops(ctx))
 				var key string
@@ -368,7 +368,7 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, s.startDynamicReconciler(t.Context()))
+	require.NoError(t, s.startReconciler(t.Context()))
 
 	desktop, err := types.NewDynamicWindowsDesktopV1("test", map[string]string{
 		"foo": "bar",
@@ -382,8 +382,6 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 	_, err = dynamicWindowsClient.CreateDynamicWindowsDesktop(ctx, desktop)
 	require.NoError(t, err)
 
-	clock.BlockUntilContext(t.Context(), 1)
-
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 		require.NoError(t, err)
@@ -395,8 +393,6 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 	// the reconciler re-created the desktop resource.
 	err = client.DeleteWindowsDesktop(ctx, s.cfg.Heartbeat.HostUUID, "test")
 	require.NoError(t, err)
-
-	t.Log("deleting windows desktop")
 
 	desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 	require.NoError(t, err)
@@ -429,6 +425,120 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 	end := desktops[0].GetMetadata().Expires
 	require.NotNil(t, start)
 	require.Equal(t, start.Add(5*time.Minute), *end, "original expiry was %v", *start)
+}
+
+// TestDynamicRegistrationAndLDAP verifies that a single desktop service
+// can handle both dynamic registration and LDAP discovery without
+// conflicts.
+func TestDynamicRegistrationAndLDAP(t *testing.T) {
+	t.Parallel()
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		ClusterName: "test",
+		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+
+	tlsServer, err := authServer.NewTestTLSServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	hostUUID := "test-host-id"
+	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	logger := slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{}))
+	if testing.Verbose() {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	}
+
+	clock := clockwork.NewFakeClock()
+	s := &WindowsService{
+		cfg: WindowsServiceConfig{
+			Heartbeat: HeartbeatConfig{
+				HostUUID: hostUUID,
+			},
+			Logger:      logger,
+			Clock:       clock,
+			AccessPoint: client,
+			AuthClient:  client,
+
+			// Enable both LDAP discovery and dynamic registration.
+			DiscoveryInterval: 5 * time.Minute,
+			Discovery:         []servicecfg.LDAPDiscoveryConfig{{BaseDN: "*"}},
+			ResourceMatchers: []services.ResourceMatcher{{
+				Labels: types.Labels{
+					"foo": {"bar"},
+				},
+			}},
+		},
+
+		// pre-cache a TLS config so we don't ask auth to issue a real cert
+		// (there isn't a real LDAP server here to connect to)
+		ldapTLSConfig:          new(tls.Config),
+		ldapTLSConfigExpiresAt: clock.Now().Add(24 * time.Hour),
+	}
+
+	// Seed a fake LDAP dekstop. Discovery will pick it up since
+	// it uses the last known results on error.
+	ldapDeskop, err := types.NewWindowsDesktopV3(
+		"ldap-desktop",
+		map[string]string{
+			"teleport.dev/computer_name":  "host-1",
+			"teleport.dev/dns_host_name":  "host-1.example.com",
+			"teleport.dev/origin":         "dynamic",
+			"teleport.dev/os":             "Windows Server 2025 Standard",
+			"teleport.dev/os_version":     "10.0 (26100)",
+			"teleport.dev/ou":             "OU=Windows,DC=example,DC=com",
+			"teleport.dev/windows_domain": "EXAMPLE.COM",
+		},
+		types.WindowsDesktopSpecV3{
+			Domain: "example.com",
+			Addr:   "192.168.1.100:3389",
+			HostID: hostUUID,
+		},
+	)
+	require.NoError(t, err)
+	s.lastDiscoveryResults = map[string]types.WindowsDesktop{
+		ldapDeskop.GetName(): ldapDeskop,
+	}
+
+	ctx := t.Context()
+	require.NoError(t, s.startReconciler(ctx))
+
+	// Create a dynamic desktop and wait for it to show up.
+	desktop, err := types.NewDynamicWindowsDesktopV1("test", map[string]string{
+		"foo": "bar",
+	}, types.DynamicWindowsDesktopSpecV1{
+		Addr: "addr",
+	})
+	require.NoError(t, err)
+
+	_, err = client.DynamicDesktopClient().CreateDynamicWindowsDesktop(ctx, desktop)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		desktops, err := client.GetWindowsDesktops(
+			ctx,
+			types.WindowsDesktopFilter{Name: desktop.GetName()},
+		)
+		require.NoError(t, err)
+		require.Len(t, desktops, 1)
+		require.Equal(t, desktop.GetName(), desktops[0].GetName())
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Force the reconciler to run.
+	clock.BlockUntilContext(t.Context(), 1)
+	clock.Advance(s.cfg.DiscoveryInterval)
+	clock.BlockUntilContext(t.Context(), 1)
+
+	// Expect that the reconciler created the new LDAP desktop,
+	// and also kept the existing dynamic desktop.
+	desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+	require.NoError(t, err)
+	require.Len(t, desktops, 2)
 }
 
 func TestCurrentDesktops(t *testing.T) {
@@ -565,6 +675,7 @@ func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 			AccessPoint:       client,
 			AuthClient:        client,
 			DiscoveryInterval: 5 * time.Minute,
+			Discovery:         []servicecfg.LDAPDiscoveryConfig{{BaseDN: "*"}},
 		},
 
 		// pre-cache a TLS config so we don't ask auth to issue a real cert
@@ -597,9 +708,9 @@ func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 
 	// Force the reconciler to run.
 	// It will fail because we aren't running a real LDAP server in the test.
-	require.NoError(t, s.startDesktopDiscovery())
+	require.NoError(t, s.startReconciler(t.Context()))
 	clock.BlockUntilContext(t.Context(), 1)
-	clock.Advance(15 * time.Second)
+	clock.Advance(s.cfg.DiscoveryInterval)
 	preReconcile := clock.Now()
 	clock.BlockUntilContext(t.Context(), 1)
 

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -415,16 +415,17 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 	start := desktops[0].GetMetadata().Expires
 	require.NotNil(t, start)
 
-	clock.Advance(5 * time.Minute)
-	clock.BlockUntilContext(t.Context(), 1)
+	clock.Advance(apidefaults.ServerAnnounceTTL / 2)
 
-	desktops, err = client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
-	require.NoError(t, err)
-	require.Len(t, desktops, 1)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+		require.NoError(t, err)
+		require.Len(t, desktops, 1)
 
-	end := desktops[0].GetMetadata().Expires
-	require.NotNil(t, start)
-	require.Equal(t, start.Add(5*time.Minute), *end, "original expiry was %v", *start)
+		end := desktops[0].GetMetadata().Expires
+		require.NotNil(t, end)
+		require.Equal(t, start.Add(5*time.Minute), *end, "original expiry was %v", *start)
+	}, 5*time.Second, 50*time.Millisecond)
 }
 
 // TestDynamicRegistrationAndLDAP verifies that a single desktop service
@@ -709,25 +710,25 @@ func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 	// Force the reconciler to run.
 	// It will fail because we aren't running a real LDAP server in the test.
 	require.NoError(t, s.startReconciler(t.Context()))
-	clock.BlockUntilContext(t.Context(), 1)
+
 	clock.Advance(s.cfg.DiscoveryInterval)
-	preReconcile := clock.Now()
-	clock.BlockUntilContext(t.Context(), 1)
 
-	// Verify that the reconciler failure did not delete desktops and that
-	// their expiry times were updated.
-	for i := 1; i <= 3; i++ {
-		name := "desktop-" + strconv.Itoa(i)
-		desktops, err := client.GetWindowsDesktops(
-			t.Context(),
-			types.WindowsDesktopFilter{HostID: hostUUID, Name: name},
-		)
-		require.NoError(t, err)
-		require.Len(t, desktops, 1)
-		require.Equal(t, name, desktops[0].GetName())
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		// Verify that the reconciler failure did not delete desktops and that
+		// their expiry times were updated.
+		for i := 1; i <= 3; i++ {
+			name := "desktop-" + strconv.Itoa(i)
+			desktops, err := client.GetWindowsDesktops(
+				t.Context(),
+				types.WindowsDesktopFilter{HostID: hostUUID, Name: name},
+			)
+			require.NoError(t, err)
+			require.Len(t, desktops, 1)
+			require.Equal(t, name, desktops[0].GetName())
 
-		// Verify the TTL was updated (3x the discovery interval).
-		actualExpiry := desktops[0].Expiry()
-		require.Equal(t, 15*time.Minute, actualExpiry.Sub(preReconcile))
-	}
+			// Verify the expiry is pushed back.
+			actualExpiry := desktops[0].Expiry()
+			require.GreaterOrEqual(t, actualExpiry, originalExpiry)
+		}
+	}, 10*time.Second, 50*time.Millisecond)
 }

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -34,8 +35,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -175,6 +178,7 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -195,7 +199,7 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 
 	dynamicWindowsClient := client.DynamicDesktopClient()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	for _, testCase := range []struct {
@@ -317,6 +321,7 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
@@ -331,8 +336,13 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 
 	dynamicWindowsClient := client.DynamicDesktopClient()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
+
+	logger := slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{}))
+	if testing.Verbose() {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	}
 
 	clock := clockwork.NewFakeClock()
 	s := &WindowsService{
@@ -340,7 +350,7 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 			Heartbeat: HeartbeatConfig{
 				HostUUID: "1234",
 			},
-			Logger:      slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
+			Logger:      logger,
 			Clock:       clock,
 			AuthClient:  client,
 			AccessPoint: client,
@@ -367,8 +377,12 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Create the dynamic desktop and verify that a corresponding desktop
+	// resource is created.
 	_, err = dynamicWindowsClient.CreateDynamicWindowsDesktop(ctx, desktop)
 	require.NoError(t, err)
+
+	clock.BlockUntilContext(t.Context(), 1)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
@@ -377,14 +391,18 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 		require.Equal(t, "test", desktops[0].GetName())
 	}, 5*time.Second, 50*time.Millisecond)
 
+	// Delete the desktop resource, advance the clock, and verify that
+	// the reconciler re-created the desktop resource.
 	err = client.DeleteWindowsDesktop(ctx, s.cfg.Heartbeat.HostUUID, "test")
 	require.NoError(t, err)
+
+	t.Log("deleting windows desktop")
 
 	desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 	require.NoError(t, err)
 	require.Empty(t, desktops)
 
-	clock.Advance(5 * time.Minute)
+	clock.Advance(apidefaults.ServerAnnounceTTL / 2)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
@@ -392,6 +410,25 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 		require.Len(t, desktops, 1)
 		require.Equal(t, "test", desktops[0].GetName())
 	}, 5*time.Second, 50*time.Millisecond)
+
+	// Ensure that the reconciler is advancing the expiry.
+	desktops, err = client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+	require.NoError(t, err)
+	require.Len(t, desktops, 1)
+
+	start := desktops[0].GetMetadata().Expires
+	require.NotNil(t, start)
+
+	clock.Advance(5 * time.Minute)
+	clock.BlockUntilContext(t.Context(), 1)
+
+	desktops, err = client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+	require.NoError(t, err)
+	require.Len(t, desktops, 1)
+
+	end := desktops[0].GetMetadata().Expires
+	require.NotNil(t, start)
+	require.Equal(t, start.Add(5*time.Minute), *end, "original expiry was %v", *start)
 }
 
 func TestCurrentDesktops(t *testing.T) {
@@ -399,6 +436,7 @@ func TestCurrentDesktops(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
@@ -502,6 +540,7 @@ func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -438,22 +438,14 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	if len(s.cfg.ResourceMatchers) == 0 && len(s.cfg.Discovery) == 0 {
+		s.cfg.Logger.WarnContext(ctx, "LDAP discovery and dynamic registration are both disabled, no reconciler will run")
+	} else if err := s.startReconciler(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	if err := s.startStaticHostHeartbeats(); err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	if err := s.startDynamicReconciler(ctx); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if len(s.cfg.Discovery) > 0 {
-		if err := s.startDesktopDiscovery(); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	} else if len(s.cfg.Heartbeat.StaticHosts) == 0 {
-		s.cfg.Logger.WarnContext(ctx, "desktop discovery via LDAP is disabled, and no hosts are defined in the configuration; there will be no Windows desktops available to connect")
-	} else {
-		s.cfg.Logger.InfoContext(ctx, "desktop discovery via LDAP is disabled, set 'base_dn' to enable")
 	}
 
 	ok = true


### PR DESCRIPTION
Use a single desktop reconciler

When a windows_desktop_service enables both dynamic registration and LDAP discovery, we would previously run a reconciler for each function. These reconcilers would conflict and even delete hosts belonging to the other reconciler.

Fix this by consolidating on a single reconciler that handles both types of desktops.

Changelog: Fixed an issue where Windows desktop LDAP discovery could conflict with dynamic registration causing desktops to be removed from the cluster.

Changelog: Fixed an issue that could cause LDAP discovery to fail when a single desktop service discovers large numbers of hosts.

## Manual Test Plan

### Test Environment

Local single-process cluster.

### Test Cases

- [ ] Service with LDAP discovery and without dynamic desktops discovers hosts.
- [ ] LDAP discovery for > 1000 hosts succeeds.
- [ ] Service with dynamic desktops and without LDAP enabled registers dynamic hosts.

Service with both dynamic desktop and LDAP enabled:
- [ ] Registers the full set of hosts
- [ ] Dynamically registered hosts are not deleted during LDAP discovery passes.
