### PR TITLE
Add rfd153 envelope type wrapper support

### DIFF
--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -137,8 +137,10 @@ type payload struct {
 	// operations following the RFD 153 resource guidelines.
 	// This must only be set for resources whose client use envelope structs.
 	RequestWrapper *RequestWrapper
-	// SubKind is Teleport sub_kind for resource
-	SubKind string
+	// DefaultSubKind is the Teleport sub_kind that is used when the user does
+	// not specify one in the resource config. The user-provided sub_kind (on
+	// the resource or in state) takes precedence; this is only a fallback.
+	DefaultSubKind string
 }
 
 // statePoll configures polling for state changes when creating or updating resources.

--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -133,6 +133,9 @@ type payload struct {
 	WithoutImportState bool
 	// StatePoll optionally configures polling for state changes when creating or updating resources.
 	StatePoll *statePoll
+	// RequestWrapper optionally configures envelope request/response types for CRUD
+	// operations following the RFD 153 resource guidelines.
+	RequestWrapper *RequestWrapper
 }
 
 // statePoll configures polling for state changes when creating or updating resources.
@@ -158,6 +161,26 @@ type statePoll struct {
 	StatePollIntervalSeconds int
 	// StateTimeoutSeconds is the maximum amount of seconds to wait for a resource to reach a target state.
 	StateTimeoutSeconds int
+}
+
+// RequestWrapper will wrap the resource types defined in RFD 153 suggested conventions for the client.
+// RFD 153 specifies suggests using request/response wrappers and consistent naming conventions for those types.
+//   - Request types:  {MethodName}Request  ex) CreateFooRequest, GetFooRequest, UpsertFooRequest, DeleteFooRequest
+//   - Response types: {MethodName}Response ex) CreateFooResponse, GetFooResponse, UpsertFooResponse, DeleteFooResponse
+//   - Resource field: The inner resource type itself that the request/response types wrap.
+//   - Response getter: Get + field name to get the inner resource.
+type RequestWrapper struct {
+	// RequestResourceField is the field name in request
+	// types that holds the resource object - ex) "Role" in ScopedRoles.
+	RequestResourceField string
+	// GetRequest is the type name for the Get request - ex) "GetScopedRoleRequest".
+	GetRequest string
+	// CreateRequest is the type name for the Create request - ex) "CreateScopedRoleRequest".
+	CreateRequest string
+	// UpdateRequest is the type name for the Update/Upsert request -ex) "UpsertScopedRoleRequest".
+	UpdateRequest string
+	// DeleteRequest is the type name for the Delete request - ex) "DeleteScopedRoleRequest".
+	DeleteRequest string
 }
 
 func (p *payload) CheckAndSetDefaults() error {
@@ -192,6 +215,23 @@ func (p *payload) CheckAndSetDefaults() error {
 
 		if p.StatePoll.StateTimeoutSeconds == 0 {
 			return errors.New("StateTimeoutSeconds must be provided when StatePoll is set")
+		}
+	}
+	if p.RequestWrapper != nil {
+		if p.RequestWrapper.RequestResourceField == "" {
+			return errors.New("RequestResourceField must be provided when RequestWrapper is set")
+		}
+		if p.RequestWrapper.GetRequest == "" {
+			return errors.New("GetRequest must be provided when RequestWrapper is set")
+		}
+		if p.RequestWrapper.CreateRequest == "" {
+			return errors.New("CreateRequest must be provided when RequestWrapper is set")
+		}
+		if p.RequestWrapper.UpdateRequest == "" {
+			return errors.New("UpdateRequest must be provided when RequestWrapper is set")
+		}
+		if p.RequestWrapper.DeleteRequest == "" {
+			return errors.New("DeleteRequest must be provided when RequestWrapper is set")
 		}
 	}
 	return nil
@@ -970,6 +1010,7 @@ var (
 		ExtraImports: []string{"apitypes \"github.com/gravitational/teleport/api/types\""},
 		ForceSetKind: "apitypes.KindInferencePolicy",
 	}
+
 	scopedToken = payload{
 		Name:                  "ScopedToken",
 		TypeName:              "ScopedToken",
@@ -992,6 +1033,7 @@ var (
 		ExtraImports:          []string{"apitypes \"github.com/gravitational/teleport/api/types\""},
 		ForceSetKind:          "apitypes.KindScopedToken",
 	}
+
 	workloadCluster = payload{
 		Name:                  "WorkloadCluster",
 		TypeName:              "WorkloadCluster",

--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -136,6 +136,8 @@ type payload struct {
 	// RequestWrapper optionally configures envelope request/response types for CRUD
 	// operations following the RFD 153 resource guidelines.
 	RequestWrapper *RequestWrapper
+	// SubKind is Teleport sub_kind for resource
+	SubKind string
 }
 
 // statePoll configures polling for state changes when creating or updating resources.

--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -135,6 +135,7 @@ type payload struct {
 	StatePoll *statePoll
 	// RequestWrapper optionally configures envelope request/response types for CRUD
 	// operations following the RFD 153 resource guidelines.
+	// This must only be set for resources whose client use envelope structs.
 	RequestWrapper *RequestWrapper
 	// SubKind is Teleport sub_kind for resource
 	SubKind string

--- a/integrations/terraform/gen/plural_data_source.go.tpl
+++ b/integrations/terraform/gen/plural_data_source.go.tpl
@@ -74,12 +74,23 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 	if resp.Diagnostics.HasError() {
 		return
 	}
+{{- if .DefaultSubKind}}
+	var subKind types.String
+	diags = req.Config.GetAttribute(ctx, path.Root("sub_kind"), &subKind)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if subKind.Value == "" {
+		subKind.Value = {{.DefaultSubKind}}
+	}
+{{- end}}
 {{- if .RequestWrapper}}
 
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: id.Value,
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: subKind.Value,
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},

--- a/integrations/terraform/gen/plural_data_source.go.tpl
+++ b/integrations/terraform/gen/plural_data_source.go.tpl
@@ -78,6 +78,9 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: id.Value,
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
 		{{- end}}

--- a/integrations/terraform/gen/plural_data_source.go.tpl
+++ b/integrations/terraform/gen/plural_data_source.go.tpl
@@ -20,7 +20,7 @@ package provider
 import (
 	"context"
 
-	{{ if not .IsPlainStruct }}
+	{{ if or (not .IsPlainStruct) .RequestWrapper }}
     {{- protoImport . }}
     {{- end }}
 	"github.com/gravitational/trace"
@@ -74,12 +74,25 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 	if resp.Diagnostics.HasError() {
 		return
 	}
+{{- if .RequestWrapper}}
+
+	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+		Name: id.Value,
+		{{- if ne .WithSecrets ""}}
+		WithSecrets: {{.WithSecrets}},
+		{{- end}}
+	})
+{{- else}}
 
 	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix.Value, {{end}}id.Value{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+{{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
+{{- if .RequestWrapper}}
+	{{.VarName}}I := {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
+{{- end}}
 
 	var state types.Object
 	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -153,6 +153,9 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 
 	_, err = r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: id,
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
 		{{- end}}
@@ -215,6 +218,9 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	{{- if .RequestWrapper}}
 		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 			Name: id,
+			{{- if .SubKind}}
+			SubKind: {{.SubKind}},
+			{{- end}}
 			{{- if ne .WithSecrets ""}}
 			WithSecrets: {{.WithSecrets}},
 			{{- end}}
@@ -303,6 +309,9 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		{{- if .RequestWrapper }}
 			{{ .VarName }}Resp, err := r.p.Client.{{ .GetMethod }}(ctx, &{{ .ProtoPackage }}.{{ .RequestWrapper.GetRequest }}{
 				Name: id,
+				{{- if .SubKind }}
+				SubKind: {{ .SubKind }},
+				{{- end }}
 				{{- if ne .WithSecrets "" }}
 				WithSecrets: {{ .WithSecrets }},
 				{{- end }}
@@ -383,6 +392,9 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: id.Value,
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
 		{{- end}}
@@ -473,6 +485,9 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 
 	{{.VarName}}BeforeResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: name,
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
 		{{- end}}
@@ -534,6 +549,9 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{- if .RequestWrapper}}
 		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 			Name: name,
+			{{- if .SubKind}}
+			SubKind: {{.SubKind}},
+			{{- end}}
 			{{- if ne .WithSecrets ""}}
 			WithSecrets: {{.WithSecrets}},
 			{{- end}}
@@ -605,6 +623,9 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		{{- if .RequestWrapper }}
 			{{ .VarName }}Resp, err := r.p.Client.{{ .GetMethod }}(ctx, &{{ .ProtoPackage }}.{{ .RequestWrapper.GetRequest }}{
 				Name: name,
+				{{- if .SubKind }}
+				SubKind: {{ .SubKind }},
+				{{- end }}
 				{{- if ne .WithSecrets "" }}
 				WithSecrets: {{ .WithSecrets }},
 				{{- end }}
@@ -678,6 +699,9 @@ func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteR
 
 	_, err := r.p.Client.{{.DeleteMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.DeleteRequest}}{
 		Name: id.Value,
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 	})
 {{- else}}
 
@@ -697,6 +721,9 @@ func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.Im
 {{- if .RequestWrapper}}
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: req.ID,
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
 		{{- end}}

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -149,8 +149,18 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	idPrefix := {{.VarName}}Resource.{{ join (slice (split .IDPrefix ".") 1) "." }}
 	{{ end -}}
 	id := {{.VarName}}Resource.Metadata.Name
+{{- if .RequestWrapper}}
+
+	_, err = r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+		Name: id,
+		{{- if ne .WithSecrets ""}}
+		WithSecrets: {{.WithSecrets}},
+		{{- end}}
+	})
+{{- else}}
 
 	_, err = r.p.Client.{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}id{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+{{- end}}
 	if !trace.IsNotFound(err) {
 		if err == nil {
 			{{ if .IDPrefix -}}
@@ -166,8 +176,15 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
+{{- if .RequestWrapper}}
+
+	_, err = r.p.Client.{{.CreateMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.CreateRequest}}{
+		{{.RequestWrapper.RequestResourceField}}: {{.VarName}}Resource,
+	})
+{{- else}}
 
 	{{if eq .UpsertMethodArity 2}}_, {{end}}err = r.p.Client.{{.CreateMethod}}(ctx, {{.VarName}}Resource)
+{{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error creating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
@@ -195,7 +212,20 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	}
 	for {
 		tries = tries + 1
+	{{- if .RequestWrapper}}
+		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+			Name: id,
+			{{- if ne .WithSecrets ""}}
+			WithSecrets: {{.WithSecrets}},
+			{{- end}}
+		})
+		err = getErr
+		if err == nil {
+			{{.VarName}}I = {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
+		}
+	{{- else}}
 		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}id{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+	{{- end}}
 		if trace.IsNotFound(err) {
 		    select {
 			case <-ctx.Done():
@@ -270,10 +300,23 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		Timeout:      {{ .StatePoll.StateTimeoutSeconds }} * time.Second,
 		PollInterval: {{ .StatePoll.StatePollIntervalSeconds }} * time.Second,
 		Refresh: func() (any, string, error) {
+		{{- if .RequestWrapper }}
+			{{ .VarName }}Resp, err := r.p.Client.{{ .GetMethod }}(ctx, &{{ .ProtoPackage }}.{{ .RequestWrapper.GetRequest }}{
+				Name: id,
+				{{- if ne .WithSecrets "" }}
+				WithSecrets: {{ .WithSecrets }},
+				{{- end }}
+			})
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+			{{ .VarName }} := {{ .VarName }}Resp.Get{{ .RequestWrapper.RequestResourceField }}()
+		{{- else }}
 			{{ .VarName }}, err := r.p.Client.{{ .GetMethod }}(ctx, id)
 			if err != nil {
 				return nil, "", trace.Wrap(err)
 			}
+		{{- end }}
 
 			if {{ .VarName }} == nil {
 				return nil, "", trace.Errorf("response from {{ .GetMethod }} was nil")
@@ -336,8 +379,18 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 	if resp.Diagnostics.HasError() {
 		return
 	}
+{{- if .RequestWrapper}}
+
+	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+		Name: id.Value,
+		{{- if ne .WithSecrets ""}}
+		WithSecrets: {{.WithSecrets}},
+		{{- end}}
+	})
+{{- else}}
 
 	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix.Value, {{end}}id.Value{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+{{- end}}
 	if trace.IsNotFound(err) {
 		resp.State.RemoveResource(ctx)
 		return
@@ -347,6 +400,9 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
+{{- if .RequestWrapper}}
+	{{.VarName}}I := {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
+{{- end}}
 	{{if .IsPlainStruct -}}
 	{{.VarName}} := {{.VarName}}I
 	{{else if .ConvertPackagePath -}}
@@ -413,18 +469,40 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	idPrefix := {{.VarName}}Resource.{{$idPrefix}}
 	{{ end -}}
 	name := {{.VarName}}Resource.Metadata.Name
+{{- if .RequestWrapper}}
+
+	{{.VarName}}BeforeResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+		Name: name,
+		{{- if ne .WithSecrets ""}}
+		WithSecrets: {{.WithSecrets}},
+		{{- end}}
+	})
+	if err != nil {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", err, "{{.Kind}}"))
+		return
+	}
+	{{.VarName}}Before := {{.VarName}}BeforeResp.Get{{.RequestWrapper.RequestResourceField}}()
+{{- else}}
 
 	{{.VarName}}Before, err := r.p.Client.{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}name{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", err, "{{.Kind}}"))
 		return
 	}
+{{- end}}
 	{{- $VarName := .VarName }}
 	{{- range $field := .PropagatedFields }}
 	{{ $VarName }}Resource.{{ $field }} = {{ $VarName }}Before.{{ $field }}
 	{{- end }}
+{{- if .RequestWrapper}}
+
+	_, err = r.p.Client.{{.UpdateMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.UpdateRequest}}{
+		{{.RequestWrapper.RequestResourceField}}: {{.VarName}}Resource,
+	})
+{{- else}}
 
 	{{if eq .UpsertMethodArity 2}}_, {{end}}err = r.p.Client.{{.UpdateMethod}}(ctx, {{.VarName}}Resource)
+{{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", err, "{{.Kind}}"))
 		return
@@ -453,7 +531,20 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	}
 	for {
 		tries = tries + 1
+	{{- if .RequestWrapper}}
+		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+			Name: name,
+			{{- if ne .WithSecrets ""}}
+			WithSecrets: {{.WithSecrets}},
+			{{- end}}
+		})
+		err = getErr
+		if err == nil {
+			{{.VarName}}I = {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
+		}
+	{{- else}}
 		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix, {{end}}name{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
+	{{- end}}
 		if err != nil {
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", err, "{{.Kind}}"))
 			return
@@ -511,10 +602,23 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		Timeout:      {{ .StatePoll.StateTimeoutSeconds }} * time.Second,
 		PollInterval: {{ .StatePoll.StatePollIntervalSeconds }} * time.Second,
 		Refresh: func() (any, string, error) {
+		{{- if .RequestWrapper }}
+			{{ .VarName }}Resp, err := r.p.Client.{{ .GetMethod }}(ctx, &{{ .ProtoPackage }}.{{ .RequestWrapper.GetRequest }}{
+				Name: name,
+				{{- if ne .WithSecrets "" }}
+				WithSecrets: {{ .WithSecrets }},
+				{{- end }}
+			})
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+			{{ .VarName }} := {{ .VarName }}Resp.Get{{ .RequestWrapper.RequestResourceField }}()
+		{{- else }}
 			{{ .VarName }}, err := r.p.Client.{{ .GetMethod }}(ctx, name)
 			if err != nil {
 				return nil, "", trace.Wrap(err)
 			}
+		{{- end }}
 
 			if {{ .VarName }} == nil {
 				return nil, "", trace.Errorf("response from {{ .GetMethod }} was nil")
@@ -570,8 +674,15 @@ func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+{{- if .RequestWrapper}}
+
+	_, err := r.p.Client.{{.DeleteMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.DeleteRequest}}{
+		Name: id.Value,
+	})
+{{- else}}
 
 	err := r.p.Client.{{.DeleteMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}{{if .IDPrefix}}idPrefix.Value, {{end}}id.Value)
+{{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting {{.TypeName}}", trace.Wrap(err), "{{.Kind}}"))
 		return
@@ -583,16 +694,30 @@ func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteR
 {{if not .WithoutImportState -}}
 // ImportState imports {{.Name}} state
 func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	{{if .IDPrefix -}}
+{{- if .RequestWrapper}}
+	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+		Name: req.ID,
+		{{- if ne .WithSecrets ""}}
+		WithSecrets: {{.WithSecrets}},
+		{{- end}}
+	})
+	if err != nil {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
+		return
+	}
+	{{.VarName}} := {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
+{{- else}}
+	{{- if .IDPrefix}}
 	idPrefix, name, err := parseID(req.ID)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error parsing Member ID", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
 	{{.VarName}}, err := r.p.Client.{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}idPrefix, name{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
-	{{else -}}
+	{{- else}}
 	{{.VarName}}, err := r.p.Client.{{.GetMethod}}(ctx, {{if .Namespaced}}defaults.Namespace, {{end}}req.ID{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
-	{{end -}}
+	{{- end}}
+{{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -24,6 +24,9 @@ import (
     "encoding/hex"
 {{- end }}
 	"fmt"
+{{- if .DefaultSubKind }}
+	"strings"
+{{- end }}
 {{- if .StatePoll }}
 	"time"
 {{- end }}
@@ -750,11 +753,19 @@ func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteR
 {{if not .WithoutImportState -}}
 // ImportState imports {{.Name}} state
 func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+{{- if .DefaultSubKind}}
+	subKind := {{.DefaultSubKind}}
+	name := req.ID
+	if before, after, ok := strings.Cut(req.ID, "/"); ok {
+		subKind = before
+		name = after
+	}
+{{- end}}
 {{- if .RequestWrapper}}
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
-		Name: req.ID,
+		Name: {{if .DefaultSubKind}}name{{else}}req.ID{{end}},
 		{{- if .DefaultSubKind}}
-		SubKind: {{.DefaultSubKind}},
+		SubKind: subKind,
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -144,6 +144,11 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		return
 	}
 {{- end}}
+{{- if .DefaultSubKind}}
+	if {{.VarName}}Resource.SubKind == "" {
+		{{.VarName}}Resource.SubKind = {{.DefaultSubKind}}
+	}
+{{- end}}
 
 	{{ if .IDPrefix -}}
 	idPrefix := {{.VarName}}Resource.{{ join (slice (split .IDPrefix ".") 1) "." }}
@@ -153,8 +158,8 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 
 	_, err = r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: id,
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: {{.VarName}}Resource.SubKind,
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
@@ -218,8 +223,8 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	{{- if .RequestWrapper}}
 		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 			Name: id,
-			{{- if .SubKind}}
-			SubKind: {{.SubKind}},
+			{{- if .DefaultSubKind}}
+			SubKind: {{.VarName}}Resource.SubKind,
 			{{- end}}
 			{{- if ne .WithSecrets ""}}
 			WithSecrets: {{.WithSecrets}},
@@ -309,8 +314,8 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		{{- if .RequestWrapper }}
 			{{ .VarName }}Resp, err := r.p.Client.{{ .GetMethod }}(ctx, &{{ .ProtoPackage }}.{{ .RequestWrapper.GetRequest }}{
 				Name: id,
-				{{- if .SubKind }}
-				SubKind: {{ .SubKind }},
+				{{- if .DefaultSubKind }}
+				SubKind: {{ .VarName }}Resource.SubKind,
 				{{- end }}
 				{{- if ne .WithSecrets "" }}
 				WithSecrets: {{ .WithSecrets }},
@@ -388,12 +393,23 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 	if resp.Diagnostics.HasError() {
 		return
 	}
+{{- if .DefaultSubKind}}
+	var subKind types.String
+	diags = req.State.GetAttribute(ctx, path.Root("sub_kind"), &subKind)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if subKind.Value == "" {
+		subKind.Value = {{.DefaultSubKind}}
+	}
+{{- end}}
 {{- if .RequestWrapper}}
 
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: id.Value,
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: subKind.Value,
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
@@ -476,6 +492,11 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		return
 	}
 	{{- end}}
+	{{- if .DefaultSubKind}}
+	if {{.VarName}}Resource.SubKind == "" {
+		{{.VarName}}Resource.SubKind = {{.DefaultSubKind}}
+	}
+	{{- end}}
 	{{ if .IDPrefix -}}
 	{{ $idPrefix := join (slice (split .IDPrefix ".") 1) "." -}}
 	idPrefix := {{.VarName}}Resource.{{$idPrefix}}
@@ -485,8 +506,8 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 
 	{{.VarName}}BeforeResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: name,
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: {{.VarName}}Resource.SubKind,
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
@@ -549,8 +570,8 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{- if .RequestWrapper}}
 		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 			Name: name,
-			{{- if .SubKind}}
-			SubKind: {{.SubKind}},
+			{{- if .DefaultSubKind}}
+			SubKind: {{.VarName}}Resource.SubKind,
 			{{- end}}
 			{{- if ne .WithSecrets ""}}
 			WithSecrets: {{.WithSecrets}},
@@ -623,8 +644,8 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		{{- if .RequestWrapper }}
 			{{ .VarName }}Resp, err := r.p.Client.{{ .GetMethod }}(ctx, &{{ .ProtoPackage }}.{{ .RequestWrapper.GetRequest }}{
 				Name: name,
-				{{- if .SubKind }}
-				SubKind: {{ .SubKind }},
+				{{- if .DefaultSubKind }}
+				SubKind: {{ .VarName }}Resource.SubKind,
 				{{- end }}
 				{{- if ne .WithSecrets "" }}
 				WithSecrets: {{ .WithSecrets }},
@@ -695,12 +716,23 @@ func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+{{- if .DefaultSubKind}}
+	var subKind types.String
+	diags = req.State.GetAttribute(ctx, path.Root("sub_kind"), &subKind)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if subKind.Value == "" {
+		subKind.Value = {{.DefaultSubKind}}
+	}
+{{- end}}
 {{- if .RequestWrapper}}
 
 	_, err := r.p.Client.{{.DeleteMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.DeleteRequest}}{
 		Name: id.Value,
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: subKind.Value,
 		{{- end}}
 	})
 {{- else}}
@@ -721,8 +753,8 @@ func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.Im
 {{- if .RequestWrapper}}
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: req.ID,
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: {{.DefaultSubKind}},
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},

--- a/integrations/terraform/gen/singular_data_source.go.tpl
+++ b/integrations/terraform/gen/singular_data_source.go.tpl
@@ -56,6 +56,9 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 {{- if .RequestWrapper}}
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 	})
 {{- else}}
 	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx)

--- a/integrations/terraform/gen/singular_data_source.go.tpl
+++ b/integrations/terraform/gen/singular_data_source.go.tpl
@@ -25,6 +25,9 @@ import (
     {{- end }}
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+{{- if .DefaultSubKind }}
+	"github.com/hashicorp/terraform-plugin-framework/path"
+{{- end }}
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -53,11 +56,21 @@ func (r dataSourceTeleport{{.Name}}Type) NewDataSource(_ context.Context, p tfsd
 
 // Read reads teleport {{.Name}}
 func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDataSourceRequest, resp *tfsdk.ReadDataSourceResponse) {
+{{- if .DefaultSubKind}}
+	var subKind types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("sub_kind"), &subKind)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if subKind.Value == "" {
+		subKind.Value = {{.DefaultSubKind}}
+	}
+{{- end}}
 {{- if .RequestWrapper}}
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: subKind.Value,
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},

--- a/integrations/terraform/gen/singular_data_source.go.tpl
+++ b/integrations/terraform/gen/singular_data_source.go.tpl
@@ -59,9 +59,12 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 		{{- if .SubKind}}
 		SubKind: {{.SubKind}},
 		{{- end}}
+		{{- if ne .WithSecrets ""}}
+		WithSecrets: {{.WithSecrets}},
+		{{- end}}
 	})
 {{- else}}
-	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx)
+	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
 {{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))

--- a/integrations/terraform/gen/singular_data_source.go.tpl
+++ b/integrations/terraform/gen/singular_data_source.go.tpl
@@ -20,7 +20,7 @@ package provider
 import (
 	"context"
 
-	{{ if not .IsPlainStruct }}
+	{{ if or (not .IsPlainStruct) .RequestWrapper }}
     {{- protoImport . }}
     {{- end }}
 	"github.com/gravitational/trace"
@@ -53,11 +53,20 @@ func (r dataSourceTeleport{{.Name}}Type) NewDataSource(_ context.Context, p tfsd
 
 // Read reads teleport {{.Name}}
 func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDataSourceRequest, resp *tfsdk.ReadDataSourceResponse) {
+{{- if .RequestWrapper}}
+	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+		Name: {{.DefaultName}},
+	})
+{{- else}}
 	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx)
+{{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
+{{- if .RequestWrapper}}
+	{{.VarName}}I := {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
+{{- end}}
 
 	var state types.Object
 	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -23,6 +23,9 @@ import (
 {{- if .WithNonce}}
 	 "math"
 {{- end}}
+{{- if .DefaultSubKind }}
+	"strings"
+{{- end }}
 {{- range $i, $a := .ExtraImports }}
 	{{$a}}
 {{- end }}
@@ -543,11 +546,17 @@ func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteR
 
 // ImportState imports {{.Name}} state
 func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+{{- if .DefaultSubKind}}
+	subKind := {{.DefaultSubKind}}
+	if before, _, ok := strings.Cut(req.ID, "/"); ok {
+		subKind = before
+	}
+{{- end}}
 {{- if .RequestWrapper}}
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
 		{{- if .DefaultSubKind}}
-		SubKind: {{.DefaultSubKind}},
+		SubKind: subKind,
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -108,11 +108,27 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	}
 	{{- end}}
 
+{{- if .RequestWrapper}}
+
+	{{.VarName}}BeforeResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+		Name: {{.DefaultName}},
+	})
+	if err != nil && !trace.IsNotFound(err) {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
+		return
+	}
+	var {{.VarName}}Before *{{.ProtoPackage}}.{{.TypeName}}
+	if err == nil {
+		{{.VarName}}Before = {{.VarName}}BeforeResp.Get{{.RequestWrapper.RequestResourceField}}()
+	}
+{{- else}}
+
 	{{.VarName}}Before, err := r.p.Client.{{.GetMethod}}(ctx)
 	if err != nil && !trace.IsNotFound(err) {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
+{{- end}}
 
 	{{- if .GetCanReturnNil }}
 
@@ -125,8 +141,15 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	{{- if .WithNonce}}
 	{{.VarName}} = {{.VarName}}.WithNonce(math.MaxUint64).(*{{.ProtoPackage}}.{{.TypeName}})
 	{{- end}}
+{{- if .RequestWrapper}}
+
+	_, err = r.p.Client.{{.CreateMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.CreateRequest}}{
+		{{.RequestWrapper.RequestResourceField}}: {{.VarName}},
+	})
+{{- else}}
 
 	{{if eq .UpsertMethodArity 2}}_, {{end}}err = r.p.Client.{{.CreateMethod}}(ctx, {{.VarName}})
+{{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error creating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
@@ -155,7 +178,17 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	}
 	for {
 		tries = tries + 1
+	{{- if .RequestWrapper}}
+		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+			Name: {{.DefaultName}},
+		})
+		err = getErr
+		if err == nil {
+			{{.VarName}}I = {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
+		}
+	{{- else}}
 		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx)
+	{{- end}}
 		if trace.IsNotFound(err) {
 		    select {
 			case <-ctx.Done():
@@ -232,8 +265,15 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 	if resp.Diagnostics.HasError() {
 		return
 	}
+{{- if .RequestWrapper}}
+
+	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+		Name: {{.DefaultName}},
+	})
+{{- else}}
 
 	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx)
+{{- end}}
 	if trace.IsNotFound(err) {
 		resp.State.RemoveResource(ctx)
 		return
@@ -242,7 +282,9 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
-
+{{ if .RequestWrapper }}
+	{{.VarName}}I := {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
+{{- end}}
 	{{if .IsPlainStruct -}}
 	{{.VarName}} := {{.VarName}}I
 	{{ else }}
@@ -304,11 +346,24 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	}
 	{{- end}}
 
+{{- if .RequestWrapper}}
+
+	{{.VarName}}BeforeResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+		Name: {{.DefaultName}},
+	})
+	if err != nil {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
+		return
+	}
+	{{.VarName}}Before := {{.VarName}}BeforeResp.Get{{.RequestWrapper.RequestResourceField}}()
+{{- else}}
+
 	{{.VarName}}Before, err := r.p.Client.{{.GetMethod}}(ctx)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
+{{- end}}
 	{{- $VarName := .VarName }}
 	{{- range $field := .PropagatedFields }}
 	{{ $VarName }}.{{ $field }} = {{ $VarName }}Before.{{ $field }}
@@ -317,8 +372,15 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{- if .WithNonce}}
 	{{.VarName}} = {{.VarName}}.WithNonce(math.MaxUint64).(*{{.ProtoPackage}}.{{.TypeName}})
 	{{- end}}
+{{- if .RequestWrapper}}
+
+	_, err = r.p.Client.{{.UpdateMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.UpdateRequest}}{
+		{{.RequestWrapper.RequestResourceField}}: {{.VarName}},
+	})
+{{- else}}
 
 	{{if eq .UpsertMethodArity 2}}_, {{end}}err = r.p.Client.{{.UpdateMethod}}(ctx, {{.VarName}})
+{{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
@@ -342,7 +404,17 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	}
 	for {
 		tries = tries + 1
+	{{- if .RequestWrapper}}
+		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+			Name: {{.DefaultName}},
+		})
+		err = getErr
+		if err == nil {
+			{{.VarName}}I = {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
+		}
+	{{- else}}
 		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx)
+	{{- end}}
 		if err != nil {
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 			return
@@ -387,7 +459,13 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 
 // Delete deletes Teleport {{.Name}}
 func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+{{- if .RequestWrapper}}
+	_, err := r.p.Client.{{.DeleteMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.DeleteRequest}}{
+		Name: {{.DefaultName}},
+	})
+{{- else}}
 	err := r.p.Client.{{.DeleteMethod}}(ctx)
+{{- end}}
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error deleting {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
@@ -398,11 +476,22 @@ func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteR
 
 // ImportState imports {{.Name}} state
 func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+{{- if .RequestWrapper}}
+	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
+		Name: {{.DefaultName}},
+	})
+	if err != nil {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
+		return
+	}
+	{{.VarName}}I := {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
+{{- else}}
 	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
 	}
+{{- end}}
 
 	{{- if .IsPlainStruct }}
 	{{.VarName}} := {{.VarName}}I

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -112,6 +112,9 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 
 	{{.VarName}}BeforeResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 	})
 	if err != nil && !trace.IsNotFound(err) {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
@@ -181,6 +184,9 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	{{- if .RequestWrapper}}
 		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 			Name: {{.DefaultName}},
+			{{- if .SubKind}}
+			SubKind: {{.SubKind}},
+			{{- end}}
 		})
 		err = getErr
 		if err == nil {
@@ -269,6 +275,9 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 	})
 {{- else}}
 
@@ -350,6 +359,9 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 
 	{{.VarName}}BeforeResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 	})
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
@@ -407,6 +419,9 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{- if .RequestWrapper}}
 		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 			Name: {{.DefaultName}},
+			{{- if .SubKind}}
+			SubKind: {{.SubKind}},
+			{{- end}}
 		})
 		err = getErr
 		if err == nil {
@@ -462,6 +477,9 @@ func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteR
 {{- if .RequestWrapper}}
 	_, err := r.p.Client.{{.DeleteMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.DeleteRequest}}{
 		Name: {{.DefaultName}},
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 	})
 {{- else}}
 	err := r.p.Client.{{.DeleteMethod}}(ctx)
@@ -479,6 +497,9 @@ func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.Im
 {{- if .RequestWrapper}}
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
+		{{- if .SubKind}}
+		SubKind: {{.SubKind}},
+		{{- end}}
 	})
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -115,6 +115,9 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		{{- if .SubKind}}
 		SubKind: {{.SubKind}},
 		{{- end}}
+		{{- if ne .WithSecrets ""}}
+		WithSecrets: {{.WithSecrets}},
+		{{- end}}
 	})
 	if err != nil && !trace.IsNotFound(err) {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
@@ -126,7 +129,7 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	}
 {{- else}}
 
-	{{.VarName}}Before, err := r.p.Client.{{.GetMethod}}(ctx)
+	{{.VarName}}Before, err := r.p.Client.{{.GetMethod}}(ctx{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
 	if err != nil && !trace.IsNotFound(err) {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
@@ -187,13 +190,16 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 			{{- if .SubKind}}
 			SubKind: {{.SubKind}},
 			{{- end}}
+			{{- if ne .WithSecrets ""}}
+			WithSecrets: {{.WithSecrets}},
+			{{- end}}
 		})
 		err = getErr
 		if err == nil {
 			{{.VarName}}I = {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
 		}
 	{{- else}}
-		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx)
+		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
 	{{- end}}
 		if trace.IsNotFound(err) {
 		    select {
@@ -278,10 +284,13 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 		{{- if .SubKind}}
 		SubKind: {{.SubKind}},
 		{{- end}}
+		{{- if ne .WithSecrets ""}}
+		WithSecrets: {{.WithSecrets}},
+		{{- end}}
 	})
 {{- else}}
 
-	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx)
+	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
 {{- end}}
 	if trace.IsNotFound(err) {
 		resp.State.RemoveResource(ctx)
@@ -362,6 +371,9 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		{{- if .SubKind}}
 		SubKind: {{.SubKind}},
 		{{- end}}
+		{{- if ne .WithSecrets ""}}
+		WithSecrets: {{.WithSecrets}},
+		{{- end}}
 	})
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
@@ -370,7 +382,7 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{.VarName}}Before := {{.VarName}}BeforeResp.Get{{.RequestWrapper.RequestResourceField}}()
 {{- else}}
 
-	{{.VarName}}Before, err := r.p.Client.{{.GetMethod}}(ctx)
+	{{.VarName}}Before, err := r.p.Client.{{.GetMethod}}(ctx{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return
@@ -422,13 +434,16 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 			{{- if .SubKind}}
 			SubKind: {{.SubKind}},
 			{{- end}}
+			{{- if ne .WithSecrets ""}}
+			WithSecrets: {{.WithSecrets}},
+			{{- end}}
 		})
 		err = getErr
 		if err == nil {
 			{{.VarName}}I = {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
 		}
 	{{- else}}
-		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx)
+		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
 	{{- end}}
 		if err != nil {
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
@@ -500,6 +515,9 @@ func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.Im
 		{{- if .SubKind}}
 		SubKind: {{.SubKind}},
 		{{- end}}
+		{{- if ne .WithSecrets ""}}
+		WithSecrets: {{.WithSecrets}},
+		{{- end}}
 	})
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
@@ -507,7 +525,7 @@ func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.Im
 	}
 	{{.VarName}}I := {{.VarName}}GetResp.Get{{.RequestWrapper.RequestResourceField}}()
 {{- else}}
-	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx)
+	{{.VarName}}I, err := r.p.Client.{{.GetMethod}}(ctx{{if ne .WithSecrets ""}}, {{.WithSecrets}}{{end}})
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 		return

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -34,6 +34,9 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+{{- if .DefaultSubKind }}
+	"github.com/hashicorp/terraform-plugin-framework/path"
+{{- end }}
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -92,6 +95,11 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		return
 	}
 {{- end}}
+{{- if .DefaultSubKind}}
+	if {{.VarName}}.SubKind == "" {
+		{{.VarName}}.SubKind = {{.DefaultSubKind}}
+	}
+{{- end}}
 
 	{{if .DefaultVersion -}}
 	if {{.VarName}}.Version == "" {
@@ -112,8 +120,8 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 
 	{{.VarName}}BeforeResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: {{.VarName}}.SubKind,
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
@@ -187,8 +195,8 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	{{- if .RequestWrapper}}
 		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 			Name: {{.DefaultName}},
-			{{- if .SubKind}}
-			SubKind: {{.SubKind}},
+			{{- if .DefaultSubKind}}
+			SubKind: {{.VarName}}.SubKind,
 			{{- end}}
 			{{- if ne .WithSecrets ""}}
 			WithSecrets: {{.WithSecrets}},
@@ -277,12 +285,23 @@ func (r resourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadResou
 	if resp.Diagnostics.HasError() {
 		return
 	}
+{{- if .DefaultSubKind}}
+	var subKind types.String
+	diags = req.State.GetAttribute(ctx, path.Root("sub_kind"), &subKind)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if subKind.Value == "" {
+		subKind.Value = {{.DefaultSubKind}}
+	}
+{{- end}}
 {{- if .RequestWrapper}}
 
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: subKind.Value,
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
@@ -354,6 +373,11 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		return
 	}
 {{- end}}
+{{- if .DefaultSubKind}}
+	if {{.VarName}}.SubKind == "" {
+		{{.VarName}}.SubKind = {{.DefaultSubKind}}
+	}
+{{- end}}
 
 	{{- if .DefaultName }}
 	if {{.VarName}}.GetMetadata() == nil {
@@ -368,8 +392,8 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 
 	{{.VarName}}BeforeResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: {{.VarName}}.SubKind,
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},
@@ -431,8 +455,8 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{- if .RequestWrapper}}
 		{{.VarName}}GetResp, getErr := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 			Name: {{.DefaultName}},
-			{{- if .SubKind}}
-			SubKind: {{.SubKind}},
+			{{- if .DefaultSubKind}}
+			SubKind: {{.VarName}}.SubKind,
 			{{- end}}
 			{{- if ne .WithSecrets ""}}
 			WithSecrets: {{.WithSecrets}},
@@ -489,11 +513,21 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 
 // Delete deletes Teleport {{.Name}}
 func (r resourceTeleport{{.Name}}) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+{{- if .DefaultSubKind}}
+	var subKind types.String
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("sub_kind"), &subKind)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if subKind.Value == "" {
+		subKind.Value = {{.DefaultSubKind}}
+	}
+{{- end}}
 {{- if .RequestWrapper}}
 	_, err := r.p.Client.{{.DeleteMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.DeleteRequest}}{
 		Name: {{.DefaultName}},
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: subKind.Value,
 		{{- end}}
 	})
 {{- else}}
@@ -512,8 +546,8 @@ func (r resourceTeleport{{.Name}}) ImportState(ctx context.Context, req tfsdk.Im
 {{- if .RequestWrapper}}
 	{{.VarName}}GetResp, err := r.p.Client.{{.GetMethod}}(ctx, &{{.ProtoPackage}}.{{.RequestWrapper.GetRequest}}{
 		Name: {{.DefaultName}},
-		{{- if .SubKind}}
-		SubKind: {{.SubKind}},
+		{{- if .DefaultSubKind}}
+		SubKind: {{.DefaultSubKind}},
 		{{- end}}
 		{{- if ne .WithSecrets ""}}
 		WithSecrets: {{.WithSecrets}},


### PR DESCRIPTION
<!-- Provide a descriptive entry for the changelog of the next release. -->

RFD 153 suggests wrapping our resources in response and request wrappers. To be consistent with that, this PR adds the ability to wrap the expected type that terraform acts on with the request and response types needed by the client. 

Changes:

* New RequestWrapper
* Added blocks of the templating to every instance of the api calls in the template files

PRs that depend on this change: https://github.com/gravitational/teleport/pull/65506 https://github.com/gravitational/teleport/pull/65623

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local terraform generation

### Test Cases
- [x] Regenerated tf schema here that requires this new wrapper: https://github.com/gravitational/teleport/pull/65868/changes#diff-973ace06c744c7d3e896f7cacdd64b1c737f543efc2384522045addf5e068923
Scoped role and scoped role assignments are the only ones that have differing rendered go code.