### PR TITLE
Add e2e tests for missing recordings of each session type

### DIFF
--- a/e2e/helpers/pages/Player.ts
+++ b/e2e/helpers/pages/Player.ts
@@ -16,22 +16,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { test as base } from './fixtures';
-import { PlayerPage } from './pages/Player';
-import { UnifiedResourcesPage } from './pages/UnifiedResources';
+import { expect, type Page } from '@playwright/test';
 
-export const CLUSTER_NAME = 'teleport-e2e';
+import { CLUSTER_NAME } from '../test';
 
-export const test = base.extend<{
-  unifiedResourcesPage: UnifiedResourcesPage;
-  playerPage: PlayerPage;
-}>({
-  unifiedResourcesPage: async ({ page }, use) => {
-    await use(new UnifiedResourcesPage(page));
-  },
-  playerPage: async ({ page }, use) => {
-    await use(new PlayerPage(page));
-  },
-});
+export type RecordingType = 'ssh' | 'k8s' | 'desktop' | 'database';
 
-export { expect } from '@playwright/test';
+export class PlayerPage {
+  constructor(private page: Page) {}
+
+  async goto(sessionId: string, recordingType: RecordingType) {
+    await this.page.goto(
+      `/web/cluster/${CLUSTER_NAME}/session/${sessionId}?recordingType=${recordingType}&durationMs=1000`
+    );
+  }
+
+  async expectError(text: string | RegExp) {
+    await expect(this.page.getByText(text)).toBeVisible();
+  }
+}

--- a/e2e/tests/web/authenticated/sessionRecordings.spec.ts
+++ b/e2e/tests/web/authenticated/sessionRecordings.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { test } from '@gravitational/e2e/helpers/test';
+
+const missingSessionId = 'ae4038d7-e6c7-4dfb-92b5-fd03ac025e36';
+
+test.describe('session recording not found', () => {
+  test('ssh', async ({ playerPage }) => {
+    await playerPage.goto(missingSessionId, 'ssh');
+    await playerPage.expectError('Session recording not found');
+  });
+
+  test('k8s', async ({ playerPage }) => {
+    await playerPage.goto(missingSessionId, 'k8s');
+    await playerPage.expectError('Session recording not found');
+  });
+
+  test('desktop', async ({ playerPage }) => {
+    await playerPage.goto(missingSessionId, 'desktop');
+    await playerPage.expectError(
+      'access denied to perform action "read" on "session"'
+    );
+  });
+
+  test('database', async ({ playerPage }) => {
+    await playerPage.goto(missingSessionId, 'database');
+    await playerPage.expectError(
+      'access denied to perform action "read" on "session"'
+    );
+  });
+});


### PR DESCRIPTION
Adds an e2e test for each session recording type asserting that an expected error message is shown when a recording doesn't exist