### PR TITLE
Stop consuming global modules in auth packages

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -933,6 +933,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		UsageEvents: as,
 		Clock:       cfg.Clock,
 		Emitter:     as.emitter,
+		Cloud:       cfg.Modules.Features().Cloud,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -520,9 +520,9 @@ func TestGitHubConnectorNameTooLarge(t *testing.T) {
 }
 
 func TestGithubAuthRequest(t *testing.T) {
-	modulestest.SetTestModules(t, *modulestest.EnterpriseModules())
+	t.Parallel()
 	ctx := context.Background()
-	srv := newTestTLSServer(t)
+	srv := newTestTLSServer(t, withModules(modulestest.EnterpriseModules()))
 
 	emptyRole, err := authtest.CreateRole(ctx, srv.Auth(), "test-empty", types.RoleSpecV6{})
 	require.NoError(t, err)
@@ -705,9 +705,9 @@ func TestGithubAuthRequest(t *testing.T) {
 // github/requests/validate which must have the same format as the requested
 // keys to support both old and new proxies.
 func TestGithubAuthCompat(t *testing.T) {
-	modulestest.SetTestModules(t, *modulestest.EnterpriseModules())
+	t.Parallel()
 	ctx := context.Background()
-	srv := newTestTLSServer(t)
+	srv := newTestTLSServer(t, withModules(modulestest.EnterpriseModules()))
 
 	connector, err := types.NewGithubConnector("example", types.GithubConnectorSpecV3{
 		ClientID:     "example-client-id",

--- a/lib/auth/autoupdate/autoupdatev1/service.go
+++ b/lib/auth/autoupdate/autoupdatev1/service.go
@@ -23,9 +23,9 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
+	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
@@ -71,6 +71,8 @@ type ServiceConfig struct {
 	Cache Cache
 	// Emitter is the event emitter.
 	Emitter apievents.Emitter
+	// Modules defines build time constraints and licensed features.
+	Modules modules.Modules
 }
 
 // Backend interface for manipulating AutoUpdate resources.
@@ -86,7 +88,7 @@ type Service struct {
 	backend    services.AutoUpdateService
 	emitter    apievents.Emitter
 	cache      Cache
-	clock      clockwork.Clock
+	modules    modules.Modules
 }
 
 // NewService returns a new AutoUpdate API service using the given storage layer and authorizer.
@@ -100,13 +102,15 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		return nil, trace.BadParameter("cache is required")
 	case cfg.Emitter == nil:
 		return nil, trace.BadParameter("Emitter is required")
+	case cfg.Modules == nil:
+		return nil, trace.BadParameter("Modules is required")
 	}
 	return &Service{
 		authorizer: cfg.Authorizer,
 		backend:    cfg.Backend,
 		cache:      cfg.Cache,
 		emitter:    cfg.Emitter,
-		clock:      clockwork.NewRealClock(),
+		modules:    cfg.Modules,
 	}, nil
 }
 
@@ -144,7 +148,7 @@ func (s *Service) CreateAutoUpdateConfig(ctx context.Context, req *autoupdate.Cr
 		return nil, trace.Wrap(err)
 	}
 
-	if err := validateServerSideAgentConfig(req.Config); err != nil {
+	if err := validateServerSideAgentConfig(req.Config, s.modules.Features()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -188,7 +192,7 @@ func (s *Service) UpdateAutoUpdateConfig(ctx context.Context, req *autoupdate.Up
 		return nil, trace.Wrap(err)
 	}
 
-	if err := validateServerSideAgentConfig(req.Config); err != nil {
+	if err := validateServerSideAgentConfig(req.Config, s.modules.Features()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -232,7 +236,7 @@ func (s *Service) UpsertAutoUpdateConfig(ctx context.Context, req *autoupdate.Up
 		return nil, trace.Wrap(err)
 	}
 
-	if err := validateServerSideAgentConfig(req.Config); err != nil {
+	if err := validateServerSideAgentConfig(req.Config, s.modules.Features()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -268,8 +272,9 @@ func UpsertAutoUpdateConfig(
 	ctx context.Context,
 	backend Backend,
 	config *autoupdate.AutoUpdateConfig,
+	features modules.Features,
 ) (*autoupdate.AutoUpdateConfig, error) {
-	if err := validateServerSideAgentConfig(config); err != nil {
+	if err := validateServerSideAgentConfig(config, features); err != nil {
 		return nil, trace.Wrap(err, "validating config")
 	}
 	out, err := backend.UpsertAutoUpdateConfig(ctx, config)
@@ -342,7 +347,7 @@ func (s *Service) CreateAutoUpdateVersion(ctx context.Context, req *autoupdate.C
 		return nil, trace.Wrap(err)
 	}
 
-	if err := checkAdminCloudAccess(authCtx); err != nil {
+	if err := checkAdminCloudAccess(authCtx, s.modules.Features().Cloud); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -387,7 +392,7 @@ func (s *Service) UpdateAutoUpdateVersion(ctx context.Context, req *autoupdate.U
 		return nil, trace.Wrap(err)
 	}
 
-	if err := checkAdminCloudAccess(authCtx); err != nil {
+	if err := checkAdminCloudAccess(authCtx, s.modules.Features().Cloud); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -432,7 +437,7 @@ func (s *Service) UpsertAutoUpdateVersion(ctx context.Context, req *autoupdate.U
 		return nil, trace.Wrap(err)
 	}
 
-	if err := checkAdminCloudAccess(authCtx); err != nil {
+	if err := checkAdminCloudAccess(authCtx, s.modules.Features().Cloud); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -489,7 +494,7 @@ func (s *Service) DeleteAutoUpdateVersion(ctx context.Context, req *autoupdate.D
 		return nil, trace.Wrap(err)
 	}
 
-	if err := checkAdminCloudAccess(authCtx); err != nil {
+	if err := checkAdminCloudAccess(authCtx, s.modules.Features().Cloud); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -732,7 +737,7 @@ func (s *Service) TriggerAutoUpdateAgentGroup(ctx context.Context, req *autoupda
 			return nil, trace.Wrap(err, "getting reports")
 		}
 
-		err = rollout.TriggerGroups(existingRollout, reports, rollout.GroupListToGroupSet(req.Groups), req.DesiredState, s.clock.Now())
+		err = rollout.TriggerGroups(existingRollout, reports, rollout.GroupListToGroupSet(req.Groups), req.DesiredState, time.Now())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -794,7 +799,7 @@ func (s *Service) ForceAutoUpdateAgentGroup(ctx context.Context, req *autoupdate
 			return nil, trace.Wrap(err)
 		}
 
-		err = rollout.ForceGroupsDone(existingRollout, rollout.GroupListToGroupSet(req.Groups), s.clock.Now())
+		err = rollout.ForceGroupsDone(existingRollout, rollout.GroupListToGroupSet(req.Groups), time.Now())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -872,7 +877,7 @@ func (s *Service) RollbackAutoUpdateAgentGroup(ctx context.Context, req *autoupd
 			return nil, trace.AlreadyExists("no groups to rollback")
 		}
 
-		err = rollout.RollbackGroups(existingRollout, groups, s.clock.Now())
+		err = rollout.RollbackGroups(existingRollout, groups, time.Now())
 
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -1116,8 +1121,8 @@ func (s *Service) emitEvent(ctx context.Context, e apievents.AuditEvent) {
 }
 
 // checkAdminCloudAccess validates if the given context has the builtin admin role if cloud feature is enabled.
-func checkAdminCloudAccess(authCtx *authz.Context) error {
-	if modules.GetModules().Features().Cloud && !authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin)) {
+func checkAdminCloudAccess(authCtx *authz.Context, cloud bool) error {
+	if cloud && !authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin)) {
 		return trace.AccessDenied("This Teleport instance is running on Teleport Cloud. "+
 			"The %q resource is managed by the Teleport Cloud team. You can use the %q resource to opt-in, "+
 			"opt-out or configure update schedules.",
@@ -1146,7 +1151,7 @@ var (
 //
 // This function should not be confused with api/types/autoupdate.ValidateAutoUpdateConfig which validates the integrity
 // of the resource and does not enforce potentially changing rules.
-func validateServerSideAgentConfig(config *autoupdate.AutoUpdateConfig) error {
+func validateServerSideAgentConfig(config *autoupdate.AutoUpdateConfig, features modules.Features) error {
 	agentsSpec := config.GetSpec().GetAgents()
 	if agentsSpec == nil {
 		return nil
@@ -1158,8 +1163,7 @@ func validateServerSideAgentConfig(config *autoupdate.AutoUpdateConfig) error {
 		return trace.Wrap(err, "validating autoupdate config")
 	}
 
-	isLimitedCloud := modules.GetModules().Features().Cloud &&
-		!modules.GetModules().Features().Entitlements[entitlements.UnrestrictedManagedUpdates].Enabled
+	isLimitedCloud := features.Cloud && !features.Entitlements[entitlements.UnrestrictedManagedUpdates].Enabled
 
 	var maxGroups int
 	switch {

--- a/lib/auth/autoupdate/autoupdatev1/service_test.go
+++ b/lib/auth/autoupdate/autoupdatev1/service_test.go
@@ -714,6 +714,7 @@ func newServiceWithStorage(t *testing.T, authState authz.AdminActionAuthState, c
 		Backend:    storage,
 		Cache:      storage,
 		Emitter:    emitter,
+		Modules:    modulestest.OSSModules(),
 	})
 	require.NoError(t, err)
 	return service
@@ -914,6 +915,7 @@ func generateGroups(n int, days []string) []*autoupdatev1pb.AgentAutoUpdateGroup
 }
 
 func TestValidateServerSideAgentConfig(t *testing.T) {
+	t.Parallel()
 	cloudModules := modulestest.Modules{
 		TestFeatures: modules.Features{
 			Cloud: true,
@@ -1084,10 +1086,9 @@ func TestValidateServerSideAgentConfig(t *testing.T) {
 					Agents: tt.config,
 				})
 			require.NoError(t, err)
-			modulestest.SetTestModules(t, tt.modules)
 
 			// Test execution.
-			tt.expectErr(t, validateServerSideAgentConfig(config))
+			tt.expectErr(t, validateServerSideAgentConfig(config, tt.modules.Features()))
 		})
 	}
 }

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -295,7 +295,7 @@ func (s *Service) UpsertAuthPreference(ctx context.Context, req *clusterconfigpb
 		return nil, trace.AccessDenied("Hardware Key support is only available with an enterprise license")
 	}
 
-	if err := dtconfig.ValidateConfigAgainstModules(req.AuthPreference.GetDeviceTrust(), modules.GetModules()); err != nil {
+	if err := dtconfig.ValidateConfigAgainstModules(req.AuthPreference.GetDeviceTrust(), s.modules); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6407,6 +6407,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Cache:            cfg.AuthServer.Cache,
 		Backend:          cfg.AuthServer.Services,
 		AuthServer:       cfg.AuthServer,
+		Modules:          cfg.AuthServer.modules,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -6433,6 +6434,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		KeyStoreManager: cfg.AuthServer.GetKeyStore(),
 		Clock:           cfg.AuthServer.clock,
 		Emitter:         cfg.Emitter,
+		Modules:         cfg.AuthServer.modules,
 		Logger:          cfg.AuthServer.logger.With(teleport.ComponentKey, "integrations.service"),
 	})
 	if err != nil {
@@ -6447,6 +6449,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		TokenCreator:          cfg.AuthServer,
 		ProxyPublicAddrGetter: cfg.AuthServer.getProxyPublicAddr,
 		Clock:                 cfg.AuthServer.clock,
+		Modules:               cfg.AuthServer.modules,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -6624,6 +6627,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Emitter:    cfg.Emitter,
 		Backend:    cfg.AuthServer.Services,
 		Cache:      cfg.AuthServer.Cache,
+		Modules:    cfg.AuthServer.modules,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -554,7 +554,7 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 	if len(cfg.ApplyOnStartupResources) > 0 {
 		asrv.logger.InfoContext(ctx, "Applying resources (apply-on-startup)", "resource_count", len(cfg.ApplyOnStartupResources))
 
-		if err := applyResources(ctx, asrv.Services, cfg.ApplyOnStartupResources); err != nil {
+		if err := applyResources(ctx, asrv.Services, cfg.ApplyOnStartupResources, cfg.Modules.Features()); err != nil {
 			return trace.Wrap(err, "applying resources failed")
 		}
 	}
@@ -1782,7 +1782,7 @@ var ResourceApplyPriority = map[string]int{
 // Unlike when resources are loaded via --bootstrap, we're inserting elements via their service.
 // This means consistency is checked. This function support applying resources
 // with dependencies (like a user referring to a role).
-func applyResources(ctx context.Context, service *Services, resources []types.Resource) error {
+func applyResources(ctx context.Context, service *Services, resources []types.Resource, features modules.Features) error {
 	var err error
 	slices.SortFunc(resources, func(a, b types.Resource) int {
 		priorityA := ResourceApplyPriority[a.GetKind()]
@@ -1817,7 +1817,7 @@ func applyResources(ctx context.Context, service *Services, resources []types.Re
 		case types.Resource153UnwrapperT[*machineidv1pb.Bot]:
 			_, err = machineidv1.UpsertBot(ctx, service, r.UnwrapT(), time.Now(), "system")
 		case types.Resource153UnwrapperT[*autoupdatev1pb.AutoUpdateConfig]:
-			_, err = autoupdatev1.UpsertAutoUpdateConfig(ctx, service, r.UnwrapT())
+			_, err = autoupdatev1.UpsertAutoUpdateConfig(ctx, service, r.UnwrapT(), features)
 		case types.Resource153UnwrapperT[*autoupdatev1pb.AutoUpdateVersion]:
 			_, err = autoupdatev1.UpsertAutoUpdateVersion(ctx, service, r.UnwrapT())
 		case types.Resource153UnwrapperT[*summarizerv1.InferenceModel]:

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -88,6 +88,7 @@ type AWSOIDCServiceConfig struct {
 	Clock                 clockwork.Clock
 	ProxyPublicAddrGetter func(context.Context) string
 	Logger                *slog.Logger
+	Modules               modules.Modules
 }
 
 // deleteAWSOIDCAssociatedResources deletes associated discovery_configs and
@@ -210,6 +211,10 @@ func (s *AWSOIDCServiceConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("proxyPublicAddrGetter is required")
 	}
 
+	if s.Modules == nil {
+		return trace.BadParameter("modules is required")
+	}
+
 	if s.Logger == nil {
 		s.Logger = slog.With(teleport.ComponentKey, "integrations.awsoidc.service")
 	}
@@ -228,6 +233,7 @@ type AWSOIDCService struct {
 	proxyPublicAddrGetter func(context.Context) string
 	cache                 CacheAWSOIDC
 	tokenCreator          TokenCreator
+	modules               modules.Modules
 }
 
 // CacheAWSOIDC is the subset of the cached resources that the Service queries.
@@ -259,6 +265,7 @@ func NewAWSOIDCService(cfg *AWSOIDCServiceConfig) (*AWSOIDCService, error) {
 		clock:                 cfg.Clock,
 		cache:                 cfg.Cache,
 		tokenCreator:          cfg.TokenCreator,
+		modules:               cfg.Modules,
 	}, nil
 }
 
@@ -684,13 +691,12 @@ func (s *AWSOIDCService) EnrollEKSClusters(ctx context.Context, req *integration
 		return nil, trace.Wrap(err)
 	}
 
-	features := modules.GetModules().Features()
-
 	clusterName, err := s.cache.GetClusterName(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
+	features := s.modules.Features()
 	enrollmentResponse, err := awsoidc.EnrollEKSClusters(ctx, s.logger, s.clock, publicProxyAddr, enrollEKSClient, awsoidc.EnrollEKSClustersRequest{
 		Region:              req.Region,
 		ClusterNames:        req.GetEksClusterNames(),

--- a/lib/auth/integration/integrationv1/awsoidc_test.go
+++ b/lib/auth/integration/integrationv1/awsoidc_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/jwt"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -225,6 +226,7 @@ func TestRBAC(t *testing.T) {
 		ProxyPublicAddrGetter: func(context.Context) string { return "128.0.0.1" },
 		Cache:                 backend,
 		TokenCreator:          backend,
+		Modules:               modulestest.OSSModules(),
 	})
 	require.NoError(t, err)
 

--- a/lib/auth/integration/integrationv1/credentials_test.go
+++ b/lib/auth/integration/integrationv1/credentials_test.go
@@ -29,13 +29,10 @@ import (
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
-	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestExportIntegrationCertAuthorities(t *testing.T) {
-	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
-
+	t.Parallel()
 	ca := newCertAuthority(t, types.HostCA, "test-cluster")
 	ctx, localClient, resourceSvc := initSvc(t, ca, ca.GetClusterName(), "127.0.0.1")
 

--- a/lib/auth/integration/integrationv1/github_test.go
+++ b/lib/auth/integration/integrationv1/github_test.go
@@ -32,13 +32,10 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cryptosuites"
-	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestGenerateGitHubUserCert(t *testing.T) {
-	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
-
+	t.Parallel()
 	ca := newCertAuthority(t, types.HostCA, "test-cluster")
 	ctx, _, resourceSvc := initSvc(t, ca, ca.GetClusterName(), "127.0.0.1.nip.io")
 

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -109,6 +109,7 @@ type ServiceConfig struct {
 	Logger          *slog.Logger
 	Clock           clockwork.Clock
 	Emitter         apievents.Emitter
+	Modules         modules.Modules
 
 	// awsRolesAnywhereCreateSessionFn is a function that creates an AWS Roles Anywhere session.
 	// This is used to allow mocking in tests, because the real implementation does
@@ -140,6 +141,9 @@ func (s *ServiceConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("emitter is required")
 	}
 
+	if s.Modules == nil {
+		return trace.BadParameter("modules is required")
+	}
 	if s.Logger == nil {
 		s.Logger = slog.With(teleport.ComponentKey, "integrations.service")
 	}
@@ -161,6 +165,7 @@ type Service struct {
 	logger          *slog.Logger
 	clock           clockwork.Clock
 	emitter         apievents.Emitter
+	modules         modules.Modules
 
 	awsRolesAnywhereCreateSessionFn func(ctx context.Context, req createsession.CreateSessionRequest) (*createsession.CreateSessionResponse, error)
 }
@@ -179,6 +184,7 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 		backend:         cfg.Backend,
 		clock:           cfg.Clock,
 		emitter:         cfg.Emitter,
+		modules:         cfg.Modules,
 
 		awsRolesAnywhereCreateSessionFn: cfg.awsRolesAnywhereCreateSessionFn,
 	}, nil
@@ -256,7 +262,7 @@ func (s *Service) CreateIntegration(ctx context.Context, req *integrationpb.Crea
 
 	switch req.Integration.GetSubKind() {
 	case types.IntegrationSubKindGitHub:
-		if modules.GetModules().BuildType() != modules.BuildEnterprise {
+		if s.modules.BuildType() != modules.BuildEnterprise {
 			return nil, trace.AccessDenied("GitHub integration requires a Teleport Enterprise license")
 		}
 		if err := s.createGitHubCredentials(ctx, req.Integration); err != nil {

--- a/lib/auth/integration/integrationv1/service_test.go
+++ b/lib/auth/integration/integrationv1/service_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -59,8 +58,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationCRUD(t *testing.T) {
-	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
-
+	t.Parallel()
 	clusterName := "test-cluster"
 	proxyPublicAddr := "127.0.0.1.nip.io"
 
@@ -1019,6 +1017,7 @@ func initSvc(t *testing.T, ca types.CertAuthority, clusterName string, proxyPubl
 		Cache:           cache,
 		KeyStoreManager: keystoreManager,
 		Emitter:         events.NewDiscardEmitter(),
+		Modules:         modulestest.EnterpriseModules(),
 		awsRolesAnywhereCreateSessionFn: func(ctx context.Context, req createsession.CreateSessionRequest) (*createsession.CreateSessionResponse, error) {
 			return &createsession.CreateSessionResponse{
 				Version:         1,

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -71,6 +72,7 @@ type ServiceConfig struct {
 	Cache            services.AuthorityGetter
 	Backend          services.TrustInternal
 	AuthServer       authServer
+	Modules          modules.Modules
 }
 
 // Service implements the teleport.trust.v1.TrustService RPC service.
@@ -81,6 +83,7 @@ type Service struct {
 	cache            services.AuthorityGetter
 	backend          services.TrustInternal
 	authServer       authServer
+	modules          modules.Modules
 }
 
 // NewService returns a new trust gRPC service.
@@ -96,6 +99,8 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 		return nil, trace.BadParameter("scoped authorizer is required")
 	case cfg.AuthServer == nil:
 		return nil, trace.BadParameter("authServer is required")
+	case cfg.Modules == nil:
+		return nil, trace.BadParameter("modules is required")
 	}
 
 	return &Service{
@@ -104,6 +109,7 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 		cache:            cfg.Cache,
 		backend:          cfg.Backend,
 		authServer:       cfg.AuthServer,
+		modules:          cfg.Modules,
 	}, nil
 }
 

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -472,6 +473,7 @@ func TestRBAC(t *testing.T) {
 				Authorizer:       &test.authorizer,
 				ScopedAuthorizer: &test.authorizer,
 				AuthServer:       &fakeAuthServer{},
+				Modules:          modulestest.OSSModules(),
 			}
 
 			service, err := NewService(cfg)
@@ -507,6 +509,7 @@ func TestGetCertAuthority(t *testing.T) {
 		Authorizer:       authorizer,
 		ScopedAuthorizer: authorizer,
 		AuthServer:       &fakeAuthServer{},
+		Modules:          modulestest.OSSModules(),
 	}
 
 	service, err := NewService(cfg)
@@ -654,6 +657,7 @@ func TestGetCertAuthority_outdatedTctl(t *testing.T) {
 		Authorizer:       authorizer,
 		ScopedAuthorizer: authorizer,
 		AuthServer:       &fakeAuthServer{}, // unused, only needs to be non-nil
+		Modules:          modulestest.OSSModules(),
 	}
 	service, err := NewService(cfg)
 	require.NoError(t, err)
@@ -772,6 +776,7 @@ func TestGetCertAuthorities(t *testing.T) {
 		Authorizer:       authorizer,
 		ScopedAuthorizer: authorizer,
 		AuthServer:       &fakeAuthServer{},
+		Modules:          modulestest.OSSModules(),
 	}
 
 	service, err := NewService(cfg)
@@ -878,6 +883,7 @@ func TestDeleteCertAuthority(t *testing.T) {
 		Authorizer:       authorizer,
 		ScopedAuthorizer: authorizer,
 		AuthServer:       &fakeAuthServer{},
+		Modules:          modulestest.OSSModules(),
 	}
 
 	service, err := NewService(cfg)
@@ -953,6 +959,7 @@ func TestUpsertCertAuthority(t *testing.T) {
 		Authorizer:       authorizer,
 		ScopedAuthorizer: authorizer,
 		AuthServer:       &fakeAuthServer{},
+		Modules:          modulestest.OSSModules(),
 	}
 
 	service, err := NewService(cfg)
@@ -1039,6 +1046,7 @@ func TestRotateCertAuthority(t *testing.T) {
 		Authorizer:       authorizer,
 		ScopedAuthorizer: authorizer,
 		AuthServer:       authServer,
+		Modules:          modulestest.OSSModules(),
 	}
 
 	tests := []struct {
@@ -1189,6 +1197,7 @@ func TestRotateExternalCertAuthority(t *testing.T) {
 			cfg := &ServiceConfig{
 				Cache:   trust,
 				Backend: trust,
+				Modules: modulestest.OSSModules(),
 				Authorizer: &fakeAuthorizer{
 					authzCtx: test.authzCtx,
 				},
@@ -1250,6 +1259,7 @@ func TestGenerateHostCert(t *testing.T) {
 		Authorizer:       authorizer,
 		ScopedAuthorizer: authorizer,
 		AuthServer:       hostCertSigner,
+		Modules:          modulestest.OSSModules(),
 	}
 
 	tests := []struct {

--- a/lib/auth/trust/trustv1/trustedcluster.go
+++ b/lib/auth/trust/trustv1/trustedcluster.go
@@ -25,14 +25,13 @@ import (
 
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 )
 
 // UpsertTrustedCluster upserts a Trusted Cluster.
 func (s *Service) UpsertTrustedCluster(ctx context.Context, req *trustpb.UpsertTrustedClusterRequest) (*types.TrustedClusterV2, error) {
 	// Don't allow a Cloud tenant to be a leaf cluster.
-	if modules.GetModules().Features().Cloud {
+	if s.modules.Features().Cloud {
 		return nil, trace.NotImplemented("cloud tenants cannot be leaf clusters")
 	}
 
@@ -64,7 +63,7 @@ func (s *Service) UpsertTrustedCluster(ctx context.Context, req *trustpb.UpsertT
 // CreateTrustedCluster creates a Trusted Cluster.
 func (s *Service) CreateTrustedCluster(ctx context.Context, req *trustpb.CreateTrustedClusterRequest) (*types.TrustedClusterV2, error) {
 	// Don't allow a Cloud tenant to be a leaf cluster.
-	if modules.GetModules().Features().Cloud {
+	if s.modules.Features().Cloud {
 		return nil, trace.NotImplemented("cloud tenants cannot be leaf clusters")
 	}
 
@@ -96,7 +95,7 @@ func (s *Service) CreateTrustedCluster(ctx context.Context, req *trustpb.CreateT
 // UpdateTrustedCluster updates a Trusted Cluster.
 func (s *Service) UpdateTrustedCluster(ctx context.Context, req *trustpb.UpdateTrustedClusterRequest) (*types.TrustedClusterV2, error) {
 	// Don't allow a Cloud tenant to be a leaf cluster.
-	if modules.GetModules().Features().Cloud {
+	if s.modules.Features().Cloud {
 		return nil, trace.NotImplemented("cloud tenants cannot be leaf clusters")
 	}
 

--- a/lib/auth/trust/trustv1/trustedcluster_test.go
+++ b/lib/auth/trust/trustv1/trustedcluster_test.go
@@ -28,33 +28,31 @@ import (
 	"github.com/gravitational/teleport"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
 // TestCloudProhibited verifies that Trusted Clusters cannot be created or updated
 // in a Cloud hosted environment.
-// Tests cannot be run in parallel because it relies on environment variables.
 func TestCloudProhibited(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	p := newTestPack(t)
 
 	trust := local.NewCAService(p.mem)
+	modules := modulestest.OSSModules()
+	modules.TestFeatures.Cloud = true
 	cfg := &ServiceConfig{
 		Cache:            trust,
 		Backend:          trust,
 		Authorizer:       &fakeAuthorizer{},
 		ScopedAuthorizer: &fakeAuthorizer{},
 		AuthServer:       &fakeAuthServer{},
+		Modules:          modules,
 	}
 
 	service, err := NewService(cfg)
 	require.NoError(t, err)
-
-	modulestest.SetTestModules(t, modulestest.Modules{
-		TestFeatures: modules.Features{Cloud: true},
-	})
 
 	tc, err := types.NewTrustedCluster("test", types.TrustedClusterSpecV2{
 		RoleMap: []types.RoleMapping{
@@ -310,6 +308,7 @@ func TestTrustedClusterRBAC(t *testing.T) {
 				Authorizer:       &test.authorizer,
 				ScopedAuthorizer: &test.authorizer,
 				AuthServer:       &fakeAuthServer{},
+				Modules:          modulestest.OSSModules(),
 			}
 
 			service, err := NewService(cfg)

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -70,6 +69,9 @@ type GeneratorConfig struct {
 
 	// Emitter is the emitter for audit events.
 	Emitter apievents.Emitter
+
+	// Cloud indicates if Teleport is running in Cloud.
+	Cloud bool
 }
 
 // UsageEventsClient is an interface that allows for submitting usage events to Posthog.
@@ -95,7 +97,7 @@ func (g *GeneratorConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing audit event emitter")
 	}
 
-	if modules.GetModules().Features().Cloud {
+	if g.Cloud {
 		if g.UsageEvents == nil {
 			return trace.BadParameter("missing usage events")
 		}

--- a/lib/auth/userloginstate/generator_bench_test.go
+++ b/lib/auth/userloginstate/generator_bench_test.go
@@ -45,7 +45,7 @@ func BenchmarkGenerate(b *testing.B) {
 	sizes := []int{100, 1_000, 10_000}
 	for _, n := range sizes {
 		b.Run(fmt.Sprintf("members=%d", n), func(b *testing.B) {
-			svc, backendSvc, err := initGeneratorSvc()
+			svc, backendSvc, err := initGeneratorSvc(false)
 			if err != nil {
 				b.Fatalf("initGeneratorSvc: %v", err)
 			}

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -37,10 +37,8 @@ import (
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/trait"
 	"github.com/gravitational/teleport/api/types/userloginstate"
-	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/events/eventstest"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -52,6 +50,7 @@ const ownerUser = "owner"
 var emptyGrants = accesslist.Grants{}
 
 func TestAccessLists(t *testing.T) {
+	t.Parallel()
 	owner, err := types.NewUser(ownerUser)
 	require.NoError(t, err)
 	owner.SetRoles([]string{"orole1"})
@@ -596,18 +595,8 @@ func TestAccessLists(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modulestest.SetTestModules(t, modulestest.Modules{
-				TestBuildType: modules.BuildEnterprise,
-				TestFeatures: modules.Features{
-					Cloud: test.cloud,
-					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-						entitlements.Identity: {Enabled: true},
-					},
-				},
-			})
-
 			ctx := context.Background()
-			svc, backendSvc, err := initGeneratorSvc()
+			svc, backendSvc, err := initGeneratorSvc(test.cloud)
 			require.NoError(t, err)
 
 			for _, accessList := range test.accessLists {
@@ -660,8 +649,9 @@ func TestAccessLists(t *testing.T) {
 }
 
 func TestGitHubIdentity(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
-	svc, backendSvc, err := initGeneratorSvc()
+	svc, backendSvc, err := initGeneratorSvc(false)
 	require.NoError(t, err)
 
 	noGitHubIdentity, err := types.NewUser("alice")
@@ -745,7 +735,7 @@ func (s *svc) SubmitUsageEvent(ctx context.Context, req *proto.SubmitUsageEventR
 	return nil
 }
 
-func initGeneratorSvc() (*Generator, *svc, error) {
+func initGeneratorSvc(cloud bool) (*Generator, *svc, error) {
 	clock := clockwork.NewFakeClock()
 	mem, err := memory.New(memory.Config{
 		Clock: clock,
@@ -782,6 +772,7 @@ func initGeneratorSvc() (*Generator, *svc, error) {
 		UsageEvents: svc,
 		Clock:       clock,
 		Emitter:     emitter,
+		Cloud:       cloud,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -176,7 +176,12 @@ func TestWebauthnLogin_web(t *testing.T) {
 }
 
 func TestWebauthnLogin_webWithPrivateKeyEnabledError(t *testing.T) {
-	env := newWebPack(t, 1)
+	t.Parallel()
+	testModules := modulestest.OSSModules()
+	testModules.MockAttestationData = &keys.AttestationData{
+		PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+	}
+	env := newWebPack(t, 1, withModules(testModules))
 	proxy := env.proxies[0]
 	ctx := context.Background()
 
@@ -202,12 +207,6 @@ func TestWebauthnLogin_webWithPrivateKeyEnabledError(t *testing.T) {
 	authServer := env.server.Auth()
 	_, err = authServer.UpsertAuthPreference(ctx, cap)
 	require.NoError(t, err)
-
-	modulestest.SetTestModules(t, modulestest.Modules{
-		MockAttestationData: &keys.AttestationData{
-			PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
-		},
-	})
 
 	httpResp, body, err := rawLoginWebMFA(ctx, loginWebMFAParams{
 		webClient:     proxy.newClient(t),

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/usertasks"
 	"github.com/gravitational/teleport/lib/auth/integration/credentials"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	libui "github.com/gravitational/teleport/lib/ui"
@@ -965,9 +964,8 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 // The test cases in this test are performed sequentially and each test case
 // depends on the previous state.
 func TestGitHubIntegration(t *testing.T) {
-	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
-
-	wPack := newWebPack(t, 1 /* proxies */)
+	t.Parallel()
+	wPack := newWebPack(t, 1 /* proxies */, withModules(modulestest.EnterpriseModules()))
 	proxy := wPack.proxies[0]
 	authPack := proxy.authPack(t, "user", []types.Role{services.NewPresetEditorRole()})
 	ctx := context.Background()


### PR DESCRIPTION
This removes the last few places in lib/auth/* that were consuming modules with modules.GetModules and setting them via modulestest.SetTestModules.

Contributes to https://github.com/gravitational/teleport/issues/62799.