### PR TITLE
[scopes] eliminate some branchy boilerplate in ScopedAccessChecker

### DIFF
--- a/lib/services/kube_access_checker.go
+++ b/lib/services/kube_access_checker.go
@@ -35,17 +35,10 @@ type KubeAccessChecker struct {
 // CanAccessCluster checks whether read access to the specified kube server is possible without
 // regard to a specific MFA state. Used for listing/filtering.
 func (c *KubeAccessChecker) CanAccessCluster(target types.KubeCluster) error {
-	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.CheckAccess(target, AccessState{MFAVerified: true})
-	}
-	return c.checker.scopedCompatChecker.CheckAccess(target, AccessState{MFAVerified: true})
+	return c.checker.CheckAccess(target, AccessState{MFAVerified: true})
 }
 
 // GetGroupsAndUsers returns the kube groups and users that are permitted for impersonation.
 func (c *KubeAccessChecker) GetGroupsAndUsers(ttl time.Duration, overrideTTL bool, matchers ...RoleMatcher) ([]string, []string, error) {
-	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.CheckKubeGroupsAndUsers(ttl, overrideTTL, matchers...)
-	}
-
-	return c.checker.scopedCompatChecker.CheckKubeGroupsAndUsers(ttl, overrideTTL, matchers...)
+	return c.checker.CheckKubeGroupsAndUsers(ttl, overrideTTL, matchers...)
 }

--- a/lib/services/kube_access_checker.go
+++ b/lib/services/kube_access_checker.go
@@ -35,10 +35,10 @@ type KubeAccessChecker struct {
 // CanAccessCluster checks whether read access to the specified kube server is possible without
 // regard to a specific MFA state. Used for listing/filtering.
 func (c *KubeAccessChecker) CanAccessCluster(target types.KubeCluster) error {
-	return c.checker.CheckAccess(target, AccessState{MFAVerified: true})
+	return c.checker.commonAccessChecker.CheckAccess(target, AccessState{MFAVerified: true})
 }
 
 // GetGroupsAndUsers returns the kube groups and users that are permitted for impersonation.
 func (c *KubeAccessChecker) GetGroupsAndUsers(ttl time.Duration, overrideTTL bool, matchers ...RoleMatcher) ([]string, []string, error) {
-	return c.checker.CheckKubeGroupsAndUsers(ttl, overrideTTL, matchers...)
+	return c.checker.commonAccessChecker.CheckKubeGroupsAndUsers(ttl, overrideTTL, matchers...)
 }

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -121,7 +121,7 @@ func (b *scopedAccessCheckerBuilder) newCheckerForRole(ctx context.Context, key 
 		scopeOfOrigin:       key.scopeOfOrigin,
 		scopeOfEffect:       key.scopeOfEffect,
 		role:                rsp.Role,
-		CommonAccessChecker: checker,
+		commonAccessChecker: checker,
 	}, nil
 }
 
@@ -136,7 +136,7 @@ func (b *scopedAccessCheckerBuilder) newDefaultImplicitChecker(_ context.Context
 	return &ScopedAccessChecker{
 		scopeOfOrigin:       scopes.Root,
 		scopeOfEffect:       scopes.Root,
-		CommonAccessChecker: commonChecker,
+		commonAccessChecker: commonChecker,
 		role: &scopedaccessv1.ScopedRole{
 			Metadata: &headerv1.Metadata{
 				Name: constants.DefaultImplicitRole,
@@ -176,7 +176,7 @@ type ScopedAccessChecker struct {
 	// Non-nil iff !isScoped().
 	unscopedChecker AccessChecker
 
-	// CommonAccessChecker provides a common implementation of some access
+	// commonAccessChecker provides a common implementation of some access
 	// checks for scoped and unscoped identities. It is always set to a valid
 	// access checker.
 	//
@@ -184,14 +184,14 @@ type ScopedAccessChecker struct {
 	//
 	// For scoped identities, it is constructed by converting a scoped role to
 	// an unscoped role with [scopedaccess.ScopedRoleToRole].
-	CommonAccessChecker
+	commonAccessChecker commonAccessChecker
 }
 
-// CommonAccessChecker is the subset of [AccessChecker] methods with a common
+// commonAccessChecker is the subset of [AccessChecker] methods with a common
 // implementation for scoped and unscoped roles. These are the methods that are
 // sementically correct when the access checker as been built from a scoped
 // role has been converted to an unscoped role with [scopedaccess.ScopedRoleToRole].
-type CommonAccessChecker interface {
+type commonAccessChecker interface {
 	CheckAccess(r AccessCheckable, state AccessState, matchers ...RoleMatcher) error
 	CheckKubeGroupsAndUsers(ttl time.Duration, overrideTTL bool, matchers ...RoleMatcher) (groups []string, users []string, err error)
 	AccessInfo() *AccessInfo
@@ -215,7 +215,7 @@ type CommonAccessChecker interface {
 func NewScopedAccessCheckerFromUnscoped(checker AccessChecker) *ScopedAccessChecker {
 	return &ScopedAccessChecker{
 		unscopedChecker:     checker,
-		CommonAccessChecker: checker,
+		commonAccessChecker: checker,
 	}
 }
 
@@ -236,9 +236,21 @@ func (c *ScopedAccessChecker) Kube() *KubeAccessChecker {
 	return &KubeAccessChecker{checker: c}
 }
 
+// AccessInfo returns the AccessInfo that this access checker is based on.
+func (c *ScopedAccessChecker) AccessInfo() *AccessInfo {
+	return c.commonAccessChecker.AccessInfo()
+}
+
+// Traits returns the set of user traits.
+func (c *ScopedAccessChecker) Traits() wrappers.Traits {
+	// there is no concept of scoped traits currently, and none is planned or would be feasible at least
+	// until we've fully migrated to PDP and deprecated certificate-based traits.
+	return c.commonAccessChecker.Traits()
+}
+
 // CheckAccessToRules verifies that *all* of a series of verbs are permitted for the specified resource.
 func (c *ScopedAccessChecker) CheckAccessToRules(ctx RuleContext, resource string, verbs ...string) error {
-	return checkAccessToRulesImpl(c.CommonAccessChecker, ctx, resource, verbs...)
+	return checkAccessToRulesImpl(c.commonAccessChecker, ctx, resource, verbs...)
 }
 
 // CheckAccessToRemoteCluster checks access to a remote cluster.
@@ -254,10 +266,43 @@ func (c *ScopedAccessChecker) CheckAccessToRemoteCluster(cluster types.RemoteClu
 	return trace.AccessDenied("remote cluster access is not permitted for scoped identities")
 }
 
+// AdjustSessionTTL will reduce the requested ttl to the lowest max allowed TTL for this role set.
+func (c *ScopedAccessChecker) AdjustSessionTTL(ttl time.Duration) time.Duration {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.commonAccessChecker.AdjustSessionTTL(ttl)
+}
+
+// PrivateKeyPolicy returns the enforced private key policy, or the provided default, whichever is stricter.
+func (c *ScopedAccessChecker) PrivateKeyPolicy(defaultPolicy keys.PrivateKeyPolicy) (keys.PrivateKeyPolicy, error) {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.commonAccessChecker.PrivateKeyPolicy(defaultPolicy)
+}
+
+// PinSourceIP returns whether source IP pinning is enforced.
+func (c *ScopedAccessChecker) PinSourceIP() bool {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.commonAccessChecker.PinSourceIP()
+}
+
+// LockingMode returns the locking mode to apply.
+func (c *ScopedAccessChecker) LockingMode(defaultMode constants.LockingMode) constants.LockingMode {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.commonAccessChecker.LockingMode(defaultMode)
+}
+
+// DelegationSessionID returns the ID of the current Delegation Session.
+func (c *ScopedAccessChecker) DelegationSessionID() string {
+	return c.commonAccessChecker.DelegationSessionID()
+}
+
 // checkAccessToRulesImpl verifies that *all* of a series of verbs are permitted for the specified resource. This
 // function differs from AccessChecker.CheckAccessToRule in that it does not support advanced context-based features
 // or namespacing, and accepts a set of verbs all of which must evaluate to allow for the check to succeed.
-func checkAccessToRulesImpl(checker CommonAccessChecker, ctx RuleContext, resource string, verbs ...string) error {
+func checkAccessToRulesImpl(checker commonAccessChecker, ctx RuleContext, resource string, verbs ...string) error {
 	if len(verbs) == 0 {
 		return trace.BadParameter("malformed rule check for %q, no verbs provided (this is a bug)", resource)
 	}

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -121,7 +121,7 @@ func (b *scopedAccessCheckerBuilder) newCheckerForRole(ctx context.Context, key 
 		scopeOfOrigin:       key.scopeOfOrigin,
 		scopeOfEffect:       key.scopeOfEffect,
 		role:                rsp.Role,
-		scopedCompatChecker: checker,
+		CommonAccessChecker: checker,
 	}, nil
 }
 
@@ -132,10 +132,11 @@ func (b *scopedAccessCheckerBuilder) newCheckerForRole(ctx context.Context, key 
 // functionality of scoped roles further diverges from unscoped roles, we may need to revisit this approach in favor of defining our
 // own default implicit scoped role instead.
 func (b *scopedAccessCheckerBuilder) newDefaultImplicitChecker(_ context.Context) *ScopedAccessChecker {
+	commonChecker := newAccessChecker(b.info, b.localCluster, NewRoleSet()) // default implicit role definition is auto-populated by NewRoleSet()
 	return &ScopedAccessChecker{
 		scopeOfOrigin:       scopes.Root,
 		scopeOfEffect:       scopes.Root,
-		scopedCompatChecker: newAccessChecker(b.info, b.localCluster, NewRoleSet()), // default implicit role definition is auto-populated by NewRoleSet()
+		CommonAccessChecker: commonChecker,
 		role: &scopedaccessv1.ScopedRole{
 			Metadata: &headerv1.Metadata{
 				Name: constants.DefaultImplicitRole,
@@ -171,19 +172,51 @@ type ScopedAccessChecker struct {
 	// role is the scoped role being evaluated, or nil for unscoped identities.
 	role *scopedaccessv1.ScopedRole
 
-	// scopedCompatChecker is a classic AccessChecker built from the scoped role via ScopedRoleToRole.
-	// Non-nil iff isScoped(). Used for checks that fall back to compat classic-role logic.
-	scopedCompatChecker AccessChecker
-
 	// unscopedChecker is the underlying unscoped AccessChecker.
 	// Non-nil iff !isScoped().
 	unscopedChecker AccessChecker
+
+	// CommonAccessChecker provides a common implementation of some access
+	// checks for scoped and unscoped identities. It is always set to a valid
+	// access checker.
+	//
+	// For unscoped identities, it is identical to unscopedChecker.
+	//
+	// For scoped identities, it is constructed by converting a scoped role to
+	// an unscoped role with [scopedaccess.ScopedRoleToRole].
+	CommonAccessChecker
+}
+
+// CommonAccessChecker is the subset of [AccessChecker] methods with a common
+// implementation for scoped and unscoped roles. These are the methods that are
+// sementically correct when the access checker as been built from a scoped
+// role has been converted to an unscoped role with [scopedaccess.ScopedRoleToRole].
+type CommonAccessChecker interface {
+	CheckAccess(r AccessCheckable, state AccessState, matchers ...RoleMatcher) error
+	CheckKubeGroupsAndUsers(ttl time.Duration, overrideTTL bool, matchers ...RoleMatcher) (groups []string, users []string, err error)
+	AccessInfo() *AccessInfo
+	Traits() wrappers.Traits
+	CheckAccessToRule(context RuleContext, namespace string, rule string, verb string) error
+	AdjustSessionTTL(ttl time.Duration) time.Duration
+	PrivateKeyPolicy(defaultPolicy keys.PrivateKeyPolicy) (keys.PrivateKeyPolicy, error)
+	PinSourceIP() bool
+	LockingMode(defaultMode constants.LockingMode) constants.LockingMode
+	DelegationSessionID() string
+	AdjustDisconnectExpiredCert(disconnect bool) bool
+	SessionRecordingMode(service constants.SessionRecordingService) constants.SessionRecordingMode
+	CanPortForward() bool
+	CanForwardAgents() bool
+	EnhancedRecordingSet() map[string]bool
+	MaxConnections() int64
 }
 
 // NewScopedAccessCheckerFromUnscoped creates a ScopedAccessChecker wrapping an unscoped AccessChecker.
 // This is used in code paths that accept *ScopedAccessChecker but operate on an unscoped identity.
 func NewScopedAccessCheckerFromUnscoped(checker AccessChecker) *ScopedAccessChecker {
-	return &ScopedAccessChecker{unscopedChecker: checker}
+	return &ScopedAccessChecker{
+		unscopedChecker:     checker,
+		CommonAccessChecker: checker,
+	}
 }
 
 // isScoped reports whether this checker operates on a scoped identity.
@@ -203,30 +236,9 @@ func (c *ScopedAccessChecker) Kube() *KubeAccessChecker {
 	return &KubeAccessChecker{checker: c}
 }
 
-// AccessInfo returns the AccessInfo that this access checker is based on.
-func (c *ScopedAccessChecker) AccessInfo() *AccessInfo {
-	if !c.isScoped() {
-		return c.unscopedChecker.AccessInfo()
-	}
-	return c.scopedCompatChecker.AccessInfo()
-}
-
-// Traits returns the set of user traits.
-func (c *ScopedAccessChecker) Traits() wrappers.Traits {
-	// there is no concept of scoped traits currently, and none is planned or would be feasible at least
-	// until we've fully migrated to PDP and deprecated certificate-based traits.
-	if !c.isScoped() {
-		return c.unscopedChecker.Traits()
-	}
-	return c.scopedCompatChecker.Traits()
-}
-
 // CheckAccessToRules verifies that *all* of a series of verbs are permitted for the specified resource.
 func (c *ScopedAccessChecker) CheckAccessToRules(ctx RuleContext, resource string, verbs ...string) error {
-	if !c.isScoped() {
-		return checkAccessToRulesImpl(c.unscopedChecker, ctx, resource, verbs...)
-	}
-	return checkAccessToRulesImpl(c.scopedCompatChecker, ctx, resource, verbs...)
+	return checkAccessToRulesImpl(c.CommonAccessChecker, ctx, resource, verbs...)
 }
 
 // CheckAccessToRemoteCluster checks access to a remote cluster.
@@ -242,58 +254,10 @@ func (c *ScopedAccessChecker) CheckAccessToRemoteCluster(cluster types.RemoteClu
 	return trace.AccessDenied("remote cluster access is not permitted for scoped identities")
 }
 
-// AdjustSessionTTL will reduce the requested ttl to the lowest max allowed TTL for this role set.
-func (c *ScopedAccessChecker) AdjustSessionTTL(ttl time.Duration) time.Duration {
-	// the naive implementation of this method for scopes may have problematic interactions with
-	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
-	if !c.isScoped() {
-		return c.unscopedChecker.AdjustSessionTTL(ttl)
-	}
-	return c.scopedCompatChecker.AdjustSessionTTL(ttl)
-}
-
-// PrivateKeyPolicy returns the enforced private key policy, or the provided default, whichever is stricter.
-func (c *ScopedAccessChecker) PrivateKeyPolicy(defaultPolicy keys.PrivateKeyPolicy) (keys.PrivateKeyPolicy, error) {
-	// the naive implementation of this method for scopes may have problematic interactions with
-	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
-	if !c.isScoped() {
-		return c.unscopedChecker.PrivateKeyPolicy(defaultPolicy)
-	}
-	return c.scopedCompatChecker.PrivateKeyPolicy(defaultPolicy)
-}
-
-// PinSourceIP returns whether source IP pinning is enforced.
-func (c *ScopedAccessChecker) PinSourceIP() bool {
-	// the naive implementation of this method for scopes may have problematic interactions with
-	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
-	if !c.isScoped() {
-		return c.unscopedChecker.PinSourceIP()
-	}
-	return c.scopedCompatChecker.PinSourceIP()
-}
-
-// LockingMode returns the locking mode to apply.
-func (c *ScopedAccessChecker) LockingMode(defaultMode constants.LockingMode) constants.LockingMode {
-	// the naive implementation of this method for scopes may have problematic interactions with
-	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
-	if !c.isScoped() {
-		return c.unscopedChecker.LockingMode(defaultMode)
-	}
-	return c.scopedCompatChecker.LockingMode(defaultMode)
-}
-
-// DelegationSessionID returns the ID of the current Delegation Session.
-func (c *ScopedAccessChecker) DelegationSessionID() string {
-	if !c.isScoped() {
-		return c.unscopedChecker.DelegationSessionID()
-	}
-	return c.scopedCompatChecker.DelegationSessionID()
-}
-
 // checkAccessToRulesImpl verifies that *all* of a series of verbs are permitted for the specified resource. This
 // function differs from AccessChecker.CheckAccessToRule in that it does not support advanced context-based features
 // or namespacing, and accepts a set of verbs all of which must evaluate to allow for the check to succeed.
-func checkAccessToRulesImpl(checker AccessChecker, ctx RuleContext, resource string, verbs ...string) error {
+func checkAccessToRulesImpl(checker CommonAccessChecker, ctx RuleContext, resource string, verbs ...string) error {
 	if len(verbs) == 0 {
 		return trace.BadParameter("malformed rule check for %q, no verbs provided (this is a bug)", resource)
 	}

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -38,19 +38,13 @@ type SSHAccessChecker struct {
 
 // CheckAccessToSSHServer checks access to an SSH server for the given OS user.
 func (c *SSHAccessChecker) CheckAccessToSSHServer(target types.Server, state AccessState, osUser string) error {
-	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.CheckAccess(target, state, NewLoginMatcher(osUser))
-	}
-	return c.checker.scopedCompatChecker.CheckAccess(target, state, NewLoginMatcher(osUser))
+	return c.checker.CheckAccess(target, state, NewLoginMatcher(osUser))
 }
 
 // CanAccessSSHServer checks whether read access to the specified SSH server is possible without
 // regard to a specific OS user or MFA state. Used for listing/filtering.
 func (c *SSHAccessChecker) CanAccessSSHServer(target types.Server) error {
-	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.CheckAccess(target, AccessState{MFAVerified: true})
-	}
-	return c.checker.scopedCompatChecker.CheckAccess(target, AccessState{MFAVerified: true})
+	return c.checker.CheckAccess(target, AccessState{MFAVerified: true})
 }
 
 // AdjustClientIdleTimeout determines the SSH client idle timeout to apply. The supplied argument must be
@@ -81,34 +75,22 @@ func (c *SSHAccessChecker) AdjustClientIdleTimeout(timeout time.Duration) (time.
 
 // AdjustDisconnectExpiredCert adjusts whether to disconnect on certificate expiry.
 func (c *SSHAccessChecker) AdjustDisconnectExpiredCert(disconnect bool) bool {
-	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.AdjustDisconnectExpiredCert(disconnect)
-	}
-	return c.checker.scopedCompatChecker.AdjustDisconnectExpiredCert(disconnect)
+	return c.checker.AdjustDisconnectExpiredCert(disconnect)
 }
 
 // SessionRecordingMode returns the session recording mode for SSH sessions.
 func (c *SSHAccessChecker) SessionRecordingMode() constants.SessionRecordingMode {
-	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH)
-	}
-	return c.checker.scopedCompatChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH)
+	return c.checker.SessionRecordingMode(constants.SessionRecordingServiceSSH)
 }
 
 // CanPortForward returns true if port forwarding is permitted.
 func (c *SSHAccessChecker) CanPortForward() bool {
-	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.CanPortForward()
-	}
-	return c.checker.scopedCompatChecker.CanPortForward()
+	return c.checker.CanPortForward()
 }
 
 // CanForwardAgents returns true if SSH agent forwarding is permitted.
 func (c *SSHAccessChecker) CanForwardAgents() bool {
-	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.CanForwardAgents()
-	}
-	return c.checker.scopedCompatChecker.CanForwardAgents()
+	return c.checker.CanForwardAgents()
 }
 
 // PermitX11Forwarding returns true if X11 forwarding is permitted.
@@ -159,10 +141,7 @@ func (c *SSHAccessChecker) HostSudoers(srv types.Server) ([]string, error) {
 
 // EnhancedRecordingSet returns the set of enhanced session recording events to capture.
 func (c *SSHAccessChecker) EnhancedRecordingSet() map[string]bool {
-	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.EnhancedRecordingSet()
-	}
-	return c.checker.scopedCompatChecker.EnhancedRecordingSet()
+	return c.checker.EnhancedRecordingSet()
 }
 
 // HostUsers returns host user creation information for the server, or nil if host user creation is disabled.
@@ -240,10 +219,7 @@ func (c *SSHAccessChecker) CheckAgentForward(login string) error {
 // MaxConnections returns the maximum number of concurrent SSH connections permitted.
 // A value of zero means unconstrained.
 func (c *SSHAccessChecker) MaxConnections() int64 {
-	if !c.checker.isScoped() {
-		return c.checker.unscopedChecker.MaxConnections()
-	}
-	return c.checker.scopedCompatChecker.MaxConnections()
+	return c.checker.MaxConnections()
 }
 
 // MaxSessions returns the maximum number of concurrent SSH sessions per connection permitted.

--- a/lib/services/ssh_access_checker.go
+++ b/lib/services/ssh_access_checker.go
@@ -38,13 +38,13 @@ type SSHAccessChecker struct {
 
 // CheckAccessToSSHServer checks access to an SSH server for the given OS user.
 func (c *SSHAccessChecker) CheckAccessToSSHServer(target types.Server, state AccessState, osUser string) error {
-	return c.checker.CheckAccess(target, state, NewLoginMatcher(osUser))
+	return c.checker.commonAccessChecker.CheckAccess(target, state, NewLoginMatcher(osUser))
 }
 
 // CanAccessSSHServer checks whether read access to the specified SSH server is possible without
 // regard to a specific OS user or MFA state. Used for listing/filtering.
 func (c *SSHAccessChecker) CanAccessSSHServer(target types.Server) error {
-	return c.checker.CheckAccess(target, AccessState{MFAVerified: true})
+	return c.checker.commonAccessChecker.CheckAccess(target, AccessState{MFAVerified: true})
 }
 
 // AdjustClientIdleTimeout determines the SSH client idle timeout to apply. The supplied argument must be
@@ -75,22 +75,22 @@ func (c *SSHAccessChecker) AdjustClientIdleTimeout(timeout time.Duration) (time.
 
 // AdjustDisconnectExpiredCert adjusts whether to disconnect on certificate expiry.
 func (c *SSHAccessChecker) AdjustDisconnectExpiredCert(disconnect bool) bool {
-	return c.checker.AdjustDisconnectExpiredCert(disconnect)
+	return c.checker.commonAccessChecker.AdjustDisconnectExpiredCert(disconnect)
 }
 
 // SessionRecordingMode returns the session recording mode for SSH sessions.
 func (c *SSHAccessChecker) SessionRecordingMode() constants.SessionRecordingMode {
-	return c.checker.SessionRecordingMode(constants.SessionRecordingServiceSSH)
+	return c.checker.commonAccessChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH)
 }
 
 // CanPortForward returns true if port forwarding is permitted.
 func (c *SSHAccessChecker) CanPortForward() bool {
-	return c.checker.CanPortForward()
+	return c.checker.commonAccessChecker.CanPortForward()
 }
 
 // CanForwardAgents returns true if SSH agent forwarding is permitted.
 func (c *SSHAccessChecker) CanForwardAgents() bool {
-	return c.checker.CanForwardAgents()
+	return c.checker.commonAccessChecker.CanForwardAgents()
 }
 
 // PermitX11Forwarding returns true if X11 forwarding is permitted.
@@ -141,7 +141,7 @@ func (c *SSHAccessChecker) HostSudoers(srv types.Server) ([]string, error) {
 
 // EnhancedRecordingSet returns the set of enhanced session recording events to capture.
 func (c *SSHAccessChecker) EnhancedRecordingSet() map[string]bool {
-	return c.checker.EnhancedRecordingSet()
+	return c.checker.commonAccessChecker.EnhancedRecordingSet()
 }
 
 // HostUsers returns host user creation information for the server, or nil if host user creation is disabled.
@@ -219,7 +219,7 @@ func (c *SSHAccessChecker) CheckAgentForward(login string) error {
 // MaxConnections returns the maximum number of concurrent SSH connections permitted.
 // A value of zero means unconstrained.
 func (c *SSHAccessChecker) MaxConnections() int64 {
-	return c.checker.MaxConnections()
+	return c.checker.commonAccessChecker.MaxConnections()
 }
 
 // MaxSessions returns the maximum number of concurrent SSH sessions per connection permitted.

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -67,7 +67,7 @@ func newScopedCheckerWithRoleAndTraits(t *testing.T, spec *scopedaccessv1.Scoped
 	commonAccessChecker := newAccessChecker(accessInfo, "local", NewRoleSet(classicRole))
 	return &ScopedAccessChecker{
 		role:                scopedRole,
-		CommonAccessChecker: commonAccessChecker,
+		commonAccessChecker: commonAccessChecker,
 	}
 }
 

--- a/lib/services/ssh_access_checker_test.go
+++ b/lib/services/ssh_access_checker_test.go
@@ -28,21 +28,46 @@ import (
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 )
 
 // newScopedCheckerWithRole is a test helper that builds a minimal ScopedAccessChecker
 // with a role whose Spec is set to the provided value.
-func newScopedCheckerWithRole(spec *scopedaccessv1.ScopedRoleSpec) *ScopedAccessChecker {
+func newScopedCheckerWithRole(t *testing.T, spec *scopedaccessv1.ScopedRoleSpec) *ScopedAccessChecker {
+	return newScopedCheckerWithRoleAndTraits(t, spec, nil)
+}
+
+func newScopedCheckerWithRoleAndTraits(t *testing.T, spec *scopedaccessv1.ScopedRoleSpec, traits wrappers.Traits) *ScopedAccessChecker {
+	t.Helper()
+	scopedRole := &scopedaccessv1.ScopedRole{
+		Metadata: &headerv1.Metadata{Name: "test-role"},
+		Scope:    "/test",
+		Spec:     spec,
+		Version:  types.V1,
+	}
+	classicRole, err := scopedaccess.ScopedRoleToRole(scopedRole, "/test")
+	require.NoError(t, err)
+	scopePin := &scopesv1.Pin{
+		Scope: "/test",
+		AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+			"/test": {
+				"/test": []string{"test-role"},
+			},
+		}),
+	}
+	accessInfo := &AccessInfo{
+		ScopePin: scopePin,
+		Traits:   traits,
+		Username: "tester",
+	}
+	commonAccessChecker := newAccessChecker(accessInfo, "local", NewRoleSet(classicRole))
 	return &ScopedAccessChecker{
-		role: &scopedaccessv1.ScopedRole{
-			Metadata: &headerv1.Metadata{Name: "test-role"},
-			Scope:    "/test",
-			Spec:     spec,
-			Version:  types.V1,
-		},
-		// scopedCompatChecker is nil; tests that don't exercise delegation paths don't need it.
+		role:                scopedRole,
+		CommonAccessChecker: commonAccessChecker,
 	}
 }
 
@@ -180,7 +205,7 @@ func TestSSHAccessCheckerAdjustClientIdleTimeout(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			checker := newScopedCheckerWithRole(t, tt.spec).SSH()
 			got, err := checker.AdjustClientIdleTimeout(tt.globalTimeout)
 			if tt.expectErr {
 				require.Error(t, err)
@@ -232,7 +257,7 @@ func TestSSHAccessCheckerPermitX11Forwarding(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			checker := newScopedCheckerWithRole(t, tt.spec).SSH()
 			require.Equal(t, tt.expect, checker.PermitX11Forwarding())
 		})
 	}
@@ -276,7 +301,7 @@ func TestSSHAccessCheckerCheckAgentForward(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			checker := newScopedCheckerWithRole(t, tt.spec).SSH()
 			err := checker.CheckAgentForward("testuser")
 			if tt.expectErr {
 				require.Error(t, err)
@@ -327,7 +352,7 @@ func TestSSHAccessCheckerCanCopyFiles(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			checker := newScopedCheckerWithRole(t, tt.spec).SSH()
 			require.Equal(t, tt.expect, checker.CanCopyFiles())
 		})
 	}
@@ -415,7 +440,7 @@ func TestSSHAccessCheckerSSHPortForwardMode(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			checker := newScopedCheckerWithRole(t, tt.spec).SSH()
 			require.Equal(t, tt.expect, checker.SSHPortForwardMode())
 		})
 	}
@@ -459,7 +484,7 @@ func TestSSHAccessCheckerMaxSessions(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			checker := newScopedCheckerWithRole(t, tt.spec).SSH()
 			require.Equal(t, tt.expect, checker.MaxSessions())
 		})
 	}
@@ -498,7 +523,7 @@ func TestSSHAccessCheckerHostSudoers(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			checker := newScopedCheckerWithRole(tt.spec).SSH()
+			checker := newScopedCheckerWithRole(t, tt.spec).SSH()
 			sudoers, err := checker.HostSudoers(srv)
 			require.NoError(t, err)
 			require.Equal(t, tt.expect, sudoers)
@@ -619,10 +644,7 @@ func TestSSHAccessCheckerHostUsers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			checker := newScopedCheckerWithRole(tt.spec).SSH()
-			checker.checker.scopedCompatChecker = newAccessChecker(&AccessInfo{
-				Traits: tt.traits,
-			}, "local", NewRoleSet())
+			checker := newScopedCheckerWithRoleAndTraits(t, tt.spec, tt.traits).SSH()
 
 			decision, err := checker.HostUsers(srv)
 			if tt.expectErr {


### PR DESCRIPTION
This is an idea to eliminate some branchy boilerplate in ScopedAccessChecker. It gets rid of the maybe-nil `scopedCompatChecker` in favor of an always-valid `CommonAccessChecker` that should be used whenever it's semantically correct to use the `ScopedRoleToRole` conversion for an access check.