### PR TITLE
fix vnet config terraform resource ID to use apitypes.MetaNameVnetConfig

### DIFF
--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -823,7 +823,7 @@ var (
 		UpsertMethodArity:     2,
 		UpdateMethod:          "VnetConfigClient().UpsertVnetConfig",
 		DeleteMethod:          "VnetConfigClient().ResetVnetConfig",
-		ID:                    `"vnet_config"`,
+		ID:                    "apitypes.MetaNameVnetConfig",
 		Kind:                  "vnet_config",
 		HasStaticID:           false,
 		ProtoPackage:          "vnet",

--- a/integrations/terraform/provider/resource_teleport_vnet_config.go
+++ b/integrations/terraform/provider/resource_teleport_vnet_config.go
@@ -165,7 +165,7 @@ func (r resourceTeleportVnetConfig) Create(ctx context.Context, req tfsdk.Create
 		return
 	}
 
-	plan.Attrs["id"] = types.String{Value: "vnet_config"}
+	plan.Attrs["id"] = types.String{Value: apitypes.MetaNameVnetConfig}
 
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
Fix teleport_vnet_config resource ID. Previously it used "vnet_config", now it uses the correct "vnet-config" via apitypes.MetaNameVnetConfig


Already fixed in v18 #64682


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

### Test Environment
Any system with Terraform configured to talk to a Teleport cluster

### Test Cases
- [x] Create `teleport_vnet_config` with Terraform
- [x] Update `teleport_vnet_config`
- [x] Destroy `teleport_vnet_config` and confirm reset to defaults

