### PR TITLE
Fixing upload size limit for encrypted recordings

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -82,7 +82,6 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	grpcutils "github.com/gravitational/teleport/api/utils/grpc"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -3957,7 +3956,7 @@ func (process *TeleportProcess) initUploaderService() error {
 
 		// encrypted uploads are aggregated and uploaded directly rather than with an event stream.
 		// Since we are using the gRPC client, we must set this maximum for the aggregation step.
-		encryptedRecordingMaxUploadSize = grpcutils.MaxClientRecvMsgSize()
+		encryptedRecordingMaxUploadSize = 4 * 1024 * 1024 // 4MiB, default server-side gRPC max msg recv size
 	}
 
 	logger.InfoContext(process.ExitContext(), "starting upload completer service")


### PR DESCRIPTION
Fixes an issue where increasing the gRPC recv size limit on a client (proxy or node) would increase the maximum allowed part size during encrypted session recording upload. This configuration says nothing about the server-side limit and makes it possible to attempt uploading encrypted upload parts that are too large for the auth server to process.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local teleport cluster with encrypted session recordings enabled

### Test Cases
- [x] Encrypted session recordings are captured and uploaded even when they're large enough to be chunked into multiple parts
