### PR TITLE
[v17] Mention tsh proxy db --tunnel in per-session MFA docs

### DIFF
--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
@@ -172,6 +172,8 @@ $ tsh db connect --db-user=KeyspacesReader keyspaces
 # KeyspacesReader@cqlsh>
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="keyspaces" dbArgs="--db-user=KeyspacesReader"!)
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
@@ -205,6 +205,8 @@ Retrieve credentials for the database and connect to it as the `teleport-docdb-u
 $ tsh db connect --db-user=teleport-docdb-user --db-name=test my-docdb
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="my-docdb" dbArgs="--db-user=teleport-docdb-user --db-name=test"!)
+
 Log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx
@@ -198,6 +198,8 @@ $ tsh db connect --db-user=alice --db-name=dev my-redshift
   Teleport does not currently use the auto-create option when generating
   tokens for Redshift databases. Users must exist in the database.
 </Admonition>
+
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="my-redshift" dbArgs="--db-user=alice --db-name=dev"!)
 </TabItem>
 
 <TabItem label="Authenticate as IAM roles">
@@ -205,6 +207,8 @@ $ tsh db connect --db-user=alice --db-name=dev my-redshift
 ```code
 $ tsh db connect --db-user=role/example-iam-role --db-name=dev my-redshift
 ```
+
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="my-redshift" dbArgs="--db-user=role/example-iam-role --db-name=dev"!)
 </TabItem>
 </Tabs>
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx
@@ -224,6 +224,8 @@ Type "help" for help.
 dev=>
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="my-redshift" dbArgs="--db-user=teleport-redshift-serverless-access --db-name=dev"!)
+
 (!docs/pages/includes/database-access/pg-access-webui.mdx!)
 
 To log out of the database and remove credentials:

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
@@ -207,6 +207,9 @@ Note that the Teleport Database Service will retrieve the access key and
 authenticate with the Redis server on the backend automatically. Therefore,
 the `AUTH <access-key>` command is **not required** here once connected.
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="my-azure-redis"!)
+
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
@@ -198,6 +198,8 @@ $ tsh db connect --db-user=cloudsql-user --db-name=mysql cloudsql
 $ tsh db connect --db-user=cloudsql-user@<Var name="project-id"/>.iam.gserviceaccount.com --db-name=mysql cloudsql
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="cloudsql" dbArgs="--db-user=cloudsql-user --db-name=mysql"!)
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
@@ -153,6 +153,18 @@ assigning <Var name="project-id" /> to your Google Cloud project ID:
 $ tsh db connect --db-user=cloudsql-user@<Var name="project-id"/>.iam --db-name=postgres cloudsql
 ```
 
+<Admonition type="tip">
+To connect to the database using a tool of your choice, like a graphical
+database client, you can create a local tunnel and point it to your software:
+
+```code
+$ tsh proxy db cloudsql --tunnel --db-user=cloudsql-user@<Var name="project-id"/>.iam --db-name=postgres
+```
+
+See [Database GUI Clients](../../../connect-your-client/gui-clients.mdx)
+guide for more information on specific tools.
+</Admonition>
+
 (!docs/pages/includes/database-access/pg-access-webui.mdx!)
 
 To log out of the database and remove credentials:

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/spanner.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/spanner.mdx
@@ -198,6 +198,8 @@ it:
 $ tsh db connect --db-user=spanner-user --db-name=example-db spanner-example
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="spanner-example" dbArgs="--db-user=spanner-user --db-name=example-db"!)
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas.mdx
@@ -268,6 +268,8 @@ To retrieve credentials for a database and connect to it:
 ```code
 $ tsh db connect --db-user=alice --db-name dev mongodb-atlas
 ```
+
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="mongodb-atlas" dbArgs="--db-user=alice --db-name=dev"!)
 </TabItem>
 <TabItem label="AWS IAM authentication">
 To retrieve credentials for a database and connect to it, you must provide the

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx
@@ -383,6 +383,18 @@ $ tsh db connect --db-user alice --db-name spark_PDB1.paas.oracle.com <Var name=
 # SQL>
 ```
 
+<Admonition type="tip">
+To connect to the database using a tool of your choice, like a graphical
+database client, you can create a local tunnel and point it to your software:
+
+```code
+$ tsh proxy db <Var name="oracle"/> --tunnel --db-user alice --db-name spark_PDB1.paas.oracle.com
+```
+
+See [Database GUI Clients](../../../connect-your-client/gui-clients.mdx)
+guide for more information on specific tools.
+</Admonition>
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/snowflake.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/snowflake.mdx
@@ -135,6 +135,8 @@ To retrieve credentials for a database and connect to it:
 $ tsh db connect --db-user=alice --db-name=SNOWFLAKE_SAMPLE_DATA example-snowflake
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="example-snowflake" dbArgs="--db-user=alice --db-name=SNOWFLAKE_SAMPLE_DATA"!)
+
 The `snowsql` command-line client should be available in the system `PATH` in order to be
 able to connect.
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
@@ -171,6 +171,8 @@ $ tsh db connect --db-user=cassandra cassandra
 # cassandra@cqlsh>
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="cassandra" dbArgs="--db-user=cassandra"!)
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
@@ -254,6 +254,8 @@ $ tsh db connect --db-user=alice roach
   in order to be able to connect.
 </Admonition>
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="roach" dbArgs="--db-user=alice"!)
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
@@ -259,6 +259,8 @@ $ tsh db connect --db-user=alice --db-name dev example-mongo
   able to connect. The Database Service attempts to run `mongosh` first and, if `mongosh` is not in `PATH`, runs `mongo`.
 </Admonition>
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="example-mongo" dbArgs="--db-user=alice --db-name=dev"!)
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
@@ -196,6 +196,8 @@ $ tsh db connect --db-user=alice --db-name=mysql example-mysql
   able to connect. `mariadb` is a default command-line client for MySQL and MariaDB.
 </Admonition>
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="example-mysql" dbArgs="--db-user=alice --db-name=mysql"!)
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
@@ -252,6 +252,8 @@ $ tsh db connect --db-user=alice --db-name=XE oracle
 # SQL>
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="oracle" dbArgs="--db-user=alice --db-name=XE"!)
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
@@ -145,6 +145,8 @@ To retrieve credentials for a database and connect to it:
 $ tsh db connect --db-user=postgres --db-name=postgres example-postgres
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="example-postgres" dbArgs="--db-user=postgres --db-name=postgres"!)
+
 (!docs/pages/includes/database-access/pg-access-webui.mdx!)
 
 To log out of the database and remove credentials:

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/vitess.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/vitess.mdx
@@ -208,6 +208,8 @@ $ tsh db connect --db-user=root --db-name=mysql example-vitess
   MySQL and MariaDB.
 </Admonition>
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="example-vitess" dbArgs="--db-user=root --db-name=mysql"!)
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/database-access/getting-started.mdx
@@ -233,6 +233,8 @@ Finally, connect to the database:
 $ tsh db connect --db-user=alice --db-name postgres aurora
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="aurora" dbArgs="--db-user=alice --db-name=postgres"!)
+
 ### Auditing
 
 (!docs/pages/includes/database-access/db-audit-events.mdx!)

--- a/docs/pages/includes/database-access/auto-user-provisioning/connect.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/connect.mdx
@@ -9,6 +9,8 @@ $ tsh login --proxy=teleport.example.com
 $ tsh db connect --db-name <database> example
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="example" dbArgs="--db-name=&lt;database&gt;"!)
+
 <Admonition type="note" title="Database Username">
 When connecting to a database with user provisioning enabled, the Database
 Service expects your Teleport username will be used as the database username .

--- a/docs/pages/includes/database-access/proxy-db-tunnel.mdx
+++ b/docs/pages/includes/database-access/proxy-db-tunnel.mdx
@@ -1,0 +1,14 @@
+{{ db="mydb" dbArgs="" }}
+
+<Admonition type="tip">
+To connect to the database using a tool of your choice (for example, a
+graphical database client), create a local tunnel and configure your client to
+use it.
+
+```code
+$ tsh proxy db {{ db }} --tunnel {{ dbArgs }}
+```
+
+See [Database GUI Clients](../../connect-your-client/gui-clients.mdx)
+guide for more information on specific tools.
+</Admonition>

--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -184,6 +184,8 @@ Retrieve credentials for the database and connect to it as the `alice` user:
 $ tsh db connect --db-user=alice --db-name=dev rds-proxy
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="rds-proxy" dbArgs="--db-user=alice --db-name=dev"!)
+
 (!docs/pages/includes/database-access/pg-access-webui.mdx!)
 
 To log out of the database and remove credentials:

--- a/docs/pages/includes/database-access/redis-connect.mdx
+++ b/docs/pages/includes/database-access/redis-connect.mdx
@@ -42,6 +42,8 @@ Now you can log in as the previously created user using the below command:
 AUTH alice STRONG_GENERATED_PASSWORD
 ```
 
+(!docs/pages/includes/database-access/proxy-db-tunnel.mdx db="example-redis"!)
+
 To log out of the database and remove credentials:
 
 ```code

--- a/docs/pages/zero-trust-access/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/per-session-mfa.mdx
@@ -11,8 +11,9 @@ Teleport supports requiring additional multi-factor authentication checks
 when starting new:
 
 - SSH connections (a single `tsh ssh` call, Web UI SSH session or Teleport Connect SSH session)
-- Kubernetes sessions (a single `kubectl` call)
-- Database sessions (a single `tsh db connect` call)
+- Kubernetes sessions (a single `kubectl` call or a single `tsh proxy kube` run)
+- Database sessions (a single `tsh db connect` call, a single `tsh db exec`
+  call, or a single `tsh proxy db --tunnel` run)
 - Application sessions
 - Desktop sessions
 
@@ -177,7 +178,9 @@ MFA with Teleport's Web UI.
 If per-session MFA was enabled cluster-wide, Jerry would be prompted for MFA
 even when logging into `dev1.example.com`.
 
-<Admonition title="Per-session MFA for Database Access" type="tip">
+{/* vale messaging.protocol-products = NO */}
+## Per-session MFA for Database Access
+{/* vale messaging.protocol-products = YES */}
 
 The Teleport Database Service supports per-connection MFA. When Jerry connects
 to the database `prod-mysql-instance` (with label `env: prod`), he gets prompted
@@ -200,6 +203,40 @@ $ tsh db connect prod-mysql-instance
 # Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 #
 # mysql>
+```
+
+If Jerry wants to avoid frequent MFA ceremonies, he can launch a local proxy
+tunnel using `tsh proxy db --tunnel` command. He will then only be required to
+perform MFA when establishing the tunnel.
+
+```code
+$ tsh proxy db --tunnel prod-postgres-instance --db-user=my-prod-user --db-name=my-prod-db
+Started authenticated tunnel for the PostgreSQL database "prod-postgres-instance" in cluster "example.com" on 127.0.0.1:65282.
+To avoid port randomization, you can choose the listening port using the --port flag.
+
+Teleport Connect is a desktop app that can manage database proxies for you.
+Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database
+
+Use the following command to connect to the database or to the address above using other database GUI/CLI clients:
+  $ psql postgres://postgres@localhost:65282/my-prod-db
+MFA is required to access Database "prod-postgres-instance"
+Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.
+If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,browser> or environment variable TELEPORT_MFA_MODE=<webauthn,browser>.
+
+Tap any security key <tap>
+Detected security key tap
+```
+
+Notice that `tsh proxy db` prints the command that can now be used to connect
+to the database. Jerry can now connect to the database without using MFA on
+every connection:
+
+```code
+$ psql postgres://postgres@localhost:65282/my-prod-db
+psql (17.5)
+Type "help" for help.
+
+my-prod-db=#
 ```
 
 Jerry can also execute a query against multiple databases with a single MFA check
@@ -228,7 +265,69 @@ Summary is saved at "logs/summary.json".
 Note that each MFA check remains valid for up to 5 minutes. After the 5-minutes
 window, a new MFA check will be requested for new connections.
 
-</Admonition>
+{/* vale messaging.protocol-products = NO */}
+## Per-session MFA for Kubernetes Access
+{/* vale messaging.protocol-products = YES */}
+
+When per-session MFA is required, each `kubectl` command Jerry will execute
+will require confirmation using an MFA device.
+
+```code
+$ tsh kube login prod-kube-cluster
+Logged into Kubernetes cluster "prod-kube-cluster". Try 'kubectl version' to test the connection.
+
+$ kubectl version
+MFA is required to access Kubernetes cluster "prod-kube-cluster"
+Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.
+If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,browser> or environment variable TELEPORT_MFA_MODE=<webauthn,browser>.
+
+Tap any security key <tap>
+Detected security key tap
+Client Version: v1.34.1
+Kustomize Version: v5.7.1
+Server Version: v1.35.0
+```
+
+If confirming every single command becomes tedious, Jerry can start a local
+proxy. That eliminates the need to confirm every single command; instead, MFA
+confirmation is required by the proxy itself.
+
+```code
+$ tsh proxy kube --exec
+Preparing the following Teleport Kubernetes clusters from the default kubeconfig:
+Teleport Cluster Name Kube Cluster Name Context Name
+--------------------- ----------------- -----------------------------
+example.com           prod-kube-cluster example.com-prod-kube-cluster
+
+MFA is required to access Kubernetes cluster "prod-kube-cluster"
+Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.
+If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,browser> or environment variable TELEPORT_MFA_MODE=<webauthn,browser>.
+
+Tap any security key <tap>
+Detected security key tap
+Started local proxy for Kubernetes Access in the background.
+
+Warning! Teleport will initiate a new shell configured with kubectl for local proxy access.
+To conclude the session, simply use the "exit" command. Upon exiting, your original shell will be restored,
+the local proxy will be closed, and future access through this headless session won't be possible.
+
+
+Try issuing a command, for example "kubectl version".
+```
+
+The `tsh proxy kube --exec` command performs the MFA ceremony and opens up a
+shell configured to access the given cluster using `kubectl`. Jerry can now
+execute this command without additional MFA:
+
+```code
+$ kubectl version
+Client Version: v1.34.1
+Kustomize Version: v5.7.1
+Server Version: v1.35.0
+```
+
+The `kubectl` call uses an already authenticated connection offered by the
+local proxy.
 
 ## Limitations
 

--- a/docs/pages/zero-trust-access/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/per-session-mfa.mdx
@@ -218,7 +218,7 @@ Teleport Connect is a desktop app that can manage database proxies for you.
 Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database
 
 Use the following command to connect to the database or to the address above using other database GUI/CLI clients:
-  $ psql postgres://postgres@localhost:65282/my-prod-db
+  $ psql postgres://my-prod-user@localhost:65282/my-prod-db
 MFA is required to access Database "prod-postgres-instance"
 Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.
 If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,browser> or environment variable TELEPORT_MFA_MODE=<webauthn,browser>.
@@ -232,7 +232,7 @@ to the database. Jerry can now connect to the database without using MFA on
 every connection:
 
 ```code
-$ psql postgres://postgres@localhost:65282/my-prod-db
+$ psql postgres://my-prod-user@localhost:65282/my-prod-db
 psql (17.5)
 Type "help" for help.
 

--- a/docs/pages/zero-trust-access/access-controls/guides/webauthn.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/webauthn.mdx
@@ -171,7 +171,7 @@ when starting new:
 
 - SSH connections (a single `tsh ssh` call, Web UI SSH session or Teleport Connect SSH session)
 - Kubernetes sessions (a single `kubectl` call)
-- Database sessions (a single `tsh db connect` call)
+- Database sessions (a single `tsh db connect` call or a single `tsh proxy db --tunnel` run)
 - Application sessions
 - Desktop sessions
 


### PR DESCRIPTION
Backport #65816 to branch/v17

Blocked by https://github.com/gravitational/docs-website/pull/630

Resolved manually:
- `docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx`
- `docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx`
- `docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx`
- `docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx`
- `docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx`: updated the link to the GUI clients page
- `docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx`
- `docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx`
- `docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx`
- `docs/pages/includes/database-access/proxy-db-tunnel.mdx`: updated the link to the GUI clients page
- `docs/pages/includes/database-access/rds-proxy.mdx`

Files removed from the original PR (not present in 17.x):
- `docs/pages/enroll-resources/database-access/enrollment/aws/aws-memorydb.mdx`
- `docs/pages/enroll-resources/database-access/enrollment/aws/elasticache-serverless.mdx`
- `docs/pages/enroll-resources/database-access/enrollment/aws/redis-aws.mdx`
- `docs/pages/enroll-resources/database-access/enrollment/google-cloud/alloydb.mdx`
- `docs/pages/includes/database-access/pg-mysql-connect.mdx`
- `docs/pages/installation/agents/high-availability.mdx`