### PR TITLE
[v18] Avoid a hard crash when WebAssembly is missing

### DIFF
--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -25,6 +25,7 @@ import { compression } from 'vite-plugin-compression2';
 import wasm from 'vite-plugin-wasm';
 
 import { generateAppHashFile } from './apphash';
+import { guardWasmPlugin } from './guard-wasm';
 import { htmlPlugin, transformPlugin } from './html';
 import { reactPlugin } from './react.mjs';
 
@@ -67,6 +68,11 @@ export function createViteConfig(
       resolve: {
         tsconfigPaths: true,
       },
+      optimizeDeps: {
+        // Exclude from pre-bundling so the guard-wasm-globals plugin can transform the
+        // module during dev.
+        exclude: ['@xterm/addon-image'],
+      },
       build: {
         outDir: outputDirectory,
         assetsDir: 'app',
@@ -103,6 +109,7 @@ export function createViteConfig(
         },
       },
       plugins: [
+        guardWasmPlugin(),
         reactPlugin(mode),
         transformPlugin(),
         generateAppHashFile(outputDirectory, ENTRY_FILE_NAME),

--- a/web/packages/build/vite/guard-wasm.ts
+++ b/web/packages/build/vite/guard-wasm.ts
@@ -1,0 +1,49 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Plugin } from 'vite';
+
+/*
+  @xterm/addon-image references the bare `WebAssembly` identifier at module scope (via its bundled InWasm helper).
+  In environments where WebAssembly is not defined this throws a ReferenceError on import,
+  crashing the app. We replace all references with a local shim that either delegates to
+  the real WebAssembly or throws a descriptive error, letting us statically import the
+  module (no extra chunk) while deferring failure to addon construction time.
+*/
+
+const shim = `
+const __WASM__ = typeof WebAssembly !== 'undefined' ? WebAssembly : {
+  validate: () => false,
+  compile() { throw new Error('WebAssembly is not available'); },
+  instantiate() { throw new Error('WebAssembly is not available'); },
+  Module: class { constructor() { throw new Error('WebAssembly is not available'); } },
+  Instance: class { constructor() { throw new Error('WebAssembly is not available'); } },
+  Memory: class { constructor() { throw new Error('WebAssembly is not available'); } },
+};
+`;
+
+export function guardWasmPlugin(): Plugin {
+  return {
+    name: 'guard-wasm',
+    transform(code, id) {
+      if (id.includes('@xterm/addon-image')) {
+        return shim + '\n' + code.replace(/\bWebAssembly\b/g, '__WASM__');
+      }
+    },
+  };
+}

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -233,10 +233,12 @@ export function DesktopSession({
     if (!shouldConnect) {
       return;
     }
-    void client.connect({
-      keyboardLayout,
-      screenSpec: canvasRendererRef.current.getSize(),
-    });
+    client
+      .connect({
+        keyboardLayout,
+        screenSpec: canvasRendererRef.current.getSize(),
+      })
+      .catch(handleConnectionClose);
     return () => {
       client.shutdown();
     };

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -319,6 +319,12 @@ export class TdpClient extends EventEmitter<EventMap> {
   };
 
   private async initWasm() {
+    if (typeof WebAssembly === 'undefined') {
+      throw new Error(
+        'WebAssembly is not supported in this browser. Desktop sessions and desktop session recordings require WebAssembly.'
+      );
+    }
+
     // select the wasm log level
     let wasmLogLevel = LogType.OFF;
     if (import.meta.env.MODE === 'development') {

--- a/web/packages/teleport/src/SessionRecordings/view/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/DesktopPlayer.tsx
@@ -156,7 +156,7 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     if (!playerClient) {
       return;
     }
-    void playerClient.connect();
+    playerClient.connect().catch(clientOnError);
     return () => {
       playerClient.shutdown();
     };

--- a/web/packages/teleport/src/SessionRecordings/view/player/tty/TtyPlayer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/player/tty/TtyPlayer.ts
@@ -68,14 +68,25 @@ export class TtyPlayer extends Player<TtyEvent> {
     });
 
     const linksAddon = new WebLinksAddon();
-    const imageAddon = new ImageAddon();
 
-    this.addons.push(this.aspectFitAddon, linksAddon, imageAddon);
+    this.addons.push(this.aspectFitAddon, linksAddon);
 
     this.aspectFitAddon.activate(this.terminal);
 
     for (const addon of this.addons) {
       this.terminal.loadAddon(addon);
+    }
+
+    // @xterm/addon-image relies on WebAssembly internally. The vite plugin
+    // guard-wasm-globals rewrites bare WebAssembly references so the module can
+    // be statically imported without crashing; construction and activation will
+    // still throw when WebAssembly is genuinely unavailable, so we catch that here.
+    try {
+      const imageAddon = new ImageAddon();
+      this.terminal.loadAddon(imageAddon);
+      this.addons.push(imageAddon);
+    } catch (e) {
+      this.logger.error(`Failed to load image addon: ${e.message}`);
     }
 
     const createCanvasAddon = () => {

--- a/web/packages/teleport/src/lib/term/terminal.ts
+++ b/web/packages/teleport/src/lib/term/terminal.ts
@@ -55,7 +55,7 @@ export default class TtyTerminal implements TerminalSearcher {
   _convertEol: boolean;
   _debouncedResize: DebouncedFunc<() => void>;
   _fitAddon = new FitAddon();
-  _imageAddon = new ImageAddon();
+  _imageAddon: ImageAddon | undefined;
   _searchAddon = new SearchAddon();
   _webLinksAddon = new WebLinksAddon();
   _webglAddon: WebglAddon;
@@ -105,8 +105,19 @@ export default class TtyTerminal implements TerminalSearcher {
 
     this.term.loadAddon(this._fitAddon);
     this.term.loadAddon(this._webLinksAddon);
-    this.term.loadAddon(this._imageAddon);
     this.term.loadAddon(this._searchAddon);
+
+    // @xterm/addon-image relies on WebAssembly internally. The vite plugin guard-wasm
+    // rewrites bare WebAssembly references so the module can be statically imported
+    // without crashing; construction will still throw when WebAssembly is genuinely
+    // unavailable, so we catch that here.
+    try {
+      this._imageAddon = new ImageAddon();
+      this.term.loadAddon(this._imageAddon);
+    } catch (e) {
+      logger.error('Failed to load image addon:', e.message);
+    }
+
     // handle context loss and load webgl addon
     try {
       // try to create a new WebglAddon. If webgl is not supported, this
@@ -188,7 +199,7 @@ export default class TtyTerminal implements TerminalSearcher {
     this._disconnect();
     this._debouncedResize.cancel();
     this._fitAddon.dispose();
-    this._imageAddon.dispose();
+    this._imageAddon?.dispose();
     this._searchAddon?.dispose();
     this._webglAddon?.dispose();
     this._canvasAddon?.dispose();


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/65771 to branch/v18

Changelog: Fixed an issue where WebAssembly not being available would crash the web UI

## Manual Test Plan
### Test Environment
Local, Chrome launched with and without WebAssembly

### Test Cases
- [x] WebAssembly available
  - [x] Connecting to a desktop works fine
  - [x] Watching a desktop recording works fine
  - [x] Watching a TTY recording works fine
- [x] WebAssembly not available
  - [x] TTY session recordings can still be watched
  - [x] Error is shown when trying to watch a desktop recording
  - [x] Error is shown when trying to connect to a desktop