### PR TITLE
Validate OID components on DN conversions

### DIFF
--- a/lib/subca/dn.go
+++ b/lib/subca/dn.go
@@ -43,7 +43,7 @@ func RDNSequenceToDistinguishedNameProto(rdns pkix.RDNSequence) (*subcav1.Distin
 	for i, nameSet := range rdns {
 		for j, atv := range nameSet {
 			oid := make([]int32, len(atv.Type))
-			for i, x := range atv.Type {
+			for k, x := range atv.Type {
 				// OID components are guaranteed to fit in a 32 bit integer as checked
 				// by encoding/asn1.parseBase128Int.
 				// https://cs.opensource.google/go/go/+/refs/tags/go1.26.2:src/encoding/asn1/asn1.go;l=323
@@ -54,7 +54,7 @@ func RDNSequenceToDistinguishedNameProto(rdns pkix.RDNSequence) (*subcav1.Distin
 						x, math.MaxInt32,
 					)
 				}
-				oid[i] = int32(x)
+				oid[k] = int32(x)
 			}
 			val, ok := atv.Value.(string)
 			if !ok {

--- a/lib/subca/dn.go
+++ b/lib/subca/dn.go
@@ -18,6 +18,7 @@ package subca
 
 import (
 	"crypto/x509/pkix"
+	"math"
 
 	"github.com/gravitational/trace"
 
@@ -46,6 +47,13 @@ func RDNSequenceToDistinguishedNameProto(rdns pkix.RDNSequence) (*subcav1.Distin
 				// OID components are guaranteed to fit in a 32 bit integer as checked
 				// by encoding/asn1.parseBase128Int.
 				// https://cs.opensource.google/go/go/+/refs/tags/go1.26.2:src/encoding/asn1/asn1.go;l=323
+				if x < 0 || x > math.MaxInt32 {
+					return nil, trace.BadParameter(
+						`rdns[%d][%d]: OID component out of bounds: %d (must be "0 <= OID <= %d")`,
+						i, j,
+						x, math.MaxInt32,
+					)
+				}
 				oid[i] = int32(x)
 			}
 			val, ok := atv.Value.(string)
@@ -89,6 +97,9 @@ func DistinguishedNameProtoToRDNSequence(dn *subcav1.DistinguishedName) (pkix.RD
 
 		oid := make([]int, len(atv.Oid))
 		for j, x := range atv.Oid {
+			if x < 0 {
+				return nil, trace.BadParameter("names[%d]: OID component out of bounds: %d (must be >= 0)", i, x)
+			}
 			oid[j] = int(x)
 		}
 		rdns = append(rdns, pkix.RelativeDistinguishedNameSET{

--- a/lib/subca/dn_test.go
+++ b/lib/subca/dn_test.go
@@ -66,8 +66,9 @@ func TestRDNSequenceToDistinguishedNameProto(t *testing.T) {
 	})
 
 	t.Run("OID component is MaxInt32", func(t *testing.T) {
-		val := "llama"
+		t.Parallel()
 
+		val := "llama"
 		got, err := subca.RDNSequenceToDistinguishedNameProto(pkix.RDNSequence{
 			{{Type: asn1.ObjectIdentifier{99, 1, 2, math.MaxInt32}, Value: val}},
 		})

--- a/lib/subca/dn_test.go
+++ b/lib/subca/dn_test.go
@@ -19,6 +19,7 @@ package subca_test
 import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -64,19 +65,61 @@ func TestRDNSequenceToDistinguishedNameProto(t *testing.T) {
 		}
 	})
 
-	t.Run("non-string value", func(t *testing.T) {
-		t.Parallel()
+	t.Run("OID component is MaxInt32", func(t *testing.T) {
+		val := "llama"
 
-		rdns := (pkix.Name{
-			ExtraNames: []pkix.AttributeTypeAndValue{
-				{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "ok"}, // OK
-				{Type: asn1.ObjectIdentifier{1, 2, 3, 5}, Value: 42},   // NOK
+		got, err := subca.RDNSequenceToDistinguishedNameProto(pkix.RDNSequence{
+			{{Type: asn1.ObjectIdentifier{99, 1, 2, math.MaxInt32}, Value: val}},
+		})
+		require.NoError(t, err)
+
+		want := &subcav1.DistinguishedName{
+			Names: []*subcav1.AttributeTypeAndValue{
+				{Oid: []int32{99, 1, 2, int32(math.MaxInt32)}, Value: &val},
 			},
-		}).ToRDNSequence()
-
-		_, err := subca.RDNSequenceToDistinguishedNameProto(rdns)
-		assert.ErrorContains(t, err, "not a string", "error mismatch")
+		}
+		if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+			t.Errorf("DistinguishedName mismatch (-want +got)\n%s", diff)
+		}
 	})
+
+	tests := []struct {
+		name    string
+		rdns    pkix.RDNSequence
+		wantErr string
+	}{
+		{
+			name: "OID negative",
+			rdns: pkix.RDNSequence{
+				{{Type: asn1.ObjectIdentifier{99, 1, 2, -1}, Value: "llama"}},
+			},
+			wantErr: "OID component out of bounds",
+		},
+		{
+			name: "OID out of bounds",
+			rdns: pkix.RDNSequence{
+				{{Type: asn1.ObjectIdentifier{99, 1, 2, math.MaxInt32 + 1}, Value: "llama"}},
+			},
+			wantErr: "OID component out of bounds",
+		},
+		{
+			name: "non-string value",
+			rdns: pkix.RDNSequence{
+				{
+					{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "ok"}, // OK
+					{Type: asn1.ObjectIdentifier{1, 2, 3, 5}, Value: 42},   // NOK
+				},
+			},
+			wantErr: "not a string",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := subca.RDNSequenceToDistinguishedNameProto(test.rdns)
+			assert.ErrorContains(t, err, test.wantErr, "error mismatch")
+		})
+	}
 }
 
 func TestDistinguishedNameProtoToRDNSequence(t *testing.T) {
@@ -117,6 +160,15 @@ func TestDistinguishedNameProtoToRDNSequence(t *testing.T) {
 				},
 			},
 			wantErr: "empty OID",
+		},
+		{
+			name: "ATV.OID negative",
+			dn: &subcav1.DistinguishedName{
+				Names: []*subcav1.AttributeTypeAndValue{
+					{Oid: []int32{1, 2, 3, -1}, Value: &exampleValue},
+				},
+			},
+			wantErr: "OID component out of bounds",
 		},
 		{
 			name: "ATV.Value nil",


### PR DESCRIPTION
Tighten OID component validation in DistinguishedName proto conversions.

Follow up from #65900.

https://github.com/gravitational/teleport.e/issues/7675