### PR TITLE
[v17] Bypass HTTP proxies for local JS gRPC clients

### DIFF
--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -894,6 +894,9 @@ async function setUpTshdClients({
     host: tshdAddress,
     channelCredentials: creds,
     interceptors: [loggingInterceptor(new Logger('tshd'))],
+    // This gRPC client talks to a localhost endpoint on Windows.
+    // Do not route it through HTTP proxies.
+    clientOptions: { 'grpc.enable_http_proxy': 0 },
   });
   return {
     terminalService: createTshdClient(transport),

--- a/web/packages/teleterm/src/preload.ts
+++ b/web/packages/teleterm/src/preload.ts
@@ -70,6 +70,9 @@ async function getElectronGlobals(): Promise<ElectronGlobals> {
     host: addresses.tsh,
     channelCredentials: credentials.tshd,
     interceptors: [loggingInterceptor(new Logger('tshd'))],
+    // This gRPC client talks to a localhost endpoint on Windows.
+    // Do not route it through HTTP proxies.
+    clientOptions: { 'grpc.enable_http_proxy': 0 },
   });
   const tshClient = withoutInsecureTshdMethods(createTshdClient(tshdTransport));
   const vnetClient = createVnetClient(tshdTransport);

--- a/web/packages/teleterm/src/services/pty/ptyHost/ptyHostClient.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/ptyHostClient.ts
@@ -32,7 +32,11 @@ export function createPtyHostClient(
   address: string,
   credentials: ChannelCredentials
 ): PtyHostClient {
-  const client = new GrpcClient(address, credentials);
+  const client = new GrpcClient(address, credentials, {
+    // This gRPC client talks to a localhost endpoint on Windows.
+    // Do not route it through HTTP proxies.
+    'grpc.enable_http_proxy': 0,
+  });
   return {
     createPtyProcess(ptyOptions) {
       const request = PtyCreate.create({


### PR DESCRIPTION
Backport #65634 to branch/v17

Changelog: Fixed a Teleport Connect issue on Windows where startup could fail when `HTTPS_PROXY` is set

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
* Built and ran the app locally.
* Added two clusters.
* Set `HTTPS_PROXY=http://127.0.0.1:9` (no proxy is running on that port).
* Set `NO_PROXY=<address of one cluster>` so I could test the `TshdEvents` path.

### Test Cases
- [x] The app launches correctly on Windows, the terminal works. 
- [x] The app receives tshd events, like headless auth.
- [x] The remote connection to the cluster is routed through the proxy (and it fails as expected).