### PR TITLE
kube: propagate DeleteCollection upstream errors

### DIFF
--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -335,6 +336,7 @@ func deleteResources[T kubeObjectInterface](
 	deleteOptions metav1.DeleteOptions,
 ) ([]T, error) {
 	deletedItems := make([]T, 0, len(items))
+	var deleteErrs []error
 	for _, item := range items {
 		// Compute users and groups from available roles that match the
 		// cluster labels and kubernetes resources.
@@ -390,13 +392,31 @@ func deleteResources[T kubeObjectInterface](
 			Version:  gvk.Version,
 			Resource: kind,
 		}).Namespace(item.GetNamespace()).Delete(params.ctx, item.GetName(), deleteOptions)
-		if err != nil {
-			// TODO(tigrato): check what should we do when delete returns an error.
-			// Should we check if it's permission error?
-			// Check if the Pod has already been deleted by a concurrent request
-			continue
+		switch {
+		case err == nil:
+			deletedItems = append(deletedItems, item)
+		case kubeerrors.IsNotFound(err):
+			// Resource already gone (concurrent deletion).
+			// Treat as success: desired state is achieved and omit from the returned list
+			// because the caller already received the status separately through the API.
+			params.log.DebugContext(params.ctx,
+				"resource already deleted, skipping",
+				"kind", kind,
+				"group", group,
+				"namespace", item.GetNamespace(),
+				"name", item.GetName(),
+			)
+		default:
+			params.log.WarnContext(params.ctx,
+				"failed to delete resource",
+				"kind", kind,
+				"group", group,
+				"namespace", item.GetNamespace(),
+				"name", item.GetName(),
+				"error", err,
+			)
+			deleteErrs = append(deleteErrs, trace.Wrap(err))
 		}
-		deletedItems = append(deletedItems, item)
 	}
-	return deletedItems, nil
+	return deletedItems, trace.NewAggregate(deleteErrs...)
 }

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -1079,6 +1079,124 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 	require.Empty(t, kubeMock.DeletedPods(""), "a request as received without metav1.DeleteOptions.Preconditions.UID")
 }
 
+// TestDeletePodCollectionErrorPropagation exercises the DeleteCollection error
+// handling paths: upstream NotFound errors are treated as success (idempotent
+// delete races), while other upstream errors are surfaced to the caller.
+func TestDeletePodCollectionErrorPropagation(t *testing.T) {
+	const username = "full_user"
+
+	tests := []struct {
+		name           string
+		podErrors      map[string]metav1.Status
+		wantErr        bool
+		wantErrCode    int32
+		wantDeletedPod string
+	}{
+		{
+			name: "NotFound is treated as success",
+			podErrors: map[string]metav1.Status{
+				"nginx-1": {
+					Status:  metav1.StatusFailure,
+					Code:    http.StatusNotFound,
+					Reason:  metav1.StatusReasonNotFound,
+					Message: "pod not found",
+				},
+			},
+			wantDeletedPod: "default/nginx-2",
+		},
+		{
+			name: "Forbidden is propagated to the caller",
+			podErrors: map[string]metav1.Status{
+				"nginx-1": {
+					Status:  metav1.StatusFailure,
+					Code:    http.StatusForbidden,
+					Reason:  metav1.StatusReasonForbidden,
+					Message: "forbidden by kube rbac",
+				},
+			},
+			wantErr:        true,
+			wantDeletedPod: "default/nginx-2",
+		},
+		{
+			name: "Internal server error is propagated",
+			podErrors: map[string]metav1.Status{
+				"nginx-1": {
+					Status:  metav1.StatusFailure,
+					Code:    http.StatusInternalServerError,
+					Reason:  metav1.StatusReasonInternalError,
+					Message: "boom",
+				},
+			},
+			wantErr:        true,
+			wantDeletedPod: "default/nginx-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := make([]tkm.Option, 0, len(tt.podErrors))
+			for name, status := range tt.podErrors {
+				opts = append(opts, tkm.WithDeletePodError(name, status))
+			}
+			kubeMock, err := tkm.NewKubeAPIMock(opts...)
+			require.NoError(t, err)
+			t.Cleanup(func() { kubeMock.Close() })
+
+			testCtx := SetupTestContext(
+				context.Background(),
+				t,
+				TestConfig{
+					Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+				},
+			)
+			t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+
+			testCtx.CreateUserAndRole(
+				testCtx.Context,
+				t,
+				username,
+				RoleSpec{
+					Name:       username,
+					KubeUsers:  roleKubeUsers,
+					KubeGroups: roleKubeGroups,
+					SetupRoleFunc: func(r types.Role) {
+						r.SetKubeResources(types.Allow, []types.KubernetesResource{
+							{
+								Kind:      "pods",
+								Name:      types.Wildcard,
+								Namespace: types.Wildcard,
+								Verbs:     []string{types.Wildcard},
+								APIGroup:  types.Wildcard,
+							},
+						})
+					},
+				},
+			)
+
+			requestID := kubetypes.UID(uuid.NewString())
+			client, _ := testCtx.GenTestKubeClientTLSCert(t, username, kubeCluster)
+			err = client.CoreV1().Pods(metav1.NamespaceDefault).DeleteCollection(
+				testCtx.Context,
+				metav1.DeleteOptions{
+					Preconditions: &metav1.Preconditions{UID: &requestID},
+				},
+				metav1.ListOptions{},
+			)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			// In all cases, the second pod should still have been
+			// attempted (and succeed), proving we don't short-circuit
+			// the whole batch on a single-item failure.
+			require.Contains(t, kubeMock.DeletedPods(string(requestID)), tt.wantDeletedPod)
+		})
+	}
+}
+
 func TestDeleteCRDCollectionRBAC(t *testing.T) {
 	const (
 		usernameWithFullAccess      = "full_user"

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -142,6 +142,17 @@ func WithExecError(status metav1.Status) Option {
 	}
 }
 
+// WithDeletePodError sets the error to be returned by the DeletePod call for a
+// specific pod name. Useful for exercising error paths in DeleteCollection.
+func WithDeletePodError(podName string, status metav1.Status) Option {
+	return func(s *KubeMockServer) {
+		if s.deletePodErrors == nil {
+			s.deletePodErrors = map[string]*metav1.Status{}
+		}
+		s.deletePodErrors[podName] = &status
+	}
+}
+
 // WithPortForwardError sets the error to be returned by the PortForward call
 func WithPortForwardError(status metav1.Status) Option {
 	return func(s *KubeMockServer) {
@@ -180,6 +191,7 @@ type KubeMockServer struct {
 	getPodError          *metav1.Status
 	execPodError         *metav1.Status
 	portforwardError     *metav1.Status
+	deletePodErrors      map[string]*metav1.Status
 	mu                   sync.Mutex
 	version              *apimachineryversion.Info
 	KubeExecRequests     KubeUpgradeRequests

--- a/lib/kube/proxy/testing/kube_server/pods.go
+++ b/lib/kube/proxy/testing/kube_server/pods.go
@@ -112,6 +112,10 @@ func (s *KubeMockServer) getPod(w http.ResponseWriter, req *http.Request, p http
 func (s *KubeMockServer) deletePod(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
 	namespace := p.ByName("namespace")
 	name := p.ByName("name")
+	if status, ok := s.deletePodErrors[name]; ok {
+		s.writeResponseError(w, nil, status.DeepCopy())
+		return nil, nil
+	}
 	deleteOpts, err := parseDeleteCollectionBody(req)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Surface errors from the upstream Kubernetes `Delete` call inside `deleteResources` instead of silently dropping them. `IsNotFound` is still treated as success (idempotent race); any other error is logged and aggregated into the return, so the caller sees a failure rather than a silently-truncated list.