### PR TITLE
tool/tsh: Initial beams CLI

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -74,6 +74,7 @@ import (
 	appauthconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/appauthconfig/v1"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
@@ -988,6 +989,11 @@ func (c *Client) RecordingEncryptionServiceClient() recordingencryptionv1pb.Reco
 // service.
 func (c *Client) DelegationSessionServiceClient() delegationv1.DelegationSessionServiceClient {
 	return delegationv1.NewDelegationSessionServiceClient(c.conn)
+}
+
+// BeamServiceClient returns a client for the beam service.
+func (c *Client) BeamServiceClient() beamsv1.BeamServiceClient {
+	return beamsv1.NewBeamServiceClient(c.conn)
 }
 
 // GetVnetConfig returns the singleton VnetConfig resource.

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -43,6 +43,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	accessgraphsecretsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessgraph/v1"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	delegationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/delegation/v1"
@@ -1974,4 +1975,7 @@ type ClientI interface {
 	// SessionSearchServiceClient returns a client for the session search
 	// service.
 	SessionSearchServiceClient() sessionsearchv1pb.SessionSearchServiceClient
+
+	// BeamServiceClient returns a client for the beam service.
+	BeamServiceClient() beamsv1.BeamServiceClient
 }

--- a/tool/tsh/common/beams.go
+++ b/tool/tsh/common/beams.go
@@ -1,0 +1,318 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/defaults"
+)
+
+type beamsCommands struct {
+	ls        *beamsLSCommand
+	add       *beamsAddCommand
+	rm        *beamsRMCommand
+	console   *beamsConsoleCommand
+	exec      *beamsExecCommand
+	publish   *beamsPublishCommand
+	unpublish *beamsUnpublishCommand
+	cp        *beamsCPCommand
+	allow     *beamsAllowCommand
+	deny      *beamsDenyCommand
+}
+
+func newBeamsCommands(app *kingpin.Application) beamsCommands {
+	beams := app.Command("beams", "View, manage and run beam instances. Beams are convenient, sandboxed environments for experimenting with AI agents.").Alias("beam")
+	return beamsCommands{
+		ls:        newBeamsLSCommand(beams),
+		add:       newBeamsAddCommand(beams),
+		rm:        newBeamsRMCommand(beams),
+		console:   newBeamsConsoleCommand(beams),
+		exec:      newBeamsExecCommand(beams),
+		publish:   newBeamsPublishCommand(beams),
+		unpublish: newBeamsUnpublishCommand(beams),
+		cp:        newBeamsCPCommand(beams),
+		allow:     newBeamsAllowCommand(beams),
+		deny:      newBeamsDenyCommand(beams),
+	}
+}
+
+type beamsLSCommand struct {
+	*kingpin.CmdClause
+	all    bool
+	format string
+}
+
+func newBeamsLSCommand(parent *kingpin.CmdClause) *beamsLSCommand {
+	cmd := &beamsLSCommand{
+		CmdClause: parent.Command("ls", "List beam instances.").Alias("list"),
+	}
+	cmd.Flag("all", "List beams for all users.").BoolVar(&cmd.all)
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	return cmd
+}
+
+func (c *beamsLSCommand) run(*CLIConf) error {
+	fmt.Printf("tsh beams ls: all=%t format=%q\n", c.all, c.format)
+	return trace.NotImplemented("tsh beams ls is not implemented yet")
+}
+
+type beamsAddCommand struct {
+	*kingpin.CmdClause
+	console bool
+	format  string
+}
+
+func newBeamsAddCommand(parent *kingpin.CmdClause) *beamsAddCommand {
+	cmd := &beamsAddCommand{
+		CmdClause: parent.Command("add", "Start a new beam instance."),
+	}
+	cmd.Flag("console", "Connect to the beam after creation.").Default("true").BoolVar(&cmd.console)
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	return cmd
+}
+
+func (c *beamsAddCommand) run(*CLIConf) error {
+	fmt.Printf("tsh beams add: console=%t format=%q\n", c.console, c.format)
+	return trace.NotImplemented("tsh beams add is not implemented yet")
+}
+
+type beamsRMCommand struct {
+	*kingpin.CmdClause
+	name   string
+	format string
+}
+
+func newBeamsRMCommand(parent *kingpin.CmdClause) *beamsRMCommand {
+	cmd := &beamsRMCommand{
+		CmdClause: parent.Command("rm", "Delete a beam instance."),
+	}
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	cmd.Arg("name", "Name (or alias) of the beam to delete.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsRMCommand) run(*CLIConf) error {
+	fmt.Printf("tsh beams rm: name=%q format=%q\n", c.name, c.format)
+	return trace.NotImplemented("tsh beams rm is not implemented yet")
+}
+
+type beamsConsoleCommand struct {
+	*kingpin.CmdClause
+	name string
+}
+
+func newBeamsConsoleCommand(parent *kingpin.CmdClause) *beamsConsoleCommand {
+	cmd := &beamsConsoleCommand{
+		CmdClause: parent.Command("console", "Start an interactive shell in a beam instance."),
+	}
+	cmd.Arg("name", "Name (or alias) of the beam to connect to.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsConsoleCommand) run(*CLIConf) error {
+	fmt.Printf("tsh beams console: name=%q\n", c.name)
+	return trace.NotImplemented("tsh beams console is not implemented yet")
+}
+
+type beamsExecCommand struct {
+	*kingpin.CmdClause
+	name    string
+	command []string
+}
+
+func newBeamsExecCommand(parent *kingpin.CmdClause) *beamsExecCommand {
+	cmd := &beamsExecCommand{
+		CmdClause: parent.Command("exec", "Run a command in a beam instance."),
+	}
+	cmd.Arg("name", "Name (or alias) of the beam to target.").Required().StringVar(&cmd.name)
+	cmd.Arg("command", "Command to execute in the instance.").Required().StringsVar(&cmd.command)
+	return cmd
+}
+
+func (c *beamsExecCommand) run(*CLIConf) error {
+	fmt.Printf("tsh beams exec: name=%q command=%q\n", c.name, c.command)
+	return trace.NotImplemented("tsh beams exec is not implemented yet")
+}
+
+type beamsPublishCommand struct {
+	*kingpin.CmdClause
+	name   string
+	tcp    bool
+	format string
+}
+
+func newBeamsPublishCommand(parent *kingpin.CmdClause) *beamsPublishCommand {
+	cmd := &beamsPublishCommand{
+		CmdClause: parent.Command("publish", "Serve an HTTP or TCP service in a beam instance."),
+	}
+	cmd.Flag("tcp", "Publish as a TCP app instead of an HTTP app.").BoolVar(&cmd.tcp)
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	cmd.Arg("name", "Name (or alias) of the beam to target.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsPublishCommand) run(*CLIConf) error {
+	fmt.Printf("tsh beams publish: name=%q tcp=%t format=%q\n", c.name, c.tcp, c.format)
+	return trace.NotImplemented("tsh beams publish is not implemented yet")
+}
+
+type beamsUnpublishCommand struct {
+	*kingpin.CmdClause
+	name   string
+	format string
+}
+
+func newBeamsUnpublishCommand(parent *kingpin.CmdClause) *beamsUnpublishCommand {
+	cmd := &beamsUnpublishCommand{
+		CmdClause: parent.Command("unpublish", "Remove a previously served service in a beam instance."),
+	}
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	cmd.Arg("name", "Name (or alias) of the beam to target.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsUnpublishCommand) run(*CLIConf) error {
+	fmt.Printf("tsh beams unpublish: name=%q format=%q\n", c.name, c.format)
+	return trace.NotImplemented("tsh beams unpublish is not implemented yet")
+}
+
+type beamsCPCommand struct {
+	*kingpin.CmdClause
+	recursive bool
+	quiet     bool
+	src       string
+	dest      string
+	format    string
+}
+
+func newBeamsCPCommand(parent *kingpin.CmdClause) *beamsCPCommand {
+	cmd := &beamsCPCommand{
+		CmdClause: parent.Command("cp", "Copy files between a beam instance and the local filesystem."),
+	}
+	cmd.Flag("recursive", "Recursive copy of subdirectories.").Short('r').BoolVar(&cmd.recursive)
+	cmd.Flag("quiet", "Quiet mode.").Short('q').BoolVar(&cmd.quiet)
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	cmd.Arg("src", "Source path to copy.").Required().StringVar(&cmd.src)
+	cmd.Arg("dest", "Destination path to copy.").Required().StringVar(&cmd.dest)
+	return cmd
+}
+
+func (c *beamsCPCommand) run(*CLIConf) error {
+	if err := c.validate(); err != nil {
+		return err
+	}
+	fmt.Printf("tsh beams cp: src=%q dest=%q recursive=%t quiet=%t format=%q\n", c.src, c.dest, c.recursive, c.quiet, c.format)
+	return trace.NotImplemented("tsh beams cp is not implemented yet")
+}
+
+func (c *beamsCPCommand) validate() error {
+	paths := []string{c.src, c.dest}
+
+	var beamPaths int
+	for _, path := range paths {
+		if isBeamCopyPath(path) {
+			beamPaths++
+		}
+	}
+
+	if beamPaths != 1 {
+		return trace.BadParameter("exactly one path must use the form BEAM_ID:PATH")
+	}
+
+	return nil
+}
+
+func isBeamCopyPath(path string) bool {
+	beamID, beamPath, ok := strings.Cut(path, ":")
+	return ok && beamID != "" && beamPath != ""
+}
+
+type beamsAllowCommand struct {
+	*kingpin.CmdClause
+	name   string
+	domain string
+	format string
+}
+
+func newBeamsAllowCommand(parent *kingpin.CmdClause) *beamsAllowCommand {
+	cmd := &beamsAllowCommand{
+		CmdClause: parent.Command("allow", "Grant access to an external domain."),
+	}
+	cmd.Flag("domain", "FQDN of a domain to allow access to.").Required().StringVar(&cmd.domain)
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	cmd.Arg("name", "Name (or alias) of the beam to target.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsAllowCommand) run(*CLIConf) error {
+	fmt.Printf("tsh beams allow: name=%q domain=%q format=%q\n", c.name, c.domain, c.format)
+	return trace.NotImplemented("tsh beams allow is not implemented yet")
+}
+
+type beamsDenyCommand struct {
+	*kingpin.CmdClause
+	name   string
+	domain string
+	format string
+}
+
+func newBeamsDenyCommand(parent *kingpin.CmdClause) *beamsDenyCommand {
+	cmd := &beamsDenyCommand{
+		CmdClause: parent.Command("deny", "Remove access to an external domain."),
+	}
+	cmd.Flag("domain", "FQDN of a domain to deny access to.").Required().StringVar(&cmd.domain)
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	cmd.Arg("name", "Name (or alias) of the beam to target.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsDenyCommand) run(*CLIConf) error {
+	fmt.Printf("tsh beams deny: name=%q domain=%q format=%q\n", c.name, c.domain, c.format)
+	return trace.NotImplemented("tsh beams deny is not implemented yet")
+}

--- a/tool/tsh/common/beams.go
+++ b/tool/tsh/common/beams.go
@@ -19,300 +19,129 @@
 package common
 
 import (
+	"context"
 	"fmt"
-	"strings"
+	"net"
+	"time"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/defaults"
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/utils"
 )
+
+const beamsLogin = "beams"
 
 type beamsCommands struct {
 	ls        *beamsLSCommand
 	add       *beamsAddCommand
 	rm        *beamsRMCommand
-	console   *beamsConsoleCommand
+	ssh       *beamsSSHCommand
 	exec      *beamsExecCommand
 	publish   *beamsPublishCommand
 	unpublish *beamsUnpublishCommand
-	cp        *beamsCPCommand
-	allow     *beamsAllowCommand
-	deny      *beamsDenyCommand
+	scp       *beamsSCPCommand
 }
 
 func newBeamsCommands(app *kingpin.Application) beamsCommands {
-	beams := app.Command("beams", "View, manage and run beam instances. Beams are convenient, sandboxed environments for experimenting with AI agents.").Alias("beam")
+	beams := app.Command("beams", "View, manage and run beams. Beams are ephemeral, sandbox VMs built for agentic workloads").Alias("beam")
 	return beamsCommands{
 		ls:        newBeamsLSCommand(beams),
 		add:       newBeamsAddCommand(beams),
 		rm:        newBeamsRMCommand(beams),
-		console:   newBeamsConsoleCommand(beams),
+		ssh:       newBeamsSSHCommand(beams),
 		exec:      newBeamsExecCommand(beams),
 		publish:   newBeamsPublishCommand(beams),
 		unpublish: newBeamsUnpublishCommand(beams),
-		cp:        newBeamsCPCommand(beams),
-		allow:     newBeamsAllowCommand(beams),
-		deny:      newBeamsDenyCommand(beams),
+		scp:       newBeamsSCPCommand(beams),
 	}
 }
 
-type beamsLSCommand struct {
-	*kingpin.CmdClause
-	all    bool
-	format string
-}
-
-func newBeamsLSCommand(parent *kingpin.CmdClause) *beamsLSCommand {
-	cmd := &beamsLSCommand{
-		CmdClause: parent.Command("ls", "List beam instances.").Alias("list"),
+func formatBeam(beam *beamsv1.Beam, proxyAddr string) formattedBeam {
+	return formattedBeam{
+		ID:      beam.GetStatus().GetAlias(),
+		UUID:    beam.GetMetadata().GetName(),
+		Owner:   beam.GetStatus().GetUser(),
+		Expires: beam.GetSpec().GetExpires().AsTime(),
+		URL:     beamPublishURL(beam, proxyAddr),
 	}
-	cmd.Flag("all", "List beams for all users.").BoolVar(&cmd.all)
-	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
-		Short('f').
-		Default(teleport.Text).
-		EnumVar(&cmd.format, defaults.DefaultFormats...)
-	return cmd
 }
 
-func (c *beamsLSCommand) run(*CLIConf) error {
-	fmt.Printf("tsh beams ls: all=%t format=%q\n", c.all, c.format)
-	return trace.NotImplemented("tsh beams ls is not implemented yet")
-}
-
-type beamsAddCommand struct {
-	*kingpin.CmdClause
-	console bool
-	format  string
-}
-
-func newBeamsAddCommand(parent *kingpin.CmdClause) *beamsAddCommand {
-	cmd := &beamsAddCommand{
-		CmdClause: parent.Command("add", "Start a new beam instance."),
-	}
-	cmd.Flag("console", "Connect to the beam after creation.").Default("true").BoolVar(&cmd.console)
-	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
-		Short('f').
-		Default(teleport.Text).
-		EnumVar(&cmd.format, defaults.DefaultFormats...)
-	return cmd
-}
-
-func (c *beamsAddCommand) run(*CLIConf) error {
-	fmt.Printf("tsh beams add: console=%t format=%q\n", c.console, c.format)
-	return trace.NotImplemented("tsh beams add is not implemented yet")
-}
-
-type beamsRMCommand struct {
-	*kingpin.CmdClause
-	name   string
-	format string
-}
-
-func newBeamsRMCommand(parent *kingpin.CmdClause) *beamsRMCommand {
-	cmd := &beamsRMCommand{
-		CmdClause: parent.Command("rm", "Delete a beam instance."),
-	}
-	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
-		Short('f').
-		Default(teleport.Text).
-		EnumVar(&cmd.format, defaults.DefaultFormats...)
-	cmd.Arg("name", "Name (or alias) of the beam to delete.").Required().StringVar(&cmd.name)
-	return cmd
-}
-
-func (c *beamsRMCommand) run(*CLIConf) error {
-	fmt.Printf("tsh beams rm: name=%q format=%q\n", c.name, c.format)
-	return trace.NotImplemented("tsh beams rm is not implemented yet")
-}
-
-type beamsConsoleCommand struct {
-	*kingpin.CmdClause
-	name string
-}
-
-func newBeamsConsoleCommand(parent *kingpin.CmdClause) *beamsConsoleCommand {
-	cmd := &beamsConsoleCommand{
-		CmdClause: parent.Command("console", "Start an interactive shell in a beam instance."),
-	}
-	cmd.Arg("name", "Name (or alias) of the beam to connect to.").Required().StringVar(&cmd.name)
-	return cmd
-}
-
-func (c *beamsConsoleCommand) run(*CLIConf) error {
-	fmt.Printf("tsh beams console: name=%q\n", c.name)
-	return trace.NotImplemented("tsh beams console is not implemented yet")
-}
-
-type beamsExecCommand struct {
-	*kingpin.CmdClause
-	name    string
-	command []string
-}
-
-func newBeamsExecCommand(parent *kingpin.CmdClause) *beamsExecCommand {
-	cmd := &beamsExecCommand{
-		CmdClause: parent.Command("exec", "Run a command in a beam instance."),
-	}
-	cmd.Arg("name", "Name (or alias) of the beam to target.").Required().StringVar(&cmd.name)
-	cmd.Arg("command", "Command to execute in the instance.").Required().StringsVar(&cmd.command)
-	return cmd
-}
-
-func (c *beamsExecCommand) run(*CLIConf) error {
-	fmt.Printf("tsh beams exec: name=%q command=%q\n", c.name, c.command)
-	return trace.NotImplemented("tsh beams exec is not implemented yet")
-}
-
-type beamsPublishCommand struct {
-	*kingpin.CmdClause
-	name   string
-	tcp    bool
-	format string
-}
-
-func newBeamsPublishCommand(parent *kingpin.CmdClause) *beamsPublishCommand {
-	cmd := &beamsPublishCommand{
-		CmdClause: parent.Command("publish", "Serve an HTTP or TCP service in a beam instance."),
-	}
-	cmd.Flag("tcp", "Publish as a TCP app instead of an HTTP app.").BoolVar(&cmd.tcp)
-	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
-		Short('f').
-		Default(teleport.Text).
-		EnumVar(&cmd.format, defaults.DefaultFormats...)
-	cmd.Arg("name", "Name (or alias) of the beam to target.").Required().StringVar(&cmd.name)
-	return cmd
-}
-
-func (c *beamsPublishCommand) run(*CLIConf) error {
-	fmt.Printf("tsh beams publish: name=%q tcp=%t format=%q\n", c.name, c.tcp, c.format)
-	return trace.NotImplemented("tsh beams publish is not implemented yet")
-}
-
-type beamsUnpublishCommand struct {
-	*kingpin.CmdClause
-	name   string
-	format string
-}
-
-func newBeamsUnpublishCommand(parent *kingpin.CmdClause) *beamsUnpublishCommand {
-	cmd := &beamsUnpublishCommand{
-		CmdClause: parent.Command("unpublish", "Remove a previously served service in a beam instance."),
-	}
-	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
-		Short('f').
-		Default(teleport.Text).
-		EnumVar(&cmd.format, defaults.DefaultFormats...)
-	cmd.Arg("name", "Name (or alias) of the beam to target.").Required().StringVar(&cmd.name)
-	return cmd
-}
-
-func (c *beamsUnpublishCommand) run(*CLIConf) error {
-	fmt.Printf("tsh beams unpublish: name=%q format=%q\n", c.name, c.format)
-	return trace.NotImplemented("tsh beams unpublish is not implemented yet")
-}
-
-type beamsCPCommand struct {
-	*kingpin.CmdClause
-	recursive bool
-	quiet     bool
-	src       string
-	dest      string
-	format    string
-}
-
-func newBeamsCPCommand(parent *kingpin.CmdClause) *beamsCPCommand {
-	cmd := &beamsCPCommand{
-		CmdClause: parent.Command("cp", "Copy files between a beam instance and the local filesystem."),
-	}
-	cmd.Flag("recursive", "Recursive copy of subdirectories.").Short('r').BoolVar(&cmd.recursive)
-	cmd.Flag("quiet", "Quiet mode.").Short('q').BoolVar(&cmd.quiet)
-	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
-		Short('f').
-		Default(teleport.Text).
-		EnumVar(&cmd.format, defaults.DefaultFormats...)
-	cmd.Arg("src", "Source path to copy.").Required().StringVar(&cmd.src)
-	cmd.Arg("dest", "Destination path to copy.").Required().StringVar(&cmd.dest)
-	return cmd
-}
-
-func (c *beamsCPCommand) run(*CLIConf) error {
-	if err := c.validate(); err != nil {
-		return err
-	}
-	fmt.Printf("tsh beams cp: src=%q dest=%q recursive=%t quiet=%t format=%q\n", c.src, c.dest, c.recursive, c.quiet, c.format)
-	return trace.NotImplemented("tsh beams cp is not implemented yet")
-}
-
-func (c *beamsCPCommand) validate() error {
-	paths := []string{c.src, c.dest}
-
-	var beamPaths int
-	for _, path := range paths {
-		if isBeamCopyPath(path) {
-			beamPaths++
-		}
+func beamPublishURL(beam *beamsv1.Beam, proxyAddr string) string {
+	publish := beam.GetSpec().GetPublish()
+	if publish == nil {
+		return ""
 	}
 
-	if beamPaths != 1 {
-		return trace.BadParameter("exactly one path must use the form BEAM_ID:PATH")
+	// We discard the port because in Teleport Cloud proxies are always listening
+	// on :443. For TCP apps, the address can only be dialed via VNet anyway (and
+	// the port doesn't need to match the proxy port).
+	proxyHost, _, err := net.SplitHostPort(proxyAddr)
+	if err != nil {
+		proxyHost = proxyAddr
 	}
 
-	return nil
-}
-
-func isBeamCopyPath(path string) bool {
-	beamID, beamPath, ok := strings.Cut(path, ":")
-	return ok && beamID != "" && beamPath != ""
-}
-
-type beamsAllowCommand struct {
-	*kingpin.CmdClause
-	name   string
-	domain string
-	format string
-}
-
-func newBeamsAllowCommand(parent *kingpin.CmdClause) *beamsAllowCommand {
-	cmd := &beamsAllowCommand{
-		CmdClause: parent.Command("allow", "Grant access to an external domain."),
+	hostname := utils.DefaultAppPublicAddr(beam.GetStatus().GetAppName(), proxyHost)
+	switch publish.GetProtocol() {
+	case beamsv1.Protocol_PROTOCOL_HTTP:
+		return fmt.Sprintf("https://%s", hostname)
+	case beamsv1.Protocol_PROTOCOL_TCP:
+		return fmt.Sprintf("tcp://%s:%d", hostname, publish.GetPort())
+	default:
+		return hostname
 	}
-	cmd.Flag("domain", "FQDN of a domain to allow access to.").Required().StringVar(&cmd.domain)
-	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
-		Short('f').
-		Default(teleport.Text).
-		EnumVar(&cmd.format, defaults.DefaultFormats...)
-	cmd.Arg("name", "Name (or alias) of the beam to target.").Required().StringVar(&cmd.name)
-	return cmd
 }
 
-func (c *beamsAllowCommand) run(*CLIConf) error {
-	fmt.Printf("tsh beams allow: name=%q domain=%q format=%q\n", c.name, c.domain, c.format)
-	return trace.NotImplemented("tsh beams allow is not implemented yet")
+// formattedBeam contains only the useful parts of the beam resource for scripting
+// or automating with an AI Agent.
+type formattedBeam struct {
+	// ID is the human-friendly name of the beam (taken from `status.alias`).
+	//
+	// As there is a limited number of possible word pairs, eventual reuse is
+	// likely but it will uniquely point to this beam for as long as the beam
+	// is alive.
+	ID string `json:"id"`
+
+	// UUID is the stable/globally-unique identifier for the beam (taken from
+	// `metadata.name`).
+	UUID string `json:"uuid"`
+
+	// Owner of this beam (taken from `status.user`).
+	Owner string `json:"owner"`
+
+	// Expires is the time at which this beam will expire and be automatically
+	// deleted (taken from `spec.expires`).
+	Expires time.Time `json:"expires"`
+
+	// URL is the address at which the beam's published application can be
+	// reached.
+	//
+	// For HTTP applications, it will be in the form: `https://<host>`.
+	//
+	// For TCP applications, it will be in the form: `tcp://<host>:<port>` but
+	// this address can only be dialed via VNet, otherwise you'll need to start
+	// a local proxy.
+	URL string `json:"url,omitempty"`
 }
 
-type beamsDenyCommand struct {
-	*kingpin.CmdClause
-	name   string
-	domain string
-	format string
-}
-
-func newBeamsDenyCommand(parent *kingpin.CmdClause) *beamsDenyCommand {
-	cmd := &beamsDenyCommand{
-		CmdClause: parent.Command("deny", "Remove access to an external domain."),
+// getBeam reads a beam by UUID or human-friendly name depending on the format
+// of the given string.
+func getBeam(ctx context.Context, client authclient.ClientI, ref string) (*beamsv1.Beam, error) {
+	req := &beamsv1.GetBeamRequest{}
+	if _, err := uuid.Parse(ref); err == nil {
+		req.Id = &beamsv1.GetBeamRequest_Name{Name: ref}
+	} else {
+		req.Id = &beamsv1.GetBeamRequest_Alias{Alias: ref}
 	}
-	cmd.Flag("domain", "FQDN of a domain to deny access to.").Required().StringVar(&cmd.domain)
-	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
-		Short('f').
-		Default(teleport.Text).
-		EnumVar(&cmd.format, defaults.DefaultFormats...)
-	cmd.Arg("name", "Name (or alias) of the beam to target.").Required().StringVar(&cmd.name)
-	return cmd
-}
 
-func (c *beamsDenyCommand) run(*CLIConf) error {
-	fmt.Printf("tsh beams deny: name=%q domain=%q format=%q\n", c.name, c.domain, c.format)
-	return trace.NotImplemented("tsh beams deny is not implemented yet")
+	rsp, err := client.
+		BeamServiceClient().
+		GetBeam(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return rsp.GetBeam(), nil
 }

--- a/tool/tsh/common/beams.go
+++ b/tool/tsh/common/beams.go
@@ -47,7 +47,7 @@ type beamsCommands struct {
 }
 
 func newBeamsCommands(app *kingpin.Application) beamsCommands {
-	beams := app.Command("beams", "View, manage and run beams. Beams are ephemeral, sandbox VMs built for agentic workloads").Alias("beam")
+	beams := app.Command("beams", "View, manage and run beams. Beams are ephemeral, sandbox VMs built for agentic workloads.").Alias("beam")
 	return beamsCommands{
 		ls:        newBeamsLSCommand(beams),
 		add:       newBeamsAddCommand(beams),

--- a/tool/tsh/common/beams_add.go
+++ b/tool/tsh/common/beams_add.go
@@ -1,0 +1,117 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/tool/common"
+)
+
+type beamsAddCommand struct {
+	*kingpin.CmdClause
+	console bool
+	format  string
+}
+
+func newBeamsAddCommand(parent *kingpin.CmdClause) *beamsAddCommand {
+	cmd := &beamsAddCommand{
+		CmdClause: parent.Command("add", "Start a new beam, and optionally connect to it via SSH."),
+	}
+	cmd.Flag("console", "Connect to the beam via SSH after creation.").Default("true").BoolVar(&cmd.console)
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	return cmd
+}
+
+func (c *beamsAddCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var beam *beamsv1.Beam
+	err = client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootClient.Close()
+
+		// Create the beam.
+		rsp, err := rootClient.
+			BeamServiceClient().
+			CreateBeam(ctx, &beamsv1.CreateBeamRequest{
+				Egress: beamsv1.EgressMode_EGRESS_MODE_UNRESTRICTED,
+			})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		beam = rsp.GetBeam()
+		return nil
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// formatBeams uses the proxy address to derive the Publish URL but we given
+	// the beam won't be published yet, there's no need to actually fetch it.
+	const proxyAddr = ""
+
+	switch strings.ToLower(c.format) {
+	case teleport.JSON:
+		return trace.Wrap(common.PrintJSONIndent(cf.Stdout(), formatBeam(beam, proxyAddr)))
+	case teleport.YAML:
+		return trace.Wrap(common.PrintYAML(cf.Stdout(), formatBeam(beam, proxyAddr)))
+	default:
+		if _, err := fmt.Fprintf(
+			cf.Stdout(),
+			"Beam %q created.\n",
+			beam.GetStatus().GetAlias(),
+		); err != nil {
+			return trace.Wrap(err)
+		}
+
+		// Connect to the beam via SSH.
+		if c.console {
+			return trace.Wrap(sshBeam(cf, tc, beam, nil))
+		}
+	}
+
+	return nil
+}

--- a/tool/tsh/common/beams_exec.go
+++ b/tool/tsh/common/beams_exec.go
@@ -1,0 +1,75 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+type beamsExecCommand struct {
+	*kingpin.CmdClause
+	name    string
+	command []string
+}
+
+func newBeamsExecCommand(parent *kingpin.CmdClause) *beamsExecCommand {
+	cmd := &beamsExecCommand{
+		CmdClause: parent.Command("exec", "Run a command in a beam, via SSH."),
+	}
+	cmd.Arg("name", "ID (or UUID) of the beam to target.").Required().StringVar(&cmd.name)
+	cmd.Arg("command", "Command to execute in the instance.").Required().StringsVar(&cmd.command)
+	return cmd
+}
+
+func (c *beamsExecCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	tc.AllowHeadless = true
+
+	var beam *beamsv1.Beam
+	err = client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootClient.Close()
+
+		beam, err = getBeam(ctx, rootClient, c.name)
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(sshBeam(cf, tc, beam, c.command))
+}

--- a/tool/tsh/common/beams_ls.go
+++ b/tool/tsh/common/beams_ls.go
@@ -44,7 +44,7 @@ type beamsLSCommand struct {
 	all    bool
 	format string
 
-	// These helper functions can be overriden
+	// These helper functions can be overridden.
 	fetchFn        func(context.Context, *client.TeleportClient, bool) ([]*beamsv1.Beam, error)
 	proxyAddrFn    func(*CLIConf) (string, error)
 	humanizeTimeFn func(time.Time) string

--- a/tool/tsh/common/beams_ls.go
+++ b/tool/tsh/common/beams_ls.go
@@ -1,0 +1,187 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"io"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/dustin/go-humanize"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/tool/common"
+)
+
+type beamsLSCommand struct {
+	*kingpin.CmdClause
+	all    bool
+	format string
+
+	// These helper functions can be overriden
+	fetchFn        func(context.Context, *client.TeleportClient, bool) ([]*beamsv1.Beam, error)
+	proxyAddrFn    func(*CLIConf) (string, error)
+	humanizeTimeFn func(time.Time) string
+}
+
+func newBeamsLSCommand(parent *kingpin.CmdClause) *beamsLSCommand {
+	cmd := &beamsLSCommand{
+		CmdClause: parent.Command("ls", "List beam instances.").Alias("list"),
+	}
+	cmd.fetchFn = cmd.fetch
+	cmd.proxyAddrFn = cmd.proxyAddr
+	cmd.humanizeTimeFn = humanize.Time
+
+	cmd.Flag("all", "List all beams. By default, filters to show only beams belonging to the current user.").BoolVar(&cmd.all)
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	return cmd
+}
+
+func (c *beamsLSCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	beams, err := c.fetchFn(ctx, tc, c.all)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	proxyAddr, err := c.proxyAddrFn(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(c.print(cf, beams, proxyAddr))
+}
+
+func (c *beamsLSCommand) fetch(ctx context.Context, tc *client.TeleportClient, all bool) ([]*beamsv1.Beam, error) {
+	var beams []*beamsv1.Beam
+	err := client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootClient.Close()
+
+		filters := &beamsv1.ListBeamsRequest_Filters{}
+		if !all {
+			user, err := rootClient.GetCurrentUser(ctx)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			filters.Users = []string{user.GetName()}
+		}
+
+		beams, err = stream.Collect(
+			clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]*beamsv1.Beam, string, error) {
+				rsp, err := rootClient.
+					BeamServiceClient().
+					ListBeams(ctx, &beamsv1.ListBeamsRequest{
+						PageSize:  int32(pageSize),
+						PageToken: pageToken,
+						Filters:   filters,
+					})
+				if err != nil {
+					return nil, "", trace.Wrap(err)
+				}
+				return rsp.GetBeams(), rsp.GetNextPageToken(), err
+			}),
+		)
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return beams, nil
+}
+
+func (c *beamsLSCommand) proxyAddr(cf *CLIConf) (string, error) {
+	_, proxyAddr, err := fetchProxyVersion(cf)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return proxyAddr, nil
+}
+
+func (c *beamsLSCommand) print(cf *CLIConf, beams []*beamsv1.Beam, proxyAddr string) error {
+	// Convert to script/agent friendly representation.
+	formatted := make([]formattedBeam, len(beams))
+	for idx, beam := range beams {
+		formatted[idx] = formatBeam(beam, proxyAddr)
+	}
+	slices.SortFunc(formatted, func(a, b formattedBeam) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+
+	switch strings.ToLower(c.format) {
+	case teleport.JSON:
+		return trace.Wrap(common.PrintJSONIndent(cf.Stdout(), formatted))
+	case teleport.YAML:
+		return trace.Wrap(common.PrintYAML(cf.Stdout(), formatted))
+	default:
+		return trace.Wrap(c.printTable(cf.Stdout(), formatted))
+	}
+}
+
+func (c *beamsLSCommand) printTable(w io.Writer, beams []formattedBeam) error {
+	headings := []string{"ID", "URL", "Expires"}
+
+	// We only show the owner column when the user passed the `--all` flag,
+	// otherwise there's no point as we're just showing them their own beams.
+	if c.all {
+		headings = append(headings, "Owner")
+	}
+
+	table := asciitable.MakeTable(headings)
+	for _, beam := range beams {
+		row := []string{
+			beam.ID,
+			beam.URL,
+			c.humanizeTimeFn(beam.Expires),
+		}
+		if c.all {
+			row = append(row, beam.Owner)
+		}
+		table.AddRow(row)
+	}
+	return trace.Wrap(table.WriteTo(w))
+}

--- a/tool/tsh/common/beams_ls.go
+++ b/tool/tsh/common/beams_ls.go
@@ -21,7 +21,6 @@ package common
 import (
 	"context"
 	"io"
-	"slices"
 	"strings"
 	"time"
 
@@ -148,10 +147,6 @@ func (c *beamsLSCommand) print(cf *CLIConf, beams []*beamsv1.Beam, proxyAddr str
 	for idx, beam := range beams {
 		formatted[idx] = formatBeam(beam, proxyAddr)
 	}
-	slices.SortFunc(formatted, func(a, b formattedBeam) int {
-		return strings.Compare(a.ID, b.ID)
-	})
-
 	switch strings.ToLower(c.format) {
 	case teleport.JSON:
 		return trace.Wrap(common.PrintJSONIndent(cf.Stdout(), formatted))

--- a/tool/tsh/common/beams_ls_test.go
+++ b/tool/tsh/common/beams_ls_test.go
@@ -40,20 +40,20 @@ func TestBeamsLSCommand(t *testing.T) {
 
 	beams := []*beamsv1.Beam{
 		makeTestBeam(
-			"bravo",
-			"22222222-2222-2222-2222-222222222222",
-			"alice",
-			"",
-			time.Date(2026, time.January, 2, 4, 5, 6, 0, time.UTC),
-			nil,
-		),
-		makeTestBeam(
 			"alpha",
 			"11111111-1111-1111-1111-111111111111",
 			"alice",
 			"alpha-app",
 			time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
 			&beamsv1.PublishSpec{Protocol: beamsv1.Protocol_PROTOCOL_HTTP, Port: 8080},
+		),
+		makeTestBeam(
+			"bravo",
+			"22222222-2222-2222-2222-222222222222",
+			"alice",
+			"",
+			time.Date(2026, time.January, 2, 4, 5, 6, 0, time.UTC),
+			nil,
 		),
 		makeTestBeam(
 			"charlie",

--- a/tool/tsh/common/beams_ls_test.go
+++ b/tool/tsh/common/beams_ls_test.go
@@ -1,0 +1,154 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/gravitational/teleport"
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils/testutils/golden"
+)
+
+func TestBeamsLSCommand(t *testing.T) {
+	now := time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)
+
+	beams := []*beamsv1.Beam{
+		makeTestBeam(
+			"bravo",
+			"22222222-2222-2222-2222-222222222222",
+			"alice",
+			"",
+			time.Date(2026, time.January, 2, 4, 5, 6, 0, time.UTC),
+			nil,
+		),
+		makeTestBeam(
+			"alpha",
+			"11111111-1111-1111-1111-111111111111",
+			"alice",
+			"alpha-app",
+			time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
+			&beamsv1.PublishSpec{Protocol: beamsv1.Protocol_PROTOCOL_HTTP, Port: 8080},
+		),
+		makeTestBeam(
+			"charlie",
+			"33333333-3333-3333-3333-333333333333",
+			"bob",
+			"charlie-app",
+			time.Date(2026, time.January, 2, 5, 6, 7, 0, time.UTC),
+			&beamsv1.PublishSpec{Protocol: beamsv1.Protocol_PROTOCOL_TCP, Port: 5432},
+		),
+	}
+
+	tests := []struct {
+		name    string
+		format  string
+		all     bool
+		wantAll bool
+	}{
+		{
+			name:    "text format",
+			wantAll: false,
+		},
+		{
+			name:    "text format with all",
+			all:     true,
+			format:  teleport.Text,
+			wantAll: true,
+		},
+		{
+			name:    "JSON format",
+			format:  teleport.JSON,
+			wantAll: false,
+		},
+		{
+			name:    "YAML format",
+			format:  teleport.YAML,
+			all:     true,
+			wantAll: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotAll bool
+			var buf bytes.Buffer
+
+			cf := &CLIConf{
+				Context:        context.Background(),
+				Proxy:          "proxy.example.com:443",
+				Username:       "alice",
+				OverrideStdout: &buf,
+				HomePath:       t.TempDir(),
+			}
+			mustCreateEmptyProfile(t, cf)
+
+			cmd := beamsLSCommand{
+				all:    tt.all,
+				format: tt.format,
+				fetchFn: func(_ context.Context, _ *client.TeleportClient, all bool) ([]*beamsv1.Beam, error) {
+					gotAll = all
+					return beams, nil
+				},
+				proxyAddrFn: func(*CLIConf) (string, error) {
+					return "proxy.example.com:443", nil
+				},
+				humanizeTimeFn: func(tm time.Time) string {
+					return humanize.RelTime(tm, now, "ago", "from now")
+				},
+			}
+
+			err := cmd.run(cf)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantAll, gotAll)
+
+			if golden.ShouldSet() {
+				golden.Set(t, buf.Bytes())
+			}
+
+			require.Equal(t, string(golden.Get(t)), buf.String())
+		})
+	}
+}
+
+func makeTestBeam(alias, name, owner, appName string, expires time.Time, publish *beamsv1.PublishSpec) *beamsv1.Beam {
+	return &beamsv1.Beam{
+		Metadata: &headerv1.Metadata{
+			Name: name,
+		},
+		Spec: &beamsv1.BeamSpec{
+			Expires: timestamppb.New(expires),
+			Publish: publish,
+		},
+		Status: &beamsv1.BeamStatus{
+			Alias:   alias,
+			User:    owner,
+			AppName: appName,
+		},
+	}
+}

--- a/tool/tsh/common/beams_publish.go
+++ b/tool/tsh/common/beams_publish.go
@@ -1,0 +1,204 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/tool/common"
+)
+
+type beamsPublishCommand struct {
+	*kingpin.CmdClause
+	name   string
+	tcp    bool
+	format string
+
+	// These helper functions can be overridden in tests.
+	getFn       func(context.Context, *client.TeleportClient, string) (*beamsv1.Beam, error)
+	updateFn    func(context.Context, *client.TeleportClient, *beamsv1.Beam) (*beamsv1.Beam, error)
+	proxyAddrFn func(*CLIConf) (string, error)
+}
+
+func newBeamsPublishCommand(parent *kingpin.CmdClause) *beamsPublishCommand {
+	cmd := &beamsPublishCommand{
+		CmdClause: parent.Command("publish", "Publish an HTTP or TCP service running in a beam."),
+	}
+	cmd.getFn = cmd.getBeam
+	cmd.updateFn = cmd.updateBeam
+	cmd.proxyAddrFn = cmd.proxyAddr
+	cmd.Flag("tcp", "Publish as a TCP app instead of an HTTP app.").BoolVar(&cmd.tcp)
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	cmd.Arg("name", "ID (or UUID) of the beam to target.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsPublishCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	beam, err := c.getFn(ctx, tc, c.name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Set the `spec.publish` to trigger the creation of an app.
+	beam.Spec.Publish = &beamsv1.PublishSpec{
+		Port:     8080,
+		Protocol: beamsv1.Protocol_PROTOCOL_HTTP,
+	}
+	if c.tcp {
+		beam.Spec.Publish.Protocol = beamsv1.Protocol_PROTOCOL_TCP
+	}
+
+	updatedBeam, err := c.updateFn(ctx, tc, beam)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	proxyAddr, err := c.proxyAddrFn(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(c.print(cf, updatedBeam, proxyAddr))
+}
+
+func (c *beamsPublishCommand) getBeam(ctx context.Context, tc *client.TeleportClient, name string) (*beamsv1.Beam, error) {
+	var beam *beamsv1.Beam
+	err := client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootClient.Close()
+
+		beam, err = getBeam(ctx, rootClient, name)
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return beam, nil
+}
+
+func (c *beamsPublishCommand) updateBeam(ctx context.Context, tc *client.TeleportClient, beam *beamsv1.Beam) (*beamsv1.Beam, error) {
+	var updatedBeam *beamsv1.Beam
+	err := client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootClient.Close()
+
+		rsp, err := rootClient.
+			BeamServiceClient().
+			UpdateBeam(ctx, &beamsv1.UpdateBeamRequest{Beam: beam})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		updatedBeam = rsp.GetBeam()
+		return nil
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return updatedBeam, nil
+}
+
+func (c *beamsPublishCommand) proxyAddr(cf *CLIConf) (string, error) {
+	_, proxyAddr, err := fetchProxyVersion(cf)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return proxyAddr, nil
+}
+
+func (c *beamsPublishCommand) print(cf *CLIConf, updatedBeam *beamsv1.Beam, proxyAddr string) error {
+	switch strings.ToLower(c.format) {
+	case teleport.JSON:
+		return trace.Wrap(common.PrintJSONIndent(cf.Stdout(), formatBeam(updatedBeam, proxyAddr)))
+	case teleport.YAML:
+		return trace.Wrap(common.PrintYAML(cf.Stdout(), formatBeam(updatedBeam, proxyAddr)))
+	default:
+		if _, err := fmt.Fprintf(
+			cf.Stdout(),
+			"Beam %q successfully published.\n\n",
+			updatedBeam.GetStatus().GetAlias(),
+		); err != nil {
+			return trace.Wrap(err)
+		}
+
+		switch updatedBeam.GetSpec().GetPublish().GetProtocol() {
+		case beamsv1.Protocol_PROTOCOL_HTTP:
+			if _, err := fmt.Fprintf(
+				cf.Stdout(),
+				"URL: %s\n",
+				beamPublishURL(updatedBeam, proxyAddr),
+			); err != nil {
+				return trace.Wrap(err)
+			}
+		case beamsv1.Protocol_PROTOCOL_TCP:
+			if _, err := fmt.Fprintf(
+				cf.Stdout(),
+				"Connect to your TCP application via VNet at:\n  %s\n\n",
+				beamPublishURL(updatedBeam, proxyAddr),
+			); err != nil {
+				return trace.Wrap(err)
+			}
+			if _, err := fmt.Fprintf(
+				cf.Stdout(),
+				"Or start a local tunnel to the application with:\n  tsh proxy app %s\n",
+				updatedBeam.GetStatus().GetAppName(),
+			); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
+		return nil
+	}
+}

--- a/tool/tsh/common/beams_publish_test.go
+++ b/tool/tsh/common/beams_publish_test.go
@@ -1,0 +1,146 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils/testutils/golden"
+)
+
+func TestBeamsPublishCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		format       string
+		tcp          bool
+		wantName     string
+		wantProtocol beamsv1.Protocol
+		beamAlias    string
+		beamName     string
+		appName      string
+		expires      time.Time
+	}{
+		{
+			name:         "text format http",
+			wantName:     "beam-ref",
+			wantProtocol: beamsv1.Protocol_PROTOCOL_HTTP,
+			beamAlias:    "alpha",
+			beamName:     "11111111-1111-1111-1111-111111111111",
+			appName:      "alpha-app",
+			expires:      time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
+		},
+		{
+			name:         "text format tcp",
+			tcp:          true,
+			wantName:     "beam-ref",
+			wantProtocol: beamsv1.Protocol_PROTOCOL_TCP,
+			beamAlias:    "charlie",
+			beamName:     "33333333-3333-3333-3333-333333333333",
+			appName:      "charlie-app",
+			expires:      time.Date(2026, time.January, 2, 5, 6, 7, 0, time.UTC),
+		},
+		{
+			name:         "JSON format",
+			format:       teleport.JSON,
+			wantName:     "beam-ref",
+			wantProtocol: beamsv1.Protocol_PROTOCOL_HTTP,
+			beamAlias:    "alpha",
+			beamName:     "11111111-1111-1111-1111-111111111111",
+			appName:      "alpha-app",
+			expires:      time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
+		},
+		{
+			name:         "YAML format",
+			format:       teleport.YAML,
+			tcp:          true,
+			wantName:     "beam-ref",
+			wantProtocol: beamsv1.Protocol_PROTOCOL_TCP,
+			beamAlias:    "charlie",
+			beamName:     "33333333-3333-3333-3333-333333333333",
+			appName:      "charlie-app",
+			expires:      time.Date(2026, time.January, 2, 5, 6, 7, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotName string
+			var updatedBeam *beamsv1.Beam
+			var output bytes.Buffer
+
+			beam := makeTestBeam(
+				tt.beamAlias,
+				tt.beamName,
+				"alice",
+				tt.appName,
+				tt.expires,
+				nil,
+			)
+
+			cf := &CLIConf{
+				Context:        context.Background(),
+				Proxy:          "proxy.example.com:443",
+				Username:       "alice",
+				OverrideStdout: &output,
+				overrideStderr: &output,
+				HomePath:       t.TempDir(),
+			}
+			mustCreateEmptyProfile(t, cf)
+
+			cmd := beamsPublishCommand{
+				name:   tt.wantName,
+				tcp:    tt.tcp,
+				format: tt.format,
+				getFn: func(_ context.Context, _ *client.TeleportClient, name string) (*beamsv1.Beam, error) {
+					gotName = name
+					return beam, nil
+				},
+				updateFn: func(_ context.Context, _ *client.TeleportClient, beam *beamsv1.Beam) (*beamsv1.Beam, error) {
+					updatedBeam = beam
+					return beam, nil
+				},
+				proxyAddrFn: func(*CLIConf) (string, error) {
+					return "proxy.example.com:443", nil
+				},
+			}
+
+			err := cmd.run(cf)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantName, gotName)
+			require.NotNil(t, updatedBeam)
+			require.NotNil(t, updatedBeam.GetSpec().GetPublish())
+			require.Equal(t, uint32(8080), updatedBeam.GetSpec().GetPublish().GetPort())
+			require.Equal(t, tt.wantProtocol, updatedBeam.GetSpec().GetPublish().GetProtocol())
+
+			if golden.ShouldSet() {
+				golden.Set(t, output.Bytes())
+			}
+
+			require.Equal(t, string(golden.Get(t)), output.String())
+		})
+	}
+}

--- a/tool/tsh/common/beams_rm.go
+++ b/tool/tsh/common/beams_rm.go
@@ -1,0 +1,92 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+type beamsRMCommand struct {
+	*kingpin.CmdClause
+	name string
+}
+
+func newBeamsRMCommand(parent *kingpin.CmdClause) *beamsRMCommand {
+	cmd := &beamsRMCommand{
+		CmdClause: parent.Command("rm", "Delete a beam."),
+	}
+	cmd.Arg("name", "ID (or UUID) of the beam to delete.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsRMCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var beam *beamsv1.Beam
+	err = client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootClient.Close()
+
+		// Read the beam to get its UUID name.
+		beam, err = getBeam(ctx, rootClient, c.name)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// Delete the beam.
+		_, err = rootClient.
+			BeamServiceClient().
+			DeleteBeam(ctx, &beamsv1.DeleteBeamRequest{
+				Name: beam.GetMetadata().GetName(),
+			})
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := fmt.Fprintf(
+		cf.Stdout(),
+		"Beam %q successfully deleted.\n",
+		beam.GetStatus().GetAlias(),
+	); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/tool/tsh/common/beams_scp.go
+++ b/tool/tsh/common/beams_scp.go
@@ -1,0 +1,165 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	filesftp "github.com/gravitational/teleport/lib/sshutils/sftp"
+)
+
+type beamsSCPCommand struct {
+	*kingpin.CmdClause
+	recursive bool
+	quiet     bool
+	src       string
+	dest      string
+	format    string
+
+	// These helper functions can be overridden in tests.
+	getBeamFn     func(context.Context, authclient.ClientI, string) (*beamsv1.Beam, error)
+	sftpFn        func(context.Context, *client.TeleportClient, client.SFTPRequest) error
+	withClusterFn func(context.Context, *client.TeleportClient, func(authclient.ClientI) error) error
+}
+
+func newBeamsSCPCommand(parent *kingpin.CmdClause) *beamsSCPCommand {
+	cmd := &beamsSCPCommand{
+		CmdClause: parent.Command("scp", "Copy files between a beam and the local filesystem.").Alias("cp"),
+	}
+	cmd.getBeamFn = getBeam
+	cmd.sftpFn = func(ctx context.Context, tc *client.TeleportClient, req client.SFTPRequest) error {
+		return trace.Wrap(tc.SFTP(ctx, req))
+	}
+	cmd.withClusterFn = cmd.withCluster
+	cmd.Flag("recursive", "Recursive copy of subdirectories.").Short('r').BoolVar(&cmd.recursive)
+	cmd.Flag("quiet", "Quiet mode.").Short('q').BoolVar(&cmd.quiet)
+	cmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).
+		Short('f').
+		Default(teleport.Text).
+		EnumVar(&cmd.format, defaults.DefaultFormats...)
+	cmd.Arg("src", "Source path to copy, in the form `BEAM_ID:PATH` or `LOCAL_PATH`.").Required().StringVar(&cmd.src)
+	cmd.Arg("dest", "Destination path to copy, in the form `BEAM_ID:PATH` or `LOCAL_PATH`.").Required().StringVar(&cmd.dest)
+	return cmd
+}
+
+func (c *beamsSCPCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	tc.AllowHeadless = true
+
+	err = c.withClusterFn(ctx, tc, func(cli authclient.ClientI) error {
+		src, err := c.parseTarget(ctx, cli, c.src)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		dest, err := c.parseTarget(ctx, cli, c.dest)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if src.beam == nil && dest.beam == nil {
+			return trace.BadParameter("at least one of <src> <dest> must be in the form `BEAM_ID:PATH`")
+		}
+
+		req := client.SFTPRequest{
+			Sources:     []string{src.toSFTP()},
+			Destination: dest.toSFTP(),
+			Recursive:   c.recursive,
+		}
+		if !c.quiet {
+			req.ProgressWriter = cf.Stdout()
+		}
+		if err := c.sftpFn(ctx, tc, req); err != nil {
+			return trace.Wrap(err)
+		}
+		if _, err := fmt.Fprintln(cf.Stdout(), "Copied successfully."); err != nil {
+			return trace.Wrap(err)
+		}
+		return nil
+	})
+	return trace.Wrap(err)
+}
+
+func (c *beamsSCPCommand) withCluster(ctx context.Context, tc *client.TeleportClient, fn func(authclient.ClientI) error) error {
+	return trace.Wrap(client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootClient.Close()
+
+		return trace.Wrap(fn(rootClient))
+	}))
+}
+
+type beamCopyTarget struct {
+	path string
+	beam *beamsv1.Beam
+}
+
+func (c *beamsSCPCommand) parseTarget(ctx context.Context, client authclient.ClientI, path string) (*beamCopyTarget, error) {
+	// This is a path to a local file.
+	if !filesftp.IsRemotePath(path) {
+		return &beamCopyTarget{path: path}, nil
+	}
+
+	// Target is in the form `BEAM:PATH` (e.g. `quantum-leap:/etc/hosts`).
+	before, after, _ := strings.Cut(path, ":")
+
+	beam, err := c.getBeamFn(ctx, client, before)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if beam.GetStatus().GetNodeId() == "" {
+		return nil, trace.Errorf("beam %q is not ready to accept SSH connections", beam.GetStatus().GetAlias())
+	}
+
+	return &beamCopyTarget{beam: beam, path: after}, nil
+}
+
+func (t *beamCopyTarget) toSFTP() string {
+	if t.beam == nil {
+		return t.path
+	}
+	return fmt.Sprintf(
+		"%s@%s:%s",
+		beamsLogin,
+		t.beam.GetStatus().GetNodeId(),
+		t.path,
+	)
+}

--- a/tool/tsh/common/beams_scp_test.go
+++ b/tool/tsh/common/beams_scp_test.go
@@ -1,0 +1,149 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+func TestBeamsSCPCommandRun(t *testing.T) {
+	tests := []struct {
+		name               string
+		src                string
+		dest               string
+		recursive          bool
+		quiet              bool
+		nodeIDByBeamName   map[string]string
+		wantSources        []string
+		wantDestination    string
+		wantProgressWriter bool
+		wantOutput         string
+		wantErr            string
+	}{
+		{
+			name:      "remote source to local destination",
+			src:       "alpha:/var/log/app.log",
+			dest:      "/tmp/app.log",
+			recursive: true,
+			nodeIDByBeamName: map[string]string{
+				"alpha": "node-123",
+			},
+			wantSources:        []string{"beams@node-123:/var/log/app.log"},
+			wantDestination:    "/tmp/app.log",
+			wantProgressWriter: true,
+			wantOutput:         "Copied successfully.\n",
+		},
+		{
+			name:  "local source to remote destination in quiet mode",
+			src:   "/tmp/app.log",
+			dest:  "alpha:/var/log/app.log",
+			quiet: true,
+			nodeIDByBeamName: map[string]string{
+				"alpha": "node-123",
+			},
+			wantSources:        []string{"/tmp/app.log"},
+			wantDestination:    "beams@node-123:/var/log/app.log",
+			wantProgressWriter: false,
+			wantOutput:         "Copied successfully.\n",
+		},
+		{
+			name:    "both local paths error",
+			src:     "/tmp/src.txt",
+			dest:    "/tmp/dest.txt",
+			wantErr: "at least one of <src> <dest> must be in the form `BEAM_ID:PATH`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			var gotReq client.SFTPRequest
+			var sftpCalled bool
+
+			cf := &CLIConf{
+				Context:        context.Background(),
+				Proxy:          "proxy.example.com:443",
+				Username:       "alice",
+				OverrideStdout: &output,
+				HomePath:       t.TempDir(),
+			}
+			mustCreateEmptyProfile(t, cf)
+
+			cmd := beamsSCPCommand{
+				src:       tt.src,
+				dest:      tt.dest,
+				recursive: tt.recursive,
+				quiet:     tt.quiet,
+				getBeamFn: func(_ context.Context, _ authclient.ClientI, name string) (*beamsv1.Beam, error) {
+					nodeID, ok := tt.nodeIDByBeamName[name]
+					if !ok {
+						t.Fatalf("unexpected getBeam call for %q", name)
+					}
+					beam := makeTestBeam(
+						name,
+						"11111111-1111-1111-1111-111111111111",
+						"alice",
+						name+"-app",
+						time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
+						nil,
+					)
+					beam.Status.NodeId = nodeID
+					return beam, nil
+				},
+				withClusterFn: func(_ context.Context, _ *client.TeleportClient, fn func(authclient.ClientI) error) error {
+					return fn(nil)
+				},
+				sftpFn: func(_ context.Context, _ *client.TeleportClient, req client.SFTPRequest) error {
+					sftpCalled = true
+					gotReq = req
+					return nil
+				},
+			}
+
+			err := cmd.run(cf)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+				require.False(t, sftpCalled)
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(t, sftpCalled)
+			require.Equal(t, tt.wantSources, gotReq.Sources)
+			require.Equal(t, tt.wantDestination, gotReq.Destination)
+			require.Equal(t, tt.recursive, gotReq.Recursive)
+			if tt.wantProgressWriter {
+				require.Same(t, cf.Stdout(), gotReq.ProgressWriter)
+			} else {
+				require.Nil(t, gotReq.ProgressWriter)
+			}
+			require.Equal(t, tt.wantOutput, output.String())
+		})
+	}
+}

--- a/tool/tsh/common/beams_ssh.go
+++ b/tool/tsh/common/beams_ssh.go
@@ -1,0 +1,125 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+type beamsSSHCommand struct {
+	*kingpin.CmdClause
+	name string
+}
+
+func newBeamsSSHCommand(parent *kingpin.CmdClause) *beamsSSHCommand {
+	cmd := &beamsSSHCommand{
+		CmdClause: parent.Command("ssh", "Start an interactive shell in a beam, via SSH.").Alias("console"),
+	}
+	cmd.Arg("name", "ID (or UUID) of the beam to connect to.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsSSHCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	tc.AllowHeadless = true
+
+	var beam *beamsv1.Beam
+	err = client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootClient.Close()
+
+		beam, err = getBeam(ctx, rootClient, c.name)
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(sshBeam(cf, tc, beam, nil))
+}
+
+func sshBeam(cf *CLIConf, tc *client.TeleportClient, beam *beamsv1.Beam, command []string) error {
+	// TODO(boxofrad): Right now, we expect the CreateBeam call to block until
+	// it's ready to accept SSH connections - which can lead to timeouts when
+	// we need to spin up more nodes. We should make this non-blocking and have
+	// the retry loop re-read the beam.
+	if beam.GetStatus().GetNodeId() == "" {
+		return trace.Errorf("beam %q is not ready to accept SSH connections", beam.GetStatus().GetAlias())
+	}
+
+	target := fmt.Sprintf("%s:0", beam.GetStatus().GetNodeId())
+	tc.HostLogin = beamsLogin
+	tc.Stdin = cf.Stdin()
+
+	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
+		First:  100 * time.Millisecond,
+		Step:   100 * time.Millisecond,
+		Max:    time.Second,
+		Jitter: retryutils.HalfJitter,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var lastErr error
+	for i := range 10 {
+		lastErr = trace.Wrap(tc.SSH(cf.Context, command, client.WithHostAddress(target)))
+		if lastErr == nil {
+			return nil
+		}
+		logger.DebugContext(cf.Context, "Connect to beam with retry", "attempt", i+1, "error", lastErr)
+
+		switch {
+		case trace.IsNotFound(lastErr):
+			// Cache may not have receive the node write.
+		case trace.IsConnectionProblem(lastErr):
+			// Beam network may not be ready yet.
+		default:
+			return trace.Wrap(convertSSHExitCode(tc, lastErr))
+		}
+
+		select {
+		case <-cf.Context.Done():
+		case <-retry.After():
+			retry.Inc()
+		}
+	}
+	return lastErr
+}

--- a/tool/tsh/common/beams_unpublish.go
+++ b/tool/tsh/common/beams_unpublish.go
@@ -31,8 +31,7 @@ import (
 
 type beamsUnpublishCommand struct {
 	*kingpin.CmdClause
-	name   string
-	format string
+	name string
 
 	// These helper functions can be overridden in tests.
 	getFn    func(context.Context, *client.TeleportClient, string) (*beamsv1.Beam, error)

--- a/tool/tsh/common/beams_unpublish.go
+++ b/tool/tsh/common/beams_unpublish.go
@@ -1,0 +1,139 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+type beamsUnpublishCommand struct {
+	*kingpin.CmdClause
+	name   string
+	format string
+
+	// These helper functions can be overridden in tests.
+	getFn    func(context.Context, *client.TeleportClient, string) (*beamsv1.Beam, error)
+	updateFn func(context.Context, *client.TeleportClient, *beamsv1.Beam) (*beamsv1.Beam, error)
+}
+
+func newBeamsUnpublishCommand(parent *kingpin.CmdClause) *beamsUnpublishCommand {
+	cmd := &beamsUnpublishCommand{
+		CmdClause: parent.Command("unpublish", "Unpublish a previously published service in a beam."),
+	}
+	cmd.getFn = cmd.getBeam
+	cmd.updateFn = cmd.updateBeam
+	cmd.Arg("name", "ID (or UUID) of the beam to target.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsUnpublishCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	beam, err := c.getFn(ctx, tc, c.name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if beam.Spec.Publish == nil {
+		return trace.Errorf("Beam %q is not published.", beam.GetStatus().GetAlias())
+	}
+
+	// Blank out the `spec.publish` to trigger the deletion of the app.
+	beam.Spec.Publish = nil
+
+	updatedBeam, err := c.updateFn(ctx, tc, beam)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := fmt.Fprintf(
+		cf.Stdout(),
+		"Beam %q successfully unpublished.\n",
+		updatedBeam.GetStatus().GetAlias(),
+	); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (c *beamsUnpublishCommand) getBeam(ctx context.Context, tc *client.TeleportClient, name string) (*beamsv1.Beam, error) {
+	var beam *beamsv1.Beam
+	err := client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootClient.Close()
+
+		beam, err = getBeam(ctx, rootClient, name)
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return beam, nil
+}
+
+func (c *beamsUnpublishCommand) updateBeam(ctx context.Context, tc *client.TeleportClient, beam *beamsv1.Beam) (*beamsv1.Beam, error) {
+	var updatedBeam *beamsv1.Beam
+	err := client.RetryWithRelogin(ctx, tc, func() error {
+		clusterClient, err := tc.ConnectToCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer clusterClient.Close()
+
+		rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer rootClient.Close()
+
+		rsp, err := rootClient.
+			BeamServiceClient().
+			UpdateBeam(ctx, &beamsv1.UpdateBeamRequest{Beam: beam})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		updatedBeam = rsp.GetBeam()
+		return nil
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return updatedBeam, nil
+}

--- a/tool/tsh/common/beams_unpublish_test.go
+++ b/tool/tsh/common/beams_unpublish_test.go
@@ -1,0 +1,113 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	beamsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/beams/v1"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+func TestBeamsUnpublishCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantName   string
+		beam       *beamsv1.Beam
+		wantOutput string
+		wantErr    string
+	}{
+		{
+			name:     "success",
+			wantName: "beam-ref",
+			beam: makeTestBeam(
+				"alpha",
+				"11111111-1111-1111-1111-111111111111",
+				"alice",
+				"alpha-app",
+				time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
+				&beamsv1.PublishSpec{Protocol: beamsv1.Protocol_PROTOCOL_HTTP, Port: 8080},
+			),
+			wantOutput: "Beam \"alpha\" successfully unpublished.\n",
+		},
+		{
+			name:     "not published",
+			wantName: "beam-ref",
+			beam: makeTestBeam(
+				"alpha",
+				"11111111-1111-1111-1111-111111111111",
+				"alice",
+				"alpha-app",
+				time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
+				nil,
+			),
+			wantErr: "Beam \"alpha\" is not published.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotName string
+			var updatedBeam *beamsv1.Beam
+			var output bytes.Buffer
+
+			cf := &CLIConf{
+				Context:        context.Background(),
+				Proxy:          "proxy.example.com:443",
+				Username:       "alice",
+				OverrideStdout: &output,
+				HomePath:       t.TempDir(),
+			}
+			mustCreateEmptyProfile(t, cf)
+
+			cmd := beamsUnpublishCommand{
+				name: tt.wantName,
+				getFn: func(_ context.Context, _ *client.TeleportClient, name string) (*beamsv1.Beam, error) {
+					gotName = name
+					return tt.beam, nil
+				},
+				updateFn: func(_ context.Context, _ *client.TeleportClient, beam *beamsv1.Beam) (*beamsv1.Beam, error) {
+					updatedBeam = beam
+					return beam, nil
+				},
+			}
+
+			err := cmd.run(cf)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Equal(t, tt.wantName, gotName)
+				require.Nil(t, updatedBeam)
+				require.Empty(t, output.String())
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantName, gotName)
+			require.NotNil(t, updatedBeam)
+			require.Nil(t, updatedBeam.GetSpec().GetPublish())
+			require.Equal(t, tt.wantOutput, output.String())
+		})
+	}
+}

--- a/tool/tsh/common/testdata/TestBeamsLSCommand/JSON_format.golden
+++ b/tool/tsh/common/testdata/TestBeamsLSCommand/JSON_format.golden
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "alpha",
+    "uuid": "11111111-1111-1111-1111-111111111111",
+    "owner": "alice",
+    "expires": "2026-01-02T03:04:05Z",
+    "url": "https://alpha-app.proxy.example.com"
+  },
+  {
+    "id": "bravo",
+    "uuid": "22222222-2222-2222-2222-222222222222",
+    "owner": "alice",
+    "expires": "2026-01-02T04:05:06Z"
+  },
+  {
+    "id": "charlie",
+    "uuid": "33333333-3333-3333-3333-333333333333",
+    "owner": "bob",
+    "expires": "2026-01-02T05:06:07Z",
+    "url": "tcp://charlie-app.proxy.example.com:5432"
+  }
+]

--- a/tool/tsh/common/testdata/TestBeamsLSCommand/YAML_format.golden
+++ b/tool/tsh/common/testdata/TestBeamsLSCommand/YAML_format.golden
@@ -1,0 +1,15 @@
+- expires: "2026-01-02T03:04:05Z"
+  id: alpha
+  owner: alice
+  url: https://alpha-app.proxy.example.com
+  uuid: 11111111-1111-1111-1111-111111111111
+- expires: "2026-01-02T04:05:06Z"
+  id: bravo
+  owner: alice
+  uuid: 22222222-2222-2222-2222-222222222222
+- expires: "2026-01-02T05:06:07Z"
+  id: charlie
+  owner: bob
+  url: tcp://charlie-app.proxy.example.com:5432
+  uuid: 33333333-3333-3333-3333-333333333333
+

--- a/tool/tsh/common/testdata/TestBeamsLSCommand/text_format.golden
+++ b/tool/tsh/common/testdata/TestBeamsLSCommand/text_format.golden
@@ -1,0 +1,5 @@
+ID      URL                                      Expires          
+------- ---------------------------------------- ---------------- 
+alpha   https://alpha-app.proxy.example.com      3 hours from now 
+bravo                                            4 hours from now 
+charlie tcp://charlie-app.proxy.example.com:5432 5 hours from now 

--- a/tool/tsh/common/testdata/TestBeamsLSCommand/text_format_with_all.golden
+++ b/tool/tsh/common/testdata/TestBeamsLSCommand/text_format_with_all.golden
@@ -1,0 +1,5 @@
+ID      URL                                      Expires          Owner 
+------- ---------------------------------------- ---------------- ----- 
+alpha   https://alpha-app.proxy.example.com      3 hours from now alice 
+bravo                                            4 hours from now alice 
+charlie tcp://charlie-app.proxy.example.com:5432 5 hours from now bob   

--- a/tool/tsh/common/testdata/TestBeamsPublishCommand/JSON_format.golden
+++ b/tool/tsh/common/testdata/TestBeamsPublishCommand/JSON_format.golden
@@ -1,0 +1,7 @@
+{
+  "id": "alpha",
+  "uuid": "11111111-1111-1111-1111-111111111111",
+  "owner": "alice",
+  "expires": "2026-01-02T03:04:05Z",
+  "url": "https://alpha-app.proxy.example.com"
+}

--- a/tool/tsh/common/testdata/TestBeamsPublishCommand/YAML_format.golden
+++ b/tool/tsh/common/testdata/TestBeamsPublishCommand/YAML_format.golden
@@ -1,0 +1,6 @@
+expires: "2026-01-02T05:06:07Z"
+id: charlie
+owner: alice
+url: tcp://charlie-app.proxy.example.com:8080
+uuid: 33333333-3333-3333-3333-333333333333
+

--- a/tool/tsh/common/testdata/TestBeamsPublishCommand/text_format_http.golden
+++ b/tool/tsh/common/testdata/TestBeamsPublishCommand/text_format_http.golden
@@ -1,0 +1,3 @@
+Beam "alpha" successfully published.
+
+URL: https://alpha-app.proxy.example.com

--- a/tool/tsh/common/testdata/TestBeamsPublishCommand/text_format_tcp.golden
+++ b/tool/tsh/common/testdata/TestBeamsPublishCommand/text_format_tcp.golden
@@ -1,0 +1,7 @@
+Beam "charlie" successfully published.
+
+Connect to your TCP application via VNet at:
+  tcp://charlie-app.proxy.example.com:8080
+
+Or start a local tunnel to the application with:
+  tsh proxy app charlie-app

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1525,6 +1525,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	connectUpdaterServiceInstallUpdateCommand := newConnectUpdaterServiceInstallUpdateCommand(connectUpdater)
 
 	gitCmd := newGitCommands(app)
+	beamsCmd := newBeamsCommands(app)
 	pivCmd := newPIVCommands(app)
 	mcpCmd := newMCPCommands(app, &cf)
 
@@ -1986,6 +1987,26 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = gitCmd.config.run(&cf)
 	case gitCmd.clone.FullCommand():
 		err = gitCmd.clone.run(&cf)
+	case beamsCmd.ls.FullCommand():
+		err = beamsCmd.ls.run(&cf)
+	case beamsCmd.add.FullCommand():
+		err = beamsCmd.add.run(&cf)
+	case beamsCmd.rm.FullCommand():
+		err = beamsCmd.rm.run(&cf)
+	case beamsCmd.console.FullCommand():
+		err = beamsCmd.console.run(&cf)
+	case beamsCmd.exec.FullCommand():
+		err = beamsCmd.exec.run(&cf)
+	case beamsCmd.publish.FullCommand():
+		err = beamsCmd.publish.run(&cf)
+	case beamsCmd.unpublish.FullCommand():
+		err = beamsCmd.unpublish.run(&cf)
+	case beamsCmd.cp.FullCommand():
+		err = beamsCmd.cp.run(&cf)
+	case beamsCmd.allow.FullCommand():
+		err = beamsCmd.allow.run(&cf)
+	case beamsCmd.deny.FullCommand():
+		err = beamsCmd.deny.run(&cf)
 	case pivCmd.agent.FullCommand():
 		err = pivCmd.agent.run(&cf)
 	case mcpCmd.dbStart.FullCommand():

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1993,20 +1993,16 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = beamsCmd.add.run(&cf)
 	case beamsCmd.rm.FullCommand():
 		err = beamsCmd.rm.run(&cf)
-	case beamsCmd.console.FullCommand():
-		err = beamsCmd.console.run(&cf)
+	case beamsCmd.ssh.FullCommand():
+		err = beamsCmd.ssh.run(&cf)
 	case beamsCmd.exec.FullCommand():
 		err = beamsCmd.exec.run(&cf)
 	case beamsCmd.publish.FullCommand():
 		err = beamsCmd.publish.run(&cf)
 	case beamsCmd.unpublish.FullCommand():
 		err = beamsCmd.unpublish.run(&cf)
-	case beamsCmd.cp.FullCommand():
-		err = beamsCmd.cp.run(&cf)
-	case beamsCmd.allow.FullCommand():
-		err = beamsCmd.allow.run(&cf)
-	case beamsCmd.deny.FullCommand():
-		err = beamsCmd.deny.run(&cf)
+	case beamsCmd.scp.FullCommand():
+		err = beamsCmd.scp.run(&cf)
 	case pivCmd.agent.FullCommand():
 		err = pivCmd.agent.run(&cf)
 	case mcpCmd.dbStart.FullCommand():


### PR DESCRIPTION
This PR adds the initial `tsh` commands for working with [Beams](https://beams.run) 🚀

They're fairly minimal at the moment (e.g. no loading spinners), and @nicholasmarais1158 and @michxsung are going to iterate on the UX.

> [!NOTE]
> We'd like to get these changes before the 18.8.0 release is cut, so folks in the public beta can use an official build of `tsh`.

Changelog: Add `tsh beams` commands for the Beams public beta

## Manual Test Plan

### Test Environment

- Local build of Teleport Enterprise, with the beams service, running on a GCP instance
- Wireguard tunnel from the GCP instance to my laptop, where a mock orchestrator service is running (with a `tbot` sidecar serving the SPIFFE Workload API)
- Fake beam running OpenSSH in Docker (exposed to the Teleport proxy over the Wireguard tunnel)

### Test Cases

**Adding a beam:**
- [x] `tsh beams add`
- [x] `tsh beams add --no-console`
- [x] `tsh beams add --format=json`
- [x] `tsh beams add --format=yaml`

**Removing a beam:**
- [x] `tsh beams rm mighty-isotope`

**Listing beams:**
- [x] `tsh beams ls`
- [x] `tsh beams ls --all`
- [x] `tsh beams ls --format=json`
- [x] `tsh beams ls --format=yaml`

**Publishing a beam:**
- [x] `tsh beams publish velvet-helix`
- [x] `tsh beams publish --tcp tidal-flux`
- [x] `tsh beams publish --format=json single-lumen`
- [x] `tsh beams publish --format=yaml pure-transit`

**Unpublishing a beam:**
- [x] `tsh beams unpublish velvet-helix`

**SSHing into a beam:**
- [x] `tsh beams ssh quiet-module`

**Executing a command on a beam:**
- [x] `tsh beams exec swift-mesh -- hostname`

**Copying files between beams:**
- [x] `tsh beams scp hello.txt starry-booster:/goodbye.txt` (local to beam)
- [x] `tsh beams scp starry-booster:/goodbye.txt howdy.txt` (beam to local)
- [x] `tsh beams scp starry-booster:/goodbye.txt still-console:/ohai.txt` (beam to beam)