### PR TITLE
[v18] [scopes] feat: filter scoped roles by name

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/service.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/service.pb.go
@@ -139,8 +139,11 @@ type ListScopedRolesRequest struct {
 	ResourceScope *v1.Filter `protobuf:"bytes,3,opt,name=resource_scope,json=resourceScope,proto3" json:"resource_scope,omitempty"`
 	// AssignableScope filters roles by their assignable scope if specified.
 	AssignableScope *v1.Filter `protobuf:"bytes,4,opt,name=assignable_scope,json=assignableScope,proto3" json:"assignable_scope,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// NameFilter filters roles by their name using a case-insensitive substring
+	// match if specified.
+	NameFilter    string `protobuf:"bytes,5,opt,name=name_filter,json=nameFilter,proto3" json:"name_filter,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListScopedRolesRequest) Reset() {
@@ -199,6 +202,13 @@ func (x *ListScopedRolesRequest) GetAssignableScope() *v1.Filter {
 		return x.AssignableScope
 	}
 	return nil
+}
+
+func (x *ListScopedRolesRequest) GetNameFilter() string {
+	if x != nil {
+		return x.NameFilter
+	}
+	return ""
 }
 
 // ListScopedRolesResponse is the response to list scoped roles.
@@ -1269,13 +1279,15 @@ const file_teleport_scopes_access_v1_service_proto_rawDesc = "" +
 	"\x14GetScopedRoleRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"R\n" +
 	"\x15GetScopedRoleResponse\x129\n" +
-	"\x04role\x18\x01 \x01(\v2%.teleport.scopes.access.v1.ScopedRoleR\x04role\"\xde\x01\n" +
+	"\x04role\x18\x01 \x01(\v2%.teleport.scopes.access.v1.ScopedRoleR\x04role\"\xff\x01\n" +
 	"\x16ListScopedRolesRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\x12A\n" +
 	"\x0eresource_scope\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\rresourceScope\x12E\n" +
-	"\x10assignable_scope\x18\x04 \x01(\v2\x1a.teleport.scopes.v1.FilterR\x0fassignableScope\"~\n" +
+	"\x10assignable_scope\x18\x04 \x01(\v2\x1a.teleport.scopes.v1.FilterR\x0fassignableScope\x12\x1f\n" +
+	"\vname_filter\x18\x05 \x01(\tR\n" +
+	"nameFilter\"~\n" +
 	"\x17ListScopedRolesResponse\x12;\n" +
 	"\x05roles\x18\x01 \x03(\v2%.teleport.scopes.access.v1.ScopedRoleR\x05roles\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"T\n" +

--- a/api/proto/teleport/scopes/access/v1/service.proto
+++ b/api/proto/teleport/scopes/access/v1/service.proto
@@ -87,6 +87,10 @@ message ListScopedRolesRequest {
 
   // AssignableScope filters roles by their assignable scope if specified.
   teleport.scopes.v1.Filter assignable_scope = 4;
+
+  // NameFilter filters roles by their name using a case-insensitive substring
+  // match if specified.
+  string name_filter = 5;
 }
 
 // ListScopedRolesResponse is the response to list scoped roles.

--- a/lib/scopes/cache/roles/role_cache.go
+++ b/lib/scopes/cache/roles/role_cache.go
@@ -21,6 +21,7 @@ package roles
 import (
 	"context"
 
+	"github.com/charlievieth/strcase"
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
 
@@ -125,10 +126,17 @@ func (c *RoleCache) ListScopedRolesWithFilter(ctx context.Context, req *scopedac
 		return nil, trace.NotImplemented("assignable scope filtering for scoped role roles is not yet supported")
 	}
 
+	finalFilter := filter
+	if nameFilter := req.GetNameFilter(); nameFilter != "" {
+		finalFilter = func(role *scopedaccessv1.ScopedRole) bool {
+			return strcase.Contains(role.GetMetadata().GetName(), nameFilter) && filter(role)
+		}
+	}
+
 	var out []*scopedaccessv1.ScopedRole
 	var nextCursor cache.Cursor[string]
 Outer:
-	for scope := range getter(scope, c.cache.WithCursor(cursor), c.cache.WithFilter(filter)) {
+	for scope := range getter(scope, c.cache.WithCursor(cursor), c.cache.WithFilter(finalFilter)) {
 		for role := range scope.Items() {
 			if len(out) == pageSize {
 				nextCursor = cache.Cursor[string]{
@@ -165,7 +173,7 @@ func (c *RoleCache) Put(role *scopedaccessv1.ScopedRole) error {
 	return nil
 }
 
-// Del removes an role from the cache by name.
+// Delete removes an role from the cache by name.
 func (c *RoleCache) Delete(name string) {
 	c.cache.Del(name)
 }

--- a/lib/scopes/cache/roles/role_cache.go
+++ b/lib/scopes/cache/roles/role_cache.go
@@ -173,7 +173,7 @@ func (c *RoleCache) Put(role *scopedaccessv1.ScopedRole) error {
 	return nil
 }
 
-// Delete removes an role from the cache by name.
+// Delete removes a role from the cache by name.
 func (c *RoleCache) Delete(name string) {
 	c.cache.Del(name)
 }

--- a/lib/scopes/cache/roles/role_cache_test.go
+++ b/lib/scopes/cache/roles/role_cache_test.go
@@ -33,7 +33,7 @@ import (
 
 // TestListScopedRolesScenarios tests particular more tricky ListScopedRoles scenarios, such
 // as attempts to use an out-of-band cursor to read values outside of the target scope.
-func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
+func TestListScopedRolesScenarios(t *testing.T) {
 	t.Parallel()
 
 	roles := []*scopedaccessv1.ScopedRole{
@@ -386,6 +386,57 @@ func TestListScopedRolesBasics(t *testing.T) {
 					"user-01",
 					"admin-02",
 					"user-02",
+				},
+			},
+		},
+		{
+			name: "name filter",
+			req: &scopedaccessv1.ListScopedRolesRequest{
+				NameFilter: "admin",
+			},
+			expect: [][]string{
+				{
+					"admin-01",
+					"admin-02",
+				},
+			},
+		},
+		{
+			name: "name case insensitive",
+			req: &scopedaccessv1.ListScopedRolesRequest{
+				NameFilter: "AdMiN",
+			},
+			expect: [][]string{
+				{
+					"admin-01",
+					"admin-02",
+				},
+			},
+		},
+		{
+			name: "name filter paged",
+			req: &scopedaccessv1.ListScopedRolesRequest{
+				NameFilter: "min",
+				PageSize:   1,
+			},
+			expect: [][]string{
+				{"admin-01"},
+				{"admin-02"},
+			},
+		},
+		{
+			name: "name filter policy scope root",
+			req: &scopedaccessv1.ListScopedRolesRequest{
+				NameFilter: "01",
+				ResourceScope: &scopespb.Filter{
+					Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+					Scope: "/",
+				},
+			},
+			expect: [][]string{
+				{
+					"admin-01",
+					"user-01",
 				},
 			},
 		},

--- a/lib/services/local/scoped_access.go
+++ b/lib/services/local/scoped_access.go
@@ -113,6 +113,10 @@ func (s *ScopedAccessService) ListScopedRoles(ctx context.Context, req *scopedac
 		return nil, trace.NotImplemented("filtering by assignable scope is not implemented for direct backend scoped role reads")
 	}
 
+	if req.GetNameFilter() != "" {
+		return nil, trace.NotImplemented("filtering by name is not implemented for direct backend scoped role reads")
+	}
+
 	if req.GetPageToken() != "" {
 		return nil, trace.NotImplemented("pagination is not implemented for direct backend scoped role reads")
 	}


### PR DESCRIPTION
Backport #65891 to branch/v18

Manually tested with the final user-visible change in https://github.com/gravitational/teleport.e/pull/8709