### PR TITLE
Discovery EKS - Support region wildcard

### DIFF
--- a/api/types/matchers_aws.go
+++ b/api/types/matchers_aws.go
@@ -150,7 +150,7 @@ func (m *AWSMatcher) CheckAndSetDefaults() error {
 	}
 
 	if len(m.Regions) == 0 {
-		return trace.BadParameter("discovery service requires at least one region, for EC2 you can also set the region to %q to iterate over all regions (requires account:ListRegions IAM permission)", Wildcard)
+		return trace.BadParameter("discovery service requires at least one region, for EC2 and EKS you can also set the region to %q to iterate over all regions (requires account:ListRegions IAM permission)", Wildcard)
 	}
 
 	for _, region := range m.Regions {

--- a/docs/pages/includes/discovery/reference/aws-iam/eks.mdx
+++ b/docs/pages/includes/discovery/reference/aws-iam/eks.mdx
@@ -6,6 +6,7 @@
             "Sid": "EKSDiscovery",
             "Effect": "Allow",
             "Action": [
+              "account:ListRegions",
               "eks:DescribeCluster",
               "eks:ListClusters"
             ],

--- a/docs/pages/installation/agents/amazon-ecs.mdx
+++ b/docs/pages/installation/agents/amazon-ecs.mdx
@@ -134,6 +134,7 @@ Pick an example depending on your use case.
       {
         Sid = "EKSDiscovery"
         Action = [
+          "account:ListRegions",
           "eks:DescribeCluster",
           "eks:ListClusters"
         ]

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -61,8 +61,7 @@ module "aws_discovery" {
     },
     {
       types   = ["eks"]
-      # EKS requires region selection.
-      regions = ["us-east-1"]
+      regions = ["*"]
       tags = {
         team = ["platform"]
       }
@@ -76,7 +75,7 @@ module "aws_discovery" {
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `types` | `list(string)` | (required) | AWS resource types to discover. Allowed values: `ec2`, `eks`. |
-| `regions` | `list(string)` | (required) | AWS regions to search. EC2 supports `"*"` for all regions. EKS requires explicit regions. |
+| `regions` | `list(string)` | (required) | AWS regions to search. Use `"*"` for all regions. |
 | `tags` | `map(list(string))` | `{ "*" : ["*"] }` | AWS resource tags to match. The default matches all resources. |
 | `setup_access_for_arn` | `string` | `""` | ARN to configure access for discovered EKS clusters. Only supported for EKS matchers. |
 | `kube_app_discovery` | `bool` | `null` | Teleport's Kubernetes App Discovery will automatically identify and enroll to Teleport HTTP applications running inside a Kubernetes cluster. |

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -47,8 +47,7 @@ module "aws_discovery" {
     },
     {
       types   = ["eks"]
-      # EKS requires region selection.
-      regions = ["us-east-1"]
+      regions = ["*"]
       tags = {
         team = ["platform"]
       }
@@ -62,7 +61,7 @@ module "aws_discovery" {
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `types` | `list(string)` | (required) | AWS resource types to discover. Allowed values: `ec2`, `eks`. |
-| `regions` | `list(string)` | (required) | AWS regions to search. EC2 supports `"*"` for all regions. EKS requires explicit regions. |
+| `regions` | `list(string)` | (required) | AWS regions to search. Use `"*"` for all regions. |
 | `tags` | `map(list(string))` | `{ "*" : ["*"] }` | AWS resource tags to match. The default matches all resources. |
 | `setup_access_for_arn` | `string` | `""` | ARN to configure access for discovered EKS clusters. Only supported for EKS matchers. |
 | `kube_app_discovery` | `bool` | `null` | Teleport's Kubernetes App Discovery will automatically identify and enroll to Teleport HTTP applications running inside a Kubernetes cluster. |

--- a/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
@@ -14,21 +14,18 @@ locals {
     : var.aws_iam_policy_name
   )
 
-  uses_ec2 = contains(local.aws_matcher_types, "ec2")
-  uses_eks = contains(local.aws_matcher_types, "eks")
+  uses_ec2             = contains(local.aws_matcher_types, "ec2")
+  uses_eks             = contains(local.aws_matcher_types, "eks")
+  uses_wildcard_region = contains(local.aws_matcher_regions, "*")
 
-  ec2_actions = concat(
-    contains(local.aws_matcher_regions, "*") ? ["account:ListRegions"] : [],
-    [
-      "ec2:DescribeInstances",
-      "ssm:DescribeInstanceInformation",
-      "ssm:GetCommandInvocation",
-      "ssm:ListCommandInvocations",
-      "ssm:SendCommand",
-    ]
-  )
+  ec2_actions = [
+    "ec2:DescribeInstances",
+    "ssm:DescribeInstanceInformation",
+    "ssm:GetCommandInvocation",
+    "ssm:ListCommandInvocations",
+    "ssm:SendCommand",
+  ]
 
-  # TODO(charles): add account:ListRegions when EKS supports wildcard region
   eks_actions = [
     "eks:ListClusters",
     "eks:DescribeCluster",
@@ -42,6 +39,7 @@ locals {
   ]
 
   policy_actions = concat(
+    local.uses_wildcard_region ? ["account:ListRegions"] : [],
     local.uses_ec2 ? local.ec2_actions : [],
     local.uses_eks ? local.eks_actions : [],
   )

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/main.tf
@@ -4,20 +4,20 @@ module "aws_discovery" {
   teleport_proxy_public_addr    = "example.teleport.sh:443"
   teleport_discovery_group_name = "cloud-discovery-group"
 
-  # Discover EC2 instances and EKS clusters with separate matching rules
+  # Discover EC2 instances and EKS clusters with separate matching rules.
+  # Both types accept "*" to discover across all enabled regions. The module
+  # adds account:ListRegions to the IAM policy automatically when "*" is used.
   aws_matchers = [
     {
-      types = ["ec2"]
-      # EC2 discovery supports a wildcard to find instances in all regions.
+      types   = ["ec2"]
       regions = ["*"]
       tags = {
         env = ["prod"]
       }
     },
     {
-      types = ["eks"]
-      # EKS requires region selection.
-      regions = ["us-east-1"]
+      types   = ["eks"]
+      regions = ["*"]
       tags = {
         team = ["platform"]
       }

--- a/integrations/terraform-modules/teleport/discovery/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/variables.tf
@@ -74,14 +74,6 @@ variable "aws_matchers" {
   validation {
     condition = !anytrue([
       for matcher in var.aws_matchers :
-      contains(matcher.types, "eks") && contains(matcher.regions, "*")
-    ])
-    error_message = "EKS discovery does not support wildcard regions. Specify explicit regions for EKS matchers."
-  }
-
-  validation {
-    condition = !anytrue([
-      for matcher in var.aws_matchers :
       matcher.setup_access_for_arn != "" && !contains(matcher.types, "eks")
     ])
     error_message = "setup_access_for_arn is only supported for EKS matchers."

--- a/lib/cloud/aws/regions/regions.go
+++ b/lib/cloud/aws/regions/regions.go
@@ -1,0 +1,69 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package regions
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/account"
+	accounttypes "github.com/aws/aws-sdk-go-v2/service/account/types"
+	"github.com/gravitational/trace"
+
+	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+)
+
+// ListerGetter gets a client that is capable of listing AWS regions.
+type ListerGetter func(ctx context.Context, opts ...awsconfig.OptionsFn) (account.ListRegionsAPIClient, error)
+
+// ListEnabledRegions returns every region enabled for the caller's AWS
+// account, using the account:ListRegions API.
+func ListEnabledRegions(ctx context.Context, listerGetter ListerGetter, opts ...awsconfig.OptionsFn) ([]string, error) {
+	regionsListerClient, err := listerGetter(ctx, opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	paginator := account.NewListRegionsPaginator(regionsListerClient, &account.ListRegionsInput{
+		RegionOptStatusContains: []accounttypes.RegionOptStatus{
+			accounttypes.RegionOptStatusEnabled,
+			accounttypes.RegionOptStatusEnabledByDefault,
+		},
+	})
+
+	var enabledRegions []string
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			convertedErr := libcloudaws.ConvertRequestFailureError(err)
+			if trace.IsAccessDenied(convertedErr) {
+				return nil, trace.BadParameter("Missing account:ListRegions permission in IAM Role, which is required to iterate over all regions. " +
+					"Add this permission to the IAM Role, or enumerate the regions explicitly.")
+			}
+			return nil, convertedErr
+		}
+
+		for _, region := range page.Regions {
+			enabledRegions = append(enabledRegions, aws.ToString(region.RegionName))
+		}
+	}
+
+	return enabledRegions, nil
+}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/api/types/usertasks"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	awsregions "github.com/gravitational/teleport/lib/cloud/aws/regions"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
@@ -129,7 +130,7 @@ type Config struct {
 	// GetEC2Client gets an AWS EC2 client for the given region.
 	GetEC2Client server.EC2ClientGetter
 	// GetAWSRegionsLister gets a client that is capable of listing AWS regions.
-	GetAWSRegionsLister server.RegionsListerGetter
+	GetAWSRegionsLister awsregions.ListerGetter
 	// GetAWSOrganizationsClient gets a client that is capable of listing AWS organizations.
 	GetAWSOrganizationsClient server.AWSOrganizationsGetter
 	// GetSSMClient gets an AWS SSM client for the given region.
@@ -681,7 +682,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 	_, otherMatchers = splitMatchers(otherMatchers, db.IsAWSMatcherType)
 
 	// Add non-integration kube fetchers.
-	kubeFetchers, err := fetchers.MakeEKSFetchersFromAWSMatchers(s.Log, s.AWSFetchersClients, otherMatchers, noDiscoveryConfig)
+	kubeFetchers, err := fetchers.MakeEKSFetchersFromAWSMatchers(s.Log, s.AWSFetchersClients, s.GetAWSRegionsLister, otherMatchers, noDiscoveryConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -897,7 +898,7 @@ func (s *Server) kubeFetchersFromMatchers(matchers Matchers, discoveryConfigName
 		return matcherType == types.AWSMatcherEKS
 	})
 	if len(awsKubeMatchers) > 0 {
-		eksFetchers, err := fetchers.MakeEKSFetchersFromAWSMatchers(s.Log, s.AWSFetchersClients, awsKubeMatchers, discoveryConfigName)
+		eksFetchers, err := fetchers.MakeEKSFetchersFromAWSMatchers(s.Log, s.AWSFetchersClients, s.GetAWSRegionsLister, awsKubeMatchers, discoveryConfigName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1964,7 +1964,7 @@ func TestDiscoveryServer_New(t *testing.T) {
 			},
 		},
 		{
-			desc:         "EKS fetcher is skipped on initialization error (missing region)",
+			desc:         "EKS fetcher surfaces initialization error (missing region)",
 			cloudClients: &mockFetchersClients{},
 			matchers: Matchers{
 				AWS: []types.AWSMatcher{
@@ -1988,12 +1988,9 @@ func TestDiscoveryServer_New(t *testing.T) {
 					},
 				},
 			},
-			errAssertion: require.NoError,
+			errAssertion: require.Error,
 			discServerAssertion: func(t require.TestingT, i any, i2 ...any) {
-				require.NotNil(t, i)
-				val, ok := i.(*Server)
-				require.True(t, ok)
-				require.Len(t, val.kubeFetchers, 1, "unexpected amount of kube fetchers")
+				require.Nil(t, i)
 			},
 		},
 	}

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	awsregions "github.com/gravitational/teleport/lib/cloud/aws/regions"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/fixtures"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
@@ -62,10 +63,20 @@ const (
 type eksFetcher struct {
 	EKSFetcherConfig
 
-	mu               sync.Mutex
-	client           EKSClient
-	stsPresignClient STSPresignClient
-	callerIdentity   string
+	callerIdentityOnce sync.Once
+	callerIdentity     string
+}
+
+// regionalFetcher discovers EKS clusters in a single AWS region.
+type regionalFetcher struct {
+	matcher           types.AWSMatcher
+	logger            *slog.Logger
+	clock             clockwork.Clock
+	cfg               aws.Config
+	eks               EKSClient
+	stsPresign        STSPresignClient
+	callerIdentity    string
+	setupAccessForARN string
 }
 
 // EKSClient is the subset of the EKS interface we use in fetchers.
@@ -104,28 +115,18 @@ type AWSClientGetter interface {
 type EKSFetcherConfig struct {
 	// ClientGetter retrieves an EKS client and an STS client.
 	ClientGetter AWSClientGetter
-	// AssumeRole provides a role ARN and ExternalID to assume an AWS role
-	// when fetching clusters.
-	AssumeRole types.AssumeRole
-	// Integration is the integration name to be used to fetch credentials.
-	// When present, it will use this integration and discard any local credentials.
-	Integration string
+	// Matcher is the AWS matcher with discovery rules: regions, tags,
+	// integration, assume role, access setup.
+	Matcher types.AWSMatcher
+	// RegionsListerGetter lists AWS regions enabled for the caller's account.
+	// Required to expand the wildcard region.
+	RegionsListerGetter awsregions.ListerGetter
 	// DiscoveryConfigName is the name of the discovery config which originated the resource.
 	// Might be empty when the fetcher is using static matchers:
 	// ie teleport.yaml/discovery_service.<cloud>.<matcher>
 	DiscoveryConfigName string
-	// KubeAppDiscovery specifies if Kubernetes App Discovery should be enabled for the
-	// discovered cluster. We don't use this information for fetching itself, but we need it for
-	// correct enrollment of the clusters returned from this fetcher.
-	KubeAppDiscovery bool
-	// Region is the region where the clusters should be located.
-	Region string
-	// FilterLabels are the filter criteria.
-	FilterLabels types.Labels
-	// Log is the logger.
+	// Logger is the logger.
 	Logger *slog.Logger
-	// SetupAccessForARN is the ARN to setup access for.
-	SetupAccessForARN string
 	// Clock is the clock.
 	Clock clockwork.Clock
 }
@@ -135,12 +136,14 @@ func (c *EKSFetcherConfig) CheckAndSetDefaults() error {
 	if c.ClientGetter == nil {
 		return trace.BadParameter("missing ClientGetter field")
 	}
-	if len(c.Region) == 0 {
-		return trace.BadParameter("missing Region field")
+	if len(c.Matcher.Regions) == 0 {
+		return trace.BadParameter("missing Matcher.Regions field")
 	}
-
-	if len(c.FilterLabels) == 0 {
-		return trace.BadParameter("missing FilterLabels field")
+	if c.Matcher.IsRegionWildcard() && c.RegionsListerGetter == nil {
+		return trace.BadParameter("missing RegionsListerGetter field for wildcard region matcher")
+	}
+	if len(c.Matcher.Tags) == 0 {
+		return trace.BadParameter("missing Matcher.Tags field")
 	}
 
 	if c.Logger == nil {
@@ -154,49 +157,31 @@ func (c *EKSFetcherConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-// MakeEKSFetchersFromAWSMatchers creates fetchers from the provided matchers. Returned fetchers are separated
-// by their reliance on the integration.
-func MakeEKSFetchersFromAWSMatchers(logger *slog.Logger, clients AWSClientGetter, matchers []types.AWSMatcher, discoveryConfigName string) (kubeFetchers []common.Fetcher, _ error) {
+// MakeEKSFetchersFromAWSMatchers creates fetchers from the provided matchers.
+// Emits one fetcher per matcher. Wildcard regions are expanded at fetch time.
+func MakeEKSFetchersFromAWSMatchers(
+	logger *slog.Logger,
+	clients AWSClientGetter,
+	regionsListerGetter awsregions.ListerGetter,
+	matchers []types.AWSMatcher,
+	discoveryConfigName string,
+) ([]common.Fetcher, error) {
+	var kubeFetchers []common.Fetcher
 	for _, matcher := range matchers {
-		var matcherAssumeRole types.AssumeRole
-		if matcher.AssumeRole != nil {
-			matcherAssumeRole = *matcher.AssumeRole
+		if !slices.Contains(matcher.Types, types.AWSMatcherEKS) {
+			continue
 		}
-
-		for _, t := range matcher.Types {
-			for _, region := range matcher.Regions {
-				switch t {
-				case types.AWSMatcherEKS:
-					if region == types.Wildcard {
-						logger.WarnContext(context.Background(), "EKS discovery does not support region discovery, remove the '*' from the regions field", "discovery_config", discoveryConfigName)
-						continue
-					}
-					fetcher, err := NewEKSFetcher(
-						EKSFetcherConfig{
-							ClientGetter:        clients,
-							AssumeRole:          matcherAssumeRole,
-							Region:              region,
-							Integration:         matcher.Integration,
-							KubeAppDiscovery:    matcher.KubeAppDiscovery,
-							FilterLabels:        matcher.Tags,
-							Logger:              logger,
-							SetupAccessForARN:   matcher.SetupAccessForARN,
-							DiscoveryConfigName: discoveryConfigName,
-						},
-					)
-					if err != nil {
-						logger.WarnContext(context.Background(), "Could not initialize EKS fetcher, skipping",
-							"error", err,
-							"region", region,
-							"labels", matcher.Tags,
-							"assume_role", matcherAssumeRole.RoleARN,
-						)
-						continue
-					}
-					kubeFetchers = append(kubeFetchers, fetcher)
-				}
-			}
+		fetcher, err := NewEKSFetcher(EKSFetcherConfig{
+			ClientGetter:        clients,
+			Matcher:             matcher,
+			RegionsListerGetter: regionsListerGetter,
+			Logger:              logger,
+			DiscoveryConfigName: discoveryConfigName,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+		kubeFetchers = append(kubeFetchers, fetcher)
 	}
 	return kubeFetchers, nil
 }
@@ -206,44 +191,44 @@ func NewEKSFetcher(cfg EKSFetcherConfig) (common.Fetcher, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	fetcher := &eksFetcher{EKSFetcherConfig: cfg}
-
-	if err := fetcher.setCallerIdentity(context.Background()); err != nil {
-		cfg.Logger.WarnContext(context.Background(), "Failed to set caller identity", "error", err)
-	}
-
-	// If the fetcher SetupAccessForARN isn't set, use the caller identity.
-	// This is useful to setup access for the caller identity itself
-	// without having to specify the ARN.
-	// If the current caller identity doesn't have access to setup access entries,
-	// the fetcher will log a warning and skip the setup access process.
-	if fetcher.SetupAccessForARN == "" {
-		fetcher.SetupAccessForARN = fetcher.callerIdentity
-	}
-	return fetcher, nil
+	return &eksFetcher{EKSFetcherConfig: cfg}, nil
 }
 
-func (a *eksFetcher) getClient(ctx context.Context) (EKSClient, error) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	if a.client != nil {
-		return a.client, nil
+// assumeRole returns the matcher's AssumeRole as a value, zero when unset.
+func (a *eksFetcher) assumeRole() types.AssumeRole {
+	if a.Matcher.AssumeRole == nil {
+		return types.AssumeRole{}
 	}
+	return *a.Matcher.AssumeRole
+}
 
-	cfg, err := a.ClientGetter.GetConfig(ctx, a.Region, getAWSOpts(a.AssumeRole, a.Integration)...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+// credentialOpts returns the AWS SDK options that apply this fetcher's
+// assume-role and integration credentials.
+func (a *eksFetcher) credentialOpts() []awsconfig.OptionsFn {
+	return getAWSOpts(a.assumeRole(), a.Matcher.Integration)
+}
 
-	a.client = a.ClientGetter.GetAWSEKSClient(cfg)
-	return a.client, nil
+// ensureCallerIdentity resolves the fetcher's AWS caller identity at most
+// once per fetcher lifetime, using the supplied region config.
+func (a *eksFetcher) ensureCallerIdentity(ctx context.Context, cfg aws.Config) {
+	a.callerIdentityOnce.Do(func() {
+		if a.Matcher.AssumeRole != nil && a.Matcher.AssumeRole.RoleARN != "" {
+			a.callerIdentity = a.Matcher.AssumeRole.RoleARN
+			return
+		}
+		stsClient := a.ClientGetter.GetAWSSTSClient(cfg)
+		identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+		if err != nil {
+			a.Logger.WarnContext(ctx, "Failed to resolve AWS caller identity", "error", err)
+			return
+		}
+		a.callerIdentity = convertAssumedRoleToIAMRole(aws.ToString(identity.Arn))
+	})
 }
 
 // GetIntegration returns the integration name that is used for getting credentials of the fetcher.
 func (a *eksFetcher) GetIntegration() string {
-	return a.Integration
+	return a.Matcher.Integration
 }
 
 type DiscoveredEKSCluster struct {
@@ -270,27 +255,80 @@ func (a *eksFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, error)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	a.rewriteKubeClusters(clusters)
 
 	resources := make(types.ResourcesWithLabels, 0, len(clusters))
 	for _, cluster := range clusters {
+		common.ApplyEKSNameSuffix(cluster)
 		resources = append(resources, &DiscoveredEKSCluster{
 			KubeCluster:            cluster,
-			Integration:            a.Integration,
-			EnableKubeAppDiscovery: a.KubeAppDiscovery,
+			Integration:            a.Matcher.Integration,
+			EnableKubeAppDiscovery: a.Matcher.KubeAppDiscovery,
 		})
 	}
 	return resources, nil
 }
 
-// rewriteKubeClusters rewrites the discovered kube clusters.
-func (a *eksFetcher) rewriteKubeClusters(clusters types.KubeClusters) {
-	for _, c := range clusters {
-		common.ApplyEKSNameSuffix(c)
+func (a *eksFetcher) getEKSClusters(ctx context.Context) (types.KubeClusters, error) {
+	regions := a.Matcher.Regions
+	if a.Matcher.IsRegionWildcard() {
+		enabled, err := awsregions.ListEnabledRegions(ctx, a.RegionsListerGetter, a.credentialOpts()...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		regions = enabled
 	}
+
+	var clusters types.KubeClusters
+	for _, region := range regions {
+		rf, err := a.newRegionalFetcher(ctx, region)
+		if err != nil {
+			a.Logger.WarnContext(ctx, "Failed to initialize regional EKS fetcher, skipping",
+				"region", region, "error", err)
+			continue
+		}
+		regionClusters, err := rf.FindClusters(ctx)
+		if err != nil {
+			a.Logger.WarnContext(ctx, "Failed to discover EKS clusters in region, skipping",
+				"region", region, "error", err)
+			continue
+		}
+		clusters = append(clusters, regionClusters...)
+	}
+	return clusters, nil
 }
 
-func (a *eksFetcher) getEKSClusters(ctx context.Context) (types.KubeClusters, error) {
+// newRegionalFetcher builds the region-scoped worker for one region.
+func (a *eksFetcher) newRegionalFetcher(ctx context.Context, region string) (*regionalFetcher, error) {
+	cfg, err := a.ClientGetter.GetConfig(ctx, region, a.credentialOpts()...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	a.ensureCallerIdentity(ctx, cfg)
+
+	setupAccessForARN := a.Matcher.SetupAccessForARN
+	if setupAccessForARN == "" {
+		setupAccessForARN = a.callerIdentity
+	}
+
+	return &regionalFetcher{
+		matcher:           a.Matcher,
+		logger:            a.Logger,
+		clock:             a.Clock,
+		cfg:               cfg,
+		eks:               a.ClientGetter.GetAWSEKSClient(cfg),
+		stsPresign:        a.ClientGetter.GetAWSSTSPresignClient(cfg),
+		callerIdentity:    a.callerIdentity,
+		setupAccessForARN: setupAccessForARN,
+	}, nil
+}
+
+// FindClusters lists EKS clusters in this region, filters them against the
+// matcher, and sets up access entries where required. Per-cluster workers
+// run in an errgroup capped at concurrencyLimit; errors on individual
+// clusters are logged and swallowed so one bad cluster cannot abort the
+// region.
+func (r *regionalFetcher) FindClusters(ctx context.Context) (types.KubeClusters, error) {
 	var (
 		clusters        types.KubeClusters
 		mu              sync.Mutex
@@ -298,31 +336,24 @@ func (a *eksFetcher) getEKSClusters(ctx context.Context) (types.KubeClusters, er
 	)
 	group.SetLimit(concurrencyLimit)
 
-	client, err := a.getClient(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed getting AWS EKS client")
-	}
-
 	// For now we should only list EKS clusters so we use nil (default) input param.
-	for p := eks.NewListClustersPaginator(client, nil); p.HasMorePages(); {
+	for p := eks.NewListClustersPaginator(r.eks, nil); p.HasMorePages(); {
 		out, err := p.NextPage(ctx)
 		if err != nil {
-			return clusters, trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 		for _, clusterName := range out.Clusters {
 			// group.Go will block if the concurrency limit is reached.
 			// It will resume once any running function finishes.
 			group.Go(func() error {
-				cluster, err := a.getMatchingKubeCluster(groupCtx, clusterName)
+				cluster, err := r.getMatchingKubeCluster(groupCtx, clusterName)
 				// trace.CompareFailed is returned if the cluster did not match the matcher filtering labels
 				// or if the cluster is not yet active.
 				if trace.IsCompareFailed(err) {
-					a.Logger.DebugContext(groupCtx, "Cluster did not match the filtering criteria", "error", err, "cluster", clusterName)
-					// never return an error otherwise we will impact discovery process
+					r.logger.DebugContext(groupCtx, "Cluster did not match the filtering criteria", "error", err, "cluster", clusterName)
 					return nil
 				} else if err != nil {
-					a.Logger.WarnContext(groupCtx, "Failed to discover EKS cluster", "error", err, "cluster", clusterName)
-					// never return an error otherwise we will impact discovery process
+					r.logger.WarnContext(groupCtx, "Failed to discover EKS cluster", "error", err, "cluster", clusterName)
 					return nil
 				}
 
@@ -336,7 +367,7 @@ func (a *eksFetcher) getEKSClusters(ctx context.Context) (types.KubeClusters, er
 
 	// The error can be discarded since we do not return any error from group.Go closure.
 	_ = group.Wait()
-	return clusters, trace.Wrap(err)
+	return clusters, nil
 }
 
 func (a *eksFetcher) ResourceType() string {
@@ -352,7 +383,7 @@ func (a *eksFetcher) Cloud() string {
 }
 
 func (a *eksFetcher) IntegrationName() string {
-	return a.Integration
+	return a.Matcher.Integration
 }
 
 func (a *eksFetcher) GetDiscoveryConfigName() string {
@@ -360,21 +391,16 @@ func (a *eksFetcher) GetDiscoveryConfigName() string {
 }
 
 func (a *eksFetcher) String() string {
-	return fmt.Sprintf("eksFetcher(Region=%v, FilterLabels=%v)",
-		a.Region, a.FilterLabels)
+	return fmt.Sprintf("eksFetcher(Regions=%v, FilterLabels=%v)",
+		a.Matcher.Regions, a.Matcher.Tags)
 }
 
 // getMatchingKubeCluster extracts EKS cluster Tags and cluster status from EKS and checks if the cluster matches
 // the AWS matcher filtering labels. It also excludes EKS clusters that are not ready.
 // If any cluster does not match the filtering criteria, this function returns a “trace.CompareFailed“ error
 // to distinguish filtering and operational errors.
-func (a *eksFetcher) getMatchingKubeCluster(ctx context.Context, clusterName string) (types.KubeCluster, error) {
-	client, err := a.getClient(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed getting AWS EKS client")
-	}
-
-	rsp, err := client.DescribeCluster(
+func (r *regionalFetcher) getMatchingKubeCluster(ctx context.Context, clusterName string) (types.KubeCluster, error) {
+	rsp, err := r.eks.DescribeCluster(
 		ctx,
 		&eks.DescribeClusterInput{
 			Name: aws.String(clusterName),
@@ -386,7 +412,7 @@ func (a *eksFetcher) getMatchingKubeCluster(ctx context.Context, clusterName str
 
 	switch st := rsp.Cluster.Status; st {
 	case ekstypes.ClusterStatusUpdating, ekstypes.ClusterStatusActive:
-		a.Logger.DebugContext(ctx, "EKS cluster status is valid", "status", st, "cluster", clusterName)
+		r.logger.DebugContext(ctx, "EKS cluster status is valid", "status", st, "cluster", clusterName)
 	default:
 		return nil, trace.CompareFailed("EKS cluster %q not enrolled due to its current status: %s", clusterName, st)
 	}
@@ -396,20 +422,20 @@ func (a *eksFetcher) getMatchingKubeCluster(ctx context.Context, clusterName str
 		return nil, trace.WrapWithMessage(err, "Unable to convert eks.Cluster cluster into types.KubernetesClusterV3.")
 	}
 
-	if match, reason, err := services.MatchLabels(a.FilterLabels, cluster.GetAllLabels()); err != nil {
+	if match, reason, err := services.MatchLabels(r.matcher.Tags, cluster.GetAllLabels()); err != nil {
 		return nil, trace.WrapWithMessage(err, "Unable to match EKS cluster labels against match labels.")
 	} else if !match {
 		return nil, trace.CompareFailed("EKS cluster %q labels does not match the selector: %s", clusterName, reason)
 	}
 
 	// If no access configuration is required, return the cluster.
-	if a.SetupAccessForARN == "" || rsp.Cluster.AccessConfig == nil || a.Integration != "" {
+	if r.setupAccessForARN == "" || rsp.Cluster.AccessConfig == nil || r.matcher.Integration != "" {
 		return cluster, nil
 	}
 
 	var assumedRole *types.AssumeRole
-	if a.AssumeRole.RoleARN != "" {
-		assumedRole = &a.AssumeRole
+	if r.matcher.AssumeRole != nil && r.matcher.AssumeRole.RoleARN != "" {
+		assumedRole = r.matcher.AssumeRole
 	}
 
 	// Set the AWS status for the cluster. This holds information about the
@@ -420,8 +446,8 @@ func (a *eksFetcher) getMatchingKubeCluster(ctx context.Context, clusterName str
 		&types.KubernetesClusterStatus{
 			Discovery: &types.KubernetesClusterDiscoveryStatus{
 				Aws: &types.KubernetesClusterAWSStatus{
-					SetupAccessForArn:    a.SetupAccessForARN,
-					Integration:          a.Integration,
+					SetupAccessForArn:    r.setupAccessForARN,
+					Integration:          r.matcher.Integration,
 					DiscoveryAssumedRole: assumedRole,
 				},
 			},
@@ -433,15 +459,15 @@ func (a *eksFetcher) getMatchingKubeCluster(ctx context.Context, clusterName str
 	// If the authentication mode is set to [eks.AuthenticationModeConfigMap], the fetcher will ignore the cluster.
 	switch st := rsp.Cluster.AccessConfig.AuthenticationMode; st {
 	case ekstypes.AuthenticationModeApiAndConfigMap, ekstypes.AuthenticationModeApi:
-		if err := a.checkOrSetupAccessForARN(ctx, client, rsp.Cluster); err != nil {
+		if err := r.checkOrSetupAccessForARN(ctx, rsp.Cluster); err != nil {
 			return nil, trace.Wrap(err, "unable to setup access for EKS cluster %q", clusterName)
 		}
 		return cluster, nil
 	default:
-		a.Logger.InfoContext(ctx, "EKS cluster must be configured manually due to its authentication mode",
+		r.logger.InfoContext(ctx, "EKS cluster must be configured manually due to its authentication mode",
 			"cluster", clusterName,
 			"authentication_mode", st,
-			"access_arn", a.SetupAccessForARN,
+			"access_arn", r.setupAccessForARN,
 		)
 		return cluster, nil
 	}
@@ -470,12 +496,12 @@ var eksDiscoveryPermissions = []string{
 // The check involves checking if the access entry exists and if the "teleport:kube-agent:eks" is part of the Kubernetes group.
 // If the access entry doesn't exist or is misconfigured, the fetcher will temporarily gain admin access and create the role and binding.
 // The fetcher will then upsert the access entry with the correct Kubernetes group.
-func (a *eksFetcher) checkOrSetupAccessForARN(ctx context.Context, client EKSClient, cluster *ekstypes.Cluster) error {
+func (r *regionalFetcher) checkOrSetupAccessForARN(ctx context.Context, cluster *ekstypes.Cluster) error {
 	entry, err := convertAWSError(
-		client.DescribeAccessEntry(ctx,
+		r.eks.DescribeAccessEntry(ctx,
 			&eks.DescribeAccessEntryInput{
 				ClusterName:  cluster.Name,
-				PrincipalArn: aws.String(a.SetupAccessForARN),
+				PrincipalArn: aws.String(r.setupAccessForARN),
 			},
 		),
 	)
@@ -483,7 +509,7 @@ func (a *eksFetcher) checkOrSetupAccessForARN(ctx context.Context, client EKSCli
 	switch {
 	case trace.IsAccessDenied(err):
 		// Access denied means that the principal does not have access to setup access entries for the cluster.
-		a.Logger.WarnContext(ctx, "Access denied to setup access for EKS cluster, ensure the required permissions are set",
+		r.logger.WarnContext(ctx, "Access denied to setup access for EKS cluster, ensure the required permissions are set",
 			"error", err,
 			"cluster", aws.ToString(cluster.Name),
 			"required_permissions", eksDiscoveryPermissions,
@@ -498,9 +524,9 @@ func (a *eksFetcher) checkOrSetupAccessForARN(ctx context.Context, client EKSCli
 	case trace.IsNotFound(err):
 		// If the access entry does not exist or the teleportKubernetesGroup is not part of the Kubernetes group, temporarily gain admin access and create the role and binding.
 		// This temporary access is granted to the identity that the Discovery service fetcher is running as (callerIdentity). If a role is assumed, the callerIdentity is the assumed role.
-		if err := a.temporarilyGainAdminAccessAndCreateRole(ctx, client, cluster); trace.IsAccessDenied(err) {
+		if err := r.temporarilyGainAdminAccessAndCreateRole(ctx, cluster); trace.IsAccessDenied(err) {
 			// Access denied means that the principal does not have access to setup access entries for the cluster.
-			a.Logger.WarnContext(ctx, "Access denied to setup access for EKS cluster, ensure the required permissions are set",
+			r.logger.WarnContext(ctx, "Access denied to setup access for EKS cluster, ensure the required permissions are set",
 				"error", err,
 				"cluster", aws.ToString(cluster.Name),
 				"required_permissions", eksDiscoveryPermissions,
@@ -511,10 +537,10 @@ func (a *eksFetcher) checkOrSetupAccessForARN(ctx context.Context, client EKSCli
 		}
 
 		// upsert the access entry with the correct Kubernetes group for the final
-		err = a.upsertAccessEntry(ctx, client, cluster)
+		err = r.upsertAccessEntry(ctx, cluster)
 		if trace.IsAccessDenied(err) {
 			// Access denied means that the principal does not have access to setup access entries for the cluster.
-			a.Logger.WarnContext(ctx, "Access denied to setup access for EKS cluster, ensure the required permissions are set",
+			r.logger.WarnContext(ctx, "Access denied to setup access for EKS cluster, ensure the required permissions are set",
 				"error", err,
 				"cluster", aws.ToString(cluster.Name),
 				"required_permissions", eksDiscoveryPermissions,
@@ -529,7 +555,7 @@ func (a *eksFetcher) checkOrSetupAccessForARN(ctx context.Context, client EKSCli
 
 // temporarilyGainAdminAccessAndCreateRole temporarily gains admin access to the EKS cluster by associating the EKS Cluster Admin Policy
 // to the callerIdentity. The fetcher will then create the role and binding for the teleportKubernetesGroup in the EKS cluster.
-func (a *eksFetcher) temporarilyGainAdminAccessAndCreateRole(ctx context.Context, client EKSClient, cluster *ekstypes.Cluster) error {
+func (r *regionalFetcher) temporarilyGainAdminAccessAndCreateRole(ctx context.Context, cluster *ekstypes.Cluster) error {
 	const (
 		// https://docs.aws.amazon.com/eks/latest/userguide/access-policies.html
 		// We use cluster admin policy to create namespace and cluster role.
@@ -538,10 +564,10 @@ func (a *eksFetcher) temporarilyGainAdminAccessAndCreateRole(ctx context.Context
 
 	// Setup access for the ARN
 	rsp, err := convertAWSError(
-		client.CreateAccessEntry(ctx,
+		r.eks.CreateAccessEntry(ctx,
 			&eks.CreateAccessEntryInput{
 				ClusterName:  cluster.Name,
-				PrincipalArn: aws.String(a.callerIdentity),
+				PrincipalArn: aws.String(r.callerIdentity),
 			},
 		),
 	)
@@ -553,15 +579,15 @@ func (a *eksFetcher) temporarilyGainAdminAccessAndCreateRole(ctx context.Context
 	if rsp != nil {
 		defer func() {
 			_, err := convertAWSError(
-				client.DeleteAccessEntry(
+				r.eks.DeleteAccessEntry(
 					ctx,
 					&eks.DeleteAccessEntryInput{
 						ClusterName:  cluster.Name,
-						PrincipalArn: aws.String(a.callerIdentity),
+						PrincipalArn: aws.String(r.callerIdentity),
 					}),
 			)
 			if err != nil {
-				a.Logger.WarnContext(ctx, "Failed to delete access entry for EKS cluster",
+				r.logger.WarnContext(ctx, "Failed to delete access entry for EKS cluster",
 					"error", err,
 					"cluster", aws.ToString(cluster.Name),
 				)
@@ -570,35 +596,35 @@ func (a *eksFetcher) temporarilyGainAdminAccessAndCreateRole(ctx context.Context
 	}
 
 	_, err = convertAWSError(
-		client.AssociateAccessPolicy(ctx, &eks.AssociateAccessPolicyInput{
+		r.eks.AssociateAccessPolicy(ctx, &eks.AssociateAccessPolicyInput{
 			AccessScope: &ekstypes.AccessScope{
 				Namespaces: nil,
 				Type:       ekstypes.AccessScopeTypeCluster,
 			},
 			ClusterName:  cluster.Name,
 			PolicyArn:    aws.String(eksClusterAdminPolicy),
-			PrincipalArn: aws.String(a.callerIdentity),
+			PrincipalArn: aws.String(r.callerIdentity),
 		}),
 	)
 	if err != nil && !trace.IsAlreadyExists(err) {
 		return trace.Wrap(err, "unable to associate EKS Access Policy to cluster %q", aws.ToString(cluster.Name))
 	}
 
-	timeout := a.Clock.NewTimer(60 * time.Second)
+	timeout := r.clock.NewTimer(60 * time.Second)
 	defer timeout.Stop()
 forLoop:
 	for {
 
 		// EKS Access Entries are eventually consistent, so we need to wait for the access to be granted.
 		// AWS API recommends to wait for 5 seconds before checking the access.
-		err = a.upsertRoleAndBinding(ctx, cluster)
+		err = r.upsertRoleAndBinding(ctx, cluster)
 		if err == nil || !kubeerrors.IsForbidden(err) && !kubeerrors.IsUnauthorized(err) {
 			break
 		}
 		select {
 		case <-timeout.Chan():
 			break forLoop
-		case <-a.Clock.After(5 * time.Second):
+		case <-r.clock.After(5 * time.Second):
 
 		}
 
@@ -607,8 +633,8 @@ forLoop:
 }
 
 // upsertRoleAndBinding upserts the ClusterRole and ClusterRoleBinding for the teleportKubernetesGroup in the EKS cluster.
-func (a *eksFetcher) upsertRoleAndBinding(ctx context.Context, cluster *ekstypes.Cluster) error {
-	client, err := a.createKubeClient(ctx, cluster)
+func (r *regionalFetcher) upsertRoleAndBinding(ctx context.Context, cluster *ekstypes.Cluster) error {
+	client, err := r.createKubeClient(ctx, cluster)
 	if err != nil {
 		return trace.Wrap(err, "unable to create Kubernetes client for cluster %q", aws.ToString(cluster.Name))
 	}
@@ -616,22 +642,22 @@ func (a *eksFetcher) upsertRoleAndBinding(ctx context.Context, cluster *ekstypes
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	if err := a.upsertClusterRoleWithAdminCredentials(ctx, client); err != nil {
+	if err := r.upsertClusterRoleWithAdminCredentials(ctx, client); err != nil {
 		return trace.Wrap(err, "unable to upsert ClusterRole for group %q", teleportKubernetesGroup)
 	}
 
-	if err := a.upsertClusterRoleBindingWithAdminCredentials(ctx, client, teleportKubernetesGroup); err != nil {
+	if err := r.upsertClusterRoleBindingWithAdminCredentials(ctx, client, teleportKubernetesGroup); err != nil {
 		return trace.Wrap(err, "unable to upsert ClusterRoleBinding for group %q", teleportKubernetesGroup)
 	}
 
 	return nil
 }
 
-func (a *eksFetcher) createKubeClient(ctx context.Context, cluster *ekstypes.Cluster) (*kubernetes.Clientset, error) {
-	if a.stsPresignClient == nil {
+func (r *regionalFetcher) createKubeClient(ctx context.Context, cluster *ekstypes.Cluster) (*kubernetes.Clientset, error) {
+	if r.stsPresign == nil {
 		return nil, trace.BadParameter("STS presign client is not set")
 	}
-	token, _, err := kubeutils.GenAWSEKSToken(ctx, a.stsPresignClient, aws.ToString(cluster.Name), a.Clock)
+	token, _, err := kubeutils.GenAWSEKSToken(ctx, r.stsPresign, aws.ToString(cluster.Name), r.clock)
 	if err != nil {
 		return nil, trace.Wrap(err, "unable to generate EKS token for cluster %q", aws.ToString(cluster.Name))
 	}
@@ -659,7 +685,7 @@ func (a *eksFetcher) createKubeClient(ctx context.Context, cluster *ekstypes.Clu
 }
 
 // upsertClusterRoleWithAdminCredentials tries to upsert the ClusterRole using admin credentials.
-func (a *eksFetcher) upsertClusterRoleWithAdminCredentials(ctx context.Context, client *kubernetes.Clientset) error {
+func (r *regionalFetcher) upsertClusterRoleWithAdminCredentials(ctx context.Context, client *kubernetes.Clientset) error {
 	clusterRole := &rbacv1.ClusterRole{}
 
 	if err := yaml.Unmarshal([]byte(fixtures.KubeClusterRoleTemplate), clusterRole); err != nil {
@@ -681,7 +707,7 @@ func (a *eksFetcher) upsertClusterRoleWithAdminCredentials(ctx context.Context, 
 
 // upsertClusterRoleBindingWithAdminCredentials tries to upsert the ClusterRoleBinding using admin credentials
 // and maps it into the principal group.
-func (a *eksFetcher) upsertClusterRoleBindingWithAdminCredentials(ctx context.Context, client *kubernetes.Clientset, groupID string) error {
+func (r *regionalFetcher) upsertClusterRoleBindingWithAdminCredentials(ctx context.Context, client *kubernetes.Clientset, groupID string) error {
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 
 	if err := yaml.Unmarshal([]byte(fixtures.KubeClusterRoleBindingTemplate), clusterRoleBinding); err != nil {
@@ -708,12 +734,12 @@ func (a *eksFetcher) upsertClusterRoleBindingWithAdminCredentials(ctx context.Co
 }
 
 // upsertAccessEntry upserts the access entry for the specified ARN with the teleportKubernetesGroup.
-func (a *eksFetcher) upsertAccessEntry(ctx context.Context, client EKSClient, cluster *ekstypes.Cluster) error {
+func (r *regionalFetcher) upsertAccessEntry(ctx context.Context, cluster *ekstypes.Cluster) error {
 	_, err := convertAWSError(
-		client.CreateAccessEntry(ctx,
+		r.eks.CreateAccessEntry(ctx,
 			&eks.CreateAccessEntryInput{
 				ClusterName:      cluster.Name,
-				PrincipalArn:     aws.String(a.SetupAccessForARN),
+				PrincipalArn:     aws.String(r.setupAccessForARN),
 				KubernetesGroups: []string{teleportKubernetesGroup},
 			},
 		))
@@ -722,38 +748,15 @@ func (a *eksFetcher) upsertAccessEntry(ctx context.Context, client EKSClient, cl
 	}
 
 	_, err = convertAWSError(
-		client.UpdateAccessEntry(ctx,
+		r.eks.UpdateAccessEntry(ctx,
 			&eks.UpdateAccessEntryInput{
 				ClusterName:      cluster.Name,
-				PrincipalArn:     aws.String(a.SetupAccessForARN),
+				PrincipalArn:     aws.String(r.setupAccessForARN),
 				KubernetesGroups: []string{teleportKubernetesGroup},
 			},
 		))
 
 	return trace.Wrap(err)
-}
-
-func (a *eksFetcher) setCallerIdentity(ctx context.Context) error {
-	cfg, err := a.ClientGetter.GetConfig(ctx,
-		a.Region,
-		getAWSOpts(a.AssumeRole, a.Integration)...,
-	)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	a.stsPresignClient = a.ClientGetter.GetAWSSTSPresignClient(cfg)
-	if a.AssumeRole.RoleARN != "" {
-		a.callerIdentity = a.AssumeRole.RoleARN
-		return nil
-	}
-
-	stsClient := a.ClientGetter.GetAWSSTSClient(cfg)
-	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	a.callerIdentity = convertAssumedRoleToIAMRole(aws.ToString(identity.Arn))
-	return nil
 }
 
 func getAWSOpts(assumeRole types.AssumeRole, integration string) []awsconfig.OptionsFn {
@@ -914,5 +917,4 @@ func DeleteKubernetesDanglingResources(ctx context.Context, cfg DeleteKubernetes
 	default:
 		return trace.Wrap(err, "failed to delete access entry for cluster %q", clusterName)
 	}
-
 }

--- a/lib/srv/discovery/fetchers/eks_test.go
+++ b/lib/srv/discovery/fetchers/eks_test.go
@@ -21,16 +21,24 @@ package fetchers
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/service/account"
+	accounttypes "github.com/aws/aws-sdk-go-v2/service/account/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	awsregions "github.com/gravitational/teleport/lib/cloud/aws/regions"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
@@ -38,101 +46,197 @@ import (
 )
 
 func TestEKSFetcher(t *testing.T) {
+	region1Clusters := []*ekstypes.Cluster{{
+		Name:   aws.String("us-east-1-cluster"),
+		Arn:    aws.String("arn:aws:eks:us-east-1:accountID:cluster/us-east-1-cluster"),
+		Status: ekstypes.ClusterStatusActive,
+		Tags:   map[string]string{"env": "prod"},
+	}}
+	region2Clusters := []*ekstypes.Cluster{{
+		Name:   aws.String("eu-west-1-cluster"),
+		Arn:    aws.String("arn:aws:eks:eu-west-1:accountID:cluster/eu-west-1-cluster"),
+		Status: ekstypes.ClusterStatusActive,
+		Tags:   map[string]string{"env": "prod"},
+	}}
+	denied := awsResponseError(http.StatusForbidden, "AccessDenied")
+	twoRegionLister := func(ctx context.Context, opts ...awsconfig.OptionsFn) (account.ListRegionsAPIClient, error) {
+		return &mockAccountClient{
+			output: &account.ListRegionsOutput{
+				Regions: []accounttypes.Region{
+					{RegionName: aws.String("us-east-1")},
+					{RegionName: aws.String("eu-west-1")},
+				},
+			},
+		}, nil
+	}
+	deniedLister := func(ctx context.Context, opts ...awsconfig.OptionsFn) (account.ListRegionsAPIClient, error) {
+		return &mockAccountClient{err: denied}, nil
+	}
+	// Single-region shorthand: dispatch the stock populated mock for one region.
+	single := func(region string) map[string]EKSClient {
+		return map[string]EKSClient{region: &mockEKSAPI{clusters: eksMockClusters}}
+	}
+
 	type args struct {
-		region       string
-		filterLabels types.Labels
+		regions         []string
+		filterLabels    types.Labels
+		clientsByRegion map[string]EKSClient
+		regionsLister   awsregions.ListerGetter
+		assumeRole      types.AssumeRole
 	}
 	tests := []struct {
-		name       string
-		args       args
-		assumeRole types.AssumeRole
-		want       types.ResourcesWithLabels
+		name    string
+		args    args
+		want    types.ResourcesWithLabels
+		wantErr require.ErrorAssertionFunc
 	}{
 		{
 			name: "list everything",
 			args: args{
-				region: "eu-west-1",
-				filterLabels: types.Labels{
-					types.Wildcard: []string{types.Wildcard},
-				},
+				regions:         []string{"eu-west-1"},
+				filterLabels:    types.Labels{types.Wildcard: []string{types.Wildcard}},
+				clientsByRegion: single("eu-west-1"),
 			},
-			want: eksClustersToResources(t, eksMockClusters...),
+			want:    eksClustersToResources(t, eksMockClusters...),
+			wantErr: require.NoError,
 		},
 		{
 			name: "list everything with assumed role",
 			args: args{
-				region: "eu-west-1",
-				filterLabels: types.Labels{
-					types.Wildcard: []string{types.Wildcard},
-				},
+				regions:         []string{"eu-west-1"},
+				filterLabels:    types.Labels{types.Wildcard: []string{types.Wildcard}},
+				clientsByRegion: single("eu-west-1"),
+				assumeRole:      types.AssumeRole{RoleARN: "arn:aws:iam::123456789012:role/test-role", ExternalID: "extID123"},
 			},
-			assumeRole: types.AssumeRole{RoleARN: "arn:aws:iam::123456789012:role/test-role", ExternalID: "extID123"},
-			want:       eksClustersToResources(t, eksMockClusters...),
+			want:    eksClustersToResources(t, eksMockClusters...),
+			wantErr: require.NoError,
 		},
 		{
 			name: "list prod clusters",
 			args: args{
-				region: "eu-west-1",
-				filterLabels: types.Labels{
-					"env": []string{"prod"},
-				},
+				regions:         []string{"eu-west-1"},
+				filterLabels:    types.Labels{"env": []string{"prod"}},
+				clientsByRegion: single("eu-west-1"),
 			},
-			want: eksClustersToResources(t, eksMockClusters[:2]...),
+			want:    eksClustersToResources(t, eksMockClusters[:2]...),
+			wantErr: require.NoError,
 		},
 		{
 			name: "list stg clusters from eu-west-1",
 			args: args{
-				region: "uswest2",
+				regions: []string{"uswest2"},
 				filterLabels: types.Labels{
 					"env":      []string{"stg"},
 					"location": []string{"eu-west-1"},
 				},
+				clientsByRegion: single("uswest2"),
 			},
-			want: eksClustersToResources(t, eksMockClusters[2:]...),
+			want:    eksClustersToResources(t, eksMockClusters[2:]...),
+			wantErr: require.NoError,
 		},
 		{
 			name: "filter not found",
 			args: args{
-				region: "uswest2",
-				filterLabels: types.Labels{
-					"env": []string{"none"},
-				},
+				regions:         []string{"uswest2"},
+				filterLabels:    types.Labels{"env": []string{"none"}},
+				clientsByRegion: single("uswest2"),
 			},
-			want: eksClustersToResources(t),
+			want:    eksClustersToResources(t),
+			wantErr: require.NoError,
 		},
 		{
 			name: "list everything with specified values",
 			args: args{
-				region: "uswest2",
-				filterLabels: types.Labels{
-					"env": []string{"prod", "stg"},
+				regions:         []string{"uswest2"},
+				filterLabels:    types.Labels{"env": []string{"prod", "stg"}},
+				clientsByRegion: single("uswest2"),
+			},
+			want:    eksClustersToResources(t, eksMockClusters...),
+			wantErr: require.NoError,
+		},
+		{
+			name: "list across explicit regions",
+			args: args{
+				regions:      []string{"us-east-1", "eu-west-1"},
+				filterLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+				clientsByRegion: map[string]EKSClient{
+					"us-east-1": &mockEKSAPI{clusters: region1Clusters},
+					"eu-west-1": &mockEKSAPI{clusters: region2Clusters},
 				},
 			},
-			want: eksClustersToResources(t, eksMockClusters...),
+			want:    eksClustersToResources(t, append(region1Clusters, region2Clusters...)...),
+			wantErr: require.NoError,
+		},
+		{
+			name: "wildcard expands to enabled regions",
+			args: args{
+				regions:      []string{types.Wildcard},
+				filterLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+				clientsByRegion: map[string]EKSClient{
+					"us-east-1": &mockEKSAPI{clusters: region1Clusters},
+					"eu-west-1": &mockEKSAPI{clusters: region2Clusters},
+				},
+				regionsLister: twoRegionLister,
+			},
+			want:    eksClustersToResources(t, append(region1Clusters, region2Clusters...)...),
+			wantErr: require.NoError,
+		},
+		{
+			name: "per-region failure does not abort matcher",
+			args: args{
+				regions:      []string{"us-east-1", "eu-west-1"},
+				filterLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+				clientsByRegion: map[string]EKSClient{
+					"us-east-1": &mockEKSAPI{listErr: denied},
+					"eu-west-1": &mockEKSAPI{clusters: region2Clusters},
+				},
+			},
+			want:    eksClustersToResources(t, region2Clusters...),
+			wantErr: require.NoError,
+		},
+		{
+			name: "wildcard account:ListRegions denied",
+			args: args{
+				regions:       []string{types.Wildcard},
+				filterLabels:  types.Labels{types.Wildcard: []string{types.Wildcard}},
+				regionsLister: deniedLister,
+			},
+			want: nil,
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %T: %v", err, err)
+				require.Contains(t, err.Error(), "account:ListRegions")
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stsClt := &mocks.STSClient{}
+			matcher := types.AWSMatcher{
+				Regions: tt.args.regions,
+				Tags:    tt.args.filterLabels,
+			}
+			if tt.args.assumeRole.RoleARN != "" {
+				matcher.AssumeRole = &tt.args.assumeRole
+			}
 			cfg := EKSFetcherConfig{
-				ClientGetter: &mockEKSClientGetter{
+				ClientGetter: &mockRegionalEKSClientGetter{
 					AWSConfigProvider: mocks.AWSConfigProvider{
 						STSClient: stsClt,
 					},
+					clientsByRegion: tt.args.clientsByRegion,
 				},
-				AssumeRole:   tt.assumeRole,
-				FilterLabels: tt.args.filterLabels,
-				Region:       tt.args.region,
-				Logger:       logtest.NewLogger(),
+				RegionsListerGetter: tt.args.regionsLister,
+				Matcher:             matcher,
+				Logger:              logtest.NewLogger(),
 			}
 			fetcher, err := NewEKSFetcher(cfg)
 			require.NoError(t, err)
-			if tt.assumeRole.RoleARN != "" {
-				require.Contains(t, stsClt.GetAssumedRoleARNs(), tt.assumeRole.RoleARN)
-				stsClt.ResetAssumeRoleHistory()
-			}
 			resources, err := fetcher.Get(context.Background())
-			require.NoError(t, err)
+			tt.wantErr(t, err)
+			if err != nil {
+				return
+			}
 
 			clusters := types.ResourcesWithLabels{}
 			for _, r := range resources {
@@ -144,27 +248,11 @@ func TestEKSFetcher(t *testing.T) {
 			}
 
 			require.Equal(t, tt.want.ToMap(), clusters.ToMap())
-			if tt.assumeRole.RoleARN != "" {
-				require.Contains(t, stsClt.GetAssumedRoleARNs(), tt.assumeRole.RoleARN)
+			if tt.args.assumeRole.RoleARN != "" {
+				require.Contains(t, stsClt.GetAssumedRoleARNs(), tt.args.assumeRole.RoleARN)
 			}
 		})
 	}
-}
-
-type mockEKSClientGetter struct {
-	mocks.AWSConfigProvider
-}
-
-func (e *mockEKSClientGetter) GetAWSEKSClient(cfg aws.Config) EKSClient {
-	return newPopulatedEKSMock()
-}
-
-func (e *mockEKSClientGetter) GetAWSSTSClient(aws.Config) STSClient {
-	return &mockSTSAPI{}
-}
-
-func (e *mockEKSClientGetter) GetAWSSTSPresignClient(aws.Config) kubeutils.STSPresignClient {
-	return &mockSTSPresignAPI{}
 }
 
 type mockSTSPresignAPI struct{}
@@ -173,17 +261,13 @@ func (a *mockSTSPresignAPI) PresignGetCallerIdentity(ctx context.Context, params
 	panic("not implemented")
 }
 
-type mockSTSAPI struct {
-	arn string
+type mockSTSAPI struct{}
+
+func (*mockSTSAPI) GetCallerIdentity(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{Arn: aws.String("")}, nil
 }
 
-func (a *mockSTSAPI) GetCallerIdentity(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
-	return &sts.GetCallerIdentityOutput{
-		Arn: aws.String(a.arn),
-	}, nil
-}
-
-func (a *mockSTSAPI) AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+func (*mockSTSAPI) AssumeRole(context.Context, *sts.AssumeRoleInput, ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
 	panic("not implemented")
 }
 
@@ -191,9 +275,13 @@ type mockEKSAPI struct {
 	EKSClient
 
 	clusters []*ekstypes.Cluster
+	listErr  error
 }
 
 func (m *mockEKSAPI) ListClusters(ctx context.Context, req *eks.ListClustersInput, _ ...func(*eks.Options)) (*eks.ListClustersOutput, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
 	var names []string
 	for _, cluster := range m.clusters {
 		names = append(names, aws.ToString(cluster.Name))
@@ -212,12 +300,6 @@ func (m *mockEKSAPI) DescribeCluster(_ context.Context, req *eks.DescribeCluster
 		}
 	}
 	return nil, errors.New("cluster not found")
-}
-
-func newPopulatedEKSMock() *mockEKSAPI {
-	return &mockEKSAPI{
-		clusters: eksMockClusters,
-	}
 }
 
 var eksMockClusters = []*ekstypes.Cluster{
@@ -270,4 +352,53 @@ func eksClustersToResources(t *testing.T, clusters ...*ekstypes.Cluster) types.R
 		kubeClusters = append(kubeClusters, kubeCluster)
 	}
 	return kubeClusters.AsResources()
+}
+
+// mockRegionalEKSClientGetter dispatches EKS clients keyed by the region
+// supplied to GetConfig.
+type mockRegionalEKSClientGetter struct {
+	mocks.AWSConfigProvider
+
+	clientsByRegion map[string]EKSClient
+}
+
+func (g *mockRegionalEKSClientGetter) GetAWSEKSClient(cfg aws.Config) EKSClient {
+	if c, ok := g.clientsByRegion[cfg.Region]; ok {
+		return c
+	}
+	return &mockEKSAPI{}
+}
+
+func (g *mockRegionalEKSClientGetter) GetAWSSTSClient(aws.Config) STSClient {
+	return &mockSTSAPI{}
+}
+
+func (g *mockRegionalEKSClientGetter) GetAWSSTSPresignClient(aws.Config) kubeutils.STSPresignClient {
+	return &mockSTSPresignAPI{}
+}
+
+// mockAccountClient implements account.ListRegionsAPIClient.
+type mockAccountClient struct {
+	output *account.ListRegionsOutput
+	err    error
+}
+
+func (m *mockAccountClient) ListRegions(context.Context, *account.ListRegionsInput, ...func(*account.Options)) (*account.ListRegionsOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.output, nil
+}
+
+// awsResponseError builds an AWS SDK v2 response error with the given HTTP
+// status so libcloudaws.ConvertRequestFailureError translates it to the
+// matching trace error.
+func awsResponseError(status int, msg string) error {
+	return &awshttp.ResponseError{
+		RequestID: "test-request-id",
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{Response: &http.Response{StatusCode: status}},
+			Err:      errors.New(msg),
+		},
+	}
 }

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -56,22 +56,28 @@ import (
 func TestServer_getKubeFetchers(t *testing.T) {
 	eks1, err := fetchers.NewEKSFetcher(fetchers.EKSFetcherConfig{
 		ClientGetter: &mockFetchersClients{},
-		FilterLabels: types.Labels{"l1": []string{"v1"}},
-		Region:       "region1",
+		Matcher: types.AWSMatcher{
+			Regions: []string{"region1"},
+			Tags:    types.Labels{"l1": []string{"v1"}},
+		},
 	})
 	require.NoError(t, err)
 	eks2, err := fetchers.NewEKSFetcher(fetchers.EKSFetcherConfig{
 		ClientGetter: &mockFetchersClients{},
-		FilterLabels: types.Labels{"l1": []string{"v1"}},
-		Region:       "region1",
-		Integration:  "aws1",
+		Matcher: types.AWSMatcher{
+			Regions:     []string{"region1"},
+			Tags:        types.Labels{"l1": []string{"v1"}},
+			Integration: "aws1",
+		},
 	})
 	require.NoError(t, err)
 	eks3, err := fetchers.NewEKSFetcher(fetchers.EKSFetcherConfig{
 		ClientGetter: &mockFetchersClients{},
-		FilterLabels: types.Labels{"l1": []string{"v1"}},
-		Region:       "region1",
-		Integration:  "aws1",
+		Matcher: types.AWSMatcher{
+			Regions:     []string{"region1"},
+			Tags:        types.Labels{"l1": []string{"v1"}},
+			Integration: "aws1",
+		},
 	})
 	require.NoError(t, err)
 
@@ -281,6 +287,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 				{
 					Types:       []string{"eks"},
 					Regions:     []string{"eu-west-1"},
+					Tags:        types.Labels{types.Wildcard: {types.Wildcard}},
 					Integration: "integration1",
 				},
 			},
@@ -311,6 +318,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 				{
 					Types:       []string{"eks"},
 					Regions:     []string{"eu-west-1"},
+					Tags:        types.Labels{types.Wildcard: {types.Wildcard}},
 					Integration: "integration1",
 				},
 			},
@@ -341,6 +349,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 				{
 					Types:       []string{"eks"},
 					Regions:     []string{"eu-west-1"},
+					Tags:        types.Labels{types.Wildcard: {types.Wildcard}},
 					Integration: "integration1",
 				},
 			},

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -26,8 +26,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/aws/aws-sdk-go-v2/service/account"
-	accounttypes "github.com/aws/aws-sdk-go-v2/service/account/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gravitational/trace"
@@ -35,6 +33,7 @@ import (
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	awsregions "github.com/gravitational/teleport/lib/cloud/aws/regions"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/utils/aws/organizations"
@@ -171,9 +170,6 @@ func (instances *EC2Instances) MakeEvents() map[string]*usageeventsv1.ResourceCr
 // EC2ClientGetter gets an AWS EC2 client for the given region.
 type EC2ClientGetter func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error)
 
-// RegionsListerGetter gets a list of AWS regions.
-type RegionsListerGetter func(ctx context.Context, opts ...awsconfig.OptionsFn) (account.ListRegionsAPIClient, error)
-
 // AWSOrganizationsGetter gets an AWS Organizations client used for listing accounts.
 type AWSOrganizationsGetter func(ctx context.Context, opts ...awsconfig.OptionsFn) (organizations.OrganizationsClient, error)
 
@@ -185,7 +181,7 @@ type MatcherToEC2FetcherParams struct {
 	// EC2ClientGetter gets an AWS EC2.
 	EC2ClientGetter EC2ClientGetter
 	// RegionsListerGetter gets a client that is capable of listing AWS regions.
-	RegionsListerGetter RegionsListerGetter
+	RegionsListerGetter awsregions.ListerGetter
 	// AWSOrganizationsGetter gets a client that is capable of listing AWS organizations.
 	AWSOrganizationsGetter AWSOrganizationsGetter
 	// DiscoveryConfigName is the name of the DiscoveryConfig that contains the matchers.
@@ -224,7 +220,7 @@ type ec2FetcherConfig struct {
 	// Example: proxy.example.com:3080 or proxy.example.com
 	ProxyPublicAddrGetter  func(ctx context.Context) (string, error)
 	EC2ClientGetter        EC2ClientGetter
-	RegionsListerGetter    RegionsListerGetter
+	RegionsListerGetter    awsregions.ListerGetter
 	AWSOrganizationsGetter AWSOrganizationsGetter
 	DiscoveryConfigName    string
 	Logger                 *slog.Logger
@@ -449,43 +445,6 @@ func chunkInstances(instancesByRegion map[string]EC2Instances) []*EC2Instances {
 	return instColl
 }
 
-func (f *ec2InstanceFetcher) matcherRegions(ctx context.Context, awsOpts []awsconfig.OptionsFn) ([]string, error) {
-	if !f.Matcher.IsRegionWildcard() {
-		return f.Matcher.Regions, nil
-	}
-
-	regionsListerClient, err := f.RegionsListerGetter(ctx, awsOpts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	paginator := account.NewListRegionsPaginator(regionsListerClient, &account.ListRegionsInput{
-		RegionOptStatusContains: []accounttypes.RegionOptStatus{
-			accounttypes.RegionOptStatusEnabled,
-			accounttypes.RegionOptStatusEnabledByDefault,
-		},
-	})
-
-	var enabledRegions []string
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			convertedErr := libcloudaws.ConvertRequestFailureError(err)
-			if trace.IsAccessDenied(convertedErr) {
-				return nil, trace.BadParameter("Missing account:ListRegions permission in IAM Role, which is required to iterate over all regions. " +
-					"Add this permission to the IAM Role, or enumerate all the regions in the AWS matcher.")
-			}
-			return nil, convertedErr
-		}
-
-		for _, region := range page.Regions {
-			enabledRegions = append(enabledRegions, aws.ToString(region.RegionName))
-		}
-	}
-
-	return enabledRegions, nil
-}
-
 func (f *ec2InstanceFetcher) fetchAccountIDsUnderOrganization(ctx context.Context) ([]string, error) {
 	awsOpts := []awsconfig.OptionsFn{
 		awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{Name: f.Matcher.Integration}),
@@ -595,13 +554,16 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 			awsconfig.WithAssumeRole(assumeRole.RoleARN, assumeRole.ExternalID),
 		}
 
-		regions, err := f.matcherRegions(ctx, awsOpts)
-		if err != nil {
-			f.Logger.WarnContext(ctx, "Failed to get regions for EC2 discovery",
-				"assume_role_arn", assumeRole.RoleARN,
-				"error", err,
-			)
-			continue
+		regions := f.Matcher.Regions
+		if f.Matcher.IsRegionWildcard() {
+			regions, err = awsregions.ListEnabledRegions(ctx, f.RegionsListerGetter, awsOpts...)
+			if err != nil {
+				f.Logger.WarnContext(ctx, "Failed to get regions for EC2 discovery",
+					"assume_role_arn", assumeRole.RoleARN,
+					"error", err,
+				)
+				continue
+			}
 		}
 
 		for _, region := range regions {

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/ResourcesSection.tsx
@@ -63,17 +63,6 @@ const nonEmptyTags: LabelsRule = (labels: Label[]) => () => {
   };
 };
 
-const requiredRegions =
-  (allowAll: boolean) => (options: readonly Option<AwsRegion>[]) => () => {
-    if (allowAll || (options && options.length > 0)) {
-      return { valid: true };
-    }
-    return {
-      valid: false,
-      message: 'At least one region must be selected',
-    };
-  };
-
 const fieldWidth = 400;
 // tags needs additional room for the close X on the right.
 const tagsWidth = fieldWidth + 32;
@@ -115,7 +104,6 @@ export function ResourcesSection({
         label="EC2 Instances"
         config={configs.ec2}
         onUpdate={patch => onConfigChange('ec2', patch)}
-        allowAllRegions={true}
         tagTooltip="Match EC2 instances by their tags. If no tags are added, Teleport will match and enroll all EC2 instances."
       />
 
@@ -124,7 +112,6 @@ export function ResourcesSection({
           label="EKS Clusters"
           config={configs.eks}
           onUpdate={patch => onConfigChange('eks', patch)}
-          allowAllRegions={false}
           tagTooltip="Match EKS clusters by their tags. If no tags are added, Teleport will match and enroll all EKS clusters."
         >
           <Box mt={2}>
@@ -158,14 +145,12 @@ function AwsService({
   label,
   config,
   onUpdate,
-  allowAllRegions,
   tagTooltip,
   children,
 }: {
   label: string;
   config: ServiceConfig;
   onUpdate: (update: Partial<ServiceConfig>) => void;
-  allowAllRegions: boolean;
   tagTooltip: string;
   children?: React.ReactNode;
 }) {
@@ -197,12 +182,7 @@ function AwsService({
                   regions: options.map(opt => opt.value),
                 })
               }
-              isDisabled={false}
-              required={!allowAllRegions}
-              rule={requiredRegions(allowAllRegions)}
-              placeholder={
-                allowAllRegions ? 'All regions' : 'Select regions...'
-              }
+              placeholder="All regions"
             />
           </Box>
           <TagsButton onClick={() => setTagsExpanded(prev => !prev)}>


### PR DESCRIPTION
Refactors discovery EKS fetcher to support region wildcard.

Updates the various frontends to allow it now:
- Terraform
- AWS discovery with terraform - enroll / settings
- Docs examples

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: EKS discovery supports region wildcard to find EKS clusters in all enabled AWS regions.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Staging tenant running local build
### Test Cases
- [x] EKS matcher with 1 explicit region - discovers 1 test cluster
- [x] EKS matcher with 2 explicit regions - discovers 2 test clusters
- [x] EKS matcher with wildcard region - discovers 2 test clusters
- [x] EKS matcher with wildcard region, without account:ListRegions permission - produces BadParameter error.

~~Todo with end-to-end build:~~ Moving to v18 backport to build everything together.
~~Discovery terraform with wildcard~~
~~Discovery terraform with omitted regions~~
