### PR TITLE
Wire CertAuthorityOverride resources to the cache

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -35,6 +35,7 @@ import (
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	summaryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
@@ -206,6 +207,10 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 	case types.Resource153UnwrapperT[*summaryv1.RetrievalModel]:
 		out.Resource = &proto.Event_RetrievalModel{
 			RetrievalModel: r.UnwrapT(),
+		}
+	case types.Resource153UnwrapperT[*subcav1.CertAuthorityOverride]:
+		out.Resource = &proto.Event_CertAuthorityOverride{
+			CertAuthorityOverride: r.UnwrapT(),
 		}
 	case validatedMFAChallengeUnwrapper:
 		out.Resource = &proto.Event_ValidatedMFAChallenge{
@@ -740,6 +745,9 @@ func EventFromGRPC(in *proto.Event) (*types.Event, error) {
 		return &out, nil
 	} else if r := in.GetRetrievalModel(); r != nil {
 		out.Resource = types.Resource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetCertAuthorityOverride(); r != nil {
+		out.Resource = types.ProtoResource153ToLegacy(r)
 		return &out, nil
 	} else if r := in.GetValidatedMFAChallenge(); r != nil {
 		out.Resource = &validatedMFAChallengeResourceWrapper{

--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -120,6 +120,7 @@ type Config struct {
 	AppAuthConfig           services.AppAuthConfigReader
 	WorkloadClusterService  services.WorkloadClusterService
 	Summarizer              services.Summarizer
+	SubCAService            services.SubCAServiceGetter
 }
 
 func (c *Config) CheckAndSetDefaults() error {
@@ -211,6 +212,7 @@ func NewCache(cfg Config) (*cache.Cache, error) {
 		AppAuthConfig:           cfg.AppAuthConfig,
 		WorkloadClusterService:  cfg.WorkloadClusterService,
 		Summarizer:              cfg.Summarizer,
+		SubCAService:            cfg.SubCAService,
 	}
 
 	return cache.New(cfg.Setup(cacheCfg))

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -668,7 +668,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 			Backend: cfg.Backend,
 		})
 		if err != nil {
-			return nil, trace.Wrap(err, "creating WorkloadClusterService")
+			return nil, trace.Wrap(err, "creating SubCAService")
 		}
 	}
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -662,6 +662,16 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		}
 	}
 
+	if cfg.SubCAService == nil {
+		var err error
+		cfg.SubCAService, err = local.NewSubCAService(local.SubCAServiceParams{
+			Backend: cfg.Backend,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err, "creating WorkloadClusterService")
+		}
+	}
+
 	services := &Services{
 		TrustInternal:                   cfg.Trust,
 		PresenceInternal:                cfg.Presence,
@@ -726,6 +736,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		MFAService:                      cfg.MFAService,
 		WorkloadClusterService:          cfg.WorkloadClusterService,
 		Beams:                           cfg.Beams,
+		SubCAService:                    cfg.SubCAService,
 	}
 
 	if cfg.FakePasswordHash == nil {

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1494,6 +1494,9 @@ type Cache interface {
 	services.SummarizerServiceGetter
 	// BeamReader defines methods for reading beam resources.
 	services.BeamReader
+
+	// SubCAServiceGetter reads CertAuthorityOverride resources.
+	services.SubCAServiceGetter
 }
 
 type NodeWrapper struct {

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -650,6 +650,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		StaticScopedToken:       p.AuthServer.Services.ClusterConfigurationInternal,
 		WorkloadClusterService:  p.AuthServer.Services.WorkloadClusterService,
 		Summarizer:              p.AuthServer.Services.Summarizer,
+		SubCAService:            p.AuthServer.Services.SubCAService,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -451,6 +451,9 @@ type InitConfig struct {
 	// Beams is the service for reading and writing beams.
 	Beams services.Beams
 
+	// SubCAService manages CertAuthorityOverride resources.
+	SubCAService services.SubCAService
+
 	// FakePasswordHash is the password hash given to all users without a password.
 	// This helps eliminate timing attacks by ensuring that all authentication attempts
 	// with a password do a bcrypt comparison.

--- a/lib/auth/services.go
+++ b/lib/auth/services.go
@@ -99,6 +99,7 @@ type Services struct {
 	MFAService
 	services.WorkloadClusterService
 	services.Beams
+	services.SubCAService
 }
 
 // MFAService defines the interface for managing MFA resources in the backend.

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -139,6 +139,7 @@ func ForAuth(cfg Config) Config {
 	cfg.EnableRelativeExpiry = true
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindCertAuthority, LoadSecrets: true},
+		//{Kind: types.KindCertAuthorityOverride},
 		{Kind: types.KindClusterName},
 		{Kind: types.KindClusterAuditConfig},
 		{Kind: types.KindClusterNetworkingConfig},

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -139,7 +139,7 @@ func ForAuth(cfg Config) Config {
 	cfg.EnableRelativeExpiry = true
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindCertAuthority, LoadSecrets: true},
-		//{Kind: types.KindCertAuthorityOverride},
+		{Kind: types.KindCertAuthorityOverride},
 		{Kind: types.KindClusterName},
 		{Kind: types.KindClusterAuditConfig},
 		{Kind: types.KindClusterNetworkingConfig},
@@ -808,6 +808,8 @@ type Config struct {
 	WorkloadClusterService services.WorkloadClusterService
 	// Summarizer is a summarizer service.
 	Summarizer services.Summarizer
+	// SubCAService reads CertAuthorityOverride resources.
+	SubCAService services.SubCAServiceGetter
 }
 
 // CheckAndSetDefaults checks parameters and sets default values

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -60,6 +60,7 @@ import (
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	summaryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
@@ -2015,6 +2016,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindInferenceSecret:                   types.Resource153ToLegacy(new(summaryv1.InferenceSecret)),
 		types.KindInferencePolicy:                   types.Resource153ToLegacy(new(summaryv1.InferencePolicy)),
 		types.KindRetrievalModel:                    types.Resource153ToLegacy(new(summaryv1.RetrievalModel)),
+		types.KindCertAuthorityOverride:             types.Resource153ToLegacy(&subcav1.CertAuthorityOverride{}),
 		types.KindValidatedMFAChallenge:             &types.ResourceHeader{Kind: types.KindValidatedMFAChallenge},
 	}
 
@@ -2099,6 +2101,8 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*summaryv1.InferencePolicy]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				case types.Resource153UnwrapperT[*summaryv1.RetrievalModel]:
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*summaryv1.RetrievalModel]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+				case types.Resource153UnwrapperT[*subcav1.CertAuthorityOverride]:
+					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*subcav1.CertAuthorityOverride]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 
 				case types.Resource153UnwrapperT[*beamsv1.Beam]:
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*beamsv1.Beam]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -178,6 +178,7 @@ type testPack struct {
 	appAuthConfigs          *local.AppAuthConfigService
 	workloadClusters        *local.WorkloadClusterService
 	summarizer              *local.SummarizerService
+	subCA                   *local.SubCAService
 }
 
 // resourceOps contains helpers to modify the state of either types.Resource or types.Resource153  which
@@ -557,6 +558,13 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	p.subCA, err = local.NewSubCAService(local.SubCAServiceParams{
+		Backend: p.backend,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return p, nil
 }
 
@@ -624,6 +632,7 @@ func newPack(t testing.TB, setupConfig func(c Config) Config, opts ...packOption
 		StaticScopedToken:       p.clusterConfigS,
 		WorkloadClusterService:  p.workloadClusters,
 		Summarizer:              p.summarizer,
+		SubCAService:            p.subCA,
 	}))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -898,6 +907,7 @@ func TestCompletenessInit(t *testing.T) {
 			StaticScopedToken:       p.clusterConfigS,
 			WorkloadClusterService:  p.workloadClusters,
 			Summarizer:              p.summarizer,
+			SubCAService:            p.subCA,
 		}))
 		require.NoError(t, err)
 
@@ -991,6 +1001,7 @@ func TestCompletenessReset(t *testing.T) {
 		StaticScopedToken:       p.clusterConfigS,
 		WorkloadClusterService:  p.workloadClusters,
 		Summarizer:              p.summarizer,
+		SubCAService:            p.subCA,
 	}))
 	require.NoError(t, err)
 
@@ -1160,6 +1171,7 @@ func TestListResources_NodesTTLVariant(t *testing.T) {
 		StaticScopedToken:       p.clusterConfigS,
 		WorkloadClusterService:  p.workloadClusters,
 		Summarizer:              p.summarizer,
+		SubCAService:            p.subCA,
 	}))
 	require.NoError(t, err)
 
@@ -1264,6 +1276,7 @@ func initStrategy(t *testing.T) {
 		StaticScopedToken:       p.clusterConfigS,
 		WorkloadClusterService:  p.workloadClusters,
 		Summarizer:              p.summarizer,
+		SubCAService:            p.subCA,
 	}))
 	require.NoError(t, err)
 

--- a/lib/cache/cert_authority_override.go
+++ b/lib/cache/cert_authority_override.go
@@ -42,9 +42,9 @@ func (c *Cache) GetCertAuthorityOverride(
 	getter := genericGetter[*subcav1.CertAuthorityOverride, certAuthorityOverrideIndex]{
 		cache:      c,
 		collection: c.collections.certAuthorityOverrides,
-		index:      certAuthorityOverrideFullNameIndex,
-		upstreamGet: func(ctx context.Context, fullName string) (*subcav1.CertAuthorityOverride, error) {
-			id, err := parseCAOverrideFullName(fullName)
+		index:      certAuthorityOverrideCacheNameIndex,
+		upstreamGet: func(ctx context.Context, cacheName string) (*subcav1.CertAuthorityOverride, error) {
+			id, err := parseCAOverrideCacheName(cacheName)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -53,7 +53,7 @@ func (c *Cache) GetCertAuthorityOverride(
 		},
 	}
 
-	out, err := getter.get(ctx, id.FullName())
+	out, err := getter.get(ctx, caOverrideIDCacheName(id))
 	return out, trace.Wrap(err)
 }
 
@@ -65,12 +65,12 @@ func (c *Cache) ListCertAuthorityOverrides(ctx context.Context, pageSize int, pa
 	lister := genericLister[*subcav1.CertAuthorityOverride, certAuthorityOverrideIndex]{
 		cache:      c,
 		collection: c.collections.certAuthorityOverrides,
-		index:      certAuthorityOverrideFullNameIndex,
+		index:      certAuthorityOverrideCacheNameIndex,
 		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*subcav1.CertAuthorityOverride, string, error) {
 			out, next, err := c.SubCAService.ListCertAuthorityOverrides(ctx, pageSize, pageToken)
 			return out, next, trace.Wrap(err)
 		},
-		nextToken: caOverrideFullName,
+		nextToken: caOverrideCacheName,
 	}
 
 	out, next, err := lister.list(ctx, pageSize, pageToken)
@@ -80,8 +80,8 @@ func (c *Cache) ListCertAuthorityOverrides(ctx context.Context, pageSize int, pa
 type certAuthorityOverrideIndex string
 
 const (
-	// certAuthorityOverrideFullNameIndex indexes by sub_kind+name.
-	certAuthorityOverrideFullNameIndex certAuthorityOverrideIndex = "full_name"
+	// certAuthorityOverrideCacheNameIndex indexes by backend ID, ie name+sub_kind.
+	certAuthorityOverrideCacheNameIndex certAuthorityOverrideIndex = "cache_name"
 )
 
 func newCertAuthorityOverrideCollection(
@@ -97,7 +97,7 @@ func newCertAuthorityOverrideCollection(
 			types.KindCertAuthorityOverride,
 			proto.CloneOf[*subcav1.CertAuthorityOverride],
 			map[certAuthorityOverrideIndex]func(*subcav1.CertAuthorityOverride) string{
-				certAuthorityOverrideFullNameIndex: caOverrideFullName,
+				certAuthorityOverrideCacheNameIndex: caOverrideCacheName,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*subcav1.CertAuthorityOverride, error) {
 			out, err := stream.Collect(clientutils.Resources(
@@ -122,21 +122,20 @@ func newCertAuthorityOverrideCollection(
 	}, nil
 }
 
-func caOverrideFullName(r *subcav1.CertAuthorityOverride) string {
-	id := types.CertAuthorityOverrideID{
-		ClusterName: r.GetMetadata().GetName(),
-		CAType:      r.GetSubKind(),
-	}
-	return id.FullName()
+func caOverrideIDCacheName(id types.CertAuthorityOverrideID) string {
+	return id.ClusterName + "/" + id.CAType
+}
+func caOverrideCacheName(r *subcav1.CertAuthorityOverride) string {
+	return r.GetMetadata().GetName() + "/" + r.GetSubKind()
 }
 
-func parseCAOverrideFullName(fullName string) (*types.CertAuthorityOverrideID, error) {
-	parts := strings.SplitN(fullName, "/", 2)
+func parseCAOverrideCacheName(cacheName string) (*types.CertAuthorityOverrideID, error) {
+	parts := strings.SplitN(cacheName, "/", 2)
 	if len(parts) != 2 {
-		return nil, trace.BadParameter("invalid CA override identifier: %q", fullName)
+		return nil, trace.BadParameter("invalid CA override identifier: %q", cacheName)
 	}
 	return &types.CertAuthorityOverrideID{
-		CAType:      parts[0],
-		ClusterName: parts[1],
+		ClusterName: parts[0],
+		CAType:      parts[1],
 	}, nil
 }

--- a/lib/cache/cert_authority_override.go
+++ b/lib/cache/cert_authority_override.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
 
-	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -106,17 +105,6 @@ func newCertAuthorityOverrideCollection(
 					return upstream.ListCertAuthorityOverrides(ctx, pageSize, pageToken)
 				}))
 			return out, trace.Wrap(err)
-		},
-		headerTransform: func(hdr *types.ResourceHeader) *subcav1.CertAuthorityOverride {
-			return &subcav1.CertAuthorityOverride{
-				Kind:    hdr.Kind,
-				Version: hdr.Version,
-				SubKind: hdr.SubKind,
-				Metadata: &headerv1.Metadata{
-					Name:        hdr.Metadata.Name,
-					Description: hdr.Metadata.Description,
-				},
-			}
 		},
 		watch: watchKind,
 	}, nil

--- a/lib/cache/cert_authority_override.go
+++ b/lib/cache/cert_authority_override.go
@@ -1,0 +1,142 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// GetCertAuthorityOverride reads a CA override resource by ID.
+func (c *Cache) GetCertAuthorityOverride(
+	ctx context.Context,
+	id types.CertAuthorityOverrideID,
+) (*subcav1.CertAuthorityOverride, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetCertAuthorityOverride")
+	defer span.End()
+
+	getter := genericGetter[*subcav1.CertAuthorityOverride, certAuthorityOverrideIndex]{
+		cache:      c,
+		collection: c.collections.certAuthorityOverrides,
+		index:      certAuthorityOverrideFullNameIndex,
+		upstreamGet: func(ctx context.Context, fullName string) (*subcav1.CertAuthorityOverride, error) {
+			id, err := parseCAOverrideFullName(fullName)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			resource, err := c.SubCAService.GetCertAuthorityOverride(ctx, *id)
+			return resource, trace.Wrap(err)
+		},
+	}
+
+	out, err := getter.get(ctx, id.FullName())
+	return out, trace.Wrap(err)
+}
+
+// ListCertAuthorityOverrides lists all CA overrides.
+func (c *Cache) ListCertAuthorityOverrides(ctx context.Context, pageSize int, pageToken string) (_ []*subcav1.CertAuthorityOverride, nextPageToken string, _ error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListCertAuthorityOverrides")
+	defer span.End()
+
+	lister := genericLister[*subcav1.CertAuthorityOverride, certAuthorityOverrideIndex]{
+		cache:      c,
+		collection: c.collections.certAuthorityOverrides,
+		index:      certAuthorityOverrideFullNameIndex,
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*subcav1.CertAuthorityOverride, string, error) {
+			out, next, err := c.SubCAService.ListCertAuthorityOverrides(ctx, pageSize, pageToken)
+			return out, next, trace.Wrap(err)
+		},
+		nextToken: caOverrideFullName,
+	}
+
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+type certAuthorityOverrideIndex string
+
+const (
+	// certAuthorityOverrideFullNameIndex indexes by sub_kind+name.
+	certAuthorityOverrideFullNameIndex certAuthorityOverrideIndex = "full_name"
+)
+
+func newCertAuthorityOverrideCollection(
+	upstream services.SubCAServiceGetter,
+	watchKind types.WatchKind,
+) (*collection[*subcav1.CertAuthorityOverride, certAuthorityOverrideIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter SubCAService")
+	}
+
+	return &collection[*subcav1.CertAuthorityOverride, certAuthorityOverrideIndex]{
+		store: newStore(
+			types.KindCertAuthorityOverride,
+			proto.CloneOf[*subcav1.CertAuthorityOverride],
+			map[certAuthorityOverrideIndex]func(*subcav1.CertAuthorityOverride) string{
+				certAuthorityOverrideFullNameIndex: caOverrideFullName,
+			}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*subcav1.CertAuthorityOverride, error) {
+			out, err := stream.Collect(clientutils.Resources(
+				ctx,
+				func(ctx context.Context, pageSize int, pageToken string) ([]*subcav1.CertAuthorityOverride, string, error) {
+					return upstream.ListCertAuthorityOverrides(ctx, pageSize, pageToken)
+				}))
+			return out, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *subcav1.CertAuthorityOverride {
+			return &subcav1.CertAuthorityOverride{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				SubKind: hdr.SubKind,
+				Metadata: &headerv1.Metadata{
+					Name:        hdr.Metadata.Name,
+					Description: hdr.Metadata.Description,
+				},
+			}
+		},
+		watch: watchKind,
+	}, nil
+}
+
+func caOverrideFullName(r *subcav1.CertAuthorityOverride) string {
+	id := types.CertAuthorityOverrideID{
+		ClusterName: r.GetMetadata().GetName(),
+		CAType:      r.GetSubKind(),
+	}
+	return id.FullName()
+}
+
+func parseCAOverrideFullName(fullName string) (*types.CertAuthorityOverrideID, error) {
+	parts := strings.SplitN(fullName, "/", 2)
+	if len(parts) != 2 {
+		return nil, trace.BadParameter("invalid CA override identifier: %q", fullName)
+	}
+	return &types.CertAuthorityOverrideID{
+		CAType:      parts[0],
+		ClusterName: parts[1],
+	}, nil
+}

--- a/lib/cache/cert_authority_override_test.go
+++ b/lib/cache/cert_authority_override_test.go
@@ -1,0 +1,99 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+func TestCertAuthorityOverrides(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	const caType = types.DatabaseClientCA
+
+	testResources153(t, p, testFuncs[*subcav1.CertAuthorityOverride]{
+		newResource: func(name string) (*subcav1.CertAuthorityOverride, error) {
+			return newCertAuthorityOverride(caType, name), nil
+		},
+		create: func(ctx context.Context, r *subcav1.CertAuthorityOverride) error {
+			_, err := p.subCA.CreateCertAuthorityOverride(ctx, r)
+			return err
+		},
+		list: func(ctx context.Context, pageSize int, pageToken string) ([]*subcav1.CertAuthorityOverride, string, error) {
+			return p.subCA.ListCertAuthorityOverrides(ctx, pageSize, pageToken)
+		},
+		cacheGet: func(ctx context.Context, name string) (*subcav1.CertAuthorityOverride, error) {
+			return p.cache.GetCertAuthorityOverride(ctx, types.CertAuthorityOverrideID{
+				CAType:      string(caType),
+				ClusterName: name,
+			})
+		},
+		cacheList: p.cache.ListCertAuthorityOverrides,
+		update: func(ctx context.Context, r *subcav1.CertAuthorityOverride) error {
+			_, err := p.subCA.UpdateCertAuthorityOverride(ctx, r)
+			return err
+		},
+		delete: func(ctx context.Context, name string) error {
+			return p.subCA.DeleteCertAuthorityOverride(ctx, types.CertAuthorityOverrideID{
+				CAType:      string(caType),
+				ClusterName: name,
+			})
+		},
+		deleteAll: func(ctx context.Context) error {
+			const pageSize = 1000 // Arbitrary.
+			pageToken := ""
+			for {
+				resources, nextPageToken, err := p.subCA.ListCertAuthorityOverrides(ctx, pageSize, pageToken)
+				if err != nil {
+					return fmt.Errorf("deleteAll: list overrides: %w", err)
+				}
+				for _, r := range resources {
+					if err := p.subCA.DeleteCertAuthorityOverride(ctx, local.CertAuthorityOverrideIDFromResource(r)); err != nil {
+						return fmt.Errorf("deleteAll: delete resource %s/%s", r.GetSubKind(), r.GetMetadata().GetName())
+					}
+				}
+				if nextPageToken == "" {
+					break
+				}
+				pageToken = nextPageToken
+			}
+			return nil
+		},
+	})
+}
+
+func newCertAuthorityOverride(caType types.CertAuthType, clusterName string) *subcav1.CertAuthorityOverride {
+	return &subcav1.CertAuthorityOverride{
+		Kind:    types.KindCertAuthorityOverride,
+		Version: types.V1,
+		SubKind: string(caType),
+		Metadata: &headerv1.Metadata{
+			Name: clusterName,
+		},
+		Spec: &subcav1.CertAuthorityOverrideSpec{},
+	}
+}

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -38,6 +38,7 @@ import (
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	userprovisioningv2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
@@ -157,6 +158,7 @@ type collections struct {
 	inferenceSecrets                   *collection[*summarizerv1.InferenceSecret, inferenceSecretIndex]
 	inferencePolicies                  *collection[*summarizerv1.InferencePolicy, inferencePolicyIndex]
 	retrievalModels                    *collection[*summarizerv1.RetrievalModel, retrievalModelIndex]
+	certAuthorityOverrides             *collection[*subcav1.CertAuthorityOverride, certAuthorityOverrideIndex]
 }
 
 // isKnownUncollectedKind is true if a resource kind is not stored in
@@ -844,6 +846,13 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.retrievalModels = collect
 			out.byKind[resourceKind] = out.retrievalModels
+		case types.KindCertAuthorityOverride:
+			collect, err := newCertAuthorityOverrideCollection(c.SubCAService, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			out.certAuthorityOverrides = collect
+			out.byKind[resourceKind] = out.certAuthorityOverrides
 		default:
 			if _, ok := out.byKind[resourceKind]; !ok {
 				return nil, trace.BadParameter("resource %q is not supported", watch.Kind)

--- a/lib/cache/inventory/inventory_cache_test.go
+++ b/lib/cache/inventory/inventory_cache_test.go
@@ -224,6 +224,11 @@ func setupTestCache(t *testing.T, setupConfig cache.SetupConfigFn) (*testCache, 
 	})
 	require.NoError(t, err)
 
+	subCA, err := local.NewSubCAService(local.SubCAServiceParams{
+		Backend: bkWrapper,
+	})
+	require.NoError(t, err)
+
 	c, err := cache.New(setupConfig(cache.Config{
 		Context:                 ctx,
 		Events:                  eventsS,
@@ -278,6 +283,7 @@ func setupTestCache(t *testing.T, setupConfig cache.SetupConfigFn) (*testCache, 
 		EventsC:                 eventsC,
 		WorkloadClusterService:  workloadClusters,
 		Summarizer:              summaries,
+		SubCAService:            subCA,
 	}))
 	require.NoError(t, err)
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3140,6 +3140,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.AppAuthConfig = services.AppAuthConfig
 	cfg.WorkloadClusterService = services.WorkloadClusterService
 	cfg.Summarizer = services.Summarizer
+	cfg.SubCAService = services.SubCAService
 
 	return accesspoint.NewCache(cfg)
 }
@@ -3189,6 +3190,7 @@ func (process *TeleportProcess) newAccessCacheForClient(cfg accesspoint.Config, 
 	cfg.GitServers = client.GitServerClient()
 	cfg.HealthCheckConfig = client
 	cfg.AppAuthConfig = client
+	cfg.SubCAService = client
 
 	return accesspoint.NewCache(cfg)
 }

--- a/lib/service/service_cache_test.go
+++ b/lib/service/service_cache_test.go
@@ -1,0 +1,99 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/cache"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/tool/teleport/testenv"
+)
+
+// TestTeleportProcess_NewLocalCache verifies that the Cache returned by
+// NewLocalCache is correctly configured.
+func TestTeleportProcess_NewLocalCache(t *testing.T) {
+	t.Parallel()
+
+	process, err := testenv.NewTeleportProcess(
+		t.TempDir(),
+		testenv.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.Proxy.Enabled = false
+		}))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if assert.NoError(t, process.Close()) {
+			assert.NoError(t, process.Wait())
+		}
+	})
+
+	authClient, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+
+	// Wrap client so we can fake Enterprise endpoints.
+	cacheClient := &fakeLocalCacheClient{
+		ClientI: authClient,
+	}
+
+	// Prepare local cache.
+	cacheSetup := func(cfg cache.Config) cache.Config {
+		cfg.Unstarted = true
+		cfg.Watches = []types.WatchKind{
+			{Kind: types.KindCertAuthorityOverride},
+		}
+		return cfg
+	}
+	localCache, err := process.NewLocalCache(cacheClient, cacheSetup, []string{"test-local-cache"})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, localCache.Close()) })
+
+	// Exercise the cache. Add a test for your resource below.
+	tests := []struct {
+		name     string
+		exercise func(t *testing.T, c *cache.Cache)
+	}{
+		{
+			name: "SubCA",
+			exercise: func(t *testing.T, c *cache.Cache) {
+				got, err := c.GetCertAuthorityOverride(t.Context(), types.CertAuthorityOverrideID{})
+				assert.NoError(t, err, "GetCertAuthorityOverride errored")
+				assert.NotNil(t, got, "GetCertAuthorityOverride: unexpected response")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			test.exercise(t, localCache)
+		})
+	}
+}
+
+type fakeLocalCacheClient struct {
+	authclient.ClientI
+}
+
+func (s *fakeLocalCacheClient) GetCertAuthorityOverride(context.Context, types.CertAuthorityOverrideID) (*subcav1.CertAuthorityOverride, error) {
+	return &subcav1.CertAuthorityOverride{}, nil
+}

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -293,6 +293,8 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newInferenceSecretParser()
 		case types.KindRetrievalModel:
 			parser = newRetrievalModelParser()
+		case types.KindCertAuthorityOverride:
+			parser = newCertAuthorityOverrideParser()
 		case types.KindValidatedMFAChallenge:
 			parser = newValidatedMFAChallengeParser()
 		default:

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
@@ -240,14 +241,14 @@ func (p *certAuthorityOverrideParser) parse(event backend.Event) (types.Resource
 		name := parts[0]
 		subKind := parts[1]
 
-		return &types.ResourceHeader{
+		return types.Resource153ToLegacy(&subcav1.CertAuthorityOverride{
 			Kind:    types.KindCertAuthorityOverride,
 			Version: types.V1,
 			SubKind: subKind,
-			Metadata: types.Metadata{
+			Metadata: &headerv1.Metadata{
 				Name: name,
 			},
-		}, nil
+		}), nil
 	case types.OpPut:
 		r, err := services.UnmarshalCertAuthorityOverride(event.Item.Value,
 			services.WithExpires(event.Item.Expires),

--- a/lib/services/local/subca_service.go
+++ b/lib/services/local/subca_service.go
@@ -215,3 +215,49 @@ func (s *SubCAService) serviceForClusterAndType(
 		return backend.NewKey(clusterName, caType)
 	}), nil
 }
+
+type certAuthorityOverrideParser struct {
+	baseParser
+}
+
+func newCertAuthorityOverrideParser() *certAuthorityOverrideParser {
+	return &certAuthorityOverrideParser{
+		baseParser: newBaseParser(newCAOverridesPrefix()),
+	}
+}
+
+func (p *certAuthorityOverrideParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		trimmedKey := event.Item.Key.TrimPrefix(newCAOverridesPrefix())
+		parts := trimmedKey.Components()
+		if len(parts) != 2 {
+			return nil, trace.BadParameter("unexpected %s key: %s", types.KindCertAuthorityOverride, event.Item.Key)
+		}
+		// Note! Storage keys mimic CAs, so they go {ClusterName}/{CAType}.
+		// This is the inverse of almost everything else (CertAuthorityOverrideID,
+		// RPCs, audit, tctl, etc), which go {CAType}/{ClusterName} instead.
+		name := parts[0]
+		subKind := parts[1]
+
+		return &types.ResourceHeader{
+			Kind:    types.KindCertAuthorityOverride,
+			Version: types.V1,
+			SubKind: subKind,
+			Metadata: types.Metadata{
+				Name: name,
+			},
+		}, nil
+	case types.OpPut:
+		r, err := services.UnmarshalCertAuthorityOverride(event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(r), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -35,7 +35,6 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
-	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -592,29 +591,6 @@ func init() {
 			return nil, trace.Wrap(err)
 		}
 		return certAuthority, nil
-	})
-
-	RegisterResourceMarshaler(types.KindCertAuthorityOverride, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
-		unwrapper, ok := resource.(types.Resource153UnwrapperT[*subcav1.CertAuthorityOverride])
-		if !ok {
-			return nil, trace.BadParameter("expected wrapped CertAuthorityOverride resource, got %T", resource)
-		}
-		caOverride := unwrapper.UnwrapT()
-		if caOverride == nil {
-			return nil, trace.BadParameter("nil CertAuthorityOverride resource")
-		}
-		bytes, err := MarshalCertAuthorityOverride(caOverride, opts...)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return bytes, nil
-	})
-	RegisterResourceUnmarshaler(types.KindCertAuthorityOverride, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
-		caOverride, err := UnmarshalCertAuthorityOverride(bytes, opts...)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return types.ProtoResource153ToLegacy(caOverride), nil
 	})
 
 	RegisterResourceMarshaler(types.KindTrustedCluster, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -35,6 +35,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -591,6 +592,29 @@ func init() {
 			return nil, trace.Wrap(err)
 		}
 		return certAuthority, nil
+	})
+
+	RegisterResourceMarshaler(types.KindCertAuthorityOverride, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		unwrapper, ok := resource.(types.Resource153UnwrapperT[*subcav1.CertAuthorityOverride])
+		if !ok {
+			return nil, trace.BadParameter("expected wrapped CertAuthorityOverride resource, got %T", resource)
+		}
+		caOverride := unwrapper.UnwrapT()
+		if caOverride == nil {
+			return nil, trace.BadParameter("nil CertAuthorityOverride resource")
+		}
+		bytes, err := MarshalCertAuthorityOverride(caOverride, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return bytes, nil
+	})
+	RegisterResourceUnmarshaler(types.KindCertAuthorityOverride, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		caOverride, err := UnmarshalCertAuthorityOverride(bytes, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.ProtoResource153ToLegacy(caOverride), nil
 	})
 
 	RegisterResourceMarshaler(types.KindTrustedCluster, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {

--- a/lib/services/subca_test.go
+++ b/lib/services/subca_test.go
@@ -40,26 +40,12 @@ func TestMarshalCertAuthOverrideRoundtrip(t *testing.T) {
 		Spec: &subcav1.CertAuthorityOverrideSpec{},
 	}
 
-	t.Run("regular", func(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
 		val, err := services.MarshalCertAuthorityOverride(want)
 		require.NoError(t, err)
 
 		got, err := services.UnmarshalCertAuthorityOverride(val)
 		require.NoError(t, err)
-		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
-			t.Errorf("CAOverride mismatch (-want +got)\n%s", diff)
-		}
-	})
-
-	t.Run("dynamic", func(t *testing.T) {
-		val, err := services.MarshalResource(types.Resource153ToLegacy(want))
-		require.NoError(t, err)
-
-		wrapped, err := services.UnmarshalResource(types.KindCertAuthorityOverride, val)
-		require.NoError(t, err)
-		unwrapper, ok := wrapped.(types.Resource153UnwrapperT[*subcav1.CertAuthorityOverride])
-		require.True(t, ok, "Wrapped resource has unexpected type: %T", wrapped)
-		got := unwrapper.UnwrapT()
 		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 			t.Errorf("CAOverride mismatch (-want +got)\n%s", diff)
 		}

--- a/lib/services/subca_test.go
+++ b/lib/services/subca_test.go
@@ -1,0 +1,67 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func TestMarshalCertAuthOverrideRoundtrip(t *testing.T) {
+	want := &subcav1.CertAuthorityOverride{
+		Kind:    types.KindCertAuthorityOverride,
+		SubKind: string(types.DatabaseClientCA),
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: "zarquon",
+		},
+		Spec: &subcav1.CertAuthorityOverrideSpec{},
+	}
+
+	t.Run("regular", func(t *testing.T) {
+		val, err := services.MarshalCertAuthorityOverride(want)
+		require.NoError(t, err)
+
+		got, err := services.UnmarshalCertAuthorityOverride(val)
+		require.NoError(t, err)
+		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+			t.Errorf("CAOverride mismatch (-want +got)\n%s", diff)
+		}
+	})
+
+	t.Run("dynamic", func(t *testing.T) {
+		val, err := services.MarshalResource(types.Resource153ToLegacy(want))
+		require.NoError(t, err)
+
+		wrapped, err := services.UnmarshalResource(types.KindCertAuthorityOverride, val)
+		require.NoError(t, err)
+		unwrapper, ok := wrapped.(types.Resource153UnwrapperT[*subcav1.CertAuthorityOverride])
+		require.True(t, ok, "Wrapped resource has unexpected type: %T", wrapped)
+		got := unwrapper.UnwrapT()
+		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+			t.Errorf("CAOverride mismatch (-want +got)\n%s", diff)
+		}
+	})
+}


### PR DESCRIPTION
Add the various pieces required to plug a new resource to the cache.

A non exhaustive list:
* Add proto.Event marshal/unmarshal
* Add a backend.Event parser
* Create a cache collection
* Implement read methods in cache.Cache
* Embed the "getter" interface in authclient.Cache
* Wire the many config objects throughout the stack

Used #62866 as reference.

https://github.com/gravitational/teleport.e/issues/7675