### PR TITLE
Connect: clarify admin privileges are required for initial installation only

### DIFF
--- a/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
@@ -39,7 +39,9 @@ Download and run the installer `.exe` file.
 The installer supports two modes:
 - `Only for me` (per-user): installs to `%LOCALAPPDATA%` and does not require administrator privileges.
 - `Anyone who uses this computer` (per-machine): installs to `%PROGRAMFILES%`, requires administrator
-  privileges (UAC), and enables [VNet](#connecting-to-tcp-apps-with-vnet).
+privileges (UAC) for the initial installation, and enables [VNet](#connecting-to-tcp-apps-with-vnet).
+
+Once installed, subsequent updates via [Managed updates](#managed-updates) do not require administrator privileges.
 
 A silent installation can be performed with `/S`. This hides the progress bar and skips launching the app after install.
 By default, `/S` installs per-machine. If a per-user installation already exists, it updates that installation instead.

--- a/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
@@ -41,7 +41,8 @@ The installer supports two modes:
 - `Anyone who uses this computer` (per-machine): installs to `%PROGRAMFILES%`, requires administrator
 privileges (UAC) for the initial installation, and enables [VNet](#connecting-to-tcp-apps-with-vnet).
 
-Once installed, subsequent updates via [Managed updates](#managed-updates) do not require administrator privileges.
+Once Teleport Connect is installed, subsequent updates via [Managed Updates](#managed-updates) do not require administrator
+privileges.
 
 A silent installation can be performed with `/S`. This hides the progress bar and skips launching the app after install.
 By default, `/S` installs per-machine. If a per-user installation already exists, it updates that installation instead.


### PR DESCRIPTION
I realized it could sound like admin privileges are needed to install updates as well.