### PR TITLE
[v17] docs: fix cli reference

### DIFF
--- a/docs/pages/installation/linux.mdx
+++ b/docs/pages/installation/linux.mdx
@@ -20,7 +20,7 @@ in [Installing Teleport as an agent](#installing-teleport-as-an-agent).
 | - | - | - | - | - | - |
 | Linux 3.2+ (RHEL/CentOS 7+, Rocky Linux 8+, Amazon Linux 2+, Amazon Linux 2023+, Ubuntu 16.04+, Debian 9+, SLES 12 SP 5+, and SLES 15 SP 5+) \[2] | yes | yes | yes \[3] | yes | yes |
 
-\[1] *`tsh` is a Command Line Client (CLI) and Teleport Connect is a Graphical User Interface (GUI) desktop client. See [Using Teleport Connect](../connect-your-client/teleport-connect.mdx) for usage and installation.*
+\[1] *`tsh` is a Command Line Inteface (CLI) client and Teleport Connect is a Graphical User Interface (GUI) desktop client. See [Using Teleport Connect](../connect-your-client/teleport-connect.mdx) for usage and installation.*
 
 \[2] *Enhanced Session Recording requires Linux kernel v5.8+.*
 

--- a/docs/pages/installation/linux.mdx
+++ b/docs/pages/installation/linux.mdx
@@ -20,7 +20,7 @@ in [Installing Teleport as an agent](#installing-teleport-as-an-agent).
 | - | - | - | - | - | - |
 | Linux 3.2+ (RHEL/CentOS 7+, Rocky Linux 8+, Amazon Linux 2+, Amazon Linux 2023+, Ubuntu 16.04+, Debian 9+, SLES 12 SP 5+, and SLES 15 SP 5+) \[2] | yes | yes | yes \[3] | yes | yes |
 
-\[1] *`tsh` is a Command Line Inteface (CLI) client and Teleport Connect is a Graphical User Interface (GUI) desktop client. See [Using Teleport Connect](../connect-your-client/teleport-connect.mdx) for usage and installation.*
+\[1] *`tsh` is a Command Line Interface (CLI) client and Teleport Connect is a Graphical User Interface (GUI) desktop client. See [Using Teleport Connect](../connect-your-client/teleport-connect.mdx) for usage and installation.*
 
 \[2] *Enhanced Session Recording requires Linux kernel v5.8+.*
 

--- a/docs/pages/installation/macos.mdx
+++ b/docs/pages/installation/macos.mdx
@@ -17,7 +17,7 @@ For an overview of Teleport installation methods and supported platforms, see
 | - | - | - | - | - | - |
 | macOS 12+  (Monterey) | yes | yes | yes | yes | yes |
 
-\[1] *`tsh` is a Command Line Client (CLI) and Teleport Connect is a Graphical User Interface (GUI) desktop client. See
+\[1] *`tsh` is a Command Line Interface (CLI) client and Teleport Connect is a Graphical User Interface (GUI) desktop client. See
   [Using Teleport Connect](../connect-your-client/teleport-connect.mdx) for usage and installation*.
 
 (!docs/pages/includes/client-cluster-compatibility.mdx!)

--- a/docs/pages/installation/windows.mdx
+++ b/docs/pages/installation/windows.mdx
@@ -16,7 +16,7 @@ For an overview of Teleport installation methods and supported platforms, see
 | - | - | - | - | - | - |
 | Windows 10+ (rev. 1607) \[2] | no | yes | yes | yes | yes |
 
-\[1] *`tsh` is a Command Line Client (CLI) and Teleport Connect is a Graphical User Interface (GUI) desktop client. See [Using Teleport Connect](../connect-your-client/teleport-connect.mdx) for usage and installation*.
+\[1] *`tsh` is a Command Line Interface (CLI) client and Teleport Connect is a Graphical User Interface (GUI) desktop client. See [Using Teleport Connect](../connect-your-client/teleport-connect.mdx) for usage and installation*.
 
 \[2] *Teleport server does not run on Windows yet, but `tsh`, `tbot`, `tctl`, and Teleport Connect (the Teleport desktop clients) support most features on Windows 10 and later.*
 


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/66115 to branch/v17