### PR TITLE
Add KeyLock utils

### DIFF
--- a/lib/utils/key_lock.go
+++ b/lib/utils/key_lock.go
@@ -1,0 +1,81 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import "sync"
+
+// KeyLock provides per-key mutual exclusion. Only one caller per key can
+// proceed at a time, while unrelated keys are processed concurrently.
+//
+// The zero value is ready to use. A KeyLock must not be copied after first use.
+type KeyLock[K comparable] struct {
+	mu sync.Mutex
+	m  map[K]*keyLockEntry
+}
+
+type keyLockEntry struct {
+	mu       sync.Mutex
+	refCount int
+}
+
+// Lock locks the given key. It blocks until the key is available.
+func (k *KeyLock[K]) Lock(key K) {
+	k.mu.Lock()
+	if k.m == nil {
+		k.m = make(map[K]*keyLockEntry)
+	}
+	entry, exists := k.m[key]
+	if !exists {
+		entry = &keyLockEntry{}
+		k.m[key] = entry
+	}
+	entry.refCount++
+	k.mu.Unlock()
+
+	entry.mu.Lock()
+}
+
+// Unlock unlocks the given key. It is a runtime error if the key is not
+// locked on entry to Unlock.
+func (k *KeyLock[K]) Unlock(key K) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	entry := k.m[key]
+	if entry == nil {
+		panic("keylock: unlock of unlocked key")
+	}
+	if entry.refCount == 0 {
+		panic("keylock: ref count is zero (this is a bug)")
+	}
+
+	entry.mu.Unlock()
+
+	entry.refCount--
+	if entry.refCount == 0 {
+		delete(k.m, key)
+	}
+}
+
+// Acquire locks the given key and returns an unlock function. The unlock
+// function is safe to call multiple times only the first call has any effect.
+func (k *KeyLock[K]) Acquire(key K) func() {
+	k.Lock(key)
+	return sync.OnceFunc(func() {
+		k.Unlock(key)
+	})
+}

--- a/lib/utils/key_lock_test.go
+++ b/lib/utils/key_lock_test.go
@@ -1,0 +1,118 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestKeyLock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lock and unlock", func(t *testing.T) {
+		t.Parallel()
+		var locker utils.KeyLock[string]
+
+		locker.Lock("test-key")
+		locker.Unlock("test-key")
+
+		// Re-locking after unlock should not block.
+		locker.Lock("test-key")
+		locker.Unlock("test-key")
+	})
+
+	t.Run("acquire", func(t *testing.T) {
+		t.Parallel()
+		var locker utils.KeyLock[string]
+
+		unlock := locker.Acquire("test-key")
+		unlock()
+	})
+
+	t.Run("re-acquiring after unlock succeeds", func(t *testing.T) {
+		t.Parallel()
+		var locker utils.KeyLock[string]
+
+		unlock1 := locker.Acquire("test-key")
+		unlock1()
+
+		unlock2 := locker.Acquire("test-key")
+		unlock2()
+	})
+
+	t.Run("concurrent goroutines on same key", func(t *testing.T) {
+		t.Parallel()
+		var locker utils.KeyLock[string]
+		const goroutineCount = 200
+
+		var concurrentCount int
+		var maxConcurrent int
+		var wg sync.WaitGroup
+
+		for i := 0; i < goroutineCount; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				unlock := locker.Acquire("key")
+
+				// It is safe to increment concurrentCount without
+				// atomic operations since the lock ensures only one
+				// goroutine is in this critical section at a time.
+				concurrentCount++
+				if concurrentCount > maxConcurrent {
+					maxConcurrent = concurrentCount
+				}
+				concurrentCount--
+
+				unlock()
+			}()
+		}
+		wg.Wait()
+		require.Equal(t, 1, maxConcurrent)
+	})
+
+	t.Run("different keys are independent", func(t *testing.T) {
+		t.Parallel()
+		var locker utils.KeyLock[string]
+
+		unlockA := locker.Acquire("key-a")
+
+		// Locking a different key should not block.
+		unlockB := locker.Acquire("key-b")
+
+		unlockA()
+		unlockB()
+	})
+
+	t.Run("double unlock is safe", func(t *testing.T) {
+		t.Parallel()
+		var locker utils.KeyLock[string]
+
+		unlock := locker.Acquire("test-key")
+
+		unlock()
+		require.NotPanics(t, func() {
+			unlock()
+		})
+	})
+}


### PR DESCRIPTION
### What

* Move the [SingleProcessLocker](https://github.com/gravitational/teleport.e/blob/master/lib/scim/service/common/lock.go#L105)  added in https://github.com/gravitational/teleport.e/pull/7674 to oss/utils package. 



### Why
- There are other cases apart from SCIM where per key lock needs to be used and we should not reinventing the wheel every time. 

TODO:
- [ ] Replace  [SingleProcessLocker](https://github.com/gravitational/teleport.e/blob/master/lib/scim/service/common/lock.go#L105) with utils.KeyLock after merging this PR. 



