### PR TITLE
[v18] Initialize keystore sign metrics to zero at startup

### DIFF
--- a/lib/auth/keystore/manager.go
+++ b/lib/auth/keystore/manager.go
@@ -231,6 +231,8 @@ func NewManager(ctx context.Context, cfg *servicecfg.KeystoreConfig, opts *Optio
 	if err := metrics.RegisterPrometheusCollectors(
 		signCounter,
 		signErrorCounter,
+		decryptCounter,
+		decryptErrorCounter,
 		createCounter,
 		createErrorCounter,
 	); err != nil {
@@ -271,12 +273,24 @@ func NewManager(ctx context.Context, cfg *servicecfg.KeystoreConfig, opts *Optio
 		usableBackends = []backend{awsBackend, softwareBackend}
 	}
 
-	return &Manager{
+	m := &Manager{
 		backendForNewKeys:  backendForNewKeys,
 		usableBackends:     usableBackends,
 		currentSuiteGetter: cryptosuites.GetCurrentSuiteFromAuthPreference(opts.AuthPreferenceGetter),
 		logger:             opts.Logger,
-	}, nil
+	}
+
+	// Initialize metrics to zero so they exist in Prometheus from startup.
+	for _, b := range usableBackends {
+		for _, keyType := range []string{keyTypeTLS, keyTypeSSH, keyTypeJWT} {
+			signCounter.WithLabelValues(keyType, b.name())
+			signErrorCounter.WithLabelValues(keyType, b.name())
+		}
+		decryptCounter.WithLabelValues(keyTypeEncryption, b.name())
+		decryptErrorCounter.WithLabelValues(keyTypeEncryption, b.name())
+	}
+
+	return m, nil
 }
 
 type cryptoCountSigner struct {


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/65857

Changelog: Initialize keystore sign and decrypt metrics at startup and register missing decrypt metric collectors.