### PR TITLE
ratelimit: Replace custom token bucket with golang.org/x/time/rate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -393,6 +393,12 @@ linters:
         - pattern: ^ssh\.(Dial|NewClientWithTimeout|NewClientConnWithTimeout)$
           pkg: ^github\.com/gravitational/teleport/api/observability/tracing/ssh$
           msg: Use api/ssh package to construct SSH clients with proper defaults
+        - pattern: ^rate\.Limiter\.(Allow|Reserve|Wait|WaitN|Tokens|SetLimit|SetBurst)$
+          pkg: ^golang\.org/x/time/rate$
+          msg: use explicit-time rate.Limiter APIs so clockwork.Clock is respected
+        - pattern: ^rate\.Reservation\.Cancel$
+          pkg: ^golang\.org/x/time/rate$
+          msg: use explicit-time rate.Reservation APIs so clockwork.Clock is respected
       analyze-types: true
     misspell:
       locale: US
@@ -563,6 +569,14 @@ linters:
           - forbidigo
         path: ^api/ssh/
         text: tracessh.NewClientConnWithTimeout
+
+      # Ban system-clock x/time/rate APIs in the ratelimit package.
+      # The ratelimit package uses clockwork.Clock, so it must call the
+      # explicit-time APIs.
+      - linters:
+          - forbidigo
+        path-except: ^lib/limiter/internal/ratelimit/
+        text: explicit-time rate
 
       # TODO: Fix forced type assertions in the rest of the codebase and remove this exclusion so that the linter can
       # enforce this rule everywhere.

--- a/lib/limiter/internal/ratelimit/bucket.go
+++ b/lib/limiter/internal/ratelimit/bucket.go
@@ -1,0 +1,101 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ratelimit
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	xrate "golang.org/x/time/rate"
+)
+
+// bucket is a rate.Limiter-backed token bucket.
+type bucket struct {
+	burst   int64
+	clock   clockwork.Clock
+	limiter *xrate.Limiter
+}
+
+// newBucket builds a bucket that matches the configured rate.
+func newBucket(r *rate, clock clockwork.Clock) *bucket {
+	return &bucket{
+		burst:   r.burst,
+		clock:   clock,
+		limiter: xrate.NewLimiter(limitFromRate(r), int(r.burst)),
+	}
+}
+
+// limitFromRate maps Teleport's (period, average) pair to
+// rate.Limit (events/second).
+func limitFromRate(r *rate) xrate.Limit {
+	return xrate.Limit(float64(r.average) / r.period.Seconds())
+}
+
+// peek checks n tokens at now without consuming them. Multi-bucket
+// sets use it to avoid consuming from any bucket until all buckets can
+// consume. Returns:
+//   - (UndefinedDelay, error) when n exceeds the bucket's burst
+//   - (delay, nil) when n tokens are not yet available
+//   - (0, nil) when n tokens are available
+func (b *bucket) peek(n int64, now time.Time) (time.Duration, error) {
+	if n > b.burst {
+		return UndefinedDelay, fmt.Errorf("requested tokens larger than max tokens")
+	}
+	return b.durationUntilAvailable(n, now)
+}
+
+// consume consumes n tokens if they are available.
+func (b *bucket) consume(n int64, now time.Time) (time.Duration, error) {
+	if n > b.burst {
+		return UndefinedDelay, fmt.Errorf("requested tokens larger than max tokens")
+	}
+	if b.limiter.AllowN(now, int(n)) {
+		return 0, nil
+	}
+	return b.durationUntilAvailable(n, now)
+}
+
+// update changes the bucket's rate.
+func (b *bucket) update(r *rate) {
+	now := b.clock.Now().UTC()
+	b.limiter.SetLimitAt(now, limitFromRate(r))
+	b.limiter.SetBurstAt(now, int(r.burst))
+	b.burst = r.burst
+}
+
+// isLimited reports whether the bucket has no tokens.
+func (b *bucket) isLimited() bool {
+	return b.limiter.TokensAt(b.clock.Now().UTC()) < 1.0
+}
+
+// durationUntilAvailable returns the delay before n tokens can be consumed.
+func (b *bucket) durationUntilAvailable(n int64, now time.Time) (time.Duration, error) {
+	available := b.limiter.TokensAt(now)
+	if available >= float64(n) {
+		return 0, nil
+	}
+	limit := b.limiter.Limit()
+	if limit <= 0 {
+		// RateSet.Add rejects average <= 0, so this is defensive.
+		return UndefinedDelay, fmt.Errorf("rate limit is non-positive")
+	}
+	delay := time.Duration((float64(n) - available) / float64(limit) * float64(time.Second))
+	return max(delay, time.Nanosecond), nil
+}

--- a/lib/limiter/internal/ratelimit/bucket.go
+++ b/lib/limiter/internal/ratelimit/bucket.go
@@ -19,9 +19,10 @@
 package ratelimit
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	xrate "golang.org/x/time/rate"
 )
@@ -56,7 +57,7 @@ func limitFromRate(r *rate) xrate.Limit {
 //   - (0, nil) when n tokens are available
 func (b *bucket) peek(n int64, now time.Time) (time.Duration, error) {
 	if n > b.burst {
-		return UndefinedDelay, fmt.Errorf("requested tokens larger than max tokens")
+		return UndefinedDelay, trace.LimitExceeded("requested tokens larger than max tokens")
 	}
 	return b.durationUntilAvailable(n, now)
 }
@@ -64,7 +65,7 @@ func (b *bucket) peek(n int64, now time.Time) (time.Duration, error) {
 // consume consumes n tokens if they are available.
 func (b *bucket) consume(n int64, now time.Time) (time.Duration, error) {
 	if n > b.burst {
-		return UndefinedDelay, fmt.Errorf("requested tokens larger than max tokens")
+		return UndefinedDelay, trace.LimitExceeded("requested tokens larger than max tokens")
 	}
 	if b.limiter.AllowN(now, int(n)) {
 		return 0, nil
@@ -74,7 +75,7 @@ func (b *bucket) consume(n int64, now time.Time) (time.Duration, error) {
 
 // update changes the bucket's rate.
 func (b *bucket) update(r *rate) {
-	now := b.clock.Now().UTC()
+	now := b.clock.Now()
 	b.limiter.SetLimitAt(now, limitFromRate(r))
 	b.limiter.SetBurstAt(now, int(r.burst))
 	b.burst = r.burst
@@ -82,7 +83,7 @@ func (b *bucket) update(r *rate) {
 
 // isLimited reports whether the bucket has no tokens.
 func (b *bucket) isLimited() bool {
-	return b.limiter.TokensAt(b.clock.Now().UTC()) < 1.0
+	return b.limiter.TokensAt(b.clock.Now()) < 1.0
 }
 
 // durationUntilAvailable returns the delay before n tokens can be consumed.
@@ -94,7 +95,7 @@ func (b *bucket) durationUntilAvailable(n int64, now time.Time) (time.Duration, 
 	limit := b.limiter.Limit()
 	if limit <= 0 {
 		// RateSet.Add rejects average <= 0, so this is defensive.
-		return UndefinedDelay, fmt.Errorf("rate limit is non-positive")
+		return UndefinedDelay, errors.New("rate limit is non-positive")
 	}
 	delay := time.Duration((float64(n) - available) / float64(limit) * float64(time.Second))
 	return max(delay, time.Nanosecond), nil

--- a/lib/limiter/internal/ratelimit/http_test.go
+++ b/lib/limiter/internal/ratelimit/http_test.go
@@ -1,0 +1,65 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServeHTTP_RetryAfter(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t, rateSpec{period: 10 * time.Second, average: 1, burst: 1})
+	clock := clockwork.NewFakeClock()
+	tl, err := New(TokenLimiterConfig{Rates: rates, Clock: clock})
+	require.NoError(t, err)
+	tl.Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	doRequest := func() *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "127.0.0.1:9999"
+		w := httptest.NewRecorder()
+		tl.ServeHTTP(w, req)
+		return w
+	}
+
+	first := doRequest()
+	require.Equal(t, http.StatusOK, first.Code)
+
+	second := doRequest()
+	require.Equal(t, http.StatusTooManyRequests, second.Code)
+	require.Equal(t, "11", second.Header().Get("Retry-After"))
+
+	clock.Advance(5 * time.Second)
+	third := doRequest()
+	require.Equal(t, http.StatusTooManyRequests, third.Code)
+	require.Equal(t, "6", third.Header().Get("Retry-After"))
+
+	clock.Advance(5 * time.Second)
+	fourth := doRequest()
+	require.Equal(t, http.StatusOK, fourth.Code)
+}

--- a/lib/limiter/internal/ratelimit/ratelimit.go
+++ b/lib/limiter/internal/ratelimit/ratelimit.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"sync"
 	"time"
@@ -170,6 +171,12 @@ func NewRateSet() *RateSet {
 
 // Add adds a rate to the set. If there is a rate with the same period in the
 // set then the new rate overrides the old one.
+//
+// `burst` is rejected above math.MaxInt32. The bucket implementation
+// passes burst to rate.NewLimiter as `int`, which is platform-
+// dependent: on 32-bit ARM (which Teleport ships) values larger than
+// math.MaxInt32 silently truncate. Reject at config time so behavior
+// is identical on every platform.
 func (rs *RateSet) Add(period time.Duration, average int64, burst int64) error {
 	if period <= 0 {
 		return trace.BadParameter("Invalid period: %v", period)
@@ -179,6 +186,9 @@ func (rs *RateSet) Add(period time.Duration, average int64, burst int64) error {
 	}
 	if burst <= 0 {
 		return trace.BadParameter("Invalid burst: %v", burst)
+	}
+	if burst > math.MaxInt32 {
+		return trace.BadParameter("Invalid burst: %v exceeds math.MaxInt32", burst)
 	}
 	rs.m[period] = &rate{period, average, burst}
 	return nil

--- a/lib/limiter/internal/ratelimit/tokenbucket.go
+++ b/lib/limiter/internal/ratelimit/tokenbucket.go
@@ -88,7 +88,7 @@ func (tbs *TokenBucketSet) IsRateLimited() bool {
 // how much time the caller needs to wait until the desired number of tokens
 // will become available for consumption.
 func (tbs *TokenBucketSet) Consume(tokens int64) (time.Duration, error) {
-	now := tbs.clock.Now().UTC()
+	now := tbs.clock.Now()
 	if len(tbs.buckets) == 1 {
 		// Fast path. Range over a single-element map costs the same
 		// as a struct field access in practice.

--- a/lib/limiter/internal/ratelimit/tokenbucket.go
+++ b/lib/limiter/internal/ratelimit/tokenbucket.go
@@ -16,16 +16,18 @@ package ratelimit
 
 import (
 	"cmp"
-	"fmt"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 )
 
+// UndefinedDelay is the sentinel returned from Consume when the
+// requested token count exceeds the bucket's burst.
+const UndefinedDelay = -1
+
 // TokenBucketSet represents a set of buckets covering different time periods.
 type TokenBucketSet struct {
-	buckets   map[time.Duration]*tokenBucket
+	buckets   map[time.Duration]*bucket
 	maxPeriod time.Duration
 	clock     clockwork.Clock
 }
@@ -34,13 +36,12 @@ type TokenBucketSet struct {
 func NewTokenBucketSet(rates *RateSet, clock clockwork.Clock) *TokenBucketSet {
 	tbs := &TokenBucketSet{
 		// In the majority of cases we will have only one bucket.
-		buckets: make(map[time.Duration]*tokenBucket, len(rates.m)),
+		buckets: make(map[time.Duration]*bucket, len(rates.m)),
 		clock:   clock,
 	}
 
 	for _, rate := range rates.m {
-		newBucket := newTokenBucket(rate, clock)
-		tbs.buckets[rate.period] = newBucket
+		tbs.buckets[rate.period] = newBucket(rate, clock)
 		tbs.maxPeriod = max(tbs.maxPeriod, rate.period)
 	}
 	return tbs
@@ -49,33 +50,31 @@ func NewTokenBucketSet(rates *RateSet, clock clockwork.Clock) *TokenBucketSet {
 // Update brings the buckets in the set in accordance with the provided rates.
 func (tbs *TokenBucketSet) Update(rates *RateSet) {
 	// Update existing buckets and delete those that have no corresponding spec.
-	for _, bucket := range tbs.buckets {
-		if rate, ok := rates.m[bucket.period]; ok {
+	for period, bucket := range tbs.buckets {
+		if rate, ok := rates.m[period]; ok {
 			bucket.update(rate)
 		} else {
-			delete(tbs.buckets, bucket.period)
+			delete(tbs.buckets, period)
 		}
 	}
 	// Add missing buckets.
 	for _, rate := range rates.m {
 		if _, ok := tbs.buckets[rate.period]; !ok {
-			newBucket := newTokenBucket(rate, tbs.clock)
-			tbs.buckets[rate.period] = newBucket
+			tbs.buckets[rate.period] = newBucket(rate, tbs.clock)
 		}
 	}
-	// Identify the maximum period in the set
+	// Identify the maximum period in the set.
 	tbs.maxPeriod = 0
-	for _, bucket := range tbs.buckets {
-		tbs.maxPeriod = max(tbs.maxPeriod, bucket.period)
+	for period := range tbs.buckets {
+		tbs.maxPeriod = max(tbs.maxPeriod, period)
 	}
 }
 
 // IsRateLimited checks if the bucket is currently rate-limited (no tokens available)
 // without actually consuming any tokens. Returns true if rate-limited, false otherwise.
 func (tbs *TokenBucketSet) IsRateLimited() bool {
-	for _, tokenBucket := range tbs.buckets {
-		tokenBucket.updateAvailableTokens()
-		if tokenBucket.availableTokens < 1 {
+	for _, bucket := range tbs.buckets {
+		if bucket.isLimited() {
 			return true
 		}
 	}
@@ -89,135 +88,40 @@ func (tbs *TokenBucketSet) IsRateLimited() bool {
 // how much time the caller needs to wait until the desired number of tokens
 // will become available for consumption.
 func (tbs *TokenBucketSet) Consume(tokens int64) (time.Duration, error) {
+	now := tbs.clock.Now().UTC()
+	if len(tbs.buckets) == 1 {
+		// Fast path. Range over a single-element map costs the same
+		// as a struct field access in practice.
+		for _, bucket := range tbs.buckets {
+			return bucket.consume(tokens, now)
+		}
+	}
+	// Multi-bucket path: peek every bucket at the same `now`. Only
+	// consume if all peeks succeeded.
 	var maxDelay time.Duration = UndefinedDelay
-	var firstErr error = nil
-	for _, tokenBucket := range tbs.buckets {
-		// We keep calling Consume even after a error is returned for one of
-		// buckets because that allows us to simplify the rollback procedure,
-		// that is to just call Rollback for all buckets.
-		delay, err := tokenBucket.consume(tokens)
-		if firstErr == nil {
-			if err != nil {
-				firstErr = err
-			} else {
-				maxDelay = max(maxDelay, delay)
-			}
+	var firstErr error
+	for _, bucket := range tbs.buckets {
+		delay, err := bucket.peek(tokens, now)
+		firstErr = cmp.Or(firstErr, err)
+		maxDelay = max(maxDelay, delay)
+	}
+	if firstErr != nil {
+		return UndefinedDelay, firstErr
+	}
+	if maxDelay > 0 {
+		return maxDelay, nil
+	}
+	for _, bucket := range tbs.buckets {
+		delay, err := bucket.consume(tokens, now)
+		if delay > 0 || err != nil {
+			return delay, err
 		}
 	}
-	// If we could not make ALL buckets consume tokens for whatever reason,
-	// then rollback consumption for all of them.
-	if firstErr != nil || maxDelay > 0 {
-		for _, tokenBucket := range tbs.buckets {
-			tokenBucket.rollback()
-		}
-	}
-	return maxDelay, firstErr
-}
-
-func (tbs *TokenBucketSet) GetMaxPeriod() time.Duration {
-	return tbs.maxPeriod
-}
-
-// tokenBucket implements the token bucket algorithm.
-type tokenBucket struct {
-	// The time period controlled by the bucket.
-	period time.Duration
-	// The amount of time that it takes to add one more token to the total
-	// number of available tokens. It effectively caches the value that could
-	// have been otherwise deduced from refillRate.
-	timePerToken time.Duration
-	// The maximum number of tokens that can be accumulate in the bucket.
-	burst int64
-	// The number of tokens available for consumption at the moment. It can
-	// never be larger than burst.
-	availableTokens int64
-
-	clock        clockwork.Clock
-	lastRefresh  time.Time
-	lastConsumed int64
-}
-
-// newTokenBucket creates a tokenBucket instance for the specified rate.
-func newTokenBucket(rate *rate, clock clockwork.Clock) *tokenBucket {
-	period := cmp.Or(rate.period, time.Nanosecond)
-	return &tokenBucket{
-		period:          period,
-		timePerToken:    time.Duration(int64(period) / rate.average),
-		burst:           rate.burst,
-		clock:           clock,
-		lastRefresh:     clock.Now().UTC(),
-		availableTokens: rate.burst,
-	}
-}
-
-const UndefinedDelay = -1
-
-func (tb *tokenBucket) consume(tokens int64) (time.Duration, error) {
-	tb.updateAvailableTokens()
-	tb.lastConsumed = 0
-	if tokens > tb.burst {
-		return UndefinedDelay, fmt.Errorf("requested tokens larger than max tokens")
-	}
-	if tb.availableTokens < tokens {
-		return tb.timeUntilAvailable(tokens), nil
-	}
-	tb.availableTokens -= tokens
-	tb.lastConsumed = tokens
 	return 0, nil
 }
 
-// rollback reverts effect of the most recent consumption. If the most recent
-// consume resulted in an error or a burst overflow, and therefore did not
-// modify the number of available tokens, then rollback won't do that either.
-// It is safe to call this method multiple times, for the second and all
-// following calls have no effect.
-func (tb *tokenBucket) rollback() {
-	tb.availableTokens += tb.lastConsumed
-	tb.lastConsumed = 0
-}
-
-// Update modifies average and burst fields of the token bucket according
-// to the provided rate.
-func (tb *tokenBucket) update(rate *rate) error {
-	if rate.period != tb.period {
-		return trace.BadParameter("Period mismatch: %v != %v", tb.period, rate.period)
-	}
-	tb.timePerToken = time.Duration(int64(tb.period) / rate.average)
-	tb.burst = rate.burst
-	if tb.availableTokens > rate.burst {
-		tb.availableTokens = rate.burst
-	}
-	return nil
-}
-
-// timeUntilAvailable returns the amount of time that we need to
-// wait until the specified number of tokens becomes available for consumption.
-func (tb *tokenBucket) timeUntilAvailable(tokens int64) time.Duration {
-	missingTokens := tokens - tb.availableTokens
-	return time.Duration(missingTokens) * tb.timePerToken
-}
-
-// updateAvailableTokens updates the number of tokens available for consumption.
-// It is calculated based on the refill rate, the time passed since last refresh,
-// and is limited by the bucket capacity.
-func (tb *tokenBucket) updateAvailableTokens() {
-	if tb.timePerToken == 0 {
-		return
-	}
-
-	now := tb.clock.Now().UTC()
-	timePassed := now.Sub(tb.lastRefresh)
-
-	tokens := tb.availableTokens + int64(timePassed/tb.timePerToken)
-
-	// If we haven't added any tokens that means that not enough time has passed,
-	// in this case do not adjust last refill checkpoint, otherwise it will be
-	// always moving in time in case of frequent requests that exceed the rate
-	if tokens != tb.availableTokens {
-		tb.lastRefresh = now
-		tb.availableTokens = tokens
-	}
-	if tb.availableTokens > tb.burst {
-		tb.availableTokens = tb.burst
-	}
+// GetMaxPeriod returns the longest period across all buckets in the
+// set, or zero if the set is empty.
+func (tbs *TokenBucketSet) GetMaxPeriod() time.Duration {
+	return tbs.maxPeriod
 }

--- a/lib/limiter/internal/ratelimit/tokenbucket_test.go
+++ b/lib/limiter/internal/ratelimit/tokenbucket_test.go
@@ -1,0 +1,269 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ratelimit
+
+import (
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func mustRates(t *testing.T, specs ...rateSpec) *RateSet {
+	t.Helper()
+	rates := NewRateSet()
+	for _, s := range specs {
+		require.NoError(t, rates.Add(s.period, s.average, s.burst))
+	}
+	return rates
+}
+
+type rateSpec struct {
+	period  time.Duration
+	average int64
+	burst   int64
+}
+
+func newTestTokenBucketSet(t *testing.T, rates *RateSet) (*TokenBucketSet, *clockwork.FakeClock) {
+	t.Helper()
+	clock := clockwork.NewFakeClock()
+	return NewTokenBucketSet(rates, clock), clock
+}
+
+func requireConsumeOK(t *testing.T, set *TokenBucketSet, n int64) {
+	t.Helper()
+	delay, err := set.Consume(n)
+	require.NoError(t, err)
+	require.Zero(t, delay)
+}
+
+func requireConsumeDelayed(t *testing.T, set *TokenBucketSet, n int64, wantDelay time.Duration) {
+	t.Helper()
+	delay, err := set.Consume(n)
+	require.NoError(t, err)
+	require.Equal(t, wantDelay, delay)
+}
+
+func requireConsumeBurstOverflow(t *testing.T, set *TokenBucketSet, n int64) {
+	t.Helper()
+	delay, err := set.Consume(n)
+	require.Error(t, err)
+	require.Equal(t, time.Duration(UndefinedDelay), delay)
+}
+
+func TestTokenBucketSet_AllBurstThenRefill(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t, rateSpec{period: time.Second, average: 5, burst: 10})
+	set, clock := newTestTokenBucketSet(t, rates)
+
+	requireConsumeOK(t, set, 10)
+	requireConsumeDelayed(t, set, 1, 200*time.Millisecond)
+	clock.Advance(time.Second)
+	requireConsumeOK(t, set, 5)
+	requireConsumeDelayed(t, set, 1, 200*time.Millisecond)
+}
+
+func TestTokenBucketSet_RefillSubTimePerToken(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t, rateSpec{period: time.Second, average: 10, burst: 10})
+	set, clock := newTestTokenBucketSet(t, rates)
+
+	requireConsumeOK(t, set, 10)
+	clock.Advance(40 * time.Millisecond)
+	requireConsumeDelayed(t, set, 1, 60*time.Millisecond)
+	clock.Advance(60 * time.Millisecond)
+	requireConsumeOK(t, set, 1)
+}
+
+func TestTokenBucketSet_FractionalRefillCanPermitEarlierConsume(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t, rateSpec{period: time.Second, average: 2, burst: 2})
+	set, clock := newTestTokenBucketSet(t, rates)
+
+	requireConsumeOK(t, set, 2)
+	clock.Advance(750 * time.Millisecond)
+	requireConsumeOK(t, set, 1)
+	clock.Advance(250 * time.Millisecond)
+	requireConsumeOK(t, set, 1)
+	requireConsumeDelayed(t, set, 1, 500*time.Millisecond)
+}
+
+func TestTokenBucketSet_BurstOverflowDoesNotConsume(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t, rateSpec{period: time.Second, average: 10, burst: 10})
+	set, _ := newTestTokenBucketSet(t, rates)
+
+	requireConsumeBurstOverflow(t, set, 11)
+	requireConsumeOK(t, set, 10)
+}
+
+func TestTokenBucketSet_BurstIncrease(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t, rateSpec{period: time.Second, average: 10, burst: 10})
+	set, clock := newTestTokenBucketSet(t, rates)
+
+	requireConsumeOK(t, set, 5)
+	biggerRates := mustRates(t, rateSpec{period: time.Second, average: 10, burst: 20})
+	set.Update(biggerRates)
+	requireConsumeOK(t, set, 5)
+	requireConsumeDelayed(t, set, 1, 100*time.Millisecond)
+	clock.Advance(2 * time.Second)
+	requireConsumeOK(t, set, 20)
+}
+
+func TestTokenBucketSet_BurstDecrease(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t, rateSpec{period: time.Second, average: 100, burst: 100})
+	set, clock := newTestTokenBucketSet(t, rates)
+
+	smallerRates := mustRates(t, rateSpec{period: time.Second, average: 100, burst: 1})
+	set.Update(smallerRates)
+	requireConsumeBurstOverflow(t, set, 2)
+	requireConsumeOK(t, set, 1)
+	requireConsumeDelayed(t, set, 1, 10*time.Millisecond)
+	clock.Advance(time.Second)
+	requireConsumeBurstOverflow(t, set, 2)
+	requireConsumeOK(t, set, 1)
+}
+
+func TestTokenBucketSet_UpdateAccruesElapsedTimeAtPreviousRate(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t, rateSpec{period: time.Second, average: 1, burst: 10})
+	set, clock := newTestTokenBucketSet(t, rates)
+
+	requireConsumeOK(t, set, 10)
+	clock.Advance(time.Second)
+
+	fasterRates := mustRates(t, rateSpec{period: time.Second, average: 10, burst: 10})
+	set.Update(fasterRates)
+
+	requireConsumeOK(t, set, 1)
+	requireConsumeDelayed(t, set, 1, 100*time.Millisecond)
+}
+
+func TestTokenBucketSet_UpdateWithNewPeriod(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t, rateSpec{period: time.Second, average: 10, burst: 10})
+	set, _ := newTestTokenBucketSet(t, rates)
+
+	requireConsumeOK(t, set, 10)
+	newPeriodRates := mustRates(t, rateSpec{period: time.Minute, average: 5, burst: 5})
+	set.Update(newPeriodRates)
+	requireConsumeOK(t, set, 5)
+	requireConsumeDelayed(t, set, 1, 12*time.Second)
+}
+
+func TestTokenBucketSet_EmptySet(t *testing.T) {
+	t.Parallel()
+	set, _ := newTestTokenBucketSet(t, NewRateSet())
+	delay, err := set.Consume(5)
+	require.NoError(t, err)
+	require.LessOrEqual(t, int64(delay), int64(0))
+	require.False(t, set.IsRateLimited())
+}
+
+func TestTokenBucketSet_MultiPeriodSet(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t,
+		rateSpec{period: 10 * time.Millisecond, average: 10, burst: 20}, // B1, 10 tokens / 10ms.
+		rateSpec{period: 40 * time.Millisecond, average: 10, burst: 40}, // B2, 2.5 tokens / 10ms.
+	)
+	set, clock := newTestTokenBucketSet(t, rates)
+
+	requireConsumeOK(t, set, 20) // B1: 0, B2: 20.
+	requireConsumeDelayed(t, set, 1, time.Millisecond)
+
+	clock.Advance(10 * time.Millisecond) // B1: 10, B2: 22.5.
+	requireConsumeOK(t, set, 10)         // B1: 0, B2: 12.5.
+	requireConsumeDelayed(t, set, 1, time.Millisecond)
+
+	clock.Advance(10 * time.Millisecond) // B1: 10, B2: 15.
+	requireConsumeOK(t, set, 10)         // B1: 0, B2: 5.
+
+	clock.Advance(10 * time.Millisecond) // B1: 10, B2: 7.5.
+	requireConsumeOK(t, set, 7)          // B1: 3, B2: 0.5.
+	requireConsumeDelayed(t, set, 1, 2*time.Millisecond)
+}
+
+func TestTokenBucketSet_UpdateNoOp(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t, rateSpec{period: time.Second, average: 100, burst: 100})
+	set, clock := newTestTokenBucketSet(t, rates)
+
+	requireConsumeOK(t, set, 99)
+
+	for range 3 {
+		clock.Advance(10 * time.Millisecond)
+		set.Update(rates)
+		set.Update(rates)
+	}
+
+	requireConsumeOK(t, set, 4)
+	requireConsumeDelayed(t, set, 1, 10*time.Millisecond)
+}
+
+// These configs exercise token intervals that do not divide cleanly into
+// common wall-clock durations, while still refilling to full burst after one
+// configured period.
+func TestTokenBucketSet_FractionalRefillConfigs(t *testing.T) {
+	t.Parallel()
+	configs := []rateSpec{
+		{period: 10 * time.Millisecond, average: 3, burst: 3},
+		{period: 7 * time.Millisecond, average: 11, burst: 11},
+		{period: time.Millisecond, average: 1, burst: 1},
+	}
+	for _, spec := range configs {
+		t.Run(spec.period.String()+"-"+strconv.FormatInt(spec.average, 10), func(t *testing.T) {
+			t.Parallel()
+			rates := mustRates(t, spec)
+			set, clock := newTestTokenBucketSet(t, rates)
+
+			requireConsumeOK(t, set, spec.burst)
+			requireConsumeDelayed(t, set, 1, spec.period/time.Duration(spec.average))
+			clock.Advance(spec.period)
+			requireConsumeOK(t, set, spec.burst)
+			requireConsumeDelayed(t, set, 1, spec.period/time.Duration(spec.average))
+		})
+	}
+}
+
+func TestTokenBucketSet_MultiPeriodBurstOverflowDoesNotConsume(t *testing.T) {
+	t.Parallel()
+	rates := mustRates(t,
+		rateSpec{period: time.Millisecond, average: 1, burst: 1},
+		rateSpec{period: time.Second, average: 10000, burst: 10000},
+	)
+	set, _ := newTestTokenBucketSet(t, rates)
+
+	requireConsumeBurstOverflow(t, set, 2)
+	requireConsumeOK(t, set, 1)
+	requireConsumeDelayed(t, set, 1, time.Millisecond)
+}
+
+func TestRateSet_Add_RejectsBurstOverInt32(t *testing.T) {
+	t.Parallel()
+	rs := NewRateSet()
+
+	require.NoError(t, rs.Add(time.Second, 1, math.MaxInt32))
+	require.Error(t, rs.Add(time.Second, 1, math.MaxInt32+1))
+	require.Error(t, rs.Add(time.Second, 1, math.MaxInt64))
+}


### PR DESCRIPTION
Replace the custom `tokenBucket` implementation in
`lib/limiter/internal/ratelimit/` with the standard
`golang.org/x/time/rate.Limiter`. The public `lib/limiter` API and
configurations remain unchanged.

This change balances compatibility and simplicity: it keeps the existing
`TokenBucketSet` wrapper and `clockwork.Clock` discipline, but uses
`rate.Limiter`'s native token accounting instead of emulating every legacy
rounding edge. The new standard limiter uses fractional tokens instead of whole
tokens. `Retry-After` now reports exact wait times rather than rounding up to
full token periods. The `TokenBucketSet` wrapper is preserved to support
existing `FnCache` type assertions. The rate-limited path is ~20% slower per
micro-benchmark due to an internal `sync.Mutex` in `rate.Limiter`. However, the
existing noop paths are unaffected, and this difference is negligible compared
to standard TCP/TLS round-trip times.

Follow-up Tasks:

- Optimize `RateLimiter` by using a direct `*bucket` field for single-period
  call sites (to recover the benchmark delta).
- Remove redundant outer locking (`TokenLimiter.mutex`).

## Manual Test Plan

### Test Environment

macOS, single-process Teleport (auth + proxy), enterprise build.
`connection_limits.rates` configured with a single period to exercise
the swapped primitive on the HTTP and gRPC paths.

```yaml
teleport:
  connection_limits:
    rates:
      - period: 10s
        average: 1
        burst: 5
```

The global `teleport.connection_limits` applies to all services (auth,
proxy, SSH, db, kube, windows, app), so the same config exercises both
the HTTP path on the proxy and the gRPC path on auth.

### Test Cases

#### Test 1: HTTP burst then rate-limit (with fix)

Send 10 unauthenticated requests to the proxy web endpoint from a
single client IP in quick succession.

- [x] First 5 requests return 200 / normal status (burst).
- [x] Remaining 5 requests return 429 with `Retry-After` set.

#### Test 2: Retry-After reflects partial refill (with fix)

After tripping the limiter in Test 1, wait 5 seconds (half of
`period`), then send one more request.

- [x] Response has `Retry-After: 6` (or similar fractional value), not
  `Retry-After: 11`.

#### Test 3: HTTP refill (with fix)

Wait at least `5 * period` (50s) after Test 1, then send 5 requests.
The configured rate is `average / period = 0.1 tok/s`, so refilling
the full `burst=5` takes 50s, not one period.

- [x] All 5 succeed (bucket has refilled to full burst).

#### Test 4: Multi-IP isolation (with fix)

From a second source IP (`127.0.0.2` via `ifconfig lo0 alias`), send 5
requests while IP 1's bucket is exhausted.

- [x] All 5 from the second IP succeed (per-IP buckets are
  independent).

#### Test 5: Regression baseline (without fix)

Build from master (before the swap) and repeat Test 2.

- [x] `Retry-After` reports the full `period` (`11`) regardless of how
  much time has passed since exhaustion. This is the legacy behaviour
  the new implementation replaces.
