### PR TITLE
Add linting against UnimplementedFooService

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -388,6 +388,12 @@ linters:
         - pattern: ^ssh\.(Dial|NewClientWithTimeout|NewClientConnWithTimeout)$
           pkg: ^github\.com/gravitational/teleport/api/observability/tracing/ssh$
           msg: Use api/ssh package to construct SSH clients with proper defaults
+        # only takes effect outside of e due to exclusion rules defined later
+        - pattern: ^.*\.Unimplemented.*Server$
+          msg: Use UnsafeFooServer instead
+        # only takes effect in e due to exclusion rules defined later
+        - pattern: ^.*\.Unsafe.*Server$
+          msg: Use UnimplementedFooServer instead
       analyze-types: true
     misspell:
       locale: US
@@ -564,6 +570,16 @@ linters:
       - linters:
           - forcetypeassert
         path-except: ^lib/tlsca/ca\.go$
+
+      - linters:
+          - forbidigo
+        text: Use UnimplementedFooServer instead
+        # no exclusion for test files because tests in e should also continue to build
+        path-except: ^e/
+      - linters:
+          - forbidigo
+        text: Use UnsafeFooServer instead
+        path: (^e/)|(_test.go$)
 
     paths:
       - (^|/)node_modules/

--- a/api/client/proto/authservice_grpc.pb.go
+++ b/api/client/proto/authservice_grpc.pb.go
@@ -4009,7 +4009,7 @@ func (c *authServiceClient) ValidateTrustedCluster(ctx context.Context, in *Vali
 }
 
 // AuthServiceServer is the server API for AuthService service.
-// All implementations should embed UnimplementedAuthServiceServer
+// All implementations must embed UnimplementedAuthServiceServer
 // for forward compatibility.
 //
 // AuthService is authentication/authorization service implementation
@@ -4770,9 +4770,10 @@ type AuthServiceServer interface {
 	// by the proxy on behalf of a cluster that wishes to join to this one as a
 	// leaf cluster.
 	ValidateTrustedCluster(context.Context, *ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error)
+	mustEmbedUnimplementedAuthServiceServer()
 }
 
-// UnimplementedAuthServiceServer should be embedded to have
+// UnimplementedAuthServiceServer must be embedded to have
 // forward compatible implementations.
 //
 // NOTE: this should be embedded by value instead of pointer to avoid a nil
@@ -5607,7 +5608,8 @@ func (UnimplementedAuthServiceServer) DeleteClusterMaintenanceConfig(context.Con
 func (UnimplementedAuthServiceServer) ValidateTrustedCluster(context.Context, *ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ValidateTrustedCluster not implemented")
 }
-func (UnimplementedAuthServiceServer) testEmbeddedByValue() {}
+func (UnimplementedAuthServiceServer) mustEmbedUnimplementedAuthServiceServer() {}
+func (UnimplementedAuthServiceServer) testEmbeddedByValue()                     {}
 
 // UnsafeAuthServiceServer may be embedded to opt out of forward compatibility for this service.
 // Use of this interface is not recommended, as added methods to AuthServiceServer will

--- a/api/client/proto/joinservice_grpc.pb.go
+++ b/api/client/proto/joinservice_grpc.pb.go
@@ -156,7 +156,7 @@ func (c *joinServiceClient) RegisterUsingToken(ctx context.Context, in *types.Re
 }
 
 // JoinServiceServer is the server API for JoinService service.
-// All implementations should embed UnimplementedJoinServiceServer
+// All implementations must embed UnimplementedJoinServiceServer
 // for forward compatibility.
 //
 // JoinService provides methods which allow Teleport nodes, proxies, and other
@@ -183,9 +183,10 @@ type JoinServiceServer interface {
 	// RegisterUsingToken is used to register a new node to the cluster using one
 	// of the legacy join methods which do not yet have their own gRPC method.
 	RegisterUsingToken(context.Context, *types.RegisterUsingTokenRequest) (*Certs, error)
+	mustEmbedUnimplementedJoinServiceServer()
 }
 
-// UnimplementedJoinServiceServer should be embedded to have
+// UnimplementedJoinServiceServer must be embedded to have
 // forward compatible implementations.
 //
 // NOTE: this should be embedded by value instead of pointer to avoid a nil
@@ -210,7 +211,8 @@ func (UnimplementedJoinServiceServer) RegisterUsingBoundKeypairMethod(grpc.BidiS
 func (UnimplementedJoinServiceServer) RegisterUsingToken(context.Context, *types.RegisterUsingTokenRequest) (*Certs, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RegisterUsingToken not implemented")
 }
-func (UnimplementedJoinServiceServer) testEmbeddedByValue() {}
+func (UnimplementedJoinServiceServer) mustEmbedUnimplementedJoinServiceServer() {}
+func (UnimplementedJoinServiceServer) testEmbeddedByValue()                     {}
 
 // UnsafeJoinServiceServer may be embedded to opt out of forward compatibility for this service.
 // Use of this interface is not recommended, as added methods to JoinServiceServer will

--- a/api/client/proto/proxyservice_grpc.pb.go
+++ b/api/client/proto/proxyservice_grpc.pb.go
@@ -81,7 +81,7 @@ func (c *proxyServiceClient) Ping(ctx context.Context, in *ProxyServicePingReque
 }
 
 // ProxyServiceServer is the server API for ProxyService service.
-// All implementations should embed UnimplementedProxyServiceServer
+// All implementations must embed UnimplementedProxyServiceServer
 // for forward compatibility.
 //
 // ProxyPeerService is a proxy to proxy api.
@@ -90,9 +90,10 @@ type ProxyServiceServer interface {
 	DialNode(grpc.BidiStreamingServer[Frame, Frame]) error
 	// Ping checks if the peer is reachable and responsive.
 	Ping(context.Context, *ProxyServicePingRequest) (*ProxyServicePingResponse, error)
+	mustEmbedUnimplementedProxyServiceServer()
 }
 
-// UnimplementedProxyServiceServer should be embedded to have
+// UnimplementedProxyServiceServer must be embedded to have
 // forward compatible implementations.
 //
 // NOTE: this should be embedded by value instead of pointer to avoid a nil
@@ -105,7 +106,8 @@ func (UnimplementedProxyServiceServer) DialNode(grpc.BidiStreamingServer[Frame, 
 func (UnimplementedProxyServiceServer) Ping(context.Context, *ProxyServicePingRequest) (*ProxyServicePingResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Ping not implemented")
 }
-func (UnimplementedProxyServiceServer) testEmbeddedByValue() {}
+func (UnimplementedProxyServiceServer) mustEmbedUnimplementedProxyServiceServer() {}
+func (UnimplementedProxyServiceServer) testEmbeddedByValue()                      {}
 
 // UnsafeProxyServiceServer may be embedded to opt out of forward compatibility for this service.
 // Use of this interface is not recommended, as added methods to ProxyServiceServer will

--- a/api/gen/proto/go/teleport/mfa/v1/service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/mfa/v1/service_grpc.pb.go
@@ -146,7 +146,7 @@ func (c *mFAServiceClient) CompleteBrowserMFAChallenge(ctx context.Context, in *
 }
 
 // MFAServiceServer is the server API for MFAService service.
-// All implementations should embed UnimplementedMFAServiceServer
+// All implementations must embed UnimplementedMFAServiceServer
 // for forward compatibility.
 //
 // MFAService defines the Multi-Factor Authentication (MFA) service. While this service is currently focused on user
@@ -179,9 +179,10 @@ type MFAServiceServer interface {
 	// response, encrypts it, appends it to tsh/tctl's callback URL and returns it to the browser.
 	// More info: https://github.com/gravitational/teleport/blob/master/rfd/0233-tsh-browser-mfa.md
 	CompleteBrowserMFAChallenge(context.Context, *CompleteBrowserMFAChallengeRequest) (*CompleteBrowserMFAChallengeResponse, error)
+	mustEmbedUnimplementedMFAServiceServer()
 }
 
-// UnimplementedMFAServiceServer should be embedded to have
+// UnimplementedMFAServiceServer must be embedded to have
 // forward compatible implementations.
 //
 // NOTE: this should be embedded by value instead of pointer to avoid a nil
@@ -206,7 +207,8 @@ func (UnimplementedMFAServiceServer) VerifyValidatedMFAChallenge(context.Context
 func (UnimplementedMFAServiceServer) CompleteBrowserMFAChallenge(context.Context, *CompleteBrowserMFAChallengeRequest) (*CompleteBrowserMFAChallengeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CompleteBrowserMFAChallenge not implemented")
 }
-func (UnimplementedMFAServiceServer) testEmbeddedByValue() {}
+func (UnimplementedMFAServiceServer) mustEmbedUnimplementedMFAServiceServer() {}
+func (UnimplementedMFAServiceServer) testEmbeddedByValue()                    {}
 
 // UnsafeMFAServiceServer may be embedded to opt out of forward compatibility for this service.
 // Use of this interface is not recommended, as added methods to MFAServiceServer will

--- a/api/utils/keys/hardwarekeyagent/agent.go
+++ b/api/utils/keys/hardwarekeyagent/agent.go
@@ -81,7 +81,7 @@ type KnownHardwareKeyFn func(ref *hardwarekey.PrivateKeyRef, keyInfo hardwarekey
 
 // agentService implements [hardwarekeyagentv1.HardwareKeyAgentServiceServer].
 type agentService struct {
-	hardwarekeyagentv1.UnimplementedHardwareKeyAgentServiceServer
+	hardwarekeyagentv1.UnsafeHardwareKeyAgentServiceServer
 	s hardwarekey.Service
 
 	// knownKeyFn is a function to determine if the hardware private key, described by the given

--- a/buf-gogo.gen.yaml
+++ b/buf-gogo.gen.yaml
@@ -32,6 +32,4 @@ plugins:
       - run
       - google.golang.org/grpc/cmd/protoc-gen-go-grpc
     out: ./gogogen
-    opt:
-      - require_unimplemented_servers=false
     strategy: all

--- a/lib/auth/accessmonitoringrules/accessmonitoringrulesv1/service.go
+++ b/lib/auth/accessmonitoringrules/accessmonitoringrulesv1/service.go
@@ -46,7 +46,7 @@ type Cache interface {
 
 // Service implements the teleport.accessmonitoringrules.v1.AccessMonitoringRulesService RPC service.
 type Service struct {
-	accessmonitoringrulesv1.UnimplementedAccessMonitoringRulesServiceServer
+	accessmonitoringrulesv1.UnsafeAccessMonitoringRulesServiceServer
 
 	backend    services.AccessMonitoringRules
 	authorizer authz.Authorizer

--- a/lib/auth/appauthconfig/appauthconfigv1/service.go
+++ b/lib/auth/appauthconfig/appauthconfigv1/service.go
@@ -48,7 +48,7 @@ type ServiceConfig struct {
 // Service implements the teleport.appauthconfig.v1.AppAuthConfigServer gRPC
 // API.
 type Service struct {
-	appauthconfigv1.UnimplementedAppAuthConfigServiceServer
+	appauthconfigv1.UnsafeAppAuthConfigServiceServer
 
 	authorizer authz.Authorizer
 	backend    services.AppAuthConfig

--- a/lib/auth/appauthconfig/appauthconfigv1/sessions_service.go
+++ b/lib/auth/appauthconfig/appauthconfigv1/sessions_service.go
@@ -80,7 +80,7 @@ type AppSessionCreator interface {
 // Service implements the teleport.appauthconfig.v1.AppAuthConfigSessionsServiceServer
 // gRPC API.
 type SessionsService struct {
-	appauthconfigv1.UnimplementedAppAuthConfigSessionsServiceServer
+	appauthconfigv1.UnsafeAppAuthConfigSessionsServiceServer
 
 	authorizer authz.Authorizer
 	cache      services.AppAuthConfigReader

--- a/lib/auth/autoupdate/autoupdatev1/service.go
+++ b/lib/auth/autoupdate/autoupdatev1/service.go
@@ -82,7 +82,7 @@ type Backend interface {
 
 // Service implements the gRPC API layer for the AutoUpdate.
 type Service struct {
-	autoupdate.UnimplementedAutoUpdateServiceServer
+	autoupdate.UnsafeAutoUpdateServiceServer
 
 	authorizer authz.Authorizer
 	backend    services.AutoUpdateService

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -21,6 +21,8 @@ import (
 	"log/slog"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -101,7 +103,7 @@ type AccessGraphConfig struct {
 
 // Service implements the teleport.clusterconfig.v1.ClusterConfigService RPC service.
 type Service struct {
-	clusterconfigpb.UnimplementedClusterConfigServiceServer
+	clusterconfigpb.UnsafeClusterConfigServiceServer
 
 	cache                         Cache
 	backend                       Backend
@@ -1192,4 +1194,9 @@ func (s *Service) GetClusterName(ctx context.Context, _ *clusterconfigpb.GetClus
 		return nil, trace.BadParameter("unexpected cluster name type %T (expected %T)", cn, cast)
 	}
 	return cast, nil
+}
+
+// GetClusterAuditConfig implements [clusterconfigpb.ClusterConfigServiceServer].
+func (*Service) GetClusterAuditConfig(context.Context, *clusterconfigpb.GetClusterAuditConfigRequest) (*types.ClusterAuditConfigV2, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetClusterAuditConfig not implemented")
 }

--- a/lib/auth/crownjewel/crownjewelv1/service.go
+++ b/lib/auth/crownjewel/crownjewelv1/service.go
@@ -78,7 +78,7 @@ type Reader interface {
 
 // Service implements the teleport.CrownJewel.v1.CrownJewelService RPC service.
 type Service struct {
-	crownjewelv1.UnimplementedCrownJewelServiceServer
+	crownjewelv1.UnsafeCrownJewelServiceServer
 
 	authorizer authz.Authorizer
 	backend    services.CrownJewels

--- a/lib/auth/delegation/delegationv1/session_service.go
+++ b/lib/auth/delegation/delegationv1/session_service.go
@@ -35,7 +35,7 @@ import (
 
 // SessionService manages DelegationSession resources.
 type SessionService struct {
-	delegationv1.UnimplementedDelegationSessionServiceServer
+	delegationv1.UnsafeDelegationSessionServiceServer
 
 	authorizer        authz.Authorizer
 	sessionReader     SessionReader

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -98,7 +98,7 @@ func (s *ServiceConfig) CheckAndSetDefaults() error {
 
 // Service implements the teleport.DiscoveryConfig.v1.DiscoveryConfigService RPC service.
 type Service struct {
-	discoveryconfigv1.UnimplementedDiscoveryConfigServiceServer
+	discoveryconfigv1.UnsafeDiscoveryConfigServiceServer
 
 	log           *slog.Logger
 	authorizer    authz.Authorizer

--- a/lib/auth/dynamicwindows/dynamicwindowsv1/service.go
+++ b/lib/auth/dynamicwindows/dynamicwindowsv1/service.go
@@ -34,7 +34,7 @@ import (
 
 // Service implements the teleport.trust.v1.TrustService RPC service.
 type Service struct {
-	dynamicwindowspb.UnimplementedDynamicWindowsServiceServer
+	dynamicwindowspb.UnsafeDynamicWindowsServiceServer
 
 	authorizer authz.Authorizer
 	backend    Backend

--- a/lib/auth/grpcclientconfig/grpcclientconfigv1/service.go
+++ b/lib/auth/grpcclientconfig/grpcclientconfigv1/service.go
@@ -54,7 +54,7 @@ func NewService() (*Service, error) {
 // Service is an impementation of the [grpcv1.ServiceConfigDiscoveryServiceServer].
 // It allows grpc clients to discover their client configuration at runtime.
 type Service struct {
-	grpcv1.UnimplementedServiceConfigDiscoveryServiceServer
+	grpcv1.UnsafeServiceConfigDiscoveryServiceServer
 	config *grpcv1.ServiceConfig
 }
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -217,8 +217,8 @@ var (
 
 // GRPCServer is gRPC Auth Server API
 type GRPCServer struct {
-	authpb.UnimplementedAuthServiceServer
-	auditlogpb.UnimplementedAuditLogServiceServer
+	authpb.UnsafeAuthServiceServer
+	auditlogpb.UnsafeAuditLogServiceServer
 	logger *slog.Logger
 	APIConfig
 	server      *grpc.Server
@@ -6921,4 +6921,69 @@ func (g *GRPCServer) ValidateTrustedCluster(
 	}
 
 	return protoResp, nil
+}
+
+// CreateSAMLIdPSession implements [authpb.AuthServiceServer].
+func (*GRPCServer) CreateSAMLIdPSession(context.Context, *authpb.CreateSAMLIdPSessionRequest) (*authpb.CreateSAMLIdPSessionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateSAMLIdPSession not implemented")
+}
+
+// CreateUser implements [authpb.AuthServiceServer].
+func (*GRPCServer) CreateUser(context.Context, *types.UserV2) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateUser not implemented")
+}
+
+// DeleteAllSAMLIdPSessions implements [authpb.AuthServiceServer].
+func (*GRPCServer) DeleteAllSAMLIdPSessions(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteAllSAMLIdPSessions not implemented")
+}
+
+// DeleteSAMLIdPSession implements [authpb.AuthServiceServer].
+func (*GRPCServer) DeleteSAMLIdPSession(context.Context, *authpb.DeleteSAMLIdPSessionRequest) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteSAMLIdPSession not implemented")
+}
+
+// DeleteUser implements [authpb.AuthServiceServer].
+func (*GRPCServer) DeleteUser(context.Context, *authpb.DeleteUserRequest) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteUser not implemented")
+}
+
+// DeleteUserSAMLIdPSessions implements [authpb.AuthServiceServer].
+func (*GRPCServer) DeleteUserSAMLIdPSessions(context.Context, *authpb.DeleteUserSAMLIdPSessionsRequest) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteUserSAMLIdPSessions not implemented")
+}
+
+// GetCurrentUser implements [authpb.AuthServiceServer].
+func (*GRPCServer) GetCurrentUser(context.Context, *emptypb.Empty) (*types.UserV2, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetCurrentUser not implemented")
+}
+
+// GetSAMLIdPSession implements [authpb.AuthServiceServer].
+func (*GRPCServer) GetSAMLIdPSession(context.Context, *authpb.GetSAMLIdPSessionRequest) (*authpb.GetSAMLIdPSessionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetSAMLIdPSession not implemented")
+}
+
+// GetUser implements [authpb.AuthServiceServer].
+func (*GRPCServer) GetUser(context.Context, *authpb.GetUserRequest) (*types.UserV2, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUser not implemented")
+}
+
+// GetUsers implements [authpb.AuthServiceServer].
+func (*GRPCServer) GetUsers(*authpb.GetUsersRequest, grpc.ServerStreamingServer[types.UserV2]) error {
+	return status.Errorf(codes.Unimplemented, "method GetUsers not implemented")
+}
+
+// ListSAMLIdPSessions implements [authpb.AuthServiceServer].
+func (*GRPCServer) ListSAMLIdPSessions(context.Context, *authpb.ListSAMLIdPSessionsRequest) (*authpb.ListSAMLIdPSessionsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListSAMLIdPSessions not implemented")
+}
+
+// UpdateRemoteCluster implements [authpb.AuthServiceServer].
+func (*GRPCServer) UpdateRemoteCluster(context.Context, *types.RemoteClusterV3) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateRemoteCluster not implemented")
+}
+
+// UpdateUser implements [authpb.AuthServiceServer].
+func (*GRPCServer) UpdateUser(context.Context, *types.UserV2) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateUser not implemented")
 }

--- a/lib/auth/healthcheckconfig/healthcheckconfigv1/service.go
+++ b/lib/auth/healthcheckconfig/healthcheckconfigv1/service.go
@@ -48,7 +48,7 @@ type ServiceConfig struct {
 // Service implements the teleport.healthcheck.v1.HealthCheckConfigService gRPC
 // API.
 type Service struct {
-	healthcheckconfigv1.UnimplementedHealthCheckConfigServiceServer
+	healthcheckconfigv1.UnsafeHealthCheckConfigServiceServer
 
 	authorizer authz.Authorizer
 	backend    services.HealthCheckConfig

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -224,7 +224,7 @@ func (s *AWSOIDCServiceConfig) CheckAndSetDefaults() error {
 
 // AWSOIDCService implements the teleport.integration.v1.AWSOIDCService RPC service.
 type AWSOIDCService struct {
-	integrationpb.UnimplementedAWSOIDCServiceServer
+	integrationpb.UnsafeAWSOIDCServiceServer
 
 	integrationService    *Service
 	authorizer            authz.Authorizer

--- a/lib/auth/integration/integrationv1/awsra.go
+++ b/lib/auth/integration/integrationv1/awsra.go
@@ -149,7 +149,7 @@ func (s *AWSRolesAnywhereServiceConfig) CheckAndSetDefaults() error {
 
 // AWSRolesAnywhereService implements the teleport.integration.v1.AWSRolesAnywhereService RPC service.
 type AWSRolesAnywhereService struct {
-	integrationpb.UnimplementedAWSRolesAnywhereServiceServer
+	integrationpb.UnsafeAWSRolesAnywhereServiceServer
 
 	integrationService *Service
 	authorizer         authz.Authorizer

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -157,7 +157,7 @@ func (s *ServiceConfig) CheckAndSetDefaults() error {
 
 // Service implements the teleport.integration.v1.IntegrationService RPC service.
 type Service struct {
-	integrationpb.UnimplementedIntegrationServiceServer
+	integrationpb.UnsafeIntegrationServiceServer
 	authorizer      authz.Authorizer
 	cache           Cache
 	keyStoreManager KeyStoreManager

--- a/lib/auth/inventory/inventoryv1/service.go
+++ b/lib/auth/inventory/inventoryv1/service.go
@@ -44,7 +44,7 @@ type ServiceConfig struct {
 
 // Service implements the teleport.inventory.v1.InventoryService RPC service.
 type Service struct {
-	inventorypb.UnimplementedInventoryServiceServer
+	inventorypb.UnsafeInventoryServiceServer
 
 	authorizer     authz.Authorizer
 	inventoryCache InventoryCache

--- a/lib/auth/issuance/v1/service.go
+++ b/lib/auth/issuance/v1/service.go
@@ -57,7 +57,7 @@ type authServer interface {
 //     CA information, we MUST ensure that different CA types are not
 //     intermingled - it must be explicit what CA is being returned.
 type Service struct {
-	issuancev1pb.UnimplementedIssuanceServiceServer
+	issuancev1pb.UnsafeIssuanceServiceServer
 	scopedAuthorizer authz.ScopedAuthorizer
 	authServer       authServer
 }

--- a/lib/auth/kubewaitingcontainer/kubewaitingcontainerv1/service.go
+++ b/lib/auth/kubewaitingcontainer/kubewaitingcontainerv1/service.go
@@ -52,7 +52,7 @@ type Cache interface {
 // Service implements the teleport.kubewaitingcontainer.v1.KubernetesWaitingContainer
 // RPC service.
 type Service struct {
-	kubewaitingcontainerpb.UnimplementedKubeWaitingContainersServiceServer
+	kubewaitingcontainerpb.UnsafeKubeWaitingContainersServiceServer
 
 	authorizer authz.Authorizer
 	backend    services.KubeWaitingContainer

--- a/lib/auth/loginrule/loginrulev1/service.go
+++ b/lib/auth/loginrule/loginrulev1/service.go
@@ -32,7 +32,7 @@ import (
 // is required to use the service. Using a [loginrulepb.UnimplementedLoginRuleServiceServer]
 // would result in ambiguous not implemented errors being returned from open source.
 type NotImplementedService struct {
-	loginrulepb.UnimplementedLoginRuleServiceServer
+	loginrulepb.UnsafeLoginRuleServiceServer
 }
 
 func (NotImplementedService) CreateLoginRule(context.Context, *loginrulepb.CreateLoginRuleRequest) (*loginrulepb.LoginRule, error) {

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -104,7 +104,7 @@ func NewBotInstanceService(cfg BotInstanceServiceConfig) (*BotInstanceService, e
 
 // BotInstanceService implements the teleport.machineid.v1.BotInstanceService RPC service.
 type BotInstanceService struct {
-	pb.UnimplementedBotInstanceServiceServer
+	pb.UnsafeBotInstanceServiceServer
 
 	backend    services.BotInstance
 	authorizer authz.ScopedAuthorizer

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -157,7 +157,7 @@ func NewBotService(cfg BotServiceConfig) (*BotService, error) {
 
 // BotService implements the teleport.machineid.v1.BotService RPC service.
 type BotService struct {
-	pb.UnimplementedBotServiceServer
+	pb.UnsafeBotServiceServer
 
 	cache            Cache
 	backend          Backend

--- a/lib/auth/machineid/machineidv1/spiffe_federation_service.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_service.go
@@ -96,7 +96,7 @@ func NewSPIFFEFederationService(
 // SPIFFEFederationService is an implementation of
 // teleport.machineid.v1.SPIFFEFederationService
 type SPIFFEFederationService struct {
-	machineidv1.UnimplementedSPIFFEFederationServiceServer
+	machineidv1.UnsafeSPIFFEFederationServiceServer
 
 	authorizer authz.Authorizer
 	backend    spiffeFederationReadWriter

--- a/lib/auth/machineid/machineidv1/workload_identity_service.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service.go
@@ -125,7 +125,7 @@ func NewWorkloadIdentityService(
 // WorkloadIdentityService implements the teleport.machineid.v1.WorkloadIdentity
 // RPC service.
 type WorkloadIdentityService struct {
-	pb.UnimplementedWorkloadIdentityServiceServer
+	pb.UnsafeWorkloadIdentityServiceServer
 
 	cache      WorkloadIdentityCacher
 	authorizer authz.Authorizer

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -107,7 +107,7 @@ type IssuanceServiceConfig struct {
 // IssuanceService is the gRPC service for managing workload identity resources.
 // It implements the workloadidentityv1pb.WorkloadIdentityIssuanceServiceServer.
 type IssuanceService struct {
-	workloadidentityv1pb.UnimplementedWorkloadIdentityIssuanceServiceServer
+	workloadidentityv1pb.UnsafeWorkloadIdentityIssuanceServiceServer
 
 	authorizer                 authz.Authorizer
 	cache                      issuerCache

--- a/lib/auth/machineid/workloadidentityv1/resource_service.go
+++ b/lib/auth/machineid/workloadidentityv1/resource_service.go
@@ -61,7 +61,7 @@ type ResourceServiceConfig struct {
 // ResourceService is the gRPC service for managing workload identity resources.
 // It implements the workloadidentityv1pb.WorkloadIdentityResourceServiceServer
 type ResourceService struct {
-	workloadidentityv1pb.UnimplementedWorkloadIdentityResourceServiceServer
+	workloadidentityv1pb.UnsafeWorkloadIdentityResourceServiceServer
 
 	authorizer authz.Authorizer
 	backend    workloadIdentityReadWriter

--- a/lib/auth/machineid/workloadidentityv1/revocation_service.go
+++ b/lib/auth/machineid/workloadidentityv1/revocation_service.go
@@ -85,7 +85,7 @@ type RevocationServiceConfig struct {
 // revocations.
 // It implements the workloadidentityv1pb.WorkloadIdentityRevocationServiceServer
 type RevocationService struct {
-	workloadidentityv1pb.UnimplementedWorkloadIdentityRevocationServiceServer
+	workloadidentityv1pb.UnsafeWorkloadIdentityRevocationServiceServer
 
 	authorizer          authz.Authorizer
 	store               workloadIdentityX509RevocationReadWriter

--- a/lib/auth/machineid/workloadidentityv1/sigstore_policy_service.go
+++ b/lib/auth/machineid/workloadidentityv1/sigstore_policy_service.go
@@ -34,7 +34,7 @@ func NewSigstorePolicyResourceService() workloadidentityv1.SigstorePolicyResourc
 }
 
 type sigstorePolicyResourceService struct {
-	workloadidentityv1.UnimplementedSigstorePolicyResourceServiceServer
+	workloadidentityv1.UnsafeSigstorePolicyResourceServiceServer
 }
 
 func (s sigstorePolicyResourceService) CreateSigstorePolicy(context.Context, *workloadidentityv1.CreateSigstorePolicyRequest) (*workloadidentityv1.SigstorePolicy, error) {
@@ -54,6 +54,11 @@ func (s sigstorePolicyResourceService) GetSigstorePolicy(context.Context, *workl
 }
 
 func (s sigstorePolicyResourceService) ListSigstorePolicies(context.Context, *workloadidentityv1.ListSigstorePoliciesRequest) (*workloadidentityv1.ListSigstorePoliciesResponse, error) {
+	return nil, s.requireEnterprise()
+}
+
+// UpsertSigstorePolicy implements [workloadidentityv1.SigstorePolicyResourceServiceServer].
+func (s sigstorePolicyResourceService) UpsertSigstorePolicy(context.Context, *workloadidentityv1.UpsertSigstorePolicyRequest) (*workloadidentityv1.SigstorePolicy, error) {
 	return nil, s.requireEnterprise()
 }
 

--- a/lib/auth/mfa/mfav1/service.go
+++ b/lib/auth/mfa/mfav1/service.go
@@ -123,7 +123,7 @@ type ServiceConfig struct {
 
 // Service implements the teleport.decision.v1alpha1.DecisionService gRPC API.
 type Service struct {
-	mfav1.UnimplementedMFAServiceServer
+	mfav1.UnsafeMFAServiceServer
 
 	logger     *slog.Logger
 	authorizer authz.Authorizer

--- a/lib/auth/notifications/notificationsv1/service.go
+++ b/lib/auth/notifications/notificationsv1/service.go
@@ -72,7 +72,7 @@ type Backend interface {
 
 // Service implements the teleport.notifications.v1.NotificationsService RPC Service.
 type Service struct {
-	notificationsv1.UnimplementedNotificationServiceServer
+	notificationsv1.UnsafeNotificationServiceServer
 
 	authorizer              authz.Authorizer
 	backend                 Backend

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/gravitational/teleport"
@@ -78,7 +80,7 @@ type ServiceConfig struct {
 
 // Service implements the teleport.presence.v1.PresenceService RPC service.
 type Service struct {
-	presencepb.UnimplementedPresenceServiceServer
+	presencepb.UnsafePresenceServiceServer
 
 	authorizer authz.Authorizer
 	authServer AuthServer
@@ -476,4 +478,14 @@ func (s *Service) DeleteRelayServer(ctx context.Context, req *presencepb.DeleteR
 	}
 
 	return &presencepb.DeleteRelayServerResponse{}, nil
+}
+
+// ListAuthServers implements [presencev1.PresenceServiceServer].
+func (*Service) ListAuthServers(context.Context, *presencepb.ListAuthServersRequest) (*presencepb.ListAuthServersResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListAuthServers not implemented")
+}
+
+// ListProxyServers implements [presencev1.PresenceServiceServer].
+func (*Service) ListProxyServers(context.Context, *presencepb.ListProxyServersRequest) (*presencepb.ListProxyServersResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListProxyServers not implemented")
 }

--- a/lib/auth/recordingencryption/recordingencryptionv1/service.go
+++ b/lib/auth/recordingencryption/recordingencryptionv1/service.go
@@ -93,7 +93,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 
 // Service implements a gRPC server for interacting with encrypted recordings.
 type Service struct {
-	recordingencryptionv1.UnimplementedRecordingEncryptionServiceServer
+	recordingencryptionv1.UnsafeRecordingEncryptionServiceServer
 
 	auth     authz.Authorizer
 	logger   *slog.Logger

--- a/lib/auth/recordingmetadata/recordingmetadatav1/service.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/service.go
@@ -41,7 +41,7 @@ import (
 // Service implements the RecordingMetadataServiceServer interface, providing methods to retrieve session recording
 // metadata and thumbnails.
 type Service struct {
-	pb.UnimplementedRecordingMetadataServiceServer
+	pb.UnsafeRecordingMetadataServiceServer
 
 	authorizer      Authorizer
 	streamer        player.Streamer

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -69,7 +69,7 @@ func (c *Config) CheckAndSetDefaults() error {
 
 // Server is the [scopedaccessv1.UnimplementedScopedAccessServiceServer] returned by [New].
 type Server struct {
-	scopedaccessv1.UnimplementedScopedAccessServiceServer
+	scopedaccessv1.UnsafeScopedAccessServiceServer
 	cfg Config
 }
 

--- a/lib/auth/summarizer/summarizerv1/service.go
+++ b/lib/auth/summarizer/summarizerv1/service.go
@@ -33,7 +33,7 @@ func NewService() *UnimplementedService {
 // UnimplementedService is an OSS version of the UnimplementedService. It
 // returns a licensing error from every RPC.
 type UnimplementedService struct {
-	summarizerv1pb.UnimplementedSummarizerServiceServer
+	summarizerv1pb.UnsafeSummarizerServiceServer
 }
 
 // CRUD operations for models
@@ -212,6 +212,46 @@ func (s *UnimplementedService) IsEnabled(
 	ctx context.Context, req *summarizerv1pb.IsEnabledRequest,
 ) (*summarizerv1pb.IsEnabledResponse, error) {
 	return &summarizerv1pb.IsEnabledResponse{Enabled: false}, nil
+}
+
+// CreateRetrievalModel implements [summarizerv1pb.SummarizerServiceServer].
+func (s *UnimplementedService) CreateRetrievalModel(context.Context, *summarizerv1pb.CreateRetrievalModelRequest) (*summarizerv1pb.CreateRetrievalModelResponse, error) {
+	return nil, requireEnterprise()
+}
+
+// DeleteRetrievalModel implements [summarizerv1pb.SummarizerServiceServer].
+func (s *UnimplementedService) DeleteRetrievalModel(context.Context, *summarizerv1pb.DeleteRetrievalModelRequest) (*summarizerv1pb.DeleteRetrievalModelResponse, error) {
+	return nil, requireEnterprise()
+}
+
+// GetRetrievalModel implements [summarizerv1pb.SummarizerServiceServer].
+func (s *UnimplementedService) GetRetrievalModel(context.Context, *summarizerv1pb.GetRetrievalModelRequest) (*summarizerv1pb.GetRetrievalModelResponse, error) {
+	return nil, requireEnterprise()
+}
+
+// GetSummary implements [summarizerv1pb.SummarizerServiceServer].
+func (s *UnimplementedService) GetSummary(context.Context, *summarizerv1pb.GetSummaryRequest) (*summarizerv1pb.GetSummaryResponse, error) {
+	return nil, requireEnterprise()
+}
+
+// TestInferenceModel implements [summarizerv1pb.SummarizerServiceServer].
+func (s *UnimplementedService) TestInferenceModel(context.Context, *summarizerv1pb.TestInferenceModelRequest) (*summarizerv1pb.TestInferenceModelResponse, error) {
+	return nil, requireEnterprise()
+}
+
+// TestRetrievalModel implements [summarizerv1pb.SummarizerServiceServer].
+func (s *UnimplementedService) TestRetrievalModel(context.Context, *summarizerv1pb.TestRetrievalModelRequest) (*summarizerv1pb.TestRetrievalModelResponse, error) {
+	return nil, requireEnterprise()
+}
+
+// UpdateRetrievalModel implements [summarizerv1pb.SummarizerServiceServer].
+func (s *UnimplementedService) UpdateRetrievalModel(context.Context, *summarizerv1pb.UpdateRetrievalModelRequest) (*summarizerv1pb.UpdateRetrievalModelResponse, error) {
+	return nil, requireEnterprise()
+}
+
+// UpsertRetrievalModel implements [summarizerv1pb.SummarizerServiceServer].
+func (s *UnimplementedService) UpsertRetrievalModel(context.Context, *summarizerv1pb.UpsertRetrievalModelRequest) (*summarizerv1pb.UpsertRetrievalModelResponse, error) {
+	return nil, requireEnterprise()
 }
 
 func requireEnterprise() error {

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -77,7 +77,7 @@ type ServiceConfig struct {
 
 // Service implements the teleport.trust.v1.TrustService RPC service.
 type Service struct {
-	trustpb.UnimplementedTrustServiceServer
+	trustpb.UnsafeTrustServiceServer
 	authorizer       authz.Authorizer
 	scopedAuthorizer authz.ScopedAuthorizer
 	cache            services.AuthorityGetter

--- a/lib/auth/userloginstate/userloginstatev1/service.go
+++ b/lib/auth/userloginstate/userloginstatev1/service.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	userloginstatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
@@ -62,7 +64,7 @@ func (c *ServiceConfig) checkAndSetDefaults() error {
 }
 
 type Service struct {
-	userloginstatev1.UnimplementedUserLoginStateServiceServer
+	userloginstatev1.UnsafeUserLoginStateServiceServer
 
 	authorizer      authz.Authorizer
 	userLoginStates services.UserLoginStates
@@ -189,4 +191,9 @@ func (s *Service) DeleteAllUserLoginStates(ctx context.Context, _ *userloginstat
 	}
 
 	return &emptypb.Empty{}, nil
+}
+
+// ListUserLoginStates implements [userloginstatev1.UserLoginStateServiceServer].
+func (*Service) ListUserLoginStates(context.Context, *userloginstatev1.ListUserLoginStatesRequest) (*userloginstatev1.ListUserLoginStatesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListUserLoginStates not implemented")
 }

--- a/lib/auth/userpreferences/userpreferencesv1/service.go
+++ b/lib/auth/userpreferences/userpreferencesv1/service.go
@@ -37,7 +37,7 @@ type ServiceConfig struct {
 
 // Service implements the teleport.userpreferences.v1.UserPreferencesService RPC service.
 type Service struct {
-	userpreferences.UnimplementedUserPreferencesServiceServer
+	userpreferences.UnsafeUserPreferencesServiceServer
 
 	backend    services.UserPreferences
 	authorizer authz.Authorizer

--- a/lib/auth/userprovisioning/userprovisioningv2/service.go
+++ b/lib/auth/userprovisioning/userprovisioningv2/service.go
@@ -53,7 +53,7 @@ type Cache interface {
 
 // Service implements the static host user RPC service.
 type Service struct {
-	userprovisioningpb.UnimplementedStaticHostUsersServiceServer
+	userprovisioningpb.UnsafeStaticHostUsersServiceServer
 
 	authorizer authz.Authorizer
 	emitter    apievents.Emitter

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -78,7 +78,7 @@ type ServiceConfig struct {
 
 // Service implements the teleport.users.v1.UsersService RPC service.
 type Service struct {
-	userspb.UnimplementedUsersServiceServer
+	userspb.UnsafeUsersServiceServer
 
 	authorizer authz.Authorizer
 	cache      Cache

--- a/lib/auth/usertasks/usertasksv1/service.go
+++ b/lib/auth/usertasks/usertasksv1/service.go
@@ -94,7 +94,7 @@ type Reader interface {
 
 // Service implements the teleport.UserTask.v1.UserTaskService RPC service.
 type Service struct {
-	usertasksv1.UnimplementedUserTaskServiceServer
+	usertasksv1.UnsafeUserTaskServiceServer
 
 	authorizer    authz.Authorizer
 	backend       services.UserTasks

--- a/lib/auth/workloadcluster/workloadclusterv1/service.go
+++ b/lib/auth/workloadcluster/workloadclusterv1/service.go
@@ -35,7 +35,7 @@ type Backend interface {
 
 // Service implements the gRPC API layer for the WorkloadCluster.
 type Service struct {
-	workloadcluster.UnimplementedWorkloadClusterServiceServer
+	workloadcluster.UnsafeWorkloadClusterServiceServer
 }
 
 // NewService returns a new service that returns a license error for every RPC

--- a/lib/decision/decisionv1/decision_service.go
+++ b/lib/decision/decisionv1/decision_service.go
@@ -22,6 +22,8 @@ import (
 	"log/slog"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	"github.com/gravitational/teleport/api/types"
@@ -39,7 +41,7 @@ type ServiceConfig struct {
 
 // Service implements the teleport.decision.v1alpha1.DecisionService gRPC API.
 type Service struct {
-	decisionpb.UnimplementedDecisionServiceServer
+	decisionpb.UnsafeDecisionServiceServer
 	pdp        *decision.Service
 	authorizer authz.Authorizer
 	logger     *slog.Logger
@@ -87,7 +89,7 @@ func (s *Service) EvaluateSSHJoin(ctx context.Context, req *decisionpb.EvaluateS
 		return nil, trace.AccessDenied("user %q does not have permission to evaluate SSH session-joining", authzContext.User.GetName())
 	}
 
-	return s.UnimplementedDecisionServiceServer.EvaluateSSHJoin(ctx, req)
+	return nil, status.Errorf(codes.Unimplemented, "method EvaluateSSHJoin not implemented")
 }
 
 func (s *Service) EvaluateDatabaseAccess(ctx context.Context, req *decisionpb.EvaluateDatabaseAccessRequest) (*decisionpb.EvaluateDatabaseAccessResponse, error) {
@@ -101,5 +103,5 @@ func (s *Service) EvaluateDatabaseAccess(ctx context.Context, req *decisionpb.Ev
 		return nil, trace.AccessDenied("user %q does not have permission to evaluate database access", authzContext.User.GetName())
 	}
 
-	return s.UnimplementedDecisionServiceServer.EvaluateDatabaseAccess(ctx, req)
+	return nil, status.Errorf(codes.Unimplemented, "method EvaluateDatabaseAccess not implemented")
 }

--- a/lib/devicetrust/testenv/fake_device_service.go
+++ b/lib/devicetrust/testenv/fake_device_service.go
@@ -61,6 +61,7 @@ type storedDeviceAuthnAttempt struct {
 }
 
 type FakeDeviceService struct {
+	//nolint:forbidigo // this is testing code
 	devicepb.UnimplementedDeviceTrustServiceServer
 
 	autoCreateDevice bool

--- a/lib/join/legacyjoin/joinserver.go
+++ b/lib/join/legacyjoin/joinserver.go
@@ -93,7 +93,7 @@ type joinServiceClient interface {
 // remain here for a while for backward compat (ETA pending until we figure out
 // an LTS strategy).
 type JoinServiceGRPCServer struct {
-	proto.UnimplementedJoinServiceServer
+	proto.UnsafeJoinServiceServer
 
 	joinServiceClient joinServiceClient
 }

--- a/lib/kube/grpc/grpc.go
+++ b/lib/kube/grpc/grpc.go
@@ -49,7 +49,7 @@ var errDone = errors.New("done iterating")
 
 // Server implements KubeService gRPC server.
 type Server struct {
-	proto.UnimplementedKubeServiceServer
+	proto.UnsafeKubeServiceServer
 	cfg               Config
 	proxyAddress      string
 	kubeProxySNI      string

--- a/lib/proxy/peer/service.go
+++ b/lib/proxy/peer/service.go
@@ -33,6 +33,8 @@ import (
 
 // proxyService implements the grpc ProxyService.
 type proxyService struct {
+	proto.UnsafeProxyServiceServer
+
 	dialer peerdial.Dialer
 	log    *slog.Logger
 }

--- a/lib/relaytunnel/discover.go
+++ b/lib/relaytunnel/discover.go
@@ -32,14 +32,14 @@ import (
 )
 
 //nolint:unused // used by StaticDiscoverServiceServer
-type unimplementedDiscoveryServiceServer = relaytunnelv1alpha.UnimplementedDiscoveryServiceServer
+type unsafeDiscoveryServiceServer = relaytunnelv1alpha.UnsafeDiscoveryServiceServer
 
 // StaticDiscoverServiceServer is a [relaytunnelv1alpha.DiscoveryServiceServer]
 // implementation that responds with fixed data to the Discover rpc.
 type StaticDiscoverServiceServer struct {
 	_ struct{} // prevent unkeyed literals
 
-	unimplementedDiscoveryServiceServer //nolint:unused // required and used by grpc-go
+	unsafeDiscoveryServiceServer //nolint:unused // required and used by grpc-go
 
 	RelayGroup            string
 	TargetConnectionCount int32

--- a/lib/secretsscanner/proxy/proxy.go
+++ b/lib/secretsscanner/proxy/proxy.go
@@ -27,6 +27,9 @@ import (
 	"log/slog"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	accessgraphsecretsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessgraph/v1"
 )
@@ -62,7 +65,7 @@ func New(cfg ServiceConfig) (*Service, error) {
 // It only implements the ReportSecrets method of the SecretsScannerService because it is the only method that needs to be proxied
 // from the proxy to the Auth's secret service.
 type Service struct {
-	accessgraphsecretsv1pb.UnimplementedSecretsScannerServiceServer
+	accessgraphsecretsv1pb.UnsafeSecretsScannerServiceServer
 	// authClient is the client to the Auth service.
 	authClient AuthClient
 
@@ -131,4 +134,9 @@ func (s *Service) forwardServerToClient(ctx context.Context,
 			return trace.Wrap(err)
 		}
 	}
+}
+
+// ReportAuthorizedKeys implements [accessgraphsecretsv1pb.SecretsScannerServiceServer].
+func (*Service) ReportAuthorizedKeys(grpc.BidiStreamingServer[accessgraphsecretsv1pb.ReportAuthorizedKeysRequest, accessgraphsecretsv1pb.ReportAuthorizedKeysResponse]) error {
+	return status.Errorf(codes.Unimplemented, "method ReportAuthorizedKeys not implemented")
 }

--- a/lib/srv/db/spanner/engine.go
+++ b/lib/srv/db/spanner/engine.go
@@ -91,6 +91,7 @@ type Engine struct {
 	engineErrors prometheus.Counter
 
 	// UnimplementedSpannerServer is embedded for forward interface compat.
+	//nolint:forbidigo // we don't own the google.spanner.v1.Spanner service
 	spannerpb.UnimplementedSpannerServer
 }
 

--- a/lib/srv/db/spanner/protocoltest/test.go
+++ b/lib/srv/db/spanner/protocoltest/test.go
@@ -158,6 +158,7 @@ type TestServer struct {
 	srv      *grpc.Server
 	listener net.Listener
 	port     string
+	//nolint:forbidigo // we don't own the google.spanner.v1.Spanner service
 	spannerpb.UnimplementedSpannerServer
 }
 

--- a/lib/srv/transport/transportv1/transport.go
+++ b/lib/srv/transport/transportv1/transport.go
@@ -128,7 +128,7 @@ func (c *ServerConfig) CheckAndSetDefaults() error {
 // Service implements the teleport.transport.v1.TransportService RPC
 // service.
 type Service struct {
-	transportv1pb.UnimplementedTransportServiceServer
+	transportv1pb.UnsafeTransportServiceServer
 
 	cfg ServerConfig
 }

--- a/lib/tbot/services/workloadidentity/workload_api.go
+++ b/lib/tbot/services/workloadidentity/workload_api.go
@@ -95,7 +95,7 @@ func WorkloadAPIServiceBuilder(
 // - https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE-ID.md
 // - https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md
 type WorkloadAPIService struct {
-	workloadpb.UnimplementedSpiffeWorkloadAPIServer
+	workloadpb.UnsafeSpiffeWorkloadAPIServer
 
 	svcIdentity               *clientcredentials.UnstableConfig
 	defaultCredentialLifetime bot.CredentialLifetime

--- a/lib/teleterm/apiserver/handler/handler.go
+++ b/lib/teleterm/apiserver/handler/handler.go
@@ -58,7 +58,7 @@ func (c *Config) CheckAndSetDefaults() error {
 
 // Handler implements teleterm api service
 type Handler struct {
-	api.UnimplementedTerminalServiceServer
+	api.UnsafeTerminalServiceServer
 
 	// Config is the service config
 	Config

--- a/lib/teleterm/autoupdate/service.go
+++ b/lib/teleterm/autoupdate/service.go
@@ -27,6 +27,8 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/gravitational/teleport/api/client/webclient"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/auto_update/v1"
@@ -46,7 +48,7 @@ const (
 
 // Service implements gRPC service for autoupdate.
 type Service struct {
-	api.UnimplementedAutoUpdateServiceServer
+	api.UnsafeAutoUpdateServiceServer
 
 	cfg Config
 }
@@ -211,4 +213,9 @@ func readConfigFromEnvVars() (*api.GetConfigResponse, error) {
 			Source: api.ConfigSource_CONFIG_SOURCE_ENV_VAR,
 		},
 	}, nil
+}
+
+// GetInstallationMetadata implements [api.AutoUpdateServiceServer].
+func (*Service) GetInstallationMetadata(context.Context, *api.GetInstallationMetadataRequest) (*api.GetInstallationMetadataResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetInstallationMetadata not implemented")
 }

--- a/lib/teleterm/autoupdate/service.go
+++ b/lib/teleterm/autoupdate/service.go
@@ -27,8 +27,6 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/gravitational/teleport/api/client/webclient"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/auto_update/v1"
@@ -213,9 +211,4 @@ func readConfigFromEnvVars() (*api.GetConfigResponse, error) {
 			Source: api.ConfigSource_CONFIG_SOURCE_ENV_VAR,
 		},
 	}, nil
-}
-
-// GetInstallationMetadata implements [api.AutoUpdateServiceServer].
-func (*Service) GetInstallationMetadata(context.Context, *api.GetInstallationMetadataRequest) (*api.GetInstallationMetadataResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetInstallationMetadata not implemented")
 }

--- a/lib/teleterm/autoupdate/service_notwindows.go
+++ b/lib/teleterm/autoupdate/service_notwindows.go
@@ -1,0 +1,33 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !windows
+
+package autoupdate
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/auto_update/v1"
+)
+
+// GetInstallationMetadata implements [api.AutoUpdateServiceServer].
+func (*Service) GetInstallationMetadata(context.Context, *api.GetInstallationMetadataRequest) (*api.GetInstallationMetadataResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetInstallationMetadata not implemented")
+}

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
@@ -832,13 +830,3 @@ func (r *disabledTelemetryUsageReporter) ReportSSHSession(profileName, rootClust
 }
 
 func (r *disabledTelemetryUsageReporter) Stop() {}
-
-// CheckInstallTimeRequirements implements [api.VnetServiceServer].
-func (*Service) CheckInstallTimeRequirements(context.Context, *api.CheckInstallTimeRequirementsRequest) (*api.CheckInstallTimeRequirementsResponse, error) {
-	return nil, grpcstatus.Errorf(codes.Unimplemented, "method CheckInstallTimeRequirements not implemented")
-}
-
-// GetBackgroundItemStatus implements [api.VnetServiceServer].
-func (*Service) GetBackgroundItemStatus(context.Context, *api.GetBackgroundItemStatusRequest) (*api.GetBackgroundItemStatusResponse, error) {
-	return nil, grpcstatus.Errorf(codes.Unimplemented, "method GetBackgroundItemStatus not implemented")
-}

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
@@ -59,7 +61,7 @@ const (
 
 // Service implements gRPC service for VNet.
 type Service struct {
-	api.UnimplementedVnetServiceServer
+	api.UnsafeVnetServiceServer
 
 	cfg                Config
 	mu                 sync.Mutex
@@ -830,3 +832,13 @@ func (r *disabledTelemetryUsageReporter) ReportSSHSession(profileName, rootClust
 }
 
 func (r *disabledTelemetryUsageReporter) Stop() {}
+
+// CheckInstallTimeRequirements implements [api.VnetServiceServer].
+func (*Service) CheckInstallTimeRequirements(context.Context, *api.CheckInstallTimeRequirementsRequest) (*api.CheckInstallTimeRequirementsResponse, error) {
+	return nil, grpcstatus.Errorf(codes.Unimplemented, "method CheckInstallTimeRequirements not implemented")
+}
+
+// GetBackgroundItemStatus implements [api.VnetServiceServer].
+func (*Service) GetBackgroundItemStatus(context.Context, *api.GetBackgroundItemStatusRequest) (*api.GetBackgroundItemStatusResponse, error) {
+	return nil, grpcstatus.Errorf(codes.Unimplemented, "method GetBackgroundItemStatus not implemented")
+}

--- a/lib/teleterm/vnet/service_notdarwindaemon.go
+++ b/lib/teleterm/vnet/service_notdarwindaemon.go
@@ -1,0 +1,33 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !vnetdaemon || !darwin
+
+package vnet
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/vnet/v1"
+)
+
+// GetBackgroundItemStatus implements [api.VnetServiceServer].
+func (*Service) GetBackgroundItemStatus(context.Context, *api.GetBackgroundItemStatusRequest) (*api.GetBackgroundItemStatusResponse, error) {
+	return nil, grpcstatus.Errorf(codes.Unimplemented, "method GetBackgroundItemStatus not implemented")
+}

--- a/lib/teleterm/vnet/service_notwindows.go
+++ b/lib/teleterm/vnet/service_notwindows.go
@@ -1,0 +1,33 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !windows
+
+package vnet
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/vnet/v1"
+)
+
+// CheckInstallTimeRequirements implements [api.VnetServiceServer].
+func (*Service) CheckInstallTimeRequirements(context.Context, *api.CheckInstallTimeRequirementsRequest) (*api.CheckInstallTimeRequirementsResponse, error) {
+	return nil, grpcstatus.Errorf(codes.Unimplemented, "method CheckInstallTimeRequirements not implemented")
+}


### PR DESCRIPTION
This PR adds linting to require the use of `UnsafeFooService` in OSS code and `UnimplementedFooService` in e code for grpc servers.

Existing missing methods that were only covered by `UnimplementedFooService` were inlined in the code with no further changes.

Because of the way that the enterprise submodule works, we can't just set `require_unimplemented_servers=false` and get rid of the `Unimplemented`/`Unsafe` embeds, since any further change to proto services would then require a three step process to not break enterprise builds; this however unfortunately means that we are still not going to be protected against #65966 in ent code, but at least it's a start.

Updates #65966