### PR TITLE
fix vnet_config terraform schema not applying exclude_fields and computed_fields

### DIFF
--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -520,12 +520,12 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	{{.VarName}} = {{.VarName}}I
 	{{- else}}
 	{{.VarName}} = {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
+	{{- end}}
 	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	{{- end}}
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/protoc-gen-terraform-vnetconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-vnetconfig.yaml
@@ -33,6 +33,7 @@ injected_fields:
 exclude_fields:
   # Metadata (we id resources by name on our side)
   - 'VnetConfig.id'
+  - 'VnetConfig.metadata.revision'
 
 # These fields will be marked as Computed: true
 computed_fields:
@@ -40,7 +41,6 @@ computed_fields:
   - 'VnetConfig.metadata'
   - 'VnetConfig.metadata.name'
   - 'VnetConfig.metadata.namespace'
-  - 'VnetConfig.metadata.revision'
   - "VnetConfig.kind"
   - "VnetConfig.sub_kind"
   - "VnetConfig.version"

--- a/integrations/terraform/protoc-gen-terraform-vnetconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-vnetconfig.yaml
@@ -33,14 +33,14 @@ injected_fields:
 exclude_fields:
   # Metadata (we id resources by name on our side)
   - 'VnetConfig.id'
-  - 'VnetConfig.metadata.namespace'
-  - 'VnetConfig.metadata.revision'
 
 # These fields will be marked as Computed: true
 computed_fields:
   # Metadata
   - 'VnetConfig.metadata'
   - 'VnetConfig.metadata.name'
+  - 'VnetConfig.metadata.namespace'
+  - 'VnetConfig.metadata.revision'
   - "VnetConfig.kind"
   - "VnetConfig.sub_kind"
   - "VnetConfig.version"

--- a/integrations/terraform/protoc-gen-terraform-vnetconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-vnetconfig.yaml
@@ -33,15 +33,17 @@ injected_fields:
 exclude_fields:
   # Metadata (we id resources by name on our side)
   - 'VnetConfig.id'
-  - 'VnetConfig.Metadata.Name'
+  - 'VnetConfig.metadata.namespace'
+  - 'VnetConfig.metadata.revision'
 
 # These fields will be marked as Computed: true
 computed_fields:
   # Metadata
-  - 'VnetConfig.Metadata.Namespace'
-  - 'VnetConfig.Metadata.Revision'
-  - "VnetConfig.Kind"
-  - "VnetConfig.Version"
+  - 'VnetConfig.metadata'
+  - 'VnetConfig.metadata.name'
+  - "VnetConfig.kind"
+  - "VnetConfig.sub_kind"
+  - "VnetConfig.version"
 
 # This must be defined for the generator to be happy, but in reality all time
 # fields are overridden (because the protobuf timestamps contain locks and the

--- a/integrations/terraform/provider/resource_teleport_autoupdate_config.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_config.go
@@ -286,6 +286,11 @@ func (r resourceTeleportAutoUpdateConfig) Update(ctx context.Context, req tfsdk.
 	}
 
 	autoUpdateConfig = autoUpdateConfigI
+	diags = schemav1.CopyAutoUpdateConfigToTerraform(ctx, autoUpdateConfig, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/provider/resource_teleport_autoupdate_version.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_version.go
@@ -286,6 +286,11 @@ func (r resourceTeleportAutoUpdateVersion) Update(ctx context.Context, req tfsdk
 	}
 
 	autoUpdateVersion = autoUpdateVersionI
+	diags = schemav1.CopyAutoUpdateVersionToTerraform(ctx, autoUpdateVersion, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/provider/resource_teleport_retrieval_model.go
+++ b/integrations/terraform/provider/resource_teleport_retrieval_model.go
@@ -286,6 +286,11 @@ func (r resourceTeleportRetrievalModel) Update(ctx context.Context, req tfsdk.Up
 	}
 
 	retrievalModel = retrievalModelI
+	diags = schemav1.CopyRetrievalModelToTerraform(ctx, retrievalModel, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/provider/resource_teleport_vnet_config.go
+++ b/integrations/terraform/provider/resource_teleport_vnet_config.go
@@ -286,6 +286,11 @@ func (r resourceTeleportVnetConfig) Update(ctx context.Context, req tfsdk.Update
 	}
 
 	vnetConfig = vnetConfigI
+	diags = schemav1.CopyVnetConfigToTerraform(ctx, vnetConfig, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/tfschema/vnet/v1/vnet_config_terraform.go
+++ b/integrations/terraform/tfschema/vnet/v1/vnet_config_terraform.go
@@ -88,13 +88,6 @@ func GenSchemaVnetConfig(ctx context.Context) (github_com_hashicorp_terraform_pl
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-				"revision": {
-					Computed:      true,
-					Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
-					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
 			}),
 			Computed:      true,
 			Description:   "",
@@ -290,23 +283,6 @@ func CopyVnetConfigFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"VnetConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -619,28 +595,6 @@ func CopyVnetConfigToTerraform(ctx context.Context, obj *github_com_gravitationa
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"VnetConfig.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"VnetConfig.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"VnetConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/vnet/v1/vnet_config_terraform.go
+++ b/integrations/terraform/tfschema/vnet/v1/vnet_config_terraform.go
@@ -81,6 +81,20 @@ func GenSchemaVnetConfig(ctx context.Context) (github_com_hashicorp_terraform_pl
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
+				"namespace": {
+					Computed:      true,
+					Description:   "namespace is object namespace. The field should be called \"namespace\" when it returns in Teleport 2.4.",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
+				},
+				"revision": {
+					Computed:      true,
+					Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
+				},
 			}),
 			Computed:      true,
 			Description:   "",
@@ -210,6 +224,23 @@ func CopyVnetConfigFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 						}
 					}
 					{
+						a, ok := tf.Attrs["namespace"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.namespace"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"VnetConfig.metadata.namespace", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+							} else {
+								var t string
+								if !v.Null && !v.Unknown {
+									t = string(v.Value)
+								}
+								obj.Namespace = t
+							}
+						}
+					}
+					{
 						a, ok := tf.Attrs["description"]
 						if !ok {
 							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.description"})
@@ -259,6 +290,23 @@ func CopyVnetConfigFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
+					}
+					{
+						a, ok := tf.Attrs["revision"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.revision"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"VnetConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+							} else {
+								var t string
+								if !v.Null && !v.Unknown {
+									t = string(v.Value)
+								}
+								obj.Revision = t
+							}
+						}
 					}
 				}
 			}
@@ -471,6 +519,28 @@ func CopyVnetConfigToTerraform(ctx context.Context, obj *github_com_gravitationa
 						}
 					}
 					{
+						t, ok := tf.AttrTypes["namespace"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"VnetConfig.metadata.namespace"})
+						} else {
+							v, ok := tf.Attrs["namespace"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+							if !ok {
+								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+								if err != nil {
+									diags.Append(attrWriteGeneralError{"VnetConfig.metadata.namespace", err})
+								}
+								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+								if !ok {
+									diags.Append(attrWriteConversionFailureDiag{"VnetConfig.metadata.namespace", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+								}
+								v.Null = string(obj.Namespace) == ""
+							}
+							v.Value = string(obj.Namespace)
+							v.Unknown = false
+							tf.Attrs["namespace"] = v
+						}
+					}
+					{
 						t, ok := tf.AttrTypes["description"]
 						if !ok {
 							diags.Append(attrWriteMissingDiag{"VnetConfig.metadata.description"})
@@ -549,6 +619,28 @@ func CopyVnetConfigToTerraform(ctx context.Context, obj *github_com_gravitationa
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
+						}
+					}
+					{
+						t, ok := tf.AttrTypes["revision"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"VnetConfig.metadata.revision"})
+						} else {
+							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+							if !ok {
+								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+								if err != nil {
+									diags.Append(attrWriteGeneralError{"VnetConfig.metadata.revision", err})
+								}
+								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+								if !ok {
+									diags.Append(attrWriteConversionFailureDiag{"VnetConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+								}
+								v.Null = string(obj.Revision) == ""
+							}
+							v.Value = string(obj.Revision)
+							v.Unknown = false
+							tf.Attrs["revision"] = v
 						}
 					}
 				}

--- a/integrations/terraform/tfschema/vnet/v1/vnet_config_terraform.go
+++ b/integrations/terraform/tfschema/vnet/v1/vnet_config_terraform.go
@@ -51,9 +51,11 @@ func GenSchemaVnetConfig(ctx context.Context) (github_com_hashicorp_terraform_pl
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"kind": {
-			Description: "",
-			Optional:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Computed:      true,
+			Description:   "",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"metadata": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
@@ -73,23 +75,17 @@ func GenSchemaVnetConfig(ctx context.Context) (github_com_hashicorp_terraform_pl
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"name": {
-					Description: "name is an object name.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"namespace": {
-					Description: "namespace is object namespace. The field should be called \"namespace\" when it returns in Teleport 2.4.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-				"revision": {
-					Description: "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					Computed:      true,
+					Description:   "name is an object name.",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
-			Description: "",
-			Optional:    true,
+			Computed:      true,
+			Description:   "",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 		},
 		"spec": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
@@ -112,14 +108,18 @@ func GenSchemaVnetConfig(ctx context.Context) (github_com_hashicorp_terraform_pl
 			Optional:    true,
 		},
 		"sub_kind": {
-			Description: "",
-			Optional:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Computed:      true,
+			Description:   "",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"version": {
-			Description: "",
-			Optional:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Computed:      true,
+			Description:   "",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 	}}, nil
 }
@@ -210,23 +210,6 @@ func CopyVnetConfigFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 						}
 					}
 					{
-						a, ok := tf.Attrs["namespace"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.namespace"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"VnetConfig.metadata.namespace", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Namespace = t
-							}
-						}
-					}
-					{
 						a, ok := tf.Attrs["description"]
 						if !ok {
 							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.description"})
@@ -276,23 +259,6 @@ func CopyVnetConfigFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.expires"})
 						}
 						CopyFromTimestamp(diags, a, &obj.Expires)
-					}
-					{
-						a, ok := tf.Attrs["revision"]
-						if !ok {
-							diags.Append(attrReadMissingDiag{"VnetConfig.metadata.revision"})
-						} else {
-							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								diags.Append(attrReadConversionFailureDiag{"VnetConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-							} else {
-								var t string
-								if !v.Null && !v.Unknown {
-									t = string(v.Value)
-								}
-								obj.Revision = t
-							}
-						}
 					}
 				}
 			}
@@ -505,28 +471,6 @@ func CopyVnetConfigToTerraform(ctx context.Context, obj *github_com_gravitationa
 						}
 					}
 					{
-						t, ok := tf.AttrTypes["namespace"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"VnetConfig.metadata.namespace"})
-						} else {
-							v, ok := tf.Attrs["namespace"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"VnetConfig.metadata.namespace", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"VnetConfig.metadata.namespace", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Namespace) == ""
-							}
-							v.Value = string(obj.Namespace)
-							v.Unknown = false
-							tf.Attrs["namespace"] = v
-						}
-					}
-					{
 						t, ok := tf.AttrTypes["description"]
 						if !ok {
 							diags.Append(attrWriteMissingDiag{"VnetConfig.metadata.description"})
@@ -605,28 +549,6 @@ func CopyVnetConfigToTerraform(ctx context.Context, obj *github_com_gravitationa
 						} else {
 							v := CopyToTimestamp(diags, obj.Expires, t, tf.Attrs["expires"])
 							tf.Attrs["expires"] = v
-						}
-					}
-					{
-						t, ok := tf.AttrTypes["revision"]
-						if !ok {
-							diags.Append(attrWriteMissingDiag{"VnetConfig.metadata.revision"})
-						} else {
-							v, ok := tf.Attrs["revision"].(github_com_hashicorp_terraform_plugin_framework_types.String)
-							if !ok {
-								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
-								if err != nil {
-									diags.Append(attrWriteGeneralError{"VnetConfig.metadata.revision", err})
-								}
-								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
-								if !ok {
-									diags.Append(attrWriteConversionFailureDiag{"VnetConfig.metadata.revision", "github.com/hashicorp/terraform-plugin-framework/types.String"})
-								}
-								v.Null = string(obj.Revision) == ""
-							}
-							v.Value = string(obj.Revision)
-							v.Unknown = false
-							tf.Attrs["revision"] = v
 						}
 					}
 				}


### PR DESCRIPTION
The terraform schema generator expects lowercase field names, so every `exclude_fields` and `computed_fields` directive did nothing.

changelog: fixed `metadata.revision` not being excluded from the `teleport_vnet_config` terraform schema. Users with existing state may need to run `terraform refresh` if `terraform show` fails with "unsupported attribute revision".


## Manual Test Plan

### Test Environment
Any system with Terraform configured to talk to a Teleport cluster

### Test Cases
- [x] Create `teleport_vnet_config` with Terraform
- [x] Update `teleport_vnet_config`
- [x] Destroy `teleport_vnet_config` and confirm reset to defaults
