### PR TITLE
Add link to Account Settings for Apple mobile on `ErrTrustedDeviceRequired`

### DIFF
--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -208,6 +208,7 @@ type ConnectionsHandler struct {
 	// authMiddleware allows wrapping connections with identity information.
 	authMiddleware *authz.Middleware
 
+	proxyHost string
 	proxyPort string
 
 	// getAppByPublicAddress returns a types.Application using the public address as matcher.
@@ -311,8 +312,8 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 	// functionality this server needs, like requiring client certificates.
 	c.tlsConfig = CopyAndConfigureTLS(c.log, c.cfg.AccessPoint, c.cfg.TLSConfig)
 
-	// Figure out the port the proxy is running on.
-	c.proxyPort = c.getProxyPort(c.closeContext)
+	// Figure out the host and port the proxy is running on.
+	c.proxyHost, c.proxyPort = c.getProxyPublicAddr(c.closeContext)
 
 	go c.expireSessions()
 
@@ -486,23 +487,23 @@ func (c *ConnectionsHandler) serveHTTP(w http.ResponseWriter, r *http.Request) e
 	}
 }
 
-// getProxyPort tries to figure out the address the proxy is running at.
-func (c *ConnectionsHandler) getProxyPort(ctx context.Context) string {
+// getProxyPublicAddr tries to figure out the host and port of the proxy's
+// public address. On any failure the host is returned as empty and the port
+// falls back to [defaults.HTTPListenPort].
+func (c *ConnectionsHandler) getProxyPublicAddr(ctx context.Context) (host, port string) {
+	port = strconv.Itoa(defaults.HTTPListenPort)
 	servers, err := clientutils.CollectWithFallback(ctx, c.cfg.AccessPoint.ListProxyServers, func(context.Context) ([]types.Server, error) {
 		//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 		return c.cfg.AccessPoint.GetProxies()
 	})
+	if err != nil || len(servers) == 0 {
+		return "", port
+	}
+	h, p, err := net.SplitHostPort(servers[0].GetPublicAddr())
 	if err != nil {
-		return strconv.Itoa(defaults.HTTPListenPort)
+		return "", port
 	}
-	if len(servers) == 0 {
-		return strconv.Itoa(defaults.HTTPListenPort)
-	}
-	_, port, err := net.SplitHostPort(servers[0].GetPublicAddr())
-	if err != nil {
-		return strconv.Itoa(defaults.HTTPListenPort)
-	}
-	return port
+	return h, p
 }
 
 // serveAWSWebConsole generates a sign-in URL for AWS management console and
@@ -788,7 +789,7 @@ func (c *ConnectionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		switch {
 		case errors.Is(err, services.ErrTrustedDeviceRequired):
-			writeTrustedDeviceRequired(w, r, code)
+			writeTrustedDeviceRequired(w, r, code, c.proxyHost, c.proxyPort)
 		case errors.Is(err, services.ErrSessionMFARequired):
 			http.Error(w, authclient.ErrNoMFADevices.Error(), code)
 		default:
@@ -805,15 +806,30 @@ const (
 
 // writeTrustedDeviceRequired writes the response body for a request that failed
 // with [services.ErrTrustedDeviceRequired]. Browsers receive a small HTML page
-// with clickable links to the docs; every other client gets plain text.
-func writeTrustedDeviceRequired(w http.ResponseWriter, r *http.Request, code int) {
-	if isBrowserUserAgent(r.UserAgent()) {
-		const body = `<!DOCTYPE html>
+// with clickable links to the docs; every other client gets plain text. When
+// the UA looks like it could come from an iPhone or iPad and proxyHost is
+// known, the HTML also includes a link to the Account Settings page in the
+// Web UI where mobile devices can be enrolled.
+func writeTrustedDeviceRequired(w http.ResponseWriter, r *http.Request, code int, proxyHost, proxyPort string) {
+	isBrowser, isPossiblyAppleMobile := classifyUserAgent(r.UserAgent())
+	if isBrowser {
+		var mobileEnrollParagraph string
+		if proxyHost != "" && isPossiblyAppleMobile {
+			addr := proxyHost
+			if proxyPort != "443" {
+				addr = net.JoinHostPort(proxyHost, proxyPort)
+			}
+			url := "https://" + addr + "/web/account/security"
+			mobileEnrollParagraph = `<p>If your iPhone or iPad is not enrolled yet, enroll it from the Trusted Devices section in <a href="` + url + `" target="_blank">the Account Settings</a>.</p>
+`
+		}
+
+		body := `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="utf-8"><title>Trusted device required</title></head>
 <body>
 <p>A trusted device is required to access this resource, but this session has not been authorized with Device Trust. Follow <a href="` + trustedDeviceRequiredWebUIDocsURL + `" target="_blank">the Web UI troubleshooting guide</a> to authorize the session with Device Trust.</p>
-<p>If accessing the resource through VNet or a local proxy, make sure the device running Teleport Connect or tsh is registered and enrolled. See <a href="` + trustedDeviceRequiredAppAccessDocsURL + `" target="_blank">the app access troubleshooting guide</a> for help.</p>
+` + mobileEnrollParagraph + `<p>If accessing the resource through VNet or a local proxy, make sure the device running Teleport Connect or tsh is registered and enrolled. See <a href="` + trustedDeviceRequiredAppAccessDocsURL + `" target="_blank">the app access troubleshooting guide</a> for help.</p>
 </body>
 </html>
 `
@@ -830,16 +846,30 @@ See `+trustedDeviceRequiredDocsURL+` for help.
 `, code)
 }
 
-// isBrowserUserAgent reports whether ua plausibly comes from a web browser, as
+// classifyUserAgent returns heuristic classifications of ua.
+//
+// isBrowser reports whether ua plausibly comes from a web browser, as
 // opposed to a CLI (tsh, curl) or some SDK client. It relies on the historical
 // quirk that essentially every browser UA begins with "Mozilla/" and contains
 // a known engine token. Modern browsers (Chrome, Safari, Edge, Opera, mobile
 // browsers) are all WebKit- or Blink-based and carry "AppleWebKit"; the Firefox
 // family carries "Gecko/".
-func isBrowserUserAgent(ua string) bool {
+//
+// isPossiblyAppleMobile matches "iPhone" and "Mac OS X": since iPadOS 13
+// iPads send the same UA as macOS, and without a navigator.maxTouchPoints
+// hint there is no way to tell them apart, so Macs match too. It is only set
+// for browser UAs — a non-browser UA is never classified as Apple mobile.
+func classifyUserAgent(ua string) (isBrowser, isPossiblyAppleMobile bool) {
 	lower := strings.ToLower(ua)
-	return strings.HasPrefix(lower, "mozilla/") &&
+	isBrowser = strings.HasPrefix(lower, "mozilla/") &&
 		(strings.Contains(lower, "applewebkit") || strings.Contains(lower, "gecko/"))
+
+	if !isBrowser {
+		return false, false
+	}
+
+	isPossiblyAppleMobile = strings.Contains(lower, "iphone") || strings.Contains(lower, "mac os x")
+	return true, isPossiblyAppleMobile
 }
 
 // getConnectionInfo extracts identity information from the provided

--- a/lib/srv/app/connections_handler_test.go
+++ b/lib/srv/app/connections_handler_test.go
@@ -189,84 +189,101 @@ func TestHandleConnection_PipeSkipsLimiter(t *testing.T) {
 	require.False(t, trace.IsLimitExceeded(err), "unexpected LimitExceeded error: %v", err)
 }
 
-func TestIsBrowserUserAgent(t *testing.T) {
+func TestClassifyUserAgent(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		ua   string
-		want bool
+		name                      string
+		ua                        string
+		wantIsBrowser             bool
+		wantIsPossiblyAppleMobile bool
 	}{
 		{
-			name: "empty",
-			ua:   "",
-			want: false,
+			name:          "empty",
+			ua:            "",
+			wantIsBrowser: false,
 		},
 		{
-			name: "tsh",
-			ua:   "tsh/17.0.0",
-			want: false,
+			name:          "tsh",
+			ua:            "tsh/17.0.0",
+			wantIsBrowser: false,
 		},
 		{
-			name: "curl",
-			ua:   "curl/8.4.0",
-			want: false,
+			name:          "curl",
+			ua:            "curl/8.4.0",
+			wantIsBrowser: false,
 		},
 		{
-			name: "Go http client",
-			ua:   "Go-http-client/1.1",
-			want: false,
+			name:          "Go http client",
+			ua:            "Go-http-client/1.1",
+			wantIsBrowser: false,
 		},
 		{
-			name: "Mozilla prefix without engine token",
-			ua:   "Mozilla/5.0 compatible",
-			want: false,
+			name:          "Mozilla prefix without engine token",
+			ua:            "Mozilla/5.0 compatible",
+			wantIsBrowser: false,
 		},
 		{
-			name: "Chrome on macOS",
-			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
-			want: true,
+			name:                      "Chrome on macOS",
+			ua:                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+			wantIsBrowser:             true,
+			wantIsPossiblyAppleMobile: true,
 		},
 		{
-			name: "Safari on macOS",
-			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.1",
-			want: true,
+			name:                      "Safari on macOS",
+			ua:                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.1",
+			wantIsBrowser:             true,
+			wantIsPossiblyAppleMobile: true,
 		},
 		{
-			name: "Safari on iPhone",
-			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H143 Safari/600.1.4",
-			want: true,
+			name:                      "Safari on iPhone",
+			ua:                        "Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H143 Safari/600.1.4",
+			wantIsBrowser:             true,
+			wantIsPossiblyAppleMobile: true,
 		},
 		{
-			name: "Firefox on Linux",
-			ua:   "Mozilla/5.0 (Linux; U; Linux 2.6; en-US; rv:1.9.9.2) Gecko/20100722 Firefox/3.6.8",
-			want: true,
+			name:                      "Firefox on Linux",
+			ua:                        "Mozilla/5.0 (Linux; U; Linux 2.6; en-US; rv:1.9.9.2) Gecko/20100722 Firefox/3.6.8",
+			wantIsBrowser:             true,
+			wantIsPossiblyAppleMobile: false,
 		},
 		{
-			name: "Firefox on iOS",
-			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/7.0.4 Mobile/16A404 Safari/605.1.15",
-			want: true,
+			name:                      "Firefox on iOS",
+			ua:                        "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/7.0.4 Mobile/16A404 Safari/605.1.15",
+			wantIsBrowser:             true,
+			wantIsPossiblyAppleMobile: true,
 		},
 		{
-			name: "Chrome on iOS",
-			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) CriOS/44.0.2403.67 Mobile/12D508 Safari/600.1.4",
-			want: true,
+			name:                      "Chrome on iOS",
+			ua:                        "Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) CriOS/44.0.2403.67 Mobile/12D508 Safari/600.1.4",
+			wantIsBrowser:             true,
+			wantIsPossiblyAppleMobile: true,
 		},
 		{
-			name: "Edge on Windows",
-			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.3912.72",
-			want: true,
+			name:                      "Edge on Windows",
+			ua:                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.3912.72",
+			wantIsBrowser:             true,
+			wantIsPossiblyAppleMobile: false,
 		},
 		{
-			name: "Opera on macOS",
-			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 OPR/108.0.0.0",
-			want: true,
+			name:                      "Opera on macOS",
+			ua:                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 OPR/108.0.0.0",
+			wantIsBrowser:             true,
+			wantIsPossiblyAppleMobile: true,
+		},
+		{
+			name:                      "Chrome on Android",
+			ua:                        "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.50 Mobile Safari/537.36",
+			wantIsBrowser:             true,
+			wantIsPossiblyAppleMobile: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, isBrowserUserAgent(tc.ua))
+			isBrowser, isPossiblyAppleMobile := classifyUserAgent(tc.ua)
+			require.Equal(t, tc.wantIsBrowser, isBrowser, "isBrowser")
+			require.Equal(t, tc.wantIsPossiblyAppleMobile, isPossiblyAppleMobile, "isPossiblyAppleMobile")
 		})
 	}
 }
@@ -274,27 +291,71 @@ func TestIsBrowserUserAgent(t *testing.T) {
 func TestWriteTrustedDeviceRequired(t *testing.T) {
 	t.Parallel()
 
-	const browserUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+	const (
+		linuxBrowserUA       = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
+		appleMobileBrowserUA = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1"
+	)
 
 	tests := []struct {
 		name            string
 		userAgent       string
+		proxyHost       string
+		proxyPort       string
 		wantContentType string
 		wantBodyParts   []string
 		wantNoBodyPart  string
 	}{
 		{
-			name:            "browser gets HTML with clickable links to Web UI and app access guides",
-			userAgent:       browserUA,
+			name:            "desktop Linux browser gets HTML with Web UI and app access guides only",
+			userAgent:       linuxBrowserUA,
+			proxyHost:       "teleport.example.com",
+			proxyPort:       "443",
 			wantContentType: "text/html; charset=utf-8",
 			wantBodyParts: []string{
 				`<a href="` + trustedDeviceRequiredWebUIDocsURL + `"`,
 				`<a href="` + trustedDeviceRequiredAppAccessDocsURL + `"`,
 			},
+			wantNoBodyPart: "/web/account/security",
+		},
+		{
+			name:            "Apple mobile browser gets HTML with Account Settings link (port 443 stripped)",
+			userAgent:       appleMobileBrowserUA,
+			proxyHost:       "teleport.example.com",
+			proxyPort:       "443",
+			wantContentType: "text/html; charset=utf-8",
+			wantBodyParts: []string{
+				`<a href="` + trustedDeviceRequiredWebUIDocsURL + `"`,
+				`<a href="https://teleport.example.com/web/account/security"`,
+				`<a href="` + trustedDeviceRequiredAppAccessDocsURL + `"`,
+			},
+		},
+		{
+			name:            "Apple mobile browser gets HTML with Account Settings link (non-443 port kept)",
+			userAgent:       appleMobileBrowserUA,
+			proxyHost:       "teleport.example.com",
+			proxyPort:       "3080",
+			wantContentType: "text/html; charset=utf-8",
+			wantBodyParts: []string{
+				`<a href="https://teleport.example.com:3080/web/account/security"`,
+			},
+		},
+		{
+			name:            "Apple mobile browser without proxy host gets HTML without Account Settings link",
+			userAgent:       appleMobileBrowserUA,
+			proxyHost:       "",
+			proxyPort:       "443",
+			wantContentType: "text/html; charset=utf-8",
+			wantBodyParts: []string{
+				`<a href="` + trustedDeviceRequiredWebUIDocsURL + `"`,
+				`<a href="` + trustedDeviceRequiredAppAccessDocsURL + `"`,
+			},
+			wantNoBodyPart: "/web/account/security",
 		},
 		{
 			name:            "non-browser gets plain text with URL but no HTML link",
 			userAgent:       "tsh/17.0.0",
+			proxyHost:       "teleport.example.com",
+			proxyPort:       "443",
 			wantContentType: "text/plain; charset=utf-8",
 			wantBodyParts:   []string{trustedDeviceRequiredDocsURL},
 			wantNoBodyPart:  "<a ",
@@ -302,6 +363,8 @@ func TestWriteTrustedDeviceRequired(t *testing.T) {
 		{
 			name:            "empty UA gets plain text with URL but no HTML link",
 			userAgent:       "",
+			proxyHost:       "teleport.example.com",
+			proxyPort:       "443",
 			wantContentType: "text/plain; charset=utf-8",
 			wantBodyParts:   []string{trustedDeviceRequiredDocsURL},
 			wantNoBodyPart:  "<a ",
@@ -316,7 +379,7 @@ func TestWriteTrustedDeviceRequired(t *testing.T) {
 			}
 			rec := httptest.NewRecorder()
 
-			writeTrustedDeviceRequired(rec, req, http.StatusForbidden)
+			writeTrustedDeviceRequired(rec, req, http.StatusForbidden, tc.proxyHost, tc.proxyPort)
 
 			require.Equal(t, http.StatusForbidden, rec.Code)
 			require.Equal(t, tc.wantContentType, rec.Header().Get("Content-Type"))


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport.e/issues/8254.

This PR builds on #65878 by adding a link to Account Settings when we detect that the UA is likely of an Apple mobile device. This is how a user accessing a web app from a session not blessed by Device Trust will learn about the fact that they can enroll their device. See ["Getting to enrollment" from RFD 32e](https://github.com/gravitational/teleport.e/blob/rfd/0032e-device-trust-ios/rfd/0032e-device-trust-ios.md#getting-to-enrollment) for more details.

To construct a link to Account Settings, we need to have a proxy host. In `NewConnectionsHandler`, we already extract the port out of the proxy public address, so in addition to this we now also extract the proxy host.

TODO: Add screenshots of before & after.