### PR TITLE
[v18] Bump terraform-docs from 0.21.0 to 0.22.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -267,7 +267,7 @@ jobs:
         # terraform-docs version must match the version in integrations/terraform-modules/.terraform-docs.yml
         run: |
           git config --global --add safe.directory $(realpath .)
-          go install github.com/terraform-docs/terraform-docs@v0.21.0
+          go install github.com/terraform-docs/terraform-docs@v0.22.0
           make terraform-module-docs-up-to-date
 
       - name: Check if the Access Monitoring reference is up to date

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account.mdx
@@ -22,7 +22,7 @@ In addition, the example uses a custom AWS IAM policy to narrow the scope of per
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | terraform | >= 1.0 |
 | aws | >= 5.0 |
 | teleport | >= 18.5.1 |
@@ -31,19 +31,19 @@ In addition, the example uses a custom AWS IAM policy to narrow the scope of per
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | aws | >= 5.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | aws\_discovery | ../.. | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_policy_document.teleport_discovery_service_single_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -53,6 +53,6 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | aws\_discovery | n/a |
 {/* END_TF_DOCS */}

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -66,7 +66,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | terraform | >= 1.5.7 |
 | aws | >= 5.0 |
 | http | >= 3.0 |
@@ -76,7 +76,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | aws | >= 5.0 |
 | http | >= 3.0 |
 | teleport | >= 18.5.1 |
@@ -89,7 +89,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_openid_connect_provider.teleport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_policy.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -107,7 +107,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | apply\_aws\_tags | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
 | apply\_teleport\_resource\_labels | Additional Teleport resource labels to apply to all created Teleport resources. | `map(string)` | `{}` | no |
 | aws\_iam\_policy\_document | Override the AWS IAM policy document attached to the AWS IAM role for resource discovery. | `string` | `""` | no |
@@ -133,7 +133,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | aws\_oidc\_provider\_arn | AWS resource name (ARN) of the AWS OpenID Connect (OIDC) provider that allows Teleport Discovery Service to assume an AWS IAM role using OIDC. |
 | teleport\_discovery\_config\_name | Name of the Teleport dynamic `discovery_config`. Configuration details can be viewed with `tctl get discovery_config/<name>`. Teleport Discovery Service instances will use this `discovery_config` if they are in the same discovery group as the `discovery_config`. |
 | teleport\_discovery\_service\_iam\_policy\_arn | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to discover resources in AWS. |

--- a/integrations/terraform-modules/.terraform-docs.yml
+++ b/integrations/terraform-modules/.terraform-docs.yml
@@ -32,4 +32,4 @@ settings:
 sort:
   enabled: true
   by: name
-version: '0.21.0'
+version: '0.22.0'

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -52,7 +52,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | terraform | >= 1.5.7 |
 | aws | >= 5.0 |
 | http | >= 3.0 |
@@ -62,7 +62,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | aws | >= 5.0 |
 | http | >= 3.0 |
 | teleport | >= 18.5.1 |
@@ -75,7 +75,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_openid_connect_provider.teleport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_policy.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -93,7 +93,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | apply\_aws\_tags | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
 | apply\_teleport\_resource\_labels | Additional Teleport resource labels to apply to all created Teleport resources. | `map(string)` | `{}` | no |
 | aws\_iam\_policy\_document | Override the AWS IAM policy document attached to the AWS IAM role for resource discovery. | `string` | `""` | no |
@@ -119,7 +119,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | aws\_oidc\_provider\_arn | AWS resource name (ARN) of the AWS OpenID Connect (OIDC) provider that allows Teleport Discovery Service to assume an AWS IAM role using OIDC. |
 | teleport\_discovery\_config\_name | Name of the Teleport dynamic `discovery_config`. Configuration details can be viewed with `tctl get discovery_config/<name>`. Teleport Discovery Service instances will use this `discovery_config` if they are in the same discovery group as the `discovery_config`. |
 | teleport\_discovery\_service\_iam\_policy\_arn | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to discover resources in AWS. |

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/README.md
@@ -8,7 +8,7 @@ In addition, the example uses a custom AWS IAM policy to narrow the scope of per
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | terraform | >= 1.0 |
 | aws | >= 5.0 |
 | teleport | >= 18.5.1 |
@@ -17,19 +17,19 @@ In addition, the example uses a custom AWS IAM policy to narrow the scope of per
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | aws | >= 5.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | aws\_discovery | ../.. | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_policy_document.teleport_discovery_service_single_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -39,6 +39,6 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | aws\_discovery | n/a |
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/66028 to branch/v18.
- https://github.com/gravitational/teleport/pull/66028
