### PR TITLE
Note that Touch ID is not supported by WEBAUTHN

### DIFF
--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -237,12 +237,15 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 		}
 	}
 
-	pingResp, err := tc.Ping(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	if c.devType == "" {
+		// If we are prompting the user for the device type, then take a glimpse at
+		// server-side settings and adjust the options accordingly.
+		// This is undesirable to do during flag setup, but we can do it here.
+		pingResp, err := tc.Ping(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
 		c.devType, err = prompt.PickOne(
 			ctx, os.Stdout, prompt.Stdin(),
 			"Choose device type", deviceTypesFromSecondFactor(pingResp.Auth.SecondFactor))

--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -237,18 +237,16 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 		}
 	}
 
-	if c.devType == "" {
-		// If we are prompting the user for the device type, then take a glimpse at
-		// server-side settings and adjust the options accordingly.
-		// This is undesirable to do during flag setup, but we can do it here.
-		pingResp, err := tc.Ping(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+	pingResp, err := tc.Ping(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	allowedDevTypes := deviceTypesFromSecondFactor(pingResp.Auth.SecondFactor)
 
+	if c.devType == "" {
 		c.devType, err = prompt.PickOne(
 			ctx, os.Stdout, prompt.Stdin(),
-			"Choose device type", deviceTypesFromSecondFactor(pingResp.Auth.SecondFactor))
+			"Choose device type", allowedDevTypes)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -282,7 +280,7 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 	}
 	logger.DebugContext(ctx, "tsh using passwordless registration?", "allow_passwordless", c.allowPasswordless)
 
-	dev, err := c.addDeviceRPC(ctx, tc)
+	dev, err := c.addDeviceRPC(ctx, tc, allowedDevTypes)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -302,7 +300,7 @@ func deviceTypesFromSecondFactor(sf constants.SecondFactorType) []string {
 	}
 }
 
-func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportClient) (*types.MFADevice, error) {
+func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportClient, allowedDevTypes []string) (*types.MFADevice, error) {
 	devTypePB := map[string]proto.DeviceType{
 		totpDeviceType:     proto.DeviceType_DEVICE_TYPE_TOTP,
 		webauthnDeviceType: proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
@@ -522,7 +520,13 @@ func promptWebauthnRegisterChallenge(ctx context.Context, origin string, cc *wan
 
 	prompt := wancli.NewDefaultPrompt(ctx, os.Stdout)
 	prompt.PINMessage = "Enter your *new* security key PIN"
-	prompt.FirstTouchMessage = "Tap your *new* security key"
+	if touchid.IsAvailable() {
+		prompt.FirstTouchMessage =
+			"(Note: Touch ID is not supported by WEBAUTHN; to register a Touch ID device, use --type=TOUCHID instead.)\n" +
+				"Tap your *new* security key"
+	} else {
+		prompt.FirstTouchMessage = "Tap your *new* security key"
+	}
 	prompt.SecondTouchMessage = "Tap your *new* security key again to complete registration"
 
 	resp, err := wancli.Register(ctx, origin, cc, prompt)

--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -280,7 +280,7 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 	}
 	logger.DebugContext(ctx, "tsh using passwordless registration?", "allow_passwordless", c.allowPasswordless)
 
-	dev, err := c.addDeviceRPC(ctx, tc, allowedDevTypes)
+	dev, err := c.addDeviceRPC(ctx, tc)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -300,7 +300,7 @@ func deviceTypesFromSecondFactor(sf constants.SecondFactorType) []string {
 	}
 }
 
-func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportClient, allowedDevTypes []string) (*types.MFADevice, error) {
+func (c *mfaAddCommand) addDeviceRPC(ctx context.Context, tc *client.TeleportClient) (*types.MFADevice, error) {
 	devTypePB := map[string]proto.DeviceType{
 		totpDeviceType:     proto.DeviceType_DEVICE_TYPE_TOTP,
 		webauthnDeviceType: proto.DeviceType_DEVICE_TYPE_WEBAUTHN,
@@ -522,7 +522,7 @@ func promptWebauthnRegisterChallenge(ctx context.Context, origin string, cc *wan
 	prompt.PINMessage = "Enter your *new* security key PIN"
 	if touchid.IsAvailable() {
 		prompt.FirstTouchMessage =
-			"(Note: Touch ID is not supported by WEBAUTHN; to register a Touch ID device, use --type=TOUCHID instead.)\n" +
+			"(WEBAUTHN is used to register security keys. To register Touch ID, use --type=TOUCHID instead.)\n" +
 				"Tap your *new* security key"
 	} else {
 		prompt.FirstTouchMessage = "Tap your *new* security key"

--- a/tool/tsh/common/mfa.go
+++ b/tool/tsh/common/mfa.go
@@ -241,12 +241,11 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	allowedDevTypes := deviceTypesFromSecondFactor(pingResp.Auth.SecondFactor)
 
 	if c.devType == "" {
 		c.devType, err = prompt.PickOne(
 			ctx, os.Stdout, prompt.Stdin(),
-			"Choose device type", allowedDevTypes)
+			"Choose device type", deviceTypesFromSecondFactor(pingResp.Auth.SecondFactor))
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -521,9 +520,9 @@ func promptWebauthnRegisterChallenge(ctx context.Context, origin string, cc *wan
 	prompt := wancli.NewDefaultPrompt(ctx, os.Stdout)
 	prompt.PINMessage = "Enter your *new* security key PIN"
 	if touchid.IsAvailable() {
-		prompt.FirstTouchMessage =
+		prompt.FirstTouchMessage = "" +
 			"(WEBAUTHN is used to register security keys. To register Touch ID, use --type=TOUCHID instead.)\n" +
-				"Tap your *new* security key"
+			"Tap your *new* security key"
 	} else {
 		prompt.FirstTouchMessage = "Tap your *new* security key"
 	}


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/22532

```
$ btsh mfa add --type=WEBAUTHN
Enter device name: yubi
Allow passwordless logins [YES, NO]: no
Available MFA methods [WEBAUTHN, BROWSER]. Continuing with WEBAUTHN.
If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,browser> or environment variable TELEPORT_MFA_MODE=<webauthn,browser>.

Using platform authenticator, follow the OS prompt
(Note: Touch ID is not supported by WEBAUTHN; to register a Touch ID device, use --type=TOUCHID instead.)
Tap your *new* security key
Detected security key tap
MFA device "yubi" added.
```

## Manual Test Plan
### Test Environment
Any cluster with webauthn MFA enabled.

### Test Cases
- [x] Add a touch ID device (Mac)
- [x] Add a Yubikey device
   - [x] Mac
   - [x] Linux
   - [x] Windows
