### PR TITLE
Reject empty cluster name in getSiteByParams

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -5039,6 +5039,9 @@ func (h *Handler) authenticateRequestWithCluster(w http.ResponseWriter, r *http.
 // remote trusted cluster) as specified by the ":site" url parameter.
 func (h *Handler) getSiteByParams(ctx context.Context, sctx *SessionContext, p httprouter.Params) (reversetunnelclient.Cluster, error) {
 	clusterName := p.ByName("site")
+	if clusterName == "" {
+		return nil, trace.BadParameter("missing cluster name in request path")
+	}
 	site, err := h.getSiteByClusterName(ctx, sctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
When the web UI loads `features.json` for Access Graph, the request routes through `getSiteByParams` with an empty `:site` path parameter. That empty string was passed to `getSiteByClusterName`, which logged an error on every request:

<details>
<summary>Error log</summary>

```
2026-04-18T17:31:24.874Z WARN [WEB]       Failed to query site error:[
ERROR REPORT:
Original Error: *trace.NotFoundError not found
Stack Trace:
    /app/lib/utils/utils.go:353 github.com/gravitational/teleport/lib/utils.OpaqueAccessDenied
    /app/lib/reversetunnelclient/api_with_roles.go:95 github.com/gravitational/teleport/lib/reversetunnelclient.(*ClusterGetterWithRoles).Cluster
    /app/lib/web/apiserver.go:5066 github.com/gravitational/teleport/lib/web.(*Handler).getSiteByClusterName
    /app/lib/web/apiserver.go:5042 github.com/gravitational/teleport/lib/web.(*Handler).getSiteByParams
    /app/lib/web/apiserver.go:5030 github.com/gravitational/teleport/lib/web.(*Handler).authenticateRequestWithCluster
    /app/lib/web/apiserver.go:5287 github.com/gravitational/teleport/lib/web.(*Handler).WithUnauthenticatedHighLimiter.(*Handler).unauthenticatedLimiterFunc.func1
    /app/lib/httplib/httplib.go:128 github.com/gravitational/teleport/lib/web.(*Handler).WithUnauthenticatedHighLimiter.(*Handler).unauthenticatedLimiterFunc.MakeHandler.MakeHandlerWithErrorWriter.func2
    /app/e/lib/web/accessgraph.go:59 github.com/gravitational/teleport/e/lib/web.(*Plugin).RegisterProxyWebHandlers.(*Plugin).accessGraphHandler.func95
    /go/pkg/mod/github.com/gravitational/httprouter@v1.3.1-0.20220408074523-c876c5e705a5/router.go:399 github.com/julienschmidt/httprouter.(*Router).ServeHTTP
    /usr/local/go/src/net/http/server.go:2384 github.com/gravitational/teleport/lib/web.NewHandler.func1.StripPrefix.1
    /usr/local/go/src/net/http/server.go:2322 net/http.HandlerFunc.ServeHTTP
    /app/lib/web/apiserver.go:732 github.com/gravitational/teleport/lib/web.NewHandler.func1
    /usr/local/go/src/net/http/server.go:2322 net/http.HandlerFunc.ServeHTTP
    /go/pkg/mod/github.com/gravitational/httprouter@v1.3.1-0.20220408074523-c876c5e705a5/router.go:460 github.com/julienschmidt/httprouter.(*Router).ServeHTTP
    /app/lib/web/apiserver.go:503 github.com/gravitational/teleport/lib/web.(*APIHandler).ServeHTTP
    /app/lib/limiter/internal/ratelimit/ratelimit.go:105 github.com/gravitational/teleport/lib/limiter/internal/ratelimit.(*TokenLimiter).ServeHTTP
    /app/lib/limiter/connlimiter.go:88 github.com/gravitational/teleport/lib/limiter.(*ConnectionsLimiter).ServeHTTP
    /app/lib/limiter/limiter.go:79 github.com/gravitational/teleport/lib/limiter.(*Limiter).ServeHTTP
    /app/lib/httplib/httplib.go:105 github.com/gravitational/teleport/lib/httplib.MakeTracingHandler.func1
    /usr/local/go/src/net/http/server.go:2322 net/http.HandlerFunc.ServeHTTP
    /go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.68.0/handler.go:178 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP
    /go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.68.0/handler.go:66 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1
    /usr/local/go/src/net/http/server.go:2322 net/http.HandlerFunc.ServeHTTP
    /usr/local/go/src/net/http/server.go:3340 net/http.serverHandler.ServeHTTP
    /usr/local/go/src/net/http/server.go:2109 net/http.(*conn).serve
    /usr/local/go/src/runtime/asm_amd64.s:1693 runtime.goexit
User Message: not found] cluster: trace_id:640b70edc9b9cea5ff5b69faf2e9a690 span_id:9f26a9fba6270e2c web/apiserver.go:5068
```

</details>

Now `getSiteByParams` returns `BadParameter` immediately when the `:site` parameter is empty, so the cluster lookup (and error log) are skipped. The request still resolves correctly.

Changelog: Fixed spurious "Failed to query site" error log when loading static files from the Identity Security service.

## Manual Test Plan

### Test Environment
Local

### Test Cases
- [x] Verified that routes without a `site` parameter still load
- [x] Fetching access graph `features.json` no longer logs the error above