### PR TITLE
recordingmetadata: recover from vt10x panic and continue session meta…

### DIFF
--- a/lib/auth/recordingmetadata/recordingmetadatav1/processor.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/processor.go
@@ -87,6 +87,10 @@ func (b *baseRecordingProcessor) captureThumbnailIfNeeded(eventTime time.Time) {
 	b.lastThumbnailTime = eventTime
 
 	thumbnail := b.thumbnailGenerator.produceThumbnail()
+	if thumbnail == nil {
+		return
+	}
+
 	thumbnail.StartOffset = durationpb.New(eventTime.Sub(b.startTime))
 	thumbnail.EndOffset = durationpb.New(eventTime.Add(b.thumbnailInterval).Add(-1 * time.Millisecond).Sub(b.startTime))
 

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata_test.go
@@ -170,6 +170,37 @@ func TestProcessSessionRecording_MalformedResizeEvent(t *testing.T) {
 	require.Empty(t, uploadHandler.metadata, "no metadata should be uploaded after cancelUpload")
 }
 
+func TestProcessSessionRecording_MaliciousTTYSequenceDoesNotCrash(t *testing.T) {
+	startTime := time.Now()
+	sessionID := session.NewID()
+
+	evts := []apievents.AuditEvent{
+		sessionStartEvent(startTime, "80:24"),
+		sessionPrintEvent(startTime.Add(1*time.Second), "\x1b[-1@"),
+		sessionPrintEvent(startTime.Add(2*time.Second), "still running\n"),
+		sessionEndEvent(startTime, startTime.Add(10*time.Second)),
+	}
+
+	streamer := &mockStreamer{
+		events:       evts,
+		errorOnEvent: -1,
+	}
+	uploadHandler := newMockUploadHandler()
+
+	service, err := NewRecordingMetadataService(RecordingMetadataServiceConfig{
+		Streamer:      streamer,
+		UploadHandler: uploadHandler,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, service.ProcessSessionRecording(t.Context(), sessionID, recordingmetadata.SessionTypeTTY, 10*time.Second))
+
+	uploadHandler.mu.Lock()
+	defer uploadHandler.mu.Unlock()
+
+	require.NotEmpty(t, uploadHandler.metadata, "metadata should still be uploaded")
+}
+
 func TestProcessSessionRecording_UploadFailsDuringProcessing(t *testing.T) {
 	startTime := time.Now()
 	sessionID := session.NewID()

--- a/lib/auth/recordingmetadata/recordingmetadatav1/ttyprocessor.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/ttyprocessor.go
@@ -40,7 +40,7 @@ type ttyRecordingProcessor struct {
 }
 
 func newTTYRecordingProcessor(base baseRecordingProcessor) *ttyRecordingProcessor {
-	base.thumbnailGenerator = newTTYThumbnailGenerator()
+	base.thumbnailGenerator = newTTYThumbnailGenerator(base.logger)
 
 	return &ttyRecordingProcessor{
 		baseRecordingProcessor: base,

--- a/lib/auth/recordingmetadata/recordingmetadatav1/ttythumbnail.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/ttythumbnail.go
@@ -19,6 +19,9 @@
 package recordingmetadatav1
 
 import (
+	"fmt"
+	"log/slog"
+
 	"github.com/gravitational/trace"
 	"github.com/hinshun/vt10x"
 
@@ -31,16 +34,27 @@ import (
 // ttyThumbnailGenerator is a thumbnail generator that produces thumbnails for a terminal session (i.e. SSH, kubernetes)
 // by maintaining an internal virtual terminal that it updates as it processes events from the session recording.
 type ttyThumbnailGenerator struct {
-	vt vt10x.Terminal
+	vt       vt10x.Terminal
+	logger   *slog.Logger
+	disabled bool
 }
 
-func newTTYThumbnailGenerator() *ttyThumbnailGenerator {
+func newTTYThumbnailGenerator(logger *slog.Logger) *ttyThumbnailGenerator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	return &ttyThumbnailGenerator{
-		vt: vt10x.New(),
+		vt:     vt10x.New(),
+		logger: logger,
 	}
 }
 
 func (t *ttyThumbnailGenerator) handleEvent(event apievents.AuditEvent) error {
+	if t.disabled {
+		return nil
+	}
+
 	switch e := event.(type) {
 	case *apievents.SessionStart:
 		return t.handleSessionStart(e)
@@ -64,6 +78,14 @@ func (t *ttyThumbnailGenerator) handleResize(evt *apievents.Resize) error {
 }
 
 func (t *ttyThumbnailGenerator) handleSessionPrint(evt *apievents.SessionPrint) error {
+	defer func() {
+		if recoverValue := recover(); recoverValue != nil {
+			t.disabled = true
+			t.logger.Warn("Disabling TTY thumbnail generation after vt10x panic",
+				"panic", fmt.Sprint(recoverValue))
+		}
+	}()
+
 	if _, err := t.vt.Write(evt.Data); err != nil {
 		return trace.Errorf("writing data to terminal: %w", err)
 	}
@@ -72,6 +94,10 @@ func (t *ttyThumbnailGenerator) handleSessionPrint(evt *apievents.SessionPrint) 
 }
 
 func (t *ttyThumbnailGenerator) handleTerminalResize(terminalSize string) error {
+	if t.disabled {
+		return nil
+	}
+
 	size, err := session.UnmarshalTerminalParams(terminalSize)
 	if err != nil {
 		return trace.Wrap(err, "parsing terminal size %q", terminalSize)
@@ -83,6 +109,10 @@ func (t *ttyThumbnailGenerator) handleTerminalResize(terminalSize string) error 
 }
 
 func (t *ttyThumbnailGenerator) produceThumbnail() *pb.SessionRecordingThumbnail {
+	if t.disabled {
+		return nil
+	}
+
 	cols, rows := t.vt.Size()
 	cursor := t.vt.Cursor()
 

--- a/lib/auth/recordingmetadata/recordingmetadatav1/ttythumbnail_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/ttythumbnail_test.go
@@ -19,6 +19,7 @@
 package recordingmetadatav1
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func TestTtyThumbnailGenerator_HandleEvent(t *testing.T) {
 	startTime := time.Now()
 
 	t.Run("session start sets terminal size", func(t *testing.T) {
-		gen := newTTYThumbnailGenerator()
+		gen := newTTYThumbnailGenerator(slog.Default())
 
 		require.NoError(t, gen.handleEvent(sessionStartEvent(startTime, "100:50")))
 
@@ -42,7 +43,7 @@ func TestTtyThumbnailGenerator_HandleEvent(t *testing.T) {
 	})
 
 	t.Run("resize updates terminal size", func(t *testing.T) {
-		gen := newTTYThumbnailGenerator()
+		gen := newTTYThumbnailGenerator(slog.Default())
 
 		require.NoError(t, gen.handleEvent(sessionStartEvent(startTime, "80:24")))
 		require.NoError(t, gen.handleEvent(resizeEvent(startTime.Add(1*time.Second), "120:40")))
@@ -54,7 +55,7 @@ func TestTtyThumbnailGenerator_HandleEvent(t *testing.T) {
 	})
 
 	t.Run("session print writes data to terminal", func(t *testing.T) {
-		gen := newTTYThumbnailGenerator()
+		gen := newTTYThumbnailGenerator(slog.Default())
 
 		require.NoError(t, gen.handleEvent(sessionStartEvent(startTime, "80:24")))
 		require.NoError(t, gen.handleEvent(sessionPrintEvent(startTime.Add(1*time.Second), "Hello World\r\n")))
@@ -67,7 +68,7 @@ func TestTtyThumbnailGenerator_HandleEvent(t *testing.T) {
 	})
 
 	t.Run("unhandled event types are ignored", func(t *testing.T) {
-		gen := newTTYThumbnailGenerator()
+		gen := newTTYThumbnailGenerator(slog.Default())
 
 		require.NoError(t, gen.handleEvent(&apievents.SessionEnd{
 			Metadata: apievents.Metadata{Type: "session.end", Time: startTime},
@@ -78,7 +79,7 @@ func TestTtyThumbnailGenerator_HandleEvent(t *testing.T) {
 	})
 
 	t.Run("malformed terminal size returns error on start", func(t *testing.T) {
-		gen := newTTYThumbnailGenerator()
+		gen := newTTYThumbnailGenerator(slog.Default())
 		err := gen.handleEvent(sessionStartEvent(startTime, "invalid"))
 
 		require.Error(t, err)
@@ -86,11 +87,21 @@ func TestTtyThumbnailGenerator_HandleEvent(t *testing.T) {
 	})
 
 	t.Run("malformed terminal size returns error on resize", func(t *testing.T) {
-		gen := newTTYThumbnailGenerator()
+		gen := newTTYThumbnailGenerator(slog.Default())
 		err := gen.handleEvent(resizeEvent(startTime, "not:valid:size"))
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "parsing terminal size")
+	})
+
+	t.Run("malicious csi sequence disables thumbnails without panicking", func(t *testing.T) {
+		gen := newTTYThumbnailGenerator(slog.Default())
+
+		require.NoError(t, gen.handleEvent(sessionStartEvent(startTime, "80:24")))
+		require.NoError(t, gen.handleEvent(sessionPrintEvent(startTime.Add(1*time.Second), "\x1b[-1@")))
+		require.NoError(t, gen.handleEvent(sessionPrintEvent(startTime.Add(2*time.Second), "still running\r\n")))
+
+		require.Nil(t, gen.produceThumbnail())
 	})
 }
 
@@ -98,7 +109,7 @@ func TestTtyThumbnailGenerator_ProduceThumbnail(t *testing.T) {
 	startTime := time.Now()
 
 	t.Run("produces valid thumbnail with all fields", func(t *testing.T) {
-		gen := newTTYThumbnailGenerator()
+		gen := newTTYThumbnailGenerator(slog.Default())
 
 		require.NoError(t, gen.handleEvent(sessionStartEvent(startTime, "80:24")))
 		require.NoError(t, gen.handleEvent(sessionPrintEvent(startTime.Add(1*time.Second), "hello\r\n")))
@@ -114,7 +125,7 @@ func TestTtyThumbnailGenerator_ProduceThumbnail(t *testing.T) {
 	})
 
 	t.Run("cursor tracks print output position", func(t *testing.T) {
-		gen := newTTYThumbnailGenerator()
+		gen := newTTYThumbnailGenerator(slog.Default())
 
 		require.NoError(t, gen.handleEvent(sessionStartEvent(startTime, "80:24")))
 
@@ -130,7 +141,7 @@ func TestTtyThumbnailGenerator_ProduceThumbnail(t *testing.T) {
 	})
 
 	t.Run("reflects latest terminal size after resize", func(t *testing.T) {
-		gen := newTTYThumbnailGenerator()
+		gen := newTTYThumbnailGenerator(slog.Default())
 
 		require.NoError(t, gen.handleEvent(sessionStartEvent(startTime, "80:24")))
 		require.NoError(t, gen.handleEvent(sessionPrintEvent(startTime.Add(1*time.Second), "before resize\r\n")))
@@ -145,7 +156,7 @@ func TestTtyThumbnailGenerator_ProduceThumbnail(t *testing.T) {
 	})
 
 	t.Run("snapshots are independent after more output", func(t *testing.T) {
-		gen := newTTYThumbnailGenerator()
+		gen := newTTYThumbnailGenerator(slog.Default())
 
 		require.NoError(t, gen.handleEvent(sessionStartEvent(startTime, "80:24")))
 		require.NoError(t, gen.handleEvent(sessionPrintEvent(startTime.Add(1*time.Second), "first\r\n")))


### PR DESCRIPTION
Prevent vt10x panic from crashing session recording metadata processing

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:
- Fixed a reliability issue where malformed TTY escape sequences in session recordings could panic thumbnail generation and interrupt recording metadata processing. Metadata upload now continues safely, and thumbnail generation is disabled for the affected session.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Local dev environment
- Repo: `teleport`
- Package under test: `lib/auth/recordingmetadata/recordingmetadatav1`

### Test Cases
- [x] Run targeted unit tests:
  - `go test ./lib/auth/recordingmetadata/recordingmetadatav1 -run 'TestTtyThumbnailGenerator|TestTTYRecordingProcessor|TestProcessSessionRecording'`
- [x] Verify malicious CSI payload (`\x1b[-1@`) no longer crashes thumbnail generation (`TestTtyThumbnailGenerator_HandleEvent/malicious csi sequence disables thumbnails without panicking`)
- [x] Verify end-to-end processing still succeeds and metadata uploads for malicious payload (`TestProcessSessionRecording_MaliciousTTYSequenceDoesNotCrash`)
- [x] Verify existing normal-path thumbnail/TTY processor tests continue to pass

