### PR TITLE
[web] Clamp `Label` text overflow, safely call `useNoMinWidth`

### DIFF
--- a/web/packages/design/src/DataTable/Cells.tsx
+++ b/web/packages/design/src/DataTable/Cells.tsx
@@ -110,7 +110,7 @@ export const DateCell = ({ data }: { data: Date }) => (
 
 const renderLabelCell = (labels: string[] = []) => {
   const $labels = labels.map((label, index) => (
-    <Label mr="1" key={`${label}${index}`} kind="secondary">
+    <Label mr="1" key={`${label}${index}`} kind="secondary" title={label}>
       {label}
     </Label>
   ));

--- a/web/packages/design/src/Label/Label.tsx
+++ b/web/packages/design/src/Label/Label.tsx
@@ -216,13 +216,15 @@ export type LabelProps = {
 const Label = styled.div<LabelProps>`
   box-sizing: border-box;
   border-radius: 999px;
-  display: inline-block;
+  display: -webkit-box;
   font-size: 10px;
   font-weight: 500;
   padding: 0 8px;
   margin: 1px 0;
   vertical-align: middle;
   overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
 
   ${kind}
   ${space}

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -255,13 +255,13 @@ export const useContentMinWidthContext = () =>
   useContext(ContentMinWidthContext);
 
 export const useNoMinWidth = () => {
-  const { setEnforceMinWidth } = useContext(ContentMinWidthContext);
+  const ctx = useContext(ContentMinWidthContext);
 
   useLayoutEffect(() => {
-    setEnforceMinWidth(false);
+    ctx?.setEnforceMinWidth(false);
 
     return () => {
-      setEnforceMinWidth(true);
+      ctx?.setEnforceMinWidth(true);
     };
   }, []);
 };


### PR DESCRIPTION
## Context
- Fix long labels' truncation; cap at 1 line within their current container
- Call `useNoMinWidth` from context via option chaining instead of destructuring to fix Storybook stories (e.g., `Users/Loaded` story) failing to load when it's not defined

### Before
<img width="1163" height="619" alt="Screenshot 2026-04-23 at 19 12 02" src="https://github.com/user-attachments/assets/25aa9340-2367-4726-92c2-6d275584570c" />

### After
<img width="1159" height="337" alt="Screenshot 2026-04-23 at 19 12 10" src="https://github.com/user-attachments/assets/91b4fda2-ced4-4636-a2dc-97f33086518f" />

## Manual Test Plan
### Test Environment
- Storybook

### Test Cases
- [x] View `Users/Loaded` story; verify it renders without error.
- [x] View `DataTable/Paginated` story; verify the long label is properly truncated at 1 line.
