### PR TITLE
tfgen: sanitize terraform resource name

### DIFF
--- a/lib/tfgen/tfgen.go
+++ b/lib/tfgen/tfgen.go
@@ -20,6 +20,7 @@ package tfgen
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -34,6 +35,16 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tfgen/internal"
 )
+
+// invalidTerraformName matches any character that is not valid in a
+// Terraform resource name.
+var invalidTerraformName = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+
+// SanitizeResourceName returns a copy of name safe for use as Terraform resource
+// name. Chars not matching "a-zA-Z0-9_-" are replaced with underscores.
+func SanitizeResourceName(name string) string {
+	return invalidTerraformName.ReplaceAllString(name, "_")
+}
 
 // Resource for which Terraform configuration can be generated. It's a subset of
 // the common methods between types.Resource and types.Resource153.

--- a/lib/tfgen/tfgen_test.go
+++ b/lib/tfgen/tfgen_test.go
@@ -307,6 +307,24 @@ func TestGenerate_ResourceComment(t *testing.T) {
 	)
 }
 
+func TestSanitizeResourceName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "Alpaca123@goteleport.com", want: "Alpaca123_goteleport_com"},
+		{input: "simple", want: "simple"},
+		{input: "with spaces", want: "with_spaces"},
+		{input: "`", want: "_"},
+		{input: `\|{}[]<>,.?/~!@#$%^&*()_+='`, want: "___________________________"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			require.Equal(t, tt.want, tfgen.SanitizeResourceName(tt.input))
+		})
+	}
+}
+
 func goldenTest(t *testing.T, resource tfgen.Resource, opts ...tfgen.GenerateOpt) {
 	t.Helper()
 


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/7183

Terraform resource name has these restrictions:

```
A name must start with a letter or underscore and may contain 
only letters, digits, underscores, and dashes.
```

Example: for the resource `access_list_member`, the terraform resource name was whatever the users name is, and name like `name@example.com` resulted in the above error. This PR sanitizes the resource name by replacing all special characters not allowed by terraform to underscores instead. So `name@example.com` becomes `name_example_com`

The usage is like below where the caller explicitly handles sanitizing:

```
memberName := "name@example.com"

tfgen.Generate(
	tfgen.WithResourceName(fmt.Sprintf("acl-member-%s", tfgen.SanitizeResourceName(memberName))
)
```