### PR TITLE
Restore TDP/TDPB Field Limits

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -513,12 +513,6 @@ func (c *Client) startInputStreaming(stopCh chan struct{}) error {
 		msg, err := c.conn.ReadMessage()
 		if utils.IsOKNetworkError(err) {
 			return nil
-		} else if legacy.IsNonFatalErr(err) {
-			_ = c.conn.WriteMessage(&tdpb.Alert{
-				Severity: tdpbv1.AlertSeverity_ALERT_SEVERITY_ERROR,
-				Message:  err.Error(),
-			})
-			continue
 		} else if err != nil {
 			c.cfg.Logger.WarnContext(context.Background(), "Failed reading TDPB input message", "error", err)
 			return err

--- a/lib/srv/desktop/rdp/rdpclient/client_test.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_test.go
@@ -56,7 +56,7 @@ func (f *fakeConn) AddMessage(message tdp.Message) error {
 
 func TestClientNew_EOF(t *testing.T) {
 	f := fakeConn{}
-	conn := tdp.NewConn(&f, tdp.DecoderAdapter(tdpb.DecodePermissive))
+	conn := tdp.NewConn(&f, tdp.DecoderAdapter(tdpb.DecodePermissive), tdpb.WarningConstructor)
 
 	_, _, err := PrepareConnecton(tdpb.ProtocolName, conn, slog.New(slog.DiscardHandler))
 	require.ErrorIs(t, err, io.EOF)
@@ -67,7 +67,7 @@ func TestClientNew_NoKeyboardLayout(t *testing.T) {
 	err := f.AddMessage(&tdpb.ClientHello{Username: "user"})
 	require.NoError(t, err)
 
-	conn := tdp.NewConn(&f, tdp.DecoderAdapter(tdpb.DecodePermissive))
+	conn := tdp.NewConn(&f, tdp.DecoderAdapter(tdpb.DecodePermissive), tdpb.WarningConstructor)
 
 	wrappedConn, hello, err := PrepareConnecton(tdpb.ProtocolName, conn, slog.New(slog.DiscardHandler))
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestClientNew_KeyboardLayout(t *testing.T) {
 	err := f.AddMessage(&tdpb.ClientHello{Username: "user", KeyboardLayout: 1})
 	require.NoError(t, err)
 
-	conn := tdp.NewConn(&f, tdp.DecoderAdapter(tdpb.DecodePermissive))
+	conn := tdp.NewConn(&f, tdp.DecoderAdapter(tdpb.DecodePermissive), tdpb.WarningConstructor)
 	wrappedConn, hello, err := PrepareConnecton(tdpb.ProtocolName, conn, slog.New(slog.DiscardHandler))
 	require.NoError(t, err)
 

--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -30,17 +30,17 @@ import (
 )
 
 const (
-	// TDPMaxAlertMessageLength is somewhat arbitrary, as it is only sent *to*
+	// MaxAlertMessageLength is somewhat arbitrary, as it is only sent *to*
 	// the browser (Teleport never receives this message, so won't be decoding it)
-	TDPMaxAlertMessageLength = 10240
+	MaxAlertMessageLength = 10240
 
-	// TDPMaxPathLength is somewhat arbitrary because we weren't able to determine
+	// MaxPathLength is somewhat arbitrary because we weren't able to determine
 	// a precise value to set it to: https://github.com/gravitational/teleport/issues/14950#issuecomment-1341632465
 	// The limit is kept as an additional defense-in-depth measure.
-	TDPMaxPathLength = 10240
+	MaxPathLength = 10240
 
-	MaxClipboardDataLength    = 1024 * 1024 // 1MB
-	TDPMaxFileReadWriteLength = 1024 * 1024 // 1MB
+	MaxClipboardDataLength = 1024 * 1024 // 1MB
+	MaxFileReadWriteLength = 1024 * 1024 // 1MB
 )
 
 var (

--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -29,6 +29,51 @@ import (
 	"github.com/gravitational/trace"
 )
 
+const (
+	// TDPMaxAlertMessageLength is somewhat arbitrary, as it is only sent *to*
+	// the browser (Teleport never receives this message, so won't be decoding it)
+	TDPMaxAlertMessageLength = 10240
+
+	// TDPMaxPathLength is somewhat arbitrary because we weren't able to determine
+	// a precise value to set it to: https://github.com/gravitational/teleport/issues/14950#issuecomment-1341632465
+	// The limit is kept as an additional defense-in-depth measure.
+	TDPMaxPathLength = 10240
+
+	MaxClipboardDataLength    = 1024 * 1024 // 1MB
+	TDPMaxFileReadWriteLength = 1024 * 1024 // 1MB
+)
+
+var (
+	ClipDataMaxLenErr      = trace.LimitExceeded("clipboard sync failed: clipboard data exceeded maximum length")
+	StringMaxLenErr        = trace.LimitExceeded("TDP string length exceeds allowable limit")
+	FileReadWriteMaxLenErr = trace.LimitExceeded("TDP file read or write message exceeds maximum size limit")
+	MFADataMaxLenErr       = trace.LimitExceeded("MFA challenge data exceeds maximum length")
+)
+
+// IsNonFatalErr returns whether or not an error arising from
+// the tdp package should be interpreted as fatal or non-fatal
+// for an ongoing TDP connection.
+func IsNonFatalErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, ClipDataMaxLenErr) ||
+		errors.Is(err, StringMaxLenErr) ||
+		errors.Is(err, FileReadWriteMaxLenErr) ||
+		errors.Is(err, MFADataMaxLenErr)
+}
+
+// IsFatalErr returns the inverse of IsNonFatalErr
+// (except for if err == nil, for which both functions return false)
+func IsFatalErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return !IsNonFatalErr(err)
+}
+
 type Message interface {
 	Encode() ([]byte, error)
 }
@@ -55,12 +100,12 @@ type MessageReadWriteCloser interface {
 // It converts between a stream of bytes (io.ReadWriter) and a stream of
 // Teleport Desktop Protocol (TDP) messages.
 type Conn struct {
-	rwc       io.ReadWriteCloser
-	writeMu   sync.Mutex
-	bufr      *bufio.Reader
-	decode    Decoder
-	closeOnce sync.Once
-
+	rwc              io.ReadWriteCloser
+	writeMu          sync.Mutex
+	bufr             *bufio.Reader
+	decode           Decoder
+	closeOnce        sync.Once
+	constructWarning WarningConstructor
 	// localAddr and remoteAddr will be set if rw is
 	// a conn that provides these fields
 	localAddr  net.Addr
@@ -86,12 +131,13 @@ func DecoderAdapter(f func(io.Reader) (Message, error)) Decoder {
 // NewConn creates a new Conn on top of a ReadWriter, for example a TCP
 // connection. If the provided ReadWriter also implements srv.TrackingConn,
 // then its LocalAddr() and RemoteAddr() will apply to this Conn.
-func NewConn(rwc io.ReadWriteCloser, decoder Decoder) *Conn {
+func NewConn(rwc io.ReadWriteCloser, decoder Decoder, wc WarningConstructor) *Conn {
 	br := bufio.NewReader(rwc)
 	c := &Conn{
-		rwc:    rwc,
-		bufr:   br,
-		decode: decoder,
+		rwc:              rwc,
+		bufr:             br,
+		decode:           decoder,
+		constructWarning: wc,
 	}
 
 	if tc, ok := rwc.(srvTrackingConn); ok {
@@ -133,10 +179,28 @@ func (c *Conn) PeekNextByte() (byte, error) {
 	return b, nil
 }
 
+// WarningConstructor is a function that constructs a TDP or TDPB
+// alert message with warning severity to be sent to the client.
+type WarningConstructor func(string) Message
+
+func (c *Conn) sendWarning(warning string) error {
+	return c.WriteMessage(c.constructWarning(warning))
+}
+
 // ReadMessage reads the next incoming message from the connection.
 func (c *Conn) ReadMessage() (Message, error) {
-	m, err := c.decode(c.bufr)
-	return m, trace.Wrap(err)
+	for {
+		m, err := c.decode(c.bufr)
+		if err != nil && IsNonFatalErr(err) {
+			if warnError := c.sendWarning(err.Error()); warnError != nil {
+				return nil, trace.Wrap(warnError, "error sending alert message in response to decode error: %v", err)
+			}
+			// Warning sent. Try reading the next message
+			continue
+		}
+		// err may still be non-nil
+		return m, trace.Wrap(err)
+	}
 }
 
 // WriteMessage sends a message to the connection.

--- a/lib/srv/desktop/tdp/conn_test.go
+++ b/lib/srv/desktop/tdp/conn_test.go
@@ -62,7 +62,7 @@ func TestTDPConnTracksLocalRemoteAddrs(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			tc := NewConn(test.conn, nil)
+			tc := NewConn(test.conn, nil, nil)
 			l := tc.LocalAddr()
 			r := tc.RemoteAddr()
 			require.Equal(t, test.local, l)

--- a/lib/srv/desktop/tdp/conn_test.go
+++ b/lib/srv/desktop/tdp/conn_test.go
@@ -136,7 +136,39 @@ func (r *mockReadWriterCloser) Close() error {
 type mockMessage string
 
 func (m mockMessage) Encode() ([]byte, error) {
-	return []byte(string(m)), nil
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(m); err != nil {
+		return nil, err
+	}
+	data := buf.Bytes()
+	return []byte(string(data)), nil
+}
+
+// Returns a Decoder which decodes a mockMessage from
+// the stream. Certain message text will yield non-fatal errors.
+func newMockDecoder() Decoder {
+	var dec *gob.Decoder
+
+	// Assume that we'll be given the same byteReader for each decode.
+	return func(br ByteReader) (Message, error) {
+		if dec == nil {
+			dec = gob.NewDecoder(br)
+		}
+		var msg string
+		err := dec.Decode(&msg)
+		// Optionally return non-fatal errors
+		switch msg {
+		case "badPath":
+			return nil, StringMaxLenErr
+		case "largeReadWrite":
+			return nil, FileReadWriteMaxLenErr
+		case "clipboard":
+			return nil, ClipDataMaxLenErr
+		case "fatal":
+			return nil, errors.New("simulated fatal error")
+		}
+		return mockMessage(msg), err
+	}
 }
 
 func TestConnProxy(t *testing.T) {
@@ -414,4 +446,44 @@ func TestRemoveNilMessages(t *testing.T) {
 			assert.NotNil(t, msg)
 		}
 	}
+}
+
+func TestErrorAlerting(t *testing.T) {
+	a, b := net.Pipe()
+	client := NewConn(a, newMockDecoder(), func(s string) Message {
+		t.Fatalf("Client's warning constructor should not be called")
+		return nil
+	})
+	defer client.Close()
+
+	server := NewConn(b, newMockDecoder(), func(s string) Message {
+		return mockMessage("warn: " + s)
+	})
+	defer server.Close()
+
+	proxy := NewConnProxy(client, server)
+	proxyErr := make(chan error)
+	go func() {
+		proxyErr <- proxy.Run()
+	}()
+
+	require.NoError(t, client.WriteMessage(mockMessage("clipboard")))
+	require.NoError(t, client.WriteMessage(mockMessage("ok")))
+	// Reads only the second message since the first yields a non-fatal error.
+	msg, err := server.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(msg.(mockMessage)))
+
+	// The non-fatal error should be communicated back to the client.
+	msg, err = client.ReadMessage()
+	require.NoError(t, err)
+	mockMsg := msg.(mockMessage)
+	require.Contains(t, mockMsg, ClipDataMaxLenErr.Error())
+
+	// Now send a message that the server treats as fatal
+	// (simulates a decode error)
+	require.NoError(t, client.WriteMessage(mockMessage("fatal")))
+	err = <-proxyErr
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "simulated fatal error")
 }

--- a/lib/srv/desktop/tdp/protocol/legacy/proto.go
+++ b/lib/srv/desktop/tdp/protocol/legacy/proto.go
@@ -174,9 +174,9 @@ func decodeMessage(firstByte byte, in tdp.ByteReader) (tdp.Message, error) {
 	case TypeSharedDirectoryReadRequest:
 		return decodeSharedDirectoryReadRequest(in)
 	case TypeSharedDirectoryReadResponse:
-		return decodeSharedDirectoryReadResponse(in, tdp.TDPMaxFileReadWriteLength)
+		return decodeSharedDirectoryReadResponse(in, tdp.MaxFileReadWriteLength)
 	case TypeSharedDirectoryWriteRequest:
-		return decodeSharedDirectoryWriteRequest(in, tdp.TDPMaxFileReadWriteLength)
+		return decodeSharedDirectoryWriteRequest(in, tdp.MaxFileReadWriteLength)
 	case TypeSharedDirectoryWriteResponse:
 		return decodeSharedDirectoryWriteResponse(in)
 	case TypeSharedDirectoryMoveRequest:
@@ -592,7 +592,7 @@ func (m Error) Encode() ([]byte, error) {
 }
 
 func decodeError(in io.Reader) (Error, error) {
-	message, err := decodeString(in, tdp.TDPMaxAlertMessageLength)
+	message, err := decodeString(in, tdp.MaxAlertMessageLength)
 	if err != nil {
 		return Error{}, trace.Wrap(err)
 	}
@@ -628,7 +628,7 @@ func (m Alert) Encode() ([]byte, error) {
 }
 
 func decodeAlert(in tdp.ByteReader) (Alert, error) {
-	message, err := decodeString(in, tdp.TDPMaxAlertMessageLength)
+	message, err := decodeString(in, tdp.MaxAlertMessageLength)
 	if err != nil {
 		return Alert{}, trace.Wrap(err)
 	}
@@ -928,7 +928,7 @@ func decodeSharedDirectoryInfoRequest(in io.Reader) (SharedDirectoryInfoRequest,
 	if err != nil {
 		return SharedDirectoryInfoRequest{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdp.TDPMaxPathLength)
+	path, err := decodeString(in, tdp.MaxPathLength)
 	if err != nil {
 		return SharedDirectoryInfoRequest{}, trace.Wrap(err)
 	}
@@ -1025,7 +1025,7 @@ func decodeFileSystemObject(in tdp.ByteReader) (FileSystemObject, error) {
 	if err != nil {
 		return FileSystemObject{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdp.TDPMaxPathLength)
+	path, err := decodeString(in, tdp.MaxPathLength)
 	if err != nil {
 		return FileSystemObject{}, trace.Wrap(err)
 	}
@@ -1075,7 +1075,7 @@ func decodeSharedDirectoryCreateRequest(in io.Reader) (SharedDirectoryCreateRequ
 	if err != nil {
 		return SharedDirectoryCreateRequest{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdp.TDPMaxPathLength)
+	path, err := decodeString(in, tdp.MaxPathLength)
 	if err != nil {
 		return SharedDirectoryCreateRequest{}, trace.Wrap(err)
 	}
@@ -1162,7 +1162,7 @@ func decodeSharedDirectoryDeleteRequest(in io.Reader) (SharedDirectoryDeleteRequ
 	if err != nil {
 		return SharedDirectoryDeleteRequest{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdp.TDPMaxPathLength)
+	path, err := decodeString(in, tdp.MaxPathLength)
 	if err != nil {
 		return SharedDirectoryDeleteRequest{}, trace.Wrap(err)
 	}
@@ -1225,7 +1225,7 @@ func decodeSharedDirectoryListRequest(in io.Reader) (SharedDirectoryListRequest,
 	if err != nil {
 		return SharedDirectoryListRequest{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdp.TDPMaxPathLength)
+	path, err := decodeString(in, tdp.MaxPathLength)
 	if err != nil {
 		return SharedDirectoryListRequest{}, trace.Wrap(err)
 	}
@@ -1332,7 +1332,7 @@ func decodeSharedDirectoryReadRequest(in io.Reader) (SharedDirectoryReadRequest,
 		return SharedDirectoryReadRequest{}, trace.Wrap(err)
 	}
 
-	path, err := decodeString(in, tdp.TDPMaxPathLength)
+	path, err := decodeString(in, tdp.MaxPathLength)
 	if err != nil {
 		return SharedDirectoryReadRequest{}, trace.Wrap(err)
 	}
@@ -1458,7 +1458,7 @@ func decodeSharedDirectoryWriteRequest(in tdp.ByteReader, maxLen uint32) (Shared
 		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
 	}
 
-	path, err := decodeString(in, tdp.TDPMaxPathLength)
+	path, err := decodeString(in, tdp.MaxPathLength)
 	if err != nil {
 		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
 	}
@@ -1546,11 +1546,11 @@ func decodeSharedDirectoryMoveRequest(in io.Reader) (SharedDirectoryMoveRequest,
 	if err != nil {
 		return SharedDirectoryMoveRequest{}, trace.Wrap(err)
 	}
-	originalPath, err := decodeString(in, tdp.TDPMaxPathLength)
+	originalPath, err := decodeString(in, tdp.MaxPathLength)
 	if err != nil {
 		return SharedDirectoryMoveRequest{}, trace.Wrap(err)
 	}
-	newPath, err := decodeString(in, tdp.TDPMaxPathLength)
+	newPath, err := decodeString(in, tdp.MaxPathLength)
 	if err != nil {
 		return SharedDirectoryMoveRequest{}, trace.Wrap(err)
 	}
@@ -1614,7 +1614,7 @@ func decodeSharedDirectoryTruncateRequest(in io.Reader) (SharedDirectoryTruncate
 	if err != nil {
 		return SharedDirectoryTruncateRequest{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdp.TDPMaxPathLength)
+	path, err := decodeString(in, tdp.MaxPathLength)
 	if err != nil {
 		return SharedDirectoryTruncateRequest{}, trace.Wrap(err)
 	}

--- a/lib/srv/desktop/tdp/protocol/legacy/proto.go
+++ b/lib/srv/desktop/tdp/protocol/legacy/proto.go
@@ -91,30 +91,6 @@ const (
 	TypeUpgrade                         = MessageType(38)
 )
 
-// IsNonFatalErr returns whether or not an error arising from
-// the tdp package should be interpreted as fatal or non-fatal
-// for an ongoing TDP connection.
-func IsNonFatalErr(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	return errors.Is(err, clipDataMaxLenErr) ||
-		errors.Is(err, stringMaxLenErr) ||
-		errors.Is(err, fileReadWriteMaxLenErr) ||
-		errors.Is(err, mfaDataMaxLenErr)
-}
-
-// IsFatalErr returns the inverse of IsNonFatalErr
-// (except for if err == nil, for which both functions return false)
-func IsFatalErr(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	return !IsNonFatalErr(err)
-}
-
 // These correspond to TdpErrCode enum in the rust RDP client.
 const (
 	ErrCodeNil           uint32 = 0
@@ -168,7 +144,7 @@ func decodeMessage(firstByte byte, in tdp.ByteReader) (tdp.Message, error) {
 	case TypeClientUsername:
 		return decodeClientUsername(in)
 	case TypeClipboardData:
-		return decodeClipboardData(in, maxClipboardDataLength)
+		return decodeClipboardData(in, tdp.MaxClipboardDataLength)
 	case TypeError:
 		return decodeError(in)
 	case TypeAlert:
@@ -198,9 +174,9 @@ func decodeMessage(firstByte byte, in tdp.ByteReader) (tdp.Message, error) {
 	case TypeSharedDirectoryReadRequest:
 		return decodeSharedDirectoryReadRequest(in)
 	case TypeSharedDirectoryReadResponse:
-		return decodeSharedDirectoryReadResponse(in, tdpMaxFileReadWriteLength)
+		return decodeSharedDirectoryReadResponse(in, tdp.TDPMaxFileReadWriteLength)
 	case TypeSharedDirectoryWriteRequest:
-		return decodeSharedDirectoryWriteRequest(in, tdpMaxFileReadWriteLength)
+		return decodeSharedDirectoryWriteRequest(in, tdp.TDPMaxFileReadWriteLength)
 	case TypeSharedDirectoryWriteResponse:
 		return decodeSharedDirectoryWriteResponse(in)
 	case TypeSharedDirectoryMoveRequest:
@@ -222,6 +198,13 @@ func decodeMessage(firstByte byte, in tdp.ByteReader) (tdp.Message, error) {
 		fallthrough
 	default:
 		return nil, trace.BadParameter("unsupported desktop protocol message type %d", firstByte)
+	}
+}
+
+func WarningConstructor(msg string) tdp.Message {
+	return &Alert{
+		Severity: SeverityWarning,
+		Message:  msg,
 	}
 }
 
@@ -579,7 +562,7 @@ func (r ClientUsername) Encode() ([]byte, error) {
 func decodeClientUsername(in io.Reader) (ClientUsername, error) {
 	username, err := decodeString(in, windowsMaxUsernameLength)
 	if err != nil {
-		if errors.Is(err, stringMaxLenErr) {
+		if errors.Is(err, tdp.StringMaxLenErr) {
 			// Change the error message here so it's considered a fatal error
 			return ClientUsername{}, trace.LimitExceeded("ClientUsername exceeded maximum length")
 		}
@@ -609,7 +592,7 @@ func (m Error) Encode() ([]byte, error) {
 }
 
 func decodeError(in io.Reader) (Error, error) {
-	message, err := decodeString(in, tdpMaxAlertMessageLength)
+	message, err := decodeString(in, tdp.TDPMaxAlertMessageLength)
 	if err != nil {
 		return Error{}, trace.Wrap(err)
 	}
@@ -645,7 +628,7 @@ func (m Alert) Encode() ([]byte, error) {
 }
 
 func decodeAlert(in tdp.ByteReader) (Alert, error) {
-	message, err := decodeString(in, tdpMaxAlertMessageLength)
+	message, err := decodeString(in, tdp.TDPMaxAlertMessageLength)
 	if err != nil {
 		return Alert{}, trace.Wrap(err)
 	}
@@ -708,7 +691,7 @@ func decodeClipboardData(in io.Reader, maxLen uint32) (ClipboardData, error) {
 		// If clipboard data exceeds maxLen,
 		// discard the rest of the message
 		_, _ = io.CopyN(io.Discard, in, int64(length))
-		return nil, clipDataMaxLenErr
+		return nil, tdp.ClipDataMaxLenErr
 	}
 
 	b := make([]byte, int(length))
@@ -788,7 +771,7 @@ func DecodeMFA(in tdp.ByteReader) (*MFA, error) {
 
 	if length > maxMFADataLength {
 		_, _ = io.CopyN(io.Discard, in, int64(length))
-		return nil, mfaDataMaxLenErr
+		return nil, tdp.MFADataMaxLenErr
 	} else if length == 0 {
 		return nil, trace.BadParameter("mfa data missing")
 	}
@@ -945,7 +928,7 @@ func decodeSharedDirectoryInfoRequest(in io.Reader) (SharedDirectoryInfoRequest,
 	if err != nil {
 		return SharedDirectoryInfoRequest{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdpMaxPathLength)
+	path, err := decodeString(in, tdp.TDPMaxPathLength)
 	if err != nil {
 		return SharedDirectoryInfoRequest{}, trace.Wrap(err)
 	}
@@ -1042,7 +1025,7 @@ func decodeFileSystemObject(in tdp.ByteReader) (FileSystemObject, error) {
 	if err != nil {
 		return FileSystemObject{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdpMaxPathLength)
+	path, err := decodeString(in, tdp.TDPMaxPathLength)
 	if err != nil {
 		return FileSystemObject{}, trace.Wrap(err)
 	}
@@ -1092,7 +1075,7 @@ func decodeSharedDirectoryCreateRequest(in io.Reader) (SharedDirectoryCreateRequ
 	if err != nil {
 		return SharedDirectoryCreateRequest{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdpMaxPathLength)
+	path, err := decodeString(in, tdp.TDPMaxPathLength)
 	if err != nil {
 		return SharedDirectoryCreateRequest{}, trace.Wrap(err)
 	}
@@ -1179,7 +1162,7 @@ func decodeSharedDirectoryDeleteRequest(in io.Reader) (SharedDirectoryDeleteRequ
 	if err != nil {
 		return SharedDirectoryDeleteRequest{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdpMaxPathLength)
+	path, err := decodeString(in, tdp.TDPMaxPathLength)
 	if err != nil {
 		return SharedDirectoryDeleteRequest{}, trace.Wrap(err)
 	}
@@ -1242,7 +1225,7 @@ func decodeSharedDirectoryListRequest(in io.Reader) (SharedDirectoryListRequest,
 	if err != nil {
 		return SharedDirectoryListRequest{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdpMaxPathLength)
+	path, err := decodeString(in, tdp.TDPMaxPathLength)
 	if err != nil {
 		return SharedDirectoryListRequest{}, trace.Wrap(err)
 	}
@@ -1349,7 +1332,7 @@ func decodeSharedDirectoryReadRequest(in io.Reader) (SharedDirectoryReadRequest,
 		return SharedDirectoryReadRequest{}, trace.Wrap(err)
 	}
 
-	path, err := decodeString(in, tdpMaxPathLength)
+	path, err := decodeString(in, tdp.TDPMaxPathLength)
 	if err != nil {
 		return SharedDirectoryReadRequest{}, trace.Wrap(err)
 	}
@@ -1413,7 +1396,7 @@ func decodeSharedDirectoryReadResponse(in io.Reader, maxLen uint32) (SharedDirec
 
 	if readDataLength > maxLen {
 		_, _ = io.CopyN(io.Discard, in, int64(readDataLength))
-		return SharedDirectoryReadResponse{}, fileReadWriteMaxLenErr
+		return SharedDirectoryReadResponse{}, tdp.FileReadWriteMaxLenErr
 	}
 
 	readData := make([]byte, int(readDataLength))
@@ -1475,7 +1458,7 @@ func decodeSharedDirectoryWriteRequest(in tdp.ByteReader, maxLen uint32) (Shared
 		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
 	}
 
-	path, err := decodeString(in, tdpMaxPathLength)
+	path, err := decodeString(in, tdp.TDPMaxPathLength)
 	if err != nil {
 		return SharedDirectoryWriteRequest{}, trace.Wrap(err)
 	}
@@ -1487,7 +1470,7 @@ func decodeSharedDirectoryWriteRequest(in tdp.ByteReader, maxLen uint32) (Shared
 
 	if writeDataLength > maxLen {
 		_, _ = io.CopyN(io.Discard, in, int64(writeDataLength))
-		return SharedDirectoryWriteRequest{}, fileReadWriteMaxLenErr
+		return SharedDirectoryWriteRequest{}, tdp.FileReadWriteMaxLenErr
 	}
 
 	writeData := make([]byte, int(writeDataLength))
@@ -1563,11 +1546,11 @@ func decodeSharedDirectoryMoveRequest(in io.Reader) (SharedDirectoryMoveRequest,
 	if err != nil {
 		return SharedDirectoryMoveRequest{}, trace.Wrap(err)
 	}
-	originalPath, err := decodeString(in, tdpMaxPathLength)
+	originalPath, err := decodeString(in, tdp.TDPMaxPathLength)
 	if err != nil {
 		return SharedDirectoryMoveRequest{}, trace.Wrap(err)
 	}
-	newPath, err := decodeString(in, tdpMaxPathLength)
+	newPath, err := decodeString(in, tdp.TDPMaxPathLength)
 	if err != nil {
 		return SharedDirectoryMoveRequest{}, trace.Wrap(err)
 	}
@@ -1631,7 +1614,7 @@ func decodeSharedDirectoryTruncateRequest(in io.Reader) (SharedDirectoryTruncate
 	if err != nil {
 		return SharedDirectoryTruncateRequest{}, trace.Wrap(err)
 	}
-	path, err := decodeString(in, tdpMaxPathLength)
+	path, err := decodeString(in, tdp.TDPMaxPathLength)
 	if err != nil {
 		return SharedDirectoryTruncateRequest{}, trace.Wrap(err)
 	}
@@ -1780,7 +1763,7 @@ func decodeString(r io.Reader, maxLen uint32) (string, error) {
 
 	if length > maxLen {
 		_, _ = io.CopyN(io.Discard, r, int64(length))
-		return "", stringMaxLenErr
+		return "", tdp.StringMaxLenErr
 	}
 
 	s := make([]byte, int(length))
@@ -1816,26 +1799,5 @@ func writeUint64(b *bytes.Buffer, v uint64) {
 	b.WriteByte(byte(v))
 }
 
-const (
-	// tdpMaxAlertMessageLength is somewhat arbitrary, as it is only sent *to*
-	// the browser (Teleport never receives this message, so won't be decoding it)
-	tdpMaxAlertMessageLength = 10240
-
-	// tdpMaxPathLength is somewhat arbitrary because we weren't able to determine
-	// a precise value to set it to: https://github.com/gravitational/teleport/issues/14950#issuecomment-1341632465
-	// The limit is kept as an additional defense-in-depth measure.
-	tdpMaxPathLength = 10240
-
-	maxClipboardDataLength    = 1024 * 1024 // 1MB
-	tdpMaxFileReadWriteLength = 1024 * 1024 // 1MB
-)
-
 // maxPNGFrameDataLength is maximum data length for PNG2Frame
 const maxPNGFrameDataLength = 10 * 1024 * 1024 // 10MB
-
-var (
-	clipDataMaxLenErr      = trace.LimitExceeded("clipboard sync failed: clipboard data exceeded maximum length")
-	stringMaxLenErr        = trace.LimitExceeded("TDP string length exceeds allowable limit")
-	fileReadWriteMaxLenErr = trace.LimitExceeded("TDP file read or write message exceeds maximum size limit")
-	mfaDataMaxLenErr       = trace.LimitExceeded("MFA challenge data exceeds maximum length")
-)

--- a/lib/srv/desktop/tdp/protocol/legacy/proto_test.go
+++ b/lib/srv/desktop/tdp/protocol/legacy/proto_test.go
@@ -192,9 +192,9 @@ func TestMFA(t *testing.T) {
 
 func TestIsNonFatalErr(t *testing.T) {
 	// Test that nil returns false
-	require.False(t, IsNonFatalErr(nil))
+	require.False(t, tdp.IsNonFatalErr(nil))
 	// Test that any other error returns false
-	require.False(t, IsNonFatalErr(errors.New("some other error")))
+	require.False(t, tdp.IsNonFatalErr(errors.New("some other error")))
 }
 
 // TDP messages must have size limits in order to prevent attacks that
@@ -222,20 +222,20 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 		},
 		{
 			name:  "rejects long Clipboard",
-			msg:   ClipboardData(bytes.Repeat([]byte("a"), maxClipboardDataLength+1)),
+			msg:   ClipboardData(bytes.Repeat([]byte("a"), tdp.MaxClipboardDataLength+1)),
 			fatal: false,
 		},
 		{
 			name: "rejects long Error",
 			msg: Error{
-				Message: string(bytes.Repeat([]byte("a"), tdpMaxAlertMessageLength+1)),
+				Message: string(bytes.Repeat([]byte("a"), tdp.TDPMaxAlertMessageLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long Alert",
 			msg: Alert{
-				Message: string(bytes.Repeat([]byte("a"), tdpMaxAlertMessageLength+1)),
+				Message: string(bytes.Repeat([]byte("a"), tdp.TDPMaxAlertMessageLength+1)),
 			},
 			fatal: false,
 		},
@@ -249,56 +249,56 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 		{
 			name: "rejects long SharedDirectoryInfoRequest",
 			msg: SharedDirectoryInfoRequest{
-				Path: string(bytes.Repeat([]byte("a"), tdpMaxPathLength+1)),
+				Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryCreateRequest",
 			msg: SharedDirectoryCreateRequest{
-				Path: string(bytes.Repeat([]byte("a"), tdpMaxPathLength+1)),
+				Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryDeleteRequest",
 			msg: SharedDirectoryDeleteRequest{
-				Path: string(bytes.Repeat([]byte("a"), tdpMaxPathLength+1)),
+				Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryListRequest",
 			msg: SharedDirectoryListRequest{
-				Path: string(bytes.Repeat([]byte("a"), tdpMaxPathLength+1)),
+				Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryReadRequest",
 			msg: SharedDirectoryReadRequest{
-				Path: string(bytes.Repeat([]byte("a"), tdpMaxPathLength+1)),
+				Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryReadResponse",
 			msg: SharedDirectoryReadResponse{
-				ReadDataLength: tdpMaxFileReadWriteLength + 1,
+				ReadDataLength: tdp.TDPMaxFileReadWriteLength + 1,
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryWriteRequest",
 			msg: SharedDirectoryWriteRequest{
-				WriteDataLength: tdpMaxFileReadWriteLength + 1,
+				WriteDataLength: tdp.TDPMaxFileReadWriteLength + 1,
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryMoveRequest",
 			msg: SharedDirectoryMoveRequest{
-				OriginalPath: string(bytes.Repeat([]byte("a"), tdpMaxPathLength+1)),
+				OriginalPath: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
 			},
 			fatal: false,
 		},
@@ -308,7 +308,7 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 				CompletionID: 0,
 				ErrCode:      0,
 				Fso: FileSystemObject{
-					Path: string(bytes.Repeat([]byte("a"), tdpMaxPathLength+1)),
+					Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
 				},
 			},
 			fatal: false,
@@ -319,7 +319,7 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 				CompletionID: 0,
 				ErrCode:      0,
 				Fso: FileSystemObject{
-					Path: string(bytes.Repeat([]byte("a"), tdpMaxPathLength+1)),
+					Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
 				},
 			},
 			fatal: false,
@@ -330,7 +330,7 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 				CompletionID: 0,
 				ErrCode:      0,
 				FsoList: []FileSystemObject{{
-					Path: string(bytes.Repeat([]byte("a"), tdpMaxPathLength+1)),
+					Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
 				}},
 			},
 			fatal: false,
@@ -341,8 +341,8 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 			require.NoError(t, err)
 			_, err = decode(bytes)
 			require.True(t, trace.IsLimitExceeded(err))
-			require.Equal(t, test.fatal, IsFatalErr(err))
-			require.Equal(t, !test.fatal, IsNonFatalErr(err))
+			require.Equal(t, test.fatal, tdp.IsFatalErr(err))
+			require.Equal(t, !test.fatal, tdp.IsNonFatalErr(err))
 		})
 	}
 }

--- a/lib/srv/desktop/tdp/protocol/legacy/proto_test.go
+++ b/lib/srv/desktop/tdp/protocol/legacy/proto_test.go
@@ -228,14 +228,14 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 		{
 			name: "rejects long Error",
 			msg: Error{
-				Message: string(bytes.Repeat([]byte("a"), tdp.TDPMaxAlertMessageLength+1)),
+				Message: string(bytes.Repeat([]byte("a"), tdp.MaxAlertMessageLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long Alert",
 			msg: Alert{
-				Message: string(bytes.Repeat([]byte("a"), tdp.TDPMaxAlertMessageLength+1)),
+				Message: string(bytes.Repeat([]byte("a"), tdp.MaxAlertMessageLength+1)),
 			},
 			fatal: false,
 		},
@@ -249,56 +249,56 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 		{
 			name: "rejects long SharedDirectoryInfoRequest",
 			msg: SharedDirectoryInfoRequest{
-				Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
+				Path: string(bytes.Repeat([]byte("a"), tdp.MaxPathLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryCreateRequest",
 			msg: SharedDirectoryCreateRequest{
-				Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
+				Path: string(bytes.Repeat([]byte("a"), tdp.MaxPathLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryDeleteRequest",
 			msg: SharedDirectoryDeleteRequest{
-				Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
+				Path: string(bytes.Repeat([]byte("a"), tdp.MaxPathLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryListRequest",
 			msg: SharedDirectoryListRequest{
-				Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
+				Path: string(bytes.Repeat([]byte("a"), tdp.MaxPathLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryReadRequest",
 			msg: SharedDirectoryReadRequest{
-				Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
+				Path: string(bytes.Repeat([]byte("a"), tdp.MaxPathLength+1)),
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryReadResponse",
 			msg: SharedDirectoryReadResponse{
-				ReadDataLength: tdp.TDPMaxFileReadWriteLength + 1,
+				ReadDataLength: tdp.MaxFileReadWriteLength + 1,
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryWriteRequest",
 			msg: SharedDirectoryWriteRequest{
-				WriteDataLength: tdp.TDPMaxFileReadWriteLength + 1,
+				WriteDataLength: tdp.MaxFileReadWriteLength + 1,
 			},
 			fatal: false,
 		},
 		{
 			name: "rejects long SharedDirectoryMoveRequest",
 			msg: SharedDirectoryMoveRequest{
-				OriginalPath: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
+				OriginalPath: string(bytes.Repeat([]byte("a"), tdp.MaxPathLength+1)),
 			},
 			fatal: false,
 		},
@@ -308,7 +308,7 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 				CompletionID: 0,
 				ErrCode:      0,
 				Fso: FileSystemObject{
-					Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
+					Path: string(bytes.Repeat([]byte("a"), tdp.MaxPathLength+1)),
 				},
 			},
 			fatal: false,
@@ -319,7 +319,7 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 				CompletionID: 0,
 				ErrCode:      0,
 				Fso: FileSystemObject{
-					Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
+					Path: string(bytes.Repeat([]byte("a"), tdp.MaxPathLength+1)),
 				},
 			},
 			fatal: false,
@@ -330,7 +330,7 @@ func TestSizeLimitsAreNonFatal(t *testing.T) {
 				CompletionID: 0,
 				ErrCode:      0,
 				FsoList: []FileSystemObject{{
-					Path: string(bytes.Repeat([]byte("a"), tdp.TDPMaxPathLength+1)),
+					Path: string(bytes.Repeat([]byte("a"), tdp.MaxPathLength+1)),
 				}},
 			},
 			fatal: false,

--- a/lib/srv/desktop/tdp/protocol/tdpb/mfa_test.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/mfa_test.go
@@ -32,8 +32,8 @@ import (
 
 func TestTDPBMFAFlow(t *testing.T) {
 	client, server := net.Pipe()
-	clientConn := tdp.NewConn(client, tdp.DecoderAdapter(DecodeStrict))
-	serverConn := tdp.NewConn(server, tdp.DecoderAdapter(DecodeStrict))
+	clientConn := tdp.NewConn(client, tdp.DecoderAdapter(DecodeStrict), WarningConstructor)
+	serverConn := tdp.NewConn(server, tdp.DecoderAdapter(DecodeStrict), WarningConstructor)
 	defer clientConn.Close()
 	defer serverConn.Close()
 

--- a/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
@@ -69,7 +69,7 @@ func (c *ClientHello) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *ClientHello) validate() error { return nil }
+func (*ClientHello) validate() error { return nil }
 
 // ServerHello is the first message sent by the server *after* receiving
 // the ClientHello. It selects and advertises server capabilities and
@@ -85,7 +85,7 @@ func (s *ServerHello) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *ServerHello) validate() error { return nil }
+func (*ServerHello) validate() error { return nil }
 
 // PNGFrame carries screen data in PNG format. It is required
 // for interop with older session recordings that came before
@@ -101,7 +101,7 @@ func (p *PNGFrame) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *PNGFrame) validate() error { return nil }
+func (*PNGFrame) validate() error { return nil }
 
 // FastPathPDU is a raw RDP Fast-Path Protocol Data Unit (PDU).
 type FastPathPDU tdpbv1.FastPathPDU
@@ -115,7 +115,7 @@ func (f *FastPathPDU) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *FastPathPDU) validate() error { return nil }
+func (*FastPathPDU) validate() error { return nil }
 
 // RDPResponsePDU is a raw RDP response PDU.
 type RDPResponsePDU tdpbv1.RDPResponsePDU
@@ -129,7 +129,7 @@ func (f *RDPResponsePDU) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *RDPResponsePDU) validate() error { return nil }
+func (*RDPResponsePDU) validate() error { return nil }
 
 // SyncKeys message is sent from the client to the server to
 // synchronize the state of keyboard's modifier keys.
@@ -144,7 +144,7 @@ func (s *SyncKeys) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *SyncKeys) validate() error { return nil }
+func (*SyncKeys) validate() error { return nil }
 
 // MouseMove contains mouse coordinates.
 type MouseMove tdpbv1.MouseMove
@@ -158,7 +158,7 @@ func (m *MouseMove) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *MouseMove) validate() error { return nil }
+func (*MouseMove) validate() error { return nil }
 
 // MouseButton contains mouse button state.
 type MouseButton tdpbv1.MouseButton
@@ -172,7 +172,7 @@ func (m *MouseButton) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *MouseButton) validate() error { return nil }
+func (*MouseButton) validate() error { return nil }
 
 // KeyboardButton encodes a keyboard button update.
 type KeyboardButton tdpbv1.KeyboardButton
@@ -186,7 +186,7 @@ func (k *KeyboardButton) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *KeyboardButton) validate() error { return nil }
+func (*KeyboardButton) validate() error { return nil }
 
 // ClientScreenSpec contains the dimensions of the client view.
 // It is included in the ClientHello at the start of the session, and
@@ -202,7 +202,7 @@ func (c *ClientScreenSpec) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *ClientScreenSpec) validate() error { return nil }
+func (*ClientScreenSpec) validate() error { return nil }
 
 // Alert encodes an error/warning/informational message and severity code.
 // Sent by the server to the client for display.
@@ -217,7 +217,7 @@ func (a *Alert) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *Alert) validate() error { return nil }
+func (*Alert) validate() error { return nil }
 
 // MouseWheel contains a mousewheel update.
 type MouseWheel tdpbv1.MouseWheel
@@ -231,7 +231,7 @@ func (m *MouseWheel) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *MouseWheel) validate() error { return nil }
+func (*MouseWheel) validate() error { return nil }
 
 // ClipboardData carries clipboard data to support copy/paste
 // operations between the client and target desktop.
@@ -266,7 +266,7 @@ func (m *MFA) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *MFA) validate() error { return nil }
+func (*MFA) validate() error { return nil }
 
 // SharedDirectoryAnnounce is sent by the client to begin sharing a directory.
 type SharedDirectoryAnnounce tdpbv1.SharedDirectoryAnnounce
@@ -280,6 +280,8 @@ func (s *SharedDirectoryAnnounce) Encode() ([]byte, error) {
 	})
 }
 
+func (*SharedDirectoryAnnounce) validate() error { return nil }
+
 // SharedDirectoryRemove is sent by the client to stop sharing a directory.
 type SharedDirectoryRemove tdpbv1.SharedDirectoryRemove
 
@@ -292,7 +294,7 @@ func (s *SharedDirectoryRemove) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *SharedDirectoryAnnounce) validate() error { return nil }
+func (*SharedDirectoryRemove) validate() error { return nil }
 
 // SharedDirectoryAcknowledge is sent by the server to acknowledge a
 // new shared directory.
@@ -307,7 +309,7 @@ func (s *SharedDirectoryAcknowledge) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *SharedDirectoryAcknowledge) validate() error { return nil }
+func (*SharedDirectoryAcknowledge) validate() error { return nil }
 
 // SharedDirectoryRequest encodes various directory operation requests
 // such as Info, Create, Delete, List, Read, Write, Move, or Truncate.
@@ -415,7 +417,7 @@ func (l *LatencyStats) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *LatencyStats) validate() error { return nil }
+func (*LatencyStats) validate() error { return nil }
 
 // Ping is used to measure latency between the Proxy and
 // target desktop.
@@ -430,7 +432,7 @@ func (p *Ping) Encode() ([]byte, error) {
 	})
 }
 
-func (_ *Ping) validate() error { return nil }
+func (*Ping) validate() error { return nil }
 
 func marshalWithHeader(msg proto.Message) ([]byte, error) {
 	data, err := proto.Marshal(msg)

--- a/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
@@ -325,39 +325,39 @@ func (s *SharedDirectoryRequest) Encode() ([]byte, error) {
 func (s *SharedDirectoryRequest) validate() error {
 	switch op := s.Operation.(type) {
 	case *tdpbv1.SharedDirectoryRequest_Create_:
-		if len(op.Create.GetPath()) > tdp.TDPMaxPathLength {
+		if len(op.Create.GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
 	case *tdpbv1.SharedDirectoryRequest_Delete_:
-		if len(op.Delete.GetPath()) > tdp.TDPMaxPathLength {
+		if len(op.Delete.GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
 	case *tdpbv1.SharedDirectoryRequest_Truncate_:
-		if len(op.Truncate.GetPath()) > tdp.TDPMaxPathLength {
+		if len(op.Truncate.GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
 	case *tdpbv1.SharedDirectoryRequest_Read_:
-		if len(op.Read.GetPath()) > tdp.TDPMaxPathLength {
+		if len(op.Read.GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
 	case *tdpbv1.SharedDirectoryRequest_Write_:
-		if len(op.Write.GetPath()) > tdp.TDPMaxPathLength {
+		if len(op.Write.GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
-		if len(op.Write.GetData()) > tdp.TDPMaxFileReadWriteLength {
+		if len(op.Write.GetData()) > tdp.MaxFileReadWriteLength {
 			return tdp.FileReadWriteMaxLenErr
 		}
 	case *tdpbv1.SharedDirectoryRequest_Info_:
-		if len(op.Info.GetPath()) > tdp.TDPMaxPathLength {
+		if len(op.Info.GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
 	case *tdpbv1.SharedDirectoryRequest_List_:
-		if len(op.List.GetPath()) > tdp.TDPMaxPathLength {
+		if len(op.List.GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
 	case *tdpbv1.SharedDirectoryRequest_Move_:
-		if len(op.Move.GetNewPath()) > tdp.TDPMaxPathLength ||
-			len(op.Move.GetOriginalPath()) > tdp.TDPMaxPathLength {
+		if len(op.Move.GetNewPath()) > tdp.MaxPathLength ||
+			len(op.Move.GetOriginalPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
 	}
@@ -379,20 +379,20 @@ func (s *SharedDirectoryResponse) Encode() ([]byte, error) {
 func (s *SharedDirectoryResponse) validate() error {
 	switch op := s.Operation.(type) {
 	case *tdpbv1.SharedDirectoryResponse_Create_:
-		if len(op.Create.GetFso().GetPath()) > tdp.TDPMaxPathLength {
+		if len(op.Create.GetFso().GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
 	case *tdpbv1.SharedDirectoryResponse_Read_:
-		if len(op.Read.GetData()) > tdp.TDPMaxFileReadWriteLength {
+		if len(op.Read.GetData()) > tdp.MaxFileReadWriteLength {
 			return tdp.FileReadWriteMaxLenErr
 		}
 	case *tdpbv1.SharedDirectoryResponse_Info_:
-		if len(op.Info.GetFso().GetPath()) > tdp.TDPMaxPathLength {
+		if len(op.Info.GetFso().GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
 	case *tdpbv1.SharedDirectoryResponse_List_:
 		for _, fso := range op.List.GetFsoList() {
-			if len(fso.GetPath()) > tdp.TDPMaxPathLength {
+			if len(fso.GetPath()) > tdp.MaxPathLength {
 				return tdp.StringMaxLenErr
 			}
 		}

--- a/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
@@ -69,6 +69,8 @@ func (c *ClientHello) Encode() ([]byte, error) {
 	})
 }
 
+func (_ *ClientHello) validate() error { return nil }
+
 // ServerHello is the first message sent by the server *after* receiving
 // the ClientHello. It selects and advertises server capabilities and
 // connection properties.
@@ -82,6 +84,8 @@ func (s *ServerHello) Encode() ([]byte, error) {
 		},
 	})
 }
+
+func (_ *ServerHello) validate() error { return nil }
 
 // PNGFrame carries screen data in PNG format. It is required
 // for interop with older session recordings that came before
@@ -97,6 +101,8 @@ func (p *PNGFrame) Encode() ([]byte, error) {
 	})
 }
 
+func (_ *PNGFrame) validate() error { return nil }
+
 // FastPathPDU is a raw RDP Fast-Path Protocol Data Unit (PDU).
 type FastPathPDU tdpbv1.FastPathPDU
 
@@ -109,6 +115,8 @@ func (f *FastPathPDU) Encode() ([]byte, error) {
 	})
 }
 
+func (_ *FastPathPDU) validate() error { return nil }
+
 // RDPResponsePDU is a raw RDP response PDU.
 type RDPResponsePDU tdpbv1.RDPResponsePDU
 
@@ -120,6 +128,8 @@ func (f *RDPResponsePDU) Encode() ([]byte, error) {
 		},
 	})
 }
+
+func (_ *RDPResponsePDU) validate() error { return nil }
 
 // SyncKeys message is sent from the client to the server to
 // synchronize the state of keyboard's modifier keys.
@@ -134,6 +144,8 @@ func (s *SyncKeys) Encode() ([]byte, error) {
 	})
 }
 
+func (_ *SyncKeys) validate() error { return nil }
+
 // MouseMove contains mouse coordinates.
 type MouseMove tdpbv1.MouseMove
 
@@ -145,6 +157,8 @@ func (m *MouseMove) Encode() ([]byte, error) {
 		},
 	})
 }
+
+func (_ *MouseMove) validate() error { return nil }
 
 // MouseButton contains mouse button state.
 type MouseButton tdpbv1.MouseButton
@@ -158,6 +172,8 @@ func (m *MouseButton) Encode() ([]byte, error) {
 	})
 }
 
+func (_ *MouseButton) validate() error { return nil }
+
 // KeyboardButton encodes a keyboard button update.
 type KeyboardButton tdpbv1.KeyboardButton
 
@@ -169,6 +185,8 @@ func (k *KeyboardButton) Encode() ([]byte, error) {
 		},
 	})
 }
+
+func (_ *KeyboardButton) validate() error { return nil }
 
 // ClientScreenSpec contains the dimensions of the client view.
 // It is included in the ClientHello at the start of the session, and
@@ -184,6 +202,8 @@ func (c *ClientScreenSpec) Encode() ([]byte, error) {
 	})
 }
 
+func (_ *ClientScreenSpec) validate() error { return nil }
+
 // Alert encodes an error/warning/informational message and severity code.
 // Sent by the server to the client for display.
 type Alert tdpbv1.Alert
@@ -197,6 +217,8 @@ func (a *Alert) Encode() ([]byte, error) {
 	})
 }
 
+func (_ *Alert) validate() error { return nil }
+
 // MouseWheel contains a mousewheel update.
 type MouseWheel tdpbv1.MouseWheel
 
@@ -208,6 +230,8 @@ func (m *MouseWheel) Encode() ([]byte, error) {
 		},
 	})
 }
+
+func (_ *MouseWheel) validate() error { return nil }
 
 // ClipboardData carries clipboard data to support copy/paste
 // operations between the client and target desktop.
@@ -222,6 +246,13 @@ func (c *ClipboardData) Encode() ([]byte, error) {
 	})
 }
 
+func (c *ClipboardData) validate() error {
+	if len(c.Data) > tdp.MaxClipboardDataLength {
+		return tdp.ClipDataMaxLenErr
+	}
+	return nil
+}
+
 // MFA encodes the MFA challenge and response when per-session
 // MFA is enabled.
 type MFA tdpbv1.MFA
@@ -234,6 +265,8 @@ func (m *MFA) Encode() ([]byte, error) {
 		},
 	})
 }
+
+func (_ *MFA) validate() error { return nil }
 
 // SharedDirectoryAnnounce is sent by the client to begin sharing a directory.
 type SharedDirectoryAnnounce tdpbv1.SharedDirectoryAnnounce
@@ -259,6 +292,8 @@ func (s *SharedDirectoryRemove) Encode() ([]byte, error) {
 	})
 }
 
+func (_ *SharedDirectoryAnnounce) validate() error { return nil }
+
 // SharedDirectoryAcknowledge is sent by the server to acknowledge a
 // new shared directory.
 type SharedDirectoryAcknowledge tdpbv1.SharedDirectoryAcknowledge
@@ -271,6 +306,8 @@ func (s *SharedDirectoryAcknowledge) Encode() ([]byte, error) {
 		},
 	})
 }
+
+func (_ *SharedDirectoryAcknowledge) validate() error { return nil }
 
 // SharedDirectoryRequest encodes various directory operation requests
 // such as Info, Create, Delete, List, Read, Write, Move, or Truncate.
@@ -285,6 +322,48 @@ func (s *SharedDirectoryRequest) Encode() ([]byte, error) {
 	})
 }
 
+func (s *SharedDirectoryRequest) validate() error {
+	switch op := s.Operation.(type) {
+	case *tdpbv1.SharedDirectoryRequest_Create_:
+		if len(op.Create.GetPath()) > tdp.TDPMaxPathLength {
+			return tdp.StringMaxLenErr
+		}
+	case *tdpbv1.SharedDirectoryRequest_Delete_:
+		if len(op.Delete.GetPath()) > tdp.TDPMaxPathLength {
+			return tdp.StringMaxLenErr
+		}
+	case *tdpbv1.SharedDirectoryRequest_Truncate_:
+		if len(op.Truncate.GetPath()) > tdp.TDPMaxPathLength {
+			return tdp.StringMaxLenErr
+		}
+	case *tdpbv1.SharedDirectoryRequest_Read_:
+		if len(op.Read.GetPath()) > tdp.TDPMaxPathLength {
+			return tdp.StringMaxLenErr
+		}
+	case *tdpbv1.SharedDirectoryRequest_Write_:
+		if len(op.Write.GetPath()) > tdp.TDPMaxPathLength {
+			return tdp.StringMaxLenErr
+		}
+		if len(op.Write.GetData()) > tdp.TDPMaxFileReadWriteLength {
+			return tdp.FileReadWriteMaxLenErr
+		}
+	case *tdpbv1.SharedDirectoryRequest_Info_:
+		if len(op.Info.GetPath()) > tdp.TDPMaxPathLength {
+			return tdp.StringMaxLenErr
+		}
+	case *tdpbv1.SharedDirectoryRequest_List_:
+		if len(op.List.GetPath()) > tdp.TDPMaxPathLength {
+			return tdp.StringMaxLenErr
+		}
+	case *tdpbv1.SharedDirectoryRequest_Move_:
+		if len(op.Move.GetNewPath()) > tdp.TDPMaxPathLength ||
+			len(op.Move.GetOriginalPath()) > tdp.TDPMaxPathLength {
+			return tdp.StringMaxLenErr
+		}
+	}
+	return nil
+}
+
 // SharedDirectoryResponse encodes a response to a previous SharedDirectoryRequest.
 type SharedDirectoryResponse tdpbv1.SharedDirectoryResponse
 
@@ -295,6 +374,31 @@ func (s *SharedDirectoryResponse) Encode() ([]byte, error) {
 			SharedDirectoryResponse: (*tdpbv1.SharedDirectoryResponse)(s),
 		},
 	})
+}
+
+func (s *SharedDirectoryResponse) validate() error {
+	switch op := s.Operation.(type) {
+	case *tdpbv1.SharedDirectoryResponse_Create_:
+		if len(op.Create.GetFso().GetPath()) > tdp.TDPMaxPathLength {
+			return tdp.StringMaxLenErr
+		}
+	case *tdpbv1.SharedDirectoryResponse_Read_:
+		if len(op.Read.GetData()) > tdp.TDPMaxFileReadWriteLength {
+			return tdp.FileReadWriteMaxLenErr
+		}
+	case *tdpbv1.SharedDirectoryResponse_Info_:
+		if len(op.Info.GetFso().GetPath()) > tdp.TDPMaxPathLength {
+			return tdp.StringMaxLenErr
+		}
+	case *tdpbv1.SharedDirectoryResponse_List_:
+		for _, fso := range op.List.GetFsoList() {
+			if len(fso.GetPath()) > tdp.TDPMaxPathLength {
+				return tdp.StringMaxLenErr
+			}
+		}
+	case *tdpbv1.SharedDirectoryResponse_Move_:
+	}
+	return nil
 }
 
 // LatencyStats are sent to the client to display connection
@@ -311,6 +415,8 @@ func (l *LatencyStats) Encode() ([]byte, error) {
 	})
 }
 
+func (_ *LatencyStats) validate() error { return nil }
+
 // Ping is used to measure latency between the Proxy and
 // target desktop.
 type Ping tdpbv1.Ping
@@ -323,6 +429,8 @@ func (p *Ping) Encode() ([]byte, error) {
 		},
 	})
 }
+
+func (_ *Ping) validate() error { return nil }
 
 func marshalWithHeader(msg proto.Message) ([]byte, error) {
 	data, err := proto.Marshal(msg)
@@ -340,6 +448,13 @@ func marshalWithHeader(msg proto.Message) ([]byte, error) {
 	copy(header[tdpbHeaderLength:], data)
 
 	return header, nil
+}
+
+func WarningConstructor(msg string) tdp.Message {
+	return &Alert{
+		Severity: tdpbv1.AlertSeverity_ALERT_SEVERITY_WARNING,
+		Message:  msg,
+	}
 }
 
 // DecodePermissive quietly tolerates unknown message types to allow interop
@@ -404,7 +519,7 @@ func DecodeStrict(rdr io.Reader) (tdp.Message, error) {
 	}
 
 	if msg := messageFromEnvelope(env); msg != nil {
-		return msg, nil
+		return msg, msg.validate()
 	}
 
 	// Allow the caller to distinguish unmarshal errors (likely considered fatal)
@@ -413,7 +528,14 @@ func DecodeStrict(rdr io.Reader) (tdp.Message, error) {
 	return nil, trace.Wrap(ErrUnknownMessage)
 }
 
-func messageFromEnvelope(e *tdpbv1.Envelope) tdp.Message {
+type validatableMessage interface {
+	tdp.Message
+	validate() error
+}
+
+// All top-level messages inside the envelope must implement
+// a 'validate' method.
+func messageFromEnvelope(e *tdpbv1.Envelope) validatableMessage {
 	switch m := e.Payload.(type) {
 	case *tdpbv1.Envelope_ClientHello:
 		return (*ClientHello)(m.ClientHello)

--- a/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/tdpb.go
@@ -342,6 +342,9 @@ func (s *SharedDirectoryRequest) validate() error {
 		if len(op.Read.GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
 		}
+		if op.Read.GetLength() > tdp.MaxFileReadWriteLength {
+			return tdp.FileReadWriteMaxLenErr
+		}
 	case *tdpbv1.SharedDirectoryRequest_Write_:
 		if len(op.Write.GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
@@ -388,6 +391,10 @@ func (s *SharedDirectoryResponse) validate() error {
 		if len(op.Read.GetData()) > tdp.MaxFileReadWriteLength {
 			return tdp.FileReadWriteMaxLenErr
 		}
+	case *tdpbv1.SharedDirectoryResponse_Write_:
+		if op.Write.GetBytesWritten() > tdp.MaxFileReadWriteLength {
+			return tdp.FileReadWriteMaxLenErr
+		}
 	case *tdpbv1.SharedDirectoryResponse_Info_:
 		if len(op.Info.GetFso().GetPath()) > tdp.MaxPathLength {
 			return tdp.StringMaxLenErr
@@ -398,7 +405,6 @@ func (s *SharedDirectoryResponse) validate() error {
 				return tdp.StringMaxLenErr
 			}
 		}
-	case *tdpbv1.SharedDirectoryResponse_Move_:
 	}
 	return nil
 }

--- a/lib/srv/desktop/tdp/protocol/tdpb/tdpb_test.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/tdpb_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -220,4 +221,252 @@ func TestSendRecv(t *testing.T) {
 
 	// Should not have received a write error
 	require.NoError(t, writeError)
+}
+
+func TestMessageValidation(t *testing.T) {
+	excessiveClipboardData := make([]byte, tdp.MaxClipboardDataLength+1)
+	excessiveReadWriteData := make([]byte, tdp.MaxFileReadWriteLength+1)
+	excessivePath := strings.Repeat("a", tdp.MaxPathLength+1)
+
+	tests := []struct {
+		name    string
+		message tdp.Message
+		expect  func(t *testing.T, e error)
+	}{
+		{
+			name: "clipboard too large",
+			message: &ClipboardData{
+				Data: excessiveClipboardData,
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.ClipDataMaxLenErr)
+			},
+		},
+		{
+			name: "create request path too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_Create_{
+					Create: &tdpbv1.SharedDirectoryRequest_Create{
+						Path: excessivePath,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "delete request path too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_Delete_{
+					Delete: &tdpbv1.SharedDirectoryRequest_Delete{
+						Path: excessivePath,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "truncate request path too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_Truncate_{
+					Truncate: &tdpbv1.SharedDirectoryRequest_Truncate{
+						Path: excessivePath,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "write request too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_Write_{
+					Write: &tdpbv1.SharedDirectoryRequest_Write{
+						Data: excessiveReadWriteData,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.FileReadWriteMaxLenErr)
+			},
+		},
+		{
+			name: "read request too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_Read_{
+					Read: &tdpbv1.SharedDirectoryRequest_Read{
+						Length: tdp.MaxFileReadWriteLength + 1,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.FileReadWriteMaxLenErr)
+			},
+		},
+		{
+			name: "read request path too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_Read_{
+					Read: &tdpbv1.SharedDirectoryRequest_Read{
+						Length: tdp.MaxFileReadWriteLength,
+						Path:   excessivePath,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "write path too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_Write_{
+					Write: &tdpbv1.SharedDirectoryRequest_Write{
+						Path: excessivePath,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "info request path too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_Info_{
+					Info: &tdpbv1.SharedDirectoryRequest_Info{
+						Path: excessivePath,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "list request path too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_List_{
+					List: &tdpbv1.SharedDirectoryRequest_List{
+						Path: excessivePath,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "move original path too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_Move_{
+					Move: &tdpbv1.SharedDirectoryRequest_Move{
+						OriginalPath: excessivePath,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "move new path too large",
+			message: &SharedDirectoryRequest{
+				Operation: &tdpbv1.SharedDirectoryRequest_Move_{
+					Move: &tdpbv1.SharedDirectoryRequest_Move{
+						NewPath: excessivePath,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "read response too large",
+			message: &SharedDirectoryResponse{
+				Operation: &tdpbv1.SharedDirectoryResponse_Read_{
+					Read: &tdpbv1.SharedDirectoryResponse_Read{
+						Data: excessiveReadWriteData,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.FileReadWriteMaxLenErr)
+			},
+		},
+		{
+			name: "write response too large",
+			message: &SharedDirectoryResponse{
+				Operation: &tdpbv1.SharedDirectoryResponse_Write_{
+					Write: &tdpbv1.SharedDirectoryResponse_Write{
+						BytesWritten: tdp.MaxFileReadWriteLength + 1,
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.FileReadWriteMaxLenErr)
+			},
+		},
+		{
+			name: "info response path too large",
+			message: &SharedDirectoryResponse{
+				Operation: &tdpbv1.SharedDirectoryResponse_Info_{
+					Info: &tdpbv1.SharedDirectoryResponse_Info{
+						Fso: &tdpbv1.FileSystemObject{
+							Path: excessivePath,
+						},
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "create response path too large",
+			message: &SharedDirectoryResponse{
+				Operation: &tdpbv1.SharedDirectoryResponse_Create_{
+					Create: &tdpbv1.SharedDirectoryResponse_Create{
+						Fso: &tdpbv1.FileSystemObject{
+							Path: excessivePath,
+						},
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+		{
+			name: "list response path too large",
+			message: &SharedDirectoryResponse{
+				Operation: &tdpbv1.SharedDirectoryResponse_List_{
+					List: &tdpbv1.SharedDirectoryResponse_List{
+						FsoList: []*tdpbv1.FileSystemObject{
+							{
+								Path: excessivePath,
+							},
+						},
+					},
+				},
+			},
+			expect: func(t *testing.T, e error) {
+				require.ErrorIs(t, e, tdp.StringMaxLenErr)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			require.NoError(t, tdp.EncodeTo(buf, test.message))
+			_, err := DecodeStrict(buf)
+			test.expect(t, err)
+		})
+	}
 }

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -658,19 +658,17 @@ func (s *WindowsService) handleConnection(proxyConn *tls.Conn) {
 
 	// Figure out which protocol the client is using
 	clientProtocol := proxyConn.ConnectionState().NegotiatedProtocol
-	var decoder tdp.Decoder
+	var tdpConn *tdp.Conn
 	switch clientProtocol {
 	case tdpb.ProtocolName:
-		decoder = tdp.DecoderAdapter(tdpb.DecodePermissive)
+		tdpConn = tdp.NewConn(proxyConn, tdp.DecoderAdapter(tdpb.DecodePermissive), tdpb.WarningConstructor)
 	case "":
 		clientProtocol = legacy.ProtocolName
-		decoder = legacy.Decode
+		tdpConn = tdp.NewConn(proxyConn, legacy.Decode, legacy.WarningConstructor)
 	default:
 		log.ErrorContext(context.Background(), "Unknown client protocol selection", "protocol", clientProtocol)
 		return
 	}
-
-	tdpConn := tdp.NewConn(proxyConn, decoder)
 	defer tdpConn.Close()
 
 	// Inline function to enforce that we are centralizing TDP/TDPB Error sending in this function.

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -145,7 +145,7 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 	}
 
 	// Client always speaks TDPB.
-	clientConn := tdp.NewConn(downstreamRW, tdp.DecoderAdapter(tdpb.DecodePermissive))
+	clientConn := tdp.NewConn(downstreamRW, tdp.DecoderAdapter(tdpb.DecodePermissive), tdpb.WarningConstructor)
 	// Receive, enrich, and forward the ClientHello message
 	msg, err := clientConn.ReadMessage()
 	if err != nil {
@@ -171,14 +171,14 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 	var tdpServerConn tdp.MessageReadWriteCloser
 	if serverProtocol == tdpb.ProtocolName {
 		// Use TDPB decoder
-		tdpServerConn = tdp.NewConn(conn, tdp.DecoderAdapter(tdpb.DecodePermissive))
+		tdpServerConn = tdp.NewConn(conn, tdp.DecoderAdapter(tdpb.DecodePermissive), tdpb.WarningConstructor)
 		// Send the client hello
 		if err := tdpServerConn.WriteMessage(hello); err != nil {
 			return trace.Wrap(err)
 		}
 	} else {
 		// Use default TDP decoder
-		tdpServerConn = tdp.NewConn(conn, legacy.Decode)
+		tdpServerConn = tdp.NewConn(conn, legacy.Decode, legacy.WarningConstructor)
 		defer tdpServerConn.Close()
 
 		// Now that we have a connection to the desktop service, we can

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2677,7 +2677,7 @@ func mustStartWindowsDesktopMock(t *testing.T, authClient *auth.Server) *windows
 }
 
 func (w *windowsDesktopServiceMock) handleConn(t *testing.T, conn *tls.Conn) {
-	tdpConn := tdp.NewConn(conn, legacy.Decode)
+	tdpConn := tdp.NewConn(conn, legacy.Decode, legacy.WarningConstructor)
 
 	// Ensure that incoming connection is MFAVerified.
 	require.NotEmpty(t, conn.ConnectionState().PeerCertificates)
@@ -2783,7 +2783,7 @@ func TestDesktopAccessMFA(t *testing.T) {
 
 			tc.mfaHandler(t, ws, dev)
 
-			tdpClient := tdp.NewConn(&WebsocketIO{Conn: ws}, legacy.Decode)
+			tdpClient := tdp.NewConn(&WebsocketIO{Conn: ws}, legacy.Decode, legacy.WarningConstructor)
 
 			msg, err := tdpClient.ReadMessage()
 			require.NoError(t, err)
@@ -2800,7 +2800,7 @@ func TestDesktopAccessMFA(t *testing.T) {
 
 func handleDesktopMFAWebauthnChallenge(t *testing.T, ws *websocket.Conn, dev *authtest.Device) {
 	wsrwc := &WebsocketIO{Conn: ws}
-	tdpConn := tdp.NewConn(wsrwc, legacy.Decode)
+	tdpConn := tdp.NewConn(wsrwc, legacy.Decode, legacy.WarningConstructor)
 
 	br := bufio.NewReader(wsrwc)
 	mt, err := br.ReadByte()

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -348,7 +348,7 @@ func newHandshaker(protocol string, ws *websocket.Conn) handshaker {
 	}
 	// Default to TDP
 	return &tdpHandshaker{
-		connection: tdp.NewConn(&WebsocketIO{Conn: ws}, legacy.Decode),
+		connection: tdp.NewConn(&WebsocketIO{Conn: ws}, legacy.Decode, legacy.WarningConstructor),
 	}
 }
 
@@ -756,9 +756,9 @@ func (d desktopPinger) pingTDPB(ctx context.Context) error {
 
 func newConn(rwc io.ReadWriteCloser, protocol string) *tdp.Conn {
 	if protocol == tdpb.ProtocolName {
-		return tdp.NewConn(rwc, tdp.DecoderAdapter(tdpb.DecodePermissive))
+		return tdp.NewConn(rwc, tdp.DecoderAdapter(tdpb.DecodePermissive), tdpb.WarningConstructor)
 	}
-	return tdp.NewConn(rwc, legacy.Decode)
+	return tdp.NewConn(rwc, legacy.Decode, legacy.WarningConstructor)
 }
 
 type desktopWebsocketProxy struct {

--- a/lib/web/desktop_test.go
+++ b/lib/web/desktop_test.go
@@ -88,7 +88,7 @@ func TestProxyConnection(t *testing.T) {
 
 	// Echos back any TDP messages received
 	tdpEchoServer := func(conn net.Conn) error {
-		tdpConn := tdp.NewConn(conn, legacy.Decode)
+		tdpConn := tdp.NewConn(conn, legacy.Decode, legacy.WarningConstructor)
 		for {
 			msg, err := tdpConn.ReadMessage()
 			if err != nil {
@@ -102,7 +102,7 @@ func TestProxyConnection(t *testing.T) {
 	}
 
 	tdpClient := func(w *websocket.Conn, expectLatency bool) error {
-		conn := tdp.NewConn(&WebsocketIO{Conn: w}, legacy.Decode)
+		conn := tdp.NewConn(&WebsocketIO{Conn: w}, legacy.Decode, legacy.WarningConstructor)
 
 		rdpMsg := legacy.RDPResponsePDU([]byte("hello"))
 		mouseMsg := legacy.MouseWheel{Axis: 2, Delta: 4}
@@ -144,7 +144,7 @@ func TestProxyConnection(t *testing.T) {
 	}
 
 	tdpbClient := func(w *websocket.Conn, expectLatency bool) error {
-		conn := tdp.NewConn(&WebsocketIO{Conn: w}, tdp.DecoderAdapter(tdpb.DecodePermissive))
+		conn := tdp.NewConn(&WebsocketIO{Conn: w}, tdp.DecoderAdapter(tdpb.DecodePermissive), tdpb.WarningConstructor)
 
 		rdpMsg := &tdpb.RDPResponsePDU{
 			Response: []byte("hello"),
@@ -467,4 +467,8 @@ func TestDesktopWebsocketAdapter(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, &tdpb.Alert{}, msg)
 	assert.Equal(t, "tdpb!", msg.(*tdpb.Alert).Message)
+}
+
+func TestLegacyErrorHandler(t *testing.T) {
+
 }

--- a/lib/web/desktop_test.go
+++ b/lib/web/desktop_test.go
@@ -468,7 +468,3 @@ func TestDesktopWebsocketAdapter(t *testing.T) {
 	require.IsType(t, &tdpb.Alert{}, msg)
 	assert.Equal(t, "tdpb!", msg.(*tdpb.Alert).Message)
 }
-
-func TestLegacyErrorHandler(t *testing.T) {
-
-}


### PR DESCRIPTION
This PR addresses [an issue found by Codex](https://github.com/gravitational/teleport/pull/65478#discussion_r3147749374) on the TDPB backport to v18. 

Legacy TDP enforced limits on message fields at decode time (Path lengths, directory read/write sizes, and clipboard length). The rework for TDPB dropped some of these checks and also made the legacy TDP checks fatal where they used to simply emit Alert messages. This PR restores the legacy behavior for both TDP and TDPB connections.

A good chunk of this PR is simply refactoring. The limit constants and associated sentinel errors have been lifted from the `legacy` package up into `tdp`. Outside of that, the main changes are:

1. `tdp.Conn` will inspect decode errors with `IsNonFatalErr` and emit Alert message at "warning" severity to the sender. It swallows the offending message and re-blocks on decoding the next message.
2. To maintain symmetry between implementations, TDPB messages now implement a `validate()` method which is called during the decoding step. Both TDP and TDPB return the same set of non-fatal errors with the same semantics during decoding. 


<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local test cluster with WDS and at least one reachable Windows Desktop configured.
### Test Cases
- [x] Unit tests that exercise the new error detection and alerting behavior of `tdp.Conn`. 
- [x] Create a connection to the desktop and attempt to copy more than 1 MiB of data to the clipboard. Observe that a warning is emitted.
