### PR TITLE
[v18] Gate AWS Identity Center Unauthorized Error to AWS IC Plugins Only

### DIFF
--- a/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import { createMemoryHistory } from 'history';
-import { Router } from 'react-router';
+import { MemoryRouter, Router } from 'react-router';
 
 import { render, screen, userEvent } from 'design/utils/testing';
 
@@ -25,6 +25,7 @@ import { IntegrationList } from 'teleport/Integrations/IntegrationList';
 import {
   IntegrationKind,
   IntegrationStatusCode,
+  type Plugin,
 } from 'teleport/services/integrations';
 
 test('integration list does not display action menu for aws-oidc, row click navigates', async () => {
@@ -54,4 +55,52 @@ test('integration list does not display action menu for aws-oidc, row click navi
   expect(history.push).toHaveBeenCalledWith(
     '/web/integrations/status/aws-oidc/aws-integration'
   );
+});
+
+test('integration list details prefer AWS IC status error message over details', () => {
+  const plugin: Plugin = {
+    resourceType: 'plugin',
+    name: 'aws-ic-plugin',
+    kind: 'aws-identity-center',
+    details: 'fallback details',
+    statusCode: IntegrationStatusCode.Unauthorized,
+    status: {
+      code: IntegrationStatusCode.Unauthorized,
+      lastRun: new Date('2026-03-31T00:00:00Z'),
+      errorMessage: 'scim token rejected',
+    },
+  };
+
+  render(
+    <MemoryRouter>
+      <IntegrationList list={[plugin]} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText('scim token rejected')).toBeInTheDocument();
+  expect(screen.queryByText('fallback details')).not.toBeInTheDocument();
+});
+
+test('integration list details ignore status error message for non-AWS-IC plugins', () => {
+  const plugin: Plugin = {
+    resourceType: 'plugin',
+    name: 'okta-plugin',
+    kind: 'okta',
+    details: 'fallback details',
+    statusCode: IntegrationStatusCode.OtherError,
+    status: {
+      code: IntegrationStatusCode.OtherError,
+      lastRun: new Date('2026-03-31T00:00:00Z'),
+      errorMessage: 'sync failed',
+    },
+  };
+
+  render(
+    <MemoryRouter>
+      <IntegrationList list={[plugin]} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText('fallback details')).toBeInTheDocument();
+  expect(screen.queryByText('sync failed')).not.toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -41,6 +41,7 @@ import cfg from 'teleport/config';
 import {
   filterByIntegrationStatus,
   filterBySearch,
+  getAwsIcErrorMessage,
   sortByStatus,
 } from 'teleport/Integrations/helpers';
 import api from 'teleport/services/api';
@@ -492,7 +493,8 @@ export function percent(n: number, d: number): string {
 }
 
 const DetailsCell = ({ integration }: { integration: IntegrationLike }) => {
-  let content = <Text>{integration.details}</Text>;
+  const awsIcErrorMessage = getAwsIcErrorMessage(integration);
+  let content = <Text>{awsIcErrorMessage ?? integration.details}</Text>;
   switch (integration.kind) {
     case IntegrationKind.AwsOidc:
     case IntegrationKind.AzureOidc:

--- a/web/packages/teleport/src/Integrations/helpers.ts
+++ b/web/packages/teleport/src/Integrations/helpers.ts
@@ -50,6 +50,18 @@ export function filterByIntegrationStatus(
   });
 }
 
+export function getAwsIcErrorMessage(
+  item: IntegrationLike
+): string | undefined {
+  if (
+    item.resourceType === 'plugin' &&
+    item.kind === 'aws-identity-center' &&
+    item.status?.errorMessage
+  ) {
+    return item.status.errorMessage;
+  }
+}
+
 export function filterBySearch(
   l: IntegrationLike[],
   s: string

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.test.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.test.tsx
@@ -20,10 +20,12 @@ import { render, screen } from 'design/utils/testing';
 
 import {
   IntegrationKind,
+  IntegrationStatusCode,
   IntegrationWithSummary,
+  type Plugin,
 } from 'teleport/services/integrations';
 
-import { SummaryStatusLabel } from './StatusLabel';
+import { getStatus, SummaryStatusLabel } from './StatusLabel';
 
 afterEach(() => {
   jest.useRealTimers();
@@ -57,6 +59,48 @@ test('SummaryStatusLabel shows healthy when sync timestamp is recent', () => {
   expect(screen.getByText('Healthy')).toBeInTheDocument();
   expect(screen.queryByText('(scanning in progress)')).not.toBeInTheDocument();
 });
+
+test('getStatus surfaces backend errorMessage for AWS IC Unauthorized', () => {
+  const plugin = makePlugin('aws-identity-center', {
+    code: IntegrationStatusCode.Unauthorized,
+    lastRun: new Date('2026-03-31T00:00:00Z'),
+    errorMessage:
+      'AWS Identity Center rejected the SCIM token. Rotate the token to restore access.',
+  });
+
+  const { status, label, tooltip } = getStatus(plugin);
+
+  expect(status).toBe('Failed');
+  expect(label).toBe('Failed');
+  expect(tooltip).toBe(
+    'AWS Identity Center rejected the SCIM token. Rotate the token to restore access.'
+  );
+});
+
+test('getStatus keeps generic tooltip for non-AWS-IC Unauthorized even when errorMessage is set', () => {
+  const plugin = makePlugin('slack', {
+    code: IntegrationStatusCode.Unauthorized,
+    lastRun: new Date('2026-03-31T00:00:00Z'),
+    errorMessage: 'some backend error',
+  });
+
+  const { tooltip } = getStatus(plugin);
+
+  expect(tooltip).toBe(
+    'Integration was denied access. This could be a result of revoked authorization on the 3rd party provider. Try removing and re-connecting the integration.'
+  );
+});
+
+function makePlugin(kind: Plugin['kind'], status: Plugin['status']): Plugin {
+  return {
+    resourceType: 'plugin',
+    name: `${kind}-plugin`,
+    kind,
+    details: 'plugin details',
+    statusCode: status.code,
+    status,
+  };
+}
 
 function makeSummary(lastSyncMs: number): IntegrationWithSummary {
   return {

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
@@ -35,6 +35,7 @@ import {
   IntegrationWithSummary,
 } from 'teleport/services/integrations';
 
+import { getAwsIcErrorMessage } from '../helpers';
 import { IntegrationLike } from '../IntegrationList';
 import { Status } from '../types';
 
@@ -164,10 +165,15 @@ export function getStatus(item: IntegrationLike): {
       return ISSUES(
         'The Slack integration must be invited to the default channel in order to receive access request notifications.'
       );
-    case IntegrationStatusCode.Unauthorized:
+    case IntegrationStatusCode.Unauthorized: {
+      const awsIcErrorMessage = getAwsIcErrorMessage(item);
+      if (awsIcErrorMessage) {
+        return FAILED(awsIcErrorMessage);
+      }
       return FAILED(
         'Integration was denied access. This could be a result of revoked authorization on the 3rd party provider. Try removing and re-connecting the integration.'
       );
+    }
     case IntegrationStatusCode.OktaConfigError:
       return FAILED(
         `There was an error with the integration's configuration.${item.status?.errorMessage ? ` ${item.status.errorMessage}` : ''}`


### PR DESCRIPTION
Backport of the following PR to branch/v18:
- #65892

## Manual Test Plan

### Test Environment
- Local Teleport cluster integrated with AWS Identity Center using the system credentials installation method

### Test Cases

- [x] Verify that an invalid AWS SCIM API token causes the AWS IAM Identity Center status to show as "Failed" on the UI
   1. Verify that the status for AWS IAM Identity Center is `Healthy` on the integrations UI page (`https://localhost:3000/web/integrations`)
   2. Delete the currently used SCIM token from the AWS Identity Center console
   3. Wait up to 5 minutes (or shorten it by decreasing [DefaultResourceSyncInterval](https://github.com/gravitational/teleport.e/blob/bdaa6286d8dae17ad54a490c24ab5b79af5df552/lib/aws/identitycenter/constants.go#L33))
   4. Verify that the status for AWS IAM Identity Center is now `Failed` on the integrations UI page (`https://localhost:3000/web/integrations`) and that the popup tooltip and the corresponding Details column suggest token rotation to resolve the issue

- [x] Verify that a valid AWS SCIM API token removes the "Failed" status on the UI
   1. Rotate the SCIM token with a valid one by running `tctl plugins rotate awsic <valid token>`
   2. Refresh the integrations UI page (`https://localhost:3000/web/integrations`)
   3. Verify that the status for AWS IAM Identity Center has returned to `Healthy`