### PR TITLE
discovery/eks: use iam:GetRole to resolve caller identity ARN

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -69,6 +69,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers/db"
 	"github.com/gravitational/teleport/lib/srv/server"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
 	liborganizations "github.com/gravitational/teleport/lib/utils/aws/organizations"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -229,6 +230,10 @@ func (f *awsFetchersClientsGetter) GetAWSSTSClient(cfg aws.Config) fetchers.STSC
 func (f *awsFetchersClientsGetter) GetAWSSTSPresignClient(cfg aws.Config) fetchers.STSPresignClient {
 	stsClient := stsutils.NewFromConfig(cfg)
 	return sts.NewPresignClient(stsClient)
+}
+
+func (f *awsFetchersClientsGetter) GetAWSIAMClient(cfg aws.Config) fetchers.IAMClient {
+	return iamutils.NewFromConfig(cfg)
 }
 
 func (c *Config) CheckAndSetDefaults() error {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -2158,6 +2158,10 @@ func (m *mockFetchersClients) GetAWSSTSPresignClient(aws.Config) fetchers.STSPre
 	return nil
 }
 
+func (m *mockFetchersClients) GetAWSIAMClient(aws.Config) fetchers.IAMClient {
+	return nil
+}
+
 var eksMockClusters = []*ekstypes.Cluster{
 	{
 		Name:   aws.String("eks-cluster1"),

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -100,6 +101,11 @@ type STSClient interface {
 // STSPresignClient is the subset of the STS presign interface we use in fetchers.
 type STSPresignClient = kubeutils.STSPresignClient
 
+// IAMClient is the subset of the IAM interface we use in fetchers.
+type IAMClient interface {
+	GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+}
+
 // AWSClientGetter is an interface for getting an EKS client and an STS client.
 type AWSClientGetter interface {
 	awsconfig.Provider
@@ -109,6 +115,8 @@ type AWSClientGetter interface {
 	GetAWSSTSClient(aws.Config) STSClient
 	// GetAWSSTSPresignClient returns AWS STS presign client for the specified config.
 	GetAWSSTSPresignClient(aws.Config) STSPresignClient
+	// GetAWSIAMClient returns AWS IAM client for the specified config.
+	GetAWSIAMClient(aws.Config) IAMClient
 }
 
 // EKSFetcherConfig configures the EKS fetcher.
@@ -224,7 +232,7 @@ func (a *eksFetcher) getCallerIdentityARN(ctx context.Context, regions []string)
 			a.Logger.WarnContext(ctx, "Failed to resolve AWS caller identity, EKS access bootstrap will be skipped this cycle", "error", err)
 			return ""
 		}
-		iamARN, err := convertAssumedRoleToIAMRole(aws.ToString(out.Arn))
+		iamARN, err := resolveIAMRoleARN(ctx, a.ClientGetter.GetAWSIAMClient(cfg), aws.ToString(out.Arn))
 		if err != nil {
 			a.Logger.WarnContext(ctx, "Failed to parse AWS caller identity ARN, EKS access bootstrap will be skipped this cycle", "error", err)
 			return ""
@@ -772,6 +780,31 @@ func (r *regionalFetcher) upsertAccessEntry(ctx context.Context, cluster *ekstyp
 	return trace.Wrap(err)
 }
 
+// resolveIAMRoleARN converts an STS caller identity ARN to the corresponding IAM role ARN.
+// For assumed-role ARNs it calls iam:GetRole to retrieve the exact ARN (including any path),
+// which is required for SSO roles that include a region in their path
+// (e.g. /aws-reserved/sso.amazonaws.com/us-west-2/). Falls back to string conversion on error.
+func resolveIAMRoleARN(ctx context.Context, iamClient IAMClient, callerARN string) (string, error) {
+	parsed, err := arn.Parse(callerARN)
+	if err != nil || !strings.HasPrefix(parsed.Resource, "assumed-role/") {
+		return callerARN, nil
+	}
+	parts := strings.SplitN(parsed.Resource, "/", 3)
+	if len(parts) < 2 {
+		return callerARN, nil
+	}
+	roleName := parts[1]
+	if iamClient == nil {
+		return convertAssumedRoleToIAMRole(callerARN), nil
+	}
+	resp, err := iamClient.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(roleName)})
+	if err != nil {
+		// Fall back to best-effort string conversion rather than failing entirely.
+		return convertAssumedRoleToIAMRole(callerARN), nil
+	}
+	return aws.ToString(resp.Role.Arn), nil
+}
+
 func getAWSOpts(assumeRole types.AssumeRole, integration string) []awsconfig.OptionsFn {
 	return []awsconfig.OptionsFn{
 		awsconfig.WithAssumeRole(
@@ -790,7 +823,8 @@ func convertAWSError[T any](rsp T, err error) (T, error) {
 // convertAssumedRoleToIAMRole converts the assumed role ARN to an IAM role ARN.
 // The assumed role ARN is in the format "arn:aws:sts::account-id:assumed-role/role-name/role-session-name".
 // The IAM role ARN is in the format "arn:aws:iam::account-id:role/role-name".
-func convertAssumedRoleToIAMRole(callerIdentity string) (string, error) {
+// Note: this does not handle roles with non-default paths (e.g. AWS SSO roles); use resolveIAMRoleARN instead.
+func convertAssumedRoleToIAMRole(callerIdentity string) string {
 	const (
 		assumeRolePrefix = "assumed-role/"
 		roleResource     = "role"
@@ -798,18 +832,18 @@ func convertAssumedRoleToIAMRole(callerIdentity string) (string, error) {
 	)
 	a, err := arn.Parse(callerIdentity)
 	if err != nil {
-		return "", trace.Wrap(err, "parsing caller identity ARN %q", callerIdentity)
+		return callerIdentity
 	}
 	if !strings.HasPrefix(a.Resource, assumeRolePrefix) {
-		return callerIdentity, nil
+		return callerIdentity
 	}
 	a.Service = serviceName
 	split := strings.Split(a.Resource, "/")
 	if len(split) <= 2 {
-		return "", trace.BadParameter("malformed assumed-role ARN %q", callerIdentity)
+		return callerIdentity
 	}
 	a.Resource = path.Join(roleResource, split[1])
-	return a.String(), nil
+	return a.String()
 }
 
 // DeleteKubernetesDanglingResourcesConfig configures the deletion of dangling Kubernetes resources

--- a/lib/srv/discovery/fetchers/eks_test.go
+++ b/lib/srv/discovery/fetchers/eks_test.go
@@ -540,6 +540,10 @@ func (g *mockRegionalEKSClientGetter) GetAWSSTSPresignClient(aws.Config) kubeuti
 	return &mockSTSPresignAPI{}
 }
 
+func (g *mockRegionalEKSClientGetter) GetAWSIAMClient(aws.Config) IAMClient {
+	return nil
+}
+
 // mockAccountClient implements account.ListRegionsAPIClient.
 type mockAccountClient struct {
 	output *account.ListRegionsOutput


### PR DESCRIPTION
AWS SSO sessions return assumed-role ARNs from GetCallerIdentity (e.g. arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_Admin_.../session) but the corresponding IAM role lives at a path that includes the SSO home region:
  arn:aws:iam::ACCOUNT:role/aws-reserved/sso.amazonaws.com/REGION/AWSReservedSSO_Admin_...

The region component is not present in the STS ARN and cannot be inferred by string manipulation, so the previous convertAssumedRoleToIAMRole approach produced an incorrect ARN for SSO credentials, causing EKS access entry creation to fail.

Fix this by adding iam:GetRole to the AWSClientGetter interface and calling it with the role name extracted from the assumed-role ARN. IAM accepts just the role name (no path required) and returns the full ARN including the correct path. convertAssumedRoleToIAMRole is retained as a fallback for cases where iam:GetRole is unavailable.






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
