### PR TITLE
MWI: Improve error message resulting from scopedness check

### DIFF
--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -335,7 +335,7 @@ func (s *Service) Initialize(ctx context.Context) error {
 		); err != nil {
 			return trace.BadParameter(
 				"bot identity loaded from storage has scoped %v, but scope config set to %v. change tbot scope configuration or delete the bot storage directory",
-				identScope,
+				identScope != "",
 				s.cfg.Scoped,
 			)
 		}


### PR DESCRIPTION
During manual testing, I realised that this error was confusing when the loaded identity had no scope as the string was empty. I've replaced this with a boolean/true false.

Before:

```
bot identity loaded from storage has scoped  , but scope config set to true. change tbot scope configuration or delete the bot storage directory
```

After:

```
bot identity loaded from storage has scoped false, but scope config set to true. change tbot scope configuration or delete the bot storage directory
```


## Manual Test Plan
### Test Environment

Local cluster

### Test Cases
- [x] `tbot` storage directory pre-filled with unscoped identity, switch bot to scoped mode and trigger one-shot. The error message should appear with two boolean values expressed within. 
