### PR TITLE
Add `set` support in labels expressions

### DIFF
--- a/lib/services/label_expressions.go
+++ b/lib/services/label_expressions.go
@@ -70,6 +70,10 @@ func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool]
 				}),
 		},
 		Functions: map[string]typical.Function{
+			"set": typical.UnaryVariadicFunction[labelExpressionEnv](
+				func(args ...string) ([]string, error) {
+					return args, nil
+				}),
 			"labels_matching": typical.UnaryFunctionWithEnv(labelsMatching),
 			"contains": typical.BinaryFunction[labelExpressionEnv](
 				func(list []string, item string) (bool, error) {

--- a/lib/services/label_expressions_test.go
+++ b/lib/services/label_expressions_test.go
@@ -95,6 +95,22 @@ func TestLabelExpressions(t *testing.T) {
 			},
 		},
 		{
+			desc: "set contains match",
+			expr: `contains(set("dev", "staging"), labels["env"])`,
+			resourceLabels: map[string]string{
+				"env": "staging",
+			},
+			expectMatch: true,
+		},
+		{
+			desc: "set misses match",
+			expr: `contains(set("dev", "staging"), labels["env"])`,
+			resourceLabels: map[string]string{
+				"env": "prod",
+			},
+			expectMatch: false,
+		},
+		{
 			desc: "boolean logic",
 			expr: `contains(user.spec.traits["allow-env"], labels["env"]) &&
 				   contains(user.spec.traits["groups"], labels["group"]) ||


### PR DESCRIPTION
Label expressions don't have a way to declare slices. This PR introduces a function that we expose for other parsers.

This will support some work in access graph repo.






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
