### PR TITLE
Updating `tsh kube ls` to use `ListUnifiedResources` and support scopes

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1397,6 +1397,7 @@ var (
 		types.KindDatabase:               {},
 		types.KindGitServer:              {},
 		types.KindKubernetesCluster:      {},
+		types.KindKubeServer:             {},
 		types.KindNode:                   {},
 		types.KindSAMLIdPServiceProvider: {},
 		types.KindWindowsDesktop:         {},
@@ -1625,8 +1626,18 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 		return nil, trace.AccessDenied("include_logins is not supported for scoped identities")
 	}
 
-	if len(req.Kinds) != 1 || req.Kinds[0] != types.KindNode {
-		return nil, trace.AccessDenied("only node kind is supported for scoped identities")
+	supportedKinds := map[string]struct{}{
+		types.KindNode:              {},
+		types.KindKubeServer:        {},
+		types.KindKubernetesCluster: {},
+	}
+
+	kindSet := make(map[string]struct{})
+	for _, kind := range req.Kinds {
+		if _, ok := supportedKinds[kind]; !ok {
+			return nil, trace.AccessDenied("scoped identities do not support kind %q", kind)
+		}
+		kindSet[kind] = struct{}{}
 	}
 
 	userFilter := services.MatchResourceFilter{
@@ -1645,13 +1656,19 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 
 	ruleCtx := a.scopedContext.RuleContext()
 
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, types.VerbList); err != nil {
-		return nil, trace.Wrap(err)
+	for k := range kindSet {
+		verbs := []string{types.VerbList, types.VerbRead}
+		if k == types.KindNode {
+			// nodes only require VerbList
+			verbs = verbs[:1]
+		}
+		if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, k, verbs...); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	unifiedResources, nextKey, err := a.authServer.UnifiedResourceCache.IterateUnifiedResources(ctx, func(resource types.ResourceWithLabels) (bool, error) {
-		// currently only nodes are supported
-		if resource.GetKind() != types.KindNode {
+		if _, ok := supportedKinds[resource.GetKind()]; !ok {
 			return false, nil
 		}
 
@@ -1669,26 +1686,39 @@ func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *p
 			return false, nil
 		}
 
-		server, ok := resource.(*types.ServerV2)
-		if !ok {
-			logger.WarnContext(ctx, "Unable to cast unified resource to server",
+		switch res := resource.(type) {
+		case *types.ServerV2:
+			if err := a.scopedContext.CheckerContext.Decision(ctx, cmp.Or(res.Scope, scopes.Root), func(checker *services.ScopedAccessChecker) error {
+				return checker.SSH().CanAccessSSHServer(res)
+			}); err == nil {
+				return true, nil
+			} else if !trace.IsAccessDenied(err) {
+				return false, trace.Wrap(err)
+			}
+		case types.KubeServer:
+			if err := a.scopedContext.CheckerContext.Decision(ctx, cmp.Or(res.GetScope(), scopes.Root), func(checker *services.ScopedAccessChecker) error {
+				return checker.Kube().CanAccessCluster(res.GetCluster())
+			}); err == nil {
+				return true, nil
+			} else if !trace.IsAccessDenied(err) {
+				return false, trace.Wrap(err)
+			}
+		case *types.KubernetesClusterV3:
+			if err := a.scopedContext.CheckerContext.Decision(ctx, cmp.Or(res.Scope, scopes.Root), func(checker *services.ScopedAccessChecker) error {
+				return checker.Kube().CanAccessCluster(res)
+			}); err == nil {
+				return true, nil
+			} else if !trace.IsAccessDenied(err) {
+				return false, trace.Wrap(err)
+			}
+
+		default:
+			logger.WarnContext(ctx, "Unable to cast unified resource to supported type",
 				"resource_name", resource.GetName(),
 				"resource_kind", resource.GetKind(),
+				"supported_types", slices.Sorted(maps.Keys(supportedKinds)),
 			)
 			return false, nil
-		}
-
-		serverScope := scopes.Root
-		if server.Scope != "" {
-			serverScope = server.Scope
-		}
-
-		if err := a.scopedContext.CheckerContext.Decision(ctx, serverScope, func(checker *services.ScopedAccessChecker) error {
-			return checker.SSH().CanAccessSSHServer(server)
-		}); err == nil {
-			return true, nil
-		} else if !trace.IsAccessDenied(err) {
-			return false, trace.Wrap(err)
 		}
 
 		return false, nil

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6390,7 +6390,7 @@ func TestListUnifiedResources_KindsFilter(t *testing.T) {
 	})
 	require.NoError(t, err)
 	waitForSRACache(t, srv, sraResp)
-	require.NoError(t, err)
+
 	scopedClient, err := srv.NewClient(authtest.TestScopedUser("user", scope))
 	require.NoError(t, err)
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -52,6 +52,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
@@ -6273,7 +6274,7 @@ func TestListUnifiedResources_search_as_roles_oktaReadOnly(t *testing.T) {
 // TestListUnifiedResources_KindsFilter will generate multiple resources
 // and filter for only one kind.
 func TestListUnifiedResources_KindsFilter(t *testing.T) {
-	t.Parallel()
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
 	ctx := context.Background()
 	srv := newTestTLSServer(t, withCacheEnabled(true))
 
@@ -6311,15 +6312,86 @@ func TestListUnifiedResources_KindsFilter(t *testing.T) {
 		require.NoError(t, err)
 		_, err = srv.Auth().UpsertDatabaseServer(ctx, db)
 		require.NoError(t, err)
-
 		createTestAppServerV3(t, srv.Auth(), name, nil)
 		createTestMCPAppServer(t, srv.Auth(), "mcp-"+name, nil)
+
+		kubeCluster, err := types.NewKubernetesClusterV3(types.Metadata{Name: name}, types.KubernetesClusterSpecV3{})
+		require.NoError(t, err)
+		kubeServer, err := types.NewKubernetesServerV3FromCluster(kubeCluster, "hostname", name)
+		require.NoError(t, err)
+		_, err = srv.Auth().UpsertKubernetesServer(ctx, kubeServer)
+		require.NoError(t, err)
+	}
+
+	scope := "/test"
+	// create scoped resources
+	for range 5 {
+		name := uuid.New().String()
+		kubeCluster, err := types.NewKubernetesClusterV3(types.Metadata{Name: name}, types.KubernetesClusterSpecV3{})
+		require.NoError(t, err)
+		kubeCluster.Scope = scope
+		kubeServer, err := types.NewKubernetesServerV3FromCluster(kubeCluster, "hostname", name)
+		require.NoError(t, err)
+
+		kubeServer.Scope = scope
+		_, err = srv.Auth().UpsertKubernetesServer(ctx, kubeServer)
+		require.NoError(t, err)
 	}
 
 	// create user and client
-	user, _, err := authtest.CreateUserAndRole(srv.Auth(), "user", nil, nil)
+	user, _, err := authtest.CreateUserAndRole(srv.Auth(), "user", nil, []types.Rule{
+		types.NewRule(types.KindKubeServer, services.RO()),
+	})
 	require.NoError(t, err)
 	clt, err := srv.NewClient(authtest.TestUser(user.GetName()))
+	require.NoError(t, err)
+
+	// create scoped role assignment and client
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+	_, err = adminClient.ScopedAccessServiceClient().CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "test-role",
+			},
+			Scope: scope,
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{scope},
+				Kube: &scopedaccessv1.ScopedRoleKube{
+					Labels: []*labelv1.Label{
+						{
+							Name:   types.Wildcard,
+							Values: []string{types.Wildcard},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	sraResp, err := adminClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			Scope: scope,
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "user",
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: "test-role", Scope: scope},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+	require.NoError(t, err)
+	scopedClient, err := srv.NewClient(authtest.TestScopedUser("user", scope))
 	require.NoError(t, err)
 
 	var resp *proto.ListUnifiedResourcesResponse
@@ -6359,6 +6431,23 @@ func TestListUnifiedResources_KindsFilter(t *testing.T) {
 			Kinds: []string{types.KindMCP},
 		})
 		require.NoError(t, err)
+		require.Len(t, resp.Resources, 5)
+	})
+	t.Run("KindKubeServer", func(t *testing.T) {
+		resp, err := clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			// KindKubernetesCluster needs to be included in Kinds to prevent matchAndFilterKubeClusters
+			// from always returning false
+			Kinds: []string{types.KindKubeServer, types.KindKubernetesCluster},
+		})
+		require.NoError(t, err)
+		// unscoped client should see all 10 kube servers, 5 unscoped + 5 scoped
+		require.Len(t, resp.Resources, 10)
+
+		resp, err = scopedClient.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds: []string{types.KindKubeServer, types.KindKubernetesCluster},
+		})
+		require.NoError(t, err)
+		// scoped client should only see the 5 scoped kube servers
 		require.Len(t, resp.Resources, 5)
 	})
 }
@@ -11659,4 +11748,18 @@ func TestRegisterInventoryControlStreamImmutableLabels(t *testing.T) {
 			require.NotNil(t, result.hello)
 		})
 	}
+}
+
+func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*scopedaccessv1.CreateScopedRoleAssignmentResponse) {
+	t.Helper()
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, resp := range resps {
+			_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+				Name:    resp.GetAssignment().GetMetadata().GetName(),
+				SubKind: resp.GetAssignment().GetSubKind(),
+			})
+			require.NoError(t, err)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -181,6 +181,8 @@ type ForwarderConfig struct {
 	// ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.
 	// It is used to determine if the cluster is licensed for Kubernetes usage.
 	ClusterFeatures ClusterFeaturesGetter
+	// Scope is the scope the forwarder will impose on the kube servers and clusters it serves.
+	Scope string
 }
 
 // ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -543,6 +543,10 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// TODO (eriktate): switch to more robust scope propagation when kube
+	// forwarder is refactored
+	srv.Scope = t.Scope
+	cluster.Scope = srv.Scope
 	srv.SetExpiry(t.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL))
 
 	// Get the kube cluster health and send it to the auth server.

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -148,15 +148,35 @@ func EncodeClusterName(clusterName string) string {
 
 // ListKubeClustersWithFilters returns a sorted list of unique kubernetes clusters
 // registered in p.
-func ListKubeClustersWithFilters(ctx context.Context, p client.GetResourcesClient, req proto.ListResourcesRequest) ([]types.KubeCluster, error) {
-	req.ResourceType = types.KindKubeServer
-
-	kss, err := client.GetAllResources[types.KubeServer](ctx, p, &req)
-	if err != nil {
-		return nil, trace.Wrap(err)
+func ListKubeClustersWithFilters(ctx context.Context, p client.ListUnifiedResourcesClient, req proto.ListUnifiedResourcesRequest) ([]types.KubeCluster, error) {
+	req.Kinds = []string{types.KindKubeServer, types.KindKubernetesCluster}
+	req.SortBy = types.SortBy{
+		Field: types.ResourceKind,
 	}
 
-	return extractAndSortKubeClusters(kss), nil
+	var servers []types.KubeServer
+	for {
+		page, next, err := client.GetUnifiedResourcePage(ctx, p, &req)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		for _, r := range page {
+			srv, ok := r.ResourceWithLabels.(types.KubeServer)
+			if !ok {
+				continue
+			}
+
+			servers = append(servers, srv)
+		}
+
+		req.StartKey = next
+		if req.StartKey == "" {
+			break
+		}
+	}
+
+	return extractAndSortKubeClusters(servers), nil
 }
 
 func extractAndSortKubeClusters(kss []types.KubeServer) []types.KubeCluster {

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -289,6 +289,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
 			PublicAddr:                    publicAddr,
 			ClusterFeatures:               process.GetClusterFeatures,
+			Scope:                         conn.Scope(),
 		},
 		TLS:                  tlsConfig,
 		AccessPoint:          accessPoint,

--- a/lib/services/kube_access_checker.go
+++ b/lib/services/kube_access_checker.go
@@ -1,0 +1,48 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"github.com/gravitational/teleport/api/types"
+)
+
+// KubeAccessChecker provides kube-specific access checking, abstracting over scoped and unscoped identities.
+// It is obtained from [ScopedAccessChecker.Kube] and should not be constructed directly. Methods on this type
+// implement kube-specific behavior, branching internally between the scoped and unscoped paths of the underlying
+// [ScopedAccessChecker].
+type KubeAccessChecker struct {
+	checker *ScopedAccessChecker
+}
+
+// CheckAccessToCluster checks access to a kube cluster.
+func (c *KubeAccessChecker) CheckAccessToCluster(target types.KubeCluster, state AccessState) error {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.CheckAccess(target, state)
+	}
+	return c.checker.scopedCompatChecker.CheckAccess(target, state)
+}
+
+// CanAccessCluster checks whether read access to the specified kube server is possible without
+// regard to a specific MFA state. Used for listing/filtering.
+func (c *KubeAccessChecker) CanAccessCluster(target types.KubeCluster) error {
+	if !c.checker.isScoped() {
+		return c.checker.unscopedChecker.CheckAccess(target, AccessState{MFAVerified: true})
+	}
+	return c.checker.scopedCompatChecker.CheckAccess(target, AccessState{MFAVerified: true})
+}

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -197,6 +197,12 @@ func (c *ScopedAccessChecker) SSH() *SSHAccessChecker {
 	return &SSHAccessChecker{checker: c}
 }
 
+// Kube returns a kube-specific access checker backed by this checker. All kube-specific methods
+// (users, groups, idle timeout, etc.) live on [KubeAccessChecker].
+func (c *ScopedAccessChecker) Kube() *KubeAccessChecker {
+	return &KubeAccessChecker{checker: c}
+}
+
 // AccessInfo returns the AccessInfo that this access checker is based on.
 func (c *ScopedAccessChecker) AccessInfo() *AccessInfo {
 	if !c.isScoped() {

--- a/lib/teleterm/clusters/cluster_kubes.go
+++ b/lib/teleterm/clusters/cluster_kubes.go
@@ -101,7 +101,7 @@ func (c *Cluster) getKube(ctx context.Context, authClient authclient.ClientI, ku
 	var kubeClusters []types.KubeCluster
 	err := AddMetadataToRetryableError(ctx, func() error {
 		var err error
-		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, authClient, proto.ListResourcesRequest{
+		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, authClient, proto.ListUnifiedResourcesRequest{
 			PredicateExpression: fmt.Sprintf("name == %q", kubeCluster),
 		})
 

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1115,7 +1115,14 @@ func (c *kubeLSCommand) runAllClusters(cf *CLIConf) error {
 		}
 
 		group.Go(func() error {
-			kc, err := kubeutils.ListKubeClustersWithFilters(groupCtx, cluster.auth, cluster.req)
+			req := proto.ListUnifiedResourcesRequest{
+				SearchKeywords:      cluster.req.SearchKeywords,
+				Labels:              cluster.req.Labels,
+				PredicateExpression: cluster.req.PredicateExpression,
+				UseSearchAsRoles:    cluster.req.UseSearchAsRoles,
+				SortBy:              cluster.req.SortBy,
+			}
+			kc, err := kubeutils.ListKubeClustersWithFilters(groupCtx, cluster.auth, req)
 			if err != nil {
 				logger.ErrorContext(groupCtx, "Failed to get kube clusters", "error", err)
 				mu.Lock()
@@ -1483,7 +1490,7 @@ func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleport
 		defer clusterClient.Close()
 
 		teleportCluster = clusterClient.ClusterName()
-		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, clusterClient.AuthClient, proto.ListResourcesRequest{
+		kubeClusters, err = kubeutils.ListKubeClustersWithFilters(ctx, clusterClient.AuthClient, proto.ListUnifiedResourcesRequest{
 			SearchKeywords:      tc.SearchKeywords,
 			PredicateExpression: tc.PredicateExpression,
 			Labels:              tc.Labels,


### PR DESCRIPTION
This updates `scopedListUnifiedResources` to support `types.KindKubeServer` and `types.KindKubernetesCluster` in order to support listing scoped variants of those resources. It also updates `tsh` to use `ListUnifiedResources` instead of `ListResources` so that scoped kube clusters can be returned and logged into using `tsh kube ls` and `tsh kube login`.



<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Local Teleport cluster running with `TELEPORT_UNSTABLE_SCOPES=yes`
- A scoped agent running the kube service
- An unscoped agent running the kube service
- A scoped role assignment assigning kube permissions to the correct scope
- A scoped role assignment assigning to an orthogonal scope
### Test Cases
- [x] Login and pin to the kube server's scope: `tsh login --scope=/kube --proxy=<proxy>`
- [x] Confirm scoped kube cluster is listed by `tsh kube ls`
  - [x] Unscoped cluster should _not_ be listed
- [x] Confirm filters work
  - [x] `tsh kube ls --search=<keywords>`
  - [x] `tsh kube ls --query=<predicate>`
  - [x] `tsh kube ls <labels>`
- [x] Confirm `tsh kube login <cluster>` succeeds 
- [x] Pin to different scope `tsh login --scope=/ssh`
- [x] Confirm no clusters are listed
- [x] Login unscoped: `tsh logout && tsh login --proxy=<proxy>`
- [x] Confirm all clusters appear with `tsh kube ls`
- [x] Confirm filters work
  - [x] `tsh kube ls --search=<keywords>`
  - [x] `tsh kube ls --query=<predicate>`
  - [x] `tsh kube ls <labels>`
- [x] Confirm `tsh kube login <cluster>` succeeds 
- [x] Resources still appear in web
- [x] Resources can be filtered in web using keyword and predicate search
- [x] Resources can be filtered by type `Kubernetes Clusters`