### PR TITLE
Wire user/role scanner into e2e runner and TS fixtures

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -67,38 +67,110 @@ Available fixtures:
 Fixtures can also be enabled manually with `--with-<name>` flags (e.g. `--with-ssh-node`, `--with-connect`),
 which is useful for modes like `--codegen` or `--browse` where auto-detection does not run.
 
-### Session Recordings
+### Users and Roles
 
-The runner automatically seeds session recordings into Teleport's data directory at startup so the Web UI's
-session recordings page has content immediately. Recordings are stored in `e2e/testdata/recordings/` organized
-by session type:
+By default, the runner creates a single user with the `access` and `editor` roles. Tests that need custom
+roles or traits can declare them via `test.use()`. Usernames are auto-generated as human-readable IDs
+(e.g. `brave-falcon`) — tests don't specify names.
 
-```
-e2e/testdata/recordings/
-├── events.jsonl          # generated - do not edit
-├── ssh/
-│   ├── <session-id>.tar
-│   ├── <session-id>.metadata
-│   └── <session-id>.thumbnail
-├── k8s/
-│   └── ...
-└── desktop/
-    └── ...
+**Single user (most common):**
+
+```ts
+test.use({
+  user: { roles: ['access', 'editor'] },
+});
 ```
 
-Each recording consists of a `.tar` file (required) and optional `.metadata` and `.thumbnail` sidecar files.
-The `events.jsonl` file contains the session end audit events and is auto-generated from the `.tar` files.
+The singular `user` form creates one user and automatically logs in as that user.
 
-**Adding a new recording:**
+**Multiple users:**
 
-To add a new recording, place the `.tar` file (and any `.metadata`/`.thumbnail` files) in the appropriate subdirectory
-(`ssh/`, `k8s/`, or `desktop/`).
+For tests that need more than one user (e.g. RBAC tests), use the `users` array. At least one user must
+have `loginAs: true` to indicate which user the test authenticates as:
 
-By default, all recordings are associated with the `bob` user. To assign a recording to a different user,
-add the session ID and username to the `recordingUserMap` in `e2e/runner/recordings.go`.
+```ts
 
-At runtime, the runner copies recording files into Teleport's records directory and appends the audit events
-to the audit log with adjusted timestamps so that sessions appear recent in the UI.
+test.use({
+  users: [
+    { roles: ['access', 'editor'], loginAs: true },
+    { roles: [{ file: '@gravitational/e2e/roles/viewer.yaml' }] },
+  ],
+});
+```
+
+**Traits:**
+
+Users can specify Teleport traits. Built-in trait keys (`logins`, `kubernetes_groups`, `db_names`, etc.)
+are typed in the `UserTraits` interface, and custom keys are also supported:
+
+```ts
+test.use({
+  user: {
+    roles: ['access'],
+    traits: { logins: ['root', 'alice'], kubernetes_groups: ['dev'] },
+  },
+});
+```
+
+When traits are omitted, the default is `{ logins: ['root'] }`.
+
+**Custom roles from YAML files:**
+
+For roles that don't exist as built-in Teleport roles, reference a YAML file in `e2e/testdata/roles/`:
+
+```ts
+test.use({
+  user: {
+    roles: [{ file: '@gravitational/e2e/roles/rbac-read-access.yaml' }],
+  },
+});
+```
+
+The `@gravitational/e2e/roles/` prefix is stripped and the file is loaded from `e2e/testdata/roles/`. The role
+name is extracted from `metadata.name` in the YAML. Custom role files are deduplicated, so multiple users can
+reference the same file.
+
+**`username` fixture:** The generated username of the logged-in user is available as the `username`
+fixture value, for use in test assertions.
+
+**Switching users mid-test:** For RBAC-style tests that need to swap users partway through, use the `loginAs`
+fixture. It takes an index into the `users` array and swaps the page's cached session state for that user
+without running the UI login flow, so the switch is near-instant.
+
+```ts
+test.use({
+  users: [
+    { roles: ['access'], loginAs: true },
+    { roles: ['editor'] },
+  ],
+});
+
+test('switch users', async ({ page, loginAs }) => {
+  // signed in as users[0] at test start
+  // ...
+  const editorName = await loginAs(1);
+  // now signed in as users[1]; `editorName` is the generated username
+});
+```
+
+**Scoping:** `test.use()` follows Playwright's normal scoping rules — place it inside a `test.describe()` block
+to limit it to that group, or at the top level of a file to apply to all tests in the file.
+
+**Account isolation:** the runner gives each spec its own bootstrapped account, even when two specs declare
+the same `user`/`users`. Concretely:
+- Tests with no `test.use({ user/users })` in a project that needs auth (web `:authenticated` projects and
+  the `connect` project) fall through to a single shared `access`/`editor` default user.
+- An explicit `test.use({ user: { roles: [...] } })` always gets a fresh account, distinct from the default
+  even when the roles match.
+- Two specs that declare identical `test.use({ user: ... })` get distinct accounts (keyed by spec path).
+- Tests in the same spec share one account when their `test.use()` resolves to identical content. To force
+  separate accounts, vary traits or use the `users: [...]` array (entries are distinguished by index).
+- Helper-declared `test.use({ user/users })` stays shared across every spec that imports the helper.
+
+**How it works (briefly):** The runner generates credentials server-side, logs each user in over HTTP
+(`/v1/webapi/mfa/login/*`) during setup, and writes the resulting cookies + localStorage to
+`e2e/.auth/<browser>-<username>.json`. Tests pick up that state via Playwright's `storageState`, so they
+start already authenticated without running the UI login flow.
 
 ### Common Commands
 

--- a/e2e/config/state.yaml.tmpl
+++ b/e2e/config/state.yaml.tmpl
@@ -1,7 +1,14 @@
+{{- range .CustomRoles }}
+{{ .YAML }}
+---
+{{ end -}}
+{{- range $i, $user := .Users -}}
+{{ if $i }}---
+{{ end -}}
 kind: user
 metadata:
   id: 1689831509413322785
-  name: bob
+  name: {{ $user.Name }}
 spec:
   created_by:
     time: "2023-07-20T05:38:29.4127778Z"
@@ -18,33 +25,30 @@ spec:
           Name: webauthn-device
           Namespace: default
         webauthn:
-          credentialId: {{ .CredentialIDBase64 }}
-          publicKeyCbor: {{ .PublicKeyCBORBase64 }}
+          credentialId: {{ $user.CredentialIDBase64 }}
+          publicKeyCbor: {{ $user.PublicKeyCBORBase64 }}
           attestationType: none
           aaguid: AAAAAAAAAAAAAAAAAAAAAA==
           signatureCounter: 0
           residentKey: false
           credentialRpId: localhost
         version: v1
-    password_hash: {{ .PasswordHashBase64 }}
+    password_hash: {{ $user.PasswordHashBase64 }}
   roles:
-    - access
-    - editor
+    {{- range $user.Roles }}
+    - {{ . }}
+    {{- end }}
   status:
     is_locked: false
     lock_expires: "0001-01-01T00:00:00Z"
     locked_time: "0001-01-01T00:00:00Z"
     recovery_attempt_lock_expires: "0001-01-01T00:00:00Z"
   traits:
-    aws_role_arns: null
-    azure_identities: null
-    db_names: null
-    db_roles: null
-    db_users: null
-    gcp_service_accounts: null
-    kubernetes_groups: null
-    kubernetes_users: null
-    logins:
-      - root
-    windows_logins: null
+    {{- range $key, $vals := $user.Traits }}
+    {{ $key }}:
+      {{- range $vals }}
+      - {{ . }}
+      {{- end }}
+    {{- end }}
 version: v2
+{{ end -}}

--- a/e2e/config/state.yaml.tmpl
+++ b/e2e/config/state.yaml.tmpl
@@ -47,7 +47,7 @@ spec:
     {{- range $key, $vals := $user.Traits }}
     {{ $key }}:
       {{- range $vals }}
-      - {{ . }}
+      - {{ . | yamlQuote }}
       {{- end }}
     {{- end }}
 version: v2

--- a/e2e/helpers/canonicalKey.ts
+++ b/e2e/helpers/canonicalKey.ts
@@ -1,0 +1,96 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// UserKeyInput is the subset of UserDefinition that participates in the
+// canonical key. Kept here (rather than importing from test.ts) so the
+// parity verification script can load it without pulling in Playwright.
+export type UserKeyInput = {
+  roles: (string | { file: string })[];
+  traits?: Record<string, string[] | undefined>;
+};
+
+export type CanonicalUserKeyOpts = {
+  // index is the position of the user within a `users: [...]` array. Pass it
+  // for entries from `users: [...]` so two duplicates-by-content stay
+  // addressable as distinct accounts.
+  index?: number;
+  // isDefault marks the implicit default user so its canonical key is distinct
+  // from any explicit `user: {}` declaration with the same roles.
+  isDefault?: boolean;
+  // source is the spec path (relative to e2eDir) where the user was declared
+  // inline. Set for explicit `test.use({ user/users })` so two specs with the
+  // same shape get distinct accounts; omit for helper-declared users so they
+  // stay shared.
+  source?: string;
+};
+
+/**
+ * Produces a canonical key for a user definition. MUST match the output of
+ * the Go runner's `canonicalUserKey` in e2e/runner/bootstrap.go — if you
+ * change this function, change that one too and regenerate the fixtures in
+ * testdata/canonical-key-fixtures.json.
+ */
+export function canonicalUserKey(
+  def: UserKeyInput,
+  opts: CanonicalUserKeyOpts = {}
+): string {
+  const roles = def.roles
+    .map(r =>
+      typeof r === 'string'
+        ? r
+        : `@file:${r.file.replace('@gravitational/e2e/roles/', '')}`
+    )
+    .sort();
+
+  // Property insertion order is preserved by JSON.stringify; insert in the
+  // same order Go's struct fields are emitted: default, source, index, roles,
+  // traits.
+  const result: {
+    default?: boolean;
+    source?: string;
+    index?: number;
+    roles: string[];
+    traits?: Record<string, string[]>;
+  } = {} as { roles: string[] };
+  if (opts.isDefault) {
+    result.default = true;
+  }
+  if (opts.source !== undefined) {
+    result.source = opts.source;
+  }
+  if (opts.index !== undefined) {
+    result.index = opts.index;
+  }
+  result.roles = roles;
+
+  if (def.traits) {
+    const sorted: Record<string, string[]> = {};
+    for (const k of Object.keys(def.traits).sort()) {
+      const v = def.traits[k];
+      if (v && v.length > 0) {
+        sorted[k] = [...v].sort();
+      }
+    }
+
+    if (Object.keys(sorted).length > 0) {
+      result.traits = sorted;
+    }
+  }
+
+  return JSON.stringify(result);
+}

--- a/e2e/helpers/connect.ts
+++ b/e2e/helpers/connect.ts
@@ -30,10 +30,13 @@ import {
   ElectronApplication,
 } from '@playwright/test';
 
-import { connectTshBin, connectAppDir, password, startUrl } from './env';
-import { test as fixtureBase } from './fixtures';
+import { defaultUsername } from './defaultUser';
+import { connectTshBin, connectAppDir, users, startUrl } from './env';
+import type { UserCredentials } from './env';
+import { test as fixtureBase } from './test';
 
-export async function launchApp(homeDir: string) {
+export async function launchApp(homeDir: string, creds?: UserCredentials) {
+  const userCreds = creds ?? lookupCreds(defaultUsername());
   const requireFromApp = module.createRequire(
     path.join(connectAppDir, 'package.json')
   );
@@ -47,6 +50,8 @@ export async function launchApp(homeDir: string) {
       TELEPORT_TOOLS_VERSION: 'off',
       CONNECT_DATA_DIR: homeDir,
       CONNECT_TSH_BIN_PATH: connectTshBin,
+      E2E_WEBAUTHN_PRIVATE_KEY: userCreds.webauthnPrivateKey,
+      E2E_WEBAUTHN_CREDENTIAL_ID: userCreds.webauthnCredentialId,
     },
   });
 
@@ -65,7 +70,26 @@ export async function launchApp(homeDir: string) {
   }
 }
 
-export async function login(page: Page): Promise<void> {
+function lookupCreds(username: string): UserCredentials {
+  const creds = users[username];
+  if (!creds) {
+    throw new Error(`no credentials for user "${username}" in E2E_USERS_FILE`);
+  }
+  return creds;
+}
+
+export async function login(
+  page: Page,
+  username?: string,
+  password?: string
+): Promise<void> {
+  if (!username) {
+    username = defaultUsername();
+    password = lookupCreds(username).password;
+  }
+  if (!password) {
+    throw new Error('login: password required when username is provided');
+  }
   await page.getByRole('button', { name: 'Connect', exact: true }).click();
   const clusterInput = page.getByPlaceholder('teleport.example.com');
   await expect(clusterInput).toBeVisible();
@@ -74,7 +98,7 @@ export async function login(page: Page): Promise<void> {
   await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
   await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-  await page.getByPlaceholder('Username').fill('bob');
+  await page.getByPlaceholder('Username').fill(username);
   await page.getByPlaceholder('Password').fill(password);
   await page.getByRole('button', { name: 'Sign In' }).click();
   await expect(page.getByPlaceholder('Search or jump to')).toBeVisible();
@@ -98,14 +122,21 @@ export const test = fixtureBase.extend<{
 }>({
   autoLogin: [false, { option: true }],
   appConfig: [withDefaultAppConfig({}), { option: true }],
-  app: async ({ autoLogin, appConfig }, use, testInfo) => {
+  app: async ({ autoLogin, appConfig, username }, use, testInfo) => {
+    if (!username) {
+      throw new Error(
+        'Connect app fixture: no username resolved — was the runner started with user-mapping.json?'
+      );
+    }
+    const creds = lookupCreds(username);
+
     await using temp = await fs.mkdtempDisposable(
       path.join(os.tmpdir(), 'connect-e2e-test-')
     );
     const { appConfigPath } = await initializeDataDir(temp.path, appConfig);
-    await using launchedApp = await launchApp(temp.path);
+    await using launchedApp = await launchApp(temp.path, creds);
     if (autoLogin) {
-      await login(launchedApp.page);
+      await login(launchedApp.page, username, creds.password);
     }
     await use({
       electronApp: launchedApp.electronApp,

--- a/e2e/helpers/defaultUser.ts
+++ b/e2e/helpers/defaultUser.ts
@@ -1,0 +1,55 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { canonicalUserKey, type UserKeyInput } from './canonicalKey';
+
+const authDir = join(dirname(fileURLToPath(import.meta.url)), '../.auth');
+
+// Duplicated from the Go runner (defaultUsers() in scan.go) because this code
+// runs before the runner produces any mapping — the TS side can't discover the
+// default through the user-mapping.json file, it has to compute the key directly.
+const DEFAULT_USER: UserKeyInput = { roles: ['access', 'editor'] };
+
+let cached: string | undefined;
+
+// defaultUsername returns the runner-generated username for the default
+// access+editor user. Used by flows that don't declare users via test.use()
+// (Connect tests, open-with-webauthn script).
+export function defaultUsername() {
+  if (cached) {
+    return cached;
+  }
+
+  const mappingPath = join(authDir, 'user-mapping.json');
+  const mapping = JSON.parse(readFileSync(mappingPath, 'utf-8')) as Record<
+    string,
+    string
+  >;
+
+  const name = mapping[canonicalUserKey(DEFAULT_USER, { isDefault: true })];
+  if (!name) {
+    throw new Error(`no default user in ${mappingPath}`);
+  }
+
+  cached = name;
+  return name;
+}

--- a/e2e/helpers/env.ts
+++ b/e2e/helpers/env.ts
@@ -18,6 +18,8 @@
 
 // This file provides helper functions to read required environment variables for the E2E tests.
 
+import { readFileSync } from 'node:fs';
+
 function required(name: string) {
   const value = process.env[name];
 
@@ -28,9 +30,15 @@ function required(name: string) {
   return value;
 }
 
-export const password = required('E2E_PASSWORD');
-export const webauthnPrivateKey = required('E2E_WEBAUTHN_PRIVATE_KEY');
-export const webauthnCredentialId = required('E2E_WEBAUTHN_CREDENTIAL_ID');
+export type UserCredentials = {
+  password: string;
+  webauthnPrivateKey: string;
+  webauthnCredentialId: string;
+};
+
+export const users: Record<string, UserCredentials> = JSON.parse(
+  readFileSync(required('E2E_USERS_FILE'), 'utf-8')
+);
 export const tctlBin = required('E2E_TCTL_BIN');
 export const teleportConfig = required('E2E_TELEPORT_CONFIG');
 export const startUrl = required('START_URL');

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -20,7 +20,7 @@
 
 import { test as base } from '@playwright/test';
 
-type Fixture =
+export type Fixture =
   | 'ssh-node'
   | 'connect';
 

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -16,17 +16,29 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
+import { Agent, fetch as undiciFetch } from 'undici';
 
-import { password as e2ePassword } from './env';
-import { expect } from './test';
-import { mockWebAuthn } from './webauthn';
+import { users } from './env';
+import { mockWebAuthn, signWebAuthnAssertion } from './webauthn';
 
-export async function login(
-  page: Page,
-  username = 'bob',
-  password = e2ePassword
-) {
+// directLogin runs during the auth setup project against a Teleport instance
+// the runner brings up with a freshly-generated self-signed cert, so the
+// global default verifier rejects the connection. Scope the bypass to these
+// two fetches via a dedicated dispatcher rather than disabling TLS globally.
+const insecureDispatcher = new Agent({
+  connect: { rejectUnauthorized: false },
+});
+
+export async function login(page: Page, username: string, password?: string) {
+  if (!password) {
+    password = users[username]?.password;
+
+    if (!password) {
+      throw new Error(`no credentials found for user "${username}"`);
+    }
+  }
+
   await page.addInitScript(() => {
     localStorage.setItem('grv_teleport_license_acknowledged', 'true');
     localStorage.setItem(
@@ -35,7 +47,7 @@ export async function login(
     );
   });
 
-  await mockWebAuthn(page);
+  await mockWebAuthn(page, username);
 
   await page.goto('/');
 
@@ -57,4 +69,223 @@ export async function logout(page: Page) {
   // inside login() don't enter a race condition which results in a
   // net::ERR_ABORTED.
   await expect(page.getByText('Sign in to Teleport')).toBeVisible();
+}
+
+// StorageState matches the format that Playwright's BrowserContext.storageState()
+// produces and that its `storageState` option consumes.
+export interface StorageState {
+  cookies: StorageCookie[];
+  origins: StorageOrigin[];
+}
+
+interface StorageCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expires: number; // unix seconds, -1 for session cookies
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: 'Strict' | 'Lax' | 'None';
+}
+
+interface StorageOrigin {
+  origin: string;
+  localStorage: { name: string; value: string }[];
+}
+
+interface LoginBeginResponse {
+  webauthn_challenge: {
+    publicKey: {
+      challenge: string; // base64url
+      rpId: string;
+      allowCredentials?: { type: string; id: string }[];
+    };
+  };
+}
+
+interface LoginFinishResponse {
+  type: string;
+  token: string;
+  expires_in: number;
+  sessionExpires: string;
+  sessionExpiresIn: number;
+  sessionInactiveTimeout: number;
+}
+
+/**
+ * performHttpLogin replicates the web-UI login ceremony over HTTP so we don't
+ * need to drive a real browser to produce a logged-in storage state. The
+ * resulting StorageState can be written to disk and passed to Playwright's
+ * `storageState` option.
+ */
+export async function directLogin(
+  startUrl: string,
+  username: string,
+  password: string
+): Promise<StorageState> {
+  const url = new URL(startUrl);
+
+  const beginRes = await undiciFetch(
+    new URL('/v1/webapi/mfa/login/begin', url).toString(),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        passwordless: false,
+        user: username,
+        pass: password,
+      }),
+      dispatcher: insecureDispatcher,
+    }
+  );
+
+  if (!beginRes.ok) {
+    throw new Error(
+      `mfa/login/begin failed: ${beginRes.status} ${await beginRes.text()}`
+    );
+  }
+
+  const challenge = (await beginRes.json()) as LoginBeginResponse;
+
+  if (!challenge.webauthn_challenge?.publicKey) {
+    throw new Error('login challenge response missing webauthn_challenge');
+  }
+
+  const assertion = signWebAuthnAssertion(
+    username,
+    challenge.webauthn_challenge.publicKey.challenge,
+    challenge.webauthn_challenge.publicKey.rpId,
+    url.origin
+  );
+
+  const finishRes = await undiciFetch(
+    new URL('/v1/webapi/mfa/login/finishsession', url).toString(),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        user: username,
+        webauthnAssertionResponse: assertion,
+      }),
+      dispatcher: insecureDispatcher,
+    }
+  );
+
+  if (!finishRes.ok) {
+    throw new Error(
+      `mfa/login/finishsession failed: ${finishRes.status} ${await finishRes.text()}`
+    );
+  }
+
+  const session = (await finishRes.json()) as LoginFinishResponse;
+  const cookies = parseSetCookieHeaders(finishRes.headers, url.hostname);
+
+  if (!cookies.some(c => c.name === '__Host-session')) {
+    throw new Error('login finish response did not set __Host-session cookie');
+  }
+
+  const nowMs = Date.now();
+  const localStorage: { name: string; value: string }[] = [
+    {
+      name: 'grv_teleport_token',
+      value: JSON.stringify({
+        accessToken: session.token,
+        expiresIn: session.expires_in,
+        created: nowMs,
+        sessionExpires: session.sessionExpires,
+        sessionExpiresIn: session.sessionExpiresIn,
+        sessionInactiveTimeout: session.sessionInactiveTimeout,
+      }),
+    },
+    {
+      name: 'grv_teleport_login_time',
+      value: String(nowMs),
+    },
+    {
+      name: 'grv_teleport_license_acknowledged',
+      value: 'true',
+    },
+    {
+      name: 'grv_teleport_identity_security_recommendations_unified_resources_cta_seen',
+      value: 'true',
+    },
+  ];
+
+  if (session.sessionInactiveTimeout) {
+    localStorage.push({
+      name: 'grv_teleport_last_active',
+      value: String(nowMs),
+    });
+  }
+
+  return {
+    cookies,
+    origins: [{ origin: url.origin, localStorage }],
+  };
+}
+
+// Playwright's cookie helpers (context.addCookies, context.cookies) operate on
+// a BrowserContext, but directLogin uses Node's fetch to avoid launching a
+// browser. That means we have to parse Set-Cookie headers ourselves into the
+// StorageCookie shape that storageState consumes.
+// Accept any object exposing getSetCookie() so we don't bind to a specific
+// Headers type — the global Web `Headers` and undici's `Headers` both satisfy
+// this shape but are not structurally interchangeable in TypeScript.
+function parseSetCookieHeaders(
+  headers: { getSetCookie(): string[] },
+  defaultDomain: string
+): StorageCookie[] {
+  return headers.getSetCookie().map(h => parseSetCookie(h, defaultDomain));
+}
+
+function parseSetCookie(header: string, defaultDomain: string): StorageCookie {
+  const [nameVal, ...attrs] = header.split(';').map(s => s.trim());
+
+  const eq = nameVal.indexOf('=');
+  const name = nameVal.slice(0, eq);
+  const value = nameVal.slice(eq + 1);
+
+  const cookie: StorageCookie = {
+    name,
+    value,
+    domain: defaultDomain,
+    path: '/',
+    expires: -1,
+    httpOnly: false,
+    secure: false,
+    sameSite: 'Lax',
+  };
+
+  for (const attr of attrs) {
+    const [k, ...rest] = attr.split('=');
+    const key = k.toLowerCase();
+    const v = rest.join('=');
+    switch (key) {
+      case 'domain':
+        cookie.domain = v;
+        break;
+      case 'path':
+        cookie.path = v;
+        break;
+      case 'expires':
+        cookie.expires = Math.floor(new Date(v).getTime() / 1000);
+        break;
+      case 'max-age':
+        cookie.expires = Math.floor(Date.now() / 1000) + Number(v);
+        break;
+      case 'httponly':
+        cookie.httpOnly = true;
+        break;
+      case 'secure':
+        cookie.secure = true;
+        break;
+      case 'samesite':
+        cookie.sameSite = (v.charAt(0).toUpperCase() +
+          v.slice(1).toLowerCase()) as StorageCookie['sameSite'];
+        break;
+    }
+  }
+
+  return cookie;
 }

--- a/e2e/helpers/signup.ts
+++ b/e2e/helpers/signup.ts
@@ -32,7 +32,7 @@ export async function signup(
     localStorage.setItem('grv_teleport_license_acknowledged', 'true')
   );
 
-  await mockWebAuthn(page);
+  await mockWebAuthn(page, username);
 
   const inviteURL = generateInviteURL(username);
   await page.goto(inviteURL);

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -16,16 +16,167 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { canonicalUserKey } from './canonicalKey';
 import { test as base } from './fixtures';
+import type { StorageState } from './login';
 import { PlayerPage } from './pages/Player';
 import { UnifiedResourcesPage } from './pages/UnifiedResources';
+import { mockWebAuthn } from './webauthn';
 
 export const CLUSTER_NAME = 'teleport-e2e';
 
-export const test = base.extend<{
+export type UserRole = string | { file: string };
+
+export interface UserTraits {
+  logins?: string[];
+  windows_logins?: string[];
+  kubernetes_groups?: string[];
+  kubernetes_users?: string[];
+  db_names?: string[];
+  db_users?: string[];
+  db_roles?: string[];
+  aws_role_arns?: string[];
+  azure_identities?: string[];
+  gcp_service_accounts?: string[];
+  host_user_uid?: string[];
+  host_user_gid?: string[];
+  [key: string]: string[] | undefined;
+}
+
+export interface UserDefinition {
+  roles: UserRole[];
+  traits?: UserTraits;
+  loginAs?: boolean;
+}
+
+const e2eDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const authDir = join(e2eDir, '.auth');
+
+const tryLoadUserMapping =
+  cachedJSONLoader<Record<string, string>>('user-mapping.json');
+
+const defaultUser: UserDefinition = { roles: ['access', 'editor'] };
+
+interface E2EFixtures {
+  user: UserDefinition;
+  users: UserDefinition[];
+  username: string;
+  loginAs: (index: number) => Promise<string>;
   unifiedResourcesPage: UnifiedResourcesPage;
   playerPage: PlayerPage;
-}>({
+}
+
+export const test = base.extend<E2EFixtures>({
+  user: [undefined as unknown as UserDefinition, { option: true }],
+  users: [[], { option: true }],
+  username: async ({ user, users }, use, testInfo) => {
+    const mapping = tryLoadUserMapping() ?? {};
+
+    const picked = pickLoginDefinition(user, users);
+    if (picked) {
+      const source = relSpecPath(testInfo);
+      const name =
+        mapping[
+          canonicalUserKey(picked.def, { index: picked.index, source })
+        ] ?? mapping[canonicalUserKey(picked.def, { index: picked.index })];
+      await use(name ?? '');
+      return;
+    }
+
+    if (wantsAuthenticatedUser(testInfo.project.name)) {
+      await use(
+        mapping[canonicalUserKey(defaultUser, { isDefault: true })] ?? ''
+      );
+      return;
+    }
+
+    await use('');
+  },
+  loginAs: async ({ page, users }, use, testInfo) => {
+    const mapping = tryLoadUserMapping();
+    if (!mapping) {
+      throw new Error(
+        `failed to read user mapping at ${join(authDir, 'user-mapping.json')} — was the runner started?`
+      );
+    }
+
+    const browser = testInfo.project.name.split(':')[0];
+
+    await use(async (index: number) => {
+      const definition = users[index];
+      if (!definition) {
+        throw new Error(
+          `users[${index}] is undefined — declare ${index + 1} users in test.use()`
+        );
+      }
+
+      const source = relSpecPath(testInfo);
+      const name =
+        mapping[canonicalUserKey(definition, { index, source })] ??
+        mapping[canonicalUserKey(definition, { index })];
+      if (!name) {
+        throw new Error(
+          `no generated username for users[${index}]: ${JSON.stringify(definition)}`
+        );
+      }
+
+      const state: StorageState = JSON.parse(
+        readFileSync(join(authDir, `${browser}-${name}.json`), 'utf-8')
+      );
+
+      const ctx = page.context();
+      await ctx.clearCookies();
+      await ctx.addCookies(state.cookies);
+
+      // The page's WebAuthn mock is bound to the user the page fixture
+      // started with; rebind it so subsequent MFA prompts answer with the
+      // switched user's credential.
+      await mockWebAuthn(page, name);
+
+      // localStorage is origin-scoped; inject per origin after navigation.
+      await page.goto('/');
+
+      for (const { origin, localStorage: items } of state.origins) {
+        await page.evaluate(
+          ({ expected, entries }) => {
+            if (location.origin !== expected) return;
+            window.localStorage.clear();
+            for (const { name, value } of entries) {
+              window.localStorage.setItem(name, value);
+            }
+          },
+          { expected: origin, entries: items }
+        );
+      }
+
+      await page.reload();
+
+      return name;
+    });
+  },
+  page: async ({ page, username }, use) => {
+    if (username) {
+      await mockWebAuthn(page, username);
+    }
+
+    await use(page);
+  },
+  storageState: async ({ username }, use, testInfo) => {
+    // Connect tests drive login through the Electron app and don't have a
+    // setup project that writes shared storage state files, so leave it unset.
+    if (!username || testInfo.project.name === 'connect') {
+      await use(undefined as unknown as string);
+      return;
+    }
+
+    const browser = testInfo.project.name.split(':')[0];
+
+    await use(join(authDir, `${browser}-${username}.json`));
+  },
   unifiedResourcesPage: async ({ page }, use) => {
     await use(new UnifiedResourcesPage(page));
   },
@@ -35,3 +186,54 @@ export const test = base.extend<{
 });
 
 export { expect } from '@playwright/test';
+
+function pickLoginDefinition(
+  user: UserDefinition | undefined,
+  users: UserDefinition[]
+): { def: UserDefinition; index?: number } | undefined {
+  if (user) {
+    return { def: user };
+  }
+
+  if (users.length === 0) {
+    return undefined;
+  }
+
+  const loginIdx = users.findIndex(u => u.loginAs);
+  const i = loginIdx >= 0 ? loginIdx : 0;
+  return { def: users[i], index: i };
+}
+
+// wantsAuthenticatedUser returns true for projects whose tests need a logged-in
+// user even when test.use() doesn't declare one — `:authenticated` web tests
+// and Connect tests both fall through to the default access/editor user.
+function wantsAuthenticatedUser(projectName: string): boolean {
+  return projectName.endsWith(':authenticated') || projectName === 'connect';
+}
+
+// relSpecPath returns the spec file path relative to e2e/, matching the
+// `source` field the Go scanner emits for inline declarations.
+function relSpecPath(testInfo: { file: string }) {
+  return relative(e2eDir, testInfo.file);
+}
+
+// Mapping files are written once at runner startup and don't change during a
+// test run, so each worker can cache them after first read.
+function cachedJSONLoader<T>(filename: string): () => T | undefined {
+  let cached: T | undefined;
+  let loaded = false;
+
+  return () => {
+    if (!loaded) {
+      loaded = true;
+
+      try {
+        cached = JSON.parse(readFileSync(join(authDir, filename), 'utf-8'));
+      } catch {
+        cached = undefined;
+      }
+    }
+
+    return cached;
+  };
+}

--- a/e2e/helpers/webauthn.ts
+++ b/e2e/helpers/webauthn.ts
@@ -21,43 +21,168 @@ import {
   createPrivateKey,
   createPublicKey,
   createSign,
+  generateKeyPairSync,
+  randomBytes,
 } from 'crypto';
 
 import { Page } from '@playwright/test';
 import { Encoder } from 'cbor-x';
 
-import { webauthnCredentialId, webauthnPrivateKey } from './env';
+import { users } from './env';
 
 declare global {
   function __e2eWebAuthn(json: string): Promise<string>;
 }
 
+// Per-username derived keys; cached because key derivation is relatively expensive.
+type DerivedCreds = {
+  credIdBuf: Buffer;
+  credIdB64: string;
+  privateKey: ReturnType<typeof createPrivateKey>;
+  pubKeyCOSE: Buffer;
+  spkiPublicKeyB64: string;
+};
+
+const derivedCache = new Map<string, DerivedCreds>();
+
+function deriveCreds(username: string): DerivedCreds {
+  const cached = derivedCache.get(username);
+  if (cached) return cached;
+
+  // Ad-hoc usernames (signup / invite flows) aren't in the bootstrapped
+  // E2E_USERS_FILE; generate a fresh keypair and credential ID so the same
+  // mock can drive both registration and subsequent assertions for them.
+  const creds = users[username];
+  let credIdBuf: Buffer;
+  let privateKey: ReturnType<typeof createPrivateKey>;
+  if (creds) {
+    credIdBuf = Buffer.from(creds.webauthnCredentialId, 'base64');
+    privateKey = createPrivateKey({
+      key: Buffer.from(creds.webauthnPrivateKey, 'base64'),
+      format: 'der',
+      type: 'pkcs8',
+    });
+  } else {
+    credIdBuf = randomBytes(32);
+    privateKey = generateKeyPairSync('ec', { namedCurve: 'P-256' }).privateKey;
+  }
+
+  const jwk = privateKey.export({ format: 'jwk' });
+  const x = Buffer.from(jwk.x!, 'base64url');
+  const y = Buffer.from(jwk.y!, 'base64url');
+  const derived: DerivedCreds = {
+    credIdBuf,
+    credIdB64: credIdBuf.toString('base64'),
+    privateKey,
+    pubKeyCOSE: encodeEC2PublicKeyCOSE(x, y),
+    spkiPublicKeyB64: createPublicKey(privateKey)
+      .export({ format: 'der', type: 'spki' })
+      .toString('base64'),
+  };
+
+  derivedCache.set(username, derived);
+
+  return derived;
+}
+
+// WebauthnAssertion is the shape expected by Teleport's /v1/webapi/mfa/login/finishsession
+// (see web/packages/teleport/src/services/mfa/makeMfa.ts:makeWebauthnAssertionResponse).
+export type WebauthnAssertion = {
+  id: string;
+  type: 'public-key';
+  extensions: { appid: boolean };
+  rawId: string;
+  response: {
+    authenticatorData: string;
+    clientDataJSON: string;
+    signature: string;
+    userHandle: string;
+  };
+};
+
+// signWebAuthnAssertion produces a WebAuthn assertion for a login challenge
+// using the stored credentials for `username`. Used to drive the HTTP login
+// flow directly from Node without a browser.
+export function signWebAuthnAssertion(
+  username: string,
+  challenge: string,
+  rpId: string,
+  origin: string
+): WebauthnAssertion {
+  const { credIdBuf, privateKey } = deriveCreds(username);
+
+  const challengeB64url = Buffer.from(challenge, 'base64').toString(
+    'base64url'
+  );
+
+  const clientDataJSON = Buffer.from(
+    JSON.stringify({
+      type: 'webauthn.get',
+      challenge: challengeB64url,
+      origin,
+      crossOrigin: false,
+    })
+  );
+
+  const rpIdHash = createHash('sha256').update(rpId).digest();
+  const counter = Buffer.alloc(4);
+  counter.writeUInt32BE(1);
+  const authenticatorData = Buffer.concat([
+    rpIdHash,
+    Buffer.from([0x05]), // UP + UV
+    counter,
+  ]);
+
+  const signature = createSign('SHA256')
+    .update(
+      Buffer.concat([
+        authenticatorData,
+        createHash('sha256').update(clientDataJSON).digest(),
+      ])
+    )
+    .sign(privateKey);
+
+  const credIdB64url = credIdBuf.toString('base64url');
+  return {
+    id: credIdB64url,
+    type: 'public-key',
+    extensions: { appid: false },
+    rawId: credIdB64url,
+    response: {
+      authenticatorData: authenticatorData.toString('base64url'),
+      clientDataJSON: clientDataJSON.toString('base64url'),
+      signature: signature.toString('base64url'),
+      userHandle: '',
+    },
+  };
+}
+
+// The exposed __e2eWebAuthn function is attached to a page once; to support
+// switching users mid-test we keep the "active" username per page and re-read
+// it on every WebAuthn call.
+const activeUsernameByPage = new WeakMap<Page, string>();
+
 // mockWebAuthn sets up a mock for the WebAuthn API in the browser context in a way that
-// is compatible with Chromium, Firefox and WebKit.
-export async function mockWebAuthn(page: Page) {
+// is compatible with Chromium, Firefox and WebKit. Safe to call multiple times per page:
+// subsequent calls switch the active user without re-exposing the function.
+export async function mockWebAuthn(page: Page, username: string) {
+  // Validate + warm the cache early so errors surface here rather than inside the browser.
+  deriveCreds(username);
+  activeUsernameByPage.set(page, username);
+
   if (await page.evaluate(() => '__e2eWebAuthn' in self)) {
     return;
   }
 
-  const credIdBuf = Buffer.from(webauthnCredentialId, 'base64');
-  const privateKey = createPrivateKey({
-    key: Buffer.from(webauthnPrivateKey, 'base64'),
-    format: 'der',
-    type: 'pkcs8',
-  });
-  const jwk = privateKey.export({ format: 'jwk' });
-  const x = Buffer.from(jwk.x!, 'base64url');
-  const y = Buffer.from(jwk.y!, 'base64url');
-  const pubKeyCOSE = encodeEC2PublicKeyCOSE(x, y);
-  const spkiPubicKey = createPublicKey(privateKey).export({
-    format: 'der',
-    type: 'spki',
-  });
-  const credIdB64 = credIdBuf.toString('base64');
-  const spkiPublicKeyB64 = spkiPubicKey.toString('base64');
-
   let signCount = 0;
   await page.exposeFunction('__e2eWebAuthn', async (optionsJSON: string) => {
+    const active = activeUsernameByPage.get(page);
+    if (!active) {
+      throw new Error('no active WebAuthn user for this page');
+    }
+    const { credIdBuf, credIdB64, privateKey, pubKeyCOSE, spkiPublicKeyB64 } =
+      deriveCreds(active);
+
     const opts: WebAuthnRequest = JSON.parse(optionsJSON);
 
     signCount++;

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,12 +6,14 @@
   "scripts": {
     "test": "./run.sh",
     "type-check": "tsc --noEmit",
+    "test:canonical-key": "tsx scripts/verify-canonical-key.ts",
     "show-report": "playwright show-report --port 0"
   },
   "license": "Apache-2.0",
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "cbor-x": "^1.6.4",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "undici": "^7.24.5"
   }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -51,7 +51,6 @@ export default defineConfig({
   projects: [
     ...browserList.flatMap(browser => {
       const setupName = `${browser}:setup`;
-      const authState = `.auth/${browser}-user.json`;
       return [
         {
           name: setupName,
@@ -62,7 +61,7 @@ export default defineConfig({
         {
           name: `${browser}:authenticated`,
           testDir: './tests/web/authenticated',
-          use: { ...browserDevices[browser], storageState: authState },
+          use: { ...browserDevices[browser] },
           dependencies: [setupName],
         },
         {

--- a/e2e/runner/bootstrap.go
+++ b/e2e/runner/bootstrap.go
@@ -58,7 +58,9 @@ type credentialsJSON struct {
 	WebauthnCredentialId string `json:"webauthnCredentialId"`
 }
 
-// readRoleFile reads e2eDir/testdata/roles/<filename> and extracts metadata.name. Uses os.Root so filenames sourced from test code can't escape the roles directory.
+// readRoleFile reads e2eDir/testdata/roles/<filename> and extracts
+// metadata.name. Uses os.Root so filenames sourced from test code can't escape
+// the roles directory.
 func readRoleFile(e2eDir, filename string) (*customRole, error) {
 	rolesDir := filepath.Join(e2eDir, "testdata", "roles")
 
@@ -105,7 +107,9 @@ type bootstrapResult struct {
 	userMapping map[string]string // canonical user key → generated name
 }
 
-// canonicalUserKey produces a deterministic key for a scanned user. The TS side computes the same format to look up generated names; both implementations must stay in lockstep.
+// canonicalUserKey produces a deterministic key for a scanned user. The TS
+// side computes the same format to look up generated names; both
+// implementations must stay in lockstep.
 func canonicalUserKey(su scannedUser) (string, error) {
 	roles := make([]string, 0, len(su.roles))
 	for _, r := range su.roles {
@@ -119,19 +123,32 @@ func canonicalUserKey(su scannedUser) (string, error) {
 	slices.Sort(roles)
 
 	type keyDef struct {
-		Index  *int                `json:"index,omitempty"`
-		Roles  []string            `json:"roles"`
-		Traits map[string][]string `json:"traits,omitempty"`
+		Default bool                `json:"default,omitempty"`
+		Source  string              `json:"source,omitempty"`
+		Index   *int                `json:"index,omitempty"`
+		Roles   []string            `json:"roles"`
+		Traits  map[string][]string `json:"traits,omitempty"`
 	}
 
-	kd := keyDef{Index: su.arrayIdx, Roles: roles}
+	kd := keyDef{
+		Default: su.isDefault,
+		Source:  su.sourceFile,
+		Index:   su.arrayIdx,
+		Roles:   roles,
+	}
 
 	if len(su.traits) > 0 {
-		kd.Traits = make(map[string][]string, len(su.traits))
+		traits := make(map[string][]string, len(su.traits))
 		for k, v := range su.traits {
+			if len(v) == 0 {
+				continue
+			}
 			sorted := slices.Clone(v)
 			slices.Sort(sorted)
-			kd.Traits[k] = sorted
+			traits[k] = sorted
+		}
+		if len(traits) > 0 {
+			kd.Traits = traits
 		}
 	}
 
@@ -143,7 +160,8 @@ func canonicalUserKey(su scannedUser) (string, error) {
 	return string(data), nil
 }
 
-// writeUserMapping writes the JSON file the Playwright fixture reads to resolve generated usernames.
+// writeUserMapping writes the JSON file the Playwright fixture reads to
+// resolve generated usernames.
 func writeUserMapping(path string, mapping map[string]string) error {
 	data, err := json.MarshalIndent(mapping, "", "  ")
 	if err != nil {
@@ -157,7 +175,8 @@ func writeUserMapping(path string, mapping map[string]string) error {
 	return os.WriteFile(path, data, 0644)
 }
 
-// buildBootstrapState assigns names + credentials per scanned user, resolves role refs, and dedupes custom-role files.
+// buildBootstrapState assigns names + credentials per scanned user, resolves
+// role refs, and dedupes custom-role files.
 func buildBootstrapState(e2eDir string, scannedUsers []scannedUser) (*bootstrapResult, error) {
 	state := &stateConfig{}
 	creds := make(map[string]*credentials)
@@ -230,7 +249,9 @@ func buildBootstrapState(e2eDir string, scannedUsers []scannedUser) (*bootstrapR
 	}, nil
 }
 
-// writeCredentialsFile writes the user-credentials JSON Playwright reads at startup. File-based (not env) so the payload doesn't grow unbounded with user count.
+// writeCredentialsFile writes the user-credentials JSON Playwright reads at
+// startup. File-based (not env) so the payload doesn't grow unbounded with
+// user count.
 func writeCredentialsFile(path string, creds map[string]*credentials) error {
 	m := make(map[string]credentialsJSON, len(creds))
 	for name, c := range creds {

--- a/e2e/runner/canonical_key_test.go
+++ b/e2e/runner/canonical_key_test.go
@@ -1,0 +1,133 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// canonicalKeyFixture matches the JSON shape of testdata/canonical-key-fixtures.json.
+// The file is also consumed by e2e/scripts/verify-canonical-key.ts, which exercises
+// the TypeScript implementation against the same inputs. Both implementations must
+// produce byte-identical output; drift is the whole thing this test exists to catch.
+type canonicalKeyFixture struct {
+	Name      string            `json:"name"`
+	Input     canonicalKeyInput `json:"input"`
+	Index     *int              `json:"index,omitempty"`
+	IsDefault bool              `json:"isDefault,omitempty"`
+	Source    string            `json:"source,omitempty"`
+	Expected  string            `json:"expected"`
+}
+
+type canonicalKeyInput struct {
+	Roles  []json.RawMessage   `json:"roles"`
+	Traits map[string][]string `json:"traits,omitempty"`
+}
+
+const fileRolePrefix = "@gravitational/e2e/roles/"
+
+func TestCanonicalUserKeyFixtures(t *testing.T) {
+	path := filepath.Join("..", "testdata", "canonical-key-fixtures.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixtures: %v", err)
+	}
+
+	var fixtures []canonicalKeyFixture
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		t.Fatalf("parse fixtures: %v", err)
+	}
+
+	if len(fixtures) == 0 {
+		t.Fatal("no fixtures found")
+	}
+
+	for _, f := range fixtures {
+		t.Run(f.Name, func(t *testing.T) {
+			su, err := scannedUserFromFixture(f.Input, f.Index, f.IsDefault, f.Source)
+			if err != nil {
+				t.Fatalf("decode input: %v", err)
+			}
+
+			got, err := canonicalUserKey(su)
+			if err != nil {
+				t.Fatalf("canonicalUserKey: %v", err)
+			}
+
+			if got != f.Expected {
+				t.Errorf("canonicalUserKey mismatch\ninput:    %s\nexpected: %s\ngot:      %s",
+					marshalJSON(t, f.Input), f.Expected, got)
+			}
+		})
+	}
+}
+
+// scannedUserFromFixture converts the TypeScript-shaped fixture input (where
+// file roles are quoted with the @gravitational/e2e/roles/ prefix) into the Go
+// scannedUser form (which strips the prefix at scan time).
+func scannedUserFromFixture(
+	in canonicalKeyInput,
+	index *int,
+	isDefault bool,
+	source string,
+) (scannedUser, error) {
+	var roles []scannedRole
+	for _, raw := range in.Roles {
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil {
+			roles = append(roles, scannedRole{name: s})
+			continue
+		}
+
+		var f struct {
+			File string `json:"file"`
+		}
+
+		if err := json.Unmarshal(raw, &f); err != nil {
+			return scannedUser{}, err
+		}
+
+		roles = append(roles, scannedRole{
+			file: strings.TrimPrefix(f.File, fileRolePrefix),
+		})
+	}
+
+	return scannedUser{
+		roles:      roles,
+		traits:     in.Traits,
+		arrayIdx:   index,
+		isDefault:  isDefault,
+		sourceFile: source,
+	}, nil
+}
+
+func marshalJSON(t *testing.T, v any) string {
+	t.Helper()
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	return string(b)
+}

--- a/e2e/runner/cmd/gen-ts-fixtures/main.go
+++ b/e2e/runner/cmd/gen-ts-fixtures/main.go
@@ -50,7 +50,7 @@ var tmpl = template.Must(template.New("fixtures.ts").Parse(`/**
 
 import { test as base } from '@playwright/test';
 
-type Fixture =
+export type Fixture =
 {{- range .Fixtures}}
   | '{{.Name}}'
 {{- end}};

--- a/e2e/runner/flags.go
+++ b/e2e/runner/flags.go
@@ -45,6 +45,7 @@ type e2eFlags struct {
 	teleportLogLevel string
 	browsers         []string
 	testFiles        []string
+	scanTargets      []scanTarget // resolved scan targets, computed once during flag parsing
 	reportPR         int
 	reportRepo       string
 	reportSHA        string
@@ -152,8 +153,14 @@ func parseFlags(repoRoot string) (*e2eFlags, runMode, error) {
 		}
 
 		if len(f.testFiles) > 0 || mode != modeUI {
-			for _, fix := range scanFixtures(e2eDir, f.testFiles) {
-				fix.Enabled = true
+			targets, resolveErr := resolveTargetsWithHelpers(e2eDir, f.testFiles)
+			if resolveErr != nil {
+				slog.Warn("scan: error resolving files", "error", resolveErr)
+			} else {
+				f.scanTargets = targets
+				for _, fix := range scanFixturesFromTargets(targets) {
+					fix.Enabled = true
+				}
 			}
 		}
 	}

--- a/e2e/runner/humanid.go
+++ b/e2e/runner/humanid.go
@@ -48,7 +48,8 @@ func newHumanIDGenerator() *humanIDGenerator {
 	return &humanIDGenerator{used: make(map[string]struct{})}
 }
 
-// Generate returns a unique human-readable identifier. On collision, it appends a numeric suffix (e.g. "brave-falcon-2").
+// Generate returns a unique human-readable identifier. On collision, it
+// appends a numeric suffix (e.g. "brave-falcon-2").
 func (g *humanIDGenerator) Generate() string {
 	id := generateHumanID()
 	if _, ok := g.used[id]; !ok {

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -140,7 +140,7 @@ type e2eConfig struct {
 	connectAppDir     string
 	connectTshBinPath string
 
-	creds *credentials
+	creds map[string]*credentials
 
 	instances       []*testInstance
 	connectInstance *testInstance
@@ -272,14 +272,41 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 			}
 		}
 
-		creds, err := generateUserCredentials()
-		if err != nil {
-			return fmt.Errorf("failed to generate credentials: %w", err)
+		targets := flags.scanTargets
+		if targets == nil {
+			var err error
+			targets, err = resolveTargetsWithHelpers(e2eDir, flags.testFiles)
+			if err != nil {
+				return fmt.Errorf("failed to resolve scan targets: %w", err)
+			}
 		}
-		config.creds = creds
+
+		scannedUsers, err := scanUsersFromTargets(targets)
+		if err != nil {
+			return fmt.Errorf("failed to scan users: %w", err)
+		}
+		slog.Debug("discovered bootstrap users", "count", len(scannedUsers))
+
+		bootstrap, err := buildBootstrapState(e2eDir, scannedUsers)
+		if err != nil {
+			return fmt.Errorf("failed to build bootstrap state: %w", err)
+		}
+		config.creds = bootstrap.creds
+
+		userMappingPath := filepath.Join(e2eDir, ".auth", "user-mapping.json")
+		if err := writeUserMapping(userMappingPath, bootstrap.userMapping); err != nil {
+			return fmt.Errorf("failed to write user mapping: %w", err)
+		}
+		slog.Debug("wrote user mapping", "path", userMappingPath, "users", len(bootstrap.userMapping))
+
+		credsPath := filepath.Join(e2eDir, ".auth", "user-credentials.json")
+		if err := writeCredentialsFile(credsPath, bootstrap.creds); err != nil {
+			return fmt.Errorf("failed to write user credentials: %w", err)
+		}
+		slog.Debug("wrote user credentials", "path", credsPath, "users", len(bootstrap.creds))
 
 		// One shared state file used by all instances.
-		stateFile, err := generateStateFile(config.stateTemplate, creds)
+		stateFile, err := generateStateFile(config.stateTemplate, bootstrap.state)
 		if err != nil {
 			return fmt.Errorf("failed to generate state file: %w", err)
 		}

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -292,12 +292,8 @@ func (p *playwrightRunner) startEnv(inst *testInstance) ([]string, error) {
 		env = append(env, "START_URL="+p.startURL(inst))
 	}
 
-	if creds := p.config.creds; creds != nil {
-		env = append(env,
-			"E2E_PASSWORD="+creds.password,
-			"E2E_WEBAUTHN_PRIVATE_KEY="+creds.privateKeyPKCS8Base64,
-			"E2E_WEBAUTHN_CREDENTIAL_ID="+creds.credentialIDBase64,
-		)
+	if p.config.creds != nil {
+		env = append(env, "E2E_USERS_FILE="+filepath.Join(p.config.e2eDir, ".auth", "user-credentials.json"))
 	}
 
 	env = append(env, "E2E_TCTL_BIN="+p.config.tctlBin)

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -41,15 +41,16 @@ var (
 
 	// The "key" regexes below require a word boundary so identifiers like
 	// `super_user:` or `myRoles:` don't match as `user:` / `roles:`.
-	usersBlockRe     = regexp.MustCompile(`\busers:\s*\[`)
-	userObjRe        = regexp.MustCompile(`\buser:\s*\{`)
-	rolesBlockRe     = regexp.MustCompile(`\broles:\s*\[`)
-	traitsBlockRe    = regexp.MustCompile(`\btraits:\s*\{`)
-	traitKeyArrayRe  = regexp.MustCompile(`\b(\w+):\s*\[`)
-	loginAsBoolRe    = regexp.MustCompile(`\bloginAs:\s*true\b`)
+	usersBlockRe    = regexp.MustCompile(`\busers:\s*\[`)
+	userObjRe       = regexp.MustCompile(`\buser:\s*\{`)
+	rolesBlockRe    = regexp.MustCompile(`\broles:\s*\[`)
+	traitsBlockRe   = regexp.MustCompile(`\btraits:\s*\{`)
+	traitKeyArrayRe = regexp.MustCompile(`(?:'([^'\\]+)'|"([^"\\]+)"|\b(\w+))\s*:\s*\[`)
+	loginAsBoolRe   = regexp.MustCompile(`\bloginAs:\s*true\b`)
 )
 
-// defaultRoleNames returns the built-in roles assigned when no roles are specified. Returns a fresh slice each call so callers can mutate/sort safely.
+// defaultRoleNames returns the built-in roles assigned when no roles are
+// specified. Returns a fresh slice each call so callers can mutate/sort safely.
 func defaultRoleNames() []scannedRole {
 	return []scannedRole{
 		{name: "access"},
@@ -59,16 +60,27 @@ func defaultRoleNames() []scannedRole {
 
 const testUseCallPrefix = "test.use("
 
-// scannedUser is a user declaration discovered in test source. Names are generated at bootstrap time, not by the test author.
+// scannedUser is a user declaration discovered in test source. Names are
+// generated at bootstrap time, not by the test author.
 type scannedUser struct {
 	roles   []scannedRole
 	traits  map[string][]string
 	loginAs bool
-	// arrayIdx is the position within a `users: [...]` array; nil otherwise. Keeps duplicate-by-content entries addressable as distinct accounts via loginAs(N).
+	// arrayIdx is the position within a `users: [...]` array; nil otherwise.
+	// Keeps duplicate-by-content entries addressable as distinct accounts via
+	// loginAs(N).
 	arrayIdx *int
+	// isDefault marks the implicit default user so its canonical key is
+	// distinct from any explicit `user: {}` declaration with the same roles.
+	isDefault bool
+	// sourceFile is the spec path (relative to e2eDir) where this user was
+	// declared inline; empty for helper-declared and default users so those
+	// stay shared.
+	sourceFile string
 }
 
-// scannedRole is a role reference; exactly one of name (built-in like "access") or file (e.g. "viewer.yaml" under e2e/testdata/roles/) is set.
+// scannedRole is a role reference; exactly one of name (built-in like
+// "access") or file (e.g. "viewer.yaml" under e2e/testdata/roles/) is set.
 type scannedRole struct {
 	name string
 	file string
@@ -78,6 +90,10 @@ type scannedRole struct {
 type scanTarget struct {
 	path string
 	line int // 0 means scan entire file
+	// sourceFile, when non-empty, is the spec path (relative to e2eDir) emitted
+	// in the canonical key for users declared in this target. Empty for helpers
+	// so helper-declared users stay shared across all importing specs.
+	sourceFile string
 }
 
 // blockRange represents a brace-delimited block in a source file (1-indexed lines).
@@ -90,11 +106,18 @@ type callRange struct {
 	start, end int
 }
 
-// resolveTargetsWithHelpers resolves test files plus any helper modules they import, so fixtures and users declared in helpers are also discovered.
+// resolveTargetsWithHelpers resolves test files plus any helper modules they
+// import, so fixtures and users declared in helpers are also discovered.
 func resolveTargetsWithHelpers(e2eDir string, testFiles []string) ([]scanTarget, error) {
 	targets, err := resolveFilesToScan(e2eDir, testFiles)
 	if err != nil {
 		return nil, err
+	}
+
+	for i := range targets {
+		if rel, err := filepath.Rel(e2eDir, targets[i].path); err == nil {
+			targets[i].sourceFile = rel
+		}
 	}
 
 	importedHelpers := make(map[string]bool)
@@ -113,7 +136,8 @@ func resolveTargetsWithHelpers(e2eDir string, testFiles []string) ([]scanTarget,
 	return targets, nil
 }
 
-// scanFixturesFromTargets scans pre-resolved targets to discover which fixtures are needed.
+// scanFixturesFromTargets scans pre-resolved targets to discover which
+// fixtures are needed.
 func scanFixturesFromTargets(targets []scanTarget) []*fixtures.Fixture {
 	seen := make(map[string]struct{})
 	var result []*fixtures.Fixture
@@ -132,7 +156,8 @@ func scanFixturesFromTargets(targets []scanTarget) []*fixtures.Fixture {
 	return result
 }
 
-// scanFixtures wraps resolveTargetsWithHelpers + scanFixturesFromTargets for callers that haven't been split yet.
+// scanFixtures wraps resolveTargetsWithHelpers + scanFixturesFromTargets for
+// callers that haven't been split yet.
 func scanFixtures(e2eDir string, testFiles []string) []*fixtures.Fixture {
 	targets, err := resolveTargetsWithHelpers(e2eDir, testFiles)
 	if err != nil {
@@ -324,7 +349,8 @@ func stripComments(lines []string) []string {
 	return cleaned
 }
 
-// findInlineComment returns the byte offset of the first // not inside a string/template literal, or -1.
+// findInlineComment returns the byte offset of the first // not inside a
+// string/template literal, or -1.
 func findInlineComment(line string) int {
 	var quote byte
 
@@ -354,7 +380,8 @@ func findInlineComment(line string) int {
 	return -1
 }
 
-// findBlockCommentOpen returns the byte offset of the first /* that is not inside a string literal, or -1.
+// findBlockCommentOpen returns the byte offset of the first /* that is not
+// inside a string literal, or -1.
 func findBlockCommentOpen(line string) int {
 	var quote byte
 
@@ -511,57 +538,41 @@ func fixtureInScope(fixtureLine, targetLine int, blocks []blockRange) bool {
 	return targetLine >= enclosing.start && targetLine <= enclosing.end
 }
 
-// scanUsersFromTargets scans pre-resolved targets for user declarations and always appends the default access/editor user so implicit-auth specs (no test.use(), :authenticated project) resolve a username in mixed runs.
+// scanUsersFromTargets scans pre-resolved targets for user declarations and
+// always appends the default access/editor user so implicit-auth specs resolve
+// a username in mixed runs. The default user has a distinct canonical key
+// (`"default": true`), so explicit `user: {}` declarations with the same roles
+// still get their own account.
 func scanUsersFromTargets(targets []scanTarget) ([]scannedUser, error) {
 	var result []scannedUser
 	for _, t := range targets {
-		users, err := scanFileUsers(t.path, t.line)
+		users, err := scanFileUsers(t.path, t.line, t.sourceFile)
 		if err != nil {
 			return nil, err
 		}
 		result = append(result, users...)
 	}
 
-	return ensureDefaultUser(result)
-}
-
-// ensureDefaultUser appends the default user unless an explicit declaration already produces the same canonical key.
-func ensureDefaultUser(users []scannedUser) ([]scannedUser, error) {
-	keys := make(map[string]bool, len(users))
-	for _, u := range users {
-		k, err := canonicalUserKey(u)
-		if err != nil {
-			return nil, err
-		}
-		keys[k] = true
-	}
-
-	for _, du := range defaultUsers() {
-		k, err := canonicalUserKey(du)
-		if err != nil {
-			return nil, err
-		}
-		if keys[k] {
-			continue
-		}
-		users = append(users, du)
-	}
-
-	return users, nil
+	return append(result, defaultUsers()...), nil
 }
 
 // defaultUsers returns a default user with access and editor roles.
 func defaultUsers() []scannedUser {
 	return []scannedUser{
 		{
-			roles:   defaultRoleNames(),
-			loginAs: true,
+			roles:     defaultRoleNames(),
+			loginAs:   true,
+			isDefault: true,
 		},
 	}
 }
 
-// scanFileUsers extracts user declarations from test.use() calls. Singular `user: {}` and array `users: [...]` are mutually exclusive per call; at most one array entry may have `loginAs: true`.
-func scanFileUsers(path string, targetLine int) ([]scannedUser, error) {
+// scanFileUsers extracts user declarations from test.use() calls. Singular
+// `user: {}` and array `users: [...]` are mutually exclusive per call; at
+// most one array entry may have `loginAs: true`. sourceFile, when non-empty,
+// is stamped onto each scanned user so its canonical key includes the spec
+// path (helpers leave it empty).
+func scanFileUsers(path string, targetLine int, sourceFile string) ([]scannedUser, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		// Helper module paths are guessed from import names (see
@@ -636,13 +647,18 @@ func scanFileUsers(path string, targetLine int) ([]scannedUser, error) {
 			}
 		}
 
+		for i := range users {
+			users[i].sourceFile = sourceFile
+		}
 		result = append(result, users...)
 	}
 
 	return result, nil
 }
 
-// scanBalanced returns the index of the close delimiter matching the open at openIdx, or -1 if unmatched. Delimiters inside string/template literals are ignored.
+// scanBalanced returns the index of the close delimiter matching the open at
+// openIdx, or -1 if unmatched. Delimiters inside string/template literals are
+// ignored.
 func scanBalanced(s string, openIdx int, open, close byte) int {
 	depth := 0
 	var quote byte
@@ -722,7 +738,8 @@ func parseUserBlock(userBlock string) scannedUser {
 	return user
 }
 
-// extractInner returns the content between the first open delimiter and its matching close, ignoring delimiters inside string/template literals.
+// extractInner returns the content between the first open delimiter and its
+// matching close, ignoring delimiters inside string/template literals.
 func extractInner(s string, open, close byte) string {
 	start := strings.IndexByte(s, open)
 	if start < 0 {
@@ -737,12 +754,22 @@ func extractInner(s string, open, close byte) string {
 	return s[start+1 : end]
 }
 
-// parseTraits parses trait key-value pairs (e.g. `logins: ['root', 'alice'], groups: ['dev']`) into a map.
+// parseTraits parses trait key-value pairs
+// (e.g. `logins: ['root', 'alice'], groups: ['dev']`) into a map.
 func parseTraits(traitsContent string) map[string][]string {
 	traits := make(map[string][]string)
 
 	for _, m := range traitKeyArrayRe.FindAllStringSubmatchIndex(traitsContent, -1) {
-		key := traitsContent[m[2]:m[3]]
+		var key string
+		switch {
+		case m[2] >= 0:
+			key = traitsContent[m[2]:m[3]]
+		case m[4] >= 0:
+			key = traitsContent[m[4]:m[5]]
+		default:
+			key = traitsContent[m[6]:m[7]]
+		}
+
 		// traitKeyArrayRe ends at the byte after `[`, so m[1]-1 is the `[` byte.
 		bracketOpen := m[1] - 1
 		bracketClose := scanBalanced(traitsContent, bracketOpen, '[', ']')
@@ -759,7 +786,8 @@ func parseTraits(traitsContent string) map[string][]string {
 	return traits
 }
 
-// extractAllOuter returns each top-level open...close block from s (including delimiters), ignoring delimiters inside string/template literals.
+// extractAllOuter returns each top-level open...close block from s (including
+// delimiters), ignoring delimiters inside string/template literals.
 func extractAllOuter(s string, open, close byte) []string {
 	var blocks []string
 	depth := 0
@@ -813,7 +841,8 @@ func warnDuplicateRoles(path string, line int, roles []scannedRole) {
 	}
 }
 
-// sortRoles sorts roles with built-in names before file refs, alphabetical within each group.
+// sortRoles sorts roles with built-in names before file refs, alphabetical
+// within each group.
 func sortRoles(roles []scannedRole) {
 	slices.SortStableFunc(roles, func(a, b scannedRole) int {
 		// Built-in names (name set) come before file refs (file set).

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -760,6 +760,9 @@ func parseTraits(traitsContent string) map[string][]string {
 	traits := make(map[string][]string)
 
 	for _, m := range traitKeyArrayRe.FindAllStringSubmatchIndex(traitsContent, -1) {
+		// traitKeyArrayRe has three alternation groups for the key:
+		// m[2:3] single-quoted, m[4:5] double-quoted, m[6:7] bare identifier.
+		// Exactly one group matches per match; the others have index -1.
 		var key string
 		switch {
 		case m[2] >= 0:

--- a/e2e/runner/scan_test.go
+++ b/e2e/runner/scan_test.go
@@ -440,7 +440,7 @@ func TestScanUsers(t *testing.T) {
 			tmpFile := filepath.Join(dir, "test.spec.ts")
 			writeFile(t, dir, "test.spec.ts", tt.content)
 
-			got, err := scanFileUsers(tmpFile, 0)
+			got, err := scanFileUsers(tmpFile, 0, "")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -543,7 +543,7 @@ func TestScanUsersMutuallyExclusiveError(t *testing.T) {
   users: [{ roles: ['access'] }],
 });`)
 
-	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0)
+	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "")
 	if err == nil {
 		t.Fatal("expected error for user + users in same test.use(), got nil")
 	}
@@ -562,7 +562,7 @@ func TestScanUsersMultipleLoginAsError(t *testing.T) {
   ],
 });`)
 
-	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0)
+	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "")
 	if err == nil {
 		t.Fatal("expected error for multiple loginAs: true, got nil")
 	}
@@ -622,7 +622,7 @@ func TestScanUsersDuplicateRoleWarn(t *testing.T) {
 			dir := t.TempDir()
 			writeFile(t, dir, "test.spec.ts", tt.content)
 
-			if _, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0); err != nil {
+			if _, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, ""); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
@@ -681,7 +681,7 @@ func TestScanUsersDelimitersInStringLiterals(t *testing.T) {
 			dir := t.TempDir()
 			writeFile(t, dir, "test.spec.ts", tt.content)
 
-			got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0)
+			got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -699,6 +699,85 @@ func TestScanUsersDelimitersInStringLiterals(t *testing.T) {
 	}
 }
 
+func TestScanUsersQuotedTraitKeys(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantTraits map[string][]string
+	}{
+		{
+			name: "single-quoted trait key with hyphen",
+			content: `test.use({
+  user: {
+    roles: ['access'],
+    traits: { 'tenant-id': ['acme', 'globex'] },
+  },
+});`,
+			wantTraits: map[string][]string{"tenant-id": {"acme", "globex"}},
+		},
+		{
+			name: "double-quoted trait key",
+			content: `test.use({
+  user: {
+    roles: ['access'],
+    traits: { "db-roles": ['reader'] },
+  },
+});`,
+			wantTraits: map[string][]string{"db-roles": {"reader"}},
+		},
+		{
+			name: "mixed quoted and bare trait keys",
+			content: `test.use({
+  user: {
+    roles: ['access'],
+    traits: { logins: ['root'], 'tenant-id': ['acme'] },
+  },
+});`,
+			wantTraits: map[string][]string{
+				"logins":    {"root"},
+				"tenant-id": {"acme"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "test.spec.ts", tt.content)
+
+			got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != 1 {
+				t.Fatalf("got %d users, want 1", len(got))
+			}
+
+			if len(got[0].traits) != len(tt.wantTraits) {
+				t.Fatalf("got %d traits, want %d: %+v", len(got[0].traits), len(tt.wantTraits), got[0].traits)
+			}
+
+			for k, want := range tt.wantTraits {
+				gotVals, ok := got[0].traits[k]
+				if !ok {
+					t.Errorf("missing trait %q", k)
+					continue
+				}
+				if len(gotVals) != len(want) {
+					t.Errorf("trait %q: got %d values, want %d", k, len(gotVals), len(want))
+					continue
+				}
+				for i, v := range gotVals {
+					if v != want[i] {
+						t.Errorf("trait %q[%d] = %q, want %q", k, i, v, want[i])
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestScanUsersIdentifierBoundaries(t *testing.T) {
 	// Declarations that look like they should match the user/users/roles/traits
 	// regexes but don't because the identifier has additional word characters.
@@ -710,7 +789,7 @@ func TestScanUsersIdentifierBoundaries(t *testing.T) {
   myRoles: ['nope'],
 });`)
 
-	got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0)
+	got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/e2e/runner/teleport.go
+++ b/e2e/runner/teleport.go
@@ -31,9 +31,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"text/template"
 	"time"
-
-	template "github.com/DataDog/datadog-agent/pkg/template/text"
 )
 
 // clusterName is the name of the Teleport cluster used for E2E testing.
@@ -195,20 +194,8 @@ func resolveDockerHost() (string, error) {
 	return conn.LocalAddr().(*net.UDPAddr).IP.String(), nil
 }
 
-type StateConfig struct {
-	PasswordHashBase64  string
-	CredentialIDBase64  string
-	PublicKeyCBORBase64 string
-}
-
-func generateStateFile(templatePath string, creds *credentials) (string, error) {
-	stateConfig := &StateConfig{
-		PasswordHashBase64:  creds.passwordHashBase64,
-		CredentialIDBase64:  creds.credentialIDBase64,
-		PublicKeyCBORBase64: creds.publicKeyCBORBase64,
-	}
-
-	return renderTemplate(templatePath, stateConfig)
+func generateStateFile(templatePath string, state *stateConfig) (string, error) {
+	return renderTemplate(templatePath, state)
 }
 
 func renderTemplate(templatePath string, data any) (string, error) {

--- a/e2e/runner/teleport.go
+++ b/e2e/runner/teleport.go
@@ -33,6 +33,8 @@ import (
 	"syscall"
 	"text/template"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // clusterName is the name of the Teleport cluster used for E2E testing.
@@ -207,7 +209,9 @@ func renderTemplateToPath(templatePath, outPath string, data any) (string, error
 		return "", err
 	}
 
-	tmpl, err := template.ParseFiles(templatePath)
+	tmpl, err := template.New(filepath.Base(templatePath)).
+		Funcs(template.FuncMap{"yamlQuote": yamlQuote}).
+		ParseFiles(templatePath)
 	if err != nil {
 		return "", err
 	}
@@ -227,4 +231,12 @@ func renderTemplateToPath(templatePath, outPath string, data any) (string, error
 	}
 
 	return outPath, nil
+}
+
+func yamlQuote(v any) (string, error) {
+	out, err := yaml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(out), "\n"), nil
 }

--- a/e2e/runner/usercredentials.go
+++ b/e2e/runner/usercredentials.go
@@ -80,7 +80,6 @@ func generateUserCredentials() (*credentials, error) {
 	}
 
 	slog.Debug("generated per-run credentials",
-		"user", "bob",
 		"credentialID", creds.credentialIDBase64,
 	)
 

--- a/e2e/scripts/open-with-webauthn.ts
+++ b/e2e/scripts/open-with-webauthn.ts
@@ -32,6 +32,7 @@ import {
   type BrowserContext,
 } from '@playwright/test';
 
+import { defaultUsername } from '../helpers/defaultUser';
 import { mockWebAuthn } from '../helpers/webauthn';
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[22m`;
@@ -63,7 +64,8 @@ const browserName = (process.env.E2E_BROWSERS || 'chromium').split(',')[0];
 const browserTypes = { chromium, firefox, webkit };
 const browserType =
   browserTypes[browserName as keyof typeof browserTypes] ?? chromium;
-const storageStatePath = join(e2eDir, `.auth/${browserName}-user.json`);
+const username = defaultUsername();
+const storageStatePath = join(e2eDir, `.auth/${browserName}-${username}.json`);
 
 info(`launching ${browserName} ${dim(`(mode: ${mode})`)}`);
 
@@ -75,7 +77,7 @@ const context = await browser.newContext({
 
 const page = await context.newPage();
 
-await mockWebAuthn(page);
+await mockWebAuthn(page, username);
 
 info('virtual WebAuthn authenticator registered');
 

--- a/e2e/scripts/verify-canonical-key.ts
+++ b/e2e/scripts/verify-canonical-key.ts
@@ -1,0 +1,65 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Runs the TypeScript canonicalUserKey over the shared fixture file and
+// asserts each input produces the expected key. Exits non-zero on any
+// mismatch. The Go runner exercises the same fixture in
+// e2e/runner/canonical_key_test.go; both implementations must agree byte-for-byte.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { canonicalUserKey, type UserKeyInput } from '../helpers/canonicalKey';
+
+type Fixture = {
+  name: string;
+  input: UserKeyInput;
+  index?: number;
+  isDefault?: boolean;
+  source?: string;
+  expected: string;
+};
+
+const fixturesPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../testdata/canonical-key-fixtures.json'
+);
+const fixtures: Fixture[] = JSON.parse(readFileSync(fixturesPath, 'utf-8'));
+
+let failed = 0;
+for (const { name, input, index, isDefault, source, expected } of fixtures) {
+  const got = canonicalUserKey(input, { index, isDefault, source });
+  if (got === expected) {
+    console.log(`ok - ${name}`);
+    continue;
+  }
+  failed++;
+  console.error(`FAIL - ${name}`);
+  console.error(`  input:    ${JSON.stringify(input)}`);
+  console.error(`  opts:     ${JSON.stringify({ index, isDefault, source })}`);
+  console.error(`  expected: ${expected}`);
+  console.error(`  got:      ${got}`);
+}
+
+if (failed > 0) {
+  console.error(`\n${failed}/${fixtures.length} fixture(s) failed`);
+  process.exit(1);
+}
+
+console.log(`\n${fixtures.length} fixture(s) verified`);

--- a/e2e/testdata/canonical-key-fixtures.json
+++ b/e2e/testdata/canonical-key-fixtures.json
@@ -1,0 +1,109 @@
+[
+  {
+    "name": "single built-in role",
+    "input": { "roles": ["access"] },
+    "expected": "{\"roles\":[\"access\"]}"
+  },
+  {
+    "name": "built-in roles sorted",
+    "input": { "roles": ["editor", "access"] },
+    "expected": "{\"roles\":[\"access\",\"editor\"]}"
+  },
+  {
+    "name": "single file role",
+    "input": { "roles": [{ "file": "@gravitational/e2e/roles/viewer.yaml" }] },
+    "expected": "{\"roles\":[\"@file:viewer.yaml\"]}"
+  },
+  {
+    "name": "mixed roles sort by code unit (@ before a)",
+    "input": {
+      "roles": [
+        "access",
+        { "file": "@gravitational/e2e/roles/viewer.yaml" }
+      ]
+    },
+    "expected": "{\"roles\":[\"@file:viewer.yaml\",\"access\"]}"
+  },
+  {
+    "name": "traits sorted by key, values sorted",
+    "input": {
+      "roles": ["access"],
+      "traits": {
+        "kubernetes_groups": ["dev"],
+        "logins": ["root", "alice"]
+      }
+    },
+    "expected": "{\"roles\":[\"access\"],\"traits\":{\"kubernetes_groups\":[\"dev\"],\"logins\":[\"alice\",\"root\"]}}"
+  },
+  {
+    "name": "empty traits map omitted",
+    "input": { "roles": ["access"], "traits": {} },
+    "expected": "{\"roles\":[\"access\"]}"
+  },
+  {
+    "name": "empty trait array dropped",
+    "input": {
+      "roles": ["access"],
+      "traits": { "logins": [] }
+    },
+    "expected": "{\"roles\":[\"access\"]}"
+  },
+  {
+    "name": "mixed empty and non-empty traits drop empties",
+    "input": {
+      "roles": ["access"],
+      "traits": { "logins": [], "kubernetes_groups": ["dev"] }
+    },
+    "expected": "{\"roles\":[\"access\"],\"traits\":{\"kubernetes_groups\":[\"dev\"]}}"
+  },
+  {
+    "name": "multiple file roles sorted by filename",
+    "input": {
+      "roles": [
+        { "file": "@gravitational/e2e/roles/viewer.yaml" },
+        { "file": "@gravitational/e2e/roles/admin.yaml" }
+      ]
+    },
+    "expected": "{\"roles\":[\"@file:admin.yaml\",\"@file:viewer.yaml\"]}"
+  },
+  {
+    "name": "users[0] index keeps duplicates distinct",
+    "input": { "roles": ["access"] },
+    "index": 0,
+    "expected": "{\"index\":0,\"roles\":[\"access\"]}"
+  },
+  {
+    "name": "users[1] with same content as [0] yields different key",
+    "input": { "roles": ["access"] },
+    "index": 1,
+    "expected": "{\"index\":1,\"roles\":[\"access\"]}"
+  },
+  {
+    "name": "indexed user with traits",
+    "input": {
+      "roles": ["access"],
+      "traits": { "logins": ["alice"] }
+    },
+    "index": 2,
+    "expected": "{\"index\":2,\"roles\":[\"access\"],\"traits\":{\"logins\":[\"alice\"]}}"
+  },
+  {
+    "name": "default user has its own key namespace",
+    "input": { "roles": ["access", "editor"] },
+    "isDefault": true,
+    "expected": "{\"default\":true,\"roles\":[\"access\",\"editor\"]}"
+  },
+  {
+    "name": "explicit user with source is distinct from default",
+    "input": { "roles": ["access", "editor"] },
+    "source": "tests/web/authenticated/foo.spec.ts",
+    "expected": "{\"source\":\"tests/web/authenticated/foo.spec.ts\",\"roles\":[\"access\",\"editor\"]}"
+  },
+  {
+    "name": "indexed user with source",
+    "input": { "roles": ["access"] },
+    "source": "tests/web/authenticated/foo.spec.ts",
+    "index": 1,
+    "expected": "{\"source\":\"tests/web/authenticated/foo.spec.ts\",\"index\":1,\"roles\":[\"access\"]}"
+  }
+]

--- a/e2e/tests/connect/headlessAuth.spec.ts
+++ b/e2e/tests/connect/headlessAuth.spec.ts
@@ -22,13 +22,13 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { test, expect } from '@gravitational/e2e/helpers/connect';
+import { defaultUsername } from '@gravitational/e2e/helpers/defaultUser';
 import { connectTshBin, startUrl } from '@gravitational/e2e/helpers/env';
 import { login as webLogin } from '@gravitational/e2e/helpers/login';
 import { HeadlessAuthDialogPage } from '@gravitational/e2e/helpers/pages/connect/HeadlessAuthDialog';
 import { chromium } from '@playwright/test';
 
 const REQUEST_URL_RE = /https?:\/\/\S+\/web\/headless\/[0-9a-f-]+/i;
-const HEADLESS_USER = 'bob';
 
 type CreatedRequest = {
   url: string;
@@ -58,7 +58,7 @@ async function startHeadlessRequestProcess(options?: {
         'ls',
         '--headless',
         '--insecure',
-        `--user=${HEADLESS_USER}`,
+        `--user=${defaultUsername()}`,
         `--proxy=${proxyHost}`,
       ],
       {
@@ -128,7 +128,7 @@ async function approveInWebUi(requestUrl: string) {
   const page = await context.newPage();
 
   try {
-    await webLogin(page);
+    await webLogin(page, defaultUsername());
     await page.goto(requestUrl);
 
     await expect(page.getByRole('button', { name: 'Approve' })).toBeVisible();

--- a/e2e/tests/web/auth.setup.ts
+++ b/e2e/tests/web/auth.setup.ts
@@ -1,4 +1,4 @@
-/*
+/**
  * Teleport
  * Copyright (C) 2026  Gravitational, Inc.
  *
@@ -16,19 +16,29 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { login } from '@gravitational/e2e/helpers/login';
-import { test as setup } from '@gravitational/e2e/helpers/test';
+import { startUrl, users } from '@gravitational/e2e/helpers/env';
+import { directLogin } from '@gravitational/e2e/helpers/login';
+// oxlint-disable-next-line no-restricted-imports
+import { test as setup } from '@playwright/test';
 
 const authDir = join(dirname(fileURLToPath(import.meta.url)), '../../.auth');
 
-setup('authenticate', async ({ page }, testInfo) => {
-  await login(page);
+mkdirSync(authDir, { recursive: true });
 
-  const browser = testInfo.project.name.split(':')[0];
-  await page
-    .context()
-    .storageState({ path: join(authDir, `${browser}-user.json`) });
-});
+for (const [username, creds] of Object.entries(users)) {
+  // oxlint-disable-next-line no-empty-pattern -- Playwright requires fixture argument to be destructured.
+  setup(`authenticate as ${username}`, async ({}, testInfo) => {
+    const state = await directLogin(startUrl, username, creds.password);
+
+    const browser = testInfo.project.name.split(':')[0];
+
+    writeFileSync(
+      join(authDir, `${browser}-${username}.json`),
+      JSON.stringify(state, null, 2)
+    );
+  });
+}

--- a/e2e/tests/web/authenticated/authconnectors.spec.ts
+++ b/e2e/tests/web/authenticated/authconnectors.spec.ts
@@ -17,13 +17,11 @@
  */
 
 import { expect, test } from '@gravitational/e2e/helpers/test';
-import { mockWebAuthn } from '@gravitational/e2e/helpers/webauthn';
 
 // TODO(@rudream): re-enable this once the UI bug is fixed.
 test.skip('verify that a user can create and delete an auth connector', async ({
   page,
 }) => {
-  await mockWebAuthn(page);
   await page.goto('/');
   await page.getByRole('button', { name: 'Zero Trust Access' }).click();
   await page.getByRole('link', { name: 'Auth Connectors' }).click();

--- a/e2e/tests/web/authenticated/roles.spec.ts
+++ b/e2e/tests/web/authenticated/roles.spec.ts
@@ -17,11 +17,8 @@
  */
 
 import { expect, test } from '@gravitational/e2e/helpers/test';
-import { mockWebAuthn } from '@gravitational/e2e/helpers/webauthn';
 
 test('verify that a user can create and delete a role', async ({ page }) => {
-  await mockWebAuthn(page);
-
   await page.goto('/');
 
   await page.getByRole('button', { name: 'Zero Trust Access' }).click();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      undici:
+        specifier: ^7.24.5
+        version: 7.24.5
 
   web/packages/build:
     dependencies:


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport/pull/66165

This wires up the user/role scanning into tests, allowing for the defined users/roles to be created and logged in as. To avoid slowing down tests, login now happens programmatically instead of using the login form.

Users that are detected from the subset of tests being ran are added to Teleport's bootstrap file, as well as the necessary roles. There's always a default user available (with editor/access roles), any test in `authenticated` not specifying a custom user will be logged in as that.

## Manual Test Plan
### Test Environment

CI

### Test Cases
- [ ] Existing e2e tests pass as expected

I will follow up with a test that exercises this new path for a better manual test case in a PR
