### PR TITLE
[v18] EC2 auto-discovery: add IAM permission issue types (#63909)

### DIFF
--- a/lib/usertasks/descriptions/ec2-perm-account-denied.md
+++ b/lib/usertasks/descriptions/ec2-perm-account-denied.md
@@ -1,0 +1,32 @@
+# Missing AWS account permissions
+
+Teleport failed to discover EC2 instances because the integration's IAM role lacks the required permissions to discover AWS account resources.
+
+**How to fix:**
+
+Add the following permissions to the IAM role used by the integration:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EC2Discovery",
+      "Effect": "Allow",
+      "Action": [
+        "account:ListRegions",
+        "ec2:DescribeInstances",
+        "ssm:DescribeInstanceInformation",
+        "ssm:SendCommand",
+        "ssm:GetCommandInvocation",
+        "ssm:ListCommandInvocations"
+      ],
+      "Resource": ["*"]
+    }
+  ]
+}
+```
+
+After applying the fix, mark this task as resolved. Teleport will retry discovery automatically.
+
+**Note:** IAM permission changes may take a few minutes to propagate in AWS. Teleport also polls for EC2 instances periodically, so the fix may not be reflected immediately. This task will automatically resolve once discovery succeeds.

--- a/lib/usertasks/descriptions/ec2-perm-org-denied.md
+++ b/lib/usertasks/descriptions/ec2-perm-org-denied.md
@@ -1,0 +1,33 @@
+# Missing AWS organization permissions
+
+Teleport failed to discover EC2 instances because the integration's IAM role lacks the required permissions to discover AWS accounts in your organization.
+
+This error occurs when using organization-wide discovery, which requires Teleport to list accounts across your AWS organization.
+
+**How to fix:**
+
+Add the following permissions to the IAM role used by the integration:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "organizations:ListRoots",
+    "organizations:ListChildren",
+    "organizations:ListAccountsForParent"
+  ],
+  "Resource": ["*"]
+}
+```
+
+These permissions allow Teleport to:
+
+- `organizations:ListRoots` - Find the root of your organization
+- `organizations:ListChildren` - Navigate organizational units (OUs)
+- `organizations:ListAccountsForParent` - List accounts within each OU
+
+After applying the fix, mark this task as resolved. Teleport will retry discovery automatically.
+
+**Important:** The IAM Role must be configured in the AWS Organizations management account (or a delegated administrator account). These APIs can only be called from the management account, even with correct permissions.
+
+**Note:** IAM permission changes may take a few minutes to propagate in AWS. Teleport also polls for EC2 instances periodically, so the fix may not be reflected immediately. This task will automatically resolve once discovery succeeds.

--- a/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
+++ b/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
@@ -202,12 +202,17 @@ function DetailsTab({ task }: { task: UserTaskDetail }) {
       <H3 mt={3}>Details</H3>
       <Markdown text={task.description || ''} enableLinks />
 
-      <H3 mt={4}>Impacted resources ({impacted.count})</H3>
-      <Table
-        data={impactsTable.data}
-        columns={impactsTable.columns}
-        emptyText="No impacted resources"
-      />
+      {impacted.count > 0 && (
+        <>
+          <H3 mt={4}>Impacted resources ({impacted.count})</H3>
+          <Table
+            data={impactsTable.data}
+            columns={impactsTable.columns}
+            emptyText="No impacted resources"
+          />
+        </>
+      )}
+
       <H3 mt={4}>Mark as Resolved</H3>
       <P>
         This issue will reappear if the underlying problem is not fixed.


### PR DESCRIPTION
Backport of #63909 to v18.

---

This is a partial fix for Fixes https://github.com/gravitational/teleport/issues/62828.

API types, descriptions, validation, and web UI: everything that defines, validates, and displays the new permission issue types. No runtime behavior change.

Part 1 of splitting https://github.com/gravitational/teleport/pull/63099.

Introduces new permission-related UserTask issue types for EC2 auto-discovery (`ec2-perm-account-denied`, `ec2-perm-org-denied`) with:

## Manual Test Plan

### Test Environment

- **Teleport cluster:** `carlisia-2.cloud.gravitational.io` (cloud staging)

### Test Cases

- [x] New issue type constants and validation in `api/types/usertasks`
- [x] Relaxed validation for permission issues: empty `account_id`, `region`, and instances allowed (errors occur before discovery)
- [x] Fenced code block support in Markdown component (renders policy JSON)
- [x] Hide empty "Impacted resources" section for permission issues (author: @charlestp)

**No runtime behavior change** — nothing emits these issue types yet.

Part 2 will wire up detection and reporting from the discovery service.