### PR TITLE
unstable scopes critical option

### DIFF
--- a/api/utils/sshutils/callback.go
+++ b/api/utils/sshutils/callback.go
@@ -25,6 +25,10 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// certCriticalOptionScopedAgent mirrors teleport.CertCriticalOptionScopedAgent from the main module.
+// It is duplicated here because the api module cannot import the main teleport module.
+const certCriticalOptionScopedAgent = "scoped-agent-v1@goteleport.com"
+
 // CheckersGetter defines a function that returns a list of ssh public keys.
 type CheckersGetter func() ([]ssh.PublicKey, error)
 
@@ -60,9 +64,10 @@ func NewHostKeyCallback(conf HostKeyCallbackConfig) (ssh.HostKeyCallback, error)
 	}
 	checker := CertChecker{
 		CertChecker: ssh.CertChecker{
-			IsHostAuthority: makeIsHostAuthorityFunc(conf.GetHostCheckers),
-			HostKeyFallback: conf.HostKeyFallback,
-			Clock:           conf.Clock.Now,
+			IsHostAuthority:          makeIsHostAuthorityFunc(conf.GetHostCheckers),
+			HostKeyFallback:          conf.HostKeyFallback,
+			Clock:                    conf.Clock.Now,
+			SupportedCriticalOptions: []string{certCriticalOptionScopedAgent},
 		},
 		FIPS:        conf.FIPS,
 		OnCheckCert: conf.OnCheckCert,

--- a/constants.go
+++ b/constants.go
@@ -549,6 +549,17 @@ const (
 	// from which this certificate is accepted for authentication.
 	// See: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.certkeys?annotate=HEAD.
 	CertCriticalOptionSourceAddress = "source-address"
+	// TLSScopedAgentTraitsSentinel is stored in the traits (PostalCode) field of scoped agent TLS
+	// certificates in place of actual traits. Versions of Teleport that predate scoped agent support
+	// will fail to unmarshal this value and reject the certificate, which is the intended fail-closed
+	// behavior. This is a temporary measure; see CertCriticalOptionScopedAgent for context.
+	TLSScopedAgentTraitsSentinel = "scoped-agent-v1-traits-sentinel"
+	// CertCriticalOptionScopedAgent is a critical option set on agent/host certificates when they
+	// use unstable scoped features. This is a temporary measure to prevent use of scoped certificates
+	// with incompatible teleport version while scopes are behind their unstable feature flag.
+	// TODO(fspmarshall/scopes): Remove scoped agent critical option in favor of more graceful
+	// fail-closed mechanic prior to stabilization of scopes.
+	CertCriticalOptionScopedAgent = "scoped-agent-v1@goteleport.com"
 	// CertExtensionGitHubUserID indicates the GitHub user ID identified by the
 	// GitHub connector.
 	CertExtensionGitHubUserID = "github-id@goteleport.com"

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3397,7 +3397,8 @@ func (a *Server) augmentUserCertificates(
 		}
 
 		certChecker := &ssh.CertChecker{
-			Clock: a.clock.Now,
+			Clock:                    a.clock.Now,
+			SupportedCriticalOptions: []string{teleport.CertCriticalOptionScopedAgent},
 		}
 		if err := certChecker.CheckCert(principal, sshCert); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/sshca"
@@ -645,6 +646,9 @@ func (k *KeyRing) checkCert(sshCert *ssh.Certificate) error {
 	// A valid principal is always passed in because the principals are not being
 	// checked here, but rather the validity period, signature, and algorithms.
 	certChecker := sshutils.CertChecker{
+		CertChecker: ssh.CertChecker{
+			SupportedCriticalOptions: []string{teleport.CertCriticalOptionScopedAgent},
+		},
 		FIPS: isFIPS(),
 	}
 	if len(sshCert.ValidPrincipals) == 0 {

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -380,8 +380,9 @@ func (a *LocalKeyAgent) HostKeyCallback(addr string, remote net.Addr, hostKey ss
 
 	certChecker := sshutils.CertChecker{
 		CertChecker: ssh.CertChecker{
-			IsHostAuthority: a.isHostAuthorityForClusters(clusters...),
-			HostKeyFallback: a.checkHostKey,
+			IsHostAuthority:          a.isHostAuthorityForClusters(clusters...),
+			HostKeyFallback:          a.checkHostKey,
+			SupportedCriticalOptions: []string{teleport.CertCriticalOptionScopedAgent},
 		},
 		FIPS: isFIPS(),
 	}

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1022,7 +1022,8 @@ func (s *server) checkClientCert(user string, clusterName string, cert *ssh.Cert
 
 	checker := apisshutils.CertChecker{
 		CertChecker: ssh.CertChecker{
-			Clock: s.Clock.Now,
+			Clock:                    s.Clock.Now,
+			SupportedCriticalOptions: []string{teleport.CertCriticalOptionScopedAgent},
 		},
 		FIPS: s.FIPS,
 	}

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -528,8 +528,9 @@ func (h *AuthHandlers) PublicKeyCallback(conn ssh.ConnMetadata, key ssh.PublicKe
 	// timestamp, etc). Fallback to keys is not supported.
 	certChecker := apisshutils.CertChecker{
 		CertChecker: ssh.CertChecker{
-			IsUserAuthority: h.IsUserAuthority,
-			Clock:           h.c.Clock.Now,
+			IsUserAuthority:          h.IsUserAuthority,
+			Clock:                    h.c.Clock.Now,
+			SupportedCriticalOptions: []string{teleport.CertCriticalOptionScopedAgent},
 		},
 		FIPS: h.c.FIPS,
 	}
@@ -854,9 +855,10 @@ func (h *AuthHandlers) HostKeyAuth(addr string, remote net.Addr, key ssh.PublicK
 	// authority (CA) or fallback to host key checking if it's allowed.
 	certChecker := apisshutils.CertChecker{
 		CertChecker: ssh.CertChecker{
-			IsHostAuthority: h.IsHostAuthority,
-			HostKeyFallback: h.hostKeyCallback,
-			Clock:           h.c.Clock.Now,
+			IsHostAuthority:          h.IsHostAuthority,
+			HostKeyFallback:          h.hostKeyCallback,
+			Clock:                    h.c.Clock.Now,
+			SupportedCriticalOptions: []string{teleport.CertCriticalOptionScopedAgent},
 		},
 		FIPS: h.c.FIPS,
 	}

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -36,6 +36,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -324,6 +325,21 @@ func (i *Identity) Encode(certFormat string) (*ssh.Certificate, error) {
 		cert.CriticalOptions[teleport.CertCriticalOptionSourceAddress] = ip
 	}
 
+	if i.AgentScope != "" {
+		if err := scopes.AssertFeatureEnabled(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if cert.CriticalOptions == nil {
+			cert.CriticalOptions = make(map[string]string)
+		}
+		// CertCriticalOptionScopedAgent is a critical option set on agent/host certificates when they
+		// use unstable scoped features. This is a temporary measure to prevent use of scoped certificates
+		// with incompatible teleport version while scopes are behind their unstable feature flag.
+		// TODO(fspmarshall/scopes): Remove scoped agent critical option in favor of more graceful
+		// fail-closed mechanic prior to stabilization of scopes.
+		cert.CriticalOptions[teleport.CertCriticalOptionScopedAgent] = ""
+	}
+
 	for _, extension := range i.CertificateExtensions {
 		// TODO(lxea): update behavior when non ssh, non extensions are supported.
 		if extension.Mode != types.CertExtensionMode_EXTENSION ||
@@ -463,6 +479,15 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 	}
 
 	ident.AgentScope = takeValue(teleport.CertExtensionAgentScope)
+	/// CertCriticalOptionScopedAgent is a critical option set on agent/host certificates when they
+	// use unstable scoped features. This is a temporary measure to prevent use of scoped certificates
+	// with incompatible teleport version while scopes are behind their unstable feature flag.
+	// TODO(fspmarshall/scopes): Remove scoped agent critical option in favor of more graceful
+	// fail-closed mechanic prior to stabilization of scopes.
+	if _, ok := cert.CriticalOptions[teleport.CertCriticalOptionScopedAgent]; ok && ident.AgentScope == "" {
+		return nil, trace.BadParameter("certificate has %q critical option but missing %q extension",
+			teleport.CertCriticalOptionScopedAgent, teleport.CertExtensionAgentScope)
+	}
 	ident.PermitX11Forwarding = takeBool(teleport.CertExtensionPermitX11Forwarding)
 	ident.PermitAgentForwarding = takeBool(teleport.CertExtensionPermitAgentForwarding)
 	ident.PermitPortForwarding = takeBool(teleport.CertExtensionPermitPortForwarding)

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
@@ -157,4 +158,97 @@ func TestIdentityConversion(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Empty(t, cmp.Diff(ident, ident2, protocmp.Transform()))
+}
+
+// TestScopedAgentCriticalOption verifies the backward-compatibility critical option used by scoped agent certificates.
+//
+// The critical option causes versions of Teleport that do not understand scoped agents to reject any certificate
+// containing it, which is the intended fail-closed behavior. This test guards against changes that would
+// accidentally break either side of that contract.
+func TestScopedAgentCriticalOption(t *testing.T) {
+	t.Run("returns error when feature disabled", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_SCOPES", "")
+		ident := &Identity{
+			CertType:   ssh.HostCert,
+			Username:   "hostid",
+			SystemRole: types.RoleNode,
+			AgentScope: "/my/scope",
+		}
+		_, err := ident.Encode(constants.CertificateFormatStandard)
+		require.Error(t, err, "Encode must fail when AgentScope is set and scopes feature is disabled")
+	})
+
+	t.Run("critical option present iff AgentScope set", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+		withScope := &Identity{
+			CertType:   ssh.HostCert,
+			Username:   "hostid",
+			SystemRole: types.RoleNode,
+			AgentScope: "/my/scope",
+		}
+		cert, err := withScope.Encode(constants.CertificateFormatStandard)
+		require.NoError(t, err)
+		require.Contains(t, cert.CriticalOptions, teleport.CertCriticalOptionScopedAgent,
+			"critical option must be present when AgentScope is set")
+
+		withoutScope := &Identity{
+			CertType:   ssh.HostCert,
+			Username:   "hostid",
+			SystemRole: types.RoleNode,
+		}
+		cert, err = withoutScope.Encode(constants.CertificateFormatStandard)
+		require.NoError(t, err)
+		require.NotContains(t, cert.CriticalOptions, teleport.CertCriticalOptionScopedAgent,
+			"critical option must be absent when AgentScope is not set")
+	})
+
+	t.Run("unknown critical option rejects cert", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+		// This is the core correctness invariant: a CertChecker without SupportedCriticalOptions
+		// must reject a scoped agent cert, matching the behavior of pre-scope Teleport versions.
+		ident := &Identity{
+			CertType:    ssh.HostCert,
+			Username:    "hostid",
+			SystemRole:  types.RoleNode,
+			AgentScope:  "/my/scope",
+			ValidAfter:  1,
+			ValidBefore: 2,
+		}
+		cert, err := ident.Encode(constants.CertificateFormatStandard)
+		require.NoError(t, err)
+
+		checker := ssh.CertChecker{}
+		err = checker.CheckCert("hostid", cert)
+		require.Error(t, err, "CertChecker without SupportedCriticalOptions must reject a scoped agent cert")
+		require.Contains(t, err.Error(), teleport.CertCriticalOptionScopedAgent)
+
+		// A checker that knows about the option must not reject it on that basis.
+		checkerWithSupport := ssh.CertChecker{
+			SupportedCriticalOptions: []string{teleport.CertCriticalOptionScopedAgent},
+		}
+		err = checkerWithSupport.CheckCert("hostid", cert)
+		// Error is expected (cert is unsigned and expired), but must NOT be about the critical option.
+		if err != nil {
+			require.NotContains(t, err.Error(), teleport.CertCriticalOptionScopedAgent)
+		}
+	})
+
+	t.Run("round-trip preserves AgentScope", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+		original := &Identity{
+			CertType:   ssh.HostCert,
+			Username:   "hostid",
+			SystemRole: types.RoleNode,
+			AgentScope: "/my/scope",
+		}
+		cert, err := original.Encode(constants.CertificateFormatStandard)
+		require.NoError(t, err)
+
+		decoded, err := DecodeIdentity(cert)
+		require.NoError(t, err)
+		require.Equal(t, original.AgentScope, decoded.AgentScope)
+	})
 }

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -797,6 +797,9 @@ func validateHostSigner(fips bool, signer ssh.Signer) error {
 	}
 
 	certChecker := sshutils.CertChecker{
+		CertChecker: ssh.CertChecker{
+			SupportedCriticalOptions: []string{teleport.CertCriticalOptionScopedAgent},
+		},
 		FIPS: fips,
 	}
 	err := certChecker.CheckCert(cert.ValidPrincipals[0], cert)

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/pinning"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -690,9 +691,25 @@ var (
 
 // Subject converts identity to X.509 subject name
 func (id *Identity) Subject() (pkix.Name, error) {
-	rawTraits, err := wrappers.MarshalTraits(&id.Traits)
-	if err != nil {
-		return pkix.Name{}, trace.Wrap(err)
+	if len(id.Traits) > 0 && id.AgentScope != "" {
+		return pkix.Name{}, trace.BadParameter("identity cannot contain mix of traits and agent scope")
+	}
+
+	// XXX: placing a sentinel value in traits is a temporary hack intended to make scoped agent certs incompatible with
+	// teleport versions that are not running the current iteration of unstable scoped features. Future iterations will
+	// use a scoped agent identity representation with more natural fail-closed mechanics.
+	var rawTraits []byte
+	if id.AgentScope != "" {
+		if err := scopes.AssertFeatureEnabled(); err != nil {
+			return pkix.Name{}, trace.Wrap(err)
+		}
+		rawTraits = []byte(teleport.TLSScopedAgentTraitsSentinel)
+	} else {
+		var err error
+		rawTraits, err = wrappers.MarshalTraits(&id.Traits)
+		if err != nil {
+			return pkix.Name{}, trace.Wrap(err)
+		}
 	}
 
 	subject := pkix.Name{
@@ -1163,7 +1180,8 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 	if len(subject.StreetAddress) > 0 {
 		id.RouteToCluster = subject.StreetAddress[0]
 	}
-	if len(subject.PostalCode) > 0 {
+	// Skip traits unmarshaling if the postal code contains the scoped agent sentinel (see teleport.TLSScopedAgentTraitsSentinel).
+	if len(subject.PostalCode) > 0 && subject.PostalCode[0] != teleport.TLSScopedAgentTraitsSentinel {
 		err := wrappers.UnmarshalTraits([]byte(subject.PostalCode[0]), &id.Traits)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types/wrappers"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -742,4 +743,75 @@ func TestDelegationSessionID(t *testing.T) {
 	require.True(t, out.IsDelegationSession())
 	require.False(t, out.Renewable)
 	require.Empty(t, cmp.Diff(out, &identity, cmpopts.EquateApproxTime(time.Second)))
+}
+
+// TestScopedAgentTraitsSentinel verifies the backward-compatibility sentinel used by scoped agent certificates.
+//
+// The sentinel is stored in the traits (PostalCode) field instead of actual traits. Pre-scope versions of Teleport
+// will fail to unmarshal this value and reject the certificate, which is the intended fail-closed behavior. This test
+// guards against changes that would accidentally break either side of that contract.
+func TestScopedAgentTraitsSentinel(t *testing.T) {
+	t.Run("unmarshal fails on sentinel", func(t *testing.T) {
+		// This is the core correctness invariant: if UnmarshalTraits ever stops returning an error for the sentinel
+		// value, pre-scope Teleport versions would silently accept scoped certs rather than rejecting them.
+		var traits wrappers.Traits
+		err := wrappers.UnmarshalTraits([]byte(teleport.TLSScopedAgentTraitsSentinel), &traits)
+		require.Error(t, err, "UnmarshalTraits must fail on the scoped agent sentinel value")
+	})
+
+	t.Run("returns error when feature disabled", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_SCOPES", "")
+		withScope := Identity{
+			Username:   "hostid",
+			Groups:     []string{string(types.RoleNode)},
+			AgentScope: "/my/scope",
+		}
+		_, err := withScope.Subject()
+		require.Error(t, err, "Subject must fail when AgentScope is set and scopes feature is disabled")
+	})
+
+	t.Run("sentinel present iff AgentScope set", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+		withScope := Identity{
+			Username:   "hostid",
+			Groups:     []string{string(types.RoleNode)},
+			AgentScope: "/my/scope",
+		}
+		subj, err := withScope.Subject()
+		require.NoError(t, err)
+		require.Equal(t, []string{teleport.TLSScopedAgentTraitsSentinel}, subj.PostalCode,
+			"PostalCode should contain only the sentinel when AgentScope is set")
+
+		withoutScope := Identity{
+			Username: "alice",
+			Groups:   []string{"editor"},
+		}
+		subj, err = withoutScope.Subject()
+		require.NoError(t, err)
+		require.NotContains(t, subj.PostalCode, teleport.TLSScopedAgentTraitsSentinel,
+			"PostalCode must not contain the sentinel when AgentScope is not set")
+	})
+
+	t.Run("round-trip preserves AgentScope and leaves traits nil", func(t *testing.T) {
+		t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+		original := Identity{
+			Username:        "hostid",
+			Groups:          []string{string(types.RoleNode)},
+			AgentScope:      "/my/scope",
+			TeleportCluster: "mycluster",
+		}
+		subj, err := original.Subject()
+		require.NoError(t, err)
+
+		// Simulate what happens when the cert is parsed: ExtraNames are merged into Names.
+		subj.Names = append(subj.Names, subj.ExtraNames...)
+		subj.ExtraNames = nil
+
+		got, err := FromSubject(subj, original.Expires)
+		require.NoError(t, err)
+		require.Equal(t, original.AgentScope, got.AgentScope)
+		require.Empty(t, got.Traits, "Traits should be empty for a scoped agent identity")
+	})
 }


### PR DESCRIPTION
This PR provides a temporary means of breaking agent certificate compatibility with other teleport versions when agent certificates are scoped.  The intent of this PR is to allow us to more freely iterate on scoped agent permissions without needing to develop graceful behavior in the event of downgrades or incompatible changes (which are comparatively labor intensive to get right).

The breaking behavior introduced by this PR is sealed behind the unstable scopes feature, and does not effect ordinary agent certificates.

This change will be reverted as soon as we've finished iterating on scoped agent identity ideas.

## Manual Test Plan

### Test Environment

Local dev build.

### Test Cases


- [x] Verify that downgrade of auth causes scoped agents to be unable to establish tunnels.
- [x] Verify that downgrade of auth causes scoped agents to be unable to access auth APIs.
- [x] Verify that scoped agents are accessible and healthy when auth and agent both include this change.
- [ ] Verify that unscoped teleport agents created before this change function normally after it.
- [ ] Verify that unscoped teleport agents created with this change in place function normally after downgrade.

