### PR TITLE
Slight Vite development speed up

### DIFF
--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -20,7 +20,7 @@ import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 
 import { visualizer } from 'rollup-plugin-visualizer';
-import { defineConfig, type UserConfig } from 'vite';
+import { defineConfig, type ProxyOptions, type UserConfig } from 'vite';
 import { compression } from 'vite-plugin-compression2';
 import wasm from 'vite-plugin-wasm';
 
@@ -57,6 +57,7 @@ export function createViteConfig(
 
     const config: UserConfig = {
       clearScreen: false,
+      cacheDir: process.env.VITE_CACHE_DIR,
       server: {
         allowedHosts: resolveAllowedHosts(target),
         fs: {
@@ -156,82 +157,32 @@ export function createViteConfig(
       }
     } else {
       config.plugins.push(htmlPlugin(target));
-      // siteName matches everything between the slashes.
+
+      // siteName matches everything between the slashes (regex format
+      // assumes slashes are escaped, e.g. `\/v1\/webapi\/sites\/:site\/connect`).
       const siteName = '([^\\/]+)';
 
-      config.server.proxy = {
-        // The format of the regex needs to assume that the slashes are escaped, for example:
-        // \/v1\/webapi\/sites\/:site\/connect
-        [`^\\/v[0-9]+\\/webapi\\/sites\\/${siteName}\\/connect`]: {
-          target: `wss://${target}`,
-          changeOrigin: false,
-          secure: false,
-          ws: true,
-        },
-        // /webapi/sites/:site/desktops/:desktopName/connect
-        [`^\\/v[0-9]+\\/webapi\\/sites\\/${siteName}\\/desktops\\/${siteName}\\/connect`]:
-          {
-            target: `wss://${target}`,
-            changeOrigin: false,
-            secure: false,
-            ws: true,
-          },
-        // /webapi/sites/:site/kube/exec
-        [`^\\/v[0-9]+\\/webapi\\/sites\\/${siteName}\\/kube/exec`]: {
-          target: `wss://${target}`,
-          changeOrigin: false,
-          secure: false,
-          ws: true,
-        },
-        // /webapi/sites/:site/db/exec - database interactive sessions
-        [`^\\/v[0-9]+\\/webapi\\/sites\\/${siteName}\\/db\\/exec`]: {
-          target: `wss://${target}`,
-          changeOrigin: false,
-          secure: false,
-          ws: true,
-        },
-        // /webapi/sites/:site/(desktopplayback|sessionrecording|ttyplayback)/:sid
-        '^(\\/v[0-9]+\\/webapi\\/sites\\/(.*?)\\/(desktopplayback|sessionrecording|ttyplayback)\\/(.*?))(\\/ws)?':
-          {
-            target: `wss://${target}`,
-            changeOrigin: true,
-            secure: false,
-            ws: true,
-            rewriteWsOrigin: true, // rewrite the origin so Teleport doesn't reject the connection
-          },
-        '^\\/v[0-9]+\\/webapi\\/assistant\\/(.*?)': {
-          target: `https://${target}`,
-          changeOrigin: false,
-          secure: false,
-        },
-        [`^\\/v[0-9]+\\/webapi\\/sites\\/${siteName}\\/assistant`]: {
-          target: `wss://${target}`,
-          changeOrigin: false,
-          secure: false,
-          ws: true,
-        },
-        '^\\/v[0-9]+\\/webapi\\/command\\/(.*?)/execute': {
-          target: `wss://${target}`,
-          changeOrigin: false,
-          secure: false,
-          ws: true,
-        },
-        '/web/config.js': {
-          target: `https://${target}`,
-          changeOrigin: true,
-          secure: false,
-        },
-        '^\\/v[0-9]+': {
-          target: `https://${target}`,
-          changeOrigin: true,
-          secure: false,
-        },
-        '/enterprise': {
-          target: `https://${target}`,
-          changeOrigin: true,
-          secure: false,
-        },
-      };
+      // All teleport websocket endpoints live under
+      // `/v{N}/webapi/(sites/<site>/{connect, desktops/<d>/connect, kube/exec,
+      // db/exec, (desktopplayback|sessionrecording|ttyplayback)/...} |
+      // command/<cmd>/execute)`. One alternation covers the lot.
+      const wsPath =
+        `^\\/v[0-9]+\\/webapi\\/(` +
+        [
+          `sites\\/${siteName}\\/connect`,
+          `sites\\/${siteName}\\/desktops\\/${siteName}\\/connect`,
+          `sites\\/${siteName}\\/(kube|db)\\/exec`,
+          `sites\\/${siteName}\\/(desktopplayback|sessionrecording|ttyplayback)\\/.+`,
+          `command\\/.+\\/execute`,
+        ].join('|') +
+        `)`;
+
+      config.server.proxy = Object.fromEntries([
+        wsRoute(target, wsPath),
+        httpRoute(target, '/web/config.js'),
+        httpRoute(target, '^\\/v[0-9]+'),
+        httpRoute(target, '/enterprise'),
+      ]);
 
       if (process.env.VITE_HTTPS_KEY && process.env.VITE_HTTPS_CERT) {
         config.server.https = {
@@ -289,4 +240,28 @@ function resolveTargetURL(url: string) {
   const parsed = new URL(target);
 
   return parsed.host;
+}
+
+function wsRoute(target: string, path: string): [string, ProxyOptions] {
+  return [
+    path,
+    {
+      target: `wss://${target}`,
+      secure: false,
+      ws: true,
+      changeOrigin: true,
+      rewriteWsOrigin: true,
+    },
+  ];
+}
+
+function httpRoute(target: string, path: string): [string, ProxyOptions] {
+  return [
+    path,
+    {
+      target: `https://${target}`,
+      secure: false,
+      changeOrigin: true,
+    },
+  ];
 }

--- a/web/packages/build/vite/html.ts
+++ b/web/packages/build/vite/html.ts
@@ -17,77 +17,12 @@
  */
 
 import { readFileSync } from 'fs';
-import type { IncomingHttpHeaders } from 'http';
-import { get } from 'https';
+import type * as http from 'http';
+import type * as http2 from 'http2';
+import { connect } from 'http2';
 import { resolve } from 'path';
 
-import { JSDOM } from 'jsdom';
 import type { Plugin } from 'vite';
-
-function getHTML(target: string, headers: IncomingHttpHeaders) {
-  return new Promise<{ data: string; headers: IncomingHttpHeaders }>(
-    (resolve, reject) => {
-      // Remove http2 pseudo-headers since the target may only accept http1.
-      const filteredHeaders: IncomingHttpHeaders = Object.fromEntries(
-        Object.entries(headers).filter(
-          ([name, value]) => value != null && !name.startsWith(':')
-        )
-      );
-
-      filteredHeaders.host = target;
-
-      get(
-        `https://${target}/web`,
-        { headers: filteredHeaders, rejectUnauthorized: false },
-        res => {
-          let data = '';
-
-          res.on('data', d => {
-            data += d.toString();
-          });
-
-          res.on('end', () => {
-            resolve({ data, headers: res.headers });
-          });
-
-          res.on('error', reject);
-        }
-      ).on('error', reject);
-    }
-  );
-}
-
-function replaceMetaTag(name: string, source: JSDOM, target: JSDOM) {
-  const sourceTag = source.window.document.querySelector(
-    `meta[name=${name}]`
-  ) as HTMLMetaElement;
-  const targetTag = target.window.document.querySelector(
-    `meta[name=${name}]`
-  ) as HTMLMetaElement;
-
-  const value = sourceTag.getAttribute('content');
-
-  targetTag.setAttribute('content', value);
-}
-
-export function transformPlugin(): Plugin {
-  return {
-    name: 'teleport-transform-html-plugin',
-    transformIndexHtml(html) {
-      return {
-        html,
-        tags: [
-          {
-            tag: 'script',
-            attrs: {
-              src: '/web/config.js',
-            },
-          },
-        ],
-      };
-    },
-  };
-}
 
 export function htmlPlugin(target: string): Plugin {
   return {
@@ -97,38 +32,48 @@ export function htmlPlugin(target: string): Plugin {
         if (req.url === '/') {
           res.writeHead(302, { Location: '/web' });
           res.end();
-
           return;
         }
-
         next();
       });
 
       return () => {
         server.middlewares.use(async (req, res, next) => {
+          if (req.url !== '/index.html') {
+            next();
+            return;
+          }
+
           try {
-            const { data, headers } = await getHTML(target, req.headers);
+            const { body, headers } = await fetchIndexHtml(req.headers, target);
 
-            let template = readFileSync(
-              resolve(process.cwd(), 'index.html'),
-              'utf-8'
-            );
+            if (cachedTemplate === null) {
+              cachedTemplate = readFileSync(indexHtmlPath, 'utf-8');
+            }
 
-            template = await server.transformIndexHtml(
+            const transformed = await server.transformIndexHtml(
               req.originalUrl,
-              template
+              cachedTemplate
             );
 
-            const source = new JSDOM(data);
-            const result = new JSDOM(template);
+            const bearerToken = body.match(BEARER_META_RE)?.[1] ?? '';
+            const csrfToken = body.match(CSRF_META_RE)?.[1] ?? '';
+            const html = transformed
+              .replace(
+                BEARER_META_RE,
+                `<meta name="grv_bearer_token" content="${bearerToken}">`
+              )
+              .replace(
+                CSRF_META_RE,
+                `<meta name="grv_csrf_token" content="${csrfToken}">`
+              );
 
-            replaceMetaTag('grv_csrf_token', source, result);
-            replaceMetaTag('grv_bearer_token', source, result);
+            if (headers['set-cookie']) {
+              res.setHeader('set-cookie', headers['set-cookie']);
+            }
 
-            res.setHeader('set-cookie', headers['set-cookie']);
             res.writeHead(200, { 'Content-Type': 'text/html' });
-            res.write(result.serialize());
-            res.end();
+            res.end(html);
           } catch (err) {
             server.ssrFixStacktrace(err);
             next(err);
@@ -137,4 +82,110 @@ export function htmlPlugin(target: string): Plugin {
       };
     },
   };
+}
+
+export function transformPlugin(): Plugin {
+  return {
+    name: 'teleport-transform-html-plugin',
+    transformIndexHtml(html) {
+      return {
+        html,
+        tags: [{ tag: 'script', attrs: { src: '/web/config.js' } }],
+      };
+    },
+  };
+}
+
+// Headers that can't cross into HTTP/2. `host` is covered by `:authority` instead.
+const H2_FORBIDDEN_HEADERS = new Set([
+  'connection',
+  'proxy-connection',
+  'keep-alive',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+]);
+
+// Captures the content of `<meta name="grv_bearer_token" content="…">` with
+// either quote style and arbitrary attribute order.
+const BEARER_META_RE =
+  /<meta\s+[^>]*name=["']grv_bearer_token["'][^>]*content=["']([^"']*)["'][^>]*>/i;
+
+// Captures the content of `<meta name="grv_csrf_token" content="…">` with
+// either quote style and arbitrary attribute order.
+const CSRF_META_RE =
+  /<meta\s+[^>]*name=["']grv_csrf_token["'][^>]*content=["']([^"']*)["'][^>]*>/i;
+
+const indexHtmlPath = resolve(process.cwd(), 'index.html');
+// index.html can't change during a dev session (vite restarts on config changes), so
+// read it once.
+let cachedTemplate: string | null = null;
+
+// One long-lived h2 session keeps every SPA-shell request on the same TCP + TLS +
+// SETTINGS handshake. Recreated lazily on close / error / GOAWAY.
+let session: http2.ClientHttp2Session | null = null;
+
+function getSession(target: string) {
+  if (session && !session.closed && !session.destroyed) {
+    return session;
+  }
+
+  const created = connect(`https://${target}`, {
+    rejectUnauthorized: false,
+  });
+
+  function invalidate() {
+    if (session === created) {
+      session = null;
+    }
+  }
+
+  created.on('close', invalidate);
+  created.on('error', invalidate);
+  created.on('goaway', invalidate);
+
+  session = created;
+
+  return created;
+}
+
+function fetchIndexHtml(reqHeaders: http.IncomingHttpHeaders, target: string) {
+  const h2Headers: http2.OutgoingHttpHeaders = {
+    ':method': 'GET',
+    ':path': '/web',
+    ':scheme': 'https',
+    ':authority': target,
+  };
+
+  for (const [name, value] of Object.entries(reqHeaders)) {
+    if (value == null || name.startsWith(':')) {
+      continue;
+    }
+
+    if (H2_FORBIDDEN_HEADERS.has(name.toLowerCase())) {
+      continue;
+    }
+
+    h2Headers[name] = value;
+  }
+
+  return new Promise<{ body: string; headers: http2.IncomingHttpHeaders }>(
+    (resolve, reject) => {
+      const req = getSession(target).request(h2Headers);
+
+      let body = '';
+      let headers: http2.IncomingHttpHeaders = {};
+
+      req.setEncoding('utf8');
+      req.on('response', h => {
+        headers = h;
+      });
+      req.on('data', chunk => {
+        body += chunk;
+      });
+      req.on('end', () => resolve({ body, headers }));
+      req.on('error', reject);
+      req.end();
+    }
+  );
 }


### PR DESCRIPTION
This speeds up the Vite development server a _little_ bit -

- Allows for a custom Vite cache directory to be set, useful when running multiple instances of Vite
- Moves the Vite HTML plugin (that rewrites `index.html` with the bearer token from the proxy) to HTTP2 with connection-reuse
- Removes JSDOM token extraction from the HTML plugin in favour of a simple regex

Finally, it simplified the Vite proxy config to make it easier to define websocket/HTTP proxy entries. It also sets the rewrite options correctly based on the Vite host being different than the proxy target. This means stuff like SSH and session recordings now work correctly during development for those who use a different domain name.

This improves time-to-first-byte for the `index.html` fetching. Negligible in most scenarios but hey, any win is great.
 
| Run          | Before (TTFB) | After (TTFB)     |
| ------------ | ------------- | ---------------- |
| 1 *(cold)*           | 67.6 ms       | 55.8 ms  |
| 2            | 35.4 ms       | 2.7 ms           |
| 3            | 34.4 ms       | 3.2 ms           |
| **Warm avg** | **~35 ms**    | **~3 ms**        |

## Manual Test Plan
### Test Environment
Local

### Test Cases
- [x] Vite development server still works as expected
- [x] SSH sessions work during development when using a Vite host that is different from the proxy target
- [x] Session recording playback works during development
