### PR TITLE
Add needrestart exception for the session helper

### DIFF
--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -300,6 +300,10 @@ if [[ "${PACKAGE_TYPE}" != "pkg" ]]; then
         mv -v ${LINUX_CONFIG_FILE} ${PACKAGE_TEMPDIR}/buildroot${LINUX_CONFIG_DIR}
         CONFIG_FILE_STANZA="--config-files /src/buildroot${LINUX_CONFIG_DIR}/${LINUX_CONFIG_FILE} "
     fi
+    if [[ "${PACKAGE_TYPE}" == "deb" ]]; then
+        mkdir -p ${PACKAGE_TEMPDIR}/buildroot/etc/needrestart/conf.d
+        printf '# necessary for needrestart before 3.9\npush(@{$nrconf{blacklist}}, qr(^/memfd:teleport-));\n' > ${PACKAGE_TEMPDIR}/buildroot/etc/needrestart/conf.d/teleport.conf
+    fi
 
     # include post-install and before-remove script
     mv -v ${TAR_PATH}/examples/systemd/post-install ${PACKAGE_TEMPDIR}

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -302,6 +302,7 @@ if [[ "${PACKAGE_TYPE}" != "pkg" ]]; then
     fi
     if [[ "${PACKAGE_TYPE}" == "deb" ]]; then
         mkdir -p ${PACKAGE_TEMPDIR}/buildroot/etc/needrestart/conf.d
+        # shellcheck disable=SC2016 # the single quotes are deliberate, we don't expect variable expansion on $nrconf
         printf '# necessary for needrestart before 3.9\npush(@{$nrconf{blacklist}}, qr(^/memfd:teleport-));\n' > ${PACKAGE_TEMPDIR}/buildroot/etc/needrestart/conf.d/teleport.conf
     fi
 


### PR DESCRIPTION
Each SSH connection uses an instance of `teleport exec` for each session and potentially a single `teleport networking` instance. When using the embedded session helper, those processes use a memfd as their executable.

Debian-like distros including Ubuntu use a program called [`needrestart`](https://github.com/liske/needrestart) that runs as a trigger after any `apt` operation, which finds any systemd service that might need to be restarted in order to pick up updated files from disk. Unfortunately, due to liske/needrestart#287, the default configuration for `needrestart` before version 3.9 treats any process running from a memfd as a process that needs to be restarted (memfds are always "deleted" since they never exist on disk). Since Ubuntu 24.04 ships needrestart 3.6, this PR changes our deb packages to include a `needrestart` config file that adds a targeted exclusion for any process running from a memfd with a name that has a `teleport-` prefix (the change in `needrestart` 3.9 is broader, excluding any process running from a memfd, but I wanted to affect as little as possible).

We don't have a good way to include files that don't come from the release tarball in packages, and since this is a very simple configuration file (one comment and one line), I added it directly in `build.assets/build-package.sh` as a printf command.

This change only affects the deb packages since `needrestart` doesn't seem to be in use by RPM-based distros and testing down to Rocky 8 showed that `needs-restarting` doesn't mind our use of memfd. The `teleport-update` machinery already adds an exception for the whole Teleport service, so this exception is only needed for standard package installs.

## Manual Test Plan
### Test Environment

Tag build running on Ubuntu 24.04 and Debian 11 as installed from the .deb package or the staging repo.

### Test Cases
- [x] a tag build includes the needrestart config file in the debs
  - [x] the needrestart config file is not included in the rpms
- [x] the tag build works and ships the config file
- [x] with sessions open, `needrestart -r l` doesn't list `teleport.service` and installing or upgrading packages does not restart Teleport
