### PR TITLE
docs: update self-hosted db

### DIFF
--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/cassandra-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/cassandra-self-hosted.mdx
@@ -163,7 +163,7 @@ databases:
 
 </Tabs>
 
-To connect to a particular database instance :
+To connect to a particular database instance:
 ```code
 $ tsh db connect --db-user=cassandra cassandra
 # Password:
@@ -179,7 +179,7 @@ To log out of the database and remove credentials:
 
 ```code
 # Remove credentials for a particular database instance.
-$ tsh db logout example
+$ tsh db logout cassandra
 # Remove credentials for all database instances.
 $ tsh db logout
 ```

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/redis.mdx
@@ -102,7 +102,7 @@ tls-protocols "TLSv1.2 TLSv1.3"
 ```
 
 Once mutual TLS has been enabled, you will no longer be able to connect to
-the cluster without providing a valid client certificate. You can use the
+the database  without providing a valid client certificate. You can use the
 `tls-auth-clients optional` setting to allow connections
 from clients that do not present a certificate.
 

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx
@@ -167,7 +167,7 @@ to publish the Teleport CA to your Active Directory domain (using the path
 to the exported Teleport `db-ca.cer` file that you copied above):
 
 ```powershell
-certutil –dspublish –f <PathToCertFile.cer> RootCA
+certutil -dspublish –f <PathToCertFile.cer> RootCA
 certutil -dspublish -f <PathToCertFile.cer> NTAuthCA
 ```
 
@@ -370,7 +370,7 @@ authentication failed` and on Teleport Database Service logs, there is the error
 entry `Failed to authenticate with KDC: Password for user@AD.TELEPORT.DEV:
 \nkinit: Cannot read password while getting initial credentials`, which means
 that the KDC hostname is wrong. You can verify your domain controller’s SPN to
-see if they’re set correctly and update the value on the field `kdc_hostname` on
+see if they’re set correctly and update the value on the field `kdc_host_name` on
 your database's configuration.
 
 ### PKINIT authentication fails due to missing SID

--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/vitess.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/vitess.mdx
@@ -110,7 +110,7 @@ cells:
 
 </TabItem>
 <TabItem label="Custom deployment">
-If you are running your Vitess cluster using a custom deployment, you will need to update the flags for the `vtgate` service. The following flags needs to be added:
+If you are running your Vitess cluster using a custom deployment, you will need to update the flags for the `vtgate` service. The following flags need to be added:
 
 ```
 vtgate ...                                      \

--- a/docs/pages/includes/database-access/tctl-auth-sign-3-files.mdx
+++ b/docs/pages/includes/database-access/tctl-auth-sign-3-files.mdx
@@ -45,8 +45,8 @@ the database, follow these instructions on your workstation:
 </TabItem>
 <TabItem label="Use a custom CA" >
 
-If the {{ dbname }} database already has a CA that it uses to sign certificates
-, you only need to export a Teleport CA certificate for the database to
+If the {{ dbname }} database already has a CA that it uses to sign certificates,
+you only need to export a Teleport CA certificate for the database to
 authenticate traffic from the Teleport Database Service. You do not need to
 enable `Db` impersonation privileges.
 

--- a/docs/pages/includes/database-access/tctl-auth-sign.mdx
+++ b/docs/pages/includes/database-access/tctl-auth-sign.mdx
@@ -3,7 +3,7 @@ databases must be configured with Teleport's certificate authority to be
 able to verify client certificates. They also need a certificate/key pair that
 Teleport can verify.
 
-To use issue certificates from your workstation with `tctl`, your Teleport user
+To issue certificates from your workstation with `tctl`, your Teleport user
 must be allowed to impersonate the system role `Db`.
 
 Include the following `allow` rule in your Teleport user's role:


### PR DESCRIPTION

docs/pages/enroll-resources/database-access/enrollment/self-hosted/cassandra-self-hosted.mdx:
- format fixes
- db name corrected

docs/pages/enroll-resources/database-access/enrollment/self-hosted/redis.mdx:
- correct db type reference, this is not a cluster db

docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx:
- correct `-` usage
- fix field reference

docs/pages/enroll-resources/database-access/enrollment/self-hosted/vitess.mdx:
- grammar fix

docs/pages/includes/database-access/tctl-auth-sign-3-files.mdx:
- spacing fix

docs/pages/includes/database-access/tctl-auth-sign.mdx:
- grammar fix