### PR TITLE
Remove unused DeleteAllTunnelConnections & DeleteTunnelConnections RPCs

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -137,8 +137,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.GET("/:version/tunnelconnections/:cluster", srv.WithAuth(srv.getTunnelConnections))
 	srv.GET("/:version/tunnelconnections", srv.WithAuth(srv.getAllTunnelConnections))
 	srv.DELETE("/:version/tunnelconnections/:cluster/:conn", srv.WithAuth(srv.deleteTunnelConnection))
-	srv.DELETE("/:version/tunnelconnections/:cluster", srv.WithAuth(srv.deleteTunnelConnections))
-	srv.DELETE("/:version/tunnelconnections", srv.WithAuth(srv.deleteAllTunnelConnections))
 
 	// trusted clusters
 	// TODO(noah): DELETE IN v21.0.0 - this has been migrated to gRPC from v19.
@@ -154,6 +152,8 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.GET("/:version/namespaces", httpMigratedHandler)
 	srv.GET("/:version/namespaces/:namespace", httpMigratedHandler)
 	srv.GET("/:version/configuration/name", httpMigratedHandler)
+	srv.DELETE("/:version/tunnelconnections/:cluster", httpMigratedHandler)
+	srv.DELETE("/:version/tunnelconnections", httpMigratedHandler)
 
 	if config.PluginRegistry != nil {
 		if err := config.PluginRegistry.RegisterAuthWebHandlers(&srv); err != nil {
@@ -600,24 +600,6 @@ func (s *APIServer) getAllTunnelConnections(auth *ServerWithRoles, w http.Respon
 // deleteTunnelConnection deletes tunnel connection by name
 func (s *APIServer) deleteTunnelConnection(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
 	err := auth.DeleteTunnelConnection(p.ByName("cluster"), p.ByName("conn"))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return message("ok"), nil
-}
-
-// deleteTunnelConnections deletes all tunnel connections for cluster
-func (s *APIServer) deleteTunnelConnections(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
-	err := auth.DeleteTunnelConnections(p.ByName("cluster"))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return message("ok"), nil
-}
-
-// deleteAllTunnelConnections deletes all tunnel connections
-func (s *APIServer) deleteAllTunnelConnections(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
-	err := auth.DeleteAllTunnelConnections()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5862,20 +5862,6 @@ func (a *ServerWithRoles) DeleteTunnelConnection(clusterName string, connName st
 	return a.authServer.DeleteTunnelConnection(clusterName, connName)
 }
 
-func (a *ServerWithRoles) DeleteTunnelConnections(clusterName string) error {
-	if err := a.authorizeAction(types.KindTunnelConnection, types.VerbList, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.DeleteTunnelConnections(clusterName)
-}
-
-func (a *ServerWithRoles) DeleteAllTunnelConnections() error {
-	if err := a.authorizeAction(types.KindTunnelConnection, types.VerbList, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.DeleteAllTunnelConnections()
-}
-
 // AcquireSemaphore acquires lease with requested resources from semaphore.
 func (a *ServerWithRoles) AcquireSemaphore(ctx context.Context, params types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
 	if err := a.authorizeAction(types.KindSemaphore, types.VerbCreate, types.VerbUpdate); err != nil {

--- a/lib/auth/authclient/http_client.go
+++ b/lib/auth/authclient/http_client.go
@@ -389,21 +389,6 @@ func (c *HTTPClient) DeleteTunnelConnection(clusterName string, connName string)
 	return trace.Wrap(err)
 }
 
-// DeleteTunnelConnections deletes all tunnel connections for cluster
-func (c *HTTPClient) DeleteTunnelConnections(clusterName string) error {
-	if clusterName == "" {
-		return trace.BadParameter("missing parameter cluster name")
-	}
-	_, err := c.Delete(context.TODO(), c.Endpoint("tunnelconnections", clusterName))
-	return trace.Wrap(err)
-}
-
-// DeleteAllTunnelConnections deletes all tunnel connections
-func (c *HTTPClient) DeleteAllTunnelConnections() error {
-	_, err := c.Delete(context.TODO(), c.Endpoint("tunnelconnections"))
-	return trace.Wrap(err)
-}
-
 type upsertServerRawReq struct {
 	Server json.RawMessage `json:"server"`
 	TTL    time.Duration   `json:"ttl"`

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1597,15 +1597,13 @@ func TestTunnelConnectionsCRUD(t *testing.T) {
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], conn, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-	err = clt.DeleteAllTunnelConnections()
+	// Delete all to reset test environment
+	out, err = clt.GetAllTunnelConnections()
 	require.NoError(t, err)
-
-	out, err = clt.GetTunnelConnections(clusterName)
-	require.NoError(t, err)
-	require.Empty(t, out)
-
-	err = clt.DeleteAllTunnelConnections()
-	require.NoError(t, err)
+	for _, tc := range out {
+		err := testSrv.Auth().DeleteTunnelConnection(tc.GetClusterName(), tc.GetName())
+		require.NoError(t, err)
+	}
 
 	// test delete individual connection
 	err = clt.UpsertTunnelConnection(conn)
@@ -4809,7 +4807,7 @@ func TestEvents(t *testing.T) {
 				out, err := testSrv.Auth().GetTunnelConnections("example.com")
 				require.NoError(t, err)
 
-				err = testSrv.Auth().DeleteAllTunnelConnections()
+				err = testSrv.Auth().DeleteTunnelConnection(conn.GetClusterName(), conn.GetName())
 				require.NoError(t, err)
 
 				return out[0]

--- a/lib/cache/remote_cluster_test.go
+++ b/lib/cache/remote_cluster_test.go
@@ -104,7 +104,17 @@ func TestTunnelConnections(t *testing.T) {
 		cacheList: getAllAdapter(func(ctx context.Context) ([]types.TunnelConnection, error) { return p.cache.GetAllTunnelConnections() }),
 		update:    modifyNoContext(p.trustS.UpsertTunnelConnection),
 		deleteAll: func(ctx context.Context) error {
-			return p.trustS.DeleteAllTunnelConnections()
+			all, err := p.trustS.GetAllTunnelConnections()
+			if err != nil {
+				return err
+			}
+			for _, tc := range all {
+				err := p.trustS.DeleteTunnelConnection(tc.GetClusterName(), tc.GetName())
+				if err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}, withSkipPaginationTest())
 

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -1248,15 +1248,12 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], conn, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-	err = s.TrustS.DeleteAllTunnelConnections()
+	out, err = s.TrustS.GetAllTunnelConnections()
 	require.NoError(t, err)
-
-	out, err = s.TrustS.GetTunnelConnections(clusterName)
-	require.NoError(t, err)
-	require.Empty(t, out)
-
-	err = s.TrustS.DeleteAllTunnelConnections()
-	require.NoError(t, err)
+	for _, tc := range out {
+		err = s.TrustS.DeleteTunnelConnection(tc.GetClusterName(), tc.GetName())
+		require.NoError(t, err)
+	}
 
 	// test delete individual connection
 	err = s.TrustS.UpsertTunnelConnection(conn)
@@ -2246,7 +2243,7 @@ func (s *ServicesTestSuite) Events(t *testing.T) {
 				out, err := s.TrustS.GetTunnelConnections("example.com")
 				require.NoError(t, err)
 
-				err = s.TrustS.DeleteAllTunnelConnections()
+				err = s.TrustS.DeleteTunnelConnection(conn.GetClusterName(), conn.GetName())
 				require.NoError(t, err)
 
 				return out[0]

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -911,23 +911,6 @@ func (s *CA) DeleteTunnelConnection(clusterName, connectionName string) error {
 	return s.Delete(context.TODO(), backend.NewKey(tunnelConnectionsPrefix, clusterName, connectionName))
 }
 
-// DeleteTunnelConnections deletes all tunnel connections for cluster
-func (s *CA) DeleteTunnelConnections(clusterName string) error {
-	if clusterName == "" {
-		return trace.BadParameter("missing cluster name")
-	}
-	startKey := backend.ExactKey(tunnelConnectionsPrefix, clusterName)
-	err := s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
-	return trace.Wrap(err)
-}
-
-// DeleteAllTunnelConnections deletes all tunnel connections
-func (s *CA) DeleteAllTunnelConnections() error {
-	startKey := backend.ExactKey(tunnelConnectionsPrefix)
-	err := s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
-	return trace.Wrap(err)
-}
-
 // CreateRemoteCluster creates a remote cluster
 func (s *CA) CreateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (types.RemoteCluster, error) {
 	rev, err := s.CreateRemoteClusterInternal(ctx, rc, nil)

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -149,12 +149,6 @@ type Clusters interface {
 	// DeleteTunnelConnection deletes tunnel connection by name
 	DeleteTunnelConnection(clusterName string, connName string) error
 
-	// DeleteTunnelConnections deletes all tunnel connections for cluster
-	DeleteTunnelConnections(clusterName string) error
-
-	// DeleteAllTunnelConnections deletes all tunnel connections for cluster
-	DeleteAllTunnelConnections() error
-
 	// CreateRemoteCluster creates a remote cluster
 	CreateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (types.RemoteCluster, error)
 


### PR DESCRIPTION
Whilst looking into what we have left to complete https://github.com/gravitational/teleport/issues/6394, I noticed that these two RPCs were not called on master, v18 or v17. Looking deeper into the history, I can't see any call sites except for in single digit versions of teleport (i.e v4).

It's entirely probable that these methods were never invoked remotely, and only ever existed to satisfy an interface that abstracted over the local service implementation and the client - as with many of our more legacy RPCs.

Removing these RPCs will reduce the amount of work necessary to migrate the remaining RPCs from HTTP to gRPC.

## Manual Test Plan
### Test Environment

Local cluster.

### Test Cases

I couldn't envision a sane test plan for the removal of endpoints that do not have any callers in the past few years of Teleport's history. If anyone has some suggestions, I'd be more than happy to give it a go.