### PR TITLE
Remove UpsertAuthServer HTTP RPC

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -124,7 +124,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.DELETE("/:version/users/:user/web/sessions/:sid", srv.WithAuth(srv.deleteWebSession))
 
 	// Servers and presence heartbeat
-	srv.POST("/:version/authservers", srv.WithAuth(srv.upsertAuthServer))
 	// TODO(kiosion) DELETE IN 21.0.0
 	srv.GET("/:version/authservers", srv.WithScopedAuth(srv.getAuthServers))
 	srv.POST("/:version/proxies", srv.WithAuth(srv.upsertProxy))
@@ -154,6 +153,7 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.DELETE("/:version/tunnelconnections", httpMigratedHandler)
 	srv.DELETE("/:version/proxies", httpMigratedHandler)
 	srv.POST("/:version/namespaces/:namespace/nodes/keepalive", httpMigratedHandler)
+	srv.POST("/:version/authservers", httpMigratedHandler)
 
 	if config.PluginRegistry != nil {
 		if err := config.PluginRegistry.RegisterAuthWebHandlers(&srv); err != nil {
@@ -236,7 +236,6 @@ type upsertServerRawReq struct {
 // presenceForAPIServer is a subset of [services.Presence].
 type presenceForAPIServer interface {
 	UpsertNode(ctx context.Context, s types.Server) (*types.KeepAlive, error)
-	UpsertAuthServer(ctx context.Context, s types.Server) error
 	UpsertProxy(ctx context.Context, s types.Server) error
 }
 
@@ -250,8 +249,6 @@ func (s *APIServer) upsertServer(auth presenceForAPIServer, role types.SystemRol
 	switch role {
 	case types.RoleNode:
 		kind = types.KindNode
-	case types.RoleAuth:
-		kind = types.KindAuthServer
 	case types.RoleProxy:
 		kind = types.KindProxy
 	default:
@@ -279,10 +276,6 @@ func (s *APIServer) upsertServer(auth presenceForAPIServer, role types.SystemRol
 			return nil, trace.Wrap(err)
 		}
 		return handle, nil
-	case types.RoleAuth:
-		if err := auth.UpsertAuthServer(r.Context(), server); err != nil {
-			return nil, trace.Wrap(err)
-		}
 	case types.RoleProxy:
 		if err := auth.UpsertProxy(r.Context(), server); err != nil {
 			return nil, trace.Wrap(err)
@@ -321,11 +314,6 @@ func (s *APIServer) deleteProxy(auth *ServerWithRoles, w http.ResponseWriter, r 
 		return nil, trace.Wrap(err)
 	}
 	return message("ok"), nil
-}
-
-// upsertAuthServer is called by remote Auth servers when they ping back into the auth service
-func (s *APIServer) upsertAuthServer(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
-	return s.upsertServer(auth, types.RoleAuth, r, p)
 }
 
 // getAuthServers returns registered auth servers

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -93,7 +93,7 @@ func TestUpsertServer(t *testing.T) {
 				Version:  types.V2,
 				Kind:     types.KindAuthServer,
 			},
-			assertErr: require.NoError,
+			assertErr: require.Error,
 		},
 		{
 			desc: "unknown",

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2578,13 +2578,6 @@ func (a *ServerWithRoles) listResourcesWithSort(ctx context.Context, req proto.L
 	return resp, nil
 }
 
-func (a *ServerWithRoles) UpsertAuthServer(ctx context.Context, s types.Server) error {
-	if err := a.authorizeAction(types.KindAuthServer, types.VerbCreate, types.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.UpsertAuthServer(ctx, s)
-}
-
 // Deprecated: Prefer paginated variant [ListAuthServers].
 //
 // TODO(kiosion) DELETE IN 21.0.0

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -828,6 +828,11 @@ func (c *Client) DeleteAccessGraphSettings(context.Context) error {
 	return trace.NotImplemented(notImplementedMessage)
 }
 
+// UpsertAuthServer is used by auth servers to report their presence.
+func (c *Client) UpsertAuthServer(ctx context.Context, s types.Server) error {
+	return trace.NotImplemented(notImplementedMessage)
+}
+
 type WebSessionReq struct {
 	// User is the user name associated with the session id.
 	User string `json:"user"`

--- a/lib/auth/authclient/http_client.go
+++ b/lib/auth/authclient/http_client.go
@@ -394,20 +394,6 @@ type upsertServerRawReq struct {
 	TTL    time.Duration   `json:"ttl"`
 }
 
-// UpsertAuthServer is used by auth servers to report their presence
-// to other auth servers in form of hearbeat expiring after ttl period.
-func (c *HTTPClient) UpsertAuthServer(ctx context.Context, s types.Server) error {
-	data, err := services.MarshalServer(s)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	args := &upsertServerRawReq{
-		Server: data,
-	}
-	_, err = c.PostJSON(ctx, c.Endpoint("authservers"), args)
-	return trace.Wrap(err)
-}
-
 // UpsertProxy is used by proxies to report their presence
 // to other auth servers in form of heartbeat expiring after ttl period.
 func (c *HTTPClient) UpsertProxy(ctx context.Context, s types.Server) error {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1704,7 +1704,7 @@ func TestServersCRUD(t *testing.T) {
 
 	auth := NewServer(types.KindAuthServer, "auth1", "127.0.0.1:2025", apidefaults.Namespace)
 	auth.Spec.Hostname = "auth.llama"
-	require.NoError(t, clt.UpsertAuthServer(ctx, auth))
+	require.NoError(t, testSrv.Auth().UpsertAuthServer(ctx, auth))
 
 	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = clt.GetAuthServers()


### PR DESCRIPTION
Another removal of an RPC as part of https://github.com/gravitational/teleport/issues/6394

I took a deep look at master, v18.0.0 and v17.0.0 - it would appear that this RPC is never called. This method is used by `srv.Heartbeat`, however, in the one place where the heartbeater is configured to heartbeat for the auth, the Announcer passed into the heartbeater is always directly the auth.Server struct - hence it is called locally and not remotely.

This appears to be the case going back to f40df845 when this code was introduced.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Locally invoke removed endpoint, verify that it returns not implemented.
- [x] Spin up cluster, verify that auth server heartbeats are registered correctly.
