### PR TITLE
[v18] Fix ./lib/tpm tests using -tags=tpmsimulator

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -136,7 +136,7 @@ jobs:
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --build-tags libfido2,piv
+          args: --build-tags libfido2,piv,tpmsimulator
           skip-cache: true
       - name: golangci-lint (assets/backport)
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0

--- a/lib/tpm/tpm_simulator_test.go
+++ b/lib/tpm/tpm_simulator_test.go
@@ -151,7 +151,7 @@ func TestWithSimulator(t *testing.T) {
 		}, att.Data))
 
 		t.Run("Success", func(t *testing.T) {
-			validated, err := tpm.Validate(ctx, log, tpm.ValidateParams{
+			validated, err := tpm.Validate(ctx, tpm.ValidateParams{
 				EKKey:        att.Data.EKPub,
 				AttestParams: att.AttestParams,
 				Solve:        att.Solve,
@@ -163,7 +163,7 @@ func TestWithSimulator(t *testing.T) {
 			}, validated))
 		})
 		t.Run("Failure due to missing EKCert", func(t *testing.T) {
-			_, err = tpm.Validate(ctx, log, tpm.ValidateParams{
+			_, err = tpm.Validate(ctx, tpm.ValidateParams{
 				EKKey:        att.Data.EKPub,
 				AttestParams: att.AttestParams,
 				Solve:        att.Solve,
@@ -202,7 +202,7 @@ func TestWithSimulator(t *testing.T) {
 		}, att.Data))
 
 		t.Run("Success without CAs", func(t *testing.T) {
-			validated, err := tpm.Validate(ctx, log, tpm.ValidateParams{
+			validated, err := tpm.Validate(ctx, tpm.ValidateParams{
 				EKKey:        att.Data.EKPub,
 				EKCert:       att.Data.EKCert.Raw,
 				AttestParams: att.AttestParams,
@@ -216,7 +216,7 @@ func TestWithSimulator(t *testing.T) {
 			}, validated))
 		})
 		t.Run("Success with CAs", func(t *testing.T) {
-			validated, err := tpm.Validate(ctx, log, tpm.ValidateParams{
+			validated, err := tpm.Validate(ctx, tpm.ValidateParams{
 				EKKey:        att.Data.EKPub,
 				EKCert:       att.Data.EKCert.Raw,
 				AttestParams: att.AttestParams,
@@ -231,7 +231,7 @@ func TestWithSimulator(t *testing.T) {
 			}, validated))
 		})
 		t.Run("Failure with wrong CA", func(t *testing.T) {
-			_, err := tpm.Validate(ctx, log, tpm.ValidateParams{
+			_, err := tpm.Validate(ctx, tpm.ValidateParams{
 				EKKey:        att.Data.EKPub,
 				EKCert:       att.Data.EKCert.Raw,
 				AttestParams: att.AttestParams,


### PR DESCRIPTION
Backport #65807 to branch/v18.

Test-only fix, no production code changes.