### PR TITLE
[v17] Fix a data race in the GCP token handler

### DIFF
--- a/lib/srv/app/gcp/handler.go
+++ b/lib/srv/app/gcp/handler.go
@@ -271,28 +271,30 @@ var defaultScopeList = []string{
 func (s *handler) getToken(ctx context.Context, serviceAccount string) (*credentialspb.GenerateAccessTokenResponse, error) {
 	key := cacheKey{serviceAccount}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
+	type result struct {
+		token *credentialspb.GenerateAccessTokenResponse
+		err   error
+	}
+	resultChan := make(chan result, 1)
+
+	ctx, cancel := context.WithTimeout(ctx, getTokenTimeout)
 	defer cancel()
 
-	var tokenResult *credentialspb.GenerateAccessTokenResponse
-	var errorResult error
-
-	// call Clock.After() before FnCacheGet gets called in a different go-routine.
-	// this ensures there is no race condition in the timeout tests
-	timeoutChan := s.Clock.After(getTokenTimeout)
-
 	go func() {
-		tokenResult, errorResult = utils.FnCacheGet(cancelCtx, s.tokenCache, key, func(ctx context.Context) (*credentialspb.GenerateAccessTokenResponse, error) {
+		token, err := utils.FnCacheGet(ctx, s.tokenCache, key, func(ctx context.Context) (*credentialspb.GenerateAccessTokenResponse, error) {
 			return s.generateAccessToken(ctx, serviceAccount, defaultScopeList)
 		})
-		cancel()
+		resultChan <- result{
+			token: token,
+			err:   err,
+		}
 	}()
 
 	select {
-	case <-timeoutChan:
-		return nil, trace.Wrap(context.DeadlineExceeded, "timeout waiting for access token for %v", getTokenTimeout)
-	case <-cancelCtx.Done():
-		return tokenResult, errorResult
+	case <-ctx.Done():
+		return nil, trace.Wrap(ctx.Err())
+	case result := <-resultChan:
+		return result.token, trace.Wrap(result.err)
 	}
 }
 

--- a/lib/srv/app/gcp/handler_test.go
+++ b/lib/srv/app/gcp/handler_test.go
@@ -157,12 +157,10 @@ func TestHandler_getToken(t *testing.T) {
 				state = tt.initState()
 			}
 
-			ctx := cmp.Or(tt.getTokenContext, context.Background())
-
-			fwd, err := newGCPHandler(ctx, tt.config(state))
+			fwd, err := newGCPHandler(t.Context(), tt.config(state))
 			require.NoError(t, err)
 
-			token, err := fwd.getToken(ctx, "MY_ACCOUNT")
+			token, err := fwd.getToken(cmp.Or(tt.getTokenContext, context.Background()), "MY_ACCOUNT")
 			require.Equal(t, tt.wantToken, token)
 			tt.checkErr(t, err)
 

--- a/lib/srv/app/gcp/handler_test.go
+++ b/lib/srv/app/gcp/handler_test.go
@@ -19,6 +19,7 @@
 package gcp
 
 import (
+	"cmp"
 	"context"
 	"testing"
 	"time"
@@ -54,12 +55,15 @@ func TestHandler_getToken(t *testing.T) {
 		}
 	}
 
+	testContext, testContextCancel := context.WithCancel(t.Context())
+
 	tests := []struct {
 		name string
 
 		initState func() any
 
-		config func(state any) HandlerConfig
+		getTokenContext context.Context
+		config          func(state any) HandlerConfig
 
 		wantToken  *credentialspb.GenerateAccessTokenResponse
 		checkErr   require.ErrorAssertionFunc
@@ -111,8 +115,7 @@ func TestHandler_getToken(t *testing.T) {
 					}),
 				}
 			},
-			checkErr: func(t require.TestingT, err error, i ...interface{}) {
-				require.ErrorContains(t, err, "timeout waiting for access token for 5s")
+			checkErr: func(t require.TestingT, err error, i ...any) {
 				require.ErrorIs(t, err, context.DeadlineExceeded)
 			},
 		},
@@ -130,6 +133,21 @@ func TestHandler_getToken(t *testing.T) {
 				require.True(t, trace.IsBadParameter(err))
 			},
 		},
+		{
+			name:            "context cancel",
+			getTokenContext: testContext,
+			config: mkConstConfig(HandlerConfig{
+				cloudClientGCP: makeTestCloudClient(&testIAMCredentialsClient{
+					generateAccessToken: func(ctx context.Context, req *credentialspb.GenerateAccessTokenRequest, opts ...gax.CallOption) (*credentialspb.GenerateAccessTokenResponse, error) {
+						testContextCancel()
+						return nil, trace.BadParameter("bad param foo")
+					},
+				}),
+			}),
+			checkErr: func(t require.TestingT, err error, i ...any) {
+				require.ErrorIs(t, err, context.Canceled)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -139,7 +157,7 @@ func TestHandler_getToken(t *testing.T) {
 				state = tt.initState()
 			}
 
-			ctx := context.Background()
+			ctx := cmp.Or(tt.getTokenContext, context.Background())
 
 			fwd, err := newGCPHandler(ctx, tt.config(state))
 			require.NoError(t, err)


### PR DESCRIPTION
The GCP and Azure code is largely a copy paste. The Azure version was fixed back in #41648 but the fix was never applied to GCP.

Backports #65910