### PR TITLE
feat: msgraph user and group delta iterators

### DIFF
--- a/lib/msgraph/client.go
+++ b/lib/msgraph/client.go
@@ -66,6 +66,16 @@ type AzureTokenProvider interface {
 	GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error)
 }
 
+// DeltaStore defines an interface for persisting delta links.
+type DeltaStore interface {
+	// Get returns a delta link for the given endpoint.
+	Get(endpoint string) string
+	// Set sets a delta link for the given endpoint.
+	Set(endpoint, deltaLink string)
+	// Clear deletes delta link for the given endpoint.
+	Clear(endpoint string)
+}
+
 func defaultHTTPClient() (*http.Client, error) {
 	transport, err := defaults.Transport()
 	if err != nil {

--- a/lib/msgraph/client_test.go
+++ b/lib/msgraph/client_test.go
@@ -34,6 +34,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -874,4 +877,399 @@ func newHTTPClient(server *httptest.Server) *http.Client {
 		},
 	}
 	return httpClient
+}
+
+func TestIterateUserDeltas(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	defaultStorage := msgraphtest.NewDefaultStorage()
+
+	// Seed storage with one user carol.
+	storage := msgraphtest.NewStorage()
+	carol := defaultStorage.Users[msgraphtest.CarolID]
+	storage.Users[*carol.ID] = carol
+
+	fakeServer := msgraphtest.NewServer(msgraphtest.WithStorage(storage))
+	t.Cleanup(func() { fakeServer.TLSServer.Close() })
+
+	client, err := NewClient(Config{
+		HTTPClient:    newHTTPClient(fakeServer.TLSServer),
+		TokenProvider: &fakeTokenProvider{},
+		RetryConfig:   &retryConfig,
+	})
+	require.NoError(t, err)
+
+	fakeDeltaStore := msgraphtest.NewFakeDeltaStore()
+	const userEndpoint = "users/delta"
+
+	// Request without the latest token should fail.
+	for _, err := range client.IterateUserDeltas(ctx, userEndpoint, fakeDeltaStore) {
+		require.ErrorIs(t, err, ErrMissingDeltaLink)
+	}
+
+	// Set up latest delta token for user endpoint.
+	err = client.SetupLatestDelta(ctx, userEndpoint, fakeDeltaStore)
+	require.NoError(t, err)
+
+	// Subsequent delta requests should now succeed.
+	require.NotEmpty(t, fakeDeltaStore.Get(userEndpoint))
+
+	sortDeltas := cmpopts.SortSlices(func(a, b *models.ListUsersDeltaResponse) bool {
+		return a.User.GetID() != nil &&
+			b.User.GetID() != nil &&
+			*a.User.GetID() < *b.User.GetID()
+	})
+
+	// Add alice and bob users.
+	alice := defaultStorage.Users[msgraphtest.AliceID]
+	bob := defaultStorage.Users[msgraphtest.BobID]
+	fakeServer.SetUsers([]*models.User{alice, bob})
+	expected := []*models.ListUsersDeltaResponse{
+		{
+			User: &models.User{
+				DirectoryObject: models.DirectoryObject{
+					ID: alice.GetID(),
+				},
+				Mail:              alice.Mail,
+				UserPrincipalName: alice.UserPrincipalName,
+			},
+		},
+		{
+			User: &models.User{
+				DirectoryObject: models.DirectoryObject{
+					ID: bob.GetID(),
+				},
+				Mail:              bob.Mail,
+				UserPrincipalName: bob.UserPrincipalName,
+			},
+		},
+	}
+	// Test new users response.
+	got := []*models.ListUsersDeltaResponse{}
+	for usersDelta, err := range client.IterateUserDeltas(ctx, userEndpoint, fakeDeltaStore) {
+		require.NoError(t, err)
+
+		got = append(got, usersDelta)
+	}
+	require.Empty(t, cmp.Diff(expected, got, sortDeltas), "expected user delta response to match")
+
+	// Test user delete response
+	fakeServer.DeleteUsers([]string{*carol.GetID()})
+	expected = []*models.ListUsersDeltaResponse{
+		{
+			User: &models.User{
+				DirectoryObject: models.DirectoryObject{
+					ID: carol.GetID(),
+				},
+			},
+			Removed: &models.RemovedReason{
+				Reason: to.Ptr("deleted"),
+			},
+		},
+	}
+	got = []*models.ListUsersDeltaResponse{}
+	for usersDelta, err := range client.IterateUserDeltas(ctx, userEndpoint, fakeDeltaStore) {
+		require.NoError(t, err)
+
+		got = append(got, usersDelta)
+	}
+
+	require.Empty(t, cmp.Diff(expected, got, sortDeltas), "expected user delta response to match")
+}
+
+func TestIterateGroupDeltas(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	defaultStorage := msgraphtest.NewDefaultStorage()
+
+	// Start with default users alice, bob and carol.
+	storage := msgraphtest.NewStorage()
+	storage.Users = defaultStorage.Users
+
+	fakeServer := msgraphtest.NewServer(msgraphtest.WithStorage(storage))
+	t.Cleanup(func() { fakeServer.TLSServer.Close() })
+
+	httpClient := &http.Client{
+		Transport: &msgraphtest.RewriteTransport{
+			Base: fakeServer.TLSServer.Client().Transport,
+			URL:  mustParseURL(t, fakeServer.TLSServer.URL),
+		},
+	}
+
+	client, err := NewClient(Config{
+		HTTPClient:    httpClient,
+		TokenProvider: &fakeTokenProvider{},
+		RetryConfig:   &retryConfig,
+	})
+	require.NoError(t, err)
+
+	fakeDeltaStore := msgraphtest.NewFakeDeltaStore()
+
+	const endpoint = "groups/delta"
+
+	// Request without the latest token should fail.
+	for _, err := range client.IterateGroupDeltas(ctx, endpoint, fakeDeltaStore) {
+		require.ErrorIs(t, err, ErrMissingDeltaLink)
+	}
+
+	// Set up latest delta token for user endpoint.
+	err = client.SetupLatestDelta(ctx, endpoint, fakeDeltaStore, WithSelect("id,displayName,description,members,owners"))
+	require.NoError(t, err)
+
+	require.NotEmpty(t, fakeDeltaStore.Get(endpoint))
+
+	sortDeltas := cmpopts.SortSlices(func(a, b *models.ListGroupsDeltaResponse) bool {
+		return a.Group.GetID() != nil &&
+			b.Group.GetID() != nil &&
+			*a.Group.GetID() < *b.Group.GetID()
+	})
+
+	// Create groups
+	group1 := defaultStorage.Groups[msgraphtest.Group1ID]
+	group2 := defaultStorage.Groups[msgraphtest.Group2ID]
+	group3 := defaultStorage.Groups[msgraphtest.Group3ID]
+	fakeServer.SetGroups([]*models.Group{group1, group2, group3})
+	// Add user alice and group3 as member
+	alice := storage.Users[msgraphtest.AliceID]
+	fakeServer.SetGroupMembers(*group1.GetID(), []models.GroupMember{alice, group3})
+	expected := []*models.ListGroupsDeltaResponse{
+		{
+			Group: &models.Group{
+				DirectoryObject: models.DirectoryObject{
+					ID:          group1.GetID(),
+					DisplayName: group1.DisplayName,
+				},
+				GroupTypes: []string{"security-groups"},
+			},
+			Members: []models.MembersDelta{
+				{
+					DirectoryObject: &models.DirectoryObject{
+						ID: alice.GetID(),
+					},
+					Type: models.ODataUser,
+				},
+				{
+					DirectoryObject: &models.DirectoryObject{
+						ID: group3.GetID(),
+					},
+					Type: models.ODataGroup,
+				},
+			},
+		},
+		{
+			Group: &models.Group{
+				DirectoryObject: models.DirectoryObject{
+					ID:          group2.GetID(),
+					DisplayName: group2.DisplayName,
+				},
+				GroupTypes: []string{"security-groups"},
+			},
+		},
+		{
+			Group: &models.Group{
+				DirectoryObject: models.DirectoryObject{
+					ID:          group3.GetID(),
+					DisplayName: group3.DisplayName,
+				},
+				GroupTypes: []string{"security-groups"},
+			},
+		},
+	}
+	got := []*models.ListGroupsDeltaResponse{}
+	for groupDeltas, err := range client.IterateGroupDeltas(ctx, endpoint, fakeDeltaStore) {
+		require.NoError(t, err)
+
+		got = append(got, groupDeltas)
+	}
+	require.Empty(t, cmp.Diff(expected, got, sortDeltas), "expected group delta response to match")
+
+	fakeServer.DeleteGroups([]string{*group3.GetID()})
+	fakeServer.DeleteUsers([]string{*alice.GetID()})
+	// Add user alice and group3 as member
+	carol := storage.Users[msgraphtest.CarolID]
+	fakeServer.SetGroupOwners(*group1.GetID(), []*models.User{carol})
+	expected = []*models.ListGroupsDeltaResponse{
+		{
+			Group: &models.Group{
+				DirectoryObject: models.DirectoryObject{
+					ID:          group1.GetID(),
+					DisplayName: group1.DisplayName,
+				},
+			},
+			Members: []models.MembersDelta{
+				{
+					DirectoryObject: &models.DirectoryObject{
+						ID: group3.GetID(),
+					},
+					Type: models.ODataGroup,
+					Removed: &models.RemovedReason{
+						Reason: to.Ptr("deleted"),
+					},
+				},
+				{
+					DirectoryObject: &models.DirectoryObject{
+						ID: alice.GetID(),
+					},
+					Type: models.ODataUser,
+					Removed: &models.RemovedReason{
+						Reason: to.Ptr("deleted"),
+					},
+				},
+			},
+			Owners: []models.OwnersDelta{
+				{
+					User: &models.User{
+						DirectoryObject: models.DirectoryObject{
+							ID: carol.GetID(),
+						},
+					},
+					Type: models.ODataUser,
+				},
+			},
+		},
+		{
+			Group: &models.Group{
+				DirectoryObject: models.DirectoryObject{
+					ID: group3.GetID(),
+				},
+			},
+			Removed: &models.RemovedReason{
+				Reason: to.Ptr("deleted"),
+			},
+		},
+	}
+	got = []*models.ListGroupsDeltaResponse{}
+	for groupDeltas, err := range client.IterateGroupDeltas(ctx, endpoint, fakeDeltaStore) {
+		require.NoError(t, err)
+
+		got = append(got, groupDeltas)
+	}
+
+	require.Empty(t, cmp.Diff(expected, got, sortDeltas), "expected group delta response to match")
+}
+
+func mustParseURL(t *testing.T, in string) *url.URL {
+	t.Helper()
+	url, err := url.Parse(in)
+	require.NoError(t, err)
+	require.Equal(t, "https", url.Scheme, "expected URL with https scheme")
+	return url
+}
+
+func TestDeltaMethodsWithoutTop(t *testing.T) {
+	ctx := t.Context()
+
+	fakeServer := msgraphtest.NewServer()
+
+	client, err := NewClient(Config{
+		HTTPClient:    newHTTPClient(fakeServer.TLSServer),
+		TokenProvider: &fakeTokenProvider{},
+		RetryConfig:   &retryConfig,
+		PageSize:      500, // pagesize added to ensure that the default $top query path is reached wihout the WithoutTop() option.
+	})
+	require.NoError(t, err)
+
+	assertNoTop := func(t *testing.T, uri string) {
+		t.Helper()
+		parsed, err := url.ParseRequestURI(uri)
+		if err != nil {
+			t.Fatalf("failed to parse delta request URI %s: %v", uri, err)
+		}
+		if parsed.Query().Has("$top") {
+			t.Fatalf("expected $top query to be absent in delta API requests, received: %s", uri)
+		}
+	}
+
+	const userEndpoint = "users/delta"
+	const groupEndpoint = "groups/delta"
+
+	deltaStore := msgraphtest.NewFakeDeltaStore()
+
+	t.Run("SetupLatestDelta", func(t *testing.T) {
+		err = client.SetupLatestDelta(ctx, userEndpoint, deltaStore)
+		require.NoError(t, err)
+		assertNoTop(t, deltaStore.Get(userEndpoint))
+
+		err = client.SetupLatestDelta(ctx, groupEndpoint, deltaStore)
+		require.NoError(t, err)
+		assertNoTop(t, deltaStore.Get(groupEndpoint))
+	})
+
+	t.Run("IterateUserDeltas", func(t *testing.T) {
+		// This test should pass by default as long as SetupLatestDelta sets up
+		// latest delta token without the $top query.
+		for _, err = range client.IterateUserDeltas(ctx, userEndpoint, deltaStore) {
+			require.NoError(t, err)
+		}
+		assertNoTop(t, deltaStore.Get(userEndpoint))
+	})
+
+	t.Run("IterateGroupDeltas", func(t *testing.T) {
+		// This test should pass by default as long as SetupLatestDelta sets up
+		// latest delta token without the $top query.
+		for _, err = range client.IterateGroupDeltas(ctx, groupEndpoint, deltaStore) {
+			require.NoError(t, err)
+		}
+		assertNoTop(t, deltaStore.Get(groupEndpoint))
+	})
+}
+
+func TestValidateDeltaLink(t *testing.T) {
+	ctx := t.Context()
+	tests := []struct {
+		name           string
+		baseURL        string
+		deltaLink      string
+		errorAssertion require.ErrorAssertionFunc
+	}{
+		{
+			name:           "matching host",
+			baseURL:        types.MSGraphDefaultEndpoint,
+			deltaLink:      fmt.Sprintf("%s/v1.0/users/delta?$deltatoken=latest", types.MSGraphDefaultEndpoint),
+			errorAssertion: require.NoError,
+		},
+		{
+			name:      "matching host with http sceheme",
+			baseURL:   types.MSGraphDefaultEndpoint,
+			deltaLink: "http://graph.microsoft.com/v1.0/users/delta?$deltatoken=latest",
+			errorAssertion: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "scheme")
+			},
+		},
+		{
+			name:      "different host",
+			baseURL:   types.MSGraphDefaultEndpoint,
+			deltaLink: fmt.Sprintf("%s/v1.0/users/delta?$deltatoken=latest", "https://cloudapp.azure.com"),
+			errorAssertion: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "host mismatch")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeServer := msgraphtest.NewServer()
+			t.Cleanup(func() { fakeServer.TLSServer.Close() })
+
+			const endpoint = "users/delta"
+			ds := msgraphtest.NewFakeDeltaStore()
+			ds.Set(endpoint, tt.deltaLink)
+
+			client, err := NewClient(Config{
+				HTTPClient:    newHTTPClient(fakeServer.TLSServer),
+				TokenProvider: &fakeTokenProvider{},
+				RetryConfig:   &retryConfig,
+				GraphEndpoint: tt.baseURL,
+			})
+			require.NoError(t, err)
+
+			err = validateDeltaLink(client.baseURL, tt.deltaLink)
+			tt.errorAssertion(t, err)
+
+			for _, err := range client.iterateDelta(ctx, endpoint, ds) {
+				tt.errorAssertion(t, err)
+			}
+		})
+	}
 }

--- a/lib/msgraph/errors.go
+++ b/lib/msgraph/errors.go
@@ -29,6 +29,9 @@ type graphErrorResponse struct {
 	Error *GraphError `json:"error,omitempty"`
 }
 
+// ErrMissingDeltaLink is returned if a delta link is missing from the delta store.
+var ErrMissingDeltaLink = &trace.BadParameterError{Message: "missing delta token"}
+
 // GraphError defines the structure of errors returned from MS Graph API.
 // https://learn.microsoft.com/en-us/graph/errors#json-representation
 type GraphError struct {

--- a/lib/msgraph/paginated.go
+++ b/lib/msgraph/paginated.go
@@ -414,14 +414,13 @@ func (c *Client) SetupLatestDelta(ctx context.Context, endpoint string, ds Delta
 		return trace.BadParameter("missing delta store")
 	}
 
-	// Wipe out existing cache but preserve older link on error.
+	// Preserve older link on error.
 	oldLink := ds.Get(endpoint)
 	defer func() {
 		if err != nil && oldLink != "" {
 			ds.Set(endpoint, oldLink)
 		}
 	}()
-	ds.Clear(endpoint)
 
 	// Configure URL. At minimum, this needs $deltatoken=latest
 	// and $select query passed by the caller.

--- a/lib/msgraph/paginated.go
+++ b/lib/msgraph/paginated.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"iter"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -71,6 +72,16 @@ func (ic *iterateConfig) query() url.Values {
 func (c *Client) newIterateConfig() *iterateConfig {
 	return &iterateConfig{
 		top:    c.pageSize,
+		header: make(http.Header),
+	}
+}
+
+// newIterateConfigDelta creates a new iterateConfig.
+// It does not set up $top query as newIterateConfig does because
+// some delta endpoints like user and groups does not support it.
+// Clients can explicitly pass WithTop() to include it.
+func (c *Client) newIterateConfigDelta() *iterateConfig {
+	return &iterateConfig{
 		header: make(http.Header),
 	}
 }
@@ -214,6 +225,237 @@ func (c *Client) IterateUsers(ctx context.Context, f func(*models.User) bool, op
 	return iterateSimple(c, ctx, "users", f, opts...)
 }
 
+// iterateDelta implements pagination for Graph delta API endpoints.
+// It expects a valid delta link for the [endpoint] available in the [ds].
+func (c *Client) iterateDelta(ctx context.Context, endpoint string, ds DeltaStore) iter.Seq2[json.RawMessage, error] {
+	if ds == nil {
+		return func(yield func(json.RawMessage, error) bool) {
+			yield(nil, trace.BadParameter("missing delta store"))
+		}
+	}
+	deltaURI := ds.Get(endpoint)
+	if deltaURI == "" {
+		return func(yield func(json.RawMessage, error) bool) {
+			yield(nil, trace.Wrap(ErrMissingDeltaLink))
+		}
+	}
+
+	// Below, the delta link host is checked against the baseURL host
+	// which has already gone through validation when constructing the
+	// graph client. This isn't strictly necessary because as per the delta
+	// API docs, the client must save the whole delta link and use it as it
+	// is in the next delta request.
+	// https://learn.microsoft.com/en-us/graph/delta-query-overview#state-tokens
+	// https://learn.microsoft.com/en-us/graph/api/group-delta?view=graph-rest-1.0&tabs=http
+	if err := validateDeltaLink(c.baseURL, deltaURI); err != nil {
+		return func(yield func(json.RawMessage, error) bool) {
+			yield(nil, trace.Wrap(err))
+		}
+	}
+
+	// For the first request, uriString will be the same as deltaURI.
+	// If response is paginated, uriString will be assigned
+	// with a new NextLink.
+	uriString := deltaURI
+	// No extra headers expected for delta query.
+	header := make(http.Header)
+
+	return func(yield func(json.RawMessage, error) bool) {
+		var deltaLink string
+
+		for uriString != "" {
+			resp, err := c.request(ctx, http.MethodGet, uriString, header, nil /* payload */)
+			if err != nil {
+				yield(nil, trace.Wrap(err))
+				return
+			}
+
+			var page models.ODataPage
+			if err := jsoniter.ConfigFastest.NewDecoder(resp.Body).Decode(&page); err != nil {
+				resp.Body.Close()
+				yield(nil, trace.Wrap(err))
+				return
+			}
+
+			resp.Body.Close()
+			uriString = page.NextLink
+
+			if page.DeltaLink != "" {
+				deltaLink = page.DeltaLink
+			}
+
+			if !yield(page.Value, nil) {
+				return
+			}
+		}
+
+		if deltaLink != "" {
+			ds.Set(endpoint, deltaLink)
+		}
+	}
+}
+
+// IterateUserDeltas iterates over users delta response.
+// A delta token for the user endpont
+// must be set up before calling this method.
+func (c *Client) IterateUserDeltas(
+	ctx context.Context,
+	endpoint string,
+	ds DeltaStore,
+) iter.Seq2[*models.ListUsersDeltaResponse, error] {
+	return func(yield func(*models.ListUsersDeltaResponse, error) bool) {
+		for msg, iterErr := range c.iterateDelta(ctx, endpoint, ds) {
+			if iterErr != nil {
+				yield(nil, trace.Wrap(iterErr))
+				return
+			}
+			var page []*models.ListUsersDeltaResponse
+			if err := utils.FastUnmarshal(msg, &page); err != nil {
+				yield(nil, trace.Wrap(err))
+				return
+			}
+			for _, item := range page {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// IterateGroupDeltas iterates over groups delta response.
+// A delta token for the group endpont
+// must be set up before calling this method.
+func (c *Client) IterateGroupDeltas(
+	ctx context.Context,
+	endpoint string,
+	ds DeltaStore,
+) iter.Seq2[*models.ListGroupsDeltaResponse, error] {
+	return func(yield func(*models.ListGroupsDeltaResponse, error) bool) {
+		for msg, iterErr := range c.iterateDelta(ctx, endpoint, ds) {
+			if iterErr != nil {
+				yield(nil, trace.Wrap(iterErr))
+				return
+			}
+			var page []*models.ListGroupsDeltaResponse
+			if err := utils.FastUnmarshal(msg, &page); err != nil {
+				yield(nil, trace.Wrap(err))
+				return
+			}
+			for _, item := range page {
+				item.Owners = filterUnsupportedGroupOwners(item.Owners)
+				item.Members = filterUnsupportedGroupMembers(item.Members)
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func filterUnsupportedGroupOwners(in []models.OwnersDelta) []models.OwnersDelta {
+	if in == nil {
+		return nil
+	}
+	out := make([]models.OwnersDelta, 0, len(in))
+	for _, owner := range in {
+		if owner.User == nil {
+			continue
+		}
+		switch owner.Type {
+		case models.ODataUser:
+			out = append(out, models.OwnersDelta{
+				User: &models.User{
+					DirectoryObject: models.DirectoryObject{
+						ID:          owner.ID,
+						DisplayName: owner.DisplayName,
+					},
+				},
+				Type:    owner.Type,
+				Removed: owner.Removed,
+			})
+		default:
+			// owners such as #microsoft.graph.servicePrincipal are discarded.
+		}
+	}
+	return out
+}
+
+func filterUnsupportedGroupMembers(in []models.MembersDelta) []models.MembersDelta {
+	if in == nil {
+		return nil
+	}
+	out := make([]models.MembersDelta, 0, len(in))
+	for _, member := range in {
+		if member.DirectoryObject == nil {
+			continue
+		}
+		switch member.Type {
+		case models.ODataUser, models.ODataGroup:
+			out = append(out, models.MembersDelta{
+				DirectoryObject: &models.DirectoryObject{
+					ID:          member.ID,
+					DisplayName: member.DisplayName,
+				},
+				Type:    member.Type,
+				Removed: member.Removed,
+			})
+		default:
+			// members such as #microsoft.graph.device are discarded.
+		}
+	}
+	return out
+}
+
+// SetupLatestDelta configures latest delta token for the given endpoint.
+// Should always be called before iterating over user and group delta API.
+func (c *Client) SetupLatestDelta(ctx context.Context, endpoint string, ds DeltaStore, opts ...IterateOpt) (err error) {
+	if ds == nil {
+		return trace.BadParameter("missing delta store")
+	}
+
+	// Wipe out existing cache but preserve older link on error.
+	oldLink := ds.Get(endpoint)
+	defer func() {
+		if err != nil && oldLink != "" {
+			ds.Set(endpoint, oldLink)
+		}
+	}()
+	ds.Clear(endpoint)
+
+	// Configure URL. At minimum, this needs $deltatoken=latest
+	// and $select query passed by the caller.
+	ic := c.newIterateConfigDelta()
+	for _, opt := range opts {
+		opt(ic)
+	}
+	q := ic.query()
+	q.Set("$deltatoken", "latest")
+	uri := *c.baseURL
+	uri.Path = path.Join(uri.Path, endpoint)
+	uri.RawQuery = q.Encode()
+	uriString := uri.String()
+
+	var resp *http.Response
+	resp, err = c.request(ctx, http.MethodGet, uriString, ic.header, nil /* payload */)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer resp.Body.Close()
+
+	var page models.ODataPage
+	if err = jsoniter.ConfigFastest.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return trace.Wrap(err)
+	}
+	if page.DeltaLink == "" {
+		return trace.Errorf("missing delta link in latest delta query response")
+	}
+
+	ds.Set(endpoint, page.DeltaLink)
+
+	return nil
+}
+
 // IterateServicePrincipals lists all service principals in the Entra ID directory using pagination.
 // `f` will be called for each object in the result set.
 // if `f` returns `false`, the iteration is stopped (equivalent to `break` in a normal loop).
@@ -329,4 +571,19 @@ func (c *Client) IterateUsersTransitiveMemberOf(ctx context.Context, userID, gro
 		return trace.Wrap(err)
 	}
 	return trace.Wrap(itErr)
+}
+
+// validateDeltaLink checks host of the baseURL and deltaLink matches.
+func validateDeltaLink(baseURL *url.URL, deltaLink string) error {
+	deltaURL, err := url.Parse(deltaLink)
+	if err != nil {
+		return trace.BadParameter("invalid delta link URL %s", deltaLink)
+	}
+	if deltaURL.Scheme != "https" {
+		return trace.BadParameter("delta link must be of HTTPs scheme, received %q", deltaURL.Scheme)
+	}
+	if baseURL.Host != deltaURL.Host {
+		return trace.BadParameter("base URL and delta link URL host mismatch, base=%q delta=%q", baseURL.Host, deltaURL.Host)
+	}
+	return nil
 }


### PR DESCRIPTION
**Delta API**
The Graph delta API is a incremental change tracking service. Any changes made in the Entra ID directory are
tracked by the delta API service.

The Entra ID plugin is only interested tracking user and group delta.
The plugin implements "sync from now" pattern where the client first requests a "latest" delta token.
In the subsequent delta request, the delta API responds with the changes tracked after issuing the "latest" delta token along with a new delta token.

To handle delta API, this PR implements the following:
- `SetupLatestDelta` method to setup a "latest" delta token. 
- `IterateUserDeltas` and `IterateGroupDeltas` methods for handling user and group delta response.  
- `iterateDelta` method to actually make the graph api request. The method is based on existing `iterate` method updated to handle delta token and update delta storage. Existing msgraph client methods can gradually migrated to use this new method. 

The caller of the delta methods is expected to follow the steps below steps:
1. setup delta token storage
2. setup latest delta token (by querying delta endpoint with a `latest` token)
3. call iterate methods.

Test depends on fake delta api server implemented in https://github.com/gravitational/teleport/pull/66272

RFD https://github.com/gravitational/teleport.e/pull/8293
Issue https://github.com/gravitational/teleport/issues/63976