### PR TITLE
fix: normalize Canadian time string

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
@@ -217,5 +217,7 @@ function formatAbsoluteTime(timestamp: number) {
   return date
     .toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
     .replace(' AM', 'am')
-    .replace(' PM', 'pm');
+    .replace(' a.m.', 'am')
+    .replace(' PM', 'pm')
+    .replace(' p.m.', 'pm');
 }


### PR DESCRIPTION
TimeMarksRenderer.test.ts has always been broken for me because I use a non-US locale (repro with `LANG=en_CA.UTF-8`). The `en_CA` locale renders time strings with ` a.m.` and ` p.m.`, but I assure you us Canadians will be able to read `am` and `pm` just fine. We already remove the space and switch to lowercase for the Americans, it seems consistent for the product to normalize to am and pm for Canada too.
