### PR TITLE
Add enhanced session recording and session recording mode for Scoped SSH

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -231,8 +231,11 @@ type ScopedRoleDefaults struct {
 	// ClientIdleTimeout sets the default idle timeout for access sessions across all protocols
 	// that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
 	ClientIdleTimeout string `protobuf:"bytes,1,opt,name=client_idle_timeout,json=clientIdleTimeout,proto3" json:"client_idle_timeout,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// SessionRecording configures the session recording strategy for all protocols that don't
+	// explicitly set their session recording mode.
+	SessionRecording *SessionRecording `protobuf:"bytes,2,opt,name=session_recording,json=sessionRecording,proto3" json:"session_recording,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ScopedRoleDefaults) Reset() {
@@ -272,6 +275,13 @@ func (x *ScopedRoleDefaults) GetClientIdleTimeout() string {
 	return ""
 }
 
+func (x *ScopedRoleDefaults) GetSessionRecording() *SessionRecording {
+	if x != nil {
+		return x.SessionRecording
+	}
+	return nil
+}
+
 // ScopedRoleSSH groups all scoped role fields relevant to SSH access. Fields within the SSH block
 // encompass selection criteria and preconditions for access, as well as the controls to be applied in
 // cases where access is permitted. An SSH block is the primary source of truth for controls to be applied
@@ -303,9 +313,13 @@ type ScopedRoleSSH struct {
 	HostSudoers []string `protobuf:"bytes,10,rep,name=host_sudoers,json=hostSudoers,proto3" json:"host_sudoers,omitempty"`
 	// FileCopy indicates whether remote file operations via SCP or SFTP are allowed
 	// over an SSH session. It defaults to allowing the user to download and upload files by default.
-	FileCopy      *bool `protobuf:"varint,11,opt,name=file_copy,json=fileCopy,proto3,oneof" json:"file_copy,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	FileCopy *bool `protobuf:"varint,11,opt,name=file_copy,json=fileCopy,proto3,oneof" json:"file_copy,omitempty"`
+	// EnhancedRecording is the set of BPF events to record for enhanced session recording.
+	EnhancedRecording *EnhancedRecording `protobuf:"bytes,12,opt,name=enhanced_recording,json=enhancedRecording,proto3" json:"enhanced_recording,omitempty"`
+	// SessionRecording configures the session recording strategy for SSH sessions.
+	SessionRecording *SessionRecording `protobuf:"bytes,13,opt,name=session_recording,json=sessionRecording,proto3" json:"session_recording,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSSH) Reset() {
@@ -406,6 +420,20 @@ func (x *ScopedRoleSSH) GetFileCopy() bool {
 		return *x.FileCopy
 	}
 	return false
+}
+
+func (x *ScopedRoleSSH) GetEnhancedRecording() *EnhancedRecording {
+	if x != nil {
+		return x.EnhancedRecording
+	}
+	return nil
+}
+
+func (x *ScopedRoleSSH) GetSessionRecording() *SessionRecording {
+	if x != nil {
+		return x.SessionRecording
+	}
+	return nil
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block
@@ -752,6 +780,116 @@ func (x *CreateHostUser) GetShell() string {
 	return ""
 }
 
+// EnhancedRecording enables what events to record for the BPF-based session recorder.
+type EnhancedRecording struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Command enables session.command in audit logs
+	Command *bool `protobuf:"varint,1,opt,name=command,proto3,oneof" json:"command,omitempty"`
+	// Network enables session.network in audit logs
+	Network *bool `protobuf:"varint,2,opt,name=network,proto3,oneof" json:"network,omitempty"`
+	// Disk enables session.disk in audit logs
+	Disk          *bool `protobuf:"varint,3,opt,name=disk,proto3,oneof" json:"disk,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnhancedRecording) Reset() {
+	*x = EnhancedRecording{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnhancedRecording) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnhancedRecording) ProtoMessage() {}
+
+func (x *EnhancedRecording) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnhancedRecording.ProtoReflect.Descriptor instead.
+func (*EnhancedRecording) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *EnhancedRecording) GetCommand() bool {
+	if x != nil && x.Command != nil {
+		return *x.Command
+	}
+	return false
+}
+
+func (x *EnhancedRecording) GetNetwork() bool {
+	if x != nil && x.Network != nil {
+		return *x.Network
+	}
+	return false
+}
+
+func (x *EnhancedRecording) GetDisk() bool {
+	if x != nil && x.Disk != nil {
+		return *x.Disk
+	}
+	return false
+}
+
+// SessionRecording sets the session recording behavior.
+type SessionRecording struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Mode sets the session recording mode. Allowed values: strict | best_effort.
+	Mode          string `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SessionRecording) Reset() {
+	*x = SessionRecording{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionRecording) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionRecording) ProtoMessage() {}
+
+func (x *SessionRecording) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionRecording.ProtoReflect.Descriptor instead.
+func (*SessionRecording) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *SessionRecording) GetMode() string {
+	if x != nil {
+		return x.Mode
+	}
+	return ""
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -770,9 +908,10 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\bdefaults\x18\x05 \x01(\v2-.teleport.scopes.access.v1.ScopedRoleDefaultsR\bdefaults\x12;\n" +
 	"\x05rules\x18\x06 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12:\n" +
 	"\x03ssh\x18\a \x01(\v2(.teleport.scopes.access.v1.ScopedRoleSSHR\x03ssh\x12=\n" +
-	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"D\n" +
+	"\x04kube\x18\b \x01(\v2).teleport.scopes.access.v1.ScopedRoleKubeR\x04kubeJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x05allowR\aoptions\"\x9e\x01\n" +
 	"\x12ScopedRoleDefaults\x12.\n" +
-	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\"\xd4\x04\n" +
+	"\x13client_idle_timeout\x18\x01 \x01(\tR\x11clientIdleTimeout\x12X\n" +
+	"\x11session_recording\x18\x02 \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecording\"\x8b\x06\n" +
 	"\rScopedRoleSSH\x12\x16\n" +
 	"\x06logins\x18\x01 \x03(\tR\x06logins\x120\n" +
 	"\x06labels\x18\x02 \x03(\v2\x18.teleport.label.v1.LabelR\x06labels\x12.\n" +
@@ -784,7 +923,9 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\fmax_sessions\x18\t \x01(\x03H\x02R\vmaxSessions\x88\x01\x01\x12!\n" +
 	"\fhost_sudoers\x18\n" +
 	" \x03(\tR\vhostSudoers\x12 \n" +
-	"\tfile_copy\x18\v \x01(\bH\x03R\bfileCopy\x88\x01\x01B\x18\n" +
+	"\tfile_copy\x18\v \x01(\bH\x03R\bfileCopy\x88\x01\x01\x12[\n" +
+	"\x12enhanced_recording\x18\f \x01(\v2,.teleport.scopes.access.v1.EnhancedRecordingR\x11enhancedRecording\x12X\n" +
+	"\x11session_recording\x18\r \x01(\v2+.teleport.scopes.access.v1.SessionRecordingR\x10sessionRecordingB\x18\n" +
 	"\x16_permit_x11_forwardingB\x10\n" +
 	"\x0e_forward_agentB\x0f\n" +
 	"\r_max_sessionsB\f\n" +
@@ -813,7 +954,18 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x0eCreateHostUser\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\x12\x16\n" +
 	"\x06groups\x18\x02 \x03(\tR\x06groups\x12\x14\n" +
-	"\x05shell\x18\x03 \x01(\tR\x05shellBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x05shell\x18\x03 \x01(\tR\x05shell\"\x8b\x01\n" +
+	"\x11EnhancedRecording\x12\x1d\n" +
+	"\acommand\x18\x01 \x01(\bH\x00R\acommand\x88\x01\x01\x12\x1d\n" +
+	"\anetwork\x18\x02 \x01(\bH\x01R\anetwork\x88\x01\x01\x12\x17\n" +
+	"\x04disk\x18\x03 \x01(\bH\x02R\x04disk\x88\x01\x01B\n" +
+	"\n" +
+	"\b_commandB\n" +
+	"\n" +
+	"\b_networkB\a\n" +
+	"\x05_disk\"&\n" +
+	"\x10SessionRecording\x12\x12\n" +
+	"\x04mode\x18\x01 \x01(\tR\x04modeBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
 var (
 	file_teleport_scopes_access_v1_role_proto_rawDescOnce sync.Once
@@ -827,7 +979,7 @@ func file_teleport_scopes_access_v1_role_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_role_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRole)(nil),              // 0: teleport.scopes.access.v1.ScopedRole
 	(*ScopedRoleSpec)(nil),          // 1: teleport.scopes.access.v1.ScopedRoleSpec
@@ -839,27 +991,32 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*SSHLocalPortForwarding)(nil),  // 7: teleport.scopes.access.v1.SSHLocalPortForwarding
 	(*SSHRemotePortForwarding)(nil), // 8: teleport.scopes.access.v1.SSHRemotePortForwarding
 	(*CreateHostUser)(nil),          // 9: teleport.scopes.access.v1.CreateHostUser
-	(*v1.Metadata)(nil),             // 10: teleport.header.v1.Metadata
-	(*v11.Label)(nil),               // 11: teleport.label.v1.Label
+	(*EnhancedRecording)(nil),       // 10: teleport.scopes.access.v1.EnhancedRecording
+	(*SessionRecording)(nil),        // 11: teleport.scopes.access.v1.SessionRecording
+	(*v1.Metadata)(nil),             // 12: teleport.header.v1.Metadata
+	(*v11.Label)(nil),               // 13: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	10, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	12, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2,  // 2: teleport.scopes.access.v1.ScopedRoleSpec.defaults:type_name -> teleport.scopes.access.v1.ScopedRoleDefaults
 	5,  // 3: teleport.scopes.access.v1.ScopedRoleSpec.rules:type_name -> teleport.scopes.access.v1.ScopedRule
 	3,  // 4: teleport.scopes.access.v1.ScopedRoleSpec.ssh:type_name -> teleport.scopes.access.v1.ScopedRoleSSH
 	4,  // 5: teleport.scopes.access.v1.ScopedRoleSpec.kube:type_name -> teleport.scopes.access.v1.ScopedRoleKube
-	11, // 6: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
-	6,  // 7: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
-	9,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
-	11, // 9: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
-	7,  // 10: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
-	8,  // 11: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	11, // 6: teleport.scopes.access.v1.ScopedRoleDefaults.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
+	13, // 7: teleport.scopes.access.v1.ScopedRoleSSH.labels:type_name -> teleport.label.v1.Label
+	6,  // 8: teleport.scopes.access.v1.ScopedRoleSSH.port_forwarding:type_name -> teleport.scopes.access.v1.SSHPortForwarding
+	9,  // 9: teleport.scopes.access.v1.ScopedRoleSSH.host_user_creation:type_name -> teleport.scopes.access.v1.CreateHostUser
+	10, // 10: teleport.scopes.access.v1.ScopedRoleSSH.enhanced_recording:type_name -> teleport.scopes.access.v1.EnhancedRecording
+	11, // 11: teleport.scopes.access.v1.ScopedRoleSSH.session_recording:type_name -> teleport.scopes.access.v1.SessionRecording
+	13, // 12: teleport.scopes.access.v1.ScopedRoleKube.labels:type_name -> teleport.label.v1.Label
+	7,  // 13: teleport.scopes.access.v1.SSHPortForwarding.local:type_name -> teleport.scopes.access.v1.SSHLocalPortForwarding
+	8,  // 14: teleport.scopes.access.v1.SSHPortForwarding.remote:type_name -> teleport.scopes.access.v1.SSHRemotePortForwarding
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -870,13 +1027,14 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 	file_teleport_scopes_access_v1_role_proto_msgTypes[3].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[7].OneofWrappers = []any{}
 	file_teleport_scopes_access_v1_role_proto_msgTypes[8].OneofWrappers = []any{}
+	file_teleport_scopes_access_v1_role_proto_msgTypes[10].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -85,6 +85,10 @@ message ScopedRoleDefaults {
   // ClientIdleTimeout sets the default idle timeout for access sessions across all protocols
   // that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
   string client_idle_timeout = 1;
+
+  // SessionRecording configures the session recording strategy for all protocols that don't
+  // explicitly set their session recording mode.
+  SessionRecording session_recording = 2;
 }
 
 // ScopedRoleSSH groups all scoped role fields relevant to SSH access. Fields within the SSH block
@@ -126,6 +130,12 @@ message ScopedRoleSSH {
   // FileCopy indicates whether remote file operations via SCP or SFTP are allowed
   // over an SSH session. It defaults to allowing the user to download and upload files by default.
   optional bool file_copy = 11;
+
+  // EnhancedRecording is the set of BPF events to record for enhanced session recording.
+  EnhancedRecording enhanced_recording = 12;
+
+  // SessionRecording configures the session recording strategy for SSH sessions.
+  SessionRecording session_recording = 13;
 }
 
 // The group of all scoped role fields relevant to kube access. Fields within the kube block
@@ -189,4 +199,20 @@ message CreateHostUser {
 
   // Shell is the shell to set for the user.
   string shell = 3;
+}
+
+// EnhancedRecording enables what events to record for the BPF-based session recorder.
+message EnhancedRecording {
+  // Command enables session.command in audit logs
+  optional bool command = 1;
+  // Network enables session.network in audit logs
+  optional bool network = 2;
+  // Disk enables session.disk in audit logs
+  optional bool disk = 3;
+}
+
+// SessionRecording sets the session recording behavior.
+message SessionRecording {
+  // Mode sets the session recording mode. Allowed values: strict | best_effort.
+  string mode = 1;
 }

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedrolesv1.mdx
@@ -41,6 +41,13 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |client_idle_timeout|string|ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").|
+|session_recording|[object](#specdefaultssession_recording)|SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode.|
+
+### spec.defaults.session_recording
+
+|Field|Type|Description|
+|---|---|---|
+|mode|string|Mode sets the session recording mode. Allowed values: strict | best_effort.|
 
 ### spec.kube
 
@@ -70,6 +77,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |client_idle_timeout|string|ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.|
+|enhanced_recording|[object](#specsshenhanced_recording)|EnhancedRecording is the set of BPF events to record for enhanced session recording.|
 |file_copy|boolean|FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.|
 |forward_agent|boolean|ForwardAgent enables SSH agent forwarding.|
 |host_sudoers|[]string|Sudoers is a list of entries to include in a users sudoer file|
@@ -79,6 +87,15 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |max_sessions|integer|MaxSessions defines the maximum number of concurrent sessions per connection.|
 |permit_x11_forwarding|boolean|PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions. If not set, X11 forwarding is not permitted.|
 |port_forwarding|[object](#specsshport_forwarding)|SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.|
+|session_recording|[object](#specsshsession_recording)|SessionRecording configures the session recording strategy for SSH sessions.|
+
+### spec.ssh.enhanced_recording
+
+|Field|Type|Description|
+|---|---|---|
+|command|boolean|Command enables session.command in audit logs|
+|disk|boolean|Disk enables session.disk in audit logs|
+|network|boolean|Network enables session.network in audit logs|
 
 ### spec.ssh.host_user_creation
 
@@ -113,4 +130,10 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |enabled|boolean||
+
+### spec.ssh.session_recording
+
+|Field|Type|Description|
+|---|---|---|
+|mode|string|Mode sets the session recording mode. Allowed values: strict | best_effort.|
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_role.mdx
@@ -63,6 +63,14 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
+- `session_recording` (Attributes) SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode. (see [below for nested schema](#nested-schema-for-specdefaultssession_recording))
+
+### Nested Schema for `spec.defaults.session_recording`
+
+Optional:
+
+- `mode` (String) Mode sets the session recording mode. Allowed values: strict | best_effort.
+
 
 
 ### Nested Schema for `spec.kube`
@@ -96,6 +104,7 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
+- `enhanced_recording` (Attributes) EnhancedRecording is the set of BPF events to record for enhanced session recording. (see [below for nested schema](#nested-schema-for-specsshenhanced_recording))
 - `file_copy` (Boolean) FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.
 - `forward_agent` (Boolean) ForwardAgent enables SSH agent forwarding.
 - `host_sudoers` (List of String) Sudoers is a list of entries to include in a users sudoer file
@@ -105,6 +114,16 @@ Optional:
 - `max_sessions` (Number) MaxSessions defines the maximum number of concurrent sessions per connection.
 - `permit_x11_forwarding` (Boolean) PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions. If not set, X11 forwarding is not permitted.
 - `port_forwarding` (Attributes) SSHPortForwarding configures what types of SSH port forwarding are allowed by a role. (see [below for nested schema](#nested-schema-for-specsshport_forwarding))
+- `session_recording` (Attributes) SessionRecording configures the session recording strategy for SSH sessions. (see [below for nested schema](#nested-schema-for-specsshsession_recording))
+
+### Nested Schema for `spec.ssh.enhanced_recording`
+
+Optional:
+
+- `command` (Boolean) Command enables session.command in audit logs
+- `disk` (Boolean) Disk enables session.disk in audit logs
+- `network` (Boolean) Network enables session.network in audit logs
+
 
 ### Nested Schema for `spec.ssh.host_user_creation`
 
@@ -142,4 +161,12 @@ Optional:
 Optional:
 
 - `enabled` (Boolean)
+
+
+
+### Nested Schema for `spec.ssh.session_recording`
+
+Optional:
+
+- `mode` (String) Mode sets the session recording mode. Allowed values: strict | best_effort.
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_role.mdx
@@ -92,6 +92,14 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. "30m", "1h").
+- `session_recording` (Attributes) SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode. (see [below for nested schema](#nested-schema-for-specdefaultssession_recording))
+
+### Nested Schema for `spec.defaults.session_recording`
+
+Optional:
+
+- `mode` (String) Mode sets the session recording mode. Allowed values: strict | best_effort.
+
 
 
 ### Nested Schema for `spec.kube`
@@ -125,6 +133,7 @@ Optional:
 Optional:
 
 - `client_idle_timeout` (String) ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. "30m", "1h"). If empty, the defaults block value (or global default) applies.
+- `enhanced_recording` (Attributes) EnhancedRecording is the set of BPF events to record for enhanced session recording. (see [below for nested schema](#nested-schema-for-specsshenhanced_recording))
 - `file_copy` (Boolean) FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.
 - `forward_agent` (Boolean) ForwardAgent enables SSH agent forwarding.
 - `host_sudoers` (List of String) Sudoers is a list of entries to include in a users sudoer file
@@ -134,6 +143,16 @@ Optional:
 - `max_sessions` (Number) MaxSessions defines the maximum number of concurrent sessions per connection.
 - `permit_x11_forwarding` (Boolean) PermitX11Forwarding, when true, authorizes use of X11 forwarding over SSH sessions. If not set, X11 forwarding is not permitted.
 - `port_forwarding` (Attributes) SSHPortForwarding configures what types of SSH port forwarding are allowed by a role. (see [below for nested schema](#nested-schema-for-specsshport_forwarding))
+- `session_recording` (Attributes) SessionRecording configures the session recording strategy for SSH sessions. (see [below for nested schema](#nested-schema-for-specsshsession_recording))
+
+### Nested Schema for `spec.ssh.enhanced_recording`
+
+Optional:
+
+- `command` (Boolean) Command enables session.command in audit logs
+- `disk` (Boolean) Disk enables session.disk in audit logs
+- `network` (Boolean) Network enables session.network in audit logs
+
 
 ### Nested Schema for `spec.ssh.host_user_creation`
 
@@ -171,3 +190,11 @@ Optional:
 Optional:
 
 - `enabled` (Boolean)
+
+
+
+### Nested Schema for `spec.ssh.session_recording`
+
+Optional:
+
+- `mode` (String) Mode sets the session recording mode. Allowed values: strict | best_effort.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedrolesv1.yaml
@@ -56,6 +56,17 @@ spec:
                       access sessions across all protocols that do not specify their
                       own value. Must be a valid Go duration string (e.g. "30m", "1h").
                     type: string
+                  session_recording:
+                    description: SessionRecording configures the session recording
+                      strategy for all protocols that don't explicitly set their session
+                      recording mode.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Mode sets the session recording mode. Allowed
+                          values: strict | best_effort.'
+                        type: string
+                    type: object
                 type: object
               kube:
                 description: The kubernetes specific configuration for a scoped role.
@@ -129,6 +140,21 @@ spec:
                       string (e.g. "30m", "1h"). If empty, the defaults block value
                       (or global default) applies.
                     type: string
+                  enhanced_recording:
+                    description: EnhancedRecording is the set of BPF events to record
+                      for enhanced session recording.
+                    nullable: true
+                    properties:
+                      command:
+                        description: Command enables session.command in audit logs
+                        type: boolean
+                      disk:
+                        description: Disk enables session.disk in audit logs
+                        type: boolean
+                      network:
+                        description: Network enables session.network in audit logs
+                        type: boolean
+                    type: object
                   file_copy:
                     description: FileCopy indicates whether remote file operations
                       via SCP or SFTP are allowed over an SSH session. It defaults
@@ -216,6 +242,16 @@ spec:
                           enabled:
                             type: boolean
                         type: object
+                    type: object
+                  session_recording:
+                    description: SessionRecording configures the session recording
+                      strategy for SSH sessions.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Mode sets the session recording mode. Allowed
+                          values: strict | best_effort.'
+                        type: string
                     type: object
                 type: object
             type: object

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedrolesv1.yaml
@@ -56,6 +56,17 @@ spec:
                       access sessions across all protocols that do not specify their
                       own value. Must be a valid Go duration string (e.g. "30m", "1h").
                     type: string
+                  session_recording:
+                    description: SessionRecording configures the session recording
+                      strategy for all protocols that don't explicitly set their session
+                      recording mode.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Mode sets the session recording mode. Allowed
+                          values: strict | best_effort.'
+                        type: string
+                    type: object
                 type: object
               kube:
                 description: The kubernetes specific configuration for a scoped role.
@@ -129,6 +140,21 @@ spec:
                       string (e.g. "30m", "1h"). If empty, the defaults block value
                       (or global default) applies.
                     type: string
+                  enhanced_recording:
+                    description: EnhancedRecording is the set of BPF events to record
+                      for enhanced session recording.
+                    nullable: true
+                    properties:
+                      command:
+                        description: Command enables session.command in audit logs
+                        type: boolean
+                      disk:
+                        description: Disk enables session.disk in audit logs
+                        type: boolean
+                      network:
+                        description: Network enables session.network in audit logs
+                        type: boolean
+                    type: object
                   file_copy:
                     description: FileCopy indicates whether remote file operations
                       via SCP or SFTP are allowed over an SSH session. It defaults
@@ -216,6 +242,16 @@ spec:
                           enabled:
                             type: boolean
                         type: object
+                    type: object
+                  session_recording:
+                    description: SessionRecording configures the session recording
+                      strategy for SSH sessions.
+                    nullable: true
+                    properties:
+                      mode:
+                        description: 'Mode sets the session recording mode. Allowed
+                          values: strict | best_effort.'
+                        type: string
                     type: object
                 type: object
             type: object

--- a/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
+++ b/integrations/terraform/tfschema/scopes/access/v1/role_terraform.go
@@ -115,11 +115,22 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"defaults": {
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"client_idle_timeout": {
-						Description: "ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. \"30m\", \"1h\").",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"client_idle_timeout": {
+							Description: "ClientIdleTimeout sets the default idle timeout for access sessions across all protocols that do not specify their own value. Must be a valid Go duration string (e.g. \"30m\", \"1h\").",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"session_recording": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"mode": {
+								Description: "Mode sets the session recording mode. Allowed values: strict | best_effort.",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							}}),
+							Description: "SessionRecording configures the session recording strategy for all protocols that don't explicitly set their session recording mode.",
+							Optional:    true,
+						},
+					}),
 					Description: "Defaults specifies default values for controls common across multiple protocols. If the same control specified in defaults is also specified in a protocol block, the value in the protocol block takes precedence.",
 					Optional:    true,
 				},
@@ -182,6 +193,27 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Description: "ClientIdleTimeout overrides the defaults block idle timeout specifically for SSH sessions. Must be a valid Go duration string (e.g. \"30m\", \"1h\"). If empty, the defaults block value (or global default) applies.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"enhanced_recording": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"command": {
+									Description: "Command enables session.command in audit logs",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+								},
+								"disk": {
+									Description: "Disk enables session.disk in audit logs",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+								},
+								"network": {
+									Description: "Network enables session.network in audit logs",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+								},
+							}),
+							Description: "EnhancedRecording is the set of BPF events to record for enhanced session recording.",
+							Optional:    true,
 						},
 						"file_copy": {
 							Description: "FileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to allowing the user to download and upload files by default.",
@@ -272,6 +304,15 @@ func GenSchemaScopedRole(ctx context.Context) (github_com_hashicorp_terraform_pl
 								},
 							}),
 							Description: "SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.",
+							Optional:    true,
+						},
+						"session_recording": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"mode": {
+								Description: "Mode sets the session recording mode. Allowed values: strict | best_effort.",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							}}),
+							Description: "SessionRecording configures the session recording strategy for SSH sessions.",
 							Optional:    true,
 						},
 					}),
@@ -555,6 +596,41 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 													t = string(v.Value)
 												}
 												obj.ClientIdleTimeout = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["session_recording"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.defaults.session_recording"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.defaults.session_recording", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.SessionRecording = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.SessionRecording = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.SessionRecording{}
+													obj := obj.SessionRecording
+													{
+														a, ok := tf.Attrs["mode"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.defaults.session_recording.mode"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.defaults.session_recording.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															} else {
+																var t string
+																if !v.Null && !v.Unknown {
+																	t = string(v.Value)
+																}
+																obj.Mode = t
+															}
+														}
+													}
+												}
 											}
 										}
 									}
@@ -1041,6 +1117,113 @@ func CopyScopedRoleFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 													t = &c
 												}
 												obj.FileCopy = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["enhanced_recording"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.enhanced_recording"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.EnhancedRecording = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.EnhancedRecording = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.EnhancedRecording{}
+													obj := obj.EnhancedRecording
+													{
+														a, ok := tf.Attrs["command"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.command"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.command", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+															} else {
+																var t *bool
+																if !v.Null && !v.Unknown {
+																	c := bool(v.Value)
+																	t = &c
+																}
+																obj.Command = t
+															}
+														}
+													}
+													{
+														a, ok := tf.Attrs["network"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.network"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.network", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+															} else {
+																var t *bool
+																if !v.Null && !v.Unknown {
+																	c := bool(v.Value)
+																	t = &c
+																}
+																obj.Network = t
+															}
+														}
+													}
+													{
+														a, ok := tf.Attrs["disk"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.disk"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.disk", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+															} else {
+																var t *bool
+																if !v.Null && !v.Unknown {
+																	c := bool(v.Value)
+																	t = &c
+																}
+																obj.Disk = t
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["session_recording"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.session_recording"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.session_recording", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+											} else {
+												obj.SessionRecording = nil
+												if !v.Null && !v.Unknown {
+													tf := v
+													obj.SessionRecording = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_access_v1.SessionRecording{}
+													obj := obj.SessionRecording
+													{
+														a, ok := tf.Attrs["mode"]
+														if !ok {
+															diags.Append(attrReadMissingDiag{"ScopedRole.spec.ssh.session_recording.mode"})
+														} else {
+															v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																diags.Append(attrReadConversionFailureDiag{"ScopedRole.spec.ssh.session_recording.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+															} else {
+																var t string
+																if !v.Null && !v.Unknown {
+																	t = string(v.Value)
+																}
+																obj.Mode = t
+															}
+														}
+													}
+												}
 											}
 										}
 									}
@@ -1617,6 +1800,60 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 											v.Value = string(obj.ClientIdleTimeout)
 											v.Unknown = false
 											tf.Attrs["client_idle_timeout"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["session_recording"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.defaults.session_recording"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.defaults.session_recording", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["session_recording"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.SessionRecording == nil {
+													v.Null = true
+												} else {
+													obj := obj.SessionRecording
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["mode"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.defaults.session_recording.mode"})
+														} else {
+															v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.defaults.session_recording.mode", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.defaults.session_recording.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																}
+																v.Null = string(obj.Mode) == ""
+															}
+															v.Value = string(obj.Mode)
+															v.Unknown = false
+															tf.Attrs["mode"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["session_recording"] = v
+											}
 										}
 									}
 								}
@@ -2455,6 +2692,170 @@ func CopyScopedRoleToTerraform(ctx context.Context, obj *github_com_gravitationa
 											}
 											v.Unknown = false
 											tf.Attrs["file_copy"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["enhanced_recording"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.enhanced_recording"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["enhanced_recording"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.EnhancedRecording == nil {
+													v.Null = true
+												} else {
+													obj := obj.EnhancedRecording
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["command"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.command"})
+														} else {
+															v, ok := tf.Attrs["command"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.enhanced_recording.command", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.command", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+																}
+															}
+															if obj.Command == nil {
+																v.Null = true
+															} else {
+																v.Null = false
+																v.Value = bool(*obj.Command)
+															}
+															v.Unknown = false
+															tf.Attrs["command"] = v
+														}
+													}
+													{
+														t, ok := tf.AttrTypes["network"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.network"})
+														} else {
+															v, ok := tf.Attrs["network"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.enhanced_recording.network", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.network", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+																}
+															}
+															if obj.Network == nil {
+																v.Null = true
+															} else {
+																v.Null = false
+																v.Value = bool(*obj.Network)
+															}
+															v.Unknown = false
+															tf.Attrs["network"] = v
+														}
+													}
+													{
+														t, ok := tf.AttrTypes["disk"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.enhanced_recording.disk"})
+														} else {
+															v, ok := tf.Attrs["disk"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.enhanced_recording.disk", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.enhanced_recording.disk", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+																}
+															}
+															if obj.Disk == nil {
+																v.Null = true
+															} else {
+																v.Null = false
+																v.Value = bool(*obj.Disk)
+															}
+															v.Unknown = false
+															tf.Attrs["disk"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["enhanced_recording"] = v
+											}
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["session_recording"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.session_recording"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.session_recording", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+											} else {
+												v, ok := tf.Attrs["session_recording"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												if !ok {
+													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+														AttrTypes: o.AttrTypes,
+														Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+													}
+												} else {
+													if v.Attrs == nil {
+														v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+													}
+												}
+												if obj.SessionRecording == nil {
+													v.Null = true
+												} else {
+													obj := obj.SessionRecording
+													tf := &v
+													{
+														t, ok := tf.AttrTypes["mode"]
+														if !ok {
+															diags.Append(attrWriteMissingDiag{"ScopedRole.spec.ssh.session_recording.mode"})
+														} else {
+															v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+															if !ok {
+																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																if err != nil {
+																	diags.Append(attrWriteGeneralError{"ScopedRole.spec.ssh.session_recording.mode", err})
+																}
+																v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																if !ok {
+																	diags.Append(attrWriteConversionFailureDiag{"ScopedRole.spec.ssh.session_recording.mode", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																}
+																v.Null = string(obj.Mode) == ""
+															}
+															v.Value = string(obj.Mode)
+															v.Unknown = false
+															tf.Attrs["mode"] = v
+														}
+													}
+												}
+												v.Unknown = false
+												tf.Attrs["session_recording"] = v
+											}
 										}
 									}
 								}

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/constants"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -252,6 +253,25 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 	// verify that max_sessions is non-negative
 	if ms := role.GetSpec().GetSsh().GetMaxSessions(); ms < 0 {
 		return trace.BadParameter("scoped role %q has invalid ssh.max_sessions %d: must be non-negative", role.GetMetadata().GetName(), ms)
+	}
+
+	// verify that session_recording_mode fields are recognized values
+	if mode := role.GetSpec().GetSsh().GetSessionRecording().GetMode(); mode != "" {
+		switch constants.SessionRecordingMode(mode) {
+		case constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort:
+		default:
+			return trace.BadParameter("scoped role %q has invalid ssh.session_recording_mode. %q: must be %q or %q",
+				role.GetMetadata().GetName(), mode, constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort)
+		}
+	}
+
+	if mode := role.GetSpec().GetDefaults().GetSessionRecording().GetMode(); mode != "" {
+		switch constants.SessionRecordingMode(mode) {
+		case constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort:
+		default:
+			return trace.BadParameter("scoped role %q has invalid defaults.session_recording_mode %q: must be %q or %q",
+				role.GetMetadata().GetName(), mode, constants.SessionRecordingModeStrict, constants.SessionRecordingModeBestEffort)
+		}
 	}
 
 	// verify that kube labels are well-formed

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
+	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
@@ -394,8 +395,83 @@ func TestValidateRole(t *testing.T) {
 			strongOk: true,
 			weakOk:   true,
 		},
+		{
+			name: "invalid defaults.session_recording_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind:     KindScopedRole,
+				Metadata: &headerv1.Metadata{Name: "test"},
+				Scope:    "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Defaults: &scopedaccessv1.ScopedRoleDefaults{
+						SessionRecording: &scopedaccessv1.SessionRecording{
+							Mode: "blah",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "valid defaults.session_recording_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind:     KindScopedRole,
+				Metadata: &headerv1.Metadata{Name: "test"},
+				Scope:    "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Defaults: &scopedaccessv1.ScopedRoleDefaults{
+						SessionRecording: &scopedaccessv1.SessionRecording{
+							Mode: string(constants.SessionRecordingModeStrict),
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "invalid ssh.session_recording_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind:     KindScopedRole,
+				Metadata: &headerv1.Metadata{Name: "test"},
+				Scope:    "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						SessionRecording: &scopedaccessv1.SessionRecording{
+							Mode: "blah",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "valid ssh.session_recording_mode",
+			role: &scopedaccessv1.ScopedRole{
+				Kind:     KindScopedRole,
+				Metadata: &headerv1.Metadata{Name: "test"},
+				Scope:    "/",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+					Ssh: &scopedaccessv1.ScopedRoleSSH{
+						SessionRecording: &scopedaccessv1.SessionRecording{
+							Mode: string(constants.SessionRecordingModeStrict),
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
 	}
-
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			err := StrongValidateRole(tt.role)
@@ -1217,6 +1293,9 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 		AssignableScopes: []string{"/foo"},
 		Defaults: &scopedaccessv1.ScopedRoleDefaults{
 			ClientIdleTimeout: "30m",
+			SessionRecording: &scopedaccessv1.SessionRecording{
+				Mode: string(constants.SessionRecordingModeStrict),
+			},
 		},
 		Rules: []*scopedaccessv1.ScopedRule{
 			{
@@ -1244,6 +1323,14 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 			},
 			HostSudoers: []string{"ALL=(ALL) NOPASSWD:ALL"},
 			MaxSessions: proto.Int64(10),
+			EnhancedRecording: &scopedaccessv1.EnhancedRecording{
+				Disk:    proto.Bool(true),
+				Network: proto.Bool(true),
+				Command: proto.Bool(true),
+			},
+			SessionRecording: &scopedaccessv1.SessionRecording{
+				Mode: string(constants.SessionRecordingModeStrict),
+			},
 		},
 		Kube: &scopedaccessv1.ScopedRoleKube{
 			Groups: []string{"viewer"},

--- a/lib/scopes/access/compat.go
+++ b/lib/scopes/access/compat.go
@@ -168,7 +168,7 @@ func ScopedRoleToRole(sr *scopedaccessv1.ScopedRole, assignedScope string) (type
 			// per-protocol disconnect on expired cert, with the global setting always applying for operations that are not tied to a
 			// specific access check. By setting this value to false we effectively make the default behavior one where we
 			// are always deferring to the global setting for scoped identities, which aught to be forwards compatible with
-			// whatever solution we eventually land on	.
+			// whatever solution we eventually land on.
 			DisconnectExpiredCert: types.NewBool(false),
 		},
 	})

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
@@ -234,6 +236,8 @@ func baseScopedRole() *scopedaccessv1.ScopedRole {
 	}
 }
 
+func ptr[T any](v T) *T { return &v }
+
 // TestClientIdleTimeoutNotInClassicRole verifies that ScopedRoleToRole does not populate ClientIdleTimeout
 // in the classic role options. Per the scoped role design, client_idle_timeout is read directly from the
 // appropriate protocol block on the scoped role, which does not have a direct classic role equivalent.
@@ -254,9 +258,8 @@ func TestClientIdleTimeoutNotInClassicRole(t *testing.T) {
 func TestX11ForwardingNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.PermitX11Forwarding = boolPtr(true)
+	sr.Spec.Ssh.PermitX11Forwarding = ptr(true)
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -266,9 +269,8 @@ func TestX11ForwardingNotInClassicRole(t *testing.T) {
 func TestForwardAgentNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.ForwardAgent = boolPtr(true)
+	sr.Spec.Ssh.ForwardAgent = ptr(true)
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -278,9 +280,8 @@ func TestForwardAgentNotInClassicRole(t *testing.T) {
 func TestMaxSessionsNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	int64Ptr := func(v int64) *int64 { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.MaxSessions = int64Ptr(10)
+	sr.Spec.Ssh.MaxSessions = ptr(int64(10))
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
@@ -290,11 +291,10 @@ func TestMaxSessionsNotInClassicRole(t *testing.T) {
 func TestSSHPortForwardingNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
 	sr.Spec.Ssh.PortForwarding = &scopedaccessv1.SSHPortForwarding{
-		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: boolPtr(false)},
-		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: boolPtr(false)},
+		Local:  &scopedaccessv1.SSHLocalPortForwarding{Enabled: ptr(false)},
+		Remote: &scopedaccessv1.SSHRemotePortForwarding{Enabled: ptr(false)},
 	}
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
@@ -318,13 +318,45 @@ func TestHostUserCreationNotInClassicRole(t *testing.T) {
 func TestSSHFileCopyNotInClassicRole(t *testing.T) {
 	t.Parallel()
 
-	boolPtr := func(v bool) *bool { return &v }
 	sr := baseScopedRole()
-	sr.Spec.Ssh.FileCopy = boolPtr(false)
+	sr.Spec.Ssh.FileCopy = ptr(false)
 
 	role, err := ScopedRoleToRole(sr, "/foo/bar")
 	require.NoError(t, err)
 	require.Equal(t, types.NewBoolOption(true), role.GetOptions().SSHFileCopy)
+}
+
+func TestEnhancedRecordingNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	sr := baseScopedRole()
+	sr.Spec.Ssh.EnhancedRecording = &scopedaccessv1.EnhancedRecording{
+		Command: ptr(true),
+		Network: ptr(true),
+		Disk:    ptr(true),
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	// BPF is the classic role equivalent of enhanced_recording.
+	require.Equal(t, apidefaults.EnhancedEvents(), role.GetOptions().BPF)
+}
+
+func TestSessionRecordingNotInClassicRole(t *testing.T) {
+	t.Parallel()
+
+	sr := baseScopedRole()
+	sr.Spec.Ssh.SessionRecording = &scopedaccessv1.SessionRecording{
+		Mode: string(constants.SessionRecordingModeBestEffort),
+	}
+
+	role, err := ScopedRoleToRole(sr, "/foo/bar")
+	require.NoError(t, err)
+	// RecordSession is the classic role equivalent of session_recording_mode.
+	require.Equal(t, &types.RecordSession{
+		Desktop: types.NewBoolOption(true),
+		Default: constants.SessionRecordingModeBestEffort,
+	}, role.GetOptions().RecordSession)
 }
 
 // TestKubeConversion verifies the various kube-related scoped role conversion scenarios.

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -88,11 +88,19 @@ func (c *SSHAccessChecker) AdjustDisconnectExpiredCert(disconnect bool) bool {
 }
 
 // SessionRecordingMode returns the session recording mode for SSH sessions.
+// SSH recording mode takes precedence over the defaults
 func (c *SSHAccessChecker) SessionRecordingMode() constants.SessionRecordingMode {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH)
 	}
-	return c.checker.scopedCompatChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH)
+	sr := c.checker.role.GetSpec().GetSsh().GetSessionRecording()
+	if sr == nil {
+		sr = c.checker.role.GetSpec().GetDefaults().GetSessionRecording()
+	}
+	if sr.GetMode() != "" {
+		return constants.SessionRecordingMode(sr.GetMode())
+	}
+	return constants.SessionRecordingModeBestEffort
 }
 
 // CanPortForward returns true if port forwarding is permitted.
@@ -162,7 +170,18 @@ func (c *SSHAccessChecker) EnhancedRecordingSet() map[string]bool {
 	if !c.checker.isScoped() {
 		return c.checker.unscopedChecker.EnhancedRecordingSet()
 	}
-	return c.checker.scopedCompatChecker.EnhancedRecordingSet()
+	events := c.checker.role.GetSpec().GetSsh().GetEnhancedRecording()
+	m := make(map[string]bool)
+	if events.GetCommand() {
+		m[constants.EnhancedRecordingCommand] = true
+	}
+	if events.GetDisk() {
+		m[constants.EnhancedRecordingDisk] = true
+	}
+	if events.GetNetwork() {
+		m[constants.EnhancedRecordingNetwork] = true
+	}
+	return m
 }
 
 // HostUsers returns host user creation information for the server, or nil if host user creation is disabled.

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -506,6 +506,109 @@ func TestSSHAccessCheckerHostSudoers(t *testing.T) {
 	}
 }
 
+func TestSSHAccessCheckerSessionRecordingMode(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect constants.SessionRecordingMode
+	}{
+		{
+			name:   "unset defaults to best_effort",
+			spec:   &scopedaccessv1.ScopedRoleSpec{Ssh: &scopedaccessv1.ScopedRoleSSH{}},
+			expect: constants.SessionRecordingModeBestEffort,
+		},
+		{
+			name: "ssh strict",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SessionRecording: &scopedaccessv1.SessionRecording{
+						Mode: string(constants.SessionRecordingModeStrict),
+					},
+				},
+			},
+			expect: constants.SessionRecordingModeStrict,
+		},
+		{
+			name: "defaults used when ssh unset",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Defaults: &scopedaccessv1.ScopedRoleDefaults{
+					SessionRecording: &scopedaccessv1.SessionRecording{
+						Mode: string(constants.SessionRecordingModeStrict),
+					},
+				},
+			},
+			expect: constants.SessionRecordingModeStrict,
+		},
+		{
+			name: "ssh overrides defaults",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Defaults: &scopedaccessv1.ScopedRoleDefaults{
+					SessionRecording: &scopedaccessv1.SessionRecording{
+						Mode: string(constants.SessionRecordingModeBestEffort),
+					},
+				},
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					SessionRecording: &scopedaccessv1.SessionRecording{
+						Mode: string(constants.SessionRecordingModeBestEffort),
+					},
+				},
+			},
+			expect: constants.SessionRecordingModeBestEffort,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.SessionRecordingMode())
+		})
+	}
+}
+
+func TestSSHAccessCheckerEnhancedRecording(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		spec   *scopedaccessv1.ScopedRoleSpec
+		expect map[string]bool
+	}{
+		{
+			name: "no events",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					EnhancedRecording: nil,
+				},
+			},
+			expect: map[string]bool{},
+		},
+		{
+			name: "has events",
+			spec: &scopedaccessv1.ScopedRoleSpec{
+				Ssh: &scopedaccessv1.ScopedRoleSSH{
+					EnhancedRecording: &scopedaccessv1.EnhancedRecording{
+						Network: ptr(true),
+						Command: ptr(true),
+						Disk:    ptr(true),
+					},
+				},
+			},
+			expect: map[string]bool{"command": true, "network": true, "disk": true},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			require.Equal(t, tt.expect, checker.EnhancedRecordingSet())
+		})
+	}
+}
+
 func TestSSHAccessCheckerHostUsers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Add Enhanced Session Recording and Session Recording Mode to scoped roles


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster, EC2 Linux Node, docker container node

### Test Cases
- [x] Enable BPF on EC2 linux node and verified that scoped roles with disk, network, and command bpf enabled have the relevant audit logs recorded
- [x] Users that don't have bpf enabled don't have the relevant audit logs recorded
- [x] When set to strict, failure to record the session ends the ssh session
- [x] When set to best effort, session continues
