### PR TITLE
Rename DiscoveryIACToolLabel to generic IACToolTerraform

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -998,7 +998,9 @@ const (
 	// DiscoveryDescription specifies the description for a discovered app created from a Kubernetes service.
 	DiscoveryDescription = TeleportNamespace + "/description"
 	// IACToolLabel is a resource metadata label that identifies which infrastructure-as-code tool created the resource.
-	DiscoveryIACToolLabel = TeleportNamespace + "/iac-tool"
+	IACToolLabel = TeleportNamespace + "/iac-tool"
+	// IACToolTerraform identifies that a IAC tool is Terraform.
+	IACToolTerraform = "terraform"
 
 	// ReqAnnotationApproveSchedulesLabel is the request annotation key at which schedules are stored for access plugins.
 	ReqAnnotationApproveSchedulesLabel = "/schedules"

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -428,7 +428,7 @@ func (s *Service) emitUsageEvent(dc *discoveryconfig.DiscoveryConfig, action pre
 	resourceTypes, cloudProviders := extractDiscoveryConfigMetadata(dc)
 
 	creationMethod := CreationMethodGuided
-	if _, ok := dc.GetMetadata().Labels[types.DiscoveryIACToolLabel]; ok {
+	if _, ok := dc.GetMetadata().Labels[types.IACToolLabel]; ok {
 		creationMethod = CreationMethodIAC
 	}
 


### PR DESCRIPTION
Just renaming so it doesn't imply the label is only for `discover` usage. This change was a result of [this comment](https://github.com/gravitational/teleport.e/pull/8444#discussion_r3062530959).

I am also using this label to just `mark` resources like `roles` and `access list` that it is managed by terraform

