### PR TITLE
kube: remove dead conditional in GetKubeAgentVersion

### DIFF
--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -188,32 +188,14 @@ type Pinger interface {
 
 // GetKubeAgentVersion returns a version of the Kube agent appropriate for this Teleport cluster. Used for example when deciding version
 // for enrolling EKS clusters.
-func GetKubeAgentVersion(ctx context.Context, pinger Pinger, clusterFeatures proto.Features, versionGetter version.Getter) (*semver.Version, error) {
+func GetKubeAgentVersion(ctx context.Context, pinger Pinger) (*semver.Version, error) {
 	pingResponse, err := pinger.Ping(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	var agentVersion *semver.Version
-
-	// TODO(hugoShaka) remove the conditional check, we always use the cluster version
-	if clusterFeatures.GetAutomaticUpgrades() && clusterFeatures.GetCloud() {
-		defaultVersion, err := versionGetter.GetVersion(ctx)
-		if err == nil {
-			agentVersion = defaultVersion
-		} else if !errors.Is(err, &version.NoNewVersionError{}) {
-			return nil, trace.Wrap(err)
-		}
+	clusterVersion, err := version.EnsureSemver(pingResponse.ServerVersion)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse cluster version")
 	}
-
-	if agentVersion == nil {
-		clusterVersion, err := version.EnsureSemver(pingResponse.ServerVersion)
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to parse cluster version")
-		} else {
-			agentVersion = clusterVersion
-		}
-	}
-
-	return agentVersion, nil
+	return clusterVersion, nil
 }

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -182,20 +182,9 @@ func extractAndSortKubeClusters(kss []types.KubeServer) []types.KubeCluster {
 	return []types.KubeCluster(sorted)
 }
 
-type Pinger interface {
-	Ping(context.Context) (proto.PingResponse, error)
-}
-
 // GetKubeAgentVersion returns a version of the Kube agent appropriate for this Teleport cluster. Used for example when deciding version
 // for enrolling EKS clusters.
-func GetKubeAgentVersion(ctx context.Context, pinger Pinger) (*semver.Version, error) {
-	pingResponse, err := pinger.Ping(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	clusterVersion, err := version.EnsureSemver(pingResponse.ServerVersion)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to parse cluster version")
-	}
-	return clusterVersion, nil
+func GetKubeAgentVersion(ctx context.Context, versionGetter version.Getter) (*semver.Version, error) {
+	v, err := versionGetter.GetVersion(ctx)
+	return v, trace.Wrap(err)
 }

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -183,32 +183,14 @@ type Pinger interface {
 
 // GetKubeAgentVersion returns a version of the Kube agent appropriate for this Teleport cluster. Used for example when deciding version
 // for enrolling EKS clusters.
-func GetKubeAgentVersion(ctx context.Context, pinger Pinger, clusterFeatures proto.Features, versionGetter version.Getter) (*semver.Version, error) {
+func GetKubeAgentVersion(ctx context.Context, pinger Pinger) (*semver.Version, error) {
 	pingResponse, err := pinger.Ping(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	var agentVersion *semver.Version
-
-	// TODO(hugoShaka) remove the conditional check, we always use the cluster version
-	if clusterFeatures.GetAutomaticUpgrades() && clusterFeatures.GetCloud() {
-		defaultVersion, err := versionGetter.GetVersion(ctx)
-		if err == nil {
-			agentVersion = defaultVersion
-		} else if !errors.Is(err, &version.NoNewVersionError{}) {
-			return nil, trace.Wrap(err)
-		}
+	clusterVersion, err := version.EnsureSemver(pingResponse.ServerVersion)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse cluster version")
 	}
-
-	if agentVersion == nil {
-		clusterVersion, err := version.EnsureSemver(pingResponse.ServerVersion)
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to parse cluster version")
-		} else {
-			agentVersion = clusterVersion
-		}
-	}
-
-	return agentVersion, nil
+	return clusterVersion, nil
 }

--- a/lib/kube/utils/utils_test.go
+++ b/lib/kube/utils/utils_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 )
 
@@ -37,52 +36,36 @@ func TestGetAgentVersion(t *testing.T) {
 
 	testCases := []struct {
 		desc            string
-		ping            func(ctx context.Context) (proto.PingResponse, error)
+		getter          version.Getter
 		expectedVersion *semver.Version
 		errorAssert     require.ErrorAssertionFunc
 	}{
 		{
-			desc: "ping error",
-			ping: func(ctx context.Context) (proto.PingResponse, error) {
-				return proto.PingResponse{}, trace.BadParameter("ping error")
-			},
+			desc:            "version getter error",
+			getter:          mustStaticGetter(t, "", trace.BadParameter("getter error")),
 			expectedVersion: nil,
 			errorAssert:     require.Error,
 		},
 		{
-			desc: "valid cluster version",
-			ping: func(ctx context.Context) (proto.PingResponse, error) {
-				return proto.PingResponse{ServerVersion: "1.2.3"}, nil
-			},
+			desc:            "version from getter",
+			getter:          mustStaticGetter(t, "1.2.3", nil),
 			expectedVersion: semver.Must(version.EnsureSemver("1.2.3")),
 			errorAssert:     require.NoError,
-		},
-		{
-			desc: "invalid cluster version",
-			ping: func(ctx context.Context) (proto.PingResponse, error) {
-				return proto.PingResponse{ServerVersion: "10"}, nil
-			},
-			expectedVersion: nil,
-			errorAssert:     require.Error,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
-			p := &pinger{pingFn: tt.ping}
-
-			result, err := GetKubeAgentVersion(ctx, p)
-
+			result, err := GetKubeAgentVersion(ctx, tt.getter)
 			tt.errorAssert(t, err)
 			require.Equal(t, tt.expectedVersion, result)
 		})
 	}
 }
 
-type pinger struct {
-	pingFn func(ctx context.Context) (proto.PingResponse, error)
-}
-
-func (p *pinger) Ping(ctx context.Context) (proto.PingResponse, error) {
-	return p.pingFn(ctx)
+func mustStaticGetter(t *testing.T, v string, err error) version.Getter {
+	t.Helper()
+	g, gerr := version.NewStaticGetter(v, err)
+	require.NoError(t, gerr)
+	return g
 }

--- a/lib/kube/utils/utils_test.go
+++ b/lib/kube/utils/utils_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 )
 
@@ -39,8 +38,6 @@ func TestGetAgentVersion(t *testing.T) {
 	testCases := []struct {
 		desc            string
 		ping            func(ctx context.Context) (proto.PingResponse, error)
-		clusterFeatures proto.Features
-		channelVersion  string
 		expectedVersion *semver.Version
 		errorAssert     require.ErrorAssertionFunc
 	}{
@@ -53,7 +50,7 @@ func TestGetAgentVersion(t *testing.T) {
 			errorAssert:     require.Error,
 		},
 		{
-			desc: "no automatic upgrades",
+			desc: "valid cluster version",
 			ping: func(ctx context.Context) (proto.PingResponse, error) {
 				return proto.PingResponse{ServerVersion: "1.2.3"}, nil
 			},
@@ -61,28 +58,20 @@ func TestGetAgentVersion(t *testing.T) {
 			errorAssert:     require.NoError,
 		},
 		{
-			desc: "automatic upgrades",
+			desc: "invalid cluster version",
 			ping: func(ctx context.Context) (proto.PingResponse, error) {
 				return proto.PingResponse{ServerVersion: "10"}, nil
 			},
-			clusterFeatures: proto.Features{AutomaticUpgrades: true, Cloud: true},
-			channelVersion:  "v1.2.3",
-			expectedVersion: semver.Must(version.EnsureSemver("1.2.3")),
-			errorAssert:     require.NoError,
+			expectedVersion: nil,
+			errorAssert:     require.Error,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
 			p := &pinger{pingFn: tt.ping}
-			var channel *automaticupgrades.Channel
-			if tt.channelVersion != "" {
-				channel = &automaticupgrades.Channel{StaticVersion: tt.channelVersion}
-				err := channel.CheckAndSetDefaults()
-				require.NoError(t, err)
-			}
 
-			result, err := GetKubeAgentVersion(ctx, p, tt.clusterFeatures, channel)
+			result, err := GetKubeAgentVersion(ctx, p)
 
 			tt.errorAssert(t, err)
 			require.Equal(t, tt.expectedVersion, result)

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -20,7 +20,10 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"maps"
+	"net/url"
+	"path"
 	"slices"
 	"strings"
 	"sync"
@@ -30,9 +33,13 @@ import (
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/webclient"
 	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/automaticupgrades"
+	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
@@ -53,6 +60,38 @@ func (s *Server) startKubeIntegrationWatchers() error {
 	enrollingClusters := map[string]bool{}
 
 	clt := s.AccessPoint
+
+	pingResponse, err := s.AccessPoint.Ping(s.ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	proxyPublicAddr := pingResponse.GetProxyPublicAddr()
+
+	var versionGetter version.Getter
+	if proxyPublicAddr == "" {
+		// If there are no proxy services running, we might fail to get the proxy URL and build a client.
+		// In this case we "gracefully" fallback to our own version.
+		// This is not supposed to happen outside of tests as the discovery service must join via a proxy.
+		s.Log.WarnContext(s.ctx,
+			"Failed to determine proxy public address, agents will install our own Teleport version instead of the one advertised by the proxy.",
+			"version", teleport.Version)
+		versionGetter, err = version.NewStaticGetter(teleport.Version, nil)
+		if err != nil {
+			return trace.BadParameter("Cannot parse Teleport's self version %q, this is a bug", teleport.Version)
+		}
+	} else {
+		versionGetter, err = versionGetterForProxy(s.ctx, proxyPublicAddr)
+		if err != nil {
+			s.Log.WarnContext(s.ctx,
+				"Failed to build a version client, falling back to Discovery service Teleport version.",
+				"error", err,
+				"version", teleport.Version)
+			versionGetter, err = version.NewStaticGetter(teleport.Version, nil)
+			if err != nil {
+				return trace.BadParameter("Cannot parse Teleport's self version %q, this is a bug", teleport.Version)
+			}
+		}
+	}
 
 	watcher, err := common.NewWatcher(s.ctx, common.WatcherConfig{
 		FetchersFn: func() []common.Fetcher {
@@ -97,7 +136,7 @@ func (s *Server) startKubeIntegrationWatchers() error {
 					continue
 				}
 
-				agentVersion, err := kubeutils.GetKubeAgentVersion(s.ctx, s.AccessPoint)
+				agentVersion, err := kubeutils.GetKubeAgentVersion(s.ctx, versionGetter)
 				if err != nil {
 					s.Log.WarnContext(s.ctx, "Could not get agent version to enroll EKS clusters", "error", err)
 					continue
@@ -352,4 +391,53 @@ func (s *Server) getKubeIntegrationFetchers() []common.Fetcher {
 
 func (s *Server) getKubeNonIntegrationFetchers() []common.Fetcher {
 	return s.getKubeFetchers(false)
+}
+
+func versionGetterForProxy(ctx context.Context, proxyPublicAddr string) (version.Getter, error) {
+	proxyClt, err := webclient.NewReusableClient(&webclient.Config{
+		Context:   ctx,
+		ProxyAddr: proxyPublicAddr,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to build proxy client")
+	}
+
+	baseURL := &url.URL{
+		Scheme:  "https",
+		Host:    proxyPublicAddr,
+		RawPath: path.Join("/webapi/automaticupgrades/channel", automaticupgrades.DefaultChannelName),
+	}
+
+	return proxyAgentVersionGetter{
+		primary: version.FailoverGetter{
+			// First try the new webapi (RFD-184).
+			version.NewProxyVersionGetter(proxyClt),
+			// If that's not implemented, fall back to release channels (RFD-109).
+			version.NewBasicHTTPVersionGetter(baseURL),
+		},
+		proxyClient: proxyClt,
+	}, nil
+}
+
+// proxyAgentVersionGetter falls back to the proxy's own ServerVersion when the
+// primary chain reports no autoupdate version is configured.
+type proxyAgentVersionGetter struct {
+	primary     version.Getter
+	proxyClient *webclient.ReusableClient
+}
+
+func (g proxyAgentVersionGetter) GetVersion(ctx context.Context) (*semver.Version, error) {
+	v, err := g.primary.GetVersion(ctx)
+	if err == nil {
+		return v, nil
+	}
+	var noNewVersionErr *version.NoNewVersionError
+	if !errors.As(trace.Unwrap(err), &noNewVersionErr) {
+		return nil, trace.Wrap(err)
+	}
+	resp, findErr := g.proxyClient.Find()
+	if findErr != nil {
+		return nil, trace.Wrap(findErr, "failed to fetch proxy ServerVersion as fallback")
+	}
+	return version.EnsureSemver(resp.ServerVersion)
 }

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -408,6 +408,11 @@ func versionGetterForProxy(ctx context.Context, proxyPublicAddr string) (version
 		RawPath: path.Join("/webapi/automaticupgrades/channel", automaticupgrades.DefaultChannelName),
 	}
 
+	selfVersion, err := version.EnsureSemver(teleport.Version)
+	if err != nil {
+		return nil, trace.BadParameter("Cannot parse Teleport's self version %q, this is a bug", teleport.Version)
+	}
+
 	return proxyAgentVersionGetter{
 		primary: version.FailoverGetter{
 			// First try the new webapi (RFD-184).
@@ -416,14 +421,19 @@ func versionGetterForProxy(ctx context.Context, proxyPublicAddr string) (version
 			version.NewBasicHTTPVersionGetter(baseURL),
 		},
 		proxyClient: proxyClt,
+		selfVersion: selfVersion,
 	}, nil
 }
 
-// proxyAgentVersionGetter falls back to the proxy's own ServerVersion when the
-// primary chain reports no autoupdate version is configured.
+// proxyAgentVersionGetter walks three tiers of fallback.
+// On primary success it returns the proxy's advertised autoupdate target.
+// On NoNewVersionError it returns the proxy's own ServerVersion from /find.
+// If the proxy can't be reached at all, it returns the Discovery service's own Teleport version
+// so enrollment can still proceed instead of stalling.
 type proxyAgentVersionGetter struct {
 	primary     version.Getter
 	proxyClient *webclient.ReusableClient
+	selfVersion *semver.Version
 }
 
 func (g proxyAgentVersionGetter) GetVersion(ctx context.Context) (*semver.Version, error) {
@@ -431,13 +441,15 @@ func (g proxyAgentVersionGetter) GetVersion(ctx context.Context) (*semver.Versio
 	if err == nil {
 		return v, nil
 	}
+
 	var noNewVersionErr *version.NoNewVersionError
-	if !errors.As(trace.Unwrap(err), &noNewVersionErr) {
-		return nil, trace.Wrap(err)
+	if errors.As(trace.Unwrap(err), &noNewVersionErr) {
+		if resp, findErr := g.proxyClient.Find(); findErr == nil {
+			if pv, perr := version.EnsureSemver(resp.ServerVersion); perr == nil {
+				return pv, nil
+			}
+		}
 	}
-	resp, findErr := g.proxyClient.Find()
-	if findErr != nil {
-		return nil, trace.Wrap(findErr, "failed to fetch proxy ServerVersion as fallback")
-	}
-	return version.EnsureSemver(resp.ServerVersion)
+
+	return g.selfVersion, nil
 }

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -21,8 +21,6 @@ package discovery
 import (
 	"context"
 	"maps"
-	"net/url"
-	"path"
 	"slices"
 	"strings"
 	"sync"
@@ -32,13 +30,9 @@ import (
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/client/webclient"
 	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/automaticupgrades"
-	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
@@ -59,38 +53,6 @@ func (s *Server) startKubeIntegrationWatchers() error {
 	enrollingClusters := map[string]bool{}
 
 	clt := s.AccessPoint
-
-	pingResponse, err := s.AccessPoint.Ping(s.ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	proxyPublicAddr := pingResponse.GetProxyPublicAddr()
-
-	var versionGetter version.Getter
-	if proxyPublicAddr == "" {
-		// If there are no proxy services running, we might fail to get the proxy URL and build a client.
-		// In this case we "gracefully" fallback to our own version.
-		// This is not supposed to happen outside of tests as the discovery service must join via a proxy.
-		s.Log.WarnContext(s.ctx,
-			"Failed to determine proxy public address, agents will install our own Teleport version instead of the one advertised by the proxy.",
-			"version", teleport.Version)
-		versionGetter, err = version.NewStaticGetter(teleport.Version, nil)
-		if err != nil {
-			return trace.BadParameter("Cannot parse Teleport's self version %q, this is a bug", teleport.Version)
-		}
-	} else {
-		versionGetter, err = versionGetterForProxy(s.ctx, proxyPublicAddr)
-		if err != nil {
-			s.Log.WarnContext(s.ctx,
-				"Failed to build a version client, falling back to Discovery service Teleport version.",
-				"error", err,
-				"version", teleport.Version)
-			versionGetter, err = version.NewStaticGetter(teleport.Version, nil)
-			if err != nil {
-				return trace.BadParameter("Cannot parse Teleport's self version %q, this is a bug", teleport.Version)
-			}
-		}
-	}
 
 	watcher, err := common.NewWatcher(s.ctx, common.WatcherConfig{
 		FetchersFn: func() []common.Fetcher {
@@ -135,7 +97,7 @@ func (s *Server) startKubeIntegrationWatchers() error {
 					continue
 				}
 
-				agentVersion, err := s.getKubeAgentVersion(versionGetter)
+				agentVersion, err := kubeutils.GetKubeAgentVersion(s.ctx, s.AccessPoint)
 				if err != nil {
 					s.Log.WarnContext(s.ctx, "Could not get agent version to enroll EKS clusters", "error", err)
 					continue
@@ -334,10 +296,6 @@ func (s *Server) enrollEKSClusters(region, integration, discoveryConfigName stri
 	}
 }
 
-func (s *Server) getKubeAgentVersion(versionGetter version.Getter) (*semver.Version, error) {
-	return kubeutils.GetKubeAgentVersion(s.ctx, s.AccessPoint, s.ClusterFeatures(), versionGetter)
-}
-
 type IntegrationFetcher interface {
 	// GetIntegration returns the integration name that is used for getting credentials of the fetcher.
 	GetIntegration() string
@@ -394,27 +352,4 @@ func (s *Server) getKubeIntegrationFetchers() []common.Fetcher {
 
 func (s *Server) getKubeNonIntegrationFetchers() []common.Fetcher {
 	return s.getKubeFetchers(false)
-}
-
-func versionGetterForProxy(ctx context.Context, proxyPublicAddr string) (version.Getter, error) {
-	proxyClt, err := webclient.NewReusableClient(&webclient.Config{
-		Context:   ctx,
-		ProxyAddr: proxyPublicAddr,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to build proxy client")
-	}
-
-	baseURL := &url.URL{
-		Scheme:  "https",
-		Host:    proxyPublicAddr,
-		RawPath: path.Join("/webapi/automaticupgrades/channel", automaticupgrades.DefaultChannelName),
-	}
-
-	return version.FailoverGetter{
-		// We try getting the version via the new webapi
-		version.NewProxyVersionGetter(proxyClt),
-		// If this is not implemented, we fallback to the release channels
-		version.NewBasicHTTPVersionGetter(baseURL),
-	}, nil
 }

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/coreos/go-semver/semver"
 	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -761,21 +760,6 @@ func (h *Handler) awsOIDCConfigureEKSIAM(w http.ResponseWriter, r *http.Request,
 	return nil, trace.Wrap(err)
 }
 
-// TODO(hugoShaka): change the version getter signature to take group and id
-// so we can get rid of this wrapper.
-
-// handlerVersionGetter is a dummy struct implementing version.Getter by wrapping Handler.GetVersion.
-type handlerVersionGetter struct {
-	*Handler
-}
-
-// GetVersion implements version.Getter.
-func (h *handlerVersionGetter) GetVersion(ctx context.Context) (*semver.Version, error) {
-	const group, updaterUUID = "", ""
-	agentVersion, err := h.autoUpdateResolver.GetVersion(ctx, group, updaterUUID)
-	return agentVersion, trace.Wrap(err)
-}
-
 // awsOIDCEnrollEKSClusters enroll EKS clusters by installing teleport-kube-agent Helm chart on them.
 // v2 endpoint introduces "extraLabels" field.
 func (h *Handler) awsOIDCEnrollEKSClusters(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, cluster reversetunnelclient.Cluster) (any, error) {
@@ -796,8 +780,7 @@ func (h *Handler) awsOIDCEnrollEKSClusters(w http.ResponseWriter, r *http.Reques
 		return nil, trace.BadParameter("integration name is required")
 	}
 
-	versionGetter := &handlerVersionGetter{h}
-	agentVersion, err := kubeutils.GetKubeAgentVersion(ctx, h.cfg.ProxyClient, h.GetClusterFeatures(), versionGetter)
+	agentVersion, err := kubeutils.GetKubeAgentVersion(ctx, h.cfg.ProxyClient)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -20,6 +20,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -29,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -45,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	autoupdateversion "github.com/gravitational/teleport/lib/automaticupgrades/version"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
@@ -760,6 +763,26 @@ func (h *Handler) awsOIDCConfigureEKSIAM(w http.ResponseWriter, r *http.Request,
 	return nil, trace.Wrap(err)
 }
 
+// handlerVersionGetter implements version.Getter by wrapping the Handler's autoupdate resolver
+// and falling back to teleport.Version (the proxy's own version) when no autoupdate target is configured.
+type handlerVersionGetter struct {
+	*Handler
+}
+
+// GetVersion implements version.Getter.
+func (h *handlerVersionGetter) GetVersion(ctx context.Context) (*semver.Version, error) {
+	const group, updaterUUID = "", ""
+	v, err := h.autoUpdateResolver.GetVersion(ctx, group, updaterUUID)
+	if err == nil {
+		return v, nil
+	}
+	var noNewVersionErr *autoupdateversion.NoNewVersionError
+	if !errors.As(trace.Unwrap(err), &noNewVersionErr) {
+		return nil, trace.Wrap(err)
+	}
+	return autoupdateversion.EnsureSemver(teleport.Version)
+}
+
 // awsOIDCEnrollEKSClusters enroll EKS clusters by installing teleport-kube-agent Helm chart on them.
 // v2 endpoint introduces "extraLabels" field.
 func (h *Handler) awsOIDCEnrollEKSClusters(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, cluster reversetunnelclient.Cluster) (any, error) {
@@ -780,7 +803,8 @@ func (h *Handler) awsOIDCEnrollEKSClusters(w http.ResponseWriter, r *http.Reques
 		return nil, trace.BadParameter("integration name is required")
 	}
 
-	agentVersion, err := kubeutils.GetKubeAgentVersion(ctx, h.cfg.ProxyClient)
+	versionGetter := &handlerVersionGetter{h}
+	agentVersion, err := kubeutils.GetKubeAgentVersion(ctx, versionGetter)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Resolves:
https://github.com/gravitational/teleport/blob/4dcfcc608fc18a473e0b431c4d6d614a1a40ad5d/lib/kube/utils/utils.go#L199

EKS agent enrollment now installs at the cluster version. On Cloud tenants with automatic upgrades enabled, the `teleport-updater` sidecar (installed by the same enrollment flow) moves the agent to the autoupdate target on its next sync cycle.

Discovery service no longer fails to start when AccessPoint is briefly unreachable: the startup Ping (previously used to build the autoupdate version getter) is gone, so transient auth outages now log a warning per iteration instead of preventing the watcher from starting.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: EKS agent enrollment installs at the cluster version.