### PR TITLE
Add session recording ownership to e2e runner

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -172,6 +172,54 @@ the same `user`/`users`. Concretely:
 `e2e/.auth/<browser>-<username>.json`. Tests pick up that state via Playwright's `storageState`, so they
 start already authenticated without running the UI login flow.
 
+### Session Recordings
+
+The runner automatically seeds session recordings into Teleport's data directory at startup so the Web UI's
+session recordings page has content immediately. Recordings are stored in `e2e/testdata/recordings/` organized
+by session type:
+
+```
+e2e/testdata/recordings/
+├── events.jsonl          # generated - do not edit
+├── ssh/
+│   ├── <session-id>.tar
+│   ├── <session-id>.metadata
+│   └── <session-id>.thumbnail
+├── k8s/
+│   └── ...
+└── desktop/
+    └── ...
+```
+
+Each recording consists of a `.tar` file (required) and optional `.metadata` and `.thumbnail` sidecar files.
+The `events.jsonl` file contains the session end audit events and is auto-generated from the `.tar` files.
+
+**Adding a new recording:**
+
+To add a new recording, place the `.tar` file (and any `.metadata`/`.thumbnail` files) in the appropriate subdirectory
+(`ssh/`, `k8s/`, or `desktop/`).
+
+Recordings are opt-in — only recordings referenced in `test.use()` via `recordings` or `UserDefinition.recordings`
+are seeded. Each recording is associated with the user that declares it, and each `(recording, owner)` pair gets
+a freshly-generated session ID so duplicates across users don't collide.
+
+**`recordingIds` fixture:** Because the runner rewrites session IDs, tests that need to navigate to a specific
+recording should look up the generated ID via the `recordingIds` fixture, which maps the logical ID (the `.tar`
+filename) to the seeded session ID for the currently-active user:
+
+```ts
+test.use({
+  user: { roles: ['access'], recordings: ['ssh-session-1'] },
+});
+
+test('open recording', async ({ page, recordingIds }) => {
+  await page.goto(`/web/recordings/${recordingIds['ssh-session-1']}`);
+});
+```
+
+At runtime, the runner copies recording files into Teleport's records directory and appends the audit events
+to the audit log with adjusted timestamps so that sessions appear recent in the UI.
+
 ### Common Commands
 
 Typically, you'll want to run with `--no-build` during test development to skip rebuilding Teleport binaries on every

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -148,8 +148,9 @@ test.use({
 test('switch users', async ({ page, loginAs }) => {
   // signed in as users[0] at test start
   // ...
-  const editorName = await loginAs(1);
+  const { name: editorName, recordingIds } = await loginAs(1);
   // now signed in as users[1]; `editorName` is the generated username
+  // and `recordingIds` is the seeded recording map for users[1].
 });
 ```
 
@@ -165,7 +166,6 @@ the same `user`/`users`. Concretely:
 - Two specs that declare identical `test.use({ user: ... })` get distinct accounts (keyed by spec path).
 - Tests in the same spec share one account when their `test.use()` resolves to identical content. To force
   separate accounts, vary traits or use the `users: [...]` array (entries are distinguished by index).
-- Helper-declared `test.use({ user/users })` stays shared across every spec that imports the helper.
 
 **How it works (briefly):** The runner generates credentials server-side, logs each user in over HTTP
 (`/v1/webapi/mfa/login/*`) during setup, and writes the resulting cookies + localStorage to

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -174,8 +174,9 @@ export const test = base.extend<E2EFixtures>({
   },
   recordingIds: async ({ username }, use) => {
     if (!username) {
-      await use({});
-      return;
+      throw new Error(
+        'recordingIds requested without a logged-in user — declare user/users (or recordings) in test.use()'
+      );
     }
 
     const mapping = tryLoadRecordingMapping() ?? {};

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -50,6 +50,7 @@ export interface UserTraits {
 export interface UserDefinition {
   roles: UserRole[];
   traits?: UserTraits;
+  recordings?: string[];
   loginAs?: boolean;
 }
 
@@ -59,18 +60,30 @@ const authDir = join(e2eDir, '.auth');
 const tryLoadUserMapping =
   cachedJSONLoader<Record<string, string>>('user-mapping.json');
 
+const tryLoadRecordingMapping = cachedJSONLoader<
+  Record<string, Record<string, string>>
+>('recording-mapping.json');
+
 const defaultUser: UserDefinition = { roles: ['access', 'editor'] };
 
 interface E2EFixtures {
+  recordings: string[];
   user: UserDefinition;
   users: UserDefinition[];
   username: string;
-  loginAs: (index: number) => Promise<string>;
+  loginAs: (index: number) => Promise<LoginAsResult>;
+  recordingIds: Record<string, string>;
   unifiedResourcesPage: UnifiedResourcesPage;
   playerPage: PlayerPage;
 }
 
+export interface LoginAsResult {
+  name: string;
+  recordingIds: Record<string, string>;
+}
+
 export const test = base.extend<E2EFixtures>({
+  recordings: [[], { option: true }],
   user: [undefined as unknown as UserDefinition, { option: true }],
   users: [[], { option: true }],
   username: async ({ user, users }, use, testInfo) => {
@@ -106,7 +119,7 @@ export const test = base.extend<E2EFixtures>({
 
     const browser = testInfo.project.name.split(':')[0];
 
-    await use(async (index: number) => {
+    await use(async (index: number): Promise<LoginAsResult> => {
       const definition = users[index];
       if (!definition) {
         throw new Error(
@@ -155,8 +168,18 @@ export const test = base.extend<E2EFixtures>({
 
       await page.reload();
 
-      return name;
+      const recordingMapping = tryLoadRecordingMapping() ?? {};
+      return { name, recordingIds: recordingMapping[name] ?? {} };
     });
+  },
+  recordingIds: async ({ username }, use) => {
+    if (!username) {
+      await use({});
+      return;
+    }
+
+    const mapping = tryLoadRecordingMapping() ?? {};
+    await use(mapping[username] ?? {});
   },
   page: async ({ page, username }, use) => {
     if (username) {

--- a/e2e/runner/bootstrap.go
+++ b/e2e/runner/bootstrap.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"slices"
 
+	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 )
 
@@ -100,11 +101,31 @@ func readRoleFile(e2eDir, filename string) (*customRole, error) {
 	}, nil
 }
 
+// recordingOwner is a single owner of a session recording: the user that
+// should appear as the session's principal and the freshly-generated session
+// ID assigned to this copy of the recording.
+type recordingOwner struct {
+	user        string
+	sessionID   string
+}
+
+type recordingOwners map[string][]recordingOwner
+
 // bootstrapResult holds the output of buildBootstrapState.
 type bootstrapResult struct {
 	state       *stateConfig
 	creds       map[string]*credentials
 	userMapping map[string]string // canonical user key → generated name
+
+	// recordingOwners maps the logical recording ID (the name of the .tar file
+	// under testdata/recordings) to the list of owners that reference it. Each
+	// owner gets its own fresh session ID so duplicates don't collide.
+	recordingOwners recordingOwners
+
+	// recordingMapping is the inverse lookup for tests: it maps a generated
+	// username to a record of `logicalID → generatedSessionID`. Written to
+	// .auth/recording-mapping.json so the TS fixture can resolve IDs.
+	recordingMapping map[string]map[string]string
 }
 
 // canonicalUserKey produces a deterministic key for a scanned user. The TS
@@ -176,29 +197,60 @@ func writeUserMapping(path string, mapping map[string]string) error {
 }
 
 // buildBootstrapState assigns names + credentials per scanned user, resolves
-// role refs, and dedupes custom-role files.
+// role refs, and dedupes custom-role files. Scanned users that share a
+// canonical key are aggregated into a single bootstrap account whose
+// recordings are the deduped union of every contributing declaration.
 func buildBootstrapState(e2eDir string, scannedUsers []scannedUser) (*bootstrapResult, error) {
-	state := &stateConfig{}
-	creds := make(map[string]*credentials)
-	nameGen := newHumanIDGenerator()
-	userMapping := make(map[string]string)
+	type userGroup struct {
+		key string
+		su  scannedUser
+	}
 
-	// Track custom role files already loaded to deduplicate.
-	customRolesByFile := make(map[string]*customRole)
-
+	groupByKey := make(map[string]*userGroup)
+	var groups []*userGroup
 	for _, su := range scannedUsers {
 		if len(su.roles) == 0 {
 			return nil, fmt.Errorf("user declaration has no roles; declare at least one role in test.use()")
 		}
-
-		name := nameGen.Generate()
 
 		key, err := canonicalUserKey(su)
 		if err != nil {
 			return nil, err
 		}
 
-		userMapping[key] = name
+		if g, ok := groupByKey[key]; ok {
+			for _, rec := range su.recordings {
+				if !slices.Contains(g.su.recordings, rec) {
+					g.su.recordings = append(g.su.recordings, rec)
+				}
+			}
+			if su.loginAs {
+				g.su.loginAs = true
+			}
+			continue
+		}
+
+		merged := su
+		merged.recordings = slices.Clone(su.recordings)
+		g := &userGroup{key: key, su: merged}
+		groupByKey[key] = g
+		groups = append(groups, g)
+	}
+
+	state := &stateConfig{}
+	creds := make(map[string]*credentials)
+	nameGen := newHumanIDGenerator()
+	userMapping := make(map[string]string)
+	recordingOwners := make(map[string][]recordingOwner)
+	recordingMapping := make(map[string]map[string]string)
+
+	// Track custom role files already loaded to deduplicate.
+	customRolesByFile := make(map[string]*customRole)
+
+	for _, g := range groups {
+		su := g.su
+		name := nameGen.Generate()
+		userMapping[g.key] = name
 
 		userCredentials, err := generateUserCredentials()
 		if err != nil {
@@ -240,13 +292,43 @@ func buildBootstrapState(e2eDir string, scannedUsers []scannedUser) (*bootstrapR
 		}
 
 		state.Users = append(state.Users, bu)
+
+		for _, rec := range su.recordings {
+			sid := uuid.NewString()
+			recordingOwners[rec] = append(recordingOwners[rec], recordingOwner{
+				user:      name,
+				sessionID: sid,
+			})
+			if recordingMapping[name] == nil {
+				recordingMapping[name] = make(map[string]string)
+			}
+			recordingMapping[name][rec] = sid
+		}
 	}
 
 	return &bootstrapResult{
-		state:       state,
-		creds:       creds,
-		userMapping: userMapping,
+		state:            state,
+		creds:            creds,
+		userMapping:      userMapping,
+		recordingOwners:  recordingOwners,
+		recordingMapping: recordingMapping,
 	}, nil
+}
+
+// writeRecordingMapping writes the recording-mapping JSON the TS `recordings`
+// fixture reads to resolve a test's logical recording ID to the seeded session
+// ID.
+func writeRecordingMapping(path string, mapping map[string]map[string]string) error {
+	data, err := json.MarshalIndent(mapping, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling recording mapping: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating recording mapping directory: %w", err)
+	}
+
+	return os.WriteFile(path, data, 0o644)
 }
 
 // writeCredentialsFile writes the user-credentials JSON Playwright reads at

--- a/e2e/runner/bootstrap_test.go
+++ b/e2e/runner/bootstrap_test.go
@@ -236,6 +236,193 @@ func TestBuildBootstrapStateCustomTraits(t *testing.T) {
 	}
 }
 
+func TestBuildBootstrapStateRecordings(t *testing.T) {
+	e2eDir := t.TempDir()
+
+	scannedUsers := []scannedUser{
+		{
+			roles:      []scannedRole{{name: "access"}},
+			recordings: []string{"ssh-session-1", "desktop-session-2"},
+			loginAs:    true,
+		},
+	}
+
+	result, err := buildBootstrapState(e2eDir, scannedUsers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	username := result.state.Users[0].Name
+
+	if len(result.recordingOwners) != 2 {
+		t.Fatalf("got %d recording owners entries, want 2", len(result.recordingOwners))
+	}
+
+	for _, recID := range []string{"ssh-session-1", "desktop-session-2"} {
+		owners, ok := result.recordingOwners[recID]
+		if !ok {
+			t.Fatalf("missing recordingOwners entry for %q", recID)
+		}
+
+		if len(owners) != 1 {
+			t.Fatalf("recording %q has %d owners, want 1", recID, len(owners))
+		}
+
+		if owners[0].user != username {
+			t.Errorf("recording %q owner = %q, want %q", recID, owners[0].user, username)
+		}
+
+		if owners[0].sessionID == "" {
+			t.Errorf("recording %q owner has empty sessionID", recID)
+		}
+	}
+
+	mapping := result.recordingMapping[username]
+	if len(mapping) != 2 {
+		t.Fatalf("got %d recordingMapping entries for %q, want 2", len(mapping), username)
+	}
+
+	if mapping["ssh-session-1"] != result.recordingOwners["ssh-session-1"][0].sessionID {
+		t.Errorf("recordingMapping sessionID does not match recordingOwners entry")
+	}
+}
+
+func TestBuildBootstrapStateSharedRecording(t *testing.T) {
+	e2eDir := t.TempDir()
+
+	// Two distinct users (different array indices → different canonical keys)
+	// each owning their own copy of the same recording.
+	idx0, idx1 := 0, 1
+	scannedUsers := []scannedUser{
+		{
+			roles:      []scannedRole{{name: "access"}},
+			recordings: []string{"shared-session"},
+			arrayIdx:   &idx0,
+			loginAs:    true,
+		},
+		{
+			roles:      []scannedRole{{name: "access"}},
+			recordings: []string{"shared-session"},
+			arrayIdx:   &idx1,
+		},
+	}
+
+	result, err := buildBootstrapState(e2eDir, scannedUsers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	owners := result.recordingOwners["shared-session"]
+	if len(owners) != 2 {
+		t.Fatalf("got %d owners for shared-session, want 2", len(owners))
+	}
+
+	if owners[0].user == owners[1].user {
+		t.Errorf("shared recording owners have same user: %q", owners[0].user)
+	}
+
+	if owners[0].sessionID == owners[1].sessionID {
+		t.Errorf("shared recording owners have same sessionID: %q", owners[0].sessionID)
+	}
+}
+
+func TestBuildBootstrapStateAggregatesDefaultRecordings(t *testing.T) {
+	e2eDir := t.TempDir()
+
+	scannedUsers := []scannedUser{
+		{
+			roles:      defaultRoleNames(),
+			recordings: []string{"ssh-1"},
+			loginAs:    true,
+			isDefault:  true,
+		},
+		{
+			roles:      defaultRoleNames(),
+			recordings: []string{"ssh-2"},
+			loginAs:    true,
+			isDefault:  true,
+		},
+		{
+			roles:     defaultRoleNames(),
+			loginAs:   true,
+			isDefault: true,
+		},
+	}
+
+	result, err := buildBootstrapState(e2eDir, scannedUsers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.state.Users) != 1 {
+		t.Fatalf("got %d users, want 1 (default + recordings synths must aggregate)", len(result.state.Users))
+	}
+
+	username := result.state.Users[0].Name
+	mapping := result.recordingMapping[username]
+	if len(mapping) != 2 {
+		t.Fatalf("got %d recordings for default user, want 2: %v", len(mapping), mapping)
+	}
+
+	for _, rec := range []string{"ssh-1", "ssh-2"} {
+		if _, ok := mapping[rec]; !ok {
+			t.Errorf("default user missing recording %q", rec)
+		}
+	}
+}
+
+func TestBuildBootstrapStateAggregatesByCanonicalKey(t *testing.T) {
+	e2eDir := t.TempDir()
+
+	// Two scannedUsers with identical canonical keys but different recording
+	// sets must collapse into a single bootstrap account whose recordings are
+	// the deduped union; otherwise the first declaration's recordings end up
+	// orphaned on a user the runtime never resolves to.
+	scannedUsers := []scannedUser{
+		{
+			roles:      []scannedRole{{name: "access"}},
+			recordings: []string{"ssh-1", "ssh-2"},
+			loginAs:    true,
+		},
+		{
+			roles:      []scannedRole{{name: "access"}},
+			recordings: []string{"ssh-2", "ssh-3"},
+		},
+	}
+
+	result, err := buildBootstrapState(e2eDir, scannedUsers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.state.Users) != 1 {
+		t.Fatalf("got %d users, want 1 (aggregation by canonical key)", len(result.state.Users))
+	}
+
+	username := result.state.Users[0].Name
+	mapping := result.recordingMapping[username]
+	if len(mapping) != 3 {
+		t.Fatalf("got %d recordingMapping entries for %q, want 3 (ssh-1, ssh-2, ssh-3); have %v",
+			len(mapping), username, mapping)
+	}
+
+	for _, rec := range []string{"ssh-1", "ssh-2", "ssh-3"} {
+		if _, ok := mapping[rec]; !ok {
+			t.Errorf("missing recording %q in user mapping", rec)
+		}
+
+		owners, ok := result.recordingOwners[rec]
+		if !ok || len(owners) != 1 {
+			t.Errorf("recording %q: want exactly 1 owner, got %d", rec, len(owners))
+			continue
+		}
+
+		if owners[0].user != username {
+			t.Errorf("recording %q owner = %q, want %q", rec, owners[0].user, username)
+		}
+	}
+}
+
 func TestBuildBootstrapStateEmptyRolesError(t *testing.T) {
 	e2eDir := t.TempDir()
 
@@ -281,6 +468,38 @@ func TestWriteUserMapping(t *testing.T) {
 		if got[k] != want {
 			t.Errorf("mapping[%q] = %q, want %q", k, got[k], want)
 		}
+	}
+}
+
+func TestWriteRecordingMapping(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "recording-mapping.json")
+
+	mapping := map[string]map[string]string{
+		"brave-falcon": {"ssh-session": "new-sid-1"},
+		"swift-river":  {"desktop-session": "new-sid-2"},
+	}
+
+	if err := writeRecordingMapping(path, mapping); err != nil {
+		t.Fatalf("writeRecordingMapping: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	var got map[string]map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got["brave-falcon"]["ssh-session"] != "new-sid-1" {
+		t.Errorf("mapping mismatch: got %+v", got)
+	}
+
+	if got["swift-river"]["desktop-session"] != "new-sid-2" {
+		t.Errorf("mapping mismatch: got %+v", got)
 	}
 }
 

--- a/e2e/runner/go.mod
+++ b/e2e/runner/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/template v0.77.2
 	github.com/docker/go-sdk/container v0.1.0-alpha013
 	github.com/google/go-github/v84 v84.0.0
+	github.com/google/uuid v1.6.0
 	github.com/gravitational/teleport v0.0.0-00010101000000-000000000000
 	github.com/gravitational/teleport/api v0.0.0-00010101000000-000000000000
 	github.com/lmittmann/tint v1.1.3
@@ -153,7 +154,6 @@ require (
 	github.com/google/go-tpm-tools v0.4.7 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/safetext v0.0.0-20240104143208-7a7d9b3d812f // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.19.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect

--- a/e2e/runner/instance.go
+++ b/e2e/runner/instance.go
@@ -56,7 +56,7 @@ func (inst *testInstance) start(ctx context.Context) error {
 		if err = inst.teleport.waitReady(ctx, 30*time.Second); err != nil {
 			return fmt.Errorf("teleport for %s failed to become ready: %w", inst.browser, err)
 		}
-		if err = seedRecordings(ctx, inst.e2eDir, inst.dataDir); err != nil {
+		if err = inst.teleport.seedRecordings(ctx, inst.e2eDir, inst.dataDir); err != nil {
 			return fmt.Errorf("failed to seed session recordings for %s: %w", inst.browser, err)
 		}
 	}

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -305,6 +305,12 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 		}
 		slog.Debug("wrote user credentials", "path", credsPath, "users", len(bootstrap.creds))
 
+		recMappingPath := filepath.Join(e2eDir, ".auth", "recording-mapping.json")
+		if err := writeRecordingMapping(recMappingPath, bootstrap.recordingMapping); err != nil {
+			return fmt.Errorf("failed to write recording mapping: %w", err)
+		}
+		slog.Debug("wrote recording mapping", "path", recMappingPath, "users", len(bootstrap.recordingMapping))
+
 		// One shared state file used by all instances.
 		stateFile, err := generateStateFile(config.stateTemplate, bootstrap.state)
 		if err != nil {
@@ -334,11 +340,12 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 		// Create teleport instances (started lazily by the playwright runner so that at most 2 run concurrently).
 		for _, inst := range allInstances {
 			teleport := &teleportInstance{
-				log:         inst.log,
-				teleportBin: config.teleportBin,
-				proxyPort:   inst.proxyPort,
-				configPath:  inst.teleportConfigPath,
-				stateFile:   stateFile,
+				log:             inst.log,
+				teleportBin:     config.teleportBin,
+				proxyPort:       inst.proxyPort,
+				configPath:      inst.teleportConfigPath,
+				stateFile:       stateFile,
+				recordingOwners: bootstrap.recordingOwners,
 			}
 
 			if config.isCI || config.quiet {

--- a/e2e/runner/recordings.go
+++ b/e2e/runner/recordings.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -36,15 +37,9 @@ import (
 )
 
 const (
-	// defaultE2EUser is the default user that seeded session recordings are associated with.
-	defaultE2EUser = "bob"
 	// defaultE2ELogin is the default login that seeded session recordings are associated with.
 	defaultE2ELogin = "root"
 )
-
-// recordingUserMap allows mapping specific session recordings to different users logins. The key is the session ID
-// which corresponds to the username.
-var recordingUserMap = map[string]string{}
 
 // kinds represents the different session recording types that can be seeded into the E2E environment. These values
 // correspond to subdirectories under recordingsDir where .tar files are stored.
@@ -65,10 +60,23 @@ type recording struct {
 	Kind      types.SessionKind
 }
 
-// seedRecordings copies session recording .tar files into Teleport's records directory and injects corresponding
-// session.end audit events so that the Web UI's session recordings page shows content immediately after startup.
-// When sharedDir differs from e2eDir, recordings from both directories are merged (e2eDir takes precedence).
-func seedRecordings(ctx context.Context, e2eDir, dataDir string) error {
+// recordingInstance represents a single seeded copy of a session recording:
+// the source recording, the owning user, and the fresh session ID assigned to
+// this copy on disk and in the audit log.
+type recordingInstance struct {
+	recording
+	user          string
+	destSessionID string
+}
+
+// seedRecordings copies session recording .tar files into Teleport's records directory and injects
+// corresponding session.end audit events. Only recordings referenced in recordingOwners are seeded.
+// Each owner of a recording gets its own copy with a freshly-generated session ID.
+func (t *teleportInstance) seedRecordings(ctx context.Context, e2eDir, dataDir string) error {
+	if len(t.recordingOwners) == 0 {
+		return nil
+	}
+
 	recordsDir := filepath.Join(dataDir, "log", "records")
 	if err := os.MkdirAll(recordsDir, 0o755); err != nil {
 		return fmt.Errorf("creating records dir: %w", err)
@@ -79,31 +87,58 @@ func seedRecordings(ctx context.Context, e2eDir, dataDir string) error {
 		return fmt.Errorf("discovering recordings: %w", err)
 	}
 
-	if len(discovered) == 0 {
-		return fmt.Errorf("no .tar files found in any session type directory")
+	// Index discovered recordings by session ID for lookup.
+	byID := make(map[string]recording, len(discovered))
+	for _, rec := range discovered {
+		byID[rec.SessionID] = rec
 	}
 
-	for _, recording := range discovered {
+	// Sort recording IDs so that instances (and the timestamps we derive from
+	// their position) are deterministic across runs.
+	recIDs := make([]string, 0, len(t.recordingOwners))
+	for id := range t.recordingOwners {
+		recIDs = append(recIDs, id)
+	}
+	slices.Sort(recIDs)
+
+	var instances []recordingInstance
+	for _, recID := range recIDs {
+		rec, ok := byID[recID]
+		if !ok {
+			return fmt.Errorf("recording %q referenced in user definition not found in testdata/recordings", recID)
+		}
+
+		for _, owner := range t.recordingOwners[recID] {
+			instances = append(instances, recordingInstance{
+				recording:     rec,
+				user:          owner.user,
+				destSessionID: owner.sessionID,
+			})
+		}
+	}
+
+	for _, inst := range instances {
+		srcDir := filepath.Dir(inst.Path)
+
 		for _, ext := range []string{".tar", ".metadata", ".thumbnail"} {
-			src := filepath.Join(filepath.Dir(recording.Path), recording.SessionID+ext)
-			dst := filepath.Join(recordsDir, recording.SessionID+ext)
+			src := filepath.Join(srcDir, inst.recording.SessionID+ext)
+			dst := filepath.Join(recordsDir, inst.destSessionID+ext)
 
 			if err := utils.CopyFile(src, dst, 0o644); err != nil {
 				if errors.Is(err, os.ErrNotExist) {
 					if ext != ".tar" {
-						// metadata and thumbnails are optional
 						continue
 					}
 
 					return fmt.Errorf("required recording file not found: %s", src)
 				}
 
-				return fmt.Errorf("copying %s: %w", recording.SessionID+ext, err)
+				return fmt.Errorf("copying %s: %w", inst.destSessionID+ext, err)
 			}
 		}
 	}
 
-	adjustedEvents, err := adjustEvents(ctx, discovered)
+	adjustedEvents, err := adjustRecordingEvents(ctx, instances)
 	if err != nil {
 		return fmt.Errorf("adjusting events: %w", err)
 	}
@@ -125,7 +160,7 @@ func seedRecordings(ctx context.Context, e2eDir, dataDir string) error {
 		}
 	}
 
-	slog.Info("seeded session recordings", "total_recordings", len(discovered))
+	slog.Info("seeded session recordings", "recordings", len(t.recordingOwners), "instances", len(instances))
 
 	return nil
 }
@@ -156,23 +191,23 @@ func discoverRecordings(e2eDir string) ([]recording, error) {
 	return recordings, nil
 }
 
-// adjustEvents reads, patches, and time-adjusts the session end event from each recording so that
-// sessions appear recent (within the UI's default "today" search window).
-func adjustEvents(ctx context.Context, discovered []recording) ([]string, error) {
+// adjustRecordingEvents reads, patches, and time-adjusts the session end event from each recording
+// instance so that sessions appear recent (within the UI's default "today" search window).
+func adjustRecordingEvents(ctx context.Context, instances []recordingInstance) ([]string, error) {
 	now := time.Now()
 	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 
 	var lines []string
-	for _, rec := range discovered {
+	for _, inst := range instances {
 		offset := time.Duration(len(lines)+1) * time.Second
-		event, err := readAndPatchEvent(ctx, rec, startOfDay.Add(offset))
+		event, err := readAndPatchEvent(ctx, inst, startOfDay.Add(offset))
 		if err != nil {
-			return nil, fmt.Errorf("processing recording %s: %w", rec.SessionID, err)
+			return nil, fmt.Errorf("processing recording %s (user %s): %w", inst.destSessionID, inst.user, err)
 		}
 
 		marshaled, err := utils.FastMarshal(event)
 		if err != nil {
-			return nil, fmt.Errorf("marshaling event for %s: %w", rec.SessionID, err)
+			return nil, fmt.Errorf("marshaling event for %s: %w", inst.destSessionID, err)
 		}
 
 		lines = append(lines, string(marshaled))
@@ -181,10 +216,10 @@ func adjustEvents(ctx context.Context, discovered []recording) ([]string, error)
 	return lines, nil
 }
 
-// readAndPatchEvent reads the session end event from a recording's .tar file, updates user/cluster
+// readAndPatchEvent reads the session end event from a recording's .tar file, updates user/cluster/session
 // fields for the E2E environment, and shifts timestamps so the session appears to end at newStop.
-func readAndPatchEvent(ctx context.Context, rec recording, newStop time.Time) (apievents.AuditEvent, error) {
-	f, err := os.Open(rec.Path)
+func readAndPatchEvent(ctx context.Context, inst recordingInstance, newStop time.Time) (apievents.AuditEvent, error) {
+	f, err := os.Open(inst.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -192,11 +227,6 @@ func readAndPatchEvent(ctx context.Context, rec recording, newStop time.Time) (a
 
 	reader := events.NewProtoReader(f, nil)
 	defer reader.Close()
-
-	user := defaultE2EUser
-	if mappedUser, ok := recordingUserMap[rec.SessionID]; ok {
-		user = mappedUser
-	}
 
 	for {
 		event, err := reader.Read(ctx)
@@ -213,9 +243,10 @@ func readAndPatchEvent(ctx context.Context, rec recording, newStop time.Time) (a
 			if duration <= 0 {
 				return nil, fmt.Errorf("invalid session duration for session %s", e.GetSessionID())
 			}
-			e.User = user
+			e.SessionMetadata.SessionID = inst.destSessionID
+			e.User = inst.user
 			e.Login = defaultE2ELogin
-			e.Participants = []string{user}
+			e.Participants = []string{inst.user}
 			e.ClusterName = clusterName
 			e.UserClusterName = clusterName
 			e.StartTime = newStop.Add(-duration)
@@ -229,7 +260,8 @@ func readAndPatchEvent(ctx context.Context, rec recording, newStop time.Time) (a
 			if duration <= 0 {
 				return nil, fmt.Errorf("invalid session duration for session %s", e.GetSessionID())
 			}
-			e.User = user
+			e.SessionMetadata.SessionID = inst.destSessionID
+			e.User = inst.user
 			e.ClusterName = clusterName
 			e.UserClusterName = clusterName
 			e.StartTime = newStop.Add(-duration)
@@ -243,7 +275,8 @@ func readAndPatchEvent(ctx context.Context, rec recording, newStop time.Time) (a
 			if duration <= 0 {
 				return nil, fmt.Errorf("invalid session duration for session %s", e.GetSessionID())
 			}
-			e.User = user
+			e.SessionMetadata.SessionID = inst.destSessionID
+			e.User = inst.user
 			e.ClusterName = clusterName
 			e.UserClusterName = clusterName
 			e.StartTime = newStop.Add(-duration)

--- a/e2e/runner/recordings.go
+++ b/e2e/runner/recordings.go
@@ -262,6 +262,7 @@ func readAndPatchEvent(ctx context.Context, inst recordingInstance, newStop time
 			}
 			e.SessionMetadata.SessionID = inst.destSessionID
 			e.User = inst.user
+			e.Participants = []string{inst.user}
 			e.ClusterName = clusterName
 			e.UserClusterName = clusterName
 			e.StartTime = newStop.Add(-duration)
@@ -277,6 +278,7 @@ func readAndPatchEvent(ctx context.Context, inst recordingInstance, newStop time
 			}
 			e.SessionMetadata.SessionID = inst.destSessionID
 			e.User = inst.user
+			e.Participants = []string{inst.user}
 			e.ClusterName = clusterName
 			e.UserClusterName = clusterName
 			e.StartTime = newStop.Add(-duration)

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -41,10 +41,6 @@ var (
 
 	// The "key" regexes below require a word boundary so identifiers like
 	// `super_user:` or `myRoles:` don't match as `user:` / `roles:`.
-	usersBlockRe    = regexp.MustCompile(`\busers:\s*\[`)
-	userObjRe       = regexp.MustCompile(`\buser:\s*\{`)
-	rolesBlockRe    = regexp.MustCompile(`\broles:\s*\[`)
-	traitsBlockRe   = regexp.MustCompile(`\btraits:\s*\{`)
 	traitKeyArrayRe = regexp.MustCompile(`(?:'([^'\\]+)'|"([^"\\]+)"|\b(\w+))\s*:\s*\[`)
 	loginAsBoolRe   = regexp.MustCompile(`\bloginAs:\s*true\b`)
 )
@@ -63,9 +59,10 @@ const testUseCallPrefix = "test.use("
 // scannedUser is a user declaration discovered in test source. Names are
 // generated at bootstrap time, not by the test author.
 type scannedUser struct {
-	roles   []scannedRole
-	traits  map[string][]string
-	loginAs bool
+	roles      []scannedRole
+	traits     map[string][]string
+	recordings []string
+	loginAs    bool
 	// arrayIdx is the position within a `users: [...]` array; nil otherwise.
 	// Keeps duplicate-by-content entries addressable as distinct accounts via
 	// loginAs(N).
@@ -74,8 +71,7 @@ type scannedUser struct {
 	// distinct from any explicit `user: {}` declaration with the same roles.
 	isDefault bool
 	// sourceFile is the spec path (relative to e2eDir) where this user was
-	// declared inline; empty for helper-declared and default users so those
-	// stay shared.
+	// declared inline; empty for the implicit default user.
 	sourceFile string
 }
 
@@ -90,15 +86,16 @@ type scannedRole struct {
 type scanTarget struct {
 	path string
 	line int // 0 means scan entire file
-	// sourceFile, when non-empty, is the spec path (relative to e2eDir) emitted
-	// in the canonical key for users declared in this target. Empty for helpers
-	// so helper-declared users stay shared across all importing specs.
+	// sourceFile, when non-empty, is the spec path emitted in the canonical
+	// key for users declared in this target. Empty for helper modules.
 	sourceFile string
 }
 
-// blockRange represents a brace-delimited block in a source file (1-indexed lines).
+// blockRange represents a brace-delimited block in a source file (1-indexed
+// lines; byte offsets index into the joined comment-stripped content).
 type blockRange struct {
-	start, end int
+	start, end         int
+	startByte, endByte int
 }
 
 // callRange represents the byte offsets of a test.use(...) call in the content string.
@@ -295,9 +292,7 @@ func scanFile(path string, targetLine int) []*fixtures.Fixture {
 
 	var result []*fixtures.Fixture
 	for _, call := range findTestUseCalls(content) {
-		callLine := 1 + strings.Count(content[:call.start], "\n")
-
-		if targetLine > 0 && !fixtureInScope(callLine, targetLine, blocks) {
+		if targetLine > 0 && !fixtureInScope(call.start, targetLine, blocks) {
 			continue
 		}
 
@@ -412,8 +407,20 @@ func findBlockCommentOpen(line string) int {
 }
 
 func parseBlocks(lines []string) []blockRange {
+	lineStarts := make([]int, len(lines))
+	off := 0
+	for i, line := range lines {
+		lineStarts[i] = off
+		off += len(line) + 1
+	}
+
+	type stackEntry struct {
+		line int
+		off  int
+	}
+
 	var blocks []blockRange
-	var stack []int
+	var stack []stackEntry
 	inTemplateLiteral := false
 
 	for i, line := range lines {
@@ -448,12 +455,17 @@ func parseBlocks(lines []string) []blockRange {
 				quote = '`'
 				inTemplateLiteral = true
 			case '{':
-				stack = append(stack, lineNum)
+				stack = append(stack, stackEntry{line: lineNum, off: lineStarts[i] + j})
 			case '}':
 				if len(stack) > 0 {
-					start := stack[len(stack)-1]
+					top := stack[len(stack)-1]
 					stack = stack[:len(stack)-1]
-					blocks = append(blocks, blockRange{start: start, end: lineNum})
+					blocks = append(blocks, blockRange{
+						start:     top.line,
+						end:       lineNum,
+						startByte: top.off,
+						endByte:   lineStarts[i] + j,
+					})
 				}
 			}
 		}
@@ -519,18 +531,8 @@ func findTestUseCalls(content string) []callRange {
 	return calls
 }
 
-func fixtureInScope(fixtureLine, targetLine int, blocks []blockRange) bool {
-	var enclosing *blockRange
-
-	for i := range blocks {
-		b := &blocks[i]
-		if fixtureLine > b.start && fixtureLine < b.end {
-			if enclosing == nil || (b.end-b.start) < (enclosing.end-enclosing.start) {
-				enclosing = b
-			}
-		}
-	}
-
+func fixtureInScope(callStart, targetLine int, blocks []blockRange) bool {
+	enclosing := smallestEnclosingBlock(callStart, blocks)
 	if enclosing == nil {
 		return true
 	}
@@ -568,10 +570,10 @@ func defaultUsers() []scannedUser {
 }
 
 // scanFileUsers extracts user declarations from test.use() calls. Singular
-// `user: {}` and array `users: [...]` are mutually exclusive per call; at
-// most one array entry may have `loginAs: true`. sourceFile, when non-empty,
-// is stamped onto each scanned user so its canonical key includes the spec
-// path (helpers leave it empty).
+// `user: {}`, array `users: [...]`, and `recordings` are mutually exclusive
+// per call; at most one array entry may have `loginAs: true`. Helper modules
+// are rejected if they declare user/users/recordings since runtime would
+// merge them into every importing spec.
 func scanFileUsers(path string, targetLine int, sourceFile string) ([]scannedUser, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -587,49 +589,77 @@ func scanFileUsers(path string, targetLine int, sourceFile string) ([]scannedUse
 	blocks := parseBlocks(cleaned)
 	content := strings.Join(cleaned, "\n")
 
-	var result []scannedUser
+	type useCall struct {
+		line  int
+		start int
+	}
+
+	var (
+		result            []scannedUser
+		recordingsCalls   []useCall
+		explicitUserCalls []useCall
+	)
 	for _, call := range findTestUseCalls(content) {
 		callLine := 1 + strings.Count(content[:call.start], "\n")
 
-		if targetLine > 0 && !fixtureInScope(callLine, targetLine, blocks) {
+		if targetLine > 0 && !fixtureInScope(call.start, targetLine, blocks) {
 			continue
 		}
 
 		body := content[call.start:call.end]
 
-		hasUser := userObjRe.MatchString(body)
-		hasUsers := usersBlockRe.MatchString(body)
+		userOpen, userClose := findKeyValueAtDepth(body, "user", '{', '}', 1)
+		usersOpen, usersClose := findKeyValueAtDepth(body, "users", '[', ']', 1)
+		hasUser := userOpen >= 0
+		hasUsers := usersOpen >= 0
+		hasRecordings := hasTopLevelRecordings(body)
 
-		if hasUser && hasUsers {
+		uc := useCall{line: callLine, start: call.start}
+		if hasUser || hasUsers {
+			explicitUserCalls = append(explicitUserCalls, uc)
+		}
+		if hasRecordings {
+			recordingsCalls = append(recordingsCalls, uc)
+		}
+
+		// Validate mutual exclusivity.
+		var present []string
+		if hasUser {
+			present = append(present, "user")
+		}
+		if hasUsers {
+			present = append(present, "users")
+		}
+		if hasRecordings {
+			present = append(present, "recordings")
+		}
+
+		if len(present) > 1 {
 			return nil, fmt.Errorf(
-				"%s:%d: user and users are mutually exclusive in test.use()",
-				path, callLine,
+				"%s:%d: user, users, and recordings are mutually exclusive in test.use() (found: %s)",
+				path, callLine, strings.Join(present, ", "),
 			)
 		}
 
 		var users []scannedUser
 
 		if hasUser {
-			if loc := userObjRe.FindStringIndex(body); loc != nil {
-				userBlock := extractInner(body[loc[0]:], '{', '}')
-				if userBlock != "" {
-					user := parseUserBlock(userBlock)
-					user.loginAs = true // singular user is implicitly loginAs
-					warnDuplicateRoles(path, callLine, user.roles)
-					users = append(users, user)
-				}
+			userBlock := body[userOpen+1 : userClose-1]
+			if userBlock != "" {
+				user := parseUserBlock(userBlock)
+				user.loginAs = true // singular user is implicitly loginAs
+				warnDuplicateRoles(path, callLine, user.roles)
+				users = append(users, user)
 			}
 		} else if hasUsers {
-			if loc := usersBlockRe.FindStringIndex(body); loc != nil {
-				usersContent := extractInner(body[loc[0]:], '[', ']')
-				if usersContent != "" {
-					for i, userBlock := range extractAllOuter(usersContent, '{', '}') {
-						u := parseUserBlock(userBlock)
-						idx := i
-						u.arrayIdx = &idx
-						warnDuplicateRoles(path, callLine, u.roles)
-						users = append(users, u)
-					}
+			usersContent := body[usersOpen+1 : usersClose-1]
+			if usersContent != "" {
+				for i, raw := range extractAllOuter(usersContent, '{', '}') {
+					u := parseUserBlock(raw[1 : len(raw)-1])
+					idx := i
+					u.arrayIdx = &idx
+					warnDuplicateRoles(path, callLine, u.roles)
+					users = append(users, u)
 				}
 			}
 
@@ -645,15 +675,182 @@ func scanFileUsers(path string, targetLine int, sourceFile string) ([]scannedUse
 					path, callLine, loginAsCount,
 				)
 			}
+		} else if hasRecordings {
+			topRecordings := scanTopLevelRecordings(body)
+			if len(topRecordings) > 0 {
+				users = append(users, scannedUser{
+					roles:      defaultRoleNames(),
+					recordings: topRecordings,
+					loginAs:    true,
+					isDefault:  true,
+				})
+			}
 		}
 
 		for i := range users {
+			if users[i].isDefault {
+				continue
+			}
 			users[i].sourceFile = sourceFile
 		}
 		result = append(result, users...)
 	}
 
+	for _, rec := range recordingsCalls {
+		for _, user := range explicitUserCalls {
+			if scopesOverlap(rec.start, user.start, blocks) {
+				return nil, fmt.Errorf(
+					"%s:%d: top-level recordings: cannot coexist with user:/users: at line %d in an overlapping scope; "+
+						"combine them into a single test.use({ user: { ..., recordings: [...] } })",
+					path, rec.line, user.line,
+				)
+			}
+		}
+	}
+
+	if sourceFile == "" && (len(recordingsCalls) > 0 || len(explicitUserCalls) > 0) {
+		var line int
+		if len(explicitUserCalls) > 0 {
+			line = explicitUserCalls[0].line
+		} else {
+			line = recordingsCalls[0].line
+		}
+		return nil, fmt.Errorf(
+			"%s:%d: helper modules cannot declare user:/users:/top-level recordings: in test.use(); declare them inline in the spec",
+			path, line,
+		)
+	}
+
 	return result, nil
+}
+
+// scopesOverlap reports whether two test.use() calls apply to any common
+// test. Two scopes overlap when at least one is file-level (no enclosing block)
+// or one's enclosing block contains the other's.
+func scopesOverlap(call1Start, call2Start int, blocks []blockRange) bool {
+	b1 := smallestEnclosingBlock(call1Start, blocks)
+	b2 := smallestEnclosingBlock(call2Start, blocks)
+	if b1 == nil || b2 == nil {
+		return true
+	}
+	return blockContains(*b1, *b2) || blockContains(*b2, *b1)
+}
+
+func smallestEnclosingBlock(callStart int, blocks []blockRange) *blockRange {
+	var best *blockRange
+	for i := range blocks {
+		b := &blocks[i]
+		if b.startByte < callStart && b.endByte > callStart {
+			if best == nil || (b.endByte-b.startByte) < (best.endByte-best.startByte) {
+				best = b
+			}
+		}
+	}
+	return best
+}
+
+func blockContains(outer, inner blockRange) bool {
+	return outer.startByte <= inner.startByte && outer.endByte >= inner.endByte
+}
+
+// hasTopLevelRecordings reports whether the test.use({...}) body has a
+// recordings: [...] key directly on the args object (depth 1), ignoring any
+// recordings: nested inside a value object/array. Depth-aware so nested keys
+// in user/users/traits/etc. don't false-positive.
+func hasTopLevelRecordings(body string) bool {
+	open, _ := findTopLevelRecordingsArray(body)
+	return open >= 0
+}
+
+// findTopLevelRecordingsArray returns the byte offsets [open, close) of the
+// `[...]` value of a `recordings:` key at depth 1 of the test.use args object.
+// Returns (-1, -1) if no such key exists.
+func findTopLevelRecordingsArray(body string) (int, int) {
+	return findKeyValueAtDepth(body, "recordings", '[', ']', 1)
+}
+
+func findKeyValueAtDepth(body, key string, openBracket, closeBracket byte, targetDepth int) (int, int) {
+	depth := 0
+	var quote byte
+
+	for i := 0; i < len(body); i++ {
+		ch := body[i]
+
+		if quote != 0 {
+			if ch == '\\' {
+				i++
+				continue
+			}
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+
+		switch ch {
+		case '\'', '"', '`':
+			quote = ch
+			continue
+		}
+
+		if depth == targetDepth {
+			if bracketAt, ok := matchesKeyAt(body, i, key, openBracket); ok {
+				closeIdx := scanBalanced(body, bracketAt, openBracket, closeBracket)
+				if closeIdx < 0 {
+					return -1, -1
+				}
+				return bracketAt, closeIdx + 1
+			}
+		}
+
+		switch ch {
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+		}
+	}
+
+	return -1, -1
+}
+
+func matchesKeyAt(body string, i int, key string, bracket byte) (int, bool) {
+	if i+len(key) > len(body) {
+		return 0, false
+	}
+	if body[i:i+len(key)] != key {
+		return 0, false
+	}
+	if i > 0 && isIdentChar(body[i-1]) {
+		return 0, false
+	}
+
+	j := i + len(key)
+	for j < len(body) && isWhitespace(body[j]) {
+		j++
+	}
+	if j >= len(body) || body[j] != ':' {
+		return 0, false
+	}
+	j++
+	for j < len(body) && isWhitespace(body[j]) {
+		j++
+	}
+	if j >= len(body) || body[j] != bracket {
+		return 0, false
+	}
+	return j, true
+}
+
+func isIdentChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') ||
+		b == '_' || b == '$'
+}
+
+func isWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
 // scanBalanced returns the index of the close delimiter matching the open at
@@ -692,13 +889,48 @@ func scanBalanced(s string, openIdx int, open, close byte) int {
 	return -1
 }
 
-// parseUserBlock extracts roles, traits, and loginAs from a single user object block.
+// findClosingDelim finds the position after the matching close delimiter
+// for the first open delimiter at or after pos. Returns -1 if not found.
+// Delimiter bytes inside string or template literals are ignored.
+func findClosingDelim(s string, pos int, open, close byte) int {
+	start := strings.IndexByte(s[pos:], open)
+	if start < 0 {
+		return -1
+	}
+
+	end := scanBalanced(s, pos+start, open, close)
+	if end < 0 {
+		return -1
+	}
+
+	return end + 1
+}
+
+// scanTopLevelRecordings extracts recordings: [...] from a test.use() body,
+// only when the recordings: key is at depth 1 of the args object.
+func scanTopLevelRecordings(body string) []string {
+	open, close := findTopLevelRecordingsArray(body)
+	if open < 0 {
+		return nil
+	}
+
+	inner := body[open+1 : close-1]
+
+	var recordings []string
+	for _, m := range fixtureRefRe.FindAllStringSubmatch(inner, -1) {
+		recordings = append(recordings, m[1])
+	}
+
+	return recordings
+}
+
+// parseUserBlock extracts roles, traits, recordings, and loginAs from a single
+// user object block. Callers MUST pass content with any surrounding `{}` already stripped.
 func parseUserBlock(userBlock string) scannedUser {
 	var user scannedUser
 
-	rolesLoc := rolesBlockRe.FindStringIndex(userBlock)
-	if rolesLoc != nil {
-		rolesContent := extractInner(userBlock[rolesLoc[0]:], '[', ']')
+	if open, close := findKeyValueAtDepth(userBlock, "roles", '[', ']', 0); open >= 0 {
+		rolesContent := userBlock[open+1 : close-1]
 		if rolesContent != "" {
 			// Collect file-role ranges first, then walk all quoted strings and
 			// classify each based on whether it falls inside a file-role match.
@@ -721,11 +953,19 @@ func parseUserBlock(userBlock string) scannedUser {
 		}
 	}
 
-	traitsLoc := traitsBlockRe.FindStringIndex(userBlock)
-	if traitsLoc != nil {
-		traitsContent := extractInner(userBlock[traitsLoc[0]:], '{', '}')
+	if open, close := findKeyValueAtDepth(userBlock, "traits", '{', '}', 0); open >= 0 {
+		traitsContent := userBlock[open+1 : close-1]
 		if traitsContent != "" {
 			user.traits = parseTraits(traitsContent)
+		}
+	}
+
+	if open, close := findKeyValueAtDepth(userBlock, "recordings", '[', ']', 0); open >= 0 {
+		recContent := userBlock[open+1 : close-1]
+		if recContent != "" {
+			for _, m := range fixtureRefRe.FindAllStringSubmatch(recContent, -1) {
+				user.recordings = append(user.recordings, m[1])
+			}
 		}
 	}
 

--- a/e2e/runner/scan_test.go
+++ b/e2e/runner/scan_test.go
@@ -440,7 +440,7 @@ func TestScanUsers(t *testing.T) {
 			tmpFile := filepath.Join(dir, "test.spec.ts")
 			writeFile(t, dir, "test.spec.ts", tt.content)
 
-			got, err := scanFileUsers(tmpFile, 0, "")
+			got, err := scanFileUsers(tmpFile, 0, "test.spec.ts")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -536,6 +536,126 @@ func TestScanUsersDefaultUser(t *testing.T) {
 	}
 }
 
+func TestScanRecordings(t *testing.T) {
+	tests := []struct {
+		name           string
+		content        string
+		wantUsers      int
+		wantRecordings []string // recordings on the first user
+		wantLoginAs    bool
+	}{
+		{
+			name: "top-level recordings creates default user",
+			content: `test.use({
+  recordings: ['ssh-session-1', 'desktop-session-2'],
+});`,
+			wantUsers:      1,
+			wantRecordings: []string{"ssh-session-1", "desktop-session-2"},
+			wantLoginAs:    true,
+		},
+		{
+			name: "recordings on user definition",
+			content: `test.use({
+  user: { roles: ['access'], recordings: ['ssh-session-1'] },
+});`,
+			wantUsers:      1,
+			wantRecordings: []string{"ssh-session-1"},
+			wantLoginAs:    true,
+		},
+		{
+			name:           "no recordings",
+			content:         `test.use({ user: { roles: ['access'] } });`,
+			wantUsers:      1,
+			wantRecordings: nil,
+			wantLoginAs:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tmpFile := filepath.Join(dir, "test.spec.ts")
+			writeFile(t, dir, "test.spec.ts", tt.content)
+
+			got, err := scanFileUsers(tmpFile, 0, "test.spec.ts")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != tt.wantUsers {
+				t.Fatalf("got %d users, want %d", len(got), tt.wantUsers)
+			}
+
+			if tt.wantUsers == 0 {
+				return
+			}
+
+			if got[0].loginAs != tt.wantLoginAs {
+				t.Errorf("loginAs = %v, want %v", got[0].loginAs, tt.wantLoginAs)
+			}
+
+			if len(got[0].recordings) != len(tt.wantRecordings) {
+				t.Fatalf("got %d recordings, want %d: %v", len(got[0].recordings), len(tt.wantRecordings), got[0].recordings)
+			}
+
+			for i, r := range got[0].recordings {
+				if r != tt.wantRecordings[i] {
+					t.Errorf("recording[%d] = %q, want %q", i, r, tt.wantRecordings[i])
+				}
+			}
+		})
+	}
+}
+
+func TestScanFileHelperRejectsUserAndRecordings(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"user", `test.use({ user: { roles: ['access'] } });`},
+		{"users", `test.use({ users: [{ roles: ['access'], loginAs: true }] });`},
+		{"recordings", `test.use({ recordings: ['ssh-1'] });`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "helper.ts", tc.content)
+
+			_, err := scanFileUsers(filepath.Join(dir, "helper.ts"), 0, "")
+			if err == nil {
+				t.Fatal("expected error for helper-declared user/users/recordings, got nil")
+			}
+
+			if !strings.Contains(err.Error(), "helper modules cannot declare") {
+				t.Errorf("expected helper-rejection error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestScanTopLevelRecordingsSynthIsDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "spec.ts", `test.use({ recordings: ['ssh-1'] });`)
+
+	got, err := scanFileUsers(filepath.Join(dir, "spec.ts"), 0, "tests/spec.ts")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d users, want 1", len(got))
+	}
+
+	if !got[0].isDefault {
+		t.Errorf("isDefault = false, want true")
+	}
+
+	if got[0].sourceFile != "" {
+		t.Errorf("sourceFile = %q, want empty", got[0].sourceFile)
+	}
+}
+
 func TestScanUsersMutuallyExclusiveError(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "test.spec.ts", `test.use({
@@ -543,7 +663,7 @@ func TestScanUsersMutuallyExclusiveError(t *testing.T) {
   users: [{ roles: ['access'] }],
 });`)
 
-	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "")
+	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
 	if err == nil {
 		t.Fatal("expected error for user + users in same test.use(), got nil")
 	}
@@ -562,7 +682,7 @@ func TestScanUsersMultipleLoginAsError(t *testing.T) {
   ],
 });`)
 
-	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "")
+	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
 	if err == nil {
 		t.Fatal("expected error for multiple loginAs: true, got nil")
 	}
@@ -622,7 +742,7 @@ func TestScanUsersDuplicateRoleWarn(t *testing.T) {
 			dir := t.TempDir()
 			writeFile(t, dir, "test.spec.ts", tt.content)
 
-			if _, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, ""); err != nil {
+			if _, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts"); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
@@ -637,6 +757,275 @@ func TestScanUsersDuplicateRoleWarn(t *testing.T) {
 			for _, want := range tt.wantWarns {
 				if !strings.Contains(out, want) {
 					t.Errorf("missing warn substring %q in output:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestScanRecordingsAfterUserBlock(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "test.spec.ts", `test.use({
+  user: { roles: ['access'], recordings: ['nested'] },
+  recordings: ['top-level'],
+});`)
+
+	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
+	if err == nil {
+		t.Fatal("expected mutual-exclusivity error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected mutual-exclusivity error mentioning recordings, got: %v", err)
+	}
+}
+
+func TestHasTopLevelRecordingsIgnoresNested(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"top-level only", `test.use({ recordings: ['a'] })`, true},
+		{"nested in user", `test.use({ user: { roles: ['x'], recordings: ['a'] } })`, false},
+		{"nested in arbitrary fixture", `test.use({ traits: { recordings: ['a'] } })`, false},
+		{"sibling top-level wins over nested", `test.use({ traits: { recordings: ['a'] }, recordings: ['b'] })`, true},
+		{"recordings inside string literal is not a key", `test.use({ note: 'recordings: [foo]' })`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := findTestUseCalls(tc.body)
+			if len(calls) != 1 {
+				t.Fatalf("findTestUseCalls returned %d calls, want 1", len(calls))
+			}
+
+			body := tc.body[calls[0].start:calls[0].end]
+			if got := hasTopLevelRecordings(body); got != tc.want {
+				t.Errorf("hasTopLevelRecordings = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScanFileTopLevelRecordingsAcrossSiblingDescribesAllowed(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "test.spec.ts", `test.describe('A', () => {
+  test.use({ user: { roles: ['access'] } });
+});
+
+test.describe('B', () => {
+  test.use({ recordings: ['ssh-1'] });
+});`)
+
+	got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
+	if err != nil {
+		t.Fatalf("unexpected error for sibling-describe scopes: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("got %d users, want 2 (one per describe)", len(got))
+	}
+}
+
+func TestScanFileTopLevelRecordingsAcrossOneLineSiblingDescribesAllowed(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "test.spec.ts", `test.describe('A', () => { test.use({ user: { roles: ['access'] } }); });
+test.describe('B', () => { test.use({ recordings: ['ssh-1'] }); });`)
+
+	got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
+	if err != nil {
+		t.Fatalf("unexpected error for one-line sibling-describe scopes: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("got %d users, want 2 (one per describe)", len(got))
+	}
+}
+
+func TestScanFileTopLevelRecordingsOneLineNestedDescribeRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "test.spec.ts", `test.use({ recordings: ['ssh-1'] });
+test.describe('inner', () => { test.use({ user: { roles: ['access'] } }); });`)
+
+	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
+	if err == nil {
+		t.Fatal("expected error for file-scope recordings + one-line describe user, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "top-level recordings") {
+		t.Errorf("expected top-level-recordings error, got: %v", err)
+	}
+}
+
+func TestScanFileTopLevelRecordingsNestedDescribeRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "test.spec.ts", `test.use({ recordings: ['ssh-1'] });
+
+test.describe('inner', () => {
+  test.use({ user: { roles: ['access'] } });
+});`)
+
+	_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
+	if err == nil {
+		t.Fatal("expected error for file-scope recordings + describe-scope user, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "top-level recordings") {
+		t.Errorf("expected top-level-recordings error, got: %v", err)
+	}
+}
+
+func TestScanFileTopLevelRecordingsWithExplicitUserError(t *testing.T) {
+	// Playwright merges multiple file-scope test.use() calls; mixing a
+	// top-level recordings call with a user/users call leaves the recordings
+	// orphaned on a synthetic default user. Scanner must reject this.
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "user then top-level recordings",
+			content: `test.use({ user: { roles: ['access'] } });
+test.use({ recordings: ['ssh-1'] });`,
+		},
+		{
+			name: "top-level recordings then users",
+			content: `test.use({ recordings: ['ssh-1'] });
+test.use({ users: [{ roles: ['access'], loginAs: true }] });`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "test.spec.ts", tc.content)
+
+			_, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
+			if err == nil {
+				t.Fatal("expected error mixing top-level recordings with explicit user/users, got nil")
+			}
+
+			if !strings.Contains(err.Error(), "top-level recordings") {
+				t.Errorf("expected top-level-recordings error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestScanUsersNestedUserFixturesIgnored(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantUsers int
+	}{
+		{
+			name: "user nested inside another fixture object is not detected",
+			content: `test.use({
+  customFixture: { user: { roles: ['nope'] } },
+  recordings: ['ssh-1'],
+});`,
+			wantUsers: 1,
+		},
+		{
+			name: "users nested inside another fixture is not detected",
+			content: `test.use({
+  customFixture: { users: [{ roles: ['nope'] }] },
+  recordings: ['ssh-1'],
+});`,
+			wantUsers: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "test.spec.ts", tt.content)
+
+			got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != tt.wantUsers {
+				t.Fatalf("got %d users, want %d: %+v", len(got), tt.wantUsers, got)
+			}
+		})
+	}
+}
+
+func TestScanUsersUserFieldsAreDepth0Only(t *testing.T) {
+	tests := []struct {
+		name           string
+		content        string
+		wantRecordings []string
+		wantRoleNames  []string
+	}{
+		{
+			name: "nested recordings inside traits ignored when no top-level recordings",
+			content: `test.use({
+  user: {
+    roles: ['access'],
+    traits: { recordings: ['nested-fake'] },
+  },
+});`,
+			wantRoleNames: []string{"access"},
+		},
+		{
+			name: "nested recordings inside traits do not shadow top-level recordings",
+			content: `test.use({
+  user: {
+    roles: ['access'],
+    traits: { recordings: ['nested-fake'] },
+    recordings: ['real-1', 'real-2'],
+  },
+});`,
+			wantRecordings: []string{"real-1", "real-2"},
+			wantRoleNames:  []string{"access"},
+		},
+		{
+			name: "nested roles inside traits do not shadow top-level roles",
+			content: `test.use({
+  user: {
+    traits: { roles: ['nested-fake'] },
+    roles: ['access', 'editor'],
+  },
+});`,
+			wantRoleNames: []string{"access", "editor"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "test.spec.ts", tt.content)
+
+			got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != 1 {
+				t.Fatalf("got %d users, want 1: %+v", len(got), got)
+			}
+
+			if len(got[0].recordings) != len(tt.wantRecordings) {
+				t.Fatalf("got %d recordings, want %d: %v", len(got[0].recordings), len(tt.wantRecordings), got[0].recordings)
+			}
+
+			for i, r := range got[0].recordings {
+				if r != tt.wantRecordings[i] {
+					t.Errorf("recording[%d] = %q, want %q", i, r, tt.wantRecordings[i])
+				}
+			}
+
+			if len(got[0].roles) != len(tt.wantRoleNames) {
+				t.Fatalf("got %d roles, want %d: %+v", len(got[0].roles), len(tt.wantRoleNames), got[0].roles)
+			}
+
+			for i, r := range got[0].roles {
+				if r.name != tt.wantRoleNames[i] {
+					t.Errorf("role[%d] name = %q, want %q", i, r.name, tt.wantRoleNames[i])
 				}
 			}
 		})
@@ -681,7 +1070,7 @@ func TestScanUsersDelimitersInStringLiterals(t *testing.T) {
 			dir := t.TempDir()
 			writeFile(t, dir, "test.spec.ts", tt.content)
 
-			got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "")
+			got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -789,7 +1178,7 @@ func TestScanUsersIdentifierBoundaries(t *testing.T) {
   myRoles: ['nope'],
 });`)
 
-	got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "")
+	got, err := scanFileUsers(filepath.Join(dir, "test.spec.ts"), 0, "test.spec.ts")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/e2e/runner/teleport.go
+++ b/e2e/runner/teleport.go
@@ -41,12 +41,13 @@ import (
 const clusterName = "teleport-e2e"
 
 type teleportInstance struct {
-	log         *slog.Logger
-	teleportBin string
-	proxyPort   int
-	configPath  string
-	stateFile   string
-	logFile     string // empty means stdout/stderr
+	log             *slog.Logger
+	teleportBin     string
+	proxyPort       int
+	configPath      string
+	stateFile       string
+	logFile         string // empty means stdout/stderr
+	recordingOwners recordingOwners
 
 	cmd      *exec.Cmd
 	logF     *os.File


### PR DESCRIPTION
Requires #66166

Now that users are dynamically created in e2e tests with random usernames, this changes the way that recordings are seeded so that a test declares which recordings it wants and it's assigned to that user. If multiple tests use the same recording, that recording is duplicated for each user. The recording IDs are passed through to the test, so if it needs to navigate to the recording it can do.

No manual test plan as I will follow this up with some e2e tests that exercise this new functionality.
