### PR TITLE
Add support for filtering by Organizational Units in IAM Join (implementation)

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -331,9 +331,6 @@ func (p *ProvisionTokenV2) CheckAndSetDefaults() error {
 			if allowRule.AWSOrganizationID != "" {
 				return trace.BadParameter(`the %q join method does not support the "aws_organization_id" parameter`, JoinMethodEC2)
 			}
-			if tokenRuleHasAWSOrganizationalUnitMatchers(allowRule) {
-				return trace.BadParameter(`the %q join method does not support the "aws_organizational_units" parameter`, JoinMethodEC2)
-			}
 			if allowRule.AWSAccount == "" && allowRule.AWSRole == "" {
 				return trace.BadParameter(`allow rule for %q join method must set "aws_account" or "aws_role"`, JoinMethodEC2)
 			}
@@ -355,9 +352,6 @@ func (p *ProvisionTokenV2) CheckAndSetDefaults() error {
 			}
 			if allowRule.AWSAccount == "" && allowRule.AWSARN == "" && allowRule.AWSOrganizationID == "" {
 				return trace.BadParameter(`allow rule for %q join method must set "aws_account", "aws_arn", or "aws_organization_id"`, JoinMethodIAM)
-			}
-			if err := validateIAMOrganizationRule(allowRule); err != nil {
-				return trace.Wrap(err)
 			}
 		}
 	case JoinMethodGitHub:
@@ -824,36 +818,6 @@ func (p *ProvisionTokenV1) V2() *ProvisionTokenV2 {
 	}
 	t.CheckAndSetDefaults()
 	return t
-}
-
-func tokenRuleHasAWSOrganizationalUnitMatchers(tokenRule *TokenRule) bool {
-	return tokenRule.AWSOrganizationalUnits != nil &&
-		(len(tokenRule.AWSOrganizationalUnits.Include) > 0 || len(tokenRule.AWSOrganizationalUnits.Exclude) > 0)
-}
-
-func validateIAMOrganizationRule(tokenRule *TokenRule) error {
-	// In order to use Organizational Unit matchers, the token must specify the AWS Organization ID.
-	if tokenRule.AWSOrganizationID == "" && tokenRuleHasAWSOrganizationalUnitMatchers(tokenRule) {
-		return trace.BadParameter(`allow rule with "aws_organizational_units" matchers must also specify "aws_organization_id" when using the %q join method`, JoinMethodIAM)
-	}
-
-	// Return early if no OU matchers are specified.
-	if !tokenRuleHasAWSOrganizationalUnitMatchers(tokenRule) {
-		return nil
-	}
-
-	if len(tokenRule.AWSOrganizationalUnits.Include) == 0 {
-		return trace.BadParameter("at least one entry in aws_organizational_units.include must be specified")
-	}
-
-	if slices.Contains(tokenRule.AWSOrganizationalUnits.Include, Wildcard) && len(tokenRule.AWSOrganizationalUnits.Include) > 1 {
-		return trace.BadParameter("when using wildcard for AWS Organizational Units include, no other values are allowed")
-	}
-	if slices.Contains(tokenRule.AWSOrganizationalUnits.Exclude, Wildcard) {
-		return trace.BadParameter("using wildcard in AWS Organizational Units exclude is not allowed")
-	}
-
-	return nil
 }
 
 // String returns the human readable representation of a provisioning token.

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -331,6 +331,9 @@ func (p *ProvisionTokenV2) CheckAndSetDefaults() error {
 			if allowRule.AWSOrganizationID != "" {
 				return trace.BadParameter(`the %q join method does not support the "aws_organization_id" parameter`, JoinMethodEC2)
 			}
+			if tokenRuleHasAWSOrganizationalUnitMatchers(allowRule) {
+				return trace.BadParameter(`the %q join method does not support the "aws_organizational_units" parameter`, JoinMethodEC2)
+			}
 			if allowRule.AWSAccount == "" && allowRule.AWSRole == "" {
 				return trace.BadParameter(`allow rule for %q join method must set "aws_account" or "aws_role"`, JoinMethodEC2)
 			}
@@ -351,7 +354,10 @@ func (p *ProvisionTokenV2) CheckAndSetDefaults() error {
 				return trace.BadParameter(`the %q join method does not support the "aws_regions" parameter`, JoinMethodIAM)
 			}
 			if allowRule.AWSAccount == "" && allowRule.AWSARN == "" && allowRule.AWSOrganizationID == "" {
-				return trace.BadParameter(`allow rule for %q join method must set "aws_account", "aws_arn", or "aws_organization"`, JoinMethodIAM)
+				return trace.BadParameter(`allow rule for %q join method must set "aws_account", "aws_arn", or "aws_organization_id"`, JoinMethodIAM)
+			}
+			if err := validateIAMOrganizationRule(allowRule); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 	case JoinMethodGitHub:
@@ -818,6 +824,36 @@ func (p *ProvisionTokenV1) V2() *ProvisionTokenV2 {
 	}
 	t.CheckAndSetDefaults()
 	return t
+}
+
+func tokenRuleHasAWSOrganizationalUnitMatchers(tokenRule *TokenRule) bool {
+	return tokenRule.AWSOrganizationalUnits != nil &&
+		(len(tokenRule.AWSOrganizationalUnits.Include) > 0 || len(tokenRule.AWSOrganizationalUnits.Exclude) > 0)
+}
+
+func validateIAMOrganizationRule(tokenRule *TokenRule) error {
+	// In order to use Organizational Unit matchers, the token must specify the AWS Organization ID.
+	if tokenRule.AWSOrganizationID == "" && tokenRuleHasAWSOrganizationalUnitMatchers(tokenRule) {
+		return trace.BadParameter(`allow rule with "aws_organizational_units" matchers must also specify "aws_organization_id" when using the %q join method`, JoinMethodIAM)
+	}
+
+	// Return early if no OU matchers are specified.
+	if !tokenRuleHasAWSOrganizationalUnitMatchers(tokenRule) {
+		return nil
+	}
+
+	if len(tokenRule.AWSOrganizationalUnits.Include) == 0 {
+		return trace.BadParameter("at least one entry in aws_organizational_units.include must be specified")
+	}
+
+	if slices.Contains(tokenRule.AWSOrganizationalUnits.Include, Wildcard) && len(tokenRule.AWSOrganizationalUnits.Include) > 1 {
+		return trace.BadParameter("when using wildcard for AWS Organizational Units include, no other values are allowed")
+	}
+	if slices.Contains(tokenRule.AWSOrganizationalUnits.Exclude, Wildcard) {
+		return trace.BadParameter("using wildcard in AWS Organizational Units exclude is not allowed")
+	}
+
+	return nil
 }
 
 // String returns the human readable representation of a provisioning token.

--- a/api/types/provisioning_test.go
+++ b/api/types/provisioning_test.go
@@ -279,6 +279,68 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			desc: "iam method with aws_organization_id and organizational unit matchers",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: "iam",
+					Allow: []*TokenRule{
+						{
+							AWSOrganizationID: "o-123abcd",
+							AWSOrganizationalUnits: &AWSOrganizationUnitsMatcher{
+								Include: []string{"*"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			desc: "iam method organizational unit matchers but without organization id: org id is required",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: "iam",
+					Allow: []*TokenRule{
+						{
+							AWSOrganizationalUnits: &AWSOrganizationUnitsMatcher{
+								Include: []string{"*"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "iam method with aws_organization_id, with exclude OUs but without include",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: "iam",
+					Allow: []*TokenRule{
+						{
+							AWSOrganizationID: "o-123abcd",
+							AWSOrganizationalUnits: &AWSOrganizationUnitsMatcher{
+								Exclude: []string{"r-123"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			desc: "github valid",
 			token: &ProvisionTokenV2{
 				Metadata: Metadata{

--- a/api/types/provisioning_test.go
+++ b/api/types/provisioning_test.go
@@ -300,47 +300,6 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			desc: "iam method organizational unit matchers but without organization id: org id is required",
-			token: &ProvisionTokenV2{
-				Metadata: Metadata{
-					Name: "test",
-				},
-				Spec: ProvisionTokenSpecV2{
-					Roles:      []SystemRole{RoleNode},
-					JoinMethod: "iam",
-					Allow: []*TokenRule{
-						{
-							AWSOrganizationalUnits: &AWSOrganizationUnitsMatcher{
-								Include: []string{"*"},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			desc: "iam method with aws_organization_id, with exclude OUs but without include",
-			token: &ProvisionTokenV2{
-				Metadata: Metadata{
-					Name: "test",
-				},
-				Spec: ProvisionTokenSpecV2{
-					Roles:      []SystemRole{RoleNode},
-					JoinMethod: "iam",
-					Allow: []*TokenRule{
-						{
-							AWSOrganizationID: "o-123abcd",
-							AWSOrganizationalUnits: &AWSOrganizationUnitsMatcher{
-								Exclude: []string{"r-123"},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
 			desc: "github valid",
 			token: &ProvisionTokenV2{
 				Metadata: Metadata{

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -606,7 +606,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 			return organizations.NewFromConfig(c)
 		}
 
-		cfg.AWSOrganizationsClientGetter, err = awsOrganizationsClientGetter(closeCtx, cfg.Clock, cfg.Modules, organizationsClientFromSDK)
+		cfg.AWSOrganizationsClientGetter, err = awsOrganizationsClientGetterWithCache(closeCtx, cfg.Clock, cfg.Modules, organizationsClientFromSDK)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -981,8 +981,8 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 	return as, nil
 }
 
-// awsOrganizationsClientGetter returns an AWS Organizations client getter.
-func awsOrganizationsClientGetter(ctx context.Context, clock clockwork.Clock, modules modules.Modules, organizationsClientFromConfig func(aws.Config) iamjoin.OrganizationsAPI) (*organizationsClientGetter, error) {
+// awsOrganizationsClientGetterWithCache returns an AWS Organizations client getter with caching.
+func awsOrganizationsClientGetterWithCache(ctx context.Context, clock clockwork.Clock, modules modules.Modules, organizationsClientFromConfig func(aws.Config) iamjoin.OrganizationsAPI) (*organizationsClientGetter, error) {
 	awsConfigProvider, err := awsconfig.NewCache()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1046,18 +1046,28 @@ func (o *organizationsClientGetter) Get(ctx context.Context, integration string,
 	}
 
 	return &organizationsClient{
+		integration:             integration,
 		describeAccountAPICache: o.describeAccountAPICache,
 		remoteAPI:               o.organizationsClientFromConfig(awsConfig),
 	}, nil
 }
 
 type organizationsClient struct {
+	integration             string
 	describeAccountAPICache *utils.FnCache
 	remoteAPI               iamjoin.OrganizationsAPI
 }
 
 func (o *organizationsClient) DescribeAccount(ctx context.Context, params *organizations.DescribeAccountInput, optFns ...func(*organizations.Options)) (*organizations.DescribeAccountOutput, error) {
-	describeAccountOutput, err := utils.FnCacheGet(ctx, o.describeAccountAPICache, aws.ToString(params.AccountId), func(ctx context.Context) (*organizations.DescribeAccountOutput, error) {
+	cacheKey := struct {
+		AccountID   string
+		Integration string
+	}{
+		AccountID:   aws.ToString(params.AccountId),
+		Integration: o.integration,
+	}
+
+	describeAccountOutput, err := utils.FnCacheGet(ctx, o.describeAccountAPICache, cacheKey, func(ctx context.Context) (*organizations.DescribeAccountOutput, error) {
 		remoteDescribeAccountOutput, err := o.remoteAPI.DescribeAccount(ctx, params, optFns...)
 		return remoteDescribeAccountOutput, trace.Wrap(err)
 	})

--- a/lib/auth/auth_iamjoin_organizations_test.go
+++ b/lib/auth/auth_iamjoin_organizations_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	organizationstypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
@@ -40,7 +41,7 @@ import (
 func TestAWSOrganizationsClientGetter(t *testing.T) {
 	t.Run("when running in cloud, the client getter returns an error (ambient credentials can't be used in cloud)", func(t *testing.T) {
 		modules := &modulestest.Modules{TestFeatures: modules.Features{Cloud: true}}
-		clientGetter, err := awsOrganizationsClientGetter(t.Context(), clockwork.NewFakeClock(), modules, nil)
+		clientGetter, err := awsOrganizationsClientGetterWithCache(t.Context(), clockwork.NewFakeClock(), modules, nil)
 		require.NoError(t, err)
 
 		const noIntegration = ""
@@ -74,7 +75,7 @@ func TestAWSOrganizationsClientGetter(t *testing.T) {
 
 		fakeClock := clockwork.NewFakeClock()
 		mockOrganizationsAPI := &mockOrganizationsAPI{}
-		clientGetter, err := awsOrganizationsClientGetter(t.Context(), fakeClock, modules, func(c aws.Config) iamjoin.OrganizationsAPI {
+		clientGetter, err := awsOrganizationsClientGetterWithCache(t.Context(), fakeClock, modules, func(c aws.Config) iamjoin.OrganizationsAPI {
 			return mockOrganizationsAPI
 		})
 		require.NoError(t, err)
@@ -122,7 +123,7 @@ func TestAWSOrganizationsClientGetter(t *testing.T) {
 		fakeClock := clockwork.NewFakeClock()
 		mockOrganizationsAPI := &mockOrganizationsAPI{}
 
-		clientGetter, err := awsOrganizationsClientGetter(t.Context(), fakeClock, modules, func(c aws.Config) iamjoin.OrganizationsAPI {
+		clientGetter, err := awsOrganizationsClientGetterWithCache(t.Context(), fakeClock, modules, func(c aws.Config) iamjoin.OrganizationsAPI {
 			return mockOrganizationsAPI
 		})
 		require.NoError(t, err)
@@ -149,6 +150,90 @@ func TestAWSOrganizationsClientGetter(t *testing.T) {
 		// However, after the cache expiration time, a new call should be made.
 		fakeClock.Advance(5 * time.Minute)
 		describeAccountAPIOutput, err = organizationsAPI.DescribeAccount(t.Context(), &organizations.DescribeAccountInput{
+			AccountId: aws.String("123456789012"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, aws.String("123456789012"), describeAccountAPIOutput.Account.Id)
+		require.Equal(t, 2, mockOrganizationsAPI.numberOfRemoteAPICalls, "expected a new remote API call after cache expiration")
+	})
+
+	t.Run("getter is cached by integration", func(t *testing.T) {
+		modules := &modulestest.Modules{
+			TestFeatures: modules.Features{
+				Cloud: true,
+			},
+		}
+
+		const integrationAName = "my-integration"
+		integrationA, err := types.NewIntegrationAWSOIDC(
+			types.Metadata{Name: integrationAName},
+			&types.AWSOIDCIntegrationSpecV1{
+				RoleARN: "arn:aws:sts::123456789012:role/TestRole",
+			},
+		)
+		require.NoError(t, err)
+
+		const integrationBName = "integrationB"
+		integrationB, err := types.NewIntegrationAWSOIDC(
+			types.Metadata{Name: integrationBName},
+			&types.AWSOIDCIntegrationSpecV1{
+				RoleARN: "arn:aws:sts::123456789012:role/TestRole",
+			},
+		)
+		require.NoError(t, err)
+
+		mockIntegrationClt := &fakeOIDCIntegrationClient{
+			getIntegrationFn: func(ctx context.Context, integrationName string) (types.Integration, error) {
+				switch integrationName {
+				case integrationAName:
+					return integrationA, nil
+				case integrationBName:
+					return integrationB, nil
+				default:
+					return nil, trace.NotFound("integration not found")
+				}
+			},
+			getTokenFn: func(context.Context, string) (string, error) {
+				return "oidc-token", nil
+			},
+		}
+
+		fakeClock := clockwork.NewFakeClock()
+		mockOrganizationsAPI := &mockOrganizationsAPI{}
+
+		clientGetter, err := awsOrganizationsClientGetterWithCache(t.Context(), fakeClock, modules, func(c aws.Config) iamjoin.OrganizationsAPI {
+			return mockOrganizationsAPI
+		})
+		require.NoError(t, err)
+
+		// Mock the STS client to prevent real AWS calls during tests.
+		clientGetter.stsClientFromConfig = func(_ aws.Config) awsconfig.STSClient {
+			return &mocks.STSClient{}
+		}
+
+		organizationsAPI, err := clientGetter.Get(t.Context(), integrationAName, mockIntegrationClt)
+		require.NoError(t, err)
+
+		describeAccountAPIOutput, err := organizationsAPI.DescribeAccount(t.Context(), &organizations.DescribeAccountInput{
+			AccountId: aws.String("123456789012"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, aws.String("123456789012"), describeAccountAPIOutput.Account.Id)
+		require.Equal(t, 1, mockOrganizationsAPI.numberOfRemoteAPICalls, "expected one remote API call")
+
+		// Call again to verify caching works.
+		describeAccountAPIOutput, err = organizationsAPI.DescribeAccount(t.Context(), &organizations.DescribeAccountInput{
+			AccountId: aws.String("123456789012"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, aws.String("123456789012"), describeAccountAPIOutput.Account.Id)
+		require.Equal(t, 1, mockOrganizationsAPI.numberOfRemoteAPICalls, "expected no additional remote API calls due to caching")
+
+		// However, using a different integration should result in a different client and thus a new remote API call.
+		organizationsAPIB, err := clientGetter.Get(t.Context(), integrationBName, mockIntegrationClt)
+		require.NoError(t, err)
+
+		describeAccountAPIOutput, err = organizationsAPIB.DescribeAccount(t.Context(), &organizations.DescribeAccountInput{
 			AccountId: aws.String("123456789012"),
 		})
 		require.NoError(t, err)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -60,7 +60,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
 	"github.com/gravitational/teleport/lib/auth/internal/cert"
 	sessionreq "github.com/gravitational/teleport/lib/auth/internal/session"
-	"github.com/gravitational/teleport/lib/auth/join/oracle"
 	"github.com/gravitational/teleport/lib/auth/moderation"
 	"github.com/gravitational/teleport/lib/auth/okta"
 	"github.com/gravitational/teleport/lib/authz"
@@ -2827,45 +2826,6 @@ func enforceEnterpriseJoinMethodCreation(buildType string, token types.Provision
 	return nil
 }
 
-// validateOracleJoinToken validates the fields in a token using the Oracle
-// join method. It's done here instead of in the client so the client doesn't
-// have to import the Oracle SDK.
-func validateOracleJoinToken(token types.ProvisionToken) error {
-	if token.GetJoinMethod() != types.JoinMethodOracle {
-		return nil
-	}
-
-	tokenV2, ok := token.(*types.ProvisionTokenV2)
-	if !ok {
-		return trace.BadParameter("%v join method requires ProvisionTokenV2", types.JoinMethodOracle)
-	}
-	oracleSpec := tokenV2.Spec.Oracle
-	if oracleSpec == nil {
-		return trace.BadParameter("missing spec")
-	}
-	for _, allow := range oracleSpec.Allow {
-		if _, err := oracle.ParseRegionFromOCID(allow.Tenancy); err != nil {
-			return trace.BadParameter("invalid tenant: %v", allow.Tenancy)
-		}
-		for _, compartment := range allow.ParentCompartments {
-			if _, err := oracle.ParseRegionFromOCID(compartment); err != nil {
-				return trace.BadParameter("invalid compartment: %v", compartment)
-			}
-		}
-		for _, region := range allow.Regions {
-			if canonicalRegion, _ := oracle.ParseRegion(region); canonicalRegion == "" {
-				return trace.BadParameter("invalid region: %v", region)
-			}
-		}
-		for _, instanceID := range allow.Instances {
-			if _, err := oracle.ParseRegionFromOCID(instanceID); err != nil {
-				return trace.BadParameter("invalid instance OCID: %s", instanceID)
-			}
-		}
-	}
-	return nil
-}
-
 // emitTokenEvent is called by Create/Upsert Token in order to emit any relevant
 // events.
 func emitTokenEvent(ctx context.Context, e apievents.Emitter, token types.ProvisionToken,
@@ -2903,7 +2863,7 @@ func (a *ServerWithRoles) UpsertToken(ctx context.Context, token types.Provision
 		return trace.Wrap(err)
 	}
 
-	if err := validateOracleJoinToken(token); err != nil {
+	if err := validateProvisionToken(token); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -2934,7 +2894,7 @@ func (a *ServerWithRoles) CreateToken(ctx context.Context, token types.Provision
 		return trace.Wrap(err)
 	}
 
-	if err := validateOracleJoinToken(token); err != nil {
+	if err := validateProvisionToken(token); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -100,6 +100,7 @@ func (a *Server) RegisterUsingIAMMethod(
 
 	// check that the GetCallerIdentity request is valid and matches the token
 	verifiedIdentity, err := iamjoin.CheckIAMRequest(ctx, &iamjoin.CheckIAMRequestParams{
+		Logger:                   a.logger,
 		Challenge:                challenge,
 		ProvisionToken:           provisionToken,
 		STSIdentityRequest:       req.StsIdentityRequest,

--- a/lib/auth/provision_tokens.go
+++ b/lib/auth/provision_tokens.go
@@ -1,0 +1,128 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"slices"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/join/oracle"
+)
+
+func validateProvisionToken(token types.ProvisionToken) error {
+	switch token.GetJoinMethod() {
+	case types.JoinMethodOracle:
+		return validateOracleJoinToken(token)
+
+	case types.JoinMethodEC2:
+		return validateEC2Token(token)
+
+	case types.JoinMethodIAM:
+		return validateIAMToken(token)
+	}
+
+	return nil
+}
+
+func validateEC2Token(token types.ProvisionToken) error {
+	for _, allowRule := range token.GetAllowRules() {
+		// EC2 join method does not support AWS Organizational Unit matchers, so we return an
+		// error if any of the token rules contain them.
+		if tokenRuleHasAWSOrganizationalUnitMatchers(allowRule) {
+			return trace.BadParameter(`the %q join method does not support the "aws_organizational_units" parameter`, types.JoinMethodEC2)
+		}
+	}
+	return nil
+}
+
+func tokenRuleHasAWSOrganizationalUnitMatchers(tokenRule *types.TokenRule) bool {
+	return tokenRule.AWSOrganizationalUnits != nil &&
+		(len(tokenRule.AWSOrganizationalUnits.Include) > 0 || len(tokenRule.AWSOrganizationalUnits.Exclude) > 0)
+}
+
+func validateIAMToken(token types.ProvisionToken) error {
+	for _, allowRule := range token.GetAllowRules() {
+		if err := validateIAMOrganizationRule(allowRule); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+func validateIAMOrganizationRule(tokenRule *types.TokenRule) error {
+	// In order to use Organizational Unit matchers, the token must specify the AWS Organization ID.
+	if tokenRule.AWSOrganizationID == "" && tokenRuleHasAWSOrganizationalUnitMatchers(tokenRule) {
+		return trace.BadParameter(`allow rule with "aws_organizational_units" matchers must also specify "aws_organization_id" when using the %q join method`, types.JoinMethodIAM)
+	}
+
+	// Return early if no OU matchers are specified.
+	if !tokenRuleHasAWSOrganizationalUnitMatchers(tokenRule) {
+		return nil
+	}
+
+	if len(tokenRule.AWSOrganizationalUnits.Include) == 0 {
+		return trace.BadParameter(`at least one entry in "aws_organizational_units.include" must be specified`)
+	}
+
+	if slices.Contains(tokenRule.AWSOrganizationalUnits.Include, types.Wildcard) && len(tokenRule.AWSOrganizationalUnits.Include) > 1 {
+		return trace.BadParameter(`when using wildcard for "aws_organizational_units.include", no other values are allowed`)
+	}
+	if slices.Contains(tokenRule.AWSOrganizationalUnits.Exclude, types.Wildcard) {
+		return trace.BadParameter(`using wildcard in "aws_organizational_units.exclude" is not allowed`)
+	}
+
+	return nil
+}
+
+// validateOracleJoinToken validates the fields in a token using the Oracle
+// join method. It's done here instead of in the client so the client doesn't
+// have to import the Oracle SDK.
+func validateOracleJoinToken(token types.ProvisionToken) error {
+	tokenV2, ok := token.(*types.ProvisionTokenV2)
+	if !ok {
+		return trace.BadParameter("%v join method requires ProvisionTokenV2", types.JoinMethodOracle)
+	}
+	oracleSpec := tokenV2.Spec.Oracle
+	if oracleSpec == nil {
+		return trace.BadParameter("missing spec")
+	}
+	for _, allow := range oracleSpec.Allow {
+		if _, err := oracle.ParseRegionFromOCID(allow.Tenancy); err != nil {
+			return trace.BadParameter("invalid tenant: %v", allow.Tenancy)
+		}
+		for _, compartment := range allow.ParentCompartments {
+			if _, err := oracle.ParseRegionFromOCID(compartment); err != nil {
+				return trace.BadParameter("invalid compartment: %v", compartment)
+			}
+		}
+		for _, region := range allow.Regions {
+			if canonicalRegion, _ := oracle.ParseRegion(region); canonicalRegion == "" {
+				return trace.BadParameter("invalid region: %v", region)
+			}
+		}
+		for _, instanceID := range allow.Instances {
+			if _, err := oracle.ParseRegionFromOCID(instanceID); err != nil {
+				return trace.BadParameter("invalid instance OCID: %s", instanceID)
+			}
+		}
+	}
+	return nil
+}

--- a/lib/auth/provision_tokens_test.go
+++ b/lib/auth/provision_tokens_test.go
@@ -1,0 +1,201 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestValidateProvisionToken(t *testing.T) {
+	t.Parallel()
+
+	makeToken := func(t *testing.T, spec types.ProvisionTokenSpecV2) types.ProvisionToken {
+		t.Helper()
+
+		if len(spec.Roles) == 0 {
+			spec.Roles = []types.SystemRole{types.RoleNode}
+		}
+
+		token, err := types.NewProvisionTokenFromSpec("test", time.Now().Add(time.Hour), spec)
+		require.NoError(t, err)
+		return token
+	}
+
+	tests := []struct {
+		name        string
+		spec        types.ProvisionTokenSpecV2
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "ec2 rejects organizational unit include matchers",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodEC2,
+				Allow: []*types.TokenRule{
+					{
+						AWSAccount: "123456789012",
+						AWSOrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Include: []string{"ou-1234"},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: `the "ec2" join method does not support the "aws_organizational_units" parameter`,
+		},
+		{
+			name: "ec2 rejects organizational unit exclude matchers",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodEC2,
+				Allow: []*types.TokenRule{
+					{
+						AWSAccount: "123456789012",
+						AWSOrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Exclude: []string{"ou-1234"},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: `the "ec2" join method does not support the "aws_organizational_units" parameter`,
+		},
+		{
+			name: "iam rejects organizational unit matchers without organization id",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodIAM,
+				Allow: []*types.TokenRule{
+					{
+						AWSAccount: "123456789012",
+						AWSOrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Include: []string{"ou-1234"},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: `allow rule with "aws_organizational_units" matchers must also specify "aws_organization_id" when using the "iam" join method`,
+		},
+		{
+			name: "iam rejects exclude-only organizational unit matchers",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodIAM,
+				Allow: []*types.TokenRule{
+					{
+						AWSOrganizationID: "o-123abcd",
+						AWSOrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Exclude: []string{"ou-1234"},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: `at least one entry in "aws_organizational_units.include" must be specified`,
+		},
+		{
+			name: "iam rejects wildcard mixed with explicit include matchers",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodIAM,
+				Allow: []*types.TokenRule{
+					{
+						AWSOrganizationID: "o-123abcd",
+						AWSOrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Include: []string{types.Wildcard, "ou-1234"},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: `when using wildcard for "aws_organizational_units.include", no other values are allowed`,
+		},
+		{
+			name: "iam rejects wildcard exclude matchers",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodIAM,
+				Allow: []*types.TokenRule{
+					{
+						AWSOrganizationID: "o-123abcd",
+						AWSOrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Include: []string{"ou-1234"},
+							Exclude: []string{types.Wildcard},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: `using wildcard in "aws_organizational_units.exclude" is not allowed`,
+		},
+		{
+			name: "iam accepts organization id without organizational unit matchers",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodIAM,
+				Allow: []*types.TokenRule{
+					{
+						AWSOrganizationID: "o-123abcd",
+					},
+				},
+			},
+		},
+		{
+			name: "iam accepts wildcard include matcher",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodIAM,
+				Allow: []*types.TokenRule{
+					{
+						AWSOrganizationID: "o-123abcd",
+						AWSOrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Include: []string{types.Wildcard},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "iam accepts explicit include and exclude matchers",
+			spec: types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodIAM,
+				Allow: []*types.TokenRule{
+					{
+						AWSOrganizationID: "o-123abcd",
+						AWSOrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Include: []string{"ou-1234"},
+							Exclude: []string{"ou-5678"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProvisionToken(makeToken(t, tt.spec))
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -26,6 +26,7 @@ import (
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/gravitational/trace"
 )
 
@@ -41,7 +42,8 @@ func ConvertRequestFailureError(err error) error {
 }
 
 var (
-	ecsClusterNotFoundException *ecstypes.ClusterNotFoundException
+	ecsClusterNotFoundException           *ecstypes.ClusterNotFoundException
+	organizationsAccountNotFoundException *orgtypes.AccountNotFoundException
 )
 
 func convertRequestFailureErrorFromStatusCode(statusCode int, requestErr error) error {
@@ -64,6 +66,10 @@ func convertRequestFailureErrorFromStatusCode(statusCode int, requestErr error) 
 		}
 
 		if strings.Contains(requestErr.Error(), ecsClusterNotFoundException.ErrorCode()) {
+			return trace.NotFound("%s", requestErr)
+		}
+
+		if strings.Contains(requestErr.Error(), organizationsAccountNotFoundException.ErrorCode()) {
 			return trace.NotFound("%s", requestErr)
 		}
 	}

--- a/lib/cloud/aws/errors_test.go
+++ b/lib/cloud/aws/errors_test.go
@@ -118,6 +118,19 @@ func TestConvertRequestFailureError(t *testing.T) {
 			},
 			wantIsError: trace.IsNotFound,
 		},
+		{
+			name: "v2 sdk error for organizations AccountNotFoundException",
+			inputError: &awshttp.ResponseError{
+				RequestID: fakeRequestID,
+				ResponseError: &smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{Response: &http.Response{
+						StatusCode: http.StatusBadRequest,
+					}},
+					Err: trace.Errorf("AccountNotFoundException"),
+				},
+			},
+			wantIsError: trace.IsNotFound,
+		},
 	}
 
 	for _, test := range tests {

--- a/lib/join/iamjoin/iam.go
+++ b/lib/join/iamjoin/iam.go
@@ -281,9 +281,15 @@ func arnMatches(pattern, arn string) (bool, error) {
 	return joinutils.GlobMatch(pattern, arn)
 }
 
+type iamIdentityDetails struct {
+	organizationID string
+}
+
 // checkIAMAllowRules checks if the given identity matches any of the given
 // allowRules.
-func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *CheckIAMRequestParams, accountFetcher *accountDetailsFetcher) error {
+// Return the account details collected during the checks and whether a match was found or an error.
+func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *CheckIAMRequestParams, accountFetcher *accountDetailsFetcher) (*iamIdentityDetails, bool, error) {
+	iamIdentity := &iamIdentityDetails{}
 	for _, rule := range params.ProvisionToken.GetAWSAllowRules() {
 		// if this rule specifies an AWS account, the identity must match
 		if rule.AWSAccount != "" {
@@ -296,7 +302,7 @@ func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *Chec
 		if rule.AWSARN != "" {
 			matches, err := arnMatches(rule.AWSARN, identity.Arn)
 			if err != nil {
-				return trace.Wrap(err)
+				return nil, false, trace.Wrap(err)
 			}
 			if !matches {
 				// arn doesn't match, continue to check the next rule
@@ -307,16 +313,20 @@ func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *Chec
 		if rule.AWSOrganizationID != "" {
 			account, err := accountFetcher.fetch(ctx, params.ProvisionToken.GetIntegration())
 			if err != nil {
-				return trace.Wrap(err)
-			}
+				// NotFound is returned when the account is not accessible from the current credentials.
+				if trace.IsNotFound(err) {
+					continue
+				}
 
-			// Set the OrganizationID in the identity for use in audit events, even if the join attempt is rejected.
-			identity.OrganizationID = account.organizationID
+				return nil, false, trace.Wrap(err)
+			}
 
 			if account.organizationID != rule.AWSOrganizationID {
 				// organization ID doesn't match, continue to check the next rule
 				continue
 			}
+
+			iamIdentity.organizationID = account.organizationID
 
 			if !accountOUIsAllowed(ctx, params, identity, account, rule.AWSOrganizationalUnits) {
 				// account's organizational unit paths don't match the allow rule, continue to check the next rule
@@ -325,9 +335,11 @@ func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *Chec
 		}
 
 		// node identity matches this allow rule
-		return nil
+		return iamIdentity, true, nil
 	}
-	return trace.AccessDenied("instance %v did not match any allow rules", identity.Arn)
+
+	// No error occurred but the identity did not match any of the allow rules.
+	return iamIdentity, false, nil
 }
 
 // accountOUIsAllowed checks if the account paths match the AWS Organizational Units matchers.
@@ -460,14 +472,21 @@ func CheckIAMRequest(ctx context.Context, params *CheckIAMRequestParams) (*AWSId
 	}
 
 	// check that the node identity matches an allow rule for this token
-	if err := checkIAMAllowRules(ctx, identity, params, accountFetcher); err != nil {
-		// We return the identity since it's "validated" but does not match the
-		// rules. This allows us to include it in a failed join audit event
-		// as additional context to help the user understand why the join failed.
-		return identity, trace.Wrap(err, "checking allow rules")
+	identityDetails, allowed, err := checkIAMAllowRules(ctx, identity, params, accountFetcher)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	return identity, nil
+	identity.OrganizationID = identityDetails.organizationID
+
+	if allowed {
+		return identity, nil
+	}
+
+	// We return the identity since it's "validated" but does not match the
+	// rules. This allows us to include it in a failed join audit event
+	// as additional context to help the user understand why the join failed.
+	return identity, trace.AccessDenied("instance %v did not match any allow rules", identity.Arn)
 }
 
 // GenerateIAMChallenge generates a random challenge string for the IAM join method.
@@ -479,7 +498,6 @@ func GenerateIAMChallenge() (string, error) {
 type accountDetailsFetcher struct {
 	accountID                string
 	organizationsAPIGetter   OrganizationsAPIGetter
-	fetchedAccountDetails    *accountDetails
 	awsOIDCIntegrationClient awsconfig.OIDCIntegrationClient
 }
 
@@ -489,10 +507,6 @@ type accountDetails struct {
 }
 
 func (f *accountDetailsFetcher) fetch(ctx context.Context, integration string) (*accountDetails, error) {
-	if f.fetchedAccountDetails != nil {
-		return f.fetchedAccountDetails, nil
-	}
-
 	organizationsClient, err := f.organizationsAPIGetter.Get(ctx, integration, f.awsOIDCIntegrationClient)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -514,6 +528,10 @@ func (f *accountDetailsFetcher) fetch(ctx context.Context, integration string) (
 			return nil, trace.BadParameter("AWS Organizations API rate limit exceeded when attempting to verify account's Organization ID/Organizational Units. Please try again later.")
 		}
 
+		if trace.IsNotFound(convertedError) {
+			return nil, trace.NotFound("the account is inaccessible from the credentials (%s) permissions", integration)
+		}
+
 		return nil, trace.Wrap(convertedError)
 	}
 
@@ -522,10 +540,8 @@ func (f *accountDetailsFetcher) fetch(ctx context.Context, integration string) (
 		return nil, trace.Wrap(err)
 	}
 
-	f.fetchedAccountDetails = &accountDetails{
+	return &accountDetails{
 		organizationID: organizationID,
 		paths:          accountDetail.Account.Paths,
-	}
-
-	return f.fetchedAccountDetails, nil
+	}, nil
 }

--- a/lib/join/iamjoin/iam.go
+++ b/lib/join/iamjoin/iam.go
@@ -25,6 +25,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -281,7 +283,7 @@ func arnMatches(pattern, arn string) (bool, error) {
 
 // checkIAMAllowRules checks if the given identity matches any of the given
 // allowRules.
-func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *CheckIAMRequestParams, organizationIDFetcher *organizationsIDFetcher) error {
+func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *CheckIAMRequestParams, accountFetcher *accountDetailsFetcher) error {
 	for _, rule := range params.ProvisionToken.GetAWSAllowRules() {
 		// if this rule specifies an AWS account, the identity must match
 		if rule.AWSAccount != "" {
@@ -303,13 +305,21 @@ func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *Chec
 		}
 
 		if rule.AWSOrganizationID != "" {
-			organizationID, err := organizationIDFetcher.fetch(ctx, params.ProvisionToken.GetIntegration())
+			account, err := accountFetcher.fetch(ctx, params.ProvisionToken.GetIntegration())
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			if organizationID != rule.AWSOrganizationID {
+			// Set the OrganizationID in the identity for use in audit events, even if the join attempt is rejected.
+			identity.OrganizationID = account.organizationID
+
+			if account.organizationID != rule.AWSOrganizationID {
 				// organization ID doesn't match, continue to check the next rule
+				continue
+			}
+
+			if !accountOUIsAllowed(ctx, params, identity, account, rule.AWSOrganizationalUnits) {
+				// account's organizational unit paths don't match the allow rule, continue to check the next rule
 				continue
 			}
 		}
@@ -318,6 +328,65 @@ func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *Chec
 		return nil
 	}
 	return trace.AccessDenied("instance %v did not match any allow rules", identity.Arn)
+}
+
+// accountOUIsAllowed checks if the account paths match the AWS Organizational Units matchers.
+func accountOUIsAllowed(ctx context.Context, params *CheckIAMRequestParams, identity *AWSIdentity, account *accountDetails, ouMatcher *types.AWSOrganizationUnitsMatcher) bool {
+	var filter liborganizations.MatchingAccountsFilter
+	if ouMatcher != nil {
+		filter = liborganizations.MatchingAccountsFilter{
+			IncludeOUs:     ouMatcher.Include,
+			ExcludeOUs:     ouMatcher.Exclude,
+			OrganizationID: identity.OrganizationID,
+		}
+	}
+
+	// If no Organizational Unit filtering is configured, the organization ID check alone is sufficient.
+	if !liborganizations.HasActiveMatchers(filter) {
+		return true
+	}
+
+	accountOUs := accountOrganizationalUnits(ctx, params, identity, account)
+	if len(accountOUs) == 0 {
+		params.Logger.WarnContext(ctx, "AWS account does not have any Organizational Units in their path, rejecting IAM join attempt",
+			"account_id", identity.Account,
+			"organization_id", account.organizationID,
+			"token_name", params.ProvisionToken.GetName(),
+			"integration_name", params.ProvisionToken.GetIntegration(),
+		)
+		return false
+	}
+
+	return liborganizations.OrganizationalUnitsMatch(filter, accountOUs)
+}
+
+// accountOrganizationalUnits returns all the Organizational Units an account belongs to.
+// The account's root ID is also returned in the list.
+func accountOrganizationalUnits(ctx context.Context, params *CheckIAMRequestParams, identity *AWSIdentity, account *accountDetails) []string {
+	accountOrganizationalUnits := make(map[string]struct{})
+	for _, accountPath := range account.paths {
+		// From https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_last-accessed-view-data-orgs.html
+		// > The path for the account in the ... OU is built using the IDs of the organization, root, the OU, and the account number.
+		// The account path contains the organization ID, root OU ID, zero or more OU IDs and the account ID, in the following format: o-rgid/rootid/ouid1/ouid2/.../ouidn/accountid
+		accountParts := strings.Split(accountPath, "/")
+
+		// The account path must always contain the organization ID, root ID and account ID, so it must contain at least 3 parts.
+		if len(accountParts) < 3 {
+			// This can only happen if AWS changes the format.
+			params.Logger.WarnContext(ctx, "Received unexpected AWS account organization path format when validating the IAM allow rules",
+				"account_path", accountPath,
+				"account_id", identity.Account,
+				"organization_id", account.organizationID,
+				"token_name", params.ProvisionToken.GetName(),
+				"integration_name", params.ProvisionToken.GetIntegration(),
+			)
+			continue
+		}
+		for _, ou := range accountParts[1 : len(accountParts)-1] {
+			accountOrganizationalUnits[ou] = struct{}{}
+		}
+	}
+	return slices.Collect(maps.Keys(accountOrganizationalUnits))
 }
 
 // OrganizationsAPI defines the subset of the AWS Organizations APIs used for IAM join.
@@ -332,6 +401,9 @@ type OrganizationsAPIGetter interface {
 
 // CheckIAMRequestParams holds parameters for checking an IAM-method join request.
 type CheckIAMRequestParams struct {
+	// Logger is used for logging.
+	// Required.
+	Logger *slog.Logger
 	// Challenge is the challenge that was sent to the client.
 	Challenge string
 	// ProvisionToken is the provision token being used.
@@ -381,22 +453,18 @@ func CheckIAMRequest(ctx context.Context, params *CheckIAMRequestParams) (*AWSId
 		return nil, trace.Wrap(err, "executing STS request")
 	}
 
-	organizationsIDFetcher := &organizationsIDFetcher{
+	accountFetcher := &accountDetailsFetcher{
 		organizationsAPIGetter:   params.OrganizationsAPIGetter,
 		accountID:                identity.Account,
 		awsOIDCIntegrationClient: params.AWSOIDCIntegrationClient,
 	}
 
 	// check that the node identity matches an allow rule for this token
-	if err := checkIAMAllowRules(ctx, identity, params, organizationsIDFetcher); err != nil {
+	if err := checkIAMAllowRules(ctx, identity, params, accountFetcher); err != nil {
 		// We return the identity since it's "validated" but does not match the
 		// rules. This allows us to include it in a failed join audit event
 		// as additional context to help the user understand why the join failed.
 		return identity, trace.Wrap(err, "checking allow rules")
-	}
-
-	if organizationsIDFetcher.fetchedOrganizationID != "" {
-		identity.OrganizationID = organizationsIDFetcher.fetchedOrganizationID
 	}
 
 	return identity, nil
@@ -408,21 +476,26 @@ func GenerateIAMChallenge() (string, error) {
 	return challenge, trace.Wrap(err)
 }
 
-type organizationsIDFetcher struct {
+type accountDetailsFetcher struct {
 	accountID                string
 	organizationsAPIGetter   OrganizationsAPIGetter
-	fetchedOrganizationID    string
+	fetchedAccountDetails    *accountDetails
 	awsOIDCIntegrationClient awsconfig.OIDCIntegrationClient
 }
 
-func (f *organizationsIDFetcher) fetch(ctx context.Context, integration string) (string, error) {
-	if f.fetchedOrganizationID != "" {
-		return f.fetchedOrganizationID, nil
+type accountDetails struct {
+	organizationID string
+	paths          []string
+}
+
+func (f *accountDetailsFetcher) fetch(ctx context.Context, integration string) (*accountDetails, error) {
+	if f.fetchedAccountDetails != nil {
+		return f.fetchedAccountDetails, nil
 	}
 
 	organizationsClient, err := f.organizationsAPIGetter.Get(ctx, integration, f.awsOIDCIntegrationClient)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	accountDetail, err := organizationsClient.DescribeAccount(ctx, &organizations.DescribeAccountInput{
@@ -431,20 +504,28 @@ func (f *organizationsIDFetcher) fetch(ctx context.Context, integration string) 
 	if err != nil {
 		convertedError := libcloudaws.ConvertRequestFailureError(err)
 		if trace.IsAccessDenied(convertedError) {
-			return "", trace.BadParameter("IAM Join attempt using an Organization requires access to 'organizations:DescribeAccount' API in the assigned IAM Role. Allow the Auth Service access to that permission.")
+			if integration != "" {
+				return nil, trace.BadParameter("IAM Join attempt using an Organization requires access to 'organizations:DescribeAccount' API in the assigned IAM Role. Allow the integration %q access to that permission.", integration)
+			}
+			return nil, trace.BadParameter("IAM Join attempt using an Organization requires access to 'organizations:DescribeAccount' API in the assigned IAM Role. Allow the Auth Service access to that permission.")
 		}
 
 		if trace.IsLimitExceeded(convertedError) {
-			return "", trace.BadParameter("AWS Organizations API rate limit exceeded when attempting to verify account's Organization ID. Please try again later.")
+			return nil, trace.BadParameter("AWS Organizations API rate limit exceeded when attempting to verify account's Organization ID/Organizational Units. Please try again later.")
 		}
 
-		return "", trace.Wrap(convertedError)
+		return nil, trace.Wrap(convertedError)
 	}
 
 	organizationID, err := liborganizations.OrganizationIDFromAccountARN(awssdk.ToString(accountDetail.Account.Arn))
 	if err != nil {
-		return "", trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	return organizationID, nil
+	f.fetchedAccountDetails = &accountDetails{
+		organizationID: organizationID,
+		paths:          accountDetail.Account.Paths,
+	}
+
+	return f.fetchedAccountDetails, nil
 }

--- a/lib/join/iamjoin/iam_test.go
+++ b/lib/join/iamjoin/iam_test.go
@@ -18,10 +18,14 @@ package iamjoin
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestValidateSTSHost(t *testing.T) {
@@ -119,6 +123,101 @@ func TestValidateSTSHost(t *testing.T) {
 		t.Run("fips required", func(t *testing.T) {
 			err := validateSTSHost(t.Context(), endpoint, true /*requireFIPS*/)
 			require.ErrorAs(t, err, new(*trace.AccessDeniedError))
+		})
+	}
+}
+
+func TestAccountOUIsAllowed(t *testing.T) {
+	const (
+		orgID     = "o-testorg"
+		rootID    = "r-root1"
+		accountID = "123456789012"
+	)
+
+	fullAccountPath := func(segments ...string) string {
+		parts := append([]string{orgID}, segments...)
+		parts = append(parts, accountID)
+		return strings.Join(parts, "/")
+	}
+
+	for _, tt := range []struct {
+		name        string
+		accountPath []string
+		ouMatcher   *types.AWSOrganizationUnitsMatcher
+		expected    bool
+	}{
+		{
+			name:        "allow when matcher is nil: validation is only for the organization id",
+			accountPath: []string{fullAccountPath(rootID, "ou-a")},
+			ouMatcher:   nil,
+			expected:    true,
+		},
+		{
+			name:        "allow when matcher has no Include or Exclude: no filtering configured",
+			accountPath: []string{fullAccountPath(rootID, "ou-a")},
+			ouMatcher:   &types.AWSOrganizationUnitsMatcher{},
+			expected:    true,
+		},
+		{
+			name:        "empty paths slice rejects account (fails closed)",
+			accountPath: []string{},
+			ouMatcher:   &types.AWSOrganizationUnitsMatcher{Include: []string{"ou-a"}},
+			expected:    false,
+		},
+		{
+			name:        "malformed path with fewer than 3 parts is skipped and rejects when no valid paths remain",
+			accountPath: []string{"invalid/path"},
+			ouMatcher:   &types.AWSOrganizationUnitsMatcher{Include: []string{"ou-a"}},
+			expected:    false,
+		},
+		{
+			name:        "valid path alongside malformed path is still evaluated",
+			accountPath: []string{"invalid/path", fullAccountPath(rootID, "ou-a")},
+			ouMatcher:   &types.AWSOrganizationUnitsMatcher{Include: []string{"ou-a"}},
+			expected:    true,
+		},
+		{
+			name: "multiple account paths: match in any path is sufficient for inclusion",
+			accountPath: []string{
+				fullAccountPath(rootID, "ou-a"),
+				fullAccountPath(rootID, "ou-b"),
+			},
+			ouMatcher: &types.AWSOrganizationUnitsMatcher{Include: []string{"ou-b"}},
+			expected:  true,
+		},
+		{
+			name: "multiple account paths: exclude match in any path rejects",
+			accountPath: []string{
+				fullAccountPath(rootID, "ou-a"),
+				fullAccountPath(rootID, "ou-b"),
+			},
+			ouMatcher: &types.AWSOrganizationUnitsMatcher{
+				Include: []string{"ou-a"},
+				Exclude: []string{"ou-b"},
+			},
+			expected: false,
+		},
+		{
+			name:        "root OU is treated as an OU for inclusion",
+			accountPath: []string{fullAccountPath(rootID)},
+			ouMatcher:   &types.AWSOrganizationUnitsMatcher{Include: []string{rootID}},
+			expected:    true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			params := &CheckIAMRequestParams{
+				Logger: logtest.NewLogger(),
+				ProvisionToken: &types.ProvisionTokenV2{
+					Metadata: types.Metadata{Name: "test-token"},
+				},
+			}
+			identity := &AWSIdentity{Account: accountID}
+			account := &accountDetails{
+				organizationID: orgID,
+				paths:          tt.accountPath,
+			}
+			got := accountOUIsAllowed(t.Context(), params, identity, account, tt.ouMatcher)
+			require.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/lib/join/join_iam_test.go
+++ b/lib/join/join_iam_test.go
@@ -144,6 +144,7 @@ func TestJoinIAM(t *testing.T) {
 	allowedOU := "ou-1234"
 
 	exampleIntegrationName := "my-integration"
+	integrationNameWithoutAccess := "integration-without-access"
 	organizationsClientGetter := &mockAWSOrganizationsClientGetter{
 		ambientCredentialsOrgsAPI: &mockAWSOrganizationsClient{
 			getAccountOutput: &organizations.DescribeAccountOutput{
@@ -160,6 +161,9 @@ func TestJoinIAM(t *testing.T) {
 						Paths: []string{allowedOrgIDUsingIntegrationCredentials + "/rootid/" + allowedOU + "/ou-1234-123/1234"},
 					},
 				},
+			},
+			integrationNameWithoutAccess: &mockAWSOrganizationsClient{
+				getAccountError: trace.NotFound("AccountNotFoundException"),
 			},
 		},
 	}
@@ -248,6 +252,33 @@ func TestJoinIAM(t *testing.T) {
 				Allow: []*types.TokenRule{
 					{
 						AWSOrganizationID: allowedOrgIDUsingIntegrationCredentials,
+					},
+				},
+				JoinMethod: types.JoinMethodIAM,
+			},
+			stsClient: &mockClient{
+				respStatusCode: http.StatusOK,
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
+					Account: "1234",
+					Arn:     "arn:aws::1234",
+				}),
+			},
+			assertError: require.NoError,
+		},
+		{
+			desc:             "with integration and rule with organization, but access is granted with explicit account id",
+			authServer:       regularServer,
+			tokenName:        "test-token",
+			requestTokenName: "test-token",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Integration: integrationNameWithoutAccess,
+				Roles:       []types.SystemRole{types.RoleNode},
+				Allow: []*types.TokenRule{
+					{
+						AWSOrganizationID: allowedOrgIDUsingIntegrationCredentials,
+					},
+					{
+						AWSAccount: "1234",
 					},
 				},
 				JoinMethod: types.JoinMethodIAM,

--- a/lib/join/join_iam_test.go
+++ b/lib/join/join_iam_test.go
@@ -141,6 +141,7 @@ func TestJoinIAM(t *testing.T) {
 
 	allowedOrgIDUsingAmbientCredentials := "o-allowedorg"
 	allowedOrgIDUsingIntegrationCredentials := "o-allowedorg-integration"
+	allowedOU := "ou-1234"
 
 	exampleIntegrationName := "my-integration"
 	organizationsClientGetter := &mockAWSOrganizationsClientGetter{
@@ -155,7 +156,8 @@ func TestJoinIAM(t *testing.T) {
 			exampleIntegrationName: &mockAWSOrganizationsClient{
 				getAccountOutput: &organizations.DescribeAccountOutput{
 					Account: &organizationstypes.Account{
-						Arn: aws.String("arn:aws:organizations::123456789012:account/" + allowedOrgIDUsingIntegrationCredentials + "/1234"),
+						Arn:   aws.String("arn:aws:organizations::123456789012:account/" + allowedOrgIDUsingIntegrationCredentials + "/1234"),
+						Paths: []string{allowedOrgIDUsingIntegrationCredentials + "/rootid/" + allowedOU + "/ou-1234-123/1234"},
 					},
 				},
 			},
@@ -246,6 +248,33 @@ func TestJoinIAM(t *testing.T) {
 				Allow: []*types.TokenRule{
 					{
 						AWSOrganizationID: allowedOrgIDUsingIntegrationCredentials,
+					},
+				},
+				JoinMethod: types.JoinMethodIAM,
+			},
+			stsClient: &mockClient{
+				respStatusCode: http.StatusOK,
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
+					Account: "1234",
+					Arn:     "arn:aws::1234",
+				}),
+			},
+			assertError: require.NoError,
+		},
+		{
+			desc:             "using organizations and organizational units matcherwith integration credentials",
+			authServer:       regularServer,
+			tokenName:        "test-token",
+			requestTokenName: "test-token",
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Integration: exampleIntegrationName,
+				Roles:       []types.SystemRole{types.RoleNode},
+				Allow: []*types.TokenRule{
+					{
+						AWSOrganizationID: allowedOrgIDUsingIntegrationCredentials,
+						AWSOrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Include: []string{allowedOU},
+						},
 					},
 				},
 				JoinMethod: types.JoinMethodIAM,

--- a/lib/join/server_iam.go
+++ b/lib/join/server_iam.go
@@ -75,6 +75,7 @@ func (s *Server) handleIAMJoin(
 	// Verify the sts:GetCallerIdentity request, send it to AWS, and make sure
 	// the verified identity matches allow rules in the provision token.
 	verifiedIdentity, err := iamjoin.CheckIAMRequest(stream.Context(), &iamjoin.CheckIAMRequestParams{
+		Logger:                   s.cfg.Logger,
 		Challenge:                challenge,
 		ProvisionToken:           token,
 		STSIdentityRequest:       solution.STSIdentityRequest,

--- a/lib/utils/aws/organizations/matcher.go
+++ b/lib/utils/aws/organizations/matcher.go
@@ -1,0 +1,54 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package organizations
+
+import (
+	"slices"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// HasActiveMatchers reports whether matcher specifies any filtering.
+func HasActiveMatchers(filter MatchingAccountsFilter) bool {
+	return len(filter.IncludeOUs) > 0 || len(filter.ExcludeOUs) > 0
+}
+
+// OrganizationalUnitsMatch returns whether the Organizational Unit chain of an account should be included according to the filter.
+func OrganizationalUnitsMatch(matcher MatchingAccountsFilter, accountOrganizationalUnits []string) bool {
+	if len(matcher.IncludeOUs) == 0 {
+		return false
+	}
+	if slices.Contains(matcher.ExcludeOUs, types.Wildcard) {
+		return false
+	}
+	for _, ou := range accountOrganizationalUnits {
+		if slices.Contains(matcher.ExcludeOUs, ou) {
+			return false
+		}
+	}
+	if slices.Contains(matcher.IncludeOUs, types.Wildcard) {
+		return true
+	}
+	for _, ou := range accountOrganizationalUnits {
+		if slices.Contains(matcher.IncludeOUs, ou) {
+			return true
+		}
+	}
+	return false
+}

--- a/lib/utils/aws/organizations/matcher_test.go
+++ b/lib/utils/aws/organizations/matcher_test.go
@@ -1,0 +1,158 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package organizations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestHasActiveMatchers(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		filter   MatchingAccountsFilter
+		expected bool
+	}{
+		{
+			name:     "empty struct",
+			filter:   MatchingAccountsFilter{},
+			expected: false,
+		},
+		{
+			name:     "include only",
+			filter:   MatchingAccountsFilter{IncludeOUs: []string{"ou-a"}},
+			expected: true,
+		},
+		{
+			name:     "exclude only",
+			filter:   MatchingAccountsFilter{ExcludeOUs: []string{"ou-b"}},
+			expected: true,
+		},
+		{
+			name:     "both",
+			filter:   MatchingAccountsFilter{IncludeOUs: []string{"ou-a"}, ExcludeOUs: []string{"ou-b"}},
+			expected: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, HasActiveMatchers(tt.filter))
+		})
+	}
+}
+
+func TestOrganizationalUnitsMatch(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		filter     MatchingAccountsFilter
+		accountOUs []string
+		expected   bool
+	}{
+		{
+			name:       "no included OU: account does not match",
+			filter:     MatchingAccountsFilter{ExcludeOUs: []string{"ou-b"}},
+			accountOUs: []string{"r-root", "ou-a"},
+			expected:   false,
+		},
+		{
+			name:       "include everything: account matches",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{types.Wildcard}},
+			accountOUs: []string{"r-root"},
+			expected:   true,
+		},
+		{
+			name:       "include everything with non-matching exclude: account matches",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{types.Wildcard}, ExcludeOUs: []string{"ou-b"}},
+			accountOUs: []string{"r-root", "ou-a"},
+			expected:   true,
+		},
+		{
+			name:       "include everything with matching exclude: account does not match",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{types.Wildcard}, ExcludeOUs: []string{"ou-a"}},
+			accountOUs: []string{"r-root", "ou-a"},
+			expected:   false,
+		},
+		{
+			name:       "include matches the account's parent",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{"ou-a"}},
+			accountOUs: []string{"r-root", "ou-a"},
+			expected:   true,
+		},
+		{
+			name:       "include matches a 2nd level ancestor OU",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{"ou-a"}},
+			accountOUs: []string{"r-root", "ou-a", "ou-child"},
+			expected:   true,
+		},
+		{
+			name:       "include does not match",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{"ou-b"}},
+			accountOUs: []string{"r-root", "ou-a"},
+			expected:   false,
+		},
+		{
+			name:       "exclude has priority over include for parent OU",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{"ou-a"}, ExcludeOUs: []string{"ou-child"}},
+			accountOUs: []string{"r-root", "ou-a", "ou-child"},
+			expected:   false,
+		},
+		{
+			name:       "exclude has priority over include for ancestor OU",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{"ou-child"}, ExcludeOUs: []string{"ou-a"}},
+			accountOUs: []string{"r-root", "ou-a", "ou-child"},
+			expected:   false,
+		},
+		{
+			name:       "root OU is treated as an OU for inclusion",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{"r-root"}},
+			accountOUs: []string{"r-root"},
+			expected:   true,
+		},
+		{
+			name:       "root OU can be excluded with wildcard include",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{types.Wildcard}, ExcludeOUs: []string{"r-root"}},
+			accountOUs: []string{"r-root", "ou-a"},
+			expected:   false,
+		},
+		{
+			name:       "if exclude everything, then no account matches even if include everything",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{types.Wildcard}, ExcludeOUs: []string{types.Wildcard}},
+			accountOUs: []string{"r-root", "ou-a"},
+			expected:   false,
+		},
+		{
+			name:       "when including everything, even if no chain is passed the account matches",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{types.Wildcard}},
+			accountOUs: nil,
+			expected:   true,
+		},
+		{
+			name:       "when including a specific OU, when no OUs are passed, the account does not match",
+			filter:     MatchingAccountsFilter{IncludeOUs: []string{"ou-a"}},
+			accountOUs: nil,
+			expected:   false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, OrganizationalUnitsMatch(tt.filter, tt.accountOUs))
+		})
+	}
+}

--- a/lib/utils/aws/organizations/matchingaccounts.go
+++ b/lib/utils/aws/organizations/matchingaccounts.go
@@ -105,24 +105,22 @@ func MatchingAccounts(ctx context.Context, log *slog.Logger, orgsClient Organiza
 		return nil, trace.Wrap(err)
 	}
 
-	includeRootAndChildrenAccounts := filter.IncludeOUs[0] == allOrganizationalUnits
-
-	includedActiveAccounts, includedNotActiveAccounts := collectIncludedAccounts(orgTree, filter.IncludeOUs, includeRootAndChildrenAccounts)
+	includedActiveAccounts, includedNotActiveAccounts := collectIncludedAccounts(orgTree, filter, nil)
 	logNotActiveAccountsAreIgnored(ctx, log, filter.OrganizationID, includedNotActiveAccounts)
 
 	return includedActiveAccounts, nil
 }
 
-func collectIncludedAccounts(orgItem *awsOrgItem, included []string, isParentIncluded bool) (activeAccounts []string, notActiveAccounts []string) {
-	includeCurrentOU := isParentIncluded || slices.Contains(included, orgItem.id)
+func collectIncludedAccounts(orgItem *awsOrgItem, filter MatchingAccountsFilter, accountOUAncestors []string) (activeAccounts []string, notActiveAccounts []string) {
+	accountOrganizationalUnits := append(slices.Clone(accountOUAncestors), orgItem.id)
 
-	if includeCurrentOU {
+	if OrganizationalUnitsMatch(filter, accountOrganizationalUnits) {
 		activeAccounts = append(activeAccounts, orgItem.accounts...)
 		notActiveAccounts = append(notActiveAccounts, orgItem.notActiveAccounts...)
 	}
 
 	for _, orgUnit := range orgItem.organizationalUnits {
-		childAccountIDs, childnotActiveAccounts := collectIncludedAccounts(orgUnit, included, includeCurrentOU)
+		childAccountIDs, childnotActiveAccounts := collectIncludedAccounts(orgUnit, filter, accountOrganizationalUnits)
 
 		activeAccounts = append(activeAccounts, childAccountIDs...)
 		notActiveAccounts = append(notActiveAccounts, childnotActiveAccounts...)


### PR DESCRIPTION
In order to access SSH servers, teleport must be installed in the those servers.
In order for them to join the cluster, so that they are accessible to users, they must provide some kind of proof.

One way for the teleport agent to prove themselves is to use the IAM Join token.
Only accessible when the server has access to valid AWS credentials.

When the node tries to access the cluster and provides its AWS Identity, the cluster can either accept or reject the join attempt.

In the case of an IAM Join token, it can be accepted or rejected based on:
- AWS Account ID
- AWS Role ARN

And more [recently](https://github.com/gravitational/teleport/pull/62405), also, the AWS Organization ID.
This new condition allows for large enterprises to define a single Organization ID and accept all of the identities (usually EC2 instances) to join the cluster.

Within an AWS Organization, multiple Organizational Units exist, which group AWS Accounts by team/sector or other business rules. Each one has its own set of rules and security invariants.

This PR goes a step further, and allows users to specify which Organizational Units within the Organization are allowed.
This allows more customization, enabling a more secure setup.

Note: we've also implemented Server Discovery for an Organization based on Organizational Units inclusion/exclusion.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Added support for allowing or denying AWS IAM join attempts using the account's Organizational Units in their current Organization.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster using integration credentials

### Test Cases
- [x] Deny: valid OUs matcher, but wrong Org ID
- [x] Deny: Rule allows another ou
- [x] Deny: Rule allows any ou, but excludes the account's ou
- [x] Deby: root OU is included, but account's parent OU is excluded
- [x] Allow: Rule allows the root ou and no exclude
- [x] Deny: Rule allows account's OU and excludes another sibling OU
- [x] Allow: Rule allows account's OU and excludes another sibling OU
- [x] Validate AWS EC2 join method works
- [x] Validate AWS IAM (without organizations) join method works

Demo:

<img width="1596" height="1148" alt="image" src="https://github.com/user-attachments/assets/ff6b5a2c-4d03-4ed6-b748-7b854d128b69" />
<img width="501" height="522" alt="image" src="https://github.com/user-attachments/assets/a79c9c28-def0-410b-a385-03e3c8c79b6e" />
