### PR TITLE
[v17] app: Preserve trailing slash in URI redirect

### DIFF
--- a/lib/srv/app/transport.go
+++ b/lib/srv/app/transport.go
@@ -252,6 +252,12 @@ func (t *transport) needsPathRedirect(r *http.Request) (string, bool) {
 	if uriPath == "." {
 		uriPath = "/"
 	}
+	// path.Clean strips trailing slashes, but administrators may configure
+	// URIs like http://backend:9000/dashboard/ where the trailing slash is
+	// significant. Preserve it when the original URI had one.
+	if uriPath != "/" && strings.HasSuffix(t.uri.Path, "/") {
+		uriPath += "/"
+	}
 	if uriPath == "/" {
 		return "", false
 	}

--- a/lib/srv/app/transport_test.go
+++ b/lib/srv/app/transport_test.go
@@ -1,0 +1,111 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package app
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestNeedsPathRedirect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		uri          string
+		requestPath  string
+		wantRedirect bool
+		wantLocation string
+	}{
+		{
+			name:         "no path",
+			uri:          "http://backend:9000",
+			requestPath:  "/",
+			wantRedirect: false,
+		},
+		{
+			name:         "root path",
+			uri:          "http://backend:9000/",
+			requestPath:  "/",
+			wantRedirect: false,
+		},
+		{
+			name:         "path without trailing slash",
+			uri:          "http://backend:9000/app",
+			requestPath:  "/",
+			wantRedirect: true,
+			wantLocation: "https://public:443/app",
+		},
+		{
+			name:         "path with trailing slash",
+			uri:          "http://backend:9000/app/",
+			requestPath:  "/",
+			wantRedirect: true,
+			wantLocation: "https://public:443/app/",
+		},
+		{
+			name:         "deep path with trailing slash",
+			uri:          "http://backend:9000/a/b/c/",
+			requestPath:  "/",
+			wantRedirect: true,
+			wantLocation: "https://public:443/a/b/c/",
+		},
+		{
+			name:         "non-root request",
+			uri:          "http://backend:9000/app/",
+			requestPath:  "/app/",
+			wantRedirect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsedURI, err := url.Parse(tt.uri)
+			require.NoError(t, err)
+
+			tr := &transport{
+				transportConfig: &transportConfig{
+					app: &types.AppV3{
+						Spec: types.AppSpecV3{
+							PublicAddr: "public",
+						},
+					},
+					publicPort: "443",
+				},
+				uri: parsedURI,
+			}
+
+			req := &http.Request{URL: &url.URL{Path: tt.requestPath}}
+			location, ok := tr.needsPathRedirect(req)
+			require.Equal(t, tt.wantRedirect, ok)
+			if tt.wantRedirect {
+				require.Equal(t, tt.wantLocation, location)
+			} else {
+				require.Empty(t, location)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When an app is configured with a trailing slash in its URI
(e.g., `uri: http://backend:9000/dashboard/`), Teleport's redirect
handler strips the slash because `path.Clean` removes trailing slashes.
The upstream backend gets `/dashboard` instead of `/dashboard/` and
returns 404.

Preserve the trailing slash from the original URI after `path.Clean`
normalization by re-appending it when the configured URI ended with one.
Add `TestNeedsPathRedirect` with table-driven subtests covering the
redirect logic.

Issue: https://github.com/gravitational/teleport/issues/47979
Backport: https://github.com/gravitational/teleport/pull/65739

## Manual Test Plan

### Test Environment

macOS, single-process Teleport (auth + proxy + app service), enterprise
build. One HTTP app configured with a trailing-slash URI pointing at a
local servedir backend.

```yaml
app_service:
  enabled: true
  apps:
    - name: app
      uri: http://127.0.0.1:9080/dashboard/
      public_addr: app.t.tp
```

<details>
<summary>Test backend (Go program that serves distinct responses per path)</summary>

```go
package main

import (
	"fmt"
	"net/http"
	"os"
)

func main() {
	http.HandleFunc("/dashboard/", func(w http.ResponseWriter, r *http.Request) {
		fmt.Fprintf(w, "OK: reached %s (trailing slash)\n", r.URL.Path)
	})
	http.HandleFunc("/dashboard", func(w http.ResponseWriter, r *http.Request) {
		fmt.Fprintf(w, "OK: reached %s (no trailing slash)\n", r.URL.Path)
	})
	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		fmt.Fprintf(w, "OK: reached %s (root)\n", r.URL.Path)
	})

	port := "9080"
	if len(os.Args) > 1 {
		port = os.Args[1]
	}
	fmt.Printf("backend listening on :%s\n", port)
	http.ListenAndServe(":"+port, nil)
}
```

Save as `backend.go` and run with `go run backend.go 9080`.

</details>

### Test Cases

#### Test 1: Trailing-slash URI redirects correctly (with fix)

Configure an app with `uri: http://backend:9080/dashboard/` (trailing
slash). Open the app through the Teleport proxy at the root path.

- [x] The redirect location preserves the trailing slash (`/dashboard/`).

#### Test 2: Non-trailing-slash URI still works (with fix)

Configure an app with `uri: http://backend:9080/dashboard` (no trailing
slash). Open the app through the Teleport proxy at the root path.

- [x] The redirect location has no trailing slash (`/dashboard`).

#### Test 3: Root URI does not redirect (with fix)

Configure an app with `uri: http://backend:9080/` (root path only).
Open the app through the Teleport proxy.

- [x] No redirect occurs. The proxy serves the backend root directly.

#### Test 4: Regression baseline (without fix)

Build from master (before the fix) and repeat Test 1.

- [x] The redirect location strips the trailing slash (`/dashboard` instead of `/dashboard/`).
