### PR TITLE
Add AppClient CA

### DIFF
--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -80,6 +80,9 @@ const (
 	//
 	// https://github.com/gravitational/teleport/blob/master/rfd/0239-windows-ca-split.md
 	WindowsCA CertAuthType = "windows"
+	// AppClientCA is the certificate authority used to issu app access client
+	// certificates.
+	AppClientCA CertAuthType = "app_client"
 )
 
 // CertAuthTypes lists all certificate authority types.
@@ -97,6 +100,7 @@ var CertAuthTypes = []CertAuthType{
 	OktaCA,
 	AWSRACA,
 	BoundKeypairCA,
+	AppClientCA,
 }
 
 // NewlyAdded should return true for CA types that were added in the current
@@ -104,9 +108,9 @@ var CertAuthTypes = []CertAuthType{
 // remote server doesn't know about them.
 func (c CertAuthType) NewlyAdded() bool {
 	return c.addedInMajorVer() >= api.VersionMajor ||
-		// WindowsCA is considered new in both v18.x and v19.
+		// WindowsCA and AppClientCA are considered new in both v18.x and v19.
 		// TODO(codingllama): DELETE IN 20. Only here for backport purposes.
-		(c == WindowsCA && api.VersionMajor == 18)
+		((c == WindowsCA || c == AppClientCA) && api.VersionMajor == 18)
 }
 
 // addedInMajorVer returns the major version in which given CA was added.
@@ -126,10 +130,10 @@ func (c CertAuthType) addedInMajorVer() int64 {
 		return 17
 	case AWSRACA, BoundKeypairCA:
 		return 18
-	case WindowsCA:
-		// Note: WindowsCA was added in a 18.x minor release, so unlike others it's
-		// considered "new" in both versions 18 and 19. That is to allow for, at
-		// least, a full release cycle.
+	case WindowsCA, AppClientCA:
+		// Note: WindowsCA and AppClientCA was added in a 18.x minor release,
+		// so unlike others it's considered "new" in both versions 18 and 19.
+		// That is to allow for, at least, a full release cycle.
 		return 19
 	default:
 		// We don't care about other CAs added before v4.0.0

--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -80,7 +80,7 @@ const (
 	//
 	// https://github.com/gravitational/teleport/blob/master/rfd/0239-windows-ca-split.md
 	WindowsCA CertAuthType = "windows"
-	// AppClientCA is the certificate authority used to issu app access client
+	// AppClientCA is the certificate authority used to issue app access client
 	// certificates.
 	AppClientCA CertAuthType = "app_client"
 )

--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -131,8 +131,8 @@ func (c CertAuthType) addedInMajorVer() int64 {
 	case AWSRACA, BoundKeypairCA:
 		return 18
 	case WindowsCA, AppClientCA:
-		// Note: WindowsCA and AppClientCA was added in a 18.x minor release,
-		// so unlike others it's considered "new" in both versions 18 and 19.
+		// Note: WindowsCA and AppClientCA were added in an 18.x minor release,
+		// so unlike others they are considered "new" in both versions 18 and 19.
 		// That is to allow for, at least, a full release cycle.
 		return 19
 	default:

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8551,7 +8551,8 @@ func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertA
 		types.OktaCA,
 		types.AWSRACA,
 		types.BoundKeypairCA,
-		types.WindowsCA:
+		types.WindowsCA,
+		types.AppClientCA:
 		// OK, known CA type.
 	default:
 		return types.CAKeySet{}, trace.BadParameter(
@@ -8579,7 +8580,8 @@ func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertA
 		types.SAMLIDPCA,
 		types.SPIFFECA,
 		types.AWSRACA,
-		types.WindowsCA:
+		types.WindowsCA,
+		types.AppClientCA:
 		tlsKeyPair, err := keyStore.NewTLSKeyPair(ctx, caID.DomainName, tlsCAKeyPurpose(caID.Type))
 		if err != nil {
 			return keySet, trace.Wrap(err)
@@ -8635,6 +8637,8 @@ func tlsCAKeyPurpose(caType types.CertAuthType) cryptosuites.KeyPurpose {
 		return cryptosuites.AWSRACATLS
 	case types.WindowsCA:
 		return cryptosuites.WindowsCARDP
+	case types.AppClientCA:
+		return cryptosuites.AppClientCATLS
 	}
 	return cryptosuites.KeyPurposeUnspecified
 }

--- a/lib/auth/authcatest/ca.go
+++ b/lib/auth/authcatest/ca.go
@@ -77,7 +77,8 @@ func NewCAWithConfig(config CAConfig) (*types.CertAuthorityV2, error) {
 		types.OktaCA,
 		types.AWSRACA,
 		types.BoundKeypairCA,
-		types.WindowsCA:
+		types.WindowsCA,
+		types.AppClientCA:
 		// OK, known CA type.
 	default:
 		return nil, trace.BadParameter("cannot generate new key set for unknown CA type %q", config.Type)
@@ -161,7 +162,8 @@ func NewCAWithConfig(config CAConfig) (*types.CertAuthorityV2, error) {
 		types.SAMLIDPCA,
 		types.SPIFFECA,
 		types.AWSRACA,
-		types.WindowsCA:
+		types.WindowsCA,
+		types.AppClientCA:
 		cert, err := tlsca.GenerateSelfSignedCAWithConfig(tlsca.GenerateCAConfig{
 			Signer: key.Signer,
 			Entity: pkix.Name{

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1594,7 +1594,8 @@ func checkResourceConsistency(ctx context.Context, mod modules.Modules, keyStore
 				types.SAMLIDPCA,
 				types.SPIFFECA,
 				types.AWSRACA,
-				types.WindowsCA:
+				types.WindowsCA,
+				types.AppClientCA:
 				_, _, signerErr = keyStore.GetTLSCertAndSigner(ctx, r)
 			case types.JWTSigner,
 				types.OIDCIdPCA,

--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -220,6 +220,13 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 			ExportPrivateKeys: exportSecrets,
 		}
 		return exportTLSAuthority(ctx, client, req)
+	case "app-client":
+		req := exportTLSAuthorityRequest{
+			AuthType:          types.AppClientCA,
+			UnpackPEM:         false,
+			ExportPrivateKeys: exportSecrets,
+		}
+		return exportTLSAuthority(ctx, client, req)
 	}
 
 	// If none of the above auth-types was requested, means we are dealing with SSH HostCA or SSH UserCA.

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -338,6 +338,15 @@ func TestExportAllAuthorities(t *testing.T) {
 			assertNoSecrets: validateTLSCertificatePEMFunc,
 			assertSecrets:   validatePrivateKeyPEMFunc,
 		},
+		{
+			name: "app-client",
+			req: ExportAuthoritiesRequest{
+				AuthType: "app-client",
+			},
+			errorCheck:      require.NoError,
+			assertNoSecrets: validateTLSCertificatePEMFunc,
+			assertSecrets:   validatePrivateKeyPEMFunc,
+		},
 	} {
 		runTest := func(
 			t *testing.T,

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -135,6 +135,9 @@ const (
 	// (Remote Desktop Protocol) certificates.
 	WindowsCARDP
 
+	// AppClientCATLS represents the TLS key used for the app_client CA.
+	AppClientCATLS
+
 	// keyPurposeMax is 1 greater than the last valid key purpose, used to test that all values less than this
 	// are valid for each suite.
 	keyPurposeMax
@@ -222,6 +225,7 @@ var (
 		BoundKeypairCAJWT:    ECDSAP256,
 		RecordingKeyWrapping: RSA4096,
 		WindowsCARDP:         RSA2048, // same as UserCATLS
+		AppClientCATLS:       RSA2048,
 	}
 
 	// balancedV1 strikes a balance between security, compatibility, and
@@ -258,6 +262,7 @@ var (
 		BoundKeypairCAJWT:       Ed25519,
 		RecordingKeyWrapping:    RSA4096,
 		WindowsCARDP:            ECDSAP256, // same as UserCATLS
+		AppClientCATLS:          ECDSAP256,
 	}
 
 	// fipsv1 is an algorithm suite tailored for FIPS compliance. It is based on
@@ -295,6 +300,7 @@ var (
 		BoundKeypairCAJWT:       ECDSAP256,
 		RecordingKeyWrapping:    RSA4096,
 		WindowsCARDP:            ECDSAP256, // same as UserCATLS
+		AppClientCATLS:          ECDSAP256,
 	}
 
 	// hsmv1 in an algorithm suite tailored for clusters using an HSM or KMS
@@ -334,6 +340,7 @@ var (
 		BoundKeypairCAJWT:       ECDSAP256,
 		RecordingKeyWrapping:    RSA4096,
 		WindowsCARDP:            ECDSAP256, // same as UserCATLS
+		AppClientCATLS:          ECDSAP256,
 	}
 
 	allSuites = map[types.SignatureAlgorithmSuite]suite{

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -225,7 +225,7 @@ var (
 		BoundKeypairCAJWT:    ECDSAP256,
 		RecordingKeyWrapping: RSA4096,
 		WindowsCARDP:         RSA2048, // same as UserCATLS
-		AppClientCATLS:       RSA2048,
+		AppClientCATLS:       ECDSAP256,
 	}
 
 	// balancedV1 strikes a balance between security, compatibility, and

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -59,6 +59,8 @@ func ValidateCertAuthority(ca types.CertAuthority) (err error) {
 		err = checkAWSRACA(ca)
 	case types.WindowsCA:
 		err = checkWindowsCA(ca)
+	case types.AppClientCA:
+		err = checkAppClientCA(ca)
 	default:
 		return trace.BadParameter("invalid CA type %q", ca.GetType())
 	}
@@ -200,6 +202,15 @@ func checkSAMLIDPCA(cai types.CertAuthority) error {
 }
 
 func checkWindowsCA(cai types.CertAuthority) error {
+	ca, ok := cai.(*types.CertAuthorityV2)
+	if !ok {
+		return trace.BadParameter("unknown CA type %T", cai)
+	}
+
+	return trace.Wrap(checkTLSKeys(ca))
+}
+
+func checkAppClientCA(cai types.CertAuthority) error {
 	ca, ok := cai.(*types.CertAuthorityV2)
 	if !ok {
 		return trace.BadParameter("unknown CA type %T", cai)

--- a/lib/services/authority_test.go
+++ b/lib/services/authority_test.go
@@ -217,6 +217,20 @@ func TestValidateCertAuthority(t *testing.T) {
 		},
 	}
 
+	appClientCA := &types.CertAuthoritySpecV2{
+		Type:        types.AppClientCA,
+		ClusterName: clusterName,
+		ActiveKeys: types.CAKeySet{
+			TLS: []*types.TLSKeyPair{
+				{
+					Cert:    certPEM,
+					Key:     keyPEM,
+					KeyType: types.PrivateKeyType_RAW,
+				},
+			},
+		},
+	}
+
 	samlIDPCA := &types.CertAuthoritySpecV2{
 		Type:        types.SAMLIDPCA,
 		ClusterName: clusterName,
@@ -435,6 +449,22 @@ func TestValidateCertAuthority(t *testing.T) {
 				return spec
 			}(),
 			wantErr: "public key",
+		},
+
+		// AppClientCA.
+		{
+			name: "valid AppClientCA",
+			spec: appClientCA,
+		},
+		{
+			// WindowsCA already covers all corner-cases of checkTLSKeys.
+			name: "AppClientCA invalid ActiveKeys",
+			spec: func() *types.CertAuthoritySpecV2 {
+				spec := clone(appClientCA)
+				spec.ActiveKeys = types.CAKeySet{}
+				return spec
+			}(),
+			wantErr: "missing TLS",
 		},
 	}
 	for _, test := range tests {

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -241,6 +241,7 @@ var allowedCertificateTypes = []string{
 	"saml-idp",
 	"github",
 	"awsra",
+	"app-client",
 }
 
 // allowedCRLCertificateTypes list of certificate authorities types that can

--- a/tool/tctl/common/auth_rotate_command.go
+++ b/tool/tctl/common/auth_rotate_command.go
@@ -1107,6 +1107,8 @@ func updateClientsPhaseHelpText(sb *strings.Builder, caType types.CertAuthType) 
 		sb.WriteString("\nAll new database connections will begin to use certificates issued by the new CA certificate.")
 	case types.WindowsCA:
 		sb.WriteString("\nAll new connections to Windows desktops will begin to use certificates issued by the new CA certificate. ")
+	case types.AppClientCA:
+		sb.WriteString("\nAll new application with client certificates connections will begin to use certificates issued by the new CA certificate. ")
 	default:
 		sb.WriteString("\nAll client certificates issued by this CA must be re-issued before proceeding to the update_servers phase.")
 	}
@@ -1276,6 +1278,19 @@ func manualSteps(caType types.CertAuthType, phase string) []string {
 	case types.BoundKeypairCA:
 		// TODO(timothyb89): add any manual steps; this should mostly be handled automatically.
 		fallthrough
+	case types.AppClientCA:
+		switch phase {
+		case "init":
+			return []string{
+				"All applictions using client certificates must be updated to trust both the new and old CA certificates.",
+			}
+		case "rollback":
+			return []string{
+				"All applictions using client certificates updated to trust the new CA certificates during the update_servers phase should be reverted to only trust the original CA certificate.",
+			}
+		case "standby":
+			return []string{"All applications using client certificates should be updated to stop trusting the CA certificates that have now been rotated out."}
+		}
 	default:
 		return []string{"Consult the CA rotation docs for any manual steps that may be required: https://goteleport.com/docs/admin-guides/management/operations/ca-rotation/"}
 	}

--- a/tool/tctl/common/auth_rotate_command.go
+++ b/tool/tctl/common/auth_rotate_command.go
@@ -1108,7 +1108,7 @@ func updateClientsPhaseHelpText(sb *strings.Builder, caType types.CertAuthType) 
 	case types.WindowsCA:
 		sb.WriteString("\nAll new connections to Windows desktops will begin to use certificates issued by the new CA certificate. ")
 	case types.AppClientCA:
-		sb.WriteString("\nAll new application with client certificates connections will begin to use certificates issued by the new CA certificate. ")
+		sb.WriteString("\nAll new applications with client certificates connections will begin to use certificates issued by the new CA certificate. ")
 	default:
 		sb.WriteString("\nAll client certificates issued by this CA must be re-issued before proceeding to the update_servers phase.")
 	}
@@ -1270,11 +1270,11 @@ func manualSteps(caType types.CertAuthType, phase string) []string {
 		switch phase {
 		case "init":
 			return []string{
-				"All applictions using client certificates must be updated to trust both the new and old CA certificates.",
+				"All applications using client certificates must be updated to trust both the new and old CA certificates.",
 			}
 		case "rollback":
 			return []string{
-				"All applictions using client certificates updated to trust the new CA certificates during the update_servers phase should be reverted to only trust the original CA certificate.",
+				"All applications using client certificates updated to trust the new CA certificates during the update_servers phase should be reverted to only trust the original CA certificate.",
 			}
 		case "standby":
 			return []string{"All applications using client certificates should be updated to stop trusting the CA certificates that have now been rotated out."}

--- a/tool/tctl/common/auth_rotate_command.go
+++ b/tool/tctl/common/auth_rotate_command.go
@@ -1266,18 +1266,6 @@ func manualSteps(caType types.CertAuthType, phase string) []string {
 				"All Windows desktops should be updated to stop trusting the CA certificates that have now been rotated out.",
 			}
 		}
-	case types.SPIFFECA:
-		// TODO(strideynet): populate any known manual steps during SPIFFE CA rotation.
-		fallthrough
-	case types.OktaCA:
-		// TODO(smallinsky): populate any known manual steps during Okta CA rotation.
-		fallthrough
-	case types.AWSRACA:
-		// TODO(marco): populate any known manual steps during AWS IAM Roles Anywhere CA rotation.
-		fallthrough
-	case types.BoundKeypairCA:
-		// TODO(timothyb89): add any manual steps; this should mostly be handled automatically.
-		fallthrough
 	case types.AppClientCA:
 		switch phase {
 		case "init":
@@ -1291,6 +1279,18 @@ func manualSteps(caType types.CertAuthType, phase string) []string {
 		case "standby":
 			return []string{"All applications using client certificates should be updated to stop trusting the CA certificates that have now been rotated out."}
 		}
+	case types.SPIFFECA:
+		// TODO(strideynet): populate any known manual steps during SPIFFE CA rotation.
+		fallthrough
+	case types.OktaCA:
+		// TODO(smallinsky): populate any known manual steps during Okta CA rotation.
+		fallthrough
+	case types.AWSRACA:
+		// TODO(marco): populate any known manual steps during AWS IAM Roles Anywhere CA rotation.
+		fallthrough
+	case types.BoundKeypairCA:
+		// TODO(timothyb89): add any manual steps; this should mostly be handled automatically.
+		fallthrough
 	default:
 		return []string{"Consult the CA rotation docs for any manual steps that may be required: https://goteleport.com/docs/admin-guides/management/operations/ca-rotation/"}
 	}


### PR DESCRIPTION
Related to [RFD 0251 - App access mTLS](https://github.com/gravitational/teleport.e/blob/rfd/0251-app-access-mtls/rfd/0251-app-access-mtls.md#new-ca-type-for-app-access-client-certificates).

This new CA will be used to sign app access client certificates (part of mTLS connections). Crypto suites are the same as the SPIFFE CA (per RFD).

This PR only introduces the CA. Its usage and support for sub-kinds will be added in future PRs.

## Manual Test Plan

### Test Cases
- [x] Fresh cluster
  - [x] `app_client` CA is correctly initialized.
  - [x] Rotate `app_client` CA.
  - [x] `tctl status` reports the correct CA status.
  - [x] `tctl auth export --type=app-client` exports the correct CA.
- [x] Existent cluster
  - [x] `app_client` CA is correctly initialized.
  - [x] Rotate `app_client` CA.
  - [x] `tctl status` reports the correct CA status.
  - [x] `tctl auth export --type=app-client` exports the correct CA.