### PR TITLE
[proxy] add kube server watcher with auth fallback

### DIFF
--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -63,6 +63,7 @@ import (
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/kube/proxy"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
+	kubewatcher "github.com/gravitational/teleport/lib/kube/proxy/watcher"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
@@ -321,14 +322,11 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	require.NoError(t, err)
 
 	// Create kubernetes proxy server.
-	kubeServersWatcher, err := services.NewKubeServerWatcher(
+	kubeServersWatcher, err := kubewatcher.NewProxyKubeServerWatcher(
 		testCtx.Context,
-		services.KubeServerWatcherConfig{
-			ResourceWatcherConfig: services.ResourceWatcherConfig{
-				Component: teleport.ComponentKube,
-				Client:    client,
-			},
-			KubernetesServerGetter: client,
+		kubewatcher.ProxyKubeServerWatcherConfig{
+			AccessPoint:    client,
+			FallbackGetter: client,
 		},
 	)
 	require.NoError(t, err)
@@ -424,8 +422,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 
 	// Ensure watcher has the correct list of clusters.
 	require.Eventually(t, func() bool {
-		kubeServers, err := kubeServersWatcher.CurrentResources(ctx)
-		return err == nil && len(kubeServers) == len(cfg.Clusters)
+		return kubeServersWatcher.ResourceCount() == len(cfg.Clusters)
 	}, 3*time.Second, time.Millisecond*100)
 
 	return testCtx

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -20,6 +20,8 @@ package proxy
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,9 +29,11 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -45,6 +49,7 @@ import (
 	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
@@ -67,27 +72,7 @@ var (
 	stdinContent             = []byte("stdin_data")
 )
 
-func TestExecKubeService(t *testing.T) {
-	kubeMock, err := testingkubemock.NewKubeAPIMock()
-	require.NoError(t, err)
-	t.Cleanup(func() { kubeMock.Close() })
-
-	// creates a Kubernetes service with a configured cluster pointing to mock api server
-	testCtx := SetupTestContext(
-		t.Context(),
-		t,
-		TestConfig{
-			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-			Scope:    scopedTestScope,
-			ScopesFeatures: scopes.Features{
-				Enabled:         true,
-				AgentPinEnabled: true,
-			},
-		},
-	)
-
-	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
-
+func testExecKubeService(t *testing.T, testCtx *TestContext) {
 	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
 	userWithSingleKubeUser, _ := testCtx.CreateUserAndRole(
 		testCtx.Context,
@@ -105,6 +90,7 @@ func TestExecKubeService(t *testing.T) {
 		userWithSingleKubeUser.GetName(),
 		kubeCluster,
 	)
+	require.NotNil(t, configWithSingleKubeUser)
 
 	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
 	userMultiKubeUsers, _ := testCtx.CreateUserAndRole(
@@ -123,6 +109,8 @@ func TestExecKubeService(t *testing.T) {
 		userMultiKubeUsers.GetName(),
 		kubeCluster,
 	)
+	require.NotNil(t, configMultiKubeUsers)
+
 	scopedWithSingleKubeUser, scopedSingleKubeUserRole := testCtx.CreateUserAndScopedRole(
 		t,
 		"scoped-"+username,
@@ -342,6 +330,7 @@ func TestExecKubeService(t *testing.T) {
 			wantErr: true,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var (
@@ -350,7 +339,7 @@ func TestExecKubeService(t *testing.T) {
 				stderr     = &bytes.Buffer{}
 			)
 
-			_, err = stdinWrite.Write(stdinContent)
+			_, err := stdinWrite.Write(stdinContent)
 			require.NoError(t, err)
 
 			streamOpts := remotecommand.StreamOptions{
@@ -387,6 +376,150 @@ func TestExecKubeService(t *testing.T) {
 			require.Equal(t, fmt.Sprintf("%s\n%s", podContainerName, string(stdinContent)), stderr.String())
 		})
 	}
+}
+
+func TestExecKubeService(t *testing.T) {
+	kubeMock, err := testingkubemock.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
+	// creates a Kubernetes service with a configured cluster pointing to mock api server
+	testCtx := SetupTestContext(t.Context(), t, TestConfig{
+		Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+		Scope:    scopedTestScope,
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
+
+	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+	testExecKubeService(t, testCtx)
+}
+
+// failingWatcherAccessPoint is a mocked accesspoint which when triggered closes the watcher and forwards an error.
+type failingWatcherAccessPoint struct {
+	authclient.ClientI
+	failCh          chan struct{} // closed when failure is triggered
+	err             atomic.Value
+	newWatcherFails atomic.Int32
+}
+
+func newFailingWatcherAccessPoint() (*failingWatcherAccessPoint, func(error)) {
+	a := &failingWatcherAccessPoint{
+		failCh: make(chan struct{}),
+	}
+
+	trigger := func(err error) {
+		a.err.Store(err)
+		close(a.failCh)
+	}
+
+	return a, trigger
+}
+
+func (f *failingWatcherAccessPoint) failed() bool {
+	select {
+	case <-f.failCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (f *failingWatcherAccessPoint) failureErr() error {
+	if v := f.err.Load(); v != nil {
+		return v.(error)
+	}
+	return nil
+}
+
+func (f *failingWatcherAccessPoint) NewWatcher(ctx context.Context, w types.Watch) (types.Watcher, error) {
+	if f.failed() {
+		f.newWatcherFails.Add(1)
+		return nil, trace.Wrap(f.failureErr(), "injected failure: NewWatcher")
+	}
+
+	watcher, err := f.ClientI.NewWatcher(ctx, w)
+	if err != nil {
+		return nil, err
+	}
+
+	return &failingWatcher{
+		Watcher: watcher,
+		failCh:  f.failCh,
+		errFn:   f.failureErr,
+	}, nil
+}
+
+type failingWatcher struct {
+	types.Watcher
+
+	failCh <-chan struct{}
+	errFn  func() error
+
+	doneOnce sync.Once
+	doneCh   chan struct{}
+}
+
+func (f *failingWatcher) Done() <-chan struct{} {
+	f.doneOnce.Do(func() {
+		f.doneCh = make(chan struct{})
+
+		go func() {
+			defer close(f.doneCh)
+
+			select {
+			case <-f.Watcher.Done():
+			case <-f.failCh:
+			}
+		}()
+	})
+
+	return f.doneCh
+}
+
+func (f *failingWatcher) Error() error {
+	select {
+	case <-f.failCh:
+		return trace.Wrap(f.errFn(), "injected failure: watcher stream")
+	default:
+		return f.Watcher.Error()
+	}
+}
+
+// TestExecKubeServiceWithFaultyPrimary tests that exec still works when the primary access point watcher
+// is failing.
+func TestExecKubeServiceWithFaultyPrimary(t *testing.T) {
+	kubeMock, err := testingkubemock.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
+	failingAccessPoint, triggerFailure := newFailingWatcherAccessPoint()
+
+	// creates a Kubernetes service with a configured cluster pointing to mock api server
+	testCtx := SetupTestContext(t.Context(), t, TestConfig{
+		Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+		WrapAuthClient: func(client authclient.ClientI) authclient.ClientI {
+			failingAccessPoint.ClientI = client
+			return failingAccessPoint
+		},
+		Scope: scopedTestScope,
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
+	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+
+	triggerFailure(errors.New("injected failure"))
+
+	// Ensure the watcher has failed the fallback back path is now in effect.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Greater(c, failingAccessPoint.newWatcherFails.Load(), int32(1))
+	}, time.Minute, time.Second)
+
+	testExecKubeService(t, testCtx)
 }
 
 type generateExecRequestConfig struct {

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/healthcheck"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/inventory"
+	kubewatcher "github.com/gravitational/teleport/lib/kube/proxy/watcher"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/multiplexer"
@@ -116,7 +117,7 @@ type TLSServerConfig struct {
 	// kubernetes cluster name. Proxy uses this map to route requests to the correct
 	// kubernetes_service. The servers are kept in memory to avoid making unnecessary
 	// unmarshal calls followed by filtering and to improve memory usage.
-	KubernetesServersWatcher *services.GenericWatcher[types.KubeServer, readonly.KubeServer]
+	KubernetesServersWatcher *kubewatcher.ProxyKubeServerWatcher
 	// PROXYProtocolMode controls behavior related to unsigned PROXY protocol headers.
 	PROXYProtocolMode multiplexer.PROXYProtocolMode
 	// InventoryHandle is used to send kube server heartbeats via the inventory control stream.
@@ -812,12 +813,7 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 			return []types.KubeServer{srv}, nil
 		}, nil
 	case ProxyService:
-		return func(ctx context.Context, name string) ([]types.KubeServer, error) {
-			servers, err := t.KubernetesServersWatcher.CurrentResourcesWithFilter(ctx, func(ks readonly.KubeServer) bool {
-				return ks.GetCluster().GetName() == name
-			})
-			return servers, trace.Wrap(err)
-		}, nil
+		return t.KubernetesServersWatcher.GetKubeServersForClusterName, nil
 	case LegacyProxyService:
 		return func(ctx context.Context, name string) ([]types.KubeServer, error) {
 			// If this is a legacy kube proxy, then we need to return the local kube servers if
@@ -825,9 +821,7 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 			// and forward the request to the next proxy.
 			kube, err := t.getKubeClusterWithServiceLabels(name)
 			if err != nil {
-				servers, err := t.KubernetesServersWatcher.CurrentResourcesWithFilter(ctx, func(ks readonly.KubeServer) bool {
-					return ks.GetCluster().GetName() == name
-				})
+				servers, err := t.KubernetesServersWatcher.GetKubeServersForClusterName(ctx, name)
 				return servers, trace.Wrap(err)
 			}
 			srv, err := types.NewKubernetesServerV3FromCluster(kube, "", t.HostID)

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -67,6 +67,7 @@ import (
 	"github.com/gravitational/teleport/lib/healthcheck"
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
+	kubewatcher "github.com/gravitational/teleport/lib/kube/proxy/watcher"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
@@ -288,6 +289,11 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		authClient = cfg.WrapAuthClient(client)
 	}
 
+	var accessPoint authclient.ClientI = client
+	if cfg.WrapAuthClient != nil {
+		accessPoint = cfg.WrapAuthClient(client)
+	}
+
 	// Create kubernetes service server.
 	testCtx.KubeServer, err = NewTLSServer(TLSServerConfig{
 		ForwarderConfig: ForwarderConfig{
@@ -306,7 +312,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			// "node-sync" as session recording mode.
 			Emitter:           testCtx.Emitter,
 			DataDir:           t.TempDir(),
-			CachingAuthClient: client,
+			CachingAuthClient: accessPoint,
 			HostID:            testCtx.HostID,
 			Context:           testCtx.Context,
 			KubeconfigPath:    kubeConfigLocation,
@@ -323,7 +329,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		},
 		DynamicLabels: nil,
 		TLS:           kubeServiceTLSConfig.Clone(),
-		AccessPoint:   client,
+		AccessPoint:   accessPoint,
 		LimiterConfig: limiter.Config{
 			MaxConnections: 1000,
 		},
@@ -342,14 +348,15 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	require.NoError(t, err)
 
 	// Create kubernetes proxy server.
-	kubeServersWatcher, err := services.NewKubeServerWatcher(
+	kubeServersWatcher, err := kubewatcher.NewProxyKubeServerWatcher(
 		testCtx.Context,
-		services.KubeServerWatcherConfig{
-			ResourceWatcherConfig: services.ResourceWatcherConfig{
-				Component: teleport.ComponentKube,
-				Client:    client,
-			},
-			KubernetesServerGetter: client,
+		kubewatcher.ProxyKubeServerWatcherConfig{
+			Logger:           logtest.NewLogger(),
+			AccessPoint:      accessPoint,
+			FallbackGetter:   proxyAuthClient,
+			PrimaryTimeout:   time.Second,
+			FallbackInterval: time.Second,
+			MaxRetryPeriod:   time.Second,
 		},
 	)
 	require.NoError(t, err)
@@ -408,7 +415,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			PROXYSigner: &multiplexer.PROXYSigner{},
 		},
 		TLS:                      proxyTLSConfig.Clone(),
-		AccessPoint:              client,
+		AccessPoint:              accessPoint,
 		KubernetesServersWatcher: kubeServersWatcher,
 		LimiterConfig: limiter.Config{
 			MaxConnections: 1000,
@@ -445,8 +452,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 
 	// Ensure watcher has the correct list of clusters.
 	require.Eventually(t, func() bool {
-		kubeServers, err := kubeServersWatcher.CurrentResources(ctx)
-		return err == nil && len(kubeServers) == len(cfg.Clusters)
+		return kubeServersWatcher.ResourceCount() == len(cfg.Clusters)
 	}, 3*time.Second, time.Millisecond*100)
 
 	return testCtx

--- a/lib/kube/proxy/watcher/watcher.go
+++ b/lib/kube/proxy/watcher/watcher.go
@@ -1,0 +1,566 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package watcher
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/defaults"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+const eventBufferSize = 128
+const componentName = "kube_server_watcher"
+
+// KubernetesServerGetter defines interface for fetching kubernetes server resources.
+type KubernetesServerGetter interface {
+	// GetKubernetesServers returns all kubernetes server resources.
+	GetKubernetesServers(context.Context) ([]types.KubeServer, error)
+}
+
+type KubeServerWatcherGetter interface {
+	KubernetesServerGetter
+	types.Events
+}
+
+// ProxyKubeServerWatcherConfig is the configuration struct for [ProxyKubeServerWatcher].
+type ProxyKubeServerWatcherConfig struct {
+	Logger *slog.Logger
+
+	// MaxRetryPeriod is the maximum retry duration for watcher backoff.
+	MaxRetryPeriod time.Duration
+
+	// AccessPoint is the primary source of kube servers.
+	AccessPoint KubeServerWatcherGetter
+
+	// PrimaryTimeout is the duration after which the primary access point is considered unhealthy.
+	PrimaryTimeout time.Duration
+
+	// FallbackGetter is used to fetch kube servers when the primary access point is considered unhealthy.
+	FallbackGetter KubernetesServerGetter
+
+	// FallbackInterval is the minimum duration between attempts to fetch kube servers from the fallback getter when the primary access point is unhealthy.
+	FallbackInterval time.Duration
+}
+
+// CheckAndSetDefaults checks the configuration and sets default values.
+func (cfg *ProxyKubeServerWatcherConfig) CheckAndSetDefaults() error {
+	const defaultPrimaryTimeout = time.Minute
+	const defaultFallbackInterval = time.Minute
+
+	if cfg.AccessPoint == nil {
+		return trace.BadParameter("missing AccessPoint")
+	}
+	if cfg.FallbackGetter == nil {
+		return trace.BadParameter("missing FallbackGetter")
+	}
+
+	if cfg.Logger == nil {
+		cfg.Logger = slog.With(teleport.ComponentKey, componentName)
+	}
+	if cfg.MaxRetryPeriod <= 0 {
+		cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
+	}
+	if cfg.PrimaryTimeout <= 0 {
+		cfg.PrimaryTimeout = defaultPrimaryTimeout
+	}
+	if cfg.FallbackInterval <= 0 {
+		cfg.FallbackInterval = defaultFallbackInterval
+	}
+
+	return nil
+}
+
+// ProxyKubeServerWatcher provides a watcher for kube servers that can tolerate local cache staleness.
+// This is used by the proxy to watch for kube servers and should never be used in Agents, faulty cache
+// on agents would lead to an excessive amount of fallback calls to the auth server and cause performance issues.
+// This watcher should only be used when the cache staleness is in the critical connection path to keep access
+// functional in a degraded state. This is currently strongly typed to kube servers but could be made more generic if needed in the future.
+type ProxyKubeServerWatcher struct {
+	ProxyKubeServerWatcherConfig
+
+	// ctx is a context controlling the lifetime of this resourceWatcher
+	// instance.
+	ctx context.Context
+
+	// retry is used to manage backoff logic for watchers.
+	retry retryutils.Retry
+
+	// cancel is used to cancel the context controlling the lifetime of this instance.
+	cancel context.CancelFunc
+
+	// initC is closed when the watcher is initialized successfully for the first time.
+	initC    chan struct{}
+	initOnce sync.Once
+
+	// rw protects below fields
+	rw sync.RWMutex
+
+	// current holds a map of the currently known servers.
+	current map[serverKey]types.KubeServer
+
+	// nextFallbackFetch is the next point in time when the watcher should attempt to fetch from the fallback getter
+	// if the primary access point is observed to be failing.
+	nextFallbackFetch time.Time
+
+	// singleFlighter is used to suppress multiple simultaneous fetches from the fallback
+	// getter when the primary access point is observed to be failing.
+	singleFlighter singleflight.Group
+}
+
+// serverKey maps [types.KubeServer] into a local cache.
+type serverKey struct {
+	Name, HostID string
+}
+
+// NewProxyKubeServerWatcher creates a new instance of [ProxyKubeServerWatcher]
+// ctx is the lifetime of the watcher.
+func NewProxyKubeServerWatcher(ctx context.Context, cfg ProxyKubeServerWatcherConfig) (*ProxyKubeServerWatcher, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err, "checking and setting defaults")
+	}
+
+	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
+		First:  retryutils.FullJitter(cfg.MaxRetryPeriod / 10),
+		Step:   cfg.MaxRetryPeriod / 5,
+		Max:    cfg.MaxRetryPeriod,
+		Jitter: retryutils.HalfJitter,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating retry")
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	w := &ProxyKubeServerWatcher{
+		ProxyKubeServerWatcherConfig: cfg,
+
+		cancel: cancel,
+		ctx:    ctx,
+		retry:  retry,
+		initC:  make(chan struct{}),
+	}
+
+	go w.runWatchLoop()
+
+	return w, nil
+}
+
+// isHealthyLocked checks if the watcher is currently healthy, it should be called with rw lock held.
+func (w *ProxyKubeServerWatcher) isHealthyLocked() bool {
+	return w.nextFallbackFetch.IsZero()
+}
+
+// shouldFetchFromFallback determines if the watcher should fetch from the fallback getter based on the health of the primary access point and the next fallback fetch time.
+func (w *ProxyKubeServerWatcher) shouldFetchFromFallback(now time.Time) bool {
+	w.rw.RLock()
+	defer w.rw.RUnlock()
+
+	if w.isHealthyLocked() {
+		return false
+	}
+
+	if now.Before(w.nextFallbackFetch) {
+		return false
+	}
+
+	return true
+}
+
+// markUnhealthyOnInitTimeout marks the watcher as unhealthy if the initial watcher creation and init process takes longer than the configured primary timeout.
+func (w *ProxyKubeServerWatcher) markUnhealthyOnInitTimeout() {
+	// Time is taken before the lock is acquired to capture the time when the timeout was observed, not when the lock is acquired.
+	now := time.Now()
+
+	w.rw.Lock()
+	defer w.rw.Unlock()
+
+	if w.nextFallbackFetch.IsZero() {
+		// Watcher is considered unhealthy after the initial timeout, given we know the timeout has elapsed, set
+		// to now for immidate fetching from fallback on next check.
+		w.nextFallbackFetch = now
+	}
+}
+
+// markUnhealthyOnWatchError handles errors from the watch loop.
+func (w *ProxyKubeServerWatcher) markUnhealthyOnWatchError(err error) {
+	// Time is taken before the lock is acquired to capture the time when the timeout was observed, not when the lock is acquired.
+	now := time.Now()
+	w.rw.Lock()
+	defer w.rw.Unlock()
+	if w.nextFallbackFetch.IsZero() {
+		w.nextFallbackFetch = now.Add(retryutils.SeventhJitter(w.PrimaryTimeout))
+		w.Logger.WarnContext(w.ctx, "Kube Server Watcher has failed.", "error", err, "next_fallback_fetch", w.nextFallbackFetch.Format(time.RFC3339))
+	}
+}
+
+// fillEventBuf fills the given buffer with events from the watcher channel until the buffer reaches the given maxSize, the context is canceled or the watcher is closed.
+func fillEventBuf(ctx context.Context, buf []types.Event, w types.Watcher, maxSize int) (out []types.Event) {
+	out = buf // does not reset, caller is responsible for clearing the buffer after processing
+
+	for len(out) < maxSize {
+		select {
+		case <-w.Done():
+			return
+		case <-ctx.Done():
+			return
+		case event := <-w.Events():
+			out = append(out, event)
+		default:
+			return
+		}
+	}
+	return
+}
+
+// createWatcherAndInit creates a new watcher and waits for the initial event to mark the watcher as initialized.
+func (w *ProxyKubeServerWatcher) createWatcherAndInit() (_ types.Watcher, err error) {
+	watcher, err := w.AccessPoint.NewWatcher(w.ctx, types.Watch{
+		Name:            componentName,
+		MetricComponent: componentName,
+		Kinds:           []types.WatchKind{{Kind: types.KindKubeServer}},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating a watcher")
+	}
+
+	defer func() {
+		if err != nil {
+			watcher.Close()
+		}
+	}()
+
+	watcherInitTimeout := time.NewTimer(w.PrimaryTimeout)
+	defer watcherInitTimeout.Stop()
+
+	for {
+		select {
+		case <-watcher.Done():
+			return nil, trace.ConnectionProblem(watcher.Error(), "watcher is closed: %v", watcher.Error())
+		case <-w.ctx.Done():
+			return nil, trace.ConnectionProblem(w.ctx.Err(), "context is closing")
+		case event := <-watcher.Events():
+			if event.Type != types.OpInit {
+				return nil, trace.BadParameter("expected init event, got %v instead", event.Type)
+			}
+		case <-watcherInitTimeout.C:
+			// Do not return timeout here but mark the failure and continue waiting.
+			// It's possible the watcher will recover eventually. If using the cache,
+			// on error the cache will close the watcher and we handle that separately.
+			w.markUnhealthyOnInitTimeout()
+			w.Logger.WarnContext(w.ctx, "Watcher failed to initialize within the expected time.", "timeout", w.PrimaryTimeout.String())
+			continue
+		}
+		break
+	}
+
+	return watcher, nil
+}
+
+// fetchAndInitializeState fetches the initial state of kube servers and applies any events that were queued during the fetch.
+// If successful, the watcher's cache is initialized and any faults are cleared.
+func (w *ProxyKubeServerWatcher) fetchAndInitializeState(watcher types.Watcher) error {
+	newCurrent, err := w.getAllKubeServers(w.ctx, w.AccessPoint)
+	if err != nil {
+		return trace.Wrap(err, "fetching from primary")
+	}
+
+	var seen int
+	queuedEvents := len(watcher.Events())
+	eventBuf := make([]types.Event, 0, eventBufferSize)
+
+	// Catch up on queued events that happened while we were fetching the initial state, these are applied to the
+	// new state we just fetched, so we end up with a consistent view of the world at the point in time when the watcher was created.
+	for seen < queuedEvents {
+		select {
+		case <-watcher.Done():
+			return trace.ConnectionProblem(watcher.Error(), "watcher is closed: %v", watcher.Error())
+		case <-w.ctx.Done():
+			return trace.ConnectionProblem(w.ctx.Err(), "context is closing")
+		case event := <-watcher.Events():
+			eventBuf = append(eventBuf[:0], event)
+			eventBuf = fillEventBuf(w.ctx, eventBuf, watcher, eventBufferSize)
+			// no lock, events applied to local copy of the new state.
+			if err := applyEvents(w.ctx, w.Logger, newCurrent, eventBuf); err != nil {
+				return trace.Wrap(err, "applying events to new state")
+			}
+			seen += len(eventBuf)
+			clear(eventBuf)
+		}
+	}
+
+	w.rw.Lock()
+	w.nextFallbackFetch = time.Time{} // mark as healthy
+	w.current = newCurrent
+	w.rw.Unlock()
+
+	w.initOnce.Do(func() {
+		close(w.initC)
+	})
+
+	// At this point watcher is successfully initialized and the cache is warmed up, we can reset the retry backoff and start processing events.
+	w.retry.Reset()
+	return nil
+
+}
+
+// watch spawns a watcher on [types.KindKubeServer] and if successful, initializes the local cache and fetches events.
+func (w *ProxyKubeServerWatcher) watch() error {
+	watcher, err := w.createWatcherAndInit()
+	if err != nil {
+		return trace.Wrap(err, "creating watcher and waiting for init")
+	}
+	defer watcher.Close()
+
+	if err := w.fetchAndInitializeState(watcher); err != nil {
+		return trace.Wrap(err, "fetching initial state and initializing watcher")
+	}
+
+	eventBuf := make([]types.Event, 0, eventBufferSize)
+	for {
+		select {
+		case <-watcher.Done():
+			return trace.ConnectionProblem(watcher.Error(), "watcher is closed: %v", watcher.Error())
+		case <-w.ctx.Done():
+			return trace.ConnectionProblem(w.ctx.Err(), "context is closing")
+		case event := <-watcher.Events():
+			eventBuf = append(eventBuf[:0], event)
+			eventBuf = fillEventBuf(w.ctx, eventBuf, watcher, eventBufferSize)
+			w.rw.Lock()
+			err := applyEvents(w.ctx, w.Logger, w.current, eventBuf)
+			w.rw.Unlock()
+			if err != nil {
+				return trace.Wrap(err, "applying events")
+			}
+			clear(eventBuf)
+		}
+	}
+}
+
+// kubeServerKey returns the key used to store the given kube server in the watcher's cache.
+func kubeServerKey(resource types.KubeServer) serverKey {
+	return serverKey{
+		Name:   resource.GetName(),
+		HostID: resource.GetHostID(),
+	}
+}
+
+// kubeServerDeleteKey returns the key used to delete the given kube server from the watcher's cache.
+func kubeServerDeleteKey(resource types.Resource) serverKey {
+	return serverKey{
+		Name: resource.GetName(),
+		// On delete events, the server description is populated with the host ID.
+		HostID: resource.GetMetadata().Description,
+	}
+}
+
+// getAllKubeServers fetches all kube servers from the given getter and returns them as a map keyed by the watcher's cache keys.
+func (w *ProxyKubeServerWatcher) getAllKubeServers(ctx context.Context, getter KubernetesServerGetter) (map[serverKey]types.KubeServer, error) {
+	resources, err := getter.GetKubernetesServers(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	current := make(map[serverKey]types.KubeServer, len(resources))
+	for _, resource := range resources {
+		current[kubeServerKey(resource)] = resource
+	}
+	return current, nil
+}
+
+// maybeFetchFromUpstream attempts to fetch the kube servers from the auth server if the cache is cold and
+// the next cold fetch time has been reached. This is used to throttle calls to the auth server when the cache is cold.
+func (w *ProxyKubeServerWatcher) maybeFetchFromUpstream(ctx context.Context) error {
+	now := time.Now()
+
+	if !w.shouldFetchFromFallback(now) {
+		return nil
+	}
+
+	ch := w.singleFlighter.DoChan("collection", func() (any, error) {
+		if !w.shouldFetchFromFallback(now) {
+			return nil, nil
+		}
+
+		newCurrent, err := w.getAllKubeServers(w.ctx, w.FallbackGetter)
+		w.rw.Lock()
+		defer w.rw.Unlock()
+
+		if w.isHealthyLocked() {
+			// If the watcher became healhy while we were fetching from the fallback use the primary data.
+			return nil, nil
+		}
+
+		// Reset the fetcher time. This is done also if the call fails.
+		// The time is added to the timestamp from the entry, which will precede the fetch time.
+		w.nextFallbackFetch = now.Add(retryutils.SeventhJitter(w.FallbackInterval))
+		if err != nil {
+			return nil, trace.Wrap(err, "fetching from fallback")
+		}
+
+		w.current = newCurrent
+		return nil, nil
+	})
+
+	select {
+	case res := <-ch:
+		return trace.Wrap(res.Err)
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err(), "context is closing")
+	}
+}
+
+// runWatchLoop is the main event loop of the watcher.
+func (w *ProxyKubeServerWatcher) runWatchLoop() {
+	for {
+		err := w.watch()
+		select {
+		case <-w.ctx.Done():
+			return
+		default:
+		}
+
+		if w.ctx.Err() != nil {
+			return
+		}
+
+		if err != nil {
+			w.markUnhealthyOnWatchError(err)
+		}
+
+		startedWaiting := time.Now()
+		select {
+		case t := <-w.retry.After():
+			w.Logger.DebugContext(w.ctx, "Attempting to restart watch after waiting", "waited", t.Sub(startedWaiting).String())
+			w.retry.Inc()
+		case <-w.ctx.Done():
+			w.Logger.DebugContext(w.ctx, "Closed, returning from watch loop.")
+			return
+		}
+		if err != nil {
+			w.Logger.WarnContext(w.ctx, "Restart watch on error", "error", err)
+		}
+	}
+}
+
+// applyEvents takes events from the watcher channel and applies them to the given resources map
+func applyEvents(ctx context.Context, log *slog.Logger, resources map[serverKey]types.KubeServer, events []types.Event) error {
+	for _, event := range events {
+		if event.Resource == nil || event.Resource.GetKind() != types.KindKubeServer {
+			log.WarnContext(ctx, "Received unexpected event", "event", logutils.StringerAttr(event))
+			continue
+		}
+
+		switch event.Type {
+		case types.OpDelete:
+			delete(resources, kubeServerDeleteKey(event.Resource))
+		case types.OpPut:
+			srv, err := types.ConvertResource[types.KubeServer](event.Resource)
+			if err != nil {
+				log.WarnContext(ctx, "Failed to convert event resource",
+					"resource", event.Resource.GetKind(),
+					"error", err,
+				)
+				continue
+			}
+
+			resources[kubeServerKey(srv)] = srv
+		default:
+			log.WarnContext(ctx, "Skipping unsupported event type", "event_type", event.Type)
+			return trace.BadParameter("unsupported event type: %v", event.Type)
+		}
+	}
+
+	return nil
+}
+
+// Done returns a channel that signals resource watcher closure.
+func (w *ProxyKubeServerWatcher) Done() <-chan struct{} {
+	return w.ctx.Done()
+}
+
+// Close closes the resource watcher and cancels all the functions.
+func (w *ProxyKubeServerWatcher) Close() {
+	w.cancel()
+}
+
+// IsInitialized is a non-blocking way to check if the watcher is initialized.
+func (w *ProxyKubeServerWatcher) IsInitialized() bool {
+	select {
+	case <-w.initC:
+		return true
+	default:
+		return false
+	}
+}
+
+// WaitInitialization blocks until watcher is initialized.
+func (w *ProxyKubeServerWatcher) WaitInitialization() error {
+	const initTickerPeriod = 5 * time.Second
+
+	ticker := time.NewTicker(initTickerPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.initC:
+			return nil
+		case <-ticker.C:
+			w.Logger.DebugContext(w.ctx, "ProxyKubeServerWatcher is not yet initialized.")
+		case <-w.ctx.Done():
+			return trace.ConnectionProblem(nil, "Failed to initialize, context closing")
+		}
+	}
+}
+
+// GetKubeServersForClusterName returns a copy of the resources known to the watcher that match the given cluster name.
+func (w *ProxyKubeServerWatcher) GetKubeServersForClusterName(ctx context.Context, clusterName string) ([]types.KubeServer, error) {
+	if err := w.maybeFetchFromUpstream(ctx); err != nil {
+		// This is an indication things are in a very bad state, it means the primary acccess point is not responsive
+		// and the fallback getter is failing. Log this as a warning.
+		w.Logger.WarnContext(ctx, "Unhealthy watcher failed to fetch from upstream", "error", err)
+		return nil, trace.Wrap(err)
+	}
+
+	w.rw.RLock()
+	defer w.rw.RUnlock()
+
+	var out []types.KubeServer
+	for _, resource := range w.current {
+		if resource.GetCluster().GetName() == clusterName {
+			out = append(out, types.KubeServer.Copy(resource))
+		}
+	}
+
+	return out, nil
+}
+
+// ResourceCount returns the number of resources currently known to the watcher. It does not trigger a stale reread, only returns the number of known items.
+func (w *ProxyKubeServerWatcher) ResourceCount() int {
+	w.rw.RLock()
+	defer w.rw.RUnlock()
+	return len(w.current)
+}

--- a/lib/kube/proxy/watcher/watcher_test.go
+++ b/lib/kube/proxy/watcher/watcher_test.go
@@ -1,0 +1,906 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// mockKubeServerWatcherGetter is a testify mock for the [services.KubernetesServerWatcherGetter] interface.
+type mockKubeServerWatcherGetter struct {
+	mock.Mock
+}
+
+func (m *mockKubeServerWatcherGetter) GetKubernetesServers(ctx context.Context) ([]types.KubeServer, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]types.KubeServer), args.Error(1)
+}
+
+func (m *mockKubeServerWatcherGetter) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
+	args := m.Called(ctx, watch)
+	if w := args.Get(0); w != nil {
+		return w.(types.Watcher), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+// fakeWatcher is a mocked implemenation of the [types.Watcher] interface that allows sending events and simulating errors.
+type fakeWatcher struct {
+	events chan types.Event
+	done   chan struct{}
+	err    error
+
+	once sync.Once
+}
+
+func newFakeWatcher(buffer int) *fakeWatcher {
+	return &fakeWatcher{
+		events: make(chan types.Event, buffer),
+		done:   make(chan struct{}),
+	}
+}
+
+func (f *fakeWatcher) Events() <-chan types.Event {
+	return f.events
+}
+
+func (f *fakeWatcher) Done() <-chan struct{} {
+	return f.done
+}
+
+func (f *fakeWatcher) Error() error {
+	return f.err
+}
+
+func (f *fakeWatcher) Close() error {
+	f.once.Do(func() {
+		close(f.done)
+		close(f.events)
+	})
+	return nil
+}
+
+func (f *fakeWatcher) send(event types.Event) {
+	f.events <- event
+}
+
+func (f *fakeWatcher) closeWithError(err error) {
+	f.err = err
+	f.Close()
+}
+
+func isHealthy(w *ProxyKubeServerWatcher) bool {
+	w.rw.RLock()
+	defer w.rw.RUnlock()
+	return w.isHealthyLocked()
+}
+
+func markUnhealthy(w *ProxyKubeServerWatcher) {
+	w.rw.Lock()
+	defer w.rw.Unlock()
+	w.nextFallbackFetch = time.Now() // ensure watcher is considered broken
+}
+
+func markHealthy(w *ProxyKubeServerWatcher) {
+	w.rw.Lock()
+	defer w.rw.Unlock()
+	w.nextFallbackFetch = time.Time{} // reset nextFallbackFetch to simulate that the watcher is healthy again
+}
+
+// newTestKubeServer is a testing helper to create a new Kubernetes server with the given name and hostID.
+func newTestKubeServer(t *testing.T, name, hostID string) types.KubeServer {
+	t.Helper()
+	return newTestKubeServerWithRevsion(t, name, hostID, 0)
+}
+
+func newTestKubeServerWithRevsion(t *testing.T, name, hostID string, revsion int) types.KubeServer {
+	t.Helper()
+	s, err := types.NewKubernetesServerV3(
+		types.Metadata{
+			Name:        name,
+			Description: hostID,
+			Revision:    fmt.Sprintf("%d", revsion),
+		},
+		types.KubernetesServerSpecV3{
+			HostID: hostID,
+			Cluster: &types.KubernetesClusterV3{
+				Metadata: types.Metadata{Name: name},
+				Spec:     types.KubernetesClusterSpecV3{},
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	return s
+}
+
+func testProxyKubeServerWatcherStartsWithFaultyPrimarySynctest(t *testing.T) {
+	ctx := t.Context()
+
+	primary := &mockKubeServerWatcherGetter{}
+	fallback := &mockKubeServerWatcherGetter{}
+
+	var calls int32
+
+	primary.On("NewWatcher", mock.Anything, mock.Anything).
+		Return(nil, context.DeadlineExceeded).
+		Run(func(args mock.Arguments) {
+			atomic.AddInt32(&calls, 1)
+		})
+
+	cfg := ProxyKubeServerWatcherConfig{
+		AccessPoint:      primary,
+		FallbackGetter:   fallback,
+		MaxRetryPeriod:   time.Second * 10,
+		PrimaryTimeout:   time.Second,
+		FallbackInterval: time.Second * 30,
+	}
+
+	w, err := NewProxyKubeServerWatcher(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+
+	waitCh := make(chan error)
+	defer close(waitCh)
+
+	go func() {
+		// This should block until the watcher is ready or closed.
+		waitCh <- w.WaitInitialization()
+	}()
+
+	require.True(t, isHealthy(w), "Watcher starts healthy")
+	require.False(t, w.IsInitialized())
+
+	time.Sleep(2 * time.Second)
+	require.False(t, w.IsInitialized())
+	require.False(t, isHealthy(w), "Watcher should not be hot since primary is failing")
+
+	fallback.On("GetKubernetesServers", mock.Anything).
+		Return([]types.KubeServer{newTestKubeServer(t, "foo", "bar")}, nil)
+	srvs, err := w.GetKubeServersForClusterName(ctx, "foo")
+	require.NoError(t, err)
+	require.Len(t, srvs, 1)
+	require.Equal(t, "foo", srvs[0].GetName())
+	require.Equal(t, 1, w.ResourceCount())
+
+	srvs, err = w.GetKubeServersForClusterName(ctx, "baz")
+	require.NoError(t, err)
+	require.Empty(t, srvs)
+
+	time.Sleep(cfg.FallbackInterval + time.Second)
+
+	var wg sync.WaitGroup
+
+	// Simulate long fetch to ensure only one is called
+	fallbackFetcher := make(chan struct{})
+	fallback.On("GetKubernetesServers", mock.Anything).
+		Run(func(args mock.Arguments) {
+			<-fallbackFetcher
+		})
+
+	type result struct {
+		srvs []types.KubeServer
+		err  error
+	}
+
+	// Concurrent access will only result in one call to fallback
+	results := make(chan result, 64)
+	for range 64 {
+		wg.Go(func() {
+			srvs, err := w.GetKubeServersForClusterName(ctx, "foo")
+			results <- result{srvs: srvs, err: err}
+		})
+	}
+
+	close(fallbackFetcher)
+
+	wg.Wait()
+	close(results)
+	for res := range results {
+		require.NoError(t, res.err)
+		require.Len(t, res.srvs, 1)
+		require.Equal(t, "foo", res.srvs[0].GetName())
+	}
+
+	w.Close() // closes context
+
+	waitErr := <-waitCh
+	require.Error(t, waitErr)
+	require.ErrorContains(t, waitErr, "context closing")
+
+	select {
+	case <-w.Done():
+	default:
+		t.Fatal("Watcher did not close in time")
+	}
+
+	require.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2))
+	primary.AssertExpectations(t)
+	fallback.AssertExpectations(t)
+}
+
+func TestProxyKubeServerWatcher_StartsWithFaultyPrimary(t *testing.T) {
+	synctest.Test(t, testProxyKubeServerWatcherStartsWithFaultyPrimarySynctest)
+}
+
+func testWatcherProcessesEventsSynctest(t *testing.T) {
+	ctx := t.Context()
+
+	fw := newFakeWatcher(10)
+	t.Cleanup(func() { fw.Close() })
+	primary := &mockKubeServerWatcherGetter{}
+	fallback := &mockKubeServerWatcherGetter{}
+
+	// In the happy path we expect a single call to the primary to pre-warm the cache.
+	primary.On("GetKubernetesServers", mock.Anything).
+		Return([]types.KubeServer{
+			newTestKubeServer(t, "foo", "host1"),
+		}, nil).Once()
+
+	watcherReady := make(chan time.Time)
+	primary.On("NewWatcher", mock.Anything, mock.Anything).Return(fw, nil).WaitUntil(watcherReady).Once()
+
+	w, err := NewProxyKubeServerWatcher(ctx, ProxyKubeServerWatcherConfig{
+		AccessPoint:    primary,
+		FallbackGetter: fallback,
+		PrimaryTimeout: time.Second,
+		MaxRetryPeriod: time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+	synctest.Wait()
+
+	// Single call to backup since watcher is not ready.
+	resources, err := w.GetKubeServersForClusterName(ctx, "foo")
+	require.NoError(t, err)
+	require.Empty(t, resources, "Watcher should start with empty cache before warm-up")
+
+	watcherReady <- time.Now() // unblock watcher
+	fw.send(types.Event{Type: types.OpInit})
+	require.NoError(t, w.WaitInitialization())
+	require.True(t, w.IsInitialized())
+	require.True(t, isHealthy(w), "Watcher starts out healthy")
+
+	fw.send(types.Event{Type: types.OpPut, Resource: newTestKubeServer(t, "foo", "host2")})
+	synctest.Wait()
+
+	resources, err = w.GetKubeServersForClusterName(ctx, "foo")
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	require.Equal(t, 2, w.ResourceCount())
+
+	// Test that incorrect resource kinds are ignored.
+	fw.send(types.Event{Type: types.OpPut, Resource: &types.DatabaseServerV3{Kind: "oops"}})
+	synctest.Wait()
+
+	// Test that resource conversion errors are handled gracefully.
+	fw.send(types.Event{Type: types.OpPut, Resource: &types.DatabaseServerV3{Kind: types.KindKubeServer}})
+	synctest.Wait()
+
+	fw.send(types.Event{Type: types.OpDelete, Resource: newTestKubeServer(t, "foo", "host2")})
+	synctest.Wait()
+
+	resources, err = w.GetKubeServersForClusterName(ctx, "foo")
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	require.Equal(t, "foo", resources[0].GetName())
+	require.Equal(t, 1, w.ResourceCount())
+
+	primary.AssertExpectations(t)
+	fallback.AssertExpectations(t)
+}
+
+func TestProxyKubeServerWatcher_ProcessesEvents(t *testing.T) {
+	synctest.Test(t, testWatcherProcessesEventsSynctest)
+}
+
+func proxyKubeServerWatcherFetchAndInitializeStateAppliesQueuedEventsSynctest(t *testing.T) {
+	ctx := t.Context()
+
+	fw := newFakeWatcher(10)
+	t.Cleanup(func() { fw.Close() })
+	primary := &mockKubeServerWatcherGetter{}
+	fallback := &mockKubeServerWatcherGetter{}
+
+	initialDeleted := newTestKubeServer(t, "deleted", "host2")
+	initialUpdated := newTestKubeServerWithRevsion(t, "updated", "host3", 0)
+	updated := newTestKubeServerWithRevsion(t, "updated", "host3", 1)
+	added := newTestKubeServer(t, "added", "host4")
+	transient := newTestKubeServer(t, "transient", "host5")
+
+	unblockFetch := make(chan time.Time)
+	primary.On("NewWatcher", mock.Anything, mock.Anything).Return(fw, nil).Once()
+
+	primary.On("GetKubernetesServers", mock.Anything).
+		Return([]types.KubeServer{
+			newTestKubeServer(t, "kept", "host1"),
+			initialDeleted,
+			initialUpdated,
+		}, nil).WaitUntil(unblockFetch).Once()
+
+	w, err := NewProxyKubeServerWatcher(ctx, ProxyKubeServerWatcherConfig{
+		AccessPoint:    primary,
+		FallbackGetter: fallback,
+		PrimaryTimeout: time.Second,
+		MaxRetryPeriod: time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+	synctest.Wait()
+
+	fw.send(types.Event{Type: types.OpInit})
+	fw.send(types.Event{Type: types.OpDelete, Resource: initialDeleted})
+	fw.send(types.Event{Type: types.OpPut, Resource: added})
+	fw.send(types.Event{Type: types.OpPut, Resource: updated})
+	fw.send(types.Event{Type: types.OpPut, Resource: transient})
+	fw.send(types.Event{Type: types.OpDelete, Resource: transient})
+
+	close(unblockFetch)
+
+	require.NoError(t, w.WaitInitialization())
+	require.True(t, w.IsInitialized())
+	require.True(t, isHealthy(w))
+	require.Empty(t, fw.Events(), "All events should be processed by the time initialization is complete")
+
+	resources, err := w.GetKubeServersForClusterName(ctx, "kept")
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+
+	resources, err = w.GetKubeServersForClusterName(ctx, "added")
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+
+	resources, err = w.GetKubeServersForClusterName(ctx, "updated")
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	require.Equal(t, "1", resources[0].GetRevision())
+
+	resources, err = w.GetKubeServersForClusterName(ctx, "deleted")
+	require.NoError(t, err)
+	require.Empty(t, resources)
+
+	resources, err = w.GetKubeServersForClusterName(ctx, "transient")
+	require.NoError(t, err)
+	require.Empty(t, resources)
+
+	primary.AssertExpectations(t)
+}
+
+func TestProxyKubeServerWatcher_FetchAndInitializeStateAppliesQueuedEvents(t *testing.T) {
+	synctest.Test(t, proxyKubeServerWatcherFetchAndInitializeStateAppliesQueuedEventsSynctest)
+}
+
+func testWatcherUnknownEventsHardFaultSynctest(t *testing.T) {
+	ctx := t.Context()
+
+	fw := newFakeWatcher(10)
+	t.Cleanup(func() { fw.Close() })
+	primary := &mockKubeServerWatcherGetter{}
+	fallback := &mockKubeServerWatcherGetter{}
+
+	// In the happy path we expect a single call to the primary to pre-warm the cache.
+	primary.On("GetKubernetesServers", mock.Anything).
+		Return([]types.KubeServer{
+			newTestKubeServer(t, "initial", "host1"),
+		}, nil).Once()
+
+	watcherReady := make(chan time.Time)
+	primary.On("NewWatcher", mock.Anything, mock.Anything).Return(fw, nil).WaitUntil(watcherReady).Once()
+
+	w, err := NewProxyKubeServerWatcher(ctx, ProxyKubeServerWatcherConfig{
+		AccessPoint:    primary,
+		FallbackGetter: fallback,
+		PrimaryTimeout: time.Second,
+		MaxRetryPeriod: time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+	synctest.Wait()
+
+	// Single call to backup since watcher is not ready.
+	resources, err := w.GetKubeServersForClusterName(ctx, "initial")
+	require.NoError(t, err)
+	require.Empty(t, resources, "Watcher should start with empty cache before warm-up")
+
+	watcherReady <- time.Now() // unblock watcher
+	fw.send(types.Event{Type: types.OpInit})
+	require.NoError(t, w.WaitInitialization())
+	require.True(t, w.IsInitialized())
+	require.True(t, isHealthy(w), "Watcher starts out healthy")
+
+	fw.send(types.Event{Type: types.OpInvalid, Resource: newTestKubeServer(t, "new", "host2")})
+	synctest.Wait()
+	require.False(t, isHealthy(w), "Watcher should be unhealthy after receiving invalid event")
+	require.False(t, w.shouldFetchFromFallback(time.Now()), "The fallback timeout should not expire yet.")
+
+	resources, err = w.GetKubeServersForClusterName(ctx, "initial")
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	require.Equal(t, "initial", resources[0].GetName())
+
+	primary.AssertExpectations(t)
+	fallback.AssertExpectations(t)
+}
+
+func TestProxyKubeServerWatcher_UnknownEventsHardFault(t *testing.T) {
+	synctest.Test(t, testWatcherUnknownEventsHardFaultSynctest)
+}
+
+func testProxyKubeServerWatcherRetryWatchAfterTimeoutSynctest(t *testing.T) {
+	ctx := t.Context()
+
+	fw1 := newFakeWatcher(20)
+	fw2 := newFakeWatcher(20)
+
+	primary := &mockKubeServerWatcherGetter{}
+	fallback := &mockKubeServerWatcherGetter{}
+
+	primary.On("NewWatcher", mock.Anything, mock.Anything).
+		Return(fw1, nil).Once()
+	primary.On("NewWatcher", mock.Anything, mock.Anything).
+		Return(fw2, nil).Once()
+	primary.On("GetKubernetesServers", mock.Anything).
+		Return([]types.KubeServer{}, nil).Twice()
+
+	w, _ := NewProxyKubeServerWatcher(ctx, ProxyKubeServerWatcherConfig{
+		AccessPoint:    primary,
+		FallbackGetter: fallback,
+		PrimaryTimeout: 10 * time.Second,
+	})
+	t.Cleanup(w.Close)
+
+	fw1.send(types.Event{Type: types.OpInit})
+	synctest.Wait()
+
+	fw1.closeWithError(context.DeadlineExceeded)
+	synctest.Wait()
+	// Initially the cache is still hot
+	require.False(t, isHealthy(w), "the watcher is imminently unhealthy after the primary watcher fails")
+	require.False(t, w.shouldFetchFromFallback(time.Now()), "the watcher should not fetch from fallback immediately after the primary watcher fails")
+	time.Sleep(10*time.Second + time.Millisecond)
+	require.False(t, isHealthy(w), "still unhealthy after primary timeout")
+	require.True(t, w.shouldFetchFromFallback(time.Now()), "watcher should fetch from fallback after primary timeout")
+
+	fw2.send(types.Event{Type: types.OpInit})
+	synctest.Wait()
+
+	require.True(t, isHealthy(w), "expected watcher to be hot")
+	require.False(t, w.shouldFetchFromFallback(time.Now()), "watcher should now be serving from the event stream, not fallback")
+
+	// Verify no calls to the back up are made.
+	srvs, err := w.GetKubeServersForClusterName(ctx, "initial")
+	require.NoError(t, err)
+	require.Empty(t, srvs)
+
+	primary.AssertExpectations(t)
+	fallback.AssertExpectations(t)
+
+}
+
+func TestProxyKubeServerWatcher_RetryWatchAfterTimeout(t *testing.T) {
+	synctest.Test(t, testProxyKubeServerWatcherRetryWatchAfterTimeoutSynctest)
+}
+
+func testProxyKubeServerWatcherRecoversAfterTimeoutSynctest(t *testing.T) {
+	ctx := t.Context()
+
+	fw := newFakeWatcher(1)
+
+	primary := &mockKubeServerWatcherGetter{}
+	fallback := &mockKubeServerWatcherGetter{}
+
+	primary.On("GetKubernetesServers", mock.Anything).
+		Return([]types.KubeServer{}, nil).Once().NotBefore(
+		primary.On("NewWatcher", mock.Anything, mock.Anything).
+			Return(fw, nil).
+			Once(),
+	)
+
+	w, err := NewProxyKubeServerWatcher(ctx, ProxyKubeServerWatcherConfig{
+		AccessPoint:    primary,
+		FallbackGetter: fallback,
+		PrimaryTimeout: 20 * time.Millisecond,
+		MaxRetryPeriod: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+
+	time.Sleep(30 * time.Millisecond)
+
+	require.False(t, isHealthy(w))
+	fw.send(types.Event{Type: types.OpInit})
+	synctest.Wait()
+
+	require.True(t, isHealthy(w))
+
+	primary.AssertExpectations(t)
+	fallback.AssertExpectations(t)
+}
+
+func TestProxyKubeServerWatcher_RecoversAfterTimeout(t *testing.T) {
+	synctest.Test(t, testProxyKubeServerWatcherRecoversAfterTimeoutSynctest)
+}
+
+func testProxyKubeServerWatcherDiscardsStaleOnFallbackFailSynctest(t *testing.T) {
+	ctx := t.Context()
+	const numberOfEvents = 256
+	fw := newFakeWatcher(512)
+	t.Cleanup(func() { fw.Close() })
+	primary := &mockKubeServerWatcherGetter{}
+	fallback := &mockKubeServerWatcherGetter{}
+
+	primary.On("GetKubernetesServers", mock.Anything).
+		Return([]types.KubeServer{}, nil).Once().NotBefore(
+		primary.On("NewWatcher", mock.Anything, mock.Anything).
+			Return(fw, nil).
+			Once(),
+	)
+
+	w, err := NewProxyKubeServerWatcher(ctx, ProxyKubeServerWatcherConfig{
+		AccessPoint:      primary,
+		FallbackGetter:   fallback,
+		PrimaryTimeout:   time.Second,
+		FallbackInterval: time.Second,
+		MaxRetryPeriod:   time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+	fw.send(types.Event{Type: types.OpInit})
+	synctest.Wait()
+	require.True(t, isHealthy(w), "Watcher should be hot after receiving OpInit event")
+
+	for i := range numberOfEvents {
+		srv := newTestKubeServerWithRevsion(t, "foo", "host", i)
+		fw.send(types.Event{Type: types.OpPut, Resource: srv})
+
+		if i%16 == 0 {
+			// simulate some batching.
+			synctest.Wait()
+		}
+	}
+
+	synctest.Wait()
+
+	srvs, err := w.GetKubeServersForClusterName(ctx, "foo")
+	require.NoError(t, err)
+	require.Len(t, srvs, 1)
+	require.Equal(t, "foo", srvs[0].GetName())
+	require.Equal(t, fmt.Sprintf("%d", numberOfEvents-1), srvs[0].GetRevision())
+
+	fw.send(types.Event{Type: types.OpDelete, Resource: srvs[0]})
+	synctest.Wait()
+
+	srvs, err = w.GetKubeServersForClusterName(ctx, "foo")
+	require.NoError(t, err)
+	require.Empty(t, srvs)
+
+	expected := make([]types.KubeServer, 0, numberOfEvents)
+	for i := range numberOfEvents {
+		srv := newTestKubeServer(t, "foo", fmt.Sprintf("server-%d", i))
+		expected = append(expected, srv)
+		fw.send(types.Event{Type: types.OpPut, Resource: srv})
+
+		if i%16 == 0 {
+			synctest.Wait()
+		}
+	}
+
+	synctest.Wait()
+
+	srvs, err = w.GetKubeServersForClusterName(ctx, "foo")
+	require.NoError(t, err)
+	require.Len(t, srvs, numberOfEvents)
+
+	require.Empty(t, cmp.Diff(expected, srvs, cmpopts.SortSlices(func(a, b types.KubeServer) bool {
+		return a.GetCluster().GetName()+a.GetHostID() < b.GetCluster().GetName()+b.GetHostID()
+	})))
+
+	primary.On("NewWatcher", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded)
+
+	// simulate failing fallback
+	fallback.On("GetKubernetesServers", mock.Anything).Return([]types.KubeServer{}, context.DeadlineExceeded).Once()
+
+	fw.closeWithError(context.DeadlineExceeded)
+	synctest.Wait()
+
+	require.False(t, isHealthy(w), "Watcher is imminently unhealthy after the primary watcher fails")
+	require.False(t, w.shouldFetchFromFallback(time.Now()), "Watcher should not fetch from fallback immediately after primary watcher fails")
+
+	nonstale, err := w.GetKubeServersForClusterName(ctx, "foo")
+	require.NoError(t, err)
+	require.Len(t, nonstale, numberOfEvents)
+
+	time.Sleep(10 * time.Second) // exceed max staleness.
+	require.False(t, isHealthy(w), "Watcher is not hot after max staleness is exceeded")
+
+	srvs, err = w.GetKubeServersForClusterName(ctx, "foo")
+	require.Error(t, err)
+	require.Empty(t, srvs, "Expected no servers to be returned when watcher is unhealthy and fallback is failing")
+
+	// Simulate recovery of the primary.
+	fw2 := newFakeWatcher(512)
+	primary.On("GetKubernetesServers", mock.Anything).
+		Return(nonstale, nil).Once().NotBefore(
+		primary.On("NewWatcher", mock.Anything, mock.Anything).Unset(),
+		primary.On("NewWatcher", mock.Anything, mock.Anything).
+			Return(fw2, nil).
+			Once(),
+	)
+
+	fw2.send(types.Event{Type: types.OpInit})
+	time.Sleep(10 * time.Second) // exceed retry staleness.
+
+	require.True(t, isHealthy(w), "Watcher should be hot after new watcher is created and receives OpInit")
+
+	// Calls should not be routed to fallback.
+	srvs, err = w.GetKubeServersForClusterName(ctx, "foo")
+	require.NoError(t, err)
+	require.Len(t, srvs, numberOfEvents)
+
+	primary.AssertExpectations(t)
+	fallback.AssertExpectations(t)
+}
+
+func TestProxyKubeServerWatcherDiscardsStaleOnFallbackFail(t *testing.T) {
+	synctest.Test(t, testProxyKubeServerWatcherDiscardsStaleOnFallbackFailSynctest)
+}
+
+func TestProxyKubeServerWatcher_MaybeFetchFromUpstreamDoesNotOverwriteHotCache(t *testing.T) {
+	ctx := t.Context()
+
+	primaryServer := newTestKubeServer(t, "primary", "host")
+	fallbackServer := newTestKubeServer(t, "fallback", "host")
+
+	fallback := &mockKubeServerWatcherGetter{}
+	fetchStarted := make(chan struct{})
+	continueFetch := make(chan struct{})
+	fallback.On("GetKubernetesServers", mock.Anything).
+		Run(func(args mock.Arguments) {
+			close(fetchStarted)
+			<-continueFetch
+		}).
+		Return([]types.KubeServer{fallbackServer}, nil).Once()
+
+	cfg := ProxyKubeServerWatcherConfig{
+		FallbackGetter:   fallback,
+		FallbackInterval: 0,
+	}
+	w := &ProxyKubeServerWatcher{
+		ProxyKubeServerWatcherConfig: cfg,
+		current: map[serverKey]types.KubeServer{
+			kubeServerKey(primaryServer): primaryServer,
+		},
+	}
+
+	markUnhealthy(w)
+	done := make(chan error, 1)
+	go func() {
+		done <- w.maybeFetchFromUpstream(ctx)
+	}()
+
+	<-fetchStarted
+
+	markHealthy(w)
+	close(continueFetch)
+	require.NoError(t, <-done)
+
+	w.rw.RLock()
+	require.Len(t, w.current, 1)
+	srv, ok := w.current[kubeServerKey(primaryServer)]
+	w.rw.RUnlock()
+
+	require.True(t, ok)
+	require.Equal(t, primaryServer.GetName(), srv.GetName())
+
+	fallback.AssertExpectations(t)
+}
+
+func testProxyKubeServerWatcherDiscardsBadInitEventSynctest(t *testing.T) {
+	ctx := t.Context()
+
+	fw1 := newFakeWatcher(20)
+	fw2 := newFakeWatcher(20)
+	t.Cleanup(func() { fw1.Close() })
+	t.Cleanup(func() { fw2.Close() })
+
+	primary := &mockKubeServerWatcherGetter{}
+	fallback := &mockKubeServerWatcherGetter{}
+
+	primary.On("GetKubernetesServers", mock.Anything).
+		Return([]types.KubeServer{}, nil).Once().NotBefore(
+		primary.On("NewWatcher", mock.Anything, mock.Anything).
+			Return(fw1, nil).
+			Once(),
+		primary.On("NewWatcher", mock.Anything, mock.Anything).
+			Return(fw2, nil).
+			Once(),
+	)
+
+	w, err := NewProxyKubeServerWatcher(ctx, ProxyKubeServerWatcherConfig{
+		AccessPoint:    primary,
+		FallbackGetter: fallback,
+	})
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+	fw1.send(types.Event{Type: types.OpInvalid})
+	fw2.send(types.Event{Type: types.OpInit})
+
+	time.Sleep(time.Minute) // wait long enough for retry backoff to init second watcher
+	require.True(t, isHealthy(w), "Watcher should be hot after receiving OpInit event")
+
+	primary.AssertExpectations(t)
+	fallback.AssertExpectations(t)
+}
+
+func TestProxyKubeServerWatcher_DiscardsBadInitEvent(t *testing.T) {
+	synctest.Test(t, testProxyKubeServerWatcherDiscardsBadInitEventSynctest)
+}
+
+func testProxyKubeServerWatcherRecoversFromFirstFetchFailSynctest(t *testing.T) {
+	ctx := t.Context()
+
+	fw1 := newFakeWatcher(20)
+	fw2 := newFakeWatcher(20)
+	t.Cleanup(func() { fw1.Close() })
+	t.Cleanup(func() { fw2.Close() })
+
+	primary := &mockKubeServerWatcherGetter{}
+	fallback := &mockKubeServerWatcherGetter{}
+
+	primary.On("GetKubernetesServers", mock.Anything).
+		Return([]types.KubeServer{}, context.DeadlineExceeded).Once().NotBefore(
+		primary.On("NewWatcher", mock.Anything, mock.Anything).
+			Return(fw1, nil).
+			Once(),
+	)
+
+	primary.On("GetKubernetesServers", mock.Anything).
+		Return([]types.KubeServer{}, nil).Once().NotBefore(
+		primary.On("NewWatcher", mock.Anything, mock.Anything).
+			Return(fw2, nil).
+			Once(),
+	)
+
+	w, err := NewProxyKubeServerWatcher(ctx, ProxyKubeServerWatcherConfig{
+		AccessPoint:    primary,
+		FallbackGetter: fallback,
+	})
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+	fw1.send(types.Event{Type: types.OpInit})
+	synctest.Wait()
+	fw2.send(types.Event{Type: types.OpInit})
+
+	time.Sleep(time.Minute) // wait long enough for retry backoff to init second watcher
+	require.True(t, isHealthy(w), "Watcher should be hot after receiving OpInit event")
+
+	primary.AssertExpectations(t)
+	fallback.AssertExpectations(t)
+}
+
+func TestProxyKubeServerWatcher_RecoversFromFirstFetchFail(t *testing.T) {
+	synctest.Test(t, testProxyKubeServerWatcherRecoversFromFirstFetchFailSynctest)
+}
+
+func TestFillEventBuf_DoesNotExceedMaxBufferSize(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	const pageCount = 3
+	const bufferSize = 64
+	const bufferStartingSize = 16
+	const totalEvents = bufferSize * pageCount
+	fw := newFakeWatcher(totalEvents)
+	t.Cleanup(func() { fw.Close() })
+
+	for i := range totalEvents {
+		fw.send(types.Event{Type: types.OpPut, Resource: newTestKubeServer(t, fmt.Sprintf("kube-%d", i), "host")})
+	}
+	eventBuf := make([]types.Event, 0, bufferStartingSize)
+	seen := make(map[string]struct{}, totalEvents)
+	for page := range pageCount {
+		eventBuf = eventBuf[:0] // caller must reset
+		eventBuf = fillEventBuf(ctx, eventBuf, fw, bufferSize)
+		require.Len(t, eventBuf, bufferSize, "expected page %d to be full", page)
+
+		pageSeen := make(map[string]struct{}, bufferSize)
+		for idx, event := range eventBuf {
+			name := event.Resource.GetName()
+			require.NotEmpty(t, name)
+			require.NotContains(t, pageSeen, name, "duplicate event in page %d", page)
+			require.NotContains(t, seen, name, "duplicate event across pages at page %d", page)
+			pageSeen[name] = struct{}{}
+			seen[name] = struct{}{}
+
+			expectedName := fmt.Sprintf("kube-%d", page*bufferSize+idx)
+			require.Equal(t, expectedName, name)
+		}
+	}
+
+	select {
+	case event := <-fw.Events():
+		t.Fatalf("expected no remaining events after consuming %d pages, got %s", totalEvents, event.Resource.GetName())
+	default:
+	}
+}
+
+func testProxyKubeServerWatcher_ParentContextCanceledSynctest(t *testing.T) {
+	parentCtx, cancelParent := context.WithCancel(t.Context())
+	watcherCtx, cancelWatcher := context.WithCancel(t.Context())
+	defer cancelWatcher()
+
+	fetchStarted := make(chan struct{})
+	unblockFetch := make(chan struct{})
+	fetchDone := make(chan struct{})
+
+	fallback := &mockKubeServerWatcherGetter{}
+	fallback.On("GetKubernetesServers", mock.Anything).
+		Run(func(args mock.Arguments) {
+			close(fetchStarted)
+			<-unblockFetch
+			close(fetchDone)
+		}).
+		Return([]types.KubeServer{newTestKubeServer(t, "fallback", "host")}, nil).
+		Once()
+
+	w := &ProxyKubeServerWatcher{
+		ProxyKubeServerWatcherConfig: ProxyKubeServerWatcherConfig{
+			Logger:           slog.Default(),
+			FallbackGetter:   fallback,
+			FallbackInterval: 0,
+		},
+		ctx:     watcherCtx,
+		cancel:  cancelWatcher,
+		current: make(map[serverKey]types.KubeServer),
+	}
+
+	markUnhealthy(w)
+
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := w.GetKubeServersForClusterName(parentCtx, "foo")
+		resultCh <- err
+	}()
+
+	<-fetchStarted
+	cancelParent()
+
+	err := <-resultCh
+	require.Error(t, err)
+	require.ErrorContains(t, err, "context is closing")
+
+	close(unblockFetch)
+	<-fetchDone
+	fallback.AssertExpectations(t)
+}
+
+func TestProxyKubeServerWatcher_ParentContextCanceled(t *testing.T) {
+	synctest.Test(t, testProxyKubeServerWatcher_ParentContextCanceledSynctest)
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -149,6 +149,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/legacyjoin"
 	kubegrpc "github.com/gravitational/teleport/lib/kube/grpc"
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
+	kubewatcher "github.com/gravitational/teleport/lib/kube/proxy/watcher"
 	kuberelay "github.com/gravitational/teleport/lib/kube/relay"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/limiter"
@@ -6153,13 +6154,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		// kubeServerWatcher is used to watch for changes in the Kubernetes servers
 		// and feed them to the kube proxy server so it can route the requests to
 		// the correct kubernetes server.
-		kubeServerWatcher, err := services.NewKubeServerWatcher(process.ExitContext(), services.KubeServerWatcherConfig{
-			ResourceWatcherConfig: services.ResourceWatcherConfig{
-				Component: component,
-				Logger:    process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
-				Client:    accessPoint,
-			},
-			KubernetesServerGetter: accessPoint,
+		kubeServerWatcher, err := kubewatcher.NewProxyKubeServerWatcher(process.ExitContext(), kubewatcher.ProxyKubeServerWatcherConfig{
+			Logger:         process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+			AccessPoint:    accessPoint,
+			FallbackGetter: conn.Client, // use auth client as a fallback
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -132,6 +132,7 @@ import (
 	"github.com/gravitational/teleport/lib/httplib/csrf"
 	"github.com/gravitational/teleport/lib/inventory"
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
+	kubewatcher "github.com/gravitational/teleport/lib/kube/proxy/watcher"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
@@ -10302,20 +10303,15 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 	if cfg.serviceType == kubeproxy.KubeService {
 		proxySigner = nil
 	}
-	clock := clockwork.NewRealClock()
-	watcher, err := services.NewKubeServerWatcher(ctx, services.KubeServerWatcherConfig{
-		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: component,
-			Client:    client,
-			Clock:     clock,
-		},
-		KubernetesServerGetter: client,
+	kubeServersWatcher, err := kubewatcher.NewProxyKubeServerWatcher(ctx, kubewatcher.ProxyKubeServerWatcherConfig{
+		AccessPoint:    client,
+		FallbackGetter: client,
 	})
 	require.NoError(t, err)
-	t.Cleanup(watcher.Close)
+	t.Cleanup(kubeServersWatcher.Close)
 
 	// wait for the watcher to init before continuing
-	require.NoError(t, watcher.WaitInitialization())
+	require.NoError(t, kubeServersWatcher.WaitInitialization())
 
 	healthCheckManager, err := healthcheck.NewManager(
 		ctx,
@@ -10399,7 +10395,7 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 		GetRotation:              func(role types.SystemRole) (*types.Rotation, error) { return &types.Rotation{}, nil },
 		ResourceMatchers:         nil,
 		OnReconcile:              func(kc types.KubeClusters) {},
-		KubernetesServersWatcher: watcher,
+		KubernetesServersWatcher: kubeServersWatcher,
 		InventoryHandle:          inventoryHandle,
 		ConnectedProxyGetter:     reversetunnel.NewConnectedProxyGetter(),
 		HealthCheckManager:       healthCheckManager,


### PR DESCRIPTION
This commit adds a dedicated Proxy watcher for Kube Servers, this watcher provides a fallback mechanism to maintain its list of servers in the event of Cache failure.

This commit specifically avoids using the existing `GenericWatcher` for the following reasons:
* When the Cache watcher fails, list gets will return the stale results forever. This is because the cache is never marked as stale after the initial fetch with the exception of a window between `fetch` and `apply` on init. Since `apply` cannot reasonably fail in the current implementation the cache status remains ok and as such the upstream path is not activated.
* `GenericWatcher` uses a single getter for both primary and fallback paths. Adding a secondary getter for fallback could open the possibility of misuse, we specifically do not want to cause thundering herd failures by letting agents try to hit the Auth directly on cache failure.
* `FnCache` stores a second copy of the full collection when the fallback path is active.

As such the `ProxyKubeServerWatcher` special case should only ever be used on Proxy instances in the attempt to circumvent cache failure due to another resource type crashing the cache into a retry loop. This is a drop in replcement for `NewKubeServerWatcher` which will remain in use for `Relay` instances.

`ProxyKubeServerWatcher` maintains the behaviour of `WaitInitialization` allowing the caller to wait for the first successful Cache init but will provide a accessible fallback if access is needed before watcher is ready. 

To discourage making large copies of the full server slice, this watcher only implements `GetKubeServersForClusterName` as all of the current call sites have no need to access the entire collection.

Because of its limited scope, the watcher is strongly typed to Kube Servers only. Should this pattern be deemed required for other resource types in the Proxy, it could be refactored with relative ease.

The default primary timeout is 1min. The default fallback interval is also 1min with jitter.

This should provide a compromise between the acceptable staleness of servers without excessive calls. 

Fixes: #66063


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed stale/degraded Proxy instance cache affecting Kube Proxy target resolution. 


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local with minikube configured for testing. 

### Test Cases
- [x] Run kube tests with `TEST_KUBE=1`
- [x] Perform cache error injection locally and verify access is maintained
