### PR TITLE
Change from compare failed error to not found

### DIFF
--- a/integrations/operator/controllers/resources/scopedrole_controller.go
+++ b/integrations/operator/controllers/resources/scopedrole_controller.go
@@ -44,11 +44,6 @@ func (s *scopedRoleClient) Delete(ctx context.Context, name string) error {
 	_, err := s.teleportClient.ScopedAccessServiceClient().DeleteScopedRole(ctx, &accessv1.DeleteScopedRoleRequest{
 		Name: name,
 	})
-	// The deletetion API for scoped roles returns CompareFailed if not found, which was an intentional decision
-	// We handle it here and return a not found error for consistency with the deletion reconcile.
-	if err != nil && trace.IsCompareFailed(err) {
-		return trace.NotFound("scoped role %q not found: %v", name, err)
-	}
 	return trace.Wrap(err)
 }
 

--- a/integrations/operator/controllers/resources/scopedroleassignment_controller.go
+++ b/integrations/operator/controllers/resources/scopedroleassignment_controller.go
@@ -46,9 +46,6 @@ func (s *scopedRoleAssignmentClient) Delete(ctx context.Context, name string) er
 		Name:    name,
 		SubKind: scopedaccess.SubKindDynamic,
 	})
-	if err != nil && trace.IsCompareFailed(err) {
-		return trace.NotFound("scoped role assignment %q not found: %v", name, err)
-	}
 	return trace.Wrap(err)
 }
 

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -184,16 +184,11 @@ func (s *Server) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.Delet
 		return s.cfg.Writer.DeleteScopedRole(ctx, req)
 	}
 
-	// load the role so we can determine the resource scope
-	grsp, err := s.cfg.Reader.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+	// load the role so we can determine the resource scope.
+	grsp, err := s.cfg.BackendReader.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
 		Name: req.GetName(),
 	})
 	if err != nil {
-		if trace.IsNotFound(err) {
-			// this API deliberately does not distinguish between kinds of concurrent modification
-			// in its error kinds.
-			return nil, trace.CompareFailed("scoped role %q has been concurrently modified and/or deleted", req.GetName())
-		}
 		return nil, trace.Wrap(err)
 	}
 
@@ -243,17 +238,12 @@ func (s *Server) DeleteScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return s.cfg.Writer.DeleteScopedRoleAssignment(ctx, req)
 	}
 
-	// load the assignment so we can determine the resource scope
-	grsp, err := s.cfg.Reader.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+	// load the assignment so we can determine the resource scope.
+	grsp, err := s.cfg.BackendReader.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
 		Name:    req.GetName(),
 		SubKind: req.GetSubKind(),
 	})
 	if err != nil {
-		if trace.IsNotFound(err) {
-			// this API deliberately does not distinguish between kinds of concurrent modification
-			// in its error kinds.
-			return nil, trace.CompareFailed("scoped role assignment %q has been concurrently modified and/or deleted", req.GetName())
-		}
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/services/local/scoped_access.go
+++ b/lib/services/local/scoped_access.go
@@ -268,7 +268,7 @@ func (s *ScopedAccessService) DeleteScopedRole(ctx context.Context, req *scopeda
 		if err := s.bk.Delete(ctx, scopedRoleKey(roleName)); err != nil {
 			if trace.IsNotFound(err) {
 				// generic condition failure keeps error handling simpler
-				return nil, trace.CompareFailed("scoped role %q not found", roleName)
+				return nil, trace.NotFound("scoped role %q not found", roleName)
 			}
 			return nil, trace.Wrap(err)
 		}
@@ -622,7 +622,7 @@ func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, re
 		if err := s.bk.Delete(ctx, key); err != nil {
 			if trace.IsNotFound(err) {
 				// generic condition failure keeps error handling simpler
-				return nil, trace.CompareFailed("scoped role assignment %q not found", assignmentName)
+				return nil, trace.NotFound("scoped role assignment %q not found", assignmentName)
 			}
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/local/scoped_access_test.go
+++ b/lib/services/local/scoped_access_test.go
@@ -339,7 +339,7 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 		Name: "non-existent",
 	})
 	require.Error(t, err)
-	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+	require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
 
 	// verify that delete fails if the revision does not match
 	_, err = service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{


### PR DESCRIPTION
Propagate NotFound error instead of compare failed in order to support IAC

<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases
- [x] Deleting non existing scoped role and scoped role assignment yields not found error
- [x] Verify k8s deletion works - Deleted a scoped role and scoped role assignment that depended on each other 
   - scoped role deletion before SRA
   - SRA deletion before SR
