### PR TITLE
Docs: Align tctl idp saml test-attribute-mapping param

### DIFF
--- a/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
+++ b/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
@@ -195,7 +195,7 @@ E.g.:
 Test with user name and service provider spec file:
 ```code
 # test with username and service provider file
-$ tctl idp saml test-attribute-mapping --user user1 --sp sp.yml
+$ tctl idp saml test-attribute-mapping --users user1 --sp sp.yml
 User: user1
 Attribute Name Attribute Value
 -------------- -----------------------------
@@ -207,12 +207,12 @@ groups         okta-admin, dev-sso, dev-rdp
 
 Test with user spec file and service provider spec file:
 ```code
-$ tctl idp saml test-attribute-mapping --user user.yml --sp sp.yml
+$ tctl idp saml test-attribute-mapping --users user.yml --sp sp.yml
 ```
 
 Print result in format of choice.
 ```code
-$ tctl idp saml test-attribute-mapping --user user.yml --sp sp.yml --format (json/yaml)
+$ tctl idp saml test-attribute-mapping --users user.yml --sp sp.yml --format (json/yaml)
 ```
 
 ## Overwriting default attributes

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
@@ -460,7 +460,7 @@ Follow these steps to update the SAML IdP service provider resource:
 You can verify the attribute mapping before applying it by running:
 
 ```code
-$ tctl idp saml test-attribute-mapping --user <username> --sp aws-ic-sp.yaml
+$ tctl idp saml test-attribute-mapping --users <username> --sp aws-ic-sp.yaml
 ```
 
 <Admonition type="note">


### PR DESCRIPTION
### What

Currently the `tctl idp saml test-attribute-mapping` wrongly reference `--user`  flag instead of  `--users` 

The flag currently is defined as: 

```
testAttrMap.Flag("users", "username or name of a file containing user spec").Required().Short('u').StringsVar(&s.testAttributeMapping.users)
```

Reference https://github.com/gravitational/teleport/blob/master/tool/tctl/common/idp_command.go#L109 
```
	# test with username and service provider file
	> tctl idp saml test-attribute-mapping --users user1 --sp sp.yaml

	# test with multiple usernames and service provider file
	> tctl idp saml test-attribute-mapping --users user1,user2 --sp sp.yaml

	# test with user and service provider file and print output in yaml format
	> tctl idp  tsamlest-attribute-mapping --users user1.yaml --sp sp.yaml --format yaml
	```