### PR TITLE
Remove unused `keepAliveNode` HTTP RPC

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -124,7 +124,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.DELETE("/:version/users/:user/web/sessions/:sid", srv.WithAuth(srv.deleteWebSession))
 
 	// Servers and presence heartbeat
-	srv.POST("/:version/namespaces/:namespace/nodes/keepalive", srv.WithAuth(srv.keepAliveNode))
 	srv.POST("/:version/authservers", srv.WithAuth(srv.upsertAuthServer))
 	// TODO(kiosion) DELETE IN 21.0.0
 	srv.GET("/:version/authservers", srv.WithScopedAuth(srv.getAuthServers))
@@ -154,6 +153,7 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.DELETE("/:version/tunnelconnections/:cluster", httpMigratedHandler)
 	srv.DELETE("/:version/tunnelconnections", httpMigratedHandler)
 	srv.DELETE("/:version/proxies", httpMigratedHandler)
+	srv.POST("/:version/namespaces/:namespace/nodes/keepalive", httpMigratedHandler)
 
 	if config.PluginRegistry != nil {
 		if err := config.PluginRegistry.RegisterAuthWebHandlers(&srv); err != nil {
@@ -289,18 +289,6 @@ func (s *APIServer) upsertServer(auth presenceForAPIServer, role types.SystemRol
 		}
 	default:
 		return nil, trace.BadParameter("unknown server role %q", role)
-	}
-	return message("ok"), nil
-}
-
-// keepAliveNode updates node TTL in the backend
-func (s *APIServer) keepAliveNode(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
-	var handle types.KeepAlive
-	if err := httplib.ReadJSON(r, &handle); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := auth.KeepAliveServer(r.Context(), handle); err != nil {
-		return nil, trace.Wrap(err)
 	}
 	return message("ok"), nil
 }


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/6394

Going back as far as 4.0, I cannot find any client mechanisms that invoke this endpoint.

The endpoint was introduced by https://github.com/gravitational/teleport/commit/f40df845, which also did not introduce any invocations of it. This commit did also introduce a gRPC mechanism for sending keep alives, which is then what is invoked by the client. My best guess is that this endpoint was added during the course of implementation, and any client calls were removed by the time the PR was raised.

## Manual Test Plan
### Test Environment

Local cluster

Open to suggestions as to how to manually test this change properly.

### Test Cases

- [x] Spun up cluster, SSH agent still heartbeats and can still be connected to.
