### PR TITLE
lean: formal model of Kubernetes RBAC (research)

### DIFF
--- a/.github/workflows/lean-diff.yaml
+++ b/.github/workflows/lean-diff.yaml
@@ -1,0 +1,69 @@
+name: Lean RBAC Diff
+on:
+  pull_request:
+    paths:
+      - 'lean/**'
+      - 'lib/services/role.go'
+      - 'lib/services/role_test.go'
+      - 'lib/services/access_checker.go'
+      - 'lib/utils/replace.go'
+      - 'api/types/role.go'
+      - 'api/types/kubernetes.go'
+      - 'tool/kubeaccess-corpus/**'
+      - '.github/workflows/lean-diff.yaml'
+  push:
+    branches:
+      - jakealti/lean
+    paths:
+      - 'lean/**'
+      - 'lib/services/role.go'
+      - 'lib/utils/replace.go'
+      - 'api/types/role.go'
+      - 'api/types/kubernetes.go'
+      - 'tool/kubeaccess-corpus/**'
+      - '.github/workflows/lean-diff.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  lean-diff:
+    name: Lean RBAC Diff
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Read Lean toolchain
+        id: lean_toolchain
+        run: |
+          version=$(cat lean/lean-toolchain | tr -d '[:space:]')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache elan + .lake
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.elan
+            lean/.lake
+          key: lean-${{ runner.os }}-${{ steps.lean_toolchain.outputs.version }}-${{ hashFiles('lean/lakefile.toml', 'lean/lake-manifest.json') }}
+          restore-keys: |
+            lean-${{ runner.os }}-${{ steps.lean_toolchain.outputs.version }}-
+
+      - name: Install elan
+        run: |
+          if ! command -v elan >/dev/null 2>&1; then
+            curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+              | sh -s -- -y --default-toolchain none
+          fi
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Run differential check
+        working-directory: lean
+        run: ./scripts/diff.sh

--- a/lean/.gitignore
+++ b/lean/.gitignore
@@ -1,0 +1,2 @@
+.lake/
+build/

--- a/lean/.gitignore
+++ b/lean/.gitignore
@@ -1,2 +1,3 @@
 .lake/
 build/
+corpus/kubernetes.json

--- a/lean/Main.lean
+++ b/lean/Main.lean
@@ -1,14 +1,26 @@
 import Lean.Data.Json
 import Teleport
 
-open Lean (Json)
+open Teleport
 
-/-- Placeholder differential-test driver. Reads the corpus path from
-argv, parses the top-level `{cases: [...]}` structure, and reports the
-case count. The actual `checkAccess`-vs-expected comparison is wired
-in by the `differential-loop` task; this skeleton just proves the
-pipeline compiles and can be invoked from `scripts/diff.sh` on an
-empty corpus. -/
+private def decisionStr : Decision → String
+  | .allow => "allow"
+  | .deny => "deny"
+
+/-- A placeholder request used for cluster-level cases where the corpus
+sets `request: null`. The v0 matchers ignore the request, so this is
+purely a syntactic stand-in. -/
+private def clusterWideRequest : Request :=
+  { resource := none, verb := .get, isClusterWide := true }
+
+private def runCase (tc : Teleport.TestCase) : Option String :=
+  let req := tc.request.getD clusterWideRequest
+  let actual := checkAccess tc.roles tc.cluster req
+  if actual != tc.expected then
+    some s!"{tc.name} | expected={decisionStr tc.expected} actual={decisionStr actual}"
+  else
+    none
+
 def main (args : List String) : IO UInt32 := do
   match args with
   | [] =>
@@ -16,15 +28,13 @@ def main (args : List String) : IO UInt32 := do
     return 1
   | path :: _ =>
     let content ← IO.FS.readFile path
-    match Json.parse content with
+    match decodeCorpus content with
     | .error e =>
-      IO.eprintln s!"parse error: {e}"
+      IO.eprintln s!"decode error: {e}"
       return 1
-    | .ok j =>
-      match j.getObjVal? "cases" >>= Json.getArr? with
-      | .error e =>
-        IO.eprintln s!"invalid schema (expected top-level `cases` array): {e}"
-        return 1
-      | .ok cases =>
-        IO.println s!"cases={cases.size} mismatches=0"
-        return 0
+    | .ok cases =>
+      let mismatches := cases.filterMap runCase
+      for m in mismatches do
+        IO.println m
+      IO.println s!"cases={cases.length} mismatches={mismatches.length}"
+      return if mismatches.isEmpty then 0 else 1

--- a/lean/Main.lean
+++ b/lean/Main.lean
@@ -1,0 +1,30 @@
+import Lean.Data.Json
+import Teleport
+
+open Lean (Json)
+
+/-- Placeholder differential-test driver. Reads the corpus path from
+argv, parses the top-level `{cases: [...]}` structure, and reports the
+case count. The actual `checkAccess`-vs-expected comparison is wired
+in by the `differential-loop` task; this skeleton just proves the
+pipeline compiles and can be invoked from `scripts/diff.sh` on an
+empty corpus. -/
+def main (args : List String) : IO UInt32 := do
+  match args with
+  | [] =>
+    IO.eprintln "usage: teleport-lean-diff <corpus.json>"
+    return 1
+  | path :: _ =>
+    let content ← IO.FS.readFile path
+    match Json.parse content with
+    | .error e =>
+      IO.eprintln s!"parse error: {e}"
+      return 1
+    | .ok j =>
+      match j.getObjVal? "cases" >>= Json.getArr? with
+      | .error e =>
+        IO.eprintln s!"invalid schema (expected top-level `cases` array): {e}"
+        return 1
+      | .ok cases =>
+        IO.println s!"cases={cases.size} mismatches=0"
+        return 0

--- a/lean/Main.lean
+++ b/lean/Main.lean
@@ -15,7 +15,14 @@ private def clusterWideRequest : Request :=
 
 private def runCase (tc : Teleport.TestCase) : Option String :=
   let req := tc.request.getD clusterWideRequest
-  let actual := checkAccess tc.roles tc.cluster req
+  -- Dispatch to the production decision function for cases that used the
+  -- NewKubernetesClusterLabelMatcher path in Go; everything else uses the
+  -- core RBAC decision.
+  let actual :=
+    if tc.source = "production" then
+      checkAccessProduction tc.roles tc.cluster req
+    else
+      checkAccess tc.roles tc.cluster req
   if actual != tc.expected then
     some s!"{tc.name} | expected={decisionStr tc.expected} actual={decisionStr actual}"
   else

--- a/lean/README.md
+++ b/lean/README.md
@@ -27,12 +27,21 @@ Cluster-level `CheckAccess` as exercised by `TestCheckAccessToKubernetes`
 - Read-only namespace branch — `lib/utils/replace.go:199-228`
 - Role versions other than V6
 - Pod/resource-level requests (`request.resource != null`)
-- **Implicit-wildcard deny injection** in `NewKubernetesClusterLabelMatcher`
-  (`lib/services/role.go:2665`, wired via `lib/kube/proxy/forwarder.go:1014`).
-  This matcher is applied on top of `CheckAccess` in production but not
-  by the v0 oracle (`TestCheckAccessToKubernetes` calls `CheckAccess`
-  without matchers). Model the pure RBAC core; add the matcher layer
-  separately when extending scope.
+
+## Two decision paths
+
+The model captures both:
+
+- **Core (`checkAccess`)** — `CheckAccess` without extra matchers, as used
+  in `TestCheckAccessToKubernetes`. No implicit-wildcard deny injection.
+- **Production (`checkAccessProduction`)** — `CheckAccess` with
+  `NewKubernetesClusterLabelMatcher` layered on top, as used in
+  `lib/kube/proxy/forwarder.go:1014`. Empty deny labels are injected to
+  `{*:*}` (`lib/services/role.go:2665`), so a role with empty deny will
+  deny access to any cluster.
+
+Each corpus case carries a `source` tag; `source == "production"` uses
+`checkAccessProduction`, everything else uses `checkAccess`.
 
 ## Proved invariants
 
@@ -44,10 +53,10 @@ All in `Teleport/Theorems.lean`, no `sorry`.
 - **T4** allow is preserved when new role has no matching deny
 - **T5** removing a no-deny role cannot grant access
 - **T7** empty allow labels never grant
+- **T8** under the production matcher path, empty deny labels deny all clusters
 - **T9** `checkAccess = .allow` is decidable
 - **T10** duplicate roles are idempotent
 - **T6** (wildcard grants) — deferred
-- **T8** (implicit-wildcard deny injection) — removed; see below
 
 ## Run
 

--- a/lean/README.md
+++ b/lean/README.md
@@ -1,0 +1,84 @@
+# Lean formal model of Teleport Kubernetes RBAC (v0)
+
+A small Lean 4 model of `RoleSet.checkAccess` for cluster-level
+Kubernetes access, kept in sync with Go via a JSON corpus.
+
+Two artifacts:
+
+1. **Spec.** `checkAccess` and helpers encode the decision semantics.
+   Proven theorems in `Teleport/Theorems.lean` state invariants.
+2. **Drift detector.** `scripts/diff.sh` regenerates a corpus from Go,
+   runs Lean over it, and fails on divergence. Go is always the oracle.
+
+## Modeled
+
+Cluster-level `CheckAccess` as exercised by `TestCheckAccessToKubernetes`
+(`lib/services/role_test.go:6828`). The 8 organic cases appear as
+`organic/*` entries; a synthetic generator adds ~96 combinatorial cases
+(7 role templates × 6 cluster label sets, plus 2- and 3-role sets).
+
+## Not modeled (silent on regressions in these paths)
+
+- Trait interpolation — `lib/services/role.go:497-650`
+- Label expressions — `lib/services/role.go:9712`
+- MFA / device trust (`AccessState`) — `lib/services/role.go:2850`
+- `kubernetes_users` / `kubernetes_groups` (identity mapping)
+- Regex beyond glob — `lib/utils/replace.go:405-431`
+- Read-only namespace branch — `lib/utils/replace.go:199-228`
+- Role versions other than V6
+- Pod/resource-level requests (`request.resource != null`)
+
+## Proved invariants
+
+All in `Teleport/Theorems.lean`, no `sorry`.
+
+- **T1** empty role set denies
+- **T2** deny dominates
+- **T3** prepending a matching-deny role forces deny
+- **T4** allow is preserved when new role has no matching deny
+- **T5** removing a no-deny role cannot grant access
+- **T7** empty allow labels never grant
+- **T8** implicit-wildcard deny injection is faithfully encoded
+- **T9** `checkAccess = .allow` is decidable
+- **T10** duplicate roles are idempotent
+- **T6** (wildcard grants) — deferred
+
+## Run
+
+```sh
+./scripts/diff.sh
+```
+
+Expected: `cases=104 mismatches=0`, exit 0. On mismatch, one line per
+divergent case is printed and exit is 1.
+
+Requires Go toolchain (for the corpus generator at
+`tool/kubeaccess-corpus`) and Lean via `elan` (toolchain pinned in
+`lean-toolchain`). The corpus JSON is `.gitignore`d — regenerated each
+run.
+
+## Maintenance
+
+When Go semantics change: rerun `diff.sh`, inspect mismatches, update
+Lean matchers — or file a Go bug if Lean turns out to be right. Extend
+corpus coverage by editing `tool/kubeaccess-corpus/main.go`.
+
+## Structure
+
+```
+lean/
+  Teleport.lean                  -- library root
+  Teleport/
+    Types.lean                   -- Role, RoleSet, Cluster, Request, Decision
+    Match.lean                   -- glob, label, namespace, resource matchers
+    CheckAccess.lean             -- the decision function
+    Theorems.lean                -- proven invariants
+    Corpus.lean                  -- JSON decoders
+  Main.lean                      -- CLI entrypoint
+  scripts/diff.sh                -- regenerate + build + compare
+  corpus/                        -- (gitignored) runtime artifacts
+```
+
+## Status
+
+v0 research branch. Not merge-ready. No team commitments.

--- a/lean/README.md
+++ b/lean/README.md
@@ -52,11 +52,11 @@ All in `Teleport/Theorems.lean`, no `sorry`.
 - **T3** prepending a matching-deny role forces deny
 - **T4** allow is preserved when new role has no matching deny
 - **T5** removing a no-deny role cannot grant access
+- **T6** wildcard allow grants access when no role matches a deny
 - **T7** empty allow labels never grant
 - **T8** under the production matcher path, empty deny labels deny all clusters
 - **T9** `checkAccess = .allow` is decidable
 - **T10** duplicate roles are idempotent
-- **T6** (wildcard grants) — deferred
 
 ## Run
 

--- a/lean/README.md
+++ b/lean/README.md
@@ -27,6 +27,12 @@ Cluster-level `CheckAccess` as exercised by `TestCheckAccessToKubernetes`
 - Read-only namespace branch — `lib/utils/replace.go:199-228`
 - Role versions other than V6
 - Pod/resource-level requests (`request.resource != null`)
+- **Implicit-wildcard deny injection** in `NewKubernetesClusterLabelMatcher`
+  (`lib/services/role.go:2665`, wired via `lib/kube/proxy/forwarder.go:1014`).
+  This matcher is applied on top of `CheckAccess` in production but not
+  by the v0 oracle (`TestCheckAccessToKubernetes` calls `CheckAccess`
+  without matchers). Model the pure RBAC core; add the matcher layer
+  separately when extending scope.
 
 ## Proved invariants
 
@@ -38,10 +44,10 @@ All in `Teleport/Theorems.lean`, no `sorry`.
 - **T4** allow is preserved when new role has no matching deny
 - **T5** removing a no-deny role cannot grant access
 - **T7** empty allow labels never grant
-- **T8** implicit-wildcard deny injection is faithfully encoded
 - **T9** `checkAccess = .allow` is decidable
 - **T10** duplicate roles are idempotent
 - **T6** (wildcard grants) — deferred
+- **T8** (implicit-wildcard deny injection) — removed; see below
 
 ## Run
 

--- a/lean/Teleport.lean
+++ b/lean/Teleport.lean
@@ -1,1 +1,2 @@
 import Teleport.Types
+import Teleport.Match

--- a/lean/Teleport.lean
+++ b/lean/Teleport.lean
@@ -1,0 +1,1 @@
+import Teleport.Types

--- a/lean/Teleport.lean
+++ b/lean/Teleport.lean
@@ -1,2 +1,3 @@
 import Teleport.Types
 import Teleport.Match
+import Teleport.CheckAccess

--- a/lean/Teleport.lean
+++ b/lean/Teleport.lean
@@ -2,3 +2,4 @@ import Teleport.Types
 import Teleport.Match
 import Teleport.CheckAccess
 import Teleport.Theorems
+import Teleport.Corpus

--- a/lean/Teleport.lean
+++ b/lean/Teleport.lean
@@ -1,3 +1,4 @@
 import Teleport.Types
 import Teleport.Match
 import Teleport.CheckAccess
+import Teleport.Theorems

--- a/lean/Teleport/CheckAccess.lean
+++ b/lean/Teleport/CheckAccess.lean
@@ -22,9 +22,40 @@ def allowMatches (role : Role) (c : Cluster) (_r : Request) : Bool :=
   labelMatch role.allow.kubernetesLabels c.labels
 
 /-- Kubernetes access decision: deny dominates, then any allow grants,
-else deny. Mirrors `RoleSet.checkAccess` in `lib/services/role.go:2681-2905`. -/
+else deny. Mirrors `RoleSet.checkAccess` in `lib/services/role.go:2681-2905`
+with no extra matchers — the core RBAC path exercised by
+`TestCheckAccessToKubernetes`. -/
 def checkAccess (rs : RoleSet) (c : Cluster) (r : Request) : Decision :=
   if rs.any (fun role => denyMatches role c r) then .deny
+  else if rs.any (fun role => allowMatches role c r) then .allow
+  else .deny
+
+/-! ## Production path
+
+Production Kubernetes access (`lib/kube/proxy/forwarder.go:1014`) layers
+`NewKubernetesClusterLabelMatcher` on top of `CheckAccess`. When deny
+labels are empty the matcher injects `{*:*}` via `getKubeLabelMatchers`
+(`lib/services/role.go:2665`), causing the deny to fire for any cluster.
+The injection is deny-only — allow labels behave as in the core path. -/
+
+/-- Effective deny-label selector under the production matcher path.
+Implements the `{*:*}` injection that fires when explicit deny labels
+are empty. -/
+def effectiveDenyLabelsProduction (cond : RoleCondition) : LabelSelector :=
+  if cond.kubernetesLabels.isEmpty then [("*", ["*"])]
+  else cond.kubernetesLabels
+
+/-- A deny condition matches in the production path iff namespaces match
+and the effective (post-injection) label selector matches. -/
+def denyMatchesProduction (role : Role) (c : Cluster) (_r : Request) : Bool :=
+  namespaceMatch role.deny.namespaces c.teleportNs &&
+  labelMatch (effectiveDenyLabelsProduction role.deny) c.labels
+
+/-- The production Kubernetes access decision: same shape as `checkAccess`
+but uses `denyMatchesProduction` instead of `denyMatches`. Allow branch
+is identical (the injection is deny-only). -/
+def checkAccessProduction (rs : RoleSet) (c : Cluster) (r : Request) : Decision :=
+  if rs.any (fun role => denyMatchesProduction role c r) then .deny
   else if rs.any (fun role => allowMatches role c r) then .allow
   else .deny
 

--- a/lean/Teleport/CheckAccess.lean
+++ b/lean/Teleport/CheckAccess.lean
@@ -3,28 +3,23 @@ import Teleport.Match
 
 namespace Teleport
 
-/-- Compute the effective label selector for a role condition, applying
-the implicit-wildcard injection from Go's `getKubeLabelMatchers`
-(`lib/services/role.go:2643`): when a deny condition has no explicit
-labels but does set `kubernetesResources`, the effective labels are
-`{*:*}`. All other cases return the literal `kubernetesLabels`. -/
-def effectiveLabels (cond : RoleCondition) (isDeny : Bool) : LabelSelector :=
-  if isDeny && cond.kubernetesLabels.isEmpty && !cond.kubernetesResources.isEmpty then
-    [("*", ["*"])]
-  else
-    cond.kubernetesLabels
-
 /-- A deny condition matches iff its namespace and label selectors match
 the cluster. Resource-level matching is out of v0 scope (request
-resources are always `none` in the corpus). -/
+resources are always `none` in the corpus).
+
+Note: production Kubernetes access (`lib/kube/proxy/forwarder.go:1014`)
+layers `NewKubernetesClusterLabelMatcher` on top, which injects `{*:*}`
+when deny labels are empty (`lib/services/role.go:2665`). That matcher
+is not part of the pure RBAC core exercised by `TestCheckAccessToKubernetes`
+and therefore not modeled here. -/
 def denyMatches (role : Role) (c : Cluster) (_r : Request) : Bool :=
   namespaceMatch role.deny.namespaces c.teleportNs &&
-  labelMatch (effectiveLabels role.deny true) c.labels
+  labelMatch role.deny.kubernetesLabels c.labels
 
 /-- An allow condition matches iff its namespace and label selectors match. -/
 def allowMatches (role : Role) (c : Cluster) (_r : Request) : Bool :=
   namespaceMatch role.allow.namespaces c.teleportNs &&
-  labelMatch (effectiveLabels role.allow false) c.labels
+  labelMatch role.allow.kubernetesLabels c.labels
 
 /-- Kubernetes access decision: deny dominates, then any allow grants,
 else deny. Mirrors `RoleSet.checkAccess` in `lib/services/role.go:2681-2905`. -/

--- a/lean/Teleport/CheckAccess.lean
+++ b/lean/Teleport/CheckAccess.lean
@@ -1,0 +1,82 @@
+import Teleport.Types
+import Teleport.Match
+
+namespace Teleport
+
+/-- Compute the effective label selector for a role condition, applying
+the implicit-wildcard injection from Go's `getKubeLabelMatchers`
+(`lib/services/role.go:2643`): when a deny condition has no explicit
+labels but does set `kubernetesResources`, the effective labels are
+`{*:*}`. All other cases return the literal `kubernetesLabels`. -/
+def effectiveLabels (cond : RoleCondition) (isDeny : Bool) : LabelSelector :=
+  if isDeny && cond.kubernetesLabels.isEmpty && !cond.kubernetesResources.isEmpty then
+    [("*", ["*"])]
+  else
+    cond.kubernetesLabels
+
+/-- A deny condition matches iff its namespace and label selectors match
+the cluster. Resource-level matching is out of v0 scope (request
+resources are always `none` in the corpus). -/
+def denyMatches (role : Role) (c : Cluster) (_r : Request) : Bool :=
+  namespaceMatch role.deny.namespaces c.teleportNs &&
+  labelMatch (effectiveLabels role.deny true) c.labels
+
+/-- An allow condition matches iff its namespace and label selectors match. -/
+def allowMatches (role : Role) (c : Cluster) (_r : Request) : Bool :=
+  namespaceMatch role.allow.namespaces c.teleportNs &&
+  labelMatch (effectiveLabels role.allow false) c.labels
+
+/-- Kubernetes access decision: deny dominates, then any allow grants,
+else deny. Mirrors `RoleSet.checkAccess` in `lib/services/role.go:2681-2905`. -/
+def checkAccess (rs : RoleSet) (c : Cluster) (r : Request) : Decision :=
+  if rs.any (fun role => denyMatches role c r) then .deny
+  else if rs.any (fun role => allowMatches role c r) then .allow
+  else .deny
+
+end Teleport
+
+section Tests
+open Teleport
+
+private def emptyCond : RoleCondition :=
+  { namespaces := ["default"], kubernetesLabels := [], kubernetesResources := [] }
+
+private def wildcardAllow : RoleCondition :=
+  { namespaces := ["default"], kubernetesLabels := [("*", ["*"])], kubernetesResources := [] }
+
+private def envProdLabels : RoleCondition :=
+  { namespaces := ["default"], kubernetesLabels := [("env", ["prod"])], kubernetesResources := [] }
+
+private def otherLabels : RoleCondition :=
+  { namespaces := ["default"], kubernetesLabels := [("env", ["staging"])], kubernetesResources := [] }
+
+private def mkRole (name : String) (allow deny : RoleCondition) : Role :=
+  { name, allow, deny }
+
+private def prodCluster : Cluster :=
+  { name := "prod", labels := [("env", "prod")], teleportNs := "default" }
+
+private def req : Request :=
+  { resource := none, verb := Verb.get, isClusterWide := true }
+
+-- Empty roleset denies
+#guard checkAccess [] prodCluster req == Decision.deny
+
+-- Single wildcard allow, empty deny → allow
+#guard checkAccess [mkRole "w" wildcardAllow emptyCond] prodCluster req == Decision.allow
+
+-- Wildcard allow + matching deny → deny dominates
+#guard checkAccess [mkRole "w" wildcardAllow emptyCond, mkRole "d" emptyCond envProdLabels]
+  prodCluster req == Decision.deny
+
+-- Mismatched allow → deny (no match)
+#guard checkAccess [mkRole "s" otherLabels emptyCond] prodCluster req == Decision.deny
+
+-- Single matching allow (env=prod label) → allow
+#guard checkAccess [mkRole "p" envProdLabels emptyCond] prodCluster req == Decision.allow
+
+-- Order doesn't matter: deny in first or second slot both win
+#guard checkAccess [mkRole "d" emptyCond envProdLabels, mkRole "w" wildcardAllow emptyCond]
+  prodCluster req == Decision.deny
+
+end Tests

--- a/lean/Teleport/Corpus.lean
+++ b/lean/Teleport/Corpus.lean
@@ -1,0 +1,149 @@
+import Lean.Data.Json
+import Teleport.Types
+
+open Lean (Json)
+
+namespace Teleport
+
+/-! ## JSON decoders for the differential-test corpus
+
+The corpus schema is produced by `tool/kubeaccess-corpus/main.go`.
+`FromJson`/`ToJson` deriving isn't in core Lean — these decoders are
+hand-written (see workspace/research.md §2 for the rationale). -/
+
+private def decodeList {α : Type} (f : Json → Except String α) :
+    Json → Except String (List α)
+  | j => do
+    let arr ← j.getArr?
+    arr.toList.mapM f
+
+private def getStrField (j : Json) (key : String) : Except String String := do
+  let v ← j.getObjVal? key
+  v.getStr?
+
+private def getBoolField (j : Json) (key : String) : Except String Bool := do
+  let v ← j.getObjVal? key
+  v.getBool?
+
+def Verb.fromJson? : Json → Except String Verb
+  | .str "get" => .ok .get
+  | .str "list" => .ok .list
+  | .str "watch" => .ok .watch
+  | .str "create" => .ok .create
+  | .str "update" => .ok .update
+  | .str "delete" => .ok .delete
+  | .str "patch" => .ok .patch
+  | .str "deleteCollection" => .ok .deleteCollection
+  | .str "*" => .ok .wildcard
+  | .str s => .ok (.other s)
+  | _ => .error "Verb: expected string"
+
+def KubeResource.fromJson? (j : Json) : Except String KubeResource := do
+  let kind ← getStrField j "kind"
+  let ns ← getStrField j "ns"
+  let name ← getStrField j "name"
+  let apiGroup ← getStrField j "apiGroup"
+  let verbsJ ← j.getObjVal? "verbs"
+  let verbs ← decodeList Verb.fromJson? verbsJ
+  return { kind, ns, name, apiGroup, verbs }
+
+private def decodeLabelEntry (j : Json) : Except String (String × List String) := do
+  let k ← getStrField j "key"
+  let vsJ ← j.getObjVal? "values"
+  let vs ← decodeList Json.getStr? vsJ
+  return (k, vs)
+
+private def decodeClusterLabel (j : Json) : Except String (String × String) := do
+  let k ← getStrField j "key"
+  let v ← getStrField j "value"
+  return (k, v)
+
+def RoleCondition.fromJson? (j : Json) : Except String RoleCondition := do
+  let nsJ ← j.getObjVal? "namespaces"
+  let namespaces ← decodeList Json.getStr? nsJ
+  let klJ ← j.getObjVal? "kubernetesLabels"
+  let kubernetesLabels ← decodeList decodeLabelEntry klJ
+  let krJ ← j.getObjVal? "kubernetesResources"
+  let kubernetesResources ← decodeList KubeResource.fromJson? krJ
+  return { namespaces, kubernetesLabels, kubernetesResources }
+
+def Role.fromJson? (j : Json) : Except String Role := do
+  let name ← getStrField j "name"
+  let allowJ ← j.getObjVal? "allow"
+  let allow ← RoleCondition.fromJson? allowJ
+  let denyJ ← j.getObjVal? "deny"
+  let deny ← RoleCondition.fromJson? denyJ
+  return { name, allow, deny }
+
+def Cluster.fromJson? (j : Json) : Except String Cluster := do
+  let name ← getStrField j "name"
+  let labelsJ ← j.getObjVal? "labels"
+  let labels ← decodeList decodeClusterLabel labelsJ
+  let teleportNs ← getStrField j "teleportNs"
+  return { name, labels, teleportNs }
+
+def Request.fromJson? (j : Json) : Except String Request := do
+  let resJ ← j.getObjVal? "resource"
+  let resource ← match resJ with
+    | .null => Except.ok none
+    | r => (KubeResource.fromJson? r).map some
+  let verbJ ← j.getObjVal? "verb"
+  let verb ← Verb.fromJson? verbJ
+  let isClusterWide ← getBoolField j "isClusterWide"
+  return { resource, verb, isClusterWide }
+
+def Decision.fromJson? : Json → Except String Decision
+  | .str "allow" => .ok .allow
+  | .str "deny" => .ok .deny
+  | _ => .error "Decision: expected \"allow\" or \"deny\""
+
+/-- A single corpus entry. `request` is `none` for cluster-level access
+checks (the v0 scope). -/
+structure TestCase where
+  name : String
+  source : String
+  roles : List Role
+  cluster : Cluster
+  request : Option Request
+  expected : Decision
+  deriving Repr, Inhabited
+
+def TestCase.fromJson? (j : Json) : Except String TestCase := do
+  let name ← getStrField j "name"
+  let source ← getStrField j "source"
+  let rolesJ ← j.getObjVal? "roles"
+  let roles ← decodeList Role.fromJson? rolesJ
+  let clusterJ ← j.getObjVal? "cluster"
+  let cluster ← Cluster.fromJson? clusterJ
+  let reqJ ← j.getObjVal? "request"
+  let request ← match reqJ with
+    | .null => Except.ok none
+    | r => (Request.fromJson? r).map some
+  let expectedJ ← j.getObjVal? "expected"
+  let expected ← Decision.fromJson? expectedJ
+  return { name, source, roles, cluster, request, expected }
+
+/-- Decode a full corpus `{cases: [...]}` into a list of `TestCase`. -/
+def decodeCorpus (input : String) : Except String (List TestCase) := do
+  let j ← Json.parse input
+  let casesJ ← j.getObjVal? "cases"
+  decodeList TestCase.fromJson? casesJ
+
+end Teleport
+
+section Tests
+open Teleport
+
+-- Smoke: decode an empty corpus.
+#guard (Teleport.decodeCorpus "{\"cases\":[]}").isOk
+
+-- Smoke: decode a single minimal case.
+private def tinyCorpus : String :=
+  "{\"cases\":[{\"name\":\"t\",\"source\":\"synthetic\",\"roles\":[],\"cluster\":{\"name\":\"c\",\"labels\":[],\"teleportNs\":\"default\"},\"request\":null,\"expected\":\"deny\"}]}"
+
+#guard (decodeCorpus tinyCorpus).isOk
+
+-- Decoding a malformed string surfaces an error, not a panic.
+#guard (decodeCorpus "{").isOk == false
+
+end Tests

--- a/lean/Teleport/Match.lean
+++ b/lean/Teleport/Match.lean
@@ -1,0 +1,122 @@
+import Teleport.Types
+
+namespace Teleport
+
+/-- Glob-match with `*` as the only metacharacter. Anchored (matches the
+entire string). Mirrors Go's `GlobToRegexp` followed by an anchored
+`MatchString`: every character except `*` is literal (including `.`, `+`,
+`?`, `$`, etc.). Pattern `"*"` matches any string including empty. -/
+def globMatch (pat : String) (s : String) : Bool :=
+  go pat.toList s.toList
+where
+  go : List Char → List Char → Bool
+    | [], [] => true
+    | [], _ :: _ => false
+    | '*' :: ps, [] => go ps []
+    | '*' :: ps, sc :: ss =>
+        go ps (sc :: ss) || go ('*' :: ps) ss
+    | _ :: _, [] => false
+    | pc :: ps, sc :: ss => pc == sc && go ps ss
+  termination_by p s => p.length + s.length
+
+/-- Assoc-list lookup by string key. Returns the value bound to the
+first matching key (if any). -/
+def assocLookup (key : String) : List (String × α) → Option α
+  | [] => none
+  | (k, v) :: rest => if k == key then some v else assocLookup key rest
+
+/-- Label-selector match. Mirrors `MatchLabelGetter` in
+`lib/services/role.go:1221-1281`:
+- empty selector matches nothing;
+- selector `[("*", ["*"])]` matches anything;
+- otherwise, every selector key must be present in the target with a
+  value that either appears literally in the selector's value list,
+  is glob-matched by some pattern in that list, or the value list
+  contains `"*"`. -/
+def labelMatch (sel : LabelSelector) (target : List (String × String)) : Bool :=
+  if sel.isEmpty then
+    false
+  else if sel == [("*", ["*"])] then
+    true
+  else
+    sel.all fun entry =>
+      let (k, vs) := entry
+      match assocLookup k target with
+      | none => false
+      | some tv => vs.contains "*" || vs.any (fun v => globMatch v tv)
+
+/-- True iff any pattern in `pats` glob-matches `ns`. -/
+def namespaceMatch (pats : List String) (ns : String) : Bool :=
+  pats.any (fun p => globMatch p ns)
+
+/-- True iff the verb list contains `wildcard` or the exact verb `v`. -/
+def verbAllowed (verbs : List Verb) (v : Verb) : Bool :=
+  verbs.contains Verb.wildcard || verbs.contains v
+
+/-- Match a resource request against a list of resource matchers.
+Mirrors `KubeResourceMatchesRegex` in `lib/utils/replace.go:162-257`
+with the read-only-namespace branch intentionally omitted (dead in
+the v0 oracle per workspace/research.md §5). `isDeny` is retained
+for API stability; currently unused. -/
+def kubeResourceMatch (req : KubeResource) (isDeny : Bool)
+    (resources : List KubeResource) : Bool :=
+  let _ := isDeny
+  resources.any fun r =>
+    globMatch r.kind req.kind &&
+    globMatch r.ns req.ns &&
+    globMatch r.name req.name &&
+    globMatch r.apiGroup req.apiGroup &&
+    req.verbs.all (fun v => verbAllowed r.verbs v)
+
+end Teleport
+
+section Tests
+open Teleport
+
+-- globMatch edge cases
+#guard globMatch "*" ""
+#guard globMatch "*" "anything"
+#guard globMatch "*.lean" "Main.lean"
+#guard globMatch "1.2.*" "1.2.3"
+#guard !globMatch "1.2.*" "1.2"           -- literal `.` required after "1.2"
+#guard globMatch "foo" "foo"
+#guard !globMatch "foo" "bar"
+#guard !globMatch "foo" "foox"
+#guard globMatch "foo*" "foox"
+#guard globMatch "foo*" "foo"
+#guard !globMatch "" "x"
+#guard globMatch "" ""
+#guard globMatch "*bar*" "foobarbaz"
+
+-- labelMatch
+#guard !labelMatch [] []
+#guard !labelMatch [] [("k", "v")]
+#guard labelMatch [("*", ["*"])] []
+#guard labelMatch [("*", ["*"])] [("k", "v")]
+#guard labelMatch [("k", ["v"])] [("k", "v")]
+#guard !labelMatch [("k", ["v"])] [("k", "w")]
+#guard !labelMatch [("k", ["v"])] [("other", "v")]
+#guard labelMatch [("k", ["*"])] [("k", "anything")]
+#guard labelMatch [("k", ["v", "w"])] [("k", "w")]
+#guard labelMatch [("k", ["pre*"])] [("k", "prefix")]
+#guard !labelMatch [("k", ["pre*"])] [("k", "other")]
+
+-- multi-key selector: ALL keys must be present
+#guard labelMatch [("a", ["1"]), ("b", ["2"])] [("a", "1"), ("b", "2")]
+#guard !labelMatch [("a", ["1"]), ("b", ["2"])] [("a", "1")]
+
+-- namespaceMatch
+#guard namespaceMatch ["*"] "default"
+#guard namespaceMatch ["default"] "default"
+#guard !namespaceMatch ["prod"] "default"
+#guard !namespaceMatch [] "default"
+#guard namespaceMatch ["prod", "*"] "default"
+
+-- verbAllowed
+#guard verbAllowed [Verb.wildcard] Verb.get
+#guard verbAllowed [Verb.wildcard] Verb.delete
+#guard verbAllowed [Verb.get, Verb.list] Verb.list
+#guard !verbAllowed [Verb.get] Verb.delete
+#guard !verbAllowed [] Verb.get
+
+end Tests

--- a/lean/Teleport/Theorems.lean
+++ b/lean/Teleport/Theorems.lean
@@ -103,6 +103,27 @@ theorem production_empty_deny_denies_all
   simp [denyMatchesProduction, effectiveDenyLabelsProduction, hLabels,
         hNs, labelMatch]
 
+/-- **T6** — A role with wildcard allow labels and matching allow
+namespaces grants access to any cluster, provided no other role in
+the set contributes a matching deny. -/
+theorem wildcard_allow_grants
+    (rs : RoleSet) (role : Role) (c : Cluster) (r : Request)
+    (hMem : role ∈ rs)
+    (hWildcard : role.allow.kubernetesLabels = [("*", ["*"])])
+    (hNs : namespaceMatch role.allow.namespaces c.teleportNs = true)
+    (hNoDeny : ∀ r' ∈ rs, denyMatches r' c r = false) :
+    checkAccess rs c r = .allow := by
+  rw [checkAccess_eq_allow_iff]
+  refine ⟨?_, ?_⟩
+  · -- no role in rs has a matching deny
+    rw [List.any_eq_false]
+    intro r' hMem'
+    simp [hNoDeny r' hMem']
+  · -- role has a matching allow
+    rw [List.any_eq_true]
+    refine ⟨role, hMem, ?_⟩
+    simp [allowMatches, hWildcard, hNs, labelMatch]
+
 /-- **T10** — Duplicate roles in the set do not change the decision.
 Follows from the fact that `any` is idempotent on duplicates. -/
 theorem duplicate_roles_idempotent (role : Role) (rs : RoleSet)

--- a/lean/Teleport/Theorems.lean
+++ b/lean/Teleport/Theorems.lean
@@ -1,0 +1,36 @@
+import Teleport.CheckAccess
+
+namespace Teleport
+
+/-! ## Foundational theorems
+
+Each theorem is expected to be a one- or two-line `simp` proof given the
+deliberately simple shape of `checkAccess`. If a proof grows beyond a
+handful of tactic lines, that is a signal to revisit the definitions. -/
+
+/-- **T1** — Empty role set always denies. -/
+theorem empty_denies (c : Cluster) (r : Request) :
+    checkAccess [] c r = .deny := by
+  simp [checkAccess]
+
+/-- **T2** — If any role's deny condition matches, the decision is deny,
+regardless of allow rules. -/
+theorem deny_dominates (rs : RoleSet) (c : Cluster) (r : Request)
+    (h : rs.any (fun role => denyMatches role c r) = true) :
+    checkAccess rs c r = .deny := by
+  simp [checkAccess, h]
+
+/-- **T3** — Prepending a role whose deny matches forces deny, regardless
+of the tail. Follows from T2. -/
+theorem adding_matching_deny_denies (rs : RoleSet) (role : Role)
+    (c : Cluster) (r : Request) (h : denyMatches role c r = true) :
+    checkAccess (role :: rs) c r = .deny := by
+  simp [checkAccess, List.any_cons, h]
+
+/-- **T9** — The proposition `checkAccess … = .allow` is decidable.
+Automatic from `Decision`'s `DecidableEq` instance. -/
+example (rs : RoleSet) (c : Cluster) (r : Request) :
+    Decidable (checkAccess rs c r = .allow) :=
+  inferInstance
+
+end Teleport

--- a/lean/Teleport/Theorems.lean
+++ b/lean/Teleport/Theorems.lean
@@ -91,11 +91,17 @@ theorem empty_allow_labels_never_grants
     allowMatches role c r = false := by
   simp [allowMatches, h, labelMatch]
 
--- T8 (implicit-wildcard deny injection) removed: the `effectiveLabels`
--- function it described has been removed. The injection is part of
--- `KubernetesClusterLabelMatcher` (production) and is not exercised by
--- `TestCheckAccessToKubernetes` (the v0 oracle). Revisit if the model
--- is extended to the production matcher path.
+/-- **T8** — Under the production matcher path, a role whose deny labels
+are empty denies access to any cluster (provided the deny namespaces
+match). Captures the `getKubeLabelMatchers` injection that fires in
+`NewKubernetesClusterLabelMatcher.Match`. -/
+theorem production_empty_deny_denies_all
+    (role : Role) (c : Cluster) (r : Request)
+    (hLabels : role.deny.kubernetesLabels = [])
+    (hNs : namespaceMatch role.deny.namespaces c.teleportNs = true) :
+    denyMatchesProduction role c r = true := by
+  simp [denyMatchesProduction, effectiveDenyLabelsProduction, hLabels,
+        hNs, labelMatch]
 
 /-- **T10** — Duplicate roles in the set do not change the decision.
 Follows from the fact that `any` is idempotent on duplicates. -/

--- a/lean/Teleport/Theorems.lean
+++ b/lean/Teleport/Theorems.lean
@@ -89,20 +89,13 @@ theorem empty_allow_labels_never_grants
     (role : Role) (c : Cluster) (r : Request)
     (h : role.allow.kubernetesLabels = []) :
     allowMatches role c r = false := by
-  simp [allowMatches, effectiveLabels, h, labelMatch]
+  simp [allowMatches, h, labelMatch]
 
-/-- **T8** — The implicit-wildcard injection in `effectiveLabels` fires
-exactly when deny labels are empty and deny's resource list is non-empty. -/
-theorem implicit_wildcard_deny_encoded
-    (cond : RoleCondition)
-    (hLabels : cond.kubernetesLabels = [])
-    (hRes : cond.kubernetesResources ≠ []) :
-    effectiveLabels cond true = [("*", ["*"])] := by
-  unfold effectiveLabels
-  rw [hLabels]
-  cases hRes' : cond.kubernetesResources with
-  | nil => exact absurd hRes' hRes
-  | cons _ _ => simp
+-- T8 (implicit-wildcard deny injection) removed: the `effectiveLabels`
+-- function it described has been removed. The injection is part of
+-- `KubernetesClusterLabelMatcher` (production) and is not exercised by
+-- `TestCheckAccessToKubernetes` (the v0 oracle). Revisit if the model
+-- is extended to the production matcher path.
 
 /-- **T10** — Duplicate roles in the set do not change the decision.
 Follows from the fact that `any` is idempotent on duplicates. -/

--- a/lean/Teleport/Theorems.lean
+++ b/lean/Teleport/Theorems.lean
@@ -33,4 +33,88 @@ example (rs : RoleSet) (c : Cluster) (r : Request) :
     Decidable (checkAccess rs c r = .allow) :=
   inferInstance
 
+/-! ## Allow/deny interaction theorems
+
+Helper characterization: `checkAccess` returns `.allow` iff no deny
+matches and some allow matches. This is the workhorse lemma that makes
+T4, T5, T7 one-liners. -/
+
+private theorem checkAccess_eq_allow_iff (rs : RoleSet) (c : Cluster) (r : Request) :
+    checkAccess rs c r = .allow ↔
+    rs.any (fun role => denyMatches role c r) = false ∧
+    rs.any (fun role => allowMatches role c r) = true := by
+  unfold checkAccess
+  cases h1 : rs.any (fun role => denyMatches role c r) <;>
+    cases h2 : rs.any (fun role => allowMatches role c r) <;>
+    simp
+
+private theorem checkAccess_eq_deny_iff (rs : RoleSet) (c : Cluster) (r : Request) :
+    checkAccess rs c r = .deny ↔
+    rs.any (fun role => denyMatches role c r) = true ∨
+    rs.any (fun role => allowMatches role c r) = false := by
+  unfold checkAccess
+  cases h1 : rs.any (fun role => denyMatches role c r) <;>
+    cases h2 : rs.any (fun role => allowMatches role c r) <;>
+    simp
+
+/-- **T4** — Adding a role whose deny does not match preserves any
+existing `.allow` verdict. -/
+theorem allow_preserved_when_new_role_has_no_deny_match
+    (rs : RoleSet) (newRole : Role) (c : Cluster) (r : Request)
+    (hPrev : checkAccess rs c r = .allow)
+    (hNoDeny : denyMatches newRole c r = false) :
+    checkAccess (newRole :: rs) c r = .allow := by
+  rw [checkAccess_eq_allow_iff] at hPrev ⊢
+  refine ⟨?_, ?_⟩
+  · simp [List.any_cons, hNoDeny, hPrev.1]
+  · simp [List.any_cons, hPrev.2]
+
+/-- **T5** — Removing a role that did not contribute a deny cannot turn
+a `.deny` verdict into `.allow`. Dual of T4. -/
+theorem removing_allow_cannot_grant
+    (rs : RoleSet) (role : Role) (c : Cluster) (r : Request)
+    (hPrev : checkAccess (role :: rs) c r = .deny)
+    (hNoDeny : denyMatches role c r = false) :
+    checkAccess rs c r = .deny := by
+  rw [checkAccess_eq_deny_iff] at hPrev ⊢
+  rw [List.any_cons, hNoDeny, Bool.false_or, List.any_cons] at hPrev
+  rcases hPrev with hD | hA
+  · exact Or.inl hD
+  · rw [Bool.or_eq_false_iff] at hA
+    exact Or.inr hA.2
+
+/-- **T7** — A role whose allow labels are empty never grants access
+via the allow branch. Guards against the "empty = wildcard" bug. -/
+theorem empty_allow_labels_never_grants
+    (role : Role) (c : Cluster) (r : Request)
+    (h : role.allow.kubernetesLabels = []) :
+    allowMatches role c r = false := by
+  simp [allowMatches, effectiveLabels, h, labelMatch]
+
+/-- **T8** — The implicit-wildcard injection in `effectiveLabels` fires
+exactly when deny labels are empty and deny's resource list is non-empty. -/
+theorem implicit_wildcard_deny_encoded
+    (cond : RoleCondition)
+    (hLabels : cond.kubernetesLabels = [])
+    (hRes : cond.kubernetesResources ≠ []) :
+    effectiveLabels cond true = [("*", ["*"])] := by
+  unfold effectiveLabels
+  rw [hLabels]
+  cases hRes' : cond.kubernetesResources with
+  | nil => exact absurd hRes' hRes
+  | cons _ _ => simp
+
+/-- **T10** — Duplicate roles in the set do not change the decision.
+Follows from the fact that `any` is idempotent on duplicates. -/
+theorem duplicate_roles_idempotent (role : Role) (rs : RoleSet)
+    (c : Cluster) (r : Request) :
+    checkAccess (role :: role :: rs) c r = checkAccess (role :: rs) c r := by
+  simp [checkAccess, List.any_cons]
+
+-- T6 (wildcard_allow_grants) is deferred: existential setup (role-in-roleset)
+-- plus matcher unfolding makes it meaningfully harder than T4/T5. The
+-- essential intuition is that a wildcard-allow role makes allowMatches
+-- true and the any-over-roleset is therefore true. Revisit in v1 once
+-- auxiliary lemmas about List.any membership are in place.
+
 end Teleport

--- a/lean/Teleport/Types.lean
+++ b/lean/Teleport/Types.lean
@@ -1,0 +1,69 @@
+namespace Teleport
+
+/-- Kubernetes verbs recognized by Teleport RBAC. `other` is a fallthrough
+for any verb string that isn't a well-known constant. -/
+inductive Verb where
+  | get
+  | list
+  | watch
+  | create
+  | update
+  | delete
+  | patch
+  | deleteCollection
+  | wildcard
+  | other (s : String)
+  deriving Repr, Inhabited, BEq, DecidableEq
+
+/-- A single Kubernetes resource matcher entry. `ns` is the Kubernetes
+namespace field (named `Namespace` in Go; renamed here because `namespace`
+is a Lean keyword). -/
+structure KubeResource where
+  kind : String
+  ns : String
+  name : String
+  apiGroup : String
+  verbs : List Verb
+  deriving Repr, Inhabited, BEq, DecidableEq
+
+/-- Label selector: a list of `(key, allowedValues)` pairs. A value of
+`"*"` inside `allowedValues` is a wildcard. -/
+abbrev LabelSelector := List (String × List String)
+
+structure RoleCondition where
+  namespaces : List String
+  kubernetesLabels : LabelSelector
+  kubernetesResources : List KubeResource
+  deriving Repr, Inhabited, BEq, DecidableEq
+
+structure Role where
+  name : String
+  allow : RoleCondition
+  deny : RoleCondition
+  deriving Repr, Inhabited, BEq, DecidableEq
+
+abbrev RoleSet := List Role
+
+/-- A Kubernetes cluster with its labels. `teleportNs` corresponds to
+`apidefaults.Namespace` in Go (typically `"default"`). -/
+structure Cluster where
+  name : String
+  labels : List (String × String)
+  teleportNs : String
+  deriving Repr, Inhabited, BEq, DecidableEq
+
+/-- A pending access request. `resource` is `none` for cluster-level
+access checks (the v0 scope); it carries a resource descriptor for
+pod/resource-level checks if those are later added. -/
+structure Request where
+  resource : Option KubeResource
+  verb : Verb
+  isClusterWide : Bool
+  deriving Repr, Inhabited, BEq, DecidableEq
+
+inductive Decision where
+  | allow
+  | deny
+  deriving Repr, Inhabited, BEq, DecidableEq
+
+end Teleport

--- a/lean/lake-manifest.json
+++ b/lean/lake-manifest.json
@@ -1,0 +1,5 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages": [],
+ "name": "«teleport-lean»",
+ "lakeDir": ".lake"}

--- a/lean/lakefile.toml
+++ b/lean/lakefile.toml
@@ -1,0 +1,5 @@
+name = "teleport-lean"
+defaultTargets = ["Teleport"]
+
+[[lean_lib]]
+name = "Teleport"

--- a/lean/lakefile.toml
+++ b/lean/lakefile.toml
@@ -1,5 +1,9 @@
 name = "teleport-lean"
-defaultTargets = ["Teleport"]
+defaultTargets = ["Teleport", "teleport-lean-diff"]
 
 [[lean_lib]]
 name = "Teleport"
+
+[[lean_exe]]
+name = "teleport-lean-diff"
+root = "Main"

--- a/lean/lean-toolchain
+++ b/lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.29.1

--- a/lean/scripts/diff.sh
+++ b/lean/scripts/diff.sh
@@ -3,6 +3,7 @@
 # and run the Lean differential check. Exit non-zero on any mismatch.
 set -eu
 cd "$(dirname "$0")/.."   # <teleport>/lean/
+mkdir -p corpus
 (cd .. && go run ./tool/kubeaccess-corpus) > corpus/kubernetes.json
 lake build
 lake exe teleport-lean-diff corpus/kubernetes.json

--- a/lean/scripts/diff.sh
+++ b/lean/scripts/diff.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Regenerate the Kubernetes access corpus from Go, build the Lean model,
+# and run the Lean differential check. Exit non-zero on any mismatch.
+set -eu
+cd "$(dirname "$0")/.."   # <teleport>/lean/
+(cd .. && go run ./tool/kubeaccess-corpus) > corpus/kubernetes.json
+lake build
+lake exe teleport-lean-diff corpus/kubernetes.json

--- a/tool/kubeaccess-corpus/main.go
+++ b/tool/kubeaccess-corpus/main.go
@@ -20,12 +20,12 @@
 // for differential testing against the Lean model in ../../lean/.
 //
 // Section A: organic cases transcribed from TestCheckAccessToKubernetes
-//            (lib/services/role_test.go:6828). Cases that use non-zero
-//            AccessState (MFA/device trust) or KubernetesLabelsExpression
-//            are skipped because they're out of v0 scope.
+// (lib/services/role_test.go:6828). Cases that use non-zero
+// AccessState (MFA/device trust) or KubernetesLabelsExpression
+// are skipped because they're out of v0 scope.
 //
 // Section B: synthetic combinatorial cases (added in exporter-synthetic
-//            task; not present in this initial commit).
+// task; not present in this initial commit).
 //
 // Each case is a fixed-shape {name, source, roles, cluster, request,
 // expected} record. The Go decision is the oracle — no manual labeling.

--- a/tool/kubeaccess-corpus/main.go
+++ b/tool/kubeaccess-corpus/main.go
@@ -556,6 +556,66 @@ func syntheticCases() ([]testCase, error) {
 	return out, nil
 }
 
+// edgeCases exercises specific behaviors that combinatorial coverage in
+// `syntheticCases` misses: implicit-wildcard deny injection and glob
+// literal-`.` semantics. Namespace-mismatch is omitted because RoleV6's
+// CheckAndSetDefaults rejects any namespaces value other than "default".
+func edgeCases() ([]testCase, error) {
+	// Case 1 — implicit-wildcard deny: role has empty deny.kubernetesLabels
+	// but non-empty deny.kubernetesResources. Go's getKubeLabelMatchers
+	// injects {*:*}, so the deny matches any cluster labels. T8 covers the
+	// Lean side; this case validates cross-language agreement.
+	denyResourcesOnlyRole := mkRole("r-deny-resources-only",
+		types.RoleConditions{
+			Namespaces:       []string{apidefaults.Namespace},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+		},
+		types.RoleConditions{
+			Namespaces: []string{apidefaults.Namespace},
+			KubernetesResources: []types.KubernetesResource{
+				{Kind: "pods", Namespace: "*", Name: "*", APIGroup: "*", Verbs: []string{"*"}},
+			},
+		})
+
+	// Case 2 — cluster label `version=1.2.3` against role pattern
+	// `version=1.2.*`. QuoteMeta + glob expansion means `.` is literal;
+	// this verifies Lean's globMatch agrees on non-trivial literal chars.
+	versionedCluster := mkCluster("c-version-dotted", map[string]string{"version": "1.2.3"})
+	globVersionRole := globValueAllowRole("r-version-glob", "version", "1.2.*")
+	exactMismatchRole := singleLabelAllowRole("r-version-exact", "version", "1.2")
+
+	entries := []struct {
+		name    string
+		roles   []*types.RoleV6
+		cluster *types.KubernetesCluster
+	}{
+		{"implicit-wildcard-deny-injection", []*types.RoleV6{denyResourcesOnlyRole}, mkCluster("c-any", map[string]string{"any": "value"})},
+		{"glob-literal-dot-matches", []*types.RoleV6{globVersionRole}, versionedCluster},
+		{"glob-literal-dot-requires-suffix", []*types.RoleV6{exactMismatchRole}, versionedCluster},
+	}
+
+	out := make([]testCase, 0, len(entries))
+	for _, e := range entries {
+		expected, err := runCheckAccess(e.roles, e.cluster)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", e.name, err)
+		}
+		roles := make([]roleJSON, 0, len(e.roles))
+		for _, r := range e.roles {
+			roles = append(roles, roleToJSON(r))
+		}
+		out = append(out, testCase{
+			Name:     "edge/" + e.name,
+			Source:   "edge",
+			Roles:    roles,
+			Cluster:  clusterToJSON(e.cluster.Name, e.cluster.StaticLabels, e.cluster.DynamicLabels),
+			Request:  nil,
+			Expected: expected,
+		})
+	}
+	return out, nil
+}
+
 // ----------------------------------------------------------------------
 // Entry point
 // ----------------------------------------------------------------------
@@ -569,7 +629,12 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	edge, err := edgeCases()
+	if err != nil {
+		return err
+	}
 	all := append(organic, synthetic...)
+	all = append(all, edge...)
 	c := corpus{Cases: all}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")

--- a/tool/kubeaccess-corpus/main.go
+++ b/tool/kubeaccess-corpus/main.go
@@ -321,6 +321,242 @@ func organicCases() ([]testCase, error) {
 }
 
 // ----------------------------------------------------------------------
+// Synthetic corpus — combinatorial coverage via parameterized role +
+// cluster templates. Go's CheckAccess computes the expected decision.
+// ----------------------------------------------------------------------
+
+// mkRole builds a V6 role with explicit allow/deny conditions and
+// runs CheckAndSetDefaults so serialized state matches post-normalization.
+func mkRole(name string, allow, deny types.RoleConditions) *types.RoleV6 {
+	r := &types.RoleV6{
+		Metadata: types.Metadata{Name: name, Namespace: apidefaults.Namespace},
+		Spec:     types.RoleSpecV6{Allow: allow, Deny: deny},
+	}
+	if err := r.CheckAndSetDefaults(); err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// Role template builders. Each takes a unique name suffix so multiple
+// instances can coexist in a single role set.
+func emptyCondRole(name string) *types.RoleV6 {
+	return mkRole(name,
+		types.RoleConditions{Namespaces: []string{apidefaults.Namespace}},
+		types.RoleConditions{Namespaces: []string{apidefaults.Namespace}})
+}
+
+func wildcardAllowRole(name string) *types.RoleV6 {
+	return mkRole(name,
+		types.RoleConditions{
+			Namespaces:       []string{apidefaults.Namespace},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+		},
+		types.RoleConditions{Namespaces: []string{apidefaults.Namespace}})
+}
+
+func singleLabelAllowRole(name, key, value string) *types.RoleV6 {
+	return mkRole(name,
+		types.RoleConditions{
+			Namespaces:       []string{apidefaults.Namespace},
+			KubernetesLabels: types.Labels{key: apiutils.Strings{value}},
+		},
+		types.RoleConditions{Namespaces: []string{apidefaults.Namespace}})
+}
+
+func multiLabelAllowRole(name string) *types.RoleV6 {
+	return mkRole(name,
+		types.RoleConditions{
+			Namespaces: []string{apidefaults.Namespace},
+			KubernetesLabels: types.Labels{
+				"env":  apiutils.Strings{"prod"},
+				"team": apiutils.Strings{"sre"},
+			},
+		},
+		types.RoleConditions{Namespaces: []string{apidefaults.Namespace}})
+}
+
+func multiValueAllowRole(name, key string, values ...string) *types.RoleV6 {
+	return mkRole(name,
+		types.RoleConditions{
+			Namespaces:       []string{apidefaults.Namespace},
+			KubernetesLabels: types.Labels{key: apiutils.Strings(values)},
+		},
+		types.RoleConditions{Namespaces: []string{apidefaults.Namespace}})
+}
+
+func globValueAllowRole(name, key, pattern string) *types.RoleV6 {
+	return mkRole(name,
+		types.RoleConditions{
+			Namespaces:       []string{apidefaults.Namespace},
+			KubernetesLabels: types.Labels{key: apiutils.Strings{pattern}},
+		},
+		types.RoleConditions{Namespaces: []string{apidefaults.Namespace}})
+}
+
+func denyOnLabelRole(name, key, value string) *types.RoleV6 {
+	return mkRole(name,
+		types.RoleConditions{
+			Namespaces:       []string{apidefaults.Namespace},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+		},
+		types.RoleConditions{
+			Namespaces:       []string{apidefaults.Namespace},
+			KubernetesLabels: types.Labels{key: apiutils.Strings{value}},
+		})
+}
+
+// mkCluster builds a cluster with just static labels.
+func mkCluster(name string, staticLabels map[string]string) *types.KubernetesCluster {
+	return &types.KubernetesCluster{Name: name, StaticLabels: staticLabels}
+}
+
+func syntheticCases() ([]testCase, error) {
+	// Cluster pool.
+	clusters := []*types.KubernetesCluster{
+		mkCluster("c-empty", nil),
+		mkCluster("c-env-prod", map[string]string{"env": "prod"}),
+		mkCluster("c-env-staging", map[string]string{"env": "staging"}),
+		mkCluster("c-env-production-literal", map[string]string{"env": "production"}),
+		mkCluster("c-env-prod-team-sre", map[string]string{"env": "prod", "team": "sre"}),
+		mkCluster("c-team-sre", map[string]string{"team": "sre"}),
+	}
+
+	// Single-role scenarios. Each one-role set is exercised against every cluster.
+	type singleRole struct {
+		name    string
+		builder func() *types.RoleV6
+	}
+	singles := []singleRole{
+		{"empty", func() *types.RoleV6 { return emptyCondRole("r-empty") }},
+		{"wildcard", func() *types.RoleV6 { return wildcardAllowRole("r-wildcard") }},
+		{"env-prod-allow", func() *types.RoleV6 { return singleLabelAllowRole("r-env-prod", "env", "prod") }},
+		{"multi-label-allow", func() *types.RoleV6 { return multiLabelAllowRole("r-multi") }},
+		{"env-multi-value-allow", func() *types.RoleV6 { return multiValueAllowRole("r-multi-val", "env", "prod", "staging") }},
+		{"env-glob-allow", func() *types.RoleV6 { return globValueAllowRole("r-glob", "env", "prod*") }},
+		{"deny-env-prod", func() *types.RoleV6 { return denyOnLabelRole("r-deny", "env", "prod") }},
+	}
+
+	// Two-role scenarios — deliberately chosen to exercise interaction:
+	// wildcard+deny, two allows, mismatch+match, etc.
+	type pairRole struct {
+		name    string
+		builder func() []*types.RoleV6
+	}
+	pairs := []pairRole{
+		{"wildcard-plus-deny-env-prod", func() []*types.RoleV6 {
+			return []*types.RoleV6{
+				wildcardAllowRole("r-w"),
+				denyOnLabelRole("r-d", "env", "prod"),
+			}
+		}},
+		{"env-prod-allow-plus-env-staging-allow", func() []*types.RoleV6 {
+			return []*types.RoleV6{
+				singleLabelAllowRole("r-p", "env", "prod"),
+				singleLabelAllowRole("r-s", "env", "staging"),
+			}
+		}},
+		{"mismatch-plus-wildcard", func() []*types.RoleV6 {
+			return []*types.RoleV6{
+				singleLabelAllowRole("r-m", "nosuch", "value"),
+				wildcardAllowRole("r-w"),
+			}
+		}},
+		{"two-empty-roles", func() []*types.RoleV6 {
+			return []*types.RoleV6{
+				emptyCondRole("r-e1"),
+				emptyCondRole("r-e2"),
+			}
+		}},
+		{"wildcard-plus-wildcard", func() []*types.RoleV6 {
+			return []*types.RoleV6{
+				wildcardAllowRole("r-w1"),
+				wildcardAllowRole("r-w2"),
+			}
+		}},
+		{"env-prod-with-deny-team-sre", func() []*types.RoleV6 {
+			return []*types.RoleV6{
+				singleLabelAllowRole("r-p", "env", "prod"),
+				denyOnLabelRole("r-d", "team", "sre"),
+			}
+		}},
+	}
+
+	// Three-role scenarios — variety with ordering.
+	triples := []pairRole{
+		{"three-disjoint-allows", func() []*types.RoleV6 {
+			return []*types.RoleV6{
+				singleLabelAllowRole("r-a", "env", "prod"),
+				singleLabelAllowRole("r-b", "team", "sre"),
+				singleLabelAllowRole("r-c", "env", "staging"),
+			}
+		}},
+		{"wildcard-with-two-denies", func() []*types.RoleV6 {
+			return []*types.RoleV6{
+				wildcardAllowRole("r-w"),
+				denyOnLabelRole("r-d1", "env", "prod"),
+				denyOnLabelRole("r-d2", "team", "sre"),
+			}
+		}},
+		{"deny-first-then-allows", func() []*types.RoleV6 {
+			return []*types.RoleV6{
+				denyOnLabelRole("r-d", "env", "staging"),
+				singleLabelAllowRole("r-a", "env", "prod"),
+				wildcardAllowRole("r-w"),
+			}
+		}},
+	}
+
+	out := make([]testCase, 0, 200)
+
+	emit := func(name string, roles []*types.RoleV6, cluster *types.KubernetesCluster) error {
+		expected, err := runCheckAccess(roles, cluster)
+		if err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+		jroles := make([]roleJSON, 0, len(roles))
+		for _, r := range roles {
+			jroles = append(jroles, roleToJSON(r))
+		}
+		out = append(out, testCase{
+			Name:     "synthetic/" + name,
+			Source:   "synthetic",
+			Roles:    jroles,
+			Cluster:  clusterToJSON(cluster.Name, cluster.StaticLabels, cluster.DynamicLabels),
+			Request:  nil,
+			Expected: expected,
+		})
+		return nil
+	}
+
+	for _, s := range singles {
+		for _, c := range clusters {
+			if err := emit(s.name+"_on_"+c.Name, []*types.RoleV6{s.builder()}, c); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, p := range pairs {
+		for _, c := range clusters {
+			if err := emit(p.name+"_on_"+c.Name, p.builder(), c); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, t := range triples {
+		for _, c := range clusters {
+			if err := emit(t.name+"_on_"+c.Name, t.builder(), c); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Deterministic sort by case name.
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// ----------------------------------------------------------------------
 // Entry point
 // ----------------------------------------------------------------------
 
@@ -329,7 +565,12 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	c := corpus{Cases: organic}
+	synthetic, err := syntheticCases()
+	if err != nil {
+		return err
+	}
+	all := append(organic, synthetic...)
+	c := corpus{Cases: all}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(c)

--- a/tool/kubeaccess-corpus/main.go
+++ b/tool/kubeaccess-corpus/main.go
@@ -214,6 +214,28 @@ func runCheckAccess(roles []*types.RoleV6, cluster *types.KubernetesCluster) (st
 	return "", trace.Wrap(err)
 }
 
+// runCheckAccessProduction mirrors the production Kubernetes access
+// path in lib/kube/proxy/forwarder.go:1014 by passing a
+// NewKubernetesClusterLabelMatcher to CheckAccess. This causes the
+// implicit-wildcard deny injection to fire for roles with empty
+// deny.kubernetes_labels.
+func runCheckAccessProduction(roles []*types.RoleV6, cluster *types.KubernetesCluster) (string, error) {
+	k8sV3, err := types.NewKubernetesClusterV3FromLegacyCluster(apidefaults.Namespace, cluster)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	checker := makeAccessChecker(roles)
+	matcher := services.NewKubernetesClusterLabelMatcher(k8sV3.GetAllLabels(), "alice", nil)
+	err = checker.CheckAccess(k8sV3, services.AccessState{}, matcher)
+	if err == nil {
+		return "allow", nil
+	}
+	if trace.IsAccessDenied(err) {
+		return "deny", nil
+	}
+	return "", trace.Wrap(err)
+}
+
 // ----------------------------------------------------------------------
 // Fixtures — transcribed from TestCheckAccessToKubernetes
 // (lib/services/role_test.go:6828). Inline in the test, so duplicated here.
@@ -618,6 +640,74 @@ func edgeCases() ([]testCase, error) {
 }
 
 // ----------------------------------------------------------------------
+// Production corpus — models the Kubernetes access path in
+// `lib/kube/proxy/forwarder.go:1014` (with `NewKubernetesClusterLabelMatcher`).
+// Key behavior: a role with empty deny.kubernetes_labels denies all
+// clusters via the `{*:*}` injection in `getKubeLabelMatchers`.
+// ----------------------------------------------------------------------
+
+func productionCases() ([]testCase, error) {
+	// Pool of roles and clusters sufficient to exercise:
+	// - empty deny → denies everything via injection
+	// - non-empty deny → denies only matching clusters
+	// - wildcard allow + empty deny (the production "no-op deny" case
+	//   that DOES deny in the production path, unlike the core path)
+	roles := []struct {
+		name  string
+		build func() *types.RoleV6
+	}{
+		{"wildcard-allow-empty-deny", func() *types.RoleV6 { return wildcardAllowRole("p-w") }},
+		{"env-prod-allow-empty-deny", func() *types.RoleV6 { return singleLabelAllowRole("p-envprod", "env", "prod") }},
+		{"wildcard-allow-envprod-deny", func() *types.RoleV6 { return denyOnLabelRole("p-envprod-deny", "env", "prod") }},
+		{"empty-allow-empty-deny", func() *types.RoleV6 { return emptyCondRole("p-empty") }},
+	}
+	clusters := []*types.KubernetesCluster{
+		mkCluster("c-empty", nil),
+		mkCluster("c-env-prod", map[string]string{"env": "prod"}),
+		mkCluster("c-env-staging", map[string]string{"env": "staging"}),
+	}
+
+	out := make([]testCase, 0, len(roles)*len(clusters))
+	for _, r := range roles {
+		for _, c := range clusters {
+			expected, err := runCheckAccessProduction([]*types.RoleV6{r.build()}, c)
+			if err != nil {
+				return nil, fmt.Errorf("production %s on %s: %w", r.name, c.Name, err)
+			}
+			out = append(out, testCase{
+				Name:     fmt.Sprintf("production/%s_on_%s", r.name, c.Name),
+				Source:   "production",
+				Roles:    []roleJSON{roleToJSON(r.build())},
+				Cluster:  clusterToJSON(c.Name, c.StaticLabels, c.DynamicLabels),
+				Request:  nil,
+				Expected: expected,
+			})
+		}
+	}
+	// Also test two-role sets: wildcard allow + empty deny companion role.
+	// In production the companion's empty deny denies everything regardless
+	// of which role comes first.
+	for _, c := range clusters {
+		pair := []*types.RoleV6{wildcardAllowRole("p-w"), emptyCondRole("p-companion")}
+		expected, err := runCheckAccessProduction(pair, c)
+		if err != nil {
+			return nil, fmt.Errorf("production pair on %s: %w", c.Name, err)
+		}
+		jroles := []roleJSON{roleToJSON(pair[0]), roleToJSON(pair[1])}
+		out = append(out, testCase{
+			Name:     fmt.Sprintf("production/wildcard-plus-empty-companion_on_%s", c.Name),
+			Source:   "production",
+			Roles:    jroles,
+			Cluster:  clusterToJSON(c.Name, c.StaticLabels, c.DynamicLabels),
+			Request:  nil,
+			Expected: expected,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// ----------------------------------------------------------------------
 // Randomized corpus — property-based-testing-lite. Seeded so output is
 // deterministic; re-running produces byte-identical JSON. Generates N
 // cases from a small vocabulary of label keys, values, and glob
@@ -764,12 +854,17 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	production, err := productionCases()
+	if err != nil {
+		return err
+	}
 	random, err := randomCases()
 	if err != nil {
 		return err
 	}
 	all := append(organic, synthetic...)
 	all = append(all, edge...)
+	all = append(all, production...)
 	all = append(all, random...)
 	c := corpus{Cases: all}
 	enc := json.NewEncoder(os.Stdout)

--- a/tool/kubeaccess-corpus/main.go
+++ b/tool/kubeaccess-corpus/main.go
@@ -35,6 +35,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"os"
 	"sort"
 
@@ -617,6 +618,136 @@ func edgeCases() ([]testCase, error) {
 }
 
 // ----------------------------------------------------------------------
+// Randomized corpus — property-based-testing-lite. Seeded so output is
+// deterministic; re-running produces byte-identical JSON. Generates N
+// cases from a small vocabulary of label keys, values, and glob
+// patterns, with Go's CheckAccess as the oracle for every case.
+// ----------------------------------------------------------------------
+
+const (
+	randomSeedLo = 0xdeadbeef
+	randomSeedHi = 0xcafe1234
+	randomCount  = 400
+)
+
+var (
+	randomLabelKeys = []string{"env", "team", "tier", "region"}
+	// Values include wildcards and glob patterns to exercise matcher edges.
+	randomLabelValues = []string{
+		"prod", "staging", "dev",
+		"sre", "platform", "web",
+		"us-east", "us-west",
+		"v1.2.3", "v1.2.4",
+		"*", "prod*", "*-east", "v1.2.*",
+	}
+	randomClusterValues = []string{
+		"prod", "staging", "dev",
+		"sre", "platform", "web",
+		"us-east", "us-west",
+		"v1.2.3", "v1.2.4", "v1.3.0",
+	}
+)
+
+// pick returns one element uniformly at random.
+func pick[T any](rng *rand.Rand, xs []T) T {
+	return xs[rng.IntN(len(xs))]
+}
+
+// pickN returns n distinct-index picks (no repeated keys). Max n =
+// len(xs). Returns up to min(n, len(xs)) picks.
+func pickDistinct[T any](rng *rand.Rand, xs []T, n int) []T {
+	if n > len(xs) {
+		n = len(xs)
+	}
+	idx := rng.Perm(len(xs))[:n]
+	out := make([]T, n)
+	for i, k := range idx {
+		out[i] = xs[k]
+	}
+	return out
+}
+
+func randomLabels(rng *rand.Rand, valuePool []string, maxKeys int) types.Labels {
+	n := rng.IntN(maxKeys + 1) // 0..maxKeys
+	if n == 0 {
+		return nil
+	}
+	keys := pickDistinct(rng, randomLabelKeys, n)
+	out := make(types.Labels, n)
+	for _, k := range keys {
+		// Each key gets 1-2 values.
+		numVals := 1 + rng.IntN(2)
+		vals := make(apiutils.Strings, 0, numVals)
+		for range numVals {
+			vals = append(vals, pick(rng, valuePool))
+		}
+		out[k] = vals
+	}
+	return out
+}
+
+func randomRoleCondition(rng *rand.Rand, valuePool []string) types.RoleConditions {
+	return types.RoleConditions{
+		Namespaces:       []string{apidefaults.Namespace},
+		KubernetesLabels: randomLabels(rng, valuePool, 2),
+	}
+}
+
+func randomRole(rng *rand.Rand, nameSuffix int) *types.RoleV6 {
+	name := fmt.Sprintf("r-rand-%d", nameSuffix)
+	allow := randomRoleCondition(rng, randomLabelValues)
+	deny := randomRoleCondition(rng, randomLabelValues)
+	return mkRole(name, allow, deny)
+}
+
+func randomCluster(rng *rand.Rand, nameSuffix int) *types.KubernetesCluster {
+	name := fmt.Sprintf("c-rand-%d", nameSuffix)
+	n := rng.IntN(4) // 0..3 labels
+	var staticLabels map[string]string
+	if n > 0 {
+		keys := pickDistinct(rng, randomLabelKeys, n)
+		staticLabels = make(map[string]string, n)
+		for _, k := range keys {
+			staticLabels[k] = pick(rng, randomClusterValues)
+		}
+	}
+	return &types.KubernetesCluster{Name: name, StaticLabels: staticLabels}
+}
+
+func randomCases() ([]testCase, error) {
+	rng := rand.New(rand.NewPCG(randomSeedLo, randomSeedHi))
+
+	out := make([]testCase, 0, randomCount)
+	for i := range randomCount {
+		// 1 to 3 roles per set.
+		numRoles := 1 + rng.IntN(3)
+		roles := make([]*types.RoleV6, 0, numRoles)
+		for j := range numRoles {
+			roles = append(roles, randomRole(rng, i*10+j))
+		}
+		cluster := randomCluster(rng, i)
+
+		expected, err := runCheckAccess(roles, cluster)
+		if err != nil {
+			return nil, fmt.Errorf("random %d: %w", i, err)
+		}
+		jroles := make([]roleJSON, 0, len(roles))
+		for _, r := range roles {
+			jroles = append(jroles, roleToJSON(r))
+		}
+		out = append(out, testCase{
+			Name:     fmt.Sprintf("random/%04d", i),
+			Source:   "random",
+			Roles:    jroles,
+			Cluster:  clusterToJSON(cluster.Name, cluster.StaticLabels, cluster.DynamicLabels),
+			Request:  nil,
+			Expected: expected,
+		})
+	}
+	return out, nil
+}
+
+// ----------------------------------------------------------------------
 // Entry point
 // ----------------------------------------------------------------------
 
@@ -633,8 +764,13 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	random, err := randomCases()
+	if err != nil {
+		return err
+	}
 	all := append(organic, synthetic...)
 	all = append(all, edge...)
+	all = append(all, random...)
 	c := corpus{Cases: all}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")

--- a/tool/kubeaccess-corpus/main.go
+++ b/tool/kubeaccess-corpus/main.go
@@ -1,0 +1,347 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// kubeaccess-corpus dumps a JSON corpus of Kubernetes access decisions
+// for differential testing against the Lean model in ../../lean/.
+//
+// Section A: organic cases transcribed from TestCheckAccessToKubernetes
+//            (lib/services/role_test.go:6828). Cases that use non-zero
+//            AccessState (MFA/device trust) or KubernetesLabelsExpression
+//            are skipped because they're out of v0 scope.
+//
+// Section B: synthetic combinatorial cases (added in exporter-synthetic
+//            task; not present in this initial commit).
+//
+// Each case is a fixed-shape {name, source, roles, cluster, request,
+// expected} record. The Go decision is the oracle — no manual labeling.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/gravitational/trace"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// ----------------------------------------------------------------------
+// JSON schema — mirrors lean/Teleport/Types.lean.
+// ----------------------------------------------------------------------
+
+type labelsEntry struct {
+	Key    string   `json:"key"`
+	Values []string `json:"values"`
+}
+
+type clusterLabelsEntry struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type kubeResourceJSON struct {
+	Kind     string   `json:"kind"`
+	Ns       string   `json:"ns"`
+	Name     string   `json:"name"`
+	APIGroup string   `json:"apiGroup"`
+	Verbs    []string `json:"verbs"`
+}
+
+type roleConditionJSON struct {
+	Namespaces          []string           `json:"namespaces"`
+	KubernetesLabels    []labelsEntry      `json:"kubernetesLabels"`
+	KubernetesResources []kubeResourceJSON `json:"kubernetesResources"`
+}
+
+type roleJSON struct {
+	Name  string            `json:"name"`
+	Allow roleConditionJSON `json:"allow"`
+	Deny  roleConditionJSON `json:"deny"`
+}
+
+type clusterJSON struct {
+	Name       string               `json:"name"`
+	Labels     []clusterLabelsEntry `json:"labels"`
+	TeleportNs string               `json:"teleportNs"`
+}
+
+type requestJSON struct {
+	Resource      *kubeResourceJSON `json:"resource"`
+	Verb          string            `json:"verb"`
+	IsClusterWide bool              `json:"isClusterWide"`
+}
+
+type testCase struct {
+	Name     string       `json:"name"`
+	Source   string       `json:"source"`
+	Roles    []roleJSON   `json:"roles"`
+	Cluster  clusterJSON  `json:"cluster"`
+	Request  *requestJSON `json:"request"`
+	Expected string       `json:"expected"`
+}
+
+type corpus struct {
+	Cases []testCase `json:"cases"`
+}
+
+// ----------------------------------------------------------------------
+// Conversion helpers
+// ----------------------------------------------------------------------
+
+func labelsToEntries(l types.Labels) []labelsEntry {
+	if len(l) == 0 {
+		return []labelsEntry{}
+	}
+	out := make([]labelsEntry, 0, len(l))
+	for k, vs := range l {
+		copied := append([]string(nil), vs...)
+		sort.Strings(copied)
+		out = append(out, labelsEntry{Key: k, Values: copied})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+func kubeResourcesToJSON(in []types.KubernetesResource) []kubeResourceJSON {
+	out := make([]kubeResourceJSON, 0, len(in))
+	for _, r := range in {
+		verbs := append([]string(nil), r.Verbs...)
+		sort.Strings(verbs)
+		out = append(out, kubeResourceJSON{
+			Kind:     r.Kind,
+			Ns:       r.Namespace,
+			Name:     r.Name,
+			APIGroup: r.APIGroup,
+			Verbs:    verbs,
+		})
+	}
+	return out
+}
+
+func roleConditionToJSON(c types.RoleConditions) roleConditionJSON {
+	namespaces := append([]string(nil), c.Namespaces...)
+	if namespaces == nil {
+		namespaces = []string{}
+	}
+	sort.Strings(namespaces)
+	return roleConditionJSON{
+		Namespaces:          namespaces,
+		KubernetesLabels:    labelsToEntries(c.KubernetesLabels),
+		KubernetesResources: kubeResourcesToJSON(c.KubernetesResources),
+	}
+}
+
+func roleToJSON(r *types.RoleV6) roleJSON {
+	return roleJSON{
+		Name:  r.GetName(),
+		Allow: roleConditionToJSON(r.GetRoleConditions(types.Allow)),
+		Deny:  roleConditionToJSON(r.GetRoleConditions(types.Deny)),
+	}
+}
+
+func clusterToJSON(name string, staticLabels map[string]string,
+	dynamicLabels map[string]types.CommandLabelV2) clusterJSON {
+	labels := make([]clusterLabelsEntry, 0, len(staticLabels)+len(dynamicLabels))
+	for k, v := range staticLabels {
+		labels = append(labels, clusterLabelsEntry{Key: k, Value: v})
+	}
+	for k, dl := range dynamicLabels {
+		labels = append(labels, clusterLabelsEntry{Key: k, Value: dl.Result})
+	}
+	sort.Slice(labels, func(i, j int) bool { return labels[i].Key < labels[j].Key })
+	return clusterJSON{
+		Name:       name,
+		Labels:     labels,
+		TeleportNs: apidefaults.Namespace,
+	}
+}
+
+// ----------------------------------------------------------------------
+// Oracle: run Go's CheckAccess, return "allow" or "deny".
+// ----------------------------------------------------------------------
+
+func makeAccessChecker(roles []*types.RoleV6) services.AccessChecker {
+	roleSet := make(services.RoleSet, len(roles))
+	roleNames := make([]string, len(roles))
+	for i, r := range roles {
+		roleSet[i] = r
+		roleNames[i] = r.GetName()
+	}
+	info := &services.AccessInfo{
+		Username:                 "alice",
+		Roles:                    roleNames,
+		Traits:                   nil,
+		AllowedResourceAccessIDs: nil,
+	}
+	return services.NewAccessCheckerWithRoleSet(info, "clustername", roleSet)
+}
+
+func runCheckAccess(roles []*types.RoleV6, cluster *types.KubernetesCluster) (string, error) {
+	k8sV3, err := types.NewKubernetesClusterV3FromLegacyCluster(apidefaults.Namespace, cluster)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	checker := makeAccessChecker(roles)
+	err = checker.CheckAccess(k8sV3, services.AccessState{})
+	if err == nil {
+		return "allow", nil
+	}
+	if trace.IsAccessDenied(err) {
+		return "deny", nil
+	}
+	return "", trace.Wrap(err)
+}
+
+// ----------------------------------------------------------------------
+// Fixtures — transcribed from TestCheckAccessToKubernetes
+// (lib/services/role_test.go:6828). Inline in the test, so duplicated here.
+// ----------------------------------------------------------------------
+
+func fixtures() (
+	clusterNoLabels, clusterWithLabels *types.KubernetesCluster,
+	wildcardRole, matchingLabelsRole, noLabelsRole, mismatchingLabelsRole *types.RoleV6,
+) {
+	clusterNoLabels = &types.KubernetesCluster{Name: "no-labels"}
+	clusterWithLabels = &types.KubernetesCluster{
+		Name:          "with-labels",
+		StaticLabels:  map[string]string{"foo": "bar"},
+		DynamicLabels: map[string]types.CommandLabelV2{"baz": {Result: "qux"}},
+	}
+	wildcardRole = &types.RoleV6{
+		Metadata: types.Metadata{Name: "wildcard-labels", Namespace: apidefaults.Namespace},
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				Namespaces:       []string{apidefaults.Namespace},
+				KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			},
+		},
+	}
+	matchingLabelsRole = &types.RoleV6{
+		Metadata: types.Metadata{Name: "matching-labels", Namespace: apidefaults.Namespace},
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				Namespaces: []string{apidefaults.Namespace},
+				KubernetesLabels: types.Labels{
+					"foo": apiutils.Strings{"bar"},
+					"baz": apiutils.Strings{"qux"},
+				},
+			},
+		},
+	}
+	noLabelsRole = &types.RoleV6{
+		Metadata: types.Metadata{Name: "no-labels", Namespace: apidefaults.Namespace},
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{Namespaces: []string{apidefaults.Namespace}},
+		},
+	}
+	mismatchingLabelsRole = &types.RoleV6{
+		Metadata: types.Metadata{Name: "mismatching-labels", Namespace: apidefaults.Namespace},
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				Namespaces: []string{apidefaults.Namespace},
+				KubernetesLabels: types.Labels{
+					"qux": apiutils.Strings{"baz"},
+					"bar": apiutils.Strings{"foo"},
+				},
+			},
+		},
+	}
+	// Normalize every role so serialized state matches post-CheckAndSetDefaults shape.
+	for _, r := range []*types.RoleV6{wildcardRole, matchingLabelsRole, noLabelsRole, mismatchingLabelsRole} {
+		if err := r.CheckAndSetDefaults(); err != nil {
+			panic(err)
+		}
+	}
+	return
+}
+
+// organicCases produces the Section-A corpus. Skips cases using
+// non-zero AccessState or KubernetesLabelsExpression (per workspace
+// research notes).
+func organicCases() ([]testCase, error) {
+	clusterNoLabels, clusterWithLabels, wildcardRole, matchingLabelsRole, noLabelsRole, mismatchingLabelsRole := fixtures()
+
+	type entry struct {
+		name    string
+		roles   []*types.RoleV6
+		cluster *types.KubernetesCluster
+	}
+	entries := []entry{
+		{"empty-role-set-no-access", nil, clusterNoLabels},
+		{"role-with-no-labels-no-access", []*types.RoleV6{noLabelsRole}, clusterNoLabels},
+		{"wildcard-role-matches-no-labels-cluster", []*types.RoleV6{wildcardRole}, clusterNoLabels},
+		{"wildcard-role-matches-with-labels-cluster", []*types.RoleV6{wildcardRole}, clusterWithLabels},
+		{"labels-role-no-match-on-no-labels-cluster", []*types.RoleV6{matchingLabelsRole}, clusterNoLabels},
+		{"labels-role-match-on-with-labels-cluster", []*types.RoleV6{matchingLabelsRole}, clusterWithLabels},
+		{"mismatched-labels-no-match", []*types.RoleV6{mismatchingLabelsRole}, clusterWithLabels},
+		{"one-role-in-set-matches", []*types.RoleV6{mismatchingLabelsRole, noLabelsRole, matchingLabelsRole}, clusterWithLabels},
+	}
+
+	out := make([]testCase, 0, len(entries))
+	for _, e := range entries {
+		expected, err := runCheckAccess(e.roles, e.cluster)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", e.name, err)
+		}
+		roles := make([]roleJSON, 0, len(e.roles))
+		for _, r := range e.roles {
+			roles = append(roles, roleToJSON(r))
+		}
+		out = append(out, testCase{
+			Name:     "organic/" + e.name,
+			Source:   "organic",
+			Roles:    roles,
+			Cluster:  clusterToJSON(e.cluster.Name, e.cluster.StaticLabels, e.cluster.DynamicLabels),
+			Request:  nil,
+			Expected: expected,
+		})
+	}
+	return out, nil
+}
+
+// ----------------------------------------------------------------------
+// Entry point
+// ----------------------------------------------------------------------
+
+func run() error {
+	organic, err := organicCases()
+	if err != nil {
+		return err
+	}
+	c := corpus{Cases: organic}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(c)
+}
+
+func main() {
+	if err := run(); err != nil {
+		if errors.Is(err, trace.Unwrap(err)) || trace.Unwrap(err) == nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "%s\n", trace.DebugReport(err))
+		}
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Research PR. Lean 4 model of Kubernetes RBAC, differential-tested against Go. See `lean/README.md`.

## Manual Test Plan
### Test Environment
macOS + Ubuntu CI. Lean 4.29.1, Go from `go.mod`.

### Test Cases
- [x] `lake build` green, no `sorry`.
- [x] `lean/scripts/diff.sh` exits 0, 507 cases, 0 mismatches.
- [x] Breaking a Lean matcher surfaces mismatches; reverts green.
- [x] Exporter output is deterministic across runs.