### PR TITLE
Migrate to github.com/go-jose/go-jose/v4, part 1

### DIFF
--- a/examples/jwt/verify-jwt.go
+++ b/examples/jwt/verify-jwt.go
@@ -33,7 +33,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 // jwk is a JSON Web Key, described in detail in RFC 7517.
@@ -161,7 +162,7 @@ func unmarshalECDSAJWK(jwk jwk) (*ecdsa.PublicKey, error) {
 // verify will verify the JWT.
 func verify(publicKey crypto.PublicKey, token string) (*claims, error) {
 	// Parse the raw token.
-	t, err := jwt.ParseSigned(token)
+	t, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.ES256})
 	if err != nil {
 		return nil, err
 	}
@@ -179,10 +180,10 @@ func verify(publicKey crypto.PublicKey, token string) (*claims, error) {
 func validate(claims *claims, issuer string, subject string, audience string) error {
 	// Validate the claims on the JWT.
 	expectedClaims := jwt.Expected{
-		Issuer:   issuer,
-		Subject:  subject,
-		Audience: jwt.Audience{audience},
-		Time:     time.Now(),
+		Issuer:      issuer,
+		Subject:     subject,
+		AnyAudience: jwt.Audience{audience},
+		Time:        time.Now(),
 	}
 
 	return claims.Validate(expectedClaims)

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -19,6 +19,9 @@ package join
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"crypto/x509"
 	"log/slog"
 	"net/http"
@@ -26,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v4"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"go.opentelemetry.io/otel"
@@ -60,7 +63,6 @@ import (
 	"github.com/gravitational/teleport/lib/join/gitlab"
 	"github.com/gravitational/teleport/lib/join/spacelift"
 	"github.com/gravitational/teleport/lib/join/terraformcloud"
-	"github.com/gravitational/teleport/lib/jwt"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/tpm"
@@ -1053,8 +1055,16 @@ func registerUsingBoundKeypairMethod(
 					return nil, trace.Wrap(err, "could not lookup signer for public key %+v", kind.Challenge.PublicKey)
 				}
 
-				alg, err := jwt.AlgorithmForPublicKey(signer.Public())
-				if err != nil {
+				// TODO(tross): Replace with jwt.AlgorithmForPublicKey once jwt users go-jose/v4
+				var alg jose.SignatureAlgorithm
+				switch signer.Public().(type) {
+				case *rsa.PublicKey:
+					alg = jose.RS256
+				case *ecdsa.PublicKey:
+					alg = jose.ES256
+				case ed25519.PublicKey:
+					alg = jose.EdDSA
+				default:
 					return nil, trace.Wrap(err, "determining signing algorithm for public key")
 				}
 

--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -25,7 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -89,7 +90,7 @@ func testBoundKeypair(t *testing.T) (crypto.Signer, string) {
 // parseJoinState parses a join state token without verification, for testing
 // purposes only.
 func parseJoinState(t *testing.T, state []byte) *boundkeypair.JoinState {
-	token, err := jwt.ParseSigned(string(state))
+	token, err := jwt.ParseSigned(string(state), []jose.SignatureAlgorithm{jose.ES256})
 	require.NoError(t, err)
 
 	var doc boundkeypair.JoinState

--- a/lib/auth/machineid/machineidv1/workload_identity_service_test.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service_test.go
@@ -24,7 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -331,7 +332,7 @@ func TestWorkloadIdentityService_SignJWTSVIDs(t *testing.T) {
 				require.NotEmpty(t, svid.Jti)
 				require.NotEmpty(t, svid.Jwt)
 
-				parsed, err := jwt.ParseSigned(svid.Jwt)
+				parsed, err := jwt.ParseSigned(svid.Jwt, []jose.SignatureAlgorithm{jose.ES256})
 				require.NoError(t, err)
 
 				claims := jwt.Claims{}

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -36,7 +36,8 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -688,7 +689,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 				require.WithinDuration(t, tp.clock.Now().Add(wantTTL), cred.GetExpiresAt().AsTime(), time.Second)
 
 				// Check the JWT
-				parsed, err := jwt.ParseSigned(cred.GetJwtSvid().GetJwt())
+				parsed, err := jwt.ParseSigned(cred.GetJwtSvid().GetJwt(), []jose.SignatureAlgorithm{jose.ES256})
 				require.NoError(t, err)
 
 				claims := jwt.Claims{}
@@ -781,7 +782,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 					"unexpected number format: %s", numericClaims.Iat.String(),
 				)
 
-				parsed, err := jwt.ParseSigned(res.GetCredential().GetJwtSvid().GetJwt())
+				parsed, err := jwt.ParseSigned(res.GetCredential().GetJwtSvid().GetJwt(), []jose.SignatureAlgorithm{jose.ES256})
 				require.NoError(t, err)
 
 				var claims struct {
@@ -1194,7 +1195,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 				wantTTL := time.Hour * 24
 				// Check expiry makes sense
 				require.WithinDuration(t, tp.clock.Now().Add(wantTTL), cred.GetExpiresAt().AsTime(), time.Second)
-				parsed, err := jwt.ParseSigned(cred.GetJwtSvid().GetJwt())
+				parsed, err := jwt.ParseSigned(cred.GetJwtSvid().GetJwt(), []jose.SignatureAlgorithm{jose.ES256})
 				require.NoError(t, err)
 				claims := jwt.Claims{}
 				err = parsed.Claims(tp.spiffeJWTSigner.Public(), &claims)
@@ -1224,7 +1225,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 				wantTTL := time.Minute * 15
 				// Check expiry makes sense
 				require.WithinDuration(t, tp.clock.Now().Add(wantTTL), cred.GetExpiresAt().AsTime(), time.Second)
-				parsed, err := jwt.ParseSigned(cred.GetJwtSvid().GetJwt())
+				parsed, err := jwt.ParseSigned(cred.GetJwtSvid().GetJwt(), []jose.SignatureAlgorithm{jose.ES256})
 				require.NoError(t, err)
 				claims := jwt.Claims{}
 				err = parsed.Claims(tp.spiffeJWTSigner.Public(), &claims)
@@ -1530,7 +1531,7 @@ func TestIssueWorkloadIdentities(t *testing.T) {
 					workloadIdentitiesIssued = append(workloadIdentitiesIssued, cred.WorkloadIdentityName)
 
 					// Check a credential was actually included and is valid.
-					parsed, err := jwt.ParseSigned(cred.GetJwtSvid().GetJwt())
+					parsed, err := jwt.ParseSigned(cred.GetJwtSvid().GetJwt(), []jose.SignatureAlgorithm{jose.ES256})
 					require.NoError(t, err)
 					claims := jwt.Claims{}
 					err = parsed.Claims(tp.spiffeJWTSigner.Public(), &claims)

--- a/lib/boundkeypair/bound_keypair.go
+++ b/lib/boundkeypair/bound_keypair.go
@@ -23,7 +23,8 @@ import (
 	"crypto/subtle"
 	"time"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
@@ -160,7 +161,7 @@ func (v *ChallengeValidator) IssueChallenge() (*ChallengeDocument, error) {
 // signature matches the requested public key, and that the claims pass JWT
 // validation.
 func (v *ChallengeValidator) ValidateChallengeResponse(issued *ChallengeDocument, compactResponse string) error {
-	token, err := jwt.ParseSigned(compactResponse)
+	token, err := jwt.ParseSigned(compactResponse, []jose.SignatureAlgorithm{jose.RS256, jose.ES256, jose.EdDSA})
 	if err != nil {
 		return trace.Wrap(err, "parsing signed response")
 	}
@@ -173,10 +174,10 @@ func (v *ChallengeValidator) ValidateChallengeResponse(issued *ChallengeDocument
 	// Validate the challenge document claims per JWT rules.
 	const leeway time.Duration = time.Minute
 	if err := document.Claims.ValidateWithLeeway(jwt.Expected{
-		Issuer:   v.clusterName,
-		Subject:  v.subject,
-		Audience: jwt.Audience{v.clusterName},
-		Time:     v.clock.Now(),
+		Issuer:      v.clusterName,
+		Subject:     v.subject,
+		AnyAudience: jwt.Audience{v.clusterName},
+		Time:        v.clock.Now(),
 	}, leeway); err != nil {
 		return trace.Wrap(err, "validating challenge claims")
 	}

--- a/lib/boundkeypair/bound_keypair_test.go
+++ b/lib/boundkeypair/bound_keypair_test.go
@@ -25,14 +25,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cryptosuites"
-	libjwt "github.com/gravitational/teleport/lib/jwt"
 )
 
 func newTestKeypair(t *testing.T) crypto.Signer {
@@ -80,12 +79,9 @@ func TestChallengeValidator_IssueChallenge(t *testing.T) {
 func signChallenge(t *testing.T, challenge string, signer crypto.Signer) string {
 	t.Helper()
 
-	alg, err := libjwt.AlgorithmForPublicKey(signer.Public())
-	require.NoError(t, err)
-
 	opts := (&jose.SignerOptions{}).WithType("JWT")
 	key := jose.SigningKey{
-		Algorithm: alg,
+		Algorithm: jose.EdDSA,
 		Key:       signer,
 	}
 

--- a/lib/join/azurejoin/azure.go
+++ b/lib/join/azurejoin/azure.go
@@ -32,7 +32,8 @@ import (
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/digitorus/pkcs7"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -146,7 +147,7 @@ type AzureJoinConfig struct {
 
 func azureVerifyFuncFromOIDCVerifier(clientID string) AzureVerifyTokenFunc {
 	return func(ctx context.Context, rawIDToken string) (*AccessTokenClaims, error) {
-		token, err := jwt.ParseSigned(rawIDToken)
+		token, err := jwt.ParseSigned(rawIDToken, []jose.SignatureAlgorithm{jose.RS256, jose.ES256})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -316,9 +317,9 @@ func verifyVMIdentity(
 	}
 
 	expectedClaims := jwt.Expected{
-		Issuer:   expectedIssuer,
-		Audience: jwt.Audience{AzureAccessTokenAudience},
-		Time:     requestStart,
+		Issuer:      expectedIssuer,
+		AnyAudience: jwt.Audience{AzureAccessTokenAudience},
+		Time:        requestStart,
 	}
 
 	if err := tokenClaims.asJWTClaims().Validate(expectedClaims); err != nil {

--- a/lib/join/azurejoin/join_azure_test.go
+++ b/lib/join/azurejoin/join_azure_test.go
@@ -36,8 +36,8 @@ import (
 	"time"
 
 	"github.com/digitorus/pkcs7"
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/join/azurejoin"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/join/jointest"
@@ -113,7 +114,7 @@ func mockVerifyToken(err error) azurejoin.AzureVerifyTokenFunc {
 		if err != nil {
 			return nil, err
 		}
-		tok, err := jwt.ParseSigned(rawToken)
+		tok, err := jwt.ParseSigned(rawToken, []jose.SignatureAlgorithm{jose.RS256})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -126,10 +127,16 @@ func mockVerifyToken(err error) azurejoin.AzureVerifyTokenFunc {
 }
 
 func makeToken(managedIdentityResourceID, azureResourceID string, issueTime time.Time) (string, error) {
-	sig, err := jose.NewSigner(jose.SigningKey{
-		Algorithm: jose.HS256,
-		Key:       []byte("test-key"),
-	}, &jose.SignerOptions{})
+
+	privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.RSA2048)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	sig, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: privateKey},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -148,7 +155,7 @@ func makeToken(managedIdentityResourceID, azureResourceID string, issueTime time
 		TenantID:                   "test-tenant-id",
 		Version:                    "1.0",
 	}
-	raw, err := jwt.Signed(sig).Claims(claims).CompactSerialize()
+	raw, err := jwt.Signed(sig).Claims(claims).Serialize()
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/join/bitbucket/token_validator_test.go
+++ b/lib/join/bitbucket/token_validator_test.go
@@ -28,8 +28,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -155,7 +155,7 @@ func (f *fakeIDP) issueToken(
 	token, err := jwt.Signed(f.signer).
 		Claims(stdClaims).
 		Claims(customClaims).
-		CompactSerialize()
+		Serialize()
 	require.NoError(t, err)
 
 	return token

--- a/lib/join/circleci/token_validator_test.go
+++ b/lib/join/circleci/token_validator_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -66,7 +66,7 @@ func (f *fakeIDP) issueToken(
 	token, err := jwt.Signed(f.signer).
 		Claims(stdClaims).
 		Claims(customClaims).
-		CompactSerialize()
+		Serialize()
 	require.NoError(t, err)
 
 	return token

--- a/lib/join/gcp/token_validator_test.go
+++ b/lib/join/gcp/token_validator_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/jonboulle/clockwork"
@@ -146,7 +146,7 @@ func (f *fakeIDP) issueToken(
 	token, err := jwt.Signed(f.signer).
 		Claims(stdClaims).
 		Claims(claims).
-		CompactSerialize()
+		Serialize()
 	require.NoError(t, err)
 
 	return token

--- a/lib/join/githubactions/token_validator.go
+++ b/lib/join/githubactions/token_validator.go
@@ -24,8 +24,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	josejwt "github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/oidc"
@@ -92,7 +92,7 @@ func ValidateTokenWithJWKS(
 	jwksData []byte,
 	token string,
 ) (*IDTokenClaims, error) {
-	parsed, err := josejwt.ParseSigned(token)
+	parsed, err := josejwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256, jose.ES256, jose.EdDSA})
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing jwt")
 	}
@@ -109,7 +109,7 @@ func ValidateTokenWithJWKS(
 
 	leeway := time.Second * 10
 	err = stdClaims.ValidateWithLeeway(josejwt.Expected{
-		Audience: []string{
+		AnyAudience: []string{
 			audience,
 		},
 		Time: now,

--- a/lib/join/githubactions/token_validator_test.go
+++ b/lib/join/githubactions/token_validator_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -179,7 +179,7 @@ func (f *fakeIDP) issueToken(
 	token, err := jwt.Signed(f.signer).
 		Claims(stdClaims).
 		Claims(customClaims).
-		CompactSerialize()
+		Serialize()
 	require.NoError(t, err)
 
 	return token
@@ -482,7 +482,7 @@ func TestValidateTokenWithJWKS(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			token, err := jwt.Signed(tt.signer).
 				Claims(tt.claims).
-				CompactSerialize()
+				Serialize()
 			require.NoError(t, err)
 
 			result, err := ValidateTokenWithJWKS(now, jwks, token)

--- a/lib/join/gitlab/token_validator.go
+++ b/lib/join/gitlab/token_validator.go
@@ -24,8 +24,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	josejwt "github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
@@ -101,7 +101,7 @@ func (id *IDTokenValidator) ValidateTokenWithJWKS(
 	jwksData []byte,
 	token string,
 ) (*IDTokenClaims, error) {
-	parsed, err := josejwt.ParseSigned(token)
+	parsed, err := josejwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256, jose.ES256, jose.EdDSA})
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing jwt")
 	}
@@ -123,7 +123,7 @@ func (id *IDTokenValidator) ValidateTokenWithJWKS(
 
 	leeway := time.Second * 10
 	err = stdClaims.ValidateWithLeeway(josejwt.Expected{
-		Audience: []string{
+		AnyAudience: []string{
 			clusterNameResource.GetClusterName(),
 		},
 		Time: id.Clock.Now(),

--- a/lib/join/gitlab/token_validator_test.go
+++ b/lib/join/gitlab/token_validator_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -160,7 +160,7 @@ func (f *fakeIDP) issueToken(
 	token, err := jwt.Signed(f.signer).
 		Claims(stdClaims).
 		Claims(customClaims).
-		CompactSerialize()
+		Serialize()
 	require.NoError(t, err)
 
 	return token

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -31,7 +31,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -66,7 +67,7 @@ func testBoundKeypair(t *testing.T) (crypto.Signer, string) {
 // parseJoinState parses a join state token without verification, for testing
 // purposes only.
 func parseJoinState(t *testing.T, state []byte) *boundkeypair.JoinState {
-	token, err := jwt.ParseSigned(string(state))
+	token, err := jwt.ParseSigned(string(state), []jose.SignatureAlgorithm{jose.ES256})
 	require.NoError(t, err)
 
 	var doc boundkeypair.JoinState

--- a/lib/join/joinclient/join_boundkeypair.go
+++ b/lib/join/joinclient/join_boundkeypair.go
@@ -19,10 +19,13 @@ package joinclient
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"log/slog"
 	"strings"
 
-	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v4"
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 
@@ -31,7 +34,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
-	"github.com/gravitational/teleport/lib/jwt"
 )
 
 type (
@@ -151,9 +153,17 @@ func solveBoundKeypairChallenge(state boundkeypair.ClientState, challengeMsg *me
 		return nil, trace.Wrap(err, "could not lookup signer for public key %s", string(challengeMsg.PublicKey))
 	}
 
-	alg, err := jwt.AlgorithmForPublicKey(signer.Public())
-	if err != nil {
-		return nil, trace.Wrap(err, "determining signing algorithm for public key")
+	// TODO(tross): Replace with jwt.AlgorithmForPublicKey once jwt users go-jose/v4
+	var alg jose.SignatureAlgorithm
+	switch signer.Public().(type) {
+	case *rsa.PublicKey:
+		alg = jose.RS256
+	case *ecdsa.PublicKey:
+		alg = jose.ES256
+	case ed25519.PublicKey:
+		alg = jose.EdDSA
+	default:
+		return nil, trace.BadParameter("unsupported public key type %T", signer.Public())
 	}
 
 	opts := (&jose.SignerOptions{}).WithType("JWT")

--- a/lib/join/spacelift/token_validator_test.go
+++ b/lib/join/spacelift/token_validator_test.go
@@ -28,8 +28,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -158,7 +158,7 @@ func (f *fakeIDP) issueToken(
 	token, err := jwt.Signed(f.signer).
 		Claims(stdClaims).
 		Claims(customClaims).
-		CompactSerialize()
+		Serialize()
 	require.NoError(t, err)
 
 	return token

--- a/lib/join/terraformcloud/token_validator_test.go
+++ b/lib/join/terraformcloud/token_validator_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -160,7 +160,7 @@ func (f *fakeIDP) issueToken(
 	token, err := jwt.Signed(f.signer).
 		Claims(stdClaims).
 		Claims(customClaims).
-		CompactSerialize()
+		Serialize()
 	require.NoError(t, err)
 
 	return token

--- a/lib/jwt/jwk.go
+++ b/lib/jwt/jwk.go
@@ -28,7 +28,7 @@ import (
 	"encoding/base64"
 	"math/big"
 
-	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v4"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/utils/keys"

--- a/lib/kube/token/claims/claims.go
+++ b/lib/kube/token/claims/claims.go
@@ -19,7 +19,7 @@
 package claims
 
 import (
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
 

--- a/lib/kube/token/validator.go
+++ b/lib/kube/token/validator.go
@@ -26,8 +26,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	josejwt "github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	v1 "k8s.io/api/authentication/v1"
@@ -120,7 +120,7 @@ func (v *TokenReviewValidator) getClient(_ context.Context) (kubernetes.Interfac
 // Bound tokens always have audiences and the list will not be empty.
 // Legacy tokens don't have audiences, the result will be an empty list and no error.
 func unsafeGetTokenAudiences(token string) ([]string, error) {
-	jwt, err := josejwt.ParseSigned(token)
+	jwt, err := josejwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256, jose.ES256, jose.EdDSA})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -262,7 +262,7 @@ func ValidateTokenWithJWKS(
 	clusterName string,
 	token string,
 ) (*ValidationResult, error) {
-	jwt, err := josejwt.ParseSigned(token)
+	jwt, err := josejwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256, jose.ES256, jose.EdDSA})
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing jwt")
 	}
@@ -282,7 +282,7 @@ func ValidateTokenWithJWKS(
 		// We don't need to check the subject or other claims here.
 		// Anything related to matching the token against ProvisionToken
 		// allow rules is left to the discretion of `lib/auth`.
-		Audience: []string{
+		AnyAudience: []string{
 			clusterName,
 		},
 		Time: now,

--- a/lib/kube/token/validator_test.go
+++ b/lib/kube/token/validator_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
@@ -654,7 +654,7 @@ func TestValidateTokenWithJWKS(t *testing.T) {
 				tt.wantResult.Raw = tt.claims
 			}
 
-			token, err := jwt.Signed(tt.signer).Claims(tt.claims).CompactSerialize()
+			token, err := jwt.Signed(tt.signer).Claims(tt.claims).Serialize()
 			require.NoError(t, err)
 
 			result, err := ValidateTokenWithJWKS(

--- a/lib/oidc/fakeissuer/kubesigner.go
+++ b/lib/oidc/fakeissuer/kubesigner.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -84,7 +84,7 @@ func (s *KubernetesSigner) GetMarshaledJWKS() (string, error) {
 }
 
 func (s *KubernetesSigner) signWithClaims(claims interface{}) (string, error) {
-	token, err := jwt.Signed(s.signer).Claims(claims).CompactSerialize()
+	token, err := jwt.Signed(s.signer).Claims(claims).Serialize()
 	return token, trace.Wrap(err)
 }
 

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -37,7 +37,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -888,7 +889,7 @@ func TestRewriteJWT(t *testing.T) {
 						},
 					},
 					ValidateRequest: func(s *Suite, r *http.Request) {
-						token, err := jwt.ParseSigned(r.Header.Get("TestHeader"))
+						token, err := jwt.ParseSigned(r.Header.Get("TestHeader"), []jose.SignatureAlgorithm{jose.ES256})
 						require.NoError(t, err)
 
 						claims := libjwt.Claims{}


### PR DESCRIPTION
We have mixed use of go-jose/v3 and go-jose/v4. This begins the transition to standardize on go-jose/v4. The migrations included here were strategic in that they don't impact teleport.e.
