### PR TITLE
Terraform teleport/discovery/aws change kube_app_discovery default

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -79,7 +79,7 @@ module "aws_discovery" {
 | `regions` | `list(string)` | (required) | AWS regions to search. EC2 supports `"*"` for all regions. EKS requires explicit regions. |
 | `tags` | `map(list(string))` | `{ "*" : ["*"] }` | AWS resource tags to match. The default matches all resources. |
 | `setup_access_for_arn` | `string` | `""` | ARN to configure access for discovered EKS clusters. Only supported for EKS matchers. |
-| `kube_app_discovery` | `bool` | `true` | Teleport's Kubernetes App Discovery will automatically identify and enroll to Teleport HTTP applications running inside a Kubernetes cluster. |
+| `kube_app_discovery` | `bool` | `null` | Teleport's Kubernetes App Discovery will automatically identify and enroll to Teleport HTTP applications running inside a Kubernetes cluster. |
 
 ## How to get help
 
@@ -140,7 +140,7 @@ No modules.
 | aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
-| aws\_matchers | AWS resource discovery matchers. Valid values for aws\_matchers.types are: ec2, eks. | ```list(object({ types = list(string) regions = optional(list(string), ["*"]) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool, true) }))``` | `[]` | no |
+| aws\_matchers | AWS resource discovery matchers. Valid values for aws\_matchers.types are: ec2, eks. | ```list(object({ types = list(string) regions = optional(list(string), ["*"]) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool) }))``` | `[]` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
 | discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool, true) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -65,7 +65,7 @@ module "aws_discovery" {
 | `regions` | `list(string)` | (required) | AWS regions to search. EC2 supports `"*"` for all regions. EKS requires explicit regions. |
 | `tags` | `map(list(string))` | `{ "*" : ["*"] }` | AWS resource tags to match. The default matches all resources. |
 | `setup_access_for_arn` | `string` | `""` | ARN to configure access for discovered EKS clusters. Only supported for EKS matchers. |
-| `kube_app_discovery` | `bool` | `true` | Teleport's Kubernetes App Discovery will automatically identify and enroll to Teleport HTTP applications running inside a Kubernetes cluster. |
+| `kube_app_discovery` | `bool` | `null` | Teleport's Kubernetes App Discovery will automatically identify and enroll to Teleport HTTP applications running inside a Kubernetes cluster. |
 
 ## How to get help
 
@@ -126,7 +126,7 @@ No modules.
 | aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
 | aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
 | aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
-| aws\_matchers | AWS resource discovery matchers. Valid values for aws\_matchers.types are: ec2, eks. | ```list(object({ types = list(string) regions = optional(list(string), ["*"]) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool, true) }))``` | `[]` | no |
+| aws\_matchers | AWS resource discovery matchers. Valid values for aws\_matchers.types are: ec2, eks. | ```list(object({ types = list(string) regions = optional(list(string), ["*"]) tags = optional(map(list(string)), { "*" : ["*"] }) setup_access_for_arn = optional(string, "") kube_app_discovery = optional(bool) }))``` | `[]` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
 | discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool, true) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/main.tf
@@ -21,6 +21,8 @@ module "aws_discovery" {
       tags = {
         team = ["platform"]
       }
+      # Teleport's Kubernetes App Discovery will automatically identify and enroll HTTP applications running inside a Kubernetes cluster.
+      kube_app_discovery = true
     }
   ]
 

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
@@ -15,7 +15,7 @@ locals {
       regions              = var.match_aws_regions
       tags                 = var.match_aws_tags
       setup_access_for_arn = ""
-      kube_app_discovery   = false
+      kube_app_discovery   = null
     }
   ]
 
@@ -66,7 +66,7 @@ locals {
         setup_access_for_arn = matcher.setup_access_for_arn
       } : {},
       contains(matcher.types, "eks") ? {
-        kube_app_discovery = matcher.kube_app_discovery
+        kube_app_discovery = matcher.kube_app_discovery == false ? null : matcher.kube_app_discovery
       } : {}
     )
   ]

--- a/integrations/terraform-modules/teleport/discovery/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/variables.tf
@@ -48,7 +48,7 @@ variable "aws_matchers" {
     regions              = optional(list(string), ["*"])
     tags                 = optional(map(list(string)), { "*" : ["*"] })
     setup_access_for_arn = optional(string, "")
-    kube_app_discovery   = optional(bool, true)
+    kube_app_discovery   = optional(bool)
   }))
   default  = []
   nullable = false


### PR DESCRIPTION
RE https://github.com/gravitational/teleport/pull/65675 and https://github.com/gravitational/protoc-gen-terraform/pull/66

The terraform provider has a bug: The "zero" value, which is treated as "unset", for booleans is false. So when a boolean field is explicitly set to false, it's returned from the provider as null, which causes a terraform inconsistency error. Fully fixing the provider could be substantial, so the immediate remediation is to use null as the false value to match the provider. The default value for this setting is false, so using null works.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Applying a local terraform config against my staging tenant charles-eks1 (which is running 18.7.4-dev.disceks.7 with the updated provider).

### Test Cases

1) `terraform apply` > check no errors
2) `tctl get discovery_config/discovery-aws-account-278576220453` > check `kube_app_discovery` value
3) `terraform destroy`

- [x] -
```
# Terraform Module
module "aws_discovery" {
  source  = "terraform-staging.releases.development.teleport.dev/teleport/discovery/aws"
  version = "18.7.4-dev.disceks.7"

  teleport_integration_use_name_prefix = false

  teleport_proxy_public_addr    = "charles-eks1.cloud.gravitational.io:443"
  teleport_discovery_group_name = "cloud-discovery-group"
  teleport_integration_name     = "aws-integration-3809d4ae"

  aws_matchers = [
    {
      types   = ["eks"]
      regions = ["us-west-2"]
      tags = {
        "teleport.dev/group" = ["test"]
      }
      kube_app_discovery = false
    }
  ]
}
```

- [x] - 
```
# Terraform Module
module "aws_discovery" {
  source  = "terraform-staging.releases.development.teleport.dev/teleport/discovery/aws"
  version = "18.7.4-dev.disceks.7"

  teleport_integration_use_name_prefix = false

  teleport_proxy_public_addr    = "charles-eks1.cloud.gravitational.io:443"
  teleport_discovery_group_name = "cloud-discovery-group"
  teleport_integration_name     = "aws-integration-3809d4ae"

  aws_matchers = [
    {
      types   = ["eks"]
      regions = ["us-west-2"]
      tags = {
        "teleport.dev/group" = ["test"]
      }
      kube_app_discovery = true
    }
  ]
}
```

- [x] -
```
# Terraform Module
module "aws_discovery" {
  source  = "terraform-staging.releases.development.teleport.dev/teleport/discovery/aws"
  version = "18.7.4-dev.disceks.7"

  teleport_integration_use_name_prefix = false

  teleport_proxy_public_addr    = "charles-eks1.cloud.gravitational.io:443"
  teleport_discovery_group_name = "cloud-discovery-group"
  teleport_integration_name     = "aws-integration-3809d4ae"

  aws_matchers = [
    {
      types   = ["eks"]
      regions = ["us-west-2"]
      tags = {
        "teleport.dev/group" = ["test"]
      }
    }
  ]
}
```
