### PR TITLE
[v18] usagereporter: Add Identity Security streaming/aggregating events

### DIFF
--- a/buf-go.gen.yaml
+++ b/buf-go.gen.yaml
@@ -30,6 +30,9 @@ plugins:
       # needed by teleport/lib/teleterm/v1/usage_events.proto because we use
       # managed mode for the go package name there
       - Mprehog/v1alpha/connect.proto=github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha;prehogv1alpha
+      # needed by proto/accessraph/v1alpha/access_graph_service.go because it imports it for
+      # usage events
+      - Mprehog/v1alpha/teleport.proto=github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha;prehogv1alpha
     strategy: all
   - local:
       - go
@@ -41,4 +44,7 @@ plugins:
       # needed by teleport/lib/teleterm/v1/usage_events.proto because we use
       # managed mode for the go package name there
       - Mprehog/v1alpha/connect.proto=github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha;prehogv1alpha
+      # needed by proto/accessraph/v1alpha/access_graph_service.go because it imports it for
+      # usage events
+      - Mprehog/v1alpha/teleport.proto=github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha;prehogv1alpha
     strategy: all

--- a/gen/proto/go/accessgraph/v1alpha/access_graph_service.pb.go
+++ b/gen/proto/go/accessgraph/v1alpha/access_graph_service.pb.go
@@ -25,6 +25,7 @@ package accessgraphv1alpha
 
 import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
+	v1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
@@ -93,7 +94,7 @@ func (x KubeAuditLogCursor_KubeAuditLogSource) Number() protoreflect.EnumNumber 
 
 // Deprecated: Use KubeAuditLogCursor_KubeAuditLogSource.Descriptor instead.
 func (KubeAuditLogCursor_KubeAuditLogSource) EnumDescriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{46, 0}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{47, 0}
 }
 
 // QueryRequest is a request to query the access graph.
@@ -666,6 +667,7 @@ type EventsStreamV2Response struct {
 	// Types that are valid to be assigned to Action:
 	//
 	//	*EventsStreamV2Response_Event
+	//	*EventsStreamV2Response_UsageEvent
 	Action        isEventsStreamV2Response_Action `protobuf_oneof:"action"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -717,6 +719,15 @@ func (x *EventsStreamV2Response) GetEvent() *AuditEvent {
 	return nil
 }
 
+func (x *EventsStreamV2Response) GetUsageEvent() *UsageEvent {
+	if x != nil {
+		if x, ok := x.Action.(*EventsStreamV2Response_UsageEvent); ok {
+			return x.UsageEvent
+		}
+	}
+	return nil
+}
+
 type isEventsStreamV2Response_Action interface {
 	isEventsStreamV2Response_Action()
 }
@@ -726,7 +737,15 @@ type EventsStreamV2Response_Event struct {
 	Event *AuditEvent `protobuf:"bytes,1,opt,name=event,proto3,oneof"`
 }
 
+type EventsStreamV2Response_UsageEvent struct {
+	// usage_event is a usage event to be submitted to the auth server, as an analog of
+	// AuthService.SubmitUsageEvent.
+	UsageEvent *UsageEvent `protobuf:"bytes,2,opt,name=usage_event,json=usageEvent,proto3,oneof"`
+}
+
 func (*EventsStreamV2Response_Event) isEventsStreamV2Response_Action() {}
+
+func (*EventsStreamV2Response_UsageEvent) isEventsStreamV2Response_Action() {}
 
 // AuditEvent is an event that should be logged by Teleport.
 type AuditEvent struct {
@@ -796,6 +815,91 @@ type AuditEvent_AccessPathChanged struct {
 
 func (*AuditEvent_AccessPathChanged) isAuditEvent_Event() {}
 
+// UsageEvent is a usage event that access graph can submit to teleport
+type UsageEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Event:
+	//
+	//	*UsageEvent_GraphSize
+	//	*UsageEvent_AuditLogsIngested
+	Event         isUsageEvent_Event `protobuf_oneof:"event"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UsageEvent) Reset() {
+	*x = UsageEvent{}
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UsageEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UsageEvent) ProtoMessage() {}
+
+func (x *UsageEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UsageEvent.ProtoReflect.Descriptor instead.
+func (*UsageEvent) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *UsageEvent) GetEvent() isUsageEvent_Event {
+	if x != nil {
+		return x.Event
+	}
+	return nil
+}
+
+func (x *UsageEvent) GetGraphSize() *v1alpha.IdentitySecurityGraphSizeEvent {
+	if x != nil {
+		if x, ok := x.Event.(*UsageEvent_GraphSize); ok {
+			return x.GraphSize
+		}
+	}
+	return nil
+}
+
+func (x *UsageEvent) GetAuditLogsIngested() *v1alpha.IdentitySecurityAuditLogsIngestedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*UsageEvent_AuditLogsIngested); ok {
+			return x.AuditLogsIngested
+		}
+	}
+	return nil
+}
+
+type isUsageEvent_Event interface {
+	isUsageEvent_Event()
+}
+
+type UsageEvent_GraphSize struct {
+	// graph_size provides the size of a provider's graph
+	GraphSize *v1alpha.IdentitySecurityGraphSizeEvent `protobuf:"bytes,1,opt,name=graph_size,json=graphSize,proto3,oneof"`
+}
+
+type UsageEvent_AuditLogsIngested struct {
+	// audit_logs_ingested provides a count of new audit logs ingested by a provider.
+	AuditLogsIngested *v1alpha.IdentitySecurityAuditLogsIngestedEvent `protobuf:"bytes,2,opt,name=audit_logs_ingested,json=auditLogsIngested,proto3,oneof"`
+}
+
+func (*UsageEvent_GraphSize) isUsageEvent_Event() {}
+
+func (*UsageEvent_AuditLogsIngested) isUsageEvent_Event() {}
+
 // AuditLogStreamRequest is sent from the client to the server over the
 // bi-directional AuditLogStream. It encapsulates distinct client actions for
 // configuring the export stream, sending batches of audit log events, and
@@ -844,7 +948,7 @@ type AuditLogStreamRequest struct {
 
 func (x *AuditLogStreamRequest) Reset() {
 	*x = AuditLogStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -856,7 +960,7 @@ func (x *AuditLogStreamRequest) String() string {
 func (*AuditLogStreamRequest) ProtoMessage() {}
 
 func (x *AuditLogStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -869,7 +973,7 @@ func (x *AuditLogStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditLogStreamRequest.ProtoReflect.Descriptor instead.
 func (*AuditLogStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{10}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *AuditLogStreamRequest) GetAction() isAuditLogStreamRequest_Action {
@@ -940,7 +1044,7 @@ type AuditLogConfig struct {
 
 func (x *AuditLogConfig) Reset() {
 	*x = AuditLogConfig{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -952,7 +1056,7 @@ func (x *AuditLogConfig) String() string {
 func (*AuditLogConfig) ProtoMessage() {}
 
 func (x *AuditLogConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -965,7 +1069,7 @@ func (x *AuditLogConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditLogConfig.ProtoReflect.Descriptor instead.
 func (*AuditLogConfig) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{11}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *AuditLogConfig) GetStartDate() *timestamppb.Timestamp {
@@ -1000,7 +1104,7 @@ type AuditLogEvents struct {
 
 func (x *AuditLogEvents) Reset() {
 	*x = AuditLogEvents{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1012,7 +1116,7 @@ func (x *AuditLogEvents) String() string {
 func (*AuditLogEvents) ProtoMessage() {}
 
 func (x *AuditLogEvents) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1025,7 +1129,7 @@ func (x *AuditLogEvents) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditLogEvents.ProtoReflect.Descriptor instead.
 func (*AuditLogEvents) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{12}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *AuditLogEvents) GetEvents() []*v1.EventUnstructured {
@@ -1105,7 +1209,7 @@ type SearchResumeState struct {
 
 func (x *SearchResumeState) Reset() {
 	*x = SearchResumeState{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1117,7 +1221,7 @@ func (x *SearchResumeState) String() string {
 func (*SearchResumeState) ProtoMessage() {}
 
 func (x *SearchResumeState) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1130,7 +1234,7 @@ func (x *SearchResumeState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchResumeState.ProtoReflect.Descriptor instead.
 func (*SearchResumeState) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{13}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SearchResumeState) GetStartKey() string {
@@ -1170,7 +1274,7 @@ type BulkResumeStateUpdate struct {
 
 func (x *BulkResumeStateUpdate) Reset() {
 	*x = BulkResumeStateUpdate{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1182,7 +1286,7 @@ func (x *BulkResumeStateUpdate) String() string {
 func (*BulkResumeStateUpdate) ProtoMessage() {}
 
 func (x *BulkResumeStateUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1195,7 +1299,7 @@ func (x *BulkResumeStateUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BulkResumeStateUpdate.ProtoReflect.Descriptor instead.
 func (*BulkResumeStateUpdate) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{14}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *BulkResumeStateUpdate) GetDate() *timestamppb.Timestamp {
@@ -1241,7 +1345,7 @@ type BulkResumeStateSync struct {
 
 func (x *BulkResumeStateSync) Reset() {
 	*x = BulkResumeStateSync{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1253,7 +1357,7 @@ func (x *BulkResumeStateSync) String() string {
 func (*BulkResumeStateSync) ProtoMessage() {}
 
 func (x *BulkResumeStateSync) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1266,7 +1370,7 @@ func (x *BulkResumeStateSync) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BulkResumeStateSync.ProtoReflect.Descriptor instead.
 func (*BulkResumeStateSync) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{15}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *BulkResumeStateSync) GetActiveDates() []*timestamppb.Timestamp {
@@ -1296,7 +1400,7 @@ type AuditLogStreamResponse struct {
 
 func (x *AuditLogStreamResponse) Reset() {
 	*x = AuditLogStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1308,7 +1412,7 @@ func (x *AuditLogStreamResponse) String() string {
 func (*AuditLogStreamResponse) ProtoMessage() {}
 
 func (x *AuditLogStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1321,7 +1425,7 @@ func (x *AuditLogStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditLogStreamResponse.ProtoReflect.Descriptor instead.
 func (*AuditLogStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{16}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *AuditLogStreamResponse) GetState() isAuditLogStreamResponse_State {
@@ -1408,7 +1512,7 @@ type BulkResumeState struct {
 
 func (x *BulkResumeState) Reset() {
 	*x = BulkResumeState{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1420,7 +1524,7 @@ func (x *BulkResumeState) String() string {
 func (*BulkResumeState) ProtoMessage() {}
 
 func (x *BulkResumeState) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1433,7 +1537,7 @@ func (x *BulkResumeState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BulkResumeState.ProtoReflect.Descriptor instead.
 func (*BulkResumeState) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{17}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *BulkResumeState) GetDates() []*BulkResumeDate {
@@ -1456,7 +1560,7 @@ type BulkResumeDate struct {
 
 func (x *BulkResumeDate) Reset() {
 	*x = BulkResumeDate{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1468,7 +1572,7 @@ func (x *BulkResumeDate) String() string {
 func (*BulkResumeDate) ProtoMessage() {}
 
 func (x *BulkResumeDate) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1481,7 +1585,7 @@ func (x *BulkResumeDate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BulkResumeDate.ProtoReflect.Descriptor instead.
 func (*BulkResumeDate) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{18}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *BulkResumeDate) GetDate() *timestamppb.Timestamp {
@@ -1528,7 +1632,7 @@ type RegisterRequest struct {
 
 func (x *RegisterRequest) Reset() {
 	*x = RegisterRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1540,7 +1644,7 @@ func (x *RegisterRequest) String() string {
 func (*RegisterRequest) ProtoMessage() {}
 
 func (x *RegisterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1553,7 +1657,7 @@ func (x *RegisterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterRequest.ProtoReflect.Descriptor instead.
 func (*RegisterRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{19}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{20}
 }
 
 // Deprecated: Marked as deprecated in accessgraph/v1alpha/access_graph_service.proto.
@@ -1587,7 +1691,7 @@ type RegisterResponse struct {
 
 func (x *RegisterResponse) Reset() {
 	*x = RegisterResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1599,7 +1703,7 @@ func (x *RegisterResponse) String() string {
 func (*RegisterResponse) ProtoMessage() {}
 
 func (x *RegisterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1612,7 +1716,7 @@ func (x *RegisterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterResponse.ProtoReflect.Descriptor instead.
 func (*RegisterResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{20}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{21}
 }
 
 // ReplaceCAsRequest is the request for ReplaceCAs.
@@ -1625,7 +1729,7 @@ type ReplaceCAsRequest struct {
 
 func (x *ReplaceCAsRequest) Reset() {
 	*x = ReplaceCAsRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1637,7 +1741,7 @@ func (x *ReplaceCAsRequest) String() string {
 func (*ReplaceCAsRequest) ProtoMessage() {}
 
 func (x *ReplaceCAsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1650,7 +1754,7 @@ func (x *ReplaceCAsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplaceCAsRequest.ProtoReflect.Descriptor instead.
 func (*ReplaceCAsRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{21}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ReplaceCAsRequest) GetHostCaPem() [][]byte {
@@ -1669,7 +1773,7 @@ type ReplaceCAsResponse struct {
 
 func (x *ReplaceCAsResponse) Reset() {
 	*x = ReplaceCAsResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1681,7 +1785,7 @@ func (x *ReplaceCAsResponse) String() string {
 func (*ReplaceCAsResponse) ProtoMessage() {}
 
 func (x *ReplaceCAsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1694,7 +1798,7 @@ func (x *ReplaceCAsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplaceCAsResponse.ProtoReflect.Descriptor instead.
 func (*ReplaceCAsResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{22}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{23}
 }
 
 // AWSEventsStreamRequest is a request to send commands to the AWS importer.
@@ -1715,7 +1819,7 @@ type AWSEventsStreamRequest struct {
 
 func (x *AWSEventsStreamRequest) Reset() {
 	*x = AWSEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1727,7 +1831,7 @@ func (x *AWSEventsStreamRequest) String() string {
 func (*AWSEventsStreamRequest) ProtoMessage() {}
 
 func (x *AWSEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1740,7 +1844,7 @@ func (x *AWSEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*AWSEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{23}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *AWSEventsStreamRequest) GetOperation() isAWSEventsStreamRequest_Operation {
@@ -1813,7 +1917,7 @@ type AWSSyncOperation struct {
 
 func (x *AWSSyncOperation) Reset() {
 	*x = AWSSyncOperation{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1825,7 +1929,7 @@ func (x *AWSSyncOperation) String() string {
 func (*AWSSyncOperation) ProtoMessage() {}
 
 func (x *AWSSyncOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1838,7 +1942,7 @@ func (x *AWSSyncOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSSyncOperation.ProtoReflect.Descriptor instead.
 func (*AWSSyncOperation) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{24}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{25}
 }
 
 // AWSEventsStreamResponse is the response from AWSEventsStream.
@@ -1850,7 +1954,7 @@ type AWSEventsStreamResponse struct {
 
 func (x *AWSEventsStreamResponse) Reset() {
 	*x = AWSEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1862,7 +1966,7 @@ func (x *AWSEventsStreamResponse) String() string {
 func (*AWSEventsStreamResponse) ProtoMessage() {}
 
 func (x *AWSEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1875,7 +1979,7 @@ func (x *AWSEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*AWSEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{25}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{26}
 }
 
 // GitlabEventsStreamRequest is a request to send commands to the Gitlab importer.
@@ -1895,7 +1999,7 @@ type GitlabEventsStreamRequest struct {
 
 func (x *GitlabEventsStreamRequest) Reset() {
 	*x = GitlabEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1907,7 +2011,7 @@ func (x *GitlabEventsStreamRequest) String() string {
 func (*GitlabEventsStreamRequest) ProtoMessage() {}
 
 func (x *GitlabEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1920,7 +2024,7 @@ func (x *GitlabEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitlabEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*GitlabEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{26}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GitlabEventsStreamRequest) GetOperation() isGitlabEventsStreamRequest_Operation {
@@ -1992,7 +2096,7 @@ type GitlabEventsStreamResponse struct {
 
 func (x *GitlabEventsStreamResponse) Reset() {
 	*x = GitlabEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2004,7 +2108,7 @@ func (x *GitlabEventsStreamResponse) String() string {
 func (*GitlabEventsStreamResponse) ProtoMessage() {}
 
 func (x *GitlabEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2017,7 +2121,7 @@ func (x *GitlabEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitlabEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*GitlabEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{27}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{28}
 }
 
 // EntraEventsStreamRequest is a request to send commands to the Gitlab importer.
@@ -2037,7 +2141,7 @@ type EntraEventsStreamRequest struct {
 
 func (x *EntraEventsStreamRequest) Reset() {
 	*x = EntraEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2049,7 +2153,7 @@ func (x *EntraEventsStreamRequest) String() string {
 func (*EntraEventsStreamRequest) ProtoMessage() {}
 
 func (x *EntraEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2062,7 +2166,7 @@ func (x *EntraEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntraEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*EntraEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{28}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *EntraEventsStreamRequest) GetOperation() isEntraEventsStreamRequest_Operation {
@@ -2134,7 +2238,7 @@ type EntraEventsStreamResponse struct {
 
 func (x *EntraEventsStreamResponse) Reset() {
 	*x = EntraEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2146,7 +2250,7 @@ func (x *EntraEventsStreamResponse) String() string {
 func (*EntraEventsStreamResponse) ProtoMessage() {}
 
 func (x *EntraEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2159,7 +2263,7 @@ func (x *EntraEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntraEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*EntraEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{29}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{30}
 }
 
 // AzureEventsStreamRequest is a request to send commands to the Azure importer
@@ -2177,7 +2281,7 @@ type AzureEventsStreamRequest struct {
 
 func (x *AzureEventsStreamRequest) Reset() {
 	*x = AzureEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2189,7 +2293,7 @@ func (x *AzureEventsStreamRequest) String() string {
 func (*AzureEventsStreamRequest) ProtoMessage() {}
 
 func (x *AzureEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2202,7 +2306,7 @@ func (x *AzureEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*AzureEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{30}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *AzureEventsStreamRequest) GetOperation() isAzureEventsStreamRequest_Operation {
@@ -2275,7 +2379,7 @@ type AzureSyncOperation struct {
 
 func (x *AzureSyncOperation) Reset() {
 	*x = AzureSyncOperation{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2287,7 +2391,7 @@ func (x *AzureSyncOperation) String() string {
 func (*AzureSyncOperation) ProtoMessage() {}
 
 func (x *AzureSyncOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2300,7 +2404,7 @@ func (x *AzureSyncOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureSyncOperation.ProtoReflect.Descriptor instead.
 func (*AzureSyncOperation) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{31}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{32}
 }
 
 // AzureEventsStreamResponse is a response from AzureEventsStream
@@ -2312,7 +2416,7 @@ type AzureEventsStreamResponse struct {
 
 func (x *AzureEventsStreamResponse) Reset() {
 	*x = AzureEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2324,7 +2428,7 @@ func (x *AzureEventsStreamResponse) String() string {
 func (*AzureEventsStreamResponse) ProtoMessage() {}
 
 func (x *AzureEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2337,7 +2441,7 @@ func (x *AzureEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*AzureEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{32}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{33}
 }
 
 // NetIQEventsStreamRequest is a request to send commands to the NetIQ importer
@@ -2355,7 +2459,7 @@ type NetIQEventsStreamRequest struct {
 
 func (x *NetIQEventsStreamRequest) Reset() {
 	*x = NetIQEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2367,7 +2471,7 @@ func (x *NetIQEventsStreamRequest) String() string {
 func (*NetIQEventsStreamRequest) ProtoMessage() {}
 
 func (x *NetIQEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2380,7 +2484,7 @@ func (x *NetIQEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetIQEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*NetIQEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{33}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *NetIQEventsStreamRequest) GetOperation() isNetIQEventsStreamRequest_Operation {
@@ -2452,7 +2556,7 @@ type NetIQSyncOperation struct {
 
 func (x *NetIQSyncOperation) Reset() {
 	*x = NetIQSyncOperation{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2464,7 +2568,7 @@ func (x *NetIQSyncOperation) String() string {
 func (*NetIQSyncOperation) ProtoMessage() {}
 
 func (x *NetIQSyncOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2477,7 +2581,7 @@ func (x *NetIQSyncOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetIQSyncOperation.ProtoReflect.Descriptor instead.
 func (*NetIQSyncOperation) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{34}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{35}
 }
 
 // NetIQEventsStreamResponse is a response from NetIQEventsStream
@@ -2489,7 +2593,7 @@ type NetIQEventsStreamResponse struct {
 
 func (x *NetIQEventsStreamResponse) Reset() {
 	*x = NetIQEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[35]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2501,7 +2605,7 @@ func (x *NetIQEventsStreamResponse) String() string {
 func (*NetIQEventsStreamResponse) ProtoMessage() {}
 
 func (x *NetIQEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[35]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2514,7 +2618,7 @@ func (x *NetIQEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetIQEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*NetIQEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{35}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{36}
 }
 
 // AWSCloudTrailStreamRequest is sent from the client to the server over the
@@ -2545,7 +2649,7 @@ type AWSCloudTrailStreamRequest struct {
 
 func (x *AWSCloudTrailStreamRequest) Reset() {
 	*x = AWSCloudTrailStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[36]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2557,7 +2661,7 @@ func (x *AWSCloudTrailStreamRequest) String() string {
 func (*AWSCloudTrailStreamRequest) ProtoMessage() {}
 
 func (x *AWSCloudTrailStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[36]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2570,7 +2674,7 @@ func (x *AWSCloudTrailStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSCloudTrailStreamRequest.ProtoReflect.Descriptor instead.
 func (*AWSCloudTrailStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{36}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *AWSCloudTrailStreamRequest) GetAction() isAWSCloudTrailStreamRequest_Action {
@@ -2627,7 +2731,7 @@ type AWSCloudTrailEventsFile struct {
 
 func (x *AWSCloudTrailEventsFile) Reset() {
 	*x = AWSCloudTrailEventsFile{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[37]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2639,7 +2743,7 @@ func (x *AWSCloudTrailEventsFile) String() string {
 func (*AWSCloudTrailEventsFile) ProtoMessage() {}
 
 func (x *AWSCloudTrailEventsFile) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[37]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2652,7 +2756,7 @@ func (x *AWSCloudTrailEventsFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSCloudTrailEventsFile.ProtoReflect.Descriptor instead.
 func (*AWSCloudTrailEventsFile) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{37}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *AWSCloudTrailEventsFile) GetPayload() []byte {
@@ -2678,7 +2782,7 @@ type AWSCloudTrailConfig struct {
 
 func (x *AWSCloudTrailConfig) Reset() {
 	*x = AWSCloudTrailConfig{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[38]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2690,7 +2794,7 @@ func (x *AWSCloudTrailConfig) String() string {
 func (*AWSCloudTrailConfig) ProtoMessage() {}
 
 func (x *AWSCloudTrailConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[38]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2703,7 +2807,7 @@ func (x *AWSCloudTrailConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSCloudTrailConfig.ProtoReflect.Descriptor instead.
 func (*AWSCloudTrailConfig) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{38}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{39}
 }
 
 // AWSCloudTrailStreamResponse is sent from the server to the client over the
@@ -2724,7 +2828,7 @@ type AWSCloudTrailStreamResponse struct {
 
 func (x *AWSCloudTrailStreamResponse) Reset() {
 	*x = AWSCloudTrailStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[39]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2736,7 +2840,7 @@ func (x *AWSCloudTrailStreamResponse) String() string {
 func (*AWSCloudTrailStreamResponse) ProtoMessage() {}
 
 func (x *AWSCloudTrailStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[39]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2749,7 +2853,7 @@ func (x *AWSCloudTrailStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSCloudTrailStreamResponse.ProtoReflect.Descriptor instead.
 func (*AWSCloudTrailStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{39}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *AWSCloudTrailStreamResponse) GetState() isAWSCloudTrailStreamResponse_State {
@@ -2803,7 +2907,7 @@ type AWSCloudTrailResumeState struct {
 
 func (x *AWSCloudTrailResumeState) Reset() {
 	*x = AWSCloudTrailResumeState{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[40]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2815,7 +2919,7 @@ func (x *AWSCloudTrailResumeState) String() string {
 func (*AWSCloudTrailResumeState) ProtoMessage() {}
 
 func (x *AWSCloudTrailResumeState) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[40]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2828,7 +2932,7 @@ func (x *AWSCloudTrailResumeState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSCloudTrailResumeState.ProtoReflect.Descriptor instead.
 func (*AWSCloudTrailResumeState) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{40}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{41}
 }
 
 // AWSCloudTrailEventResource identifies the AWS resource by name and type.
@@ -2852,7 +2956,7 @@ type AWSCloudTrailEventResource struct {
 
 func (x *AWSCloudTrailEventResource) Reset() {
 	*x = AWSCloudTrailEventResource{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[41]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2864,7 +2968,7 @@ func (x *AWSCloudTrailEventResource) String() string {
 func (*AWSCloudTrailEventResource) ProtoMessage() {}
 
 func (x *AWSCloudTrailEventResource) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[41]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2877,7 +2981,7 @@ func (x *AWSCloudTrailEventResource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSCloudTrailEventResource.ProtoReflect.Descriptor instead.
 func (*AWSCloudTrailEventResource) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{41}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *AWSCloudTrailEventResource) GetName() string {
@@ -2913,7 +3017,7 @@ type KubeAuditLogStreamRequest struct {
 
 func (x *KubeAuditLogStreamRequest) Reset() {
 	*x = KubeAuditLogStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[42]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2925,7 +3029,7 @@ func (x *KubeAuditLogStreamRequest) String() string {
 func (*KubeAuditLogStreamRequest) ProtoMessage() {}
 
 func (x *KubeAuditLogStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[42]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2938,7 +3042,7 @@ func (x *KubeAuditLogStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeAuditLogStreamRequest.ProtoReflect.Descriptor instead.
 func (*KubeAuditLogStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{42}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *KubeAuditLogStreamRequest) GetAction() isKubeAuditLogStreamRequest_Action {
@@ -3012,7 +3116,7 @@ type KubeAuditLogConfig struct {
 
 func (x *KubeAuditLogConfig) Reset() {
 	*x = KubeAuditLogConfig{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[43]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3024,7 +3128,7 @@ func (x *KubeAuditLogConfig) String() string {
 func (*KubeAuditLogConfig) ProtoMessage() {}
 
 func (x *KubeAuditLogConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[43]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3037,7 +3141,7 @@ func (x *KubeAuditLogConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeAuditLogConfig.ProtoReflect.Descriptor instead.
 func (*KubeAuditLogConfig) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{43}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{44}
 }
 
 // KubeAuditLogNewStream identifies a log source and cluster that the client
@@ -3053,7 +3157,7 @@ type KubeAuditLogNewStream struct {
 
 func (x *KubeAuditLogNewStream) Reset() {
 	*x = KubeAuditLogNewStream{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[44]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3065,7 +3169,7 @@ func (x *KubeAuditLogNewStream) String() string {
 func (*KubeAuditLogNewStream) ProtoMessage() {}
 
 func (x *KubeAuditLogNewStream) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[44]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3078,7 +3182,7 @@ func (x *KubeAuditLogNewStream) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeAuditLogNewStream.ProtoReflect.Descriptor instead.
 func (*KubeAuditLogNewStream) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{44}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *KubeAuditLogNewStream) GetInitial() *KubeAuditLogCursor {
@@ -3107,7 +3211,7 @@ type KubeAuditLogEvents struct {
 
 func (x *KubeAuditLogEvents) Reset() {
 	*x = KubeAuditLogEvents{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[45]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3119,7 +3223,7 @@ func (x *KubeAuditLogEvents) String() string {
 func (*KubeAuditLogEvents) ProtoMessage() {}
 
 func (x *KubeAuditLogEvents) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[45]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3132,7 +3236,7 @@ func (x *KubeAuditLogEvents) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeAuditLogEvents.ProtoReflect.Descriptor instead.
 func (*KubeAuditLogEvents) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{45}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *KubeAuditLogEvents) GetEvents() []*structpb.Struct {
@@ -3181,7 +3285,7 @@ type KubeAuditLogCursor struct {
 
 func (x *KubeAuditLogCursor) Reset() {
 	*x = KubeAuditLogCursor{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[46]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3193,7 +3297,7 @@ func (x *KubeAuditLogCursor) String() string {
 func (*KubeAuditLogCursor) ProtoMessage() {}
 
 func (x *KubeAuditLogCursor) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[46]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3206,7 +3310,7 @@ func (x *KubeAuditLogCursor) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeAuditLogCursor.ProtoReflect.Descriptor instead.
 func (*KubeAuditLogCursor) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{46}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *KubeAuditLogCursor) GetLogSource() KubeAuditLogCursor_KubeAuditLogSource {
@@ -3254,7 +3358,7 @@ type KubeAuditLogStreamResponse struct {
 
 func (x *KubeAuditLogStreamResponse) Reset() {
 	*x = KubeAuditLogStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[47]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3266,7 +3370,7 @@ func (x *KubeAuditLogStreamResponse) String() string {
 func (*KubeAuditLogStreamResponse) ProtoMessage() {}
 
 func (x *KubeAuditLogStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[47]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3279,7 +3383,7 @@ func (x *KubeAuditLogStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeAuditLogStreamResponse.ProtoReflect.Descriptor instead.
 func (*KubeAuditLogStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{47}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *KubeAuditLogStreamResponse) GetState() isKubeAuditLogStreamResponse_State {
@@ -3342,7 +3446,7 @@ type KubeAuditLogResumeState struct {
 
 func (x *KubeAuditLogResumeState) Reset() {
 	*x = KubeAuditLogResumeState{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[48]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3354,7 +3458,7 @@ func (x *KubeAuditLogResumeState) String() string {
 func (*KubeAuditLogResumeState) ProtoMessage() {}
 
 func (x *KubeAuditLogResumeState) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[48]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3367,7 +3471,7 @@ func (x *KubeAuditLogResumeState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeAuditLogResumeState.ProtoReflect.Descriptor instead.
 func (*KubeAuditLogResumeState) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{48}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *KubeAuditLogResumeState) GetCursor() *KubeAuditLogCursor {
@@ -3392,7 +3496,7 @@ type GitHubAuditLogStreamRequest struct {
 
 func (x *GitHubAuditLogStreamRequest) Reset() {
 	*x = GitHubAuditLogStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[49]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3404,7 +3508,7 @@ func (x *GitHubAuditLogStreamRequest) String() string {
 func (*GitHubAuditLogStreamRequest) ProtoMessage() {}
 
 func (x *GitHubAuditLogStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[49]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3417,7 +3521,7 @@ func (x *GitHubAuditLogStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitHubAuditLogStreamRequest.ProtoReflect.Descriptor instead.
 func (*GitHubAuditLogStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{49}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *GitHubAuditLogStreamRequest) GetOperation() isGitHubAuditLogStreamRequest_Operation {
@@ -3479,7 +3583,7 @@ type GitHubAuditLogStreamResponse struct {
 
 func (x *GitHubAuditLogStreamResponse) Reset() {
 	*x = GitHubAuditLogStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[50]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3491,7 +3595,7 @@ func (x *GitHubAuditLogStreamResponse) String() string {
 func (*GitHubAuditLogStreamResponse) ProtoMessage() {}
 
 func (x *GitHubAuditLogStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[50]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3504,7 +3608,7 @@ func (x *GitHubAuditLogStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitHubAuditLogStreamResponse.ProtoReflect.Descriptor instead.
 func (*GitHubAuditLogStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{50}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *GitHubAuditLogStreamResponse) GetState() isGitHubAuditLogStreamResponse_State {
@@ -3567,7 +3671,7 @@ type GitHubEventsStreamRequest struct {
 
 func (x *GitHubEventsStreamRequest) Reset() {
 	*x = GitHubEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[51]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3579,7 +3683,7 @@ func (x *GitHubEventsStreamRequest) String() string {
 func (*GitHubEventsStreamRequest) ProtoMessage() {}
 
 func (x *GitHubEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[51]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3592,7 +3696,7 @@ func (x *GitHubEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitHubEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*GitHubEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{51}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *GitHubEventsStreamRequest) GetOperation() isGitHubEventsStreamRequest_Operation {
@@ -3661,7 +3765,7 @@ type GitHubEventsStreamResponse struct {
 
 func (x *GitHubEventsStreamResponse) Reset() {
 	*x = GitHubEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[52]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3673,7 +3777,7 @@ func (x *GitHubEventsStreamResponse) String() string {
 func (*GitHubEventsStreamResponse) ProtoMessage() {}
 
 func (x *GitHubEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[52]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3686,7 +3790,7 @@ func (x *GitHubEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitHubEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*GitHubEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{52}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{53}
 }
 
 // OktaAuditLogStreamRequest represents a client message in the OktaAuditLogStream,
@@ -3704,7 +3808,7 @@ type OktaAuditLogStreamRequest struct {
 
 func (x *OktaAuditLogStreamRequest) Reset() {
 	*x = OktaAuditLogStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[53]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3716,7 +3820,7 @@ func (x *OktaAuditLogStreamRequest) String() string {
 func (*OktaAuditLogStreamRequest) ProtoMessage() {}
 
 func (x *OktaAuditLogStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[53]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3729,7 +3833,7 @@ func (x *OktaAuditLogStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OktaAuditLogStreamRequest.ProtoReflect.Descriptor instead.
 func (*OktaAuditLogStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{53}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *OktaAuditLogStreamRequest) GetOperation() isOktaAuditLogStreamRequest_Operation {
@@ -3788,7 +3892,7 @@ type OktaAuditLogStreamResponse struct {
 
 func (x *OktaAuditLogStreamResponse) Reset() {
 	*x = OktaAuditLogStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[54]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3800,7 +3904,7 @@ func (x *OktaAuditLogStreamResponse) String() string {
 func (*OktaAuditLogStreamResponse) ProtoMessage() {}
 
 func (x *OktaAuditLogStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[54]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3813,7 +3917,7 @@ func (x *OktaAuditLogStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OktaAuditLogStreamResponse.ProtoReflect.Descriptor instead.
 func (*OktaAuditLogStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{54}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *OktaAuditLogStreamResponse) GetState() isOktaAuditLogStreamResponse_State {
@@ -3873,7 +3977,7 @@ type OktaEventsStreamRequest struct {
 
 func (x *OktaEventsStreamRequest) Reset() {
 	*x = OktaEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[55]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3885,7 +3989,7 @@ func (x *OktaEventsStreamRequest) String() string {
 func (*OktaEventsStreamRequest) ProtoMessage() {}
 
 func (x *OktaEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[55]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3898,7 +4002,7 @@ func (x *OktaEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OktaEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*OktaEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{55}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *OktaEventsStreamRequest) GetOperation() isOktaEventsStreamRequest_Operation {
@@ -3967,7 +4071,7 @@ type OktaEventsStreamResponse struct {
 
 func (x *OktaEventsStreamResponse) Reset() {
 	*x = OktaEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[56]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3979,7 +4083,7 @@ func (x *OktaEventsStreamResponse) String() string {
 func (*OktaEventsStreamResponse) ProtoMessage() {}
 
 func (x *OktaEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[56]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3992,14 +4096,14 @@ func (x *OktaEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OktaEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*OktaEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{56}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{57}
 }
 
 var File_accessgraph_v1alpha_access_graph_service_proto protoreflect.FileDescriptor
 
 const file_accessgraph_v1alpha_access_graph_service_proto_rawDesc = "" +
 	"\n" +
-	".accessgraph/v1alpha/access_graph_service.proto\x12\x13accessgraph.v1alpha\x1a\x1daccessgraph/v1alpha/aws.proto\x1a\x1faccessgraph/v1alpha/azure.proto\x1a\x1faccessgraph/v1alpha/entra.proto\x1a accessgraph/v1alpha/events.proto\x1a accessgraph/v1alpha/github.proto\x1a accessgraph/v1alpha/gitlab.proto\x1a\x1faccessgraph/v1alpha/graph.proto\x1a\x1faccessgraph/v1alpha/netiq.proto\x1a\x1eaccessgraph/v1alpha/okta.proto\x1a#accessgraph/v1alpha/resources.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#teleport/auditlog/v1/auditlog.proto\"$\n" +
+	".accessgraph/v1alpha/access_graph_service.proto\x12\x13accessgraph.v1alpha\x1a\x1daccessgraph/v1alpha/aws.proto\x1a\x1faccessgraph/v1alpha/azure.proto\x1a\x1faccessgraph/v1alpha/entra.proto\x1a accessgraph/v1alpha/events.proto\x1a accessgraph/v1alpha/github.proto\x1a accessgraph/v1alpha/gitlab.proto\x1a\x1faccessgraph/v1alpha/graph.proto\x1a\x1faccessgraph/v1alpha/netiq.proto\x1a\x1eaccessgraph/v1alpha/okta.proto\x1a#accessgraph/v1alpha/resources.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1dprehog/v1alpha/teleport.proto\x1a#teleport/auditlog/v1/auditlog.proto\"$\n" +
 	"\fQueryRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\"q\n" +
 	"\rQueryResponse\x12/\n" +
@@ -4024,13 +4128,21 @@ const file_accessgraph_v1alpha_access_graph_service_proto_rawDesc = "" +
 	"\x1bexclude_access_list_members\x18\x05 \x01(\v2..accessgraph.v1alpha.ExcludeAccessListsMembersH\x00R\x18excludeAccessListMembersB\v\n" +
 	"\toperation\"\x0f\n" +
 	"\rSyncOperation\"\x16\n" +
-	"\x14EventsStreamResponse\"[\n" +
+	"\x14EventsStreamResponse\"\x9f\x01\n" +
 	"\x16EventsStreamV2Response\x127\n" +
-	"\x05event\x18\x01 \x01(\v2\x1f.accessgraph.v1alpha.AuditEventH\x00R\x05eventB\b\n" +
+	"\x05event\x18\x01 \x01(\v2\x1f.accessgraph.v1alpha.AuditEventH\x00R\x05event\x12B\n" +
+	"\vusage_event\x18\x02 \x01(\v2\x1f.accessgraph.v1alpha.UsageEventH\x00R\n" +
+	"usageEventB\b\n" +
 	"\x06action\"o\n" +
 	"\n" +
 	"AuditEvent\x12X\n" +
 	"\x13access_path_changed\x18\x01 \x01(\v2&.accessgraph.v1alpha.AccessPathChangedH\x00R\x11accessPathChangedB\a\n" +
+	"\x05event\"\xd0\x01\n" +
+	"\n" +
+	"UsageEvent\x12O\n" +
+	"\n" +
+	"graph_size\x18\x01 \x01(\v2..prehog.v1alpha.IdentitySecurityGraphSizeEventH\x00R\tgraphSize\x12h\n" +
+	"\x13audit_logs_ingested\x18\x02 \x01(\v26.prehog.v1alpha.IdentitySecurityAuditLogsIngestedEventH\x00R\x11auditLogsIngestedB\a\n" +
 	"\x05event\"\xe8\x01\n" +
 	"\x15AuditLogStreamRequest\x12=\n" +
 	"\x06config\x18\x01 \x01(\v2#.accessgraph.v1alpha.AuditLogConfigH\x00R\x06config\x12=\n" +
@@ -4221,213 +4333,219 @@ func file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP() []byte {
 }
 
 var file_accessgraph_v1alpha_access_graph_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_accessgraph_v1alpha_access_graph_service_proto_msgTypes = make([]protoimpl.MessageInfo, 58)
+var file_accessgraph_v1alpha_access_graph_service_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
 var file_accessgraph_v1alpha_access_graph_service_proto_goTypes = []any{
-	(KubeAuditLogCursor_KubeAuditLogSource)(0), // 0: accessgraph.v1alpha.KubeAuditLogCursor.KubeAuditLogSource
-	(*QueryRequest)(nil),                       // 1: accessgraph.v1alpha.QueryRequest
-	(*QueryResponse)(nil),                      // 2: accessgraph.v1alpha.QueryResponse
-	(*GetFileRequest)(nil),                     // 3: accessgraph.v1alpha.GetFileRequest
-	(*GetFileResponse)(nil),                    // 4: accessgraph.v1alpha.GetFileResponse
-	(*EventsStreamRequest)(nil),                // 5: accessgraph.v1alpha.EventsStreamRequest
-	(*EventsStreamV2Request)(nil),              // 6: accessgraph.v1alpha.EventsStreamV2Request
-	(*SyncOperation)(nil),                      // 7: accessgraph.v1alpha.SyncOperation
-	(*EventsStreamResponse)(nil),               // 8: accessgraph.v1alpha.EventsStreamResponse
-	(*EventsStreamV2Response)(nil),             // 9: accessgraph.v1alpha.EventsStreamV2Response
-	(*AuditEvent)(nil),                         // 10: accessgraph.v1alpha.AuditEvent
-	(*AuditLogStreamRequest)(nil),              // 11: accessgraph.v1alpha.AuditLogStreamRequest
-	(*AuditLogConfig)(nil),                     // 12: accessgraph.v1alpha.AuditLogConfig
-	(*AuditLogEvents)(nil),                     // 13: accessgraph.v1alpha.AuditLogEvents
-	(*SearchResumeState)(nil),                  // 14: accessgraph.v1alpha.SearchResumeState
-	(*BulkResumeStateUpdate)(nil),              // 15: accessgraph.v1alpha.BulkResumeStateUpdate
-	(*BulkResumeStateSync)(nil),                // 16: accessgraph.v1alpha.BulkResumeStateSync
-	(*AuditLogStreamResponse)(nil),             // 17: accessgraph.v1alpha.AuditLogStreamResponse
-	(*BulkResumeState)(nil),                    // 18: accessgraph.v1alpha.BulkResumeState
-	(*BulkResumeDate)(nil),                     // 19: accessgraph.v1alpha.BulkResumeDate
-	(*RegisterRequest)(nil),                    // 20: accessgraph.v1alpha.RegisterRequest
-	(*RegisterResponse)(nil),                   // 21: accessgraph.v1alpha.RegisterResponse
-	(*ReplaceCAsRequest)(nil),                  // 22: accessgraph.v1alpha.ReplaceCAsRequest
-	(*ReplaceCAsResponse)(nil),                 // 23: accessgraph.v1alpha.ReplaceCAsResponse
-	(*AWSEventsStreamRequest)(nil),             // 24: accessgraph.v1alpha.AWSEventsStreamRequest
-	(*AWSSyncOperation)(nil),                   // 25: accessgraph.v1alpha.AWSSyncOperation
-	(*AWSEventsStreamResponse)(nil),            // 26: accessgraph.v1alpha.AWSEventsStreamResponse
-	(*GitlabEventsStreamRequest)(nil),          // 27: accessgraph.v1alpha.GitlabEventsStreamRequest
-	(*GitlabEventsStreamResponse)(nil),         // 28: accessgraph.v1alpha.GitlabEventsStreamResponse
-	(*EntraEventsStreamRequest)(nil),           // 29: accessgraph.v1alpha.EntraEventsStreamRequest
-	(*EntraEventsStreamResponse)(nil),          // 30: accessgraph.v1alpha.EntraEventsStreamResponse
-	(*AzureEventsStreamRequest)(nil),           // 31: accessgraph.v1alpha.AzureEventsStreamRequest
-	(*AzureSyncOperation)(nil),                 // 32: accessgraph.v1alpha.AzureSyncOperation
-	(*AzureEventsStreamResponse)(nil),          // 33: accessgraph.v1alpha.AzureEventsStreamResponse
-	(*NetIQEventsStreamRequest)(nil),           // 34: accessgraph.v1alpha.NetIQEventsStreamRequest
-	(*NetIQSyncOperation)(nil),                 // 35: accessgraph.v1alpha.NetIQSyncOperation
-	(*NetIQEventsStreamResponse)(nil),          // 36: accessgraph.v1alpha.NetIQEventsStreamResponse
-	(*AWSCloudTrailStreamRequest)(nil),         // 37: accessgraph.v1alpha.AWSCloudTrailStreamRequest
-	(*AWSCloudTrailEventsFile)(nil),            // 38: accessgraph.v1alpha.AWSCloudTrailEventsFile
-	(*AWSCloudTrailConfig)(nil),                // 39: accessgraph.v1alpha.AWSCloudTrailConfig
-	(*AWSCloudTrailStreamResponse)(nil),        // 40: accessgraph.v1alpha.AWSCloudTrailStreamResponse
-	(*AWSCloudTrailResumeState)(nil),           // 41: accessgraph.v1alpha.AWSCloudTrailResumeState
-	(*AWSCloudTrailEventResource)(nil),         // 42: accessgraph.v1alpha.AWSCloudTrailEventResource
-	(*KubeAuditLogStreamRequest)(nil),          // 43: accessgraph.v1alpha.KubeAuditLogStreamRequest
-	(*KubeAuditLogConfig)(nil),                 // 44: accessgraph.v1alpha.KubeAuditLogConfig
-	(*KubeAuditLogNewStream)(nil),              // 45: accessgraph.v1alpha.KubeAuditLogNewStream
-	(*KubeAuditLogEvents)(nil),                 // 46: accessgraph.v1alpha.KubeAuditLogEvents
-	(*KubeAuditLogCursor)(nil),                 // 47: accessgraph.v1alpha.KubeAuditLogCursor
-	(*KubeAuditLogStreamResponse)(nil),         // 48: accessgraph.v1alpha.KubeAuditLogStreamResponse
-	(*KubeAuditLogResumeState)(nil),            // 49: accessgraph.v1alpha.KubeAuditLogResumeState
-	(*GitHubAuditLogStreamRequest)(nil),        // 50: accessgraph.v1alpha.GitHubAuditLogStreamRequest
-	(*GitHubAuditLogStreamResponse)(nil),       // 51: accessgraph.v1alpha.GitHubAuditLogStreamResponse
-	(*GitHubEventsStreamRequest)(nil),          // 52: accessgraph.v1alpha.GitHubEventsStreamRequest
-	(*GitHubEventsStreamResponse)(nil),         // 53: accessgraph.v1alpha.GitHubEventsStreamResponse
-	(*OktaAuditLogStreamRequest)(nil),          // 54: accessgraph.v1alpha.OktaAuditLogStreamRequest
-	(*OktaAuditLogStreamResponse)(nil),         // 55: accessgraph.v1alpha.OktaAuditLogStreamResponse
-	(*OktaEventsStreamRequest)(nil),            // 56: accessgraph.v1alpha.OktaEventsStreamRequest
-	(*OktaEventsStreamResponse)(nil),           // 57: accessgraph.v1alpha.OktaEventsStreamResponse
-	nil,                                        // 58: accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntry
-	(*Node)(nil),                               // 59: accessgraph.v1alpha.Node
-	(*Edge)(nil),                               // 60: accessgraph.v1alpha.Edge
-	(*ResourceList)(nil),                       // 61: accessgraph.v1alpha.ResourceList
-	(*ResourceHeaderList)(nil),                 // 62: accessgraph.v1alpha.ResourceHeaderList
-	(*AccessListsMembers)(nil),                 // 63: accessgraph.v1alpha.AccessListsMembers
-	(*ExcludeAccessListsMembers)(nil),          // 64: accessgraph.v1alpha.ExcludeAccessListsMembers
-	(*AccessPathChanged)(nil),                  // 65: accessgraph.v1alpha.AccessPathChanged
-	(*timestamppb.Timestamp)(nil),              // 66: google.protobuf.Timestamp
-	(*v1.EventUnstructured)(nil),               // 67: teleport.auditlog.v1.EventUnstructured
-	(*emptypb.Empty)(nil),                      // 68: google.protobuf.Empty
-	(*AWSResourceList)(nil),                    // 69: accessgraph.v1alpha.AWSResourceList
-	(*GitlabSyncOperation)(nil),                // 70: accessgraph.v1alpha.GitlabSyncOperation
-	(*GitlabResourceList)(nil),                 // 71: accessgraph.v1alpha.GitlabResourceList
-	(*EntraSyncOperation)(nil),                 // 72: accessgraph.v1alpha.EntraSyncOperation
-	(*EntraResourceList)(nil),                  // 73: accessgraph.v1alpha.EntraResourceList
-	(*AzureResourceList)(nil),                  // 74: accessgraph.v1alpha.AzureResourceList
-	(*NetIQResourceList)(nil),                  // 75: accessgraph.v1alpha.NetIQResourceList
-	(*structpb.Struct)(nil),                    // 76: google.protobuf.Struct
-	(*GitHubConfigV1)(nil),                     // 77: accessgraph.v1alpha.GitHubConfigV1
-	(*GitHubAuditLogV1)(nil),                   // 78: accessgraph.v1alpha.GitHubAuditLogV1
-	(*GitHubAuditLogV1Cursor)(nil),             // 79: accessgraph.v1alpha.GitHubAuditLogV1Cursor
-	(*GithubResourceList)(nil),                 // 80: accessgraph.v1alpha.GithubResourceList
-	(*GithubSync)(nil),                         // 81: accessgraph.v1alpha.GithubSync
-	(*OktaConfigV1)(nil),                       // 82: accessgraph.v1alpha.OktaConfigV1
-	(*OktaAuditLogV1)(nil),                     // 83: accessgraph.v1alpha.OktaAuditLogV1
-	(*OktaAuditLogV1Cursor)(nil),               // 84: accessgraph.v1alpha.OktaAuditLogV1Cursor
-	(*OktaResourceList)(nil),                   // 85: accessgraph.v1alpha.OktaResourceList
-	(*OktaSync)(nil),                           // 86: accessgraph.v1alpha.OktaSync
+	(KubeAuditLogCursor_KubeAuditLogSource)(0),             // 0: accessgraph.v1alpha.KubeAuditLogCursor.KubeAuditLogSource
+	(*QueryRequest)(nil),                                   // 1: accessgraph.v1alpha.QueryRequest
+	(*QueryResponse)(nil),                                  // 2: accessgraph.v1alpha.QueryResponse
+	(*GetFileRequest)(nil),                                 // 3: accessgraph.v1alpha.GetFileRequest
+	(*GetFileResponse)(nil),                                // 4: accessgraph.v1alpha.GetFileResponse
+	(*EventsStreamRequest)(nil),                            // 5: accessgraph.v1alpha.EventsStreamRequest
+	(*EventsStreamV2Request)(nil),                          // 6: accessgraph.v1alpha.EventsStreamV2Request
+	(*SyncOperation)(nil),                                  // 7: accessgraph.v1alpha.SyncOperation
+	(*EventsStreamResponse)(nil),                           // 8: accessgraph.v1alpha.EventsStreamResponse
+	(*EventsStreamV2Response)(nil),                         // 9: accessgraph.v1alpha.EventsStreamV2Response
+	(*AuditEvent)(nil),                                     // 10: accessgraph.v1alpha.AuditEvent
+	(*UsageEvent)(nil),                                     // 11: accessgraph.v1alpha.UsageEvent
+	(*AuditLogStreamRequest)(nil),                          // 12: accessgraph.v1alpha.AuditLogStreamRequest
+	(*AuditLogConfig)(nil),                                 // 13: accessgraph.v1alpha.AuditLogConfig
+	(*AuditLogEvents)(nil),                                 // 14: accessgraph.v1alpha.AuditLogEvents
+	(*SearchResumeState)(nil),                              // 15: accessgraph.v1alpha.SearchResumeState
+	(*BulkResumeStateUpdate)(nil),                          // 16: accessgraph.v1alpha.BulkResumeStateUpdate
+	(*BulkResumeStateSync)(nil),                            // 17: accessgraph.v1alpha.BulkResumeStateSync
+	(*AuditLogStreamResponse)(nil),                         // 18: accessgraph.v1alpha.AuditLogStreamResponse
+	(*BulkResumeState)(nil),                                // 19: accessgraph.v1alpha.BulkResumeState
+	(*BulkResumeDate)(nil),                                 // 20: accessgraph.v1alpha.BulkResumeDate
+	(*RegisterRequest)(nil),                                // 21: accessgraph.v1alpha.RegisterRequest
+	(*RegisterResponse)(nil),                               // 22: accessgraph.v1alpha.RegisterResponse
+	(*ReplaceCAsRequest)(nil),                              // 23: accessgraph.v1alpha.ReplaceCAsRequest
+	(*ReplaceCAsResponse)(nil),                             // 24: accessgraph.v1alpha.ReplaceCAsResponse
+	(*AWSEventsStreamRequest)(nil),                         // 25: accessgraph.v1alpha.AWSEventsStreamRequest
+	(*AWSSyncOperation)(nil),                               // 26: accessgraph.v1alpha.AWSSyncOperation
+	(*AWSEventsStreamResponse)(nil),                        // 27: accessgraph.v1alpha.AWSEventsStreamResponse
+	(*GitlabEventsStreamRequest)(nil),                      // 28: accessgraph.v1alpha.GitlabEventsStreamRequest
+	(*GitlabEventsStreamResponse)(nil),                     // 29: accessgraph.v1alpha.GitlabEventsStreamResponse
+	(*EntraEventsStreamRequest)(nil),                       // 30: accessgraph.v1alpha.EntraEventsStreamRequest
+	(*EntraEventsStreamResponse)(nil),                      // 31: accessgraph.v1alpha.EntraEventsStreamResponse
+	(*AzureEventsStreamRequest)(nil),                       // 32: accessgraph.v1alpha.AzureEventsStreamRequest
+	(*AzureSyncOperation)(nil),                             // 33: accessgraph.v1alpha.AzureSyncOperation
+	(*AzureEventsStreamResponse)(nil),                      // 34: accessgraph.v1alpha.AzureEventsStreamResponse
+	(*NetIQEventsStreamRequest)(nil),                       // 35: accessgraph.v1alpha.NetIQEventsStreamRequest
+	(*NetIQSyncOperation)(nil),                             // 36: accessgraph.v1alpha.NetIQSyncOperation
+	(*NetIQEventsStreamResponse)(nil),                      // 37: accessgraph.v1alpha.NetIQEventsStreamResponse
+	(*AWSCloudTrailStreamRequest)(nil),                     // 38: accessgraph.v1alpha.AWSCloudTrailStreamRequest
+	(*AWSCloudTrailEventsFile)(nil),                        // 39: accessgraph.v1alpha.AWSCloudTrailEventsFile
+	(*AWSCloudTrailConfig)(nil),                            // 40: accessgraph.v1alpha.AWSCloudTrailConfig
+	(*AWSCloudTrailStreamResponse)(nil),                    // 41: accessgraph.v1alpha.AWSCloudTrailStreamResponse
+	(*AWSCloudTrailResumeState)(nil),                       // 42: accessgraph.v1alpha.AWSCloudTrailResumeState
+	(*AWSCloudTrailEventResource)(nil),                     // 43: accessgraph.v1alpha.AWSCloudTrailEventResource
+	(*KubeAuditLogStreamRequest)(nil),                      // 44: accessgraph.v1alpha.KubeAuditLogStreamRequest
+	(*KubeAuditLogConfig)(nil),                             // 45: accessgraph.v1alpha.KubeAuditLogConfig
+	(*KubeAuditLogNewStream)(nil),                          // 46: accessgraph.v1alpha.KubeAuditLogNewStream
+	(*KubeAuditLogEvents)(nil),                             // 47: accessgraph.v1alpha.KubeAuditLogEvents
+	(*KubeAuditLogCursor)(nil),                             // 48: accessgraph.v1alpha.KubeAuditLogCursor
+	(*KubeAuditLogStreamResponse)(nil),                     // 49: accessgraph.v1alpha.KubeAuditLogStreamResponse
+	(*KubeAuditLogResumeState)(nil),                        // 50: accessgraph.v1alpha.KubeAuditLogResumeState
+	(*GitHubAuditLogStreamRequest)(nil),                    // 51: accessgraph.v1alpha.GitHubAuditLogStreamRequest
+	(*GitHubAuditLogStreamResponse)(nil),                   // 52: accessgraph.v1alpha.GitHubAuditLogStreamResponse
+	(*GitHubEventsStreamRequest)(nil),                      // 53: accessgraph.v1alpha.GitHubEventsStreamRequest
+	(*GitHubEventsStreamResponse)(nil),                     // 54: accessgraph.v1alpha.GitHubEventsStreamResponse
+	(*OktaAuditLogStreamRequest)(nil),                      // 55: accessgraph.v1alpha.OktaAuditLogStreamRequest
+	(*OktaAuditLogStreamResponse)(nil),                     // 56: accessgraph.v1alpha.OktaAuditLogStreamResponse
+	(*OktaEventsStreamRequest)(nil),                        // 57: accessgraph.v1alpha.OktaEventsStreamRequest
+	(*OktaEventsStreamResponse)(nil),                       // 58: accessgraph.v1alpha.OktaEventsStreamResponse
+	nil,                                                    // 59: accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntry
+	(*Node)(nil),                                           // 60: accessgraph.v1alpha.Node
+	(*Edge)(nil),                                           // 61: accessgraph.v1alpha.Edge
+	(*ResourceList)(nil),                                   // 62: accessgraph.v1alpha.ResourceList
+	(*ResourceHeaderList)(nil),                             // 63: accessgraph.v1alpha.ResourceHeaderList
+	(*AccessListsMembers)(nil),                             // 64: accessgraph.v1alpha.AccessListsMembers
+	(*ExcludeAccessListsMembers)(nil),                      // 65: accessgraph.v1alpha.ExcludeAccessListsMembers
+	(*AccessPathChanged)(nil),                              // 66: accessgraph.v1alpha.AccessPathChanged
+	(*v1alpha.IdentitySecurityGraphSizeEvent)(nil),         // 67: prehog.v1alpha.IdentitySecurityGraphSizeEvent
+	(*v1alpha.IdentitySecurityAuditLogsIngestedEvent)(nil), // 68: prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent
+	(*timestamppb.Timestamp)(nil),                          // 69: google.protobuf.Timestamp
+	(*v1.EventUnstructured)(nil),                           // 70: teleport.auditlog.v1.EventUnstructured
+	(*emptypb.Empty)(nil),                                  // 71: google.protobuf.Empty
+	(*AWSResourceList)(nil),                                // 72: accessgraph.v1alpha.AWSResourceList
+	(*GitlabSyncOperation)(nil),                            // 73: accessgraph.v1alpha.GitlabSyncOperation
+	(*GitlabResourceList)(nil),                             // 74: accessgraph.v1alpha.GitlabResourceList
+	(*EntraSyncOperation)(nil),                             // 75: accessgraph.v1alpha.EntraSyncOperation
+	(*EntraResourceList)(nil),                              // 76: accessgraph.v1alpha.EntraResourceList
+	(*AzureResourceList)(nil),                              // 77: accessgraph.v1alpha.AzureResourceList
+	(*NetIQResourceList)(nil),                              // 78: accessgraph.v1alpha.NetIQResourceList
+	(*structpb.Struct)(nil),                                // 79: google.protobuf.Struct
+	(*GitHubConfigV1)(nil),                                 // 80: accessgraph.v1alpha.GitHubConfigV1
+	(*GitHubAuditLogV1)(nil),                               // 81: accessgraph.v1alpha.GitHubAuditLogV1
+	(*GitHubAuditLogV1Cursor)(nil),                         // 82: accessgraph.v1alpha.GitHubAuditLogV1Cursor
+	(*GithubResourceList)(nil),                             // 83: accessgraph.v1alpha.GithubResourceList
+	(*GithubSync)(nil),                                     // 84: accessgraph.v1alpha.GithubSync
+	(*OktaConfigV1)(nil),                                   // 85: accessgraph.v1alpha.OktaConfigV1
+	(*OktaAuditLogV1)(nil),                                 // 86: accessgraph.v1alpha.OktaAuditLogV1
+	(*OktaAuditLogV1Cursor)(nil),                           // 87: accessgraph.v1alpha.OktaAuditLogV1Cursor
+	(*OktaResourceList)(nil),                               // 88: accessgraph.v1alpha.OktaResourceList
+	(*OktaSync)(nil),                                       // 89: accessgraph.v1alpha.OktaSync
 }
 var file_accessgraph_v1alpha_access_graph_service_proto_depIdxs = []int32{
-	59, // 0: accessgraph.v1alpha.QueryResponse.nodes:type_name -> accessgraph.v1alpha.Node
-	60, // 1: accessgraph.v1alpha.QueryResponse.edges:type_name -> accessgraph.v1alpha.Edge
+	60, // 0: accessgraph.v1alpha.QueryResponse.nodes:type_name -> accessgraph.v1alpha.Node
+	61, // 1: accessgraph.v1alpha.QueryResponse.edges:type_name -> accessgraph.v1alpha.Edge
 	7,  // 2: accessgraph.v1alpha.EventsStreamRequest.sync:type_name -> accessgraph.v1alpha.SyncOperation
-	61, // 3: accessgraph.v1alpha.EventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.ResourceList
-	62, // 4: accessgraph.v1alpha.EventsStreamRequest.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
-	63, // 5: accessgraph.v1alpha.EventsStreamRequest.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
-	64, // 6: accessgraph.v1alpha.EventsStreamRequest.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
+	62, // 3: accessgraph.v1alpha.EventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.ResourceList
+	63, // 4: accessgraph.v1alpha.EventsStreamRequest.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
+	64, // 5: accessgraph.v1alpha.EventsStreamRequest.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
+	65, // 6: accessgraph.v1alpha.EventsStreamRequest.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
 	7,  // 7: accessgraph.v1alpha.EventsStreamV2Request.sync:type_name -> accessgraph.v1alpha.SyncOperation
-	61, // 8: accessgraph.v1alpha.EventsStreamV2Request.upsert:type_name -> accessgraph.v1alpha.ResourceList
-	62, // 9: accessgraph.v1alpha.EventsStreamV2Request.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
-	63, // 10: accessgraph.v1alpha.EventsStreamV2Request.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
-	64, // 11: accessgraph.v1alpha.EventsStreamV2Request.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
+	62, // 8: accessgraph.v1alpha.EventsStreamV2Request.upsert:type_name -> accessgraph.v1alpha.ResourceList
+	63, // 9: accessgraph.v1alpha.EventsStreamV2Request.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
+	64, // 10: accessgraph.v1alpha.EventsStreamV2Request.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
+	65, // 11: accessgraph.v1alpha.EventsStreamV2Request.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
 	10, // 12: accessgraph.v1alpha.EventsStreamV2Response.event:type_name -> accessgraph.v1alpha.AuditEvent
-	65, // 13: accessgraph.v1alpha.AuditEvent.access_path_changed:type_name -> accessgraph.v1alpha.AccessPathChanged
-	12, // 14: accessgraph.v1alpha.AuditLogStreamRequest.config:type_name -> accessgraph.v1alpha.AuditLogConfig
-	13, // 15: accessgraph.v1alpha.AuditLogStreamRequest.events:type_name -> accessgraph.v1alpha.AuditLogEvents
-	16, // 16: accessgraph.v1alpha.AuditLogStreamRequest.bulk_sync:type_name -> accessgraph.v1alpha.BulkResumeStateSync
-	66, // 17: accessgraph.v1alpha.AuditLogConfig.start_date:type_name -> google.protobuf.Timestamp
-	67, // 18: accessgraph.v1alpha.AuditLogEvents.events:type_name -> teleport.auditlog.v1.EventUnstructured
-	14, // 19: accessgraph.v1alpha.AuditLogEvents.search_resume_state:type_name -> accessgraph.v1alpha.SearchResumeState
-	15, // 20: accessgraph.v1alpha.AuditLogEvents.bulk_resume_state_update:type_name -> accessgraph.v1alpha.BulkResumeStateUpdate
-	66, // 21: accessgraph.v1alpha.SearchResumeState.last_event_time:type_name -> google.protobuf.Timestamp
-	66, // 22: accessgraph.v1alpha.BulkResumeStateUpdate.date:type_name -> google.protobuf.Timestamp
-	66, // 23: accessgraph.v1alpha.BulkResumeStateSync.active_dates:type_name -> google.protobuf.Timestamp
-	12, // 24: accessgraph.v1alpha.AuditLogStreamResponse.audit_log_config:type_name -> accessgraph.v1alpha.AuditLogConfig
-	68, // 25: accessgraph.v1alpha.AuditLogStreamResponse.no_resume_state:type_name -> google.protobuf.Empty
-	14, // 26: accessgraph.v1alpha.AuditLogStreamResponse.search_resume_state:type_name -> accessgraph.v1alpha.SearchResumeState
-	18, // 27: accessgraph.v1alpha.AuditLogStreamResponse.bulk_resume_state:type_name -> accessgraph.v1alpha.BulkResumeState
-	19, // 28: accessgraph.v1alpha.BulkResumeState.dates:type_name -> accessgraph.v1alpha.BulkResumeDate
-	66, // 29: accessgraph.v1alpha.BulkResumeDate.date:type_name -> google.protobuf.Timestamp
-	58, // 30: accessgraph.v1alpha.BulkResumeDate.chunk_cursors:type_name -> accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntry
-	25, // 31: accessgraph.v1alpha.AWSEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AWSSyncOperation
-	69, // 32: accessgraph.v1alpha.AWSEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AWSResourceList
-	69, // 33: accessgraph.v1alpha.AWSEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AWSResourceList
-	70, // 34: accessgraph.v1alpha.GitlabEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.GitlabSyncOperation
-	71, // 35: accessgraph.v1alpha.GitlabEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.GitlabResourceList
-	71, // 36: accessgraph.v1alpha.GitlabEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.GitlabResourceList
-	72, // 37: accessgraph.v1alpha.EntraEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.EntraSyncOperation
-	73, // 38: accessgraph.v1alpha.EntraEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.EntraResourceList
-	73, // 39: accessgraph.v1alpha.EntraEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.EntraResourceList
-	32, // 40: accessgraph.v1alpha.AzureEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AzureSyncOperation
-	74, // 41: accessgraph.v1alpha.AzureEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AzureResourceList
-	74, // 42: accessgraph.v1alpha.AzureEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AzureResourceList
-	35, // 43: accessgraph.v1alpha.NetIQEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.NetIQSyncOperation
-	75, // 44: accessgraph.v1alpha.NetIQEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.NetIQResourceList
-	75, // 45: accessgraph.v1alpha.NetIQEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.NetIQResourceList
-	39, // 46: accessgraph.v1alpha.AWSCloudTrailStreamRequest.config:type_name -> accessgraph.v1alpha.AWSCloudTrailConfig
-	38, // 47: accessgraph.v1alpha.AWSCloudTrailStreamRequest.events_file:type_name -> accessgraph.v1alpha.AWSCloudTrailEventsFile
-	39, // 48: accessgraph.v1alpha.AWSCloudTrailStreamResponse.cloud_trail_config:type_name -> accessgraph.v1alpha.AWSCloudTrailConfig
-	41, // 49: accessgraph.v1alpha.AWSCloudTrailStreamResponse.resume_state:type_name -> accessgraph.v1alpha.AWSCloudTrailResumeState
-	44, // 50: accessgraph.v1alpha.KubeAuditLogStreamRequest.config:type_name -> accessgraph.v1alpha.KubeAuditLogConfig
-	45, // 51: accessgraph.v1alpha.KubeAuditLogStreamRequest.new_stream:type_name -> accessgraph.v1alpha.KubeAuditLogNewStream
-	46, // 52: accessgraph.v1alpha.KubeAuditLogStreamRequest.events:type_name -> accessgraph.v1alpha.KubeAuditLogEvents
-	47, // 53: accessgraph.v1alpha.KubeAuditLogNewStream.initial:type_name -> accessgraph.v1alpha.KubeAuditLogCursor
-	76, // 54: accessgraph.v1alpha.KubeAuditLogEvents.events:type_name -> google.protobuf.Struct
-	47, // 55: accessgraph.v1alpha.KubeAuditLogEvents.cursor:type_name -> accessgraph.v1alpha.KubeAuditLogCursor
-	0,  // 56: accessgraph.v1alpha.KubeAuditLogCursor.log_source:type_name -> accessgraph.v1alpha.KubeAuditLogCursor.KubeAuditLogSource
-	66, // 57: accessgraph.v1alpha.KubeAuditLogCursor.last_event_time:type_name -> google.protobuf.Timestamp
-	44, // 58: accessgraph.v1alpha.KubeAuditLogStreamResponse.config:type_name -> accessgraph.v1alpha.KubeAuditLogConfig
-	49, // 59: accessgraph.v1alpha.KubeAuditLogStreamResponse.resume_state:type_name -> accessgraph.v1alpha.KubeAuditLogResumeState
-	47, // 60: accessgraph.v1alpha.KubeAuditLogResumeState.cursor:type_name -> accessgraph.v1alpha.KubeAuditLogCursor
-	77, // 61: accessgraph.v1alpha.GitHubAuditLogStreamRequest.config:type_name -> accessgraph.v1alpha.GitHubConfigV1
-	78, // 62: accessgraph.v1alpha.GitHubAuditLogStreamRequest.audit_log:type_name -> accessgraph.v1alpha.GitHubAuditLogV1
-	77, // 63: accessgraph.v1alpha.GitHubAuditLogStreamResponse.github_config:type_name -> accessgraph.v1alpha.GitHubConfigV1
-	79, // 64: accessgraph.v1alpha.GitHubAuditLogStreamResponse.audit_log_resume_state:type_name -> accessgraph.v1alpha.GitHubAuditLogV1Cursor
-	80, // 65: accessgraph.v1alpha.GitHubEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.GithubResourceList
-	80, // 66: accessgraph.v1alpha.GitHubEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.GithubResourceList
-	81, // 67: accessgraph.v1alpha.GitHubEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.GithubSync
-	82, // 68: accessgraph.v1alpha.OktaAuditLogStreamRequest.config:type_name -> accessgraph.v1alpha.OktaConfigV1
-	83, // 69: accessgraph.v1alpha.OktaAuditLogStreamRequest.audit_log:type_name -> accessgraph.v1alpha.OktaAuditLogV1
-	82, // 70: accessgraph.v1alpha.OktaAuditLogStreamResponse.config:type_name -> accessgraph.v1alpha.OktaConfigV1
-	84, // 71: accessgraph.v1alpha.OktaAuditLogStreamResponse.audit_log_resume_state:type_name -> accessgraph.v1alpha.OktaAuditLogV1Cursor
-	85, // 72: accessgraph.v1alpha.OktaEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.OktaResourceList
-	85, // 73: accessgraph.v1alpha.OktaEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.OktaResourceList
-	86, // 74: accessgraph.v1alpha.OktaEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.OktaSync
-	1,  // 75: accessgraph.v1alpha.AccessGraphService.Query:input_type -> accessgraph.v1alpha.QueryRequest
-	3,  // 76: accessgraph.v1alpha.AccessGraphService.GetFile:input_type -> accessgraph.v1alpha.GetFileRequest
-	5,  // 77: accessgraph.v1alpha.AccessGraphService.EventsStream:input_type -> accessgraph.v1alpha.EventsStreamRequest
-	6,  // 78: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:input_type -> accessgraph.v1alpha.EventsStreamV2Request
-	11, // 79: accessgraph.v1alpha.AccessGraphService.AuditLogStream:input_type -> accessgraph.v1alpha.AuditLogStreamRequest
-	37, // 80: accessgraph.v1alpha.AccessGraphService.AWSCloudTrailStream:input_type -> accessgraph.v1alpha.AWSCloudTrailStreamRequest
-	43, // 81: accessgraph.v1alpha.AccessGraphService.KubeAuditLogStream:input_type -> accessgraph.v1alpha.KubeAuditLogStreamRequest
-	20, // 82: accessgraph.v1alpha.AccessGraphService.Register:input_type -> accessgraph.v1alpha.RegisterRequest
-	22, // 83: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:input_type -> accessgraph.v1alpha.ReplaceCAsRequest
-	24, // 84: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:input_type -> accessgraph.v1alpha.AWSEventsStreamRequest
-	27, // 85: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:input_type -> accessgraph.v1alpha.GitlabEventsStreamRequest
-	29, // 86: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:input_type -> accessgraph.v1alpha.EntraEventsStreamRequest
-	31, // 87: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:input_type -> accessgraph.v1alpha.AzureEventsStreamRequest
-	34, // 88: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:input_type -> accessgraph.v1alpha.NetIQEventsStreamRequest
-	50, // 89: accessgraph.v1alpha.AccessGraphService.GitHubAuditLogStream:input_type -> accessgraph.v1alpha.GitHubAuditLogStreamRequest
-	52, // 90: accessgraph.v1alpha.AccessGraphService.GitHubEventsStream:input_type -> accessgraph.v1alpha.GitHubEventsStreamRequest
-	54, // 91: accessgraph.v1alpha.AccessGraphService.OktaAuditLogStream:input_type -> accessgraph.v1alpha.OktaAuditLogStreamRequest
-	56, // 92: accessgraph.v1alpha.AccessGraphService.OktaEventsStream:input_type -> accessgraph.v1alpha.OktaEventsStreamRequest
-	2,  // 93: accessgraph.v1alpha.AccessGraphService.Query:output_type -> accessgraph.v1alpha.QueryResponse
-	4,  // 94: accessgraph.v1alpha.AccessGraphService.GetFile:output_type -> accessgraph.v1alpha.GetFileResponse
-	8,  // 95: accessgraph.v1alpha.AccessGraphService.EventsStream:output_type -> accessgraph.v1alpha.EventsStreamResponse
-	9,  // 96: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:output_type -> accessgraph.v1alpha.EventsStreamV2Response
-	17, // 97: accessgraph.v1alpha.AccessGraphService.AuditLogStream:output_type -> accessgraph.v1alpha.AuditLogStreamResponse
-	40, // 98: accessgraph.v1alpha.AccessGraphService.AWSCloudTrailStream:output_type -> accessgraph.v1alpha.AWSCloudTrailStreamResponse
-	48, // 99: accessgraph.v1alpha.AccessGraphService.KubeAuditLogStream:output_type -> accessgraph.v1alpha.KubeAuditLogStreamResponse
-	21, // 100: accessgraph.v1alpha.AccessGraphService.Register:output_type -> accessgraph.v1alpha.RegisterResponse
-	23, // 101: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:output_type -> accessgraph.v1alpha.ReplaceCAsResponse
-	26, // 102: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:output_type -> accessgraph.v1alpha.AWSEventsStreamResponse
-	28, // 103: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:output_type -> accessgraph.v1alpha.GitlabEventsStreamResponse
-	30, // 104: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:output_type -> accessgraph.v1alpha.EntraEventsStreamResponse
-	33, // 105: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:output_type -> accessgraph.v1alpha.AzureEventsStreamResponse
-	36, // 106: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:output_type -> accessgraph.v1alpha.NetIQEventsStreamResponse
-	51, // 107: accessgraph.v1alpha.AccessGraphService.GitHubAuditLogStream:output_type -> accessgraph.v1alpha.GitHubAuditLogStreamResponse
-	53, // 108: accessgraph.v1alpha.AccessGraphService.GitHubEventsStream:output_type -> accessgraph.v1alpha.GitHubEventsStreamResponse
-	55, // 109: accessgraph.v1alpha.AccessGraphService.OktaAuditLogStream:output_type -> accessgraph.v1alpha.OktaAuditLogStreamResponse
-	57, // 110: accessgraph.v1alpha.AccessGraphService.OktaEventsStream:output_type -> accessgraph.v1alpha.OktaEventsStreamResponse
-	93, // [93:111] is the sub-list for method output_type
-	75, // [75:93] is the sub-list for method input_type
-	75, // [75:75] is the sub-list for extension type_name
-	75, // [75:75] is the sub-list for extension extendee
-	0,  // [0:75] is the sub-list for field type_name
+	11, // 13: accessgraph.v1alpha.EventsStreamV2Response.usage_event:type_name -> accessgraph.v1alpha.UsageEvent
+	66, // 14: accessgraph.v1alpha.AuditEvent.access_path_changed:type_name -> accessgraph.v1alpha.AccessPathChanged
+	67, // 15: accessgraph.v1alpha.UsageEvent.graph_size:type_name -> prehog.v1alpha.IdentitySecurityGraphSizeEvent
+	68, // 16: accessgraph.v1alpha.UsageEvent.audit_logs_ingested:type_name -> prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent
+	13, // 17: accessgraph.v1alpha.AuditLogStreamRequest.config:type_name -> accessgraph.v1alpha.AuditLogConfig
+	14, // 18: accessgraph.v1alpha.AuditLogStreamRequest.events:type_name -> accessgraph.v1alpha.AuditLogEvents
+	17, // 19: accessgraph.v1alpha.AuditLogStreamRequest.bulk_sync:type_name -> accessgraph.v1alpha.BulkResumeStateSync
+	69, // 20: accessgraph.v1alpha.AuditLogConfig.start_date:type_name -> google.protobuf.Timestamp
+	70, // 21: accessgraph.v1alpha.AuditLogEvents.events:type_name -> teleport.auditlog.v1.EventUnstructured
+	15, // 22: accessgraph.v1alpha.AuditLogEvents.search_resume_state:type_name -> accessgraph.v1alpha.SearchResumeState
+	16, // 23: accessgraph.v1alpha.AuditLogEvents.bulk_resume_state_update:type_name -> accessgraph.v1alpha.BulkResumeStateUpdate
+	69, // 24: accessgraph.v1alpha.SearchResumeState.last_event_time:type_name -> google.protobuf.Timestamp
+	69, // 25: accessgraph.v1alpha.BulkResumeStateUpdate.date:type_name -> google.protobuf.Timestamp
+	69, // 26: accessgraph.v1alpha.BulkResumeStateSync.active_dates:type_name -> google.protobuf.Timestamp
+	13, // 27: accessgraph.v1alpha.AuditLogStreamResponse.audit_log_config:type_name -> accessgraph.v1alpha.AuditLogConfig
+	71, // 28: accessgraph.v1alpha.AuditLogStreamResponse.no_resume_state:type_name -> google.protobuf.Empty
+	15, // 29: accessgraph.v1alpha.AuditLogStreamResponse.search_resume_state:type_name -> accessgraph.v1alpha.SearchResumeState
+	19, // 30: accessgraph.v1alpha.AuditLogStreamResponse.bulk_resume_state:type_name -> accessgraph.v1alpha.BulkResumeState
+	20, // 31: accessgraph.v1alpha.BulkResumeState.dates:type_name -> accessgraph.v1alpha.BulkResumeDate
+	69, // 32: accessgraph.v1alpha.BulkResumeDate.date:type_name -> google.protobuf.Timestamp
+	59, // 33: accessgraph.v1alpha.BulkResumeDate.chunk_cursors:type_name -> accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntry
+	26, // 34: accessgraph.v1alpha.AWSEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AWSSyncOperation
+	72, // 35: accessgraph.v1alpha.AWSEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AWSResourceList
+	72, // 36: accessgraph.v1alpha.AWSEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AWSResourceList
+	73, // 37: accessgraph.v1alpha.GitlabEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.GitlabSyncOperation
+	74, // 38: accessgraph.v1alpha.GitlabEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.GitlabResourceList
+	74, // 39: accessgraph.v1alpha.GitlabEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.GitlabResourceList
+	75, // 40: accessgraph.v1alpha.EntraEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.EntraSyncOperation
+	76, // 41: accessgraph.v1alpha.EntraEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.EntraResourceList
+	76, // 42: accessgraph.v1alpha.EntraEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.EntraResourceList
+	33, // 43: accessgraph.v1alpha.AzureEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AzureSyncOperation
+	77, // 44: accessgraph.v1alpha.AzureEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AzureResourceList
+	77, // 45: accessgraph.v1alpha.AzureEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AzureResourceList
+	36, // 46: accessgraph.v1alpha.NetIQEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.NetIQSyncOperation
+	78, // 47: accessgraph.v1alpha.NetIQEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.NetIQResourceList
+	78, // 48: accessgraph.v1alpha.NetIQEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.NetIQResourceList
+	40, // 49: accessgraph.v1alpha.AWSCloudTrailStreamRequest.config:type_name -> accessgraph.v1alpha.AWSCloudTrailConfig
+	39, // 50: accessgraph.v1alpha.AWSCloudTrailStreamRequest.events_file:type_name -> accessgraph.v1alpha.AWSCloudTrailEventsFile
+	40, // 51: accessgraph.v1alpha.AWSCloudTrailStreamResponse.cloud_trail_config:type_name -> accessgraph.v1alpha.AWSCloudTrailConfig
+	42, // 52: accessgraph.v1alpha.AWSCloudTrailStreamResponse.resume_state:type_name -> accessgraph.v1alpha.AWSCloudTrailResumeState
+	45, // 53: accessgraph.v1alpha.KubeAuditLogStreamRequest.config:type_name -> accessgraph.v1alpha.KubeAuditLogConfig
+	46, // 54: accessgraph.v1alpha.KubeAuditLogStreamRequest.new_stream:type_name -> accessgraph.v1alpha.KubeAuditLogNewStream
+	47, // 55: accessgraph.v1alpha.KubeAuditLogStreamRequest.events:type_name -> accessgraph.v1alpha.KubeAuditLogEvents
+	48, // 56: accessgraph.v1alpha.KubeAuditLogNewStream.initial:type_name -> accessgraph.v1alpha.KubeAuditLogCursor
+	79, // 57: accessgraph.v1alpha.KubeAuditLogEvents.events:type_name -> google.protobuf.Struct
+	48, // 58: accessgraph.v1alpha.KubeAuditLogEvents.cursor:type_name -> accessgraph.v1alpha.KubeAuditLogCursor
+	0,  // 59: accessgraph.v1alpha.KubeAuditLogCursor.log_source:type_name -> accessgraph.v1alpha.KubeAuditLogCursor.KubeAuditLogSource
+	69, // 60: accessgraph.v1alpha.KubeAuditLogCursor.last_event_time:type_name -> google.protobuf.Timestamp
+	45, // 61: accessgraph.v1alpha.KubeAuditLogStreamResponse.config:type_name -> accessgraph.v1alpha.KubeAuditLogConfig
+	50, // 62: accessgraph.v1alpha.KubeAuditLogStreamResponse.resume_state:type_name -> accessgraph.v1alpha.KubeAuditLogResumeState
+	48, // 63: accessgraph.v1alpha.KubeAuditLogResumeState.cursor:type_name -> accessgraph.v1alpha.KubeAuditLogCursor
+	80, // 64: accessgraph.v1alpha.GitHubAuditLogStreamRequest.config:type_name -> accessgraph.v1alpha.GitHubConfigV1
+	81, // 65: accessgraph.v1alpha.GitHubAuditLogStreamRequest.audit_log:type_name -> accessgraph.v1alpha.GitHubAuditLogV1
+	80, // 66: accessgraph.v1alpha.GitHubAuditLogStreamResponse.github_config:type_name -> accessgraph.v1alpha.GitHubConfigV1
+	82, // 67: accessgraph.v1alpha.GitHubAuditLogStreamResponse.audit_log_resume_state:type_name -> accessgraph.v1alpha.GitHubAuditLogV1Cursor
+	83, // 68: accessgraph.v1alpha.GitHubEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.GithubResourceList
+	83, // 69: accessgraph.v1alpha.GitHubEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.GithubResourceList
+	84, // 70: accessgraph.v1alpha.GitHubEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.GithubSync
+	85, // 71: accessgraph.v1alpha.OktaAuditLogStreamRequest.config:type_name -> accessgraph.v1alpha.OktaConfigV1
+	86, // 72: accessgraph.v1alpha.OktaAuditLogStreamRequest.audit_log:type_name -> accessgraph.v1alpha.OktaAuditLogV1
+	85, // 73: accessgraph.v1alpha.OktaAuditLogStreamResponse.config:type_name -> accessgraph.v1alpha.OktaConfigV1
+	87, // 74: accessgraph.v1alpha.OktaAuditLogStreamResponse.audit_log_resume_state:type_name -> accessgraph.v1alpha.OktaAuditLogV1Cursor
+	88, // 75: accessgraph.v1alpha.OktaEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.OktaResourceList
+	88, // 76: accessgraph.v1alpha.OktaEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.OktaResourceList
+	89, // 77: accessgraph.v1alpha.OktaEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.OktaSync
+	1,  // 78: accessgraph.v1alpha.AccessGraphService.Query:input_type -> accessgraph.v1alpha.QueryRequest
+	3,  // 79: accessgraph.v1alpha.AccessGraphService.GetFile:input_type -> accessgraph.v1alpha.GetFileRequest
+	5,  // 80: accessgraph.v1alpha.AccessGraphService.EventsStream:input_type -> accessgraph.v1alpha.EventsStreamRequest
+	6,  // 81: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:input_type -> accessgraph.v1alpha.EventsStreamV2Request
+	12, // 82: accessgraph.v1alpha.AccessGraphService.AuditLogStream:input_type -> accessgraph.v1alpha.AuditLogStreamRequest
+	38, // 83: accessgraph.v1alpha.AccessGraphService.AWSCloudTrailStream:input_type -> accessgraph.v1alpha.AWSCloudTrailStreamRequest
+	44, // 84: accessgraph.v1alpha.AccessGraphService.KubeAuditLogStream:input_type -> accessgraph.v1alpha.KubeAuditLogStreamRequest
+	21, // 85: accessgraph.v1alpha.AccessGraphService.Register:input_type -> accessgraph.v1alpha.RegisterRequest
+	23, // 86: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:input_type -> accessgraph.v1alpha.ReplaceCAsRequest
+	25, // 87: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:input_type -> accessgraph.v1alpha.AWSEventsStreamRequest
+	28, // 88: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:input_type -> accessgraph.v1alpha.GitlabEventsStreamRequest
+	30, // 89: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:input_type -> accessgraph.v1alpha.EntraEventsStreamRequest
+	32, // 90: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:input_type -> accessgraph.v1alpha.AzureEventsStreamRequest
+	35, // 91: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:input_type -> accessgraph.v1alpha.NetIQEventsStreamRequest
+	51, // 92: accessgraph.v1alpha.AccessGraphService.GitHubAuditLogStream:input_type -> accessgraph.v1alpha.GitHubAuditLogStreamRequest
+	53, // 93: accessgraph.v1alpha.AccessGraphService.GitHubEventsStream:input_type -> accessgraph.v1alpha.GitHubEventsStreamRequest
+	55, // 94: accessgraph.v1alpha.AccessGraphService.OktaAuditLogStream:input_type -> accessgraph.v1alpha.OktaAuditLogStreamRequest
+	57, // 95: accessgraph.v1alpha.AccessGraphService.OktaEventsStream:input_type -> accessgraph.v1alpha.OktaEventsStreamRequest
+	2,  // 96: accessgraph.v1alpha.AccessGraphService.Query:output_type -> accessgraph.v1alpha.QueryResponse
+	4,  // 97: accessgraph.v1alpha.AccessGraphService.GetFile:output_type -> accessgraph.v1alpha.GetFileResponse
+	8,  // 98: accessgraph.v1alpha.AccessGraphService.EventsStream:output_type -> accessgraph.v1alpha.EventsStreamResponse
+	9,  // 99: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:output_type -> accessgraph.v1alpha.EventsStreamV2Response
+	18, // 100: accessgraph.v1alpha.AccessGraphService.AuditLogStream:output_type -> accessgraph.v1alpha.AuditLogStreamResponse
+	41, // 101: accessgraph.v1alpha.AccessGraphService.AWSCloudTrailStream:output_type -> accessgraph.v1alpha.AWSCloudTrailStreamResponse
+	49, // 102: accessgraph.v1alpha.AccessGraphService.KubeAuditLogStream:output_type -> accessgraph.v1alpha.KubeAuditLogStreamResponse
+	22, // 103: accessgraph.v1alpha.AccessGraphService.Register:output_type -> accessgraph.v1alpha.RegisterResponse
+	24, // 104: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:output_type -> accessgraph.v1alpha.ReplaceCAsResponse
+	27, // 105: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:output_type -> accessgraph.v1alpha.AWSEventsStreamResponse
+	29, // 106: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:output_type -> accessgraph.v1alpha.GitlabEventsStreamResponse
+	31, // 107: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:output_type -> accessgraph.v1alpha.EntraEventsStreamResponse
+	34, // 108: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:output_type -> accessgraph.v1alpha.AzureEventsStreamResponse
+	37, // 109: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:output_type -> accessgraph.v1alpha.NetIQEventsStreamResponse
+	52, // 110: accessgraph.v1alpha.AccessGraphService.GitHubAuditLogStream:output_type -> accessgraph.v1alpha.GitHubAuditLogStreamResponse
+	54, // 111: accessgraph.v1alpha.AccessGraphService.GitHubEventsStream:output_type -> accessgraph.v1alpha.GitHubEventsStreamResponse
+	56, // 112: accessgraph.v1alpha.AccessGraphService.OktaAuditLogStream:output_type -> accessgraph.v1alpha.OktaAuditLogStreamResponse
+	58, // 113: accessgraph.v1alpha.AccessGraphService.OktaEventsStream:output_type -> accessgraph.v1alpha.OktaEventsStreamResponse
+	96, // [96:114] is the sub-list for method output_type
+	78, // [78:96] is the sub-list for method input_type
+	78, // [78:78] is the sub-list for extension type_name
+	78, // [78:78] is the sub-list for extension extendee
+	0,  // [0:78] is the sub-list for field type_name
 }
 
 func init() { file_accessgraph_v1alpha_access_graph_service_proto_init() }
@@ -4461,89 +4579,94 @@ func file_accessgraph_v1alpha_access_graph_service_proto_init() {
 	}
 	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[8].OneofWrappers = []any{
 		(*EventsStreamV2Response_Event)(nil),
+		(*EventsStreamV2Response_UsageEvent)(nil),
 	}
 	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[9].OneofWrappers = []any{
 		(*AuditEvent_AccessPathChanged)(nil),
 	}
 	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10].OneofWrappers = []any{
+		(*UsageEvent_GraphSize)(nil),
+		(*UsageEvent_AuditLogsIngested)(nil),
+	}
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11].OneofWrappers = []any{
 		(*AuditLogStreamRequest_Config)(nil),
 		(*AuditLogStreamRequest_Events)(nil),
 		(*AuditLogStreamRequest_BulkSync)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13].OneofWrappers = []any{
 		(*AuditLogEvents_SearchResumeState)(nil),
 		(*AuditLogEvents_BulkResumeStateUpdate)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17].OneofWrappers = []any{
 		(*AuditLogStreamResponse_AuditLogConfig)(nil),
 		(*AuditLogStreamResponse_NoResumeState)(nil),
 		(*AuditLogStreamResponse_SearchResumeState)(nil),
 		(*AuditLogStreamResponse_BulkResumeState)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24].OneofWrappers = []any{
 		(*AWSEventsStreamRequest_Sync)(nil),
 		(*AWSEventsStreamRequest_Upsert)(nil),
 		(*AWSEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27].OneofWrappers = []any{
 		(*GitlabEventsStreamRequest_Sync)(nil),
 		(*GitlabEventsStreamRequest_Upsert)(nil),
 		(*GitlabEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29].OneofWrappers = []any{
 		(*EntraEventsStreamRequest_Sync)(nil),
 		(*EntraEventsStreamRequest_Upsert)(nil),
 		(*EntraEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31].OneofWrappers = []any{
 		(*AzureEventsStreamRequest_Sync)(nil),
 		(*AzureEventsStreamRequest_Upsert)(nil),
 		(*AzureEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34].OneofWrappers = []any{
 		(*NetIQEventsStreamRequest_Sync)(nil),
 		(*NetIQEventsStreamRequest_Upsert)(nil),
 		(*NetIQEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[36].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[37].OneofWrappers = []any{
 		(*AWSCloudTrailStreamRequest_Config)(nil),
 		(*AWSCloudTrailStreamRequest_EventsFile)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[39].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[40].OneofWrappers = []any{
 		(*AWSCloudTrailStreamResponse_CloudTrailConfig)(nil),
 		(*AWSCloudTrailStreamResponse_ResumeState)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[42].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[43].OneofWrappers = []any{
 		(*KubeAuditLogStreamRequest_Config)(nil),
 		(*KubeAuditLogStreamRequest_NewStream)(nil),
 		(*KubeAuditLogStreamRequest_Events)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[47].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[48].OneofWrappers = []any{
 		(*KubeAuditLogStreamResponse_Config)(nil),
 		(*KubeAuditLogStreamResponse_ResumeState)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[49].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[50].OneofWrappers = []any{
 		(*GitHubAuditLogStreamRequest_Config)(nil),
 		(*GitHubAuditLogStreamRequest_AuditLog)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[50].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[51].OneofWrappers = []any{
 		(*GitHubAuditLogStreamResponse_GithubConfig)(nil),
 		(*GitHubAuditLogStreamResponse_AuditLogResumeState)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[51].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[52].OneofWrappers = []any{
 		(*GitHubEventsStreamRequest_Upsert)(nil),
 		(*GitHubEventsStreamRequest_Delete)(nil),
 		(*GitHubEventsStreamRequest_Sync)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[53].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[54].OneofWrappers = []any{
 		(*OktaAuditLogStreamRequest_Config)(nil),
 		(*OktaAuditLogStreamRequest_AuditLog)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[54].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[55].OneofWrappers = []any{
 		(*OktaAuditLogStreamResponse_Config)(nil),
 		(*OktaAuditLogStreamResponse_AuditLogResumeState)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[55].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[56].OneofWrappers = []any{
 		(*OktaEventsStreamRequest_Upsert)(nil),
 		(*OktaEventsStreamRequest_Delete)(nil),
 		(*OktaEventsStreamRequest_Sync)(nil),
@@ -4554,7 +4677,7 @@ func file_accessgraph_v1alpha_access_graph_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_accessgraph_v1alpha_access_graph_service_proto_rawDesc), len(file_accessgraph_v1alpha_access_graph_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   58,
+			NumMessages:   59,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/go/prehog/v1/teleport.pb.go
+++ b/gen/proto/go/prehog/v1/teleport.pb.go
@@ -414,8 +414,10 @@ type UserActivityRecord struct {
 	SamlIdpSessions uint64 `protobuf:"varint,24,opt,name=saml_idp_sessions,json=samlIdpSessions,proto3" json:"saml_idp_sessions,omitempty"`
 	// counter of session summaries accessed by this user per session type and resource name.
 	SessionSummariesAccessed []*SessionSummariesAccessedRecord `protobuf:"bytes,25,rep,name=session_summaries_accessed,json=sessionSummariesAccessed,proto3" json:"session_summaries_accessed,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	// counter of access graph queries by this user.
+	AccessGraphQueries uint64 `protobuf:"varint,26,opt,name=access_graph_queries,json=accessGraphQueries,proto3" json:"access_graph_queries,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *UserActivityRecord) Reset() {
@@ -622,6 +624,13 @@ func (x *UserActivityRecord) GetSessionSummariesAccessed() []*SessionSummariesAc
 		return x.SessionSummariesAccessed
 	}
 	return nil
+}
+
+func (x *UserActivityRecord) GetAccessGraphQueries() uint64 {
+	if x != nil {
+		return x.AccessGraphQueries
+	}
+	return 0
 }
 
 type ResourcePresenceReport struct {
@@ -1244,6 +1253,232 @@ func (x *SessionSummariesGeneratedRecord) GetSummariesGenerated() uint64 {
 	return 0
 }
 
+// IdentitySecurityReport is a report of Identity Security non-user usage. It currently
+// includes the size of the access graph by provider and count of audit logs ingested
+// by provider.
+type IdentitySecurityReport struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// randomly generated UUID for this specific report, 16 bytes (in string order)
+	//
+	// PostHog property: tp.report_uuid (in 8-4-4-4-12 string form)
+	ReportUuid []byte `protobuf:"bytes,1,opt,name=report_uuid,json=reportUuid,proto3" json:"report_uuid,omitempty"`
+	// cluster name, anonymized, 32 bytes (HMAC-SHA-256)
+	//
+	// PostHog property: tp.cluster_name (in base64)
+	ClusterName []byte `protobuf:"bytes,2,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
+	// hostid of the auth that collected this report, anonymized, 32 bytes (HMAC-SHA-256)
+	//
+	// PostHog property: tp.reporter_hostid (in base64)
+	ReporterHostid []byte `protobuf:"bytes,3,opt,name=reporter_hostid,json=reporterHostid,proto3" json:"reporter_hostid,omitempty"`
+	// beginning of the time window for this data; ending is not specified but is
+	// intended to be at most 60 minutes
+	//
+	// PostHog timestamp (not a property, the ingest time is tp.report_time instead)
+	StartTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	// graph_size contains the size of each provider's graph: count of identities and
+	// count of resources.
+	GraphSizeRecords []*IdentitySecurityGraphSize `protobuf:"bytes,5,rep,name=graph_size_records,json=graphSizeRecords,proto3" json:"graph_size_records,omitempty"`
+	// audit_logs contains the counts of audit logs ingested from each provider.
+	AuditLogRecords []*IdentitySecurityAuditLogsIngested `protobuf:"bytes,6,rep,name=audit_log_records,json=auditLogRecords,proto3" json:"audit_log_records,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *IdentitySecurityReport) Reset() {
+	*x = IdentitySecurityReport{}
+	mi := &file_prehog_v1_teleport_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdentitySecurityReport) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdentitySecurityReport) ProtoMessage() {}
+
+func (x *IdentitySecurityReport) ProtoReflect() protoreflect.Message {
+	mi := &file_prehog_v1_teleport_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdentitySecurityReport.ProtoReflect.Descriptor instead.
+func (*IdentitySecurityReport) Descriptor() ([]byte, []int) {
+	return file_prehog_v1_teleport_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *IdentitySecurityReport) GetReportUuid() []byte {
+	if x != nil {
+		return x.ReportUuid
+	}
+	return nil
+}
+
+func (x *IdentitySecurityReport) GetClusterName() []byte {
+	if x != nil {
+		return x.ClusterName
+	}
+	return nil
+}
+
+func (x *IdentitySecurityReport) GetReporterHostid() []byte {
+	if x != nil {
+		return x.ReporterHostid
+	}
+	return nil
+}
+
+func (x *IdentitySecurityReport) GetStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartTime
+	}
+	return nil
+}
+
+func (x *IdentitySecurityReport) GetGraphSizeRecords() []*IdentitySecurityGraphSize {
+	if x != nil {
+		return x.GraphSizeRecords
+	}
+	return nil
+}
+
+func (x *IdentitySecurityReport) GetAuditLogRecords() []*IdentitySecurityAuditLogsIngested {
+	if x != nil {
+		return x.AuditLogRecords
+	}
+	return nil
+}
+
+// IdentitySecurityGraphSize is submitted by Access Graph for each provider
+// for which it has a graph.
+type IdentitySecurityGraphSize struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// provider is the system containing the identities and resources being counted.
+	// It is one of teleport, aws, azure, entra, gitlab, github, netiq or okta.
+	Provider string `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
+	// total_identities is the number of identities in the graph.
+	TotalIdentities uint64 `protobuf:"varint,2,opt,name=total_identities,json=totalIdentities,proto3" json:"total_identities,omitempty"`
+	// total_resources is the number of resources in the graph.
+	TotalResources uint64 `protobuf:"varint,3,opt,name=total_resources,json=totalResources,proto3" json:"total_resources,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *IdentitySecurityGraphSize) Reset() {
+	*x = IdentitySecurityGraphSize{}
+	mi := &file_prehog_v1_teleport_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdentitySecurityGraphSize) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdentitySecurityGraphSize) ProtoMessage() {}
+
+func (x *IdentitySecurityGraphSize) ProtoReflect() protoreflect.Message {
+	mi := &file_prehog_v1_teleport_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdentitySecurityGraphSize.ProtoReflect.Descriptor instead.
+func (*IdentitySecurityGraphSize) Descriptor() ([]byte, []int) {
+	return file_prehog_v1_teleport_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *IdentitySecurityGraphSize) GetProvider() string {
+	if x != nil {
+		return x.Provider
+	}
+	return ""
+}
+
+func (x *IdentitySecurityGraphSize) GetTotalIdentities() uint64 {
+	if x != nil {
+		return x.TotalIdentities
+	}
+	return 0
+}
+
+func (x *IdentitySecurityGraphSize) GetTotalResources() uint64 {
+	if x != nil {
+		return x.TotalResources
+	}
+	return 0
+}
+
+// IdentitySecurityAuditLogsIngested tracks the count of log entries ingested by
+// identity activity center.
+type IdentitySecurityAuditLogsIngested struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// provider is the system emitting audit logs. It is one of
+	// teleport, cloudtrail, kubernetes, github or okta.
+	Provider string `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
+	// logs_ingested is a count of log entries ingested into Identity Security.
+	LogsIngested  uint64 `protobuf:"varint,2,opt,name=logs_ingested,json=logsIngested,proto3" json:"logs_ingested,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdentitySecurityAuditLogsIngested) Reset() {
+	*x = IdentitySecurityAuditLogsIngested{}
+	mi := &file_prehog_v1_teleport_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdentitySecurityAuditLogsIngested) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdentitySecurityAuditLogsIngested) ProtoMessage() {}
+
+func (x *IdentitySecurityAuditLogsIngested) ProtoReflect() protoreflect.Message {
+	mi := &file_prehog_v1_teleport_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdentitySecurityAuditLogsIngested.ProtoReflect.Descriptor instead.
+func (*IdentitySecurityAuditLogsIngested) Descriptor() ([]byte, []int) {
+	return file_prehog_v1_teleport_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *IdentitySecurityAuditLogsIngested) GetProvider() string {
+	if x != nil {
+		return x.Provider
+	}
+	return ""
+}
+
+func (x *IdentitySecurityAuditLogsIngested) GetLogsIngested() uint64 {
+	if x != nil {
+		return x.LogsIngested
+	}
+	return 0
+}
+
 type SubmitUsageReportsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// at most 10 reports of all kinds in a single RPC, each shouldn't exceed 128KiB or so
@@ -1256,13 +1491,15 @@ type SubmitUsageReportsRequest struct {
 	BotInstanceActivity []*BotInstanceActivityReport `protobuf:"bytes,3,rep,name=bot_instance_activity,json=botInstanceActivity,proto3" json:"bot_instance_activity,omitempty"`
 	// encoded as a separate tp.identity_security.summaries_generated PostHog event
 	IdentitySecuritySummariesReport []*IdentitySecuritySummariesGeneratedReport `protobuf:"bytes,4,rep,name=identity_security_summaries_report,json=identitySecuritySummariesReport,proto3" json:"identity_security_summaries_report,omitempty"`
-	unknownFields                   protoimpl.UnknownFields
-	sizeCache                       protoimpl.SizeCache
+	// encoded as a separate tp.identity_security.usage PostHog event
+	IdentitySecurityReport []*IdentitySecurityReport `protobuf:"bytes,5,rep,name=identity_security_report,json=identitySecurityReport,proto3" json:"identity_security_report,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *SubmitUsageReportsRequest) Reset() {
 	*x = SubmitUsageReportsRequest{}
-	mi := &file_prehog_v1_teleport_proto_msgTypes[10]
+	mi := &file_prehog_v1_teleport_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1274,7 +1511,7 @@ func (x *SubmitUsageReportsRequest) String() string {
 func (*SubmitUsageReportsRequest) ProtoMessage() {}
 
 func (x *SubmitUsageReportsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1_teleport_proto_msgTypes[10]
+	mi := &file_prehog_v1_teleport_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1287,7 +1524,7 @@ func (x *SubmitUsageReportsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitUsageReportsRequest.ProtoReflect.Descriptor instead.
 func (*SubmitUsageReportsRequest) Descriptor() ([]byte, []int) {
-	return file_prehog_v1_teleport_proto_rawDescGZIP(), []int{10}
+	return file_prehog_v1_teleport_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *SubmitUsageReportsRequest) GetUserActivity() []*UserActivityReport {
@@ -1318,6 +1555,13 @@ func (x *SubmitUsageReportsRequest) GetIdentitySecuritySummariesReport() []*Iden
 	return nil
 }
 
+func (x *SubmitUsageReportsRequest) GetIdentitySecurityReport() []*IdentitySecurityReport {
+	if x != nil {
+		return x.IdentitySecurityReport
+	}
+	return nil
+}
+
 type SubmitUsageReportsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// randomly generated UUID for this specific batch, 16 bytes (in string order)
@@ -1330,7 +1574,7 @@ type SubmitUsageReportsResponse struct {
 
 func (x *SubmitUsageReportsResponse) Reset() {
 	*x = SubmitUsageReportsResponse{}
-	mi := &file_prehog_v1_teleport_proto_msgTypes[11]
+	mi := &file_prehog_v1_teleport_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1342,7 +1586,7 @@ func (x *SubmitUsageReportsResponse) String() string {
 func (*SubmitUsageReportsResponse) ProtoMessage() {}
 
 func (x *SubmitUsageReportsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1_teleport_proto_msgTypes[11]
+	mi := &file_prehog_v1_teleport_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1355,7 +1599,7 @@ func (x *SubmitUsageReportsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitUsageReportsResponse.ProtoReflect.Descriptor instead.
 func (*SubmitUsageReportsResponse) Descriptor() ([]byte, []int) {
-	return file_prehog_v1_teleport_proto_rawDescGZIP(), []int{11}
+	return file_prehog_v1_teleport_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SubmitUsageReportsResponse) GetBatchUuid() []byte {
@@ -1377,7 +1621,7 @@ const file_prehog_v1_teleport_proto_rawDesc = "" +
 	"\x0freporter_hostid\x18\x03 \x01(\fR\x0ereporterHostid\x129\n" +
 	"\n" +
 	"start_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x127\n" +
-	"\arecords\x18\x05 \x03(\v2\x1d.prehog.v1.UserActivityRecordR\arecords\"\x99\t\n" +
+	"\arecords\x18\x05 \x03(\v2\x1d.prehog.v1.UserActivityRecordR\arecords\"\xcb\t\n" +
 	"\x12UserActivityRecord\x12\x1b\n" +
 	"\tuser_name\x18\x01 \x01(\fR\buserName\x120\n" +
 	"\tuser_kind\x18\x0e \x01(\x0e2\x13.prehog.v1.UserKindR\buserKind\x12\x16\n" +
@@ -1407,7 +1651,8 @@ const file_prehog_v1_teleport_proto_rawDesc = "" +
 	"\x15access_lists_reviewed\x18\x16 \x01(\x04R\x13accessListsReviewed\x12.\n" +
 	"\x13access_lists_grants\x18\x17 \x01(\x04R\x11accessListsGrants\x12*\n" +
 	"\x11saml_idp_sessions\x18\x18 \x01(\x04R\x0fsamlIdpSessions\x12g\n" +
-	"\x1asession_summaries_accessed\x18\x19 \x03(\v2).prehog.v1.SessionSummariesAccessedRecordR\x18sessionSummariesAccessed\"\x9b\x02\n" +
+	"\x1asession_summaries_accessed\x18\x19 \x03(\v2).prehog.v1.SessionSummariesAccessedRecordR\x18sessionSummariesAccessed\x120\n" +
+	"\x14access_graph_queries\x18\x1a \x01(\x04R\x12accessGraphQueries\"\x9b\x02\n" +
 	"\x16ResourcePresenceReport\x12\x1f\n" +
 	"\vreport_uuid\x18\x01 \x01(\fR\n" +
 	"reportUuid\x12!\n" +
@@ -1453,12 +1698,29 @@ const file_prehog_v1_teleport_proto_rawDesc = "" +
 	"\rresource_name\x18\x02 \x01(\tR\fresourceName\x12,\n" +
 	"\x12total_input_tokens\x18\x04 \x01(\x04R\x10totalInputTokens\x12.\n" +
 	"\x13total_output_tokens\x18\x05 \x01(\x04R\x11totalOutputTokens\x12/\n" +
-	"\x13summaries_generated\x18\x06 \x01(\x04R\x12summariesGenerated\"\x8c\x03\n" +
+	"\x13summaries_generated\x18\x06 \x01(\x04R\x12summariesGenerated\"\xee\x02\n" +
+	"\x16IdentitySecurityReport\x12\x1f\n" +
+	"\vreport_uuid\x18\x01 \x01(\fR\n" +
+	"reportUuid\x12!\n" +
+	"\fcluster_name\x18\x02 \x01(\fR\vclusterName\x12'\n" +
+	"\x0freporter_hostid\x18\x03 \x01(\fR\x0ereporterHostid\x129\n" +
+	"\n" +
+	"start_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12R\n" +
+	"\x12graph_size_records\x18\x05 \x03(\v2$.prehog.v1.IdentitySecurityGraphSizeR\x10graphSizeRecords\x12X\n" +
+	"\x11audit_log_records\x18\x06 \x03(\v2,.prehog.v1.IdentitySecurityAuditLogsIngestedR\x0fauditLogRecords\"\x8b\x01\n" +
+	"\x19IdentitySecurityGraphSize\x12\x1a\n" +
+	"\bprovider\x18\x01 \x01(\tR\bprovider\x12)\n" +
+	"\x10total_identities\x18\x02 \x01(\x04R\x0ftotalIdentities\x12'\n" +
+	"\x0ftotal_resources\x18\x03 \x01(\x04R\x0etotalResources\"d\n" +
+	"!IdentitySecurityAuditLogsIngested\x12\x1a\n" +
+	"\bprovider\x18\x01 \x01(\tR\bprovider\x12#\n" +
+	"\rlogs_ingested\x18\x02 \x01(\x04R\flogsIngested\"\xe9\x03\n" +
 	"\x19SubmitUsageReportsRequest\x12B\n" +
 	"\ruser_activity\x18\x01 \x03(\v2\x1d.prehog.v1.UserActivityReportR\fuserActivity\x12N\n" +
 	"\x11resource_presence\x18\x02 \x03(\v2!.prehog.v1.ResourcePresenceReportR\x10resourcePresence\x12X\n" +
 	"\x15bot_instance_activity\x18\x03 \x03(\v2$.prehog.v1.BotInstanceActivityReportR\x13botInstanceActivity\x12\x80\x01\n" +
-	"\"identity_security_summaries_report\x18\x04 \x03(\v23.prehog.v1.IdentitySecuritySummariesGeneratedReportR\x1fidentitySecuritySummariesReport\";\n" +
+	"\"identity_security_summaries_report\x18\x04 \x03(\v23.prehog.v1.IdentitySecuritySummariesGeneratedReportR\x1fidentitySecuritySummariesReport\x12[\n" +
+	"\x18identity_security_report\x18\x05 \x03(\v2!.prehog.v1.IdentitySecurityReportR\x16identitySecurityReport\";\n" +
 	"\x1aSubmitUsageReportsResponse\x12\x1d\n" +
 	"\n" +
 	"batch_uuid\x18\x01 \x01(\fR\tbatchUuid*c\n" +
@@ -1502,7 +1764,7 @@ func file_prehog_v1_teleport_proto_rawDescGZIP() []byte {
 }
 
 var file_prehog_v1_teleport_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_prehog_v1_teleport_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_prehog_v1_teleport_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_prehog_v1_teleport_proto_goTypes = []any{
 	(UserKind)(0),                                    // 0: prehog.v1.UserKind
 	(UserOrigin)(0),                                  // 1: prehog.v1.UserOrigin
@@ -1517,35 +1779,42 @@ var file_prehog_v1_teleport_proto_goTypes = []any{
 	(*SPIFFEIDRecord)(nil),                           // 10: prehog.v1.SPIFFEIDRecord
 	(*IdentitySecuritySummariesGeneratedReport)(nil), // 11: prehog.v1.IdentitySecuritySummariesGeneratedReport
 	(*SessionSummariesGeneratedRecord)(nil),          // 12: prehog.v1.SessionSummariesGeneratedRecord
-	(*SubmitUsageReportsRequest)(nil),                // 13: prehog.v1.SubmitUsageReportsRequest
-	(*SubmitUsageReportsResponse)(nil),               // 14: prehog.v1.SubmitUsageReportsResponse
-	(*timestamppb.Timestamp)(nil),                    // 15: google.protobuf.Timestamp
+	(*IdentitySecurityReport)(nil),                   // 13: prehog.v1.IdentitySecurityReport
+	(*IdentitySecurityGraphSize)(nil),                // 14: prehog.v1.IdentitySecurityGraphSize
+	(*IdentitySecurityAuditLogsIngested)(nil),        // 15: prehog.v1.IdentitySecurityAuditLogsIngested
+	(*SubmitUsageReportsRequest)(nil),                // 16: prehog.v1.SubmitUsageReportsRequest
+	(*SubmitUsageReportsResponse)(nil),               // 17: prehog.v1.SubmitUsageReportsResponse
+	(*timestamppb.Timestamp)(nil),                    // 18: google.protobuf.Timestamp
 }
 var file_prehog_v1_teleport_proto_depIdxs = []int32{
-	15, // 0: prehog.v1.UserActivityReport.start_time:type_name -> google.protobuf.Timestamp
+	18, // 0: prehog.v1.UserActivityReport.start_time:type_name -> google.protobuf.Timestamp
 	4,  // 1: prehog.v1.UserActivityReport.records:type_name -> prehog.v1.UserActivityRecord
 	0,  // 2: prehog.v1.UserActivityRecord.user_kind:type_name -> prehog.v1.UserKind
 	10, // 3: prehog.v1.UserActivityRecord.spiffe_ids_issued:type_name -> prehog.v1.SPIFFEIDRecord
 	1,  // 4: prehog.v1.UserActivityRecord.user_origin:type_name -> prehog.v1.UserOrigin
 	7,  // 5: prehog.v1.UserActivityRecord.session_summaries_accessed:type_name -> prehog.v1.SessionSummariesAccessedRecord
-	15, // 6: prehog.v1.ResourcePresenceReport.start_time:type_name -> google.protobuf.Timestamp
+	18, // 6: prehog.v1.ResourcePresenceReport.start_time:type_name -> google.protobuf.Timestamp
 	6,  // 7: prehog.v1.ResourcePresenceReport.resource_kind_reports:type_name -> prehog.v1.ResourceKindPresenceReport
 	2,  // 8: prehog.v1.ResourceKindPresenceReport.resource_kind:type_name -> prehog.v1.ResourceKind
-	15, // 9: prehog.v1.BotInstanceActivityReport.start_time:type_name -> google.protobuf.Timestamp
+	18, // 9: prehog.v1.BotInstanceActivityReport.start_time:type_name -> google.protobuf.Timestamp
 	9,  // 10: prehog.v1.BotInstanceActivityReport.records:type_name -> prehog.v1.BotInstanceActivityRecord
-	15, // 11: prehog.v1.IdentitySecuritySummariesGeneratedReport.start_time:type_name -> google.protobuf.Timestamp
+	18, // 11: prehog.v1.IdentitySecuritySummariesGeneratedReport.start_time:type_name -> google.protobuf.Timestamp
 	12, // 12: prehog.v1.IdentitySecuritySummariesGeneratedReport.records:type_name -> prehog.v1.SessionSummariesGeneratedRecord
-	3,  // 13: prehog.v1.SubmitUsageReportsRequest.user_activity:type_name -> prehog.v1.UserActivityReport
-	5,  // 14: prehog.v1.SubmitUsageReportsRequest.resource_presence:type_name -> prehog.v1.ResourcePresenceReport
-	8,  // 15: prehog.v1.SubmitUsageReportsRequest.bot_instance_activity:type_name -> prehog.v1.BotInstanceActivityReport
-	11, // 16: prehog.v1.SubmitUsageReportsRequest.identity_security_summaries_report:type_name -> prehog.v1.IdentitySecuritySummariesGeneratedReport
-	13, // 17: prehog.v1.TeleportReportingService.SubmitUsageReports:input_type -> prehog.v1.SubmitUsageReportsRequest
-	14, // 18: prehog.v1.TeleportReportingService.SubmitUsageReports:output_type -> prehog.v1.SubmitUsageReportsResponse
-	18, // [18:19] is the sub-list for method output_type
-	17, // [17:18] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	18, // 13: prehog.v1.IdentitySecurityReport.start_time:type_name -> google.protobuf.Timestamp
+	14, // 14: prehog.v1.IdentitySecurityReport.graph_size_records:type_name -> prehog.v1.IdentitySecurityGraphSize
+	15, // 15: prehog.v1.IdentitySecurityReport.audit_log_records:type_name -> prehog.v1.IdentitySecurityAuditLogsIngested
+	3,  // 16: prehog.v1.SubmitUsageReportsRequest.user_activity:type_name -> prehog.v1.UserActivityReport
+	5,  // 17: prehog.v1.SubmitUsageReportsRequest.resource_presence:type_name -> prehog.v1.ResourcePresenceReport
+	8,  // 18: prehog.v1.SubmitUsageReportsRequest.bot_instance_activity:type_name -> prehog.v1.BotInstanceActivityReport
+	11, // 19: prehog.v1.SubmitUsageReportsRequest.identity_security_summaries_report:type_name -> prehog.v1.IdentitySecuritySummariesGeneratedReport
+	13, // 20: prehog.v1.SubmitUsageReportsRequest.identity_security_report:type_name -> prehog.v1.IdentitySecurityReport
+	16, // 21: prehog.v1.TeleportReportingService.SubmitUsageReports:input_type -> prehog.v1.SubmitUsageReportsRequest
+	17, // 22: prehog.v1.TeleportReportingService.SubmitUsageReports:output_type -> prehog.v1.SubmitUsageReportsResponse
+	22, // [22:23] is the sub-list for method output_type
+	21, // [21:22] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_prehog_v1_teleport_proto_init() }
@@ -1559,7 +1828,7 @@ func file_prehog_v1_teleport_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_prehog_v1_teleport_proto_rawDesc), len(file_prehog_v1_teleport_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   12,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/ts/prehog/v1/teleport_pb.ts
+++ b/gen/proto/ts/prehog/v1/teleport_pb.ts
@@ -246,6 +246,12 @@ export interface UserActivityRecord {
      * @generated from protobuf field: repeated prehog.v1.SessionSummariesAccessedRecord session_summaries_accessed = 25;
      */
     sessionSummariesAccessed: SessionSummariesAccessedRecord[];
+    /**
+     * counter of access graph queries by this user.
+     *
+     * @generated from protobuf field: uint64 access_graph_queries = 26;
+     */
+    accessGraphQueries: bigint;
 }
 /**
  * @generated from protobuf message prehog.v1.ResourcePresenceReport
@@ -529,6 +535,109 @@ export interface SessionSummariesGeneratedRecord {
     summariesGenerated: bigint;
 }
 /**
+ * IdentitySecurityReport is a report of Identity Security non-user usage. It currently
+ * includes the size of the access graph by provider and count of audit logs ingested
+ * by provider.
+ *
+ * @generated from protobuf message prehog.v1.IdentitySecurityReport
+ */
+export interface IdentitySecurityReport {
+    /**
+     * randomly generated UUID for this specific report, 16 bytes (in string order)
+     *
+     * PostHog property: tp.report_uuid (in 8-4-4-4-12 string form)
+     *
+     * @generated from protobuf field: bytes report_uuid = 1;
+     */
+    reportUuid: Uint8Array;
+    /**
+     * cluster name, anonymized, 32 bytes (HMAC-SHA-256)
+     *
+     * PostHog property: tp.cluster_name (in base64)
+     *
+     * @generated from protobuf field: bytes cluster_name = 2;
+     */
+    clusterName: Uint8Array;
+    /**
+     * hostid of the auth that collected this report, anonymized, 32 bytes (HMAC-SHA-256)
+     *
+     * PostHog property: tp.reporter_hostid (in base64)
+     *
+     * @generated from protobuf field: bytes reporter_hostid = 3;
+     */
+    reporterHostid: Uint8Array;
+    /**
+     * beginning of the time window for this data; ending is not specified but is
+     * intended to be at most 60 minutes
+     *
+     * PostHog timestamp (not a property, the ingest time is tp.report_time instead)
+     *
+     * @generated from protobuf field: google.protobuf.Timestamp start_time = 4;
+     */
+    startTime?: Timestamp;
+    /**
+     * graph_size contains the size of each provider's graph: count of identities and
+     * count of resources.
+     *
+     * @generated from protobuf field: repeated prehog.v1.IdentitySecurityGraphSize graph_size_records = 5;
+     */
+    graphSizeRecords: IdentitySecurityGraphSize[];
+    /**
+     * audit_logs contains the counts of audit logs ingested from each provider.
+     *
+     * @generated from protobuf field: repeated prehog.v1.IdentitySecurityAuditLogsIngested audit_log_records = 6;
+     */
+    auditLogRecords: IdentitySecurityAuditLogsIngested[];
+}
+/**
+ * IdentitySecurityGraphSize is submitted by Access Graph for each provider
+ * for which it has a graph.
+ *
+ * @generated from protobuf message prehog.v1.IdentitySecurityGraphSize
+ */
+export interface IdentitySecurityGraphSize {
+    /**
+     * provider is the system containing the identities and resources being counted.
+     * It is one of teleport, aws, azure, entra, gitlab, github, netiq or okta.
+     *
+     * @generated from protobuf field: string provider = 1;
+     */
+    provider: string;
+    /**
+     * total_identities is the number of identities in the graph.
+     *
+     * @generated from protobuf field: uint64 total_identities = 2;
+     */
+    totalIdentities: bigint;
+    /**
+     * total_resources is the number of resources in the graph.
+     *
+     * @generated from protobuf field: uint64 total_resources = 3;
+     */
+    totalResources: bigint;
+}
+/**
+ * IdentitySecurityAuditLogsIngested tracks the count of log entries ingested by
+ * identity activity center.
+ *
+ * @generated from protobuf message prehog.v1.IdentitySecurityAuditLogsIngested
+ */
+export interface IdentitySecurityAuditLogsIngested {
+    /**
+     * provider is the system emitting audit logs. It is one of
+     * teleport, cloudtrail, kubernetes, github or okta.
+     *
+     * @generated from protobuf field: string provider = 1;
+     */
+    provider: string;
+    /**
+     * logs_ingested is a count of log entries ingested into Identity Security.
+     *
+     * @generated from protobuf field: uint64 logs_ingested = 2;
+     */
+    logsIngested: bigint;
+}
+/**
  * @generated from protobuf message prehog.v1.SubmitUsageReportsRequest
  */
 export interface SubmitUsageReportsRequest {
@@ -558,6 +667,12 @@ export interface SubmitUsageReportsRequest {
      * @generated from protobuf field: repeated prehog.v1.IdentitySecuritySummariesGeneratedReport identity_security_summaries_report = 4;
      */
     identitySecuritySummariesReport: IdentitySecuritySummariesGeneratedReport[];
+    /**
+     * encoded as a separate tp.identity_security.usage PostHog event
+     *
+     * @generated from protobuf field: repeated prehog.v1.IdentitySecurityReport identity_security_report = 5;
+     */
+    identitySecurityReport: IdentitySecurityReport[];
 }
 /**
  * @generated from protobuf message prehog.v1.SubmitUsageReportsResponse
@@ -829,7 +944,8 @@ class UserActivityRecord$Type extends MessageType<UserActivityRecord> {
             { no: 22, name: "access_lists_reviewed", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 23, name: "access_lists_grants", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 24, name: "saml_idp_sessions", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
-            { no: 25, name: "session_summaries_accessed", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => SessionSummariesAccessedRecord }
+            { no: 25, name: "session_summaries_accessed", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => SessionSummariesAccessedRecord },
+            { no: 26, name: "access_graph_queries", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<UserActivityRecord>): UserActivityRecord {
@@ -859,6 +975,7 @@ class UserActivityRecord$Type extends MessageType<UserActivityRecord> {
         message.accessListsGrants = 0n;
         message.samlIdpSessions = 0n;
         message.sessionSummariesAccessed = [];
+        message.accessGraphQueries = 0n;
         if (value !== undefined)
             reflectionMergePartial<UserActivityRecord>(this, message, value);
         return message;
@@ -942,6 +1059,9 @@ class UserActivityRecord$Type extends MessageType<UserActivityRecord> {
                     break;
                 case /* repeated prehog.v1.SessionSummariesAccessedRecord session_summaries_accessed */ 25:
                     message.sessionSummariesAccessed.push(SessionSummariesAccessedRecord.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* uint64 access_graph_queries */ 26:
+                    message.accessGraphQueries = reader.uint64().toBigInt();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1030,6 +1150,9 @@ class UserActivityRecord$Type extends MessageType<UserActivityRecord> {
         /* repeated prehog.v1.SessionSummariesAccessedRecord session_summaries_accessed = 25; */
         for (let i = 0; i < message.sessionSummariesAccessed.length; i++)
             SessionSummariesAccessedRecord.internalBinaryWrite(message.sessionSummariesAccessed[i], writer.tag(25, WireType.LengthDelimited).fork(), options).join();
+        /* uint64 access_graph_queries = 26; */
+        if (message.accessGraphQueries !== 0n)
+            writer.tag(26, WireType.Varint).uint64(message.accessGraphQueries);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1614,13 +1737,218 @@ class SessionSummariesGeneratedRecord$Type extends MessageType<SessionSummariesG
  */
 export const SessionSummariesGeneratedRecord = new SessionSummariesGeneratedRecord$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class IdentitySecurityReport$Type extends MessageType<IdentitySecurityReport> {
+    constructor() {
+        super("prehog.v1.IdentitySecurityReport", [
+            { no: 1, name: "report_uuid", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "cluster_name", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "reporter_hostid", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "start_time", kind: "message", T: () => Timestamp },
+            { no: 5, name: "graph_size_records", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => IdentitySecurityGraphSize },
+            { no: 6, name: "audit_log_records", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => IdentitySecurityAuditLogsIngested }
+        ]);
+    }
+    create(value?: PartialMessage<IdentitySecurityReport>): IdentitySecurityReport {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.reportUuid = new Uint8Array(0);
+        message.clusterName = new Uint8Array(0);
+        message.reporterHostid = new Uint8Array(0);
+        message.graphSizeRecords = [];
+        message.auditLogRecords = [];
+        if (value !== undefined)
+            reflectionMergePartial<IdentitySecurityReport>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: IdentitySecurityReport): IdentitySecurityReport {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* bytes report_uuid */ 1:
+                    message.reportUuid = reader.bytes();
+                    break;
+                case /* bytes cluster_name */ 2:
+                    message.clusterName = reader.bytes();
+                    break;
+                case /* bytes reporter_hostid */ 3:
+                    message.reporterHostid = reader.bytes();
+                    break;
+                case /* google.protobuf.Timestamp start_time */ 4:
+                    message.startTime = Timestamp.internalBinaryRead(reader, reader.uint32(), options, message.startTime);
+                    break;
+                case /* repeated prehog.v1.IdentitySecurityGraphSize graph_size_records */ 5:
+                    message.graphSizeRecords.push(IdentitySecurityGraphSize.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* repeated prehog.v1.IdentitySecurityAuditLogsIngested audit_log_records */ 6:
+                    message.auditLogRecords.push(IdentitySecurityAuditLogsIngested.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: IdentitySecurityReport, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* bytes report_uuid = 1; */
+        if (message.reportUuid.length)
+            writer.tag(1, WireType.LengthDelimited).bytes(message.reportUuid);
+        /* bytes cluster_name = 2; */
+        if (message.clusterName.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.clusterName);
+        /* bytes reporter_hostid = 3; */
+        if (message.reporterHostid.length)
+            writer.tag(3, WireType.LengthDelimited).bytes(message.reporterHostid);
+        /* google.protobuf.Timestamp start_time = 4; */
+        if (message.startTime)
+            Timestamp.internalBinaryWrite(message.startTime, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
+        /* repeated prehog.v1.IdentitySecurityGraphSize graph_size_records = 5; */
+        for (let i = 0; i < message.graphSizeRecords.length; i++)
+            IdentitySecurityGraphSize.internalBinaryWrite(message.graphSizeRecords[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
+        /* repeated prehog.v1.IdentitySecurityAuditLogsIngested audit_log_records = 6; */
+        for (let i = 0; i < message.auditLogRecords.length; i++)
+            IdentitySecurityAuditLogsIngested.internalBinaryWrite(message.auditLogRecords[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message prehog.v1.IdentitySecurityReport
+ */
+export const IdentitySecurityReport = new IdentitySecurityReport$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class IdentitySecurityGraphSize$Type extends MessageType<IdentitySecurityGraphSize> {
+    constructor() {
+        super("prehog.v1.IdentitySecurityGraphSize", [
+            { no: 1, name: "provider", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "total_identities", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 3, name: "total_resources", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
+        ]);
+    }
+    create(value?: PartialMessage<IdentitySecurityGraphSize>): IdentitySecurityGraphSize {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.provider = "";
+        message.totalIdentities = 0n;
+        message.totalResources = 0n;
+        if (value !== undefined)
+            reflectionMergePartial<IdentitySecurityGraphSize>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: IdentitySecurityGraphSize): IdentitySecurityGraphSize {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string provider */ 1:
+                    message.provider = reader.string();
+                    break;
+                case /* uint64 total_identities */ 2:
+                    message.totalIdentities = reader.uint64().toBigInt();
+                    break;
+                case /* uint64 total_resources */ 3:
+                    message.totalResources = reader.uint64().toBigInt();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: IdentitySecurityGraphSize, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string provider = 1; */
+        if (message.provider !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.provider);
+        /* uint64 total_identities = 2; */
+        if (message.totalIdentities !== 0n)
+            writer.tag(2, WireType.Varint).uint64(message.totalIdentities);
+        /* uint64 total_resources = 3; */
+        if (message.totalResources !== 0n)
+            writer.tag(3, WireType.Varint).uint64(message.totalResources);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message prehog.v1.IdentitySecurityGraphSize
+ */
+export const IdentitySecurityGraphSize = new IdentitySecurityGraphSize$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class IdentitySecurityAuditLogsIngested$Type extends MessageType<IdentitySecurityAuditLogsIngested> {
+    constructor() {
+        super("prehog.v1.IdentitySecurityAuditLogsIngested", [
+            { no: 1, name: "provider", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "logs_ingested", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
+        ]);
+    }
+    create(value?: PartialMessage<IdentitySecurityAuditLogsIngested>): IdentitySecurityAuditLogsIngested {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.provider = "";
+        message.logsIngested = 0n;
+        if (value !== undefined)
+            reflectionMergePartial<IdentitySecurityAuditLogsIngested>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: IdentitySecurityAuditLogsIngested): IdentitySecurityAuditLogsIngested {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string provider */ 1:
+                    message.provider = reader.string();
+                    break;
+                case /* uint64 logs_ingested */ 2:
+                    message.logsIngested = reader.uint64().toBigInt();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: IdentitySecurityAuditLogsIngested, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string provider = 1; */
+        if (message.provider !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.provider);
+        /* uint64 logs_ingested = 2; */
+        if (message.logsIngested !== 0n)
+            writer.tag(2, WireType.Varint).uint64(message.logsIngested);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message prehog.v1.IdentitySecurityAuditLogsIngested
+ */
+export const IdentitySecurityAuditLogsIngested = new IdentitySecurityAuditLogsIngested$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class SubmitUsageReportsRequest$Type extends MessageType<SubmitUsageReportsRequest> {
     constructor() {
         super("prehog.v1.SubmitUsageReportsRequest", [
             { no: 1, name: "user_activity", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => UserActivityReport },
             { no: 2, name: "resource_presence", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => ResourcePresenceReport },
             { no: 3, name: "bot_instance_activity", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => BotInstanceActivityReport },
-            { no: 4, name: "identity_security_summaries_report", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => IdentitySecuritySummariesGeneratedReport }
+            { no: 4, name: "identity_security_summaries_report", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => IdentitySecuritySummariesGeneratedReport },
+            { no: 5, name: "identity_security_report", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => IdentitySecurityReport }
         ]);
     }
     create(value?: PartialMessage<SubmitUsageReportsRequest>): SubmitUsageReportsRequest {
@@ -1629,6 +1957,7 @@ class SubmitUsageReportsRequest$Type extends MessageType<SubmitUsageReportsReque
         message.resourcePresence = [];
         message.botInstanceActivity = [];
         message.identitySecuritySummariesReport = [];
+        message.identitySecurityReport = [];
         if (value !== undefined)
             reflectionMergePartial<SubmitUsageReportsRequest>(this, message, value);
         return message;
@@ -1649,6 +1978,9 @@ class SubmitUsageReportsRequest$Type extends MessageType<SubmitUsageReportsReque
                     break;
                 case /* repeated prehog.v1.IdentitySecuritySummariesGeneratedReport identity_security_summaries_report */ 4:
                     message.identitySecuritySummariesReport.push(IdentitySecuritySummariesGeneratedReport.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* repeated prehog.v1.IdentitySecurityReport identity_security_report */ 5:
+                    message.identitySecurityReport.push(IdentitySecurityReport.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1674,6 +2006,9 @@ class SubmitUsageReportsRequest$Type extends MessageType<SubmitUsageReportsReque
         /* repeated prehog.v1.IdentitySecuritySummariesGeneratedReport identity_security_summaries_report = 4; */
         for (let i = 0; i < message.identitySecuritySummariesReport.length; i++)
             IdentitySecuritySummariesGeneratedReport.internalBinaryWrite(message.identitySecuritySummariesReport[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
+        /* repeated prehog.v1.IdentitySecurityReport identity_security_report = 5; */
+        for (let i = 0; i < message.identitySecurityReport.length; i++)
+            IdentitySecurityReport.internalBinaryWrite(message.identitySecurityReport[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/usagereporter/teleport/aggregating/reporter.go
+++ b/lib/usagereporter/teleport/aggregating/reporter.go
@@ -198,6 +198,7 @@ func (r *Reporter) AnonymizeAndSubmit(events ...usagereporter.Anonymizable) {
 			*usagereporter.AccessRequestReviewEvent,
 			*usagereporter.AccessListReviewCreateEvent,
 			*usagereporter.AccessListGrantsToUserEvent,
+			*usagereporter.TagExecuteQueryEvent,
 			*usagereporter.SessionSummaryCreateEvent,
 			*usagereporter.SessionSummaryAccessEvent:
 			filtered = append(filtered, event)
@@ -542,6 +543,8 @@ Ingest:
 			if te.Success {
 				incrementSessionSummariesGenerated(te.SessionType, te.ResourceName, te.TotalInputTokens, te.TotalOutputTokens)
 			}
+		case *usagereporter.TagExecuteQueryEvent:
+			userRecord(te.UserName, prehogv1alpha.UserKind_USER_KIND_HUMAN).AccessGraphQueries++
 		}
 
 		if ae != nil && r.ingested != nil {

--- a/lib/usagereporter/teleport/aggregating/reporter.go
+++ b/lib/usagereporter/teleport/aggregating/reporter.go
@@ -42,7 +42,7 @@ const (
 	userActivityReportGranularity        = 15 * time.Minute
 	resourceReportGranularity            = time.Hour
 	botInstanceActivityReportGranularity = 15 * time.Minute
-	identitySecurityReportGranularity    = 15 * time.Minute
+	sessionSummaryReportGranularity      = 15 * time.Minute
 	rollbackGrace                        = time.Minute
 	reportTTL                            = 60 * 24 * time.Hour
 
@@ -125,8 +125,8 @@ func NewReporter(ctx context.Context, cfg ReporterConfig) (*Reporter, error) {
 	return r, nil
 }
 
-// identitySecuritySummariesGeneratedKey uniquely identifies a session summary by session type and resource name
-type identitySecuritySummariesGeneratedKey struct {
+// sessionSummariesGeneratedKey uniquely identifies a session summary by session type and resource name
+type sessionSummariesGeneratedKey struct {
 	sessionType  string
 	resourceName string
 }
@@ -325,13 +325,13 @@ func (r *Reporter) run(ctx context.Context) {
 
 	// sessionSummariesGenerated tracks AI-generated session summaries with token usage
 	// map[key]*SessionSummariesGeneratedRecord
-	sessionSummariesGenerated := make(map[identitySecuritySummariesGeneratedKey]*prehogv1.SessionSummariesGeneratedRecord)
-	identitySecurityStartTime := r.clock.Now().UTC().Truncate(userActivityReportGranularity)
-	identitySecurityWindowStart := identitySecurityStartTime.Add(-rollbackGrace)
-	identitySecurityWindowEnd := identitySecurityStartTime.Add(userActivityReportGranularity)
+	sessionSummariesGenerated := make(map[sessionSummariesGeneratedKey]*prehogv1.SessionSummariesGeneratedRecord)
+	sessionSummariesStartTime := r.clock.Now().UTC().Truncate(userActivityReportGranularity)
+	sessionSummariesWindowStart := sessionSummariesStartTime.Add(-rollbackGrace)
+	sessionSummariesWindowEnd := sessionSummariesStartTime.Add(userActivityReportGranularity)
 
 	incrementSessionSummariesGenerated := func(sessionType string, resourceName string, inputTokens uint64, outputTokens uint64) {
-		key := identitySecuritySummariesGeneratedKey{
+		key := sessionSummariesGeneratedKey{
 			sessionType:  sessionType,
 			resourceName: resourceName,
 		}
@@ -450,23 +450,23 @@ Ingest:
 			resourcePresences = make(map[prehogv1.ResourceKind]map[string]struct{}, len(resourcePresences))
 		}
 
-		if now := r.clock.Now().UTC(); now.Before(identitySecurityWindowStart) || !now.Before(identitySecurityWindowEnd) {
+		if now := r.clock.Now().UTC(); now.Before(sessionSummariesWindowStart) || !now.Before(sessionSummariesWindowEnd) {
 			if len(sessionSummariesGenerated) > 0 {
 				wg.Add(1)
 				go func(
 					ctx context.Context,
 					startTime time.Time,
-					summaries map[identitySecuritySummariesGeneratedKey]*prehogv1.SessionSummariesGeneratedRecord,
+					summaries map[sessionSummariesGeneratedKey]*prehogv1.SessionSummariesGeneratedRecord,
 				) {
 					defer wg.Done()
 					r.persistIdentitySecuritySummariesGenerated(ctx, startTime, summaries)
-				}(ctx, identitySecurityStartTime, sessionSummariesGenerated)
+				}(ctx, sessionSummariesStartTime, sessionSummariesGenerated)
 			}
 
-			identitySecurityStartTime = now.Truncate(identitySecurityReportGranularity)
-			identitySecurityWindowStart = identitySecurityStartTime.Add(-rollbackGrace)
-			identitySecurityWindowEnd = identitySecurityStartTime.Add(identitySecurityReportGranularity)
-			sessionSummariesGenerated = make(map[identitySecuritySummariesGeneratedKey]*prehogv1.SessionSummariesGeneratedRecord, len(sessionSummariesGenerated))
+			sessionSummariesStartTime = now.Truncate(sessionSummaryReportGranularity)
+			sessionSummariesWindowStart = sessionSummariesStartTime.Add(-rollbackGrace)
+			sessionSummariesWindowEnd = sessionSummariesStartTime.Add(sessionSummaryReportGranularity)
+			sessionSummariesGenerated = make(map[sessionSummariesGeneratedKey]*prehogv1.SessionSummariesGeneratedRecord, len(sessionSummariesGenerated))
 		}
 
 		switch te := ae.(type) {
@@ -565,7 +565,7 @@ Ingest:
 	}
 
 	if len(sessionSummariesGenerated) > 0 {
-		r.persistIdentitySecuritySummariesGenerated(ctx, identitySecurityStartTime, sessionSummariesGenerated)
+		r.persistIdentitySecuritySummariesGenerated(ctx, sessionSummariesStartTime, sessionSummariesGenerated)
 	}
 
 	wg.Wait()
@@ -719,7 +719,7 @@ func (r *Reporter) persistResourcePresence(ctx context.Context, startTime time.T
 func (r *Reporter) persistIdentitySecuritySummariesGenerated(
 	ctx context.Context,
 	startTime time.Time,
-	sessionSummariesGenerated map[identitySecuritySummariesGeneratedKey]*prehogv1.SessionSummariesGeneratedRecord,
+	sessionSummariesGenerated map[sessionSummariesGeneratedKey]*prehogv1.SessionSummariesGeneratedRecord,
 ) {
 	records := make([]*prehogv1.SessionSummariesGeneratedRecord, 0, len(sessionSummariesGenerated))
 	for _, record := range sessionSummariesGenerated {

--- a/lib/usagereporter/teleport/aggregating/reporter.go
+++ b/lib/usagereporter/teleport/aggregating/reporter.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"encoding/binary"
 	"log/slog"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -43,6 +45,7 @@ const (
 	resourceReportGranularity            = time.Hour
 	botInstanceActivityReportGranularity = 15 * time.Minute
 	sessionSummaryReportGranularity      = 15 * time.Minute
+	identitySecurityReportGranularity    = 24 * time.Hour
 	rollbackGrace                        = time.Minute
 	reportTTL                            = 60 * 24 * time.Hour
 
@@ -200,7 +203,9 @@ func (r *Reporter) AnonymizeAndSubmit(events ...usagereporter.Anonymizable) {
 			*usagereporter.AccessListGrantsToUserEvent,
 			*usagereporter.TagExecuteQueryEvent,
 			*usagereporter.SessionSummaryCreateEvent,
-			*usagereporter.SessionSummaryAccessEvent:
+			*usagereporter.SessionSummaryAccessEvent,
+			*usagereporter.IdentitySecurityGraphSizeEvent,
+			*usagereporter.IdentitySecurityAuditLogsIngestedEvent:
 			filtered = append(filtered, event)
 		}
 	}
@@ -348,6 +353,31 @@ func (r *Reporter) run(ctx context.Context) {
 		record.SummariesGenerated++
 	}
 
+	// identitySecurityGraphSize tracks the size of access graphs by provider.
+	identitySecurityGraphSize := make(map[string]*prehogv1.IdentitySecurityGraphSize)
+	// identitySecurityAuditLogsIngested tracks the count of audit logs ingested by provider.
+	identitySecurityAuditLogsIngested := make(map[string]*prehogv1.IdentitySecurityAuditLogsIngested)
+	identitySecurityStartTime := r.clock.Now().UTC().Truncate(identitySecurityReportGranularity)
+	identitySecurityWindowStart := identitySecurityStartTime.Add(-rollbackGrace)
+	identitySecurityWindowEnd := identitySecurityStartTime.Add(identitySecurityReportGranularity)
+
+	recordIdentitySecurityGraphSize := func(provider string, identities, resources uint64) {
+		// Store the latest received graph size for the provider, overwriting any previous ones.
+		identitySecurityGraphSize[provider] = &prehogv1.IdentitySecurityGraphSize{
+			Provider:        provider,
+			TotalIdentities: identities,
+			TotalResources:  resources,
+		}
+	}
+	incrementIdentitySecurityAuditLogsIngested := func(provider string, count uint64) {
+		record := identitySecurityAuditLogsIngested[provider]
+		if record == nil {
+			record = &prehogv1.IdentitySecurityAuditLogsIngested{Provider: provider}
+			identitySecurityAuditLogsIngested[provider] = record
+		}
+		record.LogsIngested += count
+	}
+
 	botInstanceActivityStartTime := r.clock.Now().UTC().Truncate(botInstanceActivityReportGranularity)
 	botInstanceActivityWindowStart := botInstanceActivityStartTime.Add(-rollbackGrace)
 	botInstanceActivityWindowEnd := botInstanceActivityStartTime.Add(botInstanceActivityReportGranularity)
@@ -469,6 +499,27 @@ Ingest:
 			sessionSummariesGenerated = make(map[sessionSummariesGeneratedKey]*prehogv1.SessionSummariesGeneratedRecord, len(sessionSummariesGenerated))
 		}
 
+		if now := r.clock.Now().UTC(); now.Before(identitySecurityWindowStart) || !now.Before(identitySecurityWindowEnd) {
+			if len(identitySecurityGraphSize) > 0 || len(identitySecurityAuditLogsIngested) > 0 {
+				wg.Add(1)
+				go func(
+					ctx context.Context,
+					startTime time.Time,
+					graphSizes map[string]*prehogv1.IdentitySecurityGraphSize,
+					logsIngested map[string]*prehogv1.IdentitySecurityAuditLogsIngested,
+				) {
+					defer wg.Done()
+					r.persistIdentitySecurity(ctx, startTime, graphSizes, logsIngested)
+				}(ctx, identitySecurityStartTime, identitySecurityGraphSize, identitySecurityAuditLogsIngested)
+			}
+
+			identitySecurityStartTime = now.Truncate(identitySecurityReportGranularity)
+			identitySecurityWindowStart = identitySecurityStartTime.Add(-rollbackGrace)
+			identitySecurityWindowEnd = identitySecurityStartTime.Add(identitySecurityReportGranularity)
+			identitySecurityGraphSize = make(map[string]*prehogv1.IdentitySecurityGraphSize, len(identitySecurityGraphSize))
+			identitySecurityAuditLogsIngested = make(map[string]*prehogv1.IdentitySecurityAuditLogsIngested, len(identitySecurityAuditLogsIngested))
+		}
+
 		switch te := ae.(type) {
 		case *usagereporter.UserLoginEvent:
 			// Bots never generate tp.user.login events.
@@ -545,6 +596,10 @@ Ingest:
 			}
 		case *usagereporter.TagExecuteQueryEvent:
 			userRecord(te.UserName, prehogv1alpha.UserKind_USER_KIND_HUMAN).AccessGraphQueries++
+		case *usagereporter.IdentitySecurityGraphSizeEvent:
+			recordIdentitySecurityGraphSize(te.Provider, te.TotalIdentities, te.TotalResources)
+		case *usagereporter.IdentitySecurityAuditLogsIngestedEvent:
+			incrementIdentitySecurityAuditLogsIngested(te.Provider, te.LogsIngested)
 		}
 
 		if ae != nil && r.ingested != nil {
@@ -566,6 +621,10 @@ Ingest:
 
 	if len(sessionSummariesGenerated) > 0 {
 		r.persistIdentitySecuritySummariesGenerated(ctx, sessionSummariesStartTime, sessionSummariesGenerated)
+	}
+
+	if len(identitySecurityGraphSize) > 0 || len(identitySecurityAuditLogsIngested) > 0 {
+		r.persistIdentitySecurity(ctx, identitySecurityStartTime, identitySecurityGraphSize, identitySecurityAuditLogsIngested)
 	}
 
 	wg.Wait()
@@ -756,6 +815,46 @@ func (r *Reporter) persistIdentitySecuritySummariesGenerated(
 			"report_uuid", reportUUID,
 			"start_time", startTime,
 			"records", len(report.Records),
+		)
+	}
+}
+
+func (r *Reporter) persistIdentitySecurity(
+	ctx context.Context,
+	startTime time.Time,
+	graphSizes map[string]*prehogv1.IdentitySecurityGraphSize,
+	logsIngested map[string]*prehogv1.IdentitySecurityAuditLogsIngested,
+) {
+	graphSizeRecords := slices.Collect(maps.Values(graphSizes))
+	logsIngestedRecords := slices.Collect(maps.Values(logsIngested))
+	anonymizedClusterName := r.anonymizer.AnonymizeNonEmpty(r.clusterName)
+	anonymizedHostID := r.anonymizer.AnonymizeNonEmpty(r.hostID)
+
+	reports, err := prepareIdentitySecurityReports(anonymizedClusterName, anonymizedHostID, startTime, graphSizeRecords, logsIngestedRecords)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "Failed to prepare identity security report, dropping data.",
+			"start_time", startTime,
+			"lost_records", len(graphSizeRecords)+len(logsIngestedRecords),
+			"error", err,
+		)
+		return
+	}
+
+	for _, report := range reports {
+		if err := r.svc.upsertIdentitySecurityReport(ctx, report, reportTTL); err != nil {
+			r.logger.ErrorContext(ctx, "Failed to persist identity security report, dropping data.",
+				"start_time", startTime,
+				"lost_records", len(report.GraphSizeRecords)+len(report.AuditLogRecords),
+				"error", err,
+			)
+			continue
+		}
+
+		reportUUID, _ := uuid.FromBytes(report.ReportUuid)
+		r.logger.DebugContext(ctx, "Persisted identity security report.",
+			"report_uuid", reportUUID,
+			"start_time", startTime,
+			"records", len(report.GraphSizeRecords)+len(report.AuditLogRecords),
 		)
 	}
 }

--- a/lib/usagereporter/teleport/aggregating/reporter_test.go
+++ b/lib/usagereporter/teleport/aggregating/reporter_test.go
@@ -471,7 +471,7 @@ func TestReporterSessionSummariesAccessed(t *testing.T) {
 			recvIngested()
 
 			// Wait for the aggregation window to complete
-			time.Sleep(identitySecurityReportGranularity)
+			time.Sleep(sessionSummaryReportGranularity)
 			synctest.Wait()
 
 			require.Equal(t, types.OpPut, recvBackendEvent().Type)

--- a/lib/usagereporter/teleport/aggregating/reporter_test.go
+++ b/lib/usagereporter/teleport/aggregating/reporter_test.go
@@ -629,3 +629,115 @@ func TestReporterIdentitySecuritySummariesGenerated(t *testing.T) {
 		}
 	})
 }
+
+func TestReporterIdentitySecurity(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		clk := clockwork.NewRealClock()
+		bk, err := memory.New(memory.Config{
+			Clock: clk,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, bk.Close()) })
+
+		// Set up a watcher to not have to poll the backend for newly added items
+		w, err := bk.NewWatcher(ctx, backend.Watch{})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, w.Close()) })
+		recvBackendEvent := func() backend.Event {
+			return <-w.Events()
+		}
+		require.Equal(t, types.OpInit, recvBackendEvent().Type)
+
+		clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
+			ClusterName: "clustername",
+		})
+		require.NoError(t, err)
+
+		anonymizer, err := utils.NewHMACAnonymizer(utils.AnonymizationKeyString("0123456789abcdef"))
+		require.NoError(t, err)
+
+		r, err := NewReporter(ctx, ReporterConfig{
+			Backend:     bk,
+			Clock:       clk,
+			ClusterName: clusterName,
+			HostID:      "host-id",
+			Anonymizer:  anonymizer,
+		})
+		require.NoError(t, err)
+
+		svc := reportService{bk}
+
+		r.ingested = make(chan usagereporter.Anonymizable, 10)
+		recvIngested := func() {
+			<-r.ingested
+		}
+
+		r.AnonymizeAndSubmit(&usagereporter.IdentitySecurityGraphSizeEvent{
+			Provider:        "teleport",
+			TotalIdentities: 1,
+			TotalResources:  2,
+		})
+		recvIngested()
+
+		// Later size should overwrite earlier size for the same provider.
+		r.AnonymizeAndSubmit(&usagereporter.IdentitySecurityGraphSizeEvent{
+			Provider:        "teleport",
+			TotalIdentities: 3,
+			TotalResources:  4,
+		})
+		recvIngested()
+
+		r.AnonymizeAndSubmit(&usagereporter.IdentitySecurityAuditLogsIngestedEvent{
+			Provider:     "teleport",
+			LogsIngested: 5,
+		})
+		recvIngested()
+
+		// Audit log counts are accumulated.
+		r.AnonymizeAndSubmit(&usagereporter.IdentitySecurityAuditLogsIngestedEvent{
+			Provider:     "teleport",
+			LogsIngested: 7,
+		})
+		recvIngested()
+
+		time.Sleep(identitySecurityReportGranularity)
+
+		for putCount := 0; putCount < 2; {
+			if recvBackendEvent().Type == types.OpPut {
+				putCount++
+			}
+		}
+
+		reports, err := svc.listIdentitySecurityReports(ctx, 10)
+		require.NoError(t, err)
+		require.Len(t, reports, 2)
+
+		expectedCluster := anonymizer.AnonymizeNonEmpty(clusterName.GetClusterName())
+		expectedHostID := anonymizer.AnonymizeNonEmpty("host-id")
+
+		var graphReport *prehogv1.IdentitySecurityReport
+		var auditReport *prehogv1.IdentitySecurityReport
+		for _, report := range reports {
+			require.Equal(t, expectedCluster, report.ClusterName)
+			require.Equal(t, expectedHostID, report.ReporterHostid)
+			if len(report.GraphSizeRecords) > 0 {
+				graphReport = report
+			}
+			if len(report.AuditLogRecords) > 0 {
+				auditReport = report
+			}
+		}
+
+		require.NotNil(t, graphReport)
+		require.Len(t, graphReport.GraphSizeRecords, 1)
+		require.Equal(t, "teleport", graphReport.GraphSizeRecords[0].Provider)
+		require.Equal(t, uint64(3), graphReport.GraphSizeRecords[0].TotalIdentities)
+		require.Equal(t, uint64(4), graphReport.GraphSizeRecords[0].TotalResources)
+
+		require.NotNil(t, auditReport)
+		require.Len(t, auditReport.AuditLogRecords, 1)
+		require.Equal(t, "teleport", auditReport.AuditLogRecords[0].Provider)
+		require.Equal(t, uint64(12), auditReport.AuditLogRecords[0].LogsIngested)
+	})
+}

--- a/lib/usagereporter/teleport/aggregating/service_test.go
+++ b/lib/usagereporter/teleport/aggregating/service_test.go
@@ -150,6 +150,14 @@ func newIdentitySecuritySummariesGeneratedReport(startTime time.Time) *prehogv1.
 	}
 }
 
+func newIdentitySecurityReport(startTime time.Time) *prehogv1.IdentitySecurityReport {
+	u := uuid.New()
+	return &prehogv1.IdentitySecurityReport{
+		ReportUuid: u[:],
+		StartTime:  timestamppb.New(startTime),
+	}
+}
+
 func TestResourcePresenceReporting(t *testing.T) {
 	ctx := context.Background()
 	clk := clockwork.NewFakeClock()

--- a/lib/usagereporter/teleport/aggregating/submitter_test.go
+++ b/lib/usagereporter/teleport/aggregating/submitter_test.go
@@ -56,14 +56,16 @@ func TestSubmitOnce(t *testing.T) {
 	var submittedPresence []*prehogv1.ResourcePresenceReport
 	var submittedBotInstanceActivity []*prehogv1.BotInstanceActivityReport
 	var submittedIdentitySecuritySummaries []*prehogv1.IdentitySecuritySummariesGeneratedReport
+	var submittedIdentitySecurityReports []*prehogv1.IdentitySecurityReport
 	submitOk := func(ctx context.Context, req *prehogv1.SubmitUsageReportsRequest) (uuid.UUID, error) {
-		if l := len(req.UserActivity) + len(req.ResourcePresence) + len(req.BotInstanceActivity) + len(req.IdentitySecuritySummariesReport); l > submitBatchSize {
+		if l := len(req.UserActivity) + len(req.ResourcePresence) + len(req.BotInstanceActivity) + len(req.IdentitySecuritySummariesReport) + len(req.IdentitySecurityReport); l > submitBatchSize {
 			return uuid.Nil, trace.LimitExceeded("got %v reports, expected at most %v", l, submitBatchSize)
 		}
 		submitted = append(submitted, req.UserActivity...)
 		submittedPresence = append(submittedPresence, req.ResourcePresence...)
 		submittedBotInstanceActivity = append(submittedBotInstanceActivity, req.BotInstanceActivity...)
 		submittedIdentitySecuritySummaries = append(submittedIdentitySecuritySummaries, req.IdentitySecuritySummariesReport...)
+		submittedIdentitySecurityReports = append(submittedIdentitySecurityReports, req.IdentitySecurityReport...)
 		return uuid.New(), nil
 	}
 	submitErr := func(ctx context.Context, req *prehogv1.SubmitUsageReportsRequest) (uuid.UUID, error) {
@@ -84,16 +86,24 @@ func TestSubmitOnce(t *testing.T) {
 	resCountReport := newResourcePresenceReport(time.Now().UTC())
 	require.NoError(t, svc.upsertResourcePresenceReport(ctx, resCountReport, reportTTL))
 
+	identityReport := newIdentitySecurityReport(time.Now().UTC())
+	require.NoError(t, svc.upsertIdentitySecurityReport(ctx, identityReport, reportTTL))
+
 	// successful submit, no alerts, no leftover reports
 	submitOnce(ctx, scfg)
 	require.Len(t, submitted, 1)
 	require.True(t, proto.Equal(reportFresh, submitted[0]))
+	require.Len(t, submittedIdentitySecurityReports, 1)
+	require.True(t, proto.Equal(identityReport, submittedIdentitySecurityReports[0]))
 	reports, err := svc.listUserActivityReports(ctx, 10)
 	require.NoError(t, err)
 	require.Empty(t, reports)
 	rReports, err := svc.listResourcePresenceReports(ctx, 10)
 	require.NoError(t, err)
 	require.Empty(t, rReports)
+	identityReports, err := svc.listIdentitySecurityReports(ctx, 10)
+	require.NoError(t, err)
+	require.Empty(t, identityReports)
 
 	submitted = nil
 
@@ -215,9 +225,10 @@ func testSubmitOnceIdentitySecuritySummaries(t *testing.T) {
 	var submittedResourcePresence []*prehogv1.ResourcePresenceReport
 	var submittedBotInstanceActivity []*prehogv1.BotInstanceActivityReport
 	var submittedIdentitySecuritySummaries []*prehogv1.IdentitySecuritySummariesGeneratedReport
+	var submittedIdentitySecurityReports []*prehogv1.IdentitySecurityReport
 
 	submitOk := func(ctx context.Context, req *prehogv1.SubmitUsageReportsRequest) (uuid.UUID, error) {
-		totalReports := len(req.UserActivity) + len(req.ResourcePresence) + len(req.BotInstanceActivity) + len(req.IdentitySecuritySummariesReport)
+		totalReports := len(req.UserActivity) + len(req.ResourcePresence) + len(req.BotInstanceActivity) + len(req.IdentitySecuritySummariesReport) + len(req.IdentitySecurityReport)
 		if totalReports > submitBatchSize {
 			return uuid.Nil, trace.LimitExceeded("got %v reports, expected at most %v", totalReports, submitBatchSize)
 		}
@@ -225,6 +236,7 @@ func testSubmitOnceIdentitySecuritySummaries(t *testing.T) {
 		submittedResourcePresence = append(submittedResourcePresence, req.ResourcePresence...)
 		submittedBotInstanceActivity = append(submittedBotInstanceActivity, req.BotInstanceActivity...)
 		submittedIdentitySecuritySummaries = append(submittedIdentitySecuritySummaries, req.IdentitySecuritySummariesReport...)
+		submittedIdentitySecurityReports = append(submittedIdentitySecurityReports, req.IdentitySecurityReport...)
 		return uuid.New(), nil
 	}
 
@@ -242,6 +254,7 @@ func testSubmitOnceIdentitySecuritySummaries(t *testing.T) {
 	submitOnce(ctx, scfg)
 	require.Len(t, submittedIdentitySecuritySummaries, 1)
 	require.True(t, proto.Equal(identityReport1, submittedIdentitySecuritySummaries[0]))
+	require.Empty(t, submittedIdentitySecurityReports)
 
 	// Verify report was deleted after submission
 	reports, err := svc.listIdentitySecuritySummariesGeneratedReports(ctx, 10)
@@ -253,6 +266,7 @@ func testSubmitOnceIdentitySecuritySummaries(t *testing.T) {
 	submittedResourcePresence = nil
 	submittedBotInstanceActivity = nil
 	submittedIdentitySecuritySummaries = nil
+	submittedIdentitySecurityReports = nil
 
 	// Test 2: Submit mixed report types respecting batch size
 	// Add 5 user activity reports
@@ -299,6 +313,7 @@ func testSubmitOnceIdentitySecuritySummaries(t *testing.T) {
 	submittedResourcePresence = nil
 	submittedBotInstanceActivity = nil
 	submittedIdentitySecuritySummaries = nil
+	submittedIdentitySecurityReports = nil
 
 	// Test 3: Priority ordering - user activity fills batch first, then resource, then bot, then identity
 	// Add enough reports to test multiple batches

--- a/lib/usagereporter/teleport/types.go
+++ b/lib/usagereporter/teleport/types.go
@@ -2219,3 +2219,34 @@ func (e *DiscoveryConfigEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEve
 		},
 	}
 }
+
+// IdentitySecurityGraphSizeEvent is emitted when the size of a providers access graph is updated.
+type IdentitySecurityGraphSizeEvent prehogv1a.IdentitySecurityGraphSizeEvent
+
+// Anonymize anonymizes the event.
+func (e *IdentitySecurityGraphSizeEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+	return prehogv1a.SubmitEventRequest{
+		Event: &prehogv1a.SubmitEventRequest_IdentitySecurityGraphSizeEvent{
+			IdentitySecurityGraphSizeEvent: &prehogv1a.IdentitySecurityGraphSizeEvent{
+				Provider:        e.Provider,
+				TotalIdentities: e.TotalIdentities,
+				TotalResources:  e.TotalResources,
+			},
+		},
+	}
+}
+
+// IdentitySecurityAuditLogsIngestedEvent is emitted when logs are ingested into indentity activity center
+type IdentitySecurityAuditLogsIngestedEvent prehogv1a.IdentitySecurityAuditLogsIngestedEvent
+
+// Anonymize anonymizes the event.
+func (e *IdentitySecurityAuditLogsIngestedEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventRequest {
+	return prehogv1a.SubmitEventRequest{
+		Event: &prehogv1a.SubmitEventRequest_IdentitySecurityAuditLogsIngestedEvent{
+			IdentitySecurityAuditLogsIngestedEvent: &prehogv1a.IdentitySecurityAuditLogsIngestedEvent{
+				Provider:     e.Provider,
+				LogsIngested: e.LogsIngested,
+			},
+		},
+	}
+}

--- a/proto/accessgraph/v1alpha/access_graph_service.proto
+++ b/proto/accessgraph/v1alpha/access_graph_service.proto
@@ -33,6 +33,7 @@ import "accessgraph/v1alpha/resources.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+import "prehog/v1alpha/teleport.proto";
 import "teleport/auditlog/v1/auditlog.proto";
 
 option go_package = "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha;accessgraphv1alpha";
@@ -309,6 +310,9 @@ message EventsStreamV2Response {
   oneof action {
     // event is a audit event that should be logged by Teleport.
     AuditEvent event = 1;
+    // usage_event is a usage event to be submitted to the auth server, as an analog of
+    // AuthService.SubmitUsageEvent.
+    UsageEvent usage_event = 2;
   }
 }
 
@@ -317,6 +321,16 @@ message AuditEvent {
   oneof event {
     // access_path_changed is an event that should be logged when the access path changes.
     AccessPathChanged access_path_changed = 1;
+  }
+}
+
+// UsageEvent is a usage event that access graph can submit to teleport
+message UsageEvent {
+  oneof event {
+    // graph_size provides the size of a provider's graph
+    prehog.v1alpha.IdentitySecurityGraphSizeEvent graph_size = 1;
+    // audit_logs_ingested provides a count of new audit logs ingested by a provider.
+    prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent audit_logs_ingested = 2;
   }
 }
 

--- a/proto/prehog/v1/teleport.proto
+++ b/proto/prehog/v1/teleport.proto
@@ -161,6 +161,8 @@ message UserActivityRecord {
   uint64 saml_idp_sessions = 24;
   // counter of session summaries accessed by this user per session type and resource name.
   repeated SessionSummariesAccessedRecord session_summaries_accessed = 25;
+  // counter of access graph queries by this user.
+  uint64 access_graph_queries = 26;
 }
 
 // the kind of a "resource" (e.g. a node, a database, a desktop, etc.)
@@ -346,6 +348,64 @@ message SessionSummariesGeneratedRecord {
   uint64 summaries_generated = 6;
 }
 
+// IdentitySecurityReport is a report of Identity Security non-user usage. It currently
+// includes the size of the access graph by provider and count of audit logs ingested
+// by provider.
+message IdentitySecurityReport {
+  // randomly generated UUID for this specific report, 16 bytes (in string order)
+  //
+  // PostHog property: tp.report_uuid (in 8-4-4-4-12 string form)
+  bytes report_uuid = 1;
+
+  // cluster name, anonymized, 32 bytes (HMAC-SHA-256)
+  //
+  // PostHog property: tp.cluster_name (in base64)
+  bytes cluster_name = 2;
+
+  // hostid of the auth that collected this report, anonymized, 32 bytes (HMAC-SHA-256)
+  //
+  // PostHog property: tp.reporter_hostid (in base64)
+  bytes reporter_hostid = 3;
+
+  // beginning of the time window for this data; ending is not specified but is
+  // intended to be at most 60 minutes
+  //
+  // PostHog timestamp (not a property, the ingest time is tp.report_time instead)
+  google.protobuf.Timestamp start_time = 4;
+
+  // graph_size contains the size of each provider's graph: count of identities and
+  // count of resources.
+  repeated IdentitySecurityGraphSize graph_size_records = 5;
+
+  // audit_logs contains the counts of audit logs ingested from each provider.
+  repeated IdentitySecurityAuditLogsIngested audit_log_records = 6;
+}
+
+// IdentitySecurityGraphSize is submitted by Access Graph for each provider
+// for which it has a graph.
+message IdentitySecurityGraphSize {
+  // provider is the system containing the identities and resources being counted.
+  // It is one of teleport, aws, azure, entra, gitlab, github, netiq or okta.
+  string provider = 1;
+
+  // total_identities is the number of identities in the graph.
+  uint64 total_identities = 2;
+
+  // total_resources is the number of resources in the graph.
+  uint64 total_resources = 3;
+}
+
+// IdentitySecurityAuditLogsIngested tracks the count of log entries ingested by
+// identity activity center.
+message IdentitySecurityAuditLogsIngested {
+  // provider is the system emitting audit logs. It is one of
+  // teleport, cloudtrail, kubernetes, github or okta.
+  string provider = 1;
+
+  // logs_ingested is a count of log entries ingested into Identity Security.
+  uint64 logs_ingested = 2;
+}
+
 message SubmitUsageReportsRequest {
   // at most 10 reports of all kinds in a single RPC, each shouldn't exceed 128KiB or so
   //
@@ -357,6 +417,8 @@ message SubmitUsageReportsRequest {
   repeated BotInstanceActivityReport bot_instance_activity = 3;
   // encoded as a separate tp.identity_security.summaries_generated PostHog event
   repeated IdentitySecuritySummariesGeneratedReport identity_security_summaries_report = 4;
+  // encoded as a separate tp.identity_security.usage PostHog event
+  repeated IdentitySecurityReport identity_security_report = 5;
 }
 message SubmitUsageReportsResponse {
   // randomly generated UUID for this specific batch, 16 bytes (in string order)


### PR DESCRIPTION
Add two Identity Security usage events for capturing usage metrics of
access graph: graph size by provider and audit logs ingested.

Add an aggregated report containing these usage metrics for reporting by
self-hosted enterprise clusters. There was some naming conflict with
a previously added report for Identity Security session summaries. Some
names have been changed to have the end product make sense together.

Update the `accessgraph.v1alpha` protobuf package to add a new message
to the `oneof` in the `EventsStreamV2Response` message for access graph
to be able to send usage events back to the auth server.

In order for the `accessgraph.v1alpha` package to use the
`prehog.v1alpha` package to use the usage events defined there, the buf
config for generating Go code has been updated to specify the module
path for `prehog.v1alpha` since the proto files in that package do not
declare a `go_package` location.

The `prehog.v1alpha` and `prehog.v1` protobuf package changes have been
copied from the cloud repository where they are mastered.

Generated proto code has been updated by running:

    make grpc/host

Note: This PR can be reviewed commit by commit - atomic commits have
been used.

Issue: https://github.com/gravitational/access-graph/issues/1724
Backport: https://github.com/gravitational/teleport/pull/63753
Related: https://github.com/gravitational/teleport.e/pull/8567

## Manual test plan
### Test Environment
- [x] Setup:
  - [x] env: `PREHOG_ENDPOINT=https://prehog.reporting-test.teleportinfra.dev`
  - [x] get license for test environment with all features (incl cloud) from cloud team
  - [x] Run Teleport with PR gravitational/teleport.e#8567
    - [x] Temporarily shorten `identitySecurityReportGranularity` in
      `lib/usagereporter/teleport/aggregating/reporter.go` from 24 hours to 5
      minutes to make testing faster.
  - [x] Run Access Graph from master (with PR gravitational/access-graph#1906)
### Test Cases
- [x] Validate `access_graph_queries` in user activity report:
  - [x] Perform queries of access graph
  - [x] Check test grafana for ExecuteQuery events (`tp.tag.query`)
  - [x] Check test grafana for user activity report (`tp.user.activity`)
- [x] Validate `IdentitySecurityGraphSizeEvent`
  - [x] Check test grafana for graph size events (`tp.tag.graph.size`)
- [x] Validate `IdentitySecurityAuditLogsIngestedEvent`
  - [x] Check test grafana for audit logs ingested events (`tp.tag.auditlogs.ingest`)
- [x] Validate `IdentitySecurityReport`
  - [x] Check test grafana for identity security usage report (`tp.identity_security.usage`)
