### PR TITLE
Remove unused DeleteAllProxies RPC/Method

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -131,7 +131,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.POST("/:version/proxies", srv.WithAuth(srv.upsertProxy))
 	// TODO(kiosion) DELETE IN 21.0.0
 	srv.GET("/:version/proxies", srv.WithScopedAuth(srv.getProxies))
-	srv.DELETE("/:version/proxies", srv.WithAuth(srv.deleteAllProxies))
 	srv.DELETE("/:version/proxies/:name", srv.WithAuth(srv.deleteProxy))
 	srv.POST("/:version/tunnelconnections", srv.WithAuth(srv.upsertTunnelConnection))
 	srv.GET("/:version/tunnelconnections/:cluster", srv.WithAuth(srv.getTunnelConnections))
@@ -154,6 +153,7 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.GET("/:version/configuration/name", httpMigratedHandler)
 	srv.DELETE("/:version/tunnelconnections/:cluster", httpMigratedHandler)
 	srv.DELETE("/:version/tunnelconnections", httpMigratedHandler)
+	srv.DELETE("/:version/proxies", httpMigratedHandler)
 
 	if config.PluginRegistry != nil {
 		if err := config.PluginRegistry.RegisterAuthWebHandlers(&srv); err != nil {
@@ -320,15 +320,6 @@ func (s *APIServer) getProxies(auth *ServerWithRoles, w http.ResponseWriter, r *
 		return nil, trace.Wrap(err)
 	}
 	return marshalServers(servers, version)
-}
-
-// deleteAllProxies deletes all proxies
-func (s *APIServer) deleteAllProxies(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
-	err := auth.DeleteAllProxies()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return message("ok"), nil
 }
 
 // deleteProxy deletes proxy

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2578,14 +2578,6 @@ func (a *ServerWithRoles) ListProxyServers(ctx context.Context, pageSize int, pa
 	return a.authServer.ListProxyServers(ctx, pageSize, pageToken)
 }
 
-// DeleteAllProxies deletes all proxies
-func (a *ServerWithRoles) DeleteAllProxies() error {
-	if err := a.authorizeAction(types.KindProxy, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.DeleteAllProxies()
-}
-
 // DeleteProxy deletes proxy by name
 func (a *ServerWithRoles) DeleteProxy(ctx context.Context, name string) error {
 	if err := a.authorizeAction(types.KindProxy, types.VerbDelete); err != nil {

--- a/lib/auth/authclient/http_client.go
+++ b/lib/auth/authclient/http_client.go
@@ -422,15 +422,6 @@ func (c *HTTPClient) UpsertProxy(ctx context.Context, s types.Server) error {
 	return trace.Wrap(err)
 }
 
-// DeleteAllProxies deletes all proxies
-func (c *HTTPClient) DeleteAllProxies() error {
-	_, err := c.Delete(context.TODO(), c.Endpoint("proxies"))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
 // DeleteProxy deletes proxy by name
 func (c *HTTPClient) DeleteProxy(ctx context.Context, name string) error {
 	if name == "" {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -4782,8 +4782,9 @@ func TestEvents(t *testing.T) {
 				out, err := testSrv.Auth().GetProxies()
 				require.NoError(t, err)
 
-				err = testSrv.Auth().DeleteAllProxies()
-				require.NoError(t, err)
+				for _, p := range out {
+					require.NoError(t, testSrv.Auth().DeleteProxy(ctx, p.GetName()))
+				}
 
 				return out[0]
 			},

--- a/lib/cache/proxy_server_test.go
+++ b/lib/cache/proxy_server_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 )
 
 // TestProxies tests proxies cache
@@ -47,8 +49,17 @@ func TestProxies(t *testing.T) {
 		list:      p.presenceS.ListProxyServers,
 		cacheList: p.cache.ListProxyServers,
 		update:    p.presenceS.UpsertProxy,
-		deleteAll: func(_ context.Context) error {
-			return p.presenceS.DeleteAllProxies()
+		deleteAll: func(ctx context.Context) error {
+			proxies, err := stream.Collect(clientutils.Resources(ctx, p.presenceS.ListProxyServers))
+			if err != nil {
+				return err
+			}
+			for _, proxy := range proxies {
+				if err := p.presenceS.DeleteProxy(ctx, proxy.GetName()); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	})
 }

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -480,12 +480,6 @@ func (s *PresenceService) ListProxyServers(ctx context.Context, pageSize int, pa
 	return generic.CollectPageAndCursor(s.rangeProxyServers(ctx, pageToken, ""), pageSize, serverToPaginationKey)
 }
 
-// DeleteAllProxies deletes all proxies
-func (s *PresenceService) DeleteAllProxies() error {
-	startKey := backend.ExactKey(proxiesPrefix)
-	return s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
-}
-
 // DeleteProxy deletes proxy
 func (s *PresenceService) DeleteProxy(ctx context.Context, name string) error {
 	key := backend.NewKey(proxiesPrefix, name)

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -2218,8 +2218,9 @@ func (s *ServicesTestSuite) Events(t *testing.T) {
 				out, err := s.PresenceS.GetProxies()
 				require.NoError(t, err)
 
-				err = s.PresenceS.DeleteAllProxies()
-				require.NoError(t, err)
+				for _, p := range out {
+					require.NoError(t, s.PresenceS.DeleteProxy(ctx, p.GetName()))
+				}
 
 				return out[0]
 			},

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -117,9 +117,6 @@ type Presence interface {
 	// DeleteProxy deletes proxy by name
 	DeleteProxy(ctx context.Context, name string) error
 
-	// DeleteAllProxies deletes all proxies
-	DeleteAllProxies() error
-
 	// UpsertReverseTunnel upserts reverse tunnel entry temporarily or permanently
 	UpsertReverseTunnel(ctx context.Context, tunnel types.ReverseTunnel) (types.ReverseTunnel, error)
 


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/6394

I searched from master down to v15.0.0 and couldn't find any invocations of this RPC. It likely existed to satisfy an interface from the period where we required auth.Server and the client to implement the same interface.

Given this RPC has not been used, and, it's relatively drastic nature, it feels more appropriate to remove rather than migrate this RPC to gRPC.

I've also tidied away the underlying backend service method since this was only being used in tests.

## Manual Test Plan
### Test Environment

No sane test plan identified for the removal of an unused RPC. Let me know if you have any suggestions.

### Test Cases
- [x] Tried to invoke RPC, now returns 501.
