### PR TITLE
Correct install-linux.mdx partial

### DIFF
--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,7 +1,6 @@
-To install a Teleport Agent on your Linux server:
-
-The recommended installation method is the cluster install script.
-It will select the correct version, edition, and installation mode for your cluster.
+To install Teleport binaries on your Linux server, the recommended installation
+method is the cluster install script. It will select the correct version,
+edition, and installation mode for your cluster.
 
 1. Assign <Var name="teleport.example.com:443"/> to your Teleport cluster
    hostname and port, but not the scheme (https://).


### PR DESCRIPTION
Closes #66104

Replace language about installing a Teleport Agent with language about installing Teleport binaries. This is more consistent with the purpose of the partial (instructions for an installation script for Teleport binaries) and allows us to use it in `tbot` guides.