### PR TITLE
[v18] Fixing upload size limit for encrypted recordings

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -80,7 +80,6 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	grpcutils "github.com/gravitational/teleport/api/utils/grpc"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -3885,7 +3884,7 @@ func (process *TeleportProcess) initUploaderService() error {
 
 		// encrypted uploads are aggregated and uploaded directly rather than with an event stream.
 		// Since we are using the gRPC client, we must set this maximum for the aggregation step.
-		encryptedRecordingMaxUploadSize = grpcutils.MaxClientRecvMsgSize()
+		encryptedRecordingMaxUploadSize = 4 * 1024 * 1024 // 4MiB, default server-side gRPC max msg recv size
 	}
 
 	logger.InfoContext(process.ExitContext(), "starting upload completer service")


### PR DESCRIPTION
Backport #65985 to branch/v18

## Manual Test Plan
### Test Environment
Local teleport cluster with encrypted session recordings enabled

### Test Cases
- [x] Encrypted session recordings are captured and uploaded even when they're large enough to be chunked into multiple parts