### PR TITLE
[v18] DiscoveryConfig Status: add current and previous iteration

### DIFF
--- a/api/gen/proto/go/teleport/discoveryconfig/v1/discoveryconfig.pb.go
+++ b/api/gen/proto/go/teleport/discoveryconfig/v1/discoveryconfig.pb.go
@@ -25,6 +25,7 @@ import (
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -269,8 +270,10 @@ type DiscoveryConfigStatus struct {
 	LastSyncTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_sync_time,json=lastSyncTime,proto3" json:"last_sync_time,omitempty"`
 	// IntegrationDiscoveredResources maps an integration to discovered resources summary.
 	IntegrationDiscoveredResources map[string]*IntegrationDiscoveredSummary `protobuf:"bytes,6,rep,name=integration_discovered_resources,json=integrationDiscoveredResources,proto3" json:"integration_discovered_resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields                  protoimpl.UnknownFields
-	sizeCache                      protoimpl.SizeCache
+	// ServerStatus contains the status from each Discovery Service that is watching this Discovery Config.
+	ServerStatus  map[string]*DiscoveryStatusServer `protobuf:"bytes,7,rep,name=server_status,json=serverStatus,proto3" json:"server_status,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DiscoveryConfigStatus) Reset() {
@@ -338,6 +341,207 @@ func (x *DiscoveryConfigStatus) GetIntegrationDiscoveredResources() map[string]*
 	return nil
 }
 
+func (x *DiscoveryConfigStatus) GetServerStatus() map[string]*DiscoveryStatusServer {
+	if x != nil {
+		return x.ServerStatus
+	}
+	return nil
+}
+
+// DiscoveryStatusServer contains the status last reported by a server.
+type DiscoveryStatusServer struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// LastUpdate is the timestamp when the server last updated the status.
+	LastUpdate *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=last_update,json=lastUpdate,proto3" json:"last_update,omitempty"`
+	// PollInterval is the interval at which the server polls for new resources.
+	PollInterval *durationpb.Duration `protobuf:"bytes,2,opt,name=poll_interval,json=pollInterval,proto3" json:"poll_interval,omitempty"`
+	// IntegrationSummaries maps an integration to a summary of the discovered resources.
+	// An empty integration means that ambient credentials were used to discover the resources.
+	IntegrationSummaries map[string]*DiscoverSummary `protobuf:"bytes,3,rep,name=integration_summaries,json=integrationSummaries,proto3" json:"integration_summaries,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *DiscoveryStatusServer) Reset() {
+	*x = DiscoveryStatusServer{}
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscoveryStatusServer) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscoveryStatusServer) ProtoMessage() {}
+
+func (x *DiscoveryStatusServer) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscoveryStatusServer.ProtoReflect.Descriptor instead.
+func (*DiscoveryStatusServer) Descriptor() ([]byte, []int) {
+	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *DiscoveryStatusServer) GetLastUpdate() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastUpdate
+	}
+	return nil
+}
+
+func (x *DiscoveryStatusServer) GetPollInterval() *durationpb.Duration {
+	if x != nil {
+		return x.PollInterval
+	}
+	return nil
+}
+
+func (x *DiscoveryStatusServer) GetIntegrationSummaries() map[string]*DiscoverSummary {
+	if x != nil {
+		return x.IntegrationSummaries
+	}
+	return nil
+}
+
+// DiscoverSummary contains the per-resource-type discovery summary with current and previous iteration tracking.
+type DiscoverSummary struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// AWSEC2 contains the summary for the AWS EC2 discovered instances.
+	AwsEc2 *ResourceSummary `protobuf:"bytes,1,opt,name=aws_ec2,json=awsEc2,proto3" json:"aws_ec2,omitempty"`
+	// AWSRDS contains the summary for the AWS RDS discovered databases.
+	AwsRds *ResourceSummary `protobuf:"bytes,2,opt,name=aws_rds,json=awsRds,proto3" json:"aws_rds,omitempty"`
+	// AWSEKS contains the summary for the AWS EKS discovered clusters.
+	AwsEks *ResourceSummary `protobuf:"bytes,3,opt,name=aws_eks,json=awsEks,proto3" json:"aws_eks,omitempty"`
+	// The summary for the Azure VM discovered instances.
+	AzureVms      *ResourceSummary `protobuf:"bytes,4,opt,name=azure_vms,json=azureVms,proto3" json:"azure_vms,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiscoverSummary) Reset() {
+	*x = DiscoverSummary{}
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscoverSummary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscoverSummary) ProtoMessage() {}
+
+func (x *DiscoverSummary) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscoverSummary.ProtoReflect.Descriptor instead.
+func (*DiscoverSummary) Descriptor() ([]byte, []int) {
+	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *DiscoverSummary) GetAwsEc2() *ResourceSummary {
+	if x != nil {
+		return x.AwsEc2
+	}
+	return nil
+}
+
+func (x *DiscoverSummary) GetAwsRds() *ResourceSummary {
+	if x != nil {
+		return x.AwsRds
+	}
+	return nil
+}
+
+func (x *DiscoverSummary) GetAwsEks() *ResourceSummary {
+	if x != nil {
+		return x.AwsEks
+	}
+	return nil
+}
+
+func (x *DiscoverSummary) GetAzureVms() *ResourceSummary {
+	if x != nil {
+		return x.AzureVms
+	}
+	return nil
+}
+
+// ResourceSummary represents the summary of the discovered resources.
+type ResourceSummary struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Current holds the in-progress summary for the ongoing discovery iteration.
+	// Populated while sync is running, cleared when the iteration completes.
+	Current *ResourcesDiscoveredSummary `protobuf:"bytes,1,opt,name=current,proto3" json:"current,omitempty"`
+	// Previous holds the final summary from the last completed discovery iteration.
+	Previous      *ResourcesDiscoveredSummary `protobuf:"bytes,2,opt,name=previous,proto3" json:"previous,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResourceSummary) Reset() {
+	*x = ResourceSummary{}
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResourceSummary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResourceSummary) ProtoMessage() {}
+
+func (x *ResourceSummary) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResourceSummary.ProtoReflect.Descriptor instead.
+func (*ResourceSummary) Descriptor() ([]byte, []int) {
+	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ResourceSummary) GetCurrent() *ResourcesDiscoveredSummary {
+	if x != nil {
+		return x.Current
+	}
+	return nil
+}
+
+func (x *ResourceSummary) GetPrevious() *ResourcesDiscoveredSummary {
+	if x != nil {
+		return x.Previous
+	}
+	return nil
+}
+
 // IntegrationDiscoveredSummary contains the a summary for each resource type that was discovered.
 type IntegrationDiscoveredSummary struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -355,7 +559,7 @@ type IntegrationDiscoveredSummary struct {
 
 func (x *IntegrationDiscoveredSummary) Reset() {
 	*x = IntegrationDiscoveredSummary{}
-	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[3]
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -367,7 +571,7 @@ func (x *IntegrationDiscoveredSummary) String() string {
 func (*IntegrationDiscoveredSummary) ProtoMessage() {}
 
 func (x *IntegrationDiscoveredSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[3]
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -380,7 +584,7 @@ func (x *IntegrationDiscoveredSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IntegrationDiscoveredSummary.ProtoReflect.Descriptor instead.
 func (*IntegrationDiscoveredSummary) Descriptor() ([]byte, []int) {
-	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{3}
+	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *IntegrationDiscoveredSummary) GetAwsEc2() *ResourcesDiscoveredSummary {
@@ -431,7 +635,7 @@ type ResourcesDiscoveredSummary struct {
 
 func (x *ResourcesDiscoveredSummary) Reset() {
 	*x = ResourcesDiscoveredSummary{}
-	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[4]
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -443,7 +647,7 @@ func (x *ResourcesDiscoveredSummary) String() string {
 func (*ResourcesDiscoveredSummary) ProtoMessage() {}
 
 func (x *ResourcesDiscoveredSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[4]
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -456,7 +660,7 @@ func (x *ResourcesDiscoveredSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourcesDiscoveredSummary.ProtoReflect.Descriptor instead.
 func (*ResourcesDiscoveredSummary) Descriptor() ([]byte, []int) {
-	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{4}
+	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ResourcesDiscoveredSummary) GetFound() uint64 {
@@ -498,7 +702,7 @@ var File_teleport_discoveryconfig_v1_discoveryconfig_proto protoreflect.FileDesc
 
 const file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDesc = "" +
 	"\n" +
-	"1teleport/discoveryconfig/v1/discoveryconfig.proto\x12\x1bteleport.discoveryconfig.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/header/v1/resourceheader.proto\x1a!teleport/legacy/types/types.proto\"\xdf\x01\n" +
+	"1teleport/discoveryconfig/v1/discoveryconfig.proto\x12\x1bteleport.discoveryconfig.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a'teleport/header/v1/resourceheader.proto\x1a!teleport/legacy/types/types.proto\"\xdf\x01\n" +
 	"\x0fDiscoveryConfig\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x12D\n" +
 	"\x04spec\x18\x02 \x01(\v20.teleport.discoveryconfig.v1.DiscoveryConfigSpecR\x04spec\x12J\n" +
@@ -509,17 +713,37 @@ const file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDesc = "" +
 	"\x05azure\x18\x03 \x03(\v2\x13.types.AzureMatcherR\x05azure\x12#\n" +
 	"\x03gcp\x18\x04 \x03(\v2\x11.types.GCPMatcherR\x03gcp\x12,\n" +
 	"\x04kube\x18\x05 \x03(\v2\x18.types.KubernetesMatcherR\x04kube\x129\n" +
-	"\faccess_graph\x18\x06 \x01(\v2\x16.types.AccessGraphSyncR\vaccessGraph\"\xe7\x04\n" +
+	"\faccess_graph\x18\x06 \x01(\v2\x16.types.AccessGraphSyncR\vaccessGraph\"\xc7\x06\n" +
 	"\x15DiscoveryConfigStatus\x12G\n" +
 	"\x05state\x18\x01 \x01(\x0e21.teleport.discoveryconfig.v1.DiscoveryConfigStateR\x05state\x12(\n" +
 	"\rerror_message\x18\x02 \x01(\tH\x00R\ferrorMessage\x88\x01\x01\x121\n" +
 	"\x14discovered_resources\x18\x03 \x01(\x04R\x13discoveredResources\x12@\n" +
 	"\x0elast_sync_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncTime\x12\xa0\x01\n" +
-	" integration_discovered_resources\x18\x06 \x03(\v2V.teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntryR\x1eintegrationDiscoveredResources\x1a\x8c\x01\n" +
+	" integration_discovered_resources\x18\x06 \x03(\v2V.teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntryR\x1eintegrationDiscoveredResources\x12i\n" +
+	"\rserver_status\x18\a \x03(\v2D.teleport.discoveryconfig.v1.DiscoveryConfigStatus.ServerStatusEntryR\fserverStatus\x1a\x8c\x01\n" +
 	"#IntegrationDiscoveredResourcesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12O\n" +
-	"\x05value\x18\x02 \x01(\v29.teleport.discoveryconfig.v1.IntegrationDiscoveredSummaryR\x05value:\x028\x01B\x10\n" +
-	"\x0e_error_messageJ\x04\b\x05\x10\x06R\x1caws_ec2_instances_discovered\"\xea\x02\n" +
+	"\x05value\x18\x02 \x01(\v29.teleport.discoveryconfig.v1.IntegrationDiscoveredSummaryR\x05value:\x028\x01\x1as\n" +
+	"\x11ServerStatusEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12H\n" +
+	"\x05value\x18\x02 \x01(\v22.teleport.discoveryconfig.v1.DiscoveryStatusServerR\x05value:\x028\x01B\x10\n" +
+	"\x0e_error_messageJ\x04\b\x05\x10\x06R\x1caws_ec2_instances_discovered\"\x8f\x03\n" +
+	"\x15DiscoveryStatusServer\x12;\n" +
+	"\vlast_update\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"lastUpdate\x12>\n" +
+	"\rpoll_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\fpollInterval\x12\x81\x01\n" +
+	"\x15integration_summaries\x18\x03 \x03(\v2L.teleport.discoveryconfig.v1.DiscoveryStatusServer.IntegrationSummariesEntryR\x14integrationSummaries\x1au\n" +
+	"\x19IntegrationSummariesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12B\n" +
+	"\x05value\x18\x02 \x01(\v2,.teleport.discoveryconfig.v1.DiscoverSummaryR\x05value:\x028\x01\"\xb1\x02\n" +
+	"\x0fDiscoverSummary\x12E\n" +
+	"\aaws_ec2\x18\x01 \x01(\v2,.teleport.discoveryconfig.v1.ResourceSummaryR\x06awsEc2\x12E\n" +
+	"\aaws_rds\x18\x02 \x01(\v2,.teleport.discoveryconfig.v1.ResourceSummaryR\x06awsRds\x12E\n" +
+	"\aaws_eks\x18\x03 \x01(\v2,.teleport.discoveryconfig.v1.ResourceSummaryR\x06awsEks\x12I\n" +
+	"\tazure_vms\x18\x04 \x01(\v2,.teleport.discoveryconfig.v1.ResourceSummaryR\bazureVms\"\xb9\x01\n" +
+	"\x0fResourceSummary\x12Q\n" +
+	"\acurrent\x18\x01 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\acurrent\x12S\n" +
+	"\bprevious\x18\x02 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\bprevious\"\xea\x02\n" +
 	"\x1cIntegrationDiscoveredSummary\x12P\n" +
 	"\aaws_ec2\x18\x01 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\x06awsEc2\x12P\n" +
 	"\aaws_rds\x18\x02 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\x06awsRds\x12P\n" +
@@ -551,47 +775,65 @@ func file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP() []byte
 }
 
 var file_teleport_discoveryconfig_v1_discoveryconfig_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_teleport_discoveryconfig_v1_discoveryconfig_proto_goTypes = []any{
 	(DiscoveryConfigState)(0),            // 0: teleport.discoveryconfig.v1.DiscoveryConfigState
 	(*DiscoveryConfig)(nil),              // 1: teleport.discoveryconfig.v1.DiscoveryConfig
 	(*DiscoveryConfigSpec)(nil),          // 2: teleport.discoveryconfig.v1.DiscoveryConfigSpec
 	(*DiscoveryConfigStatus)(nil),        // 3: teleport.discoveryconfig.v1.DiscoveryConfigStatus
-	(*IntegrationDiscoveredSummary)(nil), // 4: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
-	(*ResourcesDiscoveredSummary)(nil),   // 5: teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	nil,                                  // 6: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry
-	(*v1.ResourceHeader)(nil),            // 7: teleport.header.v1.ResourceHeader
-	(*types.AWSMatcher)(nil),             // 8: types.AWSMatcher
-	(*types.AzureMatcher)(nil),           // 9: types.AzureMatcher
-	(*types.GCPMatcher)(nil),             // 10: types.GCPMatcher
-	(*types.KubernetesMatcher)(nil),      // 11: types.KubernetesMatcher
-	(*types.AccessGraphSync)(nil),        // 12: types.AccessGraphSync
-	(*timestamppb.Timestamp)(nil),        // 13: google.protobuf.Timestamp
+	(*DiscoveryStatusServer)(nil),        // 4: teleport.discoveryconfig.v1.DiscoveryStatusServer
+	(*DiscoverSummary)(nil),              // 5: teleport.discoveryconfig.v1.DiscoverSummary
+	(*ResourceSummary)(nil),              // 6: teleport.discoveryconfig.v1.ResourceSummary
+	(*IntegrationDiscoveredSummary)(nil), // 7: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
+	(*ResourcesDiscoveredSummary)(nil),   // 8: teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	nil,                                  // 9: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry
+	nil,                                  // 10: teleport.discoveryconfig.v1.DiscoveryConfigStatus.ServerStatusEntry
+	nil,                                  // 11: teleport.discoveryconfig.v1.DiscoveryStatusServer.IntegrationSummariesEntry
+	(*v1.ResourceHeader)(nil),            // 12: teleport.header.v1.ResourceHeader
+	(*types.AWSMatcher)(nil),             // 13: types.AWSMatcher
+	(*types.AzureMatcher)(nil),           // 14: types.AzureMatcher
+	(*types.GCPMatcher)(nil),             // 15: types.GCPMatcher
+	(*types.KubernetesMatcher)(nil),      // 16: types.KubernetesMatcher
+	(*types.AccessGraphSync)(nil),        // 17: types.AccessGraphSync
+	(*timestamppb.Timestamp)(nil),        // 18: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),          // 19: google.protobuf.Duration
 }
 var file_teleport_discoveryconfig_v1_discoveryconfig_proto_depIdxs = []int32{
-	7,  // 0: teleport.discoveryconfig.v1.DiscoveryConfig.header:type_name -> teleport.header.v1.ResourceHeader
+	12, // 0: teleport.discoveryconfig.v1.DiscoveryConfig.header:type_name -> teleport.header.v1.ResourceHeader
 	2,  // 1: teleport.discoveryconfig.v1.DiscoveryConfig.spec:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigSpec
 	3,  // 2: teleport.discoveryconfig.v1.DiscoveryConfig.status:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigStatus
-	8,  // 3: teleport.discoveryconfig.v1.DiscoveryConfigSpec.aws:type_name -> types.AWSMatcher
-	9,  // 4: teleport.discoveryconfig.v1.DiscoveryConfigSpec.azure:type_name -> types.AzureMatcher
-	10, // 5: teleport.discoveryconfig.v1.DiscoveryConfigSpec.gcp:type_name -> types.GCPMatcher
-	11, // 6: teleport.discoveryconfig.v1.DiscoveryConfigSpec.kube:type_name -> types.KubernetesMatcher
-	12, // 7: teleport.discoveryconfig.v1.DiscoveryConfigSpec.access_graph:type_name -> types.AccessGraphSync
+	13, // 3: teleport.discoveryconfig.v1.DiscoveryConfigSpec.aws:type_name -> types.AWSMatcher
+	14, // 4: teleport.discoveryconfig.v1.DiscoveryConfigSpec.azure:type_name -> types.AzureMatcher
+	15, // 5: teleport.discoveryconfig.v1.DiscoveryConfigSpec.gcp:type_name -> types.GCPMatcher
+	16, // 6: teleport.discoveryconfig.v1.DiscoveryConfigSpec.kube:type_name -> types.KubernetesMatcher
+	17, // 7: teleport.discoveryconfig.v1.DiscoveryConfigSpec.access_graph:type_name -> types.AccessGraphSync
 	0,  // 8: teleport.discoveryconfig.v1.DiscoveryConfigStatus.state:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigState
-	13, // 9: teleport.discoveryconfig.v1.DiscoveryConfigStatus.last_sync_time:type_name -> google.protobuf.Timestamp
-	6,  // 10: teleport.discoveryconfig.v1.DiscoveryConfigStatus.integration_discovered_resources:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry
-	5,  // 11: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_ec2:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	5,  // 12: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_rds:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	5,  // 13: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_eks:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	5,  // 14: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.azure_vms:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	13, // 15: teleport.discoveryconfig.v1.ResourcesDiscoveredSummary.sync_start:type_name -> google.protobuf.Timestamp
-	13, // 16: teleport.discoveryconfig.v1.ResourcesDiscoveredSummary.sync_end:type_name -> google.protobuf.Timestamp
-	4,  // 17: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry.value:type_name -> teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
-	18, // [18:18] is the sub-list for method output_type
-	18, // [18:18] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	18, // 9: teleport.discoveryconfig.v1.DiscoveryConfigStatus.last_sync_time:type_name -> google.protobuf.Timestamp
+	9,  // 10: teleport.discoveryconfig.v1.DiscoveryConfigStatus.integration_discovered_resources:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry
+	10, // 11: teleport.discoveryconfig.v1.DiscoveryConfigStatus.server_status:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigStatus.ServerStatusEntry
+	18, // 12: teleport.discoveryconfig.v1.DiscoveryStatusServer.last_update:type_name -> google.protobuf.Timestamp
+	19, // 13: teleport.discoveryconfig.v1.DiscoveryStatusServer.poll_interval:type_name -> google.protobuf.Duration
+	11, // 14: teleport.discoveryconfig.v1.DiscoveryStatusServer.integration_summaries:type_name -> teleport.discoveryconfig.v1.DiscoveryStatusServer.IntegrationSummariesEntry
+	6,  // 15: teleport.discoveryconfig.v1.DiscoverSummary.aws_ec2:type_name -> teleport.discoveryconfig.v1.ResourceSummary
+	6,  // 16: teleport.discoveryconfig.v1.DiscoverSummary.aws_rds:type_name -> teleport.discoveryconfig.v1.ResourceSummary
+	6,  // 17: teleport.discoveryconfig.v1.DiscoverSummary.aws_eks:type_name -> teleport.discoveryconfig.v1.ResourceSummary
+	6,  // 18: teleport.discoveryconfig.v1.DiscoverSummary.azure_vms:type_name -> teleport.discoveryconfig.v1.ResourceSummary
+	8,  // 19: teleport.discoveryconfig.v1.ResourceSummary.current:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	8,  // 20: teleport.discoveryconfig.v1.ResourceSummary.previous:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	8,  // 21: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_ec2:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	8,  // 22: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_rds:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	8,  // 23: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_eks:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	8,  // 24: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.azure_vms:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	18, // 25: teleport.discoveryconfig.v1.ResourcesDiscoveredSummary.sync_start:type_name -> google.protobuf.Timestamp
+	18, // 26: teleport.discoveryconfig.v1.ResourcesDiscoveredSummary.sync_end:type_name -> google.protobuf.Timestamp
+	7,  // 27: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry.value:type_name -> teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
+	4,  // 28: teleport.discoveryconfig.v1.DiscoveryConfigStatus.ServerStatusEntry.value:type_name -> teleport.discoveryconfig.v1.DiscoveryStatusServer
+	5,  // 29: teleport.discoveryconfig.v1.DiscoveryStatusServer.IntegrationSummariesEntry.value:type_name -> teleport.discoveryconfig.v1.DiscoverSummary
+	30, // [30:30] is the sub-list for method output_type
+	30, // [30:30] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_teleport_discoveryconfig_v1_discoveryconfig_proto_init() }
@@ -606,7 +848,7 @@ func file_teleport_discoveryconfig_v1_discoveryconfig_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDesc), len(file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   6,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/discoveryconfig/v1/discoveryconfig.proto
+++ b/api/proto/teleport/discoveryconfig/v1/discoveryconfig.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package teleport.discoveryconfig.v1;
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "teleport/header/v1/resourceheader.proto";
 import "teleport/legacy/types/types.proto";
@@ -72,6 +73,9 @@ message DiscoveryConfigStatus {
 
   // IntegrationDiscoveredResources maps an integration to discovered resources summary.
   map<string, IntegrationDiscoveredSummary> integration_discovered_resources = 6;
+
+  // ServerStatus contains the status from each Discovery Service that is watching this Discovery Config.
+  map<string, DiscoveryStatusServer> server_status = 7;
 }
 
 // DiscoveryConfigState is the state of the discovery config resource.
@@ -85,6 +89,41 @@ enum DiscoveryConfigState {
   DISCOVERY_CONFIG_STATE_ERROR = 2;
   // DISCOVERY_CONFIG_STATE_SYNCING is used when the discovery process has started but didn't finished yet.
   DISCOVERY_CONFIG_STATE_SYNCING = 3;
+}
+
+// DiscoveryStatusServer contains the status last reported by a server.
+message DiscoveryStatusServer {
+  // LastUpdate is the timestamp when the server last updated the status.
+  google.protobuf.Timestamp last_update = 1;
+  // PollInterval is the interval at which the server polls for new resources.
+  google.protobuf.Duration poll_interval = 2;
+  // IntegrationSummaries maps an integration to a summary of the discovered resources.
+  // An empty integration means that ambient credentials were used to discover the resources.
+  map<string, DiscoverSummary> integration_summaries = 3;
+}
+
+// DiscoverSummary contains the per-resource-type discovery summary with current and previous iteration tracking.
+message DiscoverSummary {
+  // AWSEC2 contains the summary for the AWS EC2 discovered instances.
+  ResourceSummary aws_ec2 = 1;
+
+  // AWSRDS contains the summary for the AWS RDS discovered databases.
+  ResourceSummary aws_rds = 2;
+
+  // AWSEKS contains the summary for the AWS EKS discovered clusters.
+  ResourceSummary aws_eks = 3;
+
+  // The summary for the Azure VM discovered instances.
+  ResourceSummary azure_vms = 4;
+}
+
+// ResourceSummary represents the summary of the discovered resources.
+message ResourceSummary {
+  // Current holds the in-progress summary for the ongoing discovery iteration.
+  // Populated while sync is running, cleared when the iteration completes.
+  ResourcesDiscoveredSummary current = 1;
+  // Previous holds the final summary from the last completed discovery iteration.
+  ResourcesDiscoveredSummary previous = 2;
 }
 
 // IntegrationDiscoveredSummary contains the a summary for each resource type that was discovered.

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig.go
@@ -96,12 +96,19 @@ func StatusFromProto(msg *discoveryconfigv1.DiscoveryConfigStatus) discoveryconf
 		}
 	}
 
+	serverStatus := make(map[string]*discoveryconfig.DiscoveryStatusServer, len(msg.ServerStatus))
+	for k, v := range msg.ServerStatus {
+		serverStatus[k] = &discoveryconfig.DiscoveryStatusServer{
+			DiscoveryStatusServer: v,
+		}
+	}
 	return discoveryconfig.Status{
 		State:                          discoveryconfigv1.DiscoveryConfigState_name[int32(msg.State)],
 		ErrorMessage:                   msg.ErrorMessage,
 		DiscoveredResources:            msg.GetDiscoveredResources(),
 		LastSyncTime:                   lastSyncTime,
 		IntegrationDiscoveredResources: integrationDiscoveredResources,
+		ServerStatus:                   serverStatus,
 	}
 }
 
@@ -154,7 +161,21 @@ func StatusToProto(status discoveryconfig.Status) *discoveryconfigv1.DiscoveryCo
 		if v == nil {
 			v = &discoveryconfig.IntegrationDiscoveredSummary{}
 		}
+		if v.IntegrationDiscoveredSummary == nil {
+			v.IntegrationDiscoveredSummary = &discoveryconfigv1.IntegrationDiscoveredSummary{}
+		}
 		integrationDiscoveredResources[k] = v.IntegrationDiscoveredSummary
+	}
+
+	serverStatus := make(map[string]*discoveryconfigv1.DiscoveryStatusServer, len(status.ServerStatus))
+	for k, v := range status.ServerStatus {
+		if v == nil {
+			v = &discoveryconfig.DiscoveryStatusServer{}
+		}
+		if v.DiscoveryStatusServer == nil {
+			v.DiscoveryStatusServer = &discoveryconfigv1.DiscoveryStatusServer{}
+		}
+		serverStatus[k] = v.DiscoveryStatusServer
 	}
 
 	return &discoveryconfigv1.DiscoveryConfigStatus{
@@ -163,5 +184,6 @@ func StatusToProto(status discoveryconfig.Status) *discoveryconfigv1.DiscoveryCo
 		DiscoveredResources:            status.DiscoveredResources,
 		LastSyncTime:                   lastSyncTime,
 		IntegrationDiscoveredResources: integrationDiscoveredResources,
+		ServerStatus:                   serverStatus,
 	}
 }

--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -86,6 +86,8 @@ type Status struct {
 	LastSyncTime time.Time `json:"last_sync_time,omitempty" yaml:"last_sync_time,omitempty"`
 	// IntegrationDiscoveredResources maps an integration to a summary of resources that were found using that integration.
 	IntegrationDiscoveredResources map[string]*IntegrationDiscoveredSummary `json:"integration_discovered_resources,omitempty" yaml:"integration_discovered_resources,omitempty"`
+	// ServerStatus tracks the discovery iteration status for multiple discovery servers, keyed by Server ID.
+	ServerStatus map[string]*DiscoveryStatusServer `json:"server_status,omitempty" yaml:"server_status,omitempty"`
 }
 
 // NewDiscoveryConfig will create a new discovery config.
@@ -124,6 +126,30 @@ func (s *IntegrationDiscoveredSummary) UnmarshalJSON(data []byte) error {
 	return protojson.UnmarshalOptions{
 		DiscardUnknown: true,
 	}.Unmarshal(data, s.IntegrationDiscoveredSummary)
+}
+
+// ServerStatus holds the status of a discovery server.
+type DiscoveryStatusServer struct {
+	*discoveryconfigv1.DiscoveryStatusServer
+}
+
+// MarshalJSON marshals the ServerStatus into JSON.
+func (s *DiscoveryStatusServer) MarshalJSON() ([]byte, error) {
+	if s == nil {
+		s = &DiscoveryStatusServer{}
+	}
+	return protojson.Marshal(s.DiscoveryStatusServer)
+}
+
+// UnmarshalJSON unmarshals JSON data into the ServerStatus.
+func (s *DiscoveryStatusServer) UnmarshalJSON(data []byte) error {
+	if s.DiscoveryStatusServer == nil {
+		s.DiscoveryStatusServer = &discoveryconfigv1.DiscoveryStatusServer{}
+	}
+
+	return protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}.Unmarshal(data, s.DiscoveryStatusServer)
 }
 
 // CheckAndSetDefaults validates fields and populates empty fields with default values.

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
@@ -511,6 +511,49 @@ integration: "string"
 |tags|Azure tags on resources to match.|[Labels](#labels)|
 |types|Azure types to match: "mysql", "postgres", "aks", "vm"|[]string|
 
+## Discover Summary
+
+Contains the per-resource-type discovery summary with current and previous iteration tracking.
+
+
+Example:
+
+```yaml
+aws_ec2: # [...]
+aws_rds: # [...]
+aws_eks: # [...]
+azure_vms: # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|aws_ec2|AWSEC2 contains the summary for the AWS EC2 discovered instances.|[Resource Summary](#resource-summary)|
+|aws_eks|AWSEKS contains the summary for the AWS EKS discovered clusters.|[Resource Summary](#resource-summary)|
+|aws_rds|AWSRDS contains the summary for the AWS RDS discovered databases.|[Resource Summary](#resource-summary)|
+|azure_vms|The summary for the Azure VM discovered instances.|[Resource Summary](#resource-summary)|
+
+## Discovery Status Server
+
+ServerStatus holds the status of a discovery server.
+
+
+Example:
+
+```yaml
+last_update: # See description
+poll_interval: # See description
+integration_summaries: 
+  "string": # [...]
+  "string": # [...]
+  "string": # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|integration_summaries|Maps an integration to a summary of the discovered resources. An empty integration means that ambient credentials were used to discover the resources.|map[string][Discover Summary](#discover-summary)|
+|last_update|The timestamp when the server last updated the status.||
+|poll_interval|The interval at which the server polls for new resources.||
+
 ## GCP Matcher
 
 Matches GCP resources.
@@ -691,6 +734,23 @@ revision: "string"
 |name|An object name|string|
 |revision|An opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.|string|
 
+## Resource Summary
+
+Represents the summary of the discovered resources.
+
+
+Example:
+
+```yaml
+current: # [...]
+previous: # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|current|Holds the in-progress summary for the ongoing discovery iteration. Populated while sync is running, cleared when the iteration completes.|[Resources Discovered Summary](#resources-discovered-summary)|
+|previous|Holds the final summary from the last completed discovery iteration.|[Resources Discovered Summary](#resources-discovered-summary)|
+
 ## Resources Discovered Summary
 
 Represents the AWS resources that were discovered.
@@ -767,6 +827,10 @@ integration_discovered_resources:
   "string": # [...]
   "string": # [...]
   "string": # [...]
+server_status: 
+  "string": # [...]
+  "string": # [...]
+  "string": # [...]
 ```
 
 |Field Name|Description|Type|
@@ -775,5 +839,6 @@ integration_discovered_resources:
 |error_message|Holds the error message when state is DISCOVERY_CONFIG_STATE_ERROR.|string|
 |integration_discovered_resources|Maps an integration to a summary of resources that were found using that integration.|map[string][Integration Discovered Summary](#integration-discovered-summary)|
 |last_sync_time|The timestamp when the Discovery Config was last sync.||
+|server_status|Tracks the discovery iteration status for multiple discovery servers, keyed by Server ID.|map[string][Discovery Status Server](#discovery-status-server)|
 |state|The current state of the discovery config.|string|
 

--- a/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
+++ b/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
@@ -36,6 +36,7 @@ import (
 	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	github_com_hashicorp_terraform_plugin_framework_types "github.com/hashicorp/terraform-plugin-framework/types"
 	github_com_hashicorp_terraform_plugin_go_tftypes "github.com/hashicorp/terraform-plugin-go/tftypes"
+	_ "google.golang.org/protobuf/types/known/durationpb"
 	_ "google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -876,8 +876,8 @@ type ReadDiscoveryAccessPoint interface {
 	// GetApp returns the specified application resource.
 	GetApp(ctx context.Context, name string) (types.Application, error)
 
-	// ListDiscoveryConfigs returns a paginated list of Discovery Config resources.
-	ListDiscoveryConfigs(ctx context.Context, pageSize int, nextKey string) ([]*discoveryconfig.DiscoveryConfig, string, error)
+	// DiscoveryConfigsGetter lists and reads discovery config resources.
+	services.DiscoveryConfigsGetter
 
 	// GetIntegration returns the specified integration resource.
 	GetIntegration(ctx context.Context, name string) (types.Integration, error)
@@ -1761,6 +1761,12 @@ func (w *DiscoveryWrapper) Ping(ctx context.Context) (proto.PingResponse, error)
 // UpdateDiscoveryConfigStatus updates the status of a discovery config.
 func (w *DiscoveryWrapper) UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error) {
 	return w.NoCache.UpdateDiscoveryConfigStatus(ctx, name, status)
+}
+
+// GetDiscoveryConfig retrieves a discovery config by name.
+// This method is not cached to ensure that updating the DiscoveryConfig Status does not use (possibly) stale cache data.
+func (w *DiscoveryWrapper) GetDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error) {
+	return w.NoCache.GetDiscoveryConfig(ctx, name)
 }
 
 // UpserUserTask creates or updates an User Task.

--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -23,10 +23,14 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	aws_sync "github.com/gravitational/teleport/lib/srv/discovery/fetchers/aws-sync"
 )
@@ -34,6 +38,19 @@ import (
 func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 	testErr := "test error"
 	clock := clockwork.NewFakeClock()
+
+	baseServerStatusFn := func() map[string]*discoveryconfig.DiscoveryStatusServer {
+		return map[string]*discoveryconfig.DiscoveryStatusServer{
+			"server-id": {
+				DiscoveryStatusServer: &discoveryconfigv1.DiscoveryStatusServer{
+					IntegrationSummaries: map[string]*discoveryconfigv1.DiscoverSummary{},
+					LastUpdate:           timestamppb.New(clock.Now()),
+					PollInterval:         durationpb.New(time.Minute),
+				},
+			},
+		}
+	}
+
 	type args struct {
 		fetchers []*fakeFetcher
 		pushErr  error
@@ -62,6 +79,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						DiscoveredResources:            1,
 						LastSyncTime:                   clock.Now(),
 						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
+						ServerStatus:                   baseServerStatusFn(),
 					},
 				},
 			},
@@ -86,6 +104,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						DiscoveredResources:            1,
 						LastSyncTime:                   clock.Now(),
 						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
+						ServerStatus:                   baseServerStatusFn(),
 					},
 				},
 			},
@@ -109,6 +128,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						DiscoveredResources:            1,
 						LastSyncTime:                   clock.Now(),
 						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
+						ServerStatus:                   baseServerStatusFn(),
 					},
 				},
 			},
@@ -142,6 +162,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						DiscoveredResources:            0,
 						LastSyncTime:                   clock.Now(),
 						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
+						ServerStatus:                   baseServerStatusFn(),
 					},
 				},
 			},
@@ -172,6 +193,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						DiscoveredResources:            2,
 						LastSyncTime:                   clock.Now(),
 						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
+						ServerStatus:                   baseServerStatusFn(),
 					},
 				},
 				"test2": {
@@ -181,6 +203,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						DiscoveredResources:            1,
 						LastSyncTime:                   clock.Now(),
 						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
+						ServerStatus:                   baseServerStatusFn(),
 					},
 				},
 			},
@@ -206,6 +229,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						ErrorMessage:                   stringPointer("error in fetcher 1\nerror in fetcher 2"),
 						LastSyncTime:                   clock.Now(),
 						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
+						ServerStatus:                   baseServerStatusFn(),
 					},
 				},
 			},
@@ -232,6 +256,7 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 						DiscoveredResources:            2,
 						LastSyncTime:                   clock.Now(),
 						IntegrationDiscoveredResources: make(map[string]*discoveryconfig.IntegrationDiscoveredSummary),
+						ServerStatus:                   baseServerStatusFn(),
 					},
 				},
 			},
@@ -243,8 +268,10 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 			s := &Server{
 				ctx: context.Background(),
 				Config: &Config{
-					AccessPoint: accessPoint,
-					clock:       clock,
+					AccessPoint:  accessPoint,
+					ServerID:     "server-id",
+					PollInterval: time.Minute,
+					clock:        clock,
 				},
 				tagSyncStatus: newTagSyncStatus(),
 			}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -529,6 +529,10 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 	return s, nil
 }
 
+func (s *Server) newDiscoveryConfigStatusUpdaterFromServer() *discoveryConfigStatusUpdater {
+	return newDiscoveryConfigStatusUpdater(s.Config)
+}
+
 func (s *Server) runDynamicMatchersWatcher(ctx context.Context) error {
 	watcher, err := s.AccessPoint.NewWatcher(ctx, types.Watch{
 		Kinds: []types.WatchKind{{

--- a/lib/srv/discovery/discovery_eks_test.go
+++ b/lib/srv/discovery/discovery_eks_test.go
@@ -473,6 +473,15 @@ func (m *mockAuthServer) UpsertUserTask(ctx context.Context, req *usertasksv1.Us
 	return req, nil
 }
 
+func (m *mockAuthServer) GetDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error) {
+	m.storeDiscoveryConfigsMu.RLock()
+	defer m.storeDiscoveryConfigsMu.RUnlock()
+	if dc, ok := m.storeDiscoveryConfigs[name]; ok {
+		return dc.Clone(), nil
+	}
+	return nil, trace.NotFound("discovery config %q not found", name)
+}
+
 type mockEKSClusterEnroller struct {
 	resp *integrationpb.EnrollEKSClustersResponse
 	err  error

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -4039,17 +4039,38 @@ type fakeAccessPoint struct {
 	app                 types.Application
 	upsertedServerInfos chan types.ServerInfo
 	reports             map[string][]discoveryconfig.Status
+	discoveryConfigsMu  sync.RWMutex
+	discoveryConfigs    map[string]*discoveryconfig.DiscoveryConfig
+
+	mtx sync.Mutex
 }
 
 func (f *fakeAccessPoint) UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error) {
 	f.reports[name] = append(f.reports[name], status)
-	return nil, nil
+
+	f.discoveryConfigsMu.Lock()
+	defer f.discoveryConfigsMu.Unlock()
+	if _, ok := f.discoveryConfigs[name]; !ok {
+		f.discoveryConfigs[name] = &discoveryconfig.DiscoveryConfig{}
+	}
+	f.discoveryConfigs[name].Status = status
+	return f.discoveryConfigs[name], nil
+}
+
+func (f *fakeAccessPoint) GetDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error) {
+	f.discoveryConfigsMu.RLock()
+	defer f.discoveryConfigsMu.RUnlock()
+	if config, ok := f.discoveryConfigs[name]; ok {
+		return config, nil
+	}
+	return nil, trace.NotFound("not found")
 }
 
 func newFakeAccessPoint() *fakeAccessPoint {
 	return &fakeAccessPoint{
 		upsertedServerInfos: make(chan types.ServerInfo),
 		reports:             make(map[string][]discoveryconfig.Status),
+		discoveryConfigs:    make(map[string]*discoveryconfig.DiscoveryConfig),
 	}
 }
 
@@ -4120,6 +4141,18 @@ func (f *fakeAccessPoint) NewWatcher(ctx context.Context, watch types.Watch) (ty
 		return f.DiscoveryAccessPoint.NewWatcher(ctx, watch)
 	}
 	return newFakeWatcher(), nil
+}
+
+func (m *fakeAccessPoint) AcquireSemaphore(ctx context.Context, params types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
+	if !m.mtx.TryLock() {
+		return nil, trace.LimitExceeded("semaphore is already locked")
+	}
+	return &types.SemaphoreLease{Expires: params.Expires}, nil
+}
+
+func (m *fakeAccessPoint) CancelSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
+	m.mtx.Unlock()
+	return nil
 }
 
 type fakeWatcher struct{}

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -92,18 +92,9 @@ func (s *Server) updateDiscoveryConfigStatus(discoveryConfigNames ...string) {
 		// Too large error messages will cause failures when clients (which use the default MaxCallRecvMsgSize of 4MB) try to read DiscoveryConfigs.
 		discoveryConfigStatus.ErrorMessage = truncateErrorMessage(discoveryConfigStatus)
 
-		func() {
-			ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
-			defer cancel()
-
-			_, err := s.AccessPoint.UpdateDiscoveryConfigStatus(ctx, discoveryConfigName, discoveryConfigStatus)
-			switch {
-			case trace.IsNotImplemented(err):
-				s.Log.WarnContext(ctx, "UpdateDiscoveryConfigStatus method is not implemented in Auth Server. Please upgrade it to a recent version.")
-			case err != nil:
-				s.Log.WarnContext(ctx, "Error updating discovery config status", "discovery_config_name", discoveryConfigName, "error", err)
-			}
-		}()
+		if err := s.newDiscoveryConfigStatusUpdaterFromServer().update(s.ctx, discoveryConfigName, discoveryConfigStatus); err != nil {
+			s.Log.WarnContext(s.ctx, "Failed to update discovery config status", "discovery_config_name", discoveryConfigName, "error", err)
+		}
 	}
 }
 

--- a/lib/srv/discovery/status_updater.go
+++ b/lib/srv/discovery/status_updater.go
@@ -1,0 +1,232 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
+)
+
+type discoveryConfigService interface {
+	// GetDiscoveryConfig returns the DiscoveryConfig resource with the given name.
+	GetDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error)
+	// UpdateDiscoveryConfigStatus updates the Status field of the DiscoveryConfig resource with the given name.
+	UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error)
+}
+
+type discoveryConfigStatusUpdater struct {
+	log                    *slog.Logger
+	pollInterval           time.Duration
+	serverID               string
+	clock                  clockwork.Clock
+	semaphoreService       types.Semaphores
+	discoveryConfigService discoveryConfigService
+}
+
+func newDiscoveryConfigStatusUpdater(cfg *Config) *discoveryConfigStatusUpdater {
+	return &discoveryConfigStatusUpdater{
+		log:                    cfg.Log,
+		pollInterval:           cfg.PollInterval,
+		serverID:               cfg.ServerID,
+		clock:                  cfg.clock,
+		semaphoreService:       cfg.AccessPoint,
+		discoveryConfigService: cfg.AccessPoint,
+	}
+}
+
+// acquireSemaphoreDiscoveryConfigStatusUpdate tries to acquire a semaphore lock for this discovery config.
+// It returns a func which must be called to release the lock.
+// It also returns a context which is tied to the lease and will be canceled if the lease ends.
+func (s *discoveryConfigStatusUpdater) acquireSemaphoreDiscoveryConfigStatusUpdate(ctx context.Context, discoveryConfigName string) (releaseFn func(), contextWithLease context.Context, err error) {
+	const semaphoreExpiration = 10 * time.Second
+
+	// AcquireSemaphoreLock will retry until the semaphore is acquired.
+	// This prevents multiple discovery services from writing DiscoveryConfig Status resources in parallel.
+	// lease must be released to cleanup the resource in auth server.
+	lease, err := services.AcquireSemaphoreLockWithRetry(
+		ctx,
+		services.SemaphoreLockConfigWithRetry{
+			SemaphoreLockConfig: services.SemaphoreLockConfig{
+				Service: s.semaphoreService,
+				Params: types.AcquireSemaphoreRequest{
+					SemaphoreKind: types.KindDiscoveryConfig,
+					SemaphoreName: discoveryConfigName,
+					MaxLeases:     1,
+					Holder:        s.serverID,
+				},
+				Expiry: semaphoreExpiration,
+				Clock:  s.clock,
+			},
+			Retry: retryutils.LinearConfig{
+				Clock:  s.clock,
+				First:  time.Second,
+				Step:   semaphoreExpiration / 2,
+				Max:    semaphoreExpiration,
+				Jitter: retryutils.DefaultJitter,
+			},
+		},
+	)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	ctxWithLease, cancel := context.WithCancel(lease)
+	releaseFn = func() {
+		cancel()
+		lease.Stop()
+		if err := lease.Wait(); err != nil {
+			s.log.WarnContext(ctx, "Error cleaning up DiscoveryConfig Status semaphore",
+				"semaphore", discoveryConfigName,
+				"error", err,
+			)
+		}
+	}
+
+	return releaseFn, ctxWithLease, nil
+}
+
+// update updates a DiscoveryConfig's status in the backend.
+// A semaphore lock is acquired to perform a read-modify-write, ensuring concurrent Discovery Services don't overwrite each other's server iteration history.
+func (s *discoveryConfigStatusUpdater) update(ctx context.Context, discoveryConfigName string, discoveryConfigStatus discoveryconfig.Status) error {
+	releaseFn, leaseCtx, err := s.acquireSemaphoreDiscoveryConfigStatusUpdate(ctx, discoveryConfigName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer releaseFn()
+
+	existingDiscoveryConfig, err := s.discoveryConfigService.GetDiscoveryConfig(leaseCtx, discoveryConfigName)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+
+	discoveryConfigStatus = s.updateServerStatus(discoveryConfigStatus, existingDiscoveryConfig)
+
+	if _, err := s.discoveryConfigService.UpdateDiscoveryConfigStatus(leaseCtx, discoveryConfigName, discoveryConfigStatus); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// updateServerStatus merges this server's integration summaries into the DiscoveryConfig status, preserving other servers' iteration history.
+func (s *discoveryConfigStatusUpdater) updateServerStatus(status discoveryconfig.Status, existingDiscoveryConfig *discoveryconfig.DiscoveryConfig) discoveryconfig.Status {
+	existingServerStatuses := existingServerStatuses(existingDiscoveryConfig)
+
+	// Build this server's iteration history by merging each integration's current summary with its previous state.
+	integrationSummaries := make(map[string]*discoveryconfigv1.DiscoverSummary, len(status.IntegrationDiscoveredResources))
+	for integration, currentDiscoverSummary := range status.IntegrationDiscoveredResources {
+		previousSummary := existingDiscoverSummary(s.serverID, integration, existingServerStatuses)
+
+		integrationSummaries[integration] = &discoveryconfigv1.DiscoverSummary{
+			AwsEc2:   mergeResourceSummary(currentDiscoverSummary.GetAwsEc2(), previousSummary.GetAwsEc2()),
+			AwsRds:   mergeResourceSummary(currentDiscoverSummary.GetAwsRds(), previousSummary.GetAwsRds()),
+			AwsEks:   mergeResourceSummary(currentDiscoverSummary.GetAwsEks(), previousSummary.GetAwsEks()),
+			AzureVms: mergeResourceSummary(currentDiscoverSummary.GetAzureVms(), previousSummary.GetAzureVms()),
+		}
+	}
+
+	status.ServerStatus = map[string]*discoveryconfig.DiscoveryStatusServer{
+		s.serverID: {
+			DiscoveryStatusServer: &discoveryconfigv1.DiscoveryStatusServer{
+				IntegrationSummaries: integrationSummaries,
+				LastUpdate:           timestamppb.New(s.clock.Now()),
+				PollInterval:         durationpb.New(s.pollInterval),
+			},
+		},
+	}
+
+	// If multiple servers are discovering resources for this DiscoveryConfig, don't change their status report.
+	// This call is protected by a semaphore lock, so statuses are not overridden by other services.
+	for existingServerID, existingServerStatus := range existingServerStatuses {
+		if s.serverID != existingServerID {
+			if staleServerStatus(s.clock.Now(), existingServerStatus) {
+				continue
+			}
+
+			status.ServerStatus[existingServerID] = &discoveryconfig.DiscoveryStatusServer{
+				DiscoveryStatusServer: existingServerStatus.DiscoveryStatusServer,
+			}
+		}
+	}
+	return status
+}
+
+// staleServerStatus determines whether the existing summary for a server is stale.
+// The summary may be discarded if the server has not updated its status for a long time, indicating that it may be down and its status is stale.
+func staleServerStatus(now time.Time, existingServerStatus *discoveryconfig.DiscoveryStatusServer) bool {
+	serverPollInterval := existingServerStatus.GetPollInterval().AsDuration()
+	if serverPollInterval <= 0 {
+		serverPollInterval = common.DefaultDiscoveryPollInterval
+	}
+	tooOldThreshold := now.Add(-10 * serverPollInterval)
+	return existingServerStatus.GetLastUpdate().AsTime().Before(tooOldThreshold)
+}
+
+func mergeResourceSummary(summary *discoveryconfigv1.ResourcesDiscoveredSummary, existingSummary *discoveryconfigv1.ResourceSummary) *discoveryconfigv1.ResourceSummary {
+	if summary == nil {
+		return nil
+	}
+
+	if summary.GetSyncEnd() != nil {
+		return &discoveryconfigv1.ResourceSummary{
+			Previous: summary,
+			Current:  nil,
+		}
+	}
+
+	return &discoveryconfigv1.ResourceSummary{
+		Previous: existingSummary.GetPrevious(),
+		Current:  summary,
+	}
+}
+
+func existingServerStatuses(existingDiscoveryConfig *discoveryconfig.DiscoveryConfig) map[string]*discoveryconfig.DiscoveryStatusServer {
+	if existingDiscoveryConfig == nil {
+		return nil
+	}
+	return existingDiscoveryConfig.Status.ServerStatus
+}
+
+func existingDiscoverSummary(serverID, integration string, existingServerIterations map[string]*discoveryconfig.DiscoveryStatusServer) *discoveryconfigv1.DiscoverSummary {
+	if existingServerIterations == nil {
+		return nil
+	}
+	existingServerStatus, ok := existingServerIterations[serverID]
+	if !ok {
+		return nil
+	}
+
+	if existingServerStatus.DiscoveryStatusServer == nil {
+		return nil
+	}
+	return existingServerStatus.DiscoveryStatusServer.IntegrationSummaries[integration]
+}

--- a/lib/srv/discovery/status_updater_test.go
+++ b/lib/srv/discovery/status_updater_test.go
@@ -1,0 +1,427 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+)
+
+func integrationDiscoveredSummaryFinished(found uint64, syncEnd *timestamppb.Timestamp) *discoveryconfig.IntegrationDiscoveredSummary {
+	return &discoveryconfig.IntegrationDiscoveredSummary{
+		IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+			AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
+				Found:   found,
+				SyncEnd: syncEnd,
+			},
+		},
+	}
+}
+
+func integrationDiscoveredSummaryWithFound(found uint64) *discoveryconfig.IntegrationDiscoveredSummary {
+	return &discoveryconfig.IntegrationDiscoveredSummary{
+		IntegrationDiscoveredSummary: &discoveryconfigv1.IntegrationDiscoveredSummary{
+			AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
+				Found: found,
+			},
+		},
+	}
+}
+
+func discoveryStatusServerWithCurrent(found uint64, lastUpdate *timestamppb.Timestamp) *discoveryconfigv1.DiscoveryStatusServer {
+	return &discoveryconfigv1.DiscoveryStatusServer{
+		IntegrationSummaries: map[string]*discoveryconfigv1.DiscoverSummary{
+			"my-integration": {
+				AwsEc2: &discoveryconfigv1.ResourceSummary{
+					Current: &discoveryconfigv1.ResourcesDiscoveredSummary{
+						Found: found,
+					},
+				},
+			},
+		},
+		LastUpdate:   lastUpdate,
+		PollInterval: durationpb.New(5 * time.Minute),
+	}
+}
+
+func discoveryStatusServerFinished(previous uint64, syncEnd *timestamppb.Timestamp) *discoveryconfigv1.DiscoveryStatusServer {
+	return &discoveryconfigv1.DiscoveryStatusServer{
+		IntegrationSummaries: map[string]*discoveryconfigv1.DiscoverSummary{
+			"my-integration": {
+				AwsEc2: &discoveryconfigv1.ResourceSummary{
+					Previous: &discoveryconfigv1.ResourcesDiscoveredSummary{
+						Found:   previous,
+						SyncEnd: syncEnd,
+					},
+				},
+			},
+		},
+		LastUpdate:   syncEnd,
+		PollInterval: durationpb.New(5 * time.Minute),
+	}
+}
+
+func staleDiscoveryStatusServer(lastUpdate *timestamppb.Timestamp) *discoveryconfigv1.DiscoveryStatusServer {
+	ret := discoveryStatusServerFinished(5, lastUpdate)
+	ret.PollInterval = durationpb.New(1 * time.Minute)
+	ret.LastUpdate = timestamppb.New(lastUpdate.AsTime().Add(-20 * time.Hour))
+	return ret
+}
+
+func TestDiscoveryConfigStatusUpdater_merger(t *testing.T) {
+	t.Parallel()
+	fakeClock := clockwork.NewFakeClock()
+
+	syncEnd := timestamppb.New(fakeClock.Now())
+	lastSync := timestamppb.New(fakeClock.Now())
+
+	for _, tc := range []struct {
+		name                    string
+		serverID                string
+		existingDiscoveryConfig *discoveryconfig.DiscoveryConfig
+		newStatus               discoveryconfig.Status
+		expectedStatus          discoveryconfig.Status
+	}{
+		{
+			name:                    "no existing status: adds server iteration with the current summary",
+			serverID:                "server1",
+			existingDiscoveryConfig: nil,
+			newStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryWithFound(10),
+				},
+			},
+			expectedStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryWithFound(10),
+				},
+				ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+					"server1": {
+						DiscoveryStatusServer: discoveryStatusServerWithCurrent(10, lastSync),
+					},
+				},
+			},
+		},
+		{
+			name:     "status is updated when summary changes",
+			serverID: "server1",
+			existingDiscoveryConfig: &discoveryconfig.DiscoveryConfig{
+				Status: discoveryconfig.Status{
+					IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+						"my-integration": integrationDiscoveredSummaryWithFound(5),
+					},
+					ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+						"server1": {
+							DiscoveryStatusServer: discoveryStatusServerWithCurrent(5, lastSync),
+						},
+					},
+				},
+			},
+			newStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryWithFound(10),
+				},
+			},
+			expectedStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryWithFound(10),
+				},
+				ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+					"server1": {
+						DiscoveryStatusServer: discoveryStatusServerWithCurrent(10, lastSync),
+					},
+				},
+			},
+		},
+		{
+			name:     "other server IDs are not affected when updating server iterations",
+			serverID: "server1",
+			existingDiscoveryConfig: &discoveryconfig.DiscoveryConfig{
+				Status: discoveryconfig.Status{
+					ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+						"server2": {
+							DiscoveryStatusServer: discoveryStatusServerWithCurrent(5, lastSync),
+						},
+					},
+				},
+			},
+			newStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryWithFound(10),
+				},
+			},
+			expectedStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryWithFound(10),
+				},
+				ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+					"server2": {
+						DiscoveryStatusServer: discoveryStatusServerWithCurrent(5, lastSync),
+					},
+					"server1": {
+						DiscoveryStatusServer: discoveryStatusServerWithCurrent(10, lastSync),
+					},
+				},
+			},
+		},
+		{
+			name:     "summaries from other servers are discarded when stale",
+			serverID: "server1",
+			existingDiscoveryConfig: &discoveryconfig.DiscoveryConfig{
+				Status: discoveryconfig.Status{
+					ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+						"server2": {
+							DiscoveryStatusServer: discoveryStatusServerWithCurrent(5, lastSync),
+						},
+						"server3": {
+							DiscoveryStatusServer: staleDiscoveryStatusServer(lastSync),
+						},
+					},
+				},
+			},
+			newStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryWithFound(10),
+				},
+			},
+			expectedStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryWithFound(10),
+				},
+				ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+					"server2": {
+						DiscoveryStatusServer: discoveryStatusServerWithCurrent(5, lastSync),
+					},
+					"server1": {
+						DiscoveryStatusServer: discoveryStatusServerWithCurrent(10, lastSync),
+					},
+				},
+			},
+		},
+		{
+			name:     "when iteration ends, the current summary is emptied and the previous summary is populated with the last known summary",
+			serverID: "server1",
+			newStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryFinished(10, syncEnd),
+				},
+			},
+			existingDiscoveryConfig: &discoveryconfig.DiscoveryConfig{
+				Status: discoveryconfig.Status{
+					IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+						"my-integration": integrationDiscoveredSummaryWithFound(5),
+					},
+					ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+						"server1": {
+							DiscoveryStatusServer: discoveryStatusServerWithCurrent(5, lastSync),
+						},
+					},
+				},
+			},
+			expectedStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryFinished(10, syncEnd),
+				},
+				ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+					"server1": {
+						DiscoveryStatusServer: discoveryStatusServerFinished(10, syncEnd),
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			updater := &discoveryConfigStatusUpdater{
+				clock:        fakeClock,
+				pollInterval: 5 * time.Minute,
+				serverID:     tc.serverID,
+			}
+			newStatus := updater.updateServerStatus(tc.newStatus, tc.existingDiscoveryConfig)
+			require.True(t, cmp.Equal(newStatus, tc.expectedStatus, protocmp.Transform()), "unexpected result: %s", cmp.Diff(newStatus, tc.expectedStatus, protocmp.Transform()))
+		})
+	}
+}
+
+func TestDiscoveryConfigStatusUpdater(t *testing.T) {
+	t.Parallel()
+	fakeClock := clockwork.NewFakeClock()
+
+	syncEnd := timestamppb.New(fakeClock.Now())
+	lastSync := timestamppb.New(fakeClock.Now())
+
+	for _, tc := range []struct {
+		name                     string
+		discoveryConfigName      string
+		discoveryConfigStatus    discoveryconfig.Status
+		existingDiscoveryConfigs map[string]*discoveryconfig.DiscoveryConfig
+		expectedDiscoveryConfigs map[string]*discoveryconfig.DiscoveryConfig
+	}{
+		{
+			name:                "successfully update discovery config status when no existing config is found",
+			discoveryConfigName: "test-config",
+			discoveryConfigStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryWithFound(5),
+				},
+			},
+			existingDiscoveryConfigs: map[string]*discoveryconfig.DiscoveryConfig{},
+			expectedDiscoveryConfigs: map[string]*discoveryconfig.DiscoveryConfig{
+				"test-config": {
+					Status: discoveryconfig.Status{
+						IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+							"my-integration": integrationDiscoveredSummaryWithFound(5),
+						},
+						ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+							"test-server": {
+								DiscoveryStatusServer: discoveryStatusServerWithCurrent(5, lastSync),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                "successfully updates the previous field when iteration ends",
+			discoveryConfigName: "test-config",
+			discoveryConfigStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+					"my-integration": integrationDiscoveredSummaryFinished(5, syncEnd),
+				},
+			},
+			existingDiscoveryConfigs: map[string]*discoveryconfig.DiscoveryConfig{
+				"test-config": {
+					Status: discoveryconfig.Status{
+						IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+							"my-integration": integrationDiscoveredSummaryWithFound(3),
+						},
+						ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+							"test-server": {
+								DiscoveryStatusServer: discoveryStatusServerWithCurrent(3, syncEnd),
+							},
+						},
+					},
+				},
+			},
+			expectedDiscoveryConfigs: map[string]*discoveryconfig.DiscoveryConfig{
+				"test-config": {
+					Status: discoveryconfig.Status{
+						IntegrationDiscoveredResources: map[string]*discoveryconfig.IntegrationDiscoveredSummary{
+							"my-integration": integrationDiscoveredSummaryFinished(5, syncEnd),
+						},
+						ServerStatus: map[string]*discoveryconfig.DiscoveryStatusServer{
+							"test-server": {
+								DiscoveryStatusServer: discoveryStatusServerFinished(5, syncEnd),
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			discoveryConfigService := &mockDiscoveryConfigService{
+				discoveryConfigs: tc.existingDiscoveryConfigs,
+			}
+			semaphoreService := &mockSemaphore{}
+
+			updater := &discoveryConfigStatusUpdater{
+				log:                    slog.New(slog.DiscardHandler),
+				serverID:               "test-server",
+				clock:                  fakeClock,
+				pollInterval:           5 * time.Minute,
+				semaphoreService:       semaphoreService,
+				discoveryConfigService: discoveryConfigService,
+			}
+
+			err := updater.update(t.Context(), tc.discoveryConfigName, tc.discoveryConfigStatus)
+			require.NoError(t, err)
+
+			// Verify the final state of the discovery configs
+			for name, expectedConfig := range tc.expectedDiscoveryConfigs {
+				require.Contains(t, tc.existingDiscoveryConfigs, name)
+				storedDiscoveryConfig := tc.existingDiscoveryConfigs[name]
+
+				diff := cmp.Diff(expectedConfig.Status.ServerStatus, storedDiscoveryConfig.Status.ServerStatus, protocmp.Transform())
+				require.Empty(t, diff, "mismatch between expected and stored discovery config: %s", diff)
+			}
+
+			require.False(t, semaphoreService.stateLocked, "semaphore should be released after update")
+		})
+	}
+}
+
+type mockDiscoveryConfigService struct {
+	discoveryConfigs map[string]*discoveryconfig.DiscoveryConfig
+}
+
+func (m *mockDiscoveryConfigService) GetDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error) {
+	if config, ok := m.discoveryConfigs[name]; ok {
+		return config, nil
+	}
+	return nil, trace.NotFound("discovery config not found: %s", name)
+}
+
+func (m *mockDiscoveryConfigService) UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error) {
+	config, ok := m.discoveryConfigs[name]
+	if !ok {
+		config = &discoveryconfig.DiscoveryConfig{}
+	}
+	config.Status = status
+	m.discoveryConfigs[name] = config
+	return config, nil
+}
+
+type mockSemaphore struct {
+	types.Semaphores
+
+	mu          sync.Mutex
+	stateLocked bool
+}
+
+func (m *mockSemaphore) AcquireSemaphore(ctx context.Context, params types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
+	if !m.mu.TryLock() {
+		return nil, trace.Errorf("semaphore is already locked")
+	}
+
+	m.stateLocked = true
+	return &types.SemaphoreLease{
+		Expires: params.Expires,
+	}, nil
+}
+
+func (m *mockSemaphore) CancelSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
+	m.stateLocked = false
+	m.mu.Unlock()
+	return nil
+}


### PR DESCRIPTION
Discovery Service goal is to enroll resources from cloud accounts.

It can be configured with static matchers (ie, configured in `teleport.yaml/discovery_service.[aws|azure|gcp]`) or with dynamic matchers (ie, DiscoveryConfig resources).

When using dynamic matchers/ DiscoveryConfig resources, it will report the summary of what was discovered/enrolled into the DiscoveryConfig.Status field.

DiscoveryService watches for DiscoveryConfigs whose discovery group (`teleport.yaml/discovery_service.discovery_group` and `DiscoveryConfig.Spec.DiscoveryGroup`) is the same.
We can have multiple DiscoveryServices writing into DiscoveryConfig.Status.

Currently, if multiple Discovery Services watch the Discovery Config, we'll have a concurrent write into the DiscoveryConfig.Status.

This PR fixes that by creating a new field: DiscoveryConfig.Status.ServerStatus.
This is a map that is keyed by the server id (unique per running DiscoveryService), whose value contains the summary of the iteration.

Another feature that is being added is to store the current and the previous iteration.
This way, we can provide feedback to the end user that the service is currently looking for new resources but also give them a summary of what was recently discovered.

Here's an example of what status will look like with some in-line comments:
`tctl get discovery_config/<id>`
```yaml
discovered_resources: 15
integration_discovered_resources:
  "":
    azureVms:
      found: "2"
      syncEnd: "2026-03-31T17:43:45.131043Z"
      syncStart: "2026-03-31T17:43:20.598808Z"
  teleportdev:
    awsEc2:
      failed: "6"
      found: "11"
      syncStart: "2026-03-31T17:44:36.524833Z"
    awsEks:
      failed: "1"
      found: "1"
      syncStart: "2026-03-31T17:44:20.989372Z"
    awsRds:
      enrolled: "1"
      found: "1"
      syncEnd: "2026-03-31T17:44:21.368221Z"
      syncStart: "2026-03-31T17:44:21.043077Z"
last_sync_time: "2026-03-31T17:44:45.146549Z"
server_status:                                      # new field that indicates the status per server
  72492fdd-2398-4d5d-baa8-b6cfd09695c1:             # identification of the DiscoveryService's ServerID (HostID)
    integrationSummaries:                           # Summaries are grouped by integration name.
      "":                                           # Empty integration name means ambient credentials were used.
        azureVms:                                   # The type of resource, which has its own summary.
          previous:                                 # Previous summary. When current is missing, there's no sync in progress.
            found: "2"
            syncEnd: "2026-03-31T17:43:45.131043Z"
            syncStart: "2026-03-31T17:43:20.598808Z"
      teleportdev:                                  # Summary for the teleportdev integration.
        awsEc2:
          current:                                  # Summary for the sync in progress.
            failed: "6"
            found: "11"
            syncStart: "2026-03-31T17:44:36.524833Z"
          previous:                                 # Summary for the last completed sync.
            failed: "7"
            found: "11"
            syncEnd: "2026-03-31T17:43:36.502945Z"
            syncStart: "2026-03-31T17:43:20.598643Z"
        awsEks:
          current:
            failed: "1"
            found: "1"
            syncStart: "2026-03-31T17:44:20.989372Z"
        awsRds:
          previous:
            enrolled: "1"
            found: "1"
            syncEnd: "2026-03-31T17:44:21.368221Z"
            syncStart: "2026-03-31T17:44:21.043077Z"
    lastUpdate: "2026-03-31T17:44:45.150324Z"          # Timestamp of the last completed sync for this server.
    pollInterval: 60s                                # How long each it takes for each resource type to start a new iteration.
                                                     # We can provide an estimate of the next sync by adding this interval to the resource's last sync time.
state: DISCOVERY_CONFIG_STATE_SYNCING
```

Example with multiple Discovery Services running:
`tctl get discovery_config | yq -C .status`
```yaml
discovered_resources: 0
integration_discovered_resources:
  teleportdev:
    awsEc2:
      syncStart: "2026-04-07T13:40:50.807966839Z"
last_sync_time: "2026-04-07T13:40:50.807975718Z"
server_status:
  70e488f5-a370-44e0-a599-35ca9bb21cf5:
    integrationSummaries:
      teleportdev:
        awsEc2:
          previous:
            failed: "11"
            found: "11"
            syncEnd: "2026-04-07T13:35:55.709757867Z"
            syncStart: "2026-04-07T13:35:38.389878501Z"
    lastUpdate: "2026-04-07T13:35:55.718420529Z"
    pollInterval: 300s
  bd5cc30f-c493-4a53-9046-f7ea5f4fe6d4:
    integrationSummaries:
      teleportdev:
        awsEc2:
          current:
            syncStart: "2026-04-07T13:40:50.807966839Z"
          previous:
            failed: "11"
            found: "11"
            syncEnd: "2026-04-07T13:35:50.694445765Z"
            syncStart: "2026-04-07T13:35:32.940576191Z"
    lastUpdate: "2026-04-07T13:40:50.826875418Z"
    pollInterval: 300s
state: DISCOVERY_CONFIG_STATE_SYNCING
```


Changelog: Added current and previous resources discovered summary per service to Discovery Config Status.

## Manual Test Plan
### Test Environment

Test locally with a single discovery service
Test in cloud where we have two discovery services

### Test Cases
- [x] Test with AWS integration credentials locally


## Demo
`> tctl get discovery_config | yq .status`
```yaml
discovered_resources: 0
integration_discovered_resources:
  teleportdev:
    awsEc2:
      syncEnd: "2026-04-23T20:16:24.710971Z"
      syncStart: "2026-04-23T20:16:24.226601Z"
last_sync_time: "2026-04-23T20:16:24.710979Z"
server_status:
  e85f48eb-0168-4682-ab55-a290eb096293:
    integrationSummaries:
      teleportdev:
        awsEc2:
          previous:
            syncEnd: "2026-04-23T20:16:24.710971Z"
            syncStart: "2026-04-23T20:16:24.226601Z"
    lastUpdate: "2026-04-23T20:16:24.714590Z"
    pollInterval: 60s
state: DISCOVERY_CONFIG_STATE_SYNCING
```

Backports #65233