### PR TITLE
Add the "tctl auth create-override-csr" command

### DIFF
--- a/lib/subca/parsed.go
+++ b/lib/subca/parsed.go
@@ -34,9 +34,7 @@ import (
 
 // SupportedCATypes returns a slice of supported CA types for CA overrides.
 func SupportedCATypes() []string {
-	caTypes := make([]string, len(allowedCAOverrideSubKinds))
-	copy(caTypes, allowedCAOverrideSubKinds)
-	return caTypes
+	return slices.Clone(allowedCAOverrideSubKinds)
 }
 
 var (

--- a/lib/subca/parsed.go
+++ b/lib/subca/parsed.go
@@ -32,6 +32,13 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
+// SupportedCATypes returns a slice of supported CA types for CA overrides.
+func SupportedCATypes() []string {
+	caTypes := make([]string, len(allowedCAOverrideSubKinds))
+	copy(caTypes, allowedCAOverrideSubKinds)
+	return caTypes
+}
+
 var (
 	allowedCAOverrideSubKinds = []string{
 		string(types.DatabaseClientCA),

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -189,7 +189,10 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, cliFlags *tctlcfg.Glo
 // or returns match=false if 'cmd' does not belong to it
 func (a *AuthCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
 	if a.subCACommand != nil {
-		if match, err := a.subCACommand.TryRun(ctx, cmd, clientFunc); match || err != nil {
+		cf := func(ctx context.Context) (_ subcacmd.SubCAClientSource, closeFn func(context.Context), _ error) {
+			return clientFunc(ctx)
+		}
+		if match, err := a.subCACommand.TryRun(ctx, cmd, cf); match || err != nil {
 			return match, trace.Wrap(err)
 		}
 	}

--- a/tool/tctl/common/subca/export_test.go
+++ b/tool/tctl/common/subca/export_test.go
@@ -1,0 +1,19 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package subca
+
+var FindMinHashes = findMinHashes

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -18,19 +18,32 @@ package subca
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/utils/pkixname"
 	"github.com/gravitational/teleport/api/utils/tlsutils"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/subca"
-	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
+
+// SubCAClientSource is the subset of *authclient.Client used by Command.
+type SubCAClientSource interface {
+	SubCAClient() subcav1.SubCAServiceClient
+}
+
+// InitFunc "downgrades" *authclient.Client to SubCAClientSource in order to
+// enable easy testing.
+type InitFunc func(ctx context.Context) (_ SubCAClientSource, closeFn func(context.Context), _ error)
 
 // Command is the subset of "tctl auth" commands that deal with Sub CAs.
 //
@@ -48,7 +61,8 @@ type Command struct {
 	// Initialized by the Initialize function.
 	Stdout, Stderr io.Writer
 
-	pubKeyHash pubKeyHashCommand
+	createOverrideCSR createOverrideCSRCommand
+	pubKeyHash        pubKeyHashCommand
 }
 
 // Initialize initializes all Sub CA commands. Parent is expected to be "tctl
@@ -70,6 +84,27 @@ func (c *Command) Initialize(
 		c.Stderr = os.Stderr
 	}
 
+	c.createOverrideCSR.CmdClause = parent.Command(
+		"create-override-csr", "Create a CSR in preparation for CA certificate override")
+	// Don't over-validate CA types on the client. That's the server's responsibility.
+	createCSRHelp := fmt.Sprintf(
+		"CA type (%s)",
+		strings.Join(subca.SupportedCATypes(), ", "),
+	)
+	c.createOverrideCSR.
+		Flag("type", createCSRHelp). // --type mimics other "tctl auth" commands
+		Required().
+		StringVar(&c.createOverrideCSR.caType)
+	c.createOverrideCSR.
+		Flag("out", "Output path prefix. Use '-' for stdout.").
+		StringVar(&c.createOverrideCSR.out)
+	c.createOverrideCSR.
+		Flag("public-key", "Public key hash of CA certificate to be targeted").
+		StringVar(&c.createOverrideCSR.publicKey)
+	c.createOverrideCSR.
+		Flag("subject", `Customized certificate subject. Example: "O=MyClusterName,OU=MyOrgUnit,CN=MyCommonName"`).
+		StringVar(&c.createOverrideCSR.subject)
+
 	c.pubKeyHash.CmdClause = parent.Command(
 		"pub-key-hash", "Extract and print the public key hash of a PEM certificate")
 	c.pubKeyHash.Flag("cert", "Certificate file in PEM format. Use '-' to read from stdin.").
@@ -84,10 +119,15 @@ func (c *Command) Initialize(
 func (c *Command) TryRun(
 	ctx context.Context,
 	selectedCommand string,
-	clientFunc commonclient.InitFunc,
+	clientFunc InitFunc,
 ) (match bool, err error) {
-	if selectedCommand == c.pubKeyHash.FullCommand() {
-		return true, trace.Wrap(c.pubKeyHash.Run(ctx, clientFunc, c.state()))
+	for _, cmd := range []subCommand{
+		&c.createOverrideCSR,
+		&c.pubKeyHash,
+	} {
+		if selectedCommand == cmd.FullCommand() {
+			return true, trace.Wrap(cmd.Run(ctx, clientFunc, c.state()))
+		}
 	}
 	return false, nil
 }
@@ -105,6 +145,124 @@ type commandState struct {
 	Stdout, Stderr io.Writer
 }
 
+type subCommand interface {
+	FullCommand() string
+	Run(ctx context.Context, clientFunc InitFunc, s *commandState) error
+}
+
+type createOverrideCSRCommand struct {
+	*kingpin.CmdClause
+
+	caType    string
+	out       string // Output path prefix.
+	publicKey string
+	subject   string
+}
+
+func (c *createOverrideCSRCommand) Run(
+	ctx context.Context,
+	clientFunc InitFunc,
+	s *commandState,
+) error {
+	// Defensive, shouldn't happen.
+	if c.caType == "" {
+		return trace.BadParameter("type required")
+	}
+
+	var pubKey *subcav1.PublicKeyHash
+	if c.publicKey != "" {
+		pubKey = &subcav1.PublicKeyHash{
+			Value: c.publicKey,
+		}
+	}
+
+	var customSubject *subcav1.DistinguishedName
+	if c.subject != "" {
+		dn, err := pkixname.ParseDistinguishedName(c.subject)
+		if err != nil {
+			return trace.Wrap(err, "parse custom subject")
+		}
+		customSubject, err = subca.RDNSequenceToDistinguishedNameProto(dn.ToRDNSequence())
+		if err != nil {
+			return trace.Wrap(err, "convert custom subject to protobuf")
+		}
+	}
+
+	// Create gRPC client.
+	authClient, closeFn, err := clientFunc(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer closeFn(ctx)
+	subCA := authClient.SubCAClient()
+
+	// Request CSRs.
+	resp, err := subCA.CreateCSR(ctx, &subcav1.CreateCSRRequest{
+		CaType:        c.caType,
+		PublicKeyHash: pubKey,
+		CustomSubject: customSubject,
+	})
+	if err != nil {
+		return trace.Wrap(err, "create CSRs")
+	}
+	// Defensive. Should fail server-side if that's the case.
+	if len(resp.Csrs) == 0 {
+		return trace.BadParameter("no CSRs created")
+	}
+
+	// Write CSRs to files.
+	writeToStdout := c.out == "-"
+	out := fmt.Sprintf("%s%s-", c.out, c.caType)
+
+	seenHashes := make(map[string]struct{})
+	writeCSR := func(csr *subcav1.CertificateSigningRequest) error {
+		if writeToStdout {
+			fmt.Fprintln(s.Stdout, csr.Pem)
+			return nil
+		}
+
+		// Extract public key hash from CSR.
+		block, _ := pem.Decode([]byte(csr.Pem))
+		if block == nil {
+			return trace.BadParameter("CSR is not a valid PEM")
+		}
+		parsedCSR, err := x509.ParseCertificateRequest(block.Bytes)
+		if err != nil {
+			return trace.Wrap(err, "parse CSR")
+		}
+		pubKeyHash := subca.HashPublicKey(parsedCSR.RawSubjectPublicKeyInfo)
+
+		// Attempt to find a smaller hash, so the filename isn't always 73+
+		// characters.
+		// In practice this should resolve immediately the vast majority of the
+		// time.
+		const minLen = 8
+		for l := minLen; l < len(pubKeyHash); l++ {
+			pkh := pubKeyHash[:l]
+			if _, ok := seenHashes[pkh]; ok {
+				continue // Try a larger hash.
+			}
+			pubKeyHash = pkh
+			seenHashes[pubKeyHash] = struct{}{}
+			break
+		}
+
+		name := out + pubKeyHash + "-csr.pem"
+		if err := os.WriteFile(name, []byte(csr.Pem), 0644); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Fprintf(s.Stdout, "Wrote %s\n", name)
+		return nil
+	}
+
+	for _, csr := range resp.Csrs {
+		if err := writeCSR(csr); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
 type pubKeyHashCommand struct {
 	*kingpin.CmdClause
 
@@ -113,7 +271,7 @@ type pubKeyHashCommand struct {
 
 func (c *pubKeyHashCommand) Run(
 	ctx context.Context,
-	_ commonclient.InitFunc,
+	_ InitFunc,
 	s *commandState,
 ) error {
 	// Defensive, shouldn't happen.

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -96,7 +96,7 @@ func (c *Command) Initialize(
 		Required().
 		StringVar(&c.createOverrideCSR.caType)
 	c.createOverrideCSR.
-		Flag("out", "Output path prefix. Use '-' for stdout.").
+		Flag("out", "If set writes CSRs to files using --out as the path prefix").
 		StringVar(&c.createOverrideCSR.out)
 	c.createOverrideCSR.
 		Flag("public-key", "Public key hash of CA certificate to be targeted").
@@ -211,7 +211,7 @@ func (c *createOverrideCSRCommand) Run(
 	}
 
 	// If writing to stdout there's no need to parse the PEMs or form filenames.
-	if writeToStdout := c.out == "-"; writeToStdout {
+	if c.out == "" {
 		for _, csr := range resp.Csrs {
 			fmt.Fprintln(s.Stdout, csr.Pem)
 		}

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -254,22 +254,31 @@ func findMinHashes(hashes []string) []string {
 	}
 
 	minHashes := make([]string, len(hashes))
-	seenHashes := make(map[string]struct{})
 
 	const startLen = 8
-	minLen := startLen
-
 Outer:
-	for minLen < len(hashes[0]) {
-		// Trim all entries to minLen...
+	for minLen := startLen; true; minLen++ {
+		seenHashes := make(map[string]struct{})
+		trimmed := false
+
+		// Attempt to trim all entries to minLen.
 		for i, h := range hashes {
-			minHashes[i] = h[:minLen]
+			if minLen < len(h) {
+				minHashes[i] = h[:minLen]
+				trimmed = true
+			} else {
+				minHashes[i] = h
+			}
 		}
 
-		// ...then look for a repeated hash. If there is none, return.
+		// If no hashes could be trimmed stop and return original slice.
+		if !trimmed {
+			break
+		}
+
+		// Look for a repeated hash. If there is none, return.
 		for _, mh := range minHashes {
 			if _, seen := seenHashes[mh]; seen {
-				minLen++
 				continue Outer
 			}
 			seenHashes[mh] = struct{}{}

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -41,8 +41,8 @@ type SubCAClientSource interface {
 	SubCAClient() subcav1.SubCAServiceClient
 }
 
-// InitFunc "downgrades" *authclient.Client to SubCAClientSource in order to
-// enable easy testing.
+// InitFunc mimics commonclient.InitFunc, but types the client to the narrower
+// SubCAClientSource interface for testing.
 type InitFunc func(ctx context.Context) (_ SubCAClientSource, closeFn func(context.Context), _ error)
 
 // Command is the subset of "tctl auth" commands that deal with Sub CAs.

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -210,57 +210,75 @@ func (c *createOverrideCSRCommand) Run(
 		return trace.BadParameter("no CSRs created")
 	}
 
-	// Write CSRs to files.
-	writeToStdout := c.out == "-"
-	out := fmt.Sprintf("%s%s-", c.out, c.caType)
-
-	seenHashes := make(map[string]struct{})
-	writeCSR := func(csr *subcav1.CertificateSigningRequest) error {
-		if writeToStdout {
+	// If writing to stdout there's no need to parse the PEMs or form filenames.
+	if writeToStdout := c.out == "-"; writeToStdout {
+		for _, csr := range resp.Csrs {
 			fmt.Fprintln(s.Stdout, csr.Pem)
-			return nil
 		}
+		return nil
+	}
 
-		// Extract public key hash from CSR.
+	// Parse CSRs and calculate public key hashes.
+	publicKeyHashes := make([]string, len(resp.Csrs))
+	for i, csr := range resp.Csrs {
 		block, _ := pem.Decode([]byte(csr.Pem))
 		if block == nil {
-			return trace.BadParameter("CSR is not a valid PEM")
+			return trace.BadParameter("csrs[%d]: CSR is not a valid PEM", i)
 		}
 		parsedCSR, err := x509.ParseCertificateRequest(block.Bytes)
 		if err != nil {
-			return trace.Wrap(err, "parse CSR")
+			return trace.Wrap(err, "csrs[%d]: parse CSR", i)
 		}
-		pubKeyHash := subca.HashPublicKey(parsedCSR.RawSubjectPublicKeyInfo)
+		publicKeyHashes[i] = subca.HashPublicKey(parsedCSR.RawSubjectPublicKeyInfo)
+	}
 
-		// Attempt to find a smaller hash, so the filename isn't always 73+
-		// characters.
-		// In practice this should resolve immediately the vast majority of the
-		// time.
-		const minLen = 8
-		for l := minLen; l < len(pubKeyHash); l++ {
-			pkh := pubKeyHash[:l]
-			if _, ok := seenHashes[pkh]; ok {
-				continue // Try a larger hash.
-			}
-			pubKeyHash = pkh
-			seenHashes[pubKeyHash] = struct{}{}
-			break
-		}
+	// Find smaller hashes so the filenames aren't always 73+ characters.
+	minHashes := findMinHashes(publicKeyHashes)
 
-		name := out + pubKeyHash + "-csr.pem"
+	// Write output files.
+	for i, csr := range resp.Csrs {
+		name := c.out + c.caType + "-" + minHashes[i] + "-csr.pem"
 		if err := os.WriteFile(name, []byte(csr.Pem), 0644); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Fprintf(s.Stdout, "Wrote %s\n", name)
+	}
+	return nil
+}
+
+// findMinHashes finds a smaller, non-conflicting prefix of hashes.
+// Returns a slice containing the prefix hashes, all with the same length.
+func findMinHashes(hashes []string) []string {
+	if len(hashes) == 0 {
 		return nil
 	}
 
-	for _, csr := range resp.Csrs {
-		if err := writeCSR(csr); err != nil {
-			return trace.Wrap(err)
+	minHashes := make([]string, len(hashes))
+	seenHashes := make(map[string]struct{})
+
+	const startLen = 8
+	minLen := startLen
+
+Outer:
+	for minLen < len(hashes[0]) {
+		// Trim all entries to minLen...
+		for i, h := range hashes {
+			minHashes[i] = h[:minLen]
 		}
+
+		// ...then look for a repeated hash. If there is none, return.
+		for _, mh := range minHashes {
+			if _, seen := seenHashes[mh]; seen {
+				minLen++
+				continue Outer
+			}
+			seenHashes[mh] = struct{}{}
+		}
+
+		return minHashes
 	}
-	return nil
+
+	return hashes
 }
 
 type pubKeyHashCommand struct {

--- a/tool/tctl/common/subca/subca_command.go
+++ b/tool/tctl/common/subca/subca_command.go
@@ -256,7 +256,6 @@ func findMinHashes(hashes []string) []string {
 	minHashes := make([]string, len(hashes))
 
 	const startLen = 8
-Outer:
 	for minLen := startLen; true; minLen++ {
 		seenHashes := make(map[string]struct{})
 		trimmed := false
@@ -277,14 +276,17 @@ Outer:
 		}
 
 		// Look for a repeated hash. If there is none, return.
+		collision := false
 		for _, mh := range minHashes {
 			if _, seen := seenHashes[mh]; seen {
-				continue Outer
+				collision = true
+				break
 			}
 			seenHashes[mh] = struct{}{}
 		}
-
-		return minHashes
+		if !collision {
+			return minHashes
+		}
 	}
 
 	return hashes

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -62,7 +62,6 @@ func TestCommand_CreateOverrideCSR(t *testing.T) {
 			name: "ok: db_client",
 			flags: []string{
 				"--type", string(types.DatabaseClientCA),
-				"--out=-",
 			},
 			csrPEMs: []string{dbClientCSRPEM},
 			wantReq: &subcav1.CreateCSRRequest{
@@ -74,7 +73,6 @@ func TestCommand_CreateOverrideCSR(t *testing.T) {
 			name: "ok: windows",
 			flags: []string{
 				"--type", string(types.WindowsCA),
-				"--out=-",
 			},
 			csrPEMs: []string{windowsCSRPEM},
 			wantReq: &subcav1.CreateCSRRequest{
@@ -83,10 +81,9 @@ func TestCommand_CreateOverrideCSR(t *testing.T) {
 			wantStdout: windowsCSRPEM + "\n",
 		},
 		{
-			name: "all flags",
+			name: "--public-key and --subject",
 			flags: []string{
 				"--type", string(types.WindowsCA),
-				"--out=-",
 				"--public-key=f4522365888fdddcf3c854e79e5928447fe1a2388353efb2f0d30db8ba7c81bc",
 				"--subject=O=Llama,CN=Llamo",
 			},
@@ -109,7 +106,6 @@ func TestCommand_CreateOverrideCSR(t *testing.T) {
 			name: "multiple PEMs",
 			flags: []string{
 				"--type", string(types.WindowsCA),
-				"--out=-",
 			},
 			csrPEMs: []string{
 				windowsCSRPEM,

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -236,6 +236,21 @@ func TestFindMinHashes(t *testing.T) {
 				"11b52b511de1f0d8c4b5e5a3beb053fb5497727d696de6dae338560e4e2f8e0c",
 			},
 		},
+		{
+			name: "uneven/small hashes",
+			in: []string{
+				"f4522365888fdddcf3c854e79e5928447fe1a2388353efb2f0d30db8ba7c81bc", // normal len
+				"aaaaaaa",       // <8 characters, aka <minLen.
+				"bananallama1a", // clashes below.
+				"bananallama2a", // clashes above.
+			},
+			want: []string{
+				"f4522365888f", // trimmed
+				"aaaaaaa",      // original (<minLen)
+				"bananallama1", // trimmed
+				"bananallama2", // trimmed
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -18,15 +18,247 @@ package subca_test
 
 import (
 	"bytes"
+	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/testing/protocmp"
 
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/tool/tctl/common/subca"
 )
+
+func TestCommand_CreateOverrideCSR(t *testing.T) {
+	t.Parallel()
+
+	// Not consts so we can take their address.
+	oLlama := "Llama"
+	cnLlamo := "Llamo"
+
+	// Variables for the "output to files" test.
+	tempDir := t.TempDir()
+	// Suffixes are calculated from the CAType and PEM public key, therefore
+	// deterministic.
+	wantWindows1File := filepath.Join(tempDir, "windows-f4522365-csr.pem")
+	wantWindows2File := filepath.Join(tempDir, "windows-11b52b51-csr.pem")
+
+	tests := []struct {
+		name       string
+		flags      []string // flags after "tctl auth create-override-csr"
+		csrPEMs    []string // as returned by the server
+		wantReq    *subcav1.CreateCSRRequest
+		wantStdout string
+		wantFiles  map[string]string // filepath to content
+	}{
+		{
+			name: "ok: db_client",
+			flags: []string{
+				"--type", string(types.DatabaseClientCA),
+				"--out=-",
+			},
+			csrPEMs: []string{dbClientCSRPEM},
+			wantReq: &subcav1.CreateCSRRequest{
+				CaType: string(types.DatabaseClientCA),
+			},
+			wantStdout: dbClientCSRPEM + "\n",
+		},
+		{
+			name: "ok: windows",
+			flags: []string{
+				"--type", string(types.WindowsCA),
+				"--out=-",
+			},
+			csrPEMs: []string{windowsCSRPEM},
+			wantReq: &subcav1.CreateCSRRequest{
+				CaType: string(types.WindowsCA),
+			},
+			wantStdout: windowsCSRPEM + "\n",
+		},
+		{
+			name: "all flags",
+			flags: []string{
+				"--type", string(types.WindowsCA),
+				"--out=-",
+				"--public-key=f4522365888fdddcf3c854e79e5928447fe1a2388353efb2f0d30db8ba7c81bc",
+				"--subject=O=Llama,CN=Llamo",
+			},
+			csrPEMs: []string{windowsCustomCSRPEM},
+			wantReq: &subcav1.CreateCSRRequest{
+				CaType: string(types.WindowsCA),
+				PublicKeyHash: &subcav1.PublicKeyHash{
+					Value: "f4522365888fdddcf3c854e79e5928447fe1a2388353efb2f0d30db8ba7c81bc",
+				},
+				CustomSubject: &subcav1.DistinguishedName{
+					Names: []*subcav1.AttributeTypeAndValue{
+						{Oid: []int32{2, 5, 4, 10}, Value: &oLlama}, // O
+						{Oid: []int32{2, 5, 4, 3}, Value: &cnLlamo}, // CN
+					},
+				},
+			},
+			wantStdout: windowsCustomCSRPEM + "\n",
+		},
+		{
+			name: "multiple PEMs",
+			flags: []string{
+				"--type", string(types.WindowsCA),
+				"--out=-",
+			},
+			csrPEMs: []string{
+				windowsCSRPEM,
+				windowsCSRPEM2,
+			},
+			wantReq: &subcav1.CreateCSRRequest{
+				CaType: string(types.WindowsCA),
+			},
+			wantStdout: windowsCSRPEM + "\n" + windowsCSRPEM2 + "\n",
+		},
+		{
+			name: "output to files",
+			flags: []string{
+				"--type", string(types.WindowsCA),
+				"--out", tempDir + "/",
+			},
+			csrPEMs: []string{
+				windowsCSRPEM,
+				windowsCSRPEM2,
+			},
+			wantReq: &subcav1.CreateCSRRequest{
+				CaType: string(types.WindowsCA),
+			},
+			wantStdout: "" +
+				"Wrote " + wantWindows1File + "\n" +
+				"Wrote " + wantWindows2File + "\n",
+			wantFiles: map[string]string{
+				wantWindows1File: windowsCSRPEM,
+				wantWindows2File: windowsCSRPEM2,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClient := &fakeAuthClient{
+				csrPEMs: test.csrPEMs,
+			}
+			clientFunc := func(ctx context.Context) (_ subca.SubCAClientSource, closeFn func(context.Context), _ error) {
+				return fakeClient, func(ctx context.Context) {}, nil
+			}
+
+			env := newCommand(t)
+
+			flags := append([]string{"auth", "create-override-csr"}, test.flags...)
+			selectedCommand, err := env.App.Parse(flags)
+			require.NoError(t, err, "app.Parse()")
+
+			match, err := env.Cmd.TryRun(t.Context(), selectedCommand, clientFunc)
+			assert.True(t, match)
+			require.NoError(t, err, "Command errored")
+
+			// Verify server request.
+			if diff := cmp.Diff(test.wantReq, fakeClient.lastCSRRequest, protocmp.Transform()); diff != "" {
+				t.Errorf("CreateCSRRequest mismatch (-want +got)\n%s", diff)
+			}
+
+			// Verify stdout.
+			assert.Equal(t, test.wantStdout, env.Stdout.String(), "stdout mismatch")
+
+			// Verify side effects.
+			for filePath, wantContent := range test.wantFiles {
+				val, err := os.ReadFile(filePath)
+				if !assert.NoError(t, err, "Read file %s", filePath) {
+					continue
+				}
+				assert.Equal(t, wantContent, string(val), "File %s", filePath)
+			}
+		})
+	}
+}
+
+// CSR PEMs for testing.
+// The simplest way to get these is to run the "tctl auth create-override-csr"
+// command.
+// Starting a CA rotation in the "init" phase will make the corresponding CA
+// generate multiple CSRs as well.
+const (
+	dbClientCSRPEM = `-----BEGIN CERTIFICATE REQUEST-----
+MIICazCCAVMCAQAwJjERMA8GA1UEChMIemFycXVvbjIxETAPBgNVBAMTCHphcnF1
+b24yMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArK67OiXGXaqorqAM
+HRrUswRwfUMYJLq+wWTneao+KMhsvuWQPVrHmIkNpC1QjbDuLDTrc2ce/VIatMBZ
+bJl6/hPZRJWOtuSbtI5syoGtXX1xbyVMOPMh4UW7+acn0VK3s3nwcVDYic33K6J+
+SGXFUr92laNgyf49RQ0CUyDSs6H+xPyMr+oucuPdWTIkH9aYgXpd5bIFE3YzvEMM
+mTNcstMTI9pvpC3h2Qw8uvBLnu5w+RW0V0qrmUbetX7RapYzXeTUC9EnQ5WFwsoH
+gavsXr85qn3zaWa4D4PliPE9iNyaGN6k5b2UCASCkrVyYyDaiLnxPfpnF/MiQxkC
+5MNBKwIDAQABoAAwDQYJKoZIhvcNAQELBQADggEBACz9u6+/8xpFc29P3m37cAol
+tncq0dsapqP1NyQuYGlylutNZPHmFsDziXbr9e4L46qUNaoFmw7O0s8mvcmZdjzi
++4HorjyThtvzrjjXr/ul+JeDzXE592LcfA4EgoMnwhvz0Kp/YhMp+HHuK7gu6g3O
+cQVvGtshNTVdUNfeLnBh0BRZ9JFQ1sLQIMsRqPSC9nA6lRwWuWt43m46EmjGrdWc
+EZK5otyv3uhAMoIrLn2jrztz+cOVGXzZy27hnrM6MM1oKMlM4rbntX6TveG8fNoH
+Q/IMZTusP3T17YRFoW/ov3+ERDheI6DxJxOcBhMd8/rW5FBJQVSnHZXVpemppxE=
+-----END CERTIFICATE REQUEST-----`
+
+	windowsCSRPEM = `-----BEGIN CERTIFICATE REQUEST-----
+MIHgMIGIAgEAMCYxETAPBgNVBAoTCHphcnF1b24yMREwDwYDVQQDEwh6YXJxdW9u
+MjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAkIXaUNv8uoI9ICDijS4ciUOkSI
+fSV9o3nslxvseZcswjzIE1fpiVPGwLzke7hfd/UcCzemuLoajOe3hXO12i6gADAK
+BggqhkjOPQQDAgNHADBEAiByeQeUIJ2JXYYTaeSlODXHKbXlPh0XtiLj7v7rH5ZD
+QgIgKT3/AuvpTuu2FIioZnx8feSWmPVDDPVO5cNaybkEhQM=
+-----END CERTIFICATE REQUEST-----`
+
+	windowsCSRPEM2 = `-----BEGIN CERTIFICATE REQUEST-----
+MIHhMIGIAgEAMCYxETAPBgNVBAoTCHphcnF1b24yMREwDwYDVQQDEwh6YXJxdW9u
+MjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABO9DT3fpxLGp9YJq1BCoqpszLH53
+pW3AKK1VOhkEaZnTCV6Uvd92EibsP4HKto0NmfddL9JJcZ/BdLBN+9ESJxGgADAK
+BggqhkjOPQQDAgNIADBFAiEAqpQsBWTJp7zmDwsDX4YW9Sw70o45BwWh3v1eZ1s9
+JkUCIBw904bcK8yUxXqcHlpErnVN11e+Z435w6cwwO44MikG
+-----END CERTIFICATE REQUEST-----`
+
+	// O=Llama,CN=Llamo
+	windowsCustomCSRPEM = `-----BEGIN CERTIFICATE REQUEST-----
+MIHvMIGXAgEAMDUxDjAMBgNVBAoTBUxsYW1hMQ4wDAYDVQQDEwVMbGFtbzETMBEG
+BSvODwQBEwh6YXJxdW9uMjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAkIXaUN
+v8uoI9ICDijS4ciUOkSIfSV9o3nslxvseZcswjzIE1fpiVPGwLzke7hfd/UcCzem
+uLoajOe3hXO12i6gADAKBggqhkjOPQQDAgNHADBEAiBP+b9QDG4vb6ONy3g4iljg
+cxvqL75ol8ta2P/m9elRDQIgX1OP0544EUSS2AlGxEotBqe7ZFg+HBsrzqCkQe7h
+cxI=
+-----END CERTIFICATE REQUEST-----`
+)
+
+type fakeAuthClient struct {
+	subcav1.SubCAServiceClient
+
+	csrPEMs        []string
+	lastCSRRequest *subcav1.CreateCSRRequest
+}
+
+func (f *fakeAuthClient) SubCAClient() subcav1.SubCAServiceClient {
+	return f
+}
+
+func (f *fakeAuthClient) CreateCSR(
+	ctx context.Context, req *subcav1.CreateCSRRequest, _ ...grpc.CallOption) (*subcav1.CreateCSRResponse, error) {
+	f.lastCSRRequest = req
+
+	if len(f.csrPEMs) == 0 {
+		return nil, trace.BadParameter("cannot create CSRs for CA")
+	}
+
+	resp := &subcav1.CreateCSRResponse{
+		Csrs: make([]*subcav1.CertificateSigningRequest, len(f.csrPEMs)),
+	}
+	for i, pem := range f.csrPEMs {
+		resp.Csrs[i] = &subcav1.CertificateSigningRequest{
+			Pem: pem,
+		}
+	}
+	return resp, nil
+}
 
 func TestCommand_PubKeyHash(t *testing.T) {
 	t.Parallel()

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -144,6 +144,8 @@ func TestCommand_CreateOverrideCSR(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			fakeClient := &fakeAuthClient{
 				csrPEMs: test.csrPEMs,
 			}
@@ -176,6 +178,71 @@ func TestCommand_CreateOverrideCSR(t *testing.T) {
 					continue
 				}
 				assert.Equal(t, wantContent, string(val), "File %s", filePath)
+			}
+		})
+	}
+}
+
+func TestFindMinHashes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		in, want []string
+	}{
+		{
+			name: "single hash",
+			in: []string{
+				"f4522365888fdddcf3c854e79e5928447fe1a2388353efb2f0d30db8ba7c81bc",
+			},
+			want: []string{
+				"f4522365",
+			},
+		},
+		{
+			name: "multiple hashes",
+			in: []string{
+				"f4522365888fdddcf3c854e79e5928447fe1a2388353efb2f0d30db8ba7c81bc",
+				"11b52b511de1f0d8c4b5e5a3beb053fb5497727d696de6dae338560e4e2f8e0c",
+			},
+			want: []string{
+				"f4522365",
+				"11b52b51",
+			},
+		},
+		{
+			name: "conflicts",
+			in: []string{
+				"bananallama11111",
+				"bananallama21111",
+				"bananallama31111",
+			},
+			want: []string{
+				"bananallama1",
+				"bananallama2",
+				"bananallama3",
+			},
+		},
+		{
+			name: "duplicate hashes",
+			in: []string{
+				"f4522365888fdddcf3c854e79e5928447fe1a2388353efb2f0d30db8ba7c81bc",
+				"f4522365888fdddcf3c854e79e5928447fe1a2388353efb2f0d30db8ba7c81bc",
+				"11b52b511de1f0d8c4b5e5a3beb053fb5497727d696de6dae338560e4e2f8e0c",
+			},
+			want: []string{
+				"f4522365888fdddcf3c854e79e5928447fe1a2388353efb2f0d30db8ba7c81bc",
+				"f4522365888fdddcf3c854e79e5928447fe1a2388353efb2f0d30db8ba7c81bc",
+				"11b52b511de1f0d8c4b5e5a3beb053fb5497727d696de6dae338560e4e2f8e0c",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := subca.FindMinHashes(test.in)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("FindMinHashes mismatch (-want +got)\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Add the create-override-csr command, which is the first step in creating a Teleport CA override.

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan

### Test Environment

A local Teleport instance with a patched-in Sub CA service.

### Test Cases
- [x] `tctl auth create-override-csr --type=db_client` (writes to stdout)
- [x] `tctl auth create-override-csr --type=db_client --out=prefix` (writes file)
- [x] `tctl auth create-override-csr --subject`
- [x] `tctl auth create-override-csr --public-key`
- [x] `tctl auth create-override-csr` with multi-file output (CA has >1 key)
- [x] `tctl auth create-override-csr` with multi-PEM output (CA has >1 key)