### PR TITLE
docs: k8s updates

### DIFF
--- a/docs/pages/enroll-resources/kubernetes-access/controls.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/controls.mdx
@@ -1099,7 +1099,7 @@ spec:
 kind: role
 metadata:
   name: allow-exec
-  version: v7
+version: v7
 spec:
   allow:
     kubernetes_labels:
@@ -1114,7 +1114,7 @@ spec:
 kind: role
 metadata:
   name: deny-redis-exec
-  version: v7
+version: v7
 spec:
   deny:
     kubernetes_resources:

--- a/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
@@ -166,7 +166,7 @@ To set up and test access:
    <Var name="admin@example.com"/> to your Teleport username:
 
    ```code
-   $ tsh login --proxy=<Var name="teleport.example.com"/>:443 --auth=local --user=<Var name="admin@example.com"/> <Var name="teleport.example.com"/>
+   $ tsh login --proxy=<Var name="teleport.example.com"/>:443 --auth=local --user=<Var name="admin@example.com"/>
    ```
 
    List Kubernetes clusters available for you to access:

--- a/docs/pages/enroll-resources/kubernetes-access/health-checks.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/health-checks.mdx
@@ -163,7 +163,7 @@ spec:
   # config applies.
   match:
     # disable all labels and expressions for all resources in this config
-    disable: false
+    disabled: false
     # kubernetes_labels matches Kubernetes cluster labels. An empty value is ignored.
     # If kubernetes_labels_expression is also set, then the match result is the logical
     # AND of both.

--- a/docs/pages/enroll-resources/kubernetes-access/introduction.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/introduction.mdx
@@ -28,7 +28,7 @@ commands, and view your `kubectl`  activity in Teleport's audit log:
 ![Kubernetes access architecture](../../../img/k8s/architecture-diagram.png)
 
 You can set up the Teleport Discovery Service to protect Kubernetes clusters
-with your Teleport automatically. Read more about [Teleport
+with Teleport automatically. Read more about [Teleport
 auto-discovery](../auto-discovery/kubernetes/kubernetes.mdx).
 
 Teleport protects Kubernetes clusters through the Teleport Kubernetes Service,


### PR DESCRIPTION
docs/pages/enroll-resources/kubernetes-access/introduction.mdx:
- grammar fix

docs/pages/enroll-resources/kubernetes-access/controls.mdx:
- fix version location in roles examples

docs/pages/enroll-resources/kubernetes-access/getting-started.mdx:
- remove unnecessary cluster name in login

docs/pages/enroll-resources/kubernetes-access/health-checks.mdx:
- fix `match.disabled` reference
