### PR TITLE
Add cache index and method for expired beams

### DIFF
--- a/lib/cache/beam.go
+++ b/lib/cache/beam.go
@@ -18,7 +18,9 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"iter"
+	"time"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
@@ -34,8 +36,9 @@ import (
 type beamIndex string
 
 const (
-	beamNameIndex  beamIndex = "name"
-	beamAliasIndex beamIndex = "alias"
+	beamNameIndex    beamIndex = "name"
+	beamAliasIndex   beamIndex = "alias"
+	beamExpiresIndex beamIndex = "expires"
 )
 
 func newBeamCollection(upstream services.BeamReader, w types.WatchKind) (*collection[*beamsv1.Beam, beamIndex], error) {
@@ -48,8 +51,9 @@ func newBeamCollection(upstream services.BeamReader, w types.WatchKind) (*collec
 			types.KindBeam,
 			proto.CloneOf[*beamsv1.Beam],
 			map[beamIndex]func(*beamsv1.Beam) string{
-				beamNameIndex:  keyForBeamNameIndex,
-				beamAliasIndex: keyForBeamAliasIndex,
+				beamNameIndex:    keyForBeamNameIndex,
+				beamAliasIndex:   keyForBeamAliasIndex,
+				beamExpiresIndex: keyForBeamExpiryIndex,
 			},
 		),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*beamsv1.Beam, error) {
@@ -127,10 +131,43 @@ func (c *Cache) IterateBeams(ctx context.Context, pageToken string) iter.Seq2[*b
 	return lister.Range(ctx, pageToken, "")
 }
 
+// IterateExpiredBeams returns beams whose spec.expires is before expiresBefore,
+// ordered by expiry time and then metadata.name.
+func (c *Cache) IterateExpiredBeams(ctx context.Context, expiresBefore time.Time) iter.Seq2[*beamsv1.Beam, error] {
+	return func(yield func(*beamsv1.Beam, error) bool) {
+		rg, err := acquireReadGuard(c, c.collections.beams)
+		if err != nil {
+			yield(nil, trace.Wrap(err))
+			return
+		}
+		defer rg.Release()
+
+		if !rg.ReadCache() {
+			yield(nil, trace.BadParameter("IterateExpiredBeams requires a healthy cache"))
+			return
+		}
+
+		end := keyForBeamExpiryIndexAt(expiresBefore, "")
+		for beam := range rg.store.resources(beamExpiresIndex, "", end) {
+			if !yield(c.collections.beams.store.clone(beam), nil) {
+				return
+			}
+		}
+	}
+}
+
 func keyForBeamNameIndex(beam *beamsv1.Beam) string {
 	return beam.GetMetadata().GetName()
 }
 
 func keyForBeamAliasIndex(beam *beamsv1.Beam) string {
 	return beam.GetStatus().GetAlias()
+}
+
+func keyForBeamExpiryIndex(beam *beamsv1.Beam) string {
+	return keyForBeamExpiryIndexAt(beam.GetSpec().GetExpires().AsTime(), beam.GetMetadata().GetName())
+}
+
+func keyForBeamExpiryIndexAt(expires time.Time, name string) string {
+	return fmt.Sprintf("%020d/%s", expires.UnixNano(), name)
 }

--- a/lib/cache/beam.go
+++ b/lib/cache/beam.go
@@ -18,12 +18,12 @@ package cache
 
 import (
 	"context"
-	"fmt"
 	"iter"
 	"time"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
+	"rsc.io/ordered"
 
 	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -169,5 +169,5 @@ func keyForBeamExpiryIndex(beam *beamsv1.Beam) string {
 }
 
 func keyForBeamExpiryIndexAt(expires time.Time, name string) string {
-	return fmt.Sprintf("%020d/%s", expires.UnixNano(), name)
+	return string(ordered.Encode(expires.Unix(), name))
 }

--- a/lib/cache/beam_test.go
+++ b/lib/cache/beam_test.go
@@ -95,6 +95,39 @@ func TestBeam_GetBeamByAlias(t *testing.T) {
 	}, 2*time.Second, 100*time.Millisecond)
 }
 
+func TestBeam_IterateExpiredBeams(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	now := time.Now()
+	expiredEarly := newBeamResource(uuid.NewString(), "warm-orbit", now.Add(-2*time.Minute))
+	expiredA := newBeamResource("alpha", "silver-canyon", now.Add(-1*time.Minute))
+	expiredB := newBeamResource("bravo", "quiet-meadow", now.Add(-1*time.Minute))
+	active := newBeamResource(uuid.NewString(), "steady-river", now.Add(1*time.Hour))
+
+	require.NoError(t, createBeamForCacheTest(ctx, p, expiredEarly))
+	require.NoError(t, createBeamForCacheTest(ctx, p, expiredA))
+	require.NoError(t, createBeamForCacheTest(ctx, p, expiredB))
+	require.NoError(t, createBeamForCacheTest(ctx, p, active))
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		var got []string
+		for beam, err := range p.cache.IterateExpiredBeams(ctx, now) {
+			require.NoError(t, err)
+			got = append(got, beam.GetMetadata().GetName())
+		}
+
+		require.Equal(t, []string{
+			expiredEarly.GetMetadata().GetName(),
+			expiredA.GetMetadata().GetName(),
+			expiredB.GetMetadata().GetName(),
+		}, got)
+	}, 2*time.Second, 50*time.Millisecond)
+}
+
 func newBeamResource(name, alias string, expires time.Time) *beamsv1.Beam {
 	ts := timestamppb.New(expires)
 	return &beamsv1.Beam{


### PR DESCRIPTION
Unlike most resources, which rely on the storage backend to implement TTLs via the `metadata.expires` field, beams have their own expiry lifecycle. This is because Teleport is responsible for cleaning up the provisioned compute (i.e. Firecracker microVM) and must do so before we delete the record from storage.

This PR adds a new cache index for the beam's `spec.expires` field, and an `IterateExpiredBeams` method which will be used by the garbage collector (in `e`).
