### PR TITLE
GCP Server Installer: don't exit on failure

### DIFF
--- a/lib/srv/server/gcp_installer.go
+++ b/lib/srv/server/gcp_installer.go
@@ -20,6 +20,7 @@ package server
 
 import (
 	"context"
+	"sync"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
@@ -62,6 +63,9 @@ func (gi *GCPInstaller) Run(ctx context.Context, req GCPRunRequest) error {
 	// hundreds of nodes at once.
 	g.SetLimit(10)
 
+	var runErrors []error
+	runErrorsMu := &sync.Mutex{}
+
 	for _, inst := range req.Instances {
 		g.Go(func() error {
 			runRequest := gcp.RunCommandRequest{
@@ -74,8 +78,16 @@ func (gi *GCPInstaller) Run(ctx context.Context, req GCPRunRequest) error {
 				Script:     script,
 				SSHKeyAlgo: req.SSHKeyAlgo,
 			}
-			return trace.Wrap(gcp.RunCommand(ctx, &runRequest))
+
+			if runError := gcp.RunCommand(ctx, &runRequest); runError != nil {
+				runErrorsMu.Lock()
+				runErrors = append(runErrors, trace.Wrap(runError, "running installer script on instance %q", inst.Name))
+				runErrorsMu.Unlock()
+			}
+			return nil
 		})
 	}
-	return trace.Wrap(g.Wait())
+	_ = g.Wait()
+
+	return trace.NewAggregate(runErrors...)
 }

--- a/lib/srv/server/gcp_installer_test.go
+++ b/lib/srv/server/gcp_installer_test.go
@@ -1,0 +1,82 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package server
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/gcp"
+	gcpimds "github.com/gravitational/teleport/lib/cloud/imds/gcp"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+)
+
+func TestGCPInstaller(t *testing.T) {
+	t.Parallel()
+
+	newVMFn := func(id string) *gcpimds.Instance {
+		return &gcpimds.Instance{
+			ProjectID: "test-project",
+			Zone:      "test-zone",
+			Name:      "vm" + id,
+		}
+	}
+
+	const totalInstances = 1000
+	instances := make([]*gcpimds.Instance, totalInstances)
+	for i := range totalInstances {
+		instances[i] = newVMFn(strconv.Itoa(i))
+	}
+
+	mockRunner := &mockGCPRunClient{}
+	installer := &GCPInstaller{}
+	err := installer.Run(t.Context(), GCPRunRequest{
+		InstallerParams: &types.InstallerParams{
+			PublicProxyAddr: "localhost:8080",
+		},
+		Zone:       "useast-1",
+		ProjectID:  "test",
+		Instances:  instances,
+		Client:     mockRunner,
+		SSHKeyAlgo: cryptosuites.ECDSAP256,
+	})
+	require.Error(t, err)
+
+	// Each instance should have been attempted, even when they all fail.
+	require.Equal(t, int32(totalInstances), mockRunner.getInstancesCallCounter.Load())
+}
+
+type mockGCPRunClient struct {
+	gcp.InstancesClient
+	getInstancesCallCounter atomic.Int32
+}
+
+func (c *mockGCPRunClient) GetInstance(ctx context.Context, req *gcpimds.InstanceRequest) (*gcpimds.Instance, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	c.getInstancesCallCounter.Add(1)
+	return nil, trace.BadParameter("invalid something")
+}


### PR DESCRIPTION
The GCP Installer exits on first error.
Which means that if we try to install teleport in 100 VMs, and the first one fails, the remaining ones will not try to install.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed an issue that prevents GCP Server discovery to try to enroll all the VMs that are found when one of them returns an error.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Local cluster with Discovery Service

### Test Cases
- [x] Create 15 GCP VMs and suspend them. Ensure we get logs for each of them when running the discovery service.


## Demo
<details>

<summary>Previous: error for only two VMs</summary>
Some log lines redacted

```
2026-04-24T14:39:39.273+01:00 DEBU [DISCOVERY] GCP instances discovered, starting installation pid:62310.1 project_id:teleport-dev-id instances:[marcobox02, marcobox03, marcobox04, marcobox05, marcobox06, marcobox07, marcobox08, marcobox09, marcobox10, marcobox11... + 4 instance IDs truncated] discovery/discovery.go:1854
2026-04-24T14:39:39.273+01:00 DEBU [DISCOVERY] Running Teleport installation on virtual machines pid:62310.1 project_id:teleport-dev-id vms:[marcobox02, marcobox03, marcobox04, marcobox05, marcobox06, marcobox07, marcobox08, marcobox09, marcobox10, marcobox11... + 4 instance IDs truncated] discovery/discovery.go:1822
2026-04-24T14:39:51.381+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox05 ips:[10....] ip:10.... error:[
ERROR REPORT:
Original Error: *net.OpError dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/api/utils/sshutils/ssh.go:287 github.com/gravitational/teleport/api/utils/sshutils.RunSSH
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:590 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] stdout: stderr: gcp/vm.go:595
2026-04-24T14:39:51.381+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox05 ips:[10....] error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] gcp/vm.go:610
2026-04-24T14:39:51.872+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox08 ips:[10....] ip:10.... error:[
ERROR REPORT:
Original Error: *net.OpError dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/api/utils/sshutils/ssh.go:287 github.com/gravitational/teleport/api/utils/sshutils.RunSSH
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:590 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] stdout: stderr: gcp/vm.go:595
2026-04-24T14:39:51.872+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox08 ips:[10....] error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] gcp/vm.go:610
2026-04-24T14:39:51.878+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox07 ips:[10....] ip:10.... error:[
ERROR REPORT:
Original Error: *net.OpError dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/api/utils/sshutils/ssh.go:287 github.com/gravitational/teleport/api/utils/sshutils.RunSSH
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:590 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] stdout: stderr: gcp/vm.go:595
2026-04-24T14:39:51.878+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox07 ips:[10....] error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] gcp/vm.go:610
2026-04-24T14:39:51.884+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox09 ips:[10....] ip:10.... error:[
ERROR REPORT:
Original Error: *net.OpError dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/api/utils/sshutils/ssh.go:287 github.com/gravitational/teleport/api/utils/sshutils.RunSSH
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:590 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] stdout: stderr: gcp/vm.go:595
2026-04-24T14:39:51.884+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox09 ips:[10....] error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] gcp/vm.go:610
2026-04-24T14:39:51.983+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox03 ips:[10....] ip:10.... error:[
ERROR REPORT:
Original Error: *net.OpError dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/api/utils/sshutils/ssh.go:287 github.com/gravitational/teleport/api/utils/sshutils.RunSSH
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:590 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] stdout: stderr: gcp/vm.go:595
2026-04-24T14:39:51.983+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox03 ips:[10....] error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] gcp/vm.go:610
2026-04-24T14:39:52.369+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox04 ips:[10....] ip:10.... error:[
ERROR REPORT:
Original Error: *net.OpError dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/api/utils/sshutils/ssh.go:287 github.com/gravitational/teleport/api/utils/sshutils.RunSSH
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:590 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] stdout: stderr: gcp/vm.go:595
2026-04-24T14:39:52.369+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox04 ips:[10....] error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] gcp/vm.go:610
2026-04-24T14:39:52.376+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox11 ips:[10....] ip:10.... error:[
ERROR REPORT:
Original Error: *net.OpError dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/api/utils/sshutils/ssh.go:287 github.com/gravitational/teleport/api/utils/sshutils.RunSSH
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:590 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] stdout: stderr: gcp/vm.go:595
2026-04-24T14:39:52.376+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox11 ips:[10....] error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] gcp/vm.go:610
2026-04-24T14:39:52.387+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox06 ips:[10....] ip:10.... error:[
ERROR REPORT:
Original Error: *net.OpError dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/api/utils/sshutils/ssh.go:287 github.com/gravitational/teleport/api/utils/sshutils.RunSSH
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:590 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] stdout: stderr: gcp/vm.go:595
2026-04-24T14:39:52.387+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox06 ips:[10....] error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] gcp/vm.go:610
2026-04-24T14:39:52.477+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox02 ips:[10....] ip:10.... error:[
ERROR REPORT:
Original Error: *net.OpError dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/api/utils/sshutils/ssh.go:287 github.com/gravitational/teleport/api/utils/sshutils.RunSSH
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:590 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] stdout: stderr: gcp/vm.go:595
2026-04-24T14:39:52.477+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox02 ips:[10....] error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] gcp/vm.go:610
2026-04-24T14:39:52.963+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox10 ips:[10....] ip:10.... error:[
ERROR REPORT:
Original Error: *net.OpError dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/api/utils/sshutils/ssh.go:287 github.com/gravitational/teleport/api/utils/sshutils.RunSSH
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:590 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] stdout: stderr: gcp/vm.go:595
2026-04-24T14:39:52.963+01:00 ERRO  Installing teleport in GCP VM failed project_id:teleport-dev-id zone:us-central1-c vm_name:marcobox10 ips:[10....] error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] gcp/vm.go:610
2026-04-24T14:39:53.977+01:00 WARN  Error deleting SSH Key error:[
ERROR REPORT:
Original Error: *url.Error Post &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox08/setMetadata&#34;: context canceled
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:459 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).RemoveSSHKey
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:560 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand.func1
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:611 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: Post &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox08/setMetadata&#34;: context canceled] gcp/vm.go:561
2026-04-24T14:39:53.977+01:00 WARN  Error deleting SSH Key error:[
ERROR REPORT:
Original Error: *url.Error Post &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox11/setMetadata&#34;: context canceled
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:459 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).RemoveSSHKey
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:560 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand.func1
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:611 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: Post &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox11/setMetadata&#34;: context canceled] gcp/vm.go:561
2026-04-24T14:39:53.977+01:00 WARN  Error deleting SSH Key error:[
ERROR REPORT:
Original Error: *url.Error Post &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox04/setMetadata&#34;: context canceled
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:459 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).RemoveSSHKey
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:560 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand.func1
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:611 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: Post &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox04/setMetadata&#34;: context canceled] gcp/vm.go:561
2026-04-24T14:39:53.977+01:00 WARN  Error deleting SSH Key error:[
ERROR REPORT:
Original Error: *url.Error Get &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/operations/operation-1777037993072-65034e6545895-1a2c7c89-6843d546&#34;: context canceled
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:462 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).RemoveSSHKey
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:560 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand.func1
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:611 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: Get &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/operations/operation-1777037993072-65034e6545895-1a2c7c89-6843d546&#34;: context canceled] gcp/vm.go:561
2026-04-24T14:39:53.977+01:00 WARN  Error deleting SSH Key error:[
ERROR REPORT:
Original Error: *url.Error Get &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/operations/operation-1777037993179-65034e655f819-38844cf6-6fc1d6ed&#34;: context canceled
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:462 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).RemoveSSHKey
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:560 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand.func1
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:611 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: Get &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/operations/operation-1777037993179-65034e655f819-38844cf6-6fc1d6ed&#34;: context canceled] gcp/vm.go:561
2026-04-24T14:39:53.977+01:00 WARN  Error deleting SSH Key error:[
ERROR REPORT:
Original Error: *url.Error Get &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/operations/operation-1777037993137-65034e6555521-e42f6e15-c532539d&#34;: context canceled
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:462 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).RemoveSSHKey
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:560 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand.func1
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:611 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: Get &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/operations/operation-1777037993137-65034e6555521-e42f6e15-c532539d&#34;: context canceled] gcp/vm.go:561
2026-04-24T14:39:53.977+01:00 WARN  Error deleting SSH Key error:[
ERROR REPORT:
Original Error: *url.Error Post &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox06/setMetadata&#34;: context canceled
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:459 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).RemoveSSHKey
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:560 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand.func1
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:611 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: Post &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox06/setMetadata&#34;: context canceled] gcp/vm.go:561
2026-04-24T14:39:53.977+01:00 WARN  Error fetching instance error:[
ERROR REPORT:
Original Error: *url.Error Get &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox10/getGuestAttributes?queryPath=hostkeys%2F&#34;: context canceled
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:261 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).getHostKeys
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:294 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).GetInstance
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:556 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand.func1
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:611 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: Get &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox10/getGuestAttributes?queryPath=hostkeys%2F&#34;: context canceled] gcp/vm.go:557
2026-04-24T14:39:53.978+01:00 WARN  Error deleting SSH Key error:[
ERROR REPORT:
Original Error: *url.Error Post &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox02/setMetadata&#34;: context canceled
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:459 github.com/gravitational/teleport/lib/cloud/gcp.(*instancesClient).RemoveSSHKey
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:560 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand.func1
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:611 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: Post &#34;https://compute.googleapis.com/compute/v1/projects/teleport-dev-id/zones/us-central1-c/instances/marcobox02/setMetadata&#34;: context canceled] gcp/vm.go:561
2026-04-24T14:39:53.979+01:00 ERRO [DISCOVERY] Failed to enroll discovered GCP VMs pid:62310.1 error:[
ERROR REPORT:
Original Error: trace.aggregate dial tcp 10....:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/cloud/gcp/vm.go:609 github.com/gravitational/teleport/lib/cloud/gcp.RunCommand
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:77 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run.func1
        golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
        runtime/asm_arm64.s:1447 runtime.goexit
User Message: dial tcp 10....:22: i/o timeout] discovery/discovery.go:1859
2026-04-24T14:40:05.014+01:00 DEBU [AUTH:1]    Periodic agent version report routine started pid:62310.1 auth/autoupdate_agent_version_report.go:249
2026-04-24T14:40:05.014+01:00 DEBU [AUTH:1]    Collecting agent versions from inventory pid:62310.1 auth/autoupdate_agent_version_report.go:195
2026-04-24T14:40:05.014+01:00 DEBU [AUTH:1]    Building the agent version report pid:62310.1 auth/autoupdate_agent_version_report.go:203
```

</details>


<details>

<summary>After: errors from all the VMs</summary>

```
...
User Message: running installer script on instance &#34;marcobox02&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox10&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox09&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox06&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox07&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox05&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox04&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox03&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox08&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox11&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox12&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox15&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox14&#34;
        dial tcp ...:22: i/o timeout, running installer script on instance &#34;marcobox13&#34;
        dial tcp ...:22: i/o timeout] discovery/discovery.go:1859
...
```


</details>