### PR TITLE
Switch to relative links in TileGrid components

### DIFF
--- a/docs/pages/machine-workload-identity/use-cases/hybrid-multi-mwi.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/hybrid-multi-mwi.mdx
@@ -17,17 +17,17 @@ It integrates with Terraform, Pulumi, AWS, GCP, Azure, and also provides solutio
   tiles={[
     {
       icon: <Icon name="awsIdentity" size="xl" />,
-      to: "/docs/machine-workload-identity/workload-identity/aws-roles-anywhere",
+      to: "../../workload-identity/aws-roles-anywhere",
       name: "AWS Roles Anywhere and Workload Identity",
     },
     {
       icon: <Icon name="googleCloud" size="xl" />,
-      to: "/docs/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt",
+      to: "../../workload-identity/gcp-workload-identity-federation-jwt",
       name: "Google Cloud Workload Identity Federation",
     },
     {
       icon: <Icon name="azure" size="xl" />,
-      to: "/docs/machine-workload-identity/workload-identity/azure-federated-credentials",
+      to: "../../workload-identity/azure-federated-credentials",
       name: "Azure Federated Credentials",
     },
     {

--- a/docs/pages/machine-workload-identity/use-cases/iac-mwi.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/iac-mwi.mdx
@@ -18,17 +18,17 @@ AWS, GCP and Azure, as well as solutions for on-prem configuration.
   tiles={[
     {
       icon: <Icon name="awsIdentity" size="xl" />,
-      to: "/docs/machine-workload-identity/workload-identity/aws-roles-anywhere",
+      to: "../../workload-identity/aws-roles-anywhere",
       name: "AWS Roles Anywhere and Workload Identity",
     },
     {
       icon: <Icon name="googleCloud" size="xl" />,
-      to: "/docs/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt",
+      to: "../../workload-identity/gcp-workload-identity-federation-jwt",
       name: "Google Cloud Workload Identity Federation",
     },
     {
       icon: <Icon name="azure" size="xl" />,
-      to: "/docs/machine-workload-identity/workload-identity/azure-federated-credentials",
+      to: "../../workload-identity/azure-federated-credentials",
       name: "Azure Federated Credentials and Workload Identity",
     },
     {

--- a/docs/pages/machine-workload-identity/use-cases/mwi-ci-cd.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/mwi-ci-cd.mdx
@@ -18,37 +18,37 @@ certificates at runtime. Teleport natively integrates with many CI/CD providers 
   tiles={[
     {
       icon: <Icon name="azureDevops" size="xl" />,
-      to: "/docs/machine-workload-identity/deployment/azure-devops",
+      to: "../../deployment/azure-devops",
       name: "Azure DevOps",
     },
     {
       icon: <Icon name="bitbucket" size="xl" />,
-      to: "/docs/machine-workload-identity/deployment/bitbucket",
+      to: "../../deployment/bitbucket",
       name: "Bitbucket Pipelines",
     },
     {
       icon: <Icon name="circleci" size="xl" />,
-      to: "/docs/machine-workload-identity/deployment/circleci",
+      to: "../../deployment/circleci",
       name: "CircleCI",
     },
     {
       icon: <Icon name="gitlab" size="xl" />,
-      to: "/docs/machine-workload-identity/deployment/gitlab",
+      to: "../../deployment/gitlab",
       name: "GitLab CI",
     },
     {
       icon: <Icon name="githubActions" size="xl" />,
-      to: "/docs/machine-workload-identity/deployment/github-actions",
+      to: "../../deployment/github-actions",
       name: "GitHub Actions",
     },
     {
       icon: <Icon name="jenkins" size="xl" />,
-      to: "/docs/machine-workload-identity/deployment/jenkins",
+      to: "../../deployment/jenkins",
       name: "Jenkins",
     },
     {
       icon: <Icon name="spacelift" size="xl" />,
-      to: "/docs/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift",
+      to: "../../../zero-trust-access/infrastructure-as-code/terraform-provider/spacelift",
       name: "Spacelift",
     }
   ]}


### PR DESCRIPTION
Prevent absolute link paths from breaking docs site builds after a change to the way the `TileGrid` component handles link paths.