### PR TITLE
[scopes] feat: tctl scoped assignments list

### DIFF
--- a/tool/tctl/common/bots_command_test.go
+++ b/tool/tctl/common/bots_command_test.go
@@ -411,6 +411,14 @@ func TestAddAndListBotInstancesJSON(t *testing.T) {
 				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
+		Proxy: config.Proxy{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.ProxySSHAddr,
+			},
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
+		},
 	}
 	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withEnableProxy())
 	ctx := context.Background()

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package resources
 
 import (
@@ -33,17 +34,17 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-type scopedRoleAssignmentCollection struct {
+type ScopedRoleAssignmentCollection struct {
 	roleAssignments []*scopedaccessv1.ScopedRoleAssignment
 }
 
-func NewScopedRoleAssignmentCollection(roles []*scopedaccessv1.ScopedRoleAssignment) Collection {
-	return &scopedRoleAssignmentCollection{
-		roleAssignments: roles,
+func NewScopedRoleAssignmentCollection(assignments []*scopedaccessv1.ScopedRoleAssignment) Collection {
+	return &ScopedRoleAssignmentCollection{
+		roleAssignments: assignments,
 	}
 }
 
-func (c *scopedRoleAssignmentCollection) Resources() []types.Resource {
+func (c *ScopedRoleAssignmentCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.roleAssignments))
 	for i, resource := range c.roleAssignments {
 		r[i] = types.Resource153ToLegacy(resource)
@@ -51,7 +52,7 @@ func (c *scopedRoleAssignmentCollection) Resources() []types.Resource {
 	return r
 }
 
-func (c *scopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
+func (c *ScopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"SubKind", "Scope", "Name", "User", "Assigns"}
 	rows := make([][]string, len(c.roleAssignments))
 
@@ -160,14 +161,14 @@ func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref
 			return nil, trace.Wrap(err)
 		}
 
-		return &scopedRoleAssignmentCollection{roleAssignments: []*scopedaccessv1.ScopedRoleAssignment{rsp.Assignment}}, nil
+		return &ScopedRoleAssignmentCollection{roleAssignments: []*scopedaccessv1.ScopedRoleAssignment{rsp.Assignment}}, nil
 	}
 
 	items, err := stream.Collect(scopedutils.RangeScopedRoleAssignments(ctx, client.ScopedAccessServiceClient(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{}))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &scopedRoleAssignmentCollection{roleAssignments: items}, nil
+	return NewScopedRoleAssignmentCollection(items), nil
 }
 
 func deleteScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref services.Ref) error {

--- a/tool/tctl/common/scoped_assignments_command.go
+++ b/tool/tctl/common/scoped_assignments_command.go
@@ -66,7 +66,7 @@ type scopedAssignmentsListCommand struct {
 	format string
 	// user allows filtering by user to whom assignments apply.
 	user string
-	// role allowed filtering by scoped role name.
+	// role allows filtering by scoped role name.
 	role string
 }
 

--- a/tool/tctl/common/scoped_assignments_command.go
+++ b/tool/tctl/common/scoped_assignments_command.go
@@ -1,0 +1,122 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"context"
+	"io"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
+	"github.com/gravitational/teleport/lib/services"
+	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
+	"github.com/gravitational/teleport/tool/tctl/common/resources"
+)
+
+// scopedAssignmentsCommand implements `tctl scoped assignments` subcommands.
+type scopedAssignmentsCommand struct {
+	// list is the 'tctl scoped assignments list' command.
+	list scopedAssignmentsListCommand
+}
+
+// initialize allows the scoped assignments commands to plug themselves into the CLI parser.
+func (c *scopedAssignmentsCommand) initialize(parent *kingpin.CmdClause, stdout io.Writer) {
+	assignments := parent.Command("assignments", "Manage scoped role assignments")
+
+	c.list.initialize(assignments, stdout)
+}
+
+// TryRun attempts to run subcommands like `scoped assignments list`.
+func (c *scopedAssignmentsCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
+	for _, subCmd := range []RunnableCommand{&c.list} {
+		match, err := subCmd.TryRun(ctx, cmd, clientFunc)
+		if match || err != nil {
+			return match, trace.Wrap(err)
+		}
+	}
+	return false, nil
+}
+
+// scopedAssignmentsListCommand implements `tctl scoped assignments list`.
+type scopedAssignmentsListCommand struct {
+	stdout io.Writer
+	cmd    *kingpin.CmdClause
+
+	// format is the output format: text, yaml, or json.
+	format string
+	// user allows filtering by user to whom assignments apply.
+	user string
+	// role allowed filtering by scoped role name.
+	role string
+}
+
+// initialize allows the scoped assignments list command to plug itself into the CLI parser.
+func (c *scopedAssignmentsListCommand) initialize(parent *kingpin.CmdClause, stdout io.Writer) {
+	c.stdout = stdout
+
+	c.cmd = parent.Command("list", "List scoped role assignments").Alias("ls")
+	c.cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&c.format, defaults.DefaultFormats...)
+	c.cmd.Flag("user", "Filter by user.").StringVar(&c.user)
+	c.cmd.Flag("role", "Filter by assigned role.").StringVar(&c.role)
+}
+
+// TryRun attempts to run `scoped assignments list`.
+func (c *scopedAssignmentsListCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
+	if cmd != c.cmd.FullCommand() {
+		return false, nil
+	}
+
+	client, closeFn, err := clientFunc(ctx)
+	if err != nil {
+		return true, trace.Wrap(err)
+	}
+	defer closeFn(ctx)
+
+	return true, trace.Wrap(c.list(ctx, client.ScopedAccessServiceClient()))
+
+}
+
+// list retrieves scoped role assignments matching the configured filters and writes them.
+func (c *scopedAssignmentsListCommand) list(ctx context.Context, client services.ScopedRoleAssignmentReader) error {
+	items, err := stream.Collect(scopedutils.RangeScopedRoleAssignments(ctx, client, &scopedaccessv1.ListScopedRoleAssignmentsRequest{
+		User: c.user,
+		Role: c.role,
+	}))
+	if err != nil {
+		return trace.Wrap(err, "collecting filtered scoped role assignments")
+	}
+
+	collection := resources.NewScopedRoleAssignmentCollection(items)
+	switch c.format {
+	case teleport.Text:
+		return collection.WriteText(c.stdout, true)
+	case teleport.YAML:
+		return writeYAML(collection, c.stdout)
+	case teleport.JSON:
+		return writeJSON(collection, c.stdout)
+	}
+	return trace.BadParameter("unsupported format")
+}

--- a/tool/tctl/common/scoped_assignments_command_test.go
+++ b/tool/tctl/common/scoped_assignments_command_test.go
@@ -1,0 +1,222 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/config"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/tool/tctl/common/resources"
+	"github.com/gravitational/teleport/tool/teleport/testenv"
+)
+
+func TestScopedAssignmentListCommand(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Proxy: config.Proxy{
+			Service: config.Service{
+				EnabledFlag: "false",
+			},
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+
+	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	clt, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clt.Close() })
+
+	assignments := map[string]*scopedaccessv1.ScopedRoleAssignment{
+		"alice-role1": {
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Version: types.V1,
+			Scope:   "/testscope",
+			Metadata: &headerv1.Metadata{
+				Name: "alice-role1",
+			},
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*scopedaccessv1.Assignment{{
+					Role:  "role1",
+					Scope: "/testscope",
+				}},
+			},
+		},
+		"bob-role1": {
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Version: types.V1,
+			Scope:   "/testscope",
+			Metadata: &headerv1.Metadata{
+				Name: "bob-role1",
+			},
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "bob",
+				Assignments: []*scopedaccessv1.Assignment{{
+					Role:  "role1",
+					Scope: "/testscope",
+				}},
+			},
+		},
+		"charlie-role2": {
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Version: types.V1,
+			Scope:   "/testscope",
+			Metadata: &headerv1.Metadata{
+				Name: "charlie-role2",
+			},
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "charlie",
+				Assignments: []*scopedaccessv1.Assignment{{
+					Role:  "role2",
+					Scope: "/testscope",
+				}},
+			},
+		},
+		"charlie-role3": {
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Version: types.V1,
+			Scope:   "/testscope",
+			Metadata: &headerv1.Metadata{
+				Name: "charlie-role3",
+			},
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "charlie",
+				Assignments: []*scopedaccessv1.Assignment{{
+					Role:  "role3",
+					Scope: "/testscope",
+				}},
+			},
+		},
+	}
+
+	scopedClt := clt.ScopedAccessServiceClient()
+	for name, assignment := range assignments {
+		created, err := scopedClt.CreateScopedRoleAssignment(t.Context(), &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			Assignment: assignment,
+		})
+		require.NoError(t, err)
+		assignments[name] = created.Assignment
+	}
+
+	allAssignmentNames := slices.Collect(maps.Keys(assignments))
+	slices.Sort(allAssignmentNames)
+
+	collectExpectedAssignments := func(names []string) resources.Collection {
+		slice := make([]*scopedaccessv1.ScopedRoleAssignment, 0, len(names))
+		for _, name := range names {
+			slice = append(slice, assignments[name])
+		}
+		return resources.NewScopedRoleAssignmentCollection(slice)
+	}
+
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := scopedClt.ListScopedRoleAssignments(ctx, &scopedaccessv1.ListScopedRoleAssignmentsRequest{})
+		require.NoError(t, err)
+		require.Len(t, resp.Assignments, len(assignments))
+	}, 10*time.Second, 50*time.Millisecond, "waiting for scoped role assignments to be present in cache")
+
+	for _, tc := range []struct {
+		desc                    string
+		args                    []string
+		expectedAssignmentNames []string
+	}{
+		{
+			desc:                    "unfiltered list",
+			args:                    []string{"assignments", "list"},
+			expectedAssignmentNames: allAssignmentNames,
+		},
+		{
+			desc:                    "unfiltered ls",
+			args:                    []string{"assignments", "ls"},
+			expectedAssignmentNames: allAssignmentNames,
+		},
+		{
+			desc:                    "charlie",
+			args:                    []string{"assignments", "ls", "--user", "charlie"},
+			expectedAssignmentNames: []string{"charlie-role2", "charlie-role3"},
+		},
+		{
+			desc:                    "charlie role2",
+			args:                    []string{"assignments", "ls", "--user", "charlie", "--role", "role2"},
+			expectedAssignmentNames: []string{"charlie-role2"},
+		},
+		{
+			desc:                    "role1",
+			args:                    []string{"assignments", "ls", "--role", "role1"},
+			expectedAssignmentNames: []string{"alice-role1", "bob-role1"},
+		},
+		{
+			desc: "nouser",
+			args: []string{"assignments", "ls", "--user", "nouser"},
+		},
+		{
+			desc: "norole",
+			args: []string{"assignments", "ls", "--role", "norole"},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Run("text", func(t *testing.T) {
+				output, err := runScopedCommand(t, clt, tc.args)
+				require.NoError(t, err)
+				for _, name := range tc.expectedAssignmentNames {
+					require.Contains(t, output.String(), name)
+				}
+			})
+			t.Run("json", func(t *testing.T) {
+				output, err := runScopedCommand(t, clt, append(tc.args, "-f", "json"))
+				require.NoError(t, err)
+				var expectedJSON strings.Builder
+				require.NoError(t, writeJSON(collectExpectedAssignments(tc.expectedAssignmentNames), &expectedJSON))
+				require.Equal(t, expectedJSON.String(), output.String())
+			})
+			t.Run("yaml", func(t *testing.T) {
+				output, err := runScopedCommand(t, clt, append(tc.args, "-f", "yaml"))
+				require.NoError(t, err)
+				var expectedYAML strings.Builder
+				require.NoError(t, writeYAML(collectExpectedAssignments(tc.expectedAssignmentNames), &expectedYAML))
+				require.Equal(t, expectedYAML.String(), output.String())
+			})
+		})
+	}
+}

--- a/tool/tctl/common/scoped_command.go
+++ b/tool/tctl/common/scoped_command.go
@@ -42,53 +42,67 @@ import (
 // ScopedCommand implements scoped variants of tctl command groups, such as
 // `tctl scoped tokens`.
 type ScopedCommand struct {
-	config *servicecfg.Config
-	tokens *ScopedTokensCommand
 	Stdout io.Writer
 
-	status *kingpin.CmdClause
+	status      scopedStatusCommand
+	tokens      ScopedTokensCommand
+	assignments scopedAssignmentsCommand
 }
 
 // Initialize allows ScopedCommand to plug itself into the CLI parser
-func (c *ScopedCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
-	c.config = config
+func (c *ScopedCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, _ *servicecfg.Config) {
 	scoped := app.Command("scoped", "Run a subcommand using scoped auth").Alias("scopes")
 
 	if c.Stdout == nil {
 		c.Stdout = os.Stdout
 	}
 
-	c.tokens = &ScopedTokensCommand{
-		Stdout: c.Stdout,
-	}
-
-	c.tokens.Initialize(scoped, config)
-
-	c.status = scoped.Command("status", "Show the status of scoped resources.")
+	c.status.initialize(scoped, c.Stdout)
+	c.tokens.initialize(scoped, c.Stdout)
+	c.assignments.initialize(scoped, c.Stdout)
 }
 
 // TryRun takes the CLI command as an argument (like "scoped tokens") and executes it.
 func (c *ScopedCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
-	switch cmd {
-	case c.status.FullCommand():
-		commandFunc = c.Status
-	default:
-		// may match the token family of commands
-		return c.tokens.TryRun(ctx, cmd, clientFunc)
+	for _, subCmd := range []RunnableCommand{
+		&c.status,
+		&c.tokens,
+		&c.assignments,
+	} {
+		match, err := subCmd.TryRun(ctx, cmd, clientFunc)
+		if match || err != nil {
+			return match, trace.Wrap(err)
+		}
+	}
+	return false, nil
+}
+
+type scopedStatusCommand struct {
+	stdout io.Writer
+	cmd    *kingpin.CmdClause
+}
+
+func (c *scopedStatusCommand) initialize(parent *kingpin.CmdClause, stdout io.Writer) {
+	c.stdout = stdout
+	c.cmd = parent.Command("status", "Show the status of scoped resources")
+}
+
+func (c *scopedStatusCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
+	if cmd != c.cmd.FullCommand() {
+		return false, nil
 	}
 
 	client, closeFn, err := clientFunc(ctx)
 	if err != nil {
-		return false, trace.Wrap(err)
+		return true, trace.Wrap(err)
 	}
 	defer closeFn(ctx)
 
-	return true, trace.Wrap(commandFunc(ctx, client))
+	return true, trace.Wrap(c.status(ctx, client))
 }
 
-// Status shows the status of scoped resources.
-func (c *ScopedCommand) Status(ctx context.Context, client *authclient.Client) error {
+// status shows the status of scoped resources.
+func (c *scopedStatusCommand) status(ctx context.Context, client *authclient.Client) error {
 	// TODO(fspmarshall/scopes): move the calculation of counts server-side and based on
 	// scoped access cache. Ideally we want to allow for a paginated view of scope stats
 	// with one item/row per scope.  We should also consider how to optionally include
@@ -140,6 +154,6 @@ func (c *ScopedCommand) Status(ctx context.Context, client *authclient.Client) e
 		})
 	}
 
-	fmt.Fprint(c.Stdout, table.AsBuffer().String())
+	fmt.Fprint(c.stdout, table.AsBuffer().String())
 	return nil
 }

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"time"
 
@@ -109,7 +108,6 @@ func (c *ScopedTokensCommand) initialize(scopedCmd *kingpin.CmdClause, stdout io
 		Default(fmt.Sprintf("%v", defaults.ProvisioningTokenTTL)).
 		DurationVar(&c.ttl)
 	c.tokenAdd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
-		Short('f').
 		EnumVar(&c.format, defaults.DefaultFormats...)
 	c.tokenAdd.Flag("assign-scope", "Scope that should be applied to resources provisioned by this token").StringVar(&c.assignedScope)
 	c.tokenAdd.Flag("scope", "Scope assigned to the token itself").StringVar(&c.tokenScope)
@@ -126,10 +124,6 @@ func (c *ScopedTokensCommand) initialize(scopedCmd *kingpin.CmdClause, stdout io
 		Short('f').
 		EnumVar(&c.format, defaults.DefaultFormats...)
 	c.tokenList.Flag("with-secrets", "Do not redact join tokens").BoolVar(&c.withSecrets)
-
-	if c.Stdout == nil {
-		c.Stdout = os.Stdout
-	}
 }
 
 // TryRun attempts to run subcommands like like "scoped tokens ls".

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -44,7 +44,6 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes/joining"
-	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
@@ -52,8 +51,6 @@ import (
 
 // ScopedTokensCommand implements `tctl scoped tokens` group of commands
 type ScopedTokensCommand struct {
-	config *servicecfg.Config
-
 	withSecrets bool
 
 	// format is the output format, e.g. text or json
@@ -98,11 +95,10 @@ type ScopedTokensCommand struct {
 }
 
 // Initialize allows TokenCommand to plug itself into the CLI parser
-func (c *ScopedTokensCommand) Initialize(scopedCmd *kingpin.CmdClause, config *servicecfg.Config) {
-	c.config = config
-	tokens := scopedCmd.Command("tokens", "List or revoke scoped invitation tokens")
+func (c *ScopedTokensCommand) initialize(scopedCmd *kingpin.CmdClause, stdout io.Writer) {
+	c.Stdout = stdout
 
-	formats := []string{teleport.Text, teleport.JSON, teleport.YAML}
+	tokens := scopedCmd.Command("tokens", "List or revoke scoped invitation tokens")
 
 	// tctl scoped tokens add ..."
 	c.tokenAdd = tokens.Command("add", "Create a scoped invitation token.")
@@ -112,7 +108,9 @@ func (c *ScopedTokensCommand) Initialize(scopedCmd *kingpin.CmdClause, config *s
 		int(defaults.ProvisioningTokenTTL/time.Minute))).
 		Default(fmt.Sprintf("%v", defaults.ProvisioningTokenTTL)).
 		DurationVar(&c.ttl)
-	c.tokenAdd.Flag("format", "Output format, 'text', 'json', or 'yaml'").EnumVar(&c.format, formats...)
+	c.tokenAdd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		EnumVar(&c.format, defaults.DefaultFormats...)
 	c.tokenAdd.Flag("assign-scope", "Scope that should be applied to resources provisioned by this token").StringVar(&c.assignedScope)
 	c.tokenAdd.Flag("scope", "Scope assigned to the token itself").StringVar(&c.tokenScope)
 	c.tokenAdd.Flag("mode", "Usage mode of a token (default: unlimited, single_use)").StringVar(&c.mode)
@@ -124,7 +122,9 @@ func (c *ScopedTokensCommand) Initialize(scopedCmd *kingpin.CmdClause, config *s
 
 	// "tctl scoped tokens ls"
 	c.tokenList = tokens.Command("ls", "List invitation tokens.")
-	c.tokenList.Flag("format", "Output format, 'text', 'json' or 'yaml'").EnumVar(&c.format, formats...)
+	c.tokenList.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		EnumVar(&c.format, defaults.DefaultFormats...)
 	c.tokenList.Flag("with-secrets", "Do not redact join tokens").BoolVar(&c.withSecrets)
 
 	if c.Stdout == nil {

--- a/tool/tctl/common/scoped_token_command_test.go
+++ b/tool/tctl/common/scoped_token_command_test.go
@@ -54,11 +54,6 @@ func TestScopedTokens(t *testing.T) {
 		Global: config.Global{
 			DataDir: t.TempDir(),
 		},
-		Proxy: config.Proxy{
-			Service: config.Service{
-				EnabledFlag: "false",
-			},
-		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",

--- a/tool/tctl/common/scoped_token_command_test.go
+++ b/tool/tctl/common/scoped_token_command_test.go
@@ -54,17 +54,10 @@ func TestScopedTokens(t *testing.T) {
 		Global: config.Global{
 			DataDir: t.TempDir(),
 		},
-		Apps: config.Apps{
-			Service: config.Service{
-				EnabledFlag: "true",
-			},
-		},
 		Proxy: config.Proxy{
 			Service: config.Service{
-				EnabledFlag: "true",
+				EnabledFlag: "false",
 			},
-			WebAddr: dynAddr.WebAddr,
-			TunAddr: dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -56,18 +56,20 @@ const (
 	mfaModeEnvVar      = "TELEPORT_MFA_MODE"
 )
 
-// CLICommand interface must be implemented by every CLI command
-//
-// This allows OSS and Enterprise Teleport editions to plug their own
-// implementations of different CLI commands into the common execution
-// framework
+// CLICommand is an interface that must be implemented by every top-level CLI command.
 type CLICommand interface {
 	// Initialize allows a caller-defined command to plug itself into CLI
 	// argument parsing
 	Initialize(*kingpin.Application, *tctlcfg.GlobalCLIFlags, *servicecfg.Config)
 
-	// TryRun is executed after the CLI parsing is done. The command must
-	// determine if selectedCommand belongs to it and return match=true
+	RunnableCommand
+}
+
+// RunnableCommand is an interface for runnable CLI commands.
+type RunnableCommand interface {
+	// TryRun will be called after CLI parsing is done. The implementation
+	// must determine if cmd belongs to it. If so, it should run the command
+	// and return (true, err). If it does not match cmd, it must return (false, nil).
 	TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error)
 }
 


### PR DESCRIPTION
This commit adds a new command `tctl scoped assignments list` that lists scoped role assignments and accepts the following params:
- `--user` filters assignments by the user they assign to
- `--role` filters assignments by assigned role
- `--format` prints text, json, or yaml

## Manual Test Plan
### Test Environment

A cluster with `TELEPORT_UNSTABLE_SCOPES=yes`.

Some scoped role assignments:

```bash
$ cat resources.yaml
---
kind: scoped_role_assignment
sub_kind: dynamic
scope: /test
spec:
  user: alice
  assignments:
    - role: eng-access
      scope: /test/eng
version: v1
---
kind: scoped_role_assignment
sub_kind: dynamic
scope: /test
spec:
  user: bob
  assignments:
    - role: eng-access
      scope: /test/eng
version: v1
---
kind: scoped_role_assignment
sub_kind: dynamic
scope: /test
spec:
  user: charlie
  assignments:
    - role: hacker-access
      scope: /test/hacker
version: v1
$ tctl create -f ./resources.yaml
scoped_role_assignment "14470ba5-d78e-432d-b91c-b75e4307970f" has been created
scoped_role_assignment "fbcdbe80-3c59-4057-8303-c16307c12b91" has been created
scoped_role_assignment "5aa2d27d-95ee-4f93-99c6-9a58bc8a610d" has been created
```

### Test Cases
- [x] `tctl scoped assignments ls` lists all assignments
- [x] `tctl scoped assignments ls --user alice` filters by user
- [x] `tctl scoped assignments ls --role eng-access` filters by role
- [x] `--format` can select yaml or json output
