### PR TITLE
fix: allow joining with CA pin when any lock is in force

### DIFF
--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -3834,7 +3834,7 @@ func TestTLSFailover(t *testing.T) {
 func TestJoinCAPin(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
@@ -3846,6 +3846,18 @@ func TestJoinCAPin(t *testing.T) {
 		time.Time{},
 		testSrv.Auth(),
 	)
+	joinParams := func() joinclient.JoinParams {
+		return joinclient.JoinParams{
+			AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
+			Token:       token,
+			ID: state.IdentityID{
+				NodeName: "node-name",
+				Role:     types.RoleInstance,
+			},
+			AdditionalPrincipals: []string{"example.com"},
+			Clock:                clock,
+		}
+	}
 
 	// Calculate what CA pin should be.
 	localCAResponse, err := testSrv.AuthServer.AuthServer.GetClusterCACert(ctx)
@@ -3856,60 +3868,54 @@ func TestJoinCAPin(t *testing.T) {
 	caPin := caPins[0]
 
 	// Attempt to join with valid CA pin, should work.
-	_, err = joinclient.Join(ctx, joinclient.JoinParams{
-		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
-		Token:       token,
-		ID: state.IdentityID{
-			NodeName: "node-name",
-			Role:     types.RoleInstance,
-		},
-		AdditionalPrincipals: []string{"example.com"},
-		CAPins:               []string{caPin},
-		Clock:                clock,
+	params := joinParams()
+	params.CAPins = []string{caPin}
+	_, err = joinclient.Join(ctx, params)
+	require.NoError(t, err)
+
+	// An unrelated active lock should not block unauthenticated CA pin bootstrap.
+	lockTarget := types.LockTarget{User: "definitely-not-a-real-user"}
+	lock, err := types.NewLock("test-join-ca-pin-unrelated-lock", types.LockSpecV2{
+		Target: lockTarget,
 	})
+	require.NoError(t, err)
+	// Wait for the lock to actually propagate through the cache and be
+	// enforced before attempting to join.
+	lockWatcher, err := testSrv.Auth().SubscribeToLockTarget(ctx, lockTarget)
+	require.NoError(t, err)
+	require.NoError(t, testSrv.Auth().UpsertLock(ctx, lock))
+	select {
+	case evt := <-lockWatcher.Events():
+		require.Equal(t, types.OpPut, evt.Type)
+		require.Equal(t, types.KindLock, evt.Resource.GetKind())
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "did not receive lock put event within 10 seconds")
+	}
+	lockInForceErr := testSrv.Auth().CheckLockInForce(constants.LockingModeStrict, []types.LockTarget{{User: "definitely-not-a-real-user"}})
+	require.ErrorAs(t, lockInForceErr, new(*trace.AccessDeniedError))
+
+	params = joinParams()
+	params.CAPins = []string{caPin}
+	_, err = joinclient.Join(ctx, params)
 	require.NoError(t, err)
 
 	// Attempt to join with multiple CA pins where the auth server only
 	// matches one, should work.
-	_, err = joinclient.Join(ctx, joinclient.JoinParams{
-		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
-		Token:       token,
-		ID: state.IdentityID{
-			NodeName: "node-name",
-			Role:     types.RoleInstance,
-		},
-		AdditionalPrincipals: []string{"example.com"},
-		CAPins:               []string{"sha256:123", caPin},
-		Clock:                clock,
-	})
+	params = joinParams()
+	params.CAPins = []string{"sha256:123", caPin}
+	_, err = joinclient.Join(ctx, params)
 	require.NoError(t, err)
 
 	// Attempt to join with invalid CA pin, should fail.
-	_, err = joinclient.Join(ctx, joinclient.JoinParams{
-		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
-		Token:       token,
-		ID: state.IdentityID{
-			NodeName: "node-name",
-			Role:     types.RoleInstance,
-		},
-		AdditionalPrincipals: []string{"example.com"},
-		CAPins:               []string{"sha256:123"},
-		Clock:                clock,
-	})
+	params = joinParams()
+	params.CAPins = []string{"sha256:123"}
+	_, err = joinclient.Join(ctx, params)
 	require.Error(t, err)
 
 	// Attempt to join with multiple invalid CA pins, should fail.
-	_, err = joinclient.Join(ctx, joinclient.JoinParams{
-		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
-		Token:       token,
-		ID: state.IdentityID{
-			NodeName: "node-name",
-			Role:     types.RoleInstance,
-		},
-		AdditionalPrincipals: []string{"example.com"},
-		CAPins:               []string{"sha256:123", "sha256:456"},
-		Clock:                clock,
-	})
+	params = joinParams()
+	params.CAPins = []string{"sha256:123", "sha256:456"}
+	_, err = joinclient.Join(ctx, params)
 	require.Error(t, err)
 
 	// Add another cert to the CA (dupe the current one for simplicity)
@@ -3932,17 +3938,9 @@ func TestJoinCAPin(t *testing.T) {
 	require.Len(t, caPins, 2)
 
 	// Attempt to join with multiple CA pins, should work
-	_, err = joinclient.Join(ctx, joinclient.JoinParams{
-		AuthServers: []utils.NetAddr{utils.FromAddr(testSrv.Addr())},
-		Token:       token,
-		ID: state.IdentityID{
-			NodeName: "node-name",
-			Role:     types.RoleInstance,
-		},
-		AdditionalPrincipals: []string{"example.com"},
-		CAPins:               caPins,
-		Clock:                clock,
-	})
+	params = joinParams()
+	params.CAPins = caPins
+	_, err = joinclient.Join(ctx, params)
 	require.NoError(t, err)
 }
 

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1149,6 +1149,11 @@ func (p *lockCollector) Subscribe(ctx context.Context, targets ...types.LockTarg
 // CheckLockInForce returns an AccessDenied error if there is a lock in force
 // matching at least one of the targets.
 func (p *lockCollector) CheckLockInForce(mode constants.LockingMode, targets ...types.LockTarget) error {
+	if len(targets) == 0 {
+		// A lock can't match any targets if there are no targets.
+		return nil
+	}
+
 	p.currentRW.RLock()
 	defer p.currentRW.RUnlock()
 	if p.isStale && mode == constants.LockingModeStrict {
@@ -1164,9 +1169,6 @@ func (p *lockCollector) findLockInForceUnderMutex(targets []types.LockTarget) ty
 	for _, lock := range p.current {
 		if !lock.IsInForce(p.Clock.Now()) {
 			continue
-		}
-		if len(targets) == 0 {
-			return lock
 		}
 		for _, target := range targets {
 			if target.Match(lock) {


### PR DESCRIPTION
This is an OSS port of https://github.com/gravitational/teleport-private/pull/2469

## Summary

Teleport v18.7.4 broke cluster joining for all agents/proxies that join with an Auth server address AND use a CA pin when there is any lock in force in the cluster.

When agents/proxies join with a CA pin, the first thing they do is make an unauthenticated request to `GetClusterCACert` to fetch the full host TLS certificate and compare it with the configured CA pin.

The security fix in 18.7.4 made a change the resulted in unauthenticated requests using an auth context where `auth.Context.LockTargets()` return an empty list. This differs from the current behavior of `RoleNop`, where `authz.Context.LockTargets()` returns a non-empty list of lock targets that effectively match no locks.

Specifically, `lib/authz.(*Context).LockTargets` for RoleNop currently returns a `[]types.LockTarget` containing 3 completely empty targets (no fields set to a non-default value). They come from the first line of LockTargetsFromTLSIdentity, setting an empty User:
```
lockTargets := append(RolesToLockTargets(id.Groups), types.LockTarget{User: id.Username})
```

and the default case in the BuiltinRole switch in LockTargets (both lines set an empty ServerID):

```
default:
	lockTargets = append(lockTargets,
		types.LockTarget{ServerID: r.GetServerID()},
		types.LockTarget{ServerID: r.Identity.Username},
	)
```

This difference is the crux of the issue: `findLockInForceUnderMutex` will return the first in-force lock it finds if given an empty list of targets. The previous behavior with `RoleNop` would include a non-empty list of targets that match no locks, and no lock would be returned.

In this change I have modified `CheckLockInForce(constants.LockingMode, ...types.LockTarget) error` to return nil when given no targets. An unauthenticated request should be the only way to get an empty list of lock targets, and we never want it to be locked out in the presence of an unrelated lock in the system. The new behavior also better aligns with the following doc comment: "CheckLockInForce returns an AccessDenied error if there is a lock in force matching at least one of the targets." A lock can't match at least one target if there are no targets.

Changelog: fixed joining for agents and proxies connecting directly to an Auth service when they specify a CA pin and any lock in the cluster is in force.

## Manual Test Plan
### Test Environment

An Auth server running on a build of this branch. A Proxy server configured to connect to the Auth server address with a valid CA pin.

Any lock in the cluster in force:
```
$ tctl create -f - <<EOF
> kind: lock
> metadata:
>   name: test-ca-pin-lock
> spec:
>   expires: "2026-05-20T23:59:00Z"
>   message: test lock for CA-pin bootstrap
>   target:
>     user: definitely-not-a-real-user
> version: v2
> EOF
```

### Test Cases
- [x] A proxy running on this commit is able to join
- [x] A proxy running 18.7.4 is also able to join with the Auth server running this commit