### PR TITLE
[v18] Fix Terraform codegen defaults and GetMethod usage in templates

### DIFF
--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -488,6 +488,10 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{.VarName}}Resource := {{.VarName}}
 {{end}}
 
+	{{- if .ForceSetKind }}
+	{{.VarName}}Resource.Kind = {{.ForceSetKind}}
+	{{- end}}
+
 	{{if .HasCheckAndSetDefaults -}}
 	if err := {{.VarName}}Resource.CheckAndSetDefaults(); err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating {{.Name}}", err, "{{.Kind}}"))

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -365,6 +365,10 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		return
 	}
 
+{{- if .ForceSetKind }}
+	{{.VarName}}.Kind = {{.ForceSetKind}}
+{{- end}}
+
 {{- if .HasCheckAndSetDefaults }}
 
 	err := {{.VarName}}.CheckAndSetDefaults()
@@ -378,6 +382,15 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 		{{.VarName}}.SubKind = {{.DefaultSubKind}}
 	}
 {{- end}}
+
+	{{- if .DefaultName }}
+	if {{.VarName}}.GetMetadata() == nil {
+		{{.VarName}}.Metadata = &headerv1.Metadata{}
+	}
+	if {{ .VarName }}.GetMetadata().GetName() == "" {
+		{{ .VarName }}.Metadata.Name = {{ .DefaultName }}
+	}
+	{{- end}}
 
 {{- if .RequestWrapper}}
 

--- a/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
+++ b/integrations/terraform/provider/resource_teleport_access_monitoring_rule.go
@@ -210,6 +210,7 @@ func (r resourceTeleportAccessMonitoringRule) Update(ctx context.Context, req tf
 	}
 	accessMonitoringRuleResource := accessMonitoringRule
 
+	accessMonitoringRuleResource.Kind = apitypes.KindAccessMonitoringRule
 
 	
 	name := accessMonitoringRuleResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_autoupdate_config.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_config.go
@@ -216,6 +216,13 @@ func (r resourceTeleportAutoUpdateConfig) Update(ctx context.Context, req tfsdk.
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	autoUpdateConfig.Kind = apitypes.KindAutoUpdateConfig
+	if autoUpdateConfig.GetMetadata() == nil {
+		autoUpdateConfig.Metadata = &headerv1.Metadata{}
+	}
+	if autoUpdateConfig.GetMetadata().GetName() == "" {
+		autoUpdateConfig.Metadata.Name = apitypes.MetaNameAutoUpdateConfig
+	}
 
 	autoUpdateConfigBefore, err := r.p.Client.GetAutoUpdateConfig(ctx)
 	if err != nil {

--- a/integrations/terraform/provider/resource_teleport_autoupdate_version.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_version.go
@@ -216,6 +216,13 @@ func (r resourceTeleportAutoUpdateVersion) Update(ctx context.Context, req tfsdk
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	autoUpdateVersion.Kind = apitypes.KindAutoUpdateVersion
+	if autoUpdateVersion.GetMetadata() == nil {
+		autoUpdateVersion.Metadata = &headerv1.Metadata{}
+	}
+	if autoUpdateVersion.GetMetadata().GetName() == "" {
+		autoUpdateVersion.Metadata.Name = apitypes.MetaNameAutoUpdateVersion
+	}
 
 	autoUpdateVersionBefore, err := r.p.Client.GetAutoUpdateVersion(ctx)
 	if err != nil {

--- a/integrations/terraform/provider/resource_teleport_db_object_import_rule.go
+++ b/integrations/terraform/provider/resource_teleport_db_object_import_rule.go
@@ -223,6 +223,7 @@ func (r resourceTeleportDatabaseObjectImportRule) Update(ctx context.Context, re
 	}
 	importRuleResource := importRule
 
+	importRuleResource.Kind = apitypes.KindDatabaseObjectImportRule
 
 	
 	name := importRuleResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_discovery_config.go
+++ b/integrations/terraform/provider/resource_teleport_discovery_config.go
@@ -217,6 +217,7 @@ func (r resourceTeleportDiscoveryConfig) Update(ctx context.Context, req tfsdk.U
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading DiscoveryConfig", trace.Errorf("Can not convert %T to DiscoveryConfig: %s", discoveryConfigResource, err), "discovery_config"))
 		return
 	}
+	discoveryConfigResource.Kind = apitypes.KindDiscoveryConfig
 
 	
 	name := discoveryConfigResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_health_check_config.go
+++ b/integrations/terraform/provider/resource_teleport_health_check_config.go
@@ -210,6 +210,7 @@ func (r resourceTeleportHealthCheckConfig) Update(ctx context.Context, req tfsdk
 	}
 	healthCheckConfigResource := healthCheckConfig
 
+	healthCheckConfigResource.Kind = apitypes.KindHealthCheckConfig
 
 	
 	name := healthCheckConfigResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_inference_model.go
+++ b/integrations/terraform/provider/resource_teleport_inference_model.go
@@ -210,6 +210,7 @@ func (r resourceTeleportInferenceModel) Update(ctx context.Context, req tfsdk.Up
 	}
 	inferenceModelResource := inferenceModel
 
+	inferenceModelResource.Kind = apitypes.KindInferenceModel
 
 	
 	name := inferenceModelResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_inference_policy.go
+++ b/integrations/terraform/provider/resource_teleport_inference_policy.go
@@ -210,6 +210,7 @@ func (r resourceTeleportInferencePolicy) Update(ctx context.Context, req tfsdk.U
 	}
 	inferencePolicyResource := inferencePolicy
 
+	inferencePolicyResource.Kind = apitypes.KindInferencePolicy
 
 	
 	name := inferencePolicyResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_inference_secret.go
+++ b/integrations/terraform/provider/resource_teleport_inference_secret.go
@@ -218,6 +218,7 @@ func (r resourceTeleportInferenceSecret) Update(ctx context.Context, req tfsdk.U
 	}
 	inferenceSecretResource := inferenceSecret
 
+	inferenceSecretResource.Kind = apitypes.KindInferenceSecret
 
 	
 	name := inferenceSecretResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_retrieval_model.go
+++ b/integrations/terraform/provider/resource_teleport_retrieval_model.go
@@ -216,6 +216,13 @@ func (r resourceTeleportRetrievalModel) Update(ctx context.Context, req tfsdk.Up
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	retrievalModel.Kind = apitypes.KindRetrievalModel
+	if retrievalModel.GetMetadata() == nil {
+		retrievalModel.Metadata = &headerv1.Metadata{}
+	}
+	if retrievalModel.GetMetadata().GetName() == "" {
+		retrievalModel.Metadata.Name = apitypes.MetaNameRetrievalModel
+	}
 
 	retrievalModelBefore, err := r.p.Client.SummarizerClient().GetRetrievalModel(ctx)
 	if err != nil {

--- a/integrations/terraform/provider/resource_teleport_scoped_role.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_role.go
@@ -223,6 +223,7 @@ func (r resourceTeleportScopedRole) Update(ctx context.Context, req tfsdk.Update
 	}
 	scopedRoleResource := scopedRole
 
+	scopedRoleResource.Kind = apitypes.KindScopedRole
 
 	
 	name := scopedRoleResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_scoped_role_assignment.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_role_assignment.go
@@ -239,6 +239,7 @@ func (r resourceTeleportScopedRoleAssignment) Update(ctx context.Context, req tf
 	}
 	scopedRoleAssignmentResource := scopedRoleAssignment
 
+	scopedRoleAssignmentResource.Kind = apitypes.KindScopedRoleAssignment
 
 	
 	if scopedRoleAssignmentResource.SubKind == "" {

--- a/integrations/terraform/provider/resource_teleport_scoped_token.go
+++ b/integrations/terraform/provider/resource_teleport_scoped_token.go
@@ -210,6 +210,7 @@ func (r resourceTeleportScopedToken) Update(ctx context.Context, req tfsdk.Updat
 	}
 	scopedTokenResource := scopedToken
 
+	scopedTokenResource.Kind = apitypes.KindScopedToken
 
 	
 	name := scopedTokenResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_server.go
+++ b/integrations/terraform/provider/resource_teleport_server.go
@@ -221,6 +221,7 @@ func (r resourceTeleportServer) Update(ctx context.Context, req tfsdk.UpdateReso
 	}
 	serverResource := server
 
+	serverResource.Kind = apitypes.KindNode
 
 	if err := serverResource.CheckAndSetDefaults(); err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating Server", err, "node"))

--- a/integrations/terraform/provider/resource_teleport_static_host_user.go
+++ b/integrations/terraform/provider/resource_teleport_static_host_user.go
@@ -210,6 +210,7 @@ func (r resourceTeleportStaticHostUser) Update(ctx context.Context, req tfsdk.Up
 	}
 	staticHostUserResource := staticHostUser
 
+	staticHostUserResource.Kind = apitypes.KindStaticHostUser
 
 	
 	name := staticHostUserResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_vnet_config.go
+++ b/integrations/terraform/provider/resource_teleport_vnet_config.go
@@ -216,6 +216,13 @@ func (r resourceTeleportVnetConfig) Update(ctx context.Context, req tfsdk.Update
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	vnetConfig.Kind = apitypes.KindVnetConfig
+	if vnetConfig.GetMetadata() == nil {
+		vnetConfig.Metadata = &headerv1.Metadata{}
+	}
+	if vnetConfig.GetMetadata().GetName() == "" {
+		vnetConfig.Metadata.Name = apitypes.MetaNameVnetConfig
+	}
 
 	vnetConfigBefore, err := r.p.Client.VnetConfigClient().GetVnetConfig(ctx)
 	if err != nil {

--- a/integrations/terraform/provider/resource_teleport_workload_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_workload_cluster.go
@@ -242,6 +242,7 @@ func (r resourceTeleportWorkloadCluster) Update(ctx context.Context, req tfsdk.U
 	}
 	workloadclusterResource := workloadcluster
 
+	workloadclusterResource.Kind = apitypes.KindWorkloadCluster
 
 	
 	name := workloadclusterResource.Metadata.Name

--- a/integrations/terraform/provider/resource_teleport_workload_identity.go
+++ b/integrations/terraform/provider/resource_teleport_workload_identity.go
@@ -209,6 +209,7 @@ func (r resourceTeleportWorkloadIdentity) Update(ctx context.Context, req tfsdk.
 	}
 	workloadIdentityResource := workloadIdentity
 
+	workloadIdentityResource.Kind = "workload_identity"
 
 	
 	name := workloadIdentityResource.Metadata.Name


### PR DESCRIPTION
Backports #64179

Apply `ForceSetKind` and `DefaultName` in `Update` method for generated resources.
Use `GetMethod` everywhere in templates instead of hardcoded `Get{{.Name}}`.



## Manual Test Plan

### Test Environment
Any system with Terraform configured to talk to a Teleport cluster
Tested on teleport_autoupdate_config resource


### Test Cases
- [x] Create a terraform resource
- [x] Update the terraform resource
- [x] Destroy the terraform resource