### PR TITLE
tfgen: add hash to sanitized resource name

### DIFF
--- a/lib/tfgen/tfgen.go
+++ b/lib/tfgen/tfgen.go
@@ -20,6 +20,7 @@ package tfgen
 
 import (
 	"fmt"
+	"hash/fnv"
 	"regexp"
 	"strings"
 	"time"
@@ -42,8 +43,23 @@ var invalidTerraformName = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 
 // SanitizeResourceName returns a copy of name safe for use as Terraform resource
 // name. Chars not matching "a-zA-Z0-9_-" are replaced with underscores.
+//
+// Note: this method does not guarantee the resulting name is unique e.g.:
+// "alice.foo" and "alice_foo" will both sanitize to "alice_foo".
+// Use UniqueSanitizedResourceName to ensure uniqueness when needed.
 func SanitizeResourceName(name string) string {
 	return invalidTerraformName.ReplaceAllString(name, "_")
+}
+
+// UniqueSanitizedResourceName returns a sanitized name with a short hash suffix.
+// This avoid duplicates when different names sanitize to the same string e.g.:
+// "alice.foo" and "alice_foo" will now sanitize to "alice_foo_<UNIQUE HASH>").
+func UniqueSanitizedResourceName(name string) string {
+	h := fnv.New32a()
+	// h.Write() will never return an error.
+	_, _ = h.Write([]byte(name))
+	hash := h.Sum32()
+	return fmt.Sprintf("%s_%x", SanitizeResourceName(name), hash)
 }
 
 // Resource for which Terraform configuration can be generated. It's a subset of

--- a/lib/tfgen/tfgen_test.go
+++ b/lib/tfgen/tfgen_test.go
@@ -448,6 +448,23 @@ func TestGenerate_ResourceComment(t *testing.T) {
 	)
 }
 
+func TestUniqueSanitizedResourceName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "alice.foo", want: "alice_foo_3e0c50e5"},
+		{input: "alice_foo", want: "alice_foo_28a09df0"},
+		{input: "alice@foo", want: "alice_foo_d1c41c77"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := tfgen.UniqueSanitizedResourceName(tt.input)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestSanitizeResourceName(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
This PR adds `UniqueSanitizedResourceName` func where it ensures the sanitized resource name is unique by adding a hash suffix to the sanitized name. This handles the edge case where both `alice.foo` and `alice_foo` sanitized to the same value `alice_foo` with just `SanitizeResourceName`
