### PR TITLE
Explain how leaf clusters expand `internal.logins`

### DIFF
--- a/docs/pages/enroll-resources/server-access/rbac.mdx
+++ b/docs/pages/enroll-resources/server-access/rbac.mdx
@@ -119,6 +119,30 @@ spec:
     logins: ["{{internal.logins}}"]
 ```
 
+When a user signs into a protected server, the Teleport SSH Service only
+considers the logins available to a user via their roles in the root cluster,
+and ignores any additional logins made available via leaf cluster roles. For
+example, the following leaf cluster role would **not** grant the `additional`
+login:
+
+```yaml
+kind: role
+version: v8
+metadata:
+  name: admin
+spec:
+  allow:
+    logins: [additional,"{{internal.logins}}"]
+```
+
+This is because, when a user authenticates to a root cluster, Teleport issues an
+SSH certificate to the user that includes only logins listed in the user's roles
+and traits on the root cluster. When the user attempts to log in to a protected
+server on the leaf cluster, the Teleport SSH Service instance in the leaf
+cluster checks the user's SSH certificate. Since that certificate was issued by
+the root cluster, it does not contain any logins that are specific to the leaf
+cluster.
+
 For full details on how variable expansion works in Teleport roles, see the
 [Access Controls
 Reference](../../reference/access-controls/roles.mdx).

--- a/docs/pages/zero-trust-access/deploy-a-cluster/trustedclusters.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/trustedclusters.mdx
@@ -218,7 +218,7 @@ your Teleport username:
 
    ```yaml
    kind: role
-   version: v5
+   version: v8
    metadata:
      name: visitor
    spec:
@@ -530,7 +530,7 @@ allows access to clusters with the `env: demo` label:
      allow:
        cluster_labels:
          'env': 'demo'
-   version: v5
+   version: v8
    ```
 
 1. Create the role by running the following command:
@@ -713,6 +713,30 @@ logins: ["{{internal.logins}}", "{{external.logins_from_okta}}"]
 node_labels:
   env: "{{external.env_from_okta}}"
 ```
+
+The `logins` field is unique in that, when a user signs into a protected server,
+the Teleport SSH Service only considers the logins available to a user via their
+roles in the root cluster, and ignores any additional logins made available via
+leaf cluster roles. For example, the following leaf cluster role would **not**
+grant the `additional` login:
+
+```yaml
+kind: role
+version: v8
+metadata:
+  name: admin
+spec:
+  allow:
+    logins: [additional,"{{internal.logins}}"]
+```
+
+This is because, when a user authenticates to a root cluster, Teleport issues an
+SSH certificate to the user that includes only logins listed in the user's roles
+and traits on the root cluster. When the user attempts to log in to a protected
+server on the leaf cluster, the Teleport SSH Service instance in the leaf
+cluster checks the user's SSH certificate. Since that certificate was issued by
+the root cluster, it does not contain any logins that are specific to the leaf
+cluster.
 
 For full details on how variable expansion works in Teleport roles, see the
 [Access Controls

--- a/docs/pages/zero-trust-access/management/trustedclusters.mdx
+++ b/docs/pages/zero-trust-access/management/trustedclusters.mdx
@@ -218,7 +218,7 @@ your Teleport username:
 
    ```yaml
    kind: role
-   version: v5
+   version: v8
    metadata:
      name: visitor
    spec:
@@ -530,7 +530,7 @@ allows access to clusters with the `env: demo` label:
      allow:
        cluster_labels:
          'env': 'demo'
-   version: v5
+   version: v8
    ```
 
 1. Create the role by running the following command:
@@ -713,6 +713,30 @@ logins: ["{{internal.logins}}", "{{external.logins_from_okta}}"]
 node_labels:
   env: "{{external.env_from_okta}}"
 ```
+
+The `logins` field is unique in that, when a user signs into a protected server,
+the Teleport SSH Service only considers the logins available to a user via their
+roles in the root cluster, and ignores any additional logins made available via
+leaf cluster roles. For example, the following leaf cluster role would **not**
+grant the `additional` login:
+
+```yaml
+kind: role
+version: v8
+metadata:
+  name: admin
+spec:
+  allow:
+    logins: [additional,"{{internal.logins}}"]
+```
+
+This is because, when a user authenticates to a root cluster, Teleport issues an
+SSH certificate to the user that includes only logins listed in the user's roles
+and traits on the root cluster. When the user attempts to log in to a protected
+server on the leaf cluster, the Teleport SSH Service instance in the leaf
+cluster checks the user's SSH certificate. Since that certificate was issued by
+the root cluster, it does not contain any logins that are specific to the leaf
+cluster.
 
 For full details on how variable expansion works in Teleport roles, see the
 [Access Controls


### PR DESCRIPTION
Fixes #3762

Edit the trusted cluster guide and RBAC giude for protected servers to explain how leaf clusters expand the `internal.logins` template variable.