### PR TITLE
docs: Remove unnecessary tab item

### DIFF
--- a/docs/pages/installation/self-hosted/deployments/aws-gslb-proxy-peering-ha-deployment.mdx
+++ b/docs/pages/installation/self-hosted/deployments/aws-gslb-proxy-peering-ha-deployment.mdx
@@ -86,13 +86,9 @@ traffic across multiple zones. Doing this improves resiliency against localized 
 Configure the load balancer to forward traffic from the following ports on the
 load balancer to the corresponding port on an available Teleport instance.
 
-<TabItem label="NLB Proxy ports">
-
 | Port | Description |
 | - | - |
 | `443` | ALPN port for TLS Routing, HTTPS connections to authenticate `tsh` users into the cluster, and to serve Teleport's Web UI |
-
-</TabItem>
 
 ### Configure the Auth Service NLB
 


### PR DESCRIPTION
### Summary

Remove `TabItem` used outside of `Tabs` component on the following documentation page:

Current page:
  - https://goteleport.com/docs/zero-trust-access/deploy-a-cluster/deployments/aws-gslb-proxy-peering-ha-deployment/#configure-the-proxy-service-nlbs

New page:
  - https://taras-docs-tab-item-fix.d1v2yqnl3ruxch.amplifyapp.com/docs/installation/self-hosted/deployments/aws-gslb-proxy-peering-ha-deployment/#configure-the-proxy-service-nlbs

Because of this, documentation website fails to build on the latest docusaurus version - 3.10.0 with error:
```
[errors]: Error: Can't render static file for pathname "/docs/zero-trust-access/deploy-a-cluster/deployments/aws-gslb-proxy-peering-ha-deployment/"

[cause]: Error: useTabsContext() must be used within a Tabs component
```
- https://github.com/gravitational/docs-website/pull/615