### PR TITLE
[v18] Return HostResult messages for agents in bound keypair joining

### DIFF
--- a/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
+++ b/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
@@ -2557,8 +2557,10 @@ type HostResult struct {
 	HostId string `protobuf:"bytes,2,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty"`
 	// The immutable labels assigned to the host by their join token.
 	ImmutableLabels *v1.ImmutableLabels `protobuf:"bytes,3,opt,name=immutable_labels,json=immutableLabels,proto3" json:"immutable_labels,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// BoundKeypairResult holds extra result parameters relevant to the bound keypair join method.
+	BoundKeypairResult *BoundKeypairResult `protobuf:"bytes,4,opt,name=bound_keypair_result,json=boundKeypairResult,proto3,oneof" json:"bound_keypair_result,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *HostResult) Reset() {
@@ -2608,6 +2610,13 @@ func (x *HostResult) GetHostId() string {
 func (x *HostResult) GetImmutableLabels() *v1.ImmutableLabels {
 	if x != nil {
 		return x.ImmutableLabels
+	}
+	return nil
+}
+
+func (x *HostResult) GetBoundKeypairResult() *BoundKeypairResult {
+	if x != nil {
+		return x.BoundKeypairResult
 	}
 	return nil
 }
@@ -3002,12 +3011,14 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\ftls_ca_certs\x18\x02 \x03(\fR\n" +
 	"tlsCaCerts\x12\x19\n" +
 	"\bssh_cert\x18\x03 \x01(\fR\asshCert\x12\x1e\n" +
-	"\vssh_ca_keys\x18\x04 \x03(\fR\tsshCaKeys\"\xc1\x01\n" +
+	"\vssh_ca_keys\x18\x04 \x03(\fR\tsshCaKeys\"\xb7\x02\n" +
 	"\n" +
 	"HostResult\x12B\n" +
 	"\fcertificates\x18\x01 \x01(\v2\x1e.teleport.join.v1.CertificatesR\fcertificates\x12\x17\n" +
 	"\ahost_id\x18\x02 \x01(\tR\x06hostId\x12V\n" +
-	"\x10immutable_labels\x18\x03 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\"\xc5\x01\n" +
+	"\x10immutable_labels\x18\x03 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\x12[\n" +
+	"\x14bound_keypair_result\x18\x04 \x01(\v2$.teleport.join.v1.BoundKeypairResultH\x00R\x12boundKeypairResult\x88\x01\x01B\x17\n" +
+	"\x15_bound_keypair_result\"\xc5\x01\n" +
 	"\tBotResult\x12B\n" +
 	"\fcertificates\x18\x01 \x01(\v2\x1e.teleport.join.v1.CertificatesR\fcertificates\x12[\n" +
 	"\x14bound_keypair_result\x18\x02 \x01(\v2$.teleport.join.v1.BoundKeypairResultH\x00R\x12boundKeypairResult\x88\x01\x01B\x17\n" +
@@ -3119,18 +3130,19 @@ var file_teleport_join_v1_joinservice_proto_depIdxs = []int32{
 	35, // 39: teleport.join.v1.Result.bot_result:type_name -> teleport.join.v1.BotResult
 	33, // 40: teleport.join.v1.HostResult.certificates:type_name -> teleport.join.v1.Certificates
 	39, // 41: teleport.join.v1.HostResult.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
-	33, // 42: teleport.join.v1.BotResult.certificates:type_name -> teleport.join.v1.Certificates
-	13, // 43: teleport.join.v1.BotResult.bound_keypair_result:type_name -> teleport.join.v1.BoundKeypairResult
-	30, // 44: teleport.join.v1.JoinResponse.init:type_name -> teleport.join.v1.ServerInit
-	31, // 45: teleport.join.v1.JoinResponse.challenge:type_name -> teleport.join.v1.Challenge
-	32, // 46: teleport.join.v1.JoinResponse.result:type_name -> teleport.join.v1.Result
-	29, // 47: teleport.join.v1.JoinService.Join:input_type -> teleport.join.v1.JoinRequest
-	36, // 48: teleport.join.v1.JoinService.Join:output_type -> teleport.join.v1.JoinResponse
-	48, // [48:49] is the sub-list for method output_type
-	47, // [47:48] is the sub-list for method input_type
-	47, // [47:47] is the sub-list for extension type_name
-	47, // [47:47] is the sub-list for extension extendee
-	0,  // [0:47] is the sub-list for field type_name
+	13, // 42: teleport.join.v1.HostResult.bound_keypair_result:type_name -> teleport.join.v1.BoundKeypairResult
+	33, // 43: teleport.join.v1.BotResult.certificates:type_name -> teleport.join.v1.Certificates
+	13, // 44: teleport.join.v1.BotResult.bound_keypair_result:type_name -> teleport.join.v1.BoundKeypairResult
+	30, // 45: teleport.join.v1.JoinResponse.init:type_name -> teleport.join.v1.ServerInit
+	31, // 46: teleport.join.v1.JoinResponse.challenge:type_name -> teleport.join.v1.Challenge
+	32, // 47: teleport.join.v1.JoinResponse.result:type_name -> teleport.join.v1.Result
+	29, // 48: teleport.join.v1.JoinService.Join:input_type -> teleport.join.v1.JoinRequest
+	36, // 49: teleport.join.v1.JoinService.Join:output_type -> teleport.join.v1.JoinResponse
+	49, // [49:50] is the sub-list for method output_type
+	48, // [48:49] is the sub-list for method input_type
+	48, // [48:48] is the sub-list for extension type_name
+	48, // [48:48] is the sub-list for extension extendee
+	0,  // [0:48] is the sub-list for field type_name
 }
 
 func init() { file_teleport_join_v1_joinservice_proto_init() }
@@ -3181,6 +3193,7 @@ func file_teleport_join_v1_joinservice_proto_init() {
 		(*Result_HostResult)(nil),
 		(*Result_BotResult)(nil),
 	}
+	file_teleport_join_v1_joinservice_proto_msgTypes[33].OneofWrappers = []any{}
 	file_teleport_join_v1_joinservice_proto_msgTypes[34].OneofWrappers = []any{}
 	file_teleport_join_v1_joinservice_proto_msgTypes[35].OneofWrappers = []any{
 		(*JoinResponse_Init)(nil),

--- a/api/proto/teleport/join/v1/joinservice.proto
+++ b/api/proto/teleport/join/v1/joinservice.proto
@@ -496,6 +496,8 @@ message HostResult {
   string host_id = 2;
   // The immutable labels assigned to the host by their join token.
   teleport.scopes.joining.v1.ImmutableLabels immutable_labels = 3;
+  // BoundKeypairResult holds extra result parameters relevant to the bound keypair join method.
+  optional BoundKeypairResult bound_keypair_result = 4;
 }
 
 // HostResult holds results for bot joining.

--- a/lib/join/boundkeypair/boundkeypair.go
+++ b/lib/join/boundkeypair/boundkeypair.go
@@ -906,7 +906,7 @@ type ScopedTokenService interface {
 func HandleBoundKeypairJoin(
 	ctx context.Context,
 	params *JoinParams,
-) (*messages.BotResult, error) {
+) (messages.Response, error) {
 	if err := params.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1296,11 +1296,26 @@ func HandleBoundKeypairJoin(
 		return nil, trace.Wrap(err, "issuing join state document")
 	}
 
-	return &messages.BotResult{
-		Certificates: *certs,
-		BoundKeypairResult: &messages.BoundKeypairResult{
-			JoinState: []byte(newJoinState),
-			PublicKey: []byte(boundPublicKey),
-		},
-	}, nil
+	switch types.SystemRole(systemRole) {
+	case types.RoleInstance:
+		return &messages.HostResult{
+			Certificates:    *certs,
+			HostID:          generatedHostID,
+			ImmutableLabels: ptv2.GetImmutableLabels(),
+			BoundKeypairResult: &messages.BoundKeypairResult{
+				JoinState: []byte(newJoinState),
+				PublicKey: []byte(boundPublicKey),
+			},
+		}, nil
+	case types.RoleBot:
+		return &messages.BotResult{
+			Certificates: *certs,
+			BoundKeypairResult: &messages.BoundKeypairResult{
+				JoinState: []byte(newJoinState),
+				PublicKey: []byte(boundPublicKey),
+			},
+		}, nil
+	default:
+		return nil, trace.NotImplemented("bound keypair joining only supports Instance and Bot system roles, client requested %s", systemRole)
+	}
 }

--- a/lib/join/boundkeypair/boundkeypair.go
+++ b/lib/join/boundkeypair/boundkeypair.go
@@ -1296,7 +1296,7 @@ func HandleBoundKeypairJoin(
 		return nil, trace.Wrap(err, "issuing join state document")
 	}
 
-	switch types.SystemRole(systemRole) {
+	switch systemRole {
 	case types.RoleInstance:
 		return &messages.HostResult{
 			Certificates:    *certs,

--- a/lib/join/boundkeypair/boundkeypair.go
+++ b/lib/join/boundkeypair/boundkeypair.go
@@ -1301,7 +1301,7 @@ func HandleBoundKeypairJoin(
 		return &messages.HostResult{
 			Certificates:    *certs,
 			HostID:          generatedHostID,
-			ImmutableLabels: ptv2.GetImmutableLabels(),
+			ImmutableLabels: finalToken.GetImmutableLabels(),
 			BoundKeypairResult: &messages.BoundKeypairResult{
 				JoinState: []byte(newJoinState),
 				PublicKey: []byte(boundPublicKey),

--- a/lib/join/internal/messages/messages.go
+++ b/lib/join/internal/messages/messages.go
@@ -551,6 +551,8 @@ type HostResult struct {
 	// ImmutableLabels are the immutable labels that have been assigned to
 	// the host.
 	ImmutableLabels *joiningv1.ImmutableLabels
+	// BoundKeypairResult holds extra result parameters relevant to the bound keypair join method.
+	BoundKeypairResult *BoundKeypairResult
 }
 
 // BotResult holds results for bot joining.

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -279,7 +279,19 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 	// Convert the result message into a JoinResult.
 	switch typedResult := resultMsg.(type) {
 	case *messages.HostResult:
-		return makeJoinResult(signer, typedResult.Certificates, typedResult.ImmutableLabels)
+		joinResult, err := makeJoinResult(signer, typedResult.Certificates, typedResult.ImmutableLabels)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if typedResult.BoundKeypairResult != nil {
+			joinResult.BoundKeypair = &authjoin.BoundKeypairRegisterResult{
+				BoundPublicKey: string(typedResult.BoundKeypairResult.PublicKey),
+				JoinState:      typedResult.BoundKeypairResult.JoinState,
+			}
+		}
+
+		return joinResult, nil
 	case *messages.BotResult:
 		joinResult, err := makeJoinResult(signer, typedResult.Certificates, nil)
 		if err != nil {

--- a/lib/join/joinclient/join_boundkeypair.go
+++ b/lib/join/joinclient/join_boundkeypair.go
@@ -38,6 +38,32 @@ type (
 	BoundKeypairResult = authjoin.BoundKeypairRegisterResult
 )
 
+// handleBoundKeypairResult handles a bound keypair result message upon
+// successful completion of a bound keypair challenge. This updates client state
+// and persists the result to the client's configured backend.
+func handleBoundKeypairResult(
+	ctx context.Context,
+	state boundkeypair.ClientState,
+	result *messages.BoundKeypairResult,
+) error {
+	if result == nil {
+		return trace.BadParameter("register result missing required bound keypair response")
+	}
+
+	if err := state.UpdateFromRegisterResult(
+		result.PublicKey,
+		result.JoinState,
+	); err != nil {
+		return trace.Wrap(err, "updating local bound keypair state")
+	}
+
+	if err := state.Store(ctx); err != nil {
+		return trace.Wrap(err, "storing updated bound keypair state")
+	}
+
+	return nil
+}
+
 func boundKeypairJoin(
 	ctx context.Context,
 	stream messages.ClientStream,
@@ -87,19 +113,15 @@ func boundKeypairJoin(
 		switch kind := msg.(type) {
 		case *messages.BotResult:
 			// Received join result, store and return.
-			if kind.BoundKeypairResult == nil {
-				return nil, trace.BadParameter("register result missing required bound keypair response")
+			if err := handleBoundKeypairResult(ctx, state, kind.BoundKeypairResult); err != nil {
+				return nil, trace.Wrap(err)
 			}
 
-			if err := state.UpdateFromRegisterResult(
-				kind.BoundKeypairResult.PublicKey,
-				kind.BoundKeypairResult.JoinState,
-			); err != nil {
-				return nil, trace.Wrap(err, "updating local bound keypair state")
-			}
-
-			if err := state.Store(ctx); err != nil {
-				return nil, trace.Wrap(err, "storing updated bound keypair state")
+			return kind, nil
+		case *messages.HostResult:
+			// Handled identically to bots.
+			if err := handleBoundKeypairResult(ctx, state, kind.BoundKeypairResult); err != nil {
+				return nil, trace.Wrap(err)
 			}
 
 			return kind, nil

--- a/lib/join/joinv1/messages.go
+++ b/lib/join/joinv1/messages.go
@@ -529,17 +529,19 @@ func resultToMessage(resp *joinv1.Result) (messages.Response, error) {
 
 func hostResultToMessage(resp *joinv1.HostResult) *messages.HostResult {
 	return &messages.HostResult{
-		Certificates:    certificatesToMessage(resp.GetCertificates()),
-		HostID:          resp.GetHostId(),
-		ImmutableLabels: resp.GetImmutableLabels(),
+		Certificates:       certificatesToMessage(resp.GetCertificates()),
+		HostID:             resp.GetHostId(),
+		ImmutableLabels:    resp.GetImmutableLabels(),
+		BoundKeypairResult: boundKeypairResultToMessage(resp.GetBoundKeypairResult()),
 	}
 }
 
 func hostResultFromMessage(msg *messages.HostResult) *joinv1.HostResult {
 	return &joinv1.HostResult{
-		Certificates:    certificatesFromMessage(&msg.Certificates),
-		HostId:          msg.HostID,
-		ImmutableLabels: msg.ImmutableLabels,
+		Certificates:       certificatesFromMessage(&msg.Certificates),
+		HostId:             msg.HostID,
+		ImmutableLabels:    msg.ImmutableLabels,
+		BoundKeypairResult: boundKeypairResultFromMessage(msg.BoundKeypairResult),
 	}
 }
 

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -60,7 +60,7 @@ func (s *Server) handleBoundKeypairJoin(
 	authCtx *authz.Context,
 	clientInit *messages.ClientInit,
 	token provision.Token,
-) (*messages.BotResult, error) {
+) (messages.Response, error) {
 	ctx := stream.Context()
 	diag := stream.Diagnostic()
 
@@ -261,7 +261,7 @@ func AdaptRegisterUsingBoundKeypairMethod(
 		return nil, "", trace.NotImplemented("bound keypair joining for agents is not supported by the legacy join service")
 	}
 
-	botResult, err := boundkeypair.HandleBoundKeypairJoin(ctx, &boundkeypair.JoinParams{
+	joinResponse, err := boundkeypair.HandleBoundKeypairJoin(ctx, &boundkeypair.JoinParams{
 		AuthService:                 a,
 		ScopedTokenService:          nil, // Legacy does not support scoped tokens
 		AuthCtx:                     authCtx,
@@ -280,15 +280,23 @@ func AdaptRegisterUsingBoundKeypairMethod(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	certs, err := protoCertsFromCertificates(botResult.Certificates)
-	if err != nil {
-		return nil, trace.Wrap(err)
+
+	switch result := joinResponse.(type) {
+	case *messages.BotResult:
+		certs, err := protoCertsFromCertificates(result.Certificates)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &client.BoundKeypairRegistrationResponse{
+			Certs:          certs,
+			BoundPublicKey: string(result.BoundKeypairResult.PublicKey),
+			JoinState:      result.BoundKeypairResult.JoinState,
+		}, nil
+	case *messages.HostResult:
+		return nil, trace.BadParameter("bound keypair cannot join agents via the legacy join service")
+	default:
+		return nil, trace.BadParameter("received invalid bound keypair result type (%T)", result)
 	}
-	return &client.BoundKeypairRegistrationResponse{
-		Certs:          certs,
-		BoundPublicKey: string(botResult.BoundKeypairResult.PublicKey),
-		JoinState:      botResult.BoundKeypairResult.JoinState,
-	}, nil
 }
 
 func adaptBoundKeypairChallenge(challengeResponseFunc client.RegisterUsingBoundKeypairChallengeResponseFunc) boundkeypair.ChallengeResponseFunc {


### PR DESCRIPTION
Backport #65439 to branch/v18

---

The current bound keypair implementation only returns BotResult from its join implementation, despite being otherwise updated to account for host joins. This mostly works as the only real difference between bot and host results is the bound keypair result... as well as `ImmutableLabels`, which was effectively lost. Certificates were otherwise valid and returned intact. This only applies to scoped token joining as `ImmutableLabels` are nil for standard `ProvisionTokenV2`.

This would ultimately cause any host joined using a scoped token with `ImmutableLabels` configured to be inaccessible to users attempting to access that resource.

To fix the issue, this changes `HandleBoundKeypairJoin` to return a generic `messages.Result` and constructs a `messages.HostResult` appropriately for instances. The `joinclient` is also updated to account for host joins.

## Manual Test Plan

### Test Environment

Make this scoped joining token for an instance:
```yaml
kind: scoped_token
version: v1
metadata:
  name: bk-agent-scoped
scope: "/staging"
spec:
  roles:
    - Node
  assigned_scope: "/staging/foo"
  join_method: "bound_keypair"
  usage_mode: "single_use"
  immutable_labels:
    ssh:
      env: "prod"
      region: "us-west-2"
  bound_keypair:
    onboarding: {}
```

### Test Cases
- [x] Bots can still join with bound keypair
- [x] Regular instances can join using bound keypair (without a scoped token)
- [x] Regular instances can join using boundkeypair **with** a scoped token. Specify immutable labels and ensure they are still present.
