### PR TITLE
web: fix 'occured' -> 'occurred' typos in 3 files

### DIFF
--- a/web/packages/shared/libs/tdp/codec.test.ts
+++ b/web/packages/shared/libs/tdp/codec.test.ts
@@ -148,7 +148,7 @@ test('decodes message types', () => {
 test('decodes errors', () => {
   // First encode an error
   const encoder = new TextEncoder();
-  const message = encoder.encode('An error occured');
+  const message = encoder.encode('An error occurred');
   const bufLen = 1 + 4 + message.length;
   const tdpErrorBuffer = new ArrayBuffer(bufLen);
   const view = new DataView(tdpErrorBuffer);
@@ -161,7 +161,7 @@ test('decodes errors', () => {
   });
 
   const error = codec.decodeErrorMessage(tdpErrorBuffer);
-  expect(error).toBe('An error occured');
+  expect(error).toBe('An error occurred');
 });
 
 // Username/password tests inspired by https://github.com/google/closure-library/blob/master/closure/goog/crypt/crypt_test.js (Apache License)

--- a/web/packages/teleport/src/SessionRecordings/view/SshPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/SshPlayer.tsx
@@ -67,7 +67,7 @@ function Player({
   );
 
   // statusText is currently only set when an error happens, so for now we can assume
-  // if it is not empty, an error occured (even if the player is in COMPLETE state, which gets
+  // if it is not empty, an error occurred (even if the player is in COMPLETE state, which gets
   // set on close)
   const isError = playerStatus === StatusEnum.ERROR || statusText !== '';
   const isLoading = playerStatus === StatusEnum.LOADING;

--- a/web/packages/teleport/src/lib/util/eventTarget.ts
+++ b/web/packages/teleport/src/lib/util/eventTarget.ts
@@ -19,7 +19,7 @@
 import type { FocusEvent } from 'react';
 
 /**
- * Checks if a focus event occured outside target element
+ * Checks if a focus event occurred outside target element
  */
 export const focusOutsideTarget = (
   event: FocusEvent<Element>,


### PR DESCRIPTION
Fix 4 instances of \`occured\` → \`occurred\` across 3 web package files.

| File | Kind |
|------|------|
| \`web/packages/teleport/src/lib/util/eventTarget.ts\` | JSDoc on \`isOutOfTarget\` |
| \`web/packages/teleport/src/SessionRecordings/view/SshPlayer.tsx\` | Inline comment |
| \`web/packages/shared/libs/tdp/codec.test.ts\` | Test string round-tripped through encoder (both encode site and expect matched) |

String/comment-only change. Test stays green because both sides of the round-trip were updated.