### PR TITLE
[v18] [buddy] terraform-mwi: Remove eager network connection from provider Configure()

### DIFF
--- a/integrations/terraform-mwi/provider/provider.go
+++ b/integrations/terraform-mwi/provider/provider.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
@@ -127,33 +126,6 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 			InternalStorage: botInternalStore,
 			Logger:          slog.Default(),
 		}
-	}
-
-	botCfg := newBotConfig()
-	if err := botCfg.CheckAndSetDefaults(); err != nil {
-		resp.Diagnostics.AddError(
-			"Error setting defaults for bot config",
-			"Failed to set defaults for bot config: "+err.Error(),
-		)
-		return
-	}
-
-	bot, err := bot.New(botCfg)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating tbot",
-			"Failed to create tbot: "+err.Error(),
-		)
-		return
-	}
-
-	// Run bot just to validate that the configuration is correct.
-	if err := bot.OneShot(ctx); err != nil {
-		resp.Diagnostics.AddError(
-			"Error running tbot in provider",
-			"Failed to run tbot\n"+trace.DebugReport(err),
-		)
-		return
 	}
 
 	providerData := providerData{

--- a/integrations/terraform-mwi/provider/provider.go
+++ b/integrations/terraform-mwi/provider/provider.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
@@ -62,6 +63,12 @@ type ProviderModel struct {
 	JoinToken types.String `tfsdk:"join_token"`
 	// Insecure indicates whether to skip TLS verification for the proxy server.
 	Insecure types.Bool `tfsdk:"insecure"`
+	// SkipInitialConnection puts the provider into a "lazy" initialization mode
+	// where we avoid making connections to the Teleport cluster until the first
+	// resource or data source is actually used. This can be useful in scenarios
+	// where multiple providers are at play and the user wishes to selectively
+	// use the Teleport provider.
+	SkipInitialConnection types.Bool `tfsdk:"skip_initial_connection"`
 }
 
 func (p *Provider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -92,6 +99,10 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 			},
 			"insecure": schema.BoolAttribute{
 				MarkdownDescription: "When enabled, the certificates of the Proxy will not be verified. This is not recommended for production use.",
+				Optional:            true,
+			},
+			"skip_initial_connection": schema.BoolAttribute{
+				MarkdownDescription: "When enabled, puts the provider into a lazy initialization mode where we avoid making connections to the Teleport cluster until the first resource or data source is actually used.\n\nThis can be useful in scenarios where multiple providers are at play and the user wishes to selectively use the Teleport provider.",
 				Optional:            true,
 			},
 		},
@@ -125,6 +136,36 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 			},
 			InternalStorage: botInternalStore,
 			Logger:          slog.Default(),
+		}
+	}
+
+	skipInitialConnection := data.SkipInitialConnection.ValueBool()
+	if !skipInitialConnection {
+		botCfg := newBotConfig()
+		if err := botCfg.CheckAndSetDefaults(); err != nil {
+			resp.Diagnostics.AddError(
+				"Error setting defaults for bot config",
+				"Failed to set defaults for bot config: "+err.Error(),
+			)
+			return
+		}
+
+		bot, err := bot.New(botCfg)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error creating tbot",
+				"Failed to create tbot: "+err.Error(),
+			)
+			return
+		}
+
+		// Run bot just to validate that the configuration is correct.
+		if err := bot.OneShot(ctx); err != nil {
+			resp.Diagnostics.AddError(
+				"Error running tbot in provider",
+				"Failed to run tbot\n"+trace.DebugReport(err),
+			)
+			return
 		}
 	}
 

--- a/integrations/terraform-mwi/provider/provider_test.go
+++ b/integrations/terraform-mwi/provider/provider_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
@@ -35,4 +37,57 @@ var testAccProtoV6ProviderFactoriesWithEcho = map[string]func() (tfprotov6.Provi
 
 func testAccPreCheck(t *testing.T) {
 	// Code to run before any acceptance test.
+}
+
+func TestProviderConfigureNoNetwork(t *testing.T) {
+	// This test verifies that Configure() succeeds without making
+	// a network connection. Before this change, Configure() would
+	// fail here because bot.OneShot() would try to connect to a
+	// non-existent Teleport proxy.
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Provider is configured with a bogus address.
+				// With lazy Configure, this should NOT error
+				// because no resource triggers a connection.
+				Config: `
+provider "teleportmwi" {
+  proxy_server = "localhost:0"
+  join_method  = "terraform_cloud"
+  join_token   = "bogus-token"
+}
+`,
+				// No resources declared — nothing triggers a connection.
+				// Terraform should plan successfully.
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestProviderConfigureErrorDeferredToResource(t *testing.T) {
+	// This test verifies that when a resource IS used with invalid
+	// credentials, the error surfaces at resource Open/Read time.
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+provider "teleportmwi" {
+  proxy_server = "localhost:0"
+  join_method  = "terraform_cloud"
+  join_token   = "bogus-token"
+}
+
+data "teleportmwi_kubernetes" "example" {
+  selector = {
+    name = "test-cluster"
+  }
+}
+`,
+				ExpectError: regexp.MustCompile(`Error (creating|running) tbot`),
+			},
+		},
+	})
 }

--- a/integrations/terraform-mwi/provider/provider_test.go
+++ b/integrations/terraform-mwi/provider/provider_test.go
@@ -39,45 +39,47 @@ func testAccPreCheck(t *testing.T) {
 	// Code to run before any acceptance test.
 }
 
-func TestProviderConfigureNoNetwork(t *testing.T) {
-	// This test verifies that Configure() succeeds without making
-	// a network connection. Before this change, Configure() would
-	// fail here because bot.OneShot() would try to connect to a
-	// non-existent Teleport proxy.
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				// Provider is configured with a bogus address.
-				// With lazy Configure, this should NOT error
-				// because no resource triggers a connection.
-				Config: `
+func TestProviderConfigure_SkipInitalConnection(t *testing.T) {
+	t.Run("no resource", func(t *testing.T) {
+		// This test verifies that Configure() succeeds without making
+		// a network connection. Before this change, Configure() would
+		// fail here because bot.OneShot() would try to connect to a
+		// non-existent Teleport proxy.
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					// Provider is configured with a bogus address.
+					// With lazy Configure, this should NOT error
+					// because no resource triggers a connection.
+					Config: `
 provider "teleportmwi" {
-  proxy_server = "localhost:0"
-  join_method  = "terraform_cloud"
-  join_token   = "bogus-token"
+  proxy_server            = "localhost:0"
+  join_method             = "terraform_cloud"
+  join_token              = "bogus-token"
+  skip_initial_connection = true
 }
 `,
-				// No resources declared — nothing triggers a connection.
-				// Terraform should plan successfully.
-				PlanOnly: true,
+					// No resources declared — nothing triggers a connection.
+					// Terraform should plan successfully.
+					PlanOnly: true,
+				},
 			},
-		},
+		})
 	})
-}
-
-func TestProviderConfigureErrorDeferredToResource(t *testing.T) {
-	// This test verifies that when a resource IS used with invalid
-	// credentials, the error surfaces at resource Open/Read time.
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: `
+	t.Run("with resource", func(t *testing.T) {
+		// This test verifies that when a resource IS used with invalid
+		// credentials, the error surfaces at resource Open/Read time.
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: `
 provider "teleportmwi" {
-  proxy_server = "localhost:0"
-  join_method  = "terraform_cloud"
-  join_token   = "bogus-token"
+  proxy_server            = "localhost:0"
+  join_method             = "terraform_cloud"
+  join_token              = "bogus-token"
+  skip_initial_connection = true
 }
 
 data "teleportmwi_kubernetes" "example" {
@@ -86,8 +88,10 @@ data "teleportmwi_kubernetes" "example" {
   }
 }
 `,
-				ExpectError: regexp.MustCompile(`Error (creating|running) tbot`),
+					ExpectError: regexp.MustCompile(`Error (creating|running) tbot`),
+				},
 			},
-		},
+		})
 	})
+
 }


### PR DESCRIPTION
Backport #66004 to branch/v18

changelog: Introduces `skip_initial_connection` option to the `teleportmwi` provider to allow lazy initialisation of the provider.

 ## Manual Test Plan
 ### Test Environment

Terraform CLI with `dev_overrides` pointing at a local build

```
Terraform v1.14.9
on darwin_arm64
```

### Test Cases

- [x] (regression): Provider configuration standard,`terraform plan/apply` config map to Kubernetes cluster
- [x] Provider configured with `skip_initial_connection`, `terraform plan/apply` config map to Kubernetes cluster with standard configuration
  - [x] Observe from logs that `tbot` does not run in initialisation phase
- [x] `terraform plan` with provider configured with `skip_initial_connection` but no resources succeeds without network access
- [x] `terraform plan` with provider configured with `skip_initial_connection`, `teleportmwi_kubernetes` resource fails at plan time with a connection error (not at provider init)