### PR TITLE
fips: Remove IsBoringBinary method from lib/modules.Modules

### DIFF
--- a/integration/autoupdate/tools/updater/modules.go
+++ b/integration/autoupdate/tools/updater/modules.go
@@ -126,11 +126,6 @@ func (p *TestModules) Features() modules.Features {
 	}
 }
 
-// IsBoringBinary checks if the binary was compiled with BoringCrypto.
-func (p *TestModules) IsBoringBinary() bool {
-	return false
-}
-
 // AttestHardwareKey attests a hardware key.
 func (p *TestModules) AttestHardwareKey(context.Context, any, *hardwarekey.AttestationStatement, crypto.PublicKey, time.Duration) (*keys.AttestationData, error) {
 	return nil, trace.NotFound("no attestation data for the given key")

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -7680,7 +7680,7 @@ func (a *Server) Ping(ctx context.Context) (proto.PingResponse, error) {
 		ServerVersion:           teleport.Version,
 		ServerFeatures:          features,
 		ProxyPublicAddr:         a.getProxyPublicAddr(ctx),
-		IsBoring:                a.modules.IsBoringBinary(),
+		IsBoring:                modules.IsFIPSBuild(),
 		LoadAllCAs:              a.loadAllCAs,
 		SignatureAlgorithmSuite: authPref.GetSignatureAlgorithmSuite(),
 		LicenseExpiry:           &licenseExpiry,

--- a/lib/autoupdate/tools/utils.go
+++ b/lib/autoupdate/tools/utils.go
@@ -215,10 +215,10 @@ func teleportPackageURLs(ctx context.Context, uriTmpl string, baseURL, requested
 	}
 
 	var flags autoupdate.InstallFlags
-	if m.IsBoringBinary() {
+	if modules.IsFIPSBuild() {
 		flags |= autoupdate.FlagFIPS
 	}
-	if m.IsEnterpriseBuild() || m.IsBoringBinary() {
+	if m.IsEnterpriseBuild() || modules.IsFIPSBuild() {
 		flags |= autoupdate.FlagEnterprise
 	}
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -5297,7 +5297,7 @@ func InsecureSkipHostKeyChecking(host string, remote net.Addr, key ssh.PublicKey
 // isFIPS returns if the binary was built with a FIPS validated
 // module, which implies FedRAMP/FIPS mode for tsh.
 func isFIPS() bool {
-	return modules.GetModules().IsBoringBinary()
+	return modules.IsFIPSBuild()
 }
 
 func findActiveDatabases(keyRing *KeyRing) ([]tlsca.RouteToDatabase, error) {

--- a/lib/cloud/awsconfig/awsconfig.go
+++ b/lib/cloud/awsconfig/awsconfig.go
@@ -392,7 +392,7 @@ func buildConfigOptions(region string, cred aws.CredentialsProvider, opts *optio
 		awsconfig.WithCredentialsProvider(cred),
 		awsconfig.WithCredentialsCacheOptions(awsCredentialsCacheOptions),
 	}
-	if modules.GetModules().IsBoringBinary() {
+	if modules.IsFIPSBuild() {
 		configOpts = append(configOpts, awsconfig.WithUseFIPSEndpoint(aws.FIPSEndpointStateEnabled))
 	}
 	if opts.customRetryer != nil {

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -852,9 +852,7 @@ func TestEndpoints(t *testing.T) {
 			fips := types.ClusterAuditConfigSpecV2_FIPS_DISABLED
 			if tt.fips {
 				fips = types.ClusterAuditConfigSpecV2_FIPS_ENABLED
-				modulestest.SetTestModules(t, modulestest.Modules{
-					FIPS: true,
-				})
+				modulestest.SetFIPS(t, true)
 			}
 
 			mux := http.NewServeMux()

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -263,7 +263,7 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 		})
 	}
 
-	if modules.GetModules().IsBoringBinary() && cfg.UseFIPSEndpoint == types.ClusterAuditConfigSpecV2_FIPS_ENABLED {
+	if modules.IsFIPSBuild() && cfg.UseFIPSEndpoint == types.ClusterAuditConfigSpecV2_FIPS_ENABLED {
 		s3Opts = append(s3Opts, func(options *s3.Options) {
 			options.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateEnabled
 		})

--- a/lib/events/s3sessions/s3handler_config_test.go
+++ b/lib/events/s3sessions/s3handler_config_test.go
@@ -205,9 +205,7 @@ func TestEndpoints(t *testing.T) {
 			fips := types.ClusterAuditConfigSpecV2_FIPS_DISABLED
 			if tt.fips {
 				fips = types.ClusterAuditConfigSpecV2_FIPS_ENABLED
-				modulestest.SetTestModules(t, modulestest.Modules{
-					FIPS: true,
-				})
+				modulestest.SetFIPS(t, true)
 			}
 
 			var request *http.Request

--- a/lib/integrations/awsoidc/aws_app_access_iam_config.go
+++ b/lib/integrations/awsoidc/aws_app_access_iam_config.go
@@ -94,7 +94,7 @@ type defaultAWSAppAccessConfigureClient struct {
 func NewAWSAppAccessConfigureClient(ctx context.Context) (AWSAppAccessConfigureClient, error) {
 	var configOptions []func(*awsconfig.LoadOptions) error
 
-	if modules.GetModules().IsBoringBinary() {
+	if modules.IsFIPSBuild() {
 		configOptions = append(configOptions, awsconfig.WithUseFIPSEndpoint(aws.FIPSEndpointStateEnabled))
 	}
 

--- a/lib/integrations/awsoidc/credprovider/integration_config_provider.go
+++ b/lib/integrations/awsoidc/credprovider/integration_config_provider.go
@@ -150,7 +150,7 @@ func newAWSCredCache(ctx context.Context, cfg Config, stsClient stscreds.AssumeR
 
 func newAWSConfig(ctx context.Context, awsRegion string, options ...func(*awssdkconfig.LoadOptions) error) (*aws.Config, error) {
 	var useFIPS aws.FIPSEndpointState
-	if modules.GetModules().IsBoringBinary() {
+	if modules.IsFIPSBuild() {
 		useFIPS = aws.FIPSEndpointStateEnabled
 	}
 	options = append(options,

--- a/lib/integrations/externalauditstorage/configurator.go
+++ b/lib/integrations/externalauditstorage/configurator.go
@@ -99,7 +99,7 @@ func (o *Options) setDefaults(ctx context.Context, region string) error {
 	}
 	if o.stsClient == nil {
 		var useFips aws.FIPSEndpointState
-		if modules.GetModules().IsBoringBinary() {
+		if modules.IsFIPSBuild() {
 			useFips = aws.FIPSEndpointStateEnabled
 		}
 		cfg, err := config.LoadDefaultConfig(

--- a/lib/modules/boring.go
+++ b/lib/modules/boring.go
@@ -20,13 +20,13 @@ package modules
 
 import "crypto/boring"
 
-// IsBoringBinary checks if the binary was compiled with BoringCrypto.
+// IsFIPSBuild checks if the binary was compiled with FIPS crypto.
 //
 // It's possible to enable the boringcrypto GOEXPERIMENT (which will enable the
 // boringcrypto build tag) even on platforms that don't support the boringcrypto
 // module, which results in crypto packages being available and working, but not
 // actually using a certified cryptographic module, so we have to check
 // [boring.Enabled] even if this is compiled in.
-func IsBoringBinary() bool {
+func IsFIPSBuild() bool {
 	return boring.Enabled()
 }

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -255,8 +255,6 @@ type AccessListAndMembersGetter interface {
 type Modules interface {
 	// PrintVersion prints teleport version
 	PrintVersion()
-	// IsBoringBinary checks if the binary was compiled with BoringCrypto.
-	IsBoringBinary() bool
 	// Features returns supported features
 	Features() Features
 	// SetFeatures set features queried from Cloud
@@ -407,10 +405,6 @@ func (p *defaultModules) Features() Features {
 // SetFeatures sets features queried from Cloud.
 // This is a noop since OSS teleport does not support enterprise features
 func (p *defaultModules) SetFeatures(f Features) {
-}
-
-func (p *defaultModules) IsBoringBinary() bool {
-	return IsBoringBinary()
 }
 
 // AttestHardwareKey attests a hardware key.

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -42,7 +42,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestOSSModules(t *testing.T) {
-	require.False(t, modules.GetModules().IsBoringBinary())
 	require.Equal(t, modules.BuildOSS, modules.GetModules().BuildType())
 }
 

--- a/lib/modules/modulestest/fips.go
+++ b/lib/modules/modulestest/fips.go
@@ -1,5 +1,5 @@
 // Teleport
-// Copyright (C) 2025 Gravitational, Inc.
+// Copyright (C) 2026 Gravitational, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -14,17 +14,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package dynamodbutils
+//go:build !boringcrypto
+
+package modulestest
 
 import (
+	"testing"
+
 	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/utils/aws/awsfips"
 )
 
-// IsFIPSEnabled returns true if FIPS should be enabled for DynamoDB.
-// FIPS is enabled is the binary is built with FIPS crypto ([modules.IsFIPSBuild()])
-// and if FIPS is not disabled by the environment
-// ([awsfips.IsFIPSDisabledByEnv]).
-func IsFIPSEnabled() bool {
-	return !awsfips.IsFIPSDisabledByEnv() && modules.IsFIPSBuild()
+// SetFIPS sets the value to be returned by modules.IsFIPSBuild for the
+// purposes of testing FIPS-related functionality.
+func SetFIPS(t *testing.T, isFIPS bool) {
+	t.Helper()
+	t.Setenv("TELEPORT_TEST_NOT_SAFE_FOR_PARALLEL", "true")
+	t.Cleanup(func() { modules.FIPSTestOverride = nil })
+	modules.FIPSTestOverride = &isFIPS
 }

--- a/lib/modules/modulestest/modules.go
+++ b/lib/modules/modulestest/modules.go
@@ -80,8 +80,6 @@ type Modules struct {
 	TestBuildType string
 	// TestFeatures is returned from the Features function.
 	TestFeatures modules.Features
-	// FIPS is returned from the IsBoringBinary function.
-	FIPS bool
 	// MockAttestationData is fake attestation data to return
 	// during tests when hardware key support is enabled. This
 	// attestation data is shared by all logins when set.
@@ -149,11 +147,6 @@ func (m *Modules) GenerateAccessRequestSuggestedReviewers(ctx context.Context, g
 // GetSuggestedAccessLists implements modules.Modules.
 func (m *Modules) GetSuggestedAccessLists(ctx context.Context, identity *tlsca.Identity, clt modules.AccessListSuggestionClient, accessListGetter modules.AccessListAndMembersGetter, requestID string) ([]*accesslist.AccessList, error) {
 	return nil, trace.NotImplemented("GetSuggestedAccessLists not implemented")
-}
-
-// IsBoringBinary implements modules.Modules.
-func (m *Modules) IsBoringBinary() bool {
-	return m.FIPS
 }
 
 // IsEnterpriseBuild implements modules.Modules.

--- a/lib/modules/notboring.go
+++ b/lib/modules/notboring.go
@@ -18,7 +18,12 @@
 
 package modules
 
-// IsBoringBinary checks if the binary was compiled with BoringCrypto.
-func IsBoringBinary() bool {
-	return false
+// FIPSTestOverride allows the result of IsFIPSBuild() to be overridden.
+// Do not use this in production code. It should only be used via
+// moduletest.SetFIPS().
+var FIPSTestOverride *bool
+
+// IsFIPSBuild checks if the binary was compiled with BoringCrypto.
+func IsFIPSBuild() bool {
+	return FIPSTestOverride != nil && *FIPSTestOverride
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1136,9 +1136,9 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		return nil, trace.Wrap(err, "creating metrics registry")
 	}
 
-	// If FIPS mode was requested make sure binary is build against BoringCrypto.
-	if cfg.FIPS && !cfg.Modules.IsBoringBinary() {
-		return nil, trace.BadParameter("binary not compiled against BoringCrypto, check " +
+	// If FIPS mode was requested make sure binary is build with FIPS crypto.
+	if cfg.FIPS && !modules.IsFIPSBuild() {
+		return nil, trace.BadParameter("binary not compiled with FIPS crypto, check " +
 			"that Enterprise FIPS release was downloaded from " +
 			"a Teleport account https://teleport.sh")
 	}

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -342,7 +342,7 @@ func (b *Bot) preRunChecks(ctx context.Context) (_ func() error, err error) {
 	}
 
 	if b.cfg.FIPS {
-		if !b.modules.IsBoringBinary() {
+		if !modules.IsFIPSBuild() {
 			b.log.ErrorContext(ctx, "FIPS mode enabled but FIPS compatible binary not in use. Ensure you are using the Enterprise FIPS binary to use this flag.")
 			return nil, trace.BadParameter("fips mode enabled but binary was not compiled with boringcrypto")
 		}

--- a/lib/utils/aws/dynamodbutils/dynamo_test.go
+++ b/lib/utils/aws/dynamodbutils/dynamo_test.go
@@ -54,10 +54,7 @@ func TestIsFIPSEnabled(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv("TELEPORT_UNSTABLE_DISABLE_AWS_FIPS", test.envVarValue)
 
-			modulestest.SetTestModules(t, modulestest.Modules{
-				FIPS: test.fips,
-			})
-
+			modulestest.SetFIPS(t, test.fips)
 			got := dynamodbutils.IsFIPSEnabled()
 			assert.Equal(t, test.want, got, "IsFIPSEnabled mismatch")
 		})

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1820,7 +1820,7 @@ func (h *Handler) ping(w http.ResponseWriter, r *http.Request, p httprouter.Para
 		AutomaticUpgrades: pr.ServerFeatures.GetAutomaticUpgrades(),
 		AutoUpdate:        h.automaticUpdateSettings184(r.Context(), group, updaterID),
 		Edition:           h.cfg.Modules.BuildType(),
-		FIPS:              h.cfg.Modules.IsBoringBinary(),
+		FIPS:              modules.IsFIPSBuild(),
 	}, nil
 }
 
@@ -1852,7 +1852,7 @@ func (h *Handler) find(w http.ResponseWriter, r *http.Request, p httprouter.Para
 			MinClientVersion: teleport.MinClientSemVer().String(),
 			ClusterName:      h.auth.clusterName,
 			Edition:          h.cfg.Modules.BuildType(),
-			FIPS:             h.cfg.Modules.IsBoringBinary(),
+			FIPS:             modules.IsFIPSBuild(),
 			AutoUpdate:       h.automaticUpdateSettings184(ctx, group, "" /* updater UUID */),
 		}, nil
 	})
@@ -4146,7 +4146,7 @@ func (h *Handler) siteNodeConnect(
 		PresenceChecker:    h.cfg.PresenceChecker,
 		WebsocketConn:      ws,
 		SSHDialTimeout:     dialTimeout,
-		FIPSBuild:          h.cfg.Modules.IsBoringBinary(),
+		FIPSBuild:          modules.IsFIPSBuild(),
 		HostNameResolver: func(serverID string) (string, error) {
 			matches, err := nw.CurrentResourcesWithFilter(r.Context(), func(n readonly.Server) bool {
 				return n.GetName() == serverID

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/sshagent"
@@ -217,7 +218,7 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 		req.serverID+":0",
 		req.serverID,
 		tc,
-		h.cfg.Modules.IsBoringBinary(),
+		modules.IsFIPSBuild(),
 	)
 	if err != nil {
 		// The close error is ignored instead of using [trace.NewAggregate] because

--- a/lib/web/scripts.go
+++ b/lib/web/scripts.go
@@ -138,7 +138,7 @@ func (h *Handler) installScriptOptions(ctx context.Context) (scripts.InstallScri
 		CDNBaseURL:      cdnBaseURL,
 		ProxyAddr:       h.PublicProxyAddr(),
 		TeleportFlavor:  teleportFlavor,
-		FIPS:            modules.IsBoringBinary(),
+		FIPS:            modules.IsFIPSBuild(),
 	}, nil
 }
 

--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -508,11 +508,6 @@ func (p *cliModules) Features() modules.Features {
 	}
 }
 
-// IsBoringBinary checks if the binary was compiled with BoringCrypto.
-func (p *cliModules) IsBoringBinary() bool {
-	return false
-}
-
 // AttestHardwareKey attests a hardware key.
 func (p *cliModules) AttestHardwareKey(_ context.Context, _ any, _ *hardwarekey.AttestationStatement, _ crypto.PublicKey, _ time.Duration) (*keys.AttestationData, error) {
 	return nil, trace.NotFound("no attestation data for the given key")

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -890,7 +890,6 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		}
 	}
 
-	moduleCfg := modules.GetModules()
 	var cpuProfile, memProfile, traceProfile string
 
 	// configure CLI argument parser:
@@ -920,7 +919,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	app.Flag("fork-signal-fd", "File descriptor to signal parent on when forked. Overrides --fork-after-authentication. For internal use only.").Hidden().Uint64Var(&cf.forkSignalFd)
 	app.Flag("fork-kill-fd", "File descriptor to check parent health on when forked. For internal use only.").Hidden().Uint64Var(&cf.forkKillFd)
 
-	if !moduleCfg.IsBoringBinary() {
+	if !modules.IsFIPSBuild() {
 		// The user is *never* allowed to do this in FIPS mode.
 		app.Flag("insecure", "Do not verify server's certificate and host name. Use only in test environments.").
 			Default("false").
@@ -2019,7 +2018,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	// A FIPS build of tsh is attempting to use a non-FIPS key returned by the cluster.
 	var fipsErr *sshutils.FIPSError
-	if moduleCfg.IsBoringBinary() && errors.As(err, &fipsErr) {
+	if modules.IsFIPSBuild() && errors.As(err, &fipsErr) {
 		return trace.Wrap(err,
 			"tsh is running in FIPS mode, but the cluster is not FIPS-compliant. Use a non-FIPS tsh binary to connect to the cluster.",
 		)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -297,11 +297,6 @@ func (p *cliModules) Features() modules.Features {
 	}
 }
 
-// IsBoringBinary checks if the binary was compiled with BoringCrypto.
-func (p *cliModules) IsBoringBinary() bool {
-	return false
-}
-
 // AttestHardwareKey attests a hardware key.
 func (p *cliModules) AttestHardwareKey(_ context.Context, _ any, _ *hardwarekey.AttestationStatement, _ crypto.PublicKey, _ time.Duration) (*keys.AttestationData, error) {
 	return nil, trace.NotFound("no attestation data for the given key")


### PR DESCRIPTION
Remove the `IsBoringBinary` method from the `lib/modules.Modules`
interface, changing it to a global function `IsFIPSBuild`. Whether a
build is FIPS or not is not a license feature which is what the Modules
interface is intended to model.

The implementation includes a `SetFIPS` function in the `modulestest`
package for tests that need to simulate the binary being a FIPS build.
The function is not parallel-safe as it sets a global variable.

This is a preparatory step to moving the FIPS build from boringcrypto to
the inbuild Go FIPS machinery.

Issue: https://github.com/gravitational/teleport.e/issues/8538

## Manual Test Plan
### Test Environment

* Create a dev release build of the OSS, Enterprise and FIPS builds

### Test Cases
- [ ] Run the Teleport OSS build without the --fips flag and ensure it starts
- [ ] Run the Teleport OSS build with the --fips flag and ensure it reports the error:
    "binary was not compiled with FIPS crypto..."
- [ ] Run the Teleport Enterprise build without the --fips flag and ensure it starts
- [ ] Run the Teleport Enterprise build with the --fips flag and ensure it reports the error:
    "binary was not compiled with FIPS crypto..."
- [ ] Run the Teleport FIPS build without the --fips flag and ensure it starts*
- [ ] Run the Teleport FIPS build with the --fips flag and ensure it starts
- [ ] Run the tbot non-FIPS build with the --fips flag and ensure it reports the error:
    "FIPS mode enabled but FIPS compatible binary not in use..."
- [ ] Run a tsh FIPS build against Teleport not running in FIPS mode and ensure it reports the error:
    "tsh is running in FIPS mode, but the cluster is not FIPS-compliant."...
- [ ] Run a tsh FIPS build with --insecure and ensure it reports an error about an unknown flag.

* Running a FIPS Teleport binary without --fips is currently allowed. It is not an error.
