### PR TITLE
[v17] Update tbot configure description output parameter

### DIFF
--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -81,7 +81,7 @@ func Run(args []string, stdout io.Writer) error {
 
 	startCmd := app.Command("start", "Starts the renewal bot, writing certificates to the data dir at a set interval.")
 
-	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).")
+	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-o <path>).")
 	configureCmd.Flag("output", "Path to write the generated configuration file to rather than write to stdout.").Short('o').StringVar(&configureOutPath)
 
 	keypairCmd := app.Command("keypair", "Manage keypairs for bound-keypair joining")


### PR DESCRIPTION
backport #65959 to branch/v17



## Manual Test Plan
### Test Environment

      Dev environment

### Test Cases
- [x] Confirm `tbot help configure` shows `-o` instead of `-c` 
