### PR TITLE
Add Access Graph TLS cert to KeyRing

### DIFF
--- a/api/utils/keypaths/keypaths.go
+++ b/api/utils/keypaths/keypaths.go
@@ -61,6 +61,9 @@ const (
 	windowsDesktopDirSuffix = "-windowsdesktop"
 	// kubeConfigSuffix is the suffix of a kubeconfig file stored under the keys directory.
 	kubeConfigSuffix = "-kubeconfig"
+	// accessGraphSuffix is the suffix of a user's Access Graph TLS certificate
+	// used to authenticate directly to the proxy for Access Graph API queries.
+	accessGraphSuffix = "-access-graph"
 	// fileNameKubeCredLock is file name of lockfile used to prevent excessive login attempts.
 	fileNameKubeCredLock = "kube_credentials.lock"
 	// casDir is the directory name for where clusters certs are stored.
@@ -102,6 +105,7 @@ const (
 //    │   ├── certs.pem                --> TLS CA certs for the Teleport CA
 //    │   ├── foo.key                  --> TLS Private Key for user "foo"
 //    │   ├── foo.crt                  --> TLS client certificate for Auth Server
+//    │   ├── foo-access-graph.crt     --> TLS client certificate for Access Graph (direct proxy communication)
 //    │   ├── foo                      --> SSH Private Key for user "foo"
 //    │   ├── foo.pub                  --> SSH Public Key
 //    │   ├── foo.ppk                  --> PuTTY PPK-formatted keypair for user "foo"
@@ -213,6 +217,14 @@ func UserTLSKeyPath(baseDir, proxy, username string) string {
 // <baseDir>/keys/<proxy>/<username>.crt
 func TLSCertPath(baseDir, proxy, username string) string {
 	return filepath.Join(ProxyKeyDir(baseDir, proxy), username+FileExtTLSCert)
+}
+
+// AccessGraphTLSCertPath returns the path to the user's Access Graph TLS
+// certificate for the given proxy.
+//
+// <baseDir>/keys/<proxy>/<username>-access-graph.crt
+func AccessGraphTLSCertPath(baseDir, proxy, username string) string {
+	return filepath.Join(ProxyKeyDir(baseDir, proxy), username+accessGraphSuffix+FileExtTLSCert)
 }
 
 // TLSCertPathLegacy returns the legacy path used in Teleport 16.x and older to the

--- a/api/utils/keypaths/keypaths_test.go
+++ b/api/utils/keypaths/keypaths_test.go
@@ -25,6 +25,11 @@ import (
 	"github.com/gravitational/teleport/api/utils/keypaths"
 )
 
+func TestAccessGraphTLSCertPath(t *testing.T) {
+	path := keypaths.AccessGraphTLSCertPath("~/tsh", "proxy", "user")
+	require.Equal(t, "~/tsh/keys/proxy/user-access-graph.crt", path)
+}
+
 func TestIsProfileKubeConfigPath(t *testing.T) {
 	path := ""
 	isKubeConfig, err := keypaths.IsProfileKubeConfigPath(path)

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -20,6 +20,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -1924,4 +1925,50 @@ func newTestLocalAgent(t *testing.T, proxyHost, username, siteName string) *Loca
 	require.NoError(t, err)
 
 	return localAgent
+}
+
+func TestKeyRing_accessGraphHelpers(t *testing.T) {
+	t.Parallel()
+	a := newTestAuthority(t)
+	idx := KeyRingIndex{
+		ProxyHost:   "proxy.example.com",
+		ClusterName: a.trustedCerts.ClusterName,
+		Username:    "alice",
+	}
+
+	t.Run("missing cert returns NotFound", func(t *testing.T) {
+		t.Parallel()
+		keyRing := a.makeSignedKeyRing(t, idx, false)
+
+		_, err := keyRing.AccessGraphTLSCertificate()
+		require.True(t, trace.IsNotFound(err))
+
+		_, err = keyRing.AccessGraphTLSCertValidBefore()
+		require.True(t, trace.IsNotFound(err))
+
+		_, err = keyRing.AccessGraphClientTLSConfig(nil)
+		require.True(t, trace.IsNotFound(err))
+	})
+
+	t.Run("present cert parses and builds TLS config", func(t *testing.T) {
+		t.Parallel()
+		keyRing := a.makeSignedKeyRing(t, idx, false)
+		keyRing.AccessGraphTLSCert = a.signAccessGraphCert(t, keyRing, false)
+
+		parsed, err := keyRing.AccessGraphTLSCertificate()
+		require.NoError(t, err)
+		require.Equal(t, "alice", parsed.Subject.CommonName)
+
+		notAfter, err := keyRing.AccessGraphTLSCertValidBefore()
+		require.NoError(t, err)
+		require.Equal(t, parsed.NotAfter, notAfter)
+
+		tlsConfig, err := keyRing.AccessGraphClientTLSConfig(nil)
+		require.NoError(t, err)
+		require.Len(t, tlsConfig.Certificates, 1)
+		require.Equal(t, keyRing.ProxyHost, tlsConfig.ServerName)
+		// AccessGraph config talks directly to the public proxy; it relies on system CAs.
+		require.Nil(t, tlsConfig.RootCAs)
+		require.GreaterOrEqual(t, tlsConfig.MinVersion, uint16(tls.VersionTLS12))
+	})
 }

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -205,6 +205,14 @@ func (s *Store) GetKeyRing(idx KeyRingIndex, opts ...CertOption) (*KeyRing, erro
 		return nil, trace.Wrap(err)
 	}
 
+	// if the key ring has an Access Graph TLS certificate, verify it as well
+	if len(keyRing.AccessGraphTLSCert) > 0 {
+		_, err = keyRing.AccessGraphTLSCertValidBefore()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	// Validate the SSH certificate.
 	if keyRing.Cert != nil {
 		if err := keyRing.CheckCert(); err != nil {

--- a/lib/client/client_store_test.go
+++ b/lib/client/client_store_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/profile"
 	apissh "github.com/gravitational/teleport/api/ssh"
 	"github.com/gravitational/teleport/api/types"
@@ -142,6 +143,33 @@ func (s *testAuthority) signKeyRing(t *testing.T, keyRing *KeyRing, makeExpired 
 		Cert:       tlsCert,
 		PrivateKey: keyRing.TLSPrivateKey,
 	}
+}
+
+// signAccessGraphCert mints an Access Graph TLS certificate that mirrors the
+// production identity (usage=UsageAccessGraphAPIOnly + a WebSessionID), signed
+// by the same CA and bound to the keyRing's TLS key.
+func (s *testAuthority) signAccessGraphCert(t *testing.T, keyRing *KeyRing, makeExpired bool) []byte {
+	t.Helper()
+	ttl := 20 * time.Minute
+	if makeExpired {
+		ttl = -ttl
+	}
+	identity := tlsca.Identity{
+		Username:     keyRing.Username,
+		Groups:       []string{"access"},
+		Usage:        []string{teleport.UsageAccessGraphAPIOnly},
+		WebSessionID: "access-graph-session-id",
+	}
+	subject, err := identity.Subject()
+	require.NoError(t, err)
+	cert, err := s.tlsCA.GenerateCertificate(tlsca.CertificateRequest{
+		Clock:     s.clock,
+		PublicKey: keyRing.TLSPrivateKey.Public(),
+		Subject:   subject,
+		NotAfter:  s.clock.Now().UTC().Add(ttl),
+	})
+	require.NoError(t, err)
+	return cert
 }
 
 func newSelfSignedCA(privateKey []byte, cluster string) (*tlsca.CertAuthority, authclient.TrustedCerts, error) {
@@ -326,6 +354,83 @@ func TestClientStore(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestClientStore_accessGraphCertValidation(t *testing.T) {
+	t.Parallel()
+	a := newTestAuthority(t)
+
+	t.Run("absent cert is ignored", func(t *testing.T) {
+		t.Parallel()
+		testEachClientStore(t, func(t *testing.T, clientStore *Store) {
+			idx := KeyRingIndex{"test.proxy.com", "bob", "root"}
+			keyRing := a.makeSignedKeyRing(t, idx, false)
+			require.NoError(t, clientStore.AddKeyRing(keyRing))
+
+			retrieved, err := clientStore.GetKeyRing(idx, WithAllCerts...)
+			require.NoError(t, err)
+			require.Nil(t, retrieved.AccessGraphTLSCert)
+		})
+	})
+
+	t.Run("valid cert round-trips", func(t *testing.T) {
+		t.Parallel()
+		testEachClientStore(t, func(t *testing.T, clientStore *Store) {
+			idx := KeyRingIndex{"test.proxy.com", "bob", "root"}
+			keyRing := a.makeSignedKeyRing(t, idx, false)
+			keyRing.AccessGraphTLSCert = a.signAccessGraphCert(t, keyRing, false)
+			require.NoError(t, clientStore.AddKeyRing(keyRing))
+
+			retrieved, err := clientStore.GetKeyRing(idx, WithAllCerts...)
+			require.NoError(t, err)
+			require.Equal(t, keyRing.AccessGraphTLSCert, retrieved.AccessGraphTLSCert)
+
+			// The retrieved cert should carry the AccessGraph usage in its
+			// identity, confirming we really round-tripped the AccessGraph
+			// cert (not the main TLS cert).
+			parsed, err := retrieved.AccessGraphTLSCertificate()
+			require.NoError(t, err)
+			agIdentity, err := tlsca.FromSubject(parsed.Subject, parsed.NotAfter)
+			require.NoError(t, err)
+			require.Equal(t, []string{teleport.UsageAccessGraphAPIOnly}, agIdentity.Usage)
+		})
+	})
+
+	t.Run("unparseable cert is rejected", func(t *testing.T) {
+		t.Parallel()
+		testEachClientStore(t, func(t *testing.T, clientStore *Store) {
+			idx := KeyRingIndex{"test.proxy.com", "bob", "root"}
+			keyRing := a.makeSignedKeyRing(t, idx, false)
+			keyRing.AccessGraphTLSCert = []byte("not a certificate")
+			require.NoError(t, clientStore.AddKeyRing(keyRing))
+
+			_, err := clientStore.GetKeyRing(idx, WithAllCerts...)
+			require.Error(t, err)
+		})
+	})
+
+	// Expired AccessGraph certs are returned as-is, matching the main TLSCert
+	// contract (see keystore.go: "we may be returning expired certificates
+	// here, that is okay. If a certificate is expired, it's the responsibility
+	// of the TeleportClient to perform cleanup").
+	t.Run("expired cert round-trips", func(t *testing.T) {
+		t.Parallel()
+		testEachClientStore(t, func(t *testing.T, clientStore *Store) {
+			idx := KeyRingIndex{"test.proxy.com", "bob", "root"}
+			keyRing := a.makeSignedKeyRing(t, idx, false)
+			keyRing.AccessGraphTLSCert = a.signAccessGraphCert(t, keyRing, true /*makeExpired*/)
+			require.NoError(t, clientStore.AddKeyRing(keyRing))
+
+			retrieved, err := clientStore.GetKeyRing(idx, WithAllCerts...)
+			require.NoError(t, err)
+			require.Equal(t, keyRing.AccessGraphTLSCert, retrieved.AccessGraphTLSCert)
+
+			notAfter, err := retrieved.AccessGraphTLSCertValidBefore()
+			require.NoError(t, err)
+			require.True(t, notAfter.Before(a.clock.Now()),
+				"test setup: AccessGraph cert should be expired relative to the auth clock")
+		})
+	})
 }
 
 func TestPartialProfileStatusScope(t *testing.T) {

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -129,6 +129,12 @@ type KeyRing struct {
 	// TLSCert is a PEM encoded client TLS x509 certificate.
 	// It's used to authenticate to the Teleport APIs.
 	TLSCert []byte
+	// AccessGraphTLSCert is a PEM encoded client TLS x509 certificate used to
+	// authenticate directly to the proxy for Access Graph API queries. It
+	// shares the same private key as TLSCert. The proxy enforces a specific
+	// identity shape on this certificate (Usage=UsageAccessGraphAPIOnly plus a
+	// non-empty WebSessionID); see lib/web.Handler.AuthenticateReqForAccessGraphAPI.
+	AccessGraphTLSCert []byte
 
 	// KubeTLSCredentials are TLS credentials for individual kubernetes clusters.
 	// Map key is a kubernetes cluster name.
@@ -352,6 +358,38 @@ func (k *KeyRing) clientCertPoolPEM(clusters ...string) ([]byte, error) {
 	return certPoolPEM.Bytes(), nil
 }
 
+// AccessGraphClientTLSConfig returns a TLS config that can be used to
+// authenticate directly to the proxy for Access Graph API queries.
+func (k *KeyRing) AccessGraphClientTLSConfig(cipherSuites []uint16) (*tls.Config, error) {
+	if len(k.AccessGraphTLSCert) == 0 {
+		return nil, trace.NotFound("Access Graph TLS certificate not found")
+	}
+	return k.proxyClientTLSConfig(cipherSuites, TLSCredential{
+		PrivateKey: k.TLSPrivateKey,
+		Cert:       k.AccessGraphTLSCert,
+	})
+}
+
+// proxyClientTLSConfig is similar to clientTLSConfig but does not set RootCAs,
+// since the caller communicates directly with the public proxy and relies on
+// the system CA bundle to verify its public certificate.
+//
+// TODO: accept a custom RootCAs pool so self-hosted clusters whose web cert
+// isn't in the machine's system trust store (ephemeral dev environments, CI
+// runners outside MDM, etc.) can pass their own bundle — mirrors the
+// --ca-bundle / --insecure escape hatches used elsewhere in the client.
+func (k *KeyRing) proxyClientTLSConfig(cipherSuites []uint16, cred TLSCredential) (*tls.Config, error) {
+	tlsCert, err := cred.TLSCertificate()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsConfig := utils.TLSConfig(cipherSuites)
+	tlsConfig.Certificates = append(tlsConfig.Certificates, tlsCert)
+	tlsConfig.ServerName = k.ProxyHost
+	tlsConfig.MinVersion = tls.VersionTLS12
+	return tlsConfig, nil
+}
+
 // ProxyClientSSHConfig returns an ssh.ClientConfig with SSH credentials from this
 // KeyRing and HostKeyCallback matching SSH CAs in the KeyRing.
 //
@@ -484,6 +522,15 @@ func (k *KeyRing) TeleportTLSCertificate() (*x509.Certificate, error) {
 	return tlsca.ParseCertificatePEM(k.TLSCert)
 }
 
+// AccessGraphTLSCertificate returns the parsed x509 certificate for
+// authentication directly to the proxy for Access Graph API queries.
+func (k *KeyRing) AccessGraphTLSCertificate() (*x509.Certificate, error) {
+	if len(k.AccessGraphTLSCert) == 0 {
+		return nil, trace.NotFound("Access Graph TLS certificate not found")
+	}
+	return tlsca.ParseCertificatePEM(k.AccessGraphTLSCert)
+}
+
 // KubeX509Cert returns the parsed x509 certificate for authentication against
 // a named kubernetes cluster.
 func (k *KeyRing) KubeX509Cert(kubeClusterName string) (*x509.Certificate, error) {
@@ -562,6 +609,15 @@ func (k *KeyRing) AppTLSCertificates() (certs []x509.Certificate, err error) {
 // TeleportTLSCertValidBefore returns the time of the TLS cert expiration
 func (k *KeyRing) TeleportTLSCertValidBefore() (t time.Time, err error) {
 	cert, err := k.TeleportTLSCertificate()
+	if err != nil {
+		return t, trace.Wrap(err)
+	}
+	return cert.NotAfter, nil
+}
+
+// AccessGraphTLSCertValidBefore returns the time of the Access Graph TLS cert expiration
+func (k *KeyRing) AccessGraphTLSCertValidBefore() (t time.Time, err error) {
+	cert, err := k.AccessGraphTLSCertificate()
 	if err != nil {
 		return t, trace.Wrap(err)
 	}

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -139,6 +139,12 @@ func (fs *FSKeyStore) tlsCertPath(idx KeyRingIndex) string {
 	return keypaths.TLSCertPath(fs.KeyDir, idx.ProxyHost, idx.Username)
 }
 
+// accessGraphTLSCertPath returns the path to the Access Graph TLS certificate
+// for the given KeyRingIndex.
+func (fs *FSKeyStore) accessGraphTLSCertPath(idx KeyRingIndex) string {
+	return keypaths.AccessGraphTLSCertPath(fs.KeyDir, idx.ProxyHost, idx.Username)
+}
+
 // tlsCertPathLegacy returns the legacy TLS certificate path used in Teleport v16 and
 // older given KeyRingIndex.
 func (fs *FSKeyStore) tlsCertPathLegacy(idx KeyRingIndex) string {
@@ -211,6 +217,15 @@ func (fs *FSKeyStore) AddKeyRing(keyRing *KeyRing) error {
 		return trace.Wrap(err)
 	}
 
+	// Store Access Graph cert. Share the same key-file lock used for the main
+	// TLS credential so this cert doesn't drift from TLSPrivateKey under
+	// concurrent writes.
+	if len(keyRing.AccessGraphTLSCert) > 0 {
+		if err := fs.writeAccessGraphTLSCert(keyRing); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	// Store SSH private and public key.
 	sshPrivateKeyPEM, err := keyRing.SSHPrivateKey.MarshalSSHPrivateKey()
 	if err != nil {
@@ -273,6 +288,43 @@ func (fs *FSKeyStore) AddKeyRing(keyRing *KeyRing) error {
 	}
 
 	return nil
+}
+
+// readAccessGraphTLSCert reads the Access Graph TLS cert under a read lock
+// on the main TLS key file, so the returned bytes are paired with the key
+// loaded by readTLSCredential. Returns nil bytes (no error) if the cert
+// file isn't present.
+func (fs *FSKeyStore) readAccessGraphTLSCert(idx KeyRingIndex) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	unlock, err := tryReadLockFile(ctx, fs.userTLSKeyPath(idx))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer unlock()
+	cert, err := os.ReadFile(fs.accessGraphTLSCertPath(idx))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, trace.ConvertSystemError(err)
+	}
+	return cert, nil
+}
+
+// writeAccessGraphTLSCert writes the Access Graph TLS cert under a write
+// lock on the main TLS key file. The AccessGraph cert reuses TLSPrivateKey,
+// so this lock prevents a concurrent key rotation from leaving the
+// AccessGraph cert bound to a stale key.
+func (fs *FSKeyStore) writeAccessGraphTLSCert(keyRing *KeyRing) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	unlock, err := tryWriteLockFile(ctx, fs.userTLSKeyPath(keyRing.KeyRingIndex))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer unlock()
+	return trace.Wrap(fs.writeBytes(keyRing.AccessGraphTLSCert, fs.accessGraphTLSCertPath(keyRing.KeyRingIndex)))
 }
 
 func (fs *FSKeyStore) writeTLSCredential(cred TLSCredential, keyPath, certPath string) error {
@@ -441,6 +493,12 @@ func (fs *FSKeyStore) DeleteKeyRing(idx KeyRingIndex) error {
 	for _, fn := range files {
 		deleteErrs = append(deleteErrs, trace.ConvertSystemError(utils.RemoveSecure(fn)))
 	}
+
+	// Access Graph cert may not exist — it's only persisted when minted.
+	if err := utils.RemoveSecure(fs.accessGraphTLSCertPath(idx)); err != nil && !errors.Is(err, iofs.ErrNotExist) {
+		deleteErrs = append(deleteErrs, trace.Wrap(err, "failed to remove Access Graph TLS cert file"))
+	}
+
 	// we also need to delete the extra PuTTY-formatted .ppk file when running on Windows,
 	// but it may not exist when upgrading from v9 -> v10 and logging into an existing cluster.
 	// as such, deletion should be best-effort and not generate an error if it fails.
@@ -564,6 +622,11 @@ func (fs *FSKeyStore) GetKeyRing(idx KeyRingIndex, hwks hardwarekey.Service, opt
 		return nil, trace.Wrap(err)
 	}
 
+	accessGraphTLSCert, err := fs.readAccessGraphTLSCert(idx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	sshPriv, err := keys.LoadKeyPair(fs.userSSHKeyPath(idx), fs.publicKeyPath(idx), keys.WithHardwareKeyService(hwks), keys.WithContextualKeyInfo(idx.contextualKeyInfo()))
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
@@ -572,6 +635,9 @@ func (fs *FSKeyStore) GetKeyRing(idx KeyRingIndex, hwks hardwarekey.Service, opt
 	keyRing := NewKeyRing(sshPriv, tlsCred.PrivateKey)
 	keyRing.KeyRingIndex = idx
 	keyRing.TLSCert = tlsCred.Cert
+	// readAccessGraphTLSCert returns nil bytes when the file isn't present,
+	// so this is a no-op for keyrings without an Access Graph cert.
+	keyRing.AccessGraphTLSCert = accessGraphTLSCert
 
 	for _, o := range opts {
 		if err := fs.updateKeyRingWithCerts(o, hwks, keyRing); err != nil && !trace.IsNotFound(err) {
@@ -906,6 +972,7 @@ func (ms *MemKeyStore) GetKeyRing(idx KeyRingIndex, _ hardwarekey.Service, opts 
 	retKeyRing := NewKeyRing(keyRing.SSHPrivateKey, keyRing.TLSPrivateKey)
 	retKeyRing.KeyRingIndex = idx
 	retKeyRing.TLSCert = keyRing.TLSCert
+	retKeyRing.AccessGraphTLSCert = keyRing.AccessGraphTLSCert
 	for _, o := range opts {
 		switch o.(type) {
 		case WithSSHCerts:

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -132,6 +132,58 @@ func TestKeyStore(t *testing.T) {
 	}
 }
 
+func TestKeyStore_accessGraphCert(t *testing.T) {
+	t.Parallel()
+	a := newTestAuthority(t)
+
+	t.Run("round trip", func(t *testing.T) {
+		t.Parallel()
+		testEachKeyStore(t, func(t *testing.T, keyStore KeyStore) {
+			idx := KeyRingIndex{"host.a", "bob", "root"}
+			keyRing := a.makeSignedKeyRing(t, idx, false)
+			keyRing.AccessGraphTLSCert = a.signAccessGraphCert(t, keyRing, false)
+			require.NotEqual(t, keyRing.TLSCert, keyRing.AccessGraphTLSCert,
+				"AccessGraph cert must be distinct from the main TLS cert for this test to be meaningful")
+
+			require.NoError(t, keyStore.AddKeyRing(keyRing))
+
+			retrieved, err := keyStore.GetKeyRing(idx, nil /*hwks*/, WithAllCerts...)
+			require.NoError(t, err)
+			keyRing.TrustedCerts = nil
+			assertEqualKeyRings(t, keyRing, retrieved)
+		})
+	})
+
+	t.Run("fs delete removes cert file when present", func(t *testing.T) {
+		t.Parallel()
+		keyStore := newTestFSKeyStore(t)
+		idx := KeyRingIndex{"host.a", "bob", "root"}
+		keyRing := a.makeSignedKeyRing(t, idx, false)
+		keyRing.AccessGraphTLSCert = a.signAccessGraphCert(t, keyRing, false)
+		require.NoError(t, keyStore.AddKeyRing(keyRing))
+
+		certPath := keyStore.accessGraphTLSCertPath(idx)
+		require.FileExists(t, certPath)
+
+		require.NoError(t, keyStore.DeleteKeyRing(idx))
+		_, err := os.Stat(certPath)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("fs delete succeeds when cert absent", func(t *testing.T) {
+		t.Parallel()
+		keyStore := newTestFSKeyStore(t)
+		idx := KeyRingIndex{"host.a", "bob", "root"}
+		// AddKeyRing without setting AccessGraphTLSCert → file is never created.
+		require.NoError(t, keyStore.AddKeyRing(a.makeSignedKeyRing(t, idx, false)))
+
+		_, err := os.Stat(keyStore.accessGraphTLSCertPath(idx))
+		require.ErrorIs(t, err, os.ErrNotExist)
+
+		require.NoError(t, keyStore.DeleteKeyRing(idx))
+	})
+}
+
 func TestListKeys(t *testing.T) {
 	t.Parallel()
 	auth := newTestAuthority(t)


### PR DESCRIPTION
## Summary

- Adds `AccessGraphTLSCert` on `KeyRing` — a PEM-encoded TLS cert persisted per-proxy at `<baseDir>/keys/<proxy>/<username>-access-graph.crt`. It reuses `TLSPrivateKey` and is used by the forthcoming `tctl access graph` commands to authenticate directly to the proxy for Access Graph API queries.
- Plumbs read/write/delete through `FSKeyStore` (under the same key-file lock used by `writeTLSCredential` / `readTLSCredentialFiles`, so the cert can't drift from `TLSPrivateKey` under concurrent writes) and propagates through `MemKeyStore` for parity.
- Adds `KeyRing` helpers: `AccessGraphTLSCertificate`, `AccessGraphTLSCertValidBefore`, and `AccessGraphClientTLSConfig`. The TLS config trusts the system CA bundle rather than the cluster CA, since the caller is talking directly to the public proxy.

## Note on identity files

Identity file input/output is intentionally **not** extended to carry an Access Graph TLS certificate. Changing the identity-file format would be a backwards-incompatible change to a long-lived, externalizable artifact, so this PR leaves that format alone. This doesn't affect the upcoming `tctl access graph` commands: if the keyring doesn't have an Access Graph cert, the command mints a fresh one against the proxy on demand and writes it to the keystore.

## Build artifacts (for manual testing)

Local builds of both flavors are staged in the repo:

- OSS (`make full`): `build/oss/{teleport,tctl,tsh,tbot,fdpass-teleport}`
- Enterprise (`make full-ent`): `build/ent/{teleport,tctl,tsh,tbot,fdpass-teleport}`

Both built cleanly on darwin/arm64 and report the expected `v19.0.0-prealpha.2` version string.

Changelog: Add support for Identity Security Cert in Keyring

## Manual Test Plan

### Test Environment
- Setup: local development environment (CLI) against a local cluster, and separately against a cloud cluster. Additional validation of persistence + cleanup of the new credential path was done on a companion branch that wires the new `tctl access graph` commands through this plumbing.

### Test Cases
- [x] `tsh login` succeeds against a local cluster and the expected keyring layout is written under `~/.tsh/keys/<proxy>/` (no regression on the existing flow, no Access Graph cert produced on its own). Verified with both the OSS and Enterprise builds against `go.tele`: standard `<user>.{crt,key,pub}`, `<user>-ssh/<cluster>-cert.pub`, `cas/`, and `certs.pem` — no `<user>-access-graph.crt` present.
- [x] `tsh login` succeeds against a cloud cluster with the same outcome. Verified against `ghassanachi.cloud.gravitational.io`: standard layout written under `keys/<cloud-proxy>/`, no `<user>-access-graph.crt` present.
- [x] `tsh logout` cleans up the keyring directory, including any Access Graph cert file when one is present. Confirmed for the no-AG-cert case: the proxy's `keys/<proxy>/` subtree and the per-proxy `<proxy>.yaml` profile file were both removed. (The AG-cert-present case is covered by item 11 on the companion branch.)
- [x] `tctl status` runs cleanly against the authenticated profile. Verified with the Enterprise build against the cloud cluster — returned cluster name, version, CA pins, and the full CA authority table.
- [x] `tctl users ls` and `tctl get users` succeed (exercises the main TLS credential unchanged). Verified against the cloud cluster — `users ls` returned the full user table with roles; `get users` returned the equivalent YAML.
- [x] `tctl nodes ls` succeeds. Verified against the cloud cluster; `tctl db ls` was also run as bonus coverage and returned the expected database list.
- [x] `tctl auth sign --format=file --user=<user> --out=/tmp/id` produces an identity file, and the file does **not** contain any Access Graph material (backwards-compatibility check called out above). Verified against the cloud cluster — identity file contains the TLS private key, user SSH cert (with the user's normal role set), user TLS cert (standard user CN and roles — no `UsageAccessGraphAPIOnly` / no WebSessionID), and the host CA (OpenSSH `@cert-authority` line + CA TLS cert). No AG cert block present.
- [x] Consuming that identity file works end-to-end: `tctl --identity=<file> --auth-server=<cloud-proxy>:443 status`, `tctl --identity=<file> --auth-server=<cloud-proxy>:443 users ls`, and `tsh --identity=<file> --proxy=<cloud-proxy> ls` all authenticate and return results. Verified against the cloud cluster after `tsh logout` — the `tsh ls` call returned the cloud node; `tctl status`/`users ls` returned cluster/user data. Reverse direction of the identity-file path is unchanged.
- [x] Client-side identity-file generation is also unaffected by an Access Graph cert being present in the keyring. Starting from a keyring that already contained a minted `ghassan-access-graph.crt`, `tsh login --out=<file> --format=file` was run with both the older `tsh` (from master) and the new `tsh` (this branch). In both cases the resulting identity file contained no Access Graph material and authenticated successfully via `tctl --identity=<file>`.
- [x] On the companion branch (new `tctl access graph` commands wired up): first invocation mints the Access Graph cert and writes it to `<baseDir>/keys/<proxy>/<username>-access-graph.crt`. Verified against the local cluster — pre-command `tree ~/.tsh` had no AG file; post-command the file appeared at exactly that path.
- [x] On the companion branch: subsequent invocations reuse the persisted Access Graph cert rather than re-minting it. Verified against the local cluster — mtime of `~/.tsh/keys/<proxy>/<user>-access-graph.crt` was unchanged between the first and second access-graph command invocation.
- [x] On the companion branch: `tsh logout` removes the Access Graph cert file along with the rest of the keyring. Verified — post-logout `~/.tsh` contained only `bin` (no `keys/` subtree, no residual AG cert file).
- [x] Backwards compatibility with older `tsh`: an older `tsh` binary (built from master before this PR) operating on a `~/.tsh` profile whose keyring already contains an Access Graph cert (minted by a new client). Verified against the local cluster — `tsh status` and `tsh ls` returned the expected profile and node list, and `tsh logout` fully cleaned up `~/.tsh/keys/` **including** the unknown Access Graph cert file. The old binary's logout sweeps the keys directory at directory granularity, so the unknown file gets cleaned up incidentally — no stale artifact left behind.
