### PR TITLE
Fix TDPB Audit Log and Error Monitoring Backwards Compatibility

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -172,7 +172,7 @@ type Client struct {
 
 // reads in handshake messages and optionally wraps the connection in a translation layer
 // based on the client protocol.
-func prepareConnecton(clientProtocol string, conn *tdp.Conn, logger *slog.Logger) (tdp.MessageReadWriteCloser, *tdpb.ClientHello, error) {
+func PrepareConnecton(clientProtocol string, conn *tdp.Conn, logger *slog.Logger) (tdp.MessageReadWriteCloser, *tdpb.ClientHello, error) {
 	// Read Hello either from tdpb or tdp.
 	if clientProtocol == tdpb.ProtocolName {
 		hello, err := readClientHello(conn, logger)
@@ -184,7 +184,7 @@ func prepareConnecton(clientProtocol string, conn *tdp.Conn, logger *slog.Logger
 }
 
 // New creates and connects a new Client based on cfg.
-func New(conn *tdp.Conn, cfg Config) (*Client, error) {
+func New(conn tdp.MessageReadWriteCloser, hello *tdpb.ClientHello, cfg Config) (*Client, error) {
 	if err := cfg.checkAndSetDefaults(); err != nil {
 		return nil, err
 	}
@@ -193,13 +193,7 @@ func New(conn *tdp.Conn, cfg Config) (*Client, error) {
 		readyForInput: 0,
 	}
 
-	// read the client hello and wrap the connection with a translation layer (if needed)
-	wrappedConn, hello, err := prepareConnecton(cfg.ClientProtocol, conn, cfg.Logger)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	c.conn = wrappedConn
+	c.conn = conn
 	c.username = hello.Username
 	c.keyboardLayout = hello.KeyboardLayout
 

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -170,7 +170,7 @@ type Client struct {
 	mouseX, mouseY uint32
 }
 
-// reads in handshake messages and optionally wraps the connection in a translation layer
+// PrepareConnecton reads in handshake messages and optionally wraps the connection in a translation layer
 // based on the client protocol.
 func PrepareConnecton(clientProtocol string, conn *tdp.Conn, logger *slog.Logger) (tdp.MessageReadWriteCloser, *tdpb.ClientHello, error) {
 	// Read Hello either from tdpb or tdp.

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -25,15 +25,12 @@ import (
 	"encoding/binary"
 	"image/png"
 	"log/slog"
-	"slices"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
-	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/legacy"
-	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
 )
 
 // LicenseStore implements client-side license storage for Microsoft
@@ -92,9 +89,6 @@ type Config struct {
 
 	// AD indicates whether the desktop is part of an Active Directory domain.
 	AD bool
-
-	// The desktop protocol version used by the client (TDP or TDPB).
-	ClientProtocol string
 }
 
 //nolint:unused // used in client.go that is behind desktop_access_rdp build flag
@@ -110,9 +104,6 @@ func (c *Config) checkAndSetDefaults() error {
 	}
 	if c.Encoder == nil {
 		c.Encoder = tdp.PNGEncoder()
-	}
-	if !slices.Contains([]string{tdpb.ProtocolName, legacy.ProtocolName}, c.ClientProtocol) {
-		return trace.BadParameter("missing ClientProtocol in rdpclient.Config")
 	}
 	c.Logger = c.Logger.With("rdp_addr", c.Addr)
 	return nil

--- a/lib/srv/desktop/rdp/rdpclient/client_nop.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_nop.go
@@ -27,9 +27,11 @@ package rdpclient
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
+	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
 )
 
 // Client is the dummy RDP client.
@@ -39,7 +41,7 @@ type Client struct {
 // New creates and connects a new Client based on opts.
 //
 //nolint:staticcheck // SA4023. False positive, depends on build tags.
-func New(_ *tdp.Conn, cfg Config) (*Client, error) {
+func New(_ tdp.MessageReadWriteCloser, _ *tdpb.ClientHello, cfg Config) (*Client, error) {
 	return nil, errors.New("the real rdpclient.Client implementation was not included in this build")
 }
 
@@ -60,3 +62,9 @@ func (c *Client) GetClientLastActive() time.Time {
 
 // UpdateClientActivity updates the client activity timestamp.
 func (c *Client) UpdateClientActivity() {}
+
+// PrepareConnecton reads in handshake messages and optionally wraps the connection in a translation layer
+// based on the client protocol.
+func PrepareConnecton(_ string, _ *tdp.Conn, _ *slog.Logger) (tdp.MessageReadWriteCloser, *tdpb.ClientHello, error) {
+	return nil, nil, errors.New("the real rdpclient.Client implementation was not included in this build")
+}

--- a/lib/srv/desktop/rdp/rdpclient/client_test.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_test.go
@@ -58,7 +58,7 @@ func TestClientNew_EOF(t *testing.T) {
 	f := fakeConn{}
 	conn := tdp.NewConn(&f, tdp.DecoderAdapter(tdpb.DecodePermissive))
 
-	_, err := New(conn, createConfig())
+	_, _, err := PrepareConnecton(tdpb.ProtocolName, conn, slog.New(slog.DiscardHandler))
 	require.ErrorIs(t, err, io.EOF)
 }
 
@@ -69,7 +69,10 @@ func TestClientNew_NoKeyboardLayout(t *testing.T) {
 
 	conn := tdp.NewConn(&f, tdp.DecoderAdapter(tdpb.DecodePermissive))
 
-	_, err = New(conn, createConfig())
+	wrappedConn, hello, err := PrepareConnecton(tdpb.ProtocolName, conn, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+
+	_, err = New(wrappedConn, hello, createConfig())
 	require.NoError(t, err)
 }
 
@@ -79,20 +82,20 @@ func TestClientNew_KeyboardLayout(t *testing.T) {
 	require.NoError(t, err)
 
 	conn := tdp.NewConn(&f, tdp.DecoderAdapter(tdpb.DecodePermissive))
-
-	_, err = New(conn, createConfig())
+	wrappedConn, hello, err := PrepareConnecton(tdpb.ProtocolName, conn, slog.New(slog.DiscardHandler))
 	require.NoError(t, err)
 
+	_, err = New(wrappedConn, hello, createConfig())
+	require.NoError(t, err)
 }
 
 func createConfig() Config {
 	return Config{
-		Addr:           "example.com",
-		AuthorizeFn:    func(login string) error { return nil },
-		Logger:         slog.Default(),
-		Width:          1,
-		Height:         1,
-		ClientProtocol: tdpb.ProtocolName,
+		Addr:        "example.com",
+		AuthorizeFn: func(login string) error { return nil },
+		Logger:      slog.Default(),
+		Width:       1,
+		Height:      1,
 	}
 }
 

--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -61,15 +61,6 @@ type Conn struct {
 	decode    Decoder
 	closeOnce sync.Once
 
-	// OnSend is an optional callback that is invoked when a TDP message
-	// is sent on the wire. It is passed both the raw bytes and the encoded
-	// message.
-	OnSend func(m Message, b []byte)
-
-	// OnRecv is an optional callback that is invoked when a TDP message
-	// is received on the wire.
-	OnRecv func(m Message)
-
 	// localAddr and remoteAddr will be set if rw is
 	// a conn that provides these fields
 	localAddr  net.Addr
@@ -145,9 +136,6 @@ func (c *Conn) PeekNextByte() (byte, error) {
 // ReadMessage reads the next incoming message from the connection.
 func (c *Conn) ReadMessage() (Message, error) {
 	m, err := c.decode(c.bufr)
-	if c.OnRecv != nil {
-		c.OnRecv(m)
-	}
 	return m, trace.Wrap(err)
 }
 
@@ -162,9 +150,6 @@ func (c *Conn) WriteMessage(m Message) error {
 	_, err = c.rwc.Write(buf)
 	c.writeMu.Unlock()
 
-	if c.OnSend != nil {
-		c.OnSend(m, buf)
-	}
 	return trace.Wrap(err)
 }
 

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -837,12 +837,19 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 	}
 	createUsers := err == nil
 
+	// Adapt send /receive handlers to run as Interceptors.
+	asInterceptor := func(handler func(tdp.Message) error) tdp.Interceptor {
+		return func(message tdp.Message) ([]tdp.Message, error) {
+			return []tdp.Message{message}, handler(message)
+		}
+	}
+
 	// it's important that we set the OnSend and OnRecv handlers prior to
 	// initializing the client so that we capture all relevant data in the
 	// session recording
 	delay := timer()
-	tdpConn.OnSend = s.makeTDPSendHandler(ctx, recorder, delay, tdpConn, audit)
-	tdpConn.OnRecv = s.makeTDPReceiveHandler(ctx, recorder, delay, tdpConn, audit)
+	sendInterceptor := asInterceptor(s.makeTDPSendHandler(ctx, recorder, delay, audit))
+	receiveIntercetpr := asInterceptor(s.makeTDPReceiveHandler(ctx, recorder, delay, audit))
 
 	width, height := desktop.GetScreenSize()
 	log = log.With("screen_size", fmt.Sprintf("%dx%d", width, height))
@@ -876,8 +883,19 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 	log = log.With("kdc_addr", kdcAddr, "nla", nla)
 	log.InfoContext(context.Background(), "initiating RDP client", "client_protocol", clientProtocol)
 
+	// read the client hello and wrap the connection with a translation layer (if needed)
+	translatedConn, hello, err := rdpclient.PrepareConnecton(clientProtocol, tdpConn, log)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// These hooks snoop for TDPB messages (ignoring legacy TDP) to create necessary audit events.
+	// The client emits only TDPB messages natively, so as long as we run these hooks *above* the translation
+	// interceptors they will be able to properly interpret inbound/outbound messages for audit.
+	auditedConn := tdp.NewReadWriteInterceptor(translatedConn, receiveIntercetpr, sendInterceptor)
+
 	//nolint:staticcheck // SA4023. False positive, depends on build tags.
-	rdpc, err := rdpclient.New(tdpConn, rdpclient.Config{
+	rdpc, err := rdpclient.New(auditedConn, hello, rdpclient.Config{
 		LicenseStore:          s.cfg.LicenseStore,
 		HostID:                s.cfg.Heartbeat.HostUUID,
 		Logger:                log,
@@ -1010,7 +1028,11 @@ func populateCertMetadata(metadata *events.WindowsCertificateMetadata, cert *x50
 	metadata.EnhancedKeyUsage = enhancedKeyUsages
 }
 
-func (s *WindowsService) recordEvent(ctx context.Context, t time.Time, delay int64, m tdp.Message, data []byte, recorder libevents.SessionPreparerRecorder) {
+func (s *WindowsService) recordEvent(ctx context.Context, t time.Time, delay int64, m tdp.Message, recorder libevents.SessionPreparerRecorder) {
+	data, err := m.Encode()
+	if err != nil {
+		s.cfg.Logger.ErrorContext(ctx, "could not record message due to encoding error", "error", err, "type", logutils.TypeAttr(m))
+	}
 	e := &events.DesktopRecording{
 		Metadata: events.Metadata{
 			Type: libevents.DesktopRecordingEvent,
@@ -1038,13 +1060,12 @@ func (s *WindowsService) makeTDPSendHandler(
 	ctx context.Context,
 	recorder libevents.SessionPreparerRecorder,
 	delay func() int64,
-	tdpConn *tdp.Conn,
 	audit *desktopSessionAuditor,
-) func(m tdp.Message, b []byte) {
-	return func(msg tdp.Message, data []byte) {
+) func(m tdp.Message) error {
+	return func(msg tdp.Message) error {
 		switch m := msg.(type) {
 		case *tdpb.ServerHello, *tdpb.FastPathPDU, *tdpb.PNGFrame, *tdpb.Alert:
-			s.recordEvent(ctx, s.cfg.Clock.Now().UTC().Round(time.Millisecond), delay(), m, data, recorder)
+			s.recordEvent(ctx, s.cfg.Clock.Now().UTC().Round(time.Millisecond), delay(), m, recorder)
 		case *tdpb.ClipboardData:
 			// the TDP send handler emits a clipboard receive event, because we
 			// received clipboard data from the remote desktop and are sending
@@ -1060,23 +1081,22 @@ func (s *WindowsService) makeTDPSendHandler(
 				if errorEvent != nil {
 					// if we can't audit due to a full cache, abort the connection
 					// as a security measure
-					if err := tdpConn.Close(); err != nil {
-						s.cfg.Logger.ErrorContext(ctx, "error when terminating session for audit cache maximum size violation", "session_id", audit.sessionID)
-					}
+					err := trace.LimitExceeded("error when terminating session for audit cache maximum size violation", "")
 					s.emit(ctx, errorEvent)
+					return err
 				}
 			case *tdpbv1.SharedDirectoryRequest_Read_:
 				errorEvent := audit.onSharedDirectoryReadRequest(completionID(m.CompletionId), directoryID(m.DirectoryId), req.Read)
 				if errorEvent != nil {
 					// if we can't audit due to a full cache, abort the connection
 					// as a security measure
-					if err := tdpConn.Close(); err != nil {
-						s.cfg.Logger.ErrorContext(ctx, "error when terminating session for audit cache maximum size violation", "session_id", audit.sessionID)
-					}
+					err := trace.LimitExceeded("error when terminating session for audit cache maximum size violation", "")
 					s.emit(ctx, errorEvent)
+					return err
 				}
 			}
 		}
+		return nil
 	}
 }
 
@@ -1084,18 +1104,12 @@ func (s *WindowsService) makeTDPReceiveHandler(
 	ctx context.Context,
 	recorder libevents.SessionPreparerRecorder,
 	delay func() int64,
-	tdpConn *tdp.Conn,
 	audit *desktopSessionAuditor,
-) func(m tdp.Message) {
-	return func(m tdp.Message) {
+) func(m tdp.Message) error {
+	return func(m tdp.Message) error {
 		switch msg := m.(type) {
 		case *tdpb.ClientScreenSpec, *tdpb.MouseButton, *tdpb.MouseMove:
-			b, err := m.Encode()
-			if err != nil {
-				s.cfg.Logger.WarnContext(ctx, "could not emit desktop recording event", "error", err)
-			}
-
-			s.recordEvent(ctx, s.cfg.Clock.Now().UTC().Round(time.Millisecond), delay(), m, b, recorder)
+			s.recordEvent(ctx, s.cfg.Clock.Now().UTC().Round(time.Millisecond), delay(), m, recorder)
 		case *tdpb.ClipboardData:
 			// the TDP receive handler emits a clipboard send event, because we
 			// received clipboard data from the user (over TDP) and are sending
@@ -1107,11 +1121,9 @@ func (s *WindowsService) makeTDPReceiveHandler(
 			if errorEvent != nil {
 				// if we can't audit due to a full cache, abort the connection
 				// as a security measure
-				if err := tdpConn.Close(); err != nil {
-					s.cfg.Logger.ErrorContext(ctx, "error when terminating session for audit cache maximum size violation",
-						"session_id", audit.sessionID, "error", err)
-				}
+				err := trace.LimitExceeded("error when terminating session for audit cache maximum size violation", "")
 				s.emit(ctx, errorEvent)
+				return err
 			}
 		case *tdpb.SharedDirectoryResponse:
 			// shared directory audit events can be noisy, so we use a compactor
@@ -1123,6 +1135,7 @@ func (s *WindowsService) makeTDPReceiveHandler(
 				audit.compactor.handleWrite(ctx, audit.makeSharedDirectoryWriteResponse(completionID(msg.CompletionId), msg.ErrorCode, op.Write))
 			}
 		}
+		return nil
 	}
 }
 

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -882,17 +882,16 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 		}
 	}
 
-	// it's important that we set the OnSend and OnRecv handlers prior to
-	// initializing the client so that we capture all relevant data in the
-	// session recording
+	// Set the send and receive auditors prior to initializing the
+	// client so that we capture all relevant data in the session recording.
 	delay := timer()
-	sendInterceptor := asInterceptor(s.makeTDPSendHandler(ctx, recorder, delay, audit))
-	receiveIntercetpr := asInterceptor(s.makeTDPReceiveHandler(ctx, recorder, delay, audit))
+	sendInterceptor := asInterceptor(s.makeTDPSendAuditor(ctx, recorder, delay, audit))
+	receiveInterceptor := asInterceptor(s.makeTDPReceiveAuditor(ctx, recorder, delay, audit))
 
 	// These hooks snoop for TDPB messages (ignoring legacy TDP) to create necessary audit events.
 	// The client emits only TDPB messages natively, so as long as we run these hooks *above* the translation
 	// interceptors they will be able to properly interpret inbound/outbound messages for audit.
-	auditedConn := tdp.NewReadWriteInterceptor(translatedConn, receiveIntercetpr, sendInterceptor)
+	auditedConn := tdp.NewReadWriteInterceptor(translatedConn, receiveInterceptor, sendInterceptor)
 
 	//nolint:staticcheck // SA4023. False positive, depends on build tags.
 	rdpc, err := rdpclient.New(auditedConn, hello, rdpclient.Config{
@@ -1055,7 +1054,7 @@ func (s *WindowsService) recordEvent(ctx context.Context, t time.Time, delay int
 	}
 }
 
-func (s *WindowsService) makeTDPSendHandler(
+func (s *WindowsService) makeTDPSendAuditor(
 	ctx context.Context,
 	recorder libevents.SessionPreparerRecorder,
 	delay func() int64,
@@ -1099,7 +1098,7 @@ func (s *WindowsService) makeTDPSendHandler(
 	}
 }
 
-func (s *WindowsService) makeTDPReceiveHandler(
+func (s *WindowsService) makeTDPReceiveAuditor(
 	ctx context.Context,
 	recorder libevents.SessionPreparerRecorder,
 	delay func() int64,

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -837,20 +837,6 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 	}
 	createUsers := err == nil
 
-	// Adapt send /receive handlers to run as Interceptors.
-	asInterceptor := func(handler func(tdp.Message) error) tdp.Interceptor {
-		return func(message tdp.Message) ([]tdp.Message, error) {
-			return []tdp.Message{message}, handler(message)
-		}
-	}
-
-	// it's important that we set the OnSend and OnRecv handlers prior to
-	// initializing the client so that we capture all relevant data in the
-	// session recording
-	delay := timer()
-	sendInterceptor := asInterceptor(s.makeTDPSendHandler(ctx, recorder, delay, audit))
-	receiveIntercetpr := asInterceptor(s.makeTDPReceiveHandler(ctx, recorder, delay, audit))
-
 	width, height := desktop.GetScreenSize()
 	log = log.With("screen_size", fmt.Sprintf("%dx%d", width, height))
 
@@ -889,6 +875,20 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 		return trace.Wrap(err)
 	}
 
+	// Adapt send /receive handlers to run as Interceptors.
+	asInterceptor := func(handler func(tdp.Message) error) tdp.Interceptor {
+		return func(message tdp.Message) ([]tdp.Message, error) {
+			return []tdp.Message{message}, handler(message)
+		}
+	}
+
+	// it's important that we set the OnSend and OnRecv handlers prior to
+	// initializing the client so that we capture all relevant data in the
+	// session recording
+	delay := timer()
+	sendInterceptor := asInterceptor(s.makeTDPSendHandler(ctx, recorder, delay, audit))
+	receiveIntercetpr := asInterceptor(s.makeTDPReceiveHandler(ctx, recorder, delay, audit))
+
 	// These hooks snoop for TDPB messages (ignoring legacy TDP) to create necessary audit events.
 	// The client emits only TDPB messages natively, so as long as we run these hooks *above* the translation
 	// interceptors they will be able to properly interpret inbound/outbound messages for audit.
@@ -910,7 +910,6 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 		Height:                height,
 		AD:                    !desktop.NonAD(),
 		NLA:                   nla,
-		ClientProtocol:        clientProtocol,
 	})
 	// before we check the error above, we grab the Windows user so that
 	// future audit events include the proper username
@@ -1081,7 +1080,7 @@ func (s *WindowsService) makeTDPSendHandler(
 				if errorEvent != nil {
 					// if we can't audit due to a full cache, abort the connection
 					// as a security measure
-					err := trace.LimitExceeded("error when terminating session for audit cache maximum size violation", "")
+					err := trace.LimitExceeded("error when terminating session for audit cache maximum size violation")
 					s.emit(ctx, errorEvent)
 					return err
 				}
@@ -1090,7 +1089,7 @@ func (s *WindowsService) makeTDPSendHandler(
 				if errorEvent != nil {
 					// if we can't audit due to a full cache, abort the connection
 					// as a security measure
-					err := trace.LimitExceeded("error when terminating session for audit cache maximum size violation", "")
+					err := trace.LimitExceeded("error when terminating session for audit cache maximum size violation")
 					s.emit(ctx, errorEvent)
 					return err
 				}
@@ -1121,7 +1120,7 @@ func (s *WindowsService) makeTDPReceiveHandler(
 			if errorEvent != nil {
 				// if we can't audit due to a full cache, abort the connection
 				// as a security measure
-				err := trace.LimitExceeded("error when terminating session for audit cache maximum size violation", "")
+				err := trace.LimitExceeded("error when terminating session for audit cache maximum size violation")
 				s.emit(ctx, errorEvent)
 				return err
 			}

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -955,7 +955,7 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 		UserOriginClusterName: identity.OriginClusterName,
 		ServerID:              s.cfg.Heartbeat.HostUUID,
 		IdleTimeoutMessage:    netConfig.GetClientIdleTimeoutMessage(),
-		MessageWriter:         &monitorErrorSender{tdpConn: tdpConn},
+		MessageWriter:         &monitorErrorSender{tdpConn: translatedConn},
 	}
 
 	// UpdateClientActivity before starting monitor to
@@ -1393,7 +1393,7 @@ func (s *WindowsService) trackSession(ctx context.Context, id *tlsca.Identity, w
 // monitor disconnect messages back to the frontend
 // over the tdp.Conn
 type monitorErrorSender struct {
-	tdpConn *tdp.Conn
+	tdpConn tdp.MessageWriter
 }
 
 func (m *monitorErrorSender) WriteString(s string) (n int, err error) {

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -953,7 +953,7 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 		UserOriginClusterName: identity.OriginClusterName,
 		ServerID:              s.cfg.Heartbeat.HostUUID,
 		IdleTimeoutMessage:    netConfig.GetClientIdleTimeoutMessage(),
-		MessageWriter:         &monitorErrorSender{tdpConn: translatedConn},
+		MessageWriter:         &monitorErrorSender{tdpConn: auditedConn},
 	}
 
 	// UpdateClientActivity before starting monitor to

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -1030,6 +1030,7 @@ func (s *WindowsService) recordEvent(ctx context.Context, t time.Time, delay int
 	data, err := m.Encode()
 	if err != nil {
 		s.cfg.Logger.ErrorContext(ctx, "could not record message due to encoding error", "error", err, "type", logutils.TypeAttr(m))
+		return
 	}
 	e := &events.DesktopRecording{
 		Metadata: events.Metadata{

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -315,7 +315,7 @@ func TestEmitsRecordingEventsOnSend(t *testing.T) {
 	emitterPreparer := libevents.WithNoOpPreparer(emitter)
 
 	delay := func() int64 { return 0 }
-	handler := s.makeTDPSendHandler(context.Background(), emitterPreparer, delay, nil /* auditor */)
+	handler := s.makeTDPSendAuditor(context.Background(), emitterPreparer, delay, nil /* auditor */)
 
 	msg := &tdpb.PNGFrame{Data: []byte{0x01, 0x02}}
 	encoded, err := msg.Encode()
@@ -346,7 +346,7 @@ func TestSkipsExtremelyLargePNGs(t *testing.T) {
 	png := &tdpb.PNGFrame{Data: maliciousPNG}
 
 	delay := func() int64 { return 0 }
-	handler := s.makeTDPSendHandler(context.Background(), emitterPreparer, delay, nil /* auditor */)
+	handler := s.makeTDPSendAuditor(context.Background(), emitterPreparer, delay, nil /* auditor */)
 	require.NoError(t, handler(png))
 
 	require.Nil(t, emitter.LastEvent())
@@ -363,7 +363,7 @@ func TestEmitsRecordingEventsOnReceive(t *testing.T) {
 	emitterPreparer := libevents.WithNoOpPreparer(emitter)
 
 	delay := func() int64 { return 0 }
-	handler := s.makeTDPReceiveHandler(context.Background(), emitterPreparer, delay, nil /* auditor */)
+	handler := s.makeTDPReceiveAuditor(context.Background(), emitterPreparer, delay, nil /* auditor */)
 
 	msg := &tdpb.MouseButton{
 		Button:  tdpbv1.MouseButtonType_MOUSE_BUTTON_TYPE_LEFT,
@@ -390,7 +390,7 @@ func TestEmitsClipboardSendEvents(t *testing.T) {
 		},
 	}
 
-	handler := s.makeTDPReceiveHandler(
+	handler := s.makeTDPReceiveAuditor(
 		context.Background(),
 		libevents.WithNoOpPreparer(&libevents.DiscardRecorder{}),
 		func() int64 { return 0 },
@@ -427,7 +427,7 @@ func TestEmitsClipboardReceiveEvents(t *testing.T) {
 		},
 	}
 
-	handler := s.makeTDPSendHandler(
+	handler := s.makeTDPSendAuditor(
 		context.Background(),
 		libevents.WithNoOpPreparer(&libevents.DiscardRecorder{}),
 		func() int64 { return 0 },

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -50,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
 	"github.com/gravitational/teleport/lib/subca/testenv"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -316,12 +315,12 @@ func TestEmitsRecordingEventsOnSend(t *testing.T) {
 	emitterPreparer := libevents.WithNoOpPreparer(emitter)
 
 	delay := func() int64 { return 0 }
-	handler := s.makeTDPSendHandler(context.Background(), emitterPreparer, delay, nil /* conn */, nil /* auditor */)
+	handler := s.makeTDPSendHandler(context.Background(), emitterPreparer, delay, nil /* auditor */)
 
 	msg := &tdpb.PNGFrame{Data: []byte{0x01, 0x02}}
 	encoded, err := msg.Encode()
 	require.NoError(t, err)
-	handler(msg, encoded)
+	require.NoError(t, handler(msg))
 
 	e := emitter.LastEvent()
 	require.NotNil(t, e)
@@ -345,13 +344,10 @@ func TestSkipsExtremelyLargePNGs(t *testing.T) {
 	maliciousPNG := make([]byte, constants.MaxProtoMessageSizeBytes+1)
 	rand.Read(maliciousPNG)
 	png := &tdpb.PNGFrame{Data: maliciousPNG}
-	encoded, err := png.Encode()
-	require.NoError(t, err)
 
 	delay := func() int64 { return 0 }
-	handler := s.makeTDPSendHandler(context.Background(), emitterPreparer, delay, nil /* conn */, nil /* auditor */)
-
-	handler(png, encoded)
+	handler := s.makeTDPSendHandler(context.Background(), emitterPreparer, delay, nil /* auditor */)
+	require.NoError(t, handler(png))
 
 	require.Nil(t, emitter.LastEvent())
 }
@@ -367,7 +363,7 @@ func TestEmitsRecordingEventsOnReceive(t *testing.T) {
 	emitterPreparer := libevents.WithNoOpPreparer(emitter)
 
 	delay := func() int64 { return 0 }
-	handler := s.makeTDPReceiveHandler(context.Background(), emitterPreparer, delay, nil /* conn */, nil /* auditor */)
+	handler := s.makeTDPReceiveHandler(context.Background(), emitterPreparer, delay, nil /* auditor */)
 
 	msg := &tdpb.MouseButton{
 		Button:  tdpbv1.MouseButtonType_MOUSE_BUTTON_TYPE_LEFT,
@@ -398,7 +394,6 @@ func TestEmitsClipboardSendEvents(t *testing.T) {
 		context.Background(),
 		libevents.WithNoOpPreparer(&libevents.DiscardRecorder{}),
 		func() int64 { return 0 },
-		&tdp.Conn{},
 		audit,
 	)
 
@@ -436,7 +431,6 @@ func TestEmitsClipboardReceiveEvents(t *testing.T) {
 		context.Background(),
 		libevents.WithNoOpPreparer(&libevents.DiscardRecorder{}),
 		func() int64 { return 0 },
-		&tdp.Conn{},
 		audit,
 	)
 
@@ -445,9 +439,7 @@ func TestEmitsClipboardReceiveEvents(t *testing.T) {
 
 	start := s.cfg.Clock.Now().UTC()
 	msg := &tdpb.ClipboardData{Data: fakeClipboardData}
-	encoded, err := msg.Encode()
-	require.NoError(t, err)
-	handler(msg, encoded)
+	require.NoError(t, handler(msg))
 
 	e := emitter.LastEvent()
 	require.NotNil(t, e)


### PR DESCRIPTION
The Desktop Service's audit hooks snoop for specific, concrete TDPB message types for which to emit specific audit events.  When legacy (TDP) proxy/clients connect to the service no audit messages are received because these hooks snoop messages *after* they are translated to legacy messages. This also disrupts session recordings since they're captured using the same mechanism.

This PR fixes this by re-working the hooks to run before translation happens. It also fixes a minor regression the way our service monitor emits error messages. Similarly, it would write TDPB in a way that bypasses translation. This is fixed by providing it a handle to an abstracted connection instance that applies translation to TDP.



<!-- Provide a descriptive entry for the changelog of the next release. -->

No changelog. TDPB has not yet been released.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster with a Proxy/Auth instance running V18 (TDP only) and a WDS instance running this branch.
### Test Cases
- [x] Start a desktop session and start doing "auditable" actions (share a directory, read/write/create/delete files within a shared directory, run clipboard operations, etc). Note that the audit log contains events corresponding to these actions
- [x] Verify that a session recording exists for the test above (It will only be playable from a UI version that supports TDPB).
- [x] Set the `client_idle_timeout` on the auth service configuration to 1m. Start a desktop session and let it time out. Verify that the error message looks like `Client exceeded idle timeout of X`, instead of `unsupported desktop protocol message`, which is what appeared before this fix.
