### PR TITLE
Remove go-cmp from production code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,7 +108,6 @@ linters:
             - '!**/integrations/operator/controllers/resources/testlib/**'
             - '!**/lib/auth/test/**'
             - '!**/lib/services/suite/**'
-            - '!**/e/lib/accesslist/equal.go'
           deny:
             - pkg: github.com/google/go-cmp/cmp
               desc: '"github.com/google/go-cmp/cmp" should only be used in tests'


### PR DESCRIPTION
Updates e to include https://github.com/gravitational/teleport.e/pull/8354 and removes the last go-cmp depguard exception. All uses of go-cmp are now exclusively in tests or test helper packages.
