### PR TITLE
Fixing scope propagation and heartbeat enforcement for kube service

### DIFF
--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -132,17 +132,30 @@ func NewKubernetesClusterV3WithoutSecrets(cluster KubeCluster) (*KubernetesClust
 		KubernetesClusterSpecV3{
 			DynamicLabels: LabelsToV2(copiedCluster.GetDynamicLabels()),
 		},
+		KubeClusterWithScope(copiedCluster.GetScope()),
 	)
 	return clusterWithoutCreds, trace.Wrap(err)
 }
 
+type kubeClusterOpt func(*KubernetesClusterV3)
+
+// KubeClusterWithScope is an option that sets the scope when building a [KubernetesClusterV3].
+func KubeClusterWithScope(scope string) kubeClusterOpt {
+	return func(k *KubernetesClusterV3) {
+		k.Scope = scope
+	}
+}
+
 // NewKubernetesClusterV3 creates a new Kubernetes cluster resource.
-func NewKubernetesClusterV3(meta Metadata, spec KubernetesClusterSpecV3) (*KubernetesClusterV3, error) {
+func NewKubernetesClusterV3(meta Metadata, spec KubernetesClusterSpecV3, opts ...kubeClusterOpt) (*KubernetesClusterV3, error) {
 	k := &KubernetesClusterV3{
 		Metadata: meta,
 		Spec:     spec,
 	}
 
+	for _, opt := range opts {
+		opt(k)
+	}
 	if err := k.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -132,17 +132,30 @@ func NewKubernetesClusterV3WithoutSecrets(cluster KubeCluster) (*KubernetesClust
 		KubernetesClusterSpecV3{
 			DynamicLabels: LabelsToV2(copiedCluster.GetDynamicLabels()),
 		},
+		KubeClusterWithScope(copiedCluster.GetScope()),
 	)
 	return clusterWithoutCreds, trace.Wrap(err)
 }
 
+type kubeClusterOpt func(*KubernetesClusterV3)
+
+// KubeClusterWithScope is an option that sets the scope when building a KubernetesClusterV3.
+func KubeClusterWithScope(scope string) kubeClusterOpt {
+	return func(k *KubernetesClusterV3) {
+		k.Scope = scope
+	}
+}
+
 // NewKubernetesClusterV3 creates a new Kubernetes cluster resource.
-func NewKubernetesClusterV3(meta Metadata, spec KubernetesClusterSpecV3) (*KubernetesClusterV3, error) {
+func NewKubernetesClusterV3(meta Metadata, spec KubernetesClusterSpecV3, opts ...kubeClusterOpt) (*KubernetesClusterV3, error) {
 	k := &KubernetesClusterV3{
 		Metadata: meta,
 		Spec:     spec,
 	}
 
+	for _, opt := range opts {
+		opt(k)
+	}
 	if err := k.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/api/types/kubernetes_server.go
+++ b/api/types/kubernetes_server.go
@@ -78,12 +78,26 @@ type KubeServer interface {
 	IsEqual(i KubeServer) bool
 }
 
+type kubeServerOpt func(*KubernetesServerV3)
+
+// KubeServerWithScope is an option that sets the scope when building a [KubernetesServerV3].
+func KubeServerWithScope(scope string) kubeServerOpt {
+	return func(s *KubernetesServerV3) {
+		s.Scope = scope
+	}
+}
+
 // NewKubernetesServerV3 creates a new kube server instance.
-func NewKubernetesServerV3(meta Metadata, spec KubernetesServerSpecV3) (*KubernetesServerV3, error) {
+func NewKubernetesServerV3(meta Metadata, spec KubernetesServerSpecV3, opts ...kubeServerOpt) (*KubernetesServerV3, error) {
 	s := &KubernetesServerV3{
 		Metadata: meta,
 		Spec:     spec,
 	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
 	if err := s.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -92,13 +106,16 @@ func NewKubernetesServerV3(meta Metadata, spec KubernetesServerSpecV3) (*Kuberne
 
 // NewKubernetesServerV3FromCluster creates a new kubernetes server from the provided clusters.
 func NewKubernetesServerV3FromCluster(cluster *KubernetesClusterV3, hostname, hostID string) (*KubernetesServerV3, error) {
-	return NewKubernetesServerV3(Metadata{
-		Name: cluster.GetName(),
-	}, KubernetesServerSpecV3{
-		Hostname: hostname,
-		HostID:   hostID,
-		Cluster:  cluster,
-	})
+	return NewKubernetesServerV3(
+		Metadata{
+			Name: cluster.GetName(),
+		}, KubernetesServerSpecV3{
+			Hostname: hostname,
+			HostID:   hostID,
+			Cluster:  cluster,
+		},
+		KubeServerWithScope(cluster.GetScope()),
+	)
 }
 
 // GetVersion returns the kubernetes server resource version.

--- a/api/types/kubernetes_server.go
+++ b/api/types/kubernetes_server.go
@@ -78,12 +78,26 @@ type KubeServer interface {
 	IsEqual(i KubeServer) bool
 }
 
+type kubeServerOpt func(*KubernetesServerV3)
+
+// KubeServerWithScope is an option that sets the scope when building a KubernetesServerV3.
+func KubeServerWithScope(scope string) kubeServerOpt {
+	return func(s *KubernetesServerV3) {
+		s.Scope = scope
+	}
+}
+
 // NewKubernetesServerV3 creates a new kube server instance.
-func NewKubernetesServerV3(meta Metadata, spec KubernetesServerSpecV3) (*KubernetesServerV3, error) {
+func NewKubernetesServerV3(meta Metadata, spec KubernetesServerSpecV3, opts ...kubeServerOpt) (*KubernetesServerV3, error) {
 	s := &KubernetesServerV3{
 		Metadata: meta,
 		Spec:     spec,
 	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
 	if err := s.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -92,13 +106,16 @@ func NewKubernetesServerV3(meta Metadata, spec KubernetesServerSpecV3) (*Kuberne
 
 // NewKubernetesServerV3FromCluster creates a new kubernetes server from the provided clusters.
 func NewKubernetesServerV3FromCluster(cluster *KubernetesClusterV3, hostname, hostID string) (*KubernetesServerV3, error) {
-	return NewKubernetesServerV3(Metadata{
-		Name: cluster.GetName(),
-	}, KubernetesServerSpecV3{
-		Hostname: hostname,
-		HostID:   hostID,
-		Cluster:  cluster,
-	})
+	return NewKubernetesServerV3(
+		Metadata{
+			Name: cluster.GetName(),
+		}, KubernetesServerSpecV3{
+			Hostname: hostname,
+			HostID:   hostID,
+			Cluster:  cluster,
+		},
+		KubeServerWithScope(cluster.GetScope()),
+	)
 }
 
 // GetVersion returns the kubernetes server resource version.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -6782,6 +6782,10 @@ func (a *ServerWithRoles) CreateKubernetesCluster(ctx context.Context, cluster t
 	if a.hasBuiltinRole(types.RoleDiscovery) && len(cluster.GetDynamicLabels()) > 0 {
 		return trace.AccessDenied("discovered kubernetes cluster must not have dynamic labels")
 	}
+	// Dynamic scoped kube clusters are not implemented yet so we need to prevent their creation.
+	if cluster.GetScope() != "" {
+		return trace.BadParameter("scope must be empty")
+	}
 	return trace.Wrap(a.authServer.CreateKubernetesCluster(ctx, cluster))
 }
 
@@ -6805,6 +6809,10 @@ func (a *ServerWithRoles) UpdateKubernetesCluster(ctx context.Context, cluster t
 	// Don't allow discovery service to create clusters with dynamic labels.
 	if a.hasBuiltinRole(types.RoleDiscovery) && len(cluster.GetDynamicLabels()) > 0 {
 		return trace.AccessDenied("discovered kubernetes cluster must not have dynamic labels")
+	}
+	// Dynamic scoped kube clusters are not implemented yet so we need to prevent their creation.
+	if cluster.GetScope() != "" {
+		return trace.BadParameter("scope must be empty")
 	}
 	return trace.Wrap(a.authServer.UpdateKubernetesCluster(ctx, cluster))
 }

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -3113,10 +3113,24 @@ func TestKubernetesClusterCRUD_DiscoveryService(t *testing.T) {
 		},
 	})
 
+	scopedCluster, err := types.NewKubernetesClusterV3(
+		types.Metadata{
+			Name: "scoped-cluster",
+			Labels: map[string]string{
+				types.CloudLabel: types.CloudAWS,
+			},
+		},
+		types.KubernetesClusterSpecV3{},
+	)
+	require.NoError(t, err)
+	scopedCluster.SetOrigin(types.OriginCloud)
+	scopedCluster.Scope = "/test"
+
 	t.Run("Create", func(t *testing.T) {
 		require.NoError(t, discoveryClt.CreateKubernetesCluster(ctx, eksCluster))
 		require.True(t, trace.IsAccessDenied(discoveryClt.CreateKubernetesCluster(ctx, nonCloudCluster)))
 		require.True(t, trace.IsAccessDenied(discoveryClt.CreateKubernetesCluster(ctx, clusterWithDynamicLabels)))
+		require.True(t, trace.IsBadParameter(discoveryClt.CreateKubernetesCluster(ctx, scopedCluster)))
 	})
 	t.Run("Read", func(t *testing.T) {
 		diffopt := cmpopts.IgnoreFields(types.Metadata{}, "Revision")
@@ -3138,6 +3152,12 @@ func TestKubernetesClusterCRUD_DiscoveryService(t *testing.T) {
 	t.Run("Update", func(t *testing.T) {
 		require.NoError(t, discoveryClt.UpdateKubernetesCluster(ctx, eksCluster))
 		require.True(t, trace.IsAccessDenied(discoveryClt.UpdateKubernetesCluster(ctx, nonCloudCluster)))
+
+		// try to add a scope to the cluster that was successfully created
+		scopedEKSCluster, ok := eksCluster.Copy().(*types.KubernetesClusterV3)
+		require.True(t, ok, "expected eksCluster copy to be a *types.KubernetesClusterV3")
+		scopedEKSCluster.Scope = "/test"
+		require.True(t, trace.IsBadParameter(discoveryClt.UpdateKubernetesCluster(ctx, scopedEKSCluster)))
 	})
 	t.Run("Delete", func(t *testing.T) {
 		require.NoError(t, discoveryClt.DeleteAllKubernetesClusters(ctx))

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/inventory/internal/delay"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
@@ -1199,15 +1200,18 @@ func (c *Controller) handleKubernetesServerHB(handle *upstreamHandle, kubernetes
 		return trace.AccessDenied("incorrect kubernetes server ID (expected %q, got %q)", handle.Hello().ServerID, kubernetesServer.GetHostID())
 	}
 
-	// Agent's that don't know about scopes can still have a scoped identity. In that case, we consider an empty
-	// scope to defer to what was found in the identity during the initial hello.
-	if kubernetesServer.Scope == "" {
-		kubernetesServer.Scope = handle.Hello().GetScope()
+	if kubernetesServer.Scope != handle.Hello().GetScope() {
+		// The heartbeated server's scope must match the scope found in the identity during registration
+		if scopes.Compare(kubernetesServer.Scope, handle.Hello().GetScope()) != scopes.Equivalent {
+			return trace.AccessDenied("incorrect kubernetes server scope (expected %q, got %q)", handle.Hello().GetScope(), kubernetesServer.Scope)
+		}
 	}
 
-	// When an agent includes a scope in its heartbeat, we enforce that it matches what was found in the hello.
-	if kubernetesServer.Scope != handle.Hello().GetScope() {
-		return trace.AccessDenied("incorrect kubernetes server scope (expected %q, got %q)", handle.Hello().GetScope(), kubernetesServer.Scope)
+	if kubernetesServer.Scope != kubernetesServer.GetCluster().GetScope() {
+		// If a kube server's cluster scope somehow drifts from the server's scope, we should deny.
+		if scopes.Compare(kubernetesServer.GetCluster().GetScope(), kubernetesServer.Scope) != scopes.Equivalent {
+			return trace.AccessDenied("kubernetes cluster scope does not match the server's scope (expected %q, got %q)", kubernetesServer.GetScope(), kubernetesServer.GetCluster().GetScope())
+		}
 	}
 
 	if handle.kubernetesServers == nil {

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -1717,7 +1717,116 @@ func TestGoodbye(t *testing.T) {
 func TestKubernetesServerBasics(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, testKubernetesServerBasics)
+	// happy path, scopes always match
+	synctest.Test(t, testKubernetesServerScoped("/test", "/test", "/test"))
+	// server scope differs from scope given during control stream registration
+	synctest.Test(t, testKubernetesServerScoped("/test", "/other", "/test"))
+	// cluster scope differs from the server scope
+	synctest.Test(t, testKubernetesServerScoped("/test", "/test", "/other"))
 }
+
+func testKubernetesServerScoped(initialScope, serverScope, clusterScope string) func(t *testing.T) {
+	return func(t *testing.T) {
+		const serverID = "test-server"
+
+		ctx := t.Context()
+
+		events := make(chan testEvent, 1024)
+
+		auth := &fakeAuth{}
+
+		rc := &resourceCounter{}
+		controller := NewController(
+			auth,
+			usagereporter.DiscardUsageReporter{},
+			withServerKeepAlive(time.Millisecond*200),
+			withTestEventsChannel(events),
+			WithOnConnect(rc.onConnect),
+			WithOnDisconnect(rc.onDisconnect),
+		)
+		defer controller.Close()
+
+		// set up fake in-memory control stream
+		upstream, downstream := client.InventoryControlStreamPipe()
+		// launch goroutine to respond to ping requests
+		go func() {
+			for {
+				select {
+				case msg := <-downstream.Recv():
+					downstream.Send(ctx, &proto.UpstreamInventoryPong{
+						ID: msg.(*proto.DownstreamInventoryPing).GetID(),
+					})
+				case <-downstream.Done():
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+
+		controller.RegisterControlStream(upstream, &proto.UpstreamInventoryHello{
+			ServerID: serverID,
+			Version:  teleport.Version,
+			Services: types.SystemRoles{types.RoleKube}.StringSlice(),
+			Scope:    initialScope,
+		})
+
+		// verify that control stream handle is now accessible
+		_, ok := controller.GetControlStream(serverID)
+		require.True(t, ok)
+
+		// verify that hb counter has been incremented
+		require.Equal(t, int64(1), controller.instanceHBVariableDuration.Count())
+
+		// send server heartbeat with scopes applied
+		err := downstream.Send(ctx, &proto.InventoryHeartbeat{
+			KubernetesServer: &types.KubernetesServerV3{
+				Metadata: types.Metadata{
+					Name: serverID,
+				},
+				Scope: serverScope,
+				Spec: types.KubernetesServerSpecV3{
+					HostID:   serverID,
+					Hostname: serverID,
+					Cluster: &types.KubernetesClusterV3{
+						Kind:    types.KindKubernetesCluster,
+						Version: types.V3,
+						Scope:   clusterScope,
+						Metadata: types.Metadata{
+							Name: "cluster",
+						},
+						Spec: types.KubernetesClusterSpecV3{},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		if serverScope != initialScope {
+			// scope mismatch between server scope and initial scope should close
+			// the stream
+			awaitEvents(t, events,
+				expect(handlerClose),
+				deny(kubeKeepAliveErr, kubeUpsertErr),
+			)
+			return
+		}
+		if clusterScope != serverScope {
+			// scope mismatch between server scope and cluster scope should close
+			// the stream
+			awaitEvents(t, events,
+				expect(handlerClose),
+				deny(kubeKeepAliveErr, kubeUpsertErr),
+			)
+			return
+		}
+		awaitEvents(t, events,
+			expect(kubeUpsertOk, kubeKeepAliveOk),
+			deny(kubeKeepAliveErr, kubeUpsertErr, handlerClose),
+		)
+	}
+}
+
 func testKubernetesServerBasics(t *testing.T) {
 	const serverID = "test-server"
 	const kubeCount = 3

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -130,9 +130,12 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 			)
 			continue
 		}
-		kubeCluster, err := types.NewKubernetesClusterV3(types.Metadata{
-			Name: cluster,
-		}, types.KubernetesClusterSpecV3{})
+		kubeCluster, err := types.NewKubernetesClusterV3(
+			types.Metadata{
+				Name: cluster,
+			}, types.KubernetesClusterSpecV3{},
+			types.KubeClusterWithScope(f.cfg.Scope),
+		)
 		if err != nil {
 			f.log.WarnContext(ctx, "failed to create KubernetesClusterV3 from credentials for cluster",
 				"cluster", cluster,

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -28,12 +28,12 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/gravitational/trace"
 	authzapi "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
+
 	// Load kubeconfig auth plugins for gcp and azure.
 	// Without this, users can't provide a kubeconfig using those.
 	//
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/trace"
 )
 
 // getKubeDetails fetches the kubernetes API credentials.
@@ -130,9 +131,12 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 			)
 			continue
 		}
-		kubeCluster, err := types.NewKubernetesClusterV3(types.Metadata{
-			Name: cluster,
-		}, types.KubernetesClusterSpecV3{})
+		kubeCluster, err := types.NewKubernetesClusterV3(
+			types.Metadata{
+				Name: cluster,
+			}, types.KubernetesClusterSpecV3{},
+			types.KubeClusterWithScope(f.cfg.Scope),
+		)
 		if err != nil {
 			f.log.WarnContext(ctx, "failed to create KubernetesClusterV3 from credentials for cluster",
 				"cluster", cluster,

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -181,6 +181,8 @@ type ForwarderConfig struct {
 	// ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.
 	// It is used to determine if the cluster is licensed for Kubernetes usage.
 	ClusterFeatures ClusterFeaturesGetter
+	// Scope that the forwarder is pinned to.
+	Scope string
 }
 
 // ClusterFeaturesGetter is a function that returns the Teleport cluster licensed features.

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/relaytunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/srv"
@@ -539,6 +540,9 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 			RelayGroup: relayGroup,
 			RelayIds:   relayIDs,
 		},
+		// getKubeClusterWithServiceLabels already ensures that the cluster has the correct scope and that scope
+		// is usable by this forwarder. We only need to make sure that the kube server we build shares the same scope
+		types.KubeServerWithScope(cluster.GetScope()),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -638,6 +642,17 @@ func (t *TLSServer) getKubeClusterWithServiceLabels(name string) (*types.Kuberne
 	clusterWithoutCreds, err := types.NewKubernetesClusterV3WithoutSecrets(details.kubeCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	// The Proxy Service forwarder will always be unscoped and needs to be able to forward
+	// to scoped clusters as well.
+	if t.Scope != "" {
+		if scopes.Compare(t.Scope, details.kubeCluster.GetScope()) != scopes.Equivalent {
+			// This should only happen if there's a bug in scoped access checking for KubernetesCluster resources.
+			// The kube proxy should never have access to clusters from orthogonal scopes. We also block access
+			// to clusters in child scopes but this may be relaxed in the future.
+			return nil, trace.AccessDenied("kube forwarder found kube cluster from different scope, this is a bug")
+		}
 	}
 
 	if details.dynamicLabels != nil {

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/relaytunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/srv"
@@ -539,6 +540,9 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 			RelayGroup: relayGroup,
 			RelayIds:   relayIDs,
 		},
+		// getKubeClusterWithServiceLabels already ensures that the cluster has the correct scope and that scope
+		// is usable by this forwarder. We only need to make sure that the kube server we build shares the same scope
+		types.KubeServerWithScope(cluster.GetScope()),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -638,6 +642,18 @@ func (t *TLSServer) getKubeClusterWithServiceLabels(name string) (*types.Kuberne
 	clusterWithoutCreds, err := types.NewKubernetesClusterV3WithoutSecrets(details.kubeCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	// The Proxy Service forwarder will always be unscoped and needs to be able to forward
+	// to scoped clusters as well. Similarly, the Kubernetes Service can also be unscoped
+	// and should be able to forward for any dynamically registered scoped clusters.
+	if t.Scope != "" {
+		if scopes.Compare(t.Scope, details.kubeCluster.GetScope()) != scopes.Equivalent {
+			// This should only happen if there's a bug in scoped access checking for KubernetesCluster resources.
+			// The kube proxy should never have access to clusters from orthogonal scopes. We also block access
+			// to clusters in child scopes but this may be relaxed in the future.
+			return nil, trace.AccessDenied("kube forwarder found kube cluster from different scope, this is a bug")
+		}
 	}
 
 	if details.dynamicLabels != nil {

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -289,6 +289,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
 			PublicAddr:                    publicAddr,
 			ClusterFeatures:               process.GetClusterFeatures,
+			Scope:                         conn.Scope(),
 		},
 		TLS:                  tlsConfig,
 		AccessPoint:          accessPoint,


### PR DESCRIPTION
Adds a `Scope` field to `ForwarderConfig` and propagates it to heartbeats rather than using the fallback behavior of assigning the initial scope to heartbeats that were missing it. Since most RBAC happens against the `KubernetesCluster` resource and not the `KubeServer`, scoped RBAC was failing due the embedded clusters not having a scope assigned. This propagation fixes that.

I also improved the scope checking in the kube heartbeat handler to reject if the embedded cluster is mismatched with the server and included a failsafe in the kube proxy forwarder that will error if it finds a kube cluster with a mismatched scope. This should never happen in practice if scoped RBAC is properly enforced.

Since an unscoped kube service could dynamically register a manual scoped kube cluster, this PR also validates against writing scoped kube clusters to the backend over gRPC

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- A local teleport cluster with `TELEPORT_UNSTABLE_SCOPES=1`
- A scoped `Kube` join token
- An unscoped `Kube` join token 
### Test Cases
- [x] Join kube service with scoped token
- [x] Kube service becomes healthy
- [x] Both server and cluster scopes are assigned correctly `tctl get kube_server/cluster-name`
- [x] Join kube service with unscoped token
- [x] Kube service becomes healthy