### PR TITLE
Gate AWS Identity Center Unauthorized Error to AWS IC Plugins Only

### DIFF
--- a/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
@@ -61,7 +61,31 @@ test('integration list does not display action menu for aws-oidc, row click navi
   );
 });
 
-test('integration list details prefer plugin status error message over details', () => {
+test('integration list details prefer AWS IC status error message over details', () => {
+  const plugin: Plugin = {
+    resourceType: 'plugin',
+    name: 'aws-ic-plugin',
+    kind: 'aws-identity-center',
+    details: 'fallback details',
+    statusCode: IntegrationStatusCode.Unauthorized,
+    status: {
+      code: IntegrationStatusCode.Unauthorized,
+      lastRun: new Date('2026-03-31T00:00:00Z'),
+      errorMessage: 'scim token rejected',
+    },
+  };
+
+  render(
+    <MemoryRouter>
+      <IntegrationList list={[plugin]} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText('scim token rejected')).toBeInTheDocument();
+  expect(screen.queryByText('fallback details')).not.toBeInTheDocument();
+});
+
+test('integration list details ignore status error message for non-AWS-IC plugins', () => {
   const plugin: Plugin = {
     resourceType: 'plugin',
     name: 'okta-plugin',
@@ -81,6 +105,6 @@ test('integration list details prefer plugin status error message over details',
     </MemoryRouter>
   );
 
-  expect(screen.getByText('sync failed')).toBeInTheDocument();
-  expect(screen.queryByText('fallback details')).not.toBeInTheDocument();
+  expect(screen.getByText('fallback details')).toBeInTheDocument();
+  expect(screen.queryByText('sync failed')).not.toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -40,6 +40,7 @@ import cfg from 'teleport/config';
 import {
   filterByIntegrationStatus,
   filterBySearch,
+  getAwsIcErrorMessage,
   sortByStatus,
 } from 'teleport/Integrations/helpers';
 import api from 'teleport/services/api';
@@ -489,9 +490,8 @@ export function percent(n: number, d: number): string {
 }
 
 const DetailsCell = ({ integration }: { integration: IntegrationLike }) => {
-  let content = (
-    <Text>{integration.status?.errorMessage || integration.details}</Text>
-  );
+  const awsIcErrorMessage = getAwsIcErrorMessage(integration);
+  let content = <Text>{awsIcErrorMessage ?? integration.details}</Text>;
   switch (integration.kind) {
     case IntegrationKind.AwsOidc:
     case IntegrationKind.AzureOidc:

--- a/web/packages/teleport/src/Integrations/helpers.ts
+++ b/web/packages/teleport/src/Integrations/helpers.ts
@@ -50,6 +50,18 @@ export function filterByIntegrationStatus(
   });
 }
 
+export function getAwsIcErrorMessage(
+  item: IntegrationLike
+): string | undefined {
+  if (
+    item.resourceType === 'plugin' &&
+    item.kind === 'aws-identity-center' &&
+    item.status?.errorMessage
+  ) {
+    return item.status.errorMessage;
+  }
+}
+
 export function filterBySearch(
   l: IntegrationLike[],
   s: string

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.test.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.test.tsx
@@ -20,10 +20,12 @@ import { render, screen } from 'design/utils/testing';
 
 import {
   IntegrationKind,
+  IntegrationStatusCode,
   IntegrationWithSummary,
+  type Plugin,
 } from 'teleport/services/integrations';
 
-import { SummaryStatusLabel } from './StatusLabel';
+import { getStatus, SummaryStatusLabel } from './StatusLabel';
 
 afterEach(() => {
   jest.useRealTimers();
@@ -57,6 +59,48 @@ test('SummaryStatusLabel shows healthy when sync timestamp is recent', () => {
   expect(screen.getByText('Healthy')).toBeInTheDocument();
   expect(screen.queryByText('(scanning in progress)')).not.toBeInTheDocument();
 });
+
+test('getStatus surfaces backend errorMessage for AWS IC Unauthorized', () => {
+  const plugin = makePlugin('aws-identity-center', {
+    code: IntegrationStatusCode.Unauthorized,
+    lastRun: new Date('2026-03-31T00:00:00Z'),
+    errorMessage:
+      'AWS Identity Center rejected the SCIM token. Rotate the token to restore access.',
+  });
+
+  const { status, label, tooltip } = getStatus(plugin);
+
+  expect(status).toBe('Failed');
+  expect(label).toBe('Failed');
+  expect(tooltip).toBe(
+    'AWS Identity Center rejected the SCIM token. Rotate the token to restore access.'
+  );
+});
+
+test('getStatus keeps generic tooltip for non-AWS-IC Unauthorized even when errorMessage is set', () => {
+  const plugin = makePlugin('slack', {
+    code: IntegrationStatusCode.Unauthorized,
+    lastRun: new Date('2026-03-31T00:00:00Z'),
+    errorMessage: 'some backend error',
+  });
+
+  const { tooltip } = getStatus(plugin);
+
+  expect(tooltip).toBe(
+    'Integration was denied access. This could be a result of revoked authorization on the 3rd party provider. Try removing and re-connecting the integration.'
+  );
+});
+
+function makePlugin(kind: Plugin['kind'], status: Plugin['status']): Plugin {
+  return {
+    resourceType: 'plugin',
+    name: `${kind}-plugin`,
+    kind,
+    details: 'plugin details',
+    statusCode: status.code,
+    status,
+  };
+}
 
 function makeSummary(lastSyncMs: number): IntegrationWithSummary {
   return {

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
@@ -35,6 +35,7 @@ import {
   IntegrationWithSummary,
 } from 'teleport/services/integrations';
 
+import { getAwsIcErrorMessage } from '../helpers';
 import { IntegrationLike } from '../IntegrationList';
 import { Status } from '../types';
 
@@ -164,10 +165,15 @@ export function getStatus(item: IntegrationLike): {
       return ISSUES(
         'The Slack integration must be invited to the default channel in order to receive access request notifications.'
       );
-    case IntegrationStatusCode.Unauthorized:
+    case IntegrationStatusCode.Unauthorized: {
+      const awsIcErrorMessage = getAwsIcErrorMessage(item);
+      if (awsIcErrorMessage) {
+        return FAILED(awsIcErrorMessage);
+      }
       return FAILED(
         'Integration was denied access. This could be a result of revoked authorization on the 3rd party provider. Try removing and re-connecting the integration.'
       );
+    }
     case IntegrationStatusCode.OktaConfigError:
       return FAILED(
         `There was an error with the integration's configuration.${item.status?.errorMessage ? ` ${item.status.errorMessage}` : ''}`


### PR DESCRIPTION
This PR addresses feedback surfaced during a v18 backport review in [#65723](https://github.com/gravitational/teleport/pull/65723). The original change promoted `status.errorMessage` to the Details column for every integration, which risked surfacing non-user-friendly backend messages for plugins other than AWS Identity Center and let the Details cell and the Status Label tooltip drift out of sync.

The following changes were made:

- **Integration list (`IntegrationList.tsx`):** Narrowed the Details cell override so the backend error message is shown only for AWS Identity Center plugins; other integrations fall back to `details` as before.

- **Status label (`StatusLabel.tsx`):** Routed the AWS IC-specific error message through `getStatus` on the `Unauthorized` path so the Status Label tooltip and the Details cell stay in sync.

## Manual Test Plan

### Test Environment
- Local Teleport cluster integrated with AWS Identity Center using the system credentials installation method

### Test Cases

- [x] Verify that an invalid AWS SCIM API token causes the AWS IAM Identity Center status to show as "Failed" on the UI
   1. Verify that the status for AWS IAM Identity Center is `Healthy` on the integrations UI page (`https://localhost:3000/web/integrations`)
   2. Delete the currently used SCIM token from the AWS Identity Center console
   3. Wait up to 5 minutes (or shorten it by decreasing [DefaultResourceSyncInterval](https://github.com/gravitational/teleport.e/blob/bdaa6286d8dae17ad54a490c24ab5b79af5df552/lib/aws/identitycenter/constants.go#L33))
   4. Verify that the status for AWS IAM Identity Center is now `Failed` on the integrations UI page (`https://localhost:3000/web/integrations`) and that the popup tooltip and the corresponding Details column suggest token rotation to resolve the issue

- [x] Verify that a valid AWS SCIM API token removes the "Failed" status on the UI
   1. Rotate the SCIM token with a valid one by running `tctl plugins rotate awsic <valid token>`
   2. Refresh the integrations UI page (`https://localhost:3000/web/integrations`)
   3. Verify that the status for AWS IAM Identity Center has returned to `Healthy`
   
 ## Screenshots
 
<img width="1484" height="712" alt="Screenshot 2026-04-17 at 11 22 41 AM" src="https://github.com/user-attachments/assets/90105df6-f957-48d9-b1a8-fc551f611031" />

<img width="1483" height="699" alt="Screenshot 2026-04-17 at 11 25 17 AM" src="https://github.com/user-attachments/assets/37bade23-6a7e-4f6f-9ab2-2528788c24ab" />
