### PR TITLE
Migrate Delete and UpsertTunnelConnection RPCs from HTTP to gRPC

### DIFF
--- a/api/gen/proto/go/teleport/trust/v1/trust_service.pb.go
+++ b/api/gen/proto/go/teleport/trust/v1/trust_service.pb.go
@@ -1467,6 +1467,226 @@ func (b0 ListTrustedClustersResponse_builder) Build() *ListTrustedClustersRespon
 	return m0
 }
 
+// UpsertTunnelConnectionRequest is the request for UpsertTunnelConnection.
+type UpsertTunnelConnectionRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// TunnelConnection is the tunnel connection to create or update.
+	TunnelConnection *types.TunnelConnectionV2 `protobuf:"bytes,1,opt,name=tunnel_connection,json=tunnelConnection,proto3" json:"tunnel_connection,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *UpsertTunnelConnectionRequest) Reset() {
+	*x = UpsertTunnelConnectionRequest{}
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertTunnelConnectionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertTunnelConnectionRequest) ProtoMessage() {}
+
+func (x *UpsertTunnelConnectionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpsertTunnelConnectionRequest) GetTunnelConnection() *types.TunnelConnectionV2 {
+	if x != nil {
+		return x.TunnelConnection
+	}
+	return nil
+}
+
+func (x *UpsertTunnelConnectionRequest) SetTunnelConnection(v *types.TunnelConnectionV2) {
+	x.TunnelConnection = v
+}
+
+func (x *UpsertTunnelConnectionRequest) HasTunnelConnection() bool {
+	if x == nil {
+		return false
+	}
+	return x.TunnelConnection != nil
+}
+
+func (x *UpsertTunnelConnectionRequest) ClearTunnelConnection() {
+	x.TunnelConnection = nil
+}
+
+type UpsertTunnelConnectionRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// TunnelConnection is the tunnel connection to create or update.
+	TunnelConnection *types.TunnelConnectionV2
+}
+
+func (b0 UpsertTunnelConnectionRequest_builder) Build() *UpsertTunnelConnectionRequest {
+	m0 := &UpsertTunnelConnectionRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.TunnelConnection = b.TunnelConnection
+	return m0
+}
+
+// UpsertTunnelConnectionResponse is the response for UpsertTunnelConnection.
+type UpsertTunnelConnectionResponse struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// TunnelConnection is the stored tunnel connection as persisted by the
+	// backend.
+	TunnelConnection *types.TunnelConnectionV2 `protobuf:"bytes,1,opt,name=tunnel_connection,json=tunnelConnection,proto3" json:"tunnel_connection,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *UpsertTunnelConnectionResponse) Reset() {
+	*x = UpsertTunnelConnectionResponse{}
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertTunnelConnectionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertTunnelConnectionResponse) ProtoMessage() {}
+
+func (x *UpsertTunnelConnectionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpsertTunnelConnectionResponse) GetTunnelConnection() *types.TunnelConnectionV2 {
+	if x != nil {
+		return x.TunnelConnection
+	}
+	return nil
+}
+
+func (x *UpsertTunnelConnectionResponse) SetTunnelConnection(v *types.TunnelConnectionV2) {
+	x.TunnelConnection = v
+}
+
+func (x *UpsertTunnelConnectionResponse) HasTunnelConnection() bool {
+	if x == nil {
+		return false
+	}
+	return x.TunnelConnection != nil
+}
+
+func (x *UpsertTunnelConnectionResponse) ClearTunnelConnection() {
+	x.TunnelConnection = nil
+}
+
+type UpsertTunnelConnectionResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// TunnelConnection is the stored tunnel connection as persisted by the
+	// backend.
+	TunnelConnection *types.TunnelConnectionV2
+}
+
+func (b0 UpsertTunnelConnectionResponse_builder) Build() *UpsertTunnelConnectionResponse {
+	m0 := &UpsertTunnelConnectionResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.TunnelConnection = b.TunnelConnection
+	return m0
+}
+
+// DeleteTunnelConnectionRequest is the request for DeleteTunnelConnection.
+type DeleteTunnelConnectionRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// ClusterName is the name of the cluster the tunnel connection belongs to.
+	ClusterName string `protobuf:"bytes,1,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
+	// ConnectionName is the name of the tunnel connection to delete.
+	ConnectionName string `protobuf:"bytes,2,opt,name=connection_name,json=connectionName,proto3" json:"connection_name,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *DeleteTunnelConnectionRequest) Reset() {
+	*x = DeleteTunnelConnectionRequest{}
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteTunnelConnectionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteTunnelConnectionRequest) ProtoMessage() {}
+
+func (x *DeleteTunnelConnectionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DeleteTunnelConnectionRequest) GetClusterName() string {
+	if x != nil {
+		return x.ClusterName
+	}
+	return ""
+}
+
+func (x *DeleteTunnelConnectionRequest) GetConnectionName() string {
+	if x != nil {
+		return x.ConnectionName
+	}
+	return ""
+}
+
+func (x *DeleteTunnelConnectionRequest) SetClusterName(v string) {
+	x.ClusterName = v
+}
+
+func (x *DeleteTunnelConnectionRequest) SetConnectionName(v string) {
+	x.ConnectionName = v
+}
+
+type DeleteTunnelConnectionRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// ClusterName is the name of the cluster the tunnel connection belongs to.
+	ClusterName string
+	// ConnectionName is the name of the tunnel connection to delete.
+	ConnectionName string
+}
+
+func (b0 DeleteTunnelConnectionRequest_builder) Build() *DeleteTunnelConnectionRequest {
+	m0 := &DeleteTunnelConnectionRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.ClusterName = b.ClusterName
+	x.ConnectionName = b.ConnectionName
+	return m0
+}
+
 var File_teleport_trust_v1_trust_service_proto protoreflect.FileDescriptor
 
 const file_teleport_trust_v1_trust_service_proto_rawDesc = "" +
@@ -1526,7 +1746,14 @@ const file_teleport_trust_v1_trust_service_proto_rawDesc = "" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\"\x89\x01\n" +
 	"\x1bListTrustedClustersResponse\x12B\n" +
 	"\x10trusted_clusters\x18\x01 \x03(\v2\x17.types.TrustedClusterV2R\x0ftrustedClusters\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken2\xa0\t\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"g\n" +
+	"\x1dUpsertTunnelConnectionRequest\x12F\n" +
+	"\x11tunnel_connection\x18\x01 \x01(\v2\x19.types.TunnelConnectionV2R\x10tunnelConnection\"h\n" +
+	"\x1eUpsertTunnelConnectionResponse\x12F\n" +
+	"\x11tunnel_connection\x18\x01 \x01(\v2\x19.types.TunnelConnectionV2R\x10tunnelConnection\"k\n" +
+	"\x1dDeleteTunnelConnectionRequest\x12!\n" +
+	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x12'\n" +
+	"\x0fconnection_name\x18\x02 \x01(\tR\x0econnectionName2\x83\v\n" +
 	"\fTrustService\x12V\n" +
 	"\x10GetCertAuthority\x12*.teleport.trust.v1.GetCertAuthorityRequest\x1a\x16.types.CertAuthorityV2\x12q\n" +
 	"\x12GetCertAuthorities\x12,.teleport.trust.v1.GetCertAuthoritiesRequest\x1a-.teleport.trust.v1.GetCertAuthoritiesResponse\x12\\\n" +
@@ -1538,9 +1765,11 @@ const file_teleport_trust_v1_trust_service_proto_rawDesc = "" +
 	"\x14UpsertTrustedCluster\x12..teleport.trust.v1.UpsertTrustedClusterRequest\x1a\x17.types.TrustedClusterV2\x12_\n" +
 	"\x14CreateTrustedCluster\x12..teleport.trust.v1.CreateTrustedClusterRequest\x1a\x17.types.TrustedClusterV2\x12_\n" +
 	"\x14UpdateTrustedCluster\x12..teleport.trust.v1.UpdateTrustedClusterRequest\x1a\x17.types.TrustedClusterV2\x12t\n" +
-	"\x13ListTrustedClusters\x12-.teleport.trust.v1.ListTrustedClustersRequest\x1a..teleport.trust.v1.ListTrustedClustersResponseBNZLgithub.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1;trustv1b\x06proto3"
+	"\x13ListTrustedClusters\x12-.teleport.trust.v1.ListTrustedClustersRequest\x1a..teleport.trust.v1.ListTrustedClustersResponse\x12}\n" +
+	"\x16UpsertTunnelConnection\x120.teleport.trust.v1.UpsertTunnelConnectionRequest\x1a1.teleport.trust.v1.UpsertTunnelConnectionResponse\x12b\n" +
+	"\x16DeleteTunnelConnection\x120.teleport.trust.v1.DeleteTunnelConnectionRequest\x1a\x16.google.protobuf.EmptyBNZLgithub.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1;trustv1b\x06proto3"
 
-var file_teleport_trust_v1_trust_service_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_teleport_trust_v1_trust_service_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_teleport_trust_v1_trust_service_proto_goTypes = []any{
 	(*UpsertTrustedClusterRequest)(nil),         // 0: teleport.trust.v1.UpsertTrustedClusterRequest
 	(*CreateTrustedClusterRequest)(nil),         // 1: teleport.trust.v1.CreateTrustedClusterRequest
@@ -1559,53 +1788,63 @@ var file_teleport_trust_v1_trust_service_proto_goTypes = []any{
 	(*GenerateHostCertResponse)(nil),            // 14: teleport.trust.v1.GenerateHostCertResponse
 	(*ListTrustedClustersRequest)(nil),          // 15: teleport.trust.v1.ListTrustedClustersRequest
 	(*ListTrustedClustersResponse)(nil),         // 16: teleport.trust.v1.ListTrustedClustersResponse
-	(*types.TrustedClusterV2)(nil),              // 17: types.TrustedClusterV2
-	(*types.CertAuthorityV2)(nil),               // 18: types.CertAuthorityV2
-	(*durationpb.Duration)(nil),                 // 19: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),               // 20: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                       // 21: google.protobuf.Empty
+	(*UpsertTunnelConnectionRequest)(nil),       // 17: teleport.trust.v1.UpsertTunnelConnectionRequest
+	(*UpsertTunnelConnectionResponse)(nil),      // 18: teleport.trust.v1.UpsertTunnelConnectionResponse
+	(*DeleteTunnelConnectionRequest)(nil),       // 19: teleport.trust.v1.DeleteTunnelConnectionRequest
+	(*types.TrustedClusterV2)(nil),              // 20: types.TrustedClusterV2
+	(*types.CertAuthorityV2)(nil),               // 21: types.CertAuthorityV2
+	(*durationpb.Duration)(nil),                 // 22: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),               // 23: google.protobuf.Timestamp
+	(*types.TunnelConnectionV2)(nil),            // 24: types.TunnelConnectionV2
+	(*emptypb.Empty)(nil),                       // 25: google.protobuf.Empty
 }
 var file_teleport_trust_v1_trust_service_proto_depIdxs = []int32{
-	17, // 0: teleport.trust.v1.UpsertTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
-	17, // 1: teleport.trust.v1.CreateTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
-	17, // 2: teleport.trust.v1.UpdateTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
-	18, // 3: teleport.trust.v1.GetCertAuthoritiesResponse.cert_authorities_v2:type_name -> types.CertAuthorityV2
-	18, // 4: teleport.trust.v1.UpsertCertAuthorityRequest.cert_authority:type_name -> types.CertAuthorityV2
-	19, // 5: teleport.trust.v1.RotateCertAuthorityRequest.grace_period:type_name -> google.protobuf.Duration
+	20, // 0: teleport.trust.v1.UpsertTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
+	20, // 1: teleport.trust.v1.CreateTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
+	20, // 2: teleport.trust.v1.UpdateTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
+	21, // 3: teleport.trust.v1.GetCertAuthoritiesResponse.cert_authorities_v2:type_name -> types.CertAuthorityV2
+	21, // 4: teleport.trust.v1.UpsertCertAuthorityRequest.cert_authority:type_name -> types.CertAuthorityV2
+	22, // 5: teleport.trust.v1.RotateCertAuthorityRequest.grace_period:type_name -> google.protobuf.Duration
 	9,  // 6: teleport.trust.v1.RotateCertAuthorityRequest.schedule:type_name -> teleport.trust.v1.RotationSchedule
-	20, // 7: teleport.trust.v1.RotationSchedule.update_clients:type_name -> google.protobuf.Timestamp
-	20, // 8: teleport.trust.v1.RotationSchedule.update_servers:type_name -> google.protobuf.Timestamp
-	20, // 9: teleport.trust.v1.RotationSchedule.standby:type_name -> google.protobuf.Timestamp
-	18, // 10: teleport.trust.v1.RotateExternalCertAuthorityRequest.cert_authority:type_name -> types.CertAuthorityV2
-	19, // 11: teleport.trust.v1.GenerateHostCertRequest.ttl:type_name -> google.protobuf.Duration
-	17, // 12: teleport.trust.v1.ListTrustedClustersResponse.trusted_clusters:type_name -> types.TrustedClusterV2
-	3,  // 13: teleport.trust.v1.TrustService.GetCertAuthority:input_type -> teleport.trust.v1.GetCertAuthorityRequest
-	4,  // 14: teleport.trust.v1.TrustService.GetCertAuthorities:input_type -> teleport.trust.v1.GetCertAuthoritiesRequest
-	6,  // 15: teleport.trust.v1.TrustService.DeleteCertAuthority:input_type -> teleport.trust.v1.DeleteCertAuthorityRequest
-	7,  // 16: teleport.trust.v1.TrustService.UpsertCertAuthority:input_type -> teleport.trust.v1.UpsertCertAuthorityRequest
-	8,  // 17: teleport.trust.v1.TrustService.RotateCertAuthority:input_type -> teleport.trust.v1.RotateCertAuthorityRequest
-	11, // 18: teleport.trust.v1.TrustService.RotateExternalCertAuthority:input_type -> teleport.trust.v1.RotateExternalCertAuthorityRequest
-	13, // 19: teleport.trust.v1.TrustService.GenerateHostCert:input_type -> teleport.trust.v1.GenerateHostCertRequest
-	0,  // 20: teleport.trust.v1.TrustService.UpsertTrustedCluster:input_type -> teleport.trust.v1.UpsertTrustedClusterRequest
-	1,  // 21: teleport.trust.v1.TrustService.CreateTrustedCluster:input_type -> teleport.trust.v1.CreateTrustedClusterRequest
-	2,  // 22: teleport.trust.v1.TrustService.UpdateTrustedCluster:input_type -> teleport.trust.v1.UpdateTrustedClusterRequest
-	15, // 23: teleport.trust.v1.TrustService.ListTrustedClusters:input_type -> teleport.trust.v1.ListTrustedClustersRequest
-	18, // 24: teleport.trust.v1.TrustService.GetCertAuthority:output_type -> types.CertAuthorityV2
-	5,  // 25: teleport.trust.v1.TrustService.GetCertAuthorities:output_type -> teleport.trust.v1.GetCertAuthoritiesResponse
-	21, // 26: teleport.trust.v1.TrustService.DeleteCertAuthority:output_type -> google.protobuf.Empty
-	18, // 27: teleport.trust.v1.TrustService.UpsertCertAuthority:output_type -> types.CertAuthorityV2
-	10, // 28: teleport.trust.v1.TrustService.RotateCertAuthority:output_type -> teleport.trust.v1.RotateCertAuthorityResponse
-	12, // 29: teleport.trust.v1.TrustService.RotateExternalCertAuthority:output_type -> teleport.trust.v1.RotateExternalCertAuthorityResponse
-	14, // 30: teleport.trust.v1.TrustService.GenerateHostCert:output_type -> teleport.trust.v1.GenerateHostCertResponse
-	17, // 31: teleport.trust.v1.TrustService.UpsertTrustedCluster:output_type -> types.TrustedClusterV2
-	17, // 32: teleport.trust.v1.TrustService.CreateTrustedCluster:output_type -> types.TrustedClusterV2
-	17, // 33: teleport.trust.v1.TrustService.UpdateTrustedCluster:output_type -> types.TrustedClusterV2
-	16, // 34: teleport.trust.v1.TrustService.ListTrustedClusters:output_type -> teleport.trust.v1.ListTrustedClustersResponse
-	24, // [24:35] is the sub-list for method output_type
-	13, // [13:24] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	23, // 7: teleport.trust.v1.RotationSchedule.update_clients:type_name -> google.protobuf.Timestamp
+	23, // 8: teleport.trust.v1.RotationSchedule.update_servers:type_name -> google.protobuf.Timestamp
+	23, // 9: teleport.trust.v1.RotationSchedule.standby:type_name -> google.protobuf.Timestamp
+	21, // 10: teleport.trust.v1.RotateExternalCertAuthorityRequest.cert_authority:type_name -> types.CertAuthorityV2
+	22, // 11: teleport.trust.v1.GenerateHostCertRequest.ttl:type_name -> google.protobuf.Duration
+	20, // 12: teleport.trust.v1.ListTrustedClustersResponse.trusted_clusters:type_name -> types.TrustedClusterV2
+	24, // 13: teleport.trust.v1.UpsertTunnelConnectionRequest.tunnel_connection:type_name -> types.TunnelConnectionV2
+	24, // 14: teleport.trust.v1.UpsertTunnelConnectionResponse.tunnel_connection:type_name -> types.TunnelConnectionV2
+	3,  // 15: teleport.trust.v1.TrustService.GetCertAuthority:input_type -> teleport.trust.v1.GetCertAuthorityRequest
+	4,  // 16: teleport.trust.v1.TrustService.GetCertAuthorities:input_type -> teleport.trust.v1.GetCertAuthoritiesRequest
+	6,  // 17: teleport.trust.v1.TrustService.DeleteCertAuthority:input_type -> teleport.trust.v1.DeleteCertAuthorityRequest
+	7,  // 18: teleport.trust.v1.TrustService.UpsertCertAuthority:input_type -> teleport.trust.v1.UpsertCertAuthorityRequest
+	8,  // 19: teleport.trust.v1.TrustService.RotateCertAuthority:input_type -> teleport.trust.v1.RotateCertAuthorityRequest
+	11, // 20: teleport.trust.v1.TrustService.RotateExternalCertAuthority:input_type -> teleport.trust.v1.RotateExternalCertAuthorityRequest
+	13, // 21: teleport.trust.v1.TrustService.GenerateHostCert:input_type -> teleport.trust.v1.GenerateHostCertRequest
+	0,  // 22: teleport.trust.v1.TrustService.UpsertTrustedCluster:input_type -> teleport.trust.v1.UpsertTrustedClusterRequest
+	1,  // 23: teleport.trust.v1.TrustService.CreateTrustedCluster:input_type -> teleport.trust.v1.CreateTrustedClusterRequest
+	2,  // 24: teleport.trust.v1.TrustService.UpdateTrustedCluster:input_type -> teleport.trust.v1.UpdateTrustedClusterRequest
+	15, // 25: teleport.trust.v1.TrustService.ListTrustedClusters:input_type -> teleport.trust.v1.ListTrustedClustersRequest
+	17, // 26: teleport.trust.v1.TrustService.UpsertTunnelConnection:input_type -> teleport.trust.v1.UpsertTunnelConnectionRequest
+	19, // 27: teleport.trust.v1.TrustService.DeleteTunnelConnection:input_type -> teleport.trust.v1.DeleteTunnelConnectionRequest
+	21, // 28: teleport.trust.v1.TrustService.GetCertAuthority:output_type -> types.CertAuthorityV2
+	5,  // 29: teleport.trust.v1.TrustService.GetCertAuthorities:output_type -> teleport.trust.v1.GetCertAuthoritiesResponse
+	25, // 30: teleport.trust.v1.TrustService.DeleteCertAuthority:output_type -> google.protobuf.Empty
+	21, // 31: teleport.trust.v1.TrustService.UpsertCertAuthority:output_type -> types.CertAuthorityV2
+	10, // 32: teleport.trust.v1.TrustService.RotateCertAuthority:output_type -> teleport.trust.v1.RotateCertAuthorityResponse
+	12, // 33: teleport.trust.v1.TrustService.RotateExternalCertAuthority:output_type -> teleport.trust.v1.RotateExternalCertAuthorityResponse
+	14, // 34: teleport.trust.v1.TrustService.GenerateHostCert:output_type -> teleport.trust.v1.GenerateHostCertResponse
+	20, // 35: teleport.trust.v1.TrustService.UpsertTrustedCluster:output_type -> types.TrustedClusterV2
+	20, // 36: teleport.trust.v1.TrustService.CreateTrustedCluster:output_type -> types.TrustedClusterV2
+	20, // 37: teleport.trust.v1.TrustService.UpdateTrustedCluster:output_type -> types.TrustedClusterV2
+	16, // 38: teleport.trust.v1.TrustService.ListTrustedClusters:output_type -> teleport.trust.v1.ListTrustedClustersResponse
+	18, // 39: teleport.trust.v1.TrustService.UpsertTunnelConnection:output_type -> teleport.trust.v1.UpsertTunnelConnectionResponse
+	25, // 40: teleport.trust.v1.TrustService.DeleteTunnelConnection:output_type -> google.protobuf.Empty
+	28, // [28:41] is the sub-list for method output_type
+	15, // [15:28] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_teleport_trust_v1_trust_service_proto_init() }
@@ -1619,7 +1858,7 @@ func file_teleport_trust_v1_trust_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_trust_v1_trust_service_proto_rawDesc), len(file_teleport_trust_v1_trust_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   17,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/trust/v1/trust_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/trust/v1/trust_service_grpc.pb.go
@@ -46,6 +46,8 @@ const (
 	TrustService_CreateTrustedCluster_FullMethodName        = "/teleport.trust.v1.TrustService/CreateTrustedCluster"
 	TrustService_UpdateTrustedCluster_FullMethodName        = "/teleport.trust.v1.TrustService/UpdateTrustedCluster"
 	TrustService_ListTrustedClusters_FullMethodName         = "/teleport.trust.v1.TrustService/ListTrustedClusters"
+	TrustService_UpsertTunnelConnection_FullMethodName      = "/teleport.trust.v1.TrustService/UpsertTunnelConnection"
+	TrustService_DeleteTunnelConnection_FullMethodName      = "/teleport.trust.v1.TrustService/DeleteTunnelConnection"
 )
 
 // TrustServiceClient is the client API for TrustService service.
@@ -77,6 +79,12 @@ type TrustServiceClient interface {
 	UpdateTrustedCluster(ctx context.Context, in *UpdateTrustedClusterRequest, opts ...grpc.CallOption) (*types.TrustedClusterV2, error)
 	// ListTrustedClusters returns a page of current Trusted Cluster resources.
 	ListTrustedClusters(ctx context.Context, in *ListTrustedClustersRequest, opts ...grpc.CallOption) (*ListTrustedClustersResponse, error)
+	// UpsertTunnelConnection creates or updates a tunnel connection record used
+	// to advertise leaf cluster reverse tunnels to peer proxies.
+	UpsertTunnelConnection(ctx context.Context, in *UpsertTunnelConnectionRequest, opts ...grpc.CallOption) (*UpsertTunnelConnectionResponse, error)
+	// DeleteTunnelConnection removes a single tunnel connection record by
+	// cluster name and connection name.
+	DeleteTunnelConnection(ctx context.Context, in *DeleteTunnelConnectionRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
 type trustServiceClient struct {
@@ -197,6 +205,26 @@ func (c *trustServiceClient) ListTrustedClusters(ctx context.Context, in *ListTr
 	return out, nil
 }
 
+func (c *trustServiceClient) UpsertTunnelConnection(ctx context.Context, in *UpsertTunnelConnectionRequest, opts ...grpc.CallOption) (*UpsertTunnelConnectionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpsertTunnelConnectionResponse)
+	err := c.cc.Invoke(ctx, TrustService_UpsertTunnelConnection_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *trustServiceClient) DeleteTunnelConnection(ctx context.Context, in *DeleteTunnelConnectionRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, TrustService_DeleteTunnelConnection_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // TrustServiceServer is the server API for TrustService service.
 // All implementations must embed UnimplementedTrustServiceServer
 // for forward compatibility.
@@ -226,6 +254,12 @@ type TrustServiceServer interface {
 	UpdateTrustedCluster(context.Context, *UpdateTrustedClusterRequest) (*types.TrustedClusterV2, error)
 	// ListTrustedClusters returns a page of current Trusted Cluster resources.
 	ListTrustedClusters(context.Context, *ListTrustedClustersRequest) (*ListTrustedClustersResponse, error)
+	// UpsertTunnelConnection creates or updates a tunnel connection record used
+	// to advertise leaf cluster reverse tunnels to peer proxies.
+	UpsertTunnelConnection(context.Context, *UpsertTunnelConnectionRequest) (*UpsertTunnelConnectionResponse, error)
+	// DeleteTunnelConnection removes a single tunnel connection record by
+	// cluster name and connection name.
+	DeleteTunnelConnection(context.Context, *DeleteTunnelConnectionRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedTrustServiceServer()
 }
 
@@ -268,6 +302,12 @@ func (UnimplementedTrustServiceServer) UpdateTrustedCluster(context.Context, *Up
 }
 func (UnimplementedTrustServiceServer) ListTrustedClusters(context.Context, *ListTrustedClustersRequest) (*ListTrustedClustersResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListTrustedClusters not implemented")
+}
+func (UnimplementedTrustServiceServer) UpsertTunnelConnection(context.Context, *UpsertTunnelConnectionRequest) (*UpsertTunnelConnectionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpsertTunnelConnection not implemented")
+}
+func (UnimplementedTrustServiceServer) DeleteTunnelConnection(context.Context, *DeleteTunnelConnectionRequest) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteTunnelConnection not implemented")
 }
 func (UnimplementedTrustServiceServer) mustEmbedUnimplementedTrustServiceServer() {}
 func (UnimplementedTrustServiceServer) testEmbeddedByValue()                      {}
@@ -488,6 +528,42 @@ func _TrustService_ListTrustedClusters_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TrustService_UpsertTunnelConnection_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpsertTunnelConnectionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TrustServiceServer).UpsertTunnelConnection(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TrustService_UpsertTunnelConnection_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TrustServiceServer).UpsertTunnelConnection(ctx, req.(*UpsertTunnelConnectionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TrustService_DeleteTunnelConnection_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteTunnelConnectionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TrustServiceServer).DeleteTunnelConnection(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TrustService_DeleteTunnelConnection_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TrustServiceServer).DeleteTunnelConnection(ctx, req.(*DeleteTunnelConnectionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TrustService_ServiceDesc is the grpc.ServiceDesc for TrustService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -538,6 +614,14 @@ var TrustService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListTrustedClusters",
 			Handler:    _TrustService_ListTrustedClusters_Handler,
+		},
+		{
+			MethodName: "UpsertTunnelConnection",
+			Handler:    _TrustService_UpsertTunnelConnection_Handler,
+		},
+		{
+			MethodName: "DeleteTunnelConnection",
+			Handler:    _TrustService_DeleteTunnelConnection_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/gen/proto/go/teleport/trust/v1/trust_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/trust/v1/trust_service_protoopaque.pb.go
@@ -1426,6 +1426,221 @@ func (b0 ListTrustedClustersResponse_builder) Build() *ListTrustedClustersRespon
 	return m0
 }
 
+// UpsertTunnelConnectionRequest is the request for UpsertTunnelConnection.
+type UpsertTunnelConnectionRequest struct {
+	state                       protoimpl.MessageState    `protogen:"opaque.v1"`
+	xxx_hidden_TunnelConnection *types.TunnelConnectionV2 `protobuf:"bytes,1,opt,name=tunnel_connection,json=tunnelConnection,proto3"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
+}
+
+func (x *UpsertTunnelConnectionRequest) Reset() {
+	*x = UpsertTunnelConnectionRequest{}
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertTunnelConnectionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertTunnelConnectionRequest) ProtoMessage() {}
+
+func (x *UpsertTunnelConnectionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpsertTunnelConnectionRequest) GetTunnelConnection() *types.TunnelConnectionV2 {
+	if x != nil {
+		return x.xxx_hidden_TunnelConnection
+	}
+	return nil
+}
+
+func (x *UpsertTunnelConnectionRequest) SetTunnelConnection(v *types.TunnelConnectionV2) {
+	x.xxx_hidden_TunnelConnection = v
+}
+
+func (x *UpsertTunnelConnectionRequest) HasTunnelConnection() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_TunnelConnection != nil
+}
+
+func (x *UpsertTunnelConnectionRequest) ClearTunnelConnection() {
+	x.xxx_hidden_TunnelConnection = nil
+}
+
+type UpsertTunnelConnectionRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// TunnelConnection is the tunnel connection to create or update.
+	TunnelConnection *types.TunnelConnectionV2
+}
+
+func (b0 UpsertTunnelConnectionRequest_builder) Build() *UpsertTunnelConnectionRequest {
+	m0 := &UpsertTunnelConnectionRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_TunnelConnection = b.TunnelConnection
+	return m0
+}
+
+// UpsertTunnelConnectionResponse is the response for UpsertTunnelConnection.
+type UpsertTunnelConnectionResponse struct {
+	state                       protoimpl.MessageState    `protogen:"opaque.v1"`
+	xxx_hidden_TunnelConnection *types.TunnelConnectionV2 `protobuf:"bytes,1,opt,name=tunnel_connection,json=tunnelConnection,proto3"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
+}
+
+func (x *UpsertTunnelConnectionResponse) Reset() {
+	*x = UpsertTunnelConnectionResponse{}
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertTunnelConnectionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertTunnelConnectionResponse) ProtoMessage() {}
+
+func (x *UpsertTunnelConnectionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpsertTunnelConnectionResponse) GetTunnelConnection() *types.TunnelConnectionV2 {
+	if x != nil {
+		return x.xxx_hidden_TunnelConnection
+	}
+	return nil
+}
+
+func (x *UpsertTunnelConnectionResponse) SetTunnelConnection(v *types.TunnelConnectionV2) {
+	x.xxx_hidden_TunnelConnection = v
+}
+
+func (x *UpsertTunnelConnectionResponse) HasTunnelConnection() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_TunnelConnection != nil
+}
+
+func (x *UpsertTunnelConnectionResponse) ClearTunnelConnection() {
+	x.xxx_hidden_TunnelConnection = nil
+}
+
+type UpsertTunnelConnectionResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// TunnelConnection is the stored tunnel connection as persisted by the
+	// backend.
+	TunnelConnection *types.TunnelConnectionV2
+}
+
+func (b0 UpsertTunnelConnectionResponse_builder) Build() *UpsertTunnelConnectionResponse {
+	m0 := &UpsertTunnelConnectionResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_TunnelConnection = b.TunnelConnection
+	return m0
+}
+
+// DeleteTunnelConnectionRequest is the request for DeleteTunnelConnection.
+type DeleteTunnelConnectionRequest struct {
+	state                     protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_ClusterName    string                 `protobuf:"bytes,1,opt,name=cluster_name,json=clusterName,proto3"`
+	xxx_hidden_ConnectionName string                 `protobuf:"bytes,2,opt,name=connection_name,json=connectionName,proto3"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *DeleteTunnelConnectionRequest) Reset() {
+	*x = DeleteTunnelConnectionRequest{}
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteTunnelConnectionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteTunnelConnectionRequest) ProtoMessage() {}
+
+func (x *DeleteTunnelConnectionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_trust_v1_trust_service_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DeleteTunnelConnectionRequest) GetClusterName() string {
+	if x != nil {
+		return x.xxx_hidden_ClusterName
+	}
+	return ""
+}
+
+func (x *DeleteTunnelConnectionRequest) GetConnectionName() string {
+	if x != nil {
+		return x.xxx_hidden_ConnectionName
+	}
+	return ""
+}
+
+func (x *DeleteTunnelConnectionRequest) SetClusterName(v string) {
+	x.xxx_hidden_ClusterName = v
+}
+
+func (x *DeleteTunnelConnectionRequest) SetConnectionName(v string) {
+	x.xxx_hidden_ConnectionName = v
+}
+
+type DeleteTunnelConnectionRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// ClusterName is the name of the cluster the tunnel connection belongs to.
+	ClusterName string
+	// ConnectionName is the name of the tunnel connection to delete.
+	ConnectionName string
+}
+
+func (b0 DeleteTunnelConnectionRequest_builder) Build() *DeleteTunnelConnectionRequest {
+	m0 := &DeleteTunnelConnectionRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_ClusterName = b.ClusterName
+	x.xxx_hidden_ConnectionName = b.ConnectionName
+	return m0
+}
+
 var File_teleport_trust_v1_trust_service_proto protoreflect.FileDescriptor
 
 const file_teleport_trust_v1_trust_service_proto_rawDesc = "" +
@@ -1485,7 +1700,14 @@ const file_teleport_trust_v1_trust_service_proto_rawDesc = "" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\"\x89\x01\n" +
 	"\x1bListTrustedClustersResponse\x12B\n" +
 	"\x10trusted_clusters\x18\x01 \x03(\v2\x17.types.TrustedClusterV2R\x0ftrustedClusters\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken2\xa0\t\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"g\n" +
+	"\x1dUpsertTunnelConnectionRequest\x12F\n" +
+	"\x11tunnel_connection\x18\x01 \x01(\v2\x19.types.TunnelConnectionV2R\x10tunnelConnection\"h\n" +
+	"\x1eUpsertTunnelConnectionResponse\x12F\n" +
+	"\x11tunnel_connection\x18\x01 \x01(\v2\x19.types.TunnelConnectionV2R\x10tunnelConnection\"k\n" +
+	"\x1dDeleteTunnelConnectionRequest\x12!\n" +
+	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x12'\n" +
+	"\x0fconnection_name\x18\x02 \x01(\tR\x0econnectionName2\x83\v\n" +
 	"\fTrustService\x12V\n" +
 	"\x10GetCertAuthority\x12*.teleport.trust.v1.GetCertAuthorityRequest\x1a\x16.types.CertAuthorityV2\x12q\n" +
 	"\x12GetCertAuthorities\x12,.teleport.trust.v1.GetCertAuthoritiesRequest\x1a-.teleport.trust.v1.GetCertAuthoritiesResponse\x12\\\n" +
@@ -1497,9 +1719,11 @@ const file_teleport_trust_v1_trust_service_proto_rawDesc = "" +
 	"\x14UpsertTrustedCluster\x12..teleport.trust.v1.UpsertTrustedClusterRequest\x1a\x17.types.TrustedClusterV2\x12_\n" +
 	"\x14CreateTrustedCluster\x12..teleport.trust.v1.CreateTrustedClusterRequest\x1a\x17.types.TrustedClusterV2\x12_\n" +
 	"\x14UpdateTrustedCluster\x12..teleport.trust.v1.UpdateTrustedClusterRequest\x1a\x17.types.TrustedClusterV2\x12t\n" +
-	"\x13ListTrustedClusters\x12-.teleport.trust.v1.ListTrustedClustersRequest\x1a..teleport.trust.v1.ListTrustedClustersResponseBNZLgithub.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1;trustv1b\x06proto3"
+	"\x13ListTrustedClusters\x12-.teleport.trust.v1.ListTrustedClustersRequest\x1a..teleport.trust.v1.ListTrustedClustersResponse\x12}\n" +
+	"\x16UpsertTunnelConnection\x120.teleport.trust.v1.UpsertTunnelConnectionRequest\x1a1.teleport.trust.v1.UpsertTunnelConnectionResponse\x12b\n" +
+	"\x16DeleteTunnelConnection\x120.teleport.trust.v1.DeleteTunnelConnectionRequest\x1a\x16.google.protobuf.EmptyBNZLgithub.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1;trustv1b\x06proto3"
 
-var file_teleport_trust_v1_trust_service_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_teleport_trust_v1_trust_service_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_teleport_trust_v1_trust_service_proto_goTypes = []any{
 	(*UpsertTrustedClusterRequest)(nil),         // 0: teleport.trust.v1.UpsertTrustedClusterRequest
 	(*CreateTrustedClusterRequest)(nil),         // 1: teleport.trust.v1.CreateTrustedClusterRequest
@@ -1518,53 +1742,63 @@ var file_teleport_trust_v1_trust_service_proto_goTypes = []any{
 	(*GenerateHostCertResponse)(nil),            // 14: teleport.trust.v1.GenerateHostCertResponse
 	(*ListTrustedClustersRequest)(nil),          // 15: teleport.trust.v1.ListTrustedClustersRequest
 	(*ListTrustedClustersResponse)(nil),         // 16: teleport.trust.v1.ListTrustedClustersResponse
-	(*types.TrustedClusterV2)(nil),              // 17: types.TrustedClusterV2
-	(*types.CertAuthorityV2)(nil),               // 18: types.CertAuthorityV2
-	(*durationpb.Duration)(nil),                 // 19: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),               // 20: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                       // 21: google.protobuf.Empty
+	(*UpsertTunnelConnectionRequest)(nil),       // 17: teleport.trust.v1.UpsertTunnelConnectionRequest
+	(*UpsertTunnelConnectionResponse)(nil),      // 18: teleport.trust.v1.UpsertTunnelConnectionResponse
+	(*DeleteTunnelConnectionRequest)(nil),       // 19: teleport.trust.v1.DeleteTunnelConnectionRequest
+	(*types.TrustedClusterV2)(nil),              // 20: types.TrustedClusterV2
+	(*types.CertAuthorityV2)(nil),               // 21: types.CertAuthorityV2
+	(*durationpb.Duration)(nil),                 // 22: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),               // 23: google.protobuf.Timestamp
+	(*types.TunnelConnectionV2)(nil),            // 24: types.TunnelConnectionV2
+	(*emptypb.Empty)(nil),                       // 25: google.protobuf.Empty
 }
 var file_teleport_trust_v1_trust_service_proto_depIdxs = []int32{
-	17, // 0: teleport.trust.v1.UpsertTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
-	17, // 1: teleport.trust.v1.CreateTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
-	17, // 2: teleport.trust.v1.UpdateTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
-	18, // 3: teleport.trust.v1.GetCertAuthoritiesResponse.cert_authorities_v2:type_name -> types.CertAuthorityV2
-	18, // 4: teleport.trust.v1.UpsertCertAuthorityRequest.cert_authority:type_name -> types.CertAuthorityV2
-	19, // 5: teleport.trust.v1.RotateCertAuthorityRequest.grace_period:type_name -> google.protobuf.Duration
+	20, // 0: teleport.trust.v1.UpsertTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
+	20, // 1: teleport.trust.v1.CreateTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
+	20, // 2: teleport.trust.v1.UpdateTrustedClusterRequest.trusted_cluster:type_name -> types.TrustedClusterV2
+	21, // 3: teleport.trust.v1.GetCertAuthoritiesResponse.cert_authorities_v2:type_name -> types.CertAuthorityV2
+	21, // 4: teleport.trust.v1.UpsertCertAuthorityRequest.cert_authority:type_name -> types.CertAuthorityV2
+	22, // 5: teleport.trust.v1.RotateCertAuthorityRequest.grace_period:type_name -> google.protobuf.Duration
 	9,  // 6: teleport.trust.v1.RotateCertAuthorityRequest.schedule:type_name -> teleport.trust.v1.RotationSchedule
-	20, // 7: teleport.trust.v1.RotationSchedule.update_clients:type_name -> google.protobuf.Timestamp
-	20, // 8: teleport.trust.v1.RotationSchedule.update_servers:type_name -> google.protobuf.Timestamp
-	20, // 9: teleport.trust.v1.RotationSchedule.standby:type_name -> google.protobuf.Timestamp
-	18, // 10: teleport.trust.v1.RotateExternalCertAuthorityRequest.cert_authority:type_name -> types.CertAuthorityV2
-	19, // 11: teleport.trust.v1.GenerateHostCertRequest.ttl:type_name -> google.protobuf.Duration
-	17, // 12: teleport.trust.v1.ListTrustedClustersResponse.trusted_clusters:type_name -> types.TrustedClusterV2
-	3,  // 13: teleport.trust.v1.TrustService.GetCertAuthority:input_type -> teleport.trust.v1.GetCertAuthorityRequest
-	4,  // 14: teleport.trust.v1.TrustService.GetCertAuthorities:input_type -> teleport.trust.v1.GetCertAuthoritiesRequest
-	6,  // 15: teleport.trust.v1.TrustService.DeleteCertAuthority:input_type -> teleport.trust.v1.DeleteCertAuthorityRequest
-	7,  // 16: teleport.trust.v1.TrustService.UpsertCertAuthority:input_type -> teleport.trust.v1.UpsertCertAuthorityRequest
-	8,  // 17: teleport.trust.v1.TrustService.RotateCertAuthority:input_type -> teleport.trust.v1.RotateCertAuthorityRequest
-	11, // 18: teleport.trust.v1.TrustService.RotateExternalCertAuthority:input_type -> teleport.trust.v1.RotateExternalCertAuthorityRequest
-	13, // 19: teleport.trust.v1.TrustService.GenerateHostCert:input_type -> teleport.trust.v1.GenerateHostCertRequest
-	0,  // 20: teleport.trust.v1.TrustService.UpsertTrustedCluster:input_type -> teleport.trust.v1.UpsertTrustedClusterRequest
-	1,  // 21: teleport.trust.v1.TrustService.CreateTrustedCluster:input_type -> teleport.trust.v1.CreateTrustedClusterRequest
-	2,  // 22: teleport.trust.v1.TrustService.UpdateTrustedCluster:input_type -> teleport.trust.v1.UpdateTrustedClusterRequest
-	15, // 23: teleport.trust.v1.TrustService.ListTrustedClusters:input_type -> teleport.trust.v1.ListTrustedClustersRequest
-	18, // 24: teleport.trust.v1.TrustService.GetCertAuthority:output_type -> types.CertAuthorityV2
-	5,  // 25: teleport.trust.v1.TrustService.GetCertAuthorities:output_type -> teleport.trust.v1.GetCertAuthoritiesResponse
-	21, // 26: teleport.trust.v1.TrustService.DeleteCertAuthority:output_type -> google.protobuf.Empty
-	18, // 27: teleport.trust.v1.TrustService.UpsertCertAuthority:output_type -> types.CertAuthorityV2
-	10, // 28: teleport.trust.v1.TrustService.RotateCertAuthority:output_type -> teleport.trust.v1.RotateCertAuthorityResponse
-	12, // 29: teleport.trust.v1.TrustService.RotateExternalCertAuthority:output_type -> teleport.trust.v1.RotateExternalCertAuthorityResponse
-	14, // 30: teleport.trust.v1.TrustService.GenerateHostCert:output_type -> teleport.trust.v1.GenerateHostCertResponse
-	17, // 31: teleport.trust.v1.TrustService.UpsertTrustedCluster:output_type -> types.TrustedClusterV2
-	17, // 32: teleport.trust.v1.TrustService.CreateTrustedCluster:output_type -> types.TrustedClusterV2
-	17, // 33: teleport.trust.v1.TrustService.UpdateTrustedCluster:output_type -> types.TrustedClusterV2
-	16, // 34: teleport.trust.v1.TrustService.ListTrustedClusters:output_type -> teleport.trust.v1.ListTrustedClustersResponse
-	24, // [24:35] is the sub-list for method output_type
-	13, // [13:24] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	23, // 7: teleport.trust.v1.RotationSchedule.update_clients:type_name -> google.protobuf.Timestamp
+	23, // 8: teleport.trust.v1.RotationSchedule.update_servers:type_name -> google.protobuf.Timestamp
+	23, // 9: teleport.trust.v1.RotationSchedule.standby:type_name -> google.protobuf.Timestamp
+	21, // 10: teleport.trust.v1.RotateExternalCertAuthorityRequest.cert_authority:type_name -> types.CertAuthorityV2
+	22, // 11: teleport.trust.v1.GenerateHostCertRequest.ttl:type_name -> google.protobuf.Duration
+	20, // 12: teleport.trust.v1.ListTrustedClustersResponse.trusted_clusters:type_name -> types.TrustedClusterV2
+	24, // 13: teleport.trust.v1.UpsertTunnelConnectionRequest.tunnel_connection:type_name -> types.TunnelConnectionV2
+	24, // 14: teleport.trust.v1.UpsertTunnelConnectionResponse.tunnel_connection:type_name -> types.TunnelConnectionV2
+	3,  // 15: teleport.trust.v1.TrustService.GetCertAuthority:input_type -> teleport.trust.v1.GetCertAuthorityRequest
+	4,  // 16: teleport.trust.v1.TrustService.GetCertAuthorities:input_type -> teleport.trust.v1.GetCertAuthoritiesRequest
+	6,  // 17: teleport.trust.v1.TrustService.DeleteCertAuthority:input_type -> teleport.trust.v1.DeleteCertAuthorityRequest
+	7,  // 18: teleport.trust.v1.TrustService.UpsertCertAuthority:input_type -> teleport.trust.v1.UpsertCertAuthorityRequest
+	8,  // 19: teleport.trust.v1.TrustService.RotateCertAuthority:input_type -> teleport.trust.v1.RotateCertAuthorityRequest
+	11, // 20: teleport.trust.v1.TrustService.RotateExternalCertAuthority:input_type -> teleport.trust.v1.RotateExternalCertAuthorityRequest
+	13, // 21: teleport.trust.v1.TrustService.GenerateHostCert:input_type -> teleport.trust.v1.GenerateHostCertRequest
+	0,  // 22: teleport.trust.v1.TrustService.UpsertTrustedCluster:input_type -> teleport.trust.v1.UpsertTrustedClusterRequest
+	1,  // 23: teleport.trust.v1.TrustService.CreateTrustedCluster:input_type -> teleport.trust.v1.CreateTrustedClusterRequest
+	2,  // 24: teleport.trust.v1.TrustService.UpdateTrustedCluster:input_type -> teleport.trust.v1.UpdateTrustedClusterRequest
+	15, // 25: teleport.trust.v1.TrustService.ListTrustedClusters:input_type -> teleport.trust.v1.ListTrustedClustersRequest
+	17, // 26: teleport.trust.v1.TrustService.UpsertTunnelConnection:input_type -> teleport.trust.v1.UpsertTunnelConnectionRequest
+	19, // 27: teleport.trust.v1.TrustService.DeleteTunnelConnection:input_type -> teleport.trust.v1.DeleteTunnelConnectionRequest
+	21, // 28: teleport.trust.v1.TrustService.GetCertAuthority:output_type -> types.CertAuthorityV2
+	5,  // 29: teleport.trust.v1.TrustService.GetCertAuthorities:output_type -> teleport.trust.v1.GetCertAuthoritiesResponse
+	25, // 30: teleport.trust.v1.TrustService.DeleteCertAuthority:output_type -> google.protobuf.Empty
+	21, // 31: teleport.trust.v1.TrustService.UpsertCertAuthority:output_type -> types.CertAuthorityV2
+	10, // 32: teleport.trust.v1.TrustService.RotateCertAuthority:output_type -> teleport.trust.v1.RotateCertAuthorityResponse
+	12, // 33: teleport.trust.v1.TrustService.RotateExternalCertAuthority:output_type -> teleport.trust.v1.RotateExternalCertAuthorityResponse
+	14, // 34: teleport.trust.v1.TrustService.GenerateHostCert:output_type -> teleport.trust.v1.GenerateHostCertResponse
+	20, // 35: teleport.trust.v1.TrustService.UpsertTrustedCluster:output_type -> types.TrustedClusterV2
+	20, // 36: teleport.trust.v1.TrustService.CreateTrustedCluster:output_type -> types.TrustedClusterV2
+	20, // 37: teleport.trust.v1.TrustService.UpdateTrustedCluster:output_type -> types.TrustedClusterV2
+	16, // 38: teleport.trust.v1.TrustService.ListTrustedClusters:output_type -> teleport.trust.v1.ListTrustedClustersResponse
+	18, // 39: teleport.trust.v1.TrustService.UpsertTunnelConnection:output_type -> teleport.trust.v1.UpsertTunnelConnectionResponse
+	25, // 40: teleport.trust.v1.TrustService.DeleteTunnelConnection:output_type -> google.protobuf.Empty
+	28, // [28:41] is the sub-list for method output_type
+	15, // [15:28] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_teleport_trust_v1_trust_service_proto_init() }
@@ -1578,7 +1812,7 @@ func file_teleport_trust_v1_trust_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_trust_v1_trust_service_proto_rawDesc), len(file_teleport_trust_v1_trust_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   17,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/trust/v1/trust_service.proto
+++ b/api/proto/teleport/trust/v1/trust_service.proto
@@ -49,6 +49,13 @@ service TrustService {
   rpc UpdateTrustedCluster(UpdateTrustedClusterRequest) returns (types.TrustedClusterV2);
   // ListTrustedClusters returns a page of current Trusted Cluster resources.
   rpc ListTrustedClusters(ListTrustedClustersRequest) returns (ListTrustedClustersResponse);
+
+  // UpsertTunnelConnection creates or updates a tunnel connection record used
+  // to advertise leaf cluster reverse tunnels to peer proxies.
+  rpc UpsertTunnelConnection(UpsertTunnelConnectionRequest) returns (UpsertTunnelConnectionResponse);
+  // DeleteTunnelConnection removes a single tunnel connection record by
+  // cluster name and connection name.
+  rpc DeleteTunnelConnection(DeleteTunnelConnectionRequest) returns (google.protobuf.Empty);
 }
 
 // Request for UpsertTrustedCluster.
@@ -193,4 +200,25 @@ message ListTrustedClustersResponse {
   // Token to retrieve the next page of results, or empty if there are no
   // more results in the list.
   string next_page_token = 2;
+}
+
+// UpsertTunnelConnectionRequest is the request for UpsertTunnelConnection.
+message UpsertTunnelConnectionRequest {
+  // TunnelConnection is the tunnel connection to create or update.
+  types.TunnelConnectionV2 tunnel_connection = 1;
+}
+
+// UpsertTunnelConnectionResponse is the response for UpsertTunnelConnection.
+message UpsertTunnelConnectionResponse {
+  // TunnelConnection is the stored tunnel connection as persisted by the
+  // backend.
+  types.TunnelConnectionV2 tunnel_connection = 1;
+}
+
+// DeleteTunnelConnectionRequest is the request for DeleteTunnelConnection.
+message DeleteTunnelConnectionRequest {
+  // ClusterName is the name of the cluster the tunnel connection belongs to.
+  string cluster_name = 1;
+  // ConnectionName is the name of the tunnel connection to delete.
+  string connection_name = 2;
 }

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -139,9 +139,11 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.GET("/:version/proxies", srv.WithScopedAuth(srv.getProxies))
 	// TODO(noah): DELETE IN 20.0.0 - move to httpMigratedHandler
 	srv.DELETE("/:version/proxies/:name", srv.WithAuth(srv.deleteProxy))
+	// TODO(strideynet): move to httpMigratedHandler in v20.0.0
 	srv.POST("/:version/tunnelconnections", srv.WithAuth(srv.upsertTunnelConnection))
 	srv.GET("/:version/tunnelconnections/:cluster", srv.WithAuth(srv.getTunnelConnections))
 	srv.GET("/:version/tunnelconnections", srv.WithAuth(srv.getAllTunnelConnections))
+	// TODO(strideynet): move to httpMigratedHandler in v20.0.0
 	srv.DELETE("/:version/tunnelconnections/:cluster/:conn", srv.WithAuth(srv.deleteTunnelConnection))
 
 	// trusted clusters
@@ -518,7 +520,9 @@ type upsertTunnelConnectionRawReq struct {
 	TunnelConnection json.RawMessage `json:"tunnel_connection"`
 }
 
-// upsertTunnelConnection updates or inserts tunnel connection
+// upsertTunnelConnection updates or inserts tunnel connection.
+//
+// TODO(strideynet): move to httpMigratedHandler in v20.0.0
 func (s *APIServer) upsertTunnelConnection(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
 	var req upsertTunnelConnectionRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
@@ -528,7 +532,7 @@ func (s *APIServer) upsertTunnelConnection(auth *ServerWithRoles, w http.Respons
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := auth.UpsertTunnelConnection(conn); err != nil {
+	if err := auth.UpsertTunnelConnection(r.Context(), conn); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return message("ok"), nil
@@ -568,9 +572,11 @@ func (s *APIServer) getAllTunnelConnections(auth *ServerWithRoles, w http.Respon
 	return items, nil
 }
 
-// deleteTunnelConnection deletes tunnel connection by name
+// deleteTunnelConnection deletes tunnel connection by name.
+//
+// TODO(strideynet): move to httpMigratedHandler in v20.0.0
 func (s *APIServer) deleteTunnelConnection(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
-	err := auth.DeleteTunnelConnection(p.ByName("cluster"), p.ByName("conn"))
+	err := auth.DeleteTunnelConnection(r.Context(), p.ByName("cluster"), p.ByName("conn"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5862,11 +5862,14 @@ func (a *ServerWithRoles) DeleteTrustedCluster(ctx context.Context, name string)
 	return a.authServer.DeleteTrustedCluster(ctx, name)
 }
 
-func (a *ServerWithRoles) UpsertTunnelConnection(conn types.TunnelConnection) error {
+// Deprecated: Prefer the [trustv1.Service.UpsertTunnelConnection] RPC.
+//
+// TODO(strideynet): DELETE IN v20.0.0
+func (a *ServerWithRoles) UpsertTunnelConnection(ctx context.Context, conn types.TunnelConnection) error {
 	if err := a.authorizeAction(types.KindTunnelConnection, types.VerbCreate, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.UpsertTunnelConnection(conn)
+	return a.authServer.UpsertTunnelConnection(ctx, conn)
 }
 
 func (a *ServerWithRoles) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]types.TunnelConnection, error) {
@@ -5883,11 +5886,14 @@ func (a *ServerWithRoles) GetAllTunnelConnections(opts ...services.MarshalOption
 	return a.authServer.GetAllTunnelConnections(opts...)
 }
 
-func (a *ServerWithRoles) DeleteTunnelConnection(clusterName string, connName string) error {
+// Deprecated: Prefer the [trustv1.Service.DeleteTunnelConnection] RPC.
+//
+// TODO(strideynet): DELETE IN v20.0.0
+func (a *ServerWithRoles) DeleteTunnelConnection(ctx context.Context, clusterName string, connName string) error {
 	if err := a.authorizeAction(types.KindTunnelConnection, types.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.DeleteTunnelConnection(clusterName, connName)
+	return a.authServer.DeleteTunnelConnection(ctx, clusterName, connName)
 }
 
 // AcquireSemaphore acquires lease with requested resources from semaphore.

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -105,10 +105,10 @@ type accessPoint interface {
 	types.Semaphores
 
 	// UpsertTunnelConnection upserts tunnel connection
-	UpsertTunnelConnection(conn types.TunnelConnection) error
+	UpsertTunnelConnection(ctx context.Context, conn types.TunnelConnection) error
 
 	// DeleteTunnelConnection deletes tunnel connection
-	DeleteTunnelConnection(clusterName, connName string) error
+	DeleteTunnelConnection(ctx context.Context, clusterName, connName string) error
 
 	// GenerateCertAuthorityCRL returns an empty CRL for a CA.
 	GenerateCertAuthorityCRL(ctx context.Context, caType types.CertAuthType) ([]byte, error)

--- a/lib/auth/authclient/http_client.go
+++ b/lib/auth/authclient/http_client.go
@@ -315,23 +315,6 @@ func (c *HTTPClient) Delete(ctx context.Context, u string) (*roundtrip.Response,
 	return httplib.ConvertResponse(c.Client.Delete(ctx, u))
 }
 
-type upsertTunnelConnectionRawReq struct {
-	TunnelConnection json.RawMessage `json:"tunnel_connection"`
-}
-
-// UpsertTunnelConnection upserts tunnel connection
-func (c *HTTPClient) UpsertTunnelConnection(conn types.TunnelConnection) error {
-	data, err := services.MarshalTunnelConnection(conn)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	args := &upsertTunnelConnectionRawReq{
-		TunnelConnection: data,
-	}
-	_, err = c.PostJSON(context.TODO(), c.Endpoint("tunnelconnections"), args)
-	return trace.Wrap(err)
-}
-
 // GetTunnelConnections returns tunnel connections for a given cluster
 func (c *HTTPClient) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]types.TunnelConnection, error) {
 	if clusterName == "" {
@@ -375,18 +358,6 @@ func (c *HTTPClient) GetAllTunnelConnections(opts ...services.MarshalOption) ([]
 		conns[i] = conn
 	}
 	return conns, nil
-}
-
-// DeleteTunnelConnection deletes tunnel connection by name
-func (c *HTTPClient) DeleteTunnelConnection(clusterName string, connName string) error {
-	if clusterName == "" {
-		return trace.BadParameter("missing parameter cluster name")
-	}
-	if connName == "" {
-		return trace.BadParameter("missing parameter connection name")
-	}
-	_, err := c.Delete(context.TODO(), c.Endpoint("tunnelconnections", clusterName, connName))
-	return trace.Wrap(err)
 }
 
 type upsertServerRawReq struct {

--- a/lib/auth/authclient/httpfallback.go
+++ b/lib/auth/authclient/httpfallback.go
@@ -90,7 +90,7 @@ func (c *Client) UpsertTunnelConnection(ctx context.Context, conn types.TunnelCo
 	})
 	if err != nil {
 		if trace.IsNotImplemented(err) {
-			return c.HTTPClient.upsertTunnelConnection(ctx, conn)
+			return trace.Wrap(c.HTTPClient.upsertTunnelConnection(ctx, conn))
 		}
 		return trace.Wrap(err)
 	}
@@ -122,7 +122,7 @@ func (c *Client) DeleteTunnelConnection(ctx context.Context, clusterName, connNa
 	})
 	if err != nil {
 		if trace.IsNotImplemented(err) {
-			return c.HTTPClient.deleteTunnelConnection(ctx, clusterName, connName)
+			return trace.Wrap(c.HTTPClient.deleteTunnelConnection(ctx, clusterName, connName))
 		}
 		return trace.Wrap(err)
 	}

--- a/lib/auth/authclient/httpfallback.go
+++ b/lib/auth/authclient/httpfallback.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -74,6 +75,70 @@ func (c *HTTPClient) validateTrustedCluster(ctx context.Context, validateRequest
 	}
 
 	return validateResponse, nil
+}
+
+// UpsertTunnelConnection creates or updates a tunnel connection record.
+//
+// TODO(strideynet): DELETE IN v20.0.0
+func (c *Client) UpsertTunnelConnection(ctx context.Context, conn types.TunnelConnection) error {
+	connV2, ok := conn.(*types.TunnelConnectionV2)
+	if !ok {
+		return trace.BadParameter("unsupported tunnel connection type %T", conn)
+	}
+	_, err := c.TrustClient().UpsertTunnelConnection(ctx, &trustpb.UpsertTunnelConnectionRequest{
+		TunnelConnection: connV2,
+	})
+	if err != nil {
+		if trace.IsNotImplemented(err) {
+			return c.HTTPClient.upsertTunnelConnection(ctx, conn)
+		}
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// TODO(strideynet): DELETE IN v20.0.0
+func (c *HTTPClient) upsertTunnelConnection(ctx context.Context, conn types.TunnelConnection) error {
+	data, err := services.MarshalTunnelConnection(conn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	args := &struct {
+		TunnelConnection json.RawMessage `json:"tunnel_connection"`
+	}{
+		TunnelConnection: data,
+	}
+	_, err = c.PostJSON(ctx, c.Endpoint("tunnelconnections"), args)
+	return trace.Wrap(err)
+}
+
+// DeleteTunnelConnection removes a tunnel connection by cluster and connection name.
+//
+// TODO(strideynet): DELETE IN v20.0.0
+func (c *Client) DeleteTunnelConnection(ctx context.Context, clusterName, connName string) error {
+	_, err := c.TrustClient().DeleteTunnelConnection(ctx, &trustpb.DeleteTunnelConnectionRequest{
+		ClusterName:    clusterName,
+		ConnectionName: connName,
+	})
+	if err != nil {
+		if trace.IsNotImplemented(err) {
+			return c.HTTPClient.deleteTunnelConnection(ctx, clusterName, connName)
+		}
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// TODO(strideynet): DELETE IN v20.0.0
+func (c *HTTPClient) deleteTunnelConnection(ctx context.Context, clusterName, connName string) error {
+	if clusterName == "" {
+		return trace.BadParameter("missing parameter cluster name")
+	}
+	if connName == "" {
+		return trace.BadParameter("missing parameter connection name")
+	}
+	_, err := c.Delete(ctx, c.Endpoint("tunnelconnections", clusterName, connName))
+	return trace.Wrap(err)
 }
 
 // GetAuthServers returns the list of auth servers registered in the cluster.

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1612,6 +1612,7 @@ func TestAuthPreferenceSettings_ScopedIdentity(t *testing.T) {
 func TestTunnelConnectionsCRUD(t *testing.T) {
 	t.Parallel()
 
+	ctx := t.Context()
 	testSrv := newTestTLSServer(t)
 
 	clt, err := testSrv.NewClient(authtest.TestAdmin())
@@ -1630,7 +1631,7 @@ func TestTunnelConnectionsCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = clt.UpsertTunnelConnection(conn)
+	err = clt.UpsertTunnelConnection(ctx, conn)
 	require.NoError(t, err)
 
 	out, err = clt.GetTunnelConnections(clusterName)
@@ -1646,7 +1647,7 @@ func TestTunnelConnectionsCRUD(t *testing.T) {
 	dt = dt.Add(time.Hour)
 	conn.SetLastHeartbeat(dt)
 
-	err = clt.UpsertTunnelConnection(conn)
+	err = clt.UpsertTunnelConnection(ctx, conn)
 	require.NoError(t, err)
 
 	out, err = clt.GetTunnelConnections(clusterName)
@@ -1658,12 +1659,12 @@ func TestTunnelConnectionsCRUD(t *testing.T) {
 	out, err = clt.GetAllTunnelConnections()
 	require.NoError(t, err)
 	for _, tc := range out {
-		err := testSrv.Auth().DeleteTunnelConnection(tc.GetClusterName(), tc.GetName())
+		err := testSrv.Auth().DeleteTunnelConnection(ctx, tc.GetClusterName(), tc.GetName())
 		require.NoError(t, err)
 	}
 
 	// test delete individual connection
-	err = clt.UpsertTunnelConnection(conn)
+	err = clt.UpsertTunnelConnection(ctx, conn)
 	require.NoError(t, err)
 
 	out, err = clt.GetTunnelConnections(clusterName)
@@ -1671,12 +1672,53 @@ func TestTunnelConnectionsCRUD(t *testing.T) {
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], conn, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-	err = clt.DeleteTunnelConnection(clusterName, conn.GetName())
+	err = clt.DeleteTunnelConnection(ctx, clusterName, conn.GetName())
 	require.NoError(t, err)
 
 	out, err = clt.GetTunnelConnections(clusterName)
 	require.NoError(t, err)
 	require.Empty(t, out)
+}
+
+// TestTunnelConnectionsLegacyHTTP exercises the legacy HTTP handlers for
+// tunnel connection upsert/delete directly so they stay covered during the
+// v19→v20 fallback window without re-exporting the fallback helpers.
+//
+// TODO(strideynet): DELETE IN v20.0.0
+func TestTunnelConnectionsLegacyHTTP(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	testSrv := newTestTLSServer(t)
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+
+	const clusterName = "example.com"
+	conn, err := types.NewTunnelConnection("conn-legacy", types.TunnelConnectionSpecV2{
+		ClusterName:   clusterName,
+		ProxyName:     "p1",
+		LastHeartbeat: clockwork.NewFakeClock().Now(),
+	})
+	require.NoError(t, err)
+
+	data, err := services.MarshalTunnelConnection(conn)
+	require.NoError(t, err)
+	_, err = clt.HTTPClient.PostJSON(ctx, clt.HTTPClient.Endpoint("tunnelconnections"), &struct {
+		TunnelConnection json.RawMessage `json:"tunnel_connection"`
+	}{TunnelConnection: data})
+	require.NoError(t, err)
+
+	stored, err := clt.GetTunnelConnections(clusterName)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	require.Equal(t, conn.GetName(), stored[0].GetName())
+
+	_, err = clt.HTTPClient.Delete(ctx, clt.HTTPClient.Endpoint("tunnelconnections", clusterName, conn.GetName()))
+	require.NoError(t, err)
+
+	stored, err = clt.GetTunnelConnections(clusterName)
+	require.NoError(t, err)
+	require.Empty(t, stored)
 }
 
 func TestServersCRUD(t *testing.T) {
@@ -4989,7 +5031,7 @@ func TestEvents(t *testing.T) {
 			kind: types.WatchKind{
 				Kind: types.KindTunnelConnection,
 			},
-			crud: func(context.Context) types.Resource {
+			crud: func(ctx context.Context) types.Resource {
 				conn, err := types.NewTunnelConnection("conn1", types.TunnelConnectionSpecV2{
 					ClusterName:   "example.com",
 					ProxyName:     "p1",
@@ -4997,13 +5039,13 @@ func TestEvents(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				err = testSrv.Auth().UpsertTunnelConnection(conn)
+				err = testSrv.Auth().UpsertTunnelConnection(ctx, conn)
 				require.NoError(t, err)
 
 				out, err := testSrv.Auth().GetTunnelConnections("example.com")
 				require.NoError(t, err)
 
-				err = testSrv.Auth().DeleteTunnelConnection(conn.GetClusterName(), conn.GetName())
+				err = testSrv.Auth().DeleteTunnelConnection(ctx, conn.GetClusterName(), conn.GetName())
 				require.NoError(t, err)
 
 				return out[0]

--- a/lib/auth/trust/trustv1/tunnelconnection.go
+++ b/lib/auth/trust/trustv1/tunnelconnection.go
@@ -42,6 +42,9 @@ func (s *Service) UpsertTunnelConnection(ctx context.Context, req *trustpb.Upser
 	if err := authCtx.CheckAccessToKind(types.KindTunnelConnection, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	stored, err := s.backend.UpsertTunnelConnectionV2(ctx, req.TunnelConnection)
 	if err != nil {
@@ -73,6 +76,9 @@ func (s *Service) DeleteTunnelConnection(ctx context.Context, req *trustpb.Delet
 	}
 
 	if err := authCtx.CheckAccessToKind(types.KindTunnelConnection, types.VerbDelete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/trust/trustv1/tunnelconnection.go
+++ b/lib/auth/trust/trustv1/tunnelconnection.go
@@ -1,0 +1,79 @@
+/*
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package trustv1
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// UpsertTunnelConnection creates or updates the provided tunnel connection.
+func (s *Service) UpsertTunnelConnection(ctx context.Context, req *trustpb.UpsertTunnelConnectionRequest) (*trustpb.UpsertTunnelConnectionResponse, error) {
+	if req.TunnelConnection == nil {
+		return nil, trace.BadParameter("missing tunnel connection")
+	}
+
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindTunnelConnection, types.VerbCreate, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.backend.UpsertTunnelConnection(ctx, req.TunnelConnection); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &trustpb.UpsertTunnelConnectionResponse{
+		TunnelConnection: req.TunnelConnection,
+	}, nil
+}
+
+// DeleteTunnelConnection removes a single tunnel connection by cluster and
+// connection name.
+func (s *Service) DeleteTunnelConnection(ctx context.Context, req *trustpb.DeleteTunnelConnectionRequest) (*emptypb.Empty, error) {
+	if req.ClusterName == "" {
+		return nil, trace.BadParameter("missing cluster name")
+	}
+	if req.ConnectionName == "" {
+		return nil, trace.BadParameter("missing connection name")
+	}
+
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindTunnelConnection, types.VerbDelete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.backend.DeleteTunnelConnection(ctx, req.ClusterName, req.ConnectionName); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &emptypb.Empty{}, nil
+}

--- a/lib/auth/trust/trustv1/tunnelconnection.go
+++ b/lib/auth/trust/trustv1/tunnelconnection.go
@@ -43,12 +43,17 @@ func (s *Service) UpsertTunnelConnection(ctx context.Context, req *trustpb.Upser
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.backend.UpsertTunnelConnection(ctx, req.TunnelConnection); err != nil {
+	stored, err := s.backend.UpsertTunnelConnectionV2(ctx, req.TunnelConnection)
+	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+	storedV2, ok := stored.(*types.TunnelConnectionV2)
+	if !ok {
+		return nil, trace.BadParameter("encountered unexpected tunnel connection type %T", stored)
 	}
 
 	return &trustpb.UpsertTunnelConnectionResponse{
-		TunnelConnection: req.TunnelConnection,
+		TunnelConnection: storedV2,
 	}, nil
 }
 

--- a/lib/auth/trust/trustv1/tunnelconnection_test.go
+++ b/lib/auth/trust/trustv1/tunnelconnection_test.go
@@ -27,6 +27,7 @@ import (
 
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
@@ -102,6 +103,7 @@ func TestUpsertTunnelConnection(t *testing.T) {
 				Authorizer:       authorizer,
 				ScopedAuthorizer: authorizer,
 				AuthServer:       &fakeAuthServer{},
+				Modules:          modulestest.OSSModules(),
 			})
 			require.NoError(t, err)
 
@@ -194,6 +196,7 @@ func TestDeleteTunnelConnection(t *testing.T) {
 				Authorizer:       authorizer,
 				ScopedAuthorizer: authorizer,
 				AuthServer:       &fakeAuthServer{},
+				Modules:          modulestest.OSSModules(),
 			})
 			require.NoError(t, err)
 

--- a/lib/auth/trust/trustv1/tunnelconnection_test.go
+++ b/lib/auth/trust/trustv1/tunnelconnection_test.go
@@ -111,12 +111,14 @@ func TestUpsertTunnelConnection(t *testing.T) {
 			if err != nil {
 				return
 			}
+			require.NotEmpty(t, resp.TunnelConnection.GetRevision(), "response should carry the backend-assigned revision")
 			require.Equal(t, req.TunnelConnection, resp.TunnelConnection)
 
 			stored, err := trust.GetTunnelConnections(req.TunnelConnection.GetClusterName())
 			require.NoError(t, err)
 			require.Len(t, stored, 1)
 			require.Equal(t, req.TunnelConnection.GetName(), stored[0].GetName())
+			require.Equal(t, resp.TunnelConnection.GetRevision(), stored[0].GetRevision())
 		})
 	}
 }

--- a/lib/auth/trust/trustv1/tunnelconnection_test.go
+++ b/lib/auth/trust/trustv1/tunnelconnection_test.go
@@ -1,0 +1,210 @@
+/*
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package trustv1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+func TestUpsertTunnelConnection(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	newConn := func(t *testing.T) *types.TunnelConnectionV2 {
+		t.Helper()
+		conn, err := types.NewTunnelConnection("conn-1", types.TunnelConnectionSpecV2{
+			ClusterName:   "leaf.example.com",
+			ProxyName:     "proxy-1",
+			LastHeartbeat: time.Now().UTC(),
+			Type:          types.ProxyTunnel,
+		})
+		require.NoError(t, err)
+		return conn.(*types.TunnelConnectionV2)
+	}
+
+	tests := []struct {
+		name      string
+		req       func(t *testing.T) *trustpb.UpsertTunnelConnectionRequest
+		allow     map[check]bool
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "success",
+			req: func(t *testing.T) *trustpb.UpsertTunnelConnectionRequest {
+				return &trustpb.UpsertTunnelConnectionRequest{TunnelConnection: newConn(t)}
+			},
+			allow: map[check]bool{
+				{types.KindTunnelConnection, types.VerbCreate}: true,
+				{types.KindTunnelConnection, types.VerbUpdate}: true,
+			},
+			assertErr: require.NoError,
+		},
+		{
+			name: "missing tunnel connection",
+			req: func(t *testing.T) *trustpb.UpsertTunnelConnectionRequest {
+				return &trustpb.UpsertTunnelConnectionRequest{}
+			},
+			allow: map[check]bool{
+				{types.KindTunnelConnection, types.VerbCreate}: true,
+				{types.KindTunnelConnection, types.VerbUpdate}: true,
+			},
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+			},
+		},
+		{
+			name: "access denied",
+			req: func(t *testing.T) *trustpb.UpsertTunnelConnectionRequest {
+				return &trustpb.UpsertTunnelConnectionRequest{TunnelConnection: newConn(t)}
+			},
+			allow: map[check]bool{
+				{types.KindTunnelConnection, types.VerbCreate}: false,
+				{types.KindTunnelConnection, types.VerbUpdate}: false,
+			},
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %v", err)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := newTestPack(t)
+			trust := local.NewCAService(p.mem)
+			authorizer := &fakeAuthorizer{checker: &fakeChecker{allow: test.allow}}
+			service, err := NewService(&ServiceConfig{
+				Cache:            trust,
+				Backend:          trust,
+				Authorizer:       authorizer,
+				ScopedAuthorizer: authorizer,
+				AuthServer:       &fakeAuthServer{},
+			})
+			require.NoError(t, err)
+
+			req := test.req(t)
+			resp, err := service.UpsertTunnelConnection(ctx, req)
+			test.assertErr(t, err)
+			if err != nil {
+				return
+			}
+			require.Equal(t, req.TunnelConnection, resp.TunnelConnection)
+
+			stored, err := trust.GetTunnelConnections(req.TunnelConnection.GetClusterName())
+			require.NoError(t, err)
+			require.Len(t, stored, 1)
+			require.Equal(t, req.TunnelConnection.GetName(), stored[0].GetName())
+		})
+	}
+}
+
+func TestDeleteTunnelConnection(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const clusterName = "leaf.example.com"
+	const connName = "conn-1"
+
+	seed := func(t *testing.T, trust *local.CA) {
+		t.Helper()
+		conn, err := types.NewTunnelConnection(connName, types.TunnelConnectionSpecV2{
+			ClusterName:   clusterName,
+			ProxyName:     "proxy-1",
+			LastHeartbeat: time.Now().UTC(),
+			Type:          types.ProxyTunnel,
+		})
+		require.NoError(t, err)
+		require.NoError(t, trust.UpsertTunnelConnection(ctx, conn))
+	}
+
+	tests := []struct {
+		name      string
+		req       *trustpb.DeleteTunnelConnectionRequest
+		allow     map[check]bool
+		assertErr require.ErrorAssertionFunc
+		wantGone  bool
+	}{
+		{
+			name: "success",
+			req: &trustpb.DeleteTunnelConnectionRequest{
+				ClusterName:    clusterName,
+				ConnectionName: connName,
+			},
+			allow:     map[check]bool{{types.KindTunnelConnection, types.VerbDelete}: true},
+			assertErr: require.NoError,
+			wantGone:  true,
+		},
+		{
+			name:      "missing cluster name",
+			req:       &trustpb.DeleteTunnelConnectionRequest{ConnectionName: connName},
+			allow:     map[check]bool{{types.KindTunnelConnection, types.VerbDelete}: true},
+			assertErr: func(t require.TestingT, err error, _ ...any) { require.True(t, trace.IsBadParameter(err)) },
+		},
+		{
+			name:      "missing connection name",
+			req:       &trustpb.DeleteTunnelConnectionRequest{ClusterName: clusterName},
+			allow:     map[check]bool{{types.KindTunnelConnection, types.VerbDelete}: true},
+			assertErr: func(t require.TestingT, err error, _ ...any) { require.True(t, trace.IsBadParameter(err)) },
+		},
+		{
+			name: "access denied",
+			req: &trustpb.DeleteTunnelConnectionRequest{
+				ClusterName:    clusterName,
+				ConnectionName: connName,
+			},
+			allow:     map[check]bool{{types.KindTunnelConnection, types.VerbDelete}: false},
+			assertErr: func(t require.TestingT, err error, _ ...any) { require.True(t, trace.IsAccessDenied(err)) },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := newTestPack(t)
+			trust := local.NewCAService(p.mem)
+			seed(t, trust)
+			authorizer := &fakeAuthorizer{checker: &fakeChecker{allow: test.allow}}
+			service, err := NewService(&ServiceConfig{
+				Cache:            trust,
+				Backend:          trust,
+				Authorizer:       authorizer,
+				ScopedAuthorizer: authorizer,
+				AuthServer:       &fakeAuthServer{},
+			})
+			require.NoError(t, err)
+
+			_, err = service.DeleteTunnelConnection(ctx, test.req)
+			test.assertErr(t, err)
+
+			remaining, listErr := trust.GetTunnelConnections(clusterName)
+			require.NoError(t, listErr)
+			if test.wantGone {
+				require.Empty(t, remaining)
+			} else {
+				require.Len(t, remaining, 1)
+			}
+		})
+	}
+}

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -76,7 +76,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 		Type:          types.ProxyTunnel,
 	})
 	require.NoError(t, err)
-	require.NoError(t, a.UpsertTunnelConnection(tc1))
+	require.NoError(t, a.UpsertTunnelConnection(ctx, tc1))
 
 	lastHeartbeat = lastHeartbeat.Add(time.Minute)
 	tc2, err := types.NewTunnelConnection("conn-2", types.TunnelConnectionSpecV2{
@@ -86,7 +86,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 		Type:          types.ProxyTunnel,
 	})
 	require.NoError(t, err)
-	require.NoError(t, a.UpsertTunnelConnection(tc2))
+	require.NoError(t, a.UpsertTunnelConnection(ctx, tc2))
 
 	a.RefreshRemoteClusters(ctx)
 
@@ -99,7 +99,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	require.Empty(t, cmp.Diff(rc, gotRC, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 	// Delete the latest connection.
-	require.NoError(t, a.DeleteTunnelConnection(tc2.GetClusterName(), tc2.GetName()))
+	require.NoError(t, a.DeleteTunnelConnection(ctx, tc2.GetClusterName(), tc2.GetName()))
 
 	a.RefreshRemoteClusters(ctx)
 
@@ -112,7 +112,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	require.Empty(t, cmp.Diff(rc, gotRC, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 	// Delete the remaining connection
-	require.NoError(t, a.DeleteTunnelConnection(tc1.GetClusterName(), tc1.GetName()))
+	require.NoError(t, a.DeleteTunnelConnection(ctx, tc1.GetClusterName(), tc1.GetName()))
 
 	a.RefreshRemoteClusters(ctx)
 
@@ -184,7 +184,7 @@ func TestRefreshRemoteClusters(t *testing.T) {
 						Type:          types.ProxyTunnel,
 					})
 					require.NoError(t, err)
-					require.NoError(t, a.UpsertTunnelConnection(tc))
+					require.NoError(t, a.UpsertTunnelConnection(ctx, tc))
 				}
 			}
 

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2738,12 +2738,6 @@ func withKeepalive[T any](fn func(context.Context, T) (*types.KeepAlive, error))
 	}
 }
 
-func modifyNoContext[T any](fn func(T) error) func(context.Context, T) error {
-	return func(_ context.Context, resource T) error {
-		return fn(resource)
-	}
-}
-
 // A test entity descriptor from https://sptest.iamshowcase.com/testsp_metadata.xml.
 const testEntityDescriptorFmt = `<?xml version="1.0" encoding="UTF-8"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="%s" validUntil="2025-12-09T09:13:31.006Z">

--- a/lib/cache/remote_cluster_test.go
+++ b/lib/cache/remote_cluster_test.go
@@ -99,17 +99,17 @@ func TestTunnelConnections(t *testing.T) {
 				LastHeartbeat: time.Now().UTC(),
 			})
 		},
-		create:    modifyNoContext(p.trustS.UpsertTunnelConnection),
+		create:    p.trustS.UpsertTunnelConnection,
 		list:      getAllAdapter(func(ctx context.Context) ([]types.TunnelConnection, error) { return p.trustS.GetAllTunnelConnections() }),
 		cacheList: getAllAdapter(func(ctx context.Context) ([]types.TunnelConnection, error) { return p.cache.GetAllTunnelConnections() }),
-		update:    modifyNoContext(p.trustS.UpsertTunnelConnection),
+		update:    p.trustS.UpsertTunnelConnection,
 		deleteAll: func(ctx context.Context) error {
 			all, err := p.trustS.GetAllTunnelConnections()
 			if err != nil {
 				return err
 			}
 			for _, tc := range all {
-				err := p.trustS.DeleteTunnelConnection(tc.GetClusterName(), tc.GetName())
+				err := p.trustS.DeleteTunnelConnection(ctx, tc.GetClusterName(), tc.GetName())
 				if err != nil {
 					return err
 				}
@@ -126,7 +126,7 @@ func TestTunnelConnections(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.NoError(t, p.trustS.UpsertTunnelConnection(tunnel))
+		require.NoError(t, p.trustS.UpsertTunnelConnection(t.Context(), tunnel))
 	}
 
 	for i := range 3 {
@@ -136,7 +136,7 @@ func TestTunnelConnections(t *testing.T) {
 			LastHeartbeat: time.Now().UTC(),
 		})
 		require.NoError(t, err)
-		require.NoError(t, p.trustS.UpsertTunnelConnection(tunnel))
+		require.NoError(t, p.trustS.UpsertTunnelConnection(t.Context(), tunnel))
 	}
 
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {

--- a/lib/reversetunnel/leaf_cluster.go
+++ b/lib/reversetunnel/leaf_cluster.go
@@ -393,7 +393,7 @@ func (s *leafCluster) registerHeartbeat(t time.Time) {
 	connInfo.SetLastHeartbeat(t)
 	connInfo.SetExpiry(s.clock.Now().Add(s.offlineThreshold))
 	s.setLastConnInfo(connInfo)
-	err := s.localCache.UpsertTunnelConnection(connInfo)
+	err := s.localCache.UpsertTunnelConnection(s.ctx, connInfo)
 	if err != nil {
 		s.logger.WarnContext(s.ctx, "Failed to register heartbeat", "error", err)
 	}
@@ -402,7 +402,7 @@ func (s *leafCluster) registerHeartbeat(t time.Time) {
 // deleteConnectionRecord deletes connection record to let know peer proxies
 // that this node lost the connection and needs to be discovered
 func (s *leafCluster) deleteConnectionRecord() {
-	if err := s.localCache.DeleteTunnelConnection(s.connInfo.GetClusterName(), s.connInfo.GetName()); err != nil {
+	if err := s.localCache.DeleteTunnelConnection(s.ctx, s.connInfo.GetClusterName(), s.connInfo.GetName()); err != nil {
 		s.logger.WarnContext(s.ctx, "Failed to delete tunnel connection", "error", err)
 	}
 }

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -1221,6 +1221,7 @@ func (s *ServicesTestSuite) OIDCPagination(t *testing.T) {
 }
 
 func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
+	ctx := t.Context()
 	clusterName := "example.com"
 	out, err := s.TrustS.GetTunnelConnections(clusterName)
 	require.NoError(t, err)
@@ -1234,7 +1235,7 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = s.TrustS.UpsertTunnelConnection(conn)
+	err = s.TrustS.UpsertTunnelConnection(ctx, conn)
 	require.NoError(t, err)
 
 	out, err = s.TrustS.GetTunnelConnections(clusterName)
@@ -1250,7 +1251,7 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 	dt = dt.Add(time.Hour)
 	conn.SetLastHeartbeat(dt)
 
-	err = s.TrustS.UpsertTunnelConnection(conn)
+	err = s.TrustS.UpsertTunnelConnection(ctx, conn)
 	require.NoError(t, err)
 
 	out, err = s.TrustS.GetTunnelConnections(clusterName)
@@ -1261,12 +1262,12 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 	out, err = s.TrustS.GetAllTunnelConnections()
 	require.NoError(t, err)
 	for _, tc := range out {
-		err = s.TrustS.DeleteTunnelConnection(tc.GetClusterName(), tc.GetName())
+		err = s.TrustS.DeleteTunnelConnection(ctx, tc.GetClusterName(), tc.GetName())
 		require.NoError(t, err)
 	}
 
 	// test delete individual connection
-	err = s.TrustS.UpsertTunnelConnection(conn)
+	err = s.TrustS.UpsertTunnelConnection(ctx, conn)
 	require.NoError(t, err)
 
 	out, err = s.TrustS.GetTunnelConnections(clusterName)
@@ -1274,7 +1275,7 @@ func (s *ServicesTestSuite) TunnelConnectionsCRUD(t *testing.T) {
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out[0], conn, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-	err = s.TrustS.DeleteTunnelConnection(clusterName, conn.GetName())
+	err = s.TrustS.DeleteTunnelConnection(ctx, clusterName, conn.GetName())
 	require.NoError(t, err)
 
 	out, err = s.TrustS.GetTunnelConnections(clusterName)
@@ -2240,7 +2241,7 @@ func (s *ServicesTestSuite) Events(t *testing.T) {
 			kind: types.WatchKind{
 				Kind: types.KindTunnelConnection,
 			},
-			crud: func(context.Context) types.Resource {
+			crud: func(ctx context.Context) types.Resource {
 				conn, err := types.NewTunnelConnection("conn1", types.TunnelConnectionSpecV2{
 					ClusterName:   "example.com",
 					ProxyName:     "p1",
@@ -2248,13 +2249,13 @@ func (s *ServicesTestSuite) Events(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				err = s.TrustS.UpsertTunnelConnection(conn)
+				err = s.TrustS.UpsertTunnelConnection(ctx, conn)
 				require.NoError(t, err)
 
 				out, err := s.TrustS.GetTunnelConnections("example.com")
 				require.NoError(t, err)
 
-				err = s.TrustS.DeleteTunnelConnection(conn.GetClusterName(), conn.GetName())
+				err = s.TrustS.DeleteTunnelConnection(ctx, conn.GetClusterName(), conn.GetName())
 				require.NoError(t, err)
 
 				return out[0]

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -814,27 +814,38 @@ func (s *CA) DeleteTrustedClusterInternal(ctx context.Context, name string, caID
 	return nil
 }
 
-// UpsertTunnelConnection updates or creates tunnel connection
+// UpsertTunnelConnection updates or creates tunnel connection.
 func (s *CA) UpsertTunnelConnection(ctx context.Context, conn types.TunnelConnection) error {
+	_, err := s.UpsertTunnelConnectionV2(ctx, conn)
+	return trace.Wrap(err)
+}
+
+// UpsertTunnelConnectionV2 updates or creates a tunnel connection and returns
+// the upserted value with its revision populated from the backend.
+//
+// TODO(strideynet): In v20.0.0, once the legacy HTTP fallback is removed, this
+// can be renamed to UpsertTunnelConnection.
+func (s *CA) UpsertTunnelConnectionV2(ctx context.Context, conn types.TunnelConnection) (types.TunnelConnection, error) {
 	if err := services.CheckAndSetDefaults(conn); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	rev := conn.GetRevision()
 	value, err := services.MarshalTunnelConnection(conn)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	_, err = s.Put(ctx, backend.Item{
+	lease, err := s.Put(ctx, backend.Item{
 		Key:      backend.NewKey(tunnelConnectionsPrefix, conn.GetClusterName(), conn.GetName()),
 		Value:    value,
 		Expires:  conn.Expiry(),
 		Revision: rev,
 	})
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return nil
+	conn.SetRevision(lease.Revision)
+	return conn, nil
 }
 
 // GetTunnelConnection returns connection by cluster name and connection name

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -815,7 +815,7 @@ func (s *CA) DeleteTrustedClusterInternal(ctx context.Context, name string, caID
 }
 
 // UpsertTunnelConnection updates or creates tunnel connection
-func (s *CA) UpsertTunnelConnection(conn types.TunnelConnection) error {
+func (s *CA) UpsertTunnelConnection(ctx context.Context, conn types.TunnelConnection) error {
 	if err := services.CheckAndSetDefaults(conn); err != nil {
 		return trace.Wrap(err)
 	}
@@ -825,7 +825,7 @@ func (s *CA) UpsertTunnelConnection(conn types.TunnelConnection) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = s.Put(context.TODO(), backend.Item{
+	_, err = s.Put(ctx, backend.Item{
 		Key:      backend.NewKey(tunnelConnectionsPrefix, conn.GetClusterName(), conn.GetName()),
 		Value:    value,
 		Expires:  conn.Expiry(),
@@ -901,14 +901,14 @@ func (s *CA) GetAllTunnelConnections(opts ...services.MarshalOption) ([]types.Tu
 }
 
 // DeleteTunnelConnection deletes tunnel connection by name
-func (s *CA) DeleteTunnelConnection(clusterName, connectionName string) error {
+func (s *CA) DeleteTunnelConnection(ctx context.Context, clusterName, connectionName string) error {
 	if clusterName == "" {
 		return trace.BadParameter("missing cluster name")
 	}
 	if connectionName == "" {
 		return trace.BadParameter("missing connection name")
 	}
-	return s.Delete(context.TODO(), backend.NewKey(tunnelConnectionsPrefix, clusterName, connectionName))
+	return s.Delete(ctx, backend.NewKey(tunnelConnectionsPrefix, clusterName, connectionName))
 }
 
 // CreateRemoteCluster creates a remote cluster

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -115,6 +115,14 @@ type TrustInternal interface {
 
 	// DeactivateCertAuthorities deactivates multiple cert authorities atomically.
 	DeactivateCertAuthorities(context.Context, ...types.CertAuthID) error
+
+	// UpsertTunnelConnectionV2 upserts a tunnel connection and returns the
+	// upserted value, with its revision populated from the backend.
+	//
+	// TODO(strideynet): In v20.0.0, once the legacy HTTP fallback is removed,
+	// this can be renamed to UpsertTunnelConnection and the error-only
+	// [Clusters.UpsertTunnelConnection] retired.
+	UpsertTunnelConnectionV2(ctx context.Context, conn types.TunnelConnection) (types.TunnelConnection, error)
 }
 
 // Clusters is responsible for managing trusted clusters.

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -138,7 +138,7 @@ type Clusters interface {
 	DeleteTrustedCluster(ctx context.Context, name string) error
 
 	// UpsertTunnelConnection upserts tunnel connection
-	UpsertTunnelConnection(types.TunnelConnection) error
+	UpsertTunnelConnection(ctx context.Context, conn types.TunnelConnection) error
 
 	// GetTunnelConnections returns tunnel connections for a given cluster
 	GetTunnelConnections(clusterName string, opts ...MarshalOption) ([]types.TunnelConnection, error)
@@ -147,7 +147,7 @@ type Clusters interface {
 	GetAllTunnelConnections(opts ...MarshalOption) ([]types.TunnelConnection, error)
 
 	// DeleteTunnelConnection deletes tunnel connection by name
-	DeleteTunnelConnection(clusterName string, connName string) error
+	DeleteTunnelConnection(ctx context.Context, clusterName string, connName string) error
 
 	// CreateRemoteCluster creates a remote cluster
 	CreateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (types.RemoteCluster, error)


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/6394

Migrates the DeleteTunnelConnection and UpsertTunnelConnection RPCs from HTTP to gRPC:

- New DeleteTunnelConnection and UpsertTunnelConnection RPCs added to Trust gRPC service
- Existing HTTTP implementations unmodified, but marked for removal in future update.
- Client "fallback" methods implemented that try new gRPC calls first, and fall back to HTTP calls if unimplemented.
- Additionally, I've threaded `context.Context` through to the Backend service for these two methods and across the interface implementation/call-points.

## Manual Test Plan
### Test Environment

Local environment, root and leaf clusters prepared.

I won't be merging this PR until I've had an opportunity to complete this test plan as part of the next PR in the stack which will be migrating the GetTunnelConnections/GetAllTunnelConnections RPCs

### Test Cases
- [x] Invoke UpsertTunnelConnection via Go to insert dummy TC and fetch to validate persisted.
- [x] Invoke DeleteTunnelConnection via Go to delete dummy TC and fetch to validate no longer persisted.
- [x] Attach leaf cluster to root cluster, validate that root cluster has TunnelConnection for cluster.
- [x] General smoke test: Connect to SSH node in leaf cluster from root cluster.
- [x] Disconnect leaf cluster from root cluster, validate that TunnelConnection is deleted.
