### PR TITLE
Fix `tsh request show` output formatting

### DIFF
--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -224,11 +224,11 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 	}
 
 	printReviewBlock := func(title string, revs []types.AccessReview) error {
-		fmt.Fprint(cf.Stdout(), "------------------------------------------------")
+		fmt.Fprintln(cf.Stdout(), "------------------------------------------------")
 		fmt.Fprintf(cf.Stdout(), "%s:\n", title)
 
 		for _, rev := range revs {
-			fmt.Fprint(cf.Stdout(), "  ----------------------------------------------")
+			fmt.Fprintln(cf.Stdout(), "  ----------------------------------------------")
 
 			revReason := "[none]"
 			if rev.Reason != "" {


### PR DESCRIPTION
Changelog: Fixed minor formatting bug on `tsh request show` output

<details><summary>Before/After</summary>
<p>

Before
<img width="616" height="193" alt="Screenshot 2026-04-27 at 4 37 44 PM" src="https://github.com/user-attachments/assets/814f605b-0894-42ee-992f-bf5f32ea0900" />

After
<img width="621" height="224" alt="Screenshot 2026-04-27 at 4 37 53 PM" src="https://github.com/user-attachments/assets/7681f49f-4df9-4865-8893-4d6921c03732" />

</p>
</details> 

## Manual Test Plan
### Test Environment

Teleport Cloud + local dev `tsh` build.

### Test Cases
- [x]  Verify `tsh request show` output properly formats newlines
