### PR TITLE
Initialize keystore sign and decrypt metrics

### DIFF
--- a/lib/auth/keystore/manager.go
+++ b/lib/auth/keystore/manager.go
@@ -234,6 +234,8 @@ func NewManager(ctx context.Context, cfg *servicecfg.KeystoreConfig, opts *Optio
 	if err := metrics.RegisterPrometheusCollectors(
 		signCounter,
 		signErrorCounter,
+		decryptCounter,
+		decryptErrorCounter,
 		createCounter,
 		createErrorCounter,
 	); err != nil {
@@ -274,13 +276,25 @@ func NewManager(ctx context.Context, cfg *servicecfg.KeystoreConfig, opts *Optio
 		usableBackends = []backend{awsBackend, softwareBackend}
 	}
 
-	return &Manager{
+	m := &Manager{
 		backendForNewKeys:  backendForNewKeys,
 		usableBackends:     usableBackends,
 		currentSuiteGetter: cryptosuites.GetCurrentSuiteFromAuthPreference(opts.AuthPreferenceGetter),
 		logger:             opts.Logger,
 		clock:              opts.Clock,
-	}, nil
+	}
+
+	// Initialize metrics to zero so they exist in Prometheus from startup.
+	for _, b := range usableBackends {
+		for _, keyType := range []string{keyTypeTLS, keyTypeSSH, keyTypeJWT} {
+			signCounter.WithLabelValues(keyType, b.name())
+			signErrorCounter.WithLabelValues(keyType, b.name())
+		}
+		decryptCounter.WithLabelValues(keyTypeEncryption, b.name())
+		decryptErrorCounter.WithLabelValues(keyTypeEncryption, b.name())
+	}
+
+	return m, nil
 }
 
 type cryptoCountSigner struct {


### PR DESCRIPTION
Register missing decrypt metric collectors and initialize keystore sign and decrypt metrics at startup.  Initialization is the preferred way to address this instead of inside of the presentation layer (e.g. Grafana).

Supporting references:
https://www.robustperception.io/existential-issues-with-metrics/
https://betterstack.com/community/guides/monitoring/prometheus-best-practices/

Changelog: Initialize keystore sign and decrypt metrics at startup and register missing decrypt metric collectors.

## Manual Test Plan
### Test Environment
Cloud

### Test Cases
- [x] Deployed local build, verified metrics initialized.
- [x] Deployed local build, verified decrypt metrics added.


Similar to https://github.com/gravitational/teleport/pull/65619
Related to https://github.com/gravitational/cloud/issues/16070