### PR TITLE
Add user/role scanner and bootstrap library to e2e runner

### DIFF
--- a/e2e/runner/bootstrap.go
+++ b/e2e/runner/bootstrap.go
@@ -1,0 +1,254 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
+
+// bootstrapUser represents a user to be bootstrapped into the Teleport state.
+type bootstrapUser struct {
+	Name                string
+	Roles               []string
+	Traits              map[string][]string
+	PasswordHashBase64  string
+	CredentialIDBase64  string
+	PublicKeyCBORBase64 string
+}
+
+// customRole represents a custom role loaded from a YAML file.
+type customRole struct {
+	name string
+	YAML string
+}
+
+// stateConfig holds the data needed to render the bootstrap state template.
+type stateConfig struct {
+	Users       []bootstrapUser
+	CustomRoles []customRole
+}
+
+// credentialsJSON is the JSON-serializable shape for the E2E_USERS_JSON env var.
+type credentialsJSON struct {
+	Password             string `json:"password"`
+	WebauthnPrivateKey   string `json:"webauthnPrivateKey"`
+	WebauthnCredentialId string `json:"webauthnCredentialId"`
+}
+
+// readRoleFile reads e2eDir/testdata/roles/<filename> and extracts metadata.name. Uses os.Root so filenames sourced from test code can't escape the roles directory.
+func readRoleFile(e2eDir, filename string) (*customRole, error) {
+	rolesDir := filepath.Join(e2eDir, "testdata", "roles")
+
+	root, err := os.OpenRoot(rolesDir)
+	if err != nil {
+		return nil, fmt.Errorf("opening roles dir: %w", err)
+	}
+	defer root.Close()
+
+	f, err := root.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("reading role file %s: %w", filename, err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("reading role file %s: %w", filename, err)
+	}
+
+	var meta struct {
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+	}
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parsing role file %s: %w", filename, err)
+	}
+
+	if meta.Metadata.Name == "" {
+		return nil, fmt.Errorf("role file %s: metadata.name not found", filename)
+	}
+
+	return &customRole{
+		name: meta.Metadata.Name,
+		YAML: string(data),
+	}, nil
+}
+
+// bootstrapResult holds the output of buildBootstrapState.
+type bootstrapResult struct {
+	state       *stateConfig
+	creds       map[string]*credentials
+	userMapping map[string]string // canonical user key → generated name
+}
+
+// canonicalUserKey produces a deterministic key for a scanned user. The TS side computes the same format to look up generated names; both implementations must stay in lockstep.
+func canonicalUserKey(su scannedUser) (string, error) {
+	roles := make([]string, 0, len(su.roles))
+	for _, r := range su.roles {
+		if r.file != "" {
+			roles = append(roles, "@file:"+r.file)
+		} else {
+			roles = append(roles, r.name)
+		}
+	}
+
+	slices.Sort(roles)
+
+	type keyDef struct {
+		Index  *int                `json:"index,omitempty"`
+		Roles  []string            `json:"roles"`
+		Traits map[string][]string `json:"traits,omitempty"`
+	}
+
+	kd := keyDef{Index: su.arrayIdx, Roles: roles}
+
+	if len(su.traits) > 0 {
+		kd.Traits = make(map[string][]string, len(su.traits))
+		for k, v := range su.traits {
+			sorted := slices.Clone(v)
+			slices.Sort(sorted)
+			kd.Traits[k] = sorted
+		}
+	}
+
+	data, err := json.Marshal(kd)
+	if err != nil {
+		return "", fmt.Errorf("marshaling canonical user key: %w", err)
+	}
+
+	return string(data), nil
+}
+
+// writeUserMapping writes the JSON file the Playwright fixture reads to resolve generated usernames.
+func writeUserMapping(path string, mapping map[string]string) error {
+	data, err := json.MarshalIndent(mapping, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling user mapping: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating user mapping directory: %w", err)
+	}
+
+	return os.WriteFile(path, data, 0644)
+}
+
+// buildBootstrapState assigns names + credentials per scanned user, resolves role refs, and dedupes custom-role files.
+func buildBootstrapState(e2eDir string, scannedUsers []scannedUser) (*bootstrapResult, error) {
+	state := &stateConfig{}
+	creds := make(map[string]*credentials)
+	nameGen := newHumanIDGenerator()
+	userMapping := make(map[string]string)
+
+	// Track custom role files already loaded to deduplicate.
+	customRolesByFile := make(map[string]*customRole)
+
+	for _, su := range scannedUsers {
+		if len(su.roles) == 0 {
+			return nil, fmt.Errorf("user declaration has no roles; declare at least one role in test.use()")
+		}
+
+		name := nameGen.Generate()
+
+		key, err := canonicalUserKey(su)
+		if err != nil {
+			return nil, err
+		}
+
+		userMapping[key] = name
+
+		userCredentials, err := generateUserCredentials()
+		if err != nil {
+			return nil, fmt.Errorf("generating credentials for %s: %w", name, err)
+		}
+
+		creds[name] = userCredentials
+
+		traits := su.traits
+		if traits == nil {
+			traits = map[string][]string{"logins": {"root"}}
+		}
+
+		bu := bootstrapUser{
+			Name:                name,
+			Traits:              traits,
+			PasswordHashBase64:  userCredentials.passwordHashBase64,
+			CredentialIDBase64:  userCredentials.credentialIDBase64,
+			PublicKeyCBORBase64: userCredentials.publicKeyCBORBase64,
+		}
+
+		for _, role := range su.roles {
+			if role.file != "" {
+				cr, ok := customRolesByFile[role.file]
+				if !ok {
+					cr, err = readRoleFile(e2eDir, role.file)
+					if err != nil {
+						return nil, fmt.Errorf("reading role for user %s: %w", name, err)
+					}
+
+					customRolesByFile[role.file] = cr
+					state.CustomRoles = append(state.CustomRoles, *cr)
+				}
+
+				bu.Roles = append(bu.Roles, cr.name)
+			} else {
+				bu.Roles = append(bu.Roles, role.name)
+			}
+		}
+
+		state.Users = append(state.Users, bu)
+	}
+
+	return &bootstrapResult{
+		state:       state,
+		creds:       creds,
+		userMapping: userMapping,
+	}, nil
+}
+
+// writeCredentialsFile writes the user-credentials JSON Playwright reads at startup. File-based (not env) so the payload doesn't grow unbounded with user count.
+func writeCredentialsFile(path string, creds map[string]*credentials) error {
+	m := make(map[string]credentialsJSON, len(creds))
+	for name, c := range creds {
+		m[name] = credentialsJSON{
+			Password:             c.password,
+			WebauthnPrivateKey:   c.privateKeyPKCS8Base64,
+			WebauthnCredentialId: c.credentialIDBase64,
+		}
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling credentials JSON: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating credentials directory: %w", err)
+	}
+
+	return os.WriteFile(path, data, 0o600)
+}

--- a/e2e/runner/bootstrap_test.go
+++ b/e2e/runner/bootstrap_test.go
@@ -70,33 +70,6 @@ spec:
 	}
 }
 
-// TestReadRoleFileNameNotFirst ensures metadata.name parses when other fields appear before it.
-func TestReadRoleFileNameNotFirst(t *testing.T) {
-	e2eDir := t.TempDir()
-	rolesDir := createDir(t, e2eDir, "testdata", "roles")
-	writeFile(t, rolesDir, "viewer.yaml", `kind: role
-version: v7
-metadata:
-  description: a viewer role
-  labels:
-    purpose: testing
-  name: viewer
-spec:
-  allow:
-    logins: ['root']
-`)
-
-	cr, err := readRoleFile(e2eDir, "viewer.yaml")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if cr.name != "viewer" {
-		t.Errorf("name = %q, want %q", cr.name, "viewer")
-	}
-}
-
-// TestReadRoleFileRejectsTraversal ensures filenames from test code can't escape the roles directory.
 func TestReadRoleFileRejectsTraversal(t *testing.T) {
 	e2eDir := t.TempDir()
 	createDir(t, e2eDir, "testdata", "roles")
@@ -176,22 +149,12 @@ func TestBuildBootstrapState(t *testing.T) {
 		t.Errorf("first user role[1] = %q, want %q", first.Roles[1], "viewer")
 	}
 
-	if state.Users[0].Name == "" {
-		t.Error("first user has empty generated name")
-	}
-
-	if state.Users[1].Name == "" {
-		t.Error("second user has empty generated name")
+	if state.Users[0].Name == "" || state.Users[1].Name == "" {
+		t.Error("user has empty generated name")
 	}
 
 	if state.Users[0].Name == state.Users[1].Name {
 		t.Errorf("users have duplicate names: %s", state.Users[0].Name)
-	}
-
-	for _, u := range state.Users {
-		if _, ok := result.creds[u.Name]; !ok {
-			t.Errorf("missing credentials for %s", u.Name)
-		}
 	}
 
 	if len(result.userMapping) != 2 {
@@ -199,25 +162,12 @@ func TestBuildBootstrapState(t *testing.T) {
 	}
 
 	for _, u := range state.Users {
-		if u.PasswordHashBase64 == "" {
-			t.Errorf("user %s has empty PasswordHashBase64", u.Name)
+		if _, ok := result.creds[u.Name]; !ok {
+			t.Errorf("missing credentials for %s", u.Name)
 		}
 
-		if u.CredentialIDBase64 == "" {
-			t.Errorf("user %s has empty CredentialIDBase64", u.Name)
-		}
-
-		if u.PublicKeyCBORBase64 == "" {
-			t.Errorf("user %s has empty PublicKeyCBORBase64", u.Name)
-		}
-	}
-
-	for _, u := range state.Users {
-		logins, ok := u.Traits["logins"]
-		if !ok {
-			t.Errorf("user %s missing logins trait", u.Name)
-		} else if len(logins) != 1 || logins[0] != "root" {
-			t.Errorf("user %s logins = %v, want [root]", u.Name, logins)
+		if u.PasswordHashBase64 == "" || u.CredentialIDBase64 == "" || u.PublicKeyCBORBase64 == "" {
+			t.Errorf("user %s missing webauthn credential fields", u.Name)
 		}
 	}
 }

--- a/e2e/runner/bootstrap_test.go
+++ b/e2e/runner/bootstrap_test.go
@@ -1,0 +1,390 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const viewerRoleYAML = `kind: role
+version: v7
+metadata:
+  name: viewer
+spec:
+  allow:
+    logins: ['root']
+`
+
+func TestReadRoleFile(t *testing.T) {
+	e2eDir := t.TempDir()
+	rolesDir := createDir(t, e2eDir, "testdata", "roles")
+	writeFile(t, rolesDir, "viewer.yaml", viewerRoleYAML)
+
+	cr, err := readRoleFile(e2eDir, "viewer.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cr.name != "viewer" {
+		t.Errorf("name = %q, want %q", cr.name, "viewer")
+	}
+
+	if cr.YAML != viewerRoleYAML {
+		t.Errorf("YAML content mismatch")
+	}
+}
+
+func TestReadRoleFileMissingName(t *testing.T) {
+	e2eDir := t.TempDir()
+	rolesDir := createDir(t, e2eDir, "testdata", "roles")
+	writeFile(t, rolesDir, "bad.yaml", `kind: role
+version: v7
+spec:
+  allow:
+    logins: ['root']
+`)
+
+	_, err := readRoleFile(e2eDir, "bad.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing metadata.name, got nil")
+	}
+}
+
+// TestReadRoleFileNameNotFirst ensures metadata.name parses when other fields appear before it.
+func TestReadRoleFileNameNotFirst(t *testing.T) {
+	e2eDir := t.TempDir()
+	rolesDir := createDir(t, e2eDir, "testdata", "roles")
+	writeFile(t, rolesDir, "viewer.yaml", `kind: role
+version: v7
+metadata:
+  description: a viewer role
+  labels:
+    purpose: testing
+  name: viewer
+spec:
+  allow:
+    logins: ['root']
+`)
+
+	cr, err := readRoleFile(e2eDir, "viewer.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cr.name != "viewer" {
+		t.Errorf("name = %q, want %q", cr.name, "viewer")
+	}
+}
+
+// TestReadRoleFileRejectsTraversal ensures filenames from test code can't escape the roles directory.
+func TestReadRoleFileRejectsTraversal(t *testing.T) {
+	e2eDir := t.TempDir()
+	createDir(t, e2eDir, "testdata", "roles")
+
+	// Sentinel outside the roles dir that a traversal would otherwise reach.
+	writeFile(t, e2eDir, "secret.yaml", `kind: role
+version: v7
+metadata:
+  name: secret
+`)
+
+	cases := []string{
+		"../secret.yaml",
+		"../../etc/passwd",
+		"/etc/passwd",
+	}
+
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := readRoleFile(e2eDir, name); err == nil {
+				t.Fatalf("expected error for filename %q, got nil", name)
+			}
+		})
+	}
+}
+
+func TestBuildBootstrapState(t *testing.T) {
+	e2eDir := t.TempDir()
+	rolesDir := createDir(t, e2eDir, "testdata", "roles")
+	writeFile(t, rolesDir, "viewer.yaml", viewerRoleYAML)
+
+	scannedUsers := []scannedUser{
+		{
+			roles: []scannedRole{
+				{name: "access"},
+				{file: "viewer.yaml"},
+			},
+			loginAs: true,
+		},
+		{
+			roles: []scannedRole{
+				{name: "access"},
+				{name: "editor"},
+			},
+		},
+	}
+
+	result, err := buildBootstrapState(e2eDir, scannedUsers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	state := result.state
+
+	if len(state.Users) != 2 {
+		t.Fatalf("got %d users, want 2", len(state.Users))
+	}
+
+	if len(state.CustomRoles) != 1 {
+		t.Fatalf("got %d custom roles, want 1", len(state.CustomRoles))
+	}
+
+	if state.CustomRoles[0].name != "viewer" {
+		t.Errorf("custom role name = %q, want %q", state.CustomRoles[0].name, "viewer")
+	}
+
+	first := state.Users[0]
+	if len(first.Roles) != 2 {
+		t.Fatalf("first user has %d roles, want 2", len(first.Roles))
+	}
+
+	if first.Roles[0] != "access" {
+		t.Errorf("first user role[0] = %q, want %q", first.Roles[0], "access")
+	}
+
+	if first.Roles[1] != "viewer" {
+		t.Errorf("first user role[1] = %q, want %q", first.Roles[1], "viewer")
+	}
+
+	if state.Users[0].Name == "" {
+		t.Error("first user has empty generated name")
+	}
+
+	if state.Users[1].Name == "" {
+		t.Error("second user has empty generated name")
+	}
+
+	if state.Users[0].Name == state.Users[1].Name {
+		t.Errorf("users have duplicate names: %s", state.Users[0].Name)
+	}
+
+	for _, u := range state.Users {
+		if _, ok := result.creds[u.Name]; !ok {
+			t.Errorf("missing credentials for %s", u.Name)
+		}
+	}
+
+	if len(result.userMapping) != 2 {
+		t.Fatalf("got %d user mapping entries, want 2", len(result.userMapping))
+	}
+
+	for _, u := range state.Users {
+		if u.PasswordHashBase64 == "" {
+			t.Errorf("user %s has empty PasswordHashBase64", u.Name)
+		}
+
+		if u.CredentialIDBase64 == "" {
+			t.Errorf("user %s has empty CredentialIDBase64", u.Name)
+		}
+
+		if u.PublicKeyCBORBase64 == "" {
+			t.Errorf("user %s has empty PublicKeyCBORBase64", u.Name)
+		}
+	}
+
+	for _, u := range state.Users {
+		logins, ok := u.Traits["logins"]
+		if !ok {
+			t.Errorf("user %s missing logins trait", u.Name)
+		} else if len(logins) != 1 || logins[0] != "root" {
+			t.Errorf("user %s logins = %v, want [root]", u.Name, logins)
+		}
+	}
+}
+
+func TestBuildBootstrapStateDeduplicatesRoles(t *testing.T) {
+	e2eDir := t.TempDir()
+	rolesDir := createDir(t, e2eDir, "testdata", "roles")
+	writeFile(t, rolesDir, "viewer.yaml", viewerRoleYAML)
+
+	scannedUsers := []scannedUser{
+		{
+			roles: []scannedRole{
+				{file: "viewer.yaml"},
+			},
+		},
+		{
+			roles: []scannedRole{
+				{file: "viewer.yaml"},
+			},
+		},
+	}
+
+	result, err := buildBootstrapState(e2eDir, scannedUsers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.state.CustomRoles) != 1 {
+		t.Fatalf("got %d custom roles, want 1 (deduplication failed)", len(result.state.CustomRoles))
+	}
+
+	if result.state.CustomRoles[0].name != "viewer" {
+		t.Errorf("custom role name = %q, want %q", result.state.CustomRoles[0].name, "viewer")
+	}
+}
+
+func TestBuildBootstrapStateCustomTraits(t *testing.T) {
+	e2eDir := t.TempDir()
+
+	scannedUsers := []scannedUser{
+		{
+			roles: []scannedRole{{name: "access"}},
+			traits: map[string][]string{
+				"logins":            {"root", "alice"},
+				"kubernetes_groups": {"dev"},
+			},
+			loginAs: true,
+		},
+	}
+
+	result, err := buildBootstrapState(e2eDir, scannedUsers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	u := result.state.Users[0]
+
+	logins := u.Traits["logins"]
+	if len(logins) != 2 || logins[0] != "root" || logins[1] != "alice" {
+		t.Errorf("logins = %v, want [root alice]", logins)
+	}
+
+	groups := u.Traits["kubernetes_groups"]
+	if len(groups) != 1 || groups[0] != "dev" {
+		t.Errorf("kubernetes_groups = %v, want [dev]", groups)
+	}
+}
+
+func TestBuildBootstrapStateEmptyRolesError(t *testing.T) {
+	e2eDir := t.TempDir()
+
+	users := []scannedUser{{roles: nil, loginAs: true}}
+	_, err := buildBootstrapState(e2eDir, users)
+	if err == nil {
+		t.Fatal("expected error for user with no roles, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "no roles") {
+		t.Errorf("expected 'no roles' error, got: %v", err)
+	}
+}
+
+func TestWriteUserMapping(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "user-mapping.json")
+
+	mapping := map[string]string{
+		`{"roles":["access"]}`:           "brave-falcon",
+		`{"roles":["access","editor"]}`: "swift-river",
+	}
+
+	if err := writeUserMapping(path, mapping); err != nil {
+		t.Fatalf("writeUserMapping: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(got) != len(mapping) {
+		t.Fatalf("got %d entries, want %d", len(got), len(mapping))
+	}
+
+	for k, want := range mapping {
+		if got[k] != want {
+			t.Errorf("mapping[%q] = %q, want %q", k, got[k], want)
+		}
+	}
+}
+
+func TestWriteCredentialsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "user-credentials.json")
+
+	creds := map[string]*credentials{
+		"brave-falcon": {
+			password:              "pw-1",
+			privateKeyPKCS8Base64: "priv-1",
+			credentialIDBase64:    "cid-1",
+		},
+	}
+
+	if err := writeCredentialsFile(path, creds); err != nil {
+		t.Fatalf("writeCredentialsFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	// The credentials file holds password hashes and WebAuthn private keys,
+	// so restricted (0o600) perms are a load-bearing invariant.
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file mode = %o, want 0o600", perm)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	var got map[string]credentialsJSON
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	entry, ok := got["brave-falcon"]
+	if !ok {
+		t.Fatalf("missing entry for brave-falcon: %+v", got)
+	}
+
+	if entry.Password != "pw-1" {
+		t.Errorf("password = %q, want %q", entry.Password, "pw-1")
+	}
+
+	if entry.WebauthnPrivateKey != "priv-1" {
+		t.Errorf("webauthnPrivateKey = %q, want %q", entry.WebauthnPrivateKey, "priv-1")
+	}
+
+	if entry.WebauthnCredentialId != "cid-1" {
+		t.Errorf("webauthnCredentialId = %q, want %q", entry.WebauthnCredentialId, "cid-1")
+	}
+}

--- a/e2e/runner/go.mod
+++ b/e2e/runner/go.mod
@@ -14,6 +14,7 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -277,7 +278,6 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.35.1 // indirect
 	k8s.io/apimachinery v0.35.1 // indirect
 	k8s.io/client-go v0.35.1 // indirect

--- a/e2e/runner/humanid.go
+++ b/e2e/runner/humanid.go
@@ -1,0 +1,86 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+)
+
+var adjectives = []string{
+	"brave", "calm", "eager", "fair", "glad",
+	"keen", "bold", "warm", "wise", "swift",
+	"bright", "cool", "gentle", "happy", "kind",
+	"lively", "noble", "quick", "sharp", "steady",
+}
+
+var nouns = []string{
+	"falcon", "river", "maple", "summit", "coral",
+	"ember", "cedar", "brook", "crane", "dune",
+	"flint", "grove", "heron", "jade", "lark",
+	"moss", "oak", "pearl", "ridge", "stone",
+}
+
+// humanIDGenerator produces unique human-readable identifiers like "brave-falcon".
+type humanIDGenerator struct {
+	used map[string]struct{}
+}
+
+// newHumanIDGenerator creates a generator that tracks used IDs to ensure uniqueness.
+func newHumanIDGenerator() *humanIDGenerator {
+	return &humanIDGenerator{used: make(map[string]struct{})}
+}
+
+// Generate returns a unique human-readable identifier. On collision, it appends a numeric suffix (e.g. "brave-falcon-2").
+func (g *humanIDGenerator) Generate() string {
+	id := generateHumanID()
+	if _, ok := g.used[id]; !ok {
+		g.used[id] = struct{}{}
+
+		return id
+	}
+
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", id, i)
+		if _, ok := g.used[candidate]; !ok {
+			g.used[candidate] = struct{}{}
+
+			return candidate
+		}
+	}
+}
+
+func generateHumanID() string {
+	adj := adjectives[randInt(len(adjectives))]
+	noun := nouns[randInt(len(nouns))]
+
+	return fmt.Sprintf("%s-%s", adj, noun)
+}
+
+func randInt(n int) int {
+	max := big.NewInt(int64(n))
+
+	v, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		panic(fmt.Sprintf("crypto/rand failed: %v", err))
+	}
+
+	return int(v.Int64())
+}

--- a/e2e/runner/humanid_test.go
+++ b/e2e/runner/humanid_test.go
@@ -1,0 +1,78 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestHumanIDGeneratorCollisionSuffix(t *testing.T) {
+	g := newHumanIDGenerator()
+
+	// Saturate all 400 base adj-noun combos so Generate() falls through to the numeric-suffix loop.
+	for _, adj := range adjectives {
+		for _, noun := range nouns {
+			g.used[fmt.Sprintf("%s-%s", adj, noun)] = struct{}{}
+		}
+	}
+
+	id := g.Generate()
+	if !strings.HasSuffix(id, "-2") {
+		t.Errorf("expected -2 suffix after base collision, got %q", id)
+	}
+
+	if _, ok := g.used[id]; !ok {
+		t.Errorf("generated id %q not recorded as used", id)
+	}
+}
+
+func TestHumanIDGeneratorMultipleCollisions(t *testing.T) {
+	g := newHumanIDGenerator()
+
+	// Saturate every base + base-2 so the next Generate() resolves to -3 regardless of base.
+	for _, adj := range adjectives {
+		for _, noun := range nouns {
+			base := fmt.Sprintf("%s-%s", adj, noun)
+			g.used[base] = struct{}{}
+			g.used[base+"-2"] = struct{}{}
+		}
+	}
+
+	id := g.Generate()
+	if !strings.HasSuffix(id, "-3") {
+		t.Errorf("expected -3 suffix after base + -2 collision, got %q", id)
+	}
+}
+
+func TestHumanIDGeneratorUniqueness(t *testing.T) {
+	g := newHumanIDGenerator()
+
+	// Exceed the 400 base namespace to force suffix collisions and verify uniqueness.
+	seen := make(map[string]struct{})
+	for range 1000 {
+		id := g.Generate()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("duplicate id: %q", id)
+		}
+
+		seen[id] = struct{}{}
+	}
+}

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -32,40 +32,22 @@ import (
 	"github.com/gravitational/teleport/e2e/runner/fixtures"
 )
 
-// fixtureArrayRe matches fixture array declarations within a test.use() call body, e.g. fixtures: ['ssh-node'] or fixtures: [['connect'], { option: true }].
-var fixtureArrayRe = regexp.MustCompile(`fixtures:\s*\[+([^]]*)]`)
+var (
+	fixtureArrayRe     = regexp.MustCompile(`fixtures:\s*\[+([^]]*)]`)
+	lineNumberSuffixRe = regexp.MustCompile(`:\d+$`)
+	fixtureRefRe       = regexp.MustCompile(`['"]([^'"]+)['"]`)
+	helperImportRe     = regexp.MustCompile(`from\s+['"]@gravitational/e2e/helpers/(\w+)['"]`)
+	roleFileRe         = regexp.MustCompile(`\bfile:\s*['"]@gravitational/e2e/roles/([^'"]+)['"]`)
 
-// lineNumberSuffixRe matches a trailing :line_number on a test path (e.g. "my-spec.ts:42").
-var lineNumberSuffixRe = regexp.MustCompile(`:\d+$`)
-
-// fixtureRefRe extracts individual quoted fixture names from the matched array contents.
-var fixtureRefRe = regexp.MustCompile(`['"]([^'"]+)['"]`)
-
-// helperImportRe captures the module name from an `@gravitational/e2e/helpers/<name>` import.
-var helperImportRe = regexp.MustCompile(`from\s+['"]@gravitational/e2e/helpers/(\w+)['"]`)
-
-// roleFileRe extracts the role filename from a file role reference.
-var roleFileRe = regexp.MustCompile(`\bfile:\s*['"]@gravitational/e2e/roles/([^'"]+)['"]`)
-
-// The "key" regexes below all require a word boundary so identifiers like `super_user:` or `myRoles:` don't match as `user:` / `roles:`.
-
-// usersBlockRe matches the beginning of a users array declaration.
-var usersBlockRe = regexp.MustCompile(`\busers:\s*\[`)
-
-// userObjRe matches the beginning of a singular user object declaration.
-var userObjRe = regexp.MustCompile(`\buser:\s*\{`)
-
-// rolesBlockRe matches the beginning of a roles array declaration.
-var rolesBlockRe = regexp.MustCompile(`\broles:\s*\[`)
-
-// traitsBlockRe matches the beginning of a traits object declaration.
-var traitsBlockRe = regexp.MustCompile(`\btraits:\s*\{`)
-
-// traitKeyArrayRe matches a trait key followed by an array value (e.g. logins: ['root']).
-var traitKeyArrayRe = regexp.MustCompile(`\b(\w+):\s*\[`)
-
-// loginAsBoolRe matches loginAs: true within a user object.
-var loginAsBoolRe = regexp.MustCompile(`\bloginAs:\s*true\b`)
+	// The "key" regexes below require a word boundary so identifiers like
+	// `super_user:` or `myRoles:` don't match as `user:` / `roles:`.
+	usersBlockRe     = regexp.MustCompile(`\busers:\s*\[`)
+	userObjRe        = regexp.MustCompile(`\buser:\s*\{`)
+	rolesBlockRe     = regexp.MustCompile(`\broles:\s*\[`)
+	traitsBlockRe    = regexp.MustCompile(`\btraits:\s*\{`)
+	traitKeyArrayRe  = regexp.MustCompile(`\b(\w+):\s*\[`)
+	loginAsBoolRe    = regexp.MustCompile(`\bloginAs:\s*true\b`)
+)
 
 // defaultRoleNames returns the built-in roles assigned when no roles are specified. Returns a fresh slice each call so callers can mutate/sort safely.
 func defaultRoleNames() []scannedRole {

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -622,6 +622,7 @@ func scanFileUsers(path string, targetLine int) ([]scannedUser, error) {
 				if userBlock != "" {
 					user := parseUserBlock(userBlock)
 					user.loginAs = true // singular user is implicitly loginAs
+					warnDuplicateRoles(path, callLine, user.roles)
 					users = append(users, user)
 				}
 			}
@@ -633,6 +634,7 @@ func scanFileUsers(path string, targetLine int) ([]scannedUser, error) {
 						u := parseUserBlock(userBlock)
 						idx := i
 						u.arrayIdx = &idx
+						warnDuplicateRoles(path, callLine, u.roles)
 						users = append(users, u)
 					}
 				}
@@ -813,6 +815,20 @@ func extractAllOuter(s string, open, close byte) []string {
 	}
 
 	return blocks
+}
+
+func warnDuplicateRoles(path string, line int, roles []scannedRole) {
+	for i := 1; i < len(roles); i++ {
+		if roles[i] != roles[i-1] {
+			continue
+		}
+
+		ref := roles[i].name
+		if roles[i].file != "" {
+			ref = "file:" + roles[i].file
+		}
+		slog.Warn("scan: duplicate role for user", "path", path, "line", line, "role", ref)
+	}
 }
 
 // sortRoles sorts roles with built-in names before file refs, alphabetical within each group.

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -25,15 +25,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/gravitational/teleport/e2e/runner/fixtures"
 )
 
-// fixtureArrayRe matches fixture array declarations within a test.use() call body.
-//   - fixtures: ['ssh-node']
-//   - fixtures: [['connect'], { option: true }]
+// fixtureArrayRe matches fixture array declarations within a test.use() call body, e.g. fixtures: ['ssh-node'] or fixtures: [['connect'], { option: true }].
 var fixtureArrayRe = regexp.MustCompile(`fixtures:\s*\[+([^]]*)]`)
 
 // lineNumberSuffixRe matches a trailing :line_number on a test path (e.g. "my-spec.ts:42").
@@ -42,11 +41,56 @@ var lineNumberSuffixRe = regexp.MustCompile(`:\d+$`)
 // fixtureRefRe extracts individual quoted fixture names from the matched array contents.
 var fixtureRefRe = regexp.MustCompile(`['"]([^'"]+)['"]`)
 
-// helperImportRe matches imports from the e2e helpers package and captures the module name.
-// e.g. `from '@gravitational/e2e/helpers/connect'` → "connect"
+// helperImportRe captures the module name from an `@gravitational/e2e/helpers/<name>` import.
 var helperImportRe = regexp.MustCompile(`from\s+['"]@gravitational/e2e/helpers/(\w+)['"]`)
 
+// roleFileRe extracts the role filename from a file role reference.
+var roleFileRe = regexp.MustCompile(`\bfile:\s*['"]@gravitational/e2e/roles/([^'"]+)['"]`)
+
+// The "key" regexes below all require a word boundary so identifiers like `super_user:` or `myRoles:` don't match as `user:` / `roles:`.
+
+// usersBlockRe matches the beginning of a users array declaration.
+var usersBlockRe = regexp.MustCompile(`\busers:\s*\[`)
+
+// userObjRe matches the beginning of a singular user object declaration.
+var userObjRe = regexp.MustCompile(`\buser:\s*\{`)
+
+// rolesBlockRe matches the beginning of a roles array declaration.
+var rolesBlockRe = regexp.MustCompile(`\broles:\s*\[`)
+
+// traitsBlockRe matches the beginning of a traits object declaration.
+var traitsBlockRe = regexp.MustCompile(`\btraits:\s*\{`)
+
+// traitKeyArrayRe matches a trait key followed by an array value (e.g. logins: ['root']).
+var traitKeyArrayRe = regexp.MustCompile(`\b(\w+):\s*\[`)
+
+// loginAsBoolRe matches loginAs: true within a user object.
+var loginAsBoolRe = regexp.MustCompile(`\bloginAs:\s*true\b`)
+
+// defaultRoleNames returns the built-in roles assigned when no roles are specified. Returns a fresh slice each call so callers can mutate/sort safely.
+func defaultRoleNames() []scannedRole {
+	return []scannedRole{
+		{name: "access"},
+		{name: "editor"},
+	}
+}
+
 const testUseCallPrefix = "test.use("
+
+// scannedUser is a user declaration discovered in test source. Names are generated at bootstrap time, not by the test author.
+type scannedUser struct {
+	roles   []scannedRole
+	traits  map[string][]string
+	loginAs bool
+	// arrayIdx is the position within a `users: [...]` array; nil otherwise. Keeps duplicate-by-content entries addressable as distinct accounts via loginAs(N).
+	arrayIdx *int
+}
+
+// scannedRole is a role reference; exactly one of name (built-in like "access") or file (e.g. "viewer.yaml" under e2e/testdata/roles/) is set.
+type scannedRole struct {
+	name string
+	file string
+}
 
 // scanTarget represents a file to scan with an optional line constraint.
 type scanTarget struct {
@@ -64,18 +108,13 @@ type callRange struct {
 	start, end int
 }
 
-// scanFixtures scans test files and the helpers they import to discover which fixtures are needed.
-func scanFixtures(e2eDir string, testFiles []string) []*fixtures.Fixture {
+// resolveTargetsWithHelpers resolves test files plus any helper modules they import, so fixtures and users declared in helpers are also discovered.
+func resolveTargetsWithHelpers(e2eDir string, testFiles []string) ([]scanTarget, error) {
 	targets, err := resolveFilesToScan(e2eDir, testFiles)
 	if err != nil {
-		slog.Warn("fixture scan: error resolving files", "error", err)
-
-		return nil
+		return nil, err
 	}
 
-	slog.Debug("fixture scan: resolved targets", "count", len(targets))
-
-	// Helpers can also reference fixtures (such as Connect), so we need to scan them as well.
 	importedHelpers := make(map[string]bool)
 	for _, t := range targets {
 		for _, helper := range parseHelperImports(t.path) {
@@ -83,16 +122,17 @@ func scanFixtures(e2eDir string, testFiles []string) []*fixtures.Fixture {
 		}
 	}
 
-	// Helpers are always scanned fully (no line targeting).
-	// No existence check needed — scanFile handles missing files gracefully.
 	for helper := range importedHelpers {
 		targets = append(targets, scanTarget{
 			path: filepath.Join(e2eDir, "helpers", helper+".ts"),
 		})
 	}
 
-	slog.Debug("fixture scan: total files to scan", "count", len(targets))
+	return targets, nil
+}
 
+// scanFixturesFromTargets scans pre-resolved targets to discover which fixtures are needed.
+func scanFixturesFromTargets(targets []scanTarget) []*fixtures.Fixture {
 	seen := make(map[string]struct{})
 	var result []*fixtures.Fixture
 
@@ -108,6 +148,18 @@ func scanFixtures(e2eDir string, testFiles []string) []*fixtures.Fixture {
 	}
 
 	return result
+}
+
+// scanFixtures wraps resolveTargetsWithHelpers + scanFixturesFromTargets for callers that haven't been split yet.
+func scanFixtures(e2eDir string, testFiles []string) []*fixtures.Fixture {
+	targets, err := resolveTargetsWithHelpers(e2eDir, testFiles)
+	if err != nil {
+		slog.Warn("fixture scan: error resolving files", "error", err)
+
+		return nil
+	}
+
+	return scanFixturesFromTargets(targets)
 }
 
 func resolveFilesToScan(e2eDir string, testFiles []string) ([]scanTarget, error) {
@@ -290,8 +342,7 @@ func stripComments(lines []string) []string {
 	return cleaned
 }
 
-// findInlineComment returns the byte offset of the first // that is not inside a single-quoted, double-quoted, or
-// backtick string literal, or -1.
+// findInlineComment returns the byte offset of the first // not inside a string/template literal, or -1.
 func findInlineComment(line string) int {
 	var quote byte
 
@@ -477,3 +528,312 @@ func fixtureInScope(fixtureLine, targetLine int, blocks []blockRange) bool {
 
 	return targetLine >= enclosing.start && targetLine <= enclosing.end
 }
+
+// scanUsersFromTargets scans pre-resolved targets for user declarations and always appends the default access/editor user so implicit-auth specs (no test.use(), :authenticated project) resolve a username in mixed runs.
+func scanUsersFromTargets(targets []scanTarget) ([]scannedUser, error) {
+	var result []scannedUser
+	for _, t := range targets {
+		users, err := scanFileUsers(t.path, t.line)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, users...)
+	}
+
+	return ensureDefaultUser(result)
+}
+
+// ensureDefaultUser appends the default user unless an explicit declaration already produces the same canonical key.
+func ensureDefaultUser(users []scannedUser) ([]scannedUser, error) {
+	keys := make(map[string]bool, len(users))
+	for _, u := range users {
+		k, err := canonicalUserKey(u)
+		if err != nil {
+			return nil, err
+		}
+		keys[k] = true
+	}
+
+	for _, du := range defaultUsers() {
+		k, err := canonicalUserKey(du)
+		if err != nil {
+			return nil, err
+		}
+		if keys[k] {
+			continue
+		}
+		users = append(users, du)
+	}
+
+	return users, nil
+}
+
+// defaultUsers returns a default user with access and editor roles.
+func defaultUsers() []scannedUser {
+	return []scannedUser{
+		{
+			roles:   defaultRoleNames(),
+			loginAs: true,
+		},
+	}
+}
+
+// scanFileUsers extracts user declarations from test.use() calls. Singular `user: {}` and array `users: [...]` are mutually exclusive per call; at most one array entry may have `loginAs: true`.
+func scanFileUsers(path string, targetLine int) ([]scannedUser, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Missing files are not fatal: the scanner is used against a
+		// heuristic target list that may include paths that don't exist.
+		slog.Warn("scan: could not read file", "path", path, "error", err)
+		return nil, nil
+	}
+
+	lines := strings.Split(string(data), "\n")
+	cleaned := stripComments(lines)
+	blocks := parseBlocks(cleaned)
+	content := strings.Join(cleaned, "\n")
+
+	var result []scannedUser
+	for _, call := range findTestUseCalls(content) {
+		callLine := 1 + strings.Count(content[:call.start], "\n")
+
+		if targetLine > 0 && !fixtureInScope(callLine, targetLine, blocks) {
+			continue
+		}
+
+		body := content[call.start:call.end]
+
+		hasUser := userObjRe.MatchString(body)
+		hasUsers := usersBlockRe.MatchString(body)
+
+		if hasUser && hasUsers {
+			return nil, fmt.Errorf(
+				"%s:%d: user and users are mutually exclusive in test.use()",
+				path, callLine,
+			)
+		}
+
+		var users []scannedUser
+
+		if hasUser {
+			if loc := userObjRe.FindStringIndex(body); loc != nil {
+				userBlock := extractInner(body[loc[0]:], '{', '}')
+				if userBlock != "" {
+					user := parseUserBlock(userBlock)
+					user.loginAs = true // singular user is implicitly loginAs
+					users = append(users, user)
+				}
+			}
+		} else if hasUsers {
+			if loc := usersBlockRe.FindStringIndex(body); loc != nil {
+				usersContent := extractInner(body[loc[0]:], '[', ']')
+				if usersContent != "" {
+					for i, userBlock := range extractAllOuter(usersContent, '{', '}') {
+						u := parseUserBlock(userBlock)
+						idx := i
+						u.arrayIdx = &idx
+						users = append(users, u)
+					}
+				}
+			}
+
+			loginAsCount := 0
+			for _, u := range users {
+				if u.loginAs {
+					loginAsCount++
+				}
+			}
+			if loginAsCount > 1 {
+				return nil, fmt.Errorf(
+					"%s:%d: at most one user in users: [...] may have loginAs: true (found %d)",
+					path, callLine, loginAsCount,
+				)
+			}
+		}
+
+		result = append(result, users...)
+	}
+
+	return result, nil
+}
+
+// scanBalanced returns the index of the close delimiter matching the open at openIdx, or -1 if unmatched. Delimiters inside string/template literals are ignored.
+func scanBalanced(s string, openIdx int, open, close byte) int {
+	depth := 0
+	var quote byte
+
+	for i := openIdx; i < len(s); i++ {
+		ch := s[i]
+
+		if quote != 0 {
+			if ch == '\\' {
+				i++
+			} else if ch == quote {
+				quote = 0
+			}
+
+			continue
+		}
+
+		switch ch {
+		case '\'', '"', '`':
+			quote = ch
+		case open:
+			depth++
+		case close:
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+
+	return -1
+}
+
+// parseUserBlock extracts roles, traits, and loginAs from a single user object block.
+func parseUserBlock(userBlock string) scannedUser {
+	var user scannedUser
+
+	rolesLoc := rolesBlockRe.FindStringIndex(userBlock)
+	if rolesLoc != nil {
+		rolesContent := extractInner(userBlock[rolesLoc[0]:], '[', ']')
+		if rolesContent != "" {
+			// Collect file-role ranges first, then walk all quoted strings and
+			// classify each based on whether it falls inside a file-role match.
+			fileMatches := roleFileRe.FindAllStringSubmatchIndex(rolesContent, -1)
+			for _, m := range fileMatches {
+				user.roles = append(user.roles, scannedRole{file: rolesContent[m[2]:m[3]]})
+			}
+
+			fi := 0
+			for _, loc := range fixtureRefRe.FindAllStringSubmatchIndex(rolesContent, -1) {
+				for fi < len(fileMatches) && fileMatches[fi][1] <= loc[0] {
+					fi++
+				}
+				if fi < len(fileMatches) && loc[0] >= fileMatches[fi][0] && loc[0] < fileMatches[fi][1] {
+					continue
+				}
+
+				user.roles = append(user.roles, scannedRole{name: rolesContent[loc[2]:loc[3]]})
+			}
+		}
+	}
+
+	traitsLoc := traitsBlockRe.FindStringIndex(userBlock)
+	if traitsLoc != nil {
+		traitsContent := extractInner(userBlock[traitsLoc[0]:], '{', '}')
+		if traitsContent != "" {
+			user.traits = parseTraits(traitsContent)
+		}
+	}
+
+	if loginAsBoolRe.MatchString(userBlock) {
+		user.loginAs = true
+	}
+
+	sortRoles(user.roles)
+
+	return user
+}
+
+// extractInner returns the content between the first open delimiter and its matching close, ignoring delimiters inside string/template literals.
+func extractInner(s string, open, close byte) string {
+	start := strings.IndexByte(s, open)
+	if start < 0 {
+		return ""
+	}
+
+	end := scanBalanced(s, start, open, close)
+	if end < 0 {
+		return ""
+	}
+
+	return s[start+1 : end]
+}
+
+// parseTraits parses trait key-value pairs (e.g. `logins: ['root', 'alice'], groups: ['dev']`) into a map.
+func parseTraits(traitsContent string) map[string][]string {
+	traits := make(map[string][]string)
+
+	for _, m := range traitKeyArrayRe.FindAllStringSubmatchIndex(traitsContent, -1) {
+		key := traitsContent[m[2]:m[3]]
+		// traitKeyArrayRe ends at the byte after `[`, so m[1]-1 is the `[` byte.
+		bracketOpen := m[1] - 1
+		bracketClose := scanBalanced(traitsContent, bracketOpen, '[', ']')
+		if bracketClose < 0 {
+			continue
+		}
+
+		bracketContent := traitsContent[bracketOpen+1 : bracketClose]
+		for _, ref := range fixtureRefRe.FindAllStringSubmatch(bracketContent, -1) {
+			traits[key] = append(traits[key], ref[1])
+		}
+	}
+
+	return traits
+}
+
+// extractAllOuter returns each top-level open...close block from s (including delimiters), ignoring delimiters inside string/template literals.
+func extractAllOuter(s string, open, close byte) []string {
+	var blocks []string
+	depth := 0
+	start := -1
+	var quote byte
+
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+
+		if quote != 0 {
+			if ch == '\\' {
+				i++
+			} else if ch == quote {
+				quote = 0
+			}
+
+			continue
+		}
+
+		switch ch {
+		case '\'', '"', '`':
+			quote = ch
+		case open:
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case close:
+			depth--
+			if depth == 0 && start >= 0 {
+				blocks = append(blocks, s[start:i+1])
+				start = -1
+			}
+		}
+	}
+
+	return blocks
+}
+
+// sortRoles sorts roles with built-in names before file refs, alphabetical within each group.
+func sortRoles(roles []scannedRole) {
+	slices.SortStableFunc(roles, func(a, b scannedRole) int {
+		// Built-in names (name set) come before file refs (file set).
+		aIsName := a.name != ""
+		bIsName := b.name != ""
+
+		if aIsName != bIsName {
+			if aIsName {
+				return -1
+			}
+
+			return 1
+		}
+
+		if aIsName {
+			return strings.Compare(a.name, b.name)
+		}
+
+		return strings.Compare(a.file, b.file)
+	})
+}
+

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -582,8 +582,9 @@ func defaultUsers() []scannedUser {
 func scanFileUsers(path string, targetLine int) ([]scannedUser, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		// Missing files are not fatal: the scanner is used against a
-		// heuristic target list that may include paths that don't exist.
+		// Helper module paths are guessed from import names (see
+		// resolveTargetsWithHelpers), so the file may not exist. Warn
+		// but continue rather than failing the whole scan.
 		slog.Warn("scan: could not read file", "path", path, "error", err)
 		return nil, nil
 	}

--- a/e2e/runner/scan_test.go
+++ b/e2e/runner/scan_test.go
@@ -19,6 +19,8 @@
 package main
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -592,6 +594,77 @@ func TestScanUsersMultipleLoginAsError(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "loginAs") {
 		t.Errorf("expected loginAs error, got: %v", err)
+	}
+}
+
+func TestScanUsersDuplicateRoleWarn(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantWarns []string
+		wantNone  bool
+	}{
+		{
+			name: "duplicate built-in roles warn",
+			content: `test.use({
+  user: { roles: ['access', 'access', 'editor'] },
+});`,
+			wantWarns: []string{"role=access"},
+		},
+		{
+			name: "duplicate file roles warn",
+			content: `test.use({
+  user: { roles: [{ file: '@gravitational/e2e/roles/viewer.yaml' }, { file: '@gravitational/e2e/roles/viewer.yaml' }] },
+});`,
+			wantWarns: []string{"role=file:viewer.yaml"},
+		},
+		{
+			name: "duplicate triggers per-array-entry warn",
+			content: `test.use({
+  users: [
+    { roles: ['access', 'access'] },
+    { roles: ['editor', 'editor'], loginAs: true },
+  ],
+});`,
+			wantWarns: []string{"role=access", "role=editor"},
+		},
+		{
+			name: "no duplicates produces no warn",
+			content: `test.use({
+  user: { roles: ['access', 'editor'] },
+});`,
+			wantNone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			t.Cleanup(func() { slog.SetDefault(prev) })
+
+			dir := t.TempDir()
+			writeFile(t, dir, "test.spec.ts", tt.content)
+
+			if _, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			out := buf.String()
+			if tt.wantNone {
+				if strings.Contains(out, "duplicate role") {
+					t.Errorf("expected no duplicate-role warns, got: %s", out)
+				}
+				return
+			}
+
+			for _, want := range tt.wantWarns {
+				if !strings.Contains(out, want) {
+					t.Errorf("missing warn substring %q in output:\n%s", want, out)
+				}
+			}
+		})
 	}
 }
 

--- a/e2e/runner/scan_test.go
+++ b/e2e/runner/scan_test.go
@@ -360,11 +360,6 @@ func TestScanUsers(t *testing.T) {
 		wantUsers []scannedUser
 	}{
 		{
-			name:      "no users declaration",
-			content:   `test.use({ fixtures: ['ssh-node'] });`,
-			wantUsers: nil,
-		},
-		{
 			name: "singular user with built-in roles",
 			content: `test.use({
   user: { roles: ['access', 'editor'] },
@@ -432,26 +427,6 @@ func TestScanUsers(t *testing.T) {
 					traits: map[string][]string{
 						"logins":            {"root", "alice"},
 						"kubernetes_groups": {"dev"},
-					},
-					loginAs: true,
-				},
-			},
-		},
-		{
-			name:      "commented out users are ignored",
-			content:   `// test.use({ user: { roles: ['access'] } });`,
-			wantUsers: nil,
-		},
-		{
-			name: "user alongside fixtures",
-			content: `test.use({
-  fixtures: ['ssh-node'],
-  user: { roles: ['access'] },
-});`,
-			wantUsers: []scannedUser{
-				{
-					roles: []scannedRole{
-						{name: "access"},
 					},
 					loginAs: true,
 				},

--- a/e2e/runner/scan_test.go
+++ b/e2e/runner/scan_test.go
@@ -21,6 +21,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gravitational/teleport/e2e/runner/fixtures"
@@ -269,7 +270,11 @@ test('something', async () => {});
 
 	t.Run("connect test detects Connect fixture via helper", func(t *testing.T) {
 		rel, _ := filepath.Rel(e2eDir, filepath.Join(testsDir, "auth.spec.ts"))
-		got := scanFixtures(e2eDir, []string{rel})
+		targets, err := resolveTargetsWithHelpers(e2eDir, []string{rel})
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := scanFixturesFromTargets(targets)
 
 		if len(got) != 1 {
 			t.Fatalf("expected 1 fixture, got %d", len(got))
@@ -282,7 +287,11 @@ test('something', async () => {});
 
 	t.Run("web test does not detect Connect fixture", func(t *testing.T) {
 		rel, _ := filepath.Rel(e2eDir, filepath.Join(webDir, "roles.spec.ts"))
-		got := scanFixtures(e2eDir, []string{rel})
+		targets, err := resolveTargetsWithHelpers(e2eDir, []string{rel})
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := scanFixturesFromTargets(targets)
 
 		if len(got) != 0 {
 			t.Fatalf("expected 0 fixtures, got %d", len(got))
@@ -340,6 +349,327 @@ func TestResolveFilesToScan(t *testing.T) {
 			t.Fatalf("expected 1 target, got %d", len(targets))
 		}
 	})
+}
+
+func TestScanUsers(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantUsers []scannedUser
+	}{
+		{
+			name:      "no users declaration",
+			content:   `test.use({ fixtures: ['ssh-node'] });`,
+			wantUsers: nil,
+		},
+		{
+			name: "singular user with built-in roles",
+			content: `test.use({
+  user: { roles: ['access', 'editor'] },
+});`,
+			wantUsers: []scannedUser{
+				{
+					roles: []scannedRole{
+						{name: "access"},
+						{name: "editor"},
+					},
+					loginAs: true,
+				},
+			},
+		},
+		{
+			name: "users array with loginAs",
+			content: `test.use({
+  users: [
+    { roles: ['access', 'editor'], loginAs: true },
+    { roles: [{ file: '@gravitational/e2e/roles/viewer.yaml' }] },
+  ],
+});`,
+			wantUsers: []scannedUser{
+				{
+					roles: []scannedRole{
+						{name: "access"},
+						{name: "editor"},
+					},
+					loginAs: true,
+				},
+				{
+					roles: []scannedRole{
+						{file: "viewer.yaml"},
+					},
+				},
+			},
+		},
+		{
+			name: "user with file role",
+			content: `test.use({
+  user: { roles: [{ file: '@gravitational/e2e/roles/viewer.yaml' }] },
+});`,
+			wantUsers: []scannedUser{
+				{
+					roles: []scannedRole{
+						{file: "viewer.yaml"},
+					},
+					loginAs: true,
+				},
+			},
+		},
+		{
+			name: "user with traits",
+			content: `test.use({
+  user: {
+    roles: ['access'],
+    traits: { logins: ['root', 'alice'], kubernetes_groups: ['dev'] },
+  },
+});`,
+			wantUsers: []scannedUser{
+				{
+					roles: []scannedRole{
+						{name: "access"},
+					},
+					traits: map[string][]string{
+						"logins":            {"root", "alice"},
+						"kubernetes_groups": {"dev"},
+					},
+					loginAs: true,
+				},
+			},
+		},
+		{
+			name:      "commented out users are ignored",
+			content:   `// test.use({ user: { roles: ['access'] } });`,
+			wantUsers: nil,
+		},
+		{
+			name: "user alongside fixtures",
+			content: `test.use({
+  fixtures: ['ssh-node'],
+  user: { roles: ['access'] },
+});`,
+			wantUsers: []scannedUser{
+				{
+					roles: []scannedRole{
+						{name: "access"},
+					},
+					loginAs: true,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tmpFile := filepath.Join(dir, "test.spec.ts")
+			writeFile(t, dir, "test.spec.ts", tt.content)
+
+			got, err := scanFileUsers(tmpFile, 0)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != len(tt.wantUsers) {
+				t.Fatalf("got %d users, want %d", len(got), len(tt.wantUsers))
+			}
+
+			for i, u := range got {
+				want := tt.wantUsers[i]
+
+				if u.loginAs != want.loginAs {
+					t.Errorf("user[%d] loginAs = %v, want %v", i, u.loginAs, want.loginAs)
+				}
+
+				if len(u.roles) != len(want.roles) {
+					t.Fatalf("user[%d] got %d roles, want %d", i, len(u.roles), len(want.roles))
+				}
+
+				for j, r := range u.roles {
+					if r.name != want.roles[j].name {
+						t.Errorf("user[%d] role[%d] name = %q, want %q", i, j, r.name, want.roles[j].name)
+					}
+
+					if r.file != want.roles[j].file {
+						t.Errorf("user[%d] role[%d] file = %q, want %q", i, j, r.file, want.roles[j].file)
+					}
+				}
+
+				if want.traits != nil {
+					if u.traits == nil {
+						t.Errorf("user[%d] traits = nil, want %v", i, want.traits)
+					} else {
+						for k, wantVals := range want.traits {
+							gotVals, ok := u.traits[k]
+							if !ok {
+								t.Errorf("user[%d] missing trait %q", i, k)
+								continue
+							}
+
+							if len(gotVals) != len(wantVals) {
+								t.Errorf("user[%d] trait %q has %d values, want %d", i, k, len(gotVals), len(wantVals))
+								continue
+							}
+
+							for vi, v := range gotVals {
+								if v != wantVals[vi] {
+									t.Errorf("user[%d] trait %q[%d] = %q, want %q", i, k, vi, v, wantVals[vi])
+								}
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestScanUsersDefaultUser(t *testing.T) {
+	e2eDir := t.TempDir()
+	testsDir := createDir(t, e2eDir, "tests")
+
+	// A spec that declares no users at all.
+	writeFile(t, testsDir, "basic.spec.ts", `test.use({ fixtures: ['ssh-node'] });`)
+
+	targets, err := resolveTargetsWithHelpers(e2eDir, []string{"tests/basic.spec.ts"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := scanUsersFromTargets(targets)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(got))
+	}
+
+	if len(got[0].roles) != 2 {
+		t.Fatalf("expected 2 roles for default user, got %d", len(got[0].roles))
+	}
+
+	if got[0].roles[0].name != "access" {
+		t.Errorf("expected first role 'access', got %q", got[0].roles[0].name)
+	}
+
+	if got[0].roles[1].name != "editor" {
+		t.Errorf("expected second role 'editor', got %q", got[0].roles[1].name)
+	}
+
+	if !got[0].loginAs {
+		t.Error("expected default user to have loginAs=true")
+	}
+}
+
+func TestScanUsersMutuallyExclusiveError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "test.spec.ts", `test.use({
+  user: { roles: ['access'] },
+  users: [{ roles: ['access'] }],
+});`)
+
+	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0)
+	if err == nil {
+		t.Fatal("expected error for user + users in same test.use(), got nil")
+	}
+
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected mutual-exclusivity error, got: %v", err)
+	}
+}
+
+func TestScanUsersMultipleLoginAsError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "test.spec.ts", `test.use({
+  users: [
+    { roles: ['access'], loginAs: true },
+    { roles: ['editor'], loginAs: true },
+  ],
+});`)
+
+	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0)
+	if err == nil {
+		t.Fatal("expected error for multiple loginAs: true, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "loginAs") {
+		t.Errorf("expected loginAs error, got: %v", err)
+	}
+}
+
+func TestScanUsersDelimitersInStringLiterals(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantRoles []string
+	}{
+		{
+			name: "brace inside trait string does not close user block early",
+			content: `test.use({
+  user: {
+    roles: ['access'],
+    traits: { logins: ['has}brace', 'ok'] },
+  },
+});`,
+			wantRoles: []string{"access"},
+		},
+		{
+			name: "bracket inside trait string does not close users array early",
+			content: `test.use({
+  users: [
+    { roles: ['access'], traits: { logins: ['has]bracket'] } },
+    { roles: ['editor'], loginAs: true },
+  ],
+});`,
+			wantRoles: []string{"access", "editor"},
+		},
+		{
+			name: "backtick template with delimiters does not corrupt parsing",
+			content: "test.use({\n  user: {\n    roles: ['access'],\n    traits: { logins: [`weird}{`] },\n  },\n});",
+			wantRoles: []string{"access"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "test.spec.ts", tt.content)
+
+			got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != len(tt.wantRoles) {
+				t.Fatalf("got %d users, want %d: %+v", len(got), len(tt.wantRoles), got)
+			}
+
+			for i, want := range tt.wantRoles {
+				if len(got[i].roles) != 1 || got[i].roles[0].name != want {
+					t.Errorf("users[%d].roles = %+v, want [{name: %q}]", i, got[i].roles, want)
+				}
+			}
+		})
+	}
+}
+
+func TestScanUsersIdentifierBoundaries(t *testing.T) {
+	// Declarations that look like they should match the user/users/roles/traits
+	// regexes but don't because the identifier has additional word characters.
+	dir := t.TempDir()
+	writeFile(t, dir, "test.spec.ts", `test.use({
+  fixtures: ['ssh-node'],
+  super_user: { roles: ['nope'] },
+  customUsers: [{ roles: ['nope'] }],
+  myRoles: ['nope'],
+});`)
+
+	got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Fatalf("expected 0 users (identifiers should not match), got %d: %+v", len(got), got)
+	}
 }
 
 func createDir(t *testing.T, path ...string) string {


### PR DESCRIPTION
This adds user/role scanning to the e2e runner, where tests can define custom users that they require and the roles the user should have.

Because of this, sadly `bob` will disappear and usernames will be randomly generated strings instead (using adjectives/nouns). These will be auto logged in for the test, and if a test specifies more than one user, the usernames and the ability to login as the other user will also be available to the test.

No manual test plan as this is PR 1 of 3, this is just the necessary code to get going without creating a huge PR.
