### PR TITLE
Run e2e canonical-key parity and runner Go tests in CI

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -97,6 +97,9 @@ jobs:
       - name: Type-check e2e tests
         run: pnpm --filter=@gravitational/e2e type-check
 
+      - name: Verify canonical key parity (TS)
+        run: pnpm --filter=@gravitational/e2e test:canonical-key
+
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
@@ -109,6 +112,10 @@ jobs:
           path: ${{ steps.cache-paths.outputs.go-mod }}
           key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
           restore-keys: go-mod-${{ runner.os }}-
+
+      - name: Test e2e runner (Go)
+        working-directory: e2e/runner
+        run: go test ./...
 
       - name: Check generated files are up to date
         working-directory: e2e/runner


### PR DESCRIPTION
Requires #66179

Adds two CI steps to the e2e workflow so the Go scanner / TS canonical-key helper stay in sync, and the e2e runner's unit tests guard regressions in fixture scanning, user/role bootstrap, and recording seeding.