### PR TITLE
Fix flaky GCP test

### DIFF
--- a/lib/srv/app/gcp/handler_test.go
+++ b/lib/srv/app/gcp/handler_test.go
@@ -157,12 +157,10 @@ func TestHandler_getToken(t *testing.T) {
 				state = tt.initState()
 			}
 
-			ctx := cmp.Or(tt.getTokenContext, context.Background())
-
-			fwd, err := newGCPHandler(ctx, tt.config(state))
+			fwd, err := newGCPHandler(t.Context(), tt.config(state))
 			require.NoError(t, err)
 
-			token, err := fwd.getToken(ctx, "MY_ACCOUNT")
+			token, err := fwd.getToken(cmp.Or(tt.getTokenContext, context.Background()), "MY_ACCOUNT")
 			require.Equal(t, tt.wantToken, token)
 			tt.checkErr(t, err)
 


### PR DESCRIPTION
A last minute change introduced in response to Codex feedback on #65910 introduced some flakiness:
```
   handler_test.go:148:
        	Error Trace:	/__w/teleport/teleport/lib/srv/app/gcp/handler_test.go:148
        	            				/__w/teleport/teleport/lib/srv/app/gcp/handler_test.go:167
        	Error:      	Target error should be in err chain:
        	            	expected: "context canceled"
        	            	in chain: "fncache permanently closed"
        	            		"fncache permanently closed"
        	Test:       	TestHandler_getToken/context_cancel
```
Use the test's context for the FnCache so it remains running for the duration of the test.

No backports - will include it in #65980 and #65981.