### PR TITLE
Fix AWS endpoint validation

### DIFF
--- a/api/utils/aws/endpoint.go
+++ b/api/utils/aws/endpoint.go
@@ -28,9 +28,11 @@ import (
 
 // IsAWSEndpoint returns true if the input URI is an AWS endpoint.
 func IsAWSEndpoint(uri string) bool {
-	// Note that AWSCNEndpointSuffix contains AWSEndpointSuffix so there is no
-	// need to search for AWSCNEndpointSuffix explicitly.
-	return strings.Contains(uri, AWSEndpointSuffix)
+	hostname, err := removeSchemaAndPort(uri)
+	if err != nil {
+		return false
+	}
+	return strings.HasSuffix(hostname, AWSEndpointSuffix) || strings.HasSuffix(hostname, AWSCNEndpointSuffix)
 }
 
 // IsRDSEndpoint returns true if the input URI is an RDS endpoint.
@@ -689,8 +691,7 @@ func ParseMemoryDBEndpoint(endpoint string) (*RedisEndpointInfo, error) {
 // isAWSServiceEndpoint returns true if uri is a valid AWS endpoint and uri
 // contains the provided service name as a subdomain.
 func isAWSServiceEndpoint(uri, serviceName string) bool {
-	return strings.Contains(uri, fmt.Sprintf(".%s.", serviceName)) &&
-		IsAWSEndpoint(uri)
+	return IsAWSEndpoint(uri) && strings.Contains(uri, fmt.Sprintf(".%s.", serviceName))
 }
 
 func removeSchemaAndPort(endpoint string) (string, error) {

--- a/api/utils/aws/endpoint_test.go
+++ b/api/utils/aws/endpoint_test.go
@@ -24,6 +24,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsAWSEndpoint(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, endpoint := range []string{
+			"aurora-instance-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com",
+			"example.amazonaws.com",
+			"foo.amazonaws.com.cn",
+			"example.amazonaws.com:12345", // port numbers must be allowed here
+		} {
+			require.True(t, IsAWSEndpoint(endpoint))
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		for _, endpoint := range []string{
+			"example.com",
+			"foo.amazonaws.com.cn.example.com",
+			"bad.amazonaws.com.example.com",
+		} {
+			require.False(t, IsAWSEndpoint(endpoint))
+		}
+	})
+}
+
 func TestParseRDSEndpoint(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -535,7 +557,6 @@ func TestCassandraEndpointRegion(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestRedshiftServerlessEndpoint(t *testing.T) {


### PR DESCRIPTION
We should always be checking for a suffix, not containment.






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
