### PR TITLE
Add AuthCallback to SSH clients to perform in-band MFA

### DIFF
--- a/api/client/proxy/client.go
+++ b/api/client/proxy/client.go
@@ -440,6 +440,7 @@ func (c *Client) SSHConfig(user string) ssh.ClientConfig {
 		SSHConfig:         c.cfg.SSHConfig.SSHConfig,
 		User:              user,
 		PublicKeyAuth:     c.cfg.SSHConfig.PublicKeyAuth,
+		AuthCallback:      c.cfg.SSHConfig.AuthCallback,
 		HostKeyCallback:   c.cfg.SSHConfig.HostKeyCallback,
 		BannerCallback:    c.cfg.SSHConfig.BannerCallback,
 		HostKeyAlgorithms: c.cfg.SSHConfig.HostKeyAlgorithms,

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"time"
 
 	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel/attribute"
@@ -39,6 +40,12 @@ const (
 
 	// instrumentationName is the name of this instrumentation package.
 	instrumentationName = "otelssh"
+
+	// SessionMFAAuthTimeout is the maximum amount of time to wait for the SSH authentication exchange to complete in
+	// when in-band MFA might be required. WebAuthn and SSO ceremonies can take longer than the
+	// defaults.DefaultIOTimeout, so this extended timeout prevents premature connection closure during the interactive
+	// handshake.
+	SessionMFAAuthTimeout = 3 * time.Minute
 )
 
 // EnvsReq contains json marshaled key:value pairs sent as the
@@ -138,14 +145,16 @@ func Dial(ctx context.Context, network, addr string, config *ssh.ClientConfig, o
 // allowing spans to be properly correlated across the SSH connection.
 //
 // The connection respects the earliest of the following:
-// - The context's deadline or cancellation
-// - The timeout specified in the config
-// - A default timeout of 30 seconds if config doesn't specify a timeout
+//   - The context's deadline or cancellation
+//   - The timeout specified in the config
+//   - A default timeout of 30 seconds if config doesn't specify a timeout
+//   - When AuthCallback is set, timeout extends to SessionMFAAuthTimeout for interactive MFA.
 //
 // Behavior based on config.Timeout:
 // - If > 0: the timeout is applied in addition to any context deadline.
+// - If >= 0 && config.AuthCallback is non-nil: the timeout is extended to at least SessionMFAAuthTimeout.
 // - If == 0: a default timeout of 30 seconds is used to avoid hanging connections.
-// - If < 0: only the context’s deadline or cancellation is used.
+// - If < 0: only the context's deadline or cancellation is used.
 func NewClientConnWithTimeout(ctx context.Context, conn net.Conn, addr string, config *ssh.ClientConfig, opts ...tracing.Option) (ssh.Conn, <-chan ssh.NewChannel, <-chan *ssh.Request, error) {
 	tracer := tracing.NewConfig(opts).TracerProvider.Tracer(instrumentationName)
 	ctx, span := tracer.Start( //nolint:staticcheck,ineffassign // keeping shadowed ctx to avoid accidental missing in the future
@@ -164,34 +173,13 @@ func NewClientConnWithTimeout(ctx context.Context, conn net.Conn, addr string, c
 	)
 	defer span.End()
 
-	// ssh.ClientConfig.Timeout is not the total timeout for the connection
-	// establishment, including DNS resolution, TCP connection, but it doesn't
-	// include the SSH estalbishment.
-	// From the crypto/ssh docs:
-	// > Timeout is the maximum amount of time for the TCP connection to establish.
-	//
-	// Since we pass the connection here, the timeout will never be enforced by the
-	// ssh package. `NewClientConnWithDeadline` tries to enforced it by setting
-	// the read deadline on the connection, but might not be sufficient because
-	// we have some net.Conn implementations that don't support setting read deadlines
-	// and will block forever.
-	// To be sure that we don't block forever, we set up a timer that will close
-	// the connection when the timeout is reached.
-	// If the context has a deadline, we use that instead and take the minimum
-	// between the two.
-	// If neither is set, we default to 30 seconds.
-
-	// We aim to close the connection to avoid clients to hang forever
-	// if the server is not responding.
-
-	// If config.Timeout is negative, we don't set a timeout and restrict
-	// ourselves to the context deadline if any.
-	if config.Timeout >= 0 {
-		newCtx, cancel := context.WithTimeout(
-			ctx,
-			cmp.Or(config.Timeout, defaults.DefaultIOTimeout),
-		)
+	// ssh.ClientConfig.Timeout applies only to TCP dial, not the SSH handshake. Since we pass an already-connected
+	// net.Conn, x/crypto/ssh won't enforce it. We enforce a timeout around NewClientConn instead to prevent hanging
+	// connections when the server is unresponsive or net.Conn doesn't support read deadlines.
+	if timeout, ok := computeTimeout(config); ok {
+		newCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
+
 		ctx = newCtx
 	}
 
@@ -296,4 +284,19 @@ func wrapPayload(ctx context.Context, supported tracingCapability, propagator pr
 	}
 
 	return payload
+}
+
+// computeTimeout returns the effective timeout for SSH connection establishment. If config.Timeout is negative, ok is
+// false and no timeout should be applied.
+func computeTimeout(config *ssh.ClientConfig) (timeout time.Duration, ok bool) {
+	if config.Timeout < 0 {
+		return 0, false
+	}
+
+	timeout = cmp.Or(config.Timeout, defaults.DefaultIOTimeout)
+	if config.AuthCallback != nil {
+		timeout = max(timeout, SessionMFAAuthTimeout)
+	}
+
+	return timeout, true
 }

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -176,7 +176,12 @@ func NewClientConnWithTimeout(ctx context.Context, conn net.Conn, addr string, c
 	// ssh.ClientConfig.Timeout applies only to TCP dial, not the SSH handshake. Since we pass an already-connected
 	// net.Conn, x/crypto/ssh won't enforce it. We enforce a timeout around NewClientConn instead to prevent hanging
 	// connections when the server is unresponsive or net.Conn doesn't support read deadlines.
-	if timeout, ok := computeTimeout(config); ok {
+	if config.Timeout >= 0 {
+		timeout := cmp.Or(config.Timeout, defaults.DefaultIOTimeout)
+		if config.AuthCallback != nil {
+			timeout = max(timeout, sessionMFAAuthTimeout)
+		}
+
 		newCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 
@@ -284,19 +289,4 @@ func wrapPayload(ctx context.Context, supported tracingCapability, propagator pr
 	}
 
 	return payload
-}
-
-// computeTimeout returns the effective timeout for SSH connection establishment. If config.Timeout is negative, ok is
-// false and no timeout should be applied.
-func computeTimeout(config *ssh.ClientConfig) (timeout time.Duration, ok bool) {
-	if config.Timeout < 0 {
-		return 0, false
-	}
-
-	timeout = cmp.Or(config.Timeout, defaults.DefaultIOTimeout)
-	if config.AuthCallback != nil {
-		timeout = max(timeout, sessionMFAAuthTimeout)
-	}
-
-	return timeout, true
 }

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -41,11 +41,11 @@ const (
 	// instrumentationName is the name of this instrumentation package.
 	instrumentationName = "otelssh"
 
-	// SessionMFAAuthTimeout is the maximum amount of time to wait for the SSH authentication exchange to complete in
+	// sessionMFAAuthTimeout is the maximum amount of time to wait for the SSH authentication exchange to complete in
 	// when in-band MFA might be required. WebAuthn and SSO ceremonies can take longer than the
 	// defaults.DefaultIOTimeout, so this extended timeout prevents premature connection closure during the interactive
 	// handshake.
-	SessionMFAAuthTimeout = 3 * time.Minute
+	sessionMFAAuthTimeout = 3 * time.Minute
 )
 
 // EnvsReq contains json marshaled key:value pairs sent as the
@@ -295,7 +295,7 @@ func computeTimeout(config *ssh.ClientConfig) (timeout time.Duration, ok bool) {
 
 	timeout = cmp.Or(config.Timeout, defaults.DefaultIOTimeout)
 	if config.AuthCallback != nil {
-		timeout = max(timeout, SessionMFAAuthTimeout)
+		timeout = max(timeout, sessionMFAAuthTimeout)
 	}
 
 	return timeout, true

--- a/api/observability/tracing/ssh/ssh_test.go
+++ b/api/observability/tracing/ssh/ssh_test.go
@@ -35,7 +35,6 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/observability/tracing"
 )
 
@@ -428,8 +427,9 @@ func TestWrapPayload(t *testing.T) {
 func TestNewClientConnTimeout(t *testing.T) {
 	t.Parallel()
 
-	// This test ensure that NewClientConnWithTimeout respects the context
-	// timeout and does not hang indefinitely.
+	// This test ensures that NewClientConnWithTimeout respects the context timeout and does not hang indefinitely.
+	// Sub-tests use elapsed time assertions to distinguish which timeout fired, since both context deadline and config
+	// timeout produce context.DeadlineExceeded.
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
@@ -459,19 +459,23 @@ func TestNewClientConnTimeout(t *testing.T) {
 	t.Run("context timeout is respected", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
-		t.Cleanup(cancel)
-
 		conn, err := net.Dial("tcp", listener.Addr().String())
 		require.NoError(t, err)
+
+		start := time.Now()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
+		t.Cleanup(cancel)
 
 		_, _, _, err = NewClientConnWithTimeout(ctx, conn, listener.Addr().String(), &ssh.ClientConfig{
 			Timeout:         -1,
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		})
 
-		require.Error(t, err)
-		require.ErrorIs(t, err, context.DeadlineExceeded, "expected context deadline exceeded error, got: %v", err)
+		elapsed := time.Since(start)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.GreaterOrEqual(t, elapsed.Milliseconds(), int64(5))
 	})
 
 	t.Run("config timeout is respected", func(t *testing.T) {
@@ -480,77 +484,43 @@ func TestNewClientConnTimeout(t *testing.T) {
 		conn, err := net.Dial("tcp", listener.Addr().String())
 		require.NoError(t, err)
 
+		start := time.Now()
+
 		_, _, _, err = NewClientConnWithTimeout(t.Context(), conn, listener.Addr().String(), &ssh.ClientConfig{
 			Timeout:         5 * time.Millisecond,
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		})
 
-		require.Error(t, err)
-		require.ErrorIs(t, err, context.DeadlineExceeded, "expected context deadline exceeded error, got: %v", err)
+		elapsed := time.Since(start)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.GreaterOrEqual(t, elapsed.Milliseconds(), int64(5))
 	})
 
-}
+	t.Run("non-nil AuthCallback extends timeout", func(t *testing.T) {
+		t.Parallel()
 
-func TestComputeTimeout(t *testing.T) {
-	t.Parallel()
+		conn, err := net.Dial("tcp", listener.Addr().String())
+		require.NoError(t, err)
 
-	for _, tt := range []struct {
-		name          string
-		config        *ssh.ClientConfig
-		wantTimeout   time.Duration
-		wantNoTimeout bool
-	}{
-		{
-			name:        "zero timeout uses default",
-			config:      &ssh.ClientConfig{},
-			wantTimeout: defaults.DefaultIOTimeout,
-		},
-		{
-			name:          "negative timeout disables timeout",
-			config:        &ssh.ClientConfig{Timeout: -time.Second},
-			wantNoTimeout: true,
-		},
-		{
-			name:        "positive timeout is preserved",
-			config:      &ssh.ClientConfig{Timeout: 10 * time.Second},
-			wantTimeout: 10 * time.Second,
-		},
-		{
-			name: "zero timeout with auth callback extends to MFA timeout",
-			config: &ssh.ClientConfig{
-				AuthCallback: func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) { return nil, nil },
+		start := time.Now()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+		t.Cleanup(cancel)
+
+		_, _, _, err = NewClientConnWithTimeout(ctx, conn, listener.Addr().String(), &ssh.ClientConfig{
+			Timeout:         5 * time.Millisecond,
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			AuthCallback: func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
+				return nil, nil // no-op
 			},
-			wantTimeout: sessionMFAAuthTimeout,
-		},
-		{
-			name: "positive timeout less than MFA extends to MFA timeout",
-			config: &ssh.ClientConfig{
-				Timeout:      10 * time.Second,
-				AuthCallback: func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) { return nil, nil },
-			},
-			wantTimeout: sessionMFAAuthTimeout,
-		},
-		{
-			name: "positive timeout greater than MFA is preserved",
-			config: &ssh.ClientConfig{
-				Timeout:      5 * time.Minute,
-				AuthCallback: func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) { return nil, nil },
-			},
-			wantTimeout: 5 * time.Minute,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			timeout, ok := computeTimeout(tt.config)
-
-			if tt.wantNoTimeout {
-				require.False(t, ok)
-				return
-			}
-
-			require.True(t, ok)
-			require.Equal(t, tt.wantTimeout, timeout)
 		})
-	}
+
+		elapsed := time.Since(start)
+
+		// AuthCallback extends timeout to sessionMFAAuthTimeout (3 min). The 50 ms context deadline fires first,
+		// proving the extension was applied. Without the extension, config.Timeout (5 ms) would fire instead.
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.GreaterOrEqual(t, elapsed.Milliseconds(), int64(50))
+	})
 }

--- a/api/observability/tracing/ssh/ssh_test.go
+++ b/api/observability/tracing/ssh/ssh_test.go
@@ -520,7 +520,7 @@ func TestComputeTimeout(t *testing.T) {
 			config: &ssh.ClientConfig{
 				AuthCallback: func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) { return nil, nil },
 			},
-			wantTimeout: SessionMFAAuthTimeout,
+			wantTimeout: sessionMFAAuthTimeout,
 		},
 		{
 			name: "positive timeout less than MFA extends to MFA timeout",
@@ -528,7 +528,7 @@ func TestComputeTimeout(t *testing.T) {
 				Timeout:      10 * time.Second,
 				AuthCallback: func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) { return nil, nil },
 			},
-			wantTimeout: SessionMFAAuthTimeout,
+			wantTimeout: sessionMFAAuthTimeout,
 		},
 		{
 			name: "positive timeout greater than MFA is preserved",

--- a/api/observability/tracing/ssh/ssh_test.go
+++ b/api/observability/tracing/ssh/ssh_test.go
@@ -35,6 +35,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/observability/tracing"
 )
 
@@ -488,4 +489,68 @@ func TestNewClientConnTimeout(t *testing.T) {
 		require.ErrorIs(t, err, context.DeadlineExceeded, "expected context deadline exceeded error, got: %v", err)
 	})
 
+}
+
+func TestComputeTimeout(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name          string
+		config        *ssh.ClientConfig
+		wantTimeout   time.Duration
+		wantNoTimeout bool
+	}{
+		{
+			name:        "zero timeout uses default",
+			config:      &ssh.ClientConfig{},
+			wantTimeout: defaults.DefaultIOTimeout,
+		},
+		{
+			name:          "negative timeout disables timeout",
+			config:        &ssh.ClientConfig{Timeout: -time.Second},
+			wantNoTimeout: true,
+		},
+		{
+			name:        "positive timeout is preserved",
+			config:      &ssh.ClientConfig{Timeout: 10 * time.Second},
+			wantTimeout: 10 * time.Second,
+		},
+		{
+			name: "zero timeout with auth callback extends to MFA timeout",
+			config: &ssh.ClientConfig{
+				AuthCallback: func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) { return nil, nil },
+			},
+			wantTimeout: SessionMFAAuthTimeout,
+		},
+		{
+			name: "positive timeout less than MFA extends to MFA timeout",
+			config: &ssh.ClientConfig{
+				Timeout:      10 * time.Second,
+				AuthCallback: func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) { return nil, nil },
+			},
+			wantTimeout: SessionMFAAuthTimeout,
+		},
+		{
+			name: "positive timeout greater than MFA is preserved",
+			config: &ssh.ClientConfig{
+				Timeout:      5 * time.Minute,
+				AuthCallback: func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) { return nil, nil },
+			},
+			wantTimeout: 5 * time.Minute,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			timeout, ok := computeTimeout(tt.config)
+
+			if tt.wantNoTimeout {
+				require.False(t, ok)
+				return
+			}
+
+			require.True(t, ok)
+			require.Equal(t, tt.wantTimeout, timeout)
+		})
+	}
 }

--- a/api/ssh/client.go
+++ b/api/ssh/client.go
@@ -190,10 +190,7 @@ type ClientConfig struct {
 	Timeout time.Duration
 
 	// AuthCallback, if non-nil, is invoked before each authentication attempt.
-	//
-	// TODO(cthach): Enable when https://github.com/golang/go/issues/76146 is resolved and a new version of x/crypto/ssh
-	// is released.
-	// AuthCallback ssh.ClientAuthCallback
+	AuthCallback ssh.ClientAuthCallback
 }
 
 // SSHClientConfig builds a new [ssh.ClientConfig] from the client config.
@@ -215,6 +212,7 @@ func (c ClientConfig) sshClientConfig() (*ssh.ClientConfig, error) {
 		Config:            c.SSHConfig,
 		User:              c.User,
 		Auth:              authMethods,
+		AuthCallback:      c.AuthCallback,
 		HostKeyCallback:   c.HostKeyCallback,
 		BannerCallback:    c.BannerCallback,
 		ClientVersion:     c.clientVersion(),
@@ -314,10 +312,8 @@ func NewClientConn(
 
 func (c ClientConfig) clientVersion() string {
 	switch {
-	// TODO(cthach): Set the in-band MFA feature flag using if AuthCallback is non-nil once
-	// https://github.com/golang/go/issues/76146 is resolved and a new version of x/crypto/ssh is released.
-	// case c.AuthCallback != nil:
-	// 	return clientVersionWithFeatures(InBandMFAFeature)
+	case c.AuthCallback != nil:
+		return ClientVersionWithFeatures(InBandMFAFeature)
 
 	default:
 		return DefaultClientVersion

--- a/api/ssh/client.go
+++ b/api/ssh/client.go
@@ -46,6 +46,11 @@ const (
 
 	// InBandMFAFeature is a flag included in the client version string to indicate support for in-band MFA (RFD 234).
 	InBandMFAFeature = "mfav1"
+
+	// SessionMFAAuthTimeout is the timeout for authentication when in-band MFA may be required. WebAuthn and SSO
+	// ceremonies can take longer than the defaults.DefaultIOTimeout, so this extended timeout prevents premature
+	// connection closure during the interactive handshake.
+	SessionMFAAuthTimeout = 3 * time.Minute
 )
 
 // ClientVersionWithFeatures returns a client version string that includes the specified features. If no features are
@@ -208,6 +213,11 @@ func (c ClientConfig) sshClientConfig() (*ssh.ClientConfig, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	timeout := cmp.Or(c.Timeout, defaults.DefaultIOTimeout)
+	if c.AuthCallback != nil {
+		timeout = cmp.Or(c.Timeout, SessionMFAAuthTimeout)
+	}
+
 	return &ssh.ClientConfig{
 		Config:            c.SSHConfig,
 		User:              c.User,
@@ -217,7 +227,7 @@ func (c ClientConfig) sshClientConfig() (*ssh.ClientConfig, error) {
 		BannerCallback:    c.BannerCallback,
 		ClientVersion:     c.clientVersion(),
 		HostKeyAlgorithms: slices.Clone(c.HostKeyAlgorithms),
-		Timeout:           cmp.Or(c.Timeout, defaults.DefaultIOTimeout),
+		Timeout:           timeout,
 	}, nil
 }
 

--- a/api/ssh/client.go
+++ b/api/ssh/client.go
@@ -46,11 +46,6 @@ const (
 
 	// InBandMFAFeature is a flag included in the client version string to indicate support for in-band MFA (RFD 234).
 	InBandMFAFeature = "mfav1"
-
-	// SessionMFAAuthTimeout is the timeout for authentication when in-band MFA may be required. WebAuthn and SSO
-	// ceremonies can take longer than the defaults.DefaultIOTimeout, so this extended timeout prevents premature
-	// connection closure during the interactive handshake.
-	SessionMFAAuthTimeout = 3 * time.Minute
 )
 
 // ClientVersionWithFeatures returns a client version string that includes the specified features. If no features are
@@ -213,11 +208,6 @@ func (c ClientConfig) sshClientConfig() (*ssh.ClientConfig, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	timeout := cmp.Or(c.Timeout, defaults.DefaultIOTimeout)
-	if c.AuthCallback != nil {
-		timeout = cmp.Or(c.Timeout, SessionMFAAuthTimeout)
-	}
-
 	return &ssh.ClientConfig{
 		Config:            c.SSHConfig,
 		User:              c.User,
@@ -227,7 +217,7 @@ func (c ClientConfig) sshClientConfig() (*ssh.ClientConfig, error) {
 		BannerCallback:    c.BannerCallback,
 		ClientVersion:     c.clientVersion(),
 		HostKeyAlgorithms: slices.Clone(c.HostKeyAlgorithms),
-		Timeout:           timeout,
+		Timeout:           cmp.Or(c.Timeout, defaults.DefaultIOTimeout),
 	}, nil
 }
 

--- a/api/ssh/client_test.go
+++ b/api/ssh/client_test.go
@@ -506,6 +506,48 @@ func TestClientWrappedFuncsEarlyReturnsOnValidationErrors(t *testing.T) {
 	require.Nil(t, reqs)
 }
 
+func TestClientVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		config ClientConfig
+		want   string
+	}{
+		{
+			name: "no features",
+			config: ClientConfig{
+				User: "alice",
+				PublicKeyAuth: PublicKeyAuthConfig{
+					Signers: func() ([]ssh.Signer, error) {
+						return nil, nil
+					},
+				},
+			},
+			want: DefaultClientVersion,
+		},
+		{
+			name: "with in-band MFA feature",
+			config: ClientConfig{
+				User: "alice",
+				PublicKeyAuth: PublicKeyAuthConfig{
+					Signers: func() ([]ssh.Signer, error) {
+						return nil, nil
+					},
+				},
+				AuthCallback: func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
+					return struct{ ssh.AuthMethod }{}, nil
+				},
+			},
+			want: ClientVersionWithFeatures(InBandMFAFeature),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.config.clientVersion())
+		})
+	}
+}
+
 func generateSigner(t *testing.T) ssh.Signer {
 	t.Helper()
 

--- a/api/ssh/client_test.go
+++ b/api/ssh/client_test.go
@@ -363,21 +363,69 @@ func TestClientConfigSSHClientConfigSetsDefaults(t *testing.T) {
 
 	signer := generateSigner(t)
 
-	cfg := ClientConfig{
-		User: "alice",
-		PublicKeyAuth: PublicKeyAuthConfig{
-			Signers: func() ([]ssh.Signer, error) {
-				return []ssh.Signer{signer}, nil
+	base := func() ClientConfig {
+		return ClientConfig{
+			User: "alice",
+			PublicKeyAuth: PublicKeyAuthConfig{
+				Signers: func() ([]ssh.Signer, error) { return []ssh.Signer{signer}, nil },
 			},
-		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint: gosec // This is a test.
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
 	}
 
-	sshConfig, err := cfg.sshClientConfig()
-	require.NoError(t, err)
-	require.Equal(t, DefaultClientVersion, sshConfig.ClientVersion)
-	require.Len(t, sshConfig.Auth, 1)
-	require.Equal(t, defaults.DefaultIOTimeout, sshConfig.Timeout)
+	for _, tt := range []struct {
+		name        string
+		mutate      func(ClientConfig) ClientConfig
+		wantVersion string
+		wantAuthLen int
+		wantTimeout time.Duration
+	}{
+		{
+			name:        "defaults",
+			mutate:      func(cfg ClientConfig) ClientConfig { return cfg },
+			wantVersion: DefaultClientVersion,
+			wantAuthLen: 1,
+			wantTimeout: defaults.DefaultIOTimeout,
+		},
+		{
+			name: "AuthCallback extends timeout",
+			mutate: func(cfg ClientConfig) ClientConfig {
+				cfg.AuthCallback = func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
+					return nil, nil
+				}
+
+				return cfg
+			},
+			wantVersion: ClientVersionWithFeatures(InBandMFAFeature),
+			wantAuthLen: 1,
+			wantTimeout: SessionMFAAuthTimeout,
+		},
+		{
+			name: "explicit timeout overrides all defaults",
+			mutate: func(cfg ClientConfig) ClientConfig {
+				cfg.AuthCallback = func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
+					return nil, nil
+				}
+
+				cfg.Timeout = 5 * time.Minute
+
+				return cfg
+			},
+			wantVersion: ClientVersionWithFeatures(InBandMFAFeature),
+			wantAuthLen: 1,
+			wantTimeout: 5 * time.Minute,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sshConfig, err := tt.mutate(base()).sshClientConfig()
+			require.NoError(t, err)
+			require.Equal(t, tt.wantVersion, sshConfig.ClientVersion)
+			require.Len(t, sshConfig.Auth, tt.wantAuthLen)
+			require.Equal(t, tt.wantTimeout, sshConfig.Timeout)
+		})
+	}
 }
 
 func TestClientConfigSSHClientConfigClonesAlgorithmsAndPreservesFields(t *testing.T) {

--- a/api/ssh/client_test.go
+++ b/api/ssh/client_test.go
@@ -363,69 +363,21 @@ func TestClientConfigSSHClientConfigSetsDefaults(t *testing.T) {
 
 	signer := generateSigner(t)
 
-	base := func() ClientConfig {
-		return ClientConfig{
-			User: "alice",
-			PublicKeyAuth: PublicKeyAuthConfig{
-				Signers: func() ([]ssh.Signer, error) { return []ssh.Signer{signer}, nil },
+	cfg := ClientConfig{
+		User: "alice",
+		PublicKeyAuth: PublicKeyAuthConfig{
+			Signers: func() ([]ssh.Signer, error) {
+				return []ssh.Signer{signer}, nil
 			},
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		}
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint: gosec // This is a test.
 	}
 
-	for _, tt := range []struct {
-		name        string
-		mutate      func(ClientConfig) ClientConfig
-		wantVersion string
-		wantAuthLen int
-		wantTimeout time.Duration
-	}{
-		{
-			name:        "defaults",
-			mutate:      func(cfg ClientConfig) ClientConfig { return cfg },
-			wantVersion: DefaultClientVersion,
-			wantAuthLen: 1,
-			wantTimeout: defaults.DefaultIOTimeout,
-		},
-		{
-			name: "AuthCallback extends timeout",
-			mutate: func(cfg ClientConfig) ClientConfig {
-				cfg.AuthCallback = func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
-					return nil, nil
-				}
-
-				return cfg
-			},
-			wantVersion: ClientVersionWithFeatures(InBandMFAFeature),
-			wantAuthLen: 1,
-			wantTimeout: SessionMFAAuthTimeout,
-		},
-		{
-			name: "explicit timeout overrides all defaults",
-			mutate: func(cfg ClientConfig) ClientConfig {
-				cfg.AuthCallback = func(ctx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
-					return nil, nil
-				}
-
-				cfg.Timeout = 5 * time.Minute
-
-				return cfg
-			},
-			wantVersion: ClientVersionWithFeatures(InBandMFAFeature),
-			wantAuthLen: 1,
-			wantTimeout: 5 * time.Minute,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			sshConfig, err := tt.mutate(base()).sshClientConfig()
-			require.NoError(t, err)
-			require.Equal(t, tt.wantVersion, sshConfig.ClientVersion)
-			require.Len(t, sshConfig.Auth, tt.wantAuthLen)
-			require.Equal(t, tt.wantTimeout, sshConfig.Timeout)
-		})
-	}
+	sshConfig, err := cfg.sshClientConfig()
+	require.NoError(t, err)
+	require.Equal(t, DefaultClientVersion, sshConfig.ClientVersion)
+	require.Len(t, sshConfig.Auth, 1)
+	require.Equal(t, defaults.DefaultIOTimeout, sshConfig.Timeout)
 }
 
 func TestClientConfigSSHClientConfigClonesAlgorithmsAndPreservesFields(t *testing.T) {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2086,8 +2086,8 @@ func (tc *TeleportClient) connectToNode(ctx context.Context, clt *ClusterClient,
 	sshConfig := clt.ProxyClient.SSHConfig(user)
 	sshConfig.AuthCallback = clientssh.AuthCallback(
 		connectCtx,
-		func() (clientssh.MFACeremonyPerformer, error) {
-			return clt.PerformSessionMFACeremony, nil
+		clientssh.AuthCallbackConfig{
+			MFAPerformer: clt.PerformSessionMFACeremony,
 		},
 	)
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -81,6 +81,7 @@ import (
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	"github.com/gravitational/teleport/lib/authz"
 	libmfa "github.com/gravitational/teleport/lib/client/mfa"
+	clientssh "github.com/gravitational/teleport/lib/client/ssh"
 	"github.com/gravitational/teleport/lib/client/sso"
 	"github.com/gravitational/teleport/lib/client/terminal"
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -1763,6 +1764,18 @@ func (tc *TeleportClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 	return result.KeyRing, nil
 }
 
+// PerformSessionMFACeremony performs a session-bound MFA ceremony for an SSH session
+// and returns the challenge name.
+func (tc *TeleportClient) PerformSessionMFACeremony(ctx context.Context, sessionID []byte) (string, error) {
+	clusterClient, err := tc.ConnectToCluster(ctx)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	defer clusterClient.Close()
+
+	return clusterClient.PerformSessionMFACeremony(ctx, sessionID)
+}
+
 // CreateAccessRequestV2 registers a new access request with the auth server.
 func (tc *TeleportClient) CreateAccessRequestV2(ctx context.Context, req types.AccessRequest) (types.AccessRequest, error) {
 	ctx, span := tc.Tracer.Start(
@@ -2082,9 +2095,17 @@ func (tc *TeleportClient) connectToNode(ctx context.Context, clt *ClusterClient,
 		return nil, trace.Wrap(err)
 	}
 
+	sshConfig := clt.ProxyClient.SSHConfig(user)
+	sshConfig.AuthCallback = clientssh.AuthCallback(
+		connectCtx,
+		func() (clientssh.Performer, error) {
+			return tc.PerformSessionMFACeremony, nil
+		},
+	)
+
 	nodeClient, err := NewNodeClient(
 		connectCtx,
-		clt.ProxyClient.SSHConfig(user),
+		sshConfig,
 		conn,
 		nodeDetails.ProxyFormat(),
 		nodeDetails.Addr,

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2098,7 +2098,7 @@ func (tc *TeleportClient) connectToNode(ctx context.Context, clt *ClusterClient,
 	sshConfig := clt.ProxyClient.SSHConfig(user)
 	sshConfig.AuthCallback = clientssh.AuthCallback(
 		connectCtx,
-		func() (clientssh.Performer, error) {
+		func() (clientssh.MFACeremonyPerformer, error) {
 			return tc.PerformSessionMFACeremony, nil
 		},
 	)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1764,18 +1764,6 @@ func (tc *TeleportClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 	return result.KeyRing, nil
 }
 
-// PerformSessionMFACeremony performs a session-bound MFA ceremony for an SSH session
-// and returns the challenge name.
-func (tc *TeleportClient) PerformSessionMFACeremony(ctx context.Context, sessionID []byte) (string, error) {
-	clusterClient, err := tc.ConnectToCluster(ctx)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-	defer clusterClient.Close()
-
-	return clusterClient.PerformSessionMFACeremony(ctx, sessionID)
-}
-
 // CreateAccessRequestV2 registers a new access request with the auth server.
 func (tc *TeleportClient) CreateAccessRequestV2(ctx context.Context, req types.AccessRequest) (types.AccessRequest, error) {
 	ctx, span := tc.Tracer.Start(
@@ -2099,7 +2087,7 @@ func (tc *TeleportClient) connectToNode(ctx context.Context, clt *ClusterClient,
 	sshConfig.AuthCallback = clientssh.AuthCallback(
 		connectCtx,
 		func() (clientssh.MFACeremonyPerformer, error) {
-			return tc.PerformSessionMFACeremony, nil
+			return clt.PerformSessionMFACeremony, nil
 		},
 	)
 

--- a/lib/client/ssh/ssh.go
+++ b/lib/client/ssh/ssh.go
@@ -57,8 +57,7 @@ func AuthCallback(ctx context.Context, createPerformer func() (Performer, error)
 }
 
 // KeyboardInteractive returns an ssh.AuthMethod that performs any additional verification requested by the server via
-// the keyboard-interactive authentication method. This method is intended to be used with the
-// x/crypto/ssh#ClientConfig.AuthCallback field as proposed in https://github.com/golang/go/issues/76146.
+// the keyboard-interactive authentication method.
 func KeyboardInteractive(ctx context.Context, p Performer, m ssh.ConnMetadata) ssh.AuthMethod {
 	return ssh.KeyboardInteractive(
 		func(_ string, _ string, questions []string, _ []bool) ([]string, error) {

--- a/lib/client/ssh/ssh.go
+++ b/lib/client/ssh/ssh.go
@@ -30,7 +30,7 @@ import (
 )
 
 // MFACeremonyPerformer performs a session-bound MFA ceremony with the user and returns the solved challenge name.
-type MFACeremonyPerformer func(ctx context.Context, sessionID []byte) (challengeName string, _ error)
+type MFACeremonyPerformer func(ctx context.Context, sessionID []byte) (challengeName string, err error)
 
 // AuthCallback returns an ssh.ClientAuthCallback that dynamically selects an auth method based on the server's response
 // during the handshake. When the server signals partial success for publickey, it offers keyboard-interactive to

--- a/lib/client/ssh/ssh.go
+++ b/lib/client/ssh/ssh.go
@@ -20,6 +20,7 @@ package ssh
 
 import (
 	"context"
+	"slices"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
@@ -28,15 +29,37 @@ import (
 	sshpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/ssh/v1"
 )
 
-// MFACeremonyPerformer performs a session-bound MFA ceremony with the user and returns the solved challenge name.
-type MFACeremonyPerformer interface {
-	PerformSessionMFACeremony(ctx context.Context, sessionID []byte) (challengeName string, err error)
+// Performer performs a session-bound MFA ceremony with the user and returns the solved challenge name.
+type Performer func(ctx context.Context, sessionID []byte) (string, error)
+
+// AuthCallback returns an ssh.ClientAuthCallback that performs in-band MFA via keyboard-interactive when the server
+// responds with partial success after publickey.
+func AuthCallback(ctx context.Context, performerFn func() (Performer, error)) ssh.ClientAuthCallback {
+	return func(authCtx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
+		// If the server responds with partial success for publickey auth method and keyboard-interactive is allowed,
+		// then the server is likely enforcing in-band MFA. In this case, return a keyboard-interactive callback that
+		// will perform the MFA ceremony when invoked as long as it hasn't already been tried.
+		if slices.Contains(authCtx.PartialSuccessMethods, "publickey") &&
+			slices.Contains(authCtx.AllowedMethods, "keyboard-interactive") &&
+			!slices.Contains(authCtx.TriedMethods, "keyboard-interactive") {
+			performer, err := performerFn()
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			return KeyboardInteractive(ctx, performer, authCtx.Metadata), nil
+		}
+
+		// Returning nil, nil tells the SSH client there is no additional auth method to offer for this server response
+		// and fallback to the default behavior of trying the next auth method in the list.
+		return nil, nil
+	}
 }
 
 // KeyboardInteractive returns an ssh.AuthMethod that performs any additional verification requested by the server via
 // the keyboard-interactive authentication method. This method is intended to be used with the
 // x/crypto/ssh#ClientConfig.AuthCallback field as proposed in https://github.com/golang/go/issues/76146.
-func KeyboardInteractive(ctx context.Context, p MFACeremonyPerformer, m ssh.ConnMetadata) ssh.AuthMethod {
+func KeyboardInteractive(ctx context.Context, p Performer, m ssh.ConnMetadata) ssh.AuthMethod {
 	return ssh.KeyboardInteractive(
 		func(_ string, _ string, questions []string, _ []bool) ([]string, error) {
 			answers := make([]string, 0, len(questions))
@@ -73,8 +96,8 @@ func KeyboardInteractive(ctx context.Context, p MFACeremonyPerformer, m ssh.Conn
 
 // handleMFAPrompt returns an answer to a keyboard-interactive question requiring MFA by performing a session-bound MFA
 // ceremony with the user. The answer is a JSON-marshaled sshpb.MFAPromptResponse referencing the solved challenge.
-func handleMFAPrompt(ctx context.Context, p MFACeremonyPerformer, m ssh.ConnMetadata) (string, error) {
-	name, err := p.PerformSessionMFACeremony(ctx, m.SessionID())
+func handleMFAPrompt(ctx context.Context, p Performer, m ssh.ConnMetadata) (string, error) {
+	name, err := p(ctx, m.SessionID())
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/client/ssh/ssh.go
+++ b/lib/client/ssh/ssh.go
@@ -32,25 +32,28 @@ import (
 // MFACeremonyPerformer performs a session-bound MFA ceremony with the user and returns the solved challenge name.
 type MFACeremonyPerformer func(ctx context.Context, sessionID []byte) (challengeName string, err error)
 
+// AuthCallbackConfig holds configuration for in-band authentication callbacks.
+type AuthCallbackConfig struct {
+	// MFAPerformer is called when the server signals partial success for publickey + keyboard-interactive auth. If nil,
+	// the client will fall back to its default auth methods and will not perform in-band MFA.
+	MFAPerformer MFACeremonyPerformer
+}
+
 // AuthCallback returns an ssh.ClientAuthCallback that dynamically selects an auth method based on the server's response
 // during the handshake. When the server signals partial success for publickey, it offers keyboard-interactive to
 // perform additional auth (e.g., in-band MFA). Return (nil, nil) otherwise to let the client fall back to its default
 // auth methods.
-func AuthCallback(ctx context.Context, createPerformer func() (MFACeremonyPerformer, error)) ssh.ClientAuthCallback {
+func AuthCallback(ctx context.Context, config AuthCallbackConfig) ssh.ClientAuthCallback {
 	return func(authCtx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
 		// We use keyboard-interactive auth exclusively for when some auth-related data needs to be communicated to the
 		// client and back (e.g., in-band MFA). The partial success with publickey + keyboard-interactive pattern is
 		// unique to this flow and will not occur during normal auth. We offer it only once, skipping if
 		// keyboard-interactive has already been tried.
-		if slices.Contains(authCtx.PartialSuccessMethods, "publickey") &&
+		if config.MFAPerformer != nil &&
+			slices.Contains(authCtx.PartialSuccessMethods, "publickey") &&
 			slices.Contains(authCtx.AllowedMethods, "keyboard-interactive") &&
 			!slices.Contains(authCtx.TriedMethods, "keyboard-interactive") {
-			performer, err := createPerformer()
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			return KeyboardInteractive(ctx, performer, authCtx.Metadata), nil
+			return KeyboardInteractive(ctx, config.MFAPerformer, authCtx.Metadata), nil
 		}
 
 		// Returning nil, nil tells the SSH client there is no additional auth method to offer for this server response

--- a/lib/client/ssh/ssh.go
+++ b/lib/client/ssh/ssh.go
@@ -30,11 +30,11 @@ import (
 )
 
 // Performer performs a session-bound MFA ceremony with the user and returns the solved challenge name.
-type Performer func(ctx context.Context, sessionID []byte) (string, error)
+type Performer func(ctx context.Context, sessionID []byte) (challengeName string, _ error)
 
 // AuthCallback returns an ssh.ClientAuthCallback that performs in-band MFA via keyboard-interactive when the server
 // responds with partial success after publickey.
-func AuthCallback(ctx context.Context, performerFn func() (Performer, error)) ssh.ClientAuthCallback {
+func AuthCallback(ctx context.Context, createPerformer func() (Performer, error)) ssh.ClientAuthCallback {
 	return func(authCtx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
 		// If the server responds with partial success for publickey auth method and keyboard-interactive is allowed,
 		// then the server is likely enforcing in-band MFA. In this case, return a keyboard-interactive callback that
@@ -42,7 +42,7 @@ func AuthCallback(ctx context.Context, performerFn func() (Performer, error)) ss
 		if slices.Contains(authCtx.PartialSuccessMethods, "publickey") &&
 			slices.Contains(authCtx.AllowedMethods, "keyboard-interactive") &&
 			!slices.Contains(authCtx.TriedMethods, "keyboard-interactive") {
-			performer, err := performerFn()
+			performer, err := createPerformer()
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/client/ssh/ssh.go
+++ b/lib/client/ssh/ssh.go
@@ -29,16 +29,19 @@ import (
 	sshpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/ssh/v1"
 )
 
-// Performer performs a session-bound MFA ceremony with the user and returns the solved challenge name.
-type Performer func(ctx context.Context, sessionID []byte) (challengeName string, _ error)
+// MFACeremonyPerformer performs a session-bound MFA ceremony with the user and returns the solved challenge name.
+type MFACeremonyPerformer func(ctx context.Context, sessionID []byte) (challengeName string, _ error)
 
-// AuthCallback returns an ssh.ClientAuthCallback that performs in-band MFA via keyboard-interactive when the server
-// responds with partial success after publickey.
-func AuthCallback(ctx context.Context, createPerformer func() (Performer, error)) ssh.ClientAuthCallback {
+// AuthCallback returns an ssh.ClientAuthCallback that dynamically selects an auth method based on the server's response
+// during the handshake. When the server signals partial success for publickey, it offers keyboard-interactive to
+// perform additional auth (e.g., in-band MFA). Return (nil, nil) otherwise to let the client fall back to its default
+// auth methods.
+func AuthCallback(ctx context.Context, createPerformer func() (MFACeremonyPerformer, error)) ssh.ClientAuthCallback {
 	return func(authCtx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
-		// Teleport uses keyboard-interactive authentication exclusively for in-band MFA. The partial success with
-		// publickey + keyboard-interactive pattern is unique to this flow and will not occur during normal auth. We
-		// offer it only once, skipping if keyboard-interactive has already been tried.
+		// We use keyboard-interactive auth exclusively for when some auth-related data needs to be communicated to the
+		// client and back (e.g., in-band MFA). The partial success with publickey + keyboard-interactive pattern is
+		// unique to this flow and will not occur during normal auth. We offer it only once, skipping if
+		// keyboard-interactive has already been tried.
 		if slices.Contains(authCtx.PartialSuccessMethods, "publickey") &&
 			slices.Contains(authCtx.AllowedMethods, "keyboard-interactive") &&
 			!slices.Contains(authCtx.TriedMethods, "keyboard-interactive") {
@@ -58,7 +61,7 @@ func AuthCallback(ctx context.Context, createPerformer func() (Performer, error)
 
 // KeyboardInteractive returns an ssh.AuthMethod that performs any additional verification requested by the server via
 // the keyboard-interactive authentication method.
-func KeyboardInteractive(ctx context.Context, p Performer, m ssh.ConnMetadata) ssh.AuthMethod {
+func KeyboardInteractive(ctx context.Context, p MFACeremonyPerformer, m ssh.ConnMetadata) ssh.AuthMethod {
 	return ssh.KeyboardInteractive(
 		func(_ string, _ string, questions []string, _ []bool) ([]string, error) {
 			answers := make([]string, 0, len(questions))
@@ -95,7 +98,7 @@ func KeyboardInteractive(ctx context.Context, p Performer, m ssh.ConnMetadata) s
 
 // handleMFAPrompt returns an answer to a keyboard-interactive question requiring MFA by performing a session-bound MFA
 // ceremony with the user. The answer is a JSON-marshaled sshpb.MFAPromptResponse referencing the solved challenge.
-func handleMFAPrompt(ctx context.Context, p Performer, m ssh.ConnMetadata) (string, error) {
+func handleMFAPrompt(ctx context.Context, p MFACeremonyPerformer, m ssh.ConnMetadata) (string, error) {
 	name, err := p(ctx, m.SessionID())
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/client/ssh/ssh.go
+++ b/lib/client/ssh/ssh.go
@@ -36,9 +36,9 @@ type Performer func(ctx context.Context, sessionID []byte) (challengeName string
 // responds with partial success after publickey.
 func AuthCallback(ctx context.Context, createPerformer func() (Performer, error)) ssh.ClientAuthCallback {
 	return func(authCtx *ssh.ClientAuthContext) (ssh.AuthMethod, error) {
-		// If the server responds with partial success for publickey auth method and keyboard-interactive is allowed,
-		// then the server is likely enforcing in-band MFA. In this case, return a keyboard-interactive callback that
-		// will perform the MFA ceremony when invoked as long as it hasn't already been tried.
+		// Teleport uses keyboard-interactive authentication exclusively for in-band MFA. The partial success with
+		// publickey + keyboard-interactive pattern is unique to this flow and will not occur during normal auth. We
+		// offer it only once, skipping if keyboard-interactive has already been tried.
 		if slices.Contains(authCtx.PartialSuccessMethods, "publickey") &&
 			slices.Contains(authCtx.AllowedMethods, "keyboard-interactive") &&
 			!slices.Contains(authCtx.TriedMethods, "keyboard-interactive") {

--- a/lib/client/ssh/ssh_test.go
+++ b/lib/client/ssh/ssh_test.go
@@ -120,109 +120,101 @@ func TestKeyboardInteractive_InvalidAuthPrompt_NilPromptField(t *testing.T) {
 	require.Nil(t, answers)
 }
 
-func TestAuthCallback_ReturnsKeyboardInteractive(t *testing.T) {
+const (
+	keyboardInteractiveMethod = "keyboard-interactive"
+	passwordMethod            = "password"
+	publicKeyMethod           = "publickey"
+)
+
+func TestAuthCallback(t *testing.T) {
 	t.Parallel()
 
-	callback := clientssh.AuthCallback(
-		t.Context(),
-		func() (clientssh.Performer, error) {
-			return func(_ context.Context, _ []byte) (string, error) {
-				return "test-challenge", nil
-			}, nil
+	for _, tt := range []struct {
+		name             string
+		createPerformer  func() (clientssh.Performer, error)
+		authCtx          *ssh.ClientAuthContext
+		expectError      error
+		expectNil        bool
+		expectKICallback bool
+	}{
+		{
+			name: "returns keyboard-interactive callback on partial success",
+			createPerformer: func() (clientssh.Performer, error) {
+				return func(_ context.Context, _ []byte) (string, error) {
+					return "test-challenge", nil
+				}, nil
+			},
+			authCtx: &ssh.ClientAuthContext{
+				PartialSuccessMethods: []string{publicKeyMethod},
+				AllowedMethods:        []string{keyboardInteractiveMethod},
+				Metadata:              &mockConnMetadata{sessionID: []byte("test-session-id")},
+			},
+			expectKICallback: true,
 		},
-	)
-
-	authMethod, err := callback(
-		&ssh.ClientAuthContext{
-			PartialSuccessMethods: []string{"publickey"},
-			AllowedMethods:        []string{"keyboard-interactive"},
-			Metadata:              &mockConnMetadata{sessionID: []byte("test-session-id")},
+		{
+			name: "returns nil when keyboard-interactive not allowed",
+			authCtx: &ssh.ClientAuthContext{
+				PartialSuccessMethods: []string{publicKeyMethod},
+				AllowedMethods:        []string{passwordMethod},
+			},
+			expectNil: true,
 		},
-	)
-	require.NoError(t, err)
-
-	_, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
-	require.True(t, ok)
-}
-
-func TestAuthCallback_ReturnsNil_KeyboardInteractiveNotAllowed(t *testing.T) {
-	t.Parallel()
-
-	callback := clientssh.AuthCallback(
-		t.Context(),
-		func() (clientssh.Performer, error) {
-			return nil, nil
+		{
+			name: "returns nil when no publickey partial success",
+			authCtx: &ssh.ClientAuthContext{
+				PartialSuccessMethods: []string{passwordMethod},
+				AllowedMethods:        []string{keyboardInteractiveMethod},
+			},
+			expectNil: true,
 		},
-	)
-
-	authMethod, err := callback(
-		&ssh.ClientAuthContext{
-			PartialSuccessMethods: []string{"publickey"},
-			AllowedMethods:        []string{"password"},
+		{
+			name: "performer error propagates",
+			createPerformer: func() (clientssh.Performer, error) {
+				return nil, trace.BadParameter("some performer error")
+			},
+			authCtx: &ssh.ClientAuthContext{
+				PartialSuccessMethods: []string{publicKeyMethod},
+				AllowedMethods:        []string{keyboardInteractiveMethod},
+			},
+			expectError: trace.BadParameter("some performer error"),
+			expectNil:   true,
 		},
-	)
-	require.NoError(t, err)
-	require.Nil(t, authMethod)
-}
-
-func TestAuthCallback_ReturnsNil_NoPublickeyPartialSuccess(t *testing.T) {
-	t.Parallel()
-
-	callback := clientssh.AuthCallback(
-		t.Context(), func() (clientssh.Performer, error) {
-			return nil, nil
+		{
+			name: "returns nil when keyboard-interactive already tried",
+			authCtx: &ssh.ClientAuthContext{
+				PartialSuccessMethods: []string{publicKeyMethod},
+				AllowedMethods:        []string{keyboardInteractiveMethod},
+				TriedMethods:          []string{keyboardInteractiveMethod},
+			},
+			expectNil: true,
 		},
-	)
+	} {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
 
-	authMethod, err := callback(
-		&ssh.ClientAuthContext{
-			PartialSuccessMethods: []string{"password"},
-			AllowedMethods:        []string{"keyboard-interactive"},
-		},
-	)
-	require.NoError(t, err)
-	require.Nil(t, authMethod)
-}
+				callback := clientssh.AuthCallback(t.Context(), tt.createPerformer)
 
-func TestAuthCallback_PerformerErrorPropagates(t *testing.T) {
-	t.Parallel()
+				authMethod, err := callback(tt.authCtx)
 
-	callback := clientssh.AuthCallback(
-		t.Context(),
-		func() (clientssh.Performer, error) {
-			return nil, trace.BadParameter("some performer error")
-		},
-	)
+				if tt.expectError != nil {
+					require.ErrorIs(t, err, tt.expectError)
+				} else {
+					require.NoError(t, err)
+				}
 
-	authMethod, err := callback(
-		&ssh.ClientAuthContext{
-			PartialSuccessMethods: []string{"publickey"},
-			AllowedMethods:        []string{"keyboard-interactive"},
-		},
-	)
-	require.ErrorIs(t, err, trace.BadParameter("some performer error"))
-	require.Nil(t, authMethod)
-}
+				if tt.expectNil {
+					require.Nil(t, authMethod)
+				}
 
-func TestAuthCallback_ReturnsNil_TriedMethods(t *testing.T) {
-	t.Parallel()
-
-	callback := clientssh.AuthCallback(
-		t.Context(),
-		func() (clientssh.Performer, error) {
-			return nil, nil
-		},
-	)
-
-	authMethod, err := callback(
-		&ssh.ClientAuthContext{
-			PartialSuccessMethods: []string{"publickey"},
-			AllowedMethods:        []string{"keyboard-interactive"},
-			TriedMethods:          []string{"keyboard-interactive"},
-		},
-	)
-	require.NoError(t, err)
-	require.Nil(t, authMethod)
+				if tt.expectKICallback {
+					_, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+					require.True(t, ok)
+				}
+			},
+		)
+	}
 }
 
 type mockConnMetadata struct {

--- a/lib/client/ssh/ssh_test.go
+++ b/lib/client/ssh/ssh_test.go
@@ -36,14 +36,13 @@ func TestKeyboardInteractive_SuccessfulMFA(t *testing.T) {
 
 	authMethod := clientssh.KeyboardInteractive(
 		t.Context(),
-		&mockMFACeremonyPerformer{
-			challengeName: challengeName,
+		func(_ context.Context, _ []byte) (string, error) {
+			return challengeName, nil
 		},
 		&mockConnMetadata{
 			sessionID: []byte("test-session-id"),
 		},
 	)
-	require.NotNil(t, authMethod)
 
 	mfaPrompt := sshpb.AuthPrompt_builder{
 		MfaPrompt: &sshpb.MFAPrompt{},
@@ -52,8 +51,8 @@ func TestKeyboardInteractive_SuccessfulMFA(t *testing.T) {
 	require.NoError(t, err)
 
 	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
-	ki := authMethod.(ssh.KeyboardInteractiveChallenge)
-	require.IsType(t, ssh.KeyboardInteractiveChallenge(nil), ki)
+	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.True(t, ok)
 
 	answers, err := ki("", "", []string{string(mfaPromptJSON)}, []bool{})
 	require.NoError(t, err)
@@ -68,14 +67,13 @@ func TestKeyboardInteractive_SuccessfulMFA(t *testing.T) {
 func TestKeyboardInteractive_FailedMFA(t *testing.T) {
 	authMethod := clientssh.KeyboardInteractive(
 		t.Context(),
-		&mockMFACeremonyPerformer{
-			err: trace.Errorf("a-wild-error-appeared!"),
+		func(_ context.Context, _ []byte) (string, error) {
+			return "", trace.Errorf("a-wild-error-appeared!")
 		},
 		&mockConnMetadata{
 			sessionID: []byte("test-session-id"),
 		},
 	)
-	require.NotNil(t, authMethod)
 
 	mfaPrompt := sshpb.AuthPrompt_builder{
 		MfaPrompt: &sshpb.MFAPrompt{},
@@ -84,8 +82,8 @@ func TestKeyboardInteractive_FailedMFA(t *testing.T) {
 	require.NoError(t, err)
 
 	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
-	ki := authMethod.(ssh.KeyboardInteractiveChallenge)
-	require.IsType(t, ssh.KeyboardInteractiveChallenge(nil), ki)
+	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.True(t, ok)
 
 	answers, err := ki("", "", []string{string(mfaPromptJSON)}, []bool{})
 	require.ErrorContains(t, err, "a-wild-error-appeared!")
@@ -93,16 +91,11 @@ func TestKeyboardInteractive_FailedMFA(t *testing.T) {
 }
 
 func TestKeyboardInteractive_InvalidAuthPrompt_NonProtoQuestion(t *testing.T) {
-	authMethod := clientssh.KeyboardInteractive(
-		t.Context(),
-		nil,
-		nil,
-	)
-	require.NotNil(t, authMethod)
+	authMethod := clientssh.KeyboardInteractive(t.Context(), nil, nil)
 
 	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
-	ki := authMethod.(ssh.KeyboardInteractiveChallenge)
-	require.IsType(t, ssh.KeyboardInteractiveChallenge(nil), ki)
+	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.True(t, ok)
 
 	answers, err := ki("", "", []string{"invalid-auth-prompt"}, []bool{})
 	require.ErrorContains(t, err, "invalid value invalid-auth-prompt")
@@ -110,12 +103,7 @@ func TestKeyboardInteractive_InvalidAuthPrompt_NonProtoQuestion(t *testing.T) {
 }
 
 func TestKeyboardInteractive_InvalidAuthPrompt_NilPromptField(t *testing.T) {
-	authMethod := clientssh.KeyboardInteractive(
-		t.Context(),
-		nil,
-		nil,
-	)
-	require.NotNil(t, authMethod)
+	authMethod := clientssh.KeyboardInteractive(t.Context(), nil, nil)
 
 	mfaPrompt := &sshpb.AuthPrompt{
 		Prompt: nil,
@@ -124,27 +112,117 @@ func TestKeyboardInteractive_InvalidAuthPrompt_NilPromptField(t *testing.T) {
 	require.NoError(t, err)
 
 	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
-	ki := authMethod.(ssh.KeyboardInteractiveChallenge)
-	require.IsType(t, ssh.KeyboardInteractiveChallenge(nil), ki)
+	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.True(t, ok)
 
 	answers, err := ki("", "", []string{string(mfaPromptJSON)}, []bool{})
 	require.ErrorIs(t, err, trace.BadParameter("received sshpb.AuthPrompt with nil Prompt field"))
 	require.Nil(t, answers)
 }
 
-type mockMFACeremonyPerformer struct {
-	challengeName string
-	err           error
+func TestAuthCallback_ReturnsKeyboardInteractive(t *testing.T) {
+	t.Parallel()
+
+	callback := clientssh.AuthCallback(
+		t.Context(),
+		func() (clientssh.Performer, error) {
+			return func(_ context.Context, _ []byte) (string, error) {
+				return "test-challenge", nil
+			}, nil
+		},
+	)
+
+	authMethod, err := callback(
+		&ssh.ClientAuthContext{
+			PartialSuccessMethods: []string{"publickey"},
+			AllowedMethods:        []string{"keyboard-interactive"},
+			Metadata:              &mockConnMetadata{sessionID: []byte("test-session-id")},
+		},
+	)
+	require.NoError(t, err)
+
+	_, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.True(t, ok)
 }
 
-var _ clientssh.MFACeremonyPerformer = (*mockMFACeremonyPerformer)(nil)
+func TestAuthCallback_ReturnsNil_KeyboardInteractiveNotAllowed(t *testing.T) {
+	t.Parallel()
 
-func (m *mockMFACeremonyPerformer) PerformSessionMFACeremony(_ context.Context, _ []byte) (string, error) {
-	if m.err != nil {
-		return "", m.err
-	}
+	callback := clientssh.AuthCallback(
+		t.Context(),
+		func() (clientssh.Performer, error) {
+			return nil, nil
+		},
+	)
 
-	return m.challengeName, nil
+	authMethod, err := callback(
+		&ssh.ClientAuthContext{
+			PartialSuccessMethods: []string{"publickey"},
+			AllowedMethods:        []string{"password"},
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, authMethod)
+}
+
+func TestAuthCallback_ReturnsNil_NoPublickeyPartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	callback := clientssh.AuthCallback(
+		t.Context(), func() (clientssh.Performer, error) {
+			return nil, nil
+		},
+	)
+
+	authMethod, err := callback(
+		&ssh.ClientAuthContext{
+			PartialSuccessMethods: []string{"password"},
+			AllowedMethods:        []string{"keyboard-interactive"},
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, authMethod)
+}
+
+func TestAuthCallback_PerformerErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	callback := clientssh.AuthCallback(
+		t.Context(),
+		func() (clientssh.Performer, error) {
+			return nil, trace.BadParameter("some performer error")
+		},
+	)
+
+	authMethod, err := callback(
+		&ssh.ClientAuthContext{
+			PartialSuccessMethods: []string{"publickey"},
+			AllowedMethods:        []string{"keyboard-interactive"},
+		},
+	)
+	require.ErrorIs(t, err, trace.BadParameter("some performer error"))
+	require.Nil(t, authMethod)
+}
+
+func TestAuthCallback_ReturnsNil_TriedMethods(t *testing.T) {
+	t.Parallel()
+
+	callback := clientssh.AuthCallback(
+		t.Context(),
+		func() (clientssh.Performer, error) {
+			return nil, nil
+		},
+	)
+
+	authMethod, err := callback(
+		&ssh.ClientAuthContext{
+			PartialSuccessMethods: []string{"publickey"},
+			AllowedMethods:        []string{"keyboard-interactive"},
+			TriedMethods:          []string{"keyboard-interactive"},
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, authMethod)
 }
 
 type mockConnMetadata struct {

--- a/lib/client/ssh/ssh_test.go
+++ b/lib/client/ssh/ssh_test.go
@@ -131,7 +131,7 @@ func TestAuthCallback(t *testing.T) {
 
 	for _, tt := range []struct {
 		name             string
-		createPerformer  func() (clientssh.Performer, error)
+		createPerformer  func() (clientssh.MFACeremonyPerformer, error)
 		authCtx          *ssh.ClientAuthContext
 		expectError      error
 		expectNil        bool
@@ -139,7 +139,7 @@ func TestAuthCallback(t *testing.T) {
 	}{
 		{
 			name: "returns keyboard-interactive callback on partial success",
-			createPerformer: func() (clientssh.Performer, error) {
+			createPerformer: func() (clientssh.MFACeremonyPerformer, error) {
 				return func(_ context.Context, _ []byte) (string, error) {
 					return "test-challenge", nil
 				}, nil
@@ -169,7 +169,7 @@ func TestAuthCallback(t *testing.T) {
 		},
 		{
 			name: "performer error propagates",
-			createPerformer: func() (clientssh.Performer, error) {
+			createPerformer: func() (clientssh.MFACeremonyPerformer, error) {
 				return nil, trace.BadParameter("some performer error")
 			},
 			authCtx: &ssh.ClientAuthContext{

--- a/lib/client/ssh/ssh_test.go
+++ b/lib/client/ssh/ssh_test.go
@@ -131,18 +131,17 @@ func TestAuthCallback(t *testing.T) {
 
 	for _, tt := range []struct {
 		name             string
-		createPerformer  func() (clientssh.MFACeremonyPerformer, error)
+		config           clientssh.AuthCallbackConfig
 		authCtx          *ssh.ClientAuthContext
-		expectError      error
 		expectNil        bool
 		expectKICallback bool
 	}{
 		{
 			name: "returns keyboard-interactive callback on partial success",
-			createPerformer: func() (clientssh.MFACeremonyPerformer, error) {
-				return func(_ context.Context, _ []byte) (string, error) {
+			config: clientssh.AuthCallbackConfig{
+				MFAPerformer: func(_ context.Context, _ []byte) (string, error) {
 					return "test-challenge", nil
-				}, nil
+				},
 			},
 			authCtx: &ssh.ClientAuthContext{
 				PartialSuccessMethods: []string{publicKeyMethod},
@@ -160,24 +159,23 @@ func TestAuthCallback(t *testing.T) {
 			expectNil: true,
 		},
 		{
+			name: "returns nil when MFAPerformer is not set",
+			config: clientssh.AuthCallbackConfig{
+				MFAPerformer: nil,
+			},
+			authCtx: &ssh.ClientAuthContext{
+				PartialSuccessMethods: []string{publicKeyMethod},
+				AllowedMethods:        []string{keyboardInteractiveMethod},
+			},
+			expectNil: true,
+		},
+		{
 			name: "returns nil when no publickey partial success",
 			authCtx: &ssh.ClientAuthContext{
 				PartialSuccessMethods: []string{passwordMethod},
 				AllowedMethods:        []string{keyboardInteractiveMethod},
 			},
 			expectNil: true,
-		},
-		{
-			name: "performer error propagates",
-			createPerformer: func() (clientssh.MFACeremonyPerformer, error) {
-				return nil, trace.BadParameter("some performer error")
-			},
-			authCtx: &ssh.ClientAuthContext{
-				PartialSuccessMethods: []string{publicKeyMethod},
-				AllowedMethods:        []string{keyboardInteractiveMethod},
-			},
-			expectError: trace.BadParameter("some performer error"),
-			expectNil:   true,
 		},
 		{
 			name: "returns nil when keyboard-interactive already tried",
@@ -192,15 +190,10 @@ func TestAuthCallback(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			callback := clientssh.AuthCallback(t.Context(), tt.createPerformer)
+			callback := clientssh.AuthCallback(t.Context(), tt.config)
 
 			authMethod, err := callback(tt.authCtx)
-
-			if tt.expectError != nil {
-				require.ErrorIs(t, err, tt.expectError)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 
 			if tt.expectNil {
 				require.Nil(t, authMethod)

--- a/lib/client/ssh/ssh_test.go
+++ b/lib/client/ssh/ssh_test.go
@@ -189,31 +189,28 @@ func TestAuthCallback(t *testing.T) {
 			expectNil: true,
 		},
 	} {
-		t.Run(
-			tt.name,
-			func(t *testing.T) {
-				t.Parallel()
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-				callback := clientssh.AuthCallback(t.Context(), tt.createPerformer)
+			callback := clientssh.AuthCallback(t.Context(), tt.createPerformer)
 
-				authMethod, err := callback(tt.authCtx)
+			authMethod, err := callback(tt.authCtx)
 
-				if tt.expectError != nil {
-					require.ErrorIs(t, err, tt.expectError)
-				} else {
-					require.NoError(t, err)
-				}
+			if tt.expectError != nil {
+				require.ErrorIs(t, err, tt.expectError)
+			} else {
+				require.NoError(t, err)
+			}
 
-				if tt.expectNil {
-					require.Nil(t, authMethod)
-				}
+			if tt.expectNil {
+				require.Nil(t, authMethod)
+			}
 
-				if tt.expectKICallback {
-					_, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
-					require.True(t, ok)
-				}
-			},
-		)
+			if tt.expectKICallback {
+				_, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+				require.True(t, ok)
+			}
+		})
 	}
 }
 

--- a/lib/vnet/ssh_provider.go
+++ b/lib/vnet/ssh_provider.go
@@ -32,6 +32,7 @@ import (
 	apissh "github.com/gravitational/teleport/api/ssh"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+	clientssh "github.com/gravitational/teleport/lib/client/ssh"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/vnet/dns"
 )
@@ -226,9 +227,8 @@ func (p *sshProvider) sessionSSHConfig(
 	if err != nil {
 		return apissh.ClientConfig{}, trace.Wrap(err)
 	}
-	// TODO(cthach): Set AuthCallback once x/crypto/ssh releases a version that
-	// resolves https://go-review.googlesource.com/c/crypto/+/717140.
-	return apissh.ClientConfig{
+
+	config := apissh.ClientConfig{
 		PublicKeyAuth: apissh.PublicKeyAuthConfig{
 			Signers: func() ([]ssh.Signer, error) {
 				return []ssh.Signer{certSigner}, nil
@@ -236,7 +236,21 @@ func (p *sshProvider) sessionSSHConfig(
 		},
 		User:            user,
 		HostKeyCallback: hostKeyCallback,
-	}, nil
+	}
+
+	// If credential mode is direct, set AuthCallback so the client can perform in-band MFA if necessary.
+	if mode == vnetv1.SessionSSHConfigCredentialMode_SESSION_SSH_CONFIG_CREDENTIAL_MODE_DIRECT {
+		config.AuthCallback = clientssh.AuthCallback(
+			ctx,
+			func() (clientssh.Performer, error) {
+				return func(ctx context.Context, sessionID []byte) (string, error) {
+					return p.cfg.clt.PerformSessionMFACeremony(ctx, target.profile, target.leafCluster, sessionID)
+				}, nil
+			},
+		)
+	}
+
+	return config, nil
 }
 
 func buildHostKeyCallback(trustedCAs [][]byte, clock clockwork.Clock) (ssh.HostKeyCallback, error) {

--- a/lib/vnet/ssh_provider.go
+++ b/lib/vnet/ssh_provider.go
@@ -242,10 +242,10 @@ func (p *sshProvider) sessionSSHConfig(
 	if mode == vnetv1.SessionSSHConfigCredentialMode_SESSION_SSH_CONFIG_CREDENTIAL_MODE_DIRECT {
 		config.AuthCallback = clientssh.AuthCallback(
 			ctx,
-			func() (clientssh.MFACeremonyPerformer, error) {
-				return func(ctx context.Context, sessionID []byte) (string, error) {
+			clientssh.AuthCallbackConfig{
+				MFAPerformer: func(ctx context.Context, sessionID []byte) (string, error) {
 					return p.cfg.clt.PerformSessionMFACeremony(ctx, target.profile, target.leafCluster, sessionID)
-				}, nil
+				},
 			},
 		)
 	}

--- a/lib/vnet/ssh_provider.go
+++ b/lib/vnet/ssh_provider.go
@@ -242,7 +242,7 @@ func (p *sshProvider) sessionSSHConfig(
 	if mode == vnetv1.SessionSSHConfigCredentialMode_SESSION_SSH_CONFIG_CREDENTIAL_MODE_DIRECT {
 		config.AuthCallback = clientssh.AuthCallback(
 			ctx,
-			func() (clientssh.Performer, error) {
+			func() (clientssh.MFACeremonyPerformer, error) {
 				return func(ctx context.Context, sessionID []byte) (string, error) {
 					return p.cfg.clt.PerformSessionMFACeremony(ctx, target.profile, target.leafCluster, sessionID)
 				}, nil

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -46,10 +46,13 @@ import (
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
 	grpccredentials "google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	sshpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/ssh/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	apissh "github.com/gravitational/teleport/api/ssh"
 	"github.com/gravitational/teleport/api/types"
@@ -319,10 +322,11 @@ type fakeClientApp struct {
 	teleportHostCA ssh.Signer
 	teleportUserCA ssh.Signer
 
-	onNewSSHSessionCallCount    atomic.Uint32
-	onNewAppConnectionCallCount atomic.Uint32
-	onNewDBConnectionCallCount  atomic.Uint32
-	onInvalidLocalPortCallCount atomic.Uint32
+	onNewSSHSessionCallCount           atomic.Uint32
+	performSessionMFACeremonyCallCount atomic.Uint32
+	onNewAppConnectionCallCount        atomic.Uint32
+	onNewDBConnectionCallCount         atomic.Uint32
+	onInvalidLocalPortCallCount        atomic.Uint32
 	// requestedRouteToApps indexed by public address.
 	requestedRouteToApps   map[string][]*proto.RouteToApp
 	requestedRouteToAppsMu sync.RWMutex
@@ -398,6 +402,7 @@ func (p *fakeClientApp) GetCachedClient(ctx context.Context, profileName, leafCl
 				clusterName:     profileName,
 				rootClusterName: profileName,
 			},
+			clientApp:      p,
 			clusterSpec:    &rootCluster,
 			teleportHostCA: p.teleportHostCA,
 			teleportUserCA: p.teleportUserCA,
@@ -414,6 +419,7 @@ func (p *fakeClientApp) GetCachedClient(ctx context.Context, profileName, leafCl
 			clusterName:     leafClusterName,
 			rootClusterName: profileName,
 		},
+		clientApp:      p,
 		clusterSpec:    &leafCluster,
 		teleportHostCA: p.teleportHostCA,
 		teleportUserCA: p.teleportUserCA,
@@ -529,6 +535,11 @@ func (p *fakeClientApp) OnNewSSHSession(ctx context.Context, profileName, rootCl
 	p.onNewSSHSessionCallCount.Add(1)
 }
 
+func (p *fakeClientApp) PerformSessionMFACeremony(_ context.Context, _, _ string, _ []byte) (string, error) {
+	p.performSessionMFACeremonyCallCount.Add(1)
+	return "test-challenge-name", nil
+}
+
 func (p *fakeClientApp) OnNewAppConnection(_ context.Context, _ *vnetv1.AppKey) error {
 	p.onNewAppConnectionCallCount.Add(1)
 	return nil
@@ -601,6 +612,7 @@ func (p *fakeClientApp) dialSSHNode(
 
 type fakeClusterClient struct {
 	authClient     *fakeAuthClient
+	clientApp      *fakeClientApp
 	clusterSpec    *testClusterSpec
 	teleportHostCA ssh.Signer
 	teleportUserCA ssh.Signer
@@ -648,6 +660,19 @@ func (c *fakeClusterClient) SessionSSHKeyRing(ctx context.Context, user string, 
 		ValidAfter:      uint64(now.Add(-1 * time.Minute).Unix()),
 		ValidBefore:     uint64(now.Add(time.Minute).Unix()),
 	}
+
+	// We treat fallbackLegacyMFAUser as having completed MFA if the target
+	// requires MFA checks or doesn't specify them at all. This allows us to
+	// test both MFA and non-MFA scenarios without needing to implement a fake
+	// MFA service and ceremony.
+	mfaVerified := user == fallbackLegacyMFAUser &&
+		(target.MFACheck == nil || target.MFACheck.Required)
+
+	if mfaVerified {
+		cert.Extensions = map[string]string{
+			teleport.CertExtensionMFAVerified: mfaDeviceID,
+		}
+	}
 	if err := cert.SignCert(rand.Reader, c.teleportUserCA); err != nil {
 		return nil, false, trace.Wrap(err)
 	}
@@ -662,11 +687,11 @@ func (c *fakeClusterClient) SessionSSHKeyRing(ctx context.Context, user string, 
 			},
 		},
 	}
-	return k, false, nil
+	return k, mfaVerified, nil
 }
 
 func (c *fakeClusterClient) PerformSessionMFACeremony(ctx context.Context, sessionID []byte) (string, error) {
-	return "", trace.NotImplemented("PerformSessionMFACeremony not implemented")
+	return c.clientApp.PerformSessionMFACeremony(ctx, c.RootClusterName(), c.ClusterName(), sessionID)
 }
 
 // fakeAuthClient is a fake auth client that answers GetResources requests with a static list of apps.
@@ -1520,6 +1545,17 @@ func testWithAlgorithmSuite(t *testing.T, suite types.SignatureAlgorithmSuite) {
 	require.Error(t, err)
 }
 
+const (
+	// inbandMFAUser is the username used for testing in-band MFA.
+	inbandMFAUser = "in-band-mfa-user"
+
+	// fallbackLegacyMFAUser is the username used for testing fallback to legacy MFA certs.
+	fallbackLegacyMFAUser = "fallback-legacy-mfa-user"
+
+	// mfaDeviceID is the MFA device ID encoded in fake legacy MFA certs.
+	mfaDeviceID = "mfa-device-id"
+)
+
 // TestSSH tests basic VNet SSH functionality.
 func TestSSH(t *testing.T) {
 	ctx := t.Context()
@@ -1603,6 +1639,13 @@ func TestSSH(t *testing.T) {
 			"OnNewSSHSession call count does not match the expected number of reported SSH sessions")
 	})
 
+	// Check that each session-bound MFA ceremony is performed through the client application when expected.
+	var expectMFACeremonies atomic.Uint32
+	t.Cleanup(func() {
+		assert.Equal(t, expectMFACeremonies.Load(), clientApp.performSessionMFACeremonyCallCount.Load(),
+			"PerformSessionMFACeremony call count does not match the expected number of MFA ceremonies")
+	})
+
 	for _, tc := range []struct {
 		dialAddr                 string
 		dialPort                 int
@@ -1614,6 +1657,7 @@ func TestSSH(t *testing.T) {
 		expectSSHHandshakeToFail bool
 		expectBannerMessages     []string
 		expectSSHSessionReported bool
+		expectMFACeremonies      uint32
 	}{
 		{
 			// Connection to node in root cluster should work.
@@ -1676,7 +1720,30 @@ func TestSSH(t *testing.T) {
 			// The session should be reported because VNet successfully got a
 			// Teleport user SSH cert for this session and made the SSH dial to
 			// the target, only then the target SSH server rejected the
-			// connection.
+			// connection. The fallback attempt is part of the same logical SSH
+			// session and is not reported separately.
+			expectSSHSessionReported: true,
+		},
+		{
+			// When the target requests in-band MFA, VNet should complete the
+			// session-bound MFA ceremony through the client application.
+			dialAddr:                 "node.root1.example.com",
+			dialPort:                 22,
+			expectCIDR:               root1CIDR,
+			sshUser:                  inbandMFAUser,
+			sshUserSigner:            sshUserSigner,
+			expectSSHSessionReported: true,
+			expectMFACeremonies:      1,
+		},
+		{
+			// If direct auth fails because the target doesn't support in-band
+			// MFA, or if the client does not support in-band MFA, then VNet
+			// should retry with the legacy MFA cert credential mode.
+			dialAddr:                 "node.root1.example.com",
+			dialPort:                 22,
+			expectCIDR:               root1CIDR,
+			sshUser:                  fallbackLegacyMFAUser,
+			sshUserSigner:            sshUserSigner,
 			expectSSHSessionReported: true,
 		},
 		{
@@ -1729,6 +1796,7 @@ func TestSSH(t *testing.T) {
 			if tc.expectSSHSessionReported {
 				expectReportedSSHSessions.Add(1)
 			}
+			expectMFACeremonies.Add(tc.expectMFACeremonies)
 
 			if tc.expectLookupToFail {
 				// In these cases the DNS lookup is expected to fail, just run the DNS lookup.
@@ -2201,7 +2269,29 @@ func mustStartFakeWebProxy(
 				if !cfg.forwardedAgents.forwarded(pubKey) {
 					return nil, trace.Errorf("user SSH key was not forwarded")
 				}
-				return certChecker.Authenticate(conn, pubKey)
+
+				perms, err := certChecker.Authenticate(conn, pubKey)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				// Special test cases for certain usernames to test MFA behavior.
+				switch conn.User() {
+				case fallbackLegacyMFAUser:
+					cert, ok := pubKey.(*ssh.Certificate)
+					if !ok || cert.Extensions[teleport.CertExtensionMFAVerified] != mfaDeviceID {
+						return nil, trace.AccessDenied("expected legacy MFA cert, got %T", pubKey)
+					}
+
+				case inbandMFAUser:
+					return nil, &ssh.PartialSuccessError{
+						Next: ssh.ServerAuthCallbacks{
+							KeyboardInteractiveCallback: handleSSHKeyboardInteractive,
+						},
+					}
+				}
+
+				return perms, nil
 			},
 		}
 		serverConfig.AddHostKey(hostCert)
@@ -2340,4 +2430,18 @@ func (a *forwardedAgents) forwarded(key ssh.PublicKey) bool {
 		}
 	}
 	return false
+}
+
+func handleSSHKeyboardInteractive(_ ssh.ConnMetadata, clt ssh.KeyboardInteractiveChallenge) (*ssh.Permissions, error) {
+	prompt := sshpb.AuthPrompt_builder{
+		MfaPrompt: &sshpb.MFAPrompt{},
+	}.Build()
+
+	promptBytes, err := protojson.Marshal(prompt)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	_, err = clt("", "", []string{string(promptBytes)}, []bool{false})
+	return nil, trace.Wrap(err)
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -8802,10 +8802,6 @@ func (mock authProviderMock) GetRole(_ context.Context, _ string) (types.Role, e
 	return nil, nil
 }
 
-func (mock authProviderMock) MFAServiceClient() mfav1.MFAServiceClient { //nolint:staticcheck // SA1019. Required for interface compatibility.
-	return nil
-}
-
 func (mock authProviderMock) MFAServiceClientV2() mfav2.MFAServiceClient {
 	return nil
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -95,6 +95,7 @@ import (
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
 	transportpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -8799,6 +8800,14 @@ func (mock authProviderMock) GetUser(_ context.Context, _ string, _ bool) (types
 
 func (mock authProviderMock) GetRole(_ context.Context, _ string) (types.Role, error) {
 	return nil, nil
+}
+
+func (mock authProviderMock) MFAServiceClient() mfav1.MFAServiceClient { //nolint:staticcheck // required for interface compatibility
+	return nil
+}
+
+func (mock authProviderMock) MFAServiceClientV2() mfav2.MFAServiceClient {
+	return nil
 }
 
 func waitForOutput(t *testing.T, r io.Reader, substr string, msgAndArgs ...interface{}) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -8802,7 +8802,7 @@ func (mock authProviderMock) GetRole(_ context.Context, _ string) (types.Role, e
 	return nil, nil
 }
 
-func (mock authProviderMock) MFAServiceClient() mfav1.MFAServiceClient { //nolint:staticcheck // required for interface compatibility
+func (mock authProviderMock) MFAServiceClient() mfav1.MFAServiceClient { //nolint:staticcheck // SA1019. Required for interface compatibility.
 	return nil
 }
 

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -643,12 +643,7 @@ func newMFACeremony(stream *terminal.WSStream, createAuthenticateChallenge mfa.C
 	}
 }
 
-func newMFACeremonyPerformer(ws terminal.WSConn, mfaClient mfav2.MFAServiceClient, proxyAddr string, targetCluster string) (clientssh.Performer, error) {
-	stream, ok := ws.(*terminal.Stream)
-	if !ok {
-		return nil, trace.BadParameter("expected terminal.Stream type for ws connection (this is a bug)")
-	}
-
+func newMFACeremonyPerformer(stream *terminal.Stream, mfaClient mfav2.MFAServiceClient, proxyAddr string, targetCluster string) (clientssh.Performer, error) {
 	// channelID is used by the front end to differentiate between separate ongoing SSO challenges.
 	channelID := uuid.NewString()
 
@@ -724,13 +719,13 @@ func newMFACallbackCeremony(channelID string, proxyAddr string) (mfa.CallbackCer
 	}, nil
 }
 
-type connectWithMFAFn = func(ctx context.Context, scopePin *scopesv1.Pin, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error)
+type connectWithMFAFn = func(ctx context.Context, scopePin *scopesv1.Pin, stream *terminal.Stream, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error)
 
 // connectToHost establishes a connection to the target host. It first attempts to connect with the existing
 // certificates, which can succeed if per-session MFA is not required or if the node supports in-band MFA. If that
 // fails, it falls back to the legacy per-session MFA certificate flow. If both attempts fail, it returns the error
 // that is most likely to be helpful to the user.
-func (t *sshBaseHandler) connectToHost(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, connectToNodeWithMFA connectWithMFAFn) (*client.NodeClient, error) {
+func (t *sshBaseHandler) connectToHost(ctx context.Context, stream *terminal.Stream, tc *client.TeleportClient, connectToNodeWithMFA connectWithMFAFn) (*client.NodeClient, error) {
 	ctx, span := t.tracer.Start(ctx, "terminal/connectToHost")
 	defer span.End()
 
@@ -759,7 +754,7 @@ func (t *sshBaseHandler) connectToHost(ctx context.Context, ws terminal.WSConn, 
 
 	// Try to connect directly with existing certs. This can succeed if MFA is not required or if the node supports
 	// in-band MFA and the ceremony completes successfully.
-	clt, directErr := t.connectToNode(ctx, ident.ScopePin, ws, tc, accessChecker, getAgent, signer)
+	clt, directErr := t.connectToNode(ctx, ident.ScopePin, stream, tc, accessChecker, getAgent, signer)
 	if directErr == nil {
 		return clt, nil
 	}
@@ -769,7 +764,7 @@ func (t *sshBaseHandler) connectToHost(ctx context.Context, ws terminal.WSConn, 
 	// or if there are any issues during the MFA ceremony.
 	//
 	// TODO(cthach): DELETE IN v20.0 when the legacy per-session MFA with certifcates flow is removed.
-	clt, mfaErr := connectToNodeWithMFA(ctx, ident.ScopePin, ws, tc, accessChecker, getAgent, signer)
+	clt, mfaErr := connectToNodeWithMFA(ctx, ident.ScopePin, stream, tc, accessChecker, getAgent, signer)
 	if mfaErr == nil {
 		return clt, nil
 	}
@@ -931,12 +926,12 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 }
 
 // generateClientConfig creates an [apissh.ClientConfig] for the Teleport client connection.
-func (t *sshBaseHandler) generateClientConfig(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient) apissh.ClientConfig {
+func (t *sshBaseHandler) generateClientConfig(ctx context.Context, stream *terminal.Stream, tc *client.TeleportClient) apissh.ClientConfig {
 	authCallback := clientssh.AuthCallback(
 		ctx,
 		func() (clientssh.Performer, error) {
 			return newMFACeremonyPerformer(
-				ws,
+				stream,
 				t.userAuthClient.MFAServiceClientV2(),
 				t.proxyPublicAddr,
 				tc.SiteName,
@@ -955,8 +950,8 @@ func (t *sshBaseHandler) generateClientConfig(ctx context.Context, ws terminal.W
 
 // connectToNode attempts to connect to the host with the already
 // provisioned certs for the user.
-func (t *sshBaseHandler) connectToNode(ctx context.Context, scopePin *scopesv1.Pin, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
-	conn, err := t.router.DialHost(ctx, scopePin, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker.CheckAccessToRemoteCluster, getAgent, signer)
+func (t *sshBaseHandler) connectToNode(ctx context.Context, scopePin *scopesv1.Pin, stream *terminal.Stream, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
+	conn, err := t.router.DialHost(ctx, scopePin, stream.RemoteAddr(), stream.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker.CheckAccessToRemoteCluster, getAgent, signer)
 	if err != nil {
 		t.logger.WarnContext(ctx, "Unable to stream terminal - failed to dial host", "error", err)
 
@@ -968,7 +963,7 @@ func (t *sshBaseHandler) connectToNode(ctx context.Context, scopePin *scopesv1.P
 		return nil, trace.Wrap(err)
 	}
 
-	sshConfig := t.generateClientConfig(ctx, ws, tc)
+	sshConfig := t.generateClientConfig(ctx, stream, tc)
 
 	clt, err := client.NewNodeClient(ctx, sshConfig, conn,
 		net.JoinHostPort(t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort)),
@@ -1003,14 +998,14 @@ func (t *sshBaseHandler) connectToNode(ctx context.Context, scopePin *scopesv1.P
 
 // connectToNodeWithMFA attempts to perform the mfa ceremony and then dial the
 // host with the retrieved single use certs.
-func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, scopePin *scopesv1.Pin, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
+func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, scopePin *scopesv1.Pin, stream *terminal.Stream, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
 	// perform mfa ceremony and retrieve new certs
-	signers, err := t.issueSessionMFACerts(ctx, tc, t.stream.WSStream)
+	signers, err := t.issueSessionMFACerts(ctx, tc, stream.WSStream)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return t.connectToNodeWithMFABase(ctx, scopePin, ws, tc, accessChecker, getAgent, signer, signers)
+	return t.connectToNodeWithMFABase(ctx, scopePin, stream, tc, accessChecker, getAgent, signer, signers)
 }
 
 // connectToNodeWithMFABase attempts to dial the host with the provided auth
@@ -1018,7 +1013,7 @@ func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, scopePin *sc
 func (t *sshBaseHandler) connectToNodeWithMFABase(
 	ctx context.Context,
 	scopePin *scopesv1.Pin,
-	ws terminal.WSConn,
+	stream *terminal.Stream,
 	tc *client.TeleportClient,
 	accessChecker services.AccessChecker,
 	getAgent sshagent.ClientGetter,
@@ -1037,7 +1032,7 @@ func (t *sshBaseHandler) connectToNodeWithMFABase(
 	}
 
 	// connect to the node again with the new certs
-	conn, err := t.router.DialHost(ctx, scopePin, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker.CheckAccessToRemoteCluster, getAgent, agentlessSigner)
+	conn, err := t.router.DialHost(ctx, scopePin, stream.RemoteAddr(), stream.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker.CheckAccessToRemoteCluster, getAgent, agentlessSigner)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -926,16 +926,21 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 }
 
 // generateClientConfig creates an [apissh.ClientConfig] for the Teleport client connection.
-func (t *sshBaseHandler) generateClientConfig(ctx context.Context, stream *terminal.Stream, tc *client.TeleportClient) apissh.ClientConfig {
+func (t *sshBaseHandler) generateClientConfig(ctx context.Context, stream *terminal.Stream, tc *client.TeleportClient) (apissh.ClientConfig, error) {
+	performer, err := newMFACeremonyPerformer(
+		stream,
+		t.userAuthClient.MFAServiceClientV2(),
+		t.proxyPublicAddr,
+		tc.SiteName,
+	)
+	if err != nil {
+		return apissh.ClientConfig{}, trace.Wrap(err)
+	}
+
 	authCallback := clientssh.AuthCallback(
 		ctx,
-		func() (clientssh.MFACeremonyPerformer, error) {
-			return newMFACeremonyPerformer(
-				stream,
-				t.userAuthClient.MFAServiceClientV2(),
-				t.proxyPublicAddr,
-				tc.SiteName,
-			)
+		clientssh.AuthCallbackConfig{
+			MFAPerformer: performer,
 		},
 	)
 
@@ -945,7 +950,7 @@ func (t *sshBaseHandler) generateClientConfig(ctx context.Context, stream *termi
 		AuthCallback:    authCallback,
 		HostKeyCallback: tc.HostKeyCallback,
 		Timeout:         t.sshDialTimeout,
-	}
+	}, nil
 }
 
 // connectToNode attempts to connect to the host with the already
@@ -963,7 +968,10 @@ func (t *sshBaseHandler) connectToNode(ctx context.Context, scopePin *scopesv1.P
 		return nil, trace.Wrap(err)
 	}
 
-	sshConfig := t.generateClientConfig(ctx, stream, tc)
+	sshConfig, err := t.generateClientConfig(ctx, stream, tc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	clt, err := client.NewNodeClient(ctx, sshConfig, conn,
 		net.JoinHostPort(t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort)),

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	authproto "github.com/gravitational/teleport/api/client/proto"
+	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/observability/tracing"
@@ -56,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
+	clientssh "github.com/gravitational/teleport/lib/client/ssh"
 	"github.com/gravitational/teleport/lib/client/sso"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/multiplexer"
@@ -108,6 +110,7 @@ type UserAuthClient interface {
 	GenerateUserCerts(ctx context.Context, req authproto.UserCertsRequest) (*authproto.Certs, error)
 	MaintainSessionPresence(ctx context.Context) (authproto.AuthService_MaintainSessionPresenceClient, error)
 	ListUnifiedResources(ctx context.Context, req *authproto.ListUnifiedResourcesRequest) (*authproto.ListUnifiedResourcesResponse, error)
+	MFAServiceClientV2() mfav2.MFAServiceClient
 }
 
 // NewTerminal creates a web-based terminal based on WebSockets and returns a
@@ -633,45 +636,92 @@ func newMFACeremony(stream *terminal.WSStream, createAuthenticateChallenge mfa.C
 
 	return &mfa.Ceremony{
 		CreateAuthenticateChallenge: createAuthenticateChallenge,
-		MFACeremonyConstructor: func(ctx context.Context) (mfa.CallbackCeremony, error) {
+		MFACeremonyConstructor: func(context.Context) (mfa.CallbackCeremony, error) {
+			return newMFACallbackCeremony(channelID, proxyAddr)
+		},
+		PromptConstructor: newMFAPromptConstructor(stream, channelID),
+	}
+}
 
-			u, err := url.Parse(sso.WebMFARedirect)
-			if err != nil {
+func newMFACeremonyPerformer(ws terminal.WSConn, mfaClient mfav2.MFAServiceClient, proxyAddr string, targetCluster string) (clientssh.Performer, error) {
+	stream, ok := ws.(*terminal.Stream)
+	if !ok {
+		return nil, trace.BadParameter("expected terminal.Stream type for ws connection (this is a bug)")
+	}
+
+	// channelID is used by the front end to differentiate between separate ongoing SSO challenges.
+	channelID := uuid.NewString()
+
+	config := mfa.SessionBoundCeremonyConfig{
+		CreateSessionChallenge:   mfaClient.CreateSessionChallenge,
+		ValidateSessionChallenge: mfaClient.ValidateSessionChallenge,
+		PromptConstructor:        newMFAPromptConstructor(stream.WSStream, channelID),
+		CallbackCeremonyConstructor: func(context.Context) (mfa.CallbackCeremony, error) {
+			return newMFACallbackCeremony(channelID, proxyAddr)
+		},
+		TargetCluster: targetCluster,
+	}
+
+	ceremony, err := mfa.NewSessionBoundCeremony(config)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return func(ctx context.Context, sessionID []byte) (string, error) {
+		name, err := ceremony.Run(
+			ctx,
+			mfav2.SessionIdentifyingPayload_builder{
+				SshSessionId: sessionID,
+			}.Build(),
+		)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		return name, nil
+	}, nil
+}
+
+func newMFAPromptConstructor(stream *terminal.WSStream, channelID string) mfa.PromptConstructor {
+	return func(...mfa.PromptOpt) mfa.Prompt {
+		return mfa.PromptFunc(func(ctx context.Context, chal *authproto.MFAAuthenticateChallenge) (*authproto.MFAAuthenticateResponse, error) {
+			// Convert from proto to JSON types.
+			var challenge client.MFAAuthenticateChallenge
+			if chal.WebauthnChallenge != nil {
+				challenge.WebauthnChallenge = wantypes.CredentialAssertionFromProto(chal.WebauthnChallenge)
+			}
+
+			if chal.SSOChallenge != nil {
+				challenge.SSOChallenge = client.SSOChallengeFromProto(chal.SSOChallenge)
+				challenge.SSOChallenge.ChannelID = channelID
+			}
+
+			if chal.WebauthnChallenge == nil && chal.SSOChallenge == nil {
+				return nil, trace.Wrap(authclient.ErrNoMFADevices)
+			}
+
+			var codec protobufMFACodec
+			if err := stream.WriteChallenge(&challenge, codec); err != nil {
 				return nil, trace.Wrap(err)
 			}
-			u.RawQuery = url.Values{"channel_id": {channelID}}.Encode()
-			return &sso.MFACeremony{
-				ClientCallbackURL: u.String(),
-				ProxyAddress:      proxyAddr,
-			}, nil
-		},
-		PromptConstructor: func(...mfa.PromptOpt) mfa.Prompt {
-			return mfa.PromptFunc(func(ctx context.Context, chal *authproto.MFAAuthenticateChallenge) (*authproto.MFAAuthenticateResponse, error) {
-				// Convert from proto to JSON types.
-				var challenge client.MFAAuthenticateChallenge
-				if chal.WebauthnChallenge != nil {
-					challenge.WebauthnChallenge = wantypes.CredentialAssertionFromProto(chal.WebauthnChallenge)
-				}
 
-				if chal.SSOChallenge != nil {
-					challenge.SSOChallenge = client.SSOChallengeFromProto(chal.SSOChallenge)
-					challenge.SSOChallenge.ChannelID = channelID
-				}
-
-				if chal.WebauthnChallenge == nil && chal.SSOChallenge == nil {
-					return nil, trace.Wrap(authclient.ErrNoMFADevices)
-				}
-
-				var codec protobufMFACodec
-				if err := stream.WriteChallenge(&challenge, codec); err != nil {
-					return nil, trace.Wrap(err)
-				}
-
-				resp, err := stream.ReadChallengeResponse(codec)
-				return resp, trace.Wrap(err)
-			})
-		},
+			resp, err := stream.ReadChallengeResponse(codec)
+			return resp, trace.Wrap(err)
+		})
 	}
+}
+
+func newMFACallbackCeremony(channelID string, proxyAddr string) (mfa.CallbackCeremony, error) {
+	u, err := url.Parse(sso.WebMFARedirect)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	u.RawQuery = url.Values{"channel_id": {channelID}}.Encode()
+
+	return &sso.MFACeremony{
+		ClientCallbackURL: u.String(),
+		ProxyAddress:      proxyAddr,
+	}, nil
 }
 
 type connectWithMFAFn = func(ctx context.Context, scopePin *scopesv1.Pin, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error)
@@ -880,6 +930,29 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 	t.logger.DebugContext(ctx, "Sent close event to web client")
 }
 
+// generateClientConfig creates an [apissh.ClientConfig] for the Teleport client connection.
+func (t *sshBaseHandler) generateClientConfig(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient) apissh.ClientConfig {
+	authCallback := clientssh.AuthCallback(
+		ctx,
+		func() (clientssh.Performer, error) {
+			return newMFACeremonyPerformer(
+				ws,
+				t.userAuthClient.MFAServiceClientV2(),
+				t.proxyPublicAddr,
+				tc.SiteName,
+			)
+		},
+	)
+
+	return apissh.ClientConfig{
+		User:            tc.HostLogin,
+		PublicKeyAuth:   tc.PublicKeyAuthConfig,
+		AuthCallback:    authCallback,
+		HostKeyCallback: tc.HostKeyCallback,
+		Timeout:         t.sshDialTimeout,
+	}
+}
+
 // connectToNode attempts to connect to the host with the already
 // provisioned certs for the user.
 func (t *sshBaseHandler) connectToNode(ctx context.Context, scopePin *scopesv1.Pin, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
@@ -895,12 +968,7 @@ func (t *sshBaseHandler) connectToNode(ctx context.Context, scopePin *scopesv1.P
 		return nil, trace.Wrap(err)
 	}
 
-	sshConfig := apissh.ClientConfig{
-		User:            tc.HostLogin,
-		PublicKeyAuth:   tc.PublicKeyAuthConfig,
-		HostKeyCallback: tc.HostKeyCallback,
-		Timeout:         t.sshDialTimeout,
-	}
+	sshConfig := t.generateClientConfig(ctx, ws, tc)
 
 	clt, err := client.NewNodeClient(ctx, sshConfig, conn,
 		net.JoinHostPort(t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort)),

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -643,7 +643,7 @@ func newMFACeremony(stream *terminal.WSStream, createAuthenticateChallenge mfa.C
 	}
 }
 
-func newMFACeremonyPerformer(stream *terminal.Stream, mfaClient mfav2.MFAServiceClient, proxyAddr string, targetCluster string) (clientssh.Performer, error) {
+func newMFACeremonyPerformer(stream *terminal.Stream, mfaClient mfav2.MFAServiceClient, proxyAddr string, targetCluster string) (clientssh.MFACeremonyPerformer, error) {
 	// channelID is used by the front end to differentiate between separate ongoing SSO challenges.
 	channelID := uuid.NewString()
 
@@ -929,7 +929,7 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 func (t *sshBaseHandler) generateClientConfig(ctx context.Context, stream *terminal.Stream, tc *client.TeleportClient) apissh.ClientConfig {
 	authCallback := clientssh.AuthCallback(
 		ctx,
-		func() (clientssh.Performer, error) {
+		func() (clientssh.MFACeremonyPerformer, error) {
 			return newMFACeremonyPerformer(
 				stream,
 				t.userAuthClient.MFAServiceClientV2(),

--- a/lib/web/terminal_test.go
+++ b/lib/web/terminal_test.go
@@ -35,6 +35,8 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gorilla/websocket"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -122,9 +124,27 @@ func TestGenerateClientConfig(t *testing.T) {
 	}
 
 	cfg := handler.generateClientConfig(t.Context(), &terminal.Stream{}, tc)
-	require.Equal(t, "alice", cfg.User)
-	require.Equal(t, 5*time.Second, cfg.Timeout)
+
+	want := apissh.ClientConfig{
+		User:    "alice",
+		Timeout: 5 * time.Second,
+	}
+
+	require.Empty(
+		t,
+		cmp.Diff(
+			want,
+			cfg,
+			cmpopts.IgnoreFields(
+				apissh.ClientConfig{},
+				"PublicKeyAuth", "HostKeyCallback", "BannerCallback", "AuthCallback", // Must be asserted separately.
+			),
+		),
+		"generateClientConfig mismatch (-want +got)",
+	)
+	require.NotNil(t, cfg.PublicKeyAuth)
 	require.NotNil(t, cfg.HostKeyCallback)
+	require.Nil(t, cfg.BannerCallback)
 	require.NotNil(t, cfg.AuthCallback)
 
 	signers, err := cfg.PublicKeyAuth.Signers()

--- a/lib/web/terminal_test.go
+++ b/lib/web/terminal_test.go
@@ -123,7 +123,8 @@ func TestGenerateClientConfig(t *testing.T) {
 		},
 	}
 
-	cfg := handler.generateClientConfig(t.Context(), &terminal.Stream{}, tc)
+	cfg, err := handler.generateClientConfig(t.Context(), &terminal.Stream{}, tc)
+	require.NoError(t, err)
 
 	want := apissh.ClientConfig{
 		User:    "alice",

--- a/lib/web/terminal_test.go
+++ b/lib/web/terminal_test.go
@@ -119,7 +119,7 @@ func TestGenerateClientConfig(t *testing.T) {
 					return []ssh.Signer{signer}, nil
 				},
 			},
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // This is a test.
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		},
 	}
 

--- a/lib/web/terminal_test.go
+++ b/lib/web/terminal_test.go
@@ -20,6 +20,8 @@ package web
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -36,7 +38,10 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 
+	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
+	apissh "github.com/gravitational/teleport/api/ssh"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -86,6 +91,55 @@ func TestTerminalReadFromClosedConn(t *testing.T) {
 
 	_, err = io.Copy(io.Discard, stream)
 	require.NoError(t, err)
+}
+
+func TestGenerateClientConfig(t *testing.T) {
+	t.Parallel()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	signer, err := ssh.NewSignerFromSigner(privateKey)
+	require.NoError(t, err)
+
+	handler := &sshBaseHandler{
+		userAuthClient:  mockAuthClient{},
+		proxyPublicAddr: "proxy.example.com",
+		sshDialTimeout:  5 * time.Second,
+	}
+
+	tc := &client.TeleportClient{
+		Config: client.Config{
+			HostLogin: "alice",
+			SiteName:  "leaf-cluster",
+			PublicKeyAuthConfig: apissh.PublicKeyAuthConfig{
+				Signers: func() ([]ssh.Signer, error) {
+					return []ssh.Signer{signer}, nil
+				},
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // This is a test.
+		},
+	}
+
+	cfg := handler.generateClientConfig(t.Context(), &terminal.Stream{}, tc)
+	require.Equal(t, "alice", cfg.User)
+	require.Equal(t, 5*time.Second, cfg.Timeout)
+	require.NotNil(t, cfg.HostKeyCallback)
+	require.NotNil(t, cfg.AuthCallback)
+
+	signers, err := cfg.PublicKeyAuth.Signers()
+	require.NoError(t, err)
+	require.Len(t, signers, 1)
+}
+
+type mockAuthClient struct {
+	authProviderMock
+}
+
+func (m mockAuthClient) MFAServiceClientV2() mfav2.MFAServiceClient {
+	return struct {
+		mfav2.MFAServiceClient
+	}{}
 }
 
 type testTerminal struct {

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1984,7 +1984,7 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 				require.True(t, ok, i...)
 				require.Contains(t, out, "MFA response validation failed", i...)
 			},
-			mfaPromptCount: 1,
+			mfaPromptCount: 2,
 			errAssertion:   require.Error,
 		},
 		{

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1984,7 +1984,7 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 				require.True(t, ok, i...)
 				require.Contains(t, out, "MFA response validation failed", i...)
 			},
-			mfaPromptCount: 2,
+			mfaPromptCount: 2, // In-band MFA fails and fallback to legacy MFA cert fails.
 			errAssertion:   require.Error,
 		},
 		{


### PR DESCRIPTION
These changes will enable all Teleport clients (Web UI, Connect, tsh, VNet) to perform [in-band MFA for SSH sessions](https://github.com/gravitational/teleport/blob/6aaa43440e5e516016fbcdadd2ee9136dcf2ba05/rfd/0234-in-band-mfa-ssh-sessions.md).

They were dependent on https://github.com/golang/go/issues/76146 getting resolved and it finally landed in `golang.org/x/crypto/ssh` [v0.53.0](https://pkg.go.dev/golang.org/x/crypto@v0.53.0/ssh) 🎉

More specifically, the changes depend on `golang.org/x/crypto/ssh#ClientConfig.AuthCallback`. You'll notice the changes update each Teleport client's respective `ssh.ClientConfig` to set the `AuthCallback` to handle in-band MFA if the Teleport Agent supports it. If it doesn't, as for legacy Teleport Agents (i.e., v18 and older), the client will fallback to legacy per-session MFA certs.

More details in [RFD 0314](https://github.com/gravitational/teleport/blob/6aaa43440e5e516016fbcdadd2ee9136dcf2ba05/rfd/0234-in-band-mfa-ssh-sessions.md).

## Manual Test Plan
### Test Environment

My Mac with locally compiled Enterprise binaries using `make full full-ent`. Connect is running locally with `pnpm start-term`. A role was used to toggle MFA enforcement.

For the fallback case, I used a Teleport Cloud tenant with `v18.8.3` deployed.

### Test Cases
#### Web UI
- [x] Connect to a host that does not require per-session MFA, expect success
- [x] Connect to a host the requires per-session MFA, expect success and audit events show in-band flow type

#### tsh 
- [x] Connect to a host that does not require per-session MFA, expect success
- [x] Connect to a host the requires per-session MFA, expect success and audit events show in-band flow type
- [x] Execute command using host label without per-session MFA, expect success
- [x] Execute command using host label with per-session MFA, expect success and audit events show in-band flow type
- [x] Connect to a host via leaf cluster the requires per-session MFA, expect success and audit events show in-band flow type

#### Connect 
- [x] Connect to a host that does not require per-session MFA, expect success
- [x] Connect to a host the requires per-session MFA, expect success and audit events show in-band flow type

#### VNet
- [x] Connect to a host that does not require per-session MFA, expect success
- [x] Connect to a host the requires per-session MFA, expect success and audit events show in-band flow type

#### Falls back to legacy MFA cert with Agent that does not support in-band MFA
- [x] `tsh`, expect success and audit event shows fallback
- [x] Connect, expect success and audit event shows fallback
- [x] VNet, expect success and audit event shows fallback

Did I miss a test case? Let me know and I'll test it 👇🏾 
