### PR TITLE
Enforce join token locks for agents

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5296,6 +5296,8 @@ type HostCertsParams struct {
 	AgentScope string
 	// The ImmutableLabelHash that should be encoded into the resulting certificates.
 	ImmutableLabelHash string
+	// JoinToken is the name of the join token that was used to join this host.
+	JoinToken string
 }
 
 // GenerateHostCerts generates new host certificates (signed
@@ -5460,6 +5462,7 @@ func (a *Server) GenerateHostCerts(ctx context.Context, params HostCertsParams) 
 		SystemRoles:        systemRoles,
 		AgentScope:         params.AgentScope,
 		ImmutableLabelHash: params.ImmutableLabelHash,
+		JoinToken:          params.JoinToken,
 	}
 	subject, err := identity.Subject()
 	if err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -669,6 +669,7 @@ func (a *ServerWithRoles) GenerateHostCerts(ctx context.Context, req *proto.Host
 		Req:                req,
 		AgentScope:         identity.AgentScope,
 		ImmutableLabelHash: identity.ImmutableLabelHash,
+		JoinToken:          identity.JoinToken,
 	})
 }
 

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -570,6 +570,14 @@ func (a *Server) GenerateHostCertsForJoin(
 			},
 			AgentScope:         token.GetAssignedScope(),
 			ImmutableLabelHash: joining.HashImmutableLabels(token.GetImmutableLabels()),
+
+			// Include the join token name for bound keypair locking.
+			// `GetSafeName()` produces a censored name for `token` joining,
+			// which isn't ideal, but that's better than embedding the token in
+			// plaintext and we don't automatically target locks at `token`-type
+			// tokens. Other join methods (especially bound_keypair) return the
+			// full token name.
+			JoinToken: token.GetSafeName(),
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/join/boundkeypair/boundkeypair.go
+++ b/lib/join/boundkeypair/boundkeypair.go
@@ -668,7 +668,7 @@ func emitBoundKeypairRotationEvent(
 	}
 }
 
-func tryLockBotInvalidJoinState(
+func tryLockTokenInvalidJoinState(
 	ctx context.Context,
 	params *JoinParams,
 	token provision.Token,
@@ -694,17 +694,28 @@ func tryLockBotInvalidJoinState(
 		log.WarnContext(ctx, "Failed to emit failed join state verification event", "error", auditErr)
 	}
 
+	var message string
+	if token.GetRoles().Include(types.RoleBot) {
+		message = fmt.Sprintf(
+			"The join token %q has been locked by bot %q after a client "+
+				"failed to verify its join state, possibly indicating a "+
+				"stolen keypair.",
+			token.GetName(), token.GetBotName(),
+		)
+	} else {
+		message = fmt.Sprintf(
+			"The join token %q has been locked after a client failed to "+
+				"verify its join state, possibly indicating a stolen keypair.",
+			token.GetName(),
+		)
+	}
+
 	// Create a lock against this token.
 	lock, err := types.NewLock(uuid.New().String(), types.LockSpecV2{
 		Target: types.LockTarget{
 			JoinToken: token.GetName(),
 		},
-		Message: fmt.Sprintf(
-			"The join token %q has been locked by bot %q after a client "+
-				"failed to verify its join state, possibly indicating a "+
-				"stolen keypair.",
-			token.GetName(), token.GetBotName(),
-		),
+		Message:   message,
 		CreatedAt: params.Clock.Now(),
 	})
 	if err != nil {
@@ -773,7 +784,7 @@ func verifyBoundKeypairJoinState(
 	)
 	if err != nil {
 		params.Logger.ErrorContext(ctx, "bound keypair join state verification failed", "error", err)
-		tryLockBotInvalidJoinState(ctx, params, token, err)
+		tryLockTokenInvalidJoinState(ctx, params, token, err)
 
 		return "", "", trace.AccessDenied("join state verification failed")
 	}

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1666,6 +1666,137 @@ func TestJoinBoundKeypair_JoinStateFailureDuringRenewal(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
+// TestJoinBoundKeypair_JoinStateFailure_Instance tests that join state
+// verification will trigger a lock if the original client and a secondary
+// client both attempt to recover in sequence.
+func TestJoinBoundKeypair_JoinStateFailure_Instance(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	correctSigner, correctPublicKey := testBoundKeypair(t)
+	signers := map[string]crypto.Signer{
+		correctPublicKey: correctSigner,
+	}
+
+	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
+
+	srv := newTestTLSServer(t, clock)
+	authServer := srv.Auth()
+
+	_, err := authtest.CreateRole(ctx, authServer, "example", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	token, err := types.NewProvisionTokenFromSpecAndStatus(
+		"bound-keypair-test",
+		time.Now().Add(2*time.Hour),
+		types.ProvisionTokenSpecV2{
+			JoinMethod: types.JoinMethodBoundKeypair,
+			Roles:      []types.SystemRole{types.RoleInstance, types.RoleApp},
+			BoundKeypair: &types.ProvisionTokenSpecV2BoundKeypair{
+				Onboarding: &types.ProvisionTokenSpecV2BoundKeypair_OnboardingSpec{
+					InitialPublicKey: correctPublicKey,
+				},
+				Recovery: &types.ProvisionTokenSpecV2BoundKeypair_RecoverySpec{
+					Limit: 3,
+				},
+			},
+		},
+		&types.ProvisionTokenStatusV2{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, authServer.CreateBoundKeypairToken(ctx, token))
+
+	// Make an unauthenticated auth client that will be used for joining.
+	nopClient, err := srv.NewClient(authtest.TestNop())
+	require.NoError(t, err)
+
+	clientState := makeMockBoundKeypairState(signers,
+		withSingleSigningKey(correctPublicKey),
+		withNoRotation(),
+	)
+
+	originalJoinResult, err := joinclient.Join(t.Context(), joinclient.JoinParams{
+		Token: token.GetName(),
+		ID: state.IdentityID{
+			Role: types.RoleInstance,
+		},
+		AuthClient:        nopClient,
+		BoundKeypairState: clientState,
+	})
+	require.NoError(t, err)
+
+	// Perform a recovery, this time with a join state.
+	recoverResult, err := joinclient.Join(t.Context(), joinclient.JoinParams{
+		Token: token.GetName(),
+		ID: state.IdentityID{
+			Role: types.RoleInstance,
+		},
+		AuthClient: nopClient,
+		// Note: the client state manages prev join state internally in
+		// UpdateFromRegisterResult().
+		BoundKeypairState: clientState,
+	})
+	require.NoError(t, err)
+
+	recoveredClient, err := clientFromJoinResult(srv, recoverResult)
+	require.NoError(t, err)
+
+	// Try an API call with these certs.
+	_, err = recoveredClient.Ping(ctx)
+	require.NoError(t, err)
+
+	// Try to recover again, but with the original join state.
+	outdatedClientState := makeMockBoundKeypairState(signers,
+		withSingleSigningKey(correctPublicKey),
+		withPreviousJoinState(originalJoinResult.BoundKeypair.JoinState),
+		withNoRotation(),
+	)
+	_, err = joinclient.Join(ctx, joinclient.JoinParams{
+		Token: token.GetName(),
+		ID: state.IdentityID{
+			Role: types.RoleInstance,
+		},
+		AuthClient:        nopClient,
+		BoundKeypairState: outdatedClientState,
+	})
+	require.Error(t, err)
+
+	// The token should now be locked - but only once.
+	locks, err := srv.Auth().GetLocks(ctx, true, types.LockTarget{
+		JoinToken: "bound-keypair-test",
+	})
+	require.NoError(t, err)
+	require.Len(t, locks, 1, "only one lock should be generated")
+	require.Contains(t, locks[0].Message(), "failed to verify its join state")
+
+	// The previously working client should be locked.
+	require.Eventually(t, func() bool {
+		_, err = recoveredClient.Ping(ctx)
+		return err != nil && strings.Contains(err.Error(), "access denied")
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Repeat the recovery attempt but with an Eventually() to consistently
+	// check the error message. Depending on exact timing / cache propagation /
+	// etc the lock may or may not be in force, but we also need to be
+	// absolutely certain to try to generate at least 2 locking events.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		tempClientState := makeMockBoundKeypairState(signers,
+			withSingleSigningKey(correctPublicKey),
+			withPreviousJoinState(originalJoinResult.BoundKeypair.JoinState),
+			withNoRotation(),
+		)
+		_, err = joinclient.Join(ctx, joinclient.JoinParams{
+			Token: token.GetName(),
+			ID: state.IdentityID{
+				Role: types.RoleInstance,
+			},
+			AuthClient:        nopClient,
+			BoundKeypairState: tempClientState,
+		})
+		require.ErrorContains(t, err, "a client failed to verify its join state")
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
 // createScopedBot creates a scoped bot with necessary role assignments for testing.
 func createScopedBot(t *testing.T, srv *authtest.TLSServer, adminClient *authclient.Client) {
 	t.Helper()

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1678,9 +1678,7 @@ func TestJoinBoundKeypair_JoinStateFailure_Instance(t *testing.T) {
 		correctPublicKey: correctSigner,
 	}
 
-	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
-
-	srv := newTestTLSServer(t, clock)
+	srv := newTestTLSServer(t, clockwork.NewRealClock())
 	authServer := srv.Auth()
 
 	_, err := authtest.CreateRole(ctx, authServer, "example", types.RoleSpecV6{})

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1770,9 +1770,10 @@ func TestJoinBoundKeypair_JoinStateFailure_Instance(t *testing.T) {
 	require.Contains(t, locks[0].Message(), "failed to verify its join state")
 
 	// The previously working client should be locked.
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		_, err = recoveredClient.Ping(ctx)
-		return err != nil && strings.Contains(err.Error(), "access denied")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "access denied")
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// Repeat the recovery attempt but with an Eventually() to consistently

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1676,7 +1676,7 @@ func TestJoinBoundKeypair_JoinStateFailure_Instance(t *testing.T) {
 		correctPublicKey: correctSigner,
 	}
 
-	srv := newTestTLSServer(t, clockwork.NewRealClock(), authtest.WithBufconnListener())
+	srv := newTestTLSServer(t, clockwork.NewRealClock())
 	defer srv.Close()
 	authServer := srv.Auth()
 

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -75,7 +76,7 @@ func parseJoinState(t *testing.T, state []byte) *boundkeypair.JoinState {
 	return &doc
 }
 
-func newTestTLSServer(t *testing.T, clock clockwork.Clock) *authtest.TLSServer {
+func newTestTLSServer(t *testing.T, clock clockwork.Clock, opts ...authtest.TestTLSServerOption) *authtest.TLSServer {
 	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: clock,
@@ -83,7 +84,7 @@ func newTestTLSServer(t *testing.T, clock clockwork.Clock) *authtest.TLSServer {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
-	srv, err := as.NewTestTLSServer()
+	srv, err := as.NewTestTLSServer(opts...)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := srv.Close()
@@ -1670,15 +1671,18 @@ func TestJoinBoundKeypair_JoinStateFailureDuringRenewal(t *testing.T) {
 // verification will trigger a lock if the original client and a secondary
 // client both attempt to recover in sequence.
 func TestJoinBoundKeypair_JoinStateFailure_Instance(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
+	synctest.Test(t, testJoinBoundKeypairJoinStateFailureInstance)
+}
 
+func testJoinBoundKeypairJoinStateFailureInstance(t *testing.T) {
+	ctx := t.Context()
 	correctSigner, correctPublicKey := testBoundKeypair(t)
 	signers := map[string]crypto.Signer{
 		correctPublicKey: correctSigner,
 	}
 
-	srv := newTestTLSServer(t, clockwork.NewRealClock())
+	srv := newTestTLSServer(t, clockwork.NewRealClock(), authtest.WithBufconnListener())
+	defer srv.Close()
 	authServer := srv.Auth()
 
 	_, err := authtest.CreateRole(ctx, authServer, "example", types.RoleSpecV6{})
@@ -1707,6 +1711,7 @@ func TestJoinBoundKeypair_JoinStateFailure_Instance(t *testing.T) {
 	// Make an unauthenticated auth client that will be used for joining.
 	nopClient, err := srv.NewClient(authtest.TestNop())
 	require.NoError(t, err)
+	defer nopClient.Close()
 
 	clientState := makeMockBoundKeypairState(signers,
 		withSingleSigningKey(correctPublicKey),
@@ -1738,6 +1743,7 @@ func TestJoinBoundKeypair_JoinStateFailure_Instance(t *testing.T) {
 
 	recoveredClient, err := clientFromJoinResult(srv, recoverResult)
 	require.NoError(t, err)
+	defer recoveredClient.Close()
 
 	// Try an API call with these certs.
 	_, err = recoveredClient.Ping(ctx)
@@ -1768,32 +1774,30 @@ func TestJoinBoundKeypair_JoinStateFailure_Instance(t *testing.T) {
 	require.Contains(t, locks[0].Message(), "failed to verify its join state")
 
 	// The previously working client should be locked.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		_, err = recoveredClient.Ping(ctx)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "access denied")
-	}, 5*time.Second, 100*time.Millisecond)
+	synctest.Wait()
+	_, err = recoveredClient.Ping(ctx)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "access denied")
 
 	// Repeat the recovery attempt but with an Eventually() to consistently
 	// check the error message. Depending on exact timing / cache propagation /
 	// etc the lock may or may not be in force, but we also need to be
 	// absolutely certain to try to generate at least 2 locking events.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		tempClientState := makeMockBoundKeypairState(signers,
-			withSingleSigningKey(correctPublicKey),
-			withPreviousJoinState(originalJoinResult.BoundKeypair.JoinState),
-			withNoRotation(),
-		)
-		_, err = joinclient.Join(ctx, joinclient.JoinParams{
-			Token: token.GetName(),
-			ID: state.IdentityID{
-				Role: types.RoleInstance,
-			},
-			AuthClient:        nopClient,
-			BoundKeypairState: tempClientState,
-		})
-		require.ErrorContains(t, err, "a client failed to verify its join state")
-	}, 5*time.Second, 100*time.Millisecond)
+	synctest.Wait()
+	tempClientState := makeMockBoundKeypairState(signers,
+		withSingleSigningKey(correctPublicKey),
+		withPreviousJoinState(originalJoinResult.BoundKeypair.JoinState),
+		withNoRotation(),
+	)
+	_, err = joinclient.Join(ctx, joinclient.JoinParams{
+		Token: token.GetName(),
+		ID: state.IdentityID{
+			Role: types.RoleInstance,
+		},
+		AuthClient:        nopClient,
+		BoundKeypairState: tempClientState,
+	})
+	require.ErrorContains(t, err, "a client failed to verify its join state")
 }
 
 // createScopedBot creates a scoped bot with necessary role assignments for testing.

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -29,7 +29,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -1671,10 +1670,6 @@ func TestJoinBoundKeypair_JoinStateFailureDuringRenewal(t *testing.T) {
 // verification will trigger a lock if the original client and a secondary
 // client both attempt to recover in sequence.
 func TestJoinBoundKeypair_JoinStateFailure_Instance(t *testing.T) {
-	synctest.Test(t, testJoinBoundKeypairJoinStateFailureInstance)
-}
-
-func testJoinBoundKeypairJoinStateFailureInstance(t *testing.T) {
 	ctx := t.Context()
 	correctSigner, correctPublicKey := testBoundKeypair(t)
 	signers := map[string]crypto.Signer{
@@ -1749,6 +1744,13 @@ func testJoinBoundKeypairJoinStateFailureInstance(t *testing.T) {
 	_, err = recoveredClient.Ping(ctx)
 	require.NoError(t, err)
 
+	// Subscribe to events from the LockWatcher
+	lockSub, err := srv.AuthServer.LockWatcher.Subscribe(ctx, types.LockTarget{
+		JoinToken: "bound-keypair-test",
+	})
+	require.NoError(t, err)
+	defer lockSub.Close()
+
 	// Try to recover again, but with the original join state.
 	outdatedClientState := makeMockBoundKeypairState(signers,
 		withSingleSigningKey(correctPublicKey),
@@ -1773,17 +1775,25 @@ func testJoinBoundKeypairJoinStateFailureInstance(t *testing.T) {
 	require.Len(t, locks, 1, "only one lock should be generated")
 	require.Contains(t, locks[0].Message(), "failed to verify its join state")
 
+	// Wait for the LockWatcher to notify us about the new lock. Since this
+	// otherwise happens async, we need to wait explicitly, otherwise the lock
+	// may exist in the backend without being enforced.
+	select {
+	case event := <-lockSub.Events():
+		require.Equal(t, types.OpPut, event.Type)
+	case <-lockSub.Done():
+		t.Fatal("lock subscription closed unexpectedly")
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for lock event")
+	}
+
 	// The previously working client should be locked.
-	synctest.Wait()
 	_, err = recoveredClient.Ping(ctx)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "access denied")
 
-	// Repeat the recovery attempt but with an Eventually() to consistently
-	// check the error message. Depending on exact timing / cache propagation /
-	// etc the lock may or may not be in force, but we also need to be
-	// absolutely certain to try to generate at least 2 locking events.
-	synctest.Wait()
+	// Try joining again with the same parameters to try to generate another
+	// lock - they should not be duplicated.
 	tempClientState := makeMockBoundKeypairState(signers,
 		withSingleSigningKey(correctPublicKey),
 		withPreviousJoinState(originalJoinResult.BoundKeypair.JoinState),
@@ -1798,6 +1808,14 @@ func testJoinBoundKeypairJoinStateFailureInstance(t *testing.T) {
 		BoundKeypairState: tempClientState,
 	})
 	require.ErrorContains(t, err, "a client failed to verify its join state")
+
+	// Check the lock count again - only one lock should be created.
+	locks, err = srv.Auth().GetLocks(ctx, true, types.LockTarget{
+		JoinToken: "bound-keypair-test",
+	})
+	require.NoError(t, err)
+	require.Len(t, locks, 1, "only one lock should be generated")
+	require.Contains(t, locks[0].Message(), "failed to verify its join state")
 }
 
 // createScopedBot creates a scoped bot with necessary role assignments for testing.

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -206,7 +206,8 @@ type Identity struct {
 	// consumption by users or user-facing bot services.
 	BotInternal bool
 	// JoinToken contains the name of the join token used when a Machine ID bot
-	// joins. It is empty for other identity types.
+	// or agent joins. Note that agents using the `token` join method will
+	// include a censored token name.
 	JoinToken string
 	// AllowedResourceIDs lists the resources the identity should be allowed to
 	// access.
@@ -630,7 +631,8 @@ var (
 	ADStatusOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 22}
 
 	// JoinTokenOID is an extension OID that contains the name of the join token
-	// used when a bot joins.
+	// used when a bot or agent joins. It is censored for agents joining with
+	// the `token` join method.
 	JoinTokenASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 23}
 
 	// ScopePinASN1ExtensionOID is an extension OID that contains the scope pin


### PR DESCRIPTION
When agents attempt to join with the the bound keypair join method and fail join state verification, a lock is created. This lock traditionally targeted only bots.

While the lock target - the join token - is ostensibly not bot specific, we were not plumbing through the token name into host certificates, meaning the lock wasn't practically enforced for host identities. Future join attempts would still fail, but the existing agents wouldn't be locked.

This change adds a test for agent locking, plumbs through the join token name in host certificates, and updates the lock message text for agents so it isn't bot specific.

Note that agents do not have an analogous notion of renewable identities and don't have a generation counter - their identities last 10 years and don't renew. This means bound keypair agents only generate join state locks, not generation counter locks. Agents rarely (if ever) need to perform recoveries, so the actual chances of a lock being created are very low.

No changelog, Bound Keypair for Agents has yet to be released.

## Manual Test Plan

### Test Environment

Verified on a self hosted homelab Teleport cluster (running this branch) with an x86_64 Linux agent run in Debian Docker container from a full tarball build (`make -C build.assets release-amd64`) on a Linux build machine.

### Test Cases
- [x] Agents with node UUIDs can successfully join with a bound keypair token
- [x] Agents with a locked join token cannot join (`tctl create lock --join-token bk-agent`)
- [x] Agents can join if a lock is targeting a different token (`tctl create lock --join-token foo`)

### Test setup notes

1. Build Teleport (`make -C build.assets release-amd64` or similar)
2. Install the release on your Teleport cluster
3. Create a node join token:
   ```
   kind: token
   version: v2
   metadata:
     name: bk-agent
   spec:
     roles: [Node]
     join_method: bound_keypair
     bound_keypair:
       recovery:
         mode: standard
         limit: 1
   ```
   
   Create it and retrieve the registration secret:
   ```
   $ tctl create -f token-bk-agent.yaml
   $ tctl get token/bk-agent
   ```
4. Make a directory for node files, acquire/copy the `teleport` binary, and make config:
   ```
   $ mkdir bk-agent-test && cd bk-agent-test
   $ mkdir node
   $ tar zxvf teleport-ent-v19.0.0-prealpha.2-linux-amd64-bin.tar.gz # or otherwise copy the binary
   ```
5. Create the node config:
   ```yaml
   version: v3
   teleport:
     nodename: bk-agent-test
     data_dir: /var/lib/teleport
     join_params:
       token_name: bk-agent
       method: bound_keypair
       bound_keypair:
         registration_secret_value: <secret>
     proxy_server: example.teleport.sh:443
     log:
       output: stderr
       severity: INFO
       format:
         output: text
     ca_pin: ""
     diag_addr: ""
   auth_service:
     enabled: "no"
   ssh_service:
     enabled: "yes"
   proxy_service:
     enabled: "no"
     https_keypairs: []
     https_keypairs_reload_interval: 0s
     acme: {}
   ```
6. Run the container and start teleport:
   ```
   $ docker run --platform linux/amd64 --rm -v $(pwd):/mnt -v $(pwd)/node:/var/lib/teleport --entrypoint=bash -it debian:latest
   # ... inside the container ...
   $ apt update && apt install -y ca-certificates
   $ /path/to/teleport start -c /mnt/teleport.yaml
   ```