### PR TITLE
sessionsearch[17]: Add tctl recordings TUI for browsing session summaries

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -107,6 +107,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	secreportsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/secreports/v1"
+	sessionsearchv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/sessionsearch/v1"
 	stableunixusersv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/stableunixusers/v1"
 	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
@@ -956,6 +957,12 @@ func (c *Client) JoinV1Client() joinv1.JoinServiceClient {
 // recording summarizer service.
 func (c *Client) SummarizerServiceClient() summarizerv1.SummarizerServiceClient {
 	return summarizerv1.NewSummarizerServiceClient(c.conn)
+}
+
+// SessionSearchServiceClient returns a client for the session search
+// service.
+func (c *Client) SessionSearchServiceClient() sessionsearchv1pb.SessionSearchServiceClient {
+	return sessionsearchv1pb.NewSessionSearchServiceClient(c.conn)
 }
 
 // SummarizerClient returns a client for the session summarizer service that

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -57,6 +57,7 @@ import (
 	recordingmetadatav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingmetadata/v1"
 	resourceusagepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/resourceusage/v1"
 	samlidppb "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
+	sessionsearchv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/sessionsearch/v1"
 	stableunixusersv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/stableunixusers/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
@@ -1967,4 +1968,7 @@ type ClientI interface {
 	// DelegationSessionServiceClient returns a client for the delegation
 	// session service.
 	DelegationSessionServiceClient() delegationv1.DelegationSessionServiceClient
+	// SessionSearchServiceClient returns a client for the session search
+	// service.
+	SessionSearchServiceClient() sessionsearchv1pb.SessionSearchServiceClient
 }

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -304,6 +304,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindInferenceSecret, nil
 	case types.KindInferencePolicy, "inference_policies":
 		return types.KindInferencePolicy, nil
+	case types.KindRetrievalModel:
+		return types.KindRetrievalModel, nil
 	case types.KindRelayServer, types.KindRelayServer + "s":
 		return types.KindRelayServer, nil
 	case types.KindAppAuthConfig, types.KindAppAuthConfig + "s", "aac":

--- a/tool/tctl/common/recordings/detail.go
+++ b/tool/tctl/common/recordings/detail.go
@@ -23,6 +23,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -31,6 +33,127 @@ import (
 )
 
 const fieldLabelWidth = 20
+
+// sanitize removes terminal control sequences from s before it is written to
+// an operator's terminal. Call this on every string that originates from
+// external data (session metadata, resource names, command summaries, etc.) to
+// prevent terminal injection.
+func sanitize(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			c := s[i]
+			switch {
+			case c == '\x1b':
+				i = consumeEscapeSequence(s, i+1)
+			case c == '\x90' || c == '\x98' || c == '\x9d' || c == '\x9e' || c == '\x9f':
+				i = consumeStringControl(s, i+1)
+			case c == '\x9b':
+				i = consumeCSISequence(s, i+1)
+			case c == '\n' || c == '\t':
+				b.WriteByte(c)
+				i++
+			case c < ' ' || c == '\x7f' || (c >= '\x80' && c <= '\x9f'):
+				i++
+			default:
+				b.WriteByte(c)
+				i++
+			}
+			continue
+		}
+
+		switch r {
+		case '\x1b':
+			i = consumeEscapeSequence(s, i+size)
+			continue
+		case '\u0090', '\u0098', '\u009d', '\u009e', '\u009f':
+			i = consumeStringControl(s, i+size)
+			continue
+		case '\u009b':
+			i = consumeCSISequence(s, i+size)
+			continue
+		}
+
+		if unicode.IsControl(r) && r != '\n' && r != '\t' {
+			i += size
+			continue
+		}
+
+		b.WriteString(s[i : i+size])
+		i += size
+	}
+
+	return b.String()
+}
+
+func consumeEscapeSequence(s string, i int) int {
+	if i >= len(s) {
+		return i
+	}
+
+	switch s[i] {
+	case '[':
+		return consumeCSISequence(s, i+1)
+	case ']', 'P', 'X', '^', '_':
+		return consumeStringControl(s, i+1)
+	case '(', ')', '*', '+', '-', '.', '/', '#':
+		if i+1 < len(s) {
+			return i + 2
+		}
+		return i + 1
+	}
+
+	for i < len(s) {
+		c := s[i]
+		i++
+		if c >= '\x30' && c <= '\x7e' {
+			return i
+		}
+		if c < ' ' || c > '\x7e' {
+			return i
+		}
+	}
+	return i
+}
+
+func consumeCSISequence(s string, i int) int {
+	for i < len(s) {
+		c := s[i]
+		i++
+		if c >= '\x40' && c <= '\x7e' {
+			return i
+		}
+	}
+	return i
+}
+
+func consumeStringControl(s string, i int) int {
+	for i < len(s) {
+		if s[i] == '\a' {
+			return i + 1
+		}
+		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '\\' {
+			return i + 2
+		}
+
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			if s[i] == '\x9c' {
+				return i + 1
+			}
+			i++
+			continue
+		}
+		if r == '\u009c' {
+			return i + size
+		}
+		i += size
+	}
+	return i
+}
 
 // renderDetail builds the scrollable content string for the right-side detail
 // pane. It is regenerated whenever the selected item or palette changes.
@@ -46,7 +169,7 @@ func renderDetail(s *sessionsearchv1pb.SessionSummary, p palette) string {
 		}
 		fmt.Fprintf(&b, "  %s %s\n",
 			faintStyle.Render(fmt.Sprintf("%-*s", fieldLabelWidth+1, label+":")),
-			value,
+			sanitize(value),
 		)
 	}
 
@@ -96,9 +219,9 @@ func renderDetail(s *sessionsearchv1pb.SessionSummary, p palette) string {
 		indent := strings.Repeat(" ", fieldLabelWidth+4) // align with value column
 		for i, k := range keys {
 			if i == 0 {
-				field("Labels", k+"="+labels[k])
+				field("Labels", sanitize(k)+"="+sanitize(labels[k]))
 			} else {
-				fmt.Fprintf(&b, "%s%s\n", indent, k+"="+labels[k])
+				fmt.Fprintf(&b, "%s%s\n", indent, sanitize(k)+"="+sanitize(labels[k]))
 			}
 		}
 	}
@@ -123,7 +246,7 @@ func renderDetail(s *sessionsearchv1pb.SessionSummary, p palette) string {
 	return b.String()
 }
 
-// severityColor returns a terminal colour for the given risk level.
+// severityColor returns a terminal color for the given risk level.
 func severityColor(level summarizerv1pb.RiskLevel) lipgloss.TerminalColor {
 	switch level {
 	case summarizerv1pb.RiskLevel_RISK_LEVEL_LOW:
@@ -144,7 +267,7 @@ func formatSeverity(level summarizerv1pb.RiskLevel) string {
 	return strings.TrimPrefix(level.String(), "RISK_LEVEL_")
 }
 
-// formatSeverityColored returns the severity label with ANSI colour applied.
+// formatSeverityColored returns the severity label with ANSI color applied.
 func formatSeverityColored(level summarizerv1pb.RiskLevel) string {
 	label := formatSeverity(level)
 	c := severityColor(level)

--- a/tool/tctl/common/recordings/detail.go
+++ b/tool/tctl/common/recordings/detail.go
@@ -1,0 +1,161 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package recordings
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	sessionsearchv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/sessionsearch/v1"
+	summarizerv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+)
+
+const fieldLabelWidth = 20
+
+// renderDetail builds the scrollable content string for the right-side detail
+// pane. It is regenerated whenever the selected item or palette changes.
+func renderDetail(s *sessionsearchv1pb.SessionSummary, p palette) string {
+	var b strings.Builder
+
+	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(p.section)
+	faintStyle := lipgloss.NewStyle().Faint(true)
+
+	field := func(label, value string) {
+		if value == "" {
+			return
+		}
+		fmt.Fprintf(&b, "  %s %s\n",
+			faintStyle.Render(fmt.Sprintf("%-*s", fieldLabelWidth+1, label+":")),
+			value,
+		)
+	}
+
+	section := func(title string) {
+		fmt.Fprintf(&b, "%s\n", sectionStyle.Render("● "+title))
+	}
+
+	section("Session")
+	field("ID", s.GetSessionId())
+	field("Kind", s.GetKind())
+	if ts := s.GetSessionStart(); ts != nil {
+		field("Start", ts.AsTime().UTC().Format(time.RFC3339))
+	}
+	if end := s.GetSessionEnd(); end != nil {
+		field("End", end.AsTime().UTC().Format(time.RFC3339))
+		if start := s.GetSessionStart(); start != nil && !end.AsTime().IsZero() {
+			field("Duration", end.AsTime().Sub(start.AsTime()).Round(time.Second).String())
+		}
+	}
+	field("Severity", formatSeverityColored(s.GetSeverity()))
+	b.WriteString("\n")
+
+	section("User")
+	field("Username", s.GetUsername())
+	if roles := s.GetUserRoles(); len(roles) > 0 {
+		field("Roles", strings.Join(roles, ", "))
+	}
+	if ids := s.GetAccessRequestIds(); len(ids) > 0 {
+		field("Access Requests", strings.Join(ids, ", "))
+	}
+	if parts := s.GetParticipants(); len(parts) > 0 {
+		field("Participants", strings.Join(parts, ", "))
+	}
+	b.WriteString("\n")
+
+	section("Resource")
+	field("Kind", s.GetResourceKind())
+	field("Name", s.GetResourceName())
+	field("ID", s.GetResourceId())
+	field("Host ID", s.GetHostId())
+	if labels := s.GetResourceLabels(); len(labels) > 0 {
+		keys := make([]string, 0, len(labels))
+		for k := range labels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		indent := strings.Repeat(" ", fieldLabelWidth+4) // align with value column
+		for i, k := range keys {
+			if i == 0 {
+				field("Labels", k+"="+labels[k])
+			} else {
+				fmt.Fprintf(&b, "%s%s\n", indent, k+"="+labels[k])
+			}
+		}
+	}
+
+	if props := s.GetResourceProperties(); props != nil {
+		b.WriteString("\n")
+		switch t := props.Type.(type) {
+		case *sessionsearchv1pb.ResourceProperties_Ssh:
+			section("SSH Properties")
+			field("Hostname", t.Ssh.GetServerHostname())
+			field("Address", t.Ssh.GetServerAddr())
+		case *sessionsearchv1pb.ResourceProperties_Kubernetes:
+			section("Kubernetes Properties")
+			field("Namespace", t.Kubernetes.GetPodNamespace())
+			field("Pod", t.Kubernetes.GetPodName())
+		case *sessionsearchv1pb.ResourceProperties_Database:
+			section("Database Properties")
+			field("Database", t.Database.GetDatabaseName())
+		}
+	}
+
+	return b.String()
+}
+
+// severityColor returns a terminal colour for the given risk level.
+func severityColor(level summarizerv1pb.RiskLevel) lipgloss.TerminalColor {
+	switch level {
+	case summarizerv1pb.RiskLevel_RISK_LEVEL_LOW:
+		return lipgloss.Color("10") // bright green
+	case summarizerv1pb.RiskLevel_RISK_LEVEL_MEDIUM:
+		return lipgloss.Color("11") // bright yellow
+	case summarizerv1pb.RiskLevel_RISK_LEVEL_HIGH:
+		return lipgloss.Color("208") // orange
+	case summarizerv1pb.RiskLevel_RISK_LEVEL_CRITICAL:
+		return lipgloss.Color("196") // bright red
+	default:
+		return lipgloss.NoColor{}
+	}
+}
+
+// formatSeverity converts a RiskLevel to a short uppercase label.
+func formatSeverity(level summarizerv1pb.RiskLevel) string {
+	return strings.TrimPrefix(level.String(), "RISK_LEVEL_")
+}
+
+// formatSeverityColored returns the severity label with ANSI colour applied.
+func formatSeverityColored(level summarizerv1pb.RiskLevel) string {
+	label := formatSeverity(level)
+	c := severityColor(level)
+	if _, ok := c.(lipgloss.NoColor); ok {
+		return label
+	}
+	style := lipgloss.NewStyle().Foreground(c)
+	switch level {
+	case summarizerv1pb.RiskLevel_RISK_LEVEL_HIGH,
+		summarizerv1pb.RiskLevel_RISK_LEVEL_CRITICAL:
+		style = style.Bold(true)
+	}
+	return style.Render(label)
+}

--- a/tool/tctl/common/recordings/item.go
+++ b/tool/tctl/common/recordings/item.go
@@ -1,0 +1,66 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package recordings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/list"
+
+	sessionsearchv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/sessionsearch/v1"
+)
+
+var _ list.Item = sessionItem{}
+
+// sessionItem wraps a SessionSummary for rendering inside a bubbles list.
+type sessionItem struct {
+	s *sessionsearchv1pb.SessionSummary
+}
+
+// Title returns the primary row text: "[KIND] resource_name".
+func (i sessionItem) Title() string {
+	name := i.s.GetResourceName()
+	if name == "" {
+		name = i.s.GetResourceId()
+	}
+	if name == "" {
+		name = "(unknown)"
+	}
+	return fmt.Sprintf("[%s] %s", strings.ToUpper(i.s.GetKind()), name)
+}
+
+// Description returns the secondary row text: "start • username • severity".
+func (i sessionItem) Description() string {
+	start := "-"
+	if ts := i.s.GetSessionStart(); ts != nil {
+		start = ts.AsTime().UTC().Format("2006-01-02 15:04 UTC")
+	}
+	return fmt.Sprintf("%s  •  %s  •  %s", start, i.s.GetUsername(), formatSeverity(i.s.GetSeverity()))
+}
+
+// FilterValue is used by the list's built-in filter.
+func (i sessionItem) FilterValue() string {
+	return strings.Join([]string{
+		i.s.GetSessionId(),
+		i.s.GetUsername(),
+		i.s.GetResourceName(),
+		i.s.GetKind(),
+	}, " ")
+}

--- a/tool/tctl/common/recordings/item.go
+++ b/tool/tctl/common/recordings/item.go
@@ -36,14 +36,14 @@ type sessionItem struct {
 
 // Title returns the primary row text: "[KIND] resource_name".
 func (i sessionItem) Title() string {
-	name := i.s.GetResourceName()
+	name := sanitize(i.s.GetResourceName())
 	if name == "" {
-		name = i.s.GetResourceId()
+		name = sanitize(i.s.GetResourceId())
 	}
 	if name == "" {
 		name = "(unknown)"
 	}
-	return fmt.Sprintf("[%s] %s", strings.ToUpper(i.s.GetKind()), name)
+	return fmt.Sprintf("[%s] %s", strings.ToUpper(sanitize(i.s.GetKind())), name)
 }
 
 // Description returns the secondary row text: "start • username • severity".
@@ -52,7 +52,7 @@ func (i sessionItem) Description() string {
 	if ts := i.s.GetSessionStart(); ts != nil {
 		start = ts.AsTime().UTC().Format("2006-01-02 15:04 UTC")
 	}
-	return fmt.Sprintf("%s  •  %s  •  %s", start, i.s.GetUsername(), formatSeverity(i.s.GetSeverity()))
+	return fmt.Sprintf("%s  •  %s  •  %s", start, sanitize(i.s.GetUsername()), formatSeverity(i.s.GetSeverity()))
 }
 
 // FilterValue is used by the list's built-in filter.

--- a/tool/tctl/common/recordings/markdown.go
+++ b/tool/tctl/common/recordings/markdown.go
@@ -28,6 +28,7 @@ import (
 var orderedListRE = regexp.MustCompile(`^\d+\.\s+`)
 
 func renderMarkdownForTerminal(markdown string, width int, p palette) string {
+	markdown = sanitize(markdown)
 	if width < 20 {
 		width = 20
 	}
@@ -232,19 +233,18 @@ func wrapText(text string, maxWidth int) string {
 	}
 	var result strings.Builder
 	lineLen := 0
-	first := true
-	for _, word := range strings.Fields(text) {
-		if !first && lineLen+1+len(word) > maxWidth {
+	for i, word := range strings.Fields(text) {
+		if i == 0 {
+			// no leading space or newline before the first word
+		} else if lineLen+1+len(word) > maxWidth {
 			result.WriteString("\n")
 			lineLen = 0
-			first = true
-		} else if !first {
+		} else {
 			result.WriteByte(' ')
 			lineLen++
 		}
 		result.WriteString(word)
 		lineLen += len(word)
-		first = false
 	}
 	return result.String()
 }

--- a/tool/tctl/common/recordings/markdown.go
+++ b/tool/tctl/common/recordings/markdown.go
@@ -1,0 +1,250 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package recordings
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var orderedListRE = regexp.MustCompile(`^\d+\.\s+`)
+
+func renderMarkdownForTerminal(markdown string, width int, p palette) string {
+	if width < 20 {
+		width = 20
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.section)
+	subtitleStyle := lipgloss.NewStyle().Bold(true).Foreground(p.accent)
+	codeStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("252")).
+		Background(lipgloss.AdaptiveColor{Light: "236", Dark: "236"}).
+		Padding(0, 1)
+	quoteStyle := lipgloss.NewStyle().Foreground(p.faint).Italic(true)
+
+	var out []string
+	var paragraph []string
+	var codeLines []string
+	inCode := false
+
+	flushParagraph := func(prefix string) {
+		if len(paragraph) == 0 {
+			return
+		}
+		text := strings.Join(paragraph, " ")
+		wrapped := wrapText(text, width)
+		// Apply inline formatting line-by-line after wrapping so ANSI codes don't affect wrap widths.
+		lines := strings.Split(wrapped, "\n")
+		for j, line := range lines {
+			lines[j] = renderInline(line, p)
+		}
+		wrapped = strings.Join(lines, "\n")
+		if prefix != "" {
+			prefixedLines := strings.Split(wrapped, "\n")
+			for j, line := range prefixedLines {
+				if j == 0 {
+					prefixedLines[j] = prefix + line
+				} else {
+					prefixedLines[j] = strings.Repeat(" ", len(prefix)) + line
+				}
+			}
+			wrapped = strings.Join(prefixedLines, "\n")
+		}
+		out = append(out, wrapped)
+		paragraph = nil
+	}
+
+	flushCode := func() {
+		if len(codeLines) == 0 {
+			return
+		}
+		blockWidth := width
+		longest := 0
+		for _, line := range codeLines {
+			if len(line) > longest {
+				longest = len(line)
+			}
+		}
+		if longest+2 < blockWidth {
+			blockWidth = longest + 2
+		}
+		for _, line := range codeLines {
+			out = append(out, codeStyle.Width(blockWidth).Render(line))
+		}
+		codeLines = nil
+	}
+
+	for _, rawLine := range strings.Split(markdown, "\n") {
+		line := strings.TrimRight(rawLine, " \t")
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "```") {
+			flushParagraph("")
+			if inCode {
+				flushCode()
+			}
+			inCode = !inCode
+			continue
+		}
+
+		if inCode {
+			codeLines = append(codeLines, line)
+			continue
+		}
+
+		if trimmed == "" {
+			flushParagraph("")
+			if len(out) > 0 && out[len(out)-1] != "" {
+				out = append(out, "")
+			}
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "#") {
+			flushParagraph("")
+			level := 0
+			for level < len(trimmed) && trimmed[level] == '#' {
+				level++
+			}
+			text := strings.TrimSpace(trimmed[level:])
+			switch level {
+			case 1:
+				out = append(out, titleStyle.Render(text))
+			default:
+				out = append(out, subtitleStyle.Render(text))
+			}
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, ">") {
+			flushParagraph("")
+			text := strings.TrimSpace(strings.TrimPrefix(trimmed, ">"))
+			out = append(out, quoteStyle.Render(wrapText(renderInline(text, p), width-2)))
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") || strings.HasPrefix(trimmed, "+ ") {
+			flushParagraph("")
+			out = append(out, formatBulletLine(trimmed[2:], width, "• ", p))
+			continue
+		}
+
+		if orderedListRE.MatchString(trimmed) {
+			flushParagraph("")
+			match := orderedListRE.FindString(trimmed)
+			out = append(out, formatBulletLine(strings.TrimPrefix(trimmed, match), width, match, p))
+			continue
+		}
+
+		if strings.HasSuffix(trimmed, ":") && !strings.Contains(trimmed, " ") {
+			flushParagraph("")
+			out = append(out, subtitleStyle.Render(trimmed))
+			continue
+		}
+
+		paragraph = append(paragraph, trimmed)
+	}
+
+	flushParagraph("")
+	flushCode()
+
+	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}
+
+func formatBulletLine(text string, width int, prefix string, p palette) string {
+	if width <= len(prefix) {
+		return prefix + text
+	}
+	lines := strings.Split(wrapText(text, width-len(prefix)), "\n")
+	for i, line := range lines {
+		rendered := renderInline(line, p)
+		if i == 0 {
+			lines[i] = prefix + rendered
+		} else {
+			lines[i] = strings.Repeat(" ", len(prefix)) + rendered
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// renderInline applies inline span formatting to a single line of text.
+// Supported: **bold** / __bold__, *italic* / _italic_, `code`.
+// Markers must be balanced on the same line; no nesting; first match wins left-to-right.
+func renderInline(s string, _ palette) string {
+	boldStyle := lipgloss.NewStyle().Bold(true)
+	italicStyle := lipgloss.NewStyle().Italic(true)
+	codeStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("252")).
+		Background(lipgloss.AdaptiveColor{Light: "236", Dark: "236"})
+
+	var result strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == '`' {
+			if end := strings.Index(s[i+1:], "`"); end >= 0 {
+				result.WriteString(codeStyle.Render(s[i+1 : i+1+end]))
+				i += end + 2
+				continue
+			}
+		} else if i+1 < len(s) && (s[i:i+2] == "**" || s[i:i+2] == "__") {
+			marker := s[i : i+2]
+			if end := strings.Index(s[i+2:], marker); end >= 0 {
+				result.WriteString(boldStyle.Render(s[i+2 : i+2+end]))
+				i += end + 4
+				continue
+			}
+		} else if s[i] == '*' || s[i] == '_' {
+			marker := s[i : i+1]
+			if end := strings.Index(s[i+1:], marker); end >= 0 {
+				result.WriteString(italicStyle.Render(s[i+1 : i+1+end]))
+				i += end + 2
+				continue
+			}
+		}
+		result.WriteByte(s[i])
+		i++
+	}
+	return result.String()
+}
+
+// wrapText breaks text into lines not exceeding maxWidth characters.
+func wrapText(text string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return text
+	}
+	var result strings.Builder
+	lineLen := 0
+	first := true
+	for _, word := range strings.Fields(text) {
+		if !first && lineLen+1+len(word) > maxWidth {
+			result.WriteString("\n")
+			lineLen = 0
+			first = true
+		} else if !first {
+			result.WriteByte(' ')
+			lineLen++
+		}
+		result.WriteString(word)
+		lineLen += len(word)
+		first = false
+	}
+	return result.String()
+}

--- a/tool/tctl/common/recordings/markdown_test.go
+++ b/tool/tctl/common/recordings/markdown_test.go
@@ -1,0 +1,61 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package recordings
+
+import (
+	"regexp"
+	"testing"
+)
+
+// ansiRE strips ANSI escape codes so tests compare visible text only.
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiRE.ReplaceAllString(s, "")
+}
+
+func TestRenderInline(t *testing.T) {
+	p := buildPalette()
+
+	for _, tt := range []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain", "plain text", "plain text"},
+		{"bold_star", "**bold** word", "bold word"},
+		{"bold_under", "__bold__ word", "bold word"},
+		{"italic_star", "*italic* word", "italic word"},
+		{"italic_under", "_italic_ word", "italic word"},
+		{"code", "`code` word", "code word"},
+		{"unbalanced_bold", "no **closing", "no **closing"},
+		{"unbalanced_italic", "no *closing", "no *closing"},
+		{"unbalanced_code", "no `closing", "no `closing"},
+		{"mixed", "**bold** and *italic* and `code`", "bold and italic and code"},
+		{"empty", "", ""},
+		{"code_beats_star", "`*not italic*`", "*not italic*"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripANSI(renderInline(tt.input, p))
+			if got != tt.expected {
+				t.Errorf("renderInline(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/tool/tctl/common/recordings/model.go
+++ b/tool/tctl/common/recordings/model.go
@@ -1,0 +1,388 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package recordings
+
+import (
+	"context"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	sessionsearchv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/sessionsearch/v1"
+)
+
+const (
+	// listWidthPercent is the fraction of the terminal width devoted to the
+	// session list.  The detail pane takes the remainder.
+	listWidthPercent = 40
+)
+
+// palette holds the per-run resolved colours.
+type palette struct {
+	accent  lipgloss.TerminalColor
+	section lipgloss.TerminalColor
+	faint   lipgloss.TerminalColor
+}
+
+func buildPalette() palette {
+	return palette{
+		accent:  lipgloss.AdaptiveColor{Light: "#512FC9", Dark: "#9F85FF"},
+		section: lipgloss.AdaptiveColor{Light: "#512FC9", Dark: "#9F85FF"},
+		faint:   lipgloss.AdaptiveColor{Light: "243", Dark: "240"},
+	}
+}
+
+// loadMoreItem is a list sentinel shown at the bottom when more pages exist.
+type loadMoreItem struct {
+	loading  bool
+	fetchErr bool
+}
+
+func (i loadMoreItem) Title() string {
+	switch {
+	case i.loading:
+		return "── loading… ──"
+	case i.fetchErr:
+		return "── load more (retry) ──"
+	default:
+		return "── load more ──"
+	}
+}
+func (i loadMoreItem) Description() string { return "" }
+func (i loadMoreItem) FilterValue() string { return "" }
+
+// batchFetchedMsg carries the result of a BatchFetcher call.
+type batchFetchedMsg struct {
+	sessions  []*sessionsearchv1pb.SessionSummary
+	nextToken string
+	err       error
+}
+
+// model is the bubbletea model for the session search TUI.
+//
+// Layout: two fixed columns that fill the terminal:
+//
+//	+---------------- 40% -----------+----------------- 60% -----------------+
+//	|  [DB] prod-db  2025-01-01 ...  |  Session                              |
+//	|  [SSH] bastion 2025-01-01 ...  |    ID:   abc-123                      |
+//	|  ...                           |    Kind: db                           |
+//	|                                |  User                                 |
+//	|                                |    Username: alice                    |
+//	+--------------------------------+---------------------------------------+
+//
+// Pressing Enter on a session opens a summary popup for the selected session.
+type model struct {
+	list   list.Model
+	detail viewport.Model
+	help   help.Model
+	keys   keyMap
+
+	// popup is non-nil while the summary popup is active.
+	popup *summaryPopupModel
+
+	// summaryGetter is forwarded to the popup on Enter.
+	summaryGetter SummaryGetter
+
+	// pagination
+	fetchCtx       context.Context
+	cancelFetch    context.CancelFunc
+	nextBatchToken string
+	batchFetcher   BatchFetcher
+	loadingMore    bool
+
+	palette palette
+	width   int
+	height  int
+}
+
+func newModel(
+	ctx context.Context,
+	sessions []*sessionsearchv1pb.SessionSummary,
+	nextToken string,
+	summaryGetter SummaryGetter,
+	fetcher BatchFetcher,
+) *model {
+	items := make([]list.Item, len(sessions))
+	for i, s := range sessions {
+		items[i] = sessionItem{s: s}
+	}
+	if nextToken != "" {
+		items = append(items, loadMoreItem{})
+	}
+
+	p := buildPalette()
+	delegate := buildDelegate(p)
+	l := list.New(items, delegate, 0, 0)
+	l.Title = "Session Recordings"
+	l.Styles.Title = lipgloss.NewStyle().Bold(true).Foreground(p.accent)
+	l.SetShowHelp(false)
+
+	vp := viewport.New(0, 0)
+
+	ctx, cancel := context.WithCancel(ctx)
+	return &model{
+		list:           l,
+		detail:         vp,
+		help:           help.New(),
+		keys:           defaultKeyMap(),
+		summaryGetter:  summaryGetter,
+		palette:        p,
+		fetchCtx:       ctx,
+		cancelFetch:    cancel,
+		nextBatchToken: nextToken,
+		batchFetcher:   fetcher,
+	}
+}
+
+// buildDelegate creates a list delegate styled with the current palette.
+func buildDelegate(p palette) list.DefaultDelegate {
+	delegate := list.NewDefaultDelegate()
+	delegate.Styles = list.NewDefaultItemStyles()
+	delegate.Styles.SelectedTitle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(p.accent)
+	delegate.Styles.SelectedDesc = lipgloss.NewStyle().Faint(false)
+	return delegate
+}
+
+func (m *model) Init() tea.Cmd {
+	return nil
+}
+
+func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.popup != nil {
+		switch msg.(type) {
+		case closeSummaryMsg:
+			m.popup = nil
+			return m, nil
+		}
+		updated, cmd := m.popup.Update(msg)
+		m.popup = updated.(*summaryPopupModel)
+		return m, cmd
+	}
+
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.resize()
+		m.refreshDetail()
+		return m, nil
+
+	case batchFetchedMsg:
+		m.loadingMore = false
+		if msg.err != nil {
+			m.setLoadMoreItem(loadMoreItem{fetchErr: true})
+			return m, nil
+		}
+		// Rebuild item list: all current items except the loadMoreItem sentinel.
+		current := m.list.Items()
+		newItems := make([]list.Item, 0, len(current)+len(msg.sessions))
+		for _, it := range current {
+			if _, ok := it.(loadMoreItem); !ok {
+				newItems = append(newItems, it)
+			}
+		}
+		for _, s := range msg.sessions {
+			newItems = append(newItems, sessionItem{s: s})
+		}
+		m.nextBatchToken = msg.nextToken
+		if msg.nextToken != "" {
+			newItems = append(newItems, loadMoreItem{})
+		}
+		m.list.SetItems(newItems)
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.list.FilterState() == list.Filtering {
+			break
+		}
+		switch {
+		case key.Matches(msg, m.keys.Quit):
+			m.cancelFetch()
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.Enter):
+			switch item := m.list.SelectedItem().(type) {
+			case sessionItem:
+				popup := newSummaryPopupModel(m.fetchCtx, item.s, m.summaryGetter, m.palette, m.width, m.height)
+				m.popup = popup
+				return m, popup.Init()
+			case loadMoreItem:
+				if !m.loadingMore { // Prevent double-fetch while a request is already in flight.
+					m.loadingMore = true
+					m.setLoadMoreItem(loadMoreItem{loading: true})
+					return m, m.fetchNextBatch()
+				}
+			}
+		}
+	}
+
+	// Let the list consume the message; afterwards refresh the detail pane so
+	// it always tracks the currently selected item.
+	prevIdx := m.list.Index()
+	var listCmd tea.Cmd
+	m.list, listCmd = m.list.Update(msg)
+	cmds = append(cmds, listCmd)
+
+	if m.list.Index() != prevIdx || prevIdx == 0 {
+		m.refreshDetail()
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m *model) View() string {
+	if m.width == 0 {
+		return ""
+	}
+
+	leftW, rightW := m.splitWidths()
+
+	// Left column: list.
+	leftContent := lipgloss.NewStyle().
+		Width(leftW).
+		MaxWidth(leftW).
+		Render(m.list.View())
+
+	// Right column: vertical rule + detail viewport + help bar.
+	helpBar := m.help.View(m.keys)
+	detailHeight := m.height - lipgloss.Height(helpBar) - 1 // -1 for separator
+	m.detail.Height = detailHeight
+
+	sep := lipgloss.NewStyle().
+		Faint(true).
+		Render(strings.Repeat("─", rightW))
+
+	rightContent := lipgloss.JoinVertical(lipgloss.Left,
+		sep,
+		m.detail.View(),
+		helpBar,
+	)
+	rightContent = lipgloss.NewStyle().
+		Width(rightW).
+		MaxWidth(rightW).
+		Render(rightContent)
+
+	base := lipgloss.JoinHorizontal(lipgloss.Top, leftContent, rightContent)
+	if m.popup == nil {
+		return base
+	}
+	return m.popup.View()
+}
+
+// splitWidths returns the pixel widths of the left (list) and right (detail)
+// panes.
+func (m *model) splitWidths() (left, right int) {
+	left = m.width * listWidthPercent / 100
+	right = m.width - left
+	return
+}
+
+// resize propagates the current terminal size to child components.
+func (m *model) resize() {
+	leftW, rightW := m.splitWidths()
+	m.list.SetSize(leftW, m.height)
+	m.detail.Width = rightW
+}
+
+// refreshDetail re-renders the detail viewport for the currently selected
+// item.
+func (m *model) refreshDetail() {
+	switch item := m.list.SelectedItem().(type) {
+	case sessionItem:
+		m.detail.SetContent(renderDetail(item.s, m.palette))
+	default:
+		m.detail.SetContent("")
+	}
+}
+
+// fetchNextBatch returns a tea.Cmd that calls batchFetcher with the current token.
+func (m *model) fetchNextBatch() tea.Cmd {
+	if m.batchFetcher == nil {
+		return nil
+	}
+	token := m.nextBatchToken
+	fetcher := m.batchFetcher
+	ctx := m.fetchCtx
+	return func() tea.Msg {
+		sessions, nextToken, err := fetcher(ctx, token)
+		return batchFetchedMsg{sessions: sessions, nextToken: nextToken, err: err}
+	}
+}
+
+// setLoadMoreItem replaces the loadMoreItem sentinel in the list.
+func (m *model) setLoadMoreItem(item loadMoreItem) {
+	items := m.list.Items()
+	for i, it := range items {
+		if _, ok := it.(loadMoreItem); ok {
+			items[i] = item
+			m.list.SetItems(items)
+			return
+		}
+	}
+	m.loadingMore = false // sentinel absent; unblock future fetches
+}
+
+type keyMap struct {
+	// Up and Down exist for the help bar only; the list.Model handles
+	// arrow/vim navigation internally via its own key map.
+	Up    key.Binding
+	Down  key.Binding
+	Enter key.Binding
+	Quit  key.Binding
+}
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Up, k.Enter, k.Quit}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.Up, k.Down, k.Enter},
+		{k.Quit},
+	}
+}
+
+func defaultKeyMap() keyMap {
+	return keyMap{
+		Up: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "navigate"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "navigate"),
+		),
+		Enter: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "open"),
+		),
+		Quit: key.NewBinding(
+			key.WithKeys("q", "ctrl+c"),
+			key.WithHelp("q", "quit"),
+		),
+	}
+}

--- a/tool/tctl/common/recordings/model.go
+++ b/tool/tctl/common/recordings/model.go
@@ -38,7 +38,7 @@ const (
 	listWidthPercent = 40
 )
 
-// palette holds the per-run resolved colours.
+// palette holds the per-run resolved colors.
 type palette struct {
 	accent  lipgloss.TerminalColor
 	section lipgloss.TerminalColor

--- a/tool/tctl/common/recordings/sanitize_test.go
+++ b/tool/tctl/common/recordings/sanitize_test.go
@@ -1,0 +1,99 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package recordings
+
+import (
+	"strings"
+	"testing"
+
+	summarizerv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+)
+
+func TestSanitizeRemovesTerminalControlSequences(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "csi",
+			in:   "safe\x1b[31mred\x1b[0m text",
+			want: "safered text",
+		},
+		{
+			name: "osc_bel",
+			in:   "safe\x1b]0;owned title\a text",
+			want: "safe text",
+		},
+		{
+			name: "osc_st",
+			in:   "safe\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\ text",
+			want: "safelink text",
+		},
+		{
+			name: "unterminated_osc",
+			in:   "safe\x1b]0;owned title",
+			want: "safe",
+		},
+		{
+			name: "raw_c1_csi",
+			in:   "safe\x9b31mred text",
+			want: "safered text",
+		},
+		{
+			name: "utf8_preserved",
+			in:   "safe caf\xc3\xa9\n\ttext",
+			want: "safe caf\xc3\xa9\n\ttext",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitize(tt.in); got != tt.want {
+				t.Fatalf("sanitize(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderTimelineSanitizesTerminalControlSequences(t *testing.T) {
+	timeline := renderTimeline(&summarizerv1pb.EnhancedSummary{
+		NotableCommandIndexes: []int32{0},
+		Commands: []*summarizerv1pb.CommandAnalysis{
+			{
+				TimelineTitle:    "\x1b]0;owned title\aListed files\x1b[31m",
+				TimelineSubtitle: "\x1b]8;;https://example.com\aDenied\x1b]8;;\a",
+				RiskLevel:        summarizerv1pb.RiskLevel_RISK_LEVEL_HIGH,
+			},
+			{
+				Command: "\x1b]52;c;AAAA\acat /etc/passwd",
+			},
+		},
+	}, 100, buildPalette())
+
+	visible := stripANSI(timeline)
+	for _, forbidden := range []string{"\x1b", "\a", "owned title", "AAAA"} {
+		if strings.Contains(visible, forbidden) {
+			t.Fatalf("renderTimeline output contains %q: %q", forbidden, visible)
+		}
+	}
+	for _, want := range []string{"Listed files", "Denied", "cat /etc/passwd"} {
+		if !strings.Contains(visible, want) {
+			t.Fatalf("renderTimeline output = %q, want to contain %q", visible, want)
+		}
+	}
+}

--- a/tool/tctl/common/recordings/summary_popup.go
+++ b/tool/tctl/common/recordings/summary_popup.go
@@ -127,7 +127,7 @@ func (m *summaryPopupModel) View() string {
 		BorderForeground(m.palette.accent).
 		Padding(0, 1)
 
-	header := titleStyle.Render(fmt.Sprintf("Summary  %s", m.session.GetSessionId()))
+	header := titleStyle.Render(fmt.Sprintf("Summary  %s", sanitize(m.session.GetSessionId())))
 	footer := lipgloss.NewStyle().
 		Faint(true).
 		Render("j/k or arrows: scroll  q/esc: close")
@@ -259,7 +259,7 @@ func defaultSummaryKeyMap() summaryKeyMap {
 // renderTimeline builds a timeline section from EnhancedSummary commands.
 // Each entry shows the start offset, title, and optional subtitle. Commands
 // listed in NotableCommandIndexes are prefixed with "*" and their risk level
-// is shown in colour.
+// is shown in color.
 func renderTimeline(enh *summarizerv1pb.EnhancedSummary, width int, p palette) string {
 	commands := enh.GetCommands()
 	if len(commands) == 0 {
@@ -287,9 +287,9 @@ func renderTimeline(enh *summarizerv1pb.EnhancedSummary, width int, p palette) s
 	fmt.Fprintf(&b, "%s\n", sectionStyle.Render("Timeline"))
 
 	for i, cmd := range commands {
-		title := cmd.GetTimelineTitle()
+		title := sanitize(cmd.GetTimelineTitle())
 		if title == "" {
-			title = cmd.GetCommand()
+			title = sanitize(cmd.GetCommand())
 		}
 		if title == "" {
 			continue
@@ -324,7 +324,7 @@ func renderTimeline(enh *summarizerv1pb.EnhancedSummary, width int, p palette) s
 		fmt.Fprintf(&b, "%s\n", line)
 
 		if sub := cmd.GetTimelineSubtitle(); sub != "" {
-			fmt.Fprintf(&b, "%s%s\n", subtitleIndent, faintStyle.Render(sub))
+			fmt.Fprintf(&b, "%s%s\n", subtitleIndent, faintStyle.Render(sanitize(sub)))
 		}
 	}
 

--- a/tool/tctl/common/recordings/summary_popup.go
+++ b/tool/tctl/common/recordings/summary_popup.go
@@ -1,0 +1,332 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package recordings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	sessionsearchv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/sessionsearch/v1"
+	summarizerv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+)
+
+type summaryLoadedMsg struct {
+	summary *summarizerv1pb.Summary
+	err     error
+}
+
+type closeSummaryMsg struct{}
+
+type summaryPopupModel struct {
+	session       *sessionsearchv1pb.SessionSummary
+	summaryGetter SummaryGetter
+	ctx           context.Context
+	cancel        context.CancelFunc
+
+	summary       *summarizerv1pb.Summary
+	summaryStatus string // "loading" | "loaded" | "error" | "unavailable"
+
+	viewport viewport.Model
+	keys     summaryKeyMap
+	palette  palette
+	width    int
+	height   int
+}
+
+func newSummaryPopupModel(
+	ctx context.Context,
+	s *sessionsearchv1pb.SessionSummary,
+	summaryGetter SummaryGetter,
+	p palette,
+	width, height int,
+) *summaryPopupModel {
+	ctx, cancel := context.WithCancel(ctx)
+
+	m := &summaryPopupModel{
+		session:       s,
+		summaryGetter: summaryGetter,
+		ctx:           ctx,
+		cancel:        cancel,
+		summaryStatus: "loading",
+		keys:          defaultSummaryKeyMap(),
+		palette:       p,
+		width:         width,
+		height:        height,
+	}
+	m.resize()
+	return m
+}
+
+func (m *summaryPopupModel) Init() tea.Cmd {
+	if m.summaryGetter == nil {
+		m.summaryStatus = "unavailable"
+		m.refresh()
+		return nil
+	}
+	m.refresh()
+	return loadSummaryCmd(m.ctx, m.summaryGetter, m.session.GetSessionId())
+}
+
+func (m *summaryPopupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.resize()
+		m.refresh()
+	case summaryLoadedMsg:
+		if msg.err != nil {
+			m.summaryStatus = "error"
+		} else {
+			m.summary = msg.summary
+			m.summaryStatus = "loaded"
+		}
+		m.refresh()
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, m.keys.Close):
+			m.close()
+			return m, func() tea.Msg { return closeSummaryMsg{} }
+		}
+	}
+
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+func (m *summaryPopupModel) View() string {
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(m.palette.section)
+	frameStyle := lipgloss.NewStyle().
+		Width(m.popupWidth()).
+		Height(m.popupHeight()).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(m.palette.accent).
+		Padding(0, 1)
+
+	header := titleStyle.Render(fmt.Sprintf("Summary  %s", m.session.GetSessionId()))
+	footer := lipgloss.NewStyle().
+		Faint(true).
+		Render("j/k or arrows: scroll  q/esc: close")
+
+	bodyHeight := m.popupHeight() - lipgloss.Height(header) - lipgloss.Height(footer) - 2
+	if bodyHeight < 1 {
+		bodyHeight = 1
+	}
+	m.viewport.Height = bodyHeight
+
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		header,
+		"",
+		m.viewport.View(),
+		"",
+		footer,
+	)
+
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		frameStyle.Render(content),
+	)
+}
+
+func (m *summaryPopupModel) popupWidth() int {
+	width := m.width * 70 / 100
+	if width > 100 {
+		width = 100
+	}
+	if width < 48 {
+		width = min(m.width-2, 48)
+	}
+	if width < 24 {
+		width = 24
+	}
+	return width
+}
+
+func (m *summaryPopupModel) popupHeight() int {
+	height := m.height * 70 / 100
+	if height > 32 {
+		height = 32
+	}
+	if height < 12 {
+		height = min(m.height-2, 12)
+	}
+	if height < 8 {
+		height = 8
+	}
+	return height
+}
+
+func (m *summaryPopupModel) resize() {
+	bodyWidth := m.popupWidth() - 4
+	if bodyWidth < 20 {
+		bodyWidth = 20
+	}
+	bodyHeight := m.popupHeight() - 6
+	if bodyHeight < 1 {
+		bodyHeight = 1
+	}
+	m.viewport.Width = bodyWidth
+	m.viewport.Height = bodyHeight
+}
+
+func (m *summaryPopupModel) refresh() {
+	faintSt := lipgloss.NewStyle().Faint(true)
+
+	switch m.summaryStatus {
+	case "loading":
+		m.viewport.SetContent(faintSt.Render("Loading summary..."))
+	case "error":
+		m.viewport.SetContent(faintSt.Render("Summary unavailable."))
+	case "unavailable":
+		m.viewport.SetContent(faintSt.Render("Summary service is not configured."))
+	case "loaded":
+		content := ""
+		if m.summary != nil {
+			content = m.summary.GetContent()
+			if content == "" {
+				content = m.summary.GetEnhancedSummary().GetDetailedDescription()
+			}
+		}
+
+		var parts []string
+		if strings.TrimSpace(content) != "" {
+			parts = append(parts, renderMarkdownForTerminal(content, m.viewport.Width, m.palette))
+		}
+		if enh := m.summary.GetEnhancedSummary(); enh != nil && len(enh.GetCommands()) > 0 {
+			parts = append(parts, renderTimeline(enh, m.viewport.Width, m.palette))
+		}
+		if len(parts) == 0 {
+			m.viewport.SetContent(faintSt.Render("No summary available."))
+			return
+		}
+		m.viewport.SetContent(strings.Join(parts, "\n\n"))
+	default:
+		m.viewport.SetContent("")
+	}
+}
+
+func (m *summaryPopupModel) close() {
+	m.cancel()
+}
+
+func loadSummaryCmd(ctx context.Context, getter SummaryGetter, sessionID string) tea.Cmd {
+	return func() tea.Msg {
+		resp, err := getter.GetSummary(ctx, &summarizerv1pb.GetSummaryRequest{SessionId: sessionID})
+		if err != nil {
+			return summaryLoadedMsg{err: err}
+		}
+		return summaryLoadedMsg{summary: resp.GetSummary()}
+	}
+}
+
+type summaryKeyMap struct {
+	Close key.Binding
+}
+
+func defaultSummaryKeyMap() summaryKeyMap {
+	return summaryKeyMap{
+		Close: key.NewBinding(key.WithKeys("q", "esc"), key.WithHelp("q", "close")),
+	}
+}
+
+// renderTimeline builds a timeline section from EnhancedSummary commands.
+// Each entry shows the start offset, title, and optional subtitle. Commands
+// listed in NotableCommandIndexes are prefixed with "*" and their risk level
+// is shown in colour.
+func renderTimeline(enh *summarizerv1pb.EnhancedSummary, width int, p palette) string {
+	commands := enh.GetCommands()
+	if len(commands) == 0 {
+		return ""
+	}
+
+	notableIdxs := enh.GetNotableCommandIndexes()
+	notableSet := make(map[int]bool, len(notableIdxs))
+	for _, idx := range notableIdxs {
+		notableSet[int(idx)] = true
+	}
+
+	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(p.section)
+	faintStyle := lipgloss.NewStyle().Faint(true)
+	boldStyle := lipgloss.NewStyle().Bold(true)
+
+	const offsetWidth = 7 // "mm:ss  "
+	const markerWidth = 2 // "* " or "  "
+	const riskWidth = 10  // "  CRITICAL" + padding
+	subtitleIndent := strings.Repeat(" ", markerWidth+offsetWidth)
+	titleMaxWidth := width - markerWidth - offsetWidth
+	titleMaxWidthNotable := titleMaxWidth - riskWidth
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n", sectionStyle.Render("Timeline"))
+
+	for i, cmd := range commands {
+		title := cmd.GetTimelineTitle()
+		if title == "" {
+			title = cmd.GetCommand()
+		}
+		if title == "" {
+			continue
+		}
+
+		offset := "     "
+		if d := cmd.GetStartOffset(); d != nil {
+			total := d.AsDuration().Round(time.Second)
+			m := int(total.Minutes())
+			s := int(total.Seconds()) % 60
+			offset = fmt.Sprintf("%02d:%02d", m, s)
+		}
+
+		isNotable := notableSet[i]
+		marker := "  "
+		titleStyle := faintStyle
+		maxW := titleMaxWidth
+		if isNotable {
+			marker = "* "
+			titleStyle = boldStyle
+			maxW = titleMaxWidthNotable
+		}
+		if maxW > 0 && len(title) > maxW {
+			title = title[:maxW-1] + "…"
+		}
+
+		line := fmt.Sprintf("%s%s  %s", marker, offset, titleStyle.Render(title))
+		if isNotable && cmd.GetRiskLevel() != summarizerv1pb.RiskLevel_RISK_LEVEL_UNSPECIFIED {
+			riskLabel := formatSeverityColored(cmd.GetRiskLevel())
+			line = fmt.Sprintf("%-*s  %s", width-riskWidth, line, riskLabel)
+		}
+		fmt.Fprintf(&b, "%s\n", line)
+
+		if sub := cmd.GetTimelineSubtitle(); sub != "" {
+			fmt.Fprintf(&b, "%s%s\n", subtitleIndent, faintStyle.Render(sub))
+		}
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/tool/tctl/common/recordings/tui.go
+++ b/tool/tctl/common/recordings/tui.go
@@ -1,0 +1,61 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package recordings provides an interactive TUI for browsing session
+// recording search results returned by tctl recordings search.
+package recordings
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
+
+	sessionsearchv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/sessionsearch/v1"
+	summarizerv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+)
+
+// SummaryGetter fetches the AI-generated summary for a recorded session.
+// [summarizerv1pb.SummarizerServiceClient] satisfies this interface.
+type SummaryGetter interface {
+	GetSummary(context.Context, *summarizerv1pb.GetSummaryRequest, ...grpc.CallOption) (*summarizerv1pb.GetSummaryResponse, error)
+}
+
+// BatchFetcher fetches the next page of sessions using a continuation token.
+// Returns the sessions, the next token (empty = no more pages), and any error.
+type BatchFetcher func(ctx context.Context, token string) (sessions []*sessionsearchv1pb.SessionSummary, nextToken string, err error)
+
+// RunSearchTUI launches the full-screen interactive TUI for browsing session
+// search results. It blocks until the user quits.
+//
+// nextToken is the cursor from the first BatchComplete response; pass "" when
+// there are no more pages. fetcher is called when the user triggers "load
+// more" and may be nil when nextToken is "". summaryGetter may be nil; the
+// TUI degrades gracefully when summaries are not available.
+func RunSearchTUI(
+	ctx context.Context,
+	sessions []*sessionsearchv1pb.SessionSummary,
+	nextToken string,
+	getter SummaryGetter,
+	fetcher BatchFetcher,
+) error {
+	p := tea.NewProgram(newModel(ctx, sessions, nextToken, getter, fetcher), tea.WithAltScreen())
+	_, err := p.Run()
+	return trace.Wrap(err)
+}

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -20,17 +20,22 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	sessionsearchv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/sessionsearch/v1"
+	summarizerv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
@@ -39,9 +44,11 @@ import (
 	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/common"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
+	recordingstui "github.com/gravitational/teleport/tool/tctl/common/recordings"
 )
 
 // RecordingsCommand implements "tctl recordings" group of commands.
@@ -70,6 +77,35 @@ type RecordingsCommand struct {
 	// recordingsDownloadOutputDir is the output directory to download session recordings to
 	recordingsDownloadOutputDir string
 
+	// recordingsSearch implements the "tctl recordings search" subcommand.
+	recordingsSearch *kingpin.CmdClause
+	// searchQuery is the free-text semantic/keyword query.
+	searchQuery []string
+	// searchFromUTC is the start of the time range for the search.
+	searchFromUTC string
+	// searchToUTC is the end of the time range for the search.
+	searchToUTC string
+	// searchLabel filters results by resource labels (key=value pairs).
+	searchLabel string
+	// searchAccessRequests filters results by access request IDs.
+	searchAccessRequests []string
+	// searchLimit is the maximum number of results to return.
+	searchLimit int
+	// searchFormat is the output format for search results.
+	searchFormat string
+	// searchKinds filters results by session kind (ssh, db, k8s, desktop).
+	searchKinds []string
+	// searchUsername filters results by the Teleport username that initiated the session.
+	searchUsername string
+	// searchRoles filters results by roles held by the user during the session.
+	searchRoles []string
+	// searchResourceKind filters results by the Teleport resource type (node, kube_cluster, db).
+	searchResourceKind string
+	// searchResourceName filters results by the resource name.
+	searchResourceName string
+	// searchSeverity filters results by minimum severity level (low/medium/high/critical).
+	searchSeverity string
+
 	// stdout allows to switch standard output source for resource command. Used in tests.
 	stdout io.Writer
 }
@@ -88,6 +124,21 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, t *tctlcfg.Glob
 	c.recordingsList.Flag("to-utc", fmt.Sprintf("End of time range in which recordings are listed. Format %s. Defaults to current time.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.toUTC)
 	c.recordingsList.Flag("limit", fmt.Sprintf("Maximum number of recordings to show. Default %s.", defaults.TshTctlSessionListLimit)).Default(defaults.TshTctlSessionListLimit).IntVar(&c.maxRecordingsToShow)
 	c.recordingsList.Flag("last", "Duration into the past from which session recordings should be listed. Format 5h30m40s").StringVar(&c.recordingsSince)
+	c.recordingsSearch = recordings.Command("search", "Search session recordings using semantic and keyword queries.")
+	c.recordingsSearch.Arg("query", `Search query. Supports keywords and boolean operators (e.g. "DROP TABLE OR DELETE FROM").`).StringsVar(&c.searchQuery)
+	c.recordingsSearch.Flag("from", fmt.Sprintf("Start of time range. Format %s. Defaults to 24 hours ago.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.searchFromUTC)
+	c.recordingsSearch.Flag("to", fmt.Sprintf("End of time range. Format %s. Defaults to current time.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.searchToUTC)
+	c.recordingsSearch.Flag("label", "Filter by resource labels (key=value pairs), e.g. env/prod=true,db/type=postgres.").StringVar(&c.searchLabel)
+	c.recordingsSearch.Flag("access-request", "Filter by access request ID. Can be specified multiple times.").StringsVar(&c.searchAccessRequests)
+	c.recordingsSearch.Flag("kind", "Filter by session kind (ssh, db, k8s, desktop). Can be specified multiple times.").StringsVar(&c.searchKinds)
+	c.recordingsSearch.Flag("username", "Filter by the Teleport username that initiated the session.").StringVar(&c.searchUsername)
+	c.recordingsSearch.Flag("role", "Filter by role held during the session. Can be specified multiple times.").StringsVar(&c.searchRoles)
+	c.recordingsSearch.Flag("resource-kind", "Filter by Teleport resource type (node, kube_cluster, db).").StringVar(&c.searchResourceKind)
+	c.recordingsSearch.Flag("resource-name", "Filter by resource name.").StringVar(&c.searchResourceName)
+	c.recordingsSearch.Flag("severity", "Minimum severity level to include (low, medium, high, critical).").StringVar(&c.searchSeverity)
+	c.recordingsSearch.Flag("limit", "Maximum number of results to return.").Default(defaults.TshTctlSessionListLimit).IntVar(&c.searchLimit)
+	c.recordingsSearch.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+". Defaults to 'text'.").Default(teleport.Text).StringVar(&c.searchFormat)
+
 	c.recordingsEncryption.Initialize(recordings, c.stdout)
 
 	download := recordings.Command("download", "Download session recordings.")
@@ -112,6 +163,8 @@ func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, clientFunc c
 		commandFunc = c.ListRecordings
 	case c.recordingsDownload.FullCommand():
 		commandFunc = c.DownloadRecordings
+	case c.recordingsSearch.FullCommand():
+		commandFunc = c.SearchRecordings
 	default:
 		return c.recordingsEncryption.TryRun(ctx, cmd, clientFunc)
 	}
@@ -193,6 +246,160 @@ loop:
 	}
 	fmt.Fprintf(c.stdout, "Session recording %q downloaded to %s\n", string(*sessionID), path)
 	return nil
+}
+
+// SearchRecordings implements "tctl recordings search <query>".
+func (c *RecordingsCommand) SearchRecordings(ctx context.Context, tc *authclient.Client) error {
+	fromUTC, toUTC, err := defaults.SearchSessionRange(clockwork.NewRealClock(), c.searchFromUTC, c.searchToUTC, "")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	searchClient := tc.SessionSearchServiceClient()
+	if err := checkSessionSearchEnabled(ctx, searchClient); err != nil {
+		return trace.Wrap(err)
+	}
+
+	var labels map[string]string
+	if c.searchLabel != "" {
+		labels, err = client.ParseLabelSpec(c.searchLabel)
+		if err != nil {
+			return trace.Wrap(err, "parsing --label")
+		}
+	}
+	var search []string
+	if len(c.searchQuery) > 0 {
+		search = []string{strings.Join(c.searchQuery, " ")}
+	}
+	req := &sessionsearchv1pb.SearchSessionSummariesRequest{
+		StartTime:        timestamppb.New(fromUTC),
+		EndTime:          timestamppb.New(toUTC),
+		SearchQueries:    search,
+		ResourceLabels:   labels,
+		AccessRequestIds: c.searchAccessRequests,
+		Kinds:            c.searchKinds,
+		UserRoles:        c.searchRoles,
+		MaxResults:       uint32(c.searchLimit),
+	}
+	if c.searchUsername != "" {
+		req.Username = &c.searchUsername
+	}
+	if c.searchResourceKind != "" {
+		req.ResourceKind = &c.searchResourceKind
+	}
+	if c.searchResourceName != "" {
+		req.ResourceName = &c.searchResourceName
+	}
+	if c.searchSeverity != "" {
+		level, err := parseSeverity(c.searchSeverity)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.Severity = &level
+	}
+
+	stream, err := searchClient.SearchSessionSummaries(ctx, req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	sessions, nextToken, err := collectStream(stream)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fetcher := recordingstui.BatchFetcher(func(ctx context.Context, token string) ([]*sessionsearchv1pb.SessionSummary, string, error) {
+		// When BatchToken is set the server ignores all other filter fields per the proto contract.
+		batchStream, err := searchClient.SearchSessionSummaries(ctx, &sessionsearchv1pb.SearchSessionSummariesRequest{
+			BatchToken: token,
+		})
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		return collectStream(batchStream)
+	})
+
+	return trace.Wrap(showSessionSummaries(ctx, sessions, nextToken, c.searchFormat, c.stdout, tc.SummarizerServiceClient(), fetcher))
+}
+
+func showSessionSummaries(ctx context.Context, sessions []*sessionsearchv1pb.SessionSummary, nextToken, format string, w io.Writer, summaryGetter recordingstui.SummaryGetter, fetcher recordingstui.BatchFetcher) error {
+	switch format {
+	case teleport.JSON:
+		// Only the first batch is output; nextToken and fetcher are unused for
+		// non-interactive formats.
+		return trace.Wrap(utils.WriteJSONArray(w, sessions))
+	case teleport.YAML:
+		return trace.Wrap(utils.WriteYAML(w, sessions))
+	default:
+		if len(sessions) == 0 {
+			fmt.Fprintln(w, "No sessions found.")
+			return nil
+		}
+		return recordingstui.RunSearchTUI(ctx, sessions, nextToken, summaryGetter, fetcher)
+	}
+}
+
+// checkSessionSearchEnabled returns an error if session search is not active on this cluster.
+func checkSessionSearchEnabled(ctx context.Context, sc sessionsearchv1pb.SessionSearchServiceClient) error {
+	resp, err := sc.IsEnabled(ctx, &sessionsearchv1pb.IsEnabledRequest{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	switch resp.GetAvailability() {
+	case sessionsearchv1pb.SessionSearchAvailability_SESSION_SEARCH_AVAILABILITY_AVAILABLE,
+		sessionsearchv1pb.SessionSearchAvailability_SESSION_SEARCH_AVAILABILITY_UNSPECIFIED:
+		// UNSPECIFIED is the proto zero-value; older servers that predate this field
+		// return it. Treat it as available for forward-compatibility.
+		return nil
+	case sessionsearchv1pb.SessionSearchAvailability_SESSION_SEARCH_AVAILABILITY_NOT_IMPLEMENTED:
+		return trace.NotImplemented("session search requires Access Graph to be enabled with session recording support")
+	case sessionsearchv1pb.SessionSearchAvailability_SESSION_SEARCH_AVAILABILITY_PG_TRGM_UNAVAILABLE:
+		return trace.NotImplemented("session search requires the pg_trgm PostgreSQL extension to be installed")
+	case sessionsearchv1pb.SessionSearchAvailability_SESSION_SEARCH_AVAILABILITY_PG_VECTOR_UNAVAILABLE:
+		return trace.NotImplemented("session search requires the pgvector PostgreSQL extension to be installed")
+	default:
+		return nil
+	}
+}
+
+// collectStream drains a SearchSessionSummaries server stream and returns the
+// accumulated sessions and the next-page token (empty when there are no more pages).
+func collectStream(stream sessionsearchv1pb.SessionSearchService_SearchSessionSummariesClient) ([]*sessionsearchv1pb.SessionSummary, string, error) {
+	var sessions []*sessionsearchv1pb.SessionSummary
+	var nextToken string
+	for {
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		switch p := resp.Payload.(type) {
+		case *sessionsearchv1pb.SearchSessionSummariesResponse_Summary:
+			sessions = append(sessions, p.Summary)
+		case *sessionsearchv1pb.SearchSessionSummariesResponse_BatchComplete_:
+			if p.BatchComplete.GetHasMore() {
+				nextToken = p.BatchComplete.GetNextBatchToken()
+			}
+		}
+	}
+	return sessions, nextToken, nil
+}
+
+// parseSeverity converts a CLI severity string to a RiskLevel proto enum value.
+func parseSeverity(s string) (summarizerv1pb.RiskLevel, error) {
+	switch s {
+	case "low":
+		return summarizerv1pb.RiskLevel_RISK_LEVEL_LOW, nil
+	case "medium":
+		return summarizerv1pb.RiskLevel_RISK_LEVEL_MEDIUM, nil
+	case "high":
+		return summarizerv1pb.RiskLevel_RISK_LEVEL_HIGH, nil
+	case "critical":
+		return summarizerv1pb.RiskLevel_RISK_LEVEL_CRITICAL, nil
+	default:
+		return 0, trace.BadParameter("invalid --severity %q: must be one of low, medium, high, critical", s)
+	}
 }
 
 // createFileWriter creates a file-based session event writer that outputs to a file.

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -51,6 +51,12 @@ import (
 	recordingstui "github.com/gravitational/teleport/tool/tctl/common/recordings"
 )
 
+const (
+	searchModeHybrid    = "hybrid"
+	searchModeKeyword   = "keyword"
+	searchModeEmbedding = "embeddings"
+)
+
 // RecordingsCommand implements "tctl recordings" group of commands.
 type RecordingsCommand struct {
 	config *servicecfg.Config
@@ -105,6 +111,8 @@ type RecordingsCommand struct {
 	searchResourceName string
 	// searchSeverity filters results by minimum severity level (low/medium/high/critical).
 	searchSeverity string
+	// searchMode controls which search strategy to use: hybrid (default), keyword, or embedding.
+	searchMode string
 
 	// stdout allows to switch standard output source for resource command. Used in tests.
 	stdout io.Writer
@@ -136,6 +144,7 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, t *tctlcfg.Glob
 	c.recordingsSearch.Flag("resource-kind", "Filter by Teleport resource type (node, kube_cluster, db).").StringVar(&c.searchResourceKind)
 	c.recordingsSearch.Flag("resource-name", "Filter by resource name.").StringVar(&c.searchResourceName)
 	c.recordingsSearch.Flag("severity", "Minimum severity level to include (low, medium, high, critical).").StringVar(&c.searchSeverity)
+	c.recordingsSearch.Flag("search-mode", "Search strategy to use when search queries are provided.").Default(searchModeHybrid).EnumVar(&c.searchMode, searchModeHybrid, searchModeKeyword, searchModeEmbedding)
 	c.recordingsSearch.Flag("limit", "Maximum number of results to return.").Default(defaults.TshTctlSessionListLimit).Uint32Var(&c.searchLimit)
 	c.recordingsSearch.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+". Defaults to 'text'.").Default(teleport.Text).StringVar(&c.searchFormat)
 
@@ -297,6 +306,13 @@ func (c *RecordingsCommand) SearchRecordings(ctx context.Context, tc *authclient
 		}
 		req.Severity = &level
 	}
+	if c.searchMode != "" {
+		mode, err := parseSearchMode(c.searchMode)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.SearchMode = mode
+	}
 
 	stream, err := searchClient.SearchSessionSummaries(ctx, req)
 	if err != nil {
@@ -384,6 +400,20 @@ func collectStream(stream sessionsearchv1pb.SessionSearchService_SearchSessionSu
 		}
 	}
 	return sessions, nextToken, nil
+}
+
+// parseSearchMode converts a CLI search-mode string to a SearchMode proto enum value.
+func parseSearchMode(s string) (sessionsearchv1pb.SearchMode, error) {
+	switch s {
+	case searchModeHybrid:
+		return sessionsearchv1pb.SearchMode_SEARCH_MODE_HYBRID, nil
+	case searchModeKeyword:
+		return sessionsearchv1pb.SearchMode_SEARCH_MODE_KEYWORD_ONLY, nil
+	case searchModeEmbedding:
+		return sessionsearchv1pb.SearchMode_SEARCH_MODE_EMBEDDING_ONLY, nil
+	default:
+		return 0, trace.BadParameter("invalid --search-mode %q: must be one of %s, %s, %s", s, searchModeHybrid, searchModeKeyword, searchModeEmbedding)
+	}
 }
 
 // parseSeverity converts a CLI severity string to a RiskLevel proto enum value.

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -90,7 +90,7 @@ type RecordingsCommand struct {
 	// searchAccessRequests filters results by access request IDs.
 	searchAccessRequests []string
 	// searchLimit is the maximum number of results to return.
-	searchLimit int
+	searchLimit uint32
 	// searchFormat is the output format for search results.
 	searchFormat string
 	// searchKinds filters results by session kind (ssh, db, k8s, desktop).
@@ -125,7 +125,7 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, t *tctlcfg.Glob
 	c.recordingsList.Flag("limit", fmt.Sprintf("Maximum number of recordings to show. Default %s.", defaults.TshTctlSessionListLimit)).Default(defaults.TshTctlSessionListLimit).IntVar(&c.maxRecordingsToShow)
 	c.recordingsList.Flag("last", "Duration into the past from which session recordings should be listed. Format 5h30m40s").StringVar(&c.recordingsSince)
 	c.recordingsSearch = recordings.Command("search", "Search session recordings using semantic and keyword queries.")
-	c.recordingsSearch.Arg("query", `Search query. Supports keywords and boolean operators (e.g. "DROP TABLE OR DELETE FROM").`).StringsVar(&c.searchQuery)
+	c.recordingsSearch.Arg("query", `Natural language description of the sessions to find (e.g. "SSH sessions exfiltrating data to external endpoints").`).StringsVar(&c.searchQuery)
 	c.recordingsSearch.Flag("from", fmt.Sprintf("Start of time range. Format %s. Defaults to 24 hours ago.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.searchFromUTC)
 	c.recordingsSearch.Flag("to", fmt.Sprintf("End of time range. Format %s. Defaults to current time.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.searchToUTC)
 	c.recordingsSearch.Flag("label", "Filter by resource labels (key=value pairs), e.g. env/prod=true,db/type=postgres.").StringVar(&c.searchLabel)
@@ -136,7 +136,7 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, t *tctlcfg.Glob
 	c.recordingsSearch.Flag("resource-kind", "Filter by Teleport resource type (node, kube_cluster, db).").StringVar(&c.searchResourceKind)
 	c.recordingsSearch.Flag("resource-name", "Filter by resource name.").StringVar(&c.searchResourceName)
 	c.recordingsSearch.Flag("severity", "Minimum severity level to include (low, medium, high, critical).").StringVar(&c.searchSeverity)
-	c.recordingsSearch.Flag("limit", "Maximum number of results to return.").Default(defaults.TshTctlSessionListLimit).IntVar(&c.searchLimit)
+	c.recordingsSearch.Flag("limit", "Maximum number of results to return.").Default(defaults.TshTctlSessionListLimit).Uint32Var(&c.searchLimit)
 	c.recordingsSearch.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+". Defaults to 'text'.").Default(teleport.Text).StringVar(&c.searchFormat)
 
 	c.recordingsEncryption.Initialize(recordings, c.stdout)
@@ -279,7 +279,7 @@ func (c *RecordingsCommand) SearchRecordings(ctx context.Context, tc *authclient
 		AccessRequestIds: c.searchAccessRequests,
 		Kinds:            c.searchKinds,
 		UserRoles:        c.searchRoles,
-		MaxResults:       uint32(c.searchLimit),
+		MaxResults:       c.searchLimit,
 	}
 	if c.searchUsername != "" {
 		req.Username = &c.searchUsername

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -67,6 +67,7 @@ func Handlers() map[string]Handler {
 		types.KindInferenceModel:                     inferenceModelHandler(),
 		types.KindInferenceSecret:                    inferenceSecretHandler(),
 		types.KindInferencePolicy:                    inferencePolicyHandler(),
+		types.KindRetrievalModel:                     retrievalModelHandler(),
 		types.KindInstaller:                          installerHandler(),
 		types.KindKubeServer:                         kubeServerHandler(),
 		types.KindKubernetesCluster:                  kubeClusterHandler(),

--- a/tool/tctl/common/resources/retrieval_model.go
+++ b/tool/tctl/common/resources/retrieval_model.go
@@ -1,0 +1,146 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/trace"
+
+	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// retrievalModelCollection is a collection of RetrievalModel resources that
+// can be written to an io.Writer in a human-readable format.
+type retrievalModelCollection []*summarizerv1.RetrievalModel
+
+func (c retrievalModelCollection) Resources() []types.Resource {
+	out := make([]types.Resource, 0, len(c))
+	for _, item := range c {
+		out = append(out, types.ProtoResource153ToLegacy(item))
+	}
+	return out
+}
+
+func (c retrievalModelCollection) WriteText(w io.Writer, verbose bool) error {
+	headers := []string{"Name", "Description", "Provider", "Provider Model ID", "Inference Model"}
+	var rows [][]string
+	for _, item := range c {
+		meta := item.GetMetadata()
+		spec := item.GetSpec()
+		providerName := ""
+		providerModel := ""
+		if spec.GetOpenai() != nil {
+			providerName = "OpenAI"
+			providerModel = spec.GetOpenai().GetOpenaiModelId()
+		} else if spec.GetBedrock() != nil {
+			providerName = "Bedrock"
+			providerModel = spec.GetBedrock().GetBedrockModelId()
+		}
+		rows = append(rows, []string{
+			meta.GetName(),
+			meta.GetDescription(),
+			providerName,
+			providerModel,
+			spec.GetInferenceModelName(),
+		})
+	}
+	var t asciitable.Table
+	if verbose {
+		t = asciitable.MakeTable(headers, rows...)
+	} else {
+		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Description")
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func retrievalModelHandler() Handler {
+	return Handler{
+		getHandler:    getRetrievalModel,
+		createHandler: createRetrievalModel,
+		updateHandler: updateRetrievalModel,
+		deleteHandler: deleteRetrievalModel,
+		singleton:     true,
+		mfaRequired:   false,
+		description:   "Specifies the embeddings provider configuration used for session search",
+	}
+}
+
+func createRetrievalModel(ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	model, err := services.UnmarshalProtoResource[*summarizerv1.RetrievalModel](
+		raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	sclt := clt.SummarizerServiceClient()
+	if opts.Force {
+		_, err = sclt.UpsertRetrievalModel(ctx, &summarizerv1.UpsertRetrievalModelRequest{
+			Model: model,
+		})
+	} else {
+		_, err = sclt.CreateRetrievalModel(ctx, &summarizerv1.CreateRetrievalModelRequest{
+			Model: model,
+		})
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf("retrieval_model %q has been created\n", model.GetMetadata().GetName())
+	return nil
+}
+
+func updateRetrievalModel(ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	model, err := services.UnmarshalProtoResource[*summarizerv1.RetrievalModel](
+		raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if _, err := clt.SummarizerServiceClient().UpdateRetrievalModel(ctx, &summarizerv1.UpdateRetrievalModelRequest{
+		Model: model,
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("retrieval_model %q has been updated\n", model.GetMetadata().GetName())
+	return nil
+}
+
+func getRetrievalModel(ctx context.Context, clt *authclient.Client, _ services.Ref, _ GetOpts) (Collection, error) {
+	res, err := clt.SummarizerServiceClient().GetRetrievalModel(ctx, &summarizerv1.GetRetrievalModelRequest{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return retrievalModelCollection{res.GetModel()}, nil
+}
+
+func deleteRetrievalModel(ctx context.Context, clt *authclient.Client, _ services.Ref) error {
+	if _, err := clt.SummarizerServiceClient().DeleteRetrievalModel(ctx, &summarizerv1.DeleteRetrievalModelRequest{}); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Println("retrieval_model has been deleted")
+	return nil
+}


### PR DESCRIPTION
Introduces a `tctl recordings search` subcommand backed by a Bubble Tea TUI. The list pane shows sessions fetched via the SessionSearchService (with pagination and filter flags), and the detail pane renders full session metadata, resource properties, severity colouring, and summary popup.

Also include the handler to manage `retrieval_model`

```
tctl recordings search teleport.yaml --help
usage: tctl recordings search [<flags>] [<query>...]

Search session recordings using semantic and keyword queries.

Flags:
      ....
      --from=FROM          Start of time range. Format 2006-01-02. Defaults to 24 hours ago.
      --to=TO              End of time range. Format 2006-01-02. Defaults to current time.
      --label=LABEL        Filter by resource labels (key=value pairs), e.g. env/prod=true,db/type=postgres.
      --access-request=ACCESS-REQUEST ...
                           Filter by access request ID. Can be specified multiple times.
      --kind=KIND ...      Filter by session kind (ssh, db, k8s, desktop). Can be specified multiple times.
      --username=USERNAME  Filter by the Teleport username that initiated the session.
      --role=ROLE ...      Filter by role held during the session. Can be specified multiple times.
      --resource-kind=RESOURCE-KIND
                           Filter by Teleport resource type (node, kube_cluster, db).
      --resource-name=RESOURCE-NAME
                           Filter by resource name.
      --severity=SEVERITY  Minimum severity level to include (low, medium, high, critical).
      --limit=50           Maximum number of results to return.
      --format="text"      Format output (text, json, yaml).. Defaults to 'text'.

Args:
  [<query>]  Search query. Supports keywords and boolean operators (e.g. "DROP TABLE OR DELETE FROM").

Aliases:

```



https://github.com/user-attachments/assets/13ab8e6e-2747-4719-90b4-3d80412c60cb


<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

local 

### Test Cases
- [x]  tsh recordings search
  - [x] Labels
  - [x] Search keywords
  - [x] Kinds
  - [x] User
  - [x] severity
  - [x] access request
  - [x] resource name
- [x] Access Graph disabled
- [x] Access Graph without pgvector