### PR TITLE
[refactor] move app pre-flight check to lib/web/app

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -31,7 +31,6 @@ import (
 	"html/template"
 	"io"
 	"log/slog"
-	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -180,9 +179,6 @@ type Handler struct {
 	// nodeWatcher is a services.NodeWatcher used by Assist to lookup nodes from
 	// the proxy's cache and get nodes in real time.
 	nodeWatcher *services.GenericWatcher[types.Server, readonly.Server]
-
-	// appServerWatcher ia a app server watcher to speed up app look up.
-	appServerWatcher *services.GenericWatcher[types.AppServer, readonly.AppServer]
 
 	// tracer is used to create spans.
 	tracer oteltrace.Tracer
@@ -386,68 +382,6 @@ type APIHandler struct {
 // ConnectionHandler defines a function for serving incoming connections.
 type ConnectionHandler func(ctx context.Context, conn net.Conn) error
 
-func (h *APIHandler) handlePreflight(w http.ResponseWriter, r *http.Request) {
-	raddr, err := utils.ParseAddr(r.Host)
-	if err != nil {
-		return
-	}
-	publicAddr := raddr.Host()
-
-	servers, err := h.handler.appServerWatcher.CurrentResourcesWithFilter(r.Context(), app.MatchPublicAddr(publicAddr))
-	if err != nil {
-		h.handler.logger.InfoContext(r.Context(), "failed to match application with public addr", "public_addr", publicAddr)
-		return
-	}
-
-	if len(servers) == 0 {
-		h.handler.logger.InfoContext(r.Context(), "failed to match application with public addr", "public_addr", publicAddr)
-		return
-	}
-
-	foundApp := servers[rand.N(len(servers))].GetApp()
-	corsPolicy := foundApp.GetCORS()
-	if corsPolicy == nil {
-		return
-	}
-
-	origin := r.Header.Get("Origin")
-	// The Access-Control-Allow-Origin can only include one origin or a wildcard. However,
-	// any request which includes credentials _must_ return an origin and not a wildcard.
-	// https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#sect2
-	if slices.Contains(corsPolicy.AllowedOrigins, "*") || slices.Contains(corsPolicy.AllowedOrigins, origin) {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-	} else {
-		return
-	}
-
-	if len(corsPolicy.AllowedMethods) > 0 {
-		w.Header().Set("Access-Control-Allow-Methods", strings.Join(corsPolicy.AllowedMethods, ","))
-	}
-
-	// This is a list of headers that are allowed in the spec. Wildcards are allowed.
-	// Note: "Authorization" headers must be explicitly listed and cannot be wildcarded
-	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers#sect2
-	if len(corsPolicy.AllowedHeaders) > 0 {
-		w.Header().Set("Access-Control-Allow-Headers", strings.Join(corsPolicy.AllowedHeaders, ","))
-	}
-
-	if len(corsPolicy.ExposedHeaders) > 0 {
-		w.Header().Set("Access-Control-Expose-Headers", strings.Join(corsPolicy.ExposedHeaders, ","))
-	}
-
-	// The only valid value for this header is "true", so we will only set it if configured to true
-	if corsPolicy.AllowCredentials {
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
-	}
-
-	// This will allow preflight responses to be cached for the specified duration
-	if corsPolicy.MaxAge > 0 {
-		w.Header().Set("Access-Control-Max-Age", fmt.Sprintf("%d", corsPolicy.MaxAge))
-	}
-
-	w.WriteHeader(http.StatusOK)
-}
-
 // Check if this request should be forwarded to an application handler to
 // be handled by the UI and handle the request appropriately.
 func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -462,41 +396,43 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handler.accessGraphHandler.ServeHTTP(w, r)
 		return
 	}
-	// If the request is either to the fragment authentication endpoint or if the
-	// request has a session cookie or a client cert, forward to
-	// application handlers. If the request is requesting a
-	// FQDN that is not of the proxy, redirect to application launcher.
-	if h.appHandler != nil && (app.HasFragment(r) || app.HasSessionCookie(r) || app.HasClientCert(r)) {
-		h.appHandler.ServeHTTP(w, r)
-		return
-	}
-
-	// Build the proxy address list for app routing. When
-	// proxy_service.public_addr is not configured, only activate the
-	// cluster-name fallback if the request host is a subdomain of the
-	// cluster name. This avoids misclassifying requests that arrive on
-	// a different hostname (e.g. behind a load balancer) as app requests.
-	proxyAddrs := h.handler.cfg.ProxyPublicAddrs
-	if len(proxyAddrs) == 0 && h.appHandler != nil {
-		clusterName := h.handler.auth.clusterName
-		raddr, err := utils.ParseAddr(r.Host)
-		if err == nil && clusterName != "" && strings.HasSuffix(raddr.Host(), "."+clusterName) {
-			port := raddr.Port(443)
-			host := net.JoinHostPort(clusterName, strconv.Itoa(port))
-			proxyAddrs = []utils.NetAddr{{Addr: host}}
+	if h.appHandler != nil {
+		// If the request is either to the fragment authentication endpoint or
+		// if the request has a session cookie or a client cert, forward to
+		// application handlers. If the request is requesting a FQDN that is not
+		// of the proxy, redirect to application launcher.
+		if app.HasFragment(r) || app.HasSessionCookie(r) || app.HasClientCert(r) {
+			h.appHandler.ServeHTTP(w, r)
+			return
 		}
-	}
 
-	// if the request is for an app, passthrough OPTIONS requests to the app handler
-	redir, ok := app.HasName(r, proxyAddrs)
-	if ok && r.Method == http.MethodOptions {
-		h.handlePreflight(w, r)
-		return
-	}
-	// Only try to redirect if the handler is serving the full Web API.
-	if !h.handler.cfg.MinimalReverseTunnelRoutesOnly && ok {
-		http.Redirect(w, r, redir, http.StatusFound)
-		return
+		// Build the proxy address list for app routing. When
+		// proxy_service.public_addr is not configured, only activate the
+		// cluster-name fallback if the request host is a subdomain of the
+		// cluster name. This avoids misclassifying requests that arrive on
+		// a different hostname (e.g. behind a load balancer) as app requests.
+		proxyAddrs := h.handler.cfg.ProxyPublicAddrs
+		if len(proxyAddrs) == 0 {
+			clusterName := h.handler.auth.clusterName
+			raddr, err := utils.ParseAddr(r.Host)
+			if err == nil && clusterName != "" && strings.HasSuffix(raddr.Host(), "."+clusterName) {
+				port := raddr.Port(443)
+				host := net.JoinHostPort(clusterName, strconv.Itoa(port))
+				proxyAddrs = []utils.NetAddr{{Addr: host}}
+			}
+		}
+
+		// if the request is for an app, passthrough OPTIONS requests to the app handler
+		redir, ok := app.HasName(r, proxyAddrs)
+		if ok && r.Method == http.MethodOptions {
+			h.appHandler.HandlePreflight(w, r)
+			return
+		}
+		// Only try to redirect if the handler is serving the full Web API.
+		if !h.handler.cfg.MinimalReverseTunnelRoutesOnly && ok {
+			http.Redirect(w, r, redir, http.StatusFound)
+			return
+		}
 	}
 
 	// Serve the Web UI.
@@ -705,10 +641,6 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		h.nodeWatcher = cfg.NodeWatcher
 	}
 
-	if cfg.AppServerWatcher != nil {
-		h.appServerWatcher = cfg.AppServerWatcher
-	}
-
 	const v1Prefix = "/v1"
 	notFoundRoutingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Request is going to the API?
@@ -810,6 +742,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 			CipherSuites:          cfg.CipherSuites,
 			ProxyPublicAddrs:      cfg.ProxyPublicAddrs,
 			IntegrationAppHandler: cfg.IntegrationAppHandler,
+			AppServerWatcher:      cfg.AppServerWatcher,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/web/app/cors.go
+++ b/lib/web/app/cors.go
@@ -1,0 +1,100 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services/readonly"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// Watcher defines an interface for an AppServer watcher.
+type Watcher interface {
+	CurrentResourcesWithFilter(ctx context.Context, filter func(readonly.AppServer) bool) ([]types.AppServer, error)
+}
+
+// HandlePreflight responds with CORS headers derived from the target app's
+// CORS policy.
+func (h *Handler) HandlePreflight(w http.ResponseWriter, r *http.Request) {
+	raddr, err := utils.ParseAddr(r.Host)
+	if err != nil {
+		return
+	}
+	publicAddr := raddr.Host()
+
+	servers, err := h.c.AppServerWatcher.CurrentResourcesWithFilter(r.Context(), MatchPublicAddr(publicAddr))
+	if err != nil {
+		h.logger.InfoContext(r.Context(), "failed to match application with public addr", "public_addr", publicAddr)
+		return
+	}
+	if len(servers) == 0 {
+		h.logger.InfoContext(r.Context(), "failed to match application with public addr", "public_addr", publicAddr)
+		return
+	}
+
+	foundApp := servers[rand.N(len(servers))].GetApp()
+	corsPolicy := foundApp.GetCORS()
+	if corsPolicy == nil {
+		return
+	}
+
+	origin := r.Header.Get("Origin")
+	// The Access-Control-Allow-Origin can only include one origin or a wildcard. However,
+	// any request which includes credentials _must_ return an origin and not a wildcard.
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#sect2
+	if slices.Contains(corsPolicy.AllowedOrigins, "*") || slices.Contains(corsPolicy.AllowedOrigins, origin) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+	} else {
+		return
+	}
+
+	if len(corsPolicy.AllowedMethods) > 0 {
+		w.Header().Set("Access-Control-Allow-Methods", strings.Join(corsPolicy.AllowedMethods, ","))
+	}
+
+	// This is a list of headers that are allowed in the spec. Wildcards are allowed.
+	// Note: "Authorization" headers must be explicitly listed and cannot be wildcarded
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers#sect2
+	if len(corsPolicy.AllowedHeaders) > 0 {
+		w.Header().Set("Access-Control-Allow-Headers", strings.Join(corsPolicy.AllowedHeaders, ","))
+	}
+
+	if len(corsPolicy.ExposedHeaders) > 0 {
+		w.Header().Set("Access-Control-Expose-Headers", strings.Join(corsPolicy.ExposedHeaders, ","))
+	}
+
+	// The only valid value for this header is "true", so we will only set it if configured to true
+	if corsPolicy.AllowCredentials {
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+	}
+
+	// This will allow preflight responses to be cached for the specified duration
+	if corsPolicy.MaxAge > 0 {
+		w.Header().Set("Access-Control-Max-Age", fmt.Sprintf("%d", corsPolicy.MaxAge))
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/lib/web/app/cors_test.go
+++ b/lib/web/app/cors_test.go
@@ -1,0 +1,144 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package app
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services/readonly"
+)
+
+type fakeWatcher struct {
+	servers []types.AppServer
+	err     error
+}
+
+func (f fakeWatcher) CurrentResourcesWithFilter(_ context.Context, _ func(readonly.AppServer) bool) ([]types.AppServer, error) {
+	return f.servers, f.err
+}
+
+func TestHandlePreflight(t *testing.T) {
+	const (
+		targetAppURL   = "https://my-app.example.com/"
+		allowedOrigin  = "https://allowed.example.com"
+		deniedOrigin   = "https://denied.example.com"
+		wildcardOrigin = "https://wildcard.example.com"
+	)
+
+	makeServer := func(t *testing.T, cors *types.CORSPolicy) types.AppServer {
+		app, err := types.NewAppV3(types.Metadata{Name: "my-app"}, types.AppSpecV3{
+			URI:  "http://localhost",
+			CORS: cors,
+		})
+		require.NoError(t, err)
+		s, err := types.NewAppServerV3FromApp(app, "host", "hostID")
+		require.NoError(t, err)
+		return s
+	}
+
+	fullPolicy := &types.CORSPolicy{
+		AllowedOrigins:   []string{allowedOrigin},
+		AllowedMethods:   []string{"GET", "POST"},
+		AllowedHeaders:   []string{"X-Custom"},
+		ExposedHeaders:   []string{"X-Expose"},
+		AllowCredentials: true,
+		MaxAge:           600,
+	}
+
+	tests := []struct {
+		name        string
+		lookup      fakeWatcher
+		origin      string
+		wantHeaders map[string]string
+	}{
+		{
+			name:   "allowed origin gets full CORS headers",
+			lookup: fakeWatcher{servers: []types.AppServer{makeServer(t, fullPolicy)}},
+			origin: allowedOrigin,
+			wantHeaders: map[string]string{
+				"Access-Control-Allow-Origin":      allowedOrigin,
+				"Access-Control-Allow-Methods":     "GET,POST",
+				"Access-Control-Allow-Headers":     "X-Custom",
+				"Access-Control-Expose-Headers":    "X-Expose",
+				"Access-Control-Allow-Credentials": "true",
+				"Access-Control-Max-Age":           "600",
+			},
+		},
+		{
+			name: "wildcard policy echoes request origin",
+			lookup: fakeWatcher{servers: []types.AppServer{makeServer(t, &types.CORSPolicy{
+				AllowedOrigins: []string{"*"},
+			})}},
+			origin: wildcardOrigin,
+			wantHeaders: map[string]string{
+				"Access-Control-Allow-Origin": wildcardOrigin,
+			},
+		},
+		{
+			name:        "denied origin gets no CORS headers",
+			lookup:      fakeWatcher{servers: []types.AppServer{makeServer(t, fullPolicy)}},
+			origin:      deniedOrigin,
+			wantHeaders: map[string]string{"Access-Control-Allow-Origin": ""},
+		},
+		{
+			name:        "app without CORS policy gets no headers",
+			lookup:      fakeWatcher{servers: []types.AppServer{makeServer(t, nil)}},
+			origin:      allowedOrigin,
+			wantHeaders: map[string]string{"Access-Control-Allow-Origin": ""},
+		},
+		{
+			name:        "no matching servers",
+			lookup:      fakeWatcher{},
+			origin:      allowedOrigin,
+			wantHeaders: map[string]string{"Access-Control-Allow-Origin": ""},
+		},
+		{
+			name:        "lookup error",
+			lookup:      fakeWatcher{err: trace.ConnectionProblem(nil, "boom")},
+			origin:      allowedOrigin,
+			wantHeaders: map[string]string{"Access-Control-Allow-Origin": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Handler{
+				c:      &HandlerConfig{AppServerWatcher: tt.lookup},
+				logger: slog.Default(),
+			}
+
+			req := httptest.NewRequest(http.MethodOptions, targetAppURL, nil)
+			req.Header.Set("Origin", tt.origin)
+			rec := httptest.NewRecorder()
+			h.HandlePreflight(rec, req)
+
+			for k, v := range tt.wantHeaders {
+				require.Equal(t, v, rec.Header().Get(k), "header %s", k)
+			}
+		})
+	}
+}

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -67,6 +67,8 @@ type HandlerConfig struct {
 	// IntegrationAppHandler handles App Access requests directly - not requiring an AppService.
 	// Only available for AWS OIDC Integrations.
 	IntegrationAppHandler ServerHandler
+	// AppServerWatcher is used by HandlePreflight to resolve apps by public addr.
+	AppServerWatcher Watcher
 }
 
 // CheckAndSetDefaults validates configuration.
@@ -86,6 +88,9 @@ func (c *HandlerConfig) CheckAndSetDefaults() error {
 	}
 	if c.IntegrationAppHandler == nil {
 		return trace.BadParameter("integration app handler missing")
+	}
+	if c.AppServerWatcher == nil {
+		return trace.BadParameter("app server watcher missing")
 	}
 
 	return nil

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -438,6 +438,7 @@ func TestHealthCheckAppServer(t *testing.T) {
 				ClusterGetter:         tunnel,
 				CipherSuites:          utils.DefaultCipherSuites(),
 				IntegrationAppHandler: &mockIntegrationAppHandler{},
+				AppServerWatcher:      fakeWatcher{},
 			})
 			require.NoError(t, err)
 
@@ -460,6 +461,7 @@ func setup(t *testing.T, clock *clockwork.FakeClock, authClient authclient.Clien
 		ClusterGetter:         clusterGetter,
 		CipherSuites:          utils.DefaultCipherSuites(),
 		IntegrationAppHandler: &mockIntegrationAppHandler{},
+		AppServerWatcher:      fakeWatcher{},
 	})
 	require.NoError(t, err)
 
@@ -880,6 +882,7 @@ func TestHandlerAuthenticate(t *testing.T) {
 		},
 		CipherSuites:          utils.DefaultCipherSuites(),
 		IntegrationAppHandler: &mockIntegrationAppHandler{},
+		AppServerWatcher:      fakeWatcher{},
 	})
 	require.NoError(t, err)
 
@@ -953,6 +956,7 @@ func TestRedirectToLauncherClusterFallback(t *testing.T) {
 		AccessPoint:           authClient,
 		CipherSuites:          utils.DefaultCipherSuites(),
 		IntegrationAppHandler: &mockIntegrationAppHandler{},
+		AppServerWatcher:      fakeWatcher{},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Moving app pre-flight handling to from web handler to app handler so it is easier to add app-related logic when necessary. No logic change.

## Manual Test Plan
### Test Environment
steve-beams.cloud.gravitational.io

### Test Cases
setup three apps ([more details](https://github.com/greedy52/teleport-database-test-setup/tree/main/cors-preflight))
```
  apps:
    - name: target
      uri: http://localhost:9000
      cors:
        allowed_origins: ["https://allowed.<cluster>"]
        allowed_methods: ["GET", "POST"]
        allowed_headers: ["X-Custom"]
        allow_credentials: true
    - name: allowed
      uri: http://localhost:9001
    - name: evil
      uri: http://localhost:9002
```
where `allowed` and `eval` fetches from `target.steve-beams.cloud.gravitational.io`

- [x] `target` app can be launched and used as usual
- [x] `allowed` app shows `OK 200`
- [x] `denied` app sees no access-control header on OPTION call, and app shows `BLOCKED TypeError: Failed to fetch`
