### PR TITLE
fix: Impl `ListAuthServers`/`ListProxyServers` on presencev1

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6073,14 +6073,15 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	usersv1pb.RegisterUsersServiceServer(server, usersService)
 
 	presenceService, err := presencev1.NewService(presencev1.ServiceConfig{
-		Authorizer: cfg.Authorizer,
-		AuthServer: cfg.AuthServer,
-		Backend:    cfg.AuthServer.Services,
-		Cache:      cfg.AuthServer.Cache,
-		Emitter:    cfg.Emitter,
-		Reporter:   cfg.AuthServer.Services.UsageReporter,
-		Clock:      cfg.AuthServer.GetClock(),
-		Logger:     cfg.AuthServer.logger.With(teleport.ComponentKey, "presence.service"),
+		Authorizer:       cfg.Authorizer,
+		ScopedAuthorizer: cfg.ScopedAuthorizer,
+		AuthServer:       cfg.AuthServer,
+		Backend:          cfg.AuthServer.Services,
+		Cache:            cfg.AuthServer.Cache,
+		Emitter:          cfg.Emitter,
+		Reporter:         cfg.AuthServer.Services.UsageReporter,
+		Clock:            cfg.AuthServer.GetClock(),
+		Logger:           cfg.AuthServer.logger.With(teleport.ComponentKey, "presence.service"),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -3817,60 +3817,6 @@ func (g *GRPCServer) DeleteToken(ctx context.Context, req *types.ResourceRequest
 	return &emptypb.Empty{}, nil
 }
 
-// ListAuthServers returns a paginated list of auth servers.
-func (g *GRPCServer) ListAuthServers(ctx context.Context, req *presencev1pb.ListAuthServersRequest) (*presencev1pb.ListAuthServersResponse, error) {
-	auth, err := g.scopedAuthenticate(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	servers, next, err := auth.ListAuthServers(ctx, int(req.GetPageSize()), req.GetPageToken())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	serverV2s := make([]*types.ServerV2, 0, len(servers))
-	for _, server := range servers {
-		srv, ok := server.(*types.ServerV2)
-		if !ok {
-			return nil, trace.Errorf("encountered unexpected server type: %T", server)
-		}
-		serverV2s = append(serverV2s, srv)
-	}
-
-	return presencev1pb.ListAuthServersResponse_builder{
-		Servers:       serverV2s,
-		NextPageToken: next,
-	}.Build(), nil
-}
-
-// ListProxyServers returns a paginated list of proxy servers.
-func (g *GRPCServer) ListProxyServers(ctx context.Context, req *presencev1pb.ListProxyServersRequest) (*presencev1pb.ListProxyServersResponse, error) {
-	auth, err := g.scopedAuthenticate(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	servers, next, err := auth.ListProxyServers(ctx, int(req.GetPageSize()), req.GetPageToken())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	serverV2s := make([]*types.ServerV2, 0, len(servers))
-	for _, server := range servers {
-		srv, ok := server.(*types.ServerV2)
-		if !ok {
-			return nil, trace.Errorf("encountered unexpected server type: %T", server)
-		}
-		serverV2s = append(serverV2s, srv)
-	}
-
-	return presencev1pb.ListProxyServersResponse_builder{
-		Servers:       serverV2s,
-		NextPageToken: next,
-	}.Build(), nil
-}
-
 // GetNode retrieves a node by name and namespace.
 func (g *GRPCServer) GetNode(ctx context.Context, req *types.ResourceInNamespaceRequest) (*types.ServerV2, error) {
 	if req.Namespace == "" {

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -55,6 +55,8 @@ type Backend interface {
 }
 
 type Cache interface {
+	ListAuthServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
+	ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
 	ListReverseTunnels(ctx context.Context, pageSize int, nextToken string) ([]types.ReverseTunnel, string, error)
 	GetRelayServer(ctx context.Context, name string) (*presencepb.RelayServer, error)
 	ListRelayServers(ctx context.Context, pageSize int, pageToken string) (_ []*presencepb.RelayServer, nextPageToken string, _ error)
@@ -331,6 +333,80 @@ func (s *Service) DeleteRemoteCluster(
 	}
 
 	return &emptypb.Empty{}, nil
+}
+
+// ListAuthServers returns a page of auth servers.
+func (s *Service) ListAuthServers(
+	ctx context.Context, req *presencepb.ListAuthServersRequest,
+) (*presencepb.ListAuthServersResponse, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := authCtx.CheckAccessToKind(types.KindAuthServer, types.VerbList, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	servers, nextToken, err := s.cache.ListAuthServers(ctx, int(req.PageSize), req.PageToken)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	serverV2s := make([]*types.ServerV2, 0, len(servers))
+	for _, server := range servers {
+		v2, ok := server.(*types.ServerV2)
+		if !ok {
+			s.logger.WarnContext(ctx, "unexpected server type",
+				"got_type", logutils.TypeAttr(server),
+				"expected_type", "ServerV2",
+				"server", server.GetName(),
+			)
+			continue
+		}
+		serverV2s = append(serverV2s, v2)
+	}
+
+	return &presencepb.ListAuthServersResponse{
+		Servers:       serverV2s,
+		NextPageToken: nextToken,
+	}, nil
+}
+
+// ListProxyServers returns a page of proxy servers.
+func (s *Service) ListProxyServers(
+	ctx context.Context, req *presencepb.ListProxyServersRequest,
+) (*presencepb.ListProxyServersResponse, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := authCtx.CheckAccessToKind(types.KindProxy, types.VerbList, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	servers, nextToken, err := s.cache.ListProxyServers(ctx, int(req.PageSize), req.PageToken)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	serverV2s := make([]*types.ServerV2, 0, len(servers))
+	for _, server := range servers {
+		v2, ok := server.(*types.ServerV2)
+		if !ok {
+			s.logger.WarnContext(ctx, "unexpected server type",
+				"got_type", logutils.TypeAttr(server),
+				"expected_type", "ServerV2",
+				"server", server.GetName(),
+			)
+			continue
+		}
+		serverV2s = append(serverV2s, v2)
+	}
+
+	return &presencepb.ListProxyServersResponse{
+		Servers:       serverV2s,
+		NextPageToken: nextToken,
+	}, nil
 }
 
 // ListReverseTunnels returns a page of reverse tunnels.

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -72,28 +72,30 @@ type AuthServer interface {
 // ServiceConfig holds configuration options for
 // the presence gRPC service.
 type ServiceConfig struct {
-	Authorizer authz.Authorizer
-	AuthServer AuthServer
-	Backend    Backend
-	Cache      Cache
-	Logger     *slog.Logger
-	Emitter    apievents.Emitter
-	Reporter   usagereporter.UsageReporter
-	Clock      clockwork.Clock
+	Authorizer       authz.Authorizer
+	ScopedAuthorizer authz.ScopedAuthorizer
+	AuthServer       AuthServer
+	Backend          Backend
+	Cache            Cache
+	Logger           *slog.Logger
+	Emitter          apievents.Emitter
+	Reporter         usagereporter.UsageReporter
+	Clock            clockwork.Clock
 }
 
 // Service implements the teleport.presence.v1.PresenceService RPC service.
 type Service struct {
 	presencepb.UnimplementedPresenceServiceServer
 
-	authorizer authz.Authorizer
-	authServer AuthServer
-	backend    Backend
-	cache      Cache
-	logger     *slog.Logger
-	emitter    apievents.Emitter
-	reporter   usagereporter.UsageReporter
-	clock      clockwork.Clock
+	authorizer       authz.Authorizer
+	scopedAuthorizer authz.ScopedAuthorizer
+	authServer       AuthServer
+	backend          Backend
+	cache            Cache
+	logger           *slog.Logger
+	emitter          apievents.Emitter
+	reporter         usagereporter.UsageReporter
+	clock            clockwork.Clock
 }
 
 var _ presencepb.PresenceServiceServer = (*Service)(nil)
@@ -105,6 +107,8 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		return nil, trace.BadParameter("backend service is required")
 	case cfg.Authorizer == nil:
 		return nil, trace.BadParameter("authorizer is required")
+	case cfg.ScopedAuthorizer == nil:
+		return nil, trace.BadParameter("scoped authorizer is required")
 	case cfg.Emitter == nil:
 		return nil, trace.BadParameter("emitter is required")
 	case cfg.Reporter == nil:
@@ -123,11 +127,12 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	}
 
 	return &Service{
-		logger:     cfg.Logger,
-		authorizer: cfg.Authorizer,
-		authServer: cfg.AuthServer,
-		backend:    cfg.Backend,
-		cache:      cfg.Cache,
+		logger:           cfg.Logger,
+		authorizer:       cfg.Authorizer,
+		scopedAuthorizer: cfg.ScopedAuthorizer,
+		authServer:       cfg.AuthServer,
+		backend:          cfg.Backend,
+		cache:            cfg.Cache,
 
 		emitter:  cfg.Emitter,
 		reporter: cfg.Reporter,
@@ -339,15 +344,16 @@ func (s *Service) DeleteRemoteCluster(
 func (s *Service) ListAuthServers(
 	ctx context.Context, req *presencepb.ListAuthServersRequest,
 ) (*presencepb.ListAuthServersResponse, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authzCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := authCtx.CheckAccessToKind(types.KindAuthServer, types.VerbList, types.VerbRead); err != nil {
+	ruleCtx := authzCtx.RuleContext()
+	if err := authzCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadAuthServers, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	servers, nextToken, err := s.cache.ListAuthServers(ctx, int(req.PageSize), req.PageToken)
+	servers, nextToken, err := s.cache.ListAuthServers(ctx, int(req.GetPageSize()), req.GetPageToken())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -366,25 +372,26 @@ func (s *Service) ListAuthServers(
 		serverV2s = append(serverV2s, v2)
 	}
 
-	return &presencepb.ListAuthServersResponse{
+	return presencepb.ListAuthServersResponse_builder{
 		Servers:       serverV2s,
 		NextPageToken: nextToken,
-	}, nil
+	}.Build(), nil
 }
 
 // ListProxyServers returns a page of proxy servers.
 func (s *Service) ListProxyServers(
 	ctx context.Context, req *presencepb.ListProxyServersRequest,
 ) (*presencepb.ListProxyServersResponse, error) {
-	authCtx, err := s.authorizer.Authorize(ctx)
+	authzCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := authCtx.CheckAccessToKind(types.KindProxy, types.VerbList, types.VerbRead); err != nil {
+	ruleCtx := authzCtx.RuleContext()
+	if err := authzCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadProxies, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	servers, nextToken, err := s.cache.ListProxyServers(ctx, int(req.PageSize), req.PageToken)
+	servers, nextToken, err := s.cache.ListProxyServers(ctx, int(req.GetPageSize()), req.GetPageToken())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -403,10 +410,10 @@ func (s *Service) ListProxyServers(
 		serverV2s = append(serverV2s, v2)
 	}
 
-	return &presencepb.ListProxyServersResponse{
+	return presencepb.ListProxyServersResponse_builder{
 		Servers:       serverV2s,
 		NextPageToken: nextToken,
-	}, nil
+	}.Build(), nil
 }
 
 // ListReverseTunnels returns a page of reverse tunnels.

--- a/lib/auth/presence/presencev1/service_test.go
+++ b/lib/auth/presence/presencev1/service_test.go
@@ -673,6 +673,264 @@ func TestUpdateRemoteCluster(t *testing.T) {
 	}
 }
 
+// TestListAuthServers is an integration test that uses a real gRPC
+// client/server.
+func TestListAuthServers(t *testing.T) {
+	t.Parallel()
+	srv := newTestTLSServer(t)
+	ctx := context.Background()
+
+	user, role, err := authtest.CreateUserAndRole(
+		srv.Auth(),
+		"auth-server-lister",
+		[]string{},
+		[]types.Rule{
+			{
+				Resources: []string{types.KindAuthServer},
+				Verbs:     []string{types.VerbList, types.VerbRead},
+			},
+		})
+	require.NoError(t, err)
+	_, err = srv.Auth().UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	unprivilegedUser, unprivilegedRole, err := authtest.CreateUserAndRole(
+		srv.Auth(),
+		"no-perms",
+		[]string{},
+		[]types.Rule{},
+	)
+	require.NoError(t, err)
+	unprivilegedRole.SetRules(types.Deny, []types.Rule{
+		{
+			Resources: []string{types.KindAuthServer},
+			Verbs:     []string{types.VerbList},
+		},
+	})
+	_, err = srv.Auth().UpsertRole(ctx, unprivilegedRole)
+	require.NoError(t, err)
+
+	// Create a few auth servers
+	created := []*types.ServerV2{}
+	for i := range 3 {
+		server := &types.ServerV2{
+			Kind:    types.KindAuthServer,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      fmt.Sprintf("auth-%d", i),
+				Namespace: "default",
+			},
+			Spec: types.ServerSpecV2{
+				Addr: fmt.Sprintf("127.0.0.1:%d", 3025+i),
+			},
+		}
+		require.NoError(t, srv.Auth().UpsertAuthServer(ctx, server))
+		created = append(created, server)
+	}
+
+	tests := []struct {
+		name        string
+		user        string
+		req         *presencev1pb.ListAuthServersRequest
+		assertError require.ErrorAssertionFunc
+		want        []*types.ServerV2
+	}{
+		{
+			name:        "success",
+			user:        user.GetName(),
+			req:         &presencev1pb.ListAuthServersRequest{},
+			assertError: require.NoError,
+			want:        created,
+		},
+		{
+			name: "no permissions",
+			user: unprivilegedUser.GetName(),
+			req:  &presencev1pb.ListAuthServersRequest{},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "error should be access denied")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := srv.NewClient(authtest.TestUser(tt.user))
+			require.NoError(t, err)
+
+			res, err := client.PresenceServiceClient().ListAuthServers(ctx, tt.req)
+			tt.assertError(t, err)
+			if tt.want != nil {
+				require.Empty(
+					t, cmp.Diff(
+						tt.want,
+						res.Servers,
+						cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+					),
+				)
+			}
+		})
+	}
+
+	t.Run("pagination", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(user.GetName()))
+		require.NoError(t, err)
+
+		allGot := []*types.ServerV2{}
+		pageToken := ""
+		for i := range 3 {
+			var got []types.Server
+			got, pageToken, err = client.ListAuthServers(ctx, 1, pageToken)
+			require.NoError(t, err)
+			if i == 2 {
+				require.Empty(t, pageToken)
+			} else {
+				require.NotEmpty(t, pageToken)
+			}
+			require.Len(t, got, 1)
+			for _, item := range got {
+				allGot = append(allGot, item.(*types.ServerV2))
+			}
+		}
+		require.Len(t, allGot, 3)
+
+		require.Empty(
+			t, cmp.Diff(
+				allGot,
+				created,
+				cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+			),
+		)
+	})
+}
+
+// TestListProxyServers is an integration test that uses a real gRPC
+// client/server.
+func TestListProxyServers(t *testing.T) {
+	t.Parallel()
+	srv := newTestTLSServer(t)
+	ctx := context.Background()
+
+	user, role, err := authtest.CreateUserAndRole(
+		srv.Auth(),
+		"proxy-server-lister",
+		[]string{},
+		[]types.Rule{
+			{
+				Resources: []string{types.KindProxy},
+				Verbs:     []string{types.VerbList, types.VerbRead},
+			},
+		})
+	require.NoError(t, err)
+	_, err = srv.Auth().UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	unprivilegedUser, unprivilegedRole, err := authtest.CreateUserAndRole(
+		srv.Auth(),
+		"no-perms",
+		[]string{},
+		[]types.Rule{},
+	)
+	require.NoError(t, err)
+	unprivilegedRole.SetRules(types.Deny, []types.Rule{
+		{
+			Resources: []string{types.KindProxy},
+			Verbs:     []string{types.VerbList},
+		},
+	})
+	_, err = srv.Auth().UpsertRole(ctx, unprivilegedRole)
+	require.NoError(t, err)
+
+	// Create a few proxy servers
+	created := []*types.ServerV2{}
+	for i := range 3 {
+		server := &types.ServerV2{
+			Kind:    types.KindProxy,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:      fmt.Sprintf("proxy-%d", i),
+				Namespace: "default",
+			},
+			Spec: types.ServerSpecV2{
+				Addr: fmt.Sprintf("127.0.0.1:%d", 3080+i),
+			},
+		}
+		require.NoError(t, srv.Auth().UpsertProxy(ctx, server))
+		created = append(created, server)
+	}
+
+	tests := []struct {
+		name        string
+		user        string
+		req         *presencev1pb.ListProxyServersRequest
+		assertError require.ErrorAssertionFunc
+		want        []*types.ServerV2
+	}{
+		{
+			name:        "success",
+			user:        user.GetName(),
+			req:         &presencev1pb.ListProxyServersRequest{},
+			assertError: require.NoError,
+			want:        created,
+		},
+		{
+			name: "no permissions",
+			user: unprivilegedUser.GetName(),
+			req:  &presencev1pb.ListProxyServersRequest{},
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.True(t, trace.IsAccessDenied(err), "error should be access denied")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := srv.NewClient(authtest.TestUser(tt.user))
+			require.NoError(t, err)
+
+			res, err := client.PresenceServiceClient().ListProxyServers(ctx, tt.req)
+			tt.assertError(t, err)
+			if tt.want != nil {
+				require.Empty(
+					t, cmp.Diff(
+						tt.want,
+						res.Servers,
+						cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+					),
+				)
+			}
+		})
+	}
+
+	t.Run("pagination", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(user.GetName()))
+		require.NoError(t, err)
+
+		allGot := []*types.ServerV2{}
+		pageToken := ""
+		for i := range 3 {
+			var got []types.Server
+			got, pageToken, err = client.ListProxyServers(ctx, 1, pageToken)
+			require.NoError(t, err)
+			if i == 2 {
+				require.Empty(t, pageToken)
+			} else {
+				require.NotEmpty(t, pageToken)
+			}
+			require.Len(t, got, 1)
+			for _, item := range got {
+				allGot = append(allGot, item.(*types.ServerV2))
+			}
+		}
+		require.Len(t, allGot, 3)
+
+		require.Empty(
+			t, cmp.Diff(
+				allGot,
+				created,
+				cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+			),
+		)
+	})
+}
+
 // TestListReverseTunnels is an integration test that uses a real gRPC
 // client/server.
 func TestListReverseTunnels(t *testing.T) {

--- a/lib/auth/presence/presencev1/service_test.go
+++ b/lib/auth/presence/presencev1/service_test.go
@@ -853,7 +853,8 @@ func TestListProxyServers(t *testing.T) {
 				Addr: fmt.Sprintf("127.0.0.1:%d", 3080+i),
 			},
 		}
-		require.NoError(t, srv.Auth().UpsertProxy(ctx, server))
+		_, err := srv.Auth().UpsertProxyServer(ctx, server)
+		require.NoError(t, err)
 		created = append(created, server)
 	}
 


### PR DESCRIPTION
## Context
RPCs were incorrectly implemented on AuthService instead of Presence. This was masked by fallback logic we plan to remove in v21.

## Related
- See #65966 
