### PR TITLE
[v18] GCP Server Installer: don't exit on failure

### DIFF
--- a/lib/srv/server/gcp_installer.go
+++ b/lib/srv/server/gcp_installer.go
@@ -20,6 +20,7 @@ package server
 
 import (
 	"context"
+	"sync"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
@@ -62,6 +63,9 @@ func (gi *GCPInstaller) Run(ctx context.Context, req GCPRunRequest) error {
 	// hundreds of nodes at once.
 	g.SetLimit(10)
 
+	var runErrors []error
+	runErrorsMu := &sync.Mutex{}
+
 	for _, inst := range req.Instances {
 		inst := inst
 		g.Go(func() error {
@@ -75,8 +79,16 @@ func (gi *GCPInstaller) Run(ctx context.Context, req GCPRunRequest) error {
 				Script:     script,
 				SSHKeyAlgo: req.SSHKeyAlgo,
 			}
-			return trace.Wrap(gcp.RunCommand(ctx, &runRequest))
+
+			if runError := gcp.RunCommand(ctx, &runRequest); runError != nil {
+				runErrorsMu.Lock()
+				runErrors = append(runErrors, trace.Wrap(runError, "running installer script on instance %q", inst.Name))
+				runErrorsMu.Unlock()
+			}
+			return nil
 		})
 	}
-	return trace.Wrap(g.Wait())
+	_ = g.Wait()
+
+	return trace.NewAggregate(runErrors...)
 }

--- a/lib/srv/server/gcp_installer_test.go
+++ b/lib/srv/server/gcp_installer_test.go
@@ -1,0 +1,82 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package server
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/gcp"
+	gcpimds "github.com/gravitational/teleport/lib/cloud/imds/gcp"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+)
+
+func TestGCPInstaller(t *testing.T) {
+	t.Parallel()
+
+	newVMFn := func(id string) *gcpimds.Instance {
+		return &gcpimds.Instance{
+			ProjectID: "test-project",
+			Zone:      "test-zone",
+			Name:      "vm" + id,
+		}
+	}
+
+	const totalInstances = 1000
+	instances := make([]*gcpimds.Instance, totalInstances)
+	for i := range totalInstances {
+		instances[i] = newVMFn(strconv.Itoa(i))
+	}
+
+	mockRunner := &mockGCPRunClient{}
+	installer := &GCPInstaller{}
+	err := installer.Run(t.Context(), GCPRunRequest{
+		InstallerParams: &types.InstallerParams{
+			PublicProxyAddr: "localhost:8080",
+		},
+		Zone:       "useast-1",
+		ProjectID:  "test",
+		Instances:  instances,
+		Client:     mockRunner,
+		SSHKeyAlgo: cryptosuites.ECDSAP256,
+	})
+	require.Error(t, err)
+
+	// Each instance should have been attempted, even when they all fail.
+	require.Equal(t, int32(totalInstances), mockRunner.getInstancesCallCounter.Load())
+}
+
+type mockGCPRunClient struct {
+	gcp.InstancesClient
+	getInstancesCallCounter atomic.Int32
+}
+
+func (c *mockGCPRunClient) GetInstance(ctx context.Context, req *gcpimds.InstanceRequest) (*gcpimds.Instance, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	c.getInstancesCallCounter.Add(1)
+	return nil, trace.BadParameter("invalid something")
+}


### PR DESCRIPTION
Backport #66014 to branch/v18

changelog: Fixed an issue that prevents GCP Server discovery to try to enroll all the VMs that are found when one of them returns an error.


## Manual Test Plan
### Test Environment
- Local cluster with Discovery Service

### Test Cases
- [x] Create 15 GCP VMs and suspend them. Ensure we get logs for each of them when running the discovery service.

## Demo:

```
2026-04-28T09:51:08.153+01:00 ERRO [DISCOVERY] Failed to enroll discovered GCP VMs pid:28904.1 error:[
ERROR REPORT:
Original Error: trace.aggregate running installer script on instance &#34;marcobox07&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox08&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox02&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox10&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox06&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox05&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox09&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox04&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox03&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox11&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox14&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox12&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox15&#34;
        dial tcp 10...:22: i/o timeout, running installer script on instance &#34;marcobox13&#34;
        dial tcp 10...:22: i/o timeout
Stack Trace:
        github.com/gravitational/teleport/lib/srv/server/gcp_installer.go:93 github.com/gravitational/teleport/lib/srv/server.(*GCPInstaller).Run
        github.com/gravitational/teleport/lib/srv/discovery/discovery.go:1749 github.com/gravitational/teleport/lib/srv/discovery.(*Server).handleGCPInstances
        github.com/gravitational/teleport/lib/srv/discovery/discovery.go:1768 github.com/gravitational/teleport/lib/srv/discovery.(*Server).handleGCPDiscovery
        runtime/asm_arm64.s:1447 runtime.goexit
```