### PR TITLE
kube: consolidate duplicate EKS token generation

### DIFF
--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -34,8 +34,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	eksTypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/aws/smithy-go/middleware"
-	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/coreos/go-semver/semver"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -56,6 +54,7 @@ import (
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/defaults"
+	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/utils"
@@ -69,9 +68,6 @@ const (
 
 	agentNamespace              = "teleport-agent"
 	agentName                   = "teleport-kube-agent"
-	awsKubePrefix               = "k8s-aws-v1."
-	awsHeaderClusterName        = "x-k8s-aws-id"
-	awsHeaderExpires            = "X-Amz-Expires" // Header required by AWS when creating presigned URL.
 	concurrentEKSEnrollingLimit = 5
 )
 
@@ -128,13 +124,15 @@ type EnrollEKSClusterClient interface {
 	// CreateToken creates provisioning token on the auth server. That token can be used to install kube agent to an EKS cluster.
 	CreateToken(context.Context, types.ProvisionToken) error
 
-	// PresignGetCallerIdentityURL creates a presigned URL for the GetCallerIdentity action, that can be used for accessing EKS cluster.
-	PresignGetCallerIdentityURL(context.Context, string) (string, error)
+	// GenEKSAuthToken generates an EKS bearer token (a presigned STS GetCallerIdentity URL
+	// encoded as "k8s-aws-v1.<base64>") that can be used to authenticate against an EKS cluster.
+	GenEKSAuthToken(context.Context, string) (string, error)
 }
 
 type defaultEnrollEKSClustersClient struct {
 	*eks.Client
 	stsClient    *sts.Client
+	clock        clockwork.Clock
 	tokenCreator TokenCreatorFn
 }
 
@@ -143,8 +141,9 @@ func (d *defaultEnrollEKSClustersClient) GetCallerIdentity(ctx context.Context, 
 	return d.stsClient.GetCallerIdentity(ctx, params, optFns...)
 }
 
-func (d *defaultEnrollEKSClustersClient) PresignGetCallerIdentityURL(ctx context.Context, clusterName string) (string, error) {
-	return presignCallerIdentityURL(ctx, d.stsClient, clusterName)
+func (d *defaultEnrollEKSClustersClient) GenEKSAuthToken(ctx context.Context, clusterName string) (string, error) {
+	token, _, err := kubeutils.GenAWSEKSToken(ctx, sts.NewPresignClient(d.stsClient), clusterName, d.clock)
+	return token, trace.Wrap(err)
 }
 
 // CheckAgentAlreadyInstalled checks if teleport-kube-agent Helm chart is already installed on the EKS cluster.
@@ -227,6 +226,7 @@ func NewEnrollEKSClustersClient(ctx context.Context, req *AWSClientRequest, toke
 	clt := defaultEnrollEKSClustersClient{
 		Client:       eksClient,
 		stsClient:    stsClient,
+		clock:        clockwork.NewRealClock(),
 		tokenCreator: tokenCreator,
 	}
 
@@ -340,39 +340,6 @@ func EnrollEKSClusters(ctx context.Context, log *slog.Logger, clock clockwork.Cl
 	return &EnrollEKSClusterResponse{Results: results}, nil
 }
 
-func presignCallerIdentityURL(ctx context.Context, stsClient *sts.Client, clusterName string) (string, error) {
-	presignClient := sts.NewPresignClient(stsClient)
-
-	// This function adds required headers for accessing an EKS cluster to the presigned URL.
-	// Header "x-k8s-aws-id" specifies EKS cluster name and header "X-Amz-Expires" is just required for compatibility reasons.
-	addEKSHeaders := func(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (
-		out middleware.BuildOutput, metadata middleware.Metadata, err error,
-	) {
-		req, ok := in.Request.(*smithyhttp.Request)
-		if !ok {
-			return out, metadata, fmt.Errorf("unknown transport type %T", req)
-		}
-
-		req.Header.Add(awsHeaderClusterName, clusterName)
-		// 60 is put for compatibility reasons, in reality it is ignored and real expiration time is 15 minutes.
-		req.Header.Add(awsHeaderExpires, "60")
-
-		return next.HandleBuild(ctx, in)
-	}
-
-	presigned, err := presignClient.PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}, func(options *sts.PresignOptions) {
-		options.ClientOptions = append(options.ClientOptions,
-			sts.WithAPIOptions(func(stack *middleware.Stack) error {
-				return stack.Build.Add(middleware.BuildMiddlewareFunc("AddEKSHeaders", addEKSHeaders), 0)
-			}))
-	})
-	if err != nil {
-		return "", trace.Wrap(err, "failed to presign caller identity")
-	}
-
-	return presigned.URL, nil
-}
-
 // enrollEKSCluster tries to enroll a single EKS cluster using the EnrollEKSClusterClient.
 // Returns the resource id or an error and an issue type which identifies the class of the error that occurred.
 func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clock, clt EnrollEKSClusterClient, proxyAddr, clusterName string, req EnrollEKSClustersRequest) (string, string, error) {
@@ -449,12 +416,12 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 		return "", "", trace.Wrap(err, "unable to associate EKS Access Policy to cluster %q", clusterName)
 	}
 
-	presignedURL, err := clt.PresignGetCallerIdentityURL(ctx, clusterName)
+	kubeToken, err := clt.GenEKSAuthToken(ctx, clusterName)
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}
 
-	kubeClientGetter, err := getKubeClientGetter(presignedURL,
+	kubeClientGetter, err := getKubeClientGetter(kubeToken,
 		aws.ToString(eksCluster.CertificateAuthority.Data), aws.ToString(eksCluster.Endpoint))
 	if err != nil {
 		return "", "", trace.Wrap(err, "unable to build kubernetes client for EKS cluster %q", clusterName)
@@ -557,10 +524,9 @@ func maybeAddAccessEntry(ctx context.Context, log *slog.Logger, clusterName, rol
 	return err == nil, trace.Wrap(err)
 }
 
-// getKubeClientGetter returns client getter for kube that can be used to access target EKS cluster
-func getKubeClientGetter(presignedUrl, clusterCA, clusterEndpoint string) (*genericclioptions.ConfigFlags, error) {
-	kubeToken := awsKubePrefix + base64.RawURLEncoding.EncodeToString([]byte(presignedUrl))
-
+// getKubeClientGetter returns client getter for kube that can be used to access target EKS cluster.
+// kubeToken is the k8s bearer token (as produced by kubeutils.GenAWSEKSToken).
+func getKubeClientGetter(kubeToken, clusterCA, clusterEndpoint string) (*genericclioptions.ConfigFlags, error) {
 	eksClusterCA, err := base64.StdEncoding.DecodeString(clusterCA)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -481,9 +481,10 @@ func TestGetKubeClientGetter(t *testing.T) {
 		},
 	}
 
+	const kubeToken = "k8s-aws-v1.cHJlc2lnbmVkVVJM"
 	for c, tc := range testCases {
 		t.Run(fmt.Sprintf("test#%d", c), func(t *testing.T) {
-			config, err := getKubeClientGetter("presignedURL", tc.caData, tc.endpoint)
+			config, err := getKubeClientGetter(kubeToken, tc.caData, tc.endpoint)
 
 			if tc.errorCheck == nil {
 				cfg, err := config.ToRESTConfig()
@@ -547,16 +548,16 @@ func TestGetAccessEntryPrincipalArn(t *testing.T) {
 }
 
 type mockEnrollEKSClusterClient struct {
-	createAccessEntry           func(context.Context, *eks.CreateAccessEntryInput, ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error)
-	associateAccessPolicy       func(context.Context, *eks.AssociateAccessPolicyInput, ...func(*eks.Options)) (*eks.AssociateAccessPolicyOutput, error)
-	listAccessEntries           func(context.Context, *eks.ListAccessEntriesInput, ...func(*eks.Options)) (*eks.ListAccessEntriesOutput, error)
-	deleteAccessEntry           func(context.Context, *eks.DeleteAccessEntryInput, ...func(*eks.Options)) (*eks.DeleteAccessEntryOutput, error)
-	describeCluster             func(context.Context, *eks.DescribeClusterInput, ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
-	getCallerIdentity           func(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
-	checkAgentAlreadyInstalled  func(context.Context, genericclioptions.RESTClientGetter, *slog.Logger) (bool, error)
-	installKubeAgent            func(context.Context, *eksTypes.Cluster, string, string, string, genericclioptions.RESTClientGetter, *slog.Logger, EnrollEKSClustersRequest) error
-	createToken                 func(ctx context.Context, token types.ProvisionToken) error
-	presignGetCallerIdentityURL func(ctx context.Context, clusterName string) (string, error)
+	createAccessEntry          func(context.Context, *eks.CreateAccessEntryInput, ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error)
+	associateAccessPolicy      func(context.Context, *eks.AssociateAccessPolicyInput, ...func(*eks.Options)) (*eks.AssociateAccessPolicyOutput, error)
+	listAccessEntries          func(context.Context, *eks.ListAccessEntriesInput, ...func(*eks.Options)) (*eks.ListAccessEntriesOutput, error)
+	deleteAccessEntry          func(context.Context, *eks.DeleteAccessEntryInput, ...func(*eks.Options)) (*eks.DeleteAccessEntryOutput, error)
+	describeCluster            func(context.Context, *eks.DescribeClusterInput, ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
+	getCallerIdentity          func(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+	checkAgentAlreadyInstalled func(context.Context, genericclioptions.RESTClientGetter, *slog.Logger) (bool, error)
+	installKubeAgent           func(context.Context, *eksTypes.Cluster, string, string, string, genericclioptions.RESTClientGetter, *slog.Logger, EnrollEKSClustersRequest) error
+	createToken                func(ctx context.Context, token types.ProvisionToken) error
+	genEKSAuthToken            func(ctx context.Context, clusterName string) (string, error)
 }
 
 func (m *mockEnrollEKSClusterClient) CreateAccessEntry(ctx context.Context, params *eks.CreateAccessEntryInput, optFns ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error) {
@@ -622,9 +623,9 @@ func (m *mockEnrollEKSClusterClient) CreateToken(ctx context.Context, token type
 	return nil
 }
 
-func (m *mockEnrollEKSClusterClient) PresignGetCallerIdentityURL(ctx context.Context, clusterName string) (string, error) {
-	if m.presignGetCallerIdentityURL != nil {
-		return m.presignGetCallerIdentityURL(ctx, clusterName)
+func (m *mockEnrollEKSClusterClient) GenEKSAuthToken(ctx context.Context, clusterName string) (string, error) {
+	if m.genEKSAuthToken != nil {
+		return m.genEKSAuthToken(ctx, clusterName)
 	}
 	return "", nil
 }

--- a/lib/kube/utils/eks_token_signed.go
+++ b/lib/kube/utils/eks_token_signed.go
@@ -38,7 +38,6 @@ type STSPresignClient interface {
 
 // GenAWSEKSToken creates an AWS token to access EKS clusters.
 // Logic from https://github.com/aws/aws-cli/blob/6c0d168f0b44136fc6175c57c090d4b115437ad1/awscli/customizations/eks/get_token.py#L211-L229
-// TODO(@creack): Consolidate with https://github.com/gravitational/teleport/blob/d37da511c944825a47155421bf278777238eecc0/lib/integrations/awsoidc/eks_enroll_clusters.go#L341-L372
 func GenAWSEKSToken(ctx context.Context, stsClient STSPresignClient, clusterID string, clock clockwork.Clock) (string, time.Time, error) {
 	const (
 		// The actual token expiration (presigned STS urls are valid for 15 minutes after timestamp in x-amz-date).

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -539,16 +539,16 @@ func (m *mockIntegrationsTokenGenerator) GenerateAzureOIDCToken(ctx context.Cont
 }
 
 type mockEnrollEKSClusterClient struct {
-	createAccessEntry           func(context.Context, *eks.CreateAccessEntryInput, ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error)
-	associateAccessPolicy       func(context.Context, *eks.AssociateAccessPolicyInput, ...func(*eks.Options)) (*eks.AssociateAccessPolicyOutput, error)
-	listAccessEntries           func(context.Context, *eks.ListAccessEntriesInput, ...func(*eks.Options)) (*eks.ListAccessEntriesOutput, error)
-	deleteAccessEntry           func(context.Context, *eks.DeleteAccessEntryInput, ...func(*eks.Options)) (*eks.DeleteAccessEntryOutput, error)
-	describeCluster             func(context.Context, *eks.DescribeClusterInput, ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
-	getCallerIdentity           func(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
-	checkAgentAlreadyInstalled  func(context.Context, genericclioptions.RESTClientGetter, *slog.Logger) (bool, error)
-	installKubeAgent            func(context.Context, *ekstypes.Cluster, string, string, string, genericclioptions.RESTClientGetter, *slog.Logger, awsoidc.EnrollEKSClustersRequest) error
-	createToken                 func(context.Context, types.ProvisionToken) error
-	presignGetCallerIdentityURL func(ctx context.Context, clusterName string) (string, error)
+	createAccessEntry          func(context.Context, *eks.CreateAccessEntryInput, ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error)
+	associateAccessPolicy      func(context.Context, *eks.AssociateAccessPolicyInput, ...func(*eks.Options)) (*eks.AssociateAccessPolicyOutput, error)
+	listAccessEntries          func(context.Context, *eks.ListAccessEntriesInput, ...func(*eks.Options)) (*eks.ListAccessEntriesOutput, error)
+	deleteAccessEntry          func(context.Context, *eks.DeleteAccessEntryInput, ...func(*eks.Options)) (*eks.DeleteAccessEntryOutput, error)
+	describeCluster            func(context.Context, *eks.DescribeClusterInput, ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
+	getCallerIdentity          func(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+	checkAgentAlreadyInstalled func(context.Context, genericclioptions.RESTClientGetter, *slog.Logger) (bool, error)
+	installKubeAgent           func(context.Context, *ekstypes.Cluster, string, string, string, genericclioptions.RESTClientGetter, *slog.Logger, awsoidc.EnrollEKSClustersRequest) error
+	createToken                func(context.Context, types.ProvisionToken) error
+	genEKSAuthToken            func(ctx context.Context, clusterName string) (string, error)
 }
 
 func (m *mockEnrollEKSClusterClient) CreateAccessEntry(ctx context.Context, params *eks.CreateAccessEntryInput, optFns ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error) {
@@ -614,9 +614,9 @@ func (m *mockEnrollEKSClusterClient) CreateToken(ctx context.Context, token type
 	return nil
 }
 
-func (m *mockEnrollEKSClusterClient) PresignGetCallerIdentityURL(ctx context.Context, clusterName string) (string, error) {
-	if m.presignGetCallerIdentityURL != nil {
-		return m.presignGetCallerIdentityURL(ctx, clusterName)
+func (m *mockEnrollEKSClusterClient) GenEKSAuthToken(ctx context.Context, clusterName string) (string, error) {
+	if m.genEKSAuthToken != nil {
+		return m.genEKSAuthToken(ctx, clusterName)
 	}
 	return "", nil
 }


### PR DESCRIPTION
Pure refactor. No user-visible change, no behavior change.

Addresses: https://github.com/gravitational/teleport/blob/4dcfcc608fc18a473e0b431c4d6d614a1a40ad5d/lib/kube/utils/eks_token_signed.go#L41

Make `lib/kube/utils.GenAWSEKSToken` the single canonical EKS bearer-token generator. `lib/integrations/awsoidc` now delegates to it via a thin `GenEKSAuthToken` wrapper.

Interface renamed `PresignGetCallerIdentityURL` to `GenEKSAuthToken` and now returns the finished bearer token (`k8s-aws-v1.<base64>`) instead of a raw URL. This matches what `GenAWSEKSToken` produces and what `rest.Config.BearerToken` consumes, dropping the duplicate prefix+base64 step inside `getKubeClientGetter`.

