### PR TITLE
Protect recording metadata/thumbnail generation from panics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -634,7 +634,7 @@ replace (
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-teleport.2
 	github.com/gravitational/teleport/api => ./api
 	github.com/hashicorp/terraform-plugin-docs => github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf
-	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.3-teleport.1
+	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.5-teleport.1
 	github.com/julienschmidt/httprouter => github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5
 	github.com/keys-pub/go-libfido2 => github.com/gravitational/go-libfido2 v1.5.3-teleport.1
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2

--- a/go.sum
+++ b/go.sum
@@ -807,8 +807,8 @@ github.com/gravitational/selinux v1.13.0-teleport h1:XZQpZK5tteK9ZV2wIC1avhagqoV
 github.com/gravitational/selinux v1.13.0-teleport/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/gravitational/trace v1.5.4 h1:nMmF7alwvNiQJhC817Hhmgm95bzKOXbnxvkickTkRDY=
 github.com/gravitational/trace v1.5.4/go.mod h1:/uCbC3ukVU8Pdrh8+3vNLyyE1aGheBWpGGrMnwIK80E=
-github.com/gravitational/vt10x v0.0.3-teleport.1 h1:QYNPZGCQRcz1JehDn5m75UvRQbEJvT5X1pVblnCfZrY=
-github.com/gravitational/vt10x v0.0.3-teleport.1/go.mod h1:7p0/hpXPXby/VpuB6rFUq2pd7grku9KB+EcF0+jwqzQ=
+github.com/gravitational/vt10x v0.0.5-teleport.1 h1:SsBfmhlLEZaa5iT3iYKcFP8eORnohVtzz2wVZEUsrf8=
+github.com/gravitational/vt10x v0.0.5-teleport.1/go.mod h1:7p0/hpXPXby/VpuB6rFUq2pd7grku9KB+EcF0+jwqzQ=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -405,7 +405,7 @@ replace (
 	github.com/gravitational/teleport => ../..
 	github.com/gravitational/teleport/api => ../../api
 	github.com/hashicorp/terraform-plugin-docs => github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf
-	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.3-teleport.1
+	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.5-teleport.1
 	github.com/julienschmidt/httprouter => github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5
 	github.com/keys-pub/go-libfido2 => github.com/gravitational/go-libfido2 v1.5.3-teleport.1
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -549,8 +549,8 @@ github.com/gravitational/selinux v1.13.0-teleport h1:XZQpZK5tteK9ZV2wIC1avhagqoV
 github.com/gravitational/selinux v1.13.0-teleport/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
 github.com/gravitational/trace v1.5.4 h1:nMmF7alwvNiQJhC817Hhmgm95bzKOXbnxvkickTkRDY=
 github.com/gravitational/trace v1.5.4/go.mod h1:/uCbC3ukVU8Pdrh8+3vNLyyE1aGheBWpGGrMnwIK80E=
-github.com/gravitational/vt10x v0.0.3-teleport.1 h1:QYNPZGCQRcz1JehDn5m75UvRQbEJvT5X1pVblnCfZrY=
-github.com/gravitational/vt10x v0.0.3-teleport.1/go.mod h1:7p0/hpXPXby/VpuB6rFUq2pd7grku9KB+EcF0+jwqzQ=
+github.com/gravitational/vt10x v0.0.5-teleport.1 h1:SsBfmhlLEZaa5iT3iYKcFP8eORnohVtzz2wVZEUsrf8=
+github.com/gravitational/vt10x v0.0.5-teleport.1/go.mod h1:7p0/hpXPXby/VpuB6rFUq2pd7grku9KB+EcF0+jwqzQ=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -536,7 +536,7 @@ replace (
 	github.com/gravitational/teleport => ../..
 	github.com/gravitational/teleport/api => ../../api
 	github.com/hashicorp/terraform-plugin-docs => github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf
-	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.3-teleport.1
+	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.5-teleport.1
 	github.com/julienschmidt/httprouter => github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5
 	github.com/keys-pub/go-libfido2 => github.com/gravitational/go-libfido2 v1.5.3-teleport.1
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -751,8 +751,8 @@ github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5f
 github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf/go.mod h1:8eiBaRanEugPy3lh7UZ5NW6yaISaXXS4R56pi1D962k=
 github.com/gravitational/trace v1.5.4 h1:nMmF7alwvNiQJhC817Hhmgm95bzKOXbnxvkickTkRDY=
 github.com/gravitational/trace v1.5.4/go.mod h1:/uCbC3ukVU8Pdrh8+3vNLyyE1aGheBWpGGrMnwIK80E=
-github.com/gravitational/vt10x v0.0.3-teleport.1 h1:QYNPZGCQRcz1JehDn5m75UvRQbEJvT5X1pVblnCfZrY=
-github.com/gravitational/vt10x v0.0.3-teleport.1/go.mod h1:7p0/hpXPXby/VpuB6rFUq2pd7grku9KB+EcF0+jwqzQ=
+github.com/gravitational/vt10x v0.0.5-teleport.1 h1:SsBfmhlLEZaa5iT3iYKcFP8eORnohVtzz2wVZEUsrf8=
+github.com/gravitational/vt10x v0.0.5-teleport.1/go.mod h1:7p0/hpXPXby/VpuB6rFUq2pd7grku9KB+EcF0+jwqzQ=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -538,7 +538,7 @@ replace (
 	github.com/gravitational/teleport => ../..
 	github.com/gravitational/teleport/api => ../../api
 	github.com/hashicorp/terraform-plugin-docs => github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf
-	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.3-teleport.1
+	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.5-teleport.1
 	github.com/julienschmidt/httprouter => github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5
 	github.com/keys-pub/go-libfido2 => github.com/gravitational/go-libfido2 v1.5.3-teleport.1
 	github.com/microsoft/go-mssqldb => github.com/gravitational/go-mssqldb v1.8.1-teleport.2

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -850,8 +850,8 @@ github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5f
 github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf/go.mod h1:8eiBaRanEugPy3lh7UZ5NW6yaISaXXS4R56pi1D962k=
 github.com/gravitational/trace v1.5.4 h1:nMmF7alwvNiQJhC817Hhmgm95bzKOXbnxvkickTkRDY=
 github.com/gravitational/trace v1.5.4/go.mod h1:/uCbC3ukVU8Pdrh8+3vNLyyE1aGheBWpGGrMnwIK80E=
-github.com/gravitational/vt10x v0.0.3-teleport.1 h1:QYNPZGCQRcz1JehDn5m75UvRQbEJvT5X1pVblnCfZrY=
-github.com/gravitational/vt10x v0.0.3-teleport.1/go.mod h1:7p0/hpXPXby/VpuB6rFUq2pd7grku9KB+EcF0+jwqzQ=
+github.com/gravitational/vt10x v0.0.5-teleport.1 h1:SsBfmhlLEZaa5iT3iYKcFP8eORnohVtzz2wVZEUsrf8=
+github.com/gravitational/vt10x v0.0.5-teleport.1/go.mod h1:7p0/hpXPXby/VpuB6rFUq2pd7grku9KB+EcF0+jwqzQ=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"math/rand/v2"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -126,10 +127,25 @@ func NewRecordingMetadataService(cfg RecordingMetadataServiceConfig) (*Recording
 
 // ProcessSessionRecording processes the session recording associated with the provided session ID.
 // It streams session events, generates metadata, and uploads thumbnails and metadata.
-func (s *RecordingMetadataService) ProcessSessionRecording(ctx context.Context, sessionID session.ID, sessionType recordingmetadata.SessionType, startTime time.Time, duration time.Duration) error {
+//
+// Any panic in the downstream processing pipeline (e.g. a corrupt recording
+// driving vt10x into a bad state) is converted into an error return so that a
+// single bad recording cannot crash the auth server.
+func (s *RecordingMetadataService) ProcessSessionRecording(ctx context.Context, sessionID session.ID, sessionType recordingmetadata.SessionType, startTime time.Time, duration time.Duration) (err error) {
 	if sessionType == recordingmetadata.SessionTypeUnspecified {
 		return nil
 	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.ErrorContext(ctx, "panic while processing session recording",
+				"session_id", sessionID,
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
+			err = trace.Errorf("internal error while processing session recording %s", sessionID)
+		}
+	}()
 
 	sessionsPendingMetric.Inc()
 
@@ -216,8 +232,6 @@ loop:
 	if _, err := protodelim.MarshalTo(w, metadata); err != nil {
 		return trace.Wrap(err)
 	}
-
-	var err error
 
 	finish.Do(func() {
 		err = w.Close()

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata_test.go
@@ -245,6 +245,46 @@ func sessionLeaveEvent(t time.Time, user string) *apievents.SessionLeave {
 	}
 }
 
+// TestProcessSessionRecording_RecoversFromPanic verifies that a panic from
+// downstream code (e.g. vt10x tripping over a corrupt recording) is converted
+// into an error return rather than propagating and crashing auth.
+func TestProcessSessionRecording_RecoversFromPanic(t *testing.T) {
+	startTime := time.Now()
+	sessionID := session.NewID()
+
+	streamer := &mockStreamer{
+		events:       generateBasicSession(startTime),
+		errorOnEvent: -1,
+	}
+
+	service, err := NewRecordingMetadataService(RecordingMetadataServiceConfig{
+		Streamer:      streamer,
+		UploadHandler: &panickingUploadHandler{},
+	})
+	require.NoError(t, err)
+
+	err = service.ProcessSessionRecording(t.Context(), sessionID, recordingmetadata.SessionTypeTTY, 10*time.Second)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "internal error while processing session recording")
+
+	// Ensure that the panic stack trace is not included in the returned error.
+	require.NotContains(t, err.Error(), "simulated thumbnail upload panic")
+	require.NotContains(t, err.Error(), "goroutine")
+}
+
+// panickingUploadHandler panics from UploadThumbnail, which is invoked on the
+// same goroutine as ProcessSessionRecording so the defer/recover catches it.
+type panickingUploadHandler struct{}
+
+func (p *panickingUploadHandler) UploadMetadata(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	_, _ = io.Copy(io.Discard, reader)
+	return "metadata/ok", nil
+}
+
+func (p *panickingUploadHandler) UploadThumbnail(context.Context, session.ID, io.Reader) (string, error) {
+	panic("simulated thumbnail upload panic")
+}
+
 // mockUploadHandlerFailAfterRead simulates an upload failure after reading some bytes
 type mockUploadHandlerFailAfterRead struct {
 	failAfterBytes int

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata_test.go
@@ -263,7 +263,7 @@ func TestProcessSessionRecording_RecoversFromPanic(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = service.ProcessSessionRecording(t.Context(), sessionID, recordingmetadata.SessionTypeTTY, 10*time.Second)
+	err = service.ProcessSessionRecording(t.Context(), sessionID, recordingmetadata.SessionTypeTTY, startTime, 10*time.Second)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "internal error while processing session recording")
 

--- a/lib/web/recordingplayback.go
+++ b/lib/web/recordingplayback.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -184,8 +185,22 @@ func newRecordingPlayback(ctx context.Context, ws *websocket.Conn, clt events.Se
 }
 
 // run starts the recording playback handler.
+//
+// A recovered panic on the read-loop goroutine (for example, vt10x tripping
+// over a corrupt recording during handleFetchRequest) is logged rather than
+// propagating and crashing the proxy. The streamEvents goroutine has its own
+// defer/recover since it runs independently.
 func (s *recordingPlayback) run() {
 	defer s.cleanup()
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.ErrorContext(s.ctx, "panic on recording playback read loop",
+				"session_id", s.sessionID,
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
+		}
+	}()
 
 	go s.writeLoop()
 
@@ -393,6 +408,12 @@ func (s *recordingPlayback) handleFetchRequest(req *fetchRequest) {
 }
 
 // streamEvents streams session events to the client.
+//
+// A recovered panic (e.g. vt10x tripping over a corrupt recording) is logged
+// and reported to the client as an error followed by a stop event, rather
+// than crashing the proxy. The stop event is required: the web client only
+// clears its loading state on stop, so skipping it would leave playback
+// stuck in loading after a malformed recording.
 func (s *recordingPlayback) streamEvents(ctx context.Context, req *fetchRequest, eventsChan <-chan apievents.AuditEvent, errorsChan <-chan error) {
 	startSent := false
 	screenSent := false
@@ -434,6 +455,25 @@ func (s *recordingPlayback) streamEvents(ctx context.Context, req *fetchRequest,
 		s.sendEvent(eventTypeStop, 0, encodeTime(req.startOffset, req.endOffset), req.requestID)
 	}
 
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.ErrorContext(s.ctx, "panic while streaming session recording events",
+				"session_id", s.sessionID,
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
+
+			// cleanup() cancels s.ctx before closing s.writeChan, so if the context is already done we must not touch
+			// writeChan — a concurrent close would turn into a panic.
+			if s.ctx.Err() != nil {
+				return
+			}
+
+			s.sendError(trace.Errorf("internal error while streaming session recording"), req.requestID)
+			sendStop()
+		}
+	}()
+
 	// process an event, returning a boolean indicating if the events should continue being
 	// processed (i.e. returns false once we have reached the end of the requested time window)
 	processEvent := func(evt apievents.AuditEvent) bool {
@@ -472,11 +512,15 @@ func (s *recordingPlayback) streamEvents(ctx context.Context, req *fetchRequest,
 			}
 
 		case *apievents.SessionPrint:
-			s.terminal.Lock()
-			if _, err := s.terminal.vt.Write(evt.Data); err != nil {
-				s.logger.ErrorContext(s.ctx, "failed to write to terminal", "session_id", s.sessionID, "error", err)
-			}
-			s.terminal.Unlock()
+			// defer Unlock so a panic in vt.Write (caught by streamEvents' defer/recover) can't leave s.terminal locked and
+			// wedge later playback requests on the same websocket.
+			func() {
+				s.terminal.Lock()
+				defer s.terminal.Unlock()
+				if _, err := s.terminal.vt.Write(evt.Data); err != nil {
+					s.logger.ErrorContext(s.ctx, "failed to write to terminal", "session_id", s.sessionID, "error", err)
+				}
+			}()
 
 			if inTimeRange {
 				addToBatch(eventTypeSessionPrint, eventTime, evt.Data)
@@ -641,11 +685,17 @@ func (s *recordingPlayback) sendError(err error, requestID int) {
 
 // sendCurrentScreen sends the current terminal screen state to the client.
 func (s *recordingPlayback) sendCurrentScreen(requestID int, timeOffset time.Duration) {
-	s.terminal.Lock()
-	state := s.terminal.vt.DumpState()
-	cols, rows := s.terminal.vt.Size()
-	cursor := s.terminal.vt.Cursor()
-	s.terminal.Unlock()
+	// defer Unlock so a panic in any vt10x call (caught by streamEvents' defer/recover) can't leave s.terminal locked.
+	state, cols, rows, cursor := func() (vt10x.TerminalState, int, int, vt10x.Cursor) {
+		s.terminal.Lock()
+		defer s.terminal.Unlock()
+
+		state := s.terminal.vt.DumpState()
+		cols, rows := s.terminal.vt.Size()
+		cursor := s.terminal.vt.Cursor()
+
+		return state, cols, rows, cursor
+	}()
 
 	data := encodeScreenEvent(state, cols, rows, cursor)
 

--- a/lib/web/recordingplayback_test.go
+++ b/lib/web/recordingplayback_test.go
@@ -19,6 +19,7 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -27,6 +28,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -104,6 +106,135 @@ func TestResizeTerminalEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestStreamEvents_RecoversFromPanic verifies that a panic inside streamEvents
+// (e.g. vt10x tripping over a corrupt recording) is converted into an error
+// reported to the client, rather than propagating and crashing the proxy.
+//
+// The test leaves s.terminal.vt as a nil interface so that the first
+// vt10x.Terminal method call (from a SessionStart event) panics with a nil
+// pointer dereference, exercising the defer/recover at the top of
+// streamEvents.
+func TestStreamEvents_RecoversFromPanic(t *testing.T) {
+	s := &recordingPlayback{
+		ctx:       t.Context(),
+		logger:    slog.Default(),
+		sessionID: "test-session-id",
+		writeChan: make(chan websocketMessage, 16),
+	}
+
+	eventsChan := make(chan apievents.AuditEvent, 1)
+	errorsChan := make(chan error, 1)
+
+	eventsChan <- &apievents.SessionStart{
+		Metadata:     apievents.Metadata{Type: "session.start"},
+		TerminalSize: "80:24",
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.streamEvents(t.Context(), &fetchRequest{requestID: 42, endOffset: time.Hour}, eventsChan, errorsChan)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "streamEvents did not return; defer/recover likely did not fire")
+	}
+
+	// The recover handler must emit both an error event (surfacing the failure) and a stop event (clearing the web
+	// client's loading state — without this the UI hangs forever after a malformed recording).
+	types := collectEventTypes(t, s.writeChan)
+	require.Contains(t, types, eventTypeError)
+	require.Contains(t, types, eventTypeStop)
+}
+
+func collectEventTypes(t *testing.T, ch <-chan websocketMessage) []responseType {
+	t.Helper()
+
+	var types []responseType
+	for {
+		select {
+		case msg := <-ch:
+			require.Equal(t, websocket.BinaryMessage, msg.messageType)
+			require.NotEmpty(t, msg.data)
+			types = append(types, responseType(msg.data[0]))
+		default:
+			return types
+		}
+	}
+}
+
+// TestRun_RecoversFromReadLoopPanic verifies that a panic in the read-loop
+// goroutine (e.g. vt10x.New() blowing up inside handleFetchRequest) is
+// converted into a logged error rather than propagating.
+//
+// handleFetchRequest calls s.clt.StreamSessionEvents before touching vt10x,
+// so a panicking SessionStreamer is a reliable way to trip a panic on that
+// goroutine.
+func TestRun_RecoversFromReadLoopPanic(t *testing.T) {
+	logBuf := &syncBuffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+
+		playback := newRecordingPlayback(r.Context(), ws, &panickingStreamClient{}, "test-session", logger)
+		playback.run()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	ws, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+
+	if resp != nil {
+		resp.Body.Close()
+	}
+	defer ws.Close()
+
+	require.NoError(t, ws.WriteMessage(websocket.BinaryMessage, createFetchRequest(0, 1000, 1, false)))
+	require.NoError(t, ws.SetReadDeadline(time.Now().Add(time.Second)))
+
+	for {
+		_, _, err := ws.ReadMessage()
+		if err != nil {
+			break
+		}
+	}
+
+	require.Contains(t, logBuf.String(), "panic on recording playback read loop")
+	require.Contains(t, logBuf.String(), "simulated streamer panic")
+}
+
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+type panickingStreamClient struct{}
+
+func (p *panickingStreamClient) StreamSessionEvents(context.Context, session.ID, int64) (chan apievents.AuditEvent, chan error) {
+	panic("simulated streamer panic")
 }
 
 func TestCreateTaskContext(t *testing.T) {


### PR DESCRIPTION
This upgrades vt10x to v0.0.5 (https://github.com/gravitational/vt10x/compare/v0.0.3-teleport.1...v0.0.5-teleport.1) which added protection around malformed session data possibly causing a panic.

Changelog: Fixed a possible panic during TTY session processing/playback/summarization from crashing Teleport

## Manual Test Plan
### Test Environment
Deploy to https://ryan-vt10x.cloud.gravitational.io

### Test Cases
- [x] No panic path
  - [x] SSH summarization completes as expected
  - [x] Metadata/thumbnails for SSH sessions are generated as expected
- [x] Panic path
  - [x] A session with data that would've previously caused a panic no longer panics
    - [x] During playback
    - [x] During summarization
    - [x] During metadata/thumbnail generation