### PR TITLE
[Access Lists] Fix stale member Spec.AccessList blocking access list updates

### DIFF
--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -460,11 +460,6 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 	var upserted *accesslist.AccessList
 	var existingAccessList *accesslist.AccessList
 
-	membersService, err := a.membersServiceForAccessList(accesslists.ScopeQualifiedName(accessList))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	validateAccessList := func() error {
 		var err error
 
@@ -477,23 +472,11 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 		}
 		preserveAccessListFields(existingAccessList, accessList)
 
-		listMembers, err := membersService.getResources(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		// Before #65122, reconcileMembers could store members under the
-		// correct backend prefix but with a stale Spec.AccessList value.
-		// The backend key (prefix) is authoritative for list membership;
-		// normalize in memory so the validation passes. The stale value
-		// will be corrected on the next write through a validated path.
-		for _, member := range listMembers {
-			if member.Spec.AccessList != accessList.GetName() {
-				member.Spec.AccessList = accessList.GetName()
-			}
-		}
-
-		if err := accesslists.ValidateAccessListWithMembers(ctx, existingAccessList, accessList, listMembers, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
+		// Existing members are deliberately not re-validated here. This operation
+		// can't add/modify member edges so re-validating stored members can only
+		// turn pre-existing backend inconsistency, e.g., a stale Spec.AccessList,
+		// into permanent failure to update the access list itself.
+		if err := accesslists.ValidateAccessListWithMembers(ctx, existingAccessList, accessList, nil, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
 			return trace.Wrap(err)
 		}
 

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -482,6 +482,17 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 			return trace.Wrap(err)
 		}
 
+		// Before #65122, reconcileMembers could store members under the
+		// correct backend prefix but with a stale Spec.AccessList value.
+		// The backend key (prefix) is authoritative for list membership;
+		// normalize in memory so the validation passes. The stale value
+		// will be corrected on the next write through a validated path.
+		for _, member := range listMembers {
+			if member.Spec.AccessList != accessList.GetName() {
+				member.Spec.AccessList = accessList.GetName()
+			}
+		}
+
 		if err := accesslists.ValidateAccessListWithMembers(ctx, existingAccessList, accessList, listMembers, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 )
@@ -3479,6 +3480,88 @@ func TestAccessListService_EnsureNestedAccessListStatuses(t *testing.T) {
 	requireStatusMemberOf(t, service, a3, []string{})
 	requireStatusMemberOf(t, service, a4, []string{a1})
 	requireStatusMemberOf(t, service, a5, []string{ghost, a1})
+}
+
+// TestUpsertAccessListToleratesStaleSpecAccessList verifies that UpsertAccessList
+// succeeds even when existing members have a stale Spec.AccessList. Before
+// #65122, reconcileMembers could write members under the correct backend prefix
+// without normalizing Spec.AccessList. After #65122 added cross-membership
+// validation, these legacy members block all access list updates.
+func TestUpsertAccessListToleratesStaleSpecAccessList(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{Context: ctx, Clock: clock})
+	require.NoError(t, err)
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+
+	al := createAccessList(t, service, "some-list-production", clock)
+	createAccessListMember(t, service, al.GetName(), "good-user@example.com")
+
+	// Simulate a pre-#65122 member: stored under the correct prefix
+	// but with a stale Spec.AccessList.
+	stale, err := accesslist.NewAccessListMember(header.Metadata{
+		Name: "stale-user@example.com",
+	}, accesslist.AccessListMemberSpec{
+		AccessList:     "some-list",
+		Name:           "stale-user@example.com",
+		Joined:         clock.Now(),
+		AddedBy:        "okta-importer",
+		MembershipKind: accesslist.MembershipKindUser,
+	})
+	require.NoError(t, err)
+	value, err := services.MarshalAccessListMember(stale)
+	require.NoError(t, err)
+	_, err = mem.Put(ctx, backend.Item{
+		Key:   backend.NewKey("access_list_member", "some-list-production", stale.GetName()),
+		Value: value,
+	})
+	require.NoError(t, err)
+
+	// UpsertAccessList should succeed despite the stale member.
+	al.Spec.Description = "updated"
+	_, err = service.UpsertAccessList(ctx, al)
+	require.NoError(t, err)
+}
+
+// TestDeleteMemberWithStaleSpecAccessList verifies that backend-level
+// deletion works for members with a stale Spec.AccessList, since
+// DeleteAccessListMember resolves members by backend key prefix.
+func TestDeleteMemberWithStaleSpecAccessList(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{Context: ctx, Clock: clock})
+	require.NoError(t, err)
+	service := newAccessListService(t, mem, modulestest.EnterpriseModules())
+
+	al := createAccessList(t, service, "some-list-production", clock)
+
+	// Write a member with stale Spec.AccessList directly to the backend.
+	stale, err := accesslist.NewAccessListMember(header.Metadata{
+		Name: "stale-user@example.com",
+	}, accesslist.AccessListMemberSpec{
+		AccessList:     "some-list",
+		Name:           "stale-user@example.com",
+		Joined:         clock.Now(),
+		AddedBy:        "okta-importer",
+		MembershipKind: accesslist.MembershipKindUser,
+	})
+	require.NoError(t, err)
+	value, err := services.MarshalAccessListMember(stale)
+	require.NoError(t, err)
+	_, err = mem.Put(ctx, backend.Item{
+		Key:   backend.NewKey("access_list_member", al.GetName(), stale.GetName()),
+		Value: value,
+	})
+	require.NoError(t, err)
+
+	err = service.DeleteAccessListMember(ctx, al.GetName(), stale.GetName())
+	require.NoError(t, err)
+
+	members, _, err := service.ListAccessListMembers(ctx, al.GetName(), 0, "")
+	require.NoError(t, err)
+	require.Empty(t, members)
 }
 
 type testAccessListGetter interface {

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -3485,10 +3485,10 @@ func TestAccessListService_EnsureNestedAccessListStatuses(t *testing.T) {
 // TestUpsertAccessListToleratesStaleSpecAccessList verifies that UpsertAccessList
 // succeeds even when existing members have a stale Spec.AccessList. Before
 // #65122, reconcileMembers could write members under the correct backend prefix
-// without normalizing Spec.AccessList. After #65122 added cross-membership
-// validation, these legacy members block all access list updates.
+// without normalizing Spec.AccessList. UpsertAccessList must not re-validate
+// stored members, otherwise these legacy members block all access list updates.
 func TestUpsertAccessListToleratesStaleSpecAccessList(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	clock := clockwork.NewFakeClock()
 
 	mem, err := memory.New(memory.Config{Context: ctx, Clock: clock})
@@ -3528,7 +3528,7 @@ func TestUpsertAccessListToleratesStaleSpecAccessList(t *testing.T) {
 // deletion works for members with a stale Spec.AccessList, since
 // DeleteAccessListMember resolves members by backend key prefix.
 func TestDeleteMemberWithStaleSpecAccessList(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	clock := clockwork.NewFakeClock()
 
 	mem, err := memory.New(memory.Config{Context: ctx, Clock: clock})
@@ -3580,7 +3580,7 @@ func (fn testAccessListGetterFunc) GetAccessList(ctx context.Context, name strin
 
 func requireStatusOwnerOf(t *testing.T, service testAccessListGetter, accessListName string, ownerOf []string) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	accessList, err := service.GetAccessList(ctx, accessListName)
 	require.NoError(t, err)
 	require.ElementsMatch(t, ownerOf, accessList.Status.OwnerOf)


### PR DESCRIPTION
## Context
- Prior to #65122, reconcileMembers wrote members under the parent access list's backend key prefix without normalizing the member's Spec.AccessList field. After cross-membership validation was added, these pre-existing members cause UpsertAccessList to reject all updates to the enclosing Access List even when the update doesn't touch members.
- Fix by normalizing stale Spec.AccessList values to match the authoritative backend key prefix prior to validation.

Changelog: Fix stale Access List members' Spec.AccessList blocking Access List updates.

## Manual Test Plan
### Test Environment
- Local cluster

### Test Cases
- [x] Verify the added regression tests pass (`TestUpsertAccessListHealsStaleSpecAccessList` and `TestDeleteMemberWithStaleSpecAccessList`)
- [x] Verify that manually writing to the backend so an Access List member's `spec.access_list` differs from its prefix does not result in the Access List becoming uneditable.
