### PR TITLE
Add channel IDs, dirty rect info to RDP decoder/state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,6 +2336,7 @@ version = "0.1.0"
 dependencies = [
  "ironrdp-core",
  "ironrdp-graphics",
+ "ironrdp-pdu",
  "ironrdp-session",
 ]
 

--- a/lib/srv/desktop/rdp/decoder/Cargo.toml
+++ b/lib/srv/desktop/rdp/decoder/Cargo.toml
@@ -11,4 +11,5 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 ironrdp-core.workspace = true
 ironrdp-graphics.workspace = true
+ironrdp-pdu.workspace = true
 ironrdp-session.workspace = true

--- a/lib/srv/desktop/rdp/decoder/decoder.go
+++ b/lib/srv/desktop/rdp/decoder/decoder.go
@@ -42,18 +42,30 @@ package decoder
 #cgo noescape rdp_decoder_image_data
 #cgo nocallback rdp_decoder_cursor_state
 #cgo noescape rdp_decoder_cursor_state
+#cgo nocallback rdp_decoder_cursor_bitmap
+#cgo noescape rdp_decoder_cursor_bitmap
+#cgo nocallback rdp_decoder_updated_regions_count
+#cgo noescape rdp_decoder_updated_regions_count
+#cgo nocallback rdp_decoder_updated_regions
+#cgo noescape rdp_decoder_updated_regions
+#cgo nocallback rdp_decoder_reset_updated_regions
+#cgo noescape rdp_decoder_reset_updated_regions
 
 #include <stdint.h>
 
 typedef struct RdpDecoder RdpDecoder;
 
-RdpDecoder* rdp_decoder_new(uint16_t width, uint16_t height);
+RdpDecoder* rdp_decoder_new(uint16_t width, uint16_t height, uint16_t io_channel_id, uint16_t user_channel_id);
 void rdp_decoder_free(RdpDecoder* ptr);
 
 void rdp_decoder_resize(RdpDecoder* ptr, uint16_t width, uint16_t height);
 void rdp_decoder_process(RdpDecoder* ptr, const uint8_t* data, size_t len);
 const uint8_t* rdp_decoder_image_data(RdpDecoder* ptr, uint16_t* width, uint16_t* height);
 void rdp_decoder_cursor_state(RdpDecoder* ptr, uint8_t* out_visible, uint16_t* out_x, uint16_t* out_y);
+const uint8_t* rdp_decoder_cursor_bitmap(RdpDecoder* ptr, uint16_t* out_width, uint16_t* out_height, uint16_t* out_hotspot_x, uint16_t* out_hotspot_y);
+uint32_t rdp_decoder_updated_regions_count(RdpDecoder* ptr);
+uint32_t rdp_decoder_updated_regions(RdpDecoder* ptr, uint16_t* out_buf, uint32_t max_count);
+void rdp_decoder_reset_updated_regions(RdpDecoder* ptr);
 */
 import "C"
 
@@ -70,16 +82,22 @@ type Decoder struct {
 	ptr *C.RdpDecoder
 }
 
-type CursorState struct {
-	Visible bool
-	X, Y    uint16
-}
+func New(width, height uint16, opts ...Option) (*Decoder, error) {
+	var config decoderConfig
+	for _, opt := range opts {
+		opt(&config)
+	}
 
-func New(width, height uint16) (*Decoder, error) {
-	ptr := C.rdp_decoder_new(C.uint16_t(width), C.uint16_t(height))
+	ptr := C.rdp_decoder_new(
+		C.uint16_t(width),
+		C.uint16_t(height),
+		C.uint16_t(config.ioChannelID),
+		C.uint16_t(config.userChannelID),
+	)
 	if ptr == nil {
 		return nil, errors.New("failed to create decoder")
 	}
+
 	return &Decoder{ptr: ptr}, nil
 }
 
@@ -189,4 +207,72 @@ func (d *Decoder) CursorState() CursorState {
 		X:       uint16(outX),
 		Y:       uint16(outY),
 	}
+}
+
+// CursorBitmap returns the current cursor bitmap, or nil if none is available.
+func (d *Decoder) CursorBitmap() *CursorBitmapData {
+	if d == nil || d.ptr == nil {
+		return nil
+	}
+
+	var bmpW, bmpH, hotX, hotY C.uint16_t
+	bmpData := C.rdp_decoder_cursor_bitmap(d.ptr, &bmpW, &bmpH, &hotX, &hotY)
+	if bmpData == nil || bmpW == 0 || bmpH == 0 {
+		return nil
+	}
+
+	w := int(bmpW)
+	h := int(bmpH)
+
+	cursorPix := make([]byte, w*h*4)
+	copy(cursorPix, unsafe.Slice((*uint8)(bmpData), w*h*4))
+
+	return &CursorBitmapData{
+		Image: &image.RGBA{
+			Pix:    cursorPix,
+			Stride: w * 4,
+			Rect:   image.Rect(0, 0, w, h),
+		},
+		HotspotX: int(hotX),
+		HotspotY: int(hotY),
+	}
+}
+
+// UpdatedRegions returns the individual screen regions updated since the last
+// call to ResetUpdatedRegions. Each rectangle uses Go's exclusive Max convention
+// (converted from the Rust decoder's inclusive coordinates).
+func (d *Decoder) UpdatedRegions() []image.Rectangle {
+	if d == nil || d.ptr == nil {
+		return nil
+	}
+
+	count := int(C.rdp_decoder_updated_regions_count(d.ptr))
+	if count == 0 {
+		return nil
+	}
+
+	buf := make([]C.uint16_t, count*4)
+	written := int(C.rdp_decoder_updated_regions(d.ptr, &buf[0], C.uint32_t(count)))
+
+	regions := make([]image.Rectangle, written)
+	for i := range written {
+		base := i * 4
+		// Rust uses inclusive right/bottom, Go uses exclusive — add 1.
+		regions[i] = image.Rect(
+			int(buf[base]),
+			int(buf[base+1]),
+			int(buf[base+2])+1,
+			int(buf[base+3])+1,
+		)
+	}
+
+	return regions
+}
+
+// ResetUpdatedRegions clears the accumulated update regions.
+func (d *Decoder) ResetUpdatedRegions() {
+	if d == nil || d.ptr == nil {
+		return
+	}
+	C.rdp_decoder_reset_updated_regions(d.ptr)
 }

--- a/lib/srv/desktop/rdp/decoder/decoder_common.go
+++ b/lib/srv/desktop/rdp/decoder/decoder_common.go
@@ -1,0 +1,58 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package decoder
+
+import (
+	"image"
+)
+
+// This file contains types and functions that are shared between the nop decoder (built without RDP decoder flag) and
+// the decoder built with the RDP decoder flag.
+
+// CursorState represents the state of the mouse cursor, including its visibility and position.
+type CursorState struct {
+	Visible bool
+	X, Y    uint16
+}
+
+// CursorBitmapData holds the cursor bitmap image and hotspot offset.
+type CursorBitmapData struct {
+	Image    *image.RGBA
+	HotspotX int
+	HotspotY int
+}
+
+type decoderConfig struct {
+	ioChannelID, userChannelID uint16
+}
+
+// Option is an option for configuring the RDP decoder.
+type Option func(*decoderConfig)
+
+// WithIOChannelID sets the I/O channel ID in the decoder configuration.
+func WithIOChannelID(id uint16) Option {
+	return func(c *decoderConfig) {
+		c.ioChannelID = id
+	}
+}
+
+// WithUserChannelID sets the user channel ID in the decoder configuration.
+func WithUserChannelID(id uint16) Option {
+	return func(c *decoderConfig) {
+		c.userChannelID = id
+	}
+}

--- a/lib/srv/desktop/rdp/decoder/decoder_nop.go
+++ b/lib/srv/desktop/rdp/decoder/decoder_nop.go
@@ -25,18 +25,17 @@ import (
 )
 
 type Decoder struct{}
-type CursorState struct {
-	Visible bool
-	X, Y    uint16
-}
 
-func New(width, height uint16) (*Decoder, error) {
+func New(width, height uint16, opts ...Option) (*Decoder, error) {
 	return nil, trace.NotImplemented("the RDP decoder is not included in this build")
 }
 
-func (d *Decoder) Release()                       {}
-func (d *Decoder) Resize(w, h uint16)             {}
-func (d *Decoder) Process([]byte)                 {}
-func (d *Decoder) Image() *image.RGBA             { return nil }
-func (d *Decoder) Thumbnail(w, h int) *image.RGBA { return nil }
-func (d *Decoder) CursorState() CursorState       { return CursorState{} }
+func (d *Decoder) Release()                          {}
+func (d *Decoder) Resize(w, h uint16)                {}
+func (d *Decoder) Process([]byte)                    {}
+func (d *Decoder) Image() *image.RGBA                { return nil }
+func (d *Decoder) Thumbnail(w, h int) *image.RGBA    { return nil }
+func (d *Decoder) CursorState() CursorState          { return CursorState{} }
+func (d *Decoder) CursorBitmap() *CursorBitmapData   { return nil }
+func (d *Decoder) UpdatedRegions() []image.Rectangle { return nil }
+func (d *Decoder) ResetUpdatedRegions()              {}

--- a/lib/srv/desktop/rdp/decoder/src/cursor.rs
+++ b/lib/srv/desktop/rdp/decoder/src/cursor.rs
@@ -1,0 +1,89 @@
+// Teleport
+// Copyright (C) 2026  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub(crate) struct CursorBitmap {
+    width: u16,
+    height: u16,
+    hotspot_x: u16,
+    hotspot_y: u16,
+    data: Vec<u8>, // RGBA, 4 bytes per pixel
+}
+
+impl CursorBitmap {
+    pub(crate) unsafe fn write_metadata(
+        &self,
+        out_width: *mut u16,
+        out_height: *mut u16,
+        out_hotspot_x: *mut u16,
+        out_hotspot_y: *mut u16,
+    ) {
+        unsafe {
+            *out_width = self.width;
+            *out_height = self.height;
+            *out_hotspot_x = self.hotspot_x;
+            *out_hotspot_y = self.hotspot_y;
+        }
+    }
+
+    pub(crate) fn data_ptr(&self) -> *const u8 {
+        self.data.as_ptr()
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct CursorState {
+    visible: bool,
+    x: u16,
+    y: u16,
+    bitmap: Option<CursorBitmap>,
+}
+
+impl CursorState {
+    pub(crate) fn set_bitmap(&mut self, pointer: &ironrdp_graphics::pointer::DecodedPointer) {
+        if pointer.bitmap_data.is_empty() {
+            return;
+        }
+
+        self.bitmap = Some(CursorBitmap {
+            width: pointer.width,
+            height: pointer.height,
+            hotspot_x: pointer.hotspot_x,
+            hotspot_y: pointer.hotspot_y,
+            data: pointer.bitmap_data.clone(),
+        });
+    }
+
+    pub(crate) fn move_cursor(&mut self, x: u16, y: u16) {
+        self.x = x;
+        self.y = y;
+    }
+
+    pub(crate) fn set_visible(&mut self, visible: bool) {
+        self.visible = visible;
+    }
+
+    pub(crate) fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    pub(crate) fn position(&self) -> (u16, u16) {
+        (self.x, self.y)
+    }
+
+    pub(crate) fn bitmap(&self) -> Option<&CursorBitmap> {
+        self.bitmap.as_ref()
+    }
+}

--- a/lib/srv/desktop/rdp/decoder/src/cursor.rs
+++ b/lib/srv/desktop/rdp/decoder/src/cursor.rs
@@ -66,6 +66,10 @@ impl CursorState {
         });
     }
 
+    pub(crate) fn clear_bitmap(&mut self) {
+        self.bitmap = None;
+    }
+
     pub(crate) fn move_cursor(&mut self, x: u16, y: u16) {
         self.x = x;
         self.y = y;
@@ -85,5 +89,34 @@ impl CursorState {
 
     pub(crate) fn bitmap(&self) -> Option<&CursorBitmap> {
         self.bitmap.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironrdp_graphics::pointer::DecodedPointer;
+
+    fn sample_pointer() -> DecodedPointer {
+        DecodedPointer {
+            width: 2,
+            height: 2,
+            hotspot_x: 0,
+            hotspot_y: 0,
+            bitmap_data: vec![0xFF; 2 * 2 * 4],
+        }
+    }
+
+    #[test]
+    fn pointer_default_clears_cached_bitmap() {
+        let mut state = CursorState::default();
+        state.set_bitmap(&sample_pointer());
+        assert!(state.bitmap().is_some());
+
+        state.set_visible(true);
+        state.clear_bitmap();
+
+        assert!(state.bitmap().is_none());
+        assert!(state.is_visible());
     }
 }

--- a/lib/srv/desktop/rdp/decoder/src/lib.rs
+++ b/lib/srv/desktop/rdp/decoder/src/lib.rs
@@ -30,8 +30,8 @@ use ironrdp_core::WriteBuf;
 use ironrdp_graphics::image_processing::PixelFormat;
 use ironrdp_session::fast_path::UpdateKind;
 use ironrdp_session::{
-	fast_path::{Processor, ProcessorBuilder},
-	image::DecodedImage,
+    fast_path::{Processor, ProcessorBuilder},
+    image::DecodedImage,
 };
 
 pub struct RdpDecoder {

--- a/lib/srv/desktop/rdp/decoder/src/lib.rs
+++ b/lib/srv/desktop/rdp/decoder/src/lib.rs
@@ -132,7 +132,7 @@ pub extern "C" fn rdp_decoder_new(
             user_channel_id,
         )))
     }))
-    .unwrap_or_else(|_| ptr::null_mut())
+    .unwrap_or(ptr::null_mut())
 }
 
 /// Frees the memory associated with a decoder.
@@ -220,7 +220,7 @@ pub unsafe extern "C" fn rdp_decoder_image_data(
         *out_height = decoder.image.height();
         data.as_ptr()
     }))
-    .unwrap_or_else(|_| ptr::null())
+    .unwrap_or(ptr::null())
 }
 
 /// Returns the current cursor position and visibility state.

--- a/lib/srv/desktop/rdp/decoder/src/lib.rs
+++ b/lib/srv/desktop/rdp/decoder/src/lib.rs
@@ -102,7 +102,10 @@ impl RdpDecoder {
                         self.cursor_state.set_visible(true);
                         self.cursor_state.set_bitmap(&pointer);
                     }
-                    UpdateKind::PointerDefault => self.cursor_state.set_visible(true),
+                    UpdateKind::PointerDefault => {
+                        self.cursor_state.set_visible(true);
+                        self.cursor_state.clear_bitmap();
+                    }
                     UpdateKind::PointerHidden => self.cursor_state.set_visible(false),
                     UpdateKind::PointerPosition { x, y } => {
                         self.cursor_state.move_cursor(x, y);

--- a/lib/srv/desktop/rdp/decoder/src/lib.rs
+++ b/lib/srv/desktop/rdp/decoder/src/lib.rs
@@ -18,55 +18,56 @@
 //! a series of RDP fast path PDUs. It exposes a small C API so that
 //! Go (via cgo) can create a decoder and call its methods.
 
+mod cursor;
+mod regions;
+
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 
+use crate::cursor::CursorState;
+use crate::regions::UpdatedRegions;
 use ironrdp_core::WriteBuf;
 use ironrdp_graphics::image_processing::PixelFormat;
 use ironrdp_session::fast_path::UpdateKind;
 use ironrdp_session::{
-    fast_path::{Processor, ProcessorBuilder},
-    image::DecodedImage,
+	fast_path::{Processor, ProcessorBuilder},
+	image::DecodedImage,
 };
-
-#[derive(Default)]
-struct CursorState {
-    visible: bool,
-    x: u16,
-    y: u16,
-}
 
 pub struct RdpDecoder {
     image: DecodedImage,
     fast_path_processor: Processor,
     cursor_state: CursorState,
+    updated_regions: UpdatedRegions,
 }
 
 impl RdpDecoder {
     const PIXEL_FORMAT: PixelFormat = PixelFormat::RgbA32;
 
-    pub fn new(width: u16, height: u16) -> Self {
+    pub fn new(width: u16, height: u16, io_channel_id: u16, user_channel_id: u16) -> Self {
         Self {
             image: DecodedImage::new(RdpDecoder::PIXEL_FORMAT, width, height),
             fast_path_processor: ProcessorBuilder {
                 // Enable pointer updates so we can get the state of the cursor for when we create
                 // cropped & zoomed in thumbnails in the session recording metadata generation.
                 enable_server_pointer: true,
+                io_channel_id,
+                user_channel_id,
                 // These options only matter in a real RDP session when we have
                 // to send responses back to the server. We can safely leave them
                 // at defaults when decoding session recordings.
-                io_channel_id: 0,
-                user_channel_id: 0,
                 pointer_software_rendering: false,
             }
             .build(),
             cursor_state: Default::default(),
+            updated_regions: Default::default(),
         }
     }
 
     pub fn resize(&mut self, width: u16, height: u16) {
         self.image = DecodedImage::new(RdpDecoder::PIXEL_FORMAT, width, height);
         self.cursor_state = Default::default();
+        self.updated_regions.reset();
     }
 
     pub fn image_data(&self) -> &[u8] {
@@ -94,14 +95,17 @@ impl RdpDecoder {
         {
             for update in updates {
                 match update {
-                    UpdateKind::PointerBitmap(_) => {
-                        self.cursor_state.visible = true;
+                    UpdateKind::Region(rect) => {
+                        self.updated_regions.push(rect);
                     }
-                    UpdateKind::PointerDefault => self.cursor_state.visible = true,
-                    UpdateKind::PointerHidden => self.cursor_state.visible = false,
+                    UpdateKind::PointerBitmap(pointer) => {
+                        self.cursor_state.set_visible(true);
+                        self.cursor_state.set_bitmap(&pointer);
+                    }
+                    UpdateKind::PointerDefault => self.cursor_state.set_visible(true),
+                    UpdateKind::PointerHidden => self.cursor_state.set_visible(false),
                     UpdateKind::PointerPosition { x, y } => {
-                        self.cursor_state.x = x;
-                        self.cursor_state.y = y;
+                        self.cursor_state.move_cursor(x, y);
                     }
                     _ => {}
                 }
@@ -114,13 +118,21 @@ impl RdpDecoder {
 /// The caller is responsible for calling rdp_decoder_free
 /// when the decoder is no longer needed.
 #[no_mangle]
-pub extern "C" fn rdp_decoder_new(width: u16, height: u16) -> *mut RdpDecoder {
-    match catch_unwind_and_drop_panic_payload(AssertUnwindSafe(move || {
-        Box::into_raw(Box::new(RdpDecoder::new(width, height)))
-    })) {
-        Ok(ptr) => ptr,
-        Err(_) => ptr::null_mut(),
-    }
+pub extern "C" fn rdp_decoder_new(
+    width: u16,
+    height: u16,
+    io_channel_id: u16,
+    user_channel_id: u16,
+) -> *mut RdpDecoder {
+    catch_unwind_and_drop_panic_payload(AssertUnwindSafe(move || {
+        Box::into_raw(Box::new(RdpDecoder::new(
+            width,
+            height,
+            io_channel_id,
+            user_channel_id,
+        )))
+    }))
+    .unwrap_or_else(|_| ptr::null_mut())
 }
 
 /// Frees the memory associated with a decoder.
@@ -200,17 +212,15 @@ pub unsafe extern "C" fn rdp_decoder_image_data(
         return ptr::null();
     }
 
-    match catch_unwind_and_drop_panic_payload(AssertUnwindSafe(move || unsafe {
+    catch_unwind_and_drop_panic_payload(AssertUnwindSafe(move || unsafe {
         let decoder = &*ptr;
         let data = decoder.image_data();
 
         *out_width = decoder.image.width();
         *out_height = decoder.image.height();
         data.as_ptr()
-    })) {
-        Ok(p) => p,
-        Err(_) => ptr::null(),
-    }
+    }))
+    .unwrap_or_else(|_| ptr::null())
 }
 
 /// Returns the current cursor position and visibility state.
@@ -232,10 +242,115 @@ pub unsafe extern "C" fn rdp_decoder_cursor_state(
 
     let _ = catch_unwind_and_drop_panic_payload(AssertUnwindSafe(move || unsafe {
         let decoder = &*ptr;
-        *out_visible = decoder.cursor_state.visible as u8;
-        *out_x = decoder.cursor_state.x;
-        *out_y = decoder.cursor_state.y;
+        let (x, y) = decoder.cursor_state.position();
+
+        *out_visible = decoder.cursor_state.is_visible() as u8;
+        *out_x = x;
+        *out_y = y;
     }));
+}
+
+/// Returns a pointer to the cursor bitmap data and its dimensions via out-params.
+/// Returns null if no cursor bitmap is available. The returned pointer is valid
+/// as long as the decoder is alive and no new PointerBitmap update is processed.
+///
+/// # Safety
+///
+/// - `ptr` must be a valid pointer previously returned by `rdp_decoder_new`.
+/// - All out-params must be valid, non-null pointers.
+#[no_mangle]
+pub unsafe extern "C" fn rdp_decoder_cursor_bitmap(
+    ptr: *mut RdpDecoder,
+    out_width: *mut u16,
+    out_height: *mut u16,
+    out_hotspot_x: *mut u16,
+    out_hotspot_y: *mut u16,
+) -> *const u8 {
+    if ptr.is_null()
+        || out_width.is_null()
+        || out_height.is_null()
+        || out_hotspot_x.is_null()
+        || out_hotspot_y.is_null()
+    {
+        return ptr::null();
+    }
+
+    catch_unwind_and_drop_panic_payload(AssertUnwindSafe(move || unsafe {
+        let decoder = &*ptr;
+        let Some(bmp) = decoder.cursor_state.bitmap() else {
+            return ptr::null();
+        };
+        bmp.write_metadata(out_width, out_height, out_hotspot_x, out_hotspot_y);
+        bmp.data_ptr()
+    }))
+    .unwrap_or(ptr::null())
+}
+
+/// Copies update regions into the caller-provided buffer as (left, top, right, bottom)
+/// u16 tuples. Returns the number of regions written. Coordinates use inclusive
+/// right/bottom matching the RDP InclusiveRectangle convention.
+///
+/// # Safety
+///
+/// - `ptr` must be a valid pointer previously returned by `rdp_decoder_new`.
+/// - `out_buf` must point to at least `max_count * 4` writable u16 values.
+#[no_mangle]
+pub unsafe extern "C" fn rdp_decoder_updated_regions(
+    ptr: *mut RdpDecoder,
+    out_buf: *mut u16,
+    max_count: u32,
+) -> u32 {
+    if ptr.is_null() || out_buf.is_null() || max_count == 0 {
+        return 0;
+    }
+
+    catch_unwind_and_drop_panic_payload(AssertUnwindSafe(move || unsafe {
+        let decoder = &*ptr;
+        let out = std::slice::from_raw_parts_mut(out_buf as *mut [u16; 4], max_count as usize);
+
+        let n = decoder.updated_regions.len().min(max_count as usize) as u32;
+        for (slot, coords) in out.iter_mut().zip(decoder.updated_regions.iter()) {
+            *slot = coords;
+        }
+
+        n
+    }))
+    .unwrap_or(0)
+}
+
+/// Clears the accumulated update regions.
+///
+/// # Safety
+///
+/// - `ptr` must be a valid pointer previously returned by `rdp_decoder_new`.
+#[no_mangle]
+pub unsafe extern "C" fn rdp_decoder_reset_updated_regions(ptr: *mut RdpDecoder) {
+    if ptr.is_null() {
+        return;
+    }
+
+    let _ = catch_unwind_and_drop_panic_payload(AssertUnwindSafe(move || unsafe {
+        let decoder = &mut *ptr;
+        decoder.updated_regions.reset();
+    }));
+}
+
+/// Returns the number of update regions accumulated since the last reset.
+///
+/// # Safety
+///
+/// - `ptr` must be a valid pointer previously returned by `rdp_decoder_new`.
+#[no_mangle]
+pub unsafe extern "C" fn rdp_decoder_updated_regions_count(ptr: *mut RdpDecoder) -> u32 {
+    if ptr.is_null() {
+        return 0;
+    }
+
+    catch_unwind_and_drop_panic_payload(AssertUnwindSafe(move || unsafe {
+        let decoder = &*ptr;
+        decoder.updated_regions.len() as u32
+    }))
+    .unwrap_or(0)
 }
 
 fn catch_unwind_and_drop_panic_payload<F: FnOnce() -> R, R>(f: F) -> Result<R, ()> {

--- a/lib/srv/desktop/rdp/decoder/src/regions.rs
+++ b/lib/srv/desktop/rdp/decoder/src/regions.rs
@@ -1,0 +1,174 @@
+// Teleport
+// Copyright (C) 2026  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use ironrdp_pdu::geometry::{InclusiveRectangle, Rectangle};
+
+const MAX_STORED_REGIONS: usize = 256;
+
+#[derive(Default)]
+pub(crate) struct UpdatedRegions {
+    regions: Vec<InclusiveRectangle>,
+}
+
+impl UpdatedRegions {
+    pub(crate) fn push(&mut self, r: InclusiveRectangle) {
+        if self.regions.len() >= MAX_STORED_REGIONS {
+            self.compact();
+        }
+        self.regions.push(r);
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.regions.clear();
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.regions.len()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = [u16; 4]> + '_ {
+        self.regions
+            .iter()
+            .map(|r| [r.left, r.top, r.right, r.bottom])
+    }
+
+    fn compact(&mut self) {
+        let mid = self.regions.len() / 2;
+        if mid == 0 {
+            return;
+        }
+
+        let merged = self.regions[..mid]
+            .iter()
+            .cloned()
+            .reduce(|a, b| a.union(&b))
+            .unwrap();
+
+        self.regions.splice(..mid, std::iter::once(merged));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(left: u16, top: u16, right: u16, bottom: u16) -> InclusiveRectangle {
+        InclusiveRectangle {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+
+    fn bbox(r: &UpdatedRegions) -> Option<[u16; 4]> {
+        r.iter().reduce(|a, b| {
+            [
+                a[0].min(b[0]),
+                a[1].min(b[1]),
+                a[2].max(b[2]),
+                a[3].max(b[3]),
+            ]
+        })
+    }
+
+    #[test]
+    fn push_stores_coordinates_in_order() {
+        let mut r = UpdatedRegions::default();
+        r.push(rect(1, 2, 3, 4));
+        r.push(rect(5, 6, 7, 8));
+
+        let collected: Vec<[u16; 4]> = r.iter().collect();
+
+        assert_eq!(collected, vec![[1, 2, 3, 4], [5, 6, 7, 8]]);
+        assert_eq!(r.len(), 2);
+    }
+
+    #[test]
+    fn reset_clears_all_regions() {
+        let mut r = UpdatedRegions::default();
+        r.push(rect(1, 2, 3, 4));
+        r.push(rect(5, 6, 7, 8));
+        r.reset();
+
+        assert_eq!(r.len(), 0);
+        assert_eq!(r.iter().count(), 0);
+    }
+
+    #[test]
+    fn compact_triggers_at_max_and_reduces_len() {
+        let mut r = UpdatedRegions::default();
+
+        for i in 0..MAX_STORED_REGIONS {
+            let v = i as u16;
+            r.push(rect(v, v, v + 1, v + 1));
+        }
+        assert_eq!(r.len(), MAX_STORED_REGIONS);
+
+        // The next push triggers compact() before inserting.
+        r.push(rect(999, 999, 1000, 1000));
+        assert!(
+            r.len() < MAX_STORED_REGIONS,
+            "expected compaction to reduce len below MAX, got {}",
+            r.len()
+        );
+    }
+
+    #[test]
+    fn compact_preserves_overall_extremes() {
+        let mut r = UpdatedRegions::default();
+
+        // Known extremes so we can verify the union survives compaction.
+        r.push(rect(0, 0, 1, 1));
+        for i in 1..MAX_STORED_REGIONS - 1 {
+            let v = i as u16;
+            r.push(rect(v, v, v + 1, v + 1));
+        }
+        r.push(rect(5000, 6000, 7000, 8000));
+
+        let before = bbox(&r).unwrap();
+        r.push(rect(10, 10, 11, 11)); // triggers compact
+        let after = bbox(&r).unwrap();
+
+        assert_eq!(before, [0, 0, 7000, 8000]);
+
+        // Compaction only merges existing regions into a bounding box,
+        // so the overall extremes must still cover the original ones.
+        assert!(after[0] <= before[0]);
+        assert!(after[1] <= before[1]);
+        assert!(after[2] >= before[2]);
+        assert!(after[3] >= before[3]);
+    }
+
+    #[test]
+    fn compact_on_empty_is_noop() {
+        let mut r = UpdatedRegions::default();
+
+        r.compact();
+        assert_eq!(r.len(), 0);
+    }
+
+    #[test]
+    fn compact_on_single_region_is_noop() {
+        let mut r = UpdatedRegions::default();
+
+        r.push(rect(1, 2, 3, 4));
+        r.compact();
+
+        assert_eq!(r.len(), 1);
+        assert_eq!(r.iter().next(), Some([1, 2, 3, 4]));
+    }
+}

--- a/lib/srv/desktop/rdpstate/rdpstate.go
+++ b/lib/srv/desktop/rdpstate/rdpstate.go
@@ -22,7 +22,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"image"
+	"image/draw"
 	"io"
+	"math"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
@@ -55,6 +57,9 @@ const (
 // Subsequent FastPathPDU messages are fed to the decoder, which maintains the screen framebuffer and cursor state.
 type RDPState struct {
 	decoder *decoder.Decoder
+
+	mouseX, mouseY uint16
+	hasMouse       bool
 }
 
 // New creates a new RDPState.
@@ -101,6 +106,55 @@ func (s *RDPState) Release() {
 	if s.decoder != nil {
 		s.decoder.Release()
 		s.decoder = nil
+	}
+}
+
+// ImageWithCursor returns the current screen image with the cursor composited at its current position, along with the
+// cursor state.
+// When MouseMove TDPB messages have set a position, that overrides the Rust decoder's internal cursor position for compositing.
+func (s *RDPState) ImageWithCursor() (*image.RGBA, decoder.CursorState) {
+	if s.decoder == nil {
+		return nil, decoder.CursorState{}
+	}
+
+	img := s.decoder.Image()
+	cs := s.CursorState()
+	if img == nil || !cs.Visible {
+		return img, cs
+	}
+
+	bmp := s.decoder.CursorBitmap()
+	if bmp == nil {
+		return img, cs
+	}
+
+	cursorX, cursorY := cs.X, cs.Y
+	if s.hasMouse {
+		cursorX, cursorY = s.mouseX, s.mouseY
+	}
+
+	drawX := int(cursorX) - bmp.HotspotX
+	drawY := int(cursorY) - bmp.HotspotY
+	bounds := img.Bounds()
+
+	dstRect := image.Rect(drawX, drawY, drawX+bounds.Dx(), drawY+bounds.Dy())
+	draw.Draw(img, dstRect, bmp.Image, image.Point{}, draw.Over)
+
+	return img, cs
+}
+
+// UpdatedRegions returns the individual screen regions updated since the last call to ResetUpdatedRegions.
+func (s *RDPState) UpdatedRegions() []image.Rectangle {
+	if s.decoder == nil {
+		return nil
+	}
+	return s.decoder.UpdatedRegions()
+}
+
+// ResetUpdatedRegions clears the accumulated update regions.
+func (s *RDPState) ResetUpdatedRegions() {
+	if s.decoder != nil {
+		s.decoder.ResetUpdatedRegions()
 	}
 }
 
@@ -181,6 +235,8 @@ func (s *RDPState) processTDPBMessage(data []byte) error {
 		return s.handleServerHello(m.ServerHello)
 	case *tdpbv1.Envelope_FastPathPdu:
 		return s.handleFastPathPDU(m.FastPathPdu)
+	case *tdpbv1.Envelope_MouseMove:
+		return s.handleMouseMove(m.MouseMove)
 	}
 
 	return nil
@@ -206,8 +262,15 @@ func (s *RDPState) handleServerHello(msg *tdpbv1.ServerHello) error {
 	}
 
 	if s.decoder == nil {
-		d, err := decoder.New(w, h) //nolint:staticcheck // err is always non-nil in nop build but nil in RDP build
-		if err != nil {             //nolint:staticcheck // err is always non-nil in nop build but nil in RDP build
+		ioChannelID := uint16(spec.GetIoChannelId())
+		userChannelID := uint16(spec.GetUserChannelId())
+
+		d, err := decoder.New(
+			w, h,
+			decoder.WithIOChannelID(ioChannelID),
+			decoder.WithUserChannelID(userChannelID),
+		) //nolint:staticcheck // err is always non-nil in nop build but nil in RDP build
+		if err != nil { //nolint:staticcheck // err is always non-nil in nop build but nil in RDP build
 			return trace.Wrap(err, "creating RDP decoder")
 		}
 
@@ -230,6 +293,18 @@ func (s *RDPState) handleFastPathPDU(msg *tdpbv1.FastPathPDU) error {
 	}
 
 	s.decoder.Process(pdu)
+
+	return nil
+}
+
+func (s *RDPState) handleMouseMove(msg *tdpbv1.MouseMove) error {
+	if msg.X > math.MaxUint16 || msg.Y > math.MaxUint16 {
+		return trace.BadParameter("mouse coordinates out of range: (%d, %d)", msg.X, msg.Y)
+	}
+
+	s.mouseX = uint16(msg.X)
+	s.mouseY = uint16(msg.Y)
+	s.hasMouse = true
 
 	return nil
 }

--- a/lib/srv/desktop/rdpstate/rdpstate.go
+++ b/lib/srv/desktop/rdpstate/rdpstate.go
@@ -135,9 +135,9 @@ func (s *RDPState) ImageWithCursor() (*image.RGBA, decoder.CursorState) {
 
 	drawX := int(cursorX) - bmp.HotspotX
 	drawY := int(cursorY) - bmp.HotspotY
-	bounds := img.Bounds()
+	cb := bmp.Image.Bounds()
 
-	dstRect := image.Rect(drawX, drawY, drawX+bounds.Dx(), drawY+bounds.Dy())
+	dstRect := image.Rect(drawX, drawY, drawX+cb.Dx(), drawY+cb.Dy())
 	draw.Draw(img, dstRect, bmp.Image, image.Point{}, draw.Over)
 
 	return img, cs

--- a/lib/srv/desktop/rdpstate/rdpstate.go
+++ b/lib/srv/desktop/rdpstate/rdpstate.go
@@ -265,11 +265,12 @@ func (s *RDPState) handleServerHello(msg *tdpbv1.ServerHello) error {
 		ioChannelID := uint16(spec.GetIoChannelId())
 		userChannelID := uint16(spec.GetUserChannelId())
 
+		//nolint:staticcheck // err is always non-nil in nop build but nil in RDP build
 		d, err := decoder.New(
 			w, h,
 			decoder.WithIOChannelID(ioChannelID),
 			decoder.WithUserChannelID(userChannelID),
-		) //nolint:staticcheck // err is always non-nil in nop build but nil in RDP build
+		)
 		if err != nil { //nolint:staticcheck // err is always non-nil in nop build but nil in RDP build
 			return trace.Wrap(err, "creating RDP decoder")
 		}

--- a/lib/srv/desktop/rdpstate/rdpstate.go
+++ b/lib/srv/desktop/rdpstate/rdpstate.go
@@ -39,6 +39,7 @@ const (
 	// Legacy TDP message types relevant for recording replay.
 	legacyTypeConnectionActivated = 31
 	legacyTypeRDPFastPathPDU      = 29
+	legacyTypeMouseMove           = 3
 
 	// tdpbHeaderLength is the size of the TDPB message length prefix.
 	tdpbHeaderLength = 4
@@ -202,6 +203,14 @@ func (s *RDPState) processTDPMessage(data []byte) error {
 		}
 
 		return s.handleFastPathPDU(&tdpbv1.FastPathPDU{Pdu: pdu})
+
+	case legacyTypeMouseMove:
+		var mm struct{ X, Y uint32 }
+		if err := binary.Read(r, binary.BigEndian, &mm); err != nil {
+			return trace.Wrap(err, "reading legacy MouseMove")
+		}
+
+		return s.handleMouseMove(&tdpbv1.MouseMove{X: mm.X, Y: mm.Y})
 	}
 
 	return nil
@@ -262,8 +271,12 @@ func (s *RDPState) handleServerHello(msg *tdpbv1.ServerHello) error {
 	}
 
 	if s.decoder == nil {
-		ioChannelID := uint16(spec.GetIoChannelId())
-		userChannelID := uint16(spec.GetUserChannelId())
+		ioChan, userChan := spec.GetIoChannelId(), spec.GetUserChannelId()
+		if ioChan > math.MaxUint16 || userChan > math.MaxUint16 {
+			return trace.BadParameter("channel IDs out of range: io=%d, user=%d", ioChan, userChan)
+		}
+		ioChannelID := uint16(ioChan)
+		userChannelID := uint16(userChan)
 
 		//nolint:staticcheck // err is always non-nil in nop build but nil in RDP build
 		d, err := decoder.New(

--- a/lib/srv/desktop/rdpstate/rdpstate_test.go
+++ b/lib/srv/desktop/rdpstate/rdpstate_test.go
@@ -135,8 +135,8 @@ func TestServerHello_ChannelIDOutOfRange(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range []struct {
-		name              string
-		ioChan, userChan  uint32
+		name             string
+		ioChan, userChan uint32
 	}{
 		{"io channel too large", 1 << 16, 1003},
 		{"user channel too large", 1004, 1 << 16},

--- a/lib/srv/desktop/rdpstate/rdpstate_test.go
+++ b/lib/srv/desktop/rdpstate/rdpstate_test.go
@@ -101,6 +101,60 @@ func TestFastPathPDU_EmptyPDU(t *testing.T) {
 	require.Nil(t, s.decoder)
 }
 
+func TestMouseMove_Legacy(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+
+	evt, err := rdpstatetest.LegacyMouseMove(123, 456)
+	require.NoError(t, err)
+
+	require.NoError(t, s.HandleMessage(evt))
+	require.True(t, s.hasMouse)
+	require.Equal(t, uint16(123), s.mouseX)
+	require.Equal(t, uint16(456), s.mouseY)
+}
+
+func TestMouseMove_LegacyTruncated(t *testing.T) {
+	t.Parallel()
+
+	// Type byte (3) followed by only 4 bytes (need 8: x uint32 + y uint32).
+	require.Error(t, New().HandleMessage(rdpstatetest.LegacyEvent([]byte{3, 0, 0, 0, 1})))
+}
+
+func TestMouseMove_LegacyOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	evt, err := rdpstatetest.LegacyMouseMove(1<<16, 0)
+	require.NoError(t, err)
+
+	require.Error(t, New().HandleMessage(evt))
+}
+
+func TestServerHello_ChannelIDOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name              string
+		ioChan, userChan  uint32
+	}{
+		{"io channel too large", 1 << 16, 1003},
+		{"user channel too large", 1004, 1 << 16},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			evt, err := rdpstatetest.EncodeTDPBServerHelloWithChannels(800, 600, tt.ioChan, tt.userChan)
+			require.NoError(t, err)
+
+			s := New()
+			err = s.HandleMessage(evt)
+			require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+			require.Nil(t, s.decoder)
+		})
+	}
+}
+
 func TestUnknownMessage_Ignored(t *testing.T) {
 	t.Parallel()
 

--- a/lib/srv/desktop/rdpstate/rdpstatetest/events.go
+++ b/lib/srv/desktop/rdpstate/rdpstatetest/events.go
@@ -74,3 +74,31 @@ func LegacyConnectionActivated(width, height uint16) (*apievents.DesktopRecordin
 
 	return LegacyEvent(data), nil
 }
+
+// LegacyMouseMove creates a DesktopRecording event containing a legacy TDP MouseMove message at the given coordinates.
+func LegacyMouseMove(x, y uint32) (*apievents.DesktopRecording, error) {
+	data, err := legacy.MouseMove{X: x, Y: y}.Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	return LegacyEvent(data), nil
+}
+
+// EncodeTDPBServerHelloWithChannels creates a DesktopRecording event containing a TDPB ServerHello message with the
+// given screen dimensions and channel IDs.
+func EncodeTDPBServerHelloWithChannels(width, height, ioChannelID, userChannelID uint32) (*apievents.DesktopRecording, error) {
+	data, err := (&tdpb.ServerHello{
+		ActivationSpec: &tdpbv1.ConnectionActivated{
+			ScreenWidth:   width,
+			ScreenHeight:  height,
+			IoChannelId:   ioChannelID,
+			UserChannelId: userChannelID,
+		},
+	}).Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	return TDPBEvent(data), nil
+}


### PR DESCRIPTION
Adds channel IDs to the creation of `decoder.New` - this is needed if we want to get region info back from the processing of PDUs, as the IronRDP processor errors if they're not set. I chose to go for the `decoder.WithUserChannelID` pattern so future consumers of the decoder that do not need this info can keep the simple `decoder.New(width, height)` signature, and we don't end up with 4 integers being passed to the decoder.

Adds the code to surface the updated regions to Go, and through to the RDP state tracker. The RDP decoder now also tracks the cursor bitmap, which we use when creating images of the desktop recording for summarisation, as it's useful for the LLM to know where the mouse is.

Adds support for `MouseMove` events, keeping the possible pointer tracking from PDUs, but overrides these values if we have our own mouse move events instead.

No manual test plan as this code isn't used at the moment
