### PR TITLE
prevent unauthorized uploads via encrypted recordings service

### DIFF
--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -23,6 +23,32 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// UnauthenticatedRole identifies a role assigned to connections that present no
+// client certificate.  It is intentionally a distinct type from [SystemRole] so
+// that the compiler prevents it from being used anywhere a real, authenticated
+// system role is expected.
+//
+// Unlike [SystemRole], an UnauthenticatedRole must never appear inside a TLS
+// certificate.  The middleware layer rejects any certificate whose Groups or
+// SystemRoles fields contain a value that matches an UnauthenticatedRole name,
+// so it cannot be forged by a client.
+//
+// An unauthenticated connection receives an empty allow spec (no rules, no
+// namespaces) and is blocked from all RBAC-protected resources.  Callers that
+// need to act on behalf of an unauthenticated client should use
+// [authz.ContextForUnauthenticatedRole] instead of constructing a raw
+// [authz.Context].
+type UnauthenticatedRole string
+
+const (
+	// RoleNop is the role assigned to connections that carry no client
+	// certificate.  It is used for operations that rely on an out-of-band
+	// authorization mechanism (e.g. one-time tokens or passwords) rather than
+	// mutual TLS.  The role grants zero permissions: its allow spec is entirely
+	// empty, so any RBAC check will be denied.
+	RoleNop UnauthenticatedRole = "Nop"
+)
+
 // SystemRole identifies the role of an SSH connection. Unlike "user roles"
 // introduced as part of RBAC in Teleport 1.4+ these are built-in roles used
 // for different Teleport components when connecting to each other.
@@ -48,9 +74,6 @@ const (
 	RoleTrustedCluster SystemRole = "Trusted_cluster"
 	// RoleSignup is for first time signing up users
 	RoleSignup SystemRole = "Signup"
-	// RoleNop is used for actions that are already using external authz mechanisms
-	// e.g. tokens or passwords
-	RoleNop SystemRole = "Nop"
 	// RoleRemoteProxy is a role for remote SSH proxy in the cluster
 	RoleRemoteProxy SystemRole = "RemoteProxy"
 	// RoleKube is a role for a kubernetes service.
@@ -98,7 +121,6 @@ var roleMappings = map[string]SystemRole{
 	"trusted_cluster":   RoleTrustedCluster,
 	"trustedcluster":    RoleTrustedCluster,
 	"signup":            RoleSignup,
-	"nop":               RoleNop,
 	"remoteproxy":       RoleRemoteProxy,
 	"remote_proxy":      RoleRemoteProxy,
 	"kube":              RoleKube,

--- a/api/types/system_role_test.go
+++ b/api/types/system_role_test.go
@@ -28,9 +28,9 @@ func TestRolesCheck(t *testing.T) {
 	}{
 		{roles: []SystemRole{}, wantErr: false},
 		{roles: []SystemRole{RoleAuth}, wantErr: false},
-		{roles: []SystemRole{RoleAuth, RoleNode, RoleProxy, RoleAdmin, RoleProvisionToken, RoleTrustedCluster, RoleSignup, RoleNop}, wantErr: false},
+		{roles: []SystemRole{RoleAuth, RoleNode, RoleProxy, RoleAdmin, RoleProvisionToken, RoleTrustedCluster, RoleSignup}, wantErr: false},
 		{roles: []SystemRole{RoleAuth, RoleNode, RoleAuth}, wantErr: true},
-		{roles: []SystemRole{SystemRole("unknown")}, wantErr: true},
+		{roles: []SystemRole{SystemRole("unknown"), SystemRole(RoleNop)}, wantErr: true},
 	}
 
 	for _, tt := range tests {

--- a/gen/preset-roles.json
+++ b/gen/preset-roles.json
@@ -1260,6 +1260,18 @@
               "update",
               "delete"
             ]
+          },
+          {
+            "resources": [
+              "recording_encryption"
+            ],
+            "verbs": [
+              "list",
+              "create",
+              "read",
+              "update",
+              "delete"
+            ]
           }
         ]
       },

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -887,7 +887,7 @@ func (a *ServerWithRoles) GetClusterAlerts(ctx context.Context, query types.GetC
 	// unauthenticated clients can never check for alerts. we don't normally explicitly
 	// check for this kind of thing, but since alerts use an unusual access-control
 	// pattern, explicitly rejecting the nop role makes things easier.
-	if a.hasBuiltinRole(types.RoleNop) {
+	if authz.HasUnauthenticatedRole(a.context, string(types.RoleNop)) {
 		return nil, trace.AccessDenied("alerts not available to unauthenticated clients")
 	}
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -5316,8 +5316,8 @@ func TestIsLocalOrRemoteServerAction(t *testing.T) {
 			getSrvFn: func(t *testing.T) *auth.ServerWithRoles {
 				authCtx := authz.Context{
 					Identity: authz.RemoteBuiltinRole{
-						Role:        types.RoleNop,
-						Username:    string(types.RoleNop),
+						Role:        types.RoleProxy,
+						Username:    string(types.RoleProxy),
 						ClusterName: "remote-cluster",
 					},
 				}
@@ -5330,8 +5330,8 @@ func TestIsLocalOrRemoteServerAction(t *testing.T) {
 			getSrvFn: func(t *testing.T) *auth.ServerWithRoles {
 				authCtx := authz.Context{
 					Identity: authz.RemoteBuiltinRole{
-						Role:        types.RoleNop,
-						Username:    string(types.RoleNop),
+						Role:        types.RoleProxy,
+						Username:    string(types.RoleProxy),
 						ClusterName: "remote-cluster",
 					},
 				}

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1229,6 +1229,16 @@ func TestBuiltin(role types.SystemRole) TestIdentity {
 	}
 }
 
+// TestUnauthenticated returns TestIdentity for unauthenticate user
+func TestUnauthenticated(role types.UnauthenticatedRole) TestIdentity {
+	return TestIdentity{
+		I: authz.UnauthenticatedRole{
+			Role:     role,
+			Username: string(role),
+		},
+	}
+}
+
 // TestScopedHost returns TestIdentity for a scoped host
 func TestScopedHost(clusterName, hostID, scope string, role types.SystemRole) TestIdentity {
 	username := hostID
@@ -1314,7 +1324,7 @@ func (t *TLSServer) ClientTLSConfig(identity TestIdentity) (*tls.Config, error) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if identity.I != nil {
+	if !isUnauthenticated(identity) {
 		cert, err := t.AuthServer.NewCertificate(identity)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -1327,6 +1337,14 @@ func (t *TLSServer) ClientTLSConfig(identity TestIdentity) (*tls.Config, error) 
 	}
 	tlsConfig.Time = t.AuthServer.AuthServer.GetClock().Now
 	return tlsConfig, nil
+}
+
+func isUnauthenticated(identity TestIdentity) bool {
+	if identity.I == nil {
+		return true
+	}
+	_, ok := identity.I.(authz.UnauthenticatedRole)
+	return ok
 }
 
 // CloneClient uses the same credentials as the passed client

--- a/lib/auth/mfa/mfav1/service.go
+++ b/lib/auth/mfa/mfav1/service.go
@@ -512,7 +512,7 @@ func (s *Service) VerifyValidatedMFAChallenge(
 		return nil, trace.Wrap(err)
 	}
 
-	if b, ok := authCtx.Identity.(authz.BuiltinRole); !ok || (ok && !b.IsServer()) {
+	if b, ok := authCtx.Identity.(authz.BuiltinRole); !ok || !b.IsServer() {
 		return nil, trace.AccessDenied("only server identities can verify validated MFA challenges")
 	}
 

--- a/lib/auth/recordingencryption/recordingencryptionv1/service.go
+++ b/lib/auth/recordingencryption/recordingencryptionv1/service.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
+	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/recordingmetadata"
 	"github.com/gravitational/teleport/lib/auth/summarizer"
@@ -143,12 +144,8 @@ func protoAsStreamPart(part *recordingencryptionv1.Part) events.StreamPart {
 
 // CreateUpload begins a multipart upload for an encrypted session recording.
 func (s *Service) CreateUpload(ctx context.Context, req *recordingencryptionv1.CreateUploadRequest) (*recordingencryptionv1.CreateUploadResponse, error) {
-	authCtx, err := s.auth.Authorize(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if !authz.IsLocalOrRemoteService(*authCtx) {
-		return nil, trace.AccessDenied("this request can be only executed by a Teleport service")
+	if err := s.authorizeUpload(ctx); err != nil {
+		return nil, trace.AccessDenied("access denied")
 	}
 
 	s.logger.DebugContext(ctx, "creating encrypted session upload", "session_id", req.SessionId)
@@ -169,12 +166,12 @@ func (s *Service) CreateUpload(ctx context.Context, req *recordingencryptionv1.C
 
 // UploadPart uploads an encrypted session recording part to the given upload ID.
 func (s *Service) UploadPart(ctx context.Context, req *recordingencryptionv1.UploadPartRequest) (*recordingencryptionv1.UploadPartResponse, error) {
-	authCtx, err := s.auth.Authorize(ctx)
-	if err != nil {
+	if err := validateUpload(req.Upload); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !authz.IsLocalOrRemoteService(*authCtx) {
-		return nil, trace.AccessDenied("this request can be only executed by a Teleport service")
+
+	if err := s.authorizeUpload(ctx); err != nil {
+		return nil, trace.AccessDenied("access denied")
 	}
 
 	s.logger.DebugContext(ctx, "uploading encrypted session part", "upload_id", req.Upload.UploadId, "session_id", req.Upload.SessionId, "part_number", req.PartNumber)
@@ -209,12 +206,12 @@ func (s *Service) UploadPart(ctx context.Context, req *recordingencryptionv1.Upl
 
 // CompleteUpload marks a given encrypted session upload as complete.
 func (s *Service) CompleteUpload(ctx context.Context, req *recordingencryptionv1.CompleteUploadRequest) (*recordingencryptionv1.CompleteUploadResponse, error) {
-	authCtx, err := s.auth.Authorize(ctx)
-	if err != nil {
+	if err := validateUpload(req.Upload); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !authz.IsLocalOrRemoteService(*authCtx) {
-		return nil, trace.AccessDenied("this request can be only executed by a Teleport service")
+
+	if err := s.authorizeUpload(ctx); err != nil {
+		return nil, trace.AccessDenied("access denied")
 	}
 
 	s.logger.DebugContext(ctx, "completing encrypted session upload", "upload_id", req.Upload.UploadId, "session_id", req.Upload.SessionId, "parts", len(req.Parts))
@@ -262,10 +259,13 @@ func (s *Service) authorizeKeyRotation(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	if err := authCtx.AuthorizeAdminAction(); err != nil {
-		return trace.AccessDenied("Key rotation can only be performed by admins")
+	if err := authCtx.CheckAccessToKind(types.KindRecordingEncryption, types.VerbCreate, types.VerbUpdate); err != nil {
+		return trace.Wrap(err)
 	}
 
+	if err := authCtx.AuthorizeAdminAction(); err != nil {
+		return trace.Wrap(err)
+	}
 	return nil
 }
 
@@ -322,4 +322,49 @@ func (s *Service) GetRotationState(ctx context.Context, req *recordingencryption
 	return &recordingencryptionv1.GetRotationStateResponse{
 		KeyPairStates: states,
 	}, nil
+}
+
+func validateUpload(upload *recordingencryptionv1.Upload) error {
+	switch {
+	case upload == nil:
+		return trace.BadParameter("upload is required")
+	case upload.UploadId == "":
+		return trace.BadParameter("upload.upload_id is required")
+	case upload.SessionId == "":
+		return trace.BadParameter("upload.session_id is required")
+	}
+	return nil
+}
+
+// authorizeUpload verifies that the caller is allowed to write encrypted
+// session recording data.  Two conditions must both be satisfied:
+//
+//  1. Identity: the request must come from a local Teleport server (a
+//     [authz.BuiltinRole] whose [authz.BuiltinRole.IsServer] returns true).
+//     This excludes unauthenticated clients, regular users, remote (leaf
+//     cluster) services, and non-server system roles such as RoleAdmin.
+//
+//  2. RBAC: the server's role set must hold create and update permission on
+//     [types.KindEvent] in the default namespace.  Server roles that manage
+//     session recordings (e.g. RoleProxy) satisfy this requirement through
+//     their built-in rule definitions.
+func (s *Service) authorizeUpload(ctx context.Context) error {
+	authCtx, err := s.auth.Authorize(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	role, ok := authCtx.Identity.(authz.BuiltinRole)
+	if !ok || !role.IsServer() {
+		return trace.AccessDenied("this request can be only executed by a Teleport server")
+	}
+
+	var errs []error
+	for _, verb := range []string{types.VerbCreate, types.VerbUpdate} {
+		if err := authCtx.CheckAccessToKind(types.KindEvent, verb); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return trace.NewAggregate(errs...)
 }

--- a/lib/auth/recordingencryption/recordingencryptionv1/service_test.go
+++ b/lib/auth/recordingencryption/recordingencryptionv1/service_test.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -33,15 +36,23 @@ import (
 	recordingencryptionv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/recordingencryption/recordingencryptionv1"
 	"github.com/gravitational/teleport/lib/auth/recordingmetadata"
 	"github.com/gravitational/teleport/lib/auth/summarizer"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
+
+func TestMain(m *testing.M) {
+	modules.SetInsecureTestMode(true)
+	os.Exit(m.Run())
+}
 
 type authKey struct{}
 
@@ -49,205 +60,167 @@ func withAuthCtx(ctx context.Context, authCtx authz.Context) context.Context {
 	return context.WithValue(ctx, authKey{}, authCtx)
 }
 
-func TestRotateKey(t *testing.T) {
-	cases := []struct {
+func newFakeService(t *testing.T, rotater *fakeKeyRotater) *recordingencryptionv1.Service {
+	t.Helper()
+	service, err := recordingencryptionv1.NewService(recordingencryptionv1.ServiceConfig{
+		Authorizer:                &fakeAuthorizer{},
+		Logger:                    logtest.NewLogger(),
+		Uploader:                  fakeUploader{},
+		KeyRotater:                rotater,
+		RecordingMetadataProvider: recordingmetadata.NewProvider(),
+		SessionSummarizerProvider: summarizer.NewSessionSummarizerProvider(),
+		OnUploadComplete:          func(ctx context.Context, sessionID session.ID) (apievents.AuditEvent, error) { return nil, nil },
+	})
+	require.NoError(t, err)
+	return service
+}
+
+func rotationCases(t *testing.T) []struct {
+	name      string
+	ctx       authz.Context
+	assertErr require.ErrorAssertionFunc
+} {
+	t.Helper()
+	accessDenied := func(t require.TestingT, err error, _ ...any) {
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+	}
+	return []struct {
 		name      string
 		ctx       authz.Context
-		expectErr bool
+		assertErr require.ErrorAssertionFunc
 	}{
 		{
-			name: "authorized RotateKey",
-			ctx:  newAuthCtx(authz.AdminActionAuthMFAVerified),
-		}, {
-			name:      "unauthorized RotateKey",
-			ctx:       newAuthCtx(authz.AdminActionAuthUnauthorized),
-			expectErr: true,
+			name:      "MFA verified is authorized",
+			ctx:       newAuthCtx(t, authz.AdminActionAuthMFAVerified),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "MFA unauthorized is denied",
+			ctx:       newAuthCtx(t, authz.AdminActionAuthUnauthorized),
+			assertErr: accessDenied,
+		},
+		{
+			name:      "no KindRecordingEncryption access is denied",
+			ctx:       newAuthCtxWithoutRecordingEncryption(t),
+			assertErr: accessDenied,
 		},
 	}
+}
 
-	for _, c := range cases {
+func TestRotateKey(t *testing.T) {
+	for _, c := range rotationCases(t) {
 		t.Run(c.name, func(t *testing.T) {
-			ctx := withAuthCtx(t.Context(), c.ctx)
 			rotater := newFakeKeyRotater()
-			cfg := recordingencryptionv1.ServiceConfig{
-				Authorizer:                &fakeAuthorizer{},
-				Logger:                    logtest.NewLogger(),
-				Uploader:                  fakeUploader{},
-				KeyRotater:                rotater,
-				RecordingMetadataProvider: recordingmetadata.NewProvider(),
-				SessionSummarizerProvider: summarizer.NewSessionSummarizerProvider(),
-				OnUploadComplete:          func(ctx context.Context, sessionID session.ID) (apievents.AuditEvent, error) { return nil, nil },
-			}
-
-			service, err := recordingencryptionv1.NewService(cfg)
-			require.NoError(t, err)
+			service := newFakeService(t, rotater)
 			require.Len(t, rotater.keys, 1)
 
-			_, err = service.RotateKey(ctx, nil)
-			if c.expectErr {
-				require.True(t, trace.IsAccessDenied(err))
-				require.Len(t, rotater.keys, 1)
-			} else {
-				require.NoError(t, err)
+			_, err := service.RotateKey(withAuthCtx(t.Context(), c.ctx), nil)
+			c.assertErr(t, err)
+			if err == nil {
 				require.Len(t, rotater.keys, 2)
+			} else {
+				require.Len(t, rotater.keys, 1)
 			}
 		})
 	}
 }
 
 func TestCompleteRotation(t *testing.T) {
-	cases := []struct {
-		name      string
-		ctx       authz.Context
-		expectErr bool
-	}{
-		{
-			name: "authorized CompleteRotation",
-			ctx:  newAuthCtx(authz.AdminActionAuthMFAVerified),
-		}, {
-			name:      "unauthorized CompleteRotation",
-			ctx:       newAuthCtx(authz.AdminActionAuthUnauthorized),
-			expectErr: true,
-		},
-	}
-
-	for _, c := range cases {
+	for _, c := range rotationCases(t) {
 		t.Run(c.name, func(t *testing.T) {
-			authCtx := withAuthCtx(t.Context(), newAuthCtx(authz.AdminActionAuthMFAVerified))
-			ctx := withAuthCtx(t.Context(), c.ctx)
 			rotater := newFakeKeyRotater()
-			cfg := recordingencryptionv1.ServiceConfig{
-				Authorizer:                &fakeAuthorizer{},
-				Logger:                    logtest.NewLogger(),
-				Uploader:                  fakeUploader{},
-				KeyRotater:                rotater,
-				RecordingMetadataProvider: recordingmetadata.NewProvider(),
-				SessionSummarizerProvider: summarizer.NewSessionSummarizerProvider(),
-				OnUploadComplete:          func(ctx context.Context, sessionID session.ID) (apievents.AuditEvent, error) { return nil, nil },
-			}
+			service := newFakeService(t, rotater)
 
-			service, err := recordingencryptionv1.NewService(cfg)
-			require.NoError(t, err)
-
-			_, err = service.RotateKey(authCtx, nil)
+			authCtx := withAuthCtx(t.Context(), newAuthCtx(t, authz.AdminActionAuthMFAVerified))
+			_, err := service.RotateKey(authCtx, nil)
 			require.NoError(t, err)
 			require.Len(t, rotater.keys, 2)
 
-			_, err = service.CompleteRotation(ctx, nil)
-			if c.expectErr {
-				require.True(t, trace.IsAccessDenied(err))
-				require.Len(t, rotater.keys, 2)
-			} else {
-				require.NoError(t, err)
+			_, err = service.CompleteRotation(withAuthCtx(t.Context(), c.ctx), nil)
+			c.assertErr(t, err)
+			if err == nil {
 				require.Len(t, rotater.keys, 1)
+			} else {
+				require.Len(t, rotater.keys, 2)
 			}
 		})
 	}
 }
 
 func TestRollbackRotation(t *testing.T) {
-	cases := []struct {
-		name      string
-		ctx       authz.Context
-		expectErr bool
-	}{
-		{
-			name: "authorized Rollback",
-			ctx:  newAuthCtx(authz.AdminActionAuthMFAVerified),
-		}, {
-			name:      "unauthorized Rollback",
-			ctx:       newAuthCtx(authz.AdminActionAuthUnauthorized),
-			expectErr: true,
-		},
-	}
-
-	for _, c := range cases {
+	for _, c := range rotationCases(t) {
 		t.Run(c.name, func(t *testing.T) {
-			authCtx := withAuthCtx(t.Context(), newAuthCtx(authz.AdminActionAuthMFAVerified))
-			ctx := withAuthCtx(t.Context(), c.ctx)
 			rotater := newFakeKeyRotater()
-			cfg := recordingencryptionv1.ServiceConfig{
-				Authorizer:                &fakeAuthorizer{},
-				Logger:                    logtest.NewLogger(),
-				Uploader:                  fakeUploader{},
-				KeyRotater:                rotater,
-				RecordingMetadataProvider: recordingmetadata.NewProvider(),
-				SessionSummarizerProvider: summarizer.NewSessionSummarizerProvider(),
-				OnUploadComplete:          func(ctx context.Context, sessionID session.ID) (apievents.AuditEvent, error) { return nil, nil },
-			}
+			service := newFakeService(t, rotater)
 
-			service, err := recordingencryptionv1.NewService(cfg)
-			require.NoError(t, err)
-
-			_, err = service.RotateKey(authCtx, nil)
+			authCtx := withAuthCtx(t.Context(), newAuthCtx(t, authz.AdminActionAuthMFAVerified))
+			_, err := service.RotateKey(authCtx, nil)
 			require.NoError(t, err)
 			require.Len(t, rotater.keys, 2)
 
-			_, err = service.RollbackRotation(ctx, nil)
-			if c.expectErr {
-				require.True(t, trace.IsAccessDenied(err))
-				require.Len(t, rotater.keys, 2)
-			} else {
-				require.NoError(t, err)
+			_, err = service.RollbackRotation(withAuthCtx(t.Context(), c.ctx), nil)
+			c.assertErr(t, err)
+			if err == nil {
 				require.Len(t, rotater.keys, 1)
+			} else {
+				require.Len(t, rotater.keys, 2)
 			}
 		})
 	}
 }
 
 func TestGetRotationState(t *testing.T) {
-	cases := []struct {
-		name      string
-		ctx       authz.Context
-		expectErr bool
-	}{
-		{
-			name: "authorized",
-			ctx:  newAuthCtx(authz.AdminActionAuthMFAVerified),
-		}, {
-			name:      "unauthorized",
-			ctx:       newAuthCtx(authz.AdminActionAuthUnauthorized),
-			expectErr: true,
-		},
-	}
-
-	for _, c := range cases {
+	for _, c := range rotationCases(t) {
 		t.Run(c.name, func(t *testing.T) {
-			ctx := withAuthCtx(t.Context(), c.ctx)
 			rotater := newFakeKeyRotater()
-			cfg := recordingencryptionv1.ServiceConfig{
-				Authorizer:                &fakeAuthorizer{},
-				Logger:                    logtest.NewLogger(),
-				Uploader:                  fakeUploader{},
-				KeyRotater:                rotater,
-				RecordingMetadataProvider: recordingmetadata.NewProvider(),
-				SessionSummarizerProvider: summarizer.NewSessionSummarizerProvider(),
-				OnUploadComplete:          func(ctx context.Context, sessionID session.ID) (apievents.AuditEvent, error) { return nil, nil },
-			}
+			service := newFakeService(t, rotater)
 
-			service, err := recordingencryptionv1.NewService(cfg)
-			require.NoError(t, err)
-
-			res, err := service.GetRotationState(ctx, nil)
-			if c.expectErr {
-				require.Error(t, err)
-				require.Nil(t, res)
-			} else {
-				require.NoError(t, err)
+			res, err := service.GetRotationState(withAuthCtx(t.Context(), c.ctx), nil)
+			c.assertErr(t, err)
+			if err == nil {
 				require.Len(t, res.KeyPairStates, 1)
+			} else {
+				require.Nil(t, res)
 			}
 		})
 	}
 }
 
-func newAuthCtx(action authz.AdminActionAuthState) authz.Context {
-	return authz.Context{
-		AdminActionAuthState: action,
-	}
+func newAuthCtx(t *testing.T, action authz.AdminActionAuthState) authz.Context {
+	t.Helper()
+	// Build a full admin context so the RBAC checker is populated.
+	ctx, err := authz.NewBuiltinRoleContext(types.RoleAdmin)
+	require.NoError(t, err)
+	ctx.AdminActionAuthState = action
+	return *ctx
+}
+
+// newAuthCtxWithoutRecordingEncryption returns an MFA-verified context whose
+// role set does not include KindRecordingEncryption, so RBAC is the failing
+// condition rather than admin-action auth.
+func newAuthCtxWithoutRecordingEncryption(t *testing.T) authz.Context {
+	t.Helper()
+	// RoleNode has KindEvent RW (passes the event check) but no KindRecordingEncryption.
+	ctx, err := authz.NewBuiltinRoleContext(types.RoleNode)
+	require.NoError(t, err)
+	ctx.AdminActionAuthState = authz.AdminActionAuthMFAVerified
+	return *ctx
 }
 
 type fakeUploader struct {
 	events.MultipartUploader
+}
+
+func (f fakeUploader) CreateUpload(ctx context.Context, sessionID session.ID) (*events.StreamUpload, error) {
+	return &events.StreamUpload{ID: uuid.NewString(), SessionID: sessionID}, nil
+}
+
+func (f fakeUploader) ReserveUploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64) error {
+	return nil
+}
+
+func (f fakeUploader) UploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64, partBody io.ReadSeeker) (*events.StreamPart, error) {
+	return &events.StreamPart{Number: partNumber}, nil
 }
 
 func (f fakeUploader) CompleteUpload(ctx context.Context, upload events.StreamUpload, parts []events.StreamPart) error {
@@ -361,7 +334,7 @@ func TestSessionCompleter(t *testing.T) {
 	service, err := recordingencryptionv1.NewService(cfg)
 	require.NoError(t, err)
 
-	ctx := withAuthCtx(t.Context(), newServiceAuthCtx())
+	ctx := withAuthCtx(t.Context(), newServiceAuthCtx(t))
 	_, err = service.CompleteUpload(ctx, &recordingencryptionv1pb.CompleteUploadRequest{
 		Upload: &recordingencryptionv1pb.Upload{
 			SessionId:   string(sessionID),
@@ -453,7 +426,7 @@ func TestCompleteUploadRecoversMissingSessionEnd(t *testing.T) {
 	service, err := recordingencryptionv1.NewService(cfg)
 	require.NoError(t, err)
 
-	ctx := withAuthCtx(t.Context(), newServiceAuthCtx())
+	ctx := withAuthCtx(t.Context(), newServiceAuthCtx(t))
 	_, err = service.CompleteUpload(ctx, &recordingencryptionv1pb.CompleteUploadRequest{
 		Upload: &recordingencryptionv1pb.Upload{
 			SessionId:   string(sessionID),
@@ -473,13 +446,276 @@ func TestCompleteUploadRecoversMissingSessionEnd(t *testing.T) {
 	require.True(t, sessionEnd.Interactive)
 }
 
-func newServiceAuthCtx() authz.Context {
-	return authz.Context{
-		Identity: authz.BuiltinRole{
-			Role: types.RoleProxy,
+func newServiceAuthCtx(t *testing.T) authz.Context {
+	t.Helper()
+	role := authz.BuiltinRole{Role: types.RoleProxy, Username: string(types.RoleProxy)}
+	ctx, err := authz.ContextForBuiltinRole(role, nil)
+	require.NoError(t, err)
+	return *ctx
+}
+
+func TestUploadValidation(t *testing.T) {
+	newService := func(t *testing.T) *recordingencryptionv1.Service {
+		t.Helper()
+		svc, err := recordingencryptionv1.NewService(recordingencryptionv1.ServiceConfig{
+			Authorizer:                &fakeAuthorizer{},
+			Logger:                    logtest.NewLogger(),
+			Uploader:                  fakeUploader{},
+			KeyRotater:                newFakeKeyRotater(),
+			RecordingMetadataProvider: recordingmetadata.NewProvider(),
+			SessionSummarizerProvider: summarizer.NewSessionSummarizerProvider(),
+			OnUploadComplete:          func(ctx context.Context, sessionID session.ID) (apievents.AuditEvent, error) { return nil, nil },
+		})
+		require.NoError(t, err)
+		return svc
+	}
+
+	assertBadParameter := func(t require.TestingT, err error, _ ...any) {
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter error, got %v", err)
+	}
+
+	cases := []struct {
+		name          string
+		uploadPartReq *recordingencryptionv1pb.UploadPartRequest
+		completeReq   *recordingencryptionv1pb.CompleteUploadRequest
+	}{
+		{
+			name:          "nil upload field",
+			uploadPartReq: &recordingencryptionv1pb.UploadPartRequest{},
+			completeReq:   &recordingencryptionv1pb.CompleteUploadRequest{},
 		},
-		UnmappedIdentity: authz.BuiltinRole{
-			Role: types.RoleProxy,
+		{
+			name: "missing upload_id",
+			uploadPartReq: &recordingencryptionv1pb.UploadPartRequest{
+				Upload: &recordingencryptionv1pb.Upload{SessionId: uuid.NewString()},
+			},
+			completeReq: &recordingencryptionv1pb.CompleteUploadRequest{
+				Upload: &recordingencryptionv1pb.Upload{SessionId: uuid.NewString()},
+			},
 		},
+		{
+			name: "missing session_id",
+			uploadPartReq: &recordingencryptionv1pb.UploadPartRequest{
+				Upload: &recordingencryptionv1pb.Upload{UploadId: uuid.NewString()},
+			},
+			completeReq: &recordingencryptionv1pb.CompleteUploadRequest{
+				Upload: &recordingencryptionv1pb.Upload{UploadId: uuid.NewString()},
+			},
+		},
+	}
+
+	ctx := withAuthCtx(t.Context(), newServiceAuthCtx(t))
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc := newService(t)
+
+			_, err := svc.UploadPart(ctx, c.uploadPartReq)
+			assertBadParameter(t, err)
+
+			_, err = svc.CompleteUpload(ctx, c.completeReq)
+			assertBadParameter(t, err)
+		})
+	}
+}
+
+func TestAuthorizeUpload(t *testing.T) {
+	newUpload := func() *recordingencryptionv1pb.Upload {
+		return &recordingencryptionv1pb.Upload{
+			SessionId:   uuid.NewString(),
+			UploadId:    uuid.NewString(),
+			InitiatedAt: timestamppb.Now(),
+		}
+	}
+	newUploadReq := func() *recordingencryptionv1pb.CreateUploadRequest {
+		return &recordingencryptionv1pb.CreateUploadRequest{SessionId: uuid.NewString()}
+	}
+
+	accessDeniedAssert := func(t require.TestingT, err error, i ...any) {
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err))
+		require.ErrorContains(t, err, "access denied")
+	}
+
+	cases := []struct {
+		name          string
+		authCtx       authz.Context
+		errAssertFunc require.ErrorAssertionFunc
+	}{
+		{
+			name:          "server builtin role is authorized",
+			authCtx:       newServiceAuthCtx(t),
+			errAssertFunc: require.NoError,
+		},
+		{
+			name: "non-server builtin role is denied",
+			authCtx: authz.Context{
+				Identity: authz.BuiltinRole{Role: types.RoleAdmin},
+			},
+
+			errAssertFunc: accessDeniedAssert,
+		},
+		{
+			name: "local user identity is denied",
+			authCtx: authz.Context{
+				Identity: authz.LocalUser{},
+			},
+			errAssertFunc: accessDeniedAssert,
+		},
+		{
+			name: "unauthenticated role is denied",
+			authCtx: authz.Context{
+				Identity: authz.UnauthenticatedRole{Role: types.RoleNop},
+			},
+			errAssertFunc: accessDeniedAssert,
+		},
+		{
+			name: "remote builtin role is denied",
+			authCtx: authz.Context{
+				Identity: authz.RemoteBuiltinRole{Role: types.RoleProxy},
+			},
+			errAssertFunc: accessDeniedAssert,
+		},
+	}
+
+	newService := func(t *testing.T) *recordingencryptionv1.Service {
+		t.Helper()
+		svc := newFakeService(t, newFakeKeyRotater())
+		return svc
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := withAuthCtx(t.Context(), c.authCtx)
+			svc := newService(t)
+
+			// Test all three upload endpoints
+			_, err := svc.CreateUpload(ctx, newUploadReq())
+			c.errAssertFunc(t, err)
+
+			_, err = svc.UploadPart(ctx, &recordingencryptionv1pb.UploadPartRequest{Upload: newUpload(), IsLast: true})
+			c.errAssertFunc(t, err)
+
+			_, err = svc.CompleteUpload(ctx, &recordingencryptionv1pb.CompleteUploadRequest{Upload: newUpload()})
+			c.errAssertFunc(t, err)
+		})
+	}
+}
+
+func newTestTLSServer(t testing.TB) *authtest.TLSServer {
+	t.Helper()
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+
+	srv, err := as.NewTestTLSServer(authtest.WithBufconnListener())
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := srv.Close()
+		if errors.Is(err, net.ErrClosed) {
+			return
+		}
+		require.NoError(t, err)
+	})
+
+	return srv
+}
+
+func TestRecordingEncryptionService(t *testing.T) {
+	t.Parallel()
+
+	accessDenied := func(t require.TestingT, err error, _ ...any) {
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		identity  authtest.TestIdentity
+		assertErr require.ErrorAssertionFunc
+	}{
+		// Local user is never a server.
+		{
+			name:      "local user is denied",
+			identity:  authtest.TestUser("alice"),
+			assertErr: accessDenied,
+		},
+		// Server roles: IsServer() == true.
+		{
+			name:      "proxy builtin role is authorized",
+			identity:  authtest.TestBuiltin(types.RoleProxy),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "node builtin role is authorized",
+			identity:  authtest.TestBuiltin(types.RoleNode),
+			assertErr: require.NoError,
+		},
+		{
+			name:      "kube builtin role is authorized",
+			identity:  authtest.TestBuiltin(types.RoleKube),
+			assertErr: require.NoError,
+		},
+		// Non-server system roles: IsServer() == false.
+		{
+			name:      "admin builtin role is denied",
+			identity:  authtest.TestBuiltin(types.RoleAdmin),
+			assertErr: accessDenied,
+		},
+		{
+			name:      "nop (unauthenticated) is denied",
+			identity:  authtest.TestNop(),
+			assertErr: accessDenied,
+		},
+		{
+			name:      "signup role is denied",
+			identity:  authtest.TestBuiltin(types.RoleSignup),
+			assertErr: accessDenied,
+		},
+	}
+
+	testSrv := newTestTLSServer(t)
+
+	_, _, err := authtest.CreateUserAndRole(testSrv.Auth(), "alice", nil, []types.Rule{
+		types.NewRule(types.KindEvent, services.RW()),
+	})
+	require.NoError(t, err)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			authClient, err := testSrv.NewClient(c.identity)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, authClient.Close()) })
+
+			cli := authClient.RecordingEncryptionServiceClient()
+
+			upload := &recordingencryptionv1pb.Upload{
+				UploadId:    uuid.NewString(),
+				SessionId:   uuid.NewString(),
+				InitiatedAt: timestamppb.Now(),
+			}
+
+			createResp, err := cli.CreateUpload(t.Context(), &recordingencryptionv1pb.CreateUploadRequest{
+				SessionId: uuid.NewString(),
+			})
+			c.assertErr(t, err)
+			if err == nil {
+				upload = createResp.Upload
+			}
+
+			_, err = cli.UploadPart(t.Context(), &recordingencryptionv1pb.UploadPartRequest{
+				Upload: upload,
+				IsLast: true,
+			})
+			c.assertErr(t, err)
+
+			_, err = cli.CompleteUpload(t.Context(), &recordingencryptionv1pb.CompleteUploadRequest{
+				Upload: upload,
+			})
+			c.assertErr(t, err)
+		})
 	}
 }

--- a/lib/auth/stableunixusers/stableunixusers_test.go
+++ b/lib/auth/stableunixusers/stableunixusers_test.go
@@ -101,7 +101,7 @@ func TestStableUNIXUsers(t *testing.T) {
 	require.NoError(t, err)
 
 	authorizer = func(ctx context.Context) (*authz.Context, error) {
-		return authz.NewBuiltinRoleContext(types.RoleNop)
+		return authz.NewUnauthenticatedRoleContext(types.RoleNop)
 	}
 
 	obtainUIDForUsername := func(username string) (int32, error) {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -4179,7 +4179,7 @@ func TestClusterAlertAccessControls(t *testing.T) {
 	}
 
 	// verify that we still reject unauthenticated clients
-	nopClt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleNop))
+	nopClt, err := testSrv.NewClient(authtest.TestUnauthenticated(types.RoleNop))
 	require.NoError(t, err)
 	defer nopClt.Close()
 
@@ -4278,7 +4278,7 @@ func TestEventsNodePresence(t *testing.T) {
 	}
 
 	// upsert node and keep alives will fail for users with no privileges
-	nopClt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleNop))
+	nopClt, err := testSrv.NewClient(authtest.TestUnauthenticated(types.RoleNop))
 	require.NoError(t, err)
 	defer nopClt.Close()
 
@@ -4421,7 +4421,7 @@ func TestEventsPermissions(t *testing.T) {
 		},
 		{
 			name:     "nop role is not authorized to watch users and roles",
-			identity: authtest.TestBuiltin(types.RoleNop),
+			identity: authtest.TestUnauthenticated(types.RoleNop),
 			watches: []types.WatchKind{
 				{Kind: types.KindUser},
 				{Kind: types.KindRole},
@@ -4429,12 +4429,12 @@ func TestEventsPermissions(t *testing.T) {
 		},
 		{
 			name:     "nop role is not authorized to watch cert authorities",
-			identity: authtest.TestBuiltin(types.RoleNop),
+			identity: authtest.TestUnauthenticated(types.RoleNop),
 			watches:  []types.WatchKind{{Kind: types.KindCertAuthority, LoadSecrets: false}},
 		},
 		{
 			name:     "nop role is not authorized to watch cluster config resources",
-			identity: authtest.TestBuiltin(types.RoleNop),
+			identity: authtest.TestUnauthenticated(types.RoleNop),
 			watches: []types.WatchKind{
 				{Kind: types.KindClusterAuthPreference},
 				{Kind: types.KindClusterNetworkingConfig},
@@ -6008,6 +6008,7 @@ func withClock(clock clockwork.Clock) testTLSServerOption {
 		options.clock = clock
 	}
 }
+
 func withBufconnListener() testTLSServerOption {
 	return func(options *testTLSServerOptions) {
 		options.bufconnListener = true

--- a/lib/authz/middleware.go
+++ b/lib/authz/middleware.go
@@ -147,11 +147,10 @@ func (a *Middleware) GetUser(ctx context.Context, connState tls.ConnectionState)
 	// for connections without auth, but this is not active use-case
 	// therefore it is not allowed to reduce scope
 	if len(peers) == 0 {
-		return BuiltinRole{
+		return UnauthenticatedRole{
 			Role:        types.RoleNop,
 			Username:    string(types.RoleNop),
 			ClusterName: a.ClusterName,
-			Identity:    tlsca.Identity{},
 		}, nil
 	}
 	clientCert := peers[0]
@@ -221,6 +220,7 @@ func (a *Middleware) GetUser(ctx context.Context, connState tls.ConnectionState)
 			Identity:         *identity,
 		}, nil
 	}
+
 	// code below expects user or service from local cluster, to distinguish between
 	// interactive users and services (e.g. proxies), the code below
 	// checks for presence of system roles issued in certificate identity

--- a/lib/authz/middleware_test.go
+++ b/lib/authz/middleware_test.go
@@ -98,11 +98,10 @@ func TestMiddlewareGetUser(t *testing.T) {
 	}{
 		{
 			desc: "no client cert",
-			wantID: authz.BuiltinRole{
+			wantID: authz.UnauthenticatedRole{
 				Role:        types.RoleNop,
 				Username:    string(types.RoleNop),
 				ClusterName: localClusterName,
-				Identity:    tlsca.Identity{},
 			},
 			assertErr: require.NoError,
 		},

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -66,6 +66,15 @@ func NewBuiltinRoleContext(role types.SystemRole) (*Context, error) {
 	return authContext, nil
 }
 
+// NewUnauthenticatedRoleContext create auth context for the provided unauthenticated role.
+func NewUnauthenticatedRoleContext(role types.UnauthenticatedRole) (*Context, error) {
+	authContext, err := ContextForUnauthenticatedRole(UnauthenticatedRole{Role: role, Username: string(role)})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return authContext, nil
+}
+
 // DeviceAuthorizationOpts captures Device Trust options for [AuthorizerOpts].
 type DeviceAuthorizationOpts struct {
 	// DisableGlobalMode disables the global device_trust.mode toggle.
@@ -296,6 +305,9 @@ func (c *Context) GetUserMetadata() apievents.UserMetadata {
 // LockTargets returns a list of LockTargets inferred from the context's
 // Identity and UnmappedIdentity.
 func (c *Context) LockTargets() []types.LockTarget {
+	if _, ok := c.Identity.(UnauthenticatedRole); ok {
+		return nil
+	}
 	lockTargets := services.LockTargetsFromTLSIdentity(c.Identity.GetIdentity())
 Loop:
 	for _, unmappedTarget := range services.LockTargetsFromTLSIdentity(c.UnmappedIdentity.GetIdentity()) {
@@ -485,6 +497,9 @@ func (a *authorizer) enforcePrivateKeyPolicy(ctx context.Context, authContext *C
 	case BuiltinRole, RemoteBuiltinRole:
 		// built in roles do not need to pass private key policies
 		return nil
+	case UnauthenticatedRole:
+		// UnauthenticatedRole won't have the private key policies.
+		return nil
 	}
 
 	// Check that the required private key policy, defined by roles and auth pref,
@@ -511,6 +526,8 @@ func (a *authorizer) fromUser(ctx context.Context, userI any) (*Context, error) 
 		return a.authorizeBuiltinRole(ctx, user)
 	case RemoteBuiltinRole:
 		return a.authorizeRemoteBuiltinRole(user)
+	case UnauthenticatedRole:
+		return ContextForUnauthenticatedRole(user)
 	default:
 		return nil, trace.AccessDenied("unsupported context type %T", userI)
 	}
@@ -518,24 +535,36 @@ func (a *authorizer) fromUser(ctx context.Context, userI any) (*Context, error) 
 
 // checkAdminActionVerification checks if this auth request is verified for admin actions.
 func (a *authorizer) checkAdminActionVerification(ctx context.Context, authContext *Context) error {
-	required, err := a.isAdminActionAuthorizationRequired(ctx, authContext)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if !required {
+	switch authContext.Identity.(type) {
+	case BuiltinRole, RemoteBuiltinRole:
+		// Builtin roles bypass MFA
 		authContext.AdminActionAuthState = AdminActionAuthNotRequired
 		return nil
-	}
+	case UnauthenticatedRole:
+		// UnauthenticatedRole is unauthenticated client by default.
+		// Mark the AdminActionAuthState as AdminActionAuthUnauthorized.
+		authContext.AdminActionAuthState = AdminActionAuthUnauthorized
+		return nil
+	default:
+		required, err := a.isAdminActionAuthorizationRequiredForUsers(ctx, authContext)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 
-	if err := a.authorizeAdminAction(ctx, authContext); err != nil {
-		return trace.Wrap(err)
-	}
+		if !required {
+			authContext.AdminActionAuthState = AdminActionAuthNotRequired
+			return nil
+		}
 
-	return nil
+		if err := a.authorizeAdminAction(ctx, authContext); err != nil {
+			return trace.Wrap(err)
+		}
+
+		return nil
+	}
 }
 
-func (a *authorizer) isAdminActionAuthorizationRequired(ctx context.Context, authContext *Context) (bool, error) {
+func (a *authorizer) isAdminActionAuthorizationRequiredForUsers(ctx context.Context, authContext *Context) (bool, error) {
 	// Provide a way to turn off admin MFA requirements in case expected functionality
 	// is disrupted by this requirement, such as for integrations essential to a user
 	// which do not yet make use of a machine ID / AdminRole impersonated identity.
@@ -543,12 +572,6 @@ func (a *authorizer) isAdminActionAuthorizationRequired(ctx context.Context, aut
 	// TODO(Joerger): once we have fully transitioned to requiring machine ID for
 	// integrations and ironed out any bugs with admin MFA, this env var should be removed.
 	if os.Getenv("TELEPORT_UNSTABLE_DISABLE_MFA_ADMIN_ACTIONS") == "yes" {
-		return false, nil
-	}
-
-	// Builtin roles do not require MFA to perform admin actions.
-	switch authContext.Identity.(type) {
-	case BuiltinRole, RemoteBuiltinRole:
 		return false, nil
 	}
 
@@ -1002,6 +1025,31 @@ func roleSpecForProxy(clusterName string) types.RoleSpecV6 {
 	}
 }
 
+// RoleSetForUnauthenticatedRoles returns a RoleSet for unauthenticated roles.
+func RoleSetForUnauthenticatedRoles(clusterName string, roles ...types.UnauthenticatedRole) (services.RoleSet, error) {
+	var definitions []types.Role
+	for _, role := range roles {
+		switch role {
+		case types.RoleNop:
+			rd, err := services.RoleFromSpec(
+				string(role),
+				types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Namespaces: []string{},
+						Rules:      []types.Rule{},
+					},
+				})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			definitions = append(definitions, rd)
+		default:
+			return nil, trace.NotFound("unauthenticated role %q is not recognized", role)
+		}
+	}
+	return services.NewRoleSet(definitions...), nil
+}
+
 // RoleSetForBuiltinRoles returns RoleSet for embedded builtin role
 func RoleSetForBuiltinRoles(clusterName string, recConfig readonly.SessionRecordingConfig, isScoped bool, roles ...types.SystemRole) (services.RoleSet, error) {
 	var definitions []types.Role
@@ -1263,15 +1311,6 @@ func unscopedDefinitionForBuiltinRole(clusterName string, recConfig readonly.Ses
 					},
 				},
 			})
-	case types.RoleNop:
-		return services.RoleFromSpec(
-			role.String(),
-			types.RoleSpecV6{
-				Allow: types.RoleConditions{
-					Namespaces: []string{},
-					Rules:      []types.Rule{},
-				},
-			})
 	case types.RoleKube:
 		return services.RoleFromSpec(
 			role.String(),
@@ -1424,8 +1463,34 @@ func unscopedDefinitionForBuiltinRole(clusterName string, recConfig readonly.Ses
 				},
 			})
 	}
-
 	return nil, trace.NotFound("builtin role %q is not recognized", role.String())
+}
+
+// ContextForUnauthenticatedRole returns a context with the unauthenticated role information embedded.
+func ContextForUnauthenticatedRole(r UnauthenticatedRole) (*Context, error) {
+	roleSet, err := RoleSetForUnauthenticatedRoles(r.ClusterName, r.Role)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user, err := types.NewUser(r.Username)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	roles := []string{string(r.Role)}
+	user.SetRoles(roles)
+	checker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+		Roles:                    roles,
+		Traits:                   nil,
+		AllowedResourceAccessIDs: nil,
+	}, r.ClusterName, roleSet)
+	return &Context{
+		User:                  user,
+		Checker:               checker,
+		Identity:              r,
+		UnmappedIdentity:      r,
+		disableDeviceRoleMode: true,                        // Unauthenticated roles skip device trust.
+		AdminActionAuthState:  AdminActionAuthUnauthorized, // Unauthenticated won't be able to do admin actions.
+	}, nil
 }
 
 // ContextForBuiltinRole returns a context with the builtin role information embedded.
@@ -1753,6 +1818,26 @@ func (i WrapIdentity) GetIdentity() tlsca.Identity {
 	return tlsca.Identity(i)
 }
 
+// UnauthenticatedRole is the role given to a client that doesn't present
+// a certificate.
+// It's used for actions that are already using external authz mechanisms
+// e.g. tokens or passwords
+type UnauthenticatedRole struct {
+	// Role is the primary role this username is associated with
+	Role types.UnauthenticatedRole
+
+	// Username is for authentication tracking purposes
+	Username string
+
+	// ClusterName is the name of the local cluster
+	ClusterName string
+}
+
+// GetIdentity returns client identity
+func (r UnauthenticatedRole) GetIdentity() tlsca.Identity {
+	return tlsca.Identity{}
+}
+
 // BuiltinRole is the role of the Teleport service.
 type BuiltinRole struct {
 	// Role is the primary builtin role this username is associated with
@@ -1955,6 +2040,19 @@ func UserFromContext(ctx context.Context) (IdentityGetter, error) {
 // name.
 func HasBuiltinRole(authContext Context, name string) bool {
 	if _, ok := authContext.Identity.(BuiltinRole); !ok {
+		return false
+	}
+	if !authContext.Checker.HasRole(name) {
+		return false
+	}
+
+	return true
+}
+
+// HasUnauthenticatedRole checks if the identity is a unauthenticated role with the matching
+// name.
+func HasUnauthenticatedRole(authContext Context, name string) bool {
+	if _, ok := authContext.Identity.(UnauthenticatedRole); !ok {
 		return false
 	}
 	if !authContext.Checker.HasRole(name) {

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/defaults"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
@@ -224,6 +225,14 @@ func TestContextLockTargets(t *testing.T) {
 			require.ElementsMatch(t, authContext.LockTargets(), tt.want)
 		})
 	}
+
+	t.Run("UnauthenticatedRole lock targets", func(t *testing.T) {
+		authContext := &authz.Context{
+			Identity:         authz.UnauthenticatedRole{Role: types.RoleNop, Username: string(types.RoleNop)},
+			UnmappedIdentity: authz.UnauthenticatedRole{Role: types.RoleNop, Username: string(types.RoleNop)},
+		}
+		require.Empty(t, authContext.LockTargets())
+	})
 }
 
 func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
@@ -486,6 +495,11 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 				ClusterName: clusterName,
 				Identity:    userWithoutExtensions.Identity,
 			},
+		},
+		{
+			name:                 "UnauthenticatedRole: context device trust always disabled",
+			user:                 authz.UnauthenticatedRole{Role: types.RoleNop, Username: string(types.RoleNop)},
+			wantCtxAuthnDisabled: true,
 		},
 	}
 	for _, test := range tests {
@@ -755,6 +769,10 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				},
 			},
 			wantAdminActionAuthorized: true,
+		}, {
+			name:                      "NOK unauthenticated role cannot perform admin actions",
+			user:                      authz.UnauthenticatedRole{Role: types.RoleNop, Username: string(types.RoleNop)},
+			wantAdminActionAuthorized: false,
 		}, {
 			name: "OK admin impersonating local user",
 			user: authz.LocalUser{
@@ -1264,6 +1282,161 @@ func TestIsUserFunctions(t *testing.T) {
 			got := test.isUserFunc(test.authCtx)
 			assert.Equal(t, test.want, got, "%s mismatch", test.funcName)
 		})
+	}
+}
+
+func TestHasUnauthenticatedRole(t *testing.T) {
+	nopCtx := authz.Context{
+		Identity: authz.UnauthenticatedRole{
+			Role:     types.RoleNop,
+			Username: string(types.RoleNop),
+		},
+	}
+	// Populate Checker so HasRole works.
+	roleSet, err := authz.RoleSetForUnauthenticatedRoles(clusterName, types.RoleNop)
+	require.NoError(t, err)
+	nopCtx.Checker = services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+		Roles: []string{string(types.RoleNop)},
+	}, clusterName, roleSet)
+
+	builtinCtx := authz.Context{
+		Identity: authz.BuiltinRole{Role: types.RoleProxy},
+	}
+	localCtx := authz.Context{
+		Identity: authz.LocalUser{},
+	}
+
+	tests := []struct {
+		name string
+		ctx  authz.Context
+		role string
+		want bool
+	}{
+		{
+			name: "unauthenticated role matches",
+			ctx:  nopCtx,
+			role: string(types.RoleNop),
+			want: true,
+		},
+		{
+			name: "unauthenticated role case-insensitive match",
+			ctx:  nopCtx,
+			role: "nop",
+			want: false, // HasRole is exact match, not case-insensitive
+		},
+		{
+			name: "builtin role does not match",
+			ctx:  builtinCtx,
+			role: string(types.RoleNop),
+			want: false,
+		},
+		{
+			name: "local user does not match",
+			ctx:  localCtx,
+			role: string(types.RoleNop),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := authz.HasUnauthenticatedRole(tt.ctx, tt.role)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRoleSetForUnauthenticatedRoles(t *testing.T) {
+	tests := []struct {
+		name      string
+		roles     []types.UnauthenticatedRole
+		assertErr require.ErrorAssertionFunc
+		assertRS  func(t *testing.T, rs services.RoleSet)
+	}{
+		{
+			name:      "RoleNop produces empty rule set",
+			roles:     []types.UnauthenticatedRole{types.RoleNop},
+			assertErr: require.NoError,
+			assertRS: func(t *testing.T, rs services.RoleSet) {
+				require.NotEmpty(t, rs)
+				for i, r := range rs {
+					assert.Empty(t, r.GetNamespaces(types.Allow), "rs[%d]: expected no namespaces for nop role", i)
+					assert.Empty(t, r.GetRules(types.Allow), "rs[%d]: expected no rules for nop role", i)
+				}
+			},
+		},
+		{
+			name:      "unknown role returns error",
+			roles:     []types.UnauthenticatedRole{types.UnauthenticatedRole("Unknown")},
+			assertErr: require.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rs, err := authz.RoleSetForUnauthenticatedRoles(clusterName, tt.roles...)
+			tt.assertErr(t, err)
+			if tt.assertRS != nil {
+				tt.assertRS(t, rs)
+			}
+		})
+	}
+}
+
+// TestUnauthenticatedRoleHasNoPermissions verifies that the Nop unauthenticated
+// role carries an entirely empty allow/deny spec (no rules, no logins, no
+// namespaces, etc.) and is denied access to all common resources.
+func TestUnauthenticatedRoleHasNoPermissions(t *testing.T) {
+	ctx, err := authz.NewUnauthenticatedRoleContext(types.RoleNop)
+	require.NoError(t, err)
+
+	// Verify the entire Allow and Deny spec is zero-value (proto message is empty).
+	roleSet, err := authz.RoleSetForUnauthenticatedRoles(clusterName, types.RoleNop)
+	require.NoError(t, err)
+	require.Len(t, roleSet, 1, "RoleSetForUnAuthenticatedRoles should only return a single role")
+
+	rv6, ok := roleSet[0].(*types.RoleV6)
+	require.True(t, ok, "expected *types.RoleV6, got %T", roleSet[0])
+
+	require.Equal(t, rv6.GetName(), string(types.RoleNop), "role name MUST be nop")
+
+	require.Empty(t,
+		cmp.Diff(types.RoleSpecV6{
+			Deny: types.RoleConditions{
+				Namespaces: []string{defaults.Namespace},
+			},
+			Options: types.RoleOptions{
+				// these are the default values.
+				MaxSessionTTL:     types.NewDuration(defaults.MaxCertDuration),
+				CertificateFormat: constants.CertificateFormatStandard,
+				BPF:               []string{"command", "network"},
+				RecordSession: &types.RecordSession{
+					Desktop: types.NewBoolOption(true),
+					Default: constants.SessionRecordingModeBestEffort,
+				},
+				DesktopClipboard:        types.NewBoolOption(true),
+				DesktopDirectorySharing: types.NewBoolOption(true),
+				SSHFileCopy:             types.NewBoolOption(true),
+				CreateDesktopUser:       types.NewBoolOption(false),
+				CreateDatabaseUser:      types.NewBoolOption(false),
+			},
+		}, rv6.Spec, cmpopts.EquateEmpty()),
+		"Spec must be entirely empty for the Nop unauthenticated role",
+	)
+
+	// Functionally confirm that RBAC denies all access.
+	ruleCtx := &services.Context{User: ctx.User}
+	for _, resource := range []string{
+		types.KindEvent,
+		types.KindNode,
+		types.KindUser,
+		types.KindRole,
+		types.KindSession,
+		types.KindCertAuthority,
+	} {
+		for _, verb := range services.RW() {
+			err := ctx.Checker.CheckAccessToRule(ruleCtx, defaults.Namespace, resource, verb)
+			assert.Truef(t, trace.IsAccessDenied(err),
+				"expected access denied for %s/%s, got %v", resource, verb, err)
+		}
 	}
 }
 

--- a/lib/events/stream.go.rej
+++ b/lib/events/stream.go.rej
@@ -1,0 +1,24 @@
+diff a/lib/events/stream.go b/lib/events/stream.go	(rejected hunks)
+@@ -166,16 +170,18 @@ func NewProtoStreamer(cfg ProtoStreamerConfig) (*ProtoStreamer, error) {
+ 		// Min upload bytes + some overhead to prevent buffer growth (gzip writer is not precise)
+ 		bufferPool: utils.NewBufferSyncPool(cfg.MinUploadBytes + cfg.MinUploadBytes/3),
+ 		// MaxProtoMessage size + length of the message record
+-		slicePool: utils.NewSliceSyncPool(MaxProtoMessageSizeBytes + ProtoStreamV1RecordHeaderSize),
++		slicePool:        utils.NewSliceSyncPool(MaxProtoMessageSizeBytes + ProtoStreamV1RecordHeaderSize),
++		onUploadComplete: cfg.OnUploadComplete,
+ 	}, nil
+ }
+ 
+ // ProtoStreamer creates protobuf-based streams uploaded to the storage
+ // backends, for example S3 or GCS
+ type ProtoStreamer struct {
+-	cfg        ProtoStreamerConfig
+-	bufferPool *utils.BufferSyncPool
+-	slicePool  *utils.SliceSyncPool
++	cfg              ProtoStreamerConfig
++	onUploadComplete func(ctx context.Context, sessionID session.ID) (apievents.AuditEvent, error)
++	bufferPool       *utils.BufferSyncPool
++	slicePool        *utils.SliceSyncPool
+ }
+ 
+ // CreateAuditStreamForUpload creates audit stream for existing upload,

--- a/lib/service/service.go.rej
+++ b/lib/service/service.go.rej
@@ -1,0 +1,15 @@
+diff a/lib/service/service.go b/lib/service/service.go	(rejected hunks)
+@@ -2503,7 +2504,12 @@ func (process *TeleportProcess) initAuthService() error {
+ 		return trace.Wrap(err)
+ 	}
+ 	authServer.EncryptedIO = encryptedIO
+-
++	if streamer != nil {
++		streamer.SetOnUploadComplete(authServer.OnUploadComplete)
++	}
++	if localLog != nil {
++		localLog.SetOnUploadComplete(authServer.OnUploadComplete)
++	}
+ 	lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{
+ 		ResourceWatcherConfig: services.ResourceWatcherConfig{
+ 			Component: teleport.ComponentAuth,

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -230,6 +230,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindScopedToken, RW()),
 					types.NewRule(types.KindAppAuthConfig, RW()),
 					types.NewRule(types.KindWorkloadCluster, RW()),
+					types.NewRule(types.KindRecordingEncryption, RW()),
 				},
 			},
 		},


### PR DESCRIPTION
Teleport Auth server allows clients that do not present a certificate to access parts of its API. This deliberate bypass exists to support joining methods or password logins where a user or server does not have a certificate yet but has a secret that can be exchanged for a certificate.

In order to keep the system compatible and reduce the permutations required, Teleport assigned these unauthenticated connections a role called `Nop`. This role has no permissions and the only reason why it exists is so we can still build a context and checker.

This role was historically embedded in a structure called `BuiltinRole`. This struct implements the `Identity` interface and by its documentation is used by teleport services that belong to this particular cluster.

Some of the Auth server handlers are restricted to server identities and the check consists in something like:

```go
	authCtx, err := s.authorizer.Authorize(ctx)
	if err != nil {
		return nil, trace.Wrap(err)
	}

	if b, ok := authCtx.Identity.(authz.BuiltinRole); !ok || !b.IsServer() {
		return nil, trace.AccessDenied("only server identities can verify validated MFA challenges")
	}

```

As seen above, part of the verification consists in type asserting the `authCtx.Identity` to confirm it belongs to a local server and then we check if the role belongs to an actual server.

In our codebase, we have a function called `IsLocalOrRemoteService` with the following body:

```go
// IsLocalOrRemoteService checks if the identity is either a local or remote service.
func IsLocalOrRemoteService(authContext Context) bool {
	switch authContext.UnmappedIdentity.(type) {
	case BuiltinRole, RemoteBuiltinRole:
		return true
	default:
		return false
	}
}
```

Given that unauthenticated users were wrapped in `BuiltinRole`, this function would return true for them. This caused the encrypted recordings service to authorize unauthenticated clients to access the upload handlers. This was the only access check applied, so the bug allowed any client to upload and replace files in the backend storage.

This change fixes that by enforcing proper RBAC checks in the encrypted recordings `CreateUpload`, `UploadPart` and `CompleteUpload` handlers. It also forbids `RemoteBuiltinRole` (remote/leaf cluster identity) from uploading files to root clusters.

This change also moves RoleNop out of the `SystemRole` type and into a new distinct type, `UnauthenticatedRole`, so the compiler prevents it from being used anywhere a real authenticated system role is expected. As a defence-in-depth measure, the middleware now rejects any TLS certificate that claims the Nop role in its Groups or SystemRoles fields.

This PR fixes a separate issue on top of the existing one where certificate rotation of encrypted sessions was available to unauthenticated users.

The protection introduced was `authCtx.AuthorizeAdminAction()`, which verifies if someone has completed the MFA challenge (if required). That was the intended idea, but given how Teleport handles unauthenticated users, they were marked with AdminActionAuthNotRequired, which bypassed MFA checks. Because of that, any client - authenticated or unauthenticated - with the ability to complete the MFA challenge (or if MFA was not required) could rotate the encryption keys for session recordings.

This doesn't significantly affect Teleport since the private keys are never exposed externally and previous keys always remain in the backend object, allowing old recordings to still be decrypted. The main concern is if the keys were rotated so many times that the backend item size exceeds the 400KB limit on DynamoDB. While this would cause the rotation to fail beforehand, it would also prevent any further rotations from succeeding.

This PR introduces proper RBAC for modifying types.KindRecordingEncryption and ensures that unauthenticated users are always assigned AdminActionAuthNotRequired.

Fixes https://github.com/gravitational/teleport-private/issues/2430 
Fixes https://github.com/gravitational/teleport-private/issues/2429






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
