### PR TITLE
docs: login rules and sso mfa updates

### DIFF
--- a/docs/pages/zero-trust-access/sso/login-rules/guide.mdx
+++ b/docs/pages/zero-trust-access/sso/login-rules/guide.mdx
@@ -37,9 +37,6 @@ Reference](../../../reference/access-controls/login-rules.mdx).
 
 - (!docs/pages/includes/tctl.mdx!)
 
-Before you get started you’ll need a running Teleport Enterprise or Cloud
-cluster on version `11.3.1` or greater.
-
 Login Rules only operate on SSO logins, so make sure you have
 configured an OIDC, SAML, or GitHub connector before you begin.
 Check the [Single Sign-On](../../../zero-trust-access/sso/sso.mdx) docs to learn how to set this up.
@@ -49,7 +46,7 @@ Check the [Single Sign-On](../../../zero-trust-access/sso/sso.mdx) docs to learn
 First, ensure you are logged into Teleport as a user that has permissions
 to read and modify `login_rule` resources. The preset `editor` role
 has access to this already, but in case you are using a more customized configuration,
-create a role called `loginrule-manager.yaml` with the following contents:
+create a file called `loginrule-manager.yaml` with the following contents:
 
 ```yaml
 kind: role

--- a/docs/pages/zero-trust-access/sso/sso-for-mfa.mdx
+++ b/docs/pages/zero-trust-access/sso/sso-for-mfa.mdx
@@ -31,7 +31,7 @@ Administrators may want to consider enabling this feature in order to:
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)
 
 - This guide assumes that you are familiar with how to integrate your identity
   provider with Teleport. Make sure that you understand the guide in [Integrate


### PR DESCRIPTION

docs/pages/zero-trust-access/sso/login-rules/guide.mdx:
- remove reference to v11
- update verbiage on a file vs role
docs/pages/zero-trust-access/sso/sso-for-mfa.mdx:
- update prereq to include Teleport Enterprise