### PR TITLE
[v18][scopes] improve unpinned scoped read abstraction to prevent misuse

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1178,23 +1178,16 @@ func (a *ServerWithRoles) hasWatchPermissionForKindScoped(
 	// Scoped identities currently receive "special" handling. For now, we only
 	// support watching the cert_authority kind, with load_secrets=false.
 	//
-	// For this, we perform a RiskyUnpinnedDecision to permit scoped identities
-	// to read an unscoped resource.
+	// For this, we use AuthorizeUnpinnedRead to permit scoped identities to
+	// read an unscoped resource.
 	if kind.Kind != types.KindCertAuthority {
 		return trace.AccessDenied("scoped identities are not permitted to watch kind %q", kind.Kind)
 	}
 	if kind.LoadSecrets {
 		return trace.AccessDenied("scoped identities are not permitted to watch cert_authority with load_secrets=true")
 	}
-	verb := types.VerbReadNoSecrets
 	ruleCtx := a.scopedContext.RuleContext()
-	return a.scopedContext.CheckerContext.RiskyUnpinnedDecision(
-		ctx,
-		scopes.Root,
-		func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, kind.Kind, verb)
-		},
-	)
+	return a.scopedContext.CheckerContext.AuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthority, &ruleCtx)
 }
 
 // hasWatchPermissionForKind checks the permissions for data of each kind.
@@ -2477,9 +2470,7 @@ func (a *ServerWithRoles) GetAuthServers() ([]types.Server, error) {
 		// all scoped identities regardless of their current scope pinning. This pattern should not
 		// be used for any checks save essential global configuration reads that are necessary for basic
 		// teleport functionality.
-		if err := a.scopedContext.CheckerContext.RiskyUnpinnedDecision(a.CloseContext(), scopes.Root, func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindAuthServer, types.VerbList, types.VerbRead)
-		}); err != nil {
+		if err := a.scopedContext.CheckerContext.AuthorizeUnpinnedRead(a.CloseContext(), services.UnpinnedReadAuthServers, &ruleCtx); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -2502,9 +2493,7 @@ func (a *ServerWithRoles) ListAuthServers(ctx context.Context, pageSize int, pag
 		// all scoped identities regardless of their current scope pinning. This pattern should not
 		// be used for any checks save essential global configuration reads that are necessary for basic
 		// teleport functionality.
-		if err := a.scopedContext.CheckerContext.RiskyUnpinnedDecision(a.CloseContext(), scopes.Root, func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindAuthServer, types.VerbList, types.VerbRead)
-		}); err != nil {
+		if err := a.scopedContext.CheckerContext.AuthorizeUnpinnedRead(a.CloseContext(), services.UnpinnedReadAuthServers, &ruleCtx); err != nil {
 			return nil, "", trace.Wrap(err)
 		}
 
@@ -2543,9 +2532,7 @@ func (a *ServerWithRoles) GetProxies() ([]types.Server, error) {
 		// all scoped identities regardless of their current scope pinning. This pattern should not
 		// be used for any checks save essential global configuration reads that are necessary for basic
 		// teleport functionality.
-		if err := a.scopedContext.CheckerContext.RiskyUnpinnedDecision(a.CloseContext(), scopes.Root, func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindProxy, types.VerbList, types.VerbRead)
-		}); err != nil {
+		if err := a.scopedContext.CheckerContext.AuthorizeUnpinnedRead(a.CloseContext(), services.UnpinnedReadProxies, &ruleCtx); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -2568,9 +2555,7 @@ func (a *ServerWithRoles) ListProxyServers(ctx context.Context, pageSize int, pa
 		// all scoped identities regardless of their current scope pinning. This pattern should not
 		// be used for any checks save essential global configuration reads that are necessary for basic
 		// teleport functionality.
-		if err := a.scopedContext.CheckerContext.RiskyUnpinnedDecision(a.CloseContext(), scopes.Root, func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindProxy, types.VerbList, types.VerbRead)
-		}); err != nil {
+		if err := a.scopedContext.CheckerContext.AuthorizeUnpinnedRead(ctx, services.UnpinnedReadProxies, &ruleCtx); err != nil {
 			return nil, "", trace.Wrap(err)
 		}
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1178,7 +1178,7 @@ func (a *ServerWithRoles) hasWatchPermissionForKindScoped(
 	// Scoped identities currently receive "special" handling. For now, we only
 	// support watching the cert_authority kind, with load_secrets=false.
 	//
-	// For this, we use AuthorizeUnpinnedRead to permit scoped identities to
+	// For this, we use RiskyAuthorizeUnpinnedRead to permit scoped identities to
 	// read an unscoped resource.
 	if kind.Kind != types.KindCertAuthority {
 		return trace.AccessDenied("scoped identities are not permitted to watch kind %q", kind.Kind)
@@ -1187,7 +1187,7 @@ func (a *ServerWithRoles) hasWatchPermissionForKindScoped(
 		return trace.AccessDenied("scoped identities are not permitted to watch cert_authority with load_secrets=true")
 	}
 	ruleCtx := a.scopedContext.RuleContext()
-	return a.scopedContext.CheckerContext.AuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthority, &ruleCtx)
+	return a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthority, &ruleCtx)
 }
 
 // hasWatchPermissionForKind checks the permissions for data of each kind.
@@ -2470,7 +2470,7 @@ func (a *ServerWithRoles) GetAuthServers() ([]types.Server, error) {
 		// all scoped identities regardless of their current scope pinning. This pattern should not
 		// be used for any checks save essential global configuration reads that are necessary for basic
 		// teleport functionality.
-		if err := a.scopedContext.CheckerContext.AuthorizeUnpinnedRead(a.CloseContext(), services.UnpinnedReadAuthServers, &ruleCtx); err != nil {
+		if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(a.CloseContext(), services.UnpinnedReadAuthServers, &ruleCtx); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -2493,7 +2493,7 @@ func (a *ServerWithRoles) ListAuthServers(ctx context.Context, pageSize int, pag
 		// all scoped identities regardless of their current scope pinning. This pattern should not
 		// be used for any checks save essential global configuration reads that are necessary for basic
 		// teleport functionality.
-		if err := a.scopedContext.CheckerContext.AuthorizeUnpinnedRead(a.CloseContext(), services.UnpinnedReadAuthServers, &ruleCtx); err != nil {
+		if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(a.CloseContext(), services.UnpinnedReadAuthServers, &ruleCtx); err != nil {
 			return nil, "", trace.Wrap(err)
 		}
 
@@ -2532,7 +2532,7 @@ func (a *ServerWithRoles) GetProxies() ([]types.Server, error) {
 		// all scoped identities regardless of their current scope pinning. This pattern should not
 		// be used for any checks save essential global configuration reads that are necessary for basic
 		// teleport functionality.
-		if err := a.scopedContext.CheckerContext.AuthorizeUnpinnedRead(a.CloseContext(), services.UnpinnedReadProxies, &ruleCtx); err != nil {
+		if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(a.CloseContext(), services.UnpinnedReadProxies, &ruleCtx); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
@@ -2555,7 +2555,7 @@ func (a *ServerWithRoles) ListProxyServers(ctx context.Context, pageSize int, pa
 		// all scoped identities regardless of their current scope pinning. This pattern should not
 		// be used for any checks save essential global configuration reads that are necessary for basic
 		// teleport functionality.
-		if err := a.scopedContext.CheckerContext.AuthorizeUnpinnedRead(ctx, services.UnpinnedReadProxies, &ruleCtx); err != nil {
+		if err := a.scopedContext.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadProxies, &ruleCtx); err != nil {
 			return nil, "", trace.Wrap(err)
 		}
 

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -155,10 +155,10 @@ func (s *Service) GetAuthPreference(ctx context.Context, _ *clusterconfigpb.GetA
 		return nil, trace.Wrap(err)
 	}
 
-	// Use AuthorizeUnpinnedRead to allow scoped identities (regardless of their
+	// Use RiskyAuthorizeUnpinnedRead to allow scoped identities (regardless of their
 	// scope pin) to call GetAuthPreference.
 	ruleCtx := authzCtx.RuleContext()
-	if err := authzCtx.CheckerContext.AuthorizeUnpinnedRead(ctx, services.UnpinnedReadAuthPreference, &ruleCtx); err != nil {
+	if err := authzCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadAuthPreference, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -31,7 +31,6 @@ import (
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 )
@@ -156,18 +155,10 @@ func (s *Service) GetAuthPreference(ctx context.Context, _ *clusterconfigpb.GetA
 		return nil, trace.Wrap(err)
 	}
 
-	// Use RiskyUnpinnedDecision to allow scoped identities (regardless of their
+	// Use AuthorizeUnpinnedRead to allow scoped identities (regardless of their
 	// scope pin) to call GetAuthPreference.
 	ruleCtx := authzCtx.RuleContext()
-	if err := authzCtx.CheckerContext.RiskyUnpinnedDecision(
-		ctx,
-		scopes.Root,
-		func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(
-				&ruleCtx, types.KindClusterAuthPreference, types.VerbRead,
-			)
-		},
-	); err != nil {
+	if err := authzCtx.CheckerContext.AuthorizeUnpinnedRead(ctx, services.UnpinnedReadAuthPreference, &ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -268,10 +268,10 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 		}
 
 	} else {
-		// for standard reads we do not enforce scope pinning. this ensures that CAs are readable for
-		// all scoped identities regardless of their current scope pinning. this pattern should not
+		// For standard reads we do not enforce scope pinning. This ensures that CAs are readable for
+		// all scoped identities regardless of their current scope pinning. This pattern should not
 		// be used for any checks save essential global configuration reads that are necessary for basic
-		// teleport functionality.
+		// Teleport functionality.
 		if err := authCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthorities, &ruleCtx); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -114,15 +114,17 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 		return nil, trace.Wrap(err)
 	}
 
-	// For read without secrets, we use RiskyUnpinnedDecision, this is to allow
-	// scoped identities (regardless of their pinned scope) to be able to fetch
-	// cert_authority resources (which are currently unscoped/treated as root
-	// scope).
-	decisionFn := authCtx.CheckerContext.RiskyUnpinnedDecision
-	readVerb := types.VerbReadNoSecrets
-	if req.IncludeKey {
-		readVerb = types.VerbRead
-		decisionFn = authCtx.CheckerContext.Decision
+	checkAccess := func(ruleCtx services.RuleContext) error {
+		if req.IncludeKey {
+			return authCtx.CheckerContext.Decision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
+				return checker.CheckAccessToRules(ruleCtx, types.KindCertAuthority, types.VerbRead)
+			})
+		}
+		// For read without secrets we use AuthorizeUnpinnedRead, this is to
+		// allow scoped identities (regardless of their pinned scope) to be
+		// able to fetch cert_authority resources (which are currently
+		// unscoped/treated as root scope).
+		return authCtx.CheckerContext.AuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthority, ruleCtx)
 	}
 
 	// Before looking up the requested CA perform RBAC on a dummy CA to
@@ -138,13 +140,7 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 	}
 	ruleCtx := authCtx.RuleContext()
 	ruleCtx.Resource = contextCA
-	if err := decisionFn(
-		ctx,
-		scopes.Root,
-		func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindCertAuthority, readVerb)
-		},
-	); err != nil {
+	if err := checkAccess(&ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -170,12 +166,7 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 	}
 
 	ruleCtx.Resource = ca
-	if err := decisionFn(
-		ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(
-				&ruleCtx, types.KindCertAuthority, readVerb)
-		},
-	); err != nil {
+	if err := checkAccess(&ruleCtx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -247,22 +238,25 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 		return nil, trace.Wrap(err)
 	}
 
-	verbs := []string{types.VerbList, types.VerbReadNoSecrets}
-	// for standard reads we do not enforce scope pinning. this ensures that CAs are readable for
-	// all scoped identities regardless of their current scope pinning. this pattern should not
-	// be used for any checks save essential global configuration reads that are necessary for basic
-	// teleport functionality.
-	decisionFn := authCtx.CheckerContext.RiskyUnpinnedDecision
+	// Build rule context for where-clause evaluation once to avoid re-creation
+	// on each decision invocation.
+	ruleCtx := authCtx.RuleContext()
 
 	if req.IncludeKey {
-		verbs = append(verbs, types.VerbRead)
-
-		// for queries that include secrets we must enforce standard scope pinning rules.
+		// For queries that include secrets we must enforce standard scope pinning rules.
+		//
 		// NOTE: technically we have no plans to introduce scoped CA secrets. as of the time of writing,
 		// attempts to read CA secrets by scoped identities are always denied by virtue of the scoped
 		// role verb limits enforced in scopes/access. this, however, would be the correct pattern should
 		// we choose to introduce scoped CA secrets in the future.
-		decisionFn = authCtx.CheckerContext.Decision
+		//
+		// All cert authorities can be considered as being "root" resources from
+		// the perspective of scoped RBAC, so we just hard-code root as the resource scope for the decision.
+		if err := authCtx.CheckerContext.Decision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(&ruleCtx, types.KindCertAuthority, types.VerbList, types.VerbRead, types.VerbReadNoSecrets)
+		}); err != nil {
+			return nil, trace.Wrap(err)
+		}
 
 		// Require admin MFA to read secrets (admin MFA is currently only supported for unscoped identities).
 		if unscopedCtx, ok := authCtx.UnscopedContext(); ok {
@@ -272,18 +266,15 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 		} else {
 			return nil, trace.AccessDenied("cannot perform admin action %s:%s as scoped identity", types.KindCertAuthority, types.VerbRead)
 		}
-	}
 
-	// build rule context for where-clause evaluation once to avoid re-creation
-	// on each decision invocation.
-	ruleCtx := authCtx.RuleContext()
-
-	// perform access-control decision. all cert authorities can be considered as being "root" resources from
-	// the perspective of scoped RBAC, so we just hard-code root as the resource scope for the decision.
-	if err := decisionFn(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, types.KindCertAuthority, verbs...)
-	}); err != nil {
-		return nil, trace.Wrap(err)
+	} else {
+		// for standard reads we do not enforce scope pinning. this ensures that CAs are readable for
+		// all scoped identities regardless of their current scope pinning. this pattern should not
+		// be used for any checks save essential global configuration reads that are necessary for basic
+		// teleport functionality.
+		if err := authCtx.CheckerContext.AuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthorities, &ruleCtx); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	cas, err := s.cache.GetCertAuthorities(ctx, types.CertAuthType(req.Type), req.IncludeKey)

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -120,11 +120,11 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 				return checker.CheckAccessToRules(ruleCtx, types.KindCertAuthority, types.VerbRead)
 			})
 		}
-		// For read without secrets we use AuthorizeUnpinnedRead, this is to
+		// For read without secrets we use RiskyAuthorizeUnpinnedRead, this is to
 		// allow scoped identities (regardless of their pinned scope) to be
 		// able to fetch cert_authority resources (which are currently
 		// unscoped/treated as root scope).
-		return authCtx.CheckerContext.AuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthority, ruleCtx)
+		return authCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthority, ruleCtx)
 	}
 
 	// Before looking up the requested CA perform RBAC on a dummy CA to
@@ -272,7 +272,7 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 		// all scoped identities regardless of their current scope pinning. this pattern should not
 		// be used for any checks save essential global configuration reads that are necessary for basic
 		// teleport functionality.
-		if err := authCtx.CheckerContext.AuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthorities, &ruleCtx); err != nil {
+		if err := authCtx.CheckerContext.RiskyAuthorizeUnpinnedRead(ctx, services.UnpinnedReadCertAuthorities, &ruleCtx); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/itertools/stream"
@@ -116,10 +117,10 @@ func (c *ScopedAccessCheckerContext) CheckersForResourceScope(ctx context.Contex
 	return c.checkersForResourceScope(ctx, scope, enforcePinTrue)
 }
 
-// RiskyUnpinnedCheckersForResourceScope is equivalent to CheckersForResourceScope except that it bypasses
+// riskyUnpinnedCheckersForResourceScope is equivalent to CheckersForResourceScope except that it bypasses
 // enforcement of the pinning scope. This is a risky operation that should only be used for certain APIs that
 // make an exception to pinning exclusion rules (e.g. allowing read operations for resources at a parent scope).
-func (c *ScopedAccessCheckerContext) RiskyUnpinnedCheckersForResourceScope(ctx context.Context, scope string) stream.Stream[*ScopedAccessChecker] {
+func (c *ScopedAccessCheckerContext) riskyUnpinnedCheckersForResourceScope(ctx context.Context, scope string) stream.Stream[*ScopedAccessChecker] {
 	if !c.isScoped() {
 		return stream.Once(NewScopedAccessCheckerFromUnscoped(c.unscopedChecker))
 	}
@@ -245,11 +246,6 @@ func (c *ScopedAccessCheckerContext) Decision(ctx context.Context, scope string,
 	return c.decision(c.CheckersForResourceScope(ctx, scope), fn)
 }
 
-// RiskyUnpinnedDecision is equivalent to Decision except that it bypasses enforcement of the pinning scope.
-func (c *ScopedAccessCheckerContext) RiskyUnpinnedDecision(ctx context.Context, scope string, fn func(*ScopedAccessChecker) error) error {
-	return c.decision(c.RiskyUnpinnedCheckersForResourceScope(ctx, scope), fn)
-}
-
 func (c *ScopedAccessCheckerContext) decision(checkers stream.Stream[*ScopedAccessChecker], fn func(*ScopedAccessChecker) error) error {
 	for checker, err := range checkers {
 		if err != nil {
@@ -313,3 +309,101 @@ func (c *ScopedAccessCheckerContext) Traits() wrappers.Traits {
 func (c *ScopedAccessCheckerContext) CertParams() *CertificateParameterContext {
 	return &CertificateParameterContext{ctx: c}
 }
+
+// AuthorizeUnpinnedRead authorizes a read-only access check that bypasses
+// enforcement of the identity's pinned scope. This must only be used for
+// specific APIs that make an exception to pinning exclusion rules (e.g.
+// allowing read operations for resources at a parent scope). To avoid misuse,
+// a specific [UnpinnedReadAuthorization] must be provided that will encode the
+// effective scope of the access check and the allowed verbs.
+func (c *ScopedAccessCheckerContext) AuthorizeUnpinnedRead(
+	ctx context.Context,
+	authz UnpinnedReadAuthorization,
+	ruleCtx RuleContext,
+) error {
+	if err := authz.check(); err != nil {
+		return trace.Wrap(err, "invalid unpinned read authorization")
+	}
+
+	return c.decision(
+		c.riskyUnpinnedCheckersForResourceScope(ctx, authz.resourceScope),
+		func(checker *ScopedAccessChecker) error {
+			return checker.CheckAccessToRules(ruleCtx, authz.kind, authz.verbs...)
+		},
+	)
+}
+
+// UnpinnedReadAuthorization is a special authorization to complete an unscoped
+// read-only access check. This is meant to be used for access checks on
+// typically cluster-wide resources that need to be readable by identities with
+// a pinned scope.
+type UnpinnedReadAuthorization struct {
+	resourceScope string
+	kind          string
+	verbs         []string
+}
+
+func (a UnpinnedReadAuthorization) check() error {
+	switch {
+	case a.kind == "":
+		return trace.BadParameter("missing kind")
+	case len(a.verbs) == 0:
+		return trace.BadParameter("missing verbs")
+	}
+	for _, verb := range a.verbs {
+		switch verb {
+		case types.VerbList, types.VerbReadNoSecrets, types.VerbRead:
+		default:
+			return trace.BadParameter("invalid verb for unpinned read authorization: %q", verb)
+		}
+	}
+	if err := scopes.WeakValidate(a.resourceScope); err != nil {
+		return trace.Wrap(err, "invalid resourceScope")
+	}
+	return nil
+}
+
+var (
+	// UnpinnedReadCertAuthority is a special authorization to complete an
+	// unscoped access check to read a cert authority without secrets.
+	UnpinnedReadCertAuthority = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindCertAuthority,
+		verbs:         []string{types.VerbReadNoSecrets},
+	}
+	// UnpinnedReadCertAuthorities is a special authorization to complete an
+	// unscoped access check to list and read a cert authorities without secrets.
+	UnpinnedReadCertAuthorities = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindCertAuthority,
+		verbs:         []string{types.VerbList, types.VerbReadNoSecrets},
+	}
+	// UnpinnedReadAuthServers is a special authorization to complete an
+	// unscoped access check to list and read auth server resources.
+	UnpinnedReadAuthServers = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindAuthServer,
+		verbs:         []string{types.VerbList, types.VerbRead},
+	}
+	// UnpinnedReadProxies is a special authorization to complete an
+	// unscoped access check to list and read proxy resources.
+	UnpinnedReadProxies = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindProxy,
+		verbs:         []string{types.VerbList, types.VerbRead},
+	}
+	// UnpinnedReadAuthPreference is a special authorization to complete an
+	// unscoped access check to read a cluster auth preference.
+	UnpinnedReadAuthPreference = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindClusterAuthPreference,
+		verbs:         []string{types.VerbRead},
+	}
+	// UnpinnedReadVnetConfig is a special authorization to complete an
+	// unscoped access check to read a cluster VNet config.
+	UnpinnedReadVnetConfig = UnpinnedReadAuthorization{
+		resourceScope: scopes.Root,
+		kind:          types.KindVnetConfig,
+		verbs:         []string{types.VerbRead},
+	}
+)

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -310,13 +310,13 @@ func (c *ScopedAccessCheckerContext) CertParams() *CertificateParameterContext {
 	return &CertificateParameterContext{ctx: c}
 }
 
-// AuthorizeUnpinnedRead authorizes a read-only access check that bypasses
+// RiskyAuthorizeUnpinnedRead authorizes a read-only access check that bypasses
 // enforcement of the identity's pinned scope. This must only be used for
 // specific APIs that make an exception to pinning exclusion rules (e.g.
 // allowing read operations for resources at a parent scope). To avoid misuse,
 // a specific [UnpinnedReadAuthorization] must be provided that will encode the
 // effective scope of the access check and the allowed verbs.
-func (c *ScopedAccessCheckerContext) AuthorizeUnpinnedRead(
+func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedRead(
 	ctx context.Context,
 	authz UnpinnedReadAuthorization,
 	ruleCtx RuleContext,

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -1,0 +1,71 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+func TestScopedAccessCheckerContextAuthorizeUnpinnedRead(t *testing.T) {
+	ctx := context.Background()
+	checkerContext, err := NewScopedAccessCheckerContext(ctx, &AccessInfo{
+		Username: "alice",
+		ScopePin: &scopesv1.Pin{
+			Scope: "/test/scope",
+		},
+	}, "test-cluster", emptyScopedRoleReader{})
+	require.NoError(t, err)
+
+	ruleCtx := &Context{}
+
+	// A normal decision for a root-scoped resource is denied because the identity
+	// is pinned away from root before any checker, including the default implicit
+	// role checker, is evaluated.
+	err = checkerContext.Decision(ctx, scopes.Root, func(checker *ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(ruleCtx, types.KindCertAuthority, types.VerbReadNoSecrets)
+	})
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got %v", err)
+
+	// AuthorizeUnpinnedRead bypasses pin enforcement but still requires the
+	// underlying RBAC permission. The default implicit role grants CA
+	// read_no_secrets, so this succeeds.
+	err = checkerContext.AuthorizeUnpinnedRead(ctx, UnpinnedReadCertAuthority, ruleCtx)
+	require.NoError(t, err)
+
+	// Using an empty UnpinnedReadAuthorization is not allowed.
+	err = checkerContext.AuthorizeUnpinnedRead(ctx, UnpinnedReadAuthorization{}, ruleCtx)
+	require.True(t, trace.IsBadParameter(err), "expected bad parameter error, got %v", err)
+}
+
+type emptyScopedRoleReader struct{}
+
+func (emptyScopedRoleReader) GetScopedRole(context.Context, *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	return nil, trace.NotFound("scoped role not found")
+}
+
+func (emptyScopedRoleReader) ListScopedRoles(context.Context, *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	return &scopedaccessv1.ListScopedRolesResponse{}, nil
+}

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -47,7 +47,7 @@ func TestScopedAccessCheckerContextRiskyAuthorizeUnpinnedRead(t *testing.T) {
 	err = checkerContext.Decision(ctx, scopes.Root, func(checker *ScopedAccessChecker) error {
 		return checker.CheckAccessToRules(ruleCtx, types.KindCertAuthority, types.VerbReadNoSecrets)
 	})
-	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got %v", err)
+	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
 
 	// RiskyAuthorizeUnpinnedRead bypasses pin enforcement but still requires the
 	// underlying RBAC permission. The default implicit role grants CA
@@ -57,7 +57,7 @@ func TestScopedAccessCheckerContextRiskyAuthorizeUnpinnedRead(t *testing.T) {
 
 	// Using an empty UnpinnedReadAuthorization is not allowed.
 	err = checkerContext.RiskyAuthorizeUnpinnedRead(ctx, UnpinnedReadAuthorization{}, ruleCtx)
-	require.True(t, trace.IsBadParameter(err), "expected bad parameter error, got %v", err)
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
 }
 
 type emptyScopedRoleReader struct{}

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/scopes"
 )
 
-func TestScopedAccessCheckerContextAuthorizeUnpinnedRead(t *testing.T) {
+func TestScopedAccessCheckerContextRiskyAuthorizeUnpinnedRead(t *testing.T) {
 	ctx := context.Background()
 	checkerContext, err := NewScopedAccessCheckerContext(ctx, &AccessInfo{
 		Username: "alice",
@@ -49,14 +49,14 @@ func TestScopedAccessCheckerContextAuthorizeUnpinnedRead(t *testing.T) {
 	})
 	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got %v", err)
 
-	// AuthorizeUnpinnedRead bypasses pin enforcement but still requires the
+	// RiskyAuthorizeUnpinnedRead bypasses pin enforcement but still requires the
 	// underlying RBAC permission. The default implicit role grants CA
 	// read_no_secrets, so this succeeds.
-	err = checkerContext.AuthorizeUnpinnedRead(ctx, UnpinnedReadCertAuthority, ruleCtx)
+	err = checkerContext.RiskyAuthorizeUnpinnedRead(ctx, UnpinnedReadCertAuthority, ruleCtx)
 	require.NoError(t, err)
 
 	// Using an empty UnpinnedReadAuthorization is not allowed.
-	err = checkerContext.AuthorizeUnpinnedRead(ctx, UnpinnedReadAuthorization{}, ruleCtx)
+	err = checkerContext.RiskyAuthorizeUnpinnedRead(ctx, UnpinnedReadAuthorization{}, ruleCtx)
 	require.True(t, trace.IsBadParameter(err), "expected bad parameter error, got %v", err)
 }
 


### PR DESCRIPTION
Backport #66235 to branch/v18

## Manual Test Plan

### Test Environment

Run against a Teleport cluster with `TELEPORT_UNSTABLE_SCOPES=yes`.

Create a test user:

```bash
tctl users add scoped-reader --roles=access --logins=root
```

Create the scoped role and assignment used to issue a scoped identity pinned to `/test`:

```yaml
kind: scoped_role
metadata:
  name: test-cluster-read
scope: /test
spec:
  assignable_scopes: [/test]
  ssh:
    logins: [root]
version: v1
---
kind: scoped_role_assignment
sub_kind: dynamic
metadata:
  name: test-cluster-read-scoped-reader
scope: /test
spec:
  user: scoped-reader
  assignments:
    - role: test-cluster-read
      scope: /test
version: v1
```

```bash
tctl create -f /tmp/test-cluster-read-scoped-role.yaml
tsh login --user=scoped-reader --scope=/test
tsh status # verify Scope: /test
```

### Test Cases

- [x] Scoped user can list CAs without secrets: `tctl get cert_authorities`
- [x] Scoped user cannot list CAs with secrets: `tctl get cert_authorities --with-secrets`
- [x] Scoped user can read one CA without secrets: `tctl get "cert_authority/host/<cluster-name>"`
- [x] Scoped user cannot read one CA with secrets: `tctl get "cert_authority/host/<cluster-name>" --with-secrets`

- [x] Scoped user can list auth servers: `tctl get auth_servers`
- [x] Scoped user can list proxy servers: `tctl get proxies`
- [x] Scoped user can read cluster auth preference: `tctl get cluster_auth_preference`
- [x] Unscoped admin behavior is unchanged:

```bash
tsh logout
tsh login --proxy="${TELEPORT_PROXY}" --user=<admin-user>
tctl get cert_authorities
tctl get cert_authorities --with-secrets
tctl get auth_servers
tctl get proxies
tctl get cluster_auth_preference
```
