### PR TITLE
Improve web client response handling

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -219,8 +219,29 @@ func findWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.DebugContext(req.Context(), "Received unsuccessful find response", "code", resp.StatusCode)
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, trace.Wrap(err, "could not read find response body; check the network connection")
+		}
+
+		if contentType := resp.Header.Get("Content-Type"); contentType != "application/json" {
+			return nil, trace.Errorf("failed to reach Teleport Proxy: %s", string(bodyBytes))
+		}
+
+		errResp := &PingErrorResponse{}
+		if err := json.Unmarshal(bodyBytes, errResp); err != nil {
+			slog.DebugContext(req.Context(), "Could not parse find response body", "body", string(bodyBytes))
+			return nil, trace.Wrap(err, "cannot parse find response; is proxy reachable?")
+		}
+
+		return nil, trace.Wrap(errors.New(errResp.Error.Message), "proxy service returned unsuccessful find response; Teleport cluster auth may be misconfigured")
+	}
+
 	pr := &PingResponse{}
 	if err := json.NewDecoder(resp.Body).Decode(pr); err != nil {
 		return nil, trace.Wrap(err)
@@ -282,6 +303,10 @@ func pingWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, trace.Wrap(err, "could not read ping response body; check the network connection")
+		}
+
+		if contentType := resp.Header.Get("Content-Type"); contentType != "application/json" {
+			return nil, trace.Errorf("failed to reach Teleport Proxy: %s", string(bodyBytes))
 		}
 
 		errResp := &PingErrorResponse{}


### PR DESCRIPTION
Response handling from /webapi/ping and /webapi/find were not properly inspecting status codes and content type before processing responses. This results in weird error messages being provided to users for various scenarios.

To improve the situation we now:

- Only process the response in the happy path if we receive a 200 response code
- Inspect the content-type for all non-200 response codes
- Only try json decoding non-200 repsonse bodies if the content type is json

This should allow us to properly handle successful requests to a proxy, failure to handle requests at the proxy, and requests getting routed to something besides a proxy.






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
