### PR TITLE
Add DropdownMenu component to design package

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@codemirror/lang-sql": "^6.10.0",
     "@codemirror/view": "^6.40.0",
     "@floating-ui/react": "^0.27.19",
+    "@floating-ui/react-dom": "2.1.8",
     "@grpc/grpc-js": "1.14.3",
     "@hookform/resolvers": "^5.2.2",
     "@lezer/highlight": "^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@floating-ui/react':
         specifier: ^0.27.19
         version: 0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@floating-ui/react-dom':
+        specifier: 2.1.8
+        version: 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@grpc/grpc-js':
         specifier: 1.14.3
         version: 1.14.3

--- a/web/packages/design/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/web/packages/design/src/DropdownMenu/DropdownMenu.story.tsx
@@ -1,0 +1,303 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Placement } from '@floating-ui/react';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { useContext } from 'react';
+import { action } from 'storybook/actions';
+import { useArgs } from 'storybook/preview-api';
+import styled from 'styled-components';
+
+import { ButtonBorder, ButtonPrimary, Flex, Text } from 'design';
+import { ChevronDown, ChevronRight } from 'design/Icon';
+
+import {
+  DropdownMenu,
+  DropdownMenuSection,
+  DropdownMenuCheckableItem,
+  DropdownMenuContext,
+  DropdownMenuItem,
+  DropdownMenuSearch,
+  DropdownMenuStickySection,
+  DropdownMenuPanel,
+} from '.';
+
+const allItems = [
+  'Alpha',
+  'Bravo',
+  'Charlie',
+  'Delta',
+  'Echo',
+  'Foxtrot',
+  'Golf',
+  'Hotel',
+  'India',
+  'Juliet',
+  'verylongresourceprincipalnameforoverflow',
+];
+
+const disabledItems = new Set(['Delta', 'Hotel']);
+
+type Args = {
+  showSearch: boolean;
+  showSections: boolean;
+  useCheckboxes: boolean;
+  showStickyFooter: boolean;
+  showNestedMenu: boolean;
+  showDisabledItems: boolean;
+  hoverTrigger: boolean;
+  placement: Placement;
+  selected: string[];
+};
+
+export default {
+  title: 'Design/DropdownMenu',
+  argTypes: {
+    showSearch: {
+      control: 'boolean',
+      description: 'Show a search input in a sticky top section',
+    },
+    showSections: {
+      control: 'boolean',
+      description: 'Split items into two sections with headers',
+    },
+    useCheckboxes: {
+      control: 'boolean',
+      description: 'Render items as checkboxes with selection state',
+    },
+    showStickyFooter: {
+      control: 'boolean',
+      description: 'Show a sticky footer with an action button',
+    },
+    showNestedMenu: {
+      control: 'boolean',
+      description: 'Include a nested submenu trigger',
+    },
+    showDisabledItems: {
+      control: 'boolean',
+      description: 'Mark Delta and Hotel as disabled',
+    },
+    hoverTrigger: {
+      control: 'boolean',
+      description: 'Open menu on hover in addition to click',
+    },
+    placement: {
+      control: 'select',
+      options: [
+        'bottom-end',
+        'bottom-start',
+        'top-end',
+        'top-start',
+        'right-start',
+        'left-start',
+      ],
+    },
+    selected: { control: false },
+  },
+  args: {
+    showSearch: false,
+    showSections: false,
+    useCheckboxes: false,
+    showStickyFooter: false,
+    showNestedMenu: false,
+    showDisabledItems: false,
+    hoverTrigger: false,
+    placement: 'bottom-end',
+    selected: [],
+  },
+  render: (args => {
+    const [{ selected }, updateArgs] = useArgs<Args>();
+
+    const toggleItem = (item: string) => {
+      const next = selected.includes(item)
+        ? selected.filter(s => s !== item)
+        : [...selected, item];
+      updateArgs({ selected: next });
+      action('onToggle')(item, next);
+    };
+
+    return (
+      <Flex alignItems="center" justifyContent="center" minHeight="300px">
+        <DropdownMenu
+          placement={args.placement}
+          hoverTrigger={args.hoverTrigger}
+          onOpenChange={action('onOpenChange')}
+          panelComponent={CustomPanelComponent}
+          renderTrigger={({ ref, getReferenceProps }) => (
+            <ButtonBorder
+              ref={ref}
+              textTransform="none"
+              size="small"
+              css={`
+                transition:
+                  background 150ms ease,
+                  border-color 150ms ease;
+              `}
+              {...getReferenceProps()}
+            >
+              Open Menu
+              <ChevronDown ml={1} size="small" />
+            </ButtonBorder>
+          )}
+        >
+          <MenuContent {...args} selected={selected} onToggle={toggleItem} />
+        </DropdownMenu>
+      </Flex>
+    );
+  }) satisfies StoryFn<Args>,
+} satisfies Meta<Args>;
+
+const CustomPanelComponent = styled(DropdownMenuPanel)`
+  max-width: 220px;
+`;
+
+type Story = StoryObj<Args>;
+
+export const Default: Story = {};
+
+export const Checkboxes: Story = {
+  args: {
+    showSearch: true,
+    useCheckboxes: true,
+    showStickyFooter: true,
+  },
+};
+
+export const Nested: Story = {
+  args: {
+    showNestedMenu: true,
+    showSections: true,
+  },
+};
+
+const MenuContent = ({
+  showSearch,
+  showSections,
+  useCheckboxes,
+  showStickyFooter,
+  showNestedMenu,
+  showDisabledItems,
+  selected,
+  onToggle,
+}: Omit<Args, 'hoverTrigger' | 'placement'> & {
+  onToggle: (item: string) => void;
+}) => {
+  const { search } = useContext(DropdownMenuContext);
+  const q = search.trim().toLowerCase();
+
+  const items = q
+    ? allItems.filter(item => item.toLowerCase().includes(q))
+    : allItems;
+
+  const midpoint = Math.ceil(items.length / 2);
+
+  const renderItem = (item: string) => {
+    const disabled = showDisabledItems && disabledItems.has(item);
+    if (useCheckboxes) {
+      return (
+        <DropdownMenuCheckableItem
+          key={item}
+          label={item}
+          disabled={disabled}
+          checked={selected.includes(item)}
+          onChange={() => onToggle(item)}
+        />
+      );
+    }
+    return (
+      <DropdownMenuItem
+        key={item}
+        label={item}
+        disabled={disabled}
+        onClick={() => action('onItemClick')(item)}
+      >
+        {item}
+      </DropdownMenuItem>
+    );
+  };
+
+  return (
+    <>
+      {showSearch && (
+        <DropdownMenuStickySection $position="top">
+          <DropdownMenuSearch placeholder="Search items..." autoFocus />
+        </DropdownMenuStickySection>
+      )}
+
+      {items.length > 0 &&
+        (showSections ? (
+          <>
+            <DropdownMenuSection header="Group A">
+              {items.slice(0, midpoint).map(renderItem)}
+            </DropdownMenuSection>
+            <DropdownMenuSection header="Group B">
+              {items.slice(midpoint).map(renderItem)}
+            </DropdownMenuSection>
+          </>
+        ) : (
+          <DropdownMenuSection>{items.map(renderItem)}</DropdownMenuSection>
+        ))}
+
+      {showNestedMenu && (
+        <DropdownMenuSection header="Nested Menu">
+          <DropdownMenu
+            placement="right-start"
+            renderTrigger={({ ref, getReferenceProps }) => (
+              <DropdownMenuItem ref={ref} {...getReferenceProps()}>
+                <Flex
+                  flex="1"
+                  justifyContent="space-between"
+                  alignItems="center"
+                >
+                  <Text>More options</Text>
+                  <ChevronRight size="small" color="text.muted" />
+                </Flex>
+              </DropdownMenuItem>
+            )}
+          >
+            <DropdownMenuSection>
+              {['Sub-item A', 'Sub-item B', 'Sub-item C'].map(item => (
+                <DropdownMenuItem
+                  key={item}
+                  label={item}
+                  onClick={() => action('onItemClick')(item)}
+                >
+                  {item}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSection>
+          </DropdownMenu>
+        </DropdownMenuSection>
+      )}
+
+      {items.length === 0 && <DropdownMenuSection header="No results" />}
+
+      {showStickyFooter && (
+        <DropdownMenuStickySection $position="bottom">
+          <ButtonPrimary
+            size="small"
+            block
+            onClick={() => action('onApply')(selected)}
+          >
+            Apply ({selected.length} selected)
+          </ButtonPrimary>
+        </DropdownMenuStickySection>
+      )}
+    </>
+  );
+};

--- a/web/packages/design/src/DropdownMenu/DropdownMenu.tsx
+++ b/web/packages/design/src/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,393 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  autoUpdate,
+  flip as flipMiddleware,
+  FloatingFocusManager,
+  size as sizeMiddleware,
+  FloatingList,
+  FloatingNode,
+  FloatingPortal,
+  FloatingTree,
+  offset as offsetMiddleware,
+  Placement,
+  safePolygon,
+  shift as shiftMiddleware,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useFloatingParentNodeId,
+  useFloatingTree,
+  useHover,
+  useInteractions,
+  useListNavigation,
+  useMergeRefs,
+  useRole,
+  useTransitionStyles,
+} from '@floating-ui/react';
+import React, {
+  ElementType,
+  forwardRef,
+  ReactNode,
+  RefCallback,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useTheme } from 'styled-components';
+
+import { DropdownMenuContext } from 'design/DropdownMenu/DropdownMenuContext';
+import { DropdownMenuPanel } from 'design/DropdownMenu/DropdownMenuPrimitives';
+
+export type DropdownMenuProps = {
+  /**
+   * Trigger element render func. Pass `ref` and spread `getReferenceProps()`
+   * to the target element.
+   */
+  renderTrigger?: (props: {
+    ref: RefCallback<HTMLElement> | null;
+    getReferenceProps: (
+      userProps?: Record<string, unknown>
+    ) => Record<string, unknown>;
+    isOpen: boolean;
+    isNested: boolean;
+  }) => ReactNode;
+  /* Floating component used to wrap menu content */
+  panelComponent?: ElementType;
+  /* Placement of menu on side of the trigger element */
+  placement?: Placement;
+  /* Open/close the menu via hovering the trigger element */
+  hoverTrigger?: boolean;
+  /* Close the menu when hovering off it or the trigger element */
+  hoverDismiss?: boolean;
+  /* Open/close delay when hoverTrigger is enabled, or when menu is nested */
+  hoverDelay?: { open?: number; close?: number };
+  /* Open/close transition options */
+  transition?: { duration?: number };
+  /* Spacing in px from trigger element */
+  offset?: number;
+  /* Callback fired when menu is opened or closed */
+  onOpenChange?: (open: boolean) => void;
+  /* Menu content */
+  children?: ReactNode;
+};
+
+const DEFAULT_HOVER_DELAY = { open: 100, close: 200 };
+const DEFAULT_TRANSITION = { duration: 150 };
+const DEFAULT_EDGE_PADDING = 8;
+
+const MenuComponent = forwardRef<HTMLElement, DropdownMenuProps>(
+  function MenuComponent(
+    {
+      renderTrigger,
+      panelComponent,
+      placement,
+      hoverTrigger = false,
+      hoverDismiss = false,
+      hoverDelay = DEFAULT_HOVER_DELAY,
+      transition = DEFAULT_TRANSITION,
+      offset = DEFAULT_EDGE_PADDING / 2,
+      onOpenChange: onOpenChangeProp,
+      children,
+    },
+    forwardedRef
+  ) {
+    const nodeId = useFloatingNodeId();
+    const parentId = useFloatingParentNodeId();
+    const isNested = parentId != null;
+    const tree = useFloatingTree();
+    const theme = useTheme();
+
+    const [isOpenState, setIsOpenState] = useState(false);
+    const [activeIndex, setActiveIndex] = useState<number | null>(null);
+    const [search, setSearch] = useState('');
+
+    const elementsRef = useRef<(HTMLElement | null)[]>([]);
+    const labelsRef = useRef<(string | null)[]>([]);
+
+    const requestedPlacement =
+      placement ?? (isNested ? 'right-start' : 'bottom-end');
+
+    const {
+      x,
+      y,
+      strategy,
+      refs,
+      context,
+      placement: resolvedPlacement,
+    } = useFloating({
+      nodeId,
+      placement: requestedPlacement,
+      open: isOpenState,
+      onOpenChange: (open, _event, reason) => {
+        // With hoverDismiss (without hoverTrigger), hover should only
+        // close the menu, not open it. Reject hover-initiated opens.
+        if (hoverDismiss && !hoverTrigger && open && reason === 'hover') {
+          return;
+        }
+        setIsOpenState(open);
+        onOpenChangeProp?.(open);
+        if (open && tree) {
+          tree.events.emit('menuopen', { nodeId, parentId });
+        }
+        if (!open && !isNested) {
+          setSearch('');
+          setActiveIndex(null);
+        }
+      },
+      middleware: [
+        offsetMiddleware(
+          isNested
+            ? ({ placement }) => {
+                const [_, align] = placement.split('-');
+                return {
+                  mainAxis: offset,
+                  crossAxis:
+                    align === 'start'
+                      ? -theme.space[1]
+                      : align === 'end'
+                        ? theme.space[1]
+                        : 0,
+                };
+              }
+            : offset
+        ),
+        flipMiddleware(),
+        shiftMiddleware({ padding: DEFAULT_EDGE_PADDING }),
+        sizeMiddleware({
+          padding: DEFAULT_EDGE_PADDING,
+          // Prefer maxHeight/maxWidth props, but set lower if viewport is smaller.
+          apply({ availableHeight, availableWidth, elements }) {
+            const cs = getComputedStyle(elements.floating);
+            const cssMaxH = parseFloat(cs.maxHeight);
+            const cssMaxW = parseFloat(cs.maxWidth);
+            const effectiveMaxH = Number.isFinite(cssMaxH)
+              ? Math.min(cssMaxH, availableHeight)
+              : availableHeight;
+            const effectiveMaxW = Number.isFinite(cssMaxW)
+              ? Math.min(cssMaxW, availableWidth)
+              : availableWidth;
+            elements.floating.style.maxHeight = `${effectiveMaxH}px`;
+            elements.floating.style.maxWidth = `${effectiveMaxW}px`;
+          },
+        }),
+      ],
+      whileElementsMounted: autoUpdate,
+    });
+
+    const [side] = resolvedPlacement.split('-');
+    const transformOrigin =
+      { top: 'bottom', bottom: 'top', left: 'right', right: 'left' }[side] ??
+      'top';
+
+    const { isMounted, styles: transitionStyles } = useTransitionStyles(
+      context,
+      {
+        duration: transition.duration,
+        initial: { opacity: 0, transform: 'scale(0.96)' },
+        common: { transformOrigin, transitionTimingFunction: 'ease' },
+      }
+    );
+
+    // When hoverDismiss is set, useHover's leave handler normally bails
+    // if the menu was opened via useClick, because it checks
+    // dataRef.current.openEvent for click-like events. Clearing that
+    // reference after a click-initiated open lets useHover handle the close
+    // regardless of how the menu was opened.
+    useEffect(() => {
+      if (!isNested && hoverDismiss && !hoverTrigger && isOpenState) {
+        context.dataRef.current.openEvent = undefined;
+      }
+    }, [isNested, hoverDismiss, hoverTrigger, isOpenState, context.dataRef]);
+
+    const hover = useHover(context, {
+      enabled: isNested || hoverTrigger || hoverDismiss,
+      delay: hoverDelay,
+      handleClose: safePolygon({ requireIntent: true }),
+    });
+
+    const click = useClick(context, {
+      event: 'mousedown',
+      toggle: !isNested,
+      ignoreMouse: isNested,
+    });
+
+    const dismiss = useDismiss(context, { bubbles: true });
+    const role = useRole(context, { role: 'menu' });
+
+    const listNav = useListNavigation(context, {
+      listRef: elementsRef,
+      activeIndex,
+      onNavigate: setActiveIndex,
+      nested: isNested,
+    });
+
+    const {
+      getReferenceProps: getReferencePropsRaw,
+      getFloatingProps,
+      getItemProps,
+    } = useInteractions([hover, click, dismiss, role, listNav]);
+
+    // Wrap getReferenceProps so that click/mousedown events on the trigger
+    // don't bubble to ancestors (e.g., clickable table row)
+    const getReferenceProps = useCallback(
+      (userProps?: Record<string, unknown>) =>
+        getReferencePropsRaw({
+          ...userProps,
+          onClick(e: React.MouseEvent) {
+            e.stopPropagation();
+            (userProps?.onClick as React.MouseEventHandler)?.(e);
+          },
+          onMouseDown(e: React.MouseEvent) {
+            e.stopPropagation();
+            (userProps?.onMouseDown as React.MouseEventHandler)?.(e);
+          },
+          onKeyDown(e: React.KeyboardEvent) {
+            e.stopPropagation();
+            (userProps?.onKeyDown as React.KeyboardEventHandler)?.(e);
+          },
+          onKeyUp(e: React.KeyboardEvent) {
+            e.stopPropagation();
+            (userProps?.onKeyUp as React.KeyboardEventHandler)?.(e);
+          },
+        }),
+      [getReferencePropsRaw]
+    );
+
+    const mergedRef = useMergeRefs([refs.setReference, forwardedRef]);
+
+    // Close sibling submenus when another opens
+    useEffect(() => {
+      if (!tree) return;
+
+      function handleMenuOpen(event: { nodeId: string; parentId: string }) {
+        if (event.parentId === parentId && event.nodeId !== nodeId) {
+          setIsOpenState(false);
+        }
+      }
+
+      tree.events.on('menuopen', handleMenuOpen);
+      return () => {
+        tree.events.off('menuopen', handleMenuOpen);
+      };
+    }, [tree, parentId, nodeId]);
+
+    const closeMenu = useCallback(() => {
+      setIsOpenState(false);
+      onOpenChangeProp?.(false);
+    }, [onOpenChangeProp]);
+
+    const PanelComp = panelComponent ?? DropdownMenuPanel;
+
+    const panel = (
+      <PanelComp
+        ref={refs.setFloating}
+        style={{
+          position: strategy,
+          top: y ?? 0,
+          left: x ?? 0,
+          ...transitionStyles,
+        }}
+        {...getFloatingProps()}
+      >
+        {children}
+      </PanelComp>
+    );
+
+    const contextValue = useMemo(
+      () => ({
+        getItemProps,
+        activeIndex,
+        setActiveIndex,
+        isOpen: isOpenState,
+        closeMenu,
+        search,
+        setSearch,
+      }),
+      [getItemProps, activeIndex, isOpenState, closeMenu, search]
+    );
+
+    return (
+      <FloatingNode id={nodeId}>
+        {renderTrigger?.({
+          ref: mergedRef,
+          getReferenceProps,
+          isOpen: isOpenState,
+          isNested,
+        })}
+        <DropdownMenuContext.Provider value={contextValue}>
+          {isMounted && (
+            <FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
+              <FloatingPortal>
+                {isNested ? (
+                  panel
+                ) : (
+                  <FloatingFocusManager context={context} modal={false}>
+                    {panel}
+                  </FloatingFocusManager>
+                )}
+              </FloatingPortal>
+            </FloatingList>
+          )}
+        </DropdownMenuContext.Provider>
+      </FloatingNode>
+    );
+  }
+);
+
+/**
+ * Composable dropdown menu with positioning/sizing, keyboard navigation,
+ * hover interactions, and support for nested submenus.
+ *
+ * Provide a trigger via `renderTrigger` and menu content as children.
+ * Menus can be nested — placing a `DropdownMenu` inside another
+ * automatically enables submenu behavior (hover-to-open, arrow-key
+ * navigation between levels).
+ *
+ * @example
+ * ```tsx
+ * <DropdownMenu
+ *   placement="bottom-end"
+ *   renderTrigger={({ ref, getReferenceProps }) => (
+ *     <Button ref={ref} {...getReferenceProps()}>Open</Button>
+ *   )}
+ * >
+ *   <DropdownMenuSection>
+ *     <DropdownMenuItem label="Edit" onClick={handleEdit} />
+ *     <DropdownMenuItem label="Delete" onClick={handleDelete} />
+ *   </DropdownMenuSection>
+ * </DropdownMenu>
+ * ```
+ */
+export const DropdownMenu = forwardRef<HTMLElement, DropdownMenuProps>(
+  function DropdownMenu(props, ref) {
+    const parentId = useFloatingParentNodeId();
+    if (parentId == null) {
+      return (
+        <FloatingTree>
+          <MenuComponent ref={ref} {...props} />
+        </FloatingTree>
+      );
+    }
+    return <MenuComponent ref={ref} {...props} />;
+  }
+);

--- a/web/packages/design/src/DropdownMenu/DropdownMenuContext.ts
+++ b/web/packages/design/src/DropdownMenu/DropdownMenuContext.ts
@@ -1,0 +1,42 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createContext, Dispatch, HTMLProps, SetStateAction } from 'react';
+
+/**
+ * Provides shared state for a single `DropdownMenu` level. Each menu level
+ * creates its own provider so nested menus have independent state.
+ */
+export const DropdownMenuContext = createContext<{
+  getItemProps: (userProps?: HTMLProps<HTMLElement>) => Record<string, unknown>;
+  activeIndex: number | null;
+  setActiveIndex: Dispatch<SetStateAction<number | null>>;
+  isOpen: boolean;
+  /** Close the menu, firing the `onOpenChange` callback. */
+  closeMenu: () => void;
+  search: string;
+  setSearch: Dispatch<SetStateAction<string>>;
+}>({
+  getItemProps: () => ({}),
+  activeIndex: null,
+  setActiveIndex: () => {},
+  isOpen: false,
+  closeMenu: () => {},
+  search: '',
+  setSearch: () => {},
+});

--- a/web/packages/design/src/DropdownMenu/DropdownMenuPrimitives.tsx
+++ b/web/packages/design/src/DropdownMenu/DropdownMenuPrimitives.tsx
@@ -1,0 +1,406 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useListItem, useMergeRefs } from '@floating-ui/react';
+import React, { HTMLAttributes, forwardRef, useContext } from 'react';
+import styled from 'styled-components';
+
+import { Box, Flex, Text } from 'design';
+import { CheckboxInput } from 'design/Checkbox';
+import { DropdownMenuContext } from 'design/DropdownMenu/DropdownMenuContext';
+
+const SECTION_PADDING_X = 3;
+
+/**
+ * The floating panel that contains menu content. Used automatically by
+ * `DropdownMenu` as the default container. The panel automatically
+ * shrinks to fit the viewport when space is limited.
+ */
+export const DropdownMenuPanel = styled(Box)`
+  box-sizing: border-box;
+  z-index: 1500;
+  min-width: 150px;
+  max-width: 300px;
+  max-height: 400px;
+  overflow-y: auto;
+  overflow-x: clip;
+  scrollbar-width: thin;
+  scrollbar-color: ${p => p.theme.colors.spotBackground[2]} transparent;
+  background: ${p => p.theme.colors.levels.elevated};
+  border-radius: ${p => p.theme.radii[2]}px;
+  box-shadow: ${p => p.theme.boxShadow[1]};
+  /* Same-color border instead of padding so sticky sections
+     sit against the panel edge without a visible gap. */
+  border-block: ${p => p.theme.space[1]}px solid
+    ${p => p.theme.colors.levels.elevated};
+  outline: none;
+`;
+
+/**
+ * A content section within a `DropdownMenu`. Wraps menu items with
+ * consistent horizontal padding and vertical spacing between sections.
+ *
+ * Provide `header` to render a section header above the content.
+ *
+ * @example
+ * ```tsx
+ * <DropdownMenuSection header="Available Access">
+ *   <DropdownMenuItem label="Production DB" onClick={handleConnect} />
+ *   <DropdownMenuItem label="Staging DB" onClick={handleConnect} />
+ * </DropdownMenuSection>
+ * <DropdownMenuSection header="Request Access">
+ *   <DropdownMenuCheckableItem label="Admin DB" checked={checked} onChange={toggle} />
+ * </DropdownMenuSection>
+ * ```
+ */
+export const DropdownMenuSection = ({
+  header,
+  children,
+  ...bodyProps
+}: {
+  header?: React.ReactNode;
+} & React.ComponentProps<typeof StyledBodySection>) => {
+  return (
+    <StyledBodySection {...bodyProps}>
+      {!!header && <StyledHeader>{header}</StyledHeader>}
+      {children}
+    </StyledBodySection>
+  );
+};
+
+const StyledBodySection = styled(Box).attrs({
+  paddingX: SECTION_PADDING_X,
+})`
+  margin-top: ${({ theme }) => theme.space[1]}px;
+  margin-bottom: ${({ theme }) => theme.space[2]}px;
+
+  /* No top margin if first section or following another section */
+  & + &,
+  &:first-child {
+    margin-top: 0;
+  }
+  /* No bottom margin if last section or before another section */
+  &:has(+ &),
+  &:last-child {
+    margin-bottom: 0;
+  }
+  & > & {
+    padding-left: 0;
+    padding-right: 0;
+  }
+`;
+
+/**
+ * A sticky container that stays pinned to the top or bottom of the
+ * scrollable menu panel.
+ *
+ * @example
+ * ```tsx
+ * <DropdownMenuStickySection $position="top">
+ *   <DropdownMenuSearch placeholder="Search..." autoFocus />
+ * </DropdownMenuStickySection>
+ * {items}
+ * <DropdownMenuStickySection $position="bottom">
+ *   <Button onClick={handleApply}>Apply</Button>
+ * </DropdownMenuStickySection>
+ * ```
+ */
+export const DropdownMenuStickySection = styled(Box).attrs({
+  paddingX: SECTION_PADDING_X,
+})<{
+  $position: 'top' | 'bottom';
+}>`
+  position: sticky;
+  ${p => p.$position}: 0;
+  left: 0;
+  right: 0;
+  ${p => (p.$position === 'bottom' ? `margin-top: ${p.theme.space[1]}px;` : '')}
+  padding-top: ${p => p.theme.space[p.$position === 'top' ? 2 : 1]}px;
+  padding-bottom: ${p => p.theme.space[p.$position === 'bottom' ? 2 : 1]}px;
+  background-color: ${({ theme }) => theme.colors.levels.elevated};
+  z-index: 10;
+
+  /* Negate section padding if nested */
+  ${StyledBodySection} & {
+    margin-left: -${p => p.theme.space[SECTION_PADDING_X]}px;
+    margin-right: -${p => p.theme.space[SECTION_PADDING_X]}px;
+  }
+`;
+
+const StyledHeader = styled(Text).attrs({
+  typography: 'body3',
+  color: 'text.muted',
+  paddingX: SECTION_PADDING_X,
+  bold: true,
+})`
+  pointer-events: none;
+  margin-top: ${({ theme }) => theme.space[2]}px;
+  margin-bottom: ${({ theme }) => theme.space[1]}px;
+  padding-top: ${({ theme }) => theme.space[2]}px;
+  border-top: 1px solid ${({ theme }) => theme.colors.spotBackground[0]};
+
+  /* Negate section padding if nested */
+  ${StyledBodySection} & {
+    margin-left: -${p => p.theme.space[SECTION_PADDING_X]}px;
+    margin-right: -${p => p.theme.space[SECTION_PADDING_X]}px;
+  }
+  /* No bottom margin if before stickysection */
+  &:has(+ ${DropdownMenuStickySection}) {
+    margin-bottom: 0;
+  }
+  /* No top separator if first header */
+  ${DropdownMenuStickySection} ~ ${StyledBodySection}:not(
+    ${StyledBodySection} ~ ${StyledBodySection}
+  ) > &:first-child,
+  ${StyledBodySection} > ${DropdownMenuStickySection} ~ & {
+    border-top: none;
+    margin-top: ${({ theme }) => theme.space[2]}px;
+    padding-top: 0;
+  }
+  ${StyledBodySection}:first-child > &:first-child {
+    border-top: none;
+    margin-top: ${({ theme }) => theme.space[1]}px;
+    padding-top: 0;
+  }
+`;
+
+export type DropdownMenuItemProps = HTMLAttributes<HTMLElement> & {
+  label?: string;
+  disabled?: boolean;
+  as?: 'label' | 'button' | 'a';
+  closeOnSelect?: boolean;
+  $active?: boolean;
+  // Anchor props, applicable when as="a"
+  href?: string;
+  target?: string;
+  rel?: string;
+};
+
+/**
+ * A single item within a `DropdownMenu`. Participates in keyboard
+ * navigation and receives focus/hover styling automatically.
+ *
+ * Can render as a different element via the `as` prop (e.g., `"a"` for
+ * links, `"label"` for checkbox wrappers). Pass `$active` to highlight
+ * the item as selected independently of keyboard focus.
+ *
+ * Also used as a submenu trigger. Pass `ref` and `getReferenceProps()`
+ * from a nested `DropdownMenu`'s `renderTrigger`.
+ */
+export const DropdownMenuItem = forwardRef<HTMLElement, DropdownMenuItemProps>(
+  function DropdownMenuItem(
+    {
+      label,
+      disabled,
+      children,
+      as = 'button',
+      closeOnSelect = false,
+      ...props
+    },
+    forwardedRef
+  ) {
+    const menu = useContext(DropdownMenuContext);
+    const { ref: listItemRef, index } = useListItem({
+      label: disabled ? null : label,
+    });
+    const isActive = index === menu.activeIndex;
+
+    return (
+      <StyledMenuItem
+        as={as}
+        ref={useMergeRefs([listItemRef, forwardedRef])}
+        role="menuitem"
+        type="button"
+        tabIndex={isActive ? 0 : -1}
+        aria-disabled={disabled}
+        title={label}
+        {...menu.getItemProps({
+          ...props,
+          onClick: e => {
+            if (disabled) {
+              e.preventDefault();
+              return;
+            }
+            props.onClick?.(e);
+            if (closeOnSelect) {
+              menu.closeMenu();
+            }
+          },
+        })}
+      >
+        {children ?? label}
+      </StyledMenuItem>
+    );
+  }
+);
+
+/**
+ * A menu item with a checkbox. Renders as a `<label>` wrapping a
+ * checkbox input and text.
+ *
+ * @example
+ * ```tsx
+ * <DropdownMenuCheckableItem
+ *   label="Enable notifications"
+ *   checked={enabled}
+ *   onChange={() => setEnabled(!enabled)}
+ * />
+ * ```
+ */
+export const DropdownMenuCheckableItem = ({
+  label,
+  disabled,
+  checked,
+  onChange,
+  closeOnSelect,
+  ...textProps
+}: {
+  label: string;
+  disabled?: boolean;
+  checked: boolean;
+  onChange: React.ComponentProps<typeof CheckboxInput>['onChange'];
+  closeOnSelect?: boolean;
+} & React.ComponentProps<typeof Text>) => (
+  <DropdownMenuItem
+    as="label"
+    label={label}
+    title={label}
+    disabled={disabled}
+    role="menuitemcheckbox"
+    aria-checked={checked}
+    closeOnSelect={closeOnSelect}
+  >
+    <Flex flexDirection="row" alignItems="center" gap={2}>
+      <Flex alignItems="center" justifyContent="center" aria-hidden="true">
+        <CheckboxInput
+          type="checkbox"
+          checked={checked}
+          onChange={onChange}
+          disabled={disabled}
+        />
+      </Flex>
+      <Text typography="body2" {...textProps}>
+        {label}
+      </Text>
+    </Flex>
+  </DropdownMenuItem>
+);
+
+const StyledMenuItem = styled(Box)<{ $active?: boolean }>`
+  display: block;
+  min-height: ${({ theme }) => theme.space[3]}px;
+  width: -webkit-fill-available;
+  margin: 0;
+  padding: ${({ theme }) => theme.space[2]}px
+    ${({ theme }) => theme.space[SECTION_PADDING_X]}px;
+  user-select: none;
+  cursor: pointer;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  color: ${({ theme }) => theme.colors.text.main};
+  outline: none;
+  background: ${({ theme, $active }) =>
+    $active ? theme.colors.interactive.tonal.primary[0] : 'transparent'};
+  border: none;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease;
+
+  &:focus-visible,
+  &:hover {
+    background: ${({ theme }) => theme.colors.spotBackground[0]};
+    color: ${({ theme }) => theme.colors.text.main};
+  }
+
+  &[aria-disabled='true'] {
+    background: transparent;
+    color: ${({ theme }) => theme.colors.text.muted};
+    cursor: default;
+  }
+
+  /* Negate section padding if nested so clickable area spans full width */
+  ${StyledBodySection} & {
+    margin: 0 -${({ theme }) => theme.space[SECTION_PADDING_X]}px;
+  }
+`;
+
+/**
+ * A search input that reads and writes the current menu's filter state
+ * from `DropdownMenuContext`. Wrap in `DropdownMenuStickySection`
+ * to keep visible while menu content scrolls.
+ *
+ * @example
+ * ```tsx
+ * <DropdownMenuStickySection $position="top">
+ *   <DropdownMenuSearch placeholder="Search items..." autoFocus />
+ * </DropdownMenuStickySection>
+ * ```
+ */
+export const DropdownMenuSearch = ({
+  onChange,
+  ...props
+}: Omit<
+  React.ComponentProps<typeof StyledSearchInput>,
+  'value' | 'defaultValue'
+>) => {
+  const { search, setSearch } = useContext(DropdownMenuContext);
+
+  return (
+    <StyledSearchInput
+      type="text"
+      autoComplete="off"
+      aria-label="Filter items"
+      {...props}
+      value={search}
+      onChange={e => {
+        setSearch(e.target.value);
+        onChange?.(e);
+      }}
+    />
+  );
+};
+
+const StyledSearchInput = styled.input`
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  height: ${({ theme }) => theme.space[5]}px;
+  padding: ${({ theme }) => theme.space[1]}px ${({ theme }) => theme.space[2]}px;
+  border: 1px solid ${({ theme }) => theme.colors.buttons.border.active};
+  border-radius: ${({ theme }) => theme.radii[2]}px;
+  color: ${({ theme }) => theme.colors.text.main};
+  background-color: transparent;
+  outline: none;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease;
+
+  &:focus-visible {
+    border-color: ${({ theme }) => theme.colors.buttons.border.border};
+  }
+  &:focus-visible,
+  &:hover {
+    background-color: ${({ theme }) =>
+      theme.colors.interactive.tonal.neutral[0]};
+  }
+  ${DropdownMenuStickySection} & {
+    width: calc(100% + ${({ theme }) => theme.space[2]}px);
+    margin: 0 -${({ theme }) => theme.space[1]}px;
+  }
+`;

--- a/web/packages/design/src/DropdownMenu/index.ts
+++ b/web/packages/design/src/DropdownMenu/index.ts
@@ -1,0 +1,42 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { DropdownMenu, type DropdownMenuProps } from './DropdownMenu';
+import { DropdownMenuContext } from './DropdownMenuContext';
+import {
+  DropdownMenuItem,
+  type DropdownMenuItemProps,
+  DropdownMenuCheckableItem,
+  DropdownMenuSearch,
+  DropdownMenuPanel,
+  DropdownMenuStickySection,
+  DropdownMenuSection,
+} from './DropdownMenuPrimitives';
+
+export {
+  DropdownMenu,
+  type DropdownMenuProps,
+  DropdownMenuContext,
+  DropdownMenuItem,
+  type DropdownMenuItemProps,
+  DropdownMenuCheckableItem,
+  DropdownMenuPanel,
+  DropdownMenuSection,
+  DropdownMenuStickySection,
+  DropdownMenuSearch,
+};

--- a/web/packages/design/src/Text/Text.tsx
+++ b/web/packages/design/src/Text/Text.tsx
@@ -42,7 +42,7 @@ import {
 import { shouldForwardTypographyProp } from 'design/system/typography';
 import { fontWeights } from 'design/theme/typography';
 
-interface FontWeightProps {
+export interface FontWeightProps {
   fontWeight?: ResponsiveValue<Property.FontWeight | keyof typeof fontWeights>;
 }
 


### PR DESCRIPTION
## Context
Upcoming work for supporting Resource Constraints for Database resources requires nested dropdown menus. The existing `Menu` component doesn't support this as it's built on `Popover`, a class component wrapping `Modal` (each nested menu would create a stacked modal backdrop that closes its parent). Adding proper submenu supoport would require rewriting `Popover` as a functional component, removing the `Model` wrapper, and implementing something like hover-polygon and keyboard navigation across menu levels, effectively fully rewriting it.

## Changes
This PR adds a new `DropdownMenu` component to the design package built with `@floating-ui/react`'s primitives (already used for `HoverTooltip`), for use with Database/SSH node/AWS Console resources' Connect/Request Access buttons when Resource Constraints are supported and resource principals are present. It provides:
- Calculated positioning/sizing: auto-flip, shift, and viewport-aware max-sizing
- Nested menus: automatic submenu behavior with sibling close handling
- Hover: safe-polygon hover so submenu's don't close when the cursor moves diagonally toward them
- A11y/keyboard nav: valid ARIA roles and navigation via arrow keys, enter, escape, and focus traps
- Primitives: panel, sticky section, header, body section, search input, checkbox items, that callers can use as needfed

The intent is to add functionality here and incrementally replace `Menu`, avoiding a large in-place rewrite.

A Storybook story (`Design/DropdownMenu`) is included with interactive controls for all features.

## Screenshots
- Plain items:
  <img width="49%" alt="Screenshot 2026-04-22 at 20 22 30" src="https://github.com/user-attachments/assets/373d772d-3ab3-4d03-81fd-a54da8a3d00a" />
- Checkboxes/search/sections:
  <img width="49%" alt="Screenshot 2026-04-22 at 20 22 53" src="https://github.com/user-attachments/assets/0c834208-4b44-4be9-982e-ffb525afcf91" />
- Nested menus:
  <img width="99%" alt="Screenshot 2026-04-22 at 20 23 10" src="https://github.com/user-attachments/assets/97181a6d-fbff-4187-aa93-a5f0abe04dc2" />

## Manual Test Plan
### Test Environment
- Storybook

### Test Cases
- [x] Default: click trigger to open/close, verify positioning and transition
- [x] Checkboxes: toggle search, check/uncheck list items, verify selection state persists across open/close
- [x] Nested: hover submenu trigger, verify submenu opens with safe-polygon (cursor can move diagonally off the main menu to the submenu without either closing)
- [x] Toggle `hoverTrigger` control, verify menu opens on hover of trigger
- [x] Toggle `placement` control, verify menu repositions correctly
- [x] Toggle `showDisabledItems`, verify disabled items are styled appropriately and are non-interactive
- [x] Resize viewport until menu would overflow. Verify it shrinks to fit with padding from the viewport edge and scrolls
- [x] Keyboard: open via Enter on trigger, arrow keys to navigate items, left/right to enter/leave submenu, Enter to select, and Escape to close
