### PR TITLE
[v18.8] Add join failure handling for ec2 using readyz health check

### DIFF
--- a/api/types/usertasks/object.go
+++ b/api/types/usertasks/object.go
@@ -252,6 +252,10 @@ const (
 	// because the SSM Script Run (also known as Invocation) failed.
 	// This happens when there's a failure with permissions or an invalid configuration (eg, invalid document name).
 	AutoDiscoverEC2IssueSSMInvocationFailure = "ec2-ssm-invocation-failure"
+
+	// AutoDiscoverEC2IssueJoinFailure is used to identify instances where Teleport was installed
+	// but the agent failed to join the cluster.
+	AutoDiscoverEC2IssueJoinFailure = "ec2-join-failure"
 )
 
 // DiscoverEC2IssueTypes is a list of issue types that can occur when trying to auto enroll EC2 instances.
@@ -261,6 +265,7 @@ var DiscoverEC2IssueTypes = []string{
 	AutoDiscoverEC2IssueSSMInstanceUnsupportedOS,
 	AutoDiscoverEC2IssueSSMScriptFailure,
 	AutoDiscoverEC2IssueSSMInvocationFailure,
+	AutoDiscoverEC2IssueJoinFailure,
 	AutoDiscoverEC2IssuePermAccountDenied,
 	AutoDiscoverEC2IssuePermOrgDenied,
 }

--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -251,6 +251,8 @@ github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNv
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
+github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
+github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo=

--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -251,8 +251,8 @@ github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNv
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
-github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
-github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo=

--- a/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-troubleshooting.mdx
@@ -10,6 +10,7 @@ When enrolling an instance into Teleport, the installation script returns a spec
 - 102: `curl` binary is missing
 - 103: `/opt` or `/` do not have the required minimum space to install Teleport, at least 1250MB is required
 - 104: host is unable to connect to the Teleport Proxy Services's HTTPS endpoint
+- 150: Teleport was installed but the agent failed to join the cluster
 
 You can customize the installation script - as describe in the **Use a custom installation script** section above - and implement other checks with specific exit codes.
 
@@ -31,6 +32,35 @@ Example of the `ssm.run` event with an exit code:
   "stderr": "failed to run commands: exit status 102",
   "stdout": "curl is missing\n",
   "exit_code": 102
+}
+```
+
+### Interpreting exit code `150` (`join failure`)
+
+Exit code `150` means Teleport installed successfully, but join health checks did not complete.
+The `status` field is intentionally high-level; use `stderr` for root-cause details.
+
+Common `stderr` patterns:
+- `ERROR: node did not become ready (join cluster) within <duration>` means Teleport kept polling `/readyz` until the configured join-health timeout elapsed without a successful join.
+- `systemd service state: ActiveState="...", SubState="...", Result="..."` is a best-effort snapshot captured at timeout for troubleshooting context.
+- `join failure: token is expired or not found; ...` can appear as an additional enriched line when journal logs contain an explicit token-expiry signal.
+- `failed to run commands: exit status 150` can appear at the end when AWS SSM's run-shell wrapper reports the installer exit code.
+
+Example `ssm.run` event for exit code `150`:
+```json
+{
+  "code": "TDS00W",
+  "event": "ssm.run",
+  "instance_id": "i-0000",
+  "region": "<region>",
+  "invocation_url": "https://<region>.console.aws.amazon.com/systems-manager/run-command/<uuid>/i-0000",
+  "platform_name": "Ubuntu",
+  "platform_type": "Linux",
+  "platform_version": "24.04",
+  "status": "Teleport was installed successfully but the agent did not become ready within the configured timeout. Check standard error output for join diagnostics.",
+  "stderr": "...\nERROR: node did not become ready (join cluster) within <duration>\n\nsystemd service state: ActiveState=\"active\", SubState=\"running\", Result=\"success\"\n\njoin failure: token is expired or not found; systemd service state: ActiveState=\"active\", SubState=\"running\", Result=\"success\"\n\tnode did not become ready (join cluster) within <duration>\n\nJournal output:\n...\nfailed to run commands: exit status 150",
+  "stdout": "",
+  "exit_code": 150
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -133,6 +133,7 @@ require (
 	github.com/go-webauthn/webauthn v0.11.2
 	github.com/gobwas/ws v1.4.0
 	github.com/gocql/gocql v1.7.0
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gofrs/flock v0.13.0
 	github.com/gogo/protobuf v1.3.2 // replaced
 	github.com/golang-jwt/jwt/v4 v4.5.2
@@ -421,7 +422,6 @@ require (
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
-	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -126,6 +126,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.1 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/coreos/go-systemd/v22 v22.6.0 // indirect
 	github.com/crewjam/httperr v0.2.0 // indirect
 	github.com/crewjam/saml v0.4.14 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect
@@ -185,6 +186,7 @@ require (
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.4.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -276,8 +276,8 @@ github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNv
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
-github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
-github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
+github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -440,7 +440,6 @@ github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.4.0 h1:CTaoG1tojrh4ucGPcoJFiAQUAsEWekEWvLy7GsVNqGs=
 github.com/gobwas/ws v1.4.0/go.mod h1:G3gNqMNtPppf5XUz7O4shetPpcZ1VJ7zt18dlUeakrc=
-github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -232,6 +232,7 @@ require (
 	github.com/gobwas/ws v1.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gocql/gocql v1.7.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -236,6 +236,7 @@ require (
 	github.com/gobwas/ws v1.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gocql/gocql v1.7.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -411,7 +411,7 @@ func (s *Server) ReportEC2SSMInstallationResult(ctx context.Context, result *ser
 			InvocationUrl:   result.SSMRunEvent.InvocationURL,
 			DiscoveryConfig: result.DiscoveryConfigName,
 			DiscoveryGroup:  s.DiscoveryGroup,
-			SyncTime:        timestamppb.New(result.SSMRunEvent.Time),
+			SyncTime:        timestamppb.New(s.clock.Now()),
 			InstanceId:      result.SSMRunEvent.InstanceID,
 			Name:            result.InstanceName,
 		},

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -32,12 +33,14 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/automaticupgrades/constants"
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 	"github.com/gravitational/teleport/lib/cloud"
@@ -49,8 +52,27 @@ import (
 	oracleimds "github.com/gravitational/teleport/lib/cloud/imds/oracle"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/linux"
+	teleportsystemd "github.com/gravitational/teleport/lib/systemd"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/packagemanager"
+)
+
+const (
+	// JoinFailureTimeout is the maximum amount of time the installer waits for a
+	// node to become ready before returning the join-failure exit code.
+	JoinFailureTimeout = 2 * time.Minute
+
+	// joinFailureDiagnosticsTimeout bounds the time spent collecting systemd state
+	// and journal output after the readyz poll has already timed out.
+	joinFailureDiagnosticsTimeout = 5 * time.Second
+
+	// defaultReadyzPollInterval is how often to poll the Teleport readyz endpoint
+	// while waiting for the agent to join the cluster.
+	defaultReadyzPollInterval = 5 * time.Second
+
+	// defaultInstallLockGracePeriod is additional time beyond readyz polling to
+	// wait for the install lock before returning a lock contention error.
+	defaultInstallLockGracePeriod = 10 * time.Second
 )
 
 const (
@@ -113,6 +135,35 @@ type AutoDiscoverNodeInstallerConfig struct {
 	// imdsProviders contains the Cloud Instance Metadata providers.
 	// Used for testing.
 	imdsProviders []func(ctx context.Context) (imds.Client, error)
+
+	// readyzPollInterval is how often to poll the Teleport readyz endpoint while
+	// waiting for the agent to join the cluster. Defaults to
+	// defaultReadyzPollInterval (5s).
+	readyzPollInterval time.Duration
+
+	// readyzPollTimeout is the total amount of time to poll the Teleport readyz
+	// endpoint before returning a join-failure error. Defaults to JoinFailureTimeout.
+	readyzPollTimeout time.Duration
+
+	// installLockWaitTimeoutOverride, when set, overrides the default install lock
+	// timeout used by installAndConfigure. Used for testing.
+	installLockWaitTimeoutOverride time.Duration
+
+	// readyzChecker performs readyz checks against the Teleport debug socket.
+	// When nil, a default checker is created in NewAutoDiscoverNodeInstaller.
+	readyzChecker *readyzChecker
+
+	// diagnostics retrieves server diagnostics.
+	// If nil, it defaults to a systemd-backed service state reader.
+	diagnostics func(ctx context.Context, serviceName string) string
+
+	// journal captures recent journal output.
+	// If nil, it defaults to systemd-backed journalctl capture.
+	journal func(ctx context.Context, serviceName string) (string, error)
+
+	// newSystemdConn creates a systemd connection for diagnostics collection.
+	// Used for testing.
+	newSystemdConn teleportsystemd.NewConnFunc
 }
 
 func (c *AutoDiscoverNodeInstallerConfig) checkAndSetDefaults() error {
@@ -161,6 +212,14 @@ func (c *AutoDiscoverNodeInstallerConfig) checkAndSetDefaults() error {
 
 	c.binariesLocation.CheckAndSetDefaults()
 
+	if c.readyzPollInterval == 0 {
+		c.readyzPollInterval = defaultReadyzPollInterval
+	}
+
+	if c.readyzPollTimeout == 0 {
+		c.readyzPollTimeout = JoinFailureTimeout
+	}
+
 	if len(c.imdsProviders) == 0 {
 		c.imdsProviders = []func(ctx context.Context) (imds.Client, error){
 			func(ctx context.Context) (imds.Client, error) {
@@ -204,6 +263,37 @@ func NewAutoDiscoverNodeInstaller(cfg *AutoDiscoverNodeInstallerConfig) (*AutoDi
 		AutoDiscoverNodeInstallerConfig: cfg,
 	}
 
+	if ti.readyzChecker == nil {
+		ti.readyzChecker = &readyzChecker{
+			logger:  cfg.Logger,
+			dataDir: ti.buildTeleportDataDirPath(),
+		}
+	}
+	systemdClient := teleportsystemd.NewClient(teleportsystemd.Config{
+		Logger:         cfg.Logger,
+		JournalctlPath: ti.binariesLocation.Journalctl,
+		NewConn:        cfg.newSystemdConn,
+	})
+
+	if ti.diagnostics == nil {
+		ti.diagnostics = func(ctx context.Context, serviceName string) string {
+			state, err := systemdClient.ReadServiceState(ctx, serviceName)
+			if err != nil {
+				return defaultServiceDiagnosticsUnavailable
+			}
+			return state.String()
+		}
+	}
+
+	if ti.journal == nil {
+		ti.journal = func(ctx context.Context, serviceName string) (string, error) {
+			return systemdClient.CaptureJournal(ctx, serviceName, teleportsystemd.JournalOptions{
+				Lines:                   maxJournalLines,
+				FilterCurrentInvocation: true,
+			})
+		}
+	}
+
 	return ti, nil
 }
 
@@ -238,11 +328,22 @@ func (ani *AutoDiscoverNodeInstaller) Install(ctx context.Context) error {
 		)
 	}
 
+	// Install, configure, and health-check all run under the install lock.
+	return trace.Wrap(ani.installAndConfigure(ctx))
+}
+
+// installAndConfigure acquires the install lock and performs the install, configuration,
+// and health-check steps. The health check runs under the lock to prevent a concurrent
+// installer from restarting Teleport while we're waiting for the readyz result.
+func (ani *AutoDiscoverNodeInstaller) installAndConfigure(ctx context.Context) error {
 	// Ensure only one installer is running by locking the same file as the script installers.
 	lockFile := ani.buildAbsoluteFilePath(exclusiveInstallFileLock)
-	unlockFn, err := utils.FSTryWriteLock(lockFile)
+	unlockFn, err := utils.FSTryWriteLockTimeout(ctx, lockFile, ani.getInstallLockWaitTimeout())
 	if err != nil {
-		return trace.BadParameter("Could not get lock %s. Either remove it or wait for the other installer to finish.", lockFile)
+		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			return trace.BadParameter("could not acquire lock file %s; either remove it or wait for the other installer to finish", lockFile)
+		}
+		return trace.Wrap(err, "acquiring install lock file %s", lockFile)
 	}
 	defer func() {
 		if err := unlockFn(); err != nil {
@@ -279,9 +380,9 @@ func (ani *AutoDiscoverNodeInstaller) Install(ctx context.Context) error {
 				"configuration_file", ani.buildTeleportConfigurationPath(),
 				"systemd_service", ani.buildTeleportSystemdUnitName(),
 			)
-			// Restarting teleport is not required because the target teleport.yaml
-			// is up to date with the existing one.
-			return nil
+			// Config unchanged, so skip restart but still run a health check. This preserves visibility into
+			// lingering join/service failures on subsequent polls.
+			return trace.Wrap(ani.checkJoinHealth(ctx))
 		}
 
 		return trace.Wrap(err)
@@ -297,29 +398,149 @@ func (ani *AutoDiscoverNodeInstaller) Install(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	return nil
+	// Health check runs while the install lock is still held, so another installer flow that
+	// uses this lock can't restart Teleport while we're waiting for the readyz result.
+	return trace.Wrap(ani.checkJoinHealth(ctx))
 }
 
-// enableAndRestartTeleportService will enable and (re)start the teleport.service.
-// This function must be idempotent because we can call it in either one of the following scenarios:
-// - teleport was just installed and teleport.service is inactive
-// - teleport was already installed but the service is failing
-func (ani *AutoDiscoverNodeInstaller) enableAndRestartTeleportService(ctx context.Context) error {
-	serviceName := ani.buildTeleportSystemdUnitName()
-
-	systemctlEnableNowCMD := exec.CommandContext(ctx, ani.binariesLocation.Systemctl, "enable", serviceName)
-	systemctlEnableNowCMDOutput, err := systemctlEnableNowCMD.CombinedOutput()
-	if err != nil {
-		return trace.Wrap(err, string(systemctlEnableNowCMDOutput))
+func (a *AutoDiscoverNodeInstaller) getInstallLockWaitTimeout() time.Duration {
+	if a.installLockWaitTimeoutOverride > 0 {
+		return a.installLockWaitTimeoutOverride
 	}
 
-	systemctlRestartCMD := exec.CommandContext(ctx, ani.binariesLocation.Systemctl, "restart", serviceName)
-	systemctlRestartCMDOutput, err := systemctlRestartCMD.CombinedOutput()
+	return a.readyzPollTimeout + defaultInstallLockGracePeriod
+}
+
+// checkJoinHealth polls Teleport's readyz endpoint until the node becomes ready,
+// or until the readyz poll timeout elapses. On timeout, it returns an error enriched
+// with systemd service diagnostics and recent journal logs.
+func (a *AutoDiscoverNodeInstaller) checkJoinHealth(ctx context.Context) error {
+	serviceName := a.buildTeleportSystemdUnitName()
+	pollRetry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
+		Driver: retryutils.NewConstantDriver(a.readyzPollInterval),
+		Max:    a.readyzPollInterval,
+	})
 	if err != nil {
-		return trace.Wrap(err, string(systemctlRestartCMDOutput))
+		return trace.Wrap(err)
+	}
+	pollCtx, cancelPoll := context.WithTimeout(ctx, a.readyzPollTimeout)
+	defer cancelPoll()
+
+	// Run the first check immediately. Unexpected (non-transient) errors from check
+	// are saved but do not abort the loop; they are surfaced in the timeout diagnostics.
+	var lastUnexpectedErr error
+	ready, err := a.readyzChecker.check(pollCtx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return trace.Wrap(ctx.Err())
+		}
+		if pollCtx.Err() == nil {
+			lastUnexpectedErr = err
+		}
+	}
+	if ready {
+		return nil
 	}
 
-	return nil
+pollLoop:
+	for {
+		select {
+		case <-pollRetry.After():
+			pollRetry.Inc()
+			ready, err = a.readyzChecker.check(pollCtx)
+			if err != nil {
+				if ctx.Err() != nil {
+					return trace.Wrap(ctx.Err())
+				}
+				if pollCtx.Err() == nil {
+					lastUnexpectedErr = err
+				}
+				continue
+			}
+			if ready {
+				return nil
+			}
+		case <-pollCtx.Done():
+			if ctx.Err() != nil {
+				return trace.Wrap(ctx.Err())
+			}
+			break pollLoop
+		}
+	}
+
+	joinErr := &JoinFailureError{
+		Message: fmt.Sprintf(
+			"node did not become ready (join cluster) within %s",
+			a.readyzPollTimeout),
+	}
+	if lastUnexpectedErr != nil {
+		joinErr.LastError = lastUnexpectedErr.Error()
+	}
+
+	diagCtx, diagCancel := context.WithTimeout(ctx, joinFailureDiagnosticsTimeout)
+	defer diagCancel()
+
+	type journalResult struct {
+		output string
+		err    error
+	}
+
+	var (
+		serviceDiagnostics = defaultServiceDiagnosticsUnavailable
+		journalOutput      string
+		journalErr         error
+	)
+	serviceDiagnosticsC := make(chan string, 1)
+	journalResultC := make(chan journalResult, 1)
+	go func() {
+		serviceDiagnosticsC <- a.diagnostics(diagCtx, serviceName)
+	}()
+	go func() {
+		output, err := a.journal(diagCtx, serviceName)
+		journalResultC <- journalResult{output: output, err: err}
+	}()
+	// Both goroutines receive diagCtx (joinFailureDiagnosticsTimeout = 5s), but we stop
+	// waiting once the context is done so stuck implementations can't block join failure reporting.
+	servicePending := true
+	journalPending := true
+	for servicePending || journalPending {
+		select {
+		case serviceDiagnostics = <-serviceDiagnosticsC:
+			servicePending = false
+		case result := <-journalResultC:
+			journalOutput = result.output
+			journalErr = result.err
+			journalPending = false
+		case <-diagCtx.Done():
+			if journalPending && journalErr == nil {
+				journalErr = diagCtx.Err()
+			}
+			servicePending = false
+			journalPending = false
+		}
+	}
+
+	joinErr.ServiceDiagnostics = serviceDiagnostics
+
+	if journalErr != nil {
+		a.Logger.WarnContext(ctx,
+			"Failed to capture journal for join-failure diagnostics",
+			"service", serviceName,
+			"error", journalErr,
+		)
+		switch {
+		case errors.Is(journalErr, context.DeadlineExceeded):
+			joinErr.JournalOutput = fmt.Sprintf("(journal output unavailable: diagnostics timed out after %s)", joinFailureDiagnosticsTimeout)
+		case errors.Is(journalErr, context.Canceled):
+			joinErr.JournalOutput = "(journal output unavailable: diagnostics were canceled)"
+		default:
+			joinErr.JournalOutput = fmt.Sprintf("(journal capture failed: %v)", journalErr)
+		}
+	} else if journalOutput != "" {
+		joinErr.JournalOutput = journalOutput
+	}
+
+	return trace.Wrap(joinErr)
 }
 
 func (ani *AutoDiscoverNodeInstaller) configureTeleportNode(ctx context.Context, imdsClient imds.Client) error {
@@ -363,7 +584,11 @@ func (ani *AutoDiscoverNodeInstaller) configureTeleportNode(ctx context.Context,
 			fmt.Sprintf(`--azure-client-id=%s`, shsprintf.EscapeDefaultContext(ani.AzureClientID)))
 	}
 
-	ani.Logger.InfoContext(ctx, "Generating teleport configuration", "teleport", ani.binariesLocation.Teleport, "args", teleportNodeConfigureArgs)
+	ani.Logger.InfoContext(ctx,
+		"Generating teleport configuration",
+		"teleport", ani.binariesLocation.Teleport,
+		"args", teleportNodeConfigureArgs,
+	)
 	teleportNodeConfigureCmd := exec.CommandContext(ctx, ani.binariesLocation.Teleport, teleportNodeConfigureArgs...)
 	teleportNodeConfigureCmdOutput, err := teleportNodeConfigureCmd.CombinedOutput()
 	if err != nil {
@@ -477,10 +702,10 @@ func (ani *AutoDiscoverNodeInstaller) installTeleportFromRepo(ctx context.Contex
 	packagesToInstall = append(packagesToInstall, packagemanager.PackageVersion{Name: ani.TeleportPackage, Version: targetVersion})
 
 	if err := packageManager.AddTeleportRepository(ctx, linuxInfo, ani.RepositoryChannel); err != nil {
-		return trace.BadParameter("failed to add teleport repository to system: %v", err)
+		return trace.Wrap(err, "failed to add teleport repository to system")
 	}
 	if err := packageManager.InstallPackages(ctx, packagesToInstall); err != nil {
-		return trace.BadParameter("failed to install teleport: %v", err)
+		return trace.Wrap(err, "failed to install teleport")
 	}
 
 	return nil
@@ -631,10 +856,10 @@ func (ani *AutoDiscoverNodeInstaller) buildTeleportDataDirPath() string {
 
 func (ani *AutoDiscoverNodeInstaller) buildTeleportSystemdUnitName() string {
 	if ani.InstallationManagedByTeleportUpdateWithSuffix != "" {
-		return "teleport_" + ani.InstallationManagedByTeleportUpdateWithSuffix
+		return "teleport_" + ani.InstallationManagedByTeleportUpdateWithSuffix + ".service"
 	}
 
-	return "teleport"
+	return "teleport.service"
 }
 
 // linuxDistribution reads the current file system to detect the Linux Distro and Version of the current system.

--- a/lib/srv/server/installer/autodiscover_test.go
+++ b/lib/srv/server/installer/autodiscover_test.go
@@ -22,26 +22,37 @@ import (
 	"context"
 	"io/fs"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/buildkite/bintest/v3"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/lib/client/debug"
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/cloud/imds/azure"
 	"github.com/gravitational/teleport/lib/cloud/imds/gcp"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/packagemanager"
 )
 
+// readyzAlwaysReady is a readyzCheck override used by install-focused tests to bypass
+// join-health checks (including macOS Unix socket path-length issues from t.TempDir()).
+func readyzAlwaysReady(_ context.Context) (debug.Readiness, error) {
+	return debug.Readiness{Ready: true, Status: "ok"}, nil
+}
+
 func buildMockBins(t *testing.T) (map[string]*bintest.Mock, packagemanager.BinariesLocation, []func() error) {
-	mockedBins := []string{"systemctl",
+	mockedBins := []string{"systemctl", "journalctl",
 		"apt-get", "apt-key",
 		"rpm",
 		"yum", "yum-config-manager",
@@ -61,6 +72,7 @@ func buildMockBins(t *testing.T) (map[string]*bintest.Mock, packagemanager.Binar
 
 	return mapMockBins, packagemanager.BinariesLocation{
 		Systemctl:        mapMockBins["systemctl"].Path,
+		Journalctl:       mapMockBins["journalctl"].Path,
 		AptGet:           mapMockBins["apt-get"].Path,
 		AptKey:           mapMockBins["apt-key"].Path,
 		Rpm:              mapMockBins["rpm"].Path,
@@ -127,9 +139,12 @@ func TestAutoDiscoverNode_CheckAndSetDefaults(t *testing.T) {
 				autoUpgradesChannelURL: "https://proxy.example.com/v1/webapi/automaticupgrades/channel/default",
 				fsRootPrefix:           "/",
 				imdsProviders:          mockIMDSProviders,
+				readyzPollInterval:     defaultReadyzPollInterval,
+				readyzPollTimeout:      JoinFailureTimeout,
 				binariesLocation: packagemanager.BinariesLocation{
 					Teleport:         "/opt/teleport/example-suffix/bin/teleport",
 					Systemctl:        "systemctl",
+					Journalctl:       "journalctl",
 					AptGet:           "apt-get",
 					AptKey:           "apt-key",
 					Rpm:              "rpm",
@@ -236,6 +251,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, "/opt/teleport/example-suffix/bin/teleport", ani.binariesLocation.Teleport)
+			require.Equal(t, "teleport_example-suffix.service", ani.buildTeleportSystemdUnitName())
 		})
 	})
 
@@ -260,6 +276,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 						imdsProviders:        mockIMDSProviders,
 						binariesLocation:     binariesLocation,
 						aptPublicKeyEndpoint: mockRepoKeys.URL,
+						readyzPollInterval:   time.Millisecond,
+						readyzChecker:        &readyzChecker{logger: slog.Default(), checkOverride: readyzAlwaysReady},
 					}
 
 					teleportInstaller, err := NewAutoDiscoverNodeInstaller(installerConfig)
@@ -314,8 +332,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 						c.Exit(0)
 					})
 
-					mockBins["systemctl"].Expect("enable", "teleport")
-					mockBins["systemctl"].Expect("restart", "teleport")
+					mockBins["systemctl"].Expect("enable", "teleport.service")
+					mockBins["systemctl"].Expect("restart", "teleport.service")
 
 					require.NoError(t, teleportInstaller.Install(ctx))
 
@@ -360,6 +378,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			binariesLocation:       binariesLocation,
 			aptPublicKeyEndpoint:   mockRepoKeys.URL,
 			autoUpgradesChannelURL: proxyServer.URL,
+			readyzPollInterval:     time.Millisecond,
+			readyzChecker:          &readyzChecker{logger: slog.Default(), checkOverride: readyzAlwaysReady},
 		}
 
 		teleportInstaller, err := NewAutoDiscoverNodeInstaller(installerConfig)
@@ -388,8 +408,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			c.Exit(0)
 		})
 
-		mockBins["systemctl"].Expect("enable", "teleport_example-suffix")
-		mockBins["systemctl"].Expect("restart", "teleport_example-suffix")
+		mockBins["systemctl"].Expect("enable", "teleport_example-suffix.service")
+		mockBins["systemctl"].Expect("restart", "teleport_example-suffix.service")
 
 		require.NoError(t, teleportInstaller.Install(ctx))
 
@@ -430,6 +450,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			binariesLocation:       binariesLocation,
 			aptPublicKeyEndpoint:   mockRepoKeys.URL,
 			autoUpgradesChannelURL: proxyServer.URL,
+			readyzPollInterval:     time.Millisecond,
+			readyzChecker:          &readyzChecker{logger: slog.Default(), checkOverride: readyzAlwaysReady},
 		}
 
 		teleportInstaller, err := NewAutoDiscoverNodeInstaller(installerConfig)
@@ -464,8 +486,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			c.Exit(0)
 		})
 
-		mockBins["systemctl"].Expect("enable", "teleport")
-		mockBins["systemctl"].Expect("restart", "teleport")
+		mockBins["systemctl"].Expect("enable", "teleport.service")
+		mockBins["systemctl"].Expect("restart", "teleport.service")
 
 		require.NoError(t, teleportInstaller.Install(ctx))
 
@@ -515,6 +537,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			imdsProviders:        mockIMDSProviders,
 			binariesLocation:     binariesLocation,
 			aptPublicKeyEndpoint: mockRepoKeys.URL,
+			readyzPollInterval:   time.Millisecond,
+			readyzChecker:        &readyzChecker{logger: slog.Default(), checkOverride: readyzAlwaysReady},
 		}
 
 		teleportInstaller, err := NewAutoDiscoverNodeInstaller(installerConfig)
@@ -545,8 +569,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			c.Exit(0)
 		})
 
-		mockBins["systemctl"].Expect("enable", "teleport")
-		mockBins["systemctl"].Expect("restart", "teleport")
+		mockBins["systemctl"].Expect("enable", "teleport.service")
+		mockBins["systemctl"].Expect("restart", "teleport.service")
 
 		require.NoError(t, teleportInstaller.Install(ctx))
 
@@ -586,6 +610,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			},
 			binariesLocation:     binariesLocation,
 			aptPublicKeyEndpoint: mockRepoKeys.URL,
+			readyzPollInterval:   time.Millisecond,
+			readyzChecker:        &readyzChecker{logger: slog.Default(), checkOverride: readyzAlwaysReady},
 		}
 
 		teleportInstaller, err := NewAutoDiscoverNodeInstaller(installerConfig)
@@ -620,6 +646,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			imdsProviders:        mockIMDSProviders,
 			binariesLocation:     binariesLocation,
 			aptPublicKeyEndpoint: mockRepoKeys.URL,
+			readyzPollInterval:   time.Millisecond,
+			readyzChecker:        &readyzChecker{logger: slog.Default(), checkOverride: readyzAlwaysReady},
 		}
 
 		teleportInstaller, err := NewAutoDiscoverNodeInstaller(installerConfig)
@@ -651,8 +679,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			c.Exit(0)
 		})
 
-		mockBins["systemctl"].Expect("enable", "teleport")
-		mockBins["systemctl"].Expect("restart", "teleport")
+		mockBins["systemctl"].Expect("enable", "teleport.service")
+		mockBins["systemctl"].Expect("restart", "teleport.service")
 
 		require.NoError(t, teleportInstaller.Install(ctx))
 
@@ -687,6 +715,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			imdsProviders:        mockIMDSProviders,
 			binariesLocation:     binariesLocation,
 			aptPublicKeyEndpoint: mockRepoKeys.URL,
+			readyzPollInterval:   time.Millisecond,
+			readyzChecker:        &readyzChecker{logger: slog.Default(), checkOverride: readyzAlwaysReady},
 		}
 
 		teleportInstaller, err := NewAutoDiscoverNodeInstaller(installerConfig)
@@ -750,6 +780,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			imdsProviders:        mockIMDSProviders,
 			binariesLocation:     binariesLocation,
 			aptPublicKeyEndpoint: mockRepoKeys.URL,
+			readyzPollInterval:   time.Millisecond,
+			readyzChecker:        &readyzChecker{logger: slog.Default(), checkOverride: readyzAlwaysReady},
 		}
 
 		teleportInstaller, err := NewAutoDiscoverNodeInstaller(installerConfig)
@@ -813,6 +845,8 @@ func TestAutoDiscoverNode(t *testing.T) {
 			imdsProviders:        mockIMDSProviders,
 			binariesLocation:     binariesLocation,
 			aptPublicKeyEndpoint: mockRepoKeys.URL,
+			readyzPollInterval:   time.Millisecond,
+			readyzChecker:        &readyzChecker{logger: slog.Default(), checkOverride: readyzAlwaysReady},
 		}
 
 		teleportInstaller, err := NewAutoDiscoverNodeInstaller(installerConfig)
@@ -1203,3 +1237,416 @@ ID="sles"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:suse:sles:12:sp3"`
 )
+
+func TestCheckJoinHealth(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns success immediately when ready", func(t *testing.T) {
+		t.Parallel()
+
+		inst := newTestJoinHealthInstaller(t.TempDir())
+		calls := 0
+		inst.readyzChecker.checkOverride = func(_ context.Context) (debug.Readiness, error) {
+			calls++
+			return debug.Readiness{Ready: true, Status: "ok"}, nil
+		}
+
+		require.NoError(t, inst.checkJoinHealth(t.Context()))
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("retries until ready", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			inst := newTestJoinHealthInstaller(t.TempDir())
+			inst.readyzPollInterval = 5 * time.Second
+			inst.readyzPollTimeout = 30 * time.Second
+
+			calls := 0
+			inst.readyzChecker.checkOverride = func(_ context.Context) (debug.Readiness, error) {
+				calls++
+				if calls < 3 {
+					return debug.Readiness{Ready: false, Status: "starting"}, nil
+				}
+				return debug.Readiness{Ready: true, Status: "ok"}, nil
+			}
+
+			errC := make(chan error, 1)
+			go func() {
+				errC <- inst.checkJoinHealth(t.Context())
+			}()
+
+			// Call 1 is immediate (not ready). Sleep to trigger call 2.
+			time.Sleep(inst.readyzPollInterval)
+			synctest.Wait()
+
+			// Call 2 (not ready). Sleep to trigger call 3.
+			time.Sleep(inst.readyzPollInterval)
+			synctest.Wait()
+
+			// Call 3 returns ready → function returns nil.
+			require.NoError(t, <-errC)
+			require.Equal(t, 3, calls)
+		})
+	})
+
+	t.Run("times out and includes diagnostics", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			inst := newTestJoinHealthInstaller(t.TempDir())
+			inst.readyzPollInterval = 5 * time.Second
+			inst.readyzPollTimeout = 10 * time.Second
+			inst.readyzChecker.checkOverride = func(_ context.Context) (debug.Readiness, error) {
+				return debug.Readiness{Ready: false, Status: "starting"}, nil
+			}
+			inst.diagnostics = func(_ context.Context, _ string) string {
+				return `systemd service state: ActiveState="active", SubState="running", Result="success"`
+			}
+			inst.journal = func(_ context.Context, _ string) (string, error) {
+				return "journal line", nil
+			}
+
+			errC := make(chan error, 1)
+			go func() {
+				errC <- inst.checkJoinHealth(t.Context())
+			}()
+
+			// Immediate check (not ready). Sleep to trigger second check.
+			time.Sleep(inst.readyzPollInterval)
+			synctest.Wait()
+
+			// Second check (not ready). Sleep past deadline.
+			time.Sleep(inst.readyzPollInterval)
+			synctest.Wait()
+
+			err := <-errC
+			var joinErr *JoinFailureError
+			require.ErrorAs(t, err, &joinErr)
+			require.Contains(t, joinErr.Error(), "agent failed to join the cluster")
+			require.Contains(t, joinErr.Error(), "Journal output:\njournal line")
+			require.Equal(t, "node did not become ready (join cluster) within 10s", joinErr.Message)
+			require.Equal(t, `systemd service state: ActiveState="active", SubState="running", Result="success"`, joinErr.ServiceDiagnostics)
+			require.Equal(t, "journal line", joinErr.JournalOutput)
+		})
+	})
+
+	t.Run("times out at deadline boundary", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			inst := newTestJoinHealthInstaller(t.TempDir())
+			inst.readyzPollInterval = 5 * time.Second
+			inst.readyzPollTimeout = 10 * time.Second
+			inst.readyzChecker.checkOverride = func(_ context.Context) (debug.Readiness, error) {
+				return debug.Readiness{Ready: false, Status: "starting"}, nil
+			}
+			inst.diagnostics = func(_ context.Context, _ string) string {
+				return `systemd service state: ActiveState="active", SubState="running", Result="success"`
+			}
+			inst.journal = func(_ context.Context, _ string) (string, error) {
+				return "journal line", nil
+			}
+
+			errC := make(chan error, 1)
+			go func() {
+				errC <- inst.checkJoinHealth(t.Context())
+			}()
+
+			time.Sleep(inst.readyzPollInterval)
+			synctest.Wait()
+
+			time.Sleep(inst.readyzPollInterval)
+			synctest.Wait()
+
+			err := <-errC
+			var joinErr *JoinFailureError
+			require.ErrorAs(t, err, &joinErr)
+			require.Equal(t, "node did not become ready (join cluster) within 10s", joinErr.Message)
+		})
+	})
+
+	t.Run("returns context cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		inst := newTestJoinHealthInstaller(t.TempDir())
+		inst.readyzPollInterval = 20 * time.Millisecond
+		inst.readyzPollTimeout = time.Second
+		inst.readyzChecker.checkOverride = func(_ context.Context) (debug.Readiness, error) {
+			return debug.Readiness{Ready: false, Status: "starting"}, nil
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		err := inst.checkJoinHealth(ctx)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
+		require.NotContains(t, err.Error(), "agent failed to join the cluster")
+		require.NotErrorAs(t, err, new(*JoinFailureError))
+	})
+}
+
+func TestInstallAndConfigureLockContention(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	inst := &AutoDiscoverNodeInstaller{
+		AutoDiscoverNodeInstallerConfig: &AutoDiscoverNodeInstallerConfig{
+			Logger:                         slog.Default(),
+			fsRootPrefix:                   tmpDir,
+			installLockWaitTimeoutOverride: 10 * time.Millisecond,
+		},
+	}
+
+	lockFile := inst.buildAbsoluteFilePath(exclusiveInstallFileLock)
+	require.NoError(t, os.MkdirAll(filepath.Dir(lockFile), 0o755))
+
+	unlock, err := utils.FSTryWriteLock(lockFile)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, unlock())
+	})
+
+	err = inst.installAndConfigure(t.Context())
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err))
+	require.Contains(t, err.Error(), "could not acquire lock file")
+}
+
+func TestCheckJoinHealthTimeoutIncludesJournalOutput(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inst := newTestJoinHealthInstaller(t.TempDir())
+		inst.readyzPollInterval = 5 * time.Second
+		inst.readyzPollTimeout = 10 * time.Second
+		inst.readyzChecker.checkOverride = func(_ context.Context) (debug.Readiness, error) {
+			return debug.Readiness{Ready: false, Status: "bad token"}, nil
+		}
+		inst.diagnostics = func(_ context.Context, _ string) string {
+			return `systemd service state: ActiveState="active", SubState="running", Result="success"`
+		}
+		inst.journal = func(_ context.Context, _ string) (string, error) {
+			return "Can not join the cluster, the token is expired or not found. Regenerate the token and try again.", nil
+		}
+
+		errC := make(chan error, 1)
+		go func() {
+			errC <- inst.checkJoinHealth(t.Context())
+		}()
+
+		time.Sleep(inst.readyzPollInterval)
+		synctest.Wait()
+
+		time.Sleep(inst.readyzPollInterval)
+		synctest.Wait()
+
+		err := <-errC
+		var joinErr *JoinFailureError
+		require.ErrorAs(t, err, &joinErr)
+		require.Equal(t, "node did not become ready (join cluster) within 10s", joinErr.Message)
+		require.Equal(t, "Can not join the cluster, the token is expired or not found. Regenerate the token and try again.", joinErr.JournalOutput)
+	})
+}
+
+func TestCheckJoinHealthHandlesMissingSystemctlDiagnostics(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inst := newTestJoinHealthInstaller(t.TempDir())
+		inst.readyzPollInterval = 5 * time.Second
+		inst.readyzPollTimeout = 10 * time.Second
+		inst.readyzChecker.checkOverride = func(_ context.Context) (debug.Readiness, error) {
+			return debug.Readiness{Ready: false, Status: "starting"}, nil
+		}
+		inst.diagnostics = func(_ context.Context, _ string) string {
+			return defaultServiceDiagnosticsUnavailable
+		}
+		inst.journal = func(_ context.Context, _ string) (string, error) {
+			return "journal output", nil
+		}
+
+		errC := make(chan error, 1)
+		go func() {
+			errC <- inst.checkJoinHealth(t.Context())
+		}()
+
+		time.Sleep(inst.readyzPollInterval)
+		synctest.Wait()
+
+		time.Sleep(inst.readyzPollInterval)
+		synctest.Wait()
+
+		err := <-errC
+		var joinErr *JoinFailureError
+		require.ErrorAs(t, err, &joinErr)
+		require.Equal(t, defaultServiceDiagnosticsUnavailable, joinErr.ServiceDiagnostics)
+	})
+}
+
+func TestCheckJoinHealthDiagnosticsTimeoutDoesNotMaskJoinFailure(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inst := newTestJoinHealthInstaller(t.TempDir())
+		inst.readyzPollInterval = 5 * time.Second
+		inst.readyzPollTimeout = 10 * time.Second
+		inst.readyzChecker.checkOverride = func(_ context.Context) (debug.Readiness, error) {
+			return debug.Readiness{Ready: false, Status: "starting"}, nil
+		}
+		inst.diagnostics = func(ctx context.Context, _ string) string {
+			<-ctx.Done()
+			return defaultServiceDiagnosticsUnavailable
+		}
+		inst.journal = func(ctx context.Context, _ string) (string, error) {
+			<-ctx.Done()
+			return "", ctx.Err()
+		}
+
+		errC := make(chan error, 1)
+		go func() {
+			errC <- inst.checkJoinHealth(t.Context())
+		}()
+
+		time.Sleep(inst.readyzPollInterval)
+		synctest.Wait()
+
+		time.Sleep(inst.readyzPollInterval)
+		synctest.Wait()
+
+		time.Sleep(joinFailureDiagnosticsTimeout)
+		synctest.Wait()
+
+		err := <-errC
+		var joinErr *JoinFailureError
+		require.ErrorAs(t, err, &joinErr)
+		require.Equal(t, "node did not become ready (join cluster) within 10s", joinErr.Message)
+		require.Equal(t, defaultServiceDiagnosticsUnavailable, joinErr.ServiceDiagnostics)
+		require.Equal(t, "(journal output unavailable: diagnostics timed out after 5s)", joinErr.JournalOutput)
+	})
+}
+
+func TestCheckJoinHealthPollTimeoutDoesNotPopulateLastError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inst := newTestJoinHealthInstaller(t.TempDir())
+		inst.readyzPollInterval = 5 * time.Second
+		inst.readyzPollTimeout = 10 * time.Second
+		inst.readyzChecker.checkOverride = func(ctx context.Context) (debug.Readiness, error) {
+			<-ctx.Done()
+			return debug.Readiness{}, ctx.Err()
+		}
+		inst.diagnostics = func(_ context.Context, _ string) string {
+			return defaultServiceDiagnosticsUnavailable
+		}
+		inst.journal = func(_ context.Context, _ string) (string, error) {
+			return "", nil
+		}
+
+		errC := make(chan error, 1)
+		go func() {
+			errC <- inst.checkJoinHealth(t.Context())
+		}()
+
+		time.Sleep(inst.readyzPollTimeout)
+		synctest.Wait()
+
+		err := <-errC
+		var joinErr *JoinFailureError
+		require.ErrorAs(t, err, &joinErr)
+		require.Equal(t, "node did not become ready (join cluster) within 10s", joinErr.Message)
+		require.Empty(t, joinErr.LastError)
+	})
+}
+
+func TestCheckJoinHealthRetriesSocketUnavailableThenReady(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inst := newTestJoinHealthInstaller(t.TempDir())
+		inst.readyzPollInterval = 5 * time.Second
+		inst.readyzPollTimeout = 30 * time.Second
+
+		checkCalls := 0
+		inst.readyzChecker.checkOverride = func(_ context.Context) (debug.Readiness, error) {
+			checkCalls++
+			if checkCalls == 1 {
+				return debug.Readiness{}, &net.OpError{Op: "dial", Net: "unix", Err: os.ErrNotExist}
+			}
+			return debug.Readiness{Ready: true, Status: "ok"}, nil
+		}
+
+		errC := make(chan error, 1)
+		go func() {
+			errC <- inst.checkJoinHealth(t.Context())
+		}()
+
+		// Call 1 is immediate (connection error, retries). Sleep to trigger call 2.
+		time.Sleep(inst.readyzPollInterval)
+		synctest.Wait()
+
+		// Call 2 returns ready.
+		require.NoError(t, <-errC)
+		require.Equal(t, 2, checkCalls)
+	})
+}
+
+func TestCheckJoinHealthParentCancellationDoesNotBlockOnStuckDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	inst := newTestJoinHealthInstaller(t.TempDir())
+	inst.readyzPollInterval = 10 * time.Millisecond
+	inst.readyzPollTimeout = 20 * time.Millisecond
+	inst.readyzChecker.checkOverride = func(_ context.Context) (debug.Readiness, error) {
+		return debug.Readiness{Ready: false, Status: "starting"}, nil
+	}
+
+	diagnosticsStarted := make(chan struct{})
+	journalStarted := make(chan struct{})
+	block := make(chan struct{})
+	defer close(block)
+
+	inst.diagnostics = func(context.Context, string) string {
+		close(diagnosticsStarted)
+		<-block
+		return "unexpected"
+	}
+	inst.journal = func(context.Context, string) (string, error) {
+		close(journalStarted)
+		<-block
+		return "unexpected", nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errC := make(chan error, 1)
+	go func() {
+		errC <- inst.checkJoinHealth(ctx)
+	}()
+
+	select {
+	case <-diagnosticsStarted:
+	case <-time.After(time.Second):
+		t.Fatal("diagnostics did not start")
+	}
+
+	select {
+	case <-journalStarted:
+	case <-time.After(time.Second):
+		t.Fatal("journal capture did not start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errC:
+		var joinErr *JoinFailureError
+		require.ErrorAs(t, err, &joinErr)
+		require.Equal(t, defaultServiceDiagnosticsUnavailable, joinErr.ServiceDiagnostics)
+		require.Equal(t, "(journal output unavailable: diagnostics were canceled)", joinErr.JournalOutput)
+	case <-time.After(time.Second):
+		t.Fatal("checkJoinHealth did not return after cancellation")
+	}
+}
+
+// newTestJoinHealthInstaller returns an AutoDiscoverNodeInstaller configured
+// for join-health tests with fast polling defaults.
+func newTestJoinHealthInstaller(tmpDir string) *AutoDiscoverNodeInstaller {
+	return &AutoDiscoverNodeInstaller{
+		AutoDiscoverNodeInstallerConfig: &AutoDiscoverNodeInstallerConfig{
+			Logger:             slog.Default(),
+			readyzPollInterval: time.Millisecond,
+			readyzPollTimeout:  100 * time.Millisecond,
+			fsRootPrefix:       tmpDir,
+			readyzChecker:      &readyzChecker{logger: slog.Default(), dataDir: tmpDir},
+		},
+	}
+}

--- a/lib/srv/server/installer/diagnostics.go
+++ b/lib/srv/server/installer/diagnostics.go
@@ -1,0 +1,126 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package installer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// JoinFailureError is returned when the Teleport agent is installed but fails to join
+// the cluster. It carries structured diagnostics so callers can extract individual fields via [errors.As].
+type JoinFailureError struct {
+	// Message describes what went wrong at a high level.
+	Message string
+	// ServiceDiagnostics contains the systemd unit snapshot (ActiveState, SubState, Result).
+	ServiceDiagnostics string
+	// JournalOutput contains recent journalctl lines for the Teleport service,
+	// or an explanatory note when logs could not be collected.
+	JournalOutput string
+	// LastError is the last unexpected error from the readyz endpoint, if any.
+	// It surfaces errors that would otherwise be lost when the poll loop times out.
+	LastError string
+}
+
+// Error returns the formatted join-failure diagnostics.
+func (e *JoinFailureError) Error() string {
+	parts := []string{e.Message}
+	if e.ServiceDiagnostics != "" {
+		parts = append(parts, e.ServiceDiagnostics)
+	}
+	if e.LastError != "" {
+		parts = append(parts, "last readyz error: "+e.LastError)
+	}
+	if e.JournalOutput != "" {
+		parts = append(parts, "\nJournal output:\n"+e.JournalOutput)
+	}
+	return strings.Join(parts, "; ") + ": agent failed to join the cluster"
+}
+
+const (
+	// maxJournalLines is the number of recent journalctl lines to capture.
+	maxJournalLines = 100
+
+	// defaultServiceDiagnosticsUnavailable is appended when systemd state cannot
+	// be retrieved while preparing a join-failure error.
+	defaultServiceDiagnosticsUnavailable = "systemd service state: unavailable"
+)
+
+// enableAndRestartTeleportService will enable and (re)start the configured Teleport service.
+// This function must be idempotent because we can call it in either one of the following scenarios:
+// - teleport was just installed and teleport.service is inactive
+// - teleport was already installed but the service is failing
+func (ani *AutoDiscoverNodeInstaller) enableAndRestartTeleportService(ctx context.Context) error {
+	serviceName := ani.buildTeleportSystemdUnitName()
+
+	if err := ani.runSystemctlCommand(ctx, "enable", serviceName); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := ani.runSystemctlCommand(ctx, "restart", serviceName); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func (a *AutoDiscoverNodeInstaller) runSystemctlCommand(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, a.binariesLocation.Systemctl, args...)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	err := cmd.Run()
+	if err != nil {
+		// Prefer the context error when present so callers can distinguish user- or
+		// timeout-driven cancellation from systemctl execution failures.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return trace.Wrap(ctxErr)
+		}
+
+		stdout := strings.TrimSpace(stdoutBuf.String())
+		stderr := strings.TrimSpace(stderrBuf.String())
+
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// systemctl uses non-zero exits for command failures after launch, so include
+			// the exit code and captured streams to preserve the observed service state.
+			return trace.Wrap(err,
+				"%q exited with code %d (stdout: %s, stderr: %s)",
+				cmd,
+				exitErr.ExitCode(),
+				stdout,
+				stderr,
+			)
+		}
+
+		return trace.Wrap(err,
+			"failed to execute %q (stdout: %s, stderr: %s)",
+			cmd,
+			stdout,
+			stderr,
+		)
+	}
+
+	return nil
+}

--- a/lib/srv/server/installer/diagnostics_test.go
+++ b/lib/srv/server/installer/diagnostics_test.go
@@ -1,0 +1,83 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package installer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJoinFailureErrorString(t *testing.T) {
+	t.Parallel()
+	joinFailureMessage := fmt.Sprintf("node did not become ready (join cluster) within %s", JoinFailureTimeout)
+
+	tests := []struct {
+		name     string
+		err      *JoinFailureError
+		contains []string
+	}{
+		{
+			name: "all fields populated",
+			err: &JoinFailureError{
+				Message:            "node did not become ready (join cluster) within 10s",
+				ServiceDiagnostics: `systemd service state: ActiveState="failed", SubState="exited", Result="exit-code"`,
+				JournalOutput:      "error: token expired",
+			},
+			contains: []string{
+				"node did not become ready (join cluster) within 10s",
+				`ActiveState="failed"`,
+				"Journal output:\nerror: token expired",
+				"agent failed to join the cluster",
+			},
+		},
+		{
+			name: "no journal output",
+			err: &JoinFailureError{
+				Message:            joinFailureMessage,
+				ServiceDiagnostics: "systemd service state: unavailable",
+			},
+			contains: []string{
+				joinFailureMessage,
+				"systemd service state: unavailable",
+				"agent failed to join the cluster",
+			},
+		},
+		{
+			name: "message only",
+			err: &JoinFailureError{
+				Message: "node did not become ready (join cluster) within 10s",
+			},
+			contains: []string{
+				"node did not become ready (join cluster) within 10s",
+				"agent failed to join the cluster",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			for _, want := range tt.contains {
+				require.Contains(t, got, want)
+			}
+		})
+	}
+}

--- a/lib/srv/server/installer/readyz_check.go
+++ b/lib/srv/server/installer/readyz_check.go
@@ -1,0 +1,105 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package installer
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/client/debug"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	// defaultReadyzCheckTimeout is the timeout for a single readyz query.
+	defaultReadyzCheckTimeout = 5 * time.Second
+)
+
+// readyzChecker queries the Teleport debug socket's readyz endpoint and classifies errors
+// for poll-based callers.
+type readyzChecker struct {
+	// logger is used for diagnostic logging during readyz checks.
+	logger *slog.Logger
+
+	// dataDir is the Teleport data directory that contains the debug socket.
+	dataDir string
+
+	// timeout is the per-attempt timeout for a single readyz query.
+	// Defaults to defaultReadyzCheckTimeout (5s) when zero.
+	timeout time.Duration
+
+	// checkOverride, when set, replaces the default debug-socket readyz
+	// call. Used for testing.
+	checkOverride func(ctx context.Context) (debug.Readiness, error)
+}
+
+// check queries readyz once with a per-attempt timeout. Returns (true, nil) when
+// the agent is ready, (false, nil) when not ready or on transient errors
+// the caller should retry, and (false, err) only for context cancellation.
+func (r *readyzChecker) check(ctx context.Context) (ready bool, err error) {
+	timeout := r.timeout
+	if timeout == 0 {
+		timeout = defaultReadyzCheckTimeout
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var readiness debug.Readiness
+	if r.checkOverride != nil {
+		readiness, err = r.checkOverride(checkCtx)
+	} else {
+		clt := debug.NewClient(r.dataDir)
+		readiness, err = clt.GetReadiness(checkCtx)
+	}
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, trace.Wrap(ctxErr)
+		}
+
+		// Socket genuinely absent (connection error) or endpoint doesn't exist, so keep polling.
+		if utils.IsConnectionError(err) || trace.IsNotFound(err) {
+			r.logger.DebugContext(checkCtx, "Debug socket unavailable", "error", trace.UserMessage(err))
+			return false, nil
+		}
+
+		// Per-attempt timeout is expected when Teleport is overloaded; keep polling.
+		if errors.Is(err, context.DeadlineExceeded) {
+			r.logger.DebugContext(checkCtx, "Readyz check timed out", "timeout", timeout)
+			return false, nil
+		}
+
+		// Return the unexpected error so the caller can surface it in
+		// timeout diagnostics. The caller keeps polling; it does not abort.
+		r.logger.WarnContext(checkCtx, "Readyz check returned unexpected error", "error", trace.UserMessage(err))
+		return false, err
+	}
+
+	if !readiness.Ready {
+		r.logger.InfoContext(checkCtx, "Teleport agent is not ready yet", "status", readiness.Status)
+		return false, nil
+	}
+
+	r.logger.InfoContext(checkCtx, "Teleport agent is ready and has joined the cluster")
+	return true, nil
+}

--- a/lib/srv/server/installer/readyz_check_test.go
+++ b/lib/srv/server/installer/readyz_check_test.go
@@ -1,0 +1,103 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package installer
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/client/debug"
+)
+
+func TestCheckReturnsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	checker := &readyzChecker{
+		logger:  slog.Default(),
+		dataDir: t.TempDir(),
+		checkOverride: func(ctx context.Context) (debug.Readiness, error) {
+			<-ctx.Done()
+			return debug.Readiness{}, &net.OpError{Op: "dial", Net: "unix", Err: ctx.Err()}
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	ready, err := checker.check(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, ready)
+}
+
+func TestCheckTimeoutReturnsNotReady(t *testing.T) {
+	t.Parallel()
+
+	checker := &readyzChecker{
+		logger:  slog.Default(),
+		dataDir: t.TempDir(),
+		timeout: 10 * time.Millisecond,
+		checkOverride: func(ctx context.Context) (debug.Readiness, error) {
+			<-ctx.Done()
+			return debug.Readiness{}, ctx.Err()
+		},
+	}
+
+	ready, err := checker.check(t.Context())
+	require.NoError(t, err)
+	require.False(t, ready)
+}
+
+func TestCheckRetriesOnConnectionError(t *testing.T) {
+	t.Parallel()
+
+	checker := &readyzChecker{
+		logger:  slog.Default(),
+		dataDir: t.TempDir(),
+		checkOverride: func(_ context.Context) (debug.Readiness, error) {
+			return debug.Readiness{}, &net.OpError{Op: "dial", Net: "unix", Err: os.ErrNotExist}
+		},
+	}
+
+	ready, err := checker.check(t.Context())
+	require.NoError(t, err)
+	require.False(t, ready)
+}
+
+func TestCheckReturnsReady(t *testing.T) {
+	t.Parallel()
+
+	checker := &readyzChecker{
+		logger:  slog.Default(),
+		dataDir: t.TempDir(),
+		checkOverride: func(_ context.Context) (debug.Readiness, error) {
+			return debug.Readiness{Ready: true, Status: "ok"}, nil
+		},
+	}
+
+	ready, err := checker.check(t.Context())
+	require.NoError(t, err)
+	require.True(t, ready)
+}

--- a/lib/srv/server/installstatus/exitcodes.go
+++ b/lib/srv/server/installstatus/exitcodes.go
@@ -20,6 +20,8 @@ package installstatus
 
 import (
 	"fmt"
+
+	"github.com/gravitational/teleport/api/types/usertasks"
 )
 
 // ExitCode represents a classified exit code from the auto-enrollment installer pipeline.
@@ -32,6 +34,9 @@ const (
 	CurlNotFound          ExitCode = 102
 	InsufficientDiskSpace ExitCode = 103
 	ProxyPingError        ExitCode = 104
+
+	// Post-install exit codes (Go binary, 150–199).
+	JoinFailure ExitCode = 150
 )
 
 // InstallerMinFreeDiskMB is the minimum free disk space in megabytes required for Teleport installation.
@@ -62,10 +67,24 @@ func (c ExitCode) String() string {
 	case ProxyPingError:
 		return "Failed to connect to Teleport cluster HTTPS endpoint. " +
 			"Ensure this host can access your cluster and its certificate is trusted."
+	case JoinFailure:
+		return "Teleport was installed successfully but the agent " +
+			"did not become ready within the configured timeout. " +
+			"Check standard error output for join diagnostics."
 	default:
 		return fmt.Sprintf(
 			"Installation failed with exit code %d. "+
 				"Please check stdout and stderr and try again.",
 			int(c))
+	}
+}
+
+// IssueType returns the user task issue type for the exit code. Unrecognized codes default to ec2-ssm-script-failure.
+func (c ExitCode) IssueType() string {
+	switch c {
+	case JoinFailure:
+		return usertasks.AutoDiscoverEC2IssueJoinFailure
+	default:
+		return usertasks.AutoDiscoverEC2IssueSSMScriptFailure
 	}
 }

--- a/lib/srv/server/ssm_install.go
+++ b/lib/srv/server/ssm_install.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types/usertasks"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	libevents "github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/srv/server/installer"
 	"github.com/gravitational/teleport/lib/srv/server/installstatus"
 )
 
@@ -52,6 +53,24 @@ const (
 	//nolint:misspell // ignore Cancelled and Cancelling
 	// executed waiter when the command state transitions to one of Cancelled, TimedOut, Failed or Cancelling.
 	waiterTransitionedToFailureErrorMessage = "waiter state transitioned to Failure"
+	// waitTimeoutPad is extra waiter headroom beyond the installer's join-failure timeout.
+	// The installer decides success/failure based on whether join completes in time.
+	// This pad avoids reporting a temporary "still running" SSM state as the final outcome.
+	// Tradeoff: EC2 install handling is still synchronous in discovery, so a wedged
+	// SSM invocation can delay later groups until waitTimeout elapses.
+	//
+	// TODO(carlisia): Decouple SSM result waiting from synchronous discovery
+	// iterations so a wedged invocation does not stall later EC2 groups.
+	waitTimeoutPad = 10 * time.Minute
+
+	// waitTimeout is how long we wait for AWS to report a terminal command state
+	// for the installer result.
+	waitTimeout = installer.JoinFailureTimeout + waitTimeoutPad
+
+	// maxSSMRunOutputChars limits stdout/stderr size while preserving the most recent diagnostics.
+	// 24_000 matches the documented per-field cap for SSMRun stdout/stderr in the event schema,
+	// and also leaves room for the rest of the event under the 64KB stream message limit.
+	maxSSMRunOutputChars = 24_000
 )
 
 // SSMClient is the subset of the AWS SSM API required for EC2 discovery.
@@ -439,8 +458,7 @@ func (si *SSMInstaller) checkCommand(ctx context.Context, req SSMRunRequest, com
 	err := si.getWaiter(req.SSM).Wait(ctx, &ssm.GetCommandInvocationInput{
 		CommandId:  commandID,
 		InstanceId: aws.String(instanceMetadata.InstanceID),
-		// 100 seconds to match v1 sdk waiter default.
-	}, 100*time.Second)
+	}, waitTimeout)
 	switch {
 	case err == nil:
 		// Command executed successfully.
@@ -479,27 +497,18 @@ func (si *SSMInstaller) checkCommand(ctx context.Context, req SSMRunRequest, com
 	}
 
 	for i, step := range invocationSteps {
-		stepResultEvent, err := si.getCommandStepStatusEvent(ctx, step, req, commandID, instanceMetadata)
+		outcome, err := si.getCommandStepOutcome(ctx, step, req, commandID, instanceMetadata)
 		if err != nil {
 			var invalidPluginNameErr *ssmtypes.InvalidPluginName
 			if errors.As(err, &invalidPluginNameErr) {
 				// If using a custom SSM Document and the client does not have access to ssm:ListCommandInvocations
 				// the list of invocationSteps (ie plugin name) might be wrong.
 				// If that's the case, emit an event with the overall invocation result (ignoring specific steps' stdout and stderr).
-				invocationResultEvent, err := si.getCommandStepStatusEvent(ctx, "" /*no step*/, req, commandID, instanceMetadata)
+				outcome, err = si.getCommandStepOutcome(ctx, "" /*no step*/, req, commandID, instanceMetadata)
 				if err != nil {
 					return trace.Wrap(err)
 				}
-
-				return trace.Wrap(si.ReportSSMInstallationResultFunc(ctx, &SSMInstallationResult{
-					SSMRunEvent:         invocationResultEvent,
-					IntegrationName:     req.IntegrationName,
-					DiscoveryConfigName: req.DiscoveryConfigName,
-					IssueType:           usertasks.AutoDiscoverEC2IssueSSMScriptFailure,
-					SSMDocumentName:     req.DocumentName,
-					InstallerScript:     req.InstallerScriptName(),
-					InstanceName:        instanceMetadata.InstanceName,
-				}))
+				return trace.Wrap(si.reportCommandStepOutcome(ctx, req, instanceMetadata, outcome))
 			}
 
 			return trace.Wrap(err)
@@ -507,16 +516,8 @@ func (si *SSMInstaller) checkCommand(ctx context.Context, req SSMRunRequest, com
 
 		// Emit an event for the first failed step or for the latest step.
 		lastStep := i+1 == len(invocationSteps)
-		if stepResultEvent.Metadata.Code != libevents.SSMRunSuccessCode || lastStep {
-			return trace.Wrap(si.ReportSSMInstallationResultFunc(ctx, &SSMInstallationResult{
-				SSMRunEvent:         stepResultEvent,
-				IntegrationName:     req.IntegrationName,
-				DiscoveryConfigName: req.DiscoveryConfigName,
-				IssueType:           usertasks.AutoDiscoverEC2IssueSSMScriptFailure,
-				SSMDocumentName:     req.DocumentName,
-				InstallerScript:     req.InstallerScriptName(),
-				InstanceName:        instanceMetadata.InstanceName,
-			}))
+		if outcome.SSMRunEvent.Metadata.Code != libevents.SSMRunSuccessCode || lastStep {
+			return trace.Wrap(si.reportCommandStepOutcome(ctx, req, instanceMetadata, outcome))
 		}
 	}
 
@@ -559,7 +560,40 @@ func (si *SSMInstaller) getInvocationSteps(ctx context.Context, req SSMRunReques
 	return documentSteps, nil
 }
 
-func (si *SSMInstaller) getCommandStepStatusEvent(ctx context.Context, step string, req SSMRunRequest, commandID *string, instanceMetadata instanceMetadata) (*apievents.SSMRun, error) {
+// classifyEC2SSMInvocationIssueType maps SSM command-invocation outcomes to Discover EC2 issue types.
+//
+// Classification matrix:
+//   - status=Failed + exit=150 => ec2-join-failure
+//   - status=Failed + any other exit => ec2-ssm-script-failure
+//   - any non-Failed status (TimedOut/Canceling/InProgress/...) => ec2-ssm-script-failure
+//
+// This ensures only definitive terminal failures are eligible for join-failure issue typing.
+func classifyEC2SSMInvocationIssueType(status ssmtypes.CommandInvocationStatus, exitCode int64) string {
+	if status != ssmtypes.CommandInvocationStatusFailed {
+		return usertasks.AutoDiscoverEC2IssueSSMScriptFailure
+	}
+
+	return installstatus.ExitCode(exitCode).IssueType()
+}
+
+type commandStepOutcome struct {
+	SSMRunEvent *apievents.SSMRun
+	IssueType   string
+}
+
+func (si *SSMInstaller) reportCommandStepOutcome(ctx context.Context, req SSMRunRequest, instanceMetadata instanceMetadata, outcome commandStepOutcome) error {
+	return si.ReportSSMInstallationResultFunc(ctx, &SSMInstallationResult{
+		SSMRunEvent:         outcome.SSMRunEvent,
+		IntegrationName:     req.IntegrationName,
+		DiscoveryConfigName: req.DiscoveryConfigName,
+		IssueType:           outcome.IssueType,
+		SSMDocumentName:     req.DocumentName,
+		InstallerScript:     req.InstallerScriptName(),
+		InstanceName:        instanceMetadata.InstanceName,
+	})
+}
+
+func (si *SSMInstaller) getCommandStepOutcome(ctx context.Context, step string, req SSMRunRequest, commandID *string, instanceMetadata instanceMetadata) (commandStepOutcome, error) {
 	getCommandInvocationReq := &ssm.GetCommandInvocationInput{
 		CommandId:  commandID,
 		InstanceId: aws.String(instanceMetadata.InstanceID),
@@ -569,17 +603,21 @@ func (si *SSMInstaller) getCommandStepStatusEvent(ctx context.Context, step stri
 	}
 	stepResult, err := req.SSM.GetCommandInvocation(ctx, getCommandInvocationReq)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return commandStepOutcome{}, trace.Wrap(err)
 	}
 
 	status := string(stepResult.Status)
 	exitCode := int64(stepResult.ResponseCode)
+	issueType := classifyEC2SSMInvocationIssueType(stepResult.Status, exitCode)
 
 	eventCode := libevents.SSMRunSuccessCode
 	if stepResult.Status != ssmtypes.CommandInvocationStatusSuccess {
 		eventCode = libevents.SSMRunFailCode
 		if stepResult.Status == ssmtypes.CommandInvocationStatusFailed {
 			status = installstatus.ExitCode(exitCode).String()
+			if installstatus.ExitCode(exitCode) == installstatus.JoinFailure {
+				status = fmt.Sprintf("%s (timeout: %v)", status, installer.JoinFailureTimeout)
+			}
 		}
 		if exitCode == 0 {
 			exitCode = -1
@@ -593,8 +631,10 @@ func (si *SSMInstaller) getCommandStepStatusEvent(ctx context.Context, step stri
 	invocationURL := fmt.Sprintf("https://%s.console.aws.amazon.com/systems-manager/run-command/%s/%s",
 		req.Region, aws.ToString(commandID), instanceMetadata.InstanceID,
 	)
+	standardOutput := trimToRecentTail(stepResult.StandardOutputContent, maxSSMRunOutputChars)
+	standardError := trimToRecentTail(stepResult.StandardErrorContent, maxSSMRunOutputChars)
 
-	return &apievents.SSMRun{
+	return commandStepOutcome{SSMRunEvent: &apievents.SSMRun{
 		Metadata: apievents.Metadata{
 			Type: libevents.SSMRunEvent,
 			Code: eventCode,
@@ -605,11 +645,43 @@ func (si *SSMInstaller) getCommandStepStatusEvent(ctx context.Context, step stri
 		Region:          req.Region,
 		ExitCode:        exitCode,
 		Status:          status,
-		StandardOutput:  aws.ToString(stepResult.StandardOutputContent),
-		StandardError:   aws.ToString(stepResult.StandardErrorContent),
+		StandardOutput:  standardOutput,
+		StandardError:   standardError,
 		InvocationURL:   invocationURL,
 		PlatformName:    instanceMetadata.PlatformName,
 		PlatformType:    instanceMetadata.PlatformType,
 		PlatformVersion: instanceMetadata.PlatformVersion,
-	}, nil
+	}, IssueType: issueType}, nil
+}
+
+// trimToRecentTail keeps only the trailing maxChars characters of a string.
+// This is intentionally separate from apievents.SSMRun.TrimToMaxSize: here we want to
+// preserve the most recent stdout/stderr diagnostics and keep line boundaries, not just
+// generically truncate fields to fit the event. If trimming happens and the retained chunk
+// contains a newline, it drops the leading partial line so the output starts at a full line boundary.
+func trimToRecentTail(s *string, maxChars int) string {
+	if s == nil || *s == "" || maxChars <= 0 {
+		return ""
+	}
+
+	out := *s
+	if len(out) <= maxChars {
+		return out
+	}
+
+	runes := []rune(out)
+	if len(runes) <= maxChars {
+		return out
+	}
+
+	trimStart := len(runes) - maxChars
+	trimmed := string(runes[trimStart:])
+	if runes[trimStart-1] != '\n' {
+		newLineIdx := strings.Index(trimmed, "\n")
+		if newLineIdx >= 0 && newLineIdx+1 < len(trimmed) {
+			return trimmed[newLineIdx+1:]
+		}
+	}
+
+	return trimmed
 }

--- a/lib/srv/server/ssm_install_test.go
+++ b/lib/srv/server/ssm_install_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,7 +33,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/types/usertasks"
 	libevent "github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/srv/server/installer"
+	"github.com/gravitational/teleport/lib/srv/server/installstatus"
 )
 
 type mockSSMClient struct {
@@ -42,6 +46,72 @@ type mockSSMClient struct {
 	commandInvokeOutput    map[string]*ssm.GetCommandInvocationOutput
 	describeOutput         *ssm.DescribeInstanceInformationOutput
 	listCommandInvocations *ssm.ListCommandInvocationsOutput
+}
+
+func TestTrimToRecentTail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    *string
+		maxChars int
+		want     string
+	}{
+		{
+			name:     "returns full string when below limit",
+			input:    aws.String("line-a\nline-b"),
+			maxChars: len([]rune("line-a\nline-b")) + 1,
+			want:     "line-a\nline-b",
+		},
+		{
+			name: "keeps tail and aligns to line boundary",
+			input: aws.String(strings.Join([]string{
+				"line-1",
+				"line-2",
+				"line-3",
+				"line-4",
+			}, "\n")),
+			maxChars: len("e-2\nline-3\nline-4"),
+			want:     "line-3\nline-4",
+		},
+		{
+			name:     "handles multi-byte runes",
+			input:    aws.String("🙂🙂🙂\nlast"),
+			maxChars: 6,
+			want:     "last",
+		},
+		{
+			name:     "returns empty for nil input",
+			input:    nil,
+			maxChars: 10,
+			want:     "",
+		},
+		{
+			name:     "returns empty for non-positive max chars",
+			input:    aws.String("line-a"),
+			maxChars: 0,
+			want:     "",
+		},
+		{
+			name:     "keeps raw tail when no newline is present",
+			input:    aws.String("aaaaabbbbb"),
+			maxChars: 4,
+			want:     "bbbb",
+		},
+		{
+			name:     "keeps boundary-aligned tail when cut starts after newline",
+			input:    aws.String("line-1\nline-2"),
+			maxChars: len("line-2"),
+			want:     "line-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, trimToRecentTail(tt.input, tt.maxChars))
+		})
+	}
 }
 
 const docWithoutSSHDConfigPathParam = "ssmdocument-without-sshdConfigPath-param"
@@ -110,6 +180,10 @@ func (me *mockInstallationResults) ReportInstallationResult(ctx context.Context,
 
 func TestSSMInstaller(t *testing.T) {
 	document := "ssmdocument"
+	joinFailureTimeout := installer.JoinFailureTimeout.String()
+	joinFailureMessage := fmt.Sprintf("node did not become ready (join cluster) within %s", joinFailureTimeout)
+	joinFailureStatus := fmt.Sprintf("Teleport was installed successfully but the agent did not become ready within the configured timeout. Check standard error output for join diagnostics. (timeout: %s)", joinFailureTimeout)
+	joinFailureStandardError := fmt.Sprintf("ERROR: join failure: token is expired or not found; %s", joinFailureMessage)
 
 	for _, tc := range []struct {
 		client                *mockSSMClient
@@ -399,6 +473,104 @@ func TestSSMInstaller(t *testing.T) {
 			}},
 		},
 		{
+			name: "ssm run failed in run shell script with join failure exit code",
+			req: SSMRunRequest{
+				DocumentName: document,
+				Instances: []EC2Instance{
+					{InstanceID: "instance-id-1"},
+				},
+				Params:    map[string]string{"token": "abcdefg"},
+				Region:    "eu-central-1",
+				AccountID: "account-id",
+			},
+			client: &mockSSMClient{
+				commandOutput: &ssm.SendCommandOutput{
+					Command: &ssmtypes.Command{
+						CommandId: aws.String("command-id-1"),
+						Status:    ssmtypes.CommandStatusFailed,
+					},
+				},
+				commandInvokeOutput: map[string]*ssm.GetCommandInvocationOutput{
+					"downloadContent": {
+						Status:       ssmtypes.CommandInvocationStatusSuccess,
+						ResponseCode: 0,
+					},
+					"runShellScript": {
+						Status:                ssmtypes.CommandInvocationStatusFailed,
+						ResponseCode:          150,
+						StandardErrorContent:  aws.String(joinFailureStandardError),
+						StandardOutputContent: aws.String(""),
+					},
+				},
+			},
+			expectedInstallations: []*SSMInstallationResult{{
+				SSMRunEvent: &events.SSMRun{
+					Metadata: events.Metadata{
+						Type: libevent.SSMRunEvent,
+						Code: libevent.SSMRunFailCode,
+					},
+					CommandID:      "command-id-1",
+					InstanceID:     "instance-id-1",
+					AccountID:      "account-id",
+					Region:         "eu-central-1",
+					ExitCode:       150,
+					Status:         joinFailureStatus,
+					StandardOutput: "",
+					StandardError:  joinFailureStandardError,
+					InvocationURL:  "https://eu-central-1.console.aws.amazon.com/systems-manager/run-command/command-id-1/instance-id-1",
+				},
+				IssueType:       "ec2-join-failure",
+				SSMDocumentName: "ssmdocument",
+			}},
+		},
+		{
+			name: "non-failed command invocation status with join failure exit code remains script failure",
+			req: SSMRunRequest{
+				DocumentName: document,
+				Instances: []EC2Instance{
+					{InstanceID: "instance-id-1"},
+				},
+				Region:    "eu-central-1",
+				AccountID: "account-id",
+			},
+			client: &mockSSMClient{
+				waiterTimeout: true,
+				commandOutput: &ssm.SendCommandOutput{
+					Command: &ssmtypes.Command{
+						CommandId: aws.String("command-id-1"),
+						Status:    ssmtypes.CommandStatusInProgress,
+					},
+				},
+				commandInvokeOutput: map[string]*ssm.GetCommandInvocationOutput{
+					"downloadContent": {
+						Status:                ssmtypes.CommandInvocationStatusInProgress,
+						ResponseCode:          150,
+						StandardErrorContent:  aws.String("still running"),
+						StandardOutputContent: aws.String(""),
+					},
+				},
+			},
+			expectedInstallations: []*SSMInstallationResult{{
+				SSMRunEvent: &events.SSMRun{
+					Metadata: events.Metadata{
+						Type: libevent.SSMRunEvent,
+						Code: libevent.SSMRunFailCode,
+					},
+					CommandID:      "command-id-1",
+					InstanceID:     "instance-id-1",
+					AccountID:      "account-id",
+					Region:         "eu-central-1",
+					ExitCode:       150,
+					Status:         string(ssmtypes.CommandInvocationStatusInProgress),
+					StandardOutput: "",
+					StandardError:  "still running",
+					InvocationURL:  "https://eu-central-1.console.aws.amazon.com/systems-manager/run-command/command-id-1/instance-id-1",
+				},
+				IssueType:       "ec2-ssm-script-failure",
+				SSMDocumentName: "ssmdocument",
+			}},
+		},
+		{
 			name: "detailed events if ssm:DescribeInstanceInformation is available",
 			req: SSMRunRequest{
 				Instances: []EC2Instance{
@@ -650,6 +822,42 @@ func TestSSMInstaller(t *testing.T) {
 			}
 
 			require.ElementsMatch(t, tc.expectedInstallations, installationResultsCollector.installations)
+		})
+	}
+}
+
+func TestClassifyEC2SSMInvocationIssueType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   ssmtypes.CommandInvocationStatus
+		exitCode int64
+		want     string
+	}{
+		{
+			name:     "failed with join failure exit code maps to join failure issue",
+			status:   ssmtypes.CommandInvocationStatusFailed,
+			exitCode: int64(installstatus.JoinFailure),
+			want:     usertasks.AutoDiscoverEC2IssueJoinFailure,
+		},
+		{
+			name:     "failed with other exit code maps to script failure issue",
+			status:   ssmtypes.CommandInvocationStatusFailed,
+			exitCode: 1,
+			want:     usertasks.AutoDiscoverEC2IssueSSMScriptFailure,
+		},
+		{
+			name:     "in progress with join failure exit code stays script failure issue",
+			status:   ssmtypes.CommandInvocationStatusInProgress,
+			exitCode: int64(installstatus.JoinFailure),
+			want:     usertasks.AutoDiscoverEC2IssueSSMScriptFailure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, classifyEC2SSMInvocationIssueType(tt.status, tt.exitCode))
 		})
 	}
 }

--- a/lib/systemd/doc.go
+++ b/lib/systemd/doc.go
@@ -1,0 +1,22 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package systemd provides best-effort helpers for reading systemd unit state,
+// current invocation IDs, and recent journal output without leaking installer-
+// specific policy into the shared systemd integration layer.
+package systemd

--- a/lib/systemd/systemd.go
+++ b/lib/systemd/systemd.go
@@ -1,0 +1,293 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package systemd
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+
+	systemddbus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/gravitational/trace"
+)
+
+// Conn is the subset of the systemd D-Bus API used by Teleport.
+type Conn interface {
+	GetUnitPropertyContext(context.Context, string, string) (*systemddbus.Property, error)
+	GetServicePropertyContext(context.Context, string, string) (*systemddbus.Property, error)
+	Close()
+}
+
+// NewConnFunc opens a new systemd D-Bus connection.
+type NewConnFunc func(context.Context) (Conn, error)
+
+var _ Conn = (*systemddbus.Conn)(nil)
+
+// Config configures a systemd client.
+type Config struct {
+	Logger         *slog.Logger
+	JournalctlPath string
+	NewConn        NewConnFunc
+}
+
+// JournalOptions configures journal capture.
+type JournalOptions struct {
+	Lines                   int
+	FilterCurrentInvocation bool
+}
+
+// ServiceState is a one-shot snapshot of a systemd unit state.
+type ServiceState struct {
+	ActiveState string
+	SubState    string
+	Result      string
+}
+
+// String formats the service state for diagnostics.
+func (s ServiceState) String() string {
+	return fmt.Sprintf("systemd service state: ActiveState=%q, SubState=%q, Result=%q", s.ActiveState, s.SubState, s.Result)
+}
+
+// Client retrieves systemd state and journal output.
+type Client struct {
+	log            *slog.Logger
+	journalctlPath string
+	newConn        NewConnFunc
+}
+
+// NewClient returns a new systemd client.
+func NewClient(cfg Config) *Client {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.JournalctlPath == "" {
+		cfg.JournalctlPath = "journalctl"
+	}
+	if cfg.NewConn == nil {
+		cfg.NewConn = func(ctx context.Context) (Conn, error) {
+			return systemddbus.NewWithContext(ctx)
+		}
+	}
+
+	return &Client{
+		log:            cfg.Logger,
+		journalctlPath: cfg.JournalctlPath,
+		newConn:        cfg.NewConn,
+	}
+}
+
+type propertyGetter func(context.Context, string, string) (*systemddbus.Property, error)
+
+const invocationIDBytes = 16
+
+func (c *Client) getStringProperty(ctx context.Context, getter propertyGetter, unit, propertyName string) (string, bool) {
+	prop, err := getter(ctx, unit, propertyName)
+	if err != nil {
+		c.log.DebugContext(ctx, "Could not retrieve systemd property",
+			"service", unit,
+			"property", propertyName,
+			"error", err,
+		)
+		return "", false
+	}
+	if prop == nil {
+		c.log.DebugContext(ctx, "Systemd property lookup returned no value",
+			"service", unit,
+			"property", propertyName,
+		)
+		return "", false
+	}
+
+	raw := prop.Value.Value()
+	value, ok := raw.(string)
+	if !ok {
+		c.log.DebugContext(ctx, "Ignoring non-string systemd property",
+			"service", unit,
+			"property", propertyName,
+			"value_type", fmt.Sprintf("%T", raw),
+		)
+		return "", false
+	}
+	if value == "" {
+		c.log.DebugContext(ctx, "Ignoring empty systemd property",
+			"service", unit,
+			"property", propertyName,
+		)
+		return "", false
+	}
+
+	return value, true
+}
+
+// ReadServiceState returns a best-effort systemd state snapshot for a unit.
+func (c *Client) ReadServiceState(ctx context.Context, unit string) (ServiceState, error) {
+	conn, err := c.newConn(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ServiceState{}, trace.Wrap(ctx.Err())
+		}
+
+		c.log.DebugContext(ctx, "Could not connect to systemd D-Bus while gathering service diagnostics",
+			"service", unit,
+			"error", err,
+		)
+		return ServiceState{}, trace.Wrap(err)
+	}
+	defer conn.Close()
+
+	state := ServiceState{
+		ActiveState: "unknown",
+		SubState:    "unknown",
+		Result:      "unknown",
+	}
+	if value, ok := c.getStringProperty(ctx, conn.GetUnitPropertyContext, unit, "ActiveState"); ok {
+		state.ActiveState = value
+	}
+	if value, ok := c.getStringProperty(ctx, conn.GetUnitPropertyContext, unit, "SubState"); ok {
+		state.SubState = value
+	}
+	if value, ok := c.getStringProperty(ctx, conn.GetServicePropertyContext, unit, "Result"); ok {
+		state.Result = value
+	}
+
+	return state, nil
+}
+
+// InvocationID retrieves a validated systemd InvocationID for unit.
+// It returns ("", nil) when the ID is unavailable, invalid, or cannot be retrieved.
+// It returns a non-nil error only if ctx is canceled or expires.
+func (c *Client) InvocationID(ctx context.Context, unit string) (string, error) {
+	conn, err := c.newConn(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", trace.Wrap(ctx.Err())
+		}
+
+		c.log.DebugContext(ctx, "Could not connect to systemd D-Bus while retrieving service invocation ID",
+			"service", unit,
+			"error", err,
+		)
+		return "", nil
+	}
+	defer conn.Close()
+
+	prop, err := conn.GetUnitPropertyContext(ctx, unit, "InvocationID")
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", trace.Wrap(ctx.Err())
+		}
+
+		c.log.DebugContext(ctx, "Could not retrieve service invocation ID",
+			"service", unit,
+			"error", err,
+		)
+		return "", nil
+	}
+	if prop == nil {
+		c.log.DebugContext(ctx, "Service invocation ID lookup returned no value",
+			"service", unit,
+		)
+		return "", nil
+	}
+
+	value, ok := prop.Value.Value().([]byte)
+	if !ok {
+		c.log.DebugContext(ctx, "Ignoring invalid service invocation ID type",
+			"service", unit,
+			"value_type", fmt.Sprintf("%T", prop.Value.Value()),
+		)
+		return "", nil
+	}
+	if len(value) != invocationIDBytes {
+		c.log.DebugContext(ctx, "Ignoring invalid service invocation ID length",
+			"service", unit,
+			"length", len(value),
+		)
+		return "", nil
+	}
+
+	return hex.EncodeToString(value), nil
+}
+
+func buildJournalctlArgs(unit, invocationID string, lines int) []string {
+	args := []string{"--unit", unit, "--no-pager"}
+	if lines > 0 {
+		args = append(args, "--lines", fmt.Sprintf("%d", lines))
+	}
+	if invocationID != "" {
+		// journalctl accepts field matches as positional arguments in addition to flags.
+		args = append(args, "_SYSTEMD_INVOCATION_ID="+invocationID)
+	}
+	return args
+}
+
+// CaptureJournal is a best-effort helper that runs journalctl to retrieve recent log lines
+// for the given systemd unit.
+//
+// Non-zero journalctl exits are treated as best-effort diagnostics failures: they are
+// logged and any stdout is still returned. Command launch failures return an error so
+// callers can distinguish them from empty journal output.
+func (c *Client) CaptureJournal(ctx context.Context, unit string, opts JournalOptions) (string, error) {
+	invocationID := ""
+	if opts.FilterCurrentInvocation {
+		var err error
+		invocationID, err = c.InvocationID(ctx, unit)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, c.journalctlPath, buildJournalctlArgs(unit, invocationID, opts.Lines)...)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+	stdoutOutput := strings.TrimSpace(stdoutBuf.String())
+	stderrOutput := strings.TrimSpace(stderrBuf.String())
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", trace.Wrap(ctx.Err())
+		}
+
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			c.log.DebugContext(ctx, "journalctl exited non-zero",
+				"service", unit,
+				"exit_code", exitErr.ExitCode(),
+				"stderr", stderrOutput,
+			)
+			return stdoutOutput, nil
+		} else {
+			c.log.WarnContext(ctx, "Failed to capture journal output",
+				"service", unit,
+				"error", err,
+				"stderr", stderrOutput,
+			)
+			return "", trace.Wrap(err)
+		}
+	}
+
+	return stdoutOutput, nil
+}

--- a/lib/systemd/systemd_test.go
+++ b/lib/systemd/systemd_test.go
@@ -1,0 +1,344 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package systemd
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/buildkite/bintest/v3"
+	systemddbus "github.com/coreos/go-systemd/v22/dbus"
+	godbus "github.com/godbus/dbus/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newBintestMock(t *testing.T, name string) *bintest.Mock {
+	t.Helper()
+
+	mock, err := bintest.NewMock(name)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, mock.Close())
+	})
+
+	return mock
+}
+
+func expectJournalctlCall(journalctlMock *bintest.Mock, unit, invocationID string, lines int, stdoutOutput, stderrOutput string) {
+	args := buildJournalctlArgs(unit, invocationID, lines)
+	callArgs := make([]any, 0, len(args))
+	for _, arg := range args {
+		callArgs = append(callArgs, arg)
+	}
+	call := journalctlMock.Expect(callArgs...)
+	call.AndCallFunc(func(c *bintest.Call) {
+		if stdoutOutput != "" {
+			fmt.Fprintln(c.Stdout, stdoutOutput)
+		}
+		if stderrOutput != "" {
+			fmt.Fprintln(c.Stderr, stderrOutput)
+		}
+		c.Exit(0)
+	})
+}
+
+type mockConn struct {
+	expectedUnit      string
+	unitProperties    map[string]*systemddbus.Property
+	serviceProperties map[string]*systemddbus.Property
+	unitErrors        map[string]error
+	serviceErrors     map[string]error
+	closed            bool
+}
+
+func (m *mockConn) GetUnitPropertyContext(_ context.Context, unit, propertyName string) (*systemddbus.Property, error) {
+	if m.expectedUnit != "" && unit != m.expectedUnit {
+		return nil, fmt.Errorf("unexpected unit %q", unit)
+	}
+	if err := m.unitErrors[propertyName]; err != nil {
+		return nil, err
+	}
+	return m.unitProperties[propertyName], nil
+}
+
+func (m *mockConn) GetServicePropertyContext(_ context.Context, unit, propertyName string) (*systemddbus.Property, error) {
+	if m.expectedUnit != "" && unit != m.expectedUnit {
+		return nil, fmt.Errorf("unexpected unit %q", unit)
+	}
+	if err := m.serviceErrors[propertyName]; err != nil {
+		return nil, err
+	}
+	return m.serviceProperties[propertyName], nil
+}
+
+func (m *mockConn) Close() {
+	m.closed = true
+}
+
+func newDBusProperty(name string, value any) *systemddbus.Property {
+	return &systemddbus.Property{Name: name, Value: godbus.MakeVariant(value)}
+}
+
+func TestCaptureJournalFiltersByInvocationID(t *testing.T) {
+	t.Parallel()
+
+	invocationID := "0123456789abcdef0123456789abcdef"
+	invocationBytes, err := hex.DecodeString(invocationID)
+	require.NoError(t, err)
+	conn := &mockConn{
+		expectedUnit: "teleport.service",
+		unitProperties: map[string]*systemddbus.Property{
+			"InvocationID": newDBusProperty("InvocationID", invocationBytes),
+		},
+	}
+	journalctlMock := newBintestMock(t, "journalctl")
+	expectJournalctlCall(journalctlMock, "teleport.service", invocationID, 50, "--unit teleport.service --no-pager --lines 50 _SYSTEMD_INVOCATION_ID="+invocationID, "")
+
+	client := NewClient(Config{
+		Logger:         slog.Default(),
+		JournalctlPath: journalctlMock.Path,
+		NewConn: func(context.Context) (Conn, error) {
+			return conn, nil
+		},
+	})
+
+	got, err := client.CaptureJournal(t.Context(), "teleport.service", JournalOptions{
+		Lines:                   50,
+		FilterCurrentInvocation: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "--unit teleport.service --no-pager --lines 50 _SYSTEMD_INVOCATION_ID="+invocationID, got)
+	require.True(t, conn.closed)
+	require.True(t, journalctlMock.Check(t), "mismatch between expected invocations and actual calls for %q", "journalctl")
+}
+
+func TestCaptureJournalFallsBackWithoutInvocationID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		unitProperties map[string]*systemddbus.Property
+	}{
+		{
+			name: "wrong type",
+			unitProperties: map[string]*systemddbus.Property{
+				"InvocationID": newDBusProperty("InvocationID", "active"),
+			},
+		},
+		{
+			name:           "nil prop",
+			unitProperties: nil,
+		},
+		{
+			name: "empty bytes",
+			unitProperties: map[string]*systemddbus.Property{
+				"InvocationID": newDBusProperty("InvocationID", []byte{}),
+			},
+		},
+		{
+			name: "invalid length",
+			unitProperties: map[string]*systemddbus.Property{
+				"InvocationID": newDBusProperty("InvocationID", []byte{1, 2, 3}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &mockConn{
+				expectedUnit:   "teleport.service",
+				unitProperties: tt.unitProperties,
+			}
+			journalctlMock := newBintestMock(t, "journalctl")
+			expectJournalctlCall(journalctlMock, "teleport.service", "", 50, "--unit teleport.service --no-pager --lines 50", "")
+
+			client := NewClient(Config{
+				Logger:         slog.Default(),
+				JournalctlPath: journalctlMock.Path,
+				NewConn: func(context.Context) (Conn, error) {
+					return conn, nil
+				},
+			})
+
+			got, err := client.CaptureJournal(t.Context(), "teleport.service", JournalOptions{
+				Lines:                   50,
+				FilterCurrentInvocation: true,
+			})
+			require.NoError(t, err)
+			require.Equal(t, "--unit teleport.service --no-pager --lines 50", got)
+			require.True(t, conn.closed)
+			require.True(t, journalctlMock.Check(t), "mismatch between expected invocations and actual calls for %q", "journalctl")
+		})
+	}
+}
+
+func TestCaptureJournalReturnsStdoutOnNonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	journalctlMock := newBintestMock(t, "journalctl")
+	call := journalctlMock.Expect("--unit", "teleport.service", "--no-pager", "--lines", "50")
+	call.AndCallFunc(func(c *bintest.Call) {
+		fmt.Fprintln(c.Stdout, "recent log line")
+		fmt.Fprintln(c.Stderr, "journalctl warning")
+		c.Exit(1)
+	})
+
+	client := NewClient(Config{
+		Logger:         slog.Default(),
+		JournalctlPath: journalctlMock.Path,
+	})
+
+	got, err := client.CaptureJournal(t.Context(), "teleport.service", JournalOptions{Lines: 50})
+	require.NoError(t, err)
+	require.Equal(t, "recent log line", got)
+	require.True(t, journalctlMock.Check(t), "mismatch between expected invocations and actual calls for %q", "journalctl")
+}
+
+func TestCaptureJournalReturnsErrorWhenJournalctlCannotStart(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Config{
+		Logger:         slog.Default(),
+		JournalctlPath: "/nonexistent/journalctl",
+	})
+
+	got, err := client.CaptureJournal(t.Context(), "teleport.service", JournalOptions{Lines: 50})
+	require.Empty(t, got)
+	require.Error(t, err)
+}
+
+func TestCaptureJournalPropagatesContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Config{
+		Logger: slog.Default(),
+		NewConn: func(ctx context.Context) (Conn, error) {
+			return nil, ctx.Err()
+		},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	got, err := client.CaptureJournal(ctx, "teleport.service", JournalOptions{FilterCurrentInvocation: true})
+	require.Empty(t, got)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestReadServiceStateUsesDBusProperties(t *testing.T) {
+	t.Parallel()
+
+	conn := &mockConn{
+		expectedUnit: "teleport.service",
+		unitProperties: map[string]*systemddbus.Property{
+			"ActiveState": newDBusProperty("ActiveState", "failed"),
+			"SubState":    newDBusProperty("SubState", "exited"),
+		},
+		serviceProperties: map[string]*systemddbus.Property{
+			"Result": newDBusProperty("Result", "exit-code"),
+		},
+	}
+
+	client := NewClient(Config{
+		Logger: slog.Default(),
+		NewConn: func(context.Context) (Conn, error) {
+			return conn, nil
+		},
+	})
+
+	state, err := client.ReadServiceState(t.Context(), "teleport.service")
+	require.NoError(t, err)
+	require.Equal(t, `systemd service state: ActiveState="failed", SubState="exited", Result="exit-code"`, state.String())
+	require.True(t, conn.closed)
+}
+
+func TestReadServiceStateHandlesPartialDBusFailures(t *testing.T) {
+	t.Parallel()
+
+	conn := &mockConn{
+		expectedUnit: "teleport.service",
+		unitProperties: map[string]*systemddbus.Property{
+			"ActiveState": newDBusProperty("ActiveState", "failed"),
+		},
+		serviceProperties: map[string]*systemddbus.Property{
+			"Result": newDBusProperty("Result", "exit-code"),
+		},
+		unitErrors: map[string]error{
+			"SubState": assert.AnError,
+		},
+	}
+
+	client := NewClient(Config{
+		Logger: slog.Default(),
+		NewConn: func(context.Context) (Conn, error) {
+			return conn, nil
+		},
+	})
+
+	state, err := client.ReadServiceState(t.Context(), "teleport.service")
+	require.NoError(t, err)
+	require.Equal(t, `systemd service state: ActiveState="failed", SubState="unknown", Result="exit-code"`, state.String())
+	require.True(t, conn.closed)
+}
+
+func TestReadServiceStateReturnsUnknownsWhenAllPropertiesFail(t *testing.T) {
+	t.Parallel()
+
+	conn := &mockConn{
+		expectedUnit: "teleport.service",
+		unitErrors: map[string]error{
+			"ActiveState": assert.AnError,
+			"SubState":    assert.AnError,
+		},
+		serviceErrors: map[string]error{
+			"Result": assert.AnError,
+		},
+	}
+
+	client := NewClient(Config{
+		Logger: slog.Default(),
+		NewConn: func(context.Context) (Conn, error) {
+			return conn, nil
+		},
+	})
+
+	state, err := client.ReadServiceState(t.Context(), "teleport.service")
+	require.NoError(t, err)
+	require.Equal(t, `systemd service state: ActiveState="unknown", SubState="unknown", Result="unknown"`, state.String())
+	require.True(t, conn.closed)
+}
+
+func TestReadServiceStateReturnsErrorWhenDBusUnavailable(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Config{
+		Logger: slog.Default(),
+		NewConn: func(context.Context) (Conn, error) {
+			return nil, assert.AnError
+		},
+	})
+
+	_, err := client.ReadServiceState(t.Context(), "teleport.service")
+	require.Error(t, err)
+}

--- a/lib/usertasks/descriptions/ec2-join-failure.md
+++ b/lib/usertasks/descriptions/ec2-join-failure.md
@@ -1,0 +1,19 @@
+# EC2 Join Failure
+
+Teleport was installed on the EC2 instance but the enrollment process did not observe a successful join before timing out.
+
+Review failure details and captured diagnostics in the corresponding `ssm.run` event in the **Audit Log**, or click the **Invocation Link** to view the output in the AWS SSM console.
+
+Common causes and fixes:
+
+**Invalid or nonexistent join token**
+
+The token name in the discovery config does not match any token in the cluster. Verify the token exists (`tctl get token/<name>`), has not expired, and the name in the discovery config matches exactly.
+
+**IAM ARN mismatch in token allow rules**
+
+The token exists but its `allow` rules do not match the EC2 instance's identity. A token can match by AWS account ID alone (`spec.allow[].aws_account`) or by IAM role ARN (`spec.allow[].aws_arn`). The instance joins as `arn:aws:sts::<account>:assumed-role/<role-name>/<instance-id>`. If the token specifies `aws_arn`, the pattern must match the instance's assumed role. Verify the token's allow rules with `tctl get token/<name>`. See [Create the AWS joining token](https://goteleport.com/docs/enroll-resources/agents/aws-iam/#step-25-create-the-aws-joining-token).
+
+**Network connectivity**
+
+The instance cannot reach the Teleport Proxy. Ensure security groups and network ACLs allow outbound HTTPS to the proxy public address. Note that a successful package install does not guarantee proxy reachability, as packages are downloaded from external repositories (cdn.teleport.dev). If the instance requires an HTTP proxy to reach external services, ensure the Teleport systemd unit is configured to use it via its environment file. See [HTTP CONNECT proxies](https://goteleport.com/docs/reference/deployment/networking/#http-connect-proxies).

--- a/lib/utils/errors.go
+++ b/lib/utils/errors.go
@@ -77,6 +77,13 @@ func IsConnectionRefused(err error) bool {
 	return false
 }
 
+// IsConnectionError returns true when the error indicates a socket-level connection failure
+// (e.g. file not found, connection refused), as opposed to an HTTP or application-level error.
+func IsConnectionError(err error) bool {
+	var opErr *net.OpError
+	return errors.As(err, &opErr)
+}
+
 // IsUntrustedCertErr checks if an error is an untrusted cert error.
 func IsUntrustedCertErr(err error) bool {
 	if err == nil {

--- a/lib/utils/packagemanager/system_binaries.go
+++ b/lib/utils/packagemanager/system_binaries.go
@@ -19,7 +19,8 @@ package packagemanager
 // BinariesLocation contains all the required external binaries used when installing teleport.
 // Used for testing.
 type BinariesLocation struct {
-	Systemctl string
+	Systemctl  string
+	Journalctl string
 
 	AptGet string
 	AptKey string
@@ -39,6 +40,10 @@ type BinariesLocation struct {
 func (bi *BinariesLocation) CheckAndSetDefaults() {
 	if bi.Systemctl == "" {
 		bi.Systemctl = "systemctl"
+	}
+
+	if bi.Journalctl == "" {
+		bi.Journalctl = "journalctl"
 	}
 
 	if bi.AptGet == "" {

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -53,6 +53,8 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/srv/server/installer"
+	"github.com/gravitational/teleport/lib/srv/server/installstatus"
 	"github.com/gravitational/teleport/lib/sshutils/scp"
 	"github.com/gravitational/teleport/lib/tpm"
 	"github.com/gravitational/teleport/lib/utils"
@@ -784,7 +786,13 @@ Examples:
 	case systemdInstall.FullCommand():
 		err = onDumpSystemdUnitFile(systemdInstallFlags)
 	case installAutoDiscoverNode.FullCommand():
-		err = onInstallAutoDiscoverNode(installAutoDiscoverNodeFlags)
+		// Join failures use a specific exit code so that SSM can classify the failure for the user task.
+		// The normal utils.FatalError path always exits with code 1, so we handle this case separately.
+		var joinErr *installer.JoinFailureError
+		if err = onInstallAutoDiscoverNode(installAutoDiscoverNodeFlags); errors.As(err, &joinErr) {
+			writeInstallJoinFailureError(os.Stderr, joinErr)
+			os.Exit(int(installstatus.JoinFailure))
+		}
 	case discoveryBootstrapCmd.FullCommand():
 		configureDiscoveryBootstrapFlags.config.Service = configurators.DiscoveryService
 		err = onConfigureDiscoveryBootstrap(ctx, configureDiscoveryBootstrapFlags)
@@ -908,6 +916,23 @@ Examples:
 	}
 
 	return app, command, conf
+}
+
+// writeInstallJoinFailureError writes a user-facing join-failure error
+// message to w, with each diagnostic section on its own line for
+// readability.
+func writeInstallJoinFailureError(w io.Writer, joinErr *installer.JoinFailureError) {
+	fmt.Fprintln(w, "ERROR: agent failed to join the cluster")
+	fmt.Fprintf(w, "%s\n", joinErr.Message)
+	if joinErr.ServiceDiagnostics != "" {
+		fmt.Fprintf(w, "%s\n", joinErr.ServiceDiagnostics)
+	}
+	if joinErr.LastError != "" {
+		fmt.Fprintf(w, "Last readyz error: %s\n", joinErr.LastError)
+	}
+	if joinErr.JournalOutput != "" {
+		fmt.Fprintf(w, "Journal output:\n%s\n", joinErr.JournalOutput)
+	}
 }
 
 // OnStart is the handler for "start" CLI command

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/server/installer"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -278,6 +279,56 @@ func TestDumpConfigFile(t *testing.T) {
 			tc.assert(t, err)
 		})
 	}
+}
+
+func TestWriteInstallJoinFailureError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all fields populated", func(t *testing.T) {
+		t.Parallel()
+
+		var stderr bytes.Buffer
+		writeInstallJoinFailureError(&stderr, &installer.JoinFailureError{
+			Message:            "node did not become ready (join cluster) within 5m0s",
+			ServiceDiagnostics: `systemd service state: ActiveState="failed"`,
+			JournalOutput:      "error: token expired",
+		})
+
+		out := stderr.String()
+		require.Contains(t, out, "ERROR: agent failed to join the cluster\n")
+		require.Contains(t, out, "node did not become ready (join cluster) within 5m0s\n")
+		require.Contains(t, out, `systemd service state: ActiveState="failed"`)
+		require.Contains(t, out, "Journal output:\nerror: token expired\n")
+	})
+
+	t.Run("message only", func(t *testing.T) {
+		t.Parallel()
+
+		var stderr bytes.Buffer
+		writeInstallJoinFailureError(&stderr, &installer.JoinFailureError{
+			Message: "node did not become ready (join cluster) within 5m0s",
+		})
+
+		out := stderr.String()
+		require.Contains(t, out, "ERROR: agent failed to join the cluster\n")
+		require.Contains(t, out, "node did not become ready (join cluster) within 5m0s\n")
+	})
+
+	t.Run("no journal output", func(t *testing.T) {
+		t.Parallel()
+
+		var stderr bytes.Buffer
+		writeInstallJoinFailureError(&stderr, &installer.JoinFailureError{
+			Message:            "node did not become ready (join cluster) within 5m0s",
+			ServiceDiagnostics: "systemd service state: unavailable",
+		})
+
+		out := stderr.String()
+		require.Contains(t, out, "ERROR: agent failed to join the cluster\n")
+		require.Contains(t, out, "node did not become ready (join cluster) within 5m0s\n")
+		require.Contains(t, out, "systemd service state: unavailable\n")
+		require.NotContains(t, out, "Journal output:")
+	})
 }
 
 const configData = `


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/64296

---

Fixes https://github.com/gravitational/teleport/issues/62837

Changelog: Fixed an issue where EC2 auto-discovery could install Teleport on an instance but silently drop the failure when the agent could not join the cluster. A new `ec2-join-failure` user task is now raised with the actual join error message surfaced from the agent's readyz socket.

## Out of scope for this PR

Usability improvements for existing ui
More granular-level user tasks for failure to join

## Manual Test Plan
### Test Environment

- **Teleport cluster:** `carlisia-4.cloud.gravitational.io` (cloud staging)

### Test Cases

- [x] Happy path — valid token, agent joins, no user task emitted, exit 0
- [x] Join failure — invalid token triggers `ec2-join-failure` user task with exit code 150 and structured `JoinFailureError` (Message, ServiceDiagnostics, JournalOutput, LastError)
- [x] Journal capture — `JoinFailureError.JournalOutput` includes connect.go's `"Can not join the cluster, the token is expired or not found. Regenerate the token and try again."` log line; verified via SSM stderr trailer
- [x] Readyz timeout — `JoinFailureTimeout = 2 * time.Minute` (v18 backport) enforced via `checkJoinHealth` poll loop; 24 polls every 5s, then `JoinFailureError` with the `"node did not become ready (join cluster) within 2m0s"` message
- [x] Exit code wiring — `tool/teleport/common/teleport.go:786-792` converts `*installer.JoinFailureError` to `os.Exit(installstatus.JoinFailure)` (150); other errors fall through to default
- [x] User task issue type mapping — `installstatus.ExitCode(150).IssueType()` returns `usertasks.AutoDiscoverEC2IssueJoinFailure`; the cluster's discovery service classifies the SSM failure accordingly

All the above tests were done using the same custom binary.

---

**Custom binary deployment for manual testing**

A custom binary uploaded to S3 is used as the installer (`/tmp/teleport-custom`), and the service binary at `/usr/local/bin/teleport` is installed from the stock apt package and does not include the branch changes. The installer runs `install autodiscover-node`, while the service binary runs `teleport start` and serves the readyz endpoint. The enriched join error message (from `lib/service/state.go` + `connect.go`) requires the service binary to include the branch changes.
