### PR TITLE
Fix a data race in the GCP token handler

### DIFF
--- a/lib/srv/app/gcp/handler.go
+++ b/lib/srv/app/gcp/handler.go
@@ -261,28 +261,30 @@ var defaultScopeList = []string{
 func (s *handler) getToken(ctx context.Context, serviceAccount string) (*credentialspb.GenerateAccessTokenResponse, error) {
 	key := cacheKey{serviceAccount}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
+	type result struct {
+		token *credentialspb.GenerateAccessTokenResponse
+		err   error
+	}
+	resultChan := make(chan result, 1)
+
+	ctx, cancel := context.WithTimeout(ctx, getTokenTimeout)
 	defer cancel()
 
-	var tokenResult *credentialspb.GenerateAccessTokenResponse
-	var errorResult error
-
-	// call Clock.After() before FnCacheGet gets called in a different go-routine.
-	// this ensures there is no race condition in the timeout tests
-	timeoutChan := s.Clock.After(getTokenTimeout)
-
 	go func() {
-		tokenResult, errorResult = utils.FnCacheGet(cancelCtx, s.tokenCache, key, func(ctx context.Context) (*credentialspb.GenerateAccessTokenResponse, error) {
+		token, err := utils.FnCacheGet(ctx, s.tokenCache, key, func(ctx context.Context) (*credentialspb.GenerateAccessTokenResponse, error) {
 			return s.generateAccessToken(ctx, serviceAccount, defaultScopeList)
 		})
-		cancel()
+		resultChan <- result{
+			token: token,
+			err:   err,
+		}
 	}()
 
 	select {
-	case <-timeoutChan:
-		return nil, trace.Wrap(context.DeadlineExceeded, "timeout waiting for access token for %v", getTokenTimeout)
-	case <-cancelCtx.Done():
-		return tokenResult, errorResult
+	case <-ctx.Done():
+		return nil, trace.Wrap(ctx.Err())
+	case result := <-resultChan:
+		return result.token, trace.Wrap(result.err)
 	}
 }
 

--- a/lib/srv/app/gcp/handler_test.go
+++ b/lib/srv/app/gcp/handler_test.go
@@ -19,6 +19,7 @@
 package gcp
 
 import (
+	"cmp"
 	"context"
 	"testing"
 	"time"
@@ -54,12 +55,15 @@ func TestHandler_getToken(t *testing.T) {
 		}
 	}
 
+	testContext, testContextCancel := context.WithCancel(t.Context())
+
 	tests := []struct {
 		name string
 
 		initState func() any
 
-		config func(state any) HandlerConfig
+		getTokenContext context.Context
+		config          func(state any) HandlerConfig
 
 		wantToken  *credentialspb.GenerateAccessTokenResponse
 		checkErr   require.ErrorAssertionFunc
@@ -112,7 +116,6 @@ func TestHandler_getToken(t *testing.T) {
 				}
 			},
 			checkErr: func(t require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, "timeout waiting for access token for 5s")
 				require.ErrorIs(t, err, context.DeadlineExceeded)
 			},
 		},
@@ -130,6 +133,21 @@ func TestHandler_getToken(t *testing.T) {
 				require.True(t, trace.IsBadParameter(err))
 			},
 		},
+		{
+			name:            "context cancel",
+			getTokenContext: testContext,
+			config: mkConstConfig(HandlerConfig{
+				cloudClientGCP: makeTestCloudClient(&testIAMCredentialsClient{
+					generateAccessToken: func(ctx context.Context, req *credentialspb.GenerateAccessTokenRequest, opts ...gax.CallOption) (*credentialspb.GenerateAccessTokenResponse, error) {
+						testContextCancel()
+						return nil, trace.BadParameter("bad param foo")
+					},
+				}),
+			}),
+			checkErr: func(t require.TestingT, err error, i ...any) {
+				require.ErrorIs(t, err, context.Canceled)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -139,7 +157,7 @@ func TestHandler_getToken(t *testing.T) {
 				state = tt.initState()
 			}
 
-			ctx := context.Background()
+			ctx := cmp.Or(tt.getTokenContext, context.Background())
 
 			fwd, err := newGCPHandler(ctx, tt.config(state))
 			require.NoError(t, err)


### PR DESCRIPTION
The GCP and Azure code is largely a copy paste. The Azure version was fixed back in #41648 but the fix was never applied to GCP.

No manual test plan - the issue is fully covered by the additional unit tests.

Before:

```
➜ go test ./lib/srv/app/gcp -race -run TestHandler_getToken
==================
WARNING: DATA RACE
Write at 0x00c000103dc8 by goroutine 34:
  github.com/gravitational/teleport/lib/srv/app/gcp.(*handler).getToken.func1()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler.go:275 +0x16c

Previous read at 0x00c000103dc8 by goroutine 33:
  github.com/gravitational/teleport/lib/srv/app/gcp.(*handler).getToken()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler.go:285 +0x3d4
  github.com/gravitational/teleport/lib/srv/app/gcp.TestHandler_getToken.func10()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler_test.go:166 +0x1fc
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2101 +0x34

Goroutine 34 (running) created at:
  github.com/gravitational/teleport/lib/srv/app/gcp.(*handler).getToken()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler.go:274 +0x2c8
  github.com/gravitational/teleport/lib/srv/app/gcp.TestHandler_getToken.func10()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler_test.go:166 +0x1fc
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2101 +0x34

Goroutine 33 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2101 +0x7bc
  github.com/gravitational/teleport/lib/srv/app/gcp.TestHandler_getToken()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler_test.go:155 +0x78c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Write at 0x00c0004f62f0 by goroutine 34:
  github.com/gravitational/teleport/lib/srv/app/gcp.(*handler).getToken.func1()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler.go:275 +0x1a4

Previous read at 0x00c0004f62f0 by goroutine 33:
  github.com/gravitational/teleport/lib/srv/app/gcp.(*handler).getToken()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler.go:285 +0x3bc
  github.com/gravitational/teleport/lib/srv/app/gcp.TestHandler_getToken.func10()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler_test.go:166 +0x1fc
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2101 +0x34

Goroutine 34 (running) created at:
  github.com/gravitational/teleport/lib/srv/app/gcp.(*handler).getToken()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler.go:274 +0x2c8
  github.com/gravitational/teleport/lib/srv/app/gcp.TestHandler_getToken.func10()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler_test.go:166 +0x1fc
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2101 +0x34

Goroutine 33 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2101 +0x7bc
  github.com/gravitational/teleport/lib/srv/app/gcp.TestHandler_getToken()
      /Users/zmb/src/teleport/lib/srv/app/gcp/handler_test.go:155 +0x78c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2101 +0x34
==================
--- FAIL: TestHandler_getToken (0.00s)
    --- FAIL: TestHandler_getToken/context_cancel (0.00s)
        handler_test.go:149:
            	Error Trace:	/Users/zmb/src/teleport/lib/srv/app/gcp/handler_test.go:149
            	            				/Users/zmb/src/teleport/lib/srv/app/gcp/handler_test.go:168
            	Error:      	Expected error with "context canceled" in chain but got nil.
            	Test:       	TestHandler_getToken/context_cancel
        testing.go:1712: race detected during execution of test
FAIL
FAIL	github.com/gravitational/teleport/lib/srv/app/gcp	1.600s
FAIL
```

After:

```
➜ go test ./lib/srv/app/gcp -race -run TestHandler_getToken
ok  	github.com/gravitational/teleport/lib/srv/app/gcp	2.604s
```