### PR TITLE
[v18] MWI Scopes[6]: tbot changes

### DIFF
--- a/lib/tbot/bot/bot.go
+++ b/lib/tbot/bot/bot.go
@@ -273,6 +273,7 @@ func (b *Bot) buildServices(ctx context.Context, registry *readyz.Registry) ([]*
 				teleport.ComponentKey,
 				teleport.Component(teleport.ComponentTBot, "svc", handle.name),
 			),
+			Scoped: b.cfg.Scoped,
 		})
 		if err != nil {
 			return nil, closeFn, trace.Wrap(err, "building service [%d]", idx)
@@ -364,6 +365,7 @@ func (b *Bot) buildIdentityService(
 		ClientBuilder:  clientBuilder,
 		ReloadCh:       reloadCh,
 		StatusReporter: handle.statusReporter,
+		Scoped:         b.cfg.Scoped,
 	})
 	if err != nil {
 		unsubscribe()

--- a/lib/tbot/bot/config.go
+++ b/lib/tbot/bot/config.go
@@ -75,6 +75,9 @@ type Config struct {
 
 	// ClientMetrics will be used to record the bot's API client metrics.
 	ClientMetrics *prometheus.ClientMetrics
+
+	// Scoped indicates whether the bot is running in scoped mode.
+	Scoped bool
 }
 
 // CheckAndSetDefaults validates the configuration and sets any default values.

--- a/lib/tbot/bot/service.go
+++ b/lib/tbot/bot/service.go
@@ -107,6 +107,9 @@ type ServiceDependencies struct {
 
 	// StatusRegistry can be used to read the health of the bot's services.
 	StatusRegistry readyz.ReadOnlyRegistry
+
+	// Scoped indicates whether the bot is running in scoped mode.
+	Scoped bool
 }
 
 // ServiceBuilder will be used by the bot to create a service.

--- a/lib/tbot/cli/start_legacy.go
+++ b/lib/tbot/cli/start_legacy.go
@@ -139,6 +139,11 @@ type LegacyCommand struct {
 	// PIDFile is the path to the PID file. If not set, no PID file will be created.
 	PIDFile string
 
+	// Scoped indicates if the user expects this instance of tbot to interact
+	// with a scoped Bot.
+	Scoped          bool
+	scopedSetByUser bool
+
 	oneshotSetByUser bool
 }
 
@@ -167,6 +172,7 @@ func NewLegacyCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode C
 	c.cmd.Flag("diag-addr", "If set and the bot is in debug mode, a diagnostics service will listen on specified address.").StringVar(&c.DiagAddr)
 	c.cmd.Flag("diag-socket-for-updater", "If set, run the diagnostics service on the specified socket path for teleport-update to consume.").Hidden().StringVar(&c.DiagSocketForUpdater)
 	c.cmd.Flag("pid-file", "Full path to the PID file. By default no PID file will be created.").StringVar(&c.PIDFile)
+	c.cmd.Flag("scoped", "Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.").IsSetByUser(&c.scopedSetByUser).BoolVar(&c.Scoped)
 
 	return c
 }
@@ -199,6 +205,10 @@ func (c *LegacyCommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) error
 
 	if c.oneshotSetByUser {
 		cfg.Oneshot = c.Oneshot
+	}
+
+	if c.scopedSetByUser {
+		cfg.Scoped = c.Scoped
 	}
 
 	if c.CertificateTTL != 0 {

--- a/lib/tbot/cli/start_legacy_test.go
+++ b/lib/tbot/cli/start_legacy_test.go
@@ -82,5 +82,18 @@ func TestLegacyCommand(t *testing.T) {
 				require.Equal(t, "/bar", dir.Path)
 			},
 		},
+		{
+			name: "scoped",
+			args: []string{
+				"start",
+				"--scoped",
+				"--token=foo",
+				"--join-method=github",
+				"--auth-server=example.com:3024",
+			},
+			assertConfig: func(t *testing.T, cfg *config.BotConfig) {
+				require.True(t, cfg.Scoped)
+			},
+		},
 	})
 }

--- a/lib/tbot/cli/start_shared.go
+++ b/lib/tbot/cli/start_shared.go
@@ -119,6 +119,11 @@ type sharedStartArgs struct {
 	StaticKeyPath          string
 	Keypair                string
 
+	// Scoped indicates if the user expects this instance of tbot to interact
+	// with a scoped Bot.
+	Scoped          bool
+	scopedSetByUser bool
+
 	Oneshot              bool
 	DiagAddr             string
 	DiagSocketForUpdater string
@@ -150,6 +155,7 @@ func newSharedStartArgs(cmd *kingpin.CmdClause) *sharedStartArgs {
 	cmd.Flag("join-uri", "An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.").StringVar(&args.JoiningURI)
 	cmd.Flag("diag-socket-for-updater", "If set, run the diagnostics service on the specified socket path for teleport-update to consume.").Hidden().StringVar(&args.DiagSocketForUpdater)
 	cmd.Flag("pid-file", "Full path to the PID file. By default no PID file will be created.").StringVar(&args.PIDFile)
+	cmd.Flag("scoped", "Indicates whether tbot should run in scoped mode. This is required when authenticating as a scoped Bot.").IsSetByUser(&args.scopedSetByUser).BoolVar(&args.Scoped)
 
 	return args
 }
@@ -169,6 +175,10 @@ func (s *sharedStartArgs) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) err
 
 	if s.oneshotSetByUser {
 		cfg.Oneshot = s.Oneshot
+	}
+
+	if s.scopedSetByUser {
+		cfg.Scoped = s.Scoped
 	}
 
 	if s.CertificateTTL != 0 {

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -98,6 +98,10 @@ type BotConfig struct {
 
 	Oneshot bool `yaml:"oneshot"`
 
+	// Scoped indicates whether `tbot` should run in scoped mode. This must
+	// be set to true when `tbot` is authenticating as a scoped Bot.
+	Scoped bool `yaml:"scoped,omitempty"`
+
 	// FIPS instructs `tbot` to run in a mode designed to comply with FIPS
 	// regulations. This means the bot should:
 	// - Refuse to run if not compiled with boringcrypto
@@ -212,7 +216,7 @@ func (conf *BotConfig) CheckAndSetDefaults() error {
 
 	namer := newServiceNamer()
 	for i, service := range conf.Services {
-		if err := service.CheckAndSetDefaults(); err != nil {
+		if err := service.CheckAndSetDefaults(conf.Scoped); err != nil {
 			return trace.Wrap(err, "validating service[%d]", i)
 		}
 		if err := service.GetCredentialLifetime().Validate(conf.Oneshot); err != nil {
@@ -317,7 +321,7 @@ func (conf *BotConfig) CheckAndSetDefaults() error {
 // ServiceConfig is an interface over the various service configurations.
 type ServiceConfig interface {
 	Type() string
-	CheckAndSetDefaults() error
+	CheckAndSetDefaults(scoped bool) error
 
 	// GetCredentialLifetime returns the service's custom certificate TTL and
 	// RenewalInterval. It's used for validation purposes; services that do not

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -347,6 +347,7 @@ func TestBotConfig_YAML(t *testing.T) {
 			name: "minimal config",
 			in: BotConfig{
 				Version:    V2,
+				Scoped:     true,
 				AuthServer: "example.teleport.sh:443",
 				CredentialLifetime: bot.CredentialLifetime{
 					TTL:             time.Minute,

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/minimal_config.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/minimal_config.golden
@@ -8,4 +8,5 @@ auth_server: example.teleport.sh:443
 credential_ttl: 1m0s
 renewal_interval: 30s
 oneshot: false
+scoped: true
 fips: false

--- a/lib/tbot/identity/generator.go
+++ b/lib/tbot/identity/generator.go
@@ -27,9 +27,11 @@ import (
 	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -39,6 +41,9 @@ import (
 var tracer = otel.Tracer("github.com/gravitational/teleport/lib/tbot/identity")
 
 // GeneratorConfig contains the configuration options for a Generator.
+//
+// TODO(strideynet): There's some general tidy-up work to be done here with how
+// we handle CAs to make it more uniform and clearly sourced
 type GeneratorConfig struct {
 	// Client that will be used to request identity certificates.
 	Client *apiclient.Client
@@ -355,6 +360,89 @@ func (g *Generator) botDefaultRoles(ctx context.Context) ([]string, error) {
 	}
 	conditions := role.GetImpersonateConditions(types.Allow)
 	return conditions.Roles, nil
+}
+
+// GenerateScoped generates scoped certificates. Bot must already be scoped/
+// hold a scoped identity.
+// TODO(noah): add optional args to this like for Generate.
+func (g *Generator) GenerateScoped(
+	ctx context.Context, ttl, renewalInterval time.Duration,
+) (*Identity, error) {
+	req := &issuancev1pb.IssueScopedBotCertsRequest{
+		Ttl:   durationpb.New(ttl),
+		Usage: &issuancev1pb.IssueScopedBotCertsRequest_Identity{},
+	}
+
+	keyPurpose := cryptosuites.BotImpersonatedIdentity
+	key, err := cryptosuites.GenerateKey(ctx,
+		cryptosuites.GetCurrentSuiteFromAuthPreference(g.client),
+		keyPurpose)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	sshPub, err := ssh.NewPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req.SshPublicKey = ssh.MarshalAuthorizedKey(sshPub)
+
+	req.TlsPublicKey, err = keys.MarshalPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	res, err := g.client.IssuanceClient().IssueScopedBotCerts(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	privateKeyPEM, err := keys.MarshalPrivateKey(key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Fetch CAs for new identity
+	localCA, err := g.client.GetClusterCACert(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	caCerts, err := tlsca.ParseCertificatePEMs(localCA.TLSCA)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsHostCAs := [][]byte{}
+	// Append the host CAs from the auth server.
+	for _, cert := range caCerts {
+		pemBytes, err := tlsca.MarshalCertificatePEM(cert)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		tlsHostCAs = append(tlsHostCAs, pemBytes)
+	}
+
+	newIdentity, err := ReadIdentityFromStore(&LoadIdentityParams{
+		PrivateKeyBytes: privateKeyPEM,
+		PublicKeyBytes:  req.SshPublicKey,
+	}, &proto.Certs{
+		SSH:        res.Certs.Ssh,
+		TLS:        res.Certs.Tls,
+		TLSCACerts: tlsHostCAs,
+		SSHCACerts: g.botIdentity.Get().SSHCACertBytes,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	warnOnEarlyExpiration(
+		ctx,
+		log,
+		newIdentity,
+		ttl,
+		renewalInterval,
+	)
+
+	return newIdentity, nil
 }
 
 // warnOnEarlyExpiration logs a warning if the given identity is likely to

--- a/lib/tbot/identity/identity.go
+++ b/lib/tbot/identity/identity.go
@@ -407,9 +407,14 @@ func (i *Identity) LogValue() slog.Value {
 		botDesc = fmt.Sprintf(", id=%s", tlsIdent.BotInstanceID)
 	}
 
+	scopePin := ""
+	if tlsIdent.ScopePin != nil {
+		scopePin = tlsIdent.ScopePin.Scope
+	}
+
 	duration := cert.NotAfter.Sub(cert.NotBefore)
 	description := fmt.Sprintf(
-		"%s%s | valid: after=%v, before=%v, duration=%s | kind=tls, renewable=%v, disallow-reissue=%v, roles=%v, principals=%v, generation=%v",
+		"%s%s | valid: after=%v, before=%v, duration=%s | kind=tls, renewable=%v, disallow-reissue=%v, roles=%v, principals=%v, generation=%v, scopePin=%v",
 		tlsIdent.BotName,
 		botDesc,
 		cert.NotBefore.Format(time.RFC3339),
@@ -420,6 +425,7 @@ func (i *Identity) LogValue() slog.Value {
 		tlsIdent.Groups,
 		principals,
 		tlsIdent.Generation,
+		scopePin,
 	)
 	return slog.StringValue(description)
 }

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -335,7 +335,7 @@ func (s *Service) Initialize(ctx context.Context) error {
 		); err != nil {
 			return trace.BadParameter(
 				"bot identity loaded from storage has scoped %v, but scope config set to %v. change tbot scope configuration or delete the bot storage directory",
-				identScope,
+				identScope != "",
 				s.cfg.Scoped,
 			)
 		}

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -71,6 +72,8 @@ type Config struct {
 	ReloadCh       <-chan struct{}
 	ClientBuilder  *client.Builder
 	StatusReporter readyz.Reporter
+
+	Scoped bool
 }
 
 func (cfg *Config) CheckAndSetDefaults() error {
@@ -811,5 +814,34 @@ func botIdentityFromToken(
 		PublicKeyBytes:  ssh.MarshalAuthorizedKey(sshPub),
 		TokenHashBytes:  []byte(tokenHash),
 	}, result.Certs)
-	return ident, trace.Wrap(err)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := checkScopeCorrectness(
+		ident.TLSIdentity,
+		cfg.Scoped,
+	); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ident, nil
+}
+
+// checkScopeCorrectness returns an error if the presented identity is:
+// - Scoped, but tbot is not running in scoped mode.
+// - Unscoped, but tbot is running in scoped mode.
+func checkScopeCorrectness(tlsIdent *tlsca.Identity, scoped bool) error {
+	identScoped := tlsIdent.ScopePin != nil && tlsIdent.ScopePin.Scope != ""
+	if identScoped && !scoped {
+		return trace.BadParameter(
+			"received scoped identity upon join, but tbot is not configured in scoped mode",
+		)
+	}
+	if !identScoped && scoped {
+		return trace.BadParameter(
+			"received unscoped identity upon join, but tbot is configured in scoped mode",
+		)
+	}
+	return nil
 }

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -329,14 +329,13 @@ func (s *Service) Initialize(ctx context.Context) error {
 		//
 		// Rather than forcing a rejoin, we force a hard exit here to encourage
 		// the user to re-assess what they are doing.
-		if err := checkScopeCorrectness(
+		if identScope, err := checkScopeCorrectness(
 			loadedIdent.TLSIdentity,
 			s.cfg.Scoped,
 		); err != nil {
-			identScoped := loadedIdent.TLSIdentity.ScopePin != nil && loadedIdent.TLSIdentity.ScopePin.Scope != ""
 			return trace.BadParameter(
 				"bot identity loaded from storage has scoped %v, but scope config set to %v. change tbot scope configuration or delete the bot storage directory",
-				identScoped,
+				identScope,
 				s.cfg.Scoped,
 			)
 		}
@@ -836,7 +835,7 @@ func botIdentityFromToken(
 		return nil, trace.Wrap(err)
 	}
 
-	if err := checkScopeCorrectness(
+	if _, err := checkScopeCorrectness(
 		ident.TLSIdentity,
 		cfg.Scoped,
 	); err != nil {
@@ -849,17 +848,21 @@ func botIdentityFromToken(
 // checkScopeCorrectness returns an error if the presented identity is:
 // - Scoped, but tbot is not running in scoped mode.
 // - Unscoped, but tbot is running in scoped mode.
-func checkScopeCorrectness(tlsIdent *tlsca.Identity, scoped bool) error {
+func checkScopeCorrectness(tlsIdent *tlsca.Identity, scoped bool) (string, error) {
 	identScoped := tlsIdent.ScopePin != nil && tlsIdent.ScopePin.Scope != ""
+	identScope := ""
+	if identScoped {
+		identScope = tlsIdent.ScopePin.Scope
+	}
 	if identScoped && !scoped {
-		return trace.BadParameter(
+		return identScope, trace.BadParameter(
 			"received scoped identity upon join, but tbot is not configured in scoped mode",
 		)
 	}
 	if !identScoped && scoped {
-		return trace.BadParameter(
+		return identScope, trace.BadParameter(
 			"received unscoped identity upon join, but tbot is configured in scoped mode",
 		)
 	}
-	return nil
+	return identScope, nil
 }

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -323,6 +323,24 @@ func (s *Service) Initialize(ctx context.Context) error {
 			return trace.Wrap(err, "joining with token")
 		}
 	} else {
+		// If identity is loaded from disk, we need to validate it has the
+		// correct scoped-ness. This catches the case where a user changes the
+		// tbot scoped-ness setting for a pre-existing install of `tbot`.
+		//
+		// Rather than forcing a rejoin, we force a hard exit here to encourage
+		// the user to re-assess what they are doing.
+		if err := checkScopeCorrectness(
+			loadedIdent.TLSIdentity,
+			s.cfg.Scoped,
+		); err != nil {
+			identScoped := loadedIdent.TLSIdentity.ScopePin != nil && loadedIdent.TLSIdentity.ScopePin.Scope != ""
+			return trace.BadParameter(
+				"bot identity loaded from storage has scoped %v, but scope config set to %v. change tbot scope configuration or delete the bot storage directory",
+				identScoped,
+				s.cfg.Scoped,
+			)
+		}
+
 		if valid {
 			// If the identity is valid (not expired), try to renew it.
 			newIdentity, err = renewIdentity(ctx, s.log, s.cfg, s.clientBuilder, loadedIdent)

--- a/lib/tbot/services/application/helpers_test.go
+++ b/lib/tbot/services/application/helpers_test.go
@@ -80,12 +80,16 @@ func testYAML[T any](t *testing.T, tests []testYAMLCase[T]) {
 }
 
 type checkAndSetDefaulter interface {
-	CheckAndSetDefaults() error
+	CheckAndSetDefaults(scoped bool) error
 }
 
 type testCheckAndSetDefaultsCase[T checkAndSetDefaulter] struct {
 	name string
 	in   func() T
+
+	// scoped indicates that CheckAndSetDefaults should be called with
+	// scoped set to true.
+	scoped bool
 
 	// want specifies the desired state of the checkAndSetDefaulter after
 	// check and set defaults has been run. If want is nil, the Output is
@@ -100,7 +104,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.in()
-			err := got.CheckAndSetDefaults()
+			err := got.CheckAndSetDefaults(tt.scoped)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/lib/tbot/services/application/output_config.go
+++ b/lib/tbot/services/application/output_config.go
@@ -57,7 +57,10 @@ func (o *OutputConfig) Init(ctx context.Context) error {
 	return trace.Wrap(o.Destination.Init(ctx, []string{}))
 }
 
-func (o *OutputConfig) CheckAndSetDefaults() error {
+func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", OutputServiceType)
+	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}

--- a/lib/tbot/services/application/output_config_test.go
+++ b/lib/tbot/services/application/output_config_test.go
@@ -83,6 +83,17 @@ func TestApplicationOutput_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "app_name must not be empty",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *OutputConfig {
+				return &OutputConfig{
+					Destination: destination.NewMemory(),
+					AppName:     "app",
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/application/output_service.go
+++ b/lib/tbot/services/application/output_service.go
@@ -39,7 +39,7 @@ import (
 
 func OutputServiceBuilder(cfg *OutputConfig, defaultCredentialLifetime bot.CredentialLifetime) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &OutputService{

--- a/lib/tbot/services/application/proxy_config.go
+++ b/lib/tbot/services/application/proxy_config.go
@@ -84,7 +84,10 @@ func (c *ProxyServiceConfig) UnmarshalYAML(node *yaml.Node) error {
 
 // CheckAndSetDefaults checks the user-provided configuration against validation
 // rules and sets any default values.
-func (c *ProxyServiceConfig) CheckAndSetDefaults() error {
+func (c *ProxyServiceConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", ProxyServiceType)
+	}
 	switch {
 	case c.Listen == "" && c.Listener == nil:
 		return trace.BadParameter("listen: should not be empty")

--- a/lib/tbot/services/application/proxy_config_test.go
+++ b/lib/tbot/services/application/proxy_config_test.go
@@ -73,6 +73,16 @@ func TestProxyServiceConfig_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "parsing listen",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *ProxyServiceConfig {
+				return &ProxyServiceConfig{
+					Listen: "tcp://0.0.0.0:3621",
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/application/proxy_service.go
+++ b/lib/tbot/services/application/proxy_service.go
@@ -53,7 +53,7 @@ func ProxyServiceBuilder(
 	alpnUpgradeCache *internal.ALPNUpgradeCache,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &ProxyService{

--- a/lib/tbot/services/application/tunnel_config.go
+++ b/lib/tbot/services/application/tunnel_config.go
@@ -93,7 +93,10 @@ func (s *TunnelConfig) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func (s *TunnelConfig) CheckAndSetDefaults() error {
+func (s *TunnelConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", TunnelServiceType)
+	}
 	switch {
 	case s.Listen == "" && s.Listener == nil:
 		return trace.BadParameter("listen: should not be empty")

--- a/lib/tbot/services/application/tunnel_config_test.go
+++ b/lib/tbot/services/application/tunnel_config_test.go
@@ -101,6 +101,17 @@ func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "app_name: should not be empty",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *TunnelConfig {
+				return &TunnelConfig{
+					Listen:  "tcp://0.0.0.0:3621",
+					AppName: "my-app",
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -48,7 +48,7 @@ func TunnelServiceBuilder(
 	leeway time.Duration,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &TunnelService{

--- a/lib/tbot/services/awsra/config.go
+++ b/lib/tbot/services/awsra/config.go
@@ -113,7 +113,10 @@ func (o *Config) Init(ctx context.Context) error {
 }
 
 // CheckAndSetDefaults checks the WorkloadIdentityAWSRAService values and sets any defaults.
-func (o *Config) CheckAndSetDefaults() error {
+func (o *Config) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", ServiceType)
+	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}

--- a/lib/tbot/services/awsra/config_test.go
+++ b/lib/tbot/services/awsra/config_test.go
@@ -323,6 +323,27 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "validating region",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *Config {
+				return &Config{
+					Selector: bot.WorkloadIdentitySelector{
+						Name: "my-workload-identity",
+					},
+					Destination: &destination.Directory{
+						Path:     "/opt/machine-id",
+						ACLs:     botfs.ACLOff,
+						Symlinks: botfs.SymlinksInsecure,
+					},
+					RoleARN:        "arn:aws:iam::123456789012:role/example-role",
+					TrustAnchorARN: "arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/0000000-0000-0000-0000-000000000000",
+					ProfileARN:     "arn:aws:rolesanywhere:us-east-1:123456789012:profile/0000000-0000-0000-0000-00000000000",
+					Region:         "us-east-1",
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/awsra/helpers_test.go
+++ b/lib/tbot/services/awsra/helpers_test.go
@@ -84,12 +84,16 @@ func testYAML[T any](t *testing.T, tests []testYAMLCase[T]) {
 }
 
 type checkAndSetDefaulter interface {
-	CheckAndSetDefaults() error
+	CheckAndSetDefaults(scoped bool) error
 }
 
 type testCheckAndSetDefaultsCase[T checkAndSetDefaulter] struct {
 	name string
 	in   func() T
+
+	// scoped indicates that CheckAndSetDefaults should be called with
+	// scoped set to true.
+	scoped bool
 
 	// want specifies the desired state of the checkAndSetDefaulter after
 	// check and set defaults has been run. If want is nil, the Output is
@@ -104,7 +108,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.in()
-			err := got.CheckAndSetDefaults()
+			err := got.CheckAndSetDefaults(tt.scoped)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/lib/tbot/services/awsra/service.go
+++ b/lib/tbot/services/awsra/service.go
@@ -49,7 +49,7 @@ var tracer = otel.Tracer("github.com/gravitational/teleport/lib/tbot/services/aw
 
 func ServiceBuilder(cfg *Config) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &Service{

--- a/lib/tbot/services/clientcredentials/config.go
+++ b/lib/tbot/services/clientcredentials/config.go
@@ -146,7 +146,10 @@ func (o *UnstableConfig) SetOrUpdateFacade(id *identity.Identity) {
 }
 
 // CheckAndSetDefaults checks and sets default values for the configuration.
-func (o *UnstableConfig) CheckAndSetDefaults() error {
+func (o *UnstableConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", ServiceType)
+	}
 	return nil
 }
 

--- a/lib/tbot/services/clientcredentials/service.go
+++ b/lib/tbot/services/clientcredentials/service.go
@@ -39,7 +39,7 @@ import (
 // another service (e.g. the SPIFFE Workload API service) use NewSidecar instead.
 func ServiceBuilder(cfg *UnstableConfig, credentialLifetime bot.CredentialLifetime) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &Service{

--- a/lib/tbot/services/database/helpers_test.go
+++ b/lib/tbot/services/database/helpers_test.go
@@ -68,12 +68,16 @@ func testYAML[T any](t *testing.T, tests []testYAMLCase[T]) {
 }
 
 type checkAndSetDefaulter interface {
-	CheckAndSetDefaults() error
+	CheckAndSetDefaults(scoped bool) error
 }
 
 type testCheckAndSetDefaultsCase[T checkAndSetDefaulter] struct {
 	name string
 	in   func() T
+
+	// scoped indicates that CheckAndSetDefaults should be called with
+	// scoped set to true.
+	scoped bool
 
 	// want specifies the desired state of the checkAndSetDefaulter after
 	// check and set defaults has been run. If want is nil, the Output is
@@ -88,7 +92,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.in()
-			err := got.CheckAndSetDefaults()
+			err := got.CheckAndSetDefaults(tt.scoped)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/lib/tbot/services/database/output_config.go
+++ b/lib/tbot/services/database/output_config.go
@@ -117,7 +117,10 @@ func (o *OutputConfig) Init(ctx context.Context) error {
 	return trace.Wrap(o.Destination.Init(ctx, subDirs))
 }
 
-func (o *OutputConfig) CheckAndSetDefaults() error {
+func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", OutputServiceType)
+	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}

--- a/lib/tbot/services/database/output_config_test.go
+++ b/lib/tbot/services/database/output_config_test.go
@@ -99,6 +99,17 @@ func TestDatabaseOutput_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "unrecognized format (no-such-format)",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *OutputConfig {
+				return &OutputConfig{
+					Destination: destination.NewMemory(),
+					Service:     "service",
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/database/output_service.go
+++ b/lib/tbot/services/database/output_service.go
@@ -39,7 +39,7 @@ import (
 
 func OutputServiceBuilder(cfg *OutputConfig, defaultCredentialLifetime bot.CredentialLifetime) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &OutputService{

--- a/lib/tbot/services/database/tunnel_config.go
+++ b/lib/tbot/services/database/tunnel_config.go
@@ -88,7 +88,10 @@ func (s *TunnelConfig) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func (s *TunnelConfig) CheckAndSetDefaults() error {
+func (s *TunnelConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", TunnelServiceType)
+	}
 	switch {
 	case s.Listen == "" && s.Listener == nil:
 		return trace.BadParameter("listen: should not be empty")

--- a/lib/tbot/services/database/tunnel_config_test.go
+++ b/lib/tbot/services/database/tunnel_config_test.go
@@ -112,6 +112,19 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "username: should not be empty",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *TunnelConfig {
+				return &TunnelConfig{
+					Listen:   "tcp://0.0.0.0:3621",
+					Service:  "service",
+					Database: "database",
+					Username: "username",
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -49,7 +49,7 @@ func TunnelServiceBuilder(
 	leeway time.Duration,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &TunnelService{

--- a/lib/tbot/services/example/config.go
+++ b/lib/tbot/services/example/config.go
@@ -55,7 +55,7 @@ func (s *Config) MarshalYAML() (any, error) {
 	return encoding.WithTypeHeader((*raw)(s), ServiceType)
 }
 
-func (s *Config) CheckAndSetDefaults() error {
+func (s *Config) CheckAndSetDefaults(scoped bool) error {
 	if s.Message == "" {
 		return trace.BadParameter("message: should not be empty")
 	}

--- a/lib/tbot/services/example/service.go
+++ b/lib/tbot/services/example/service.go
@@ -31,8 +31,8 @@ import (
 
 // ServiceBuilder returns an example service builder.
 func ServiceBuilder(cfg *Config) bot.ServiceBuilder {
-	buildFn := func(bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &Service{cfg: cfg}, nil

--- a/lib/tbot/services/identity/helpers_test.go
+++ b/lib/tbot/services/identity/helpers_test.go
@@ -67,12 +67,16 @@ func testYAML[T any](t *testing.T, tests []testYAMLCase[T]) {
 }
 
 type checkAndSetDefaulter interface {
-	CheckAndSetDefaults() error
+	CheckAndSetDefaults(scoped bool) error
 }
 
 type testCheckAndSetDefaultsCase[T checkAndSetDefaulter] struct {
 	name string
 	in   func() T
+
+	// scoped indicates that CheckAndSetDefaults should be called with
+	// scoped set to true.
+	scoped bool
 
 	// want specifies the desired state of the checkAndSetDefaulter after
 	// check and set defaults has been run. If want is nil, the Output is
@@ -87,7 +91,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.in()
-			err := got.CheckAndSetDefaults()
+			err := got.CheckAndSetDefaults(tt.scoped)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/lib/tbot/services/identity/output.go
+++ b/lib/tbot/services/identity/output.go
@@ -51,7 +51,7 @@ func OutputServiceBuilder(
 	insecure, fips bool,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &OutputService{
@@ -69,6 +69,7 @@ func OutputServiceBuilder(
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
 			statusReporter:            deps.GetStatusReporter(),
+			scoped:                    deps.Scoped,
 		}
 		return svc, nil
 	}
@@ -96,6 +97,8 @@ type OutputService struct {
 	alpnUpgradeCache  *internal.ALPNUpgradeCache
 	identityGenerator *identity.Generator
 	clientBuilder     *client.Builder
+
+	scoped bool
 }
 
 func (s *OutputService) String() string {
@@ -106,14 +109,23 @@ func (s *OutputService) String() string {
 }
 
 func (s *OutputService) OneShot(ctx context.Context) error {
-	return s.generate(ctx)
+	f := s.generate
+	if s.scoped {
+		f = s.generateScoped
+	}
+
+	return f(ctx)
 }
 
 func (s *OutputService) Run(ctx context.Context) error {
+	f := s.generate
+	if s.scoped {
+		f = s.generateScoped
+	}
 	err := internal.RunOnInterval(ctx, internal.RunOnIntervalConfig{
 		Service:         s.String(),
 		Name:            "output-renewal",
-		F:               s.generate,
+		F:               f,
 		Interval:        cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime).RenewalInterval,
 		RetryLimit:      internal.RenewalRetryLimit,
 		Log:             s.log,
@@ -195,6 +207,80 @@ func (s *OutputService) generate(ctx context.Context) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		proxyPing, err := s.proxyPinger.Ping(ctx)
+		if err != nil {
+			return trace.Wrap(err, "pinging proxy")
+		}
+		if err := renderSSHConfig(
+			ctx,
+			s.log,
+			proxyPing,
+			clusterNames,
+			s.cfg.Destination,
+			s.botAuthClient,
+			s.executablePath,
+			s.alpnUpgradeCache,
+			s.insecure,
+			s.fips,
+		); err != nil {
+			return trace.Wrap(err, "rendering OpenSSH configuration files")
+		}
+	}
+
+	return nil
+}
+
+func (s *OutputService) generateScoped(ctx context.Context) error {
+	ctx, span := tracer.Start(
+		ctx,
+		"OutputService/generateScoped",
+	)
+	defer span.End()
+	s.log.InfoContext(ctx, "Generating output in scoped mode")
+
+	// Check the ACLs. We can't fix them, but we can warn if they're
+	// misconfigured. We'll need to precompute a list of keys to check.
+	// Note: This may only log a warning, depending on configuration.
+	if err := s.cfg.Destination.Verify(identity.ListKeys(identity.DestinationKinds()...)); err != nil {
+		return trace.Wrap(err)
+	}
+	// Ensure this destination is also writable. This is a hard fail if
+	// ACLs are misconfigured, regardless of configuration.
+	if err := identity.VerifyWrite(ctx, s.cfg.Destination); err != nil {
+		return trace.Wrap(err, "verifying destination")
+	}
+
+	hostCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	userCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.UserCA, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	databaseCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.DatabaseCA, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
+	id, err := s.identityGenerator.GenerateScoped(
+		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval,
+	)
+	if err != nil {
+		return trace.Wrap(err, "generating scoped identity")
+	}
+
+	if err := s.render(ctx, id, hostCAs, userCAs, databaseCAs); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if s.cfg.SSHConfigMode == SSHConfigModeOn {
+		// For unscoped, we'd actually fetch all the clusters we can access
+		// here, but scopes don't support trusted clusters, so we can just
+		// use our cluster as indicated by our identity.
+		clusterNames := []string{id.ClusterName}
+
 		proxyPing, err := s.proxyPinger.Ping(ctx)
 		if err != nil {
 			return trace.Wrap(err, "pinging proxy")

--- a/lib/tbot/services/identity/output_config.go
+++ b/lib/tbot/services/identity/output_config.go
@@ -114,12 +114,23 @@ func (o *OutputConfig) GetDestination() destination.Destination {
 	return o.Destination
 }
 
-func (o *OutputConfig) CheckAndSetDefaults() error {
+func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}
 	if err := o.Destination.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err, "validating destination")
+	}
+
+	if scoped {
+		switch {
+		case len(o.Roles) != 0:
+			return trace.BadParameter("roles: not supported with scopes")
+		case o.AllowReissue:
+			return trace.BadParameter("allow_reissue: not supported with scopes")
+		case o.Cluster != "":
+			return trace.BadParameter("cluster: not supported with scopes")
+		}
 	}
 
 	if _, ok := o.Destination.(*destination.Directory); !ok {

--- a/lib/tbot/services/identity/output_config_test.go
+++ b/lib/tbot/services/identity/output_config_test.go
@@ -96,6 +96,52 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "ssh_config: unrecognized value \"invalid\"",
 		},
+		{
+			name:   "scoped valid",
+			scoped: true,
+			in: func() *OutputConfig {
+				return &OutputConfig{
+					Destination: destination.NewMemory(),
+				}
+			},
+			want: &OutputConfig{
+				Destination:   destination.NewMemory(),
+				SSHConfigMode: SSHConfigModeOn,
+			},
+		},
+		{
+			name:   "scoped with roles",
+			scoped: true,
+			in: func() *OutputConfig {
+				return &OutputConfig{
+					Destination: destination.NewMemory(),
+					Roles:       []string{"access"},
+				}
+			},
+			wantErr: "roles: not supported with scopes",
+		},
+		{
+			name:   "scoped with allow_reissue",
+			scoped: true,
+			in: func() *OutputConfig {
+				return &OutputConfig{
+					Destination:  destination.NewMemory(),
+					AllowReissue: true,
+				}
+			},
+			wantErr: "allow_reissue: not supported with scopes",
+		},
+		{
+			name:   "scoped with cluster",
+			scoped: true,
+			in: func() *OutputConfig {
+				return &OutputConfig{
+					Destination: destination.NewMemory(),
+					Cluster:     "leaf.example.com",
+				}
+			},
+			wantErr: "cluster: not supported with scopes",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -52,7 +52,7 @@ import (
 // ArgoCDServiceBuilder builds a new ArgoCDOutput.
 func ArgoCDServiceBuilder(cfg *ArgoCDOutputConfig, opts ...ArgoCDServiceOption) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 

--- a/lib/tbot/services/k8s/argocd_output_config.go
+++ b/lib/tbot/services/k8s/argocd_output_config.go
@@ -114,7 +114,10 @@ func (o *ArgoCDOutputConfig) SetName(name string) {
 
 // CheckAndSetDefaults validates the service configuration and sets any default
 // values.
-func (o *ArgoCDOutputConfig) CheckAndSetDefaults() error {
+func (o *ArgoCDOutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", ArgoCDOutputServiceType)
+	}
 	if len(o.Selectors) == 0 {
 		return trace.BadParameter("at least one selector is required")
 	}

--- a/lib/tbot/services/k8s/argocd_output_config_test.go
+++ b/lib/tbot/services/k8s/argocd_output_config_test.go
@@ -240,6 +240,21 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 				ClusterNameTemplate: "{{.ClusterName}}-{{.KubeName}}",
 			},
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *ArgoCDOutputConfig {
+				return &ArgoCDOutputConfig{
+					Selectors: []*KubernetesSelector{
+						{Name: "foo", Labels: make(map[string]string)},
+					},
+					SecretNamespace:     "argocd",
+					SecretNamePrefix:    "argo-cluster",
+					ClusterNameTemplate: "{{.KubeName}}",
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/k8s/helpers_test.go
+++ b/lib/tbot/services/k8s/helpers_test.go
@@ -80,12 +80,16 @@ func testYAML[T any](t *testing.T, tests []testYAMLCase[T]) {
 }
 
 type checkAndSetDefaulter interface {
-	CheckAndSetDefaults() error
+	CheckAndSetDefaults(scoped bool) error
 }
 
 type testCheckAndSetDefaultsCase[T checkAndSetDefaulter] struct {
 	name string
 	in   func() T
+
+	// scoped indicates that CheckAndSetDefaults should be called with
+	// scoped set to true.
+	scoped bool
 
 	// want specifies the desired state of the checkAndSetDefaulter after
 	// check and set defaults has been run. If want is nil, the Output is
@@ -100,7 +104,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.in()
-			err := got.CheckAndSetDefaults()
+			err := got.CheckAndSetDefaults(tt.scoped)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/lib/tbot/services/k8s/output_v1.go
+++ b/lib/tbot/services/k8s/output_v1.go
@@ -53,7 +53,7 @@ const defaultKubeconfigPath = "kubeconfig.yaml"
 
 func OutputV1ServiceBuilder(cfg *OutputV1Config, opts ...OutputV1Option) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &OutputV1Service{

--- a/lib/tbot/services/k8s/output_v1_config.go
+++ b/lib/tbot/services/k8s/output_v1_config.go
@@ -70,7 +70,10 @@ func (o *OutputV1Config) SetName(name string) {
 	o.Name = name
 }
 
-func (o *OutputV1Config) CheckAndSetDefaults() error {
+func (o *OutputV1Config) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", OutputV1ServiceType)
+	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}

--- a/lib/tbot/services/k8s/output_v1_config_test.go
+++ b/lib/tbot/services/k8s/output_v1_config_test.go
@@ -83,6 +83,17 @@ func TestKubernetesOutput_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "kubernetes_cluster must not be empty",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *OutputV1Config {
+				return &OutputV1Config{
+					Destination:       destination.NewMemory(),
+					KubernetesCluster: "my-cluster",
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/k8s/output_v2.go
+++ b/lib/tbot/services/k8s/output_v2.go
@@ -55,7 +55,7 @@ import (
 
 func OutputV2ServiceBuilder(cfg *OutputV2Config, opts ...OutputV2Option) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &OutputV2Service{

--- a/lib/tbot/services/k8s/output_v2_config.go
+++ b/lib/tbot/services/k8s/output_v2_config.go
@@ -84,7 +84,10 @@ func (o *OutputV2Config) SetName(name string) {
 	o.Name = name
 }
 
-func (o *OutputV2Config) CheckAndSetDefaults() error {
+func (o *OutputV2Config) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", OutputV2ServiceType)
+	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}

--- a/lib/tbot/services/k8s/output_v2_config_test.go
+++ b/lib/tbot/services/k8s/output_v2_config_test.go
@@ -170,6 +170,20 @@ func TestKubernetesV2Output_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "can't evaluate field InvalidVariable",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *OutputV2Config {
+				return &OutputV2Config{
+					Destination: destination.NewMemory(),
+					Selectors: []*KubernetesSelector{
+						{Name: "foo", Labels: map[string]string{}},
+					},
+					ContextNameTemplate: "{{.KubeName}}",
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/k8s/secret_destination_test.go
+++ b/lib/tbot/services/k8s/secret_destination_test.go
@@ -122,7 +122,11 @@ func TestDestinationKubernetesSecret(t *testing.T) {
 }
 
 func TestDestinationKubernetesSecret_CheckAndSetDefaults(t *testing.T) {
-	tests := []testCheckAndSetDefaultsCase[*SecretDestination]{
+	tests := []struct {
+		name    string
+		in      func() *SecretDestination
+		wantErr string
+	}{
 		{
 			name: "valid",
 			in: func() *SecretDestination {
@@ -139,7 +143,17 @@ func TestDestinationKubernetesSecret_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "name must not be empty",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in()
+			err := got.CheckAndSetDefaults()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestDestinationKubernetesSecret_YAML(t *testing.T) {

--- a/lib/tbot/services/legacyspiffe/helpers_test.go
+++ b/lib/tbot/services/legacyspiffe/helpers_test.go
@@ -73,12 +73,16 @@ func testYAML[T any](t *testing.T, tests []testYAMLCase[T]) {
 }
 
 type checkAndSetDefaulter interface {
-	CheckAndSetDefaults() error
+	CheckAndSetDefaults(scoped bool) error
 }
 
 type testCheckAndSetDefaultsCase[T checkAndSetDefaulter] struct {
 	name string
 	in   func() T
+
+	// scoped indicates that CheckAndSetDefaults should be called with
+	// scoped set to true.
+	scoped bool
 
 	// want specifies the desired state of the checkAndSetDefaulter after
 	// check and set defaults has been run. If want is nil, the Output is
@@ -93,7 +97,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.in()
-			err := got.CheckAndSetDefaults()
+			err := got.CheckAndSetDefaults(tt.scoped)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/lib/tbot/services/legacyspiffe/svid_output.go
+++ b/lib/tbot/services/legacyspiffe/svid_output.go
@@ -50,7 +50,7 @@ func SVIDOutputServiceBuilder(
 	defaultCredentialLifetime bot.CredentialLifetime,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &SVIDOutputService{

--- a/lib/tbot/services/legacyspiffe/svid_output_config.go
+++ b/lib/tbot/services/legacyspiffe/svid_output_config.go
@@ -142,7 +142,11 @@ func (o *SVIDOutputConfig) GetDestination() destination.Destination {
 }
 
 // CheckAndSetDefaults checks the SPIFFESVIDOutput values and sets any defaults.
-func (o *SVIDOutputConfig) CheckAndSetDefaults() error {
+func (o *SVIDOutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", SVIDOutputServiceType)
+	}
+
 	if err := o.SVID.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err, "validating svid")
 	}

--- a/lib/tbot/services/legacyspiffe/workload_api.go
+++ b/lib/tbot/services/legacyspiffe/workload_api.go
@@ -70,7 +70,7 @@ func WorkloadAPIServiceBuilder(
 	defaultCredentialLifetime bot.CredentialLifetime,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		sidecar, credential := clientcredentials.NewSidecar(deps, defaultCredentialLifetime)

--- a/lib/tbot/services/legacyspiffe/workload_api_config.go
+++ b/lib/tbot/services/legacyspiffe/workload_api_config.go
@@ -163,7 +163,11 @@ func (s *WorkloadAPIConfig) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func (s *WorkloadAPIConfig) CheckAndSetDefaults() error {
+func (s *WorkloadAPIConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", WorkloadAPIServiceType)
+	}
+
 	if s.Listen == "" {
 		return trace.BadParameter("listen: should not be empty")
 	}

--- a/lib/tbot/services/ssh/helpers_test.go
+++ b/lib/tbot/services/ssh/helpers_test.go
@@ -67,12 +67,16 @@ func testYAML[T any](t *testing.T, tests []testYAMLCase[T]) {
 }
 
 type checkAndSetDefaulter interface {
-	CheckAndSetDefaults() error
+	CheckAndSetDefaults(scoped bool) error
 }
 
 type testCheckAndSetDefaultsCase[T checkAndSetDefaulter] struct {
 	name string
 	in   func() T
+
+	// scoped indicates that CheckAndSetDefaults should be called with
+	// scoped set to true.
+	scoped bool
 
 	// want specifies the desired state of the checkAndSetDefaulter after
 	// check and set defaults has been run. If want is nil, the Output is
@@ -87,7 +91,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.in()
-			err := got.CheckAndSetDefaults()
+			err := got.CheckAndSetDefaults(tt.scoped)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/lib/tbot/services/ssh/host_output.go
+++ b/lib/tbot/services/ssh/host_output.go
@@ -45,7 +45,7 @@ import (
 
 func HostOutputServiceBuilder(cfg *HostOutputConfig, defaultCredentialLifetime bot.CredentialLifetime) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &HostOutputService{

--- a/lib/tbot/services/ssh/host_output_config.go
+++ b/lib/tbot/services/ssh/host_output_config.go
@@ -86,7 +86,10 @@ func (o *HostOutputConfig) GetDestination() destination.Destination {
 	return o.Destination
 }
 
-func (o *HostOutputConfig) CheckAndSetDefaults() error {
+func (o *HostOutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", HostOutputServiceType)
+	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}

--- a/lib/tbot/services/ssh/host_output_config_test.go
+++ b/lib/tbot/services/ssh/host_output_config_test.go
@@ -101,6 +101,17 @@ func TestSSHHostOutput_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "at least one principal must be specified",
 		},
 		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *HostOutputConfig {
+				return &HostOutputConfig{
+					Destination: destination.NewMemory(),
+					Principals:  []string{"host.example.com"},
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
+		{
 			name: "invalid ca_type",
 			in: func() *HostOutputConfig {
 				return &HostOutputConfig{

--- a/lib/tbot/services/ssh/multiplexer.go
+++ b/lib/tbot/services/ssh/multiplexer.go
@@ -100,7 +100,7 @@ func MultiplexerServiceBuilder(
 	clientMetrics *grpcprom.ClientMetrics,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &MultiplexerService{

--- a/lib/tbot/services/ssh/multiplexer_config.go
+++ b/lib/tbot/services/ssh/multiplexer_config.go
@@ -106,7 +106,10 @@ func (o *MultiplexerConfig) UnmarshalConfig(ctx bot.UnmarshalConfigContext, node
 	return nil
 }
 
-func (s *MultiplexerConfig) CheckAndSetDefaults() error {
+func (s *MultiplexerConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", MultiplexerServiceType)
+	}
 	if s.Destination == nil {
 		return trace.BadParameter("destination: must be specified")
 	}

--- a/lib/tbot/services/ssh/multiplexer_config_test.go
+++ b/lib/tbot/services/ssh/multiplexer_config_test.go
@@ -84,6 +84,20 @@ func TestSSHMultiplexerService_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "destination: must be of type `directory`",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *MultiplexerConfig {
+				return &MultiplexerConfig{
+					Destination: &destination.Directory{
+						Path:     "/opt/machine-id",
+						ACLs:     botfs.ACLOff,
+						Symlinks: botfs.SymlinksInsecure,
+					},
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/workloadidentity/helpers_test.go
+++ b/lib/tbot/services/workloadidentity/helpers_test.go
@@ -84,12 +84,16 @@ func testYAML[T any](t *testing.T, tests []testYAMLCase[T]) {
 }
 
 type checkAndSetDefaulter interface {
-	CheckAndSetDefaults() error
+	CheckAndSetDefaults(scoped bool) error
 }
 
 type testCheckAndSetDefaultsCase[T checkAndSetDefaulter] struct {
 	name string
 	in   func() T
+
+	// scoped indicates that CheckAndSetDefaults should be called with
+	// scoped set to true.
+	scoped bool
 
 	// want specifies the desired state of the checkAndSetDefaulter after
 	// check and set defaults has been run. If want is nil, the Output is
@@ -104,7 +108,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.in()
-			err := got.CheckAndSetDefaults()
+			err := got.CheckAndSetDefaults(tt.scoped)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/lib/tbot/services/workloadidentity/jwt_output.go
+++ b/lib/tbot/services/workloadidentity/jwt_output.go
@@ -43,7 +43,7 @@ func JWTOutputServiceBuilder(
 	defaultCredentialLifetime bot.CredentialLifetime,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &JWTOutputService{

--- a/lib/tbot/services/workloadidentity/jwt_output_config.go
+++ b/lib/tbot/services/workloadidentity/jwt_output_config.go
@@ -64,7 +64,10 @@ func (o *JWTOutputConfig) Init(ctx context.Context) error {
 }
 
 // CheckAndSetDefaults checks the WorkloadIdentityJWTService values and sets any defaults.
-func (o *JWTOutputConfig) CheckAndSetDefaults() error {
+func (o *JWTOutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", JWTOutputServiceType)
+	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}

--- a/lib/tbot/services/workloadidentity/jwt_output_config_test.go
+++ b/lib/tbot/services/workloadidentity/jwt_output_config_test.go
@@ -150,6 +150,24 @@ func TestWorkloadIdentityJWTService_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "no destination configured for output",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *JWTOutputConfig {
+				return &JWTOutputConfig{
+					Selector: bot.WorkloadIdentitySelector{
+						Name: "my-workload-identity",
+					},
+					Destination: &destination.Directory{
+						Path:     "/opt/machine-id",
+						ACLs:     botfs.ACLOff,
+						Symlinks: botfs.SymlinksInsecure,
+					},
+					Audiences: []string{"audience1"},
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/workloadidentity/workload_api.go
+++ b/lib/tbot/services/workloadidentity/workload_api.go
@@ -66,7 +66,7 @@ func WorkloadAPIServiceBuilder(
 	defaultCredentialLifetime bot.CredentialLifetime,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		sidecar, credential := clientcredentials.NewSidecar(deps, defaultCredentialLifetime)

--- a/lib/tbot/services/workloadidentity/workload_api_config.go
+++ b/lib/tbot/services/workloadidentity/workload_api_config.go
@@ -46,7 +46,10 @@ type WorkloadAPIConfig struct {
 }
 
 // CheckAndSetDefaults checks the SPIFFESVIDOutput values and sets any defaults.
-func (o *WorkloadAPIConfig) CheckAndSetDefaults() error {
+func (o *WorkloadAPIConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", WorkloadAPIServiceType)
+	}
 	if o.Listen == "" {
 		return trace.BadParameter("listen: should not be empty")
 	}

--- a/lib/tbot/services/workloadidentity/workload_api_config_test.go
+++ b/lib/tbot/services/workloadidentity/workload_api_config_test.go
@@ -154,6 +154,19 @@ func TestWorkloadIdentityAPIService_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "listen: should not be empty",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *WorkloadAPIConfig {
+				return &WorkloadAPIConfig{
+					Selector: bot.WorkloadIdentitySelector{
+						Name: "my-workload-identity",
+					},
+					Listen: "tcp://0.0.0.0:4040",
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/services/workloadidentity/x509_output.go
+++ b/lib/tbot/services/workloadidentity/x509_output.go
@@ -56,7 +56,7 @@ func X509OutputServiceBuilder(
 	defaultCredentialLifetime bot.CredentialLifetime,
 ) bot.ServiceBuilder {
 	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
-		if err := cfg.CheckAndSetDefaults(); err != nil {
+		if err := cfg.CheckAndSetDefaults(deps.Scoped); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		svc := &X509OutputService{

--- a/lib/tbot/services/workloadidentity/x509_output_config.go
+++ b/lib/tbot/services/workloadidentity/x509_output_config.go
@@ -70,7 +70,10 @@ func (o *X509OutputConfig) GetDestination() destination.Destination {
 }
 
 // CheckAndSetDefaults checks the SPIFFESVIDOutput values and sets any defaults.
-func (o *X509OutputConfig) CheckAndSetDefaults() error {
+func (o *X509OutputConfig) CheckAndSetDefaults(scoped bool) error {
+	if scoped {
+		return trace.BadParameter("service type %q is not supported in scoped mode", X509OutputServiceType)
+	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}

--- a/lib/tbot/services/workloadidentity/x509_output_config_test.go
+++ b/lib/tbot/services/workloadidentity/x509_output_config_test.go
@@ -135,6 +135,23 @@ func TestWorkloadIdentityX509Service_CheckAndSetDefaults(t *testing.T) {
 			},
 			wantErr: "no destination configured for output",
 		},
+		{
+			name:   "scoped",
+			scoped: true,
+			in: func() *X509OutputConfig {
+				return &X509OutputConfig{
+					Selector: bot.WorkloadIdentitySelector{
+						Name: "my-workload-identity",
+					},
+					Destination: &destination.Directory{
+						Path:     "/opt/machine-id",
+						ACLs:     botfs.ACLOff,
+						Symlinks: botfs.SymlinksInsecure,
+					},
+				}
+			},
+			wantErr: "is not supported in scoped mode",
+		},
 	}
 	testCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -307,6 +307,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 		ReloadCh:           b.cfg.ReloadCh,
 		Services:           services,
 		ClientMetrics:      clientMetrics,
+		Scoped:             b.cfg.Scoped,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -39,13 +39,9 @@ import (
 	"testing"
 	"time"
 
-<<<<<<< HEAD
-	"github.com/jackc/pgconn"
-=======
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgconn"
->>>>>>> 9a22eadaf53 (MWI Scopes[6]: tbot changes)
+	"github.com/jackc/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -58,13 +54,9 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
-<<<<<<< HEAD
-=======
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
-	apissh "github.com/gravitational/teleport/api/ssh"
->>>>>>> 9a22eadaf53 (MWI Scopes[6]: tbot changes)
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -33,35 +33,59 @@ import (
 	"os/user"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+<<<<<<< HEAD
 	"github.com/jackc/pgconn"
+=======
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+>>>>>>> 9a22eadaf53 (MWI Scopes[6]: tbot changes)
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+<<<<<<< HEAD
+=======
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	apissh "github.com/gravitational/teleport/api/ssh"
+>>>>>>> 9a22eadaf53 (MWI Scopes[6]: tbot changes)
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	libclient "github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/cryptosuites/cryptosuitestest"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/observability/tracing"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	jointoken "github.com/gravitational/teleport/lib/scopes/joining"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
+	"github.com/gravitational/teleport/lib/sshca"
 	apisshutils "github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
@@ -1329,4 +1353,341 @@ func TestBotJoiningURI(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, "test", tlsIdent.BotName)
+}
+
+// TestScopedBotSSH tests that a scoped bot can produce an identity output
+// with scope pins, and that the identity can be used to SSH to a scoped node.
+func TestScopedBotSSH(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	ctx := t.Context()
+	log := logtest.NewLogger()
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	const (
+		scopeName      = "/test-scope"
+		scopedRoleName = "scoped-ssh-access"
+		botName        = "scoped-ssh-bot"
+		nodeHostname   = "scoped-node"
+	)
+
+	// Start the main Teleport process (auth + proxy, no SSH).
+	process, err := testenv.NewTeleportProcess(
+		t.TempDir(),
+		defaultTestServerOpts(log),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+
+	rootClient, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rootClient.Close() })
+
+	clusterName := process.Config.Auth.ClusterName.GetClusterName()
+
+	// Create a scoped role that grants SSH access.
+	scopedSvc := rootClient.ScopedAccessServiceClient()
+	_, err = scopedSvc.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: scopedRoleName,
+			},
+			Scope: scopeName,
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{scopeName},
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					Logins: []string{currentUser.Username},
+					Labels: []*labelv1.Label{
+						{
+							Name:   "*",
+							Values: []string{"*"},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Create scoped bot (no roles, only scope).
+	_, err = rootClient.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
+		Bot: &machineidv1pb.Bot{
+			Metadata: &headerv1.Metadata{
+				Name: botName,
+			},
+			Scope: scopeName,
+			Spec:  &machineidv1pb.BotSpec{},
+		},
+	})
+	require.NoError(t, err)
+
+	// Generate a keypair for the bot's bound keypair join.
+	botKey, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	botPublicKey := strings.TrimSpace(string(botKey.MarshalSSHPublicKey()))
+
+	// Write the private key to a temp file for tbot's static key config.
+	botKeyPath := filepath.Join(t.TempDir(), "bot_key.pem")
+	require.NoError(t, os.WriteFile(botKeyPath, botKey.PrivateKeyPEM(), 0600))
+
+	// Create a scoped token with bound keypair join method for the bot.
+	botTokenResp, err := process.GetAuthServer().ScopedTokenService.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: &joiningv1.ScopedToken{
+			Kind:    types.KindScopedToken,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "bot-token",
+			},
+			Scope: scopeName,
+			Spec: &joiningv1.ScopedTokenSpec{
+				Roles:      []string{types.RoleBot.String()},
+				JoinMethod: string(types.JoinMethodBoundKeypair),
+				UsageMode:  jointoken.TokenUsageModeBot,
+				BotName:    botName,
+				BotScope:   scopeName,
+				BoundKeypair: &joiningv1.BoundKeypairSpec{
+					Onboarding: &joiningv1.BoundKeypairSpec_OnboardingSpec{
+						InitialPublicKey: botPublicKey,
+					},
+					Recovery: &joiningv1.BoundKeypairSpec_RecoverySpec{
+						Limit: 10,
+						Mode:  "insecure",
+					},
+				},
+			},
+			Status: &joiningv1.ScopedTokenStatus{
+				Usage: &joiningv1.UsageStatus{
+					Status: &joiningv1.UsageStatus_BoundKeypair{
+						BoundKeypair: &joiningv1.BoundKeypairStatus{},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Create scoped role assignment linking the bot to the scoped role.
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			SubKind: scopedaccess.SubKindDynamic,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.NewString(),
+			},
+			Scope: scopeName,
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				BotName:  botName,
+				BotScope: scopeName,
+				Assignments: []*scopedaccessv1.Assignment{
+					{Role: scopedRoleName, Scope: scopeName},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	waitForSRACache(t, process.GetAuthServer(), sraResp)
+
+	// Create a scoped join token for the SSH node so it registers with the
+	// correct scope.
+	nodeTokenResp, err := process.GetAuthServer().ScopedTokenService.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: &joiningv1.ScopedToken{
+			Kind:    types.KindScopedToken,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "node-token",
+			},
+			Scope: scopeName,
+			Spec: &joiningv1.ScopedTokenSpec{
+				AssignedScope: scopeName,
+				Roles:         []string{types.RoleNode.String()},
+				JoinMethod:    string(types.JoinMethodToken),
+				UsageMode:     string(jointoken.TokenUsageModeUnlimited),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Start a second Teleport process as an SSH-only node, joining with the
+	// scoped token so the node gets scope "/test-scope".
+	nodeCfg := servicecfg.MakeDefaultConfig()
+	nodeCfg.Hostname = nodeHostname
+	nodeCfg.DataDir = t.TempDir()
+	nodeCfg.SetToken(nodeTokenResp.Token.Metadata.Name)
+	nodeCfg.SetTokenSecret(nodeTokenResp.Token.Status.Secret)
+	nodeCfg.SetAuthServerAddress(process.Config.Auth.ListenAddr)
+	nodeCfg.Auth.Enabled = false
+	nodeCfg.Proxy.Enabled = false
+	nodeCfg.SSH.Enabled = true
+	nodeCfg.SSH.Addr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
+	nodeCfg.SSH.DisableCreateHostUser = true
+	nodeCfg.CachePolicy.Enabled = false
+	nodeCfg.InstanceMetadataClient = nil
+	nodeCfg.DebugService.Enabled = false
+	nodeCfg.Logger = log
+
+	nodeProcess, err := service.NewTeleport(nodeCfg)
+	require.NoError(t, err)
+	require.NoError(t, nodeProcess.Start())
+	t.Cleanup(func() {
+		require.NoError(t, nodeProcess.Close())
+		require.NoError(t, nodeProcess.Wait())
+	})
+
+	// Wait for the SSH node to be ready.
+	_, err = nodeProcess.WaitForEvent(ctx, service.NodeSSHReady)
+	require.NoError(t, err)
+
+	// Wait for the scoped SSH node to be visible in the reverse tunnel.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		rts, err := process.GetReverseTunnelServer()
+		require.NoError(t, err)
+		cluster, err := rts.Cluster(ctx, clusterName)
+		require.NoError(t, err)
+		nw, err := cluster.NodeWatcher()
+		require.NoError(t, err)
+		got, err := nw.CurrentResourcesWithFilter(ctx, func(r readonly.Server) bool {
+			return r.GetHostname() == nodeHostname
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// Configure and run tbot with an identity output.
+	identityOutput := &identitysvc.OutputConfig{
+		Destination: &destination.Memory{},
+	}
+	botConfig := defaultBotConfig(
+		t, process, &onboarding.Config{
+			TokenValue: botTokenResp.Token.Metadata.Name,
+			JoinMethod: types.JoinMethodBoundKeypair,
+			BoundKeypair: onboarding.BoundKeypairOnboardingConfig{
+				StaticPrivateKeyPath: botKeyPath,
+			},
+		}, config.ServiceConfigs{
+			identityOutput,
+		},
+		defaultBotConfigOpts{
+			useAuthServer: true,
+			insecure:      true,
+		},
+	)
+	botConfig.Scoped = true
+	b := New(botConfig, log)
+	require.NoError(t, b.Run(ctx))
+
+	t.Run("identity certificates have scope pins", func(t *testing.T) {
+		expectedPin := &scopesv1.Pin{
+			Scope: scopeName,
+			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+				scopeName: {scopeName: {scopedRoleName}},
+			}),
+		}
+
+		// Check TLS certificate.
+		tlsIdent := tlsIdentFromDest(ctx, t, identityOutput.GetDestination())
+		require.NotNil(t, tlsIdent.ScopePin, "TLS identity should have a scope pin")
+		require.Empty(t, cmp.Diff(expectedPin, tlsIdent.ScopePin, protocmp.Transform()))
+		require.Empty(t, tlsIdent.Groups, "scoped identity should not have groups/roles")
+
+		// Check SSH certificate.
+		certBytes, err := identityOutput.GetDestination().Read(ctx, identity.SSHCertKey)
+		require.NoError(t, err)
+		sshCert, err := sshutils.ParseCertificate(certBytes)
+		require.NoError(t, err)
+		sshIdent, err := sshca.DecodeIdentity(sshCert)
+		require.NoError(t, err)
+		require.NotNil(t, sshIdent.ScopePin, "SSH identity should have a scope pin")
+		require.Empty(t, cmp.Diff(expectedPin, sshIdent.ScopePin, protocmp.Transform()))
+		require.Empty(t, sshIdent.Roles, "scoped SSH identity should not have roles")
+	})
+
+	t.Run("ssh connection succeeds", func(t *testing.T) {
+		ctx := t.Context()
+		dest := identityOutput.GetDestination()
+
+		// Read individual artifacts from the destination.
+		keyBytes, err := dest.Read(ctx, identity.PrivateKeyKey)
+		require.NoError(t, err)
+		sshCertBytes, err := dest.Read(ctx, identity.SSHCertKey)
+		require.NoError(t, err)
+		tlsCertBytes, err := dest.Read(ctx, identity.TLSCertKey)
+		require.NoError(t, err)
+
+		privKey, err := keys.ParsePrivateKey(keyBytes)
+		require.NoError(t, err)
+
+		// Get host CA for trusted cert verification.
+		hostCA, err := rootClient.GetCertAuthority(ctx, types.CertAuthID{
+			Type:       types.HostCA,
+			DomainName: clusterName,
+		}, false)
+		require.NoError(t, err)
+
+		proxyHost, err := utils.Host(process.Config.Proxy.WebAddr.String())
+		require.NoError(t, err)
+
+		// Parse the TLS cert to extract the username.
+		x509Cert, err := tlsca.ParseCertificatePEM(tlsCertBytes)
+		require.NoError(t, err)
+		tlsIdent, err := tlsca.FromSubject(x509Cert.Subject, x509Cert.NotAfter)
+		require.NoError(t, err)
+
+		// Build a KeyRing from the identity output.
+		keyRing := libclient.NewKeyRing(privKey, privKey)
+		keyRing.Cert = sshCertBytes
+		keyRing.TLSCert = tlsCertBytes
+		keyRing.KeyRingIndex = libclient.KeyRingIndex{
+			ProxyHost:   proxyHost,
+			ClusterName: clusterName,
+			Username:    tlsIdent.Username,
+		}
+
+		// Create a TeleportClient configured with the scoped bot identity.
+		var stdout bytes.Buffer
+		tc, err := libclient.NewClient(&libclient.Config{
+			Username:           tlsIdent.Username,
+			Host:               nodeHostname,
+			HostLogin:          currentUser.Username,
+			WebProxyAddr:       process.Config.Proxy.WebAddr.String(),
+			SSHProxyAddr:       process.Config.Proxy.SSHAddr.String(),
+			SiteName:           clusterName,
+			InsecureSkipVerify: true,
+			NonInteractive:     true,
+			ClientStore:        libclient.NewFSClientStore(t.TempDir()),
+			Stdout:             &stdout,
+			Stderr:             io.Discard,
+			Stdin:              &bytes.Buffer{},
+			Tracer:             tracing.NoopProvider().Tracer("test"),
+			AddKeysToAgent:     libclient.AddKeysToAgentNo,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, tc.AddKeyRing(keyRing))
+		require.NoError(t, tc.AddTrustedCA(ctx, hostCA))
+
+		require.NoError(t, tc.SSH(ctx, []string{"echo hello"}))
+		require.Equal(t, "hello\n", stdout.String())
+	})
+}
+
+func waitForSRACache(t *testing.T, authServer *auth.Server, resps ...*scopedaccessv1.CreateScopedRoleAssignmentResponse) {
+	t.Helper()
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, resp := range resps {
+			_, err := authServer.ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+				Name:    resp.GetAssignment().GetMetadata().GetName(),
+				SubKind: resp.GetAssignment().GetSubKind(),
+			})
+			require.NoError(t, err)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
Backports #65351

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases
- [x] Unscoped (regression)
  - [x] Run `tbot` with `identity` service, oneshot and daemon
    - [x] Use resulting identity with `tsh` to connect to a host
    - [x] Use resulting OpenSSH configuration with `ssh` to connect to a host 
- [x] Scoped
  - [x] Run `tbot` without `--scoped` against scoped Bot (should fail)
  - [x] Run  `tbot` with `--scoped` against an unscoped Bot(should fail)
  - [x] Run `tbot` with `identity` service, oneshot and daemon - Bound Keypair 
    - [x] Use resulting identity with `tsh` to connect to a host
    - [x] Use resulting OpenSSH configuration with `ssh` to connect to a host 
    - [x] Run again prior to internal expiry to test standard renewal
    - [x] Run again after internal expiry to test recovery
  - [x] Run `tbot` oneshot with Kubernetes join method
    - [x] Test with `--scoped` CLI flag and `scoped` config file entry. 
    - [x] Run again prior to internal expiry to test renewal - ensure BotInstanceID remains the same.
    - [x] Run again after internal expiry to test rejoin - ensure BotInstanceID changes. 
  - [x] Run `tbot` with `--scoped` and non-scopes-supporting service, expect clear error. 
