### PR TITLE
Azure VM support for `tctl discovery nodes` command

### DIFF
--- a/tool/tctl/common/discovery/command.go
+++ b/tool/tctl/common/discovery/command.go
@@ -40,6 +40,7 @@ type Command struct {
 	nodesLast         time.Duration
 	nodesFormat       string
 	nodesFailuresOnly bool
+	nodesCloudFilter  string
 }
 
 // Initialize registers the "discovery" command and its subcommands with the CLI parser.
@@ -67,6 +68,9 @@ Examples:
 		EnumVar(&c.nodesFormat, teleport.Text, teleport.JSON)
 	c.nodesCmd.Flag("failures-only", "Only show instances with enrollment failures.").
 		BoolVar(&c.nodesFailuresOnly)
+	c.nodesCmd.Flag("cloud", "Comma-separated list of cloud providers to include (allowed: aws, azure). Empty (default) returns all.").
+		Default("").
+		StringVar(&c.nodesCloudFilter)
 }
 
 // TryRun attempts to run the matched subcommand.
@@ -95,7 +99,12 @@ func (c *Command) runNodes(ctx context.Context, clt discoveryClient, w io.Writer
 		"last", c.nodesLast,
 	)
 
-	instances, err := buildNodes(ctx, clt, dateFrom, dateTo)
+	cfg, err := parseCloudProviders(c.nodesCloudFilter)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	instances, err := buildNodes(ctx, clt, dateFrom, dateTo, cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/discovery/command.go
+++ b/tool/tctl/common/discovery/command.go
@@ -35,19 +35,15 @@ import (
 
 // Command implements the "tctl discovery" CLI command group.
 type Command struct {
-	config *servicecfg.Config
-
 	nodesCmd *kingpin.CmdClause
 
-	nodesLast         string
+	nodesLast         time.Duration
 	nodesFormat       string
 	nodesFailuresOnly bool
 }
 
 // Initialize registers the "discovery" command and its subcommands with the CLI parser.
-func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
-	c.config = config
-
+func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, _ *servicecfg.Config) {
 	discovery := app.Command("discovery", "Troubleshoot auto-discovery issues.")
 	c.nodesCmd = discovery.Command("nodes", "Report discovered server instances and their enrollment status using Teleport audit log and cluster state.")
 	c.nodesCmd.Alias(`
@@ -65,7 +61,7 @@ Examples:
 
 	c.nodesCmd.Flag("last", "Time window to look back for failures in Teleport audit log (e.g. 1h, 24h, 30m).").
 		Default("1h").
-		StringVar(&c.nodesLast)
+		DurationVar(&c.nodesLast)
 	c.nodesCmd.Flag("format", "Output format.").
 		Default(teleport.Text).
 		EnumVar(&c.nodesFormat, teleport.Text, teleport.JSON)
@@ -79,10 +75,8 @@ func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclien
 		return false, nil
 	}
 
-	dateFrom, dateTo, err := resolveTimeRange(c.config.Clock, c.nodesLast)
-	if err != nil {
-		return true, trace.Wrap(err)
-	}
+	dateTo := time.Now().UTC()
+	dateFrom := dateTo.Add(-c.nodesLast)
 
 	client, closeFn, err := clientFunc(ctx)
 	if err != nil {

--- a/tool/tctl/common/discovery/command_test.go
+++ b/tool/tctl/common/discovery/command_test.go
@@ -19,6 +19,8 @@ package discovery
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -46,12 +48,20 @@ func (m *mockUserTasks) ListUserTasks(_ context.Context, _ int64, _ string, _ *u
 
 // mockClient implements discoveryClient for testing.
 type mockClient struct {
-	events    []apievents.AuditEvent
-	nodes     []*types.ServerV2
-	userTasks []*usertasksv1.UserTask
+	events             []apievents.AuditEvent
+	nodes              []*types.ServerV2
+	userTasks          []*usertasksv1.UserTask
+	acceptedEventTypes []string
 }
 
 func (m *mockClient) SearchEvents(_ context.Context, req libevents.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
+	if m.acceptedEventTypes != nil {
+		for _, want := range req.EventTypes {
+			if !slices.Contains(m.acceptedEventTypes, want) {
+				return nil, "", fmt.Errorf("unexpected event type %q (accepted: %v)", want, m.acceptedEventTypes)
+			}
+		}
+	}
 	return m.events, "", nil
 }
 
@@ -334,6 +344,54 @@ Azure sub-1   eastus rg-1/vm-on...               Online
 				require.NoError(t, c.runNodes(t.Context(), tt.client, &buf, time.Now().Add(-time.Hour), time.Now()))
 				require.Equal(t, tt.wantJSON, buf.String())
 			})
+		})
+	}
+}
+
+func TestBuildNodes_CloudFilter(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		desc       string
+		cfg        cloudProviderConfig
+		accepted   []string
+		wantClouds []string
+	}{
+		{
+			desc:       "aws only",
+			cfg:        cloudProviderConfig{aws: true},
+			accepted:   []string{libevents.SSMRunEvent},
+			wantClouds: []string{cloudAWS},
+		},
+		{
+			desc:       "azure only",
+			cfg:        cloudProviderConfig{azure: true},
+			accepted:   []string{libevents.AzureRunEvent},
+			wantClouds: []string{cloudAzure},
+		},
+		{
+			desc:       "both clouds",
+			cfg:        cloudProviderConfig{aws: true, azure: true},
+			accepted:   []string{libevents.SSMRunEvent, libevents.AzureRunEvent},
+			wantClouds: []string{cloudAWS, cloudAzure},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			client := &mockClient{
+				events: []apievents.AuditEvent{
+					makeSSMRun("i-1", "111", "us-east-1", "Success", 0, "", now),
+					makeAzureRun("vm-1", "sub-1", "rg-1", "eastus", azureExecStateSucceeded, 0, "", "", now),
+				},
+				acceptedEventTypes: tt.accepted,
+			}
+			instances, err := buildNodes(t.Context(), client, now.Add(-time.Hour), now, tt.cfg)
+			require.NoError(t, err)
+
+			var clouds []string
+			for _, inst := range instances {
+				clouds = append(clouds, inst.cloud().cloudName())
+			}
+			require.Equal(t, tt.wantClouds, clouds)
 		})
 	}
 }

--- a/tool/tctl/common/discovery/command_test.go
+++ b/tool/tctl/common/discovery/command_test.go
@@ -104,7 +104,6 @@ AWS   222     us-west-2 i-success   2026-01-15... Installed ...
     {
         "region": "us-east-1",
         "is_online": false,
-        "expiry": "0001-01-01T00:00:00Z",
         "run_result": {
             "exit_code": 1,
             "output": "install failed",
@@ -119,7 +118,6 @@ AWS   222     us-west-2 i-success   2026-01-15... Installed ...
     {
         "region": "us-west-2",
         "is_online": false,
-        "expiry": "0001-01-01T00:00:00Z",
         "run_result": {
             "exit_code": 0,
             "output": "",
@@ -158,7 +156,6 @@ AWS   111     us-east-1 i-online1   2026-01-15... Online, ex... Script out...
     {
         "region": "us-east-1",
         "is_online": true,
-        "expiry": "0001-01-01T00:00:00Z",
         "run_result": {
             "exit_code": 1,
             "output": "err",

--- a/tool/tctl/common/discovery/command_test.go
+++ b/tool/tctl/common/discovery/command_test.go
@@ -90,6 +90,8 @@ func newTestCommand(format string) *Command {
 }
 
 func TestRunNodes(t *testing.T) {
+	t.Parallel()
+
 	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -349,6 +351,8 @@ Azure sub-1   eastus rg-1/vm-on...               Online
 }
 
 func TestBuildNodes_CloudFilter(t *testing.T) {
+	t.Parallel()
+
 	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
 		desc       string

--- a/tool/tctl/common/discovery/command_test.go
+++ b/tool/tctl/common/discovery/command_test.go
@@ -29,6 +29,7 @@ import (
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	usertaskstypes "github.com/gravitational/teleport/api/types/usertasks"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -95,16 +96,17 @@ func TestRunNodes(t *testing.T) {
 					makeSSMRun("i-success", "222", "us-west-2", "Success", 0, "", now),
 				},
 			},
-			wantText: `Cloud Account Region    Instance ID Time          Status        Details       
------ ------- --------- ----------- ------------- ------------- ------------- 
-AWS   111     us-east-1 i-fail111   2026-01-15... Failed (ex... Script out... 
-AWS   222     us-west-2 i-success   2026-01-15... Installed ...               
+			wantText: `Cloud Account Region    Instance  Time          Status        Details           
+----- ------- --------- --------- ------------- ------------- ----------------- 
+AWS   111     us-east-1 i-fail111 2026-01-15... Failed (ex... Script output:... 
+AWS   222     us-west-2 i-success 2026-01-15... Installed ...                   
 `,
 			wantJSON: `[
     {
         "region": "us-east-1",
         "is_online": false,
         "run_result": {
+            "api_error": "",
             "exit_code": 1,
             "output": "install failed",
             "time": "2026-01-15T12:00:00Z",
@@ -119,6 +121,7 @@ AWS   222     us-west-2 i-success   2026-01-15... Installed ...
         "region": "us-west-2",
         "is_online": false,
         "run_result": {
+            "api_error": "",
             "exit_code": 0,
             "output": "",
             "time": "2026-01-15T12:00:00Z",
@@ -148,15 +151,16 @@ AWS   222     us-west-2 i-success   2026-01-15... Installed ...
 				},
 				nodes: []*types.ServerV2{makeNode("node-1", "i-online1", "111", "us-east-1", time.Time{})},
 			},
-			wantText: `Cloud Account Region    Instance ID Time          Status        Details       
------ ------- --------- ----------- ------------- ------------- ------------- 
-AWS   111     us-east-1 i-online1   2026-01-15... Online, ex... Script out... 
+			wantText: `Cloud Account Region    Instance  Time          Status        Details           
+----- ------- --------- --------- ------------- ------------- ----------------- 
+AWS   111     us-east-1 i-online1 2026-01-15... Online, ex... Script output:... 
 `,
 			wantJSON: `[
     {
         "region": "us-east-1",
         "is_online": true,
         "run_result": {
+            "api_error": "",
             "exit_code": 1,
             "output": "err",
             "time": "2026-01-15T12:00:00Z",
@@ -165,6 +169,151 @@ AWS   111     us-east-1 i-online1   2026-01-15... Online, ex... Script out...
         "aws": {
             "instance_id": "i-online1",
             "account_id": "111"
+        }
+    }
+]
+`,
+		},
+		{
+			desc: "Azure run failure with online Azure node",
+			client: &mockClient{
+				events: []apievents.AuditEvent{
+					makeAzureRun("vm-online", "sub-1", "rg-1", "eastus", azureExecStateFailed, 1, "err", "", now),
+				},
+				nodes: []*types.ServerV2{makeAzureNode("node-1", "vm-online", "sub-1", "rg-1", "eastus", time.Time{})},
+			},
+			wantText: `Cloud Account Region Instance      Time          Status        Details          
+----- ------- ------ ------------- ------------- ------------- ---------------- 
+Azure sub-1   eastus rg-1/vm-on... 2026-01-15... Online, ex... Script output... 
+`,
+			wantJSON: `[
+    {
+        "region": "eastus",
+        "is_online": true,
+        "run_result": {
+            "api_error": "",
+            "exit_code": 1,
+            "output": "err",
+            "time": "2026-01-15T12:00:00Z",
+            "is_failure": true
+        },
+        "azure": {
+            "vm_id": "vm-online",
+            "subscription_id": "sub-1",
+            "resource_group": "rg-1"
+        }
+    }
+]
+`,
+		},
+		{
+			desc: "AWS instance with user task",
+			client: &mockClient{
+				events: []apievents.AuditEvent{
+					makeSSMRun("i-bad", "111", "us-east-1", "Failed", 1, "install failed", now),
+				},
+				userTasks: []*usertasksv1.UserTask{
+					makeEC2Task(t, usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure, "i-bad"),
+				},
+			},
+			wantText: `Cloud Account Region    Instance Time          Status        Details            
+----- ------- --------- -------- ------------- ------------- ------------------ 
+AWS   111     us-east-1 i-bad    2026-01-15... Failed (ex... SSM Script fail... 
+`,
+			wantJSON: `[
+    {
+        "region": "us-east-1",
+        "is_online": false,
+        "run_result": {
+            "api_error": "",
+            "exit_code": 1,
+            "output": "install failed",
+            "time": "2026-01-15T12:00:00Z",
+            "is_failure": true
+        },
+        "user_task_id": "07cccc8f-bb13-5f93-99d8-0ba51ca1da92",
+        "user_task_issue": "ec2-ssm-script-failure",
+        "aws": {
+            "instance_id": "i-bad",
+            "account_id": "111"
+        }
+    }
+]
+`,
+		},
+		{
+			desc: "Azure VM with user task",
+			client: &mockClient{
+				events: []apievents.AuditEvent{
+					makeAzureRun("vm-bad", "sub-1", "rg-1", "eastus", azureExecStateFailed, 1, "", "forbidden", now),
+				},
+				userTasks: []*usertasksv1.UserTask{
+					makeAzureVMTask(t, usertaskstypes.AutoDiscoverAzureVMIssueEnrollmentError, "vm-bad"),
+				},
+			},
+			wantText: `Cloud Account Region Instance      Time          Status        Details          
+----- ------- ------ ------------- ------------- ------------- ---------------- 
+Azure sub-1   eastus rg-1/vm-ba... 2026-01-15... Failed (AP... Enrollment fa... 
+`,
+			wantJSON: `[
+    {
+        "region": "eastus",
+        "is_online": false,
+        "run_result": {
+            "api_error": "forbidden",
+            "exit_code": 1,
+            "output": "",
+            "time": "2026-01-15T12:00:00Z",
+            "is_failure": true
+        },
+        "user_task_id": "a8febb79-9ffd-519b-8be7-98e2fd80be86",
+        "user_task_issue": "azure-vm-enrollment-error",
+        "azure": {
+            "vm_id": "vm-bad",
+            "subscription_id": "sub-1",
+            "resource_group": "rg-1"
+        }
+    }
+]
+`,
+		},
+		{
+			desc: "Azure API failure",
+			client: &mockClient{
+				events: []apievents.AuditEvent{
+					makeAzureRun("vm-offline", "sub-1", "rg-1", "eastus", azureExecStateFailed, 1, "", "forbidden", now),
+				},
+				nodes: []*types.ServerV2{makeAzureNode("node-1", "vm-online", "sub-1", "rg-1", "eastus", time.Time{})},
+			},
+			wantText: `Cloud Account Region Instance      Time          Status        Details          
+----- ------- ------ ------------- ------------- ------------- ---------------- 
+Azure sub-1   eastus rg-1/vm-of... 2026-01-15... Failed (AP... API error: "f... 
+Azure sub-1   eastus rg-1/vm-on...               Online                         
+`,
+			wantJSON: `[
+    {
+        "region": "eastus",
+        "is_online": false,
+        "run_result": {
+            "api_error": "forbidden",
+            "exit_code": 1,
+            "output": "",
+            "time": "2026-01-15T12:00:00Z",
+            "is_failure": true
+        },
+        "azure": {
+            "vm_id": "vm-offline",
+            "subscription_id": "sub-1",
+            "resource_group": "rg-1"
+        }
+    },
+    {
+        "region": "eastus",
+        "is_online": true,
+        "azure": {
+            "vm_id": "vm-online",
+            "subscription_id": "sub-1",
+            "resource_group": "rg-1"
         }
     }
 ]

--- a/tool/tctl/common/discovery/command_test.go
+++ b/tool/tctl/common/discovery/command_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -31,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	libevents "github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -75,8 +73,7 @@ func (m *mockClient) GetResources(_ context.Context, _ *proto.ListResourcesReque
 // newTestCommand creates a Command for testing.
 func newTestCommand(format string) *Command {
 	return &Command{
-		config:      &servicecfg.Config{Clock: clockwork.NewRealClock()},
-		nodesLast:   "1h",
+		nodesLast:   time.Hour,
 		nodesFormat: format,
 	}
 }

--- a/tool/tctl/common/discovery/nodes.go
+++ b/tool/tctl/common/discovery/nodes.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -54,6 +55,7 @@ type discoveryClient interface {
 // runResult captures the most recent installation script result for an instance,
 // sourced from audit events (e.g. SSM run events for AWS).
 type runResult struct {
+	APIError  string    `json:"api_error"`
 	ExitCode  int64     `json:"exit_code"`
 	Output    string    `json:"output"`
 	Time      time.Time `json:"time"`
@@ -70,15 +72,16 @@ type instanceInfo struct {
 	UserTaskID    string     `json:"user_task_id,omitempty"`
 	UserTaskIssue string     `json:"user_task_issue,omitempty"`
 
-	AWS *awsInfo `json:"aws,omitempty"`
+	AWS   *awsInfo   `json:"aws,omitempty"`
+	Azure *azureInfo `json:"azure,omitempty"`
 }
 
 // cloudInfo provides cloud-specific identifiers for an instance.
 // Used for rendering, sorting, and matching against user tasks.
 type cloudInfo interface {
 	cloudName() string
-	cloudInstanceID() string
 	cloudAccountID() string
+	instanceText() string
 }
 
 // cloud returns the cloud-specific metadata for this instance, or nil
@@ -87,7 +90,19 @@ func (inst instanceInfo) cloud() cloudInfo {
 	if inst.AWS != nil {
 		return inst.AWS
 	}
+	if inst.Azure != nil {
+		return inst.Azure
+	}
 	return nil
+}
+
+// accountID returns the cloud account ID for this instance, or "" if no
+// cloud provider info is available.
+func (inst instanceInfo) accountID() string {
+	if ci := inst.cloud(); ci != nil {
+		return ci.cloudAccountID()
+	}
+	return ""
 }
 
 // lastTimeValue returns the most recent timestamp for sorting.
@@ -109,90 +124,127 @@ func (inst instanceInfo) lastTime() string {
 	return t.Format(time.RFC3339)
 }
 
-// runOutput returns the run command stdout/stderr with newlines escaped for
-// single-line display. Output longer than runOutputMaxLen is truncated.
-func (inst instanceInfo) runOutput() string {
-	if inst.RunResult == nil {
-		return ""
-	}
-	out := strings.TrimSpace(inst.RunResult.Output)
+func trimEscape(out string) string {
+	out = strings.TrimSpace(out)
 	if out == "" {
 		return ""
 	}
 
-	// runOutputMaxLen is the maximum length of the raw output string before
+	// maxLen is the maximum length of the raw output string before
 	// quoting. Longer values are truncated with an ellipsis.
-	const runOutputMaxLen = 100
-
-	if len(out) > runOutputMaxLen {
-		out = out[:runOutputMaxLen] + "..."
+	const maxLen = 100
+	if len(out) > maxLen {
+		out = out[:maxLen] + "..."
 	}
 	return fmt.Sprintf("%q", out)
 }
 
-// details returns a column combining available information. If the user task is present, it will return the title of this task.
-// Otherwise, if non-empty script output is available, we'll return it instead.
+// details returns a column combining available information: the user task title
+// (if any), followed by the script output or API error (if any).
 // Full, non-combined details are always available in JSON output.
 func (inst instanceInfo) details() string {
-	if inst.UserTaskIssue != "" {
-		// keep title, ignore description, it is fairly long.
-		title, _ := usertasks.DescriptionForDiscoverEC2Issue(inst.UserTaskIssue)
-		if title == "" {
-			title = inst.UserTaskIssue
+	title := inst.userTaskTitle()
+	var extra string
+	if inst.RunResult != nil {
+		if out := trimEscape(inst.RunResult.Output); out != "" {
+			extra = "Script output: " + out
+		} else if apiErr := trimEscape(inst.RunResult.APIError); apiErr != "" {
+			extra = "API error: " + apiErr
 		}
+	}
+	switch {
+	case title != "" && extra != "":
+		return title + ". " + extra
+	case title != "":
 		return title
+	default:
+		return extra
 	}
-
-	if out := inst.runOutput(); out != "" {
-		return "Script output: " + out
-	}
-
-	return ""
 }
 
-// status returns a human-readable status combining online state and run result.
-func (inst instanceInfo) status() string {
-	if inst.RunResult == nil {
-		if inst.IsOnline {
-			return "Online"
-		}
+// userTaskTitle returns the human-readable title for this instance's user task
+// issue, or "" if there is no task. Falls back to the raw issue string when
+// the cloud is unknown or the issue type has no registered description.
+func (inst instanceInfo) userTaskTitle() string {
+	if inst.UserTaskIssue == "" {
 		return ""
 	}
-	if !inst.RunResult.IsFailure {
-		if inst.IsOnline {
+	var title string
+	if ci := inst.cloud(); ci != nil {
+		switch ci.cloudName() {
+		case cloudAWS:
+			title, _ = usertasks.DescriptionForDiscoverEC2Issue(inst.UserTaskIssue)
+		case cloudAzure:
+			title, _ = usertasks.DescriptionForDiscoverAzureVMIssue(inst.UserTaskIssue)
+		}
+	}
+	return cmp.Or(title, inst.UserTaskIssue)
+}
+
+// status returns a short human-readable status combining online state and run result.
+func (inst instanceInfo) status() string {
+	var runResultStatus string
+	if inst.RunResult != nil && inst.RunResult.IsFailure {
+		if inst.RunResult.APIError != "" {
+			runResultStatus = "API error" // details column will have more information.
+		} else {
+			runResultStatus = fmt.Sprintf("exit code=%d", inst.RunResult.ExitCode)
+		}
+	}
+
+	// machine is online
+	if inst.IsOnline {
+		if runResultStatus == "" {
 			return "Online"
 		}
+		// most recent installation attempt failed, yet the machine is online anyway.
+		// odd, but it can happen in some configurations.
+		return "Online, " + runResultStatus
+	}
+
+	// offline machine, no run result... why are we even here?
+	if inst.RunResult == nil {
+		return "Unknown"
+	}
+
+	// installation worked, but machine failed to join or went down for some other reason.
+	if !inst.RunResult.IsFailure {
 		return "Installed (offline)"
 	}
-	if inst.IsOnline {
-		return fmt.Sprintf("Online, exit code=%d", inst.RunResult.ExitCode)
-	}
-	return fmt.Sprintf("Failed (exit code=%d)", inst.RunResult.ExitCode)
+
+	// plain failure; include the reason.
+	return fmt.Sprintf("Failed (%s)", runResultStatus)
 }
 
-// filterFailures returns only instances that have a failed run result or a user task.
+func (inst instanceInfo) failed() bool {
+	if inst.RunResult != nil && inst.RunResult.IsFailure {
+		return true
+	}
+	if inst.UserTaskID != "" {
+		return true
+	}
+	return false
+}
+
+// filterFailures returns only instances that have failed in some way.
 func filterFailures(instances []instanceInfo) []instanceInfo {
-	result := make([]instanceInfo, 0, len(instances))
-	for _, inst := range instances {
-		if (inst.RunResult != nil && inst.RunResult.IsFailure) || inst.UserTaskID != "" {
-			result = append(result, inst)
-		}
-	}
-	return result
+	return slices.DeleteFunc(slices.Clone(instances), func(inst instanceInfo) bool {
+		return !inst.failed()
+	})
 }
 
-// buildNodes builds a report of discovered cloud instances by correlating three
-// data sources on the cloud instance ID (e.g. AWS EC2 instance ID):
-//  1. Installation script audit events (e.g. SSM runs) — provides run results.
-//  2. Online Teleport nodes — provides enrollment/online status.
-//  3. User tasks — provides human-readable issue descriptions.
+// buildNodes combines information about cloud instances from three sources,
+// matching on cloud instance ID:
+//  1. Installation audit events.
+//  2. Online Teleport nodes.
+//  3. User tasks.
 func buildNodes(ctx context.Context, clt discoveryClient, from, to time.Time) ([]instanceInfo, error) {
 	slog.DebugContext(ctx, "Fetching installation audit events")
-	ssmEvents, err := getRunEvents(ctx, clt, from, to)
+	ssmEvents, azureEvents, err := getRunEvents(ctx, clt, from, to)
 	if err != nil {
 		return nil, trace.Wrap(err, "fetching installation audit events")
 	}
-	slog.DebugContext(ctx, "Fetched installation audit events", "ssm_count", len(ssmEvents))
+	slog.DebugContext(ctx, "Fetched installation audit events", "ssm_count", len(ssmEvents), "azure_count", len(azureEvents))
 
 	slog.DebugContext(ctx, "Fetching online nodes")
 	nodes, err := client.GetAllResources[types.Server](ctx, clt, &proto.ListResourcesRequest{
@@ -204,8 +256,6 @@ func buildNodes(ctx context.Context, clt discoveryClient, from, to time.Time) ([
 	}
 	slog.DebugContext(ctx, "Fetched online nodes", "count", len(nodes))
 
-	instances := correlate(ssmEvents, nodes)
-
 	slog.DebugContext(ctx, "Fetching user tasks")
 	tasks, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, token string) ([]*usertasksv1.UserTask, string, error) {
 		return clt.UserTasksClient().ListUserTasks(ctx, int64(limit), token, nil)
@@ -214,108 +264,110 @@ func buildNodes(ctx context.Context, clt discoveryClient, from, to time.Time) ([
 		return nil, trace.Wrap(err, "fetching user tasks")
 	}
 	slog.DebugContext(ctx, "Fetched user tasks", "count", len(tasks))
-	matchUserTasks(instances, tasks)
 
-	return instances, nil
+	awsInstances := cloudNodes(
+		mergeInstances(correlateSSMEvents(ssmEvents), correlateAWSNodes(nodes)),
+		tasks, awsTaskInstanceKeys)
+	azureInstances := cloudNodes(
+		mergeInstances(correlateAzureRunEvents(azureEvents), correlateAzureNodes(nodes)),
+		tasks, azureTaskInstanceKeys)
+
+	return append(awsInstances, azureInstances...), nil
 }
 
-// matchUserTasks populates user task fields on instances whose cloud instance
-// ID appears in a user task's instance list (e.g. DiscoverEC2.Instances map).
-func matchUserTasks(instances []instanceInfo, tasks []*usertasksv1.UserTask) {
-	// Build lookup: cloud name -> instance ID -> user task.
-	taskByInstance := map[string]map[string]*usertasksv1.UserTask{
-		cloudAWS: make(map[string]*usertasksv1.UserTask),
-	}
-
+// cloudNodes finalizes one cloud's pipeline: flatten the instance map to a
+// slice, populate user-task fields, and sort.
+func cloudNodes(
+	instances map[string]instanceInfo,
+	tasks []*usertasksv1.UserTask,
+	taskInstanceKeys func(*usertasksv1.UserTask) []string,
+) []instanceInfo {
+	taskMap := make(map[string]*usertasksv1.UserTask)
 	for _, task := range tasks {
-		spec := task.GetSpec()
-		if spec == nil {
-			continue
-		}
-		if ec2 := spec.GetDiscoverEc2(); ec2 != nil {
-			for instanceID := range ec2.GetInstances() {
-				taskByInstance[cloudAWS][instanceID] = task
-			}
+		for _, instanceKey := range taskInstanceKeys(task) {
+			taskMap[instanceKey] = task
 		}
 	}
 
-	for i := range instances {
-		ci := instances[i].cloud()
-		if ci == nil {
-			continue
+	result := make([]instanceInfo, 0, len(instances))
+	for instanceKey, info := range instances {
+		if task, match := taskMap[instanceKey]; match {
+			info.UserTaskID = task.GetMetadata().GetName()
+			info.UserTaskIssue = task.GetSpec().GetIssueType()
 		}
-		if task, ok := taskByInstance[ci.cloudName()][ci.cloudInstanceID()]; ok {
-			instances[i].UserTaskID = task.GetMetadata().GetName()
-			instances[i].UserTaskIssue = task.GetSpec().GetIssueType()
-		}
+		// collect updated copy
+		result = append(result, info)
 	}
+	slices.SortFunc(result, sortInstances)
+
+	return result
+}
+
+// sortInstances orders instances by cloud account, region, then descending time.
+func sortInstances(a, b instanceInfo) int {
+	return cmp.Or(
+		cmp.Compare(a.accountID(), b.accountID()),
+		cmp.Compare(a.Region, b.Region),
+		// Descending time: newer entries first.
+		b.lastTimeValue().Compare(a.lastTimeValue()),
+	)
 }
 
 // getRunEvents fetches installation script audit events in descending time order
-// (most recent first). Currently returns SSM run events; will include Azure/GCP
-// equivalents when available.
-func getRunEvents(ctx context.Context, clt discoveryClient, from, to time.Time) ([]*apievents.SSMRun, error) {
+// (most recent first). Returns SSM run events (AWS) and Azure run events; will
+// include GCP equivalents when available.
+func getRunEvents(ctx context.Context, clt discoveryClient, from, to time.Time) ([]*apievents.SSMRun, []*apievents.AzureRun, error) {
 	events, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, token string) ([]apievents.AuditEvent, string, error) {
 		return clt.SearchEvents(ctx, libevents.SearchEventsRequest{
 			From:       from,
 			To:         to,
-			EventTypes: []string{libevents.SSMRunEvent},
+			EventTypes: []string{libevents.SSMRunEvent, libevents.AzureRunEvent},
 			Order:      types.EventOrderDescending,
 			Limit:      limit,
 			StartKey:   token,
 		})
 	}))
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
-	// Type-assert to concrete event types. Currently only SSM runs exist;
-	// Azure/GCP run command events would be extracted here as well.
+	// Type-assert to concrete event types. GCP run command events would be
+	// extracted here as well.
 	var ssmRuns []*apievents.SSMRun
+	var azureRuns []*apievents.AzureRun
 	for _, ev := range events {
 		switch run := ev.(type) {
 		case *apievents.SSMRun:
 			ssmRuns = append(ssmRuns, run)
+		case *apievents.AzureRun:
+			azureRuns = append(azureRuns, run)
 		}
 	}
-	return ssmRuns, nil
+	return ssmRuns, azureRuns, nil
 }
 
-// correlate joins installation audit events and online nodes into a unified
-// instance list, keyed by cloud instance ID. Events are processed first to
-// seed the map with run results, then nodes enrich existing entries with
-// online status or create new entries for instances with no audit events.
-// The result is sorted by account, region, then descending time.
-func correlate(ssmEvents []*apievents.SSMRun, nodes []types.Server) []instanceInfo {
-	// Key: cloud instance ID (e.g. AWS EC2 instance ID like "i-abc123").
-	instances := make(map[string]*instanceInfo)
-
-	correlateSSMEvents(instances, ssmEvents)
-	correlateNodes(instances, nodes)
-
-	// Convert map to sorted slice.
-	result := make([]instanceInfo, 0, len(instances))
-	for _, info := range instances {
-		result = append(result, *info)
+// mergeInstances merges two instanceInfo maps with bias toward fstMap.
+func mergeInstances(fstMap, sndMap map[string]instanceInfo) map[string]instanceInfo {
+	out := make(map[string]instanceInfo)
+	maps.Copy(out, fstMap)
+	for k, sndValue := range sndMap {
+		out[k] = mergeInstanceInfo(out[k], sndValue)
 	}
-	slices.SortFunc(result, func(a, b instanceInfo) int {
-		var aAccount, bAccount string
-		if ci := a.cloud(); ci != nil {
-			aAccount = ci.cloudAccountID()
-		}
-		if ci := b.cloud(); ci != nil {
-			bAccount = ci.cloudAccountID()
-		}
-		if c := cmp.Compare(aAccount, bAccount); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.Region, b.Region); c != 0 {
-			return c
-		}
-		// Descending time: newer entries first.
-		return b.lastTimeValue().Compare(a.lastTimeValue())
-	})
-	return result
+	return out
+}
+
+// mergeInstanceInfo merges two instance info structs with bias toward fst.
+func mergeInstanceInfo(fst, snd instanceInfo) instanceInfo {
+	return instanceInfo{
+		Region:        cmp.Or(fst.Region, snd.Region),
+		IsOnline:      cmp.Or(fst.IsOnline, snd.IsOnline),
+		Expiry:        cmp.Or(fst.Expiry, snd.Expiry),
+		RunResult:     cmp.Or(fst.RunResult, snd.RunResult),
+		UserTaskID:    cmp.Or(fst.UserTaskID, snd.UserTaskID),
+		UserTaskIssue: cmp.Or(fst.UserTaskIssue, snd.UserTaskIssue),
+		AWS:           cmp.Or(fst.AWS, snd.AWS),
+		Azure:         cmp.Or(fst.Azure, snd.Azure),
+	}
 }
 
 // combineOutput joins stdout and stderr with a newline separator.

--- a/tool/tctl/common/discovery/nodes.go
+++ b/tool/tctl/common/discovery/nodes.go
@@ -65,7 +65,7 @@ type runResult struct {
 type instanceInfo struct {
 	Region        string     `json:"region"`
 	IsOnline      bool       `json:"is_online"`
-	Expiry        time.Time  `json:"expiry,omitempty"`
+	Expiry        time.Time  `json:"expiry,omitzero"`
 	RunResult     *runResult `json:"run_result,omitempty"`
 	UserTaskID    string     `json:"user_task_id,omitempty"`
 	UserTaskIssue string     `json:"user_task_issue,omitempty"`

--- a/tool/tctl/common/discovery/nodes.go
+++ b/tool/tctl/common/discovery/nodes.go
@@ -233,14 +233,48 @@ func filterFailures(instances []instanceInfo) []instanceInfo {
 	})
 }
 
+type cloudProviderConfig struct {
+	aws, azure bool
+}
+
+func parseCloudProviders(value string) (cloudProviderConfig, error) {
+	const (
+		cloudProviderAWS   = "aws"
+		cloudProviderAzure = "azure"
+	)
+
+	if value == "" {
+		return cloudProviderConfig{
+			aws:   true,
+			azure: true,
+		}, nil
+	}
+
+	cfg := cloudProviderConfig{}
+	parts := strings.Split(value, ",")
+	for _, part := range parts {
+		switch strings.ToLower(strings.TrimSpace(part)) {
+		case cloudProviderAWS:
+			cfg.aws = true
+		case cloudProviderAzure:
+			cfg.azure = true
+		case "":
+			return cloudProviderConfig{}, trace.BadParameter("empty cloud provider in --cloud (allowed: aws, azure)")
+		default:
+			return cloudProviderConfig{}, trace.BadParameter("unknown cloud provider %q (allowed: aws, azure)", part)
+		}
+	}
+	return cfg, nil
+}
+
 // buildNodes combines information about cloud instances from three sources,
 // matching on cloud instance ID:
 //  1. Installation audit events.
 //  2. Online Teleport nodes.
 //  3. User tasks.
-func buildNodes(ctx context.Context, clt discoveryClient, from, to time.Time) ([]instanceInfo, error) {
+func buildNodes(ctx context.Context, clt discoveryClient, from, to time.Time, cfg cloudProviderConfig) ([]instanceInfo, error) {
 	slog.DebugContext(ctx, "Fetching installation audit events")
-	ssmEvents, azureEvents, err := getRunEvents(ctx, clt, from, to)
+	ssmEvents, azureEvents, err := getRunEvents(ctx, clt, from, to, cfg)
 	if err != nil {
 		return nil, trace.Wrap(err, "fetching installation audit events")
 	}
@@ -265,14 +299,21 @@ func buildNodes(ctx context.Context, clt discoveryClient, from, to time.Time) ([
 	}
 	slog.DebugContext(ctx, "Fetched user tasks", "count", len(tasks))
 
-	awsInstances := cloudNodes(
-		mergeInstances(correlateSSMEvents(ssmEvents), correlateAWSNodes(nodes)),
-		tasks, awsTaskInstanceKeys)
-	azureInstances := cloudNodes(
-		mergeInstances(correlateAzureRunEvents(azureEvents), correlateAzureNodes(nodes)),
-		tasks, azureTaskInstanceKeys)
+	var instances []instanceInfo
+	if cfg.aws {
+		awsInstances := cloudNodes(
+			mergeInstances(correlateSSMEvents(ssmEvents), correlateAWSNodes(nodes)),
+			tasks, awsTaskInstanceKeys)
+		instances = append(instances, awsInstances...)
+	}
+	if cfg.azure {
+		azureInstances := cloudNodes(
+			mergeInstances(correlateAzureRunEvents(azureEvents), correlateAzureNodes(nodes)),
+			tasks, azureTaskInstanceKeys)
+		instances = append(instances, azureInstances...)
+	}
 
-	return append(awsInstances, azureInstances...), nil
+	return instances, nil
 }
 
 // cloudNodes finalizes one cloud's pipeline: flatten the instance map to a
@@ -316,12 +357,20 @@ func sortInstances(a, b instanceInfo) int {
 // getRunEvents fetches installation script audit events in descending time order
 // (most recent first). Returns SSM run events (AWS) and Azure run events; will
 // include GCP equivalents when available.
-func getRunEvents(ctx context.Context, clt discoveryClient, from, to time.Time) ([]*apievents.SSMRun, []*apievents.AzureRun, error) {
+func getRunEvents(ctx context.Context, clt discoveryClient, from, to time.Time, cfg cloudProviderConfig) ([]*apievents.SSMRun, []*apievents.AzureRun, error) {
+	var eventTypes []string
+	if cfg.aws {
+		eventTypes = append(eventTypes, libevents.SSMRunEvent)
+	}
+	if cfg.azure {
+		eventTypes = append(eventTypes, libevents.AzureRunEvent)
+	}
+
 	events, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, token string) ([]apievents.AuditEvent, string, error) {
 		return clt.SearchEvents(ctx, libevents.SearchEventsRequest{
 			From:       from,
 			To:         to,
-			EventTypes: []string{libevents.SSMRunEvent, libevents.AzureRunEvent},
+			EventTypes: eventTypes,
 			Order:      types.EventOrderDescending,
 			Limit:      limit,
 			StartKey:   token,

--- a/tool/tctl/common/discovery/nodes.go
+++ b/tool/tctl/common/discovery/nodes.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
@@ -330,17 +329,4 @@ func combineOutput(stdout, stderr string) string {
 		return stdout
 	}
 	return stderr
-}
-
-// resolveTimeRange parses a --last duration string into a (from, to) pair.
-func resolveTimeRange(clock clockwork.Clock, last string) (from, to time.Time, err error) {
-	if clock == nil {
-		clock = clockwork.NewRealClock()
-	}
-	now := clock.Now().UTC()
-	d, err := types.ParseDuration(strings.TrimSpace(last))
-	if err != nil {
-		return time.Time{}, time.Time{}, trace.BadParameter("invalid --last value %q, expected a duration like 1h, 24h, or 30m", last)
-	}
-	return now.Add(-d.Duration()), now, nil
 }

--- a/tool/tctl/common/discovery/nodes_aws.go
+++ b/tool/tctl/common/discovery/nodes_aws.go
@@ -17,6 +17,10 @@
 package discovery
 
 import (
+	"maps"
+	"slices"
+
+	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	libevents "github.com/gravitational/teleport/lib/events"
@@ -30,14 +34,15 @@ type awsInfo struct {
 	AccountID  string `json:"account_id"`
 }
 
-func (a *awsInfo) cloudName() string       { return cloudAWS }
-func (a *awsInfo) cloudInstanceID() string { return a.InstanceID }
-func (a *awsInfo) cloudAccountID() string  { return a.AccountID }
+func (a *awsInfo) cloudName() string      { return cloudAWS }
+func (a *awsInfo) cloudAccountID() string { return a.AccountID }
+func (a *awsInfo) instanceText() string   { return a.InstanceID }
 
-// correlateSSMEvents processes SSM run events into the instances map.
+// correlateSSMEvents builds an instance map from SSM run events.
 // Events must be in descending order (most recent first); only the first
 // event per instance ID is kept.
-func correlateSSMEvents(instances map[string]*instanceInfo, events []*apievents.SSMRun) {
+func correlateSSMEvents(events []*apievents.SSMRun) map[string]instanceInfo {
+	instances := make(map[string]instanceInfo)
 	for _, run := range events {
 		if run.InstanceID == "" {
 			continue
@@ -45,7 +50,7 @@ func correlateSSMEvents(instances map[string]*instanceInfo, events []*apievents.
 		if _, ok := instances[run.InstanceID]; ok {
 			continue // events are most-recent-first; keep only the latest
 		}
-		instances[run.InstanceID] = &instanceInfo{
+		instances[run.InstanceID] = instanceInfo{
 			Region: run.Region,
 			AWS: &awsInfo{
 				InstanceID: run.InstanceID,
@@ -59,41 +64,37 @@ func correlateSSMEvents(instances map[string]*instanceInfo, events []*apievents.
 			},
 		}
 	}
+	return instances
 }
 
-// correlateNodes merges online Teleport nodes into the instances map. For nodes
-// that already have an entry (from audit events), it sets IsOnline and fills in
-// any missing region/account fields. For nodes with no prior entry, it creates
-// a new one with only online status and cloud metadata.
-func correlateNodes(instances map[string]*instanceInfo, nodes []types.Server) {
+// correlateAWSNodes builds an instance map from online AWS-discovered Teleport
+// nodes. Nodes without an AWS instance ID label are not AWS-discovered and are
+// skipped. First node wins if two nodes share an instance ID.
+func correlateAWSNodes(nodes []types.Server) map[string]instanceInfo {
+	instances := make(map[string]instanceInfo)
 	for _, node := range nodes {
-		// TODO(Tener): handle Azure and GCP nodes once CloudMetadata supports them.
-
 		id := node.GetAWSInstanceID()
 		if id == "" {
 			continue
 		}
-		info, ok := instances[id]
-		if !ok {
-			info = &instanceInfo{}
-			instances[id] = info
-		}
-		info.IsOnline = true
-
-		if info.AWS == nil {
-			info.AWS = &awsInfo{InstanceID: id}
+		info := instanceInfo{
+			IsOnline: true,
+			AWS:      &awsInfo{InstanceID: id, AccountID: node.GetAWSAccountID()},
 		}
 		if aws := node.GetAWSInfo(); aws != nil {
-			if info.Region == "" {
-				info.Region = aws.Region
-			}
+			info.Region = aws.Region
 		}
-		if info.AWS.AccountID == "" {
-			info.AWS.AccountID = node.GetAWSAccountID()
-		}
-
 		if !node.Expiry().IsZero() {
 			info.Expiry = node.Expiry()
 		}
+		instances[id] = info
 	}
+	return instances
+}
+
+func awsTaskInstanceKeys(task *usertasksv1.UserTask) []string {
+	if instanceGroup := task.GetSpec().GetDiscoverEc2(); instanceGroup != nil {
+		return slices.Collect(maps.Keys(instanceGroup.GetInstances()))
+	}
+	return nil
 }

--- a/tool/tctl/common/discovery/nodes_aws_test.go
+++ b/tool/tctl/common/discovery/nodes_aws_test.go
@@ -87,7 +87,7 @@ func TestCorrelateSSMEvents(t *testing.T) {
 	tests := []struct {
 		desc   string
 		events []*apievents.SSMRun
-		want   map[string]*instanceInfo
+		want   map[string]instanceInfo
 	}{
 		{
 			desc: "failures and successes both included",
@@ -95,7 +95,7 @@ func TestCorrelateSSMEvents(t *testing.T) {
 				makeSSMRun("i-aaa", "111", "us-east-1", awsStatusFailed, 1, "install failed", now),
 				makeSSMRun("i-bbb", "222", "us-west-2", awsStatusSuccess, 0, "", now),
 			},
-			want: map[string]*instanceInfo{
+			want: map[string]instanceInfo{
 				"i-aaa": {
 					AWS:       &awsInfo{InstanceID: "i-aaa", AccountID: "111"},
 					Region:    "us-east-1",
@@ -113,7 +113,7 @@ func TestCorrelateSSMEvents(t *testing.T) {
 			events: []*apievents.SSMRun{
 				makeSSMRun("", "", "", awsStatusFailed, 1, "", now),
 			},
-			want: map[string]*instanceInfo{},
+			want: map[string]instanceInfo{},
 		},
 		{
 			desc: "dedup keeps most recent",
@@ -121,7 +121,7 @@ func TestCorrelateSSMEvents(t *testing.T) {
 				makeSSMRun("i-aaa", "111", "us-east-1", awsStatusFailed, 1, "newest error", now),
 				makeSSMRun("i-aaa", "111", "us-east-1", awsStatusFailed, 2, "older error", now.Add(-10*time.Minute)),
 			},
-			want: map[string]*instanceInfo{
+			want: map[string]instanceInfo{
 				"i-aaa": {
 					AWS:       &awsInfo{InstanceID: "i-aaa", AccountID: "111"},
 					Region:    "us-east-1",
@@ -132,8 +132,41 @@ func TestCorrelateSSMEvents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			got := make(map[string]*instanceInfo)
-			correlateSSMEvents(got, tt.events)
+			got := correlateSSMEvents(tt.events)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCorrelateAWSNodes(t *testing.T) {
+	expiry := time.Now().UTC().Truncate(time.Second).Add(time.Hour)
+
+	tests := []struct {
+		desc  string
+		nodes []types.Server
+		want  map[string]instanceInfo
+	}{
+		{
+			desc:  "node with expiry propagates",
+			nodes: []types.Server{makeNode("node-1", "i-aaa", "111", "us-east-1", expiry)},
+			want: map[string]instanceInfo{
+				"i-aaa": {
+					IsOnline: true,
+					Region:   "us-east-1",
+					Expiry:   expiry,
+					AWS:      &awsInfo{InstanceID: "i-aaa", AccountID: "111"},
+				},
+			},
+		},
+		{
+			desc:  "node without AWS instance ID is skipped",
+			nodes: []types.Server{makeAzureNode("node-1", "vm-aaa", "sub-1", "rg-1", "eastus", time.Time{})},
+			want:  map[string]instanceInfo{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := correlateAWSNodes(tt.nodes)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/tool/tctl/common/discovery/nodes_aws_test.go
+++ b/tool/tctl/common/discovery/nodes_aws_test.go
@@ -82,6 +82,8 @@ func makeNode(name, awsInstanceID, accountID, region string, expiry time.Time) *
 }
 
 func TestCorrelateSSMEvents(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now().UTC().Truncate(time.Second)
 
 	tests := []struct {
@@ -139,6 +141,8 @@ func TestCorrelateSSMEvents(t *testing.T) {
 }
 
 func TestCorrelateAWSNodes(t *testing.T) {
+	t.Parallel()
+
 	expiry := time.Now().UTC().Truncate(time.Second).Add(time.Hour)
 
 	tests := []struct {

--- a/tool/tctl/common/discovery/nodes_azure.go
+++ b/tool/tctl/common/discovery/nodes_azure.go
@@ -1,0 +1,118 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"cmp"
+	"maps"
+	"slices"
+
+	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	libevents "github.com/gravitational/teleport/lib/events"
+)
+
+const cloudAzure = "Azure"
+
+// azureInfo holds Azure-specific instance metadata.
+type azureInfo struct {
+	VMID           string `json:"vm_id"`
+	VMName         string `json:"vm_name,omitempty"`
+	SubscriptionID string `json:"subscription_id,omitempty"`
+	ResourceGroup  string `json:"resource_group,omitempty"`
+	ResourceID     string `json:"resource_id,omitempty"`
+}
+
+func (a *azureInfo) cloudName() string      { return cloudAzure }
+func (a *azureInfo) cloudAccountID() string { return a.SubscriptionID }
+
+// instanceText renders "<resource-group>/<vm-id>" when the resource group is
+// known, since bare VM IDs are 36-char UUIDs that aren't useful on their own.
+// Falls back to just the VM ID when the resource group is missing.
+func (a *azureInfo) instanceText() string {
+	if a.ResourceGroup != "" {
+		return a.ResourceGroup + "/" + a.VMID
+	}
+	return a.VMID
+}
+
+// correlateAzureRunEvents builds an instance map from Azure run events.
+// Events must be in descending order (most recent first); only the first
+// event per VM ID is kept.
+func correlateAzureRunEvents(events []*apievents.AzureRun) map[string]instanceInfo {
+	instances := make(map[string]instanceInfo)
+	for _, run := range events {
+		if run.VMID == "" {
+			continue
+		}
+		if _, ok := instances[run.VMID]; ok {
+			continue // events are most-recent-first; keep only the latest
+		}
+		instances[run.VMID] = instanceInfo{
+			Region: run.Region,
+			Azure: &azureInfo{
+				VMID:           run.VMID,
+				VMName:         run.VMName,
+				SubscriptionID: run.SubscriptionID,
+				ResourceGroup:  run.ResourceGroup,
+				ResourceID:     run.ResourceID,
+			},
+			RunResult: &runResult{
+				Time:      run.Time,
+				ExitCode:  int64(run.ExitCode),
+				Output:    combineOutput(run.StandardOutput, run.StandardError),
+				APIError:  run.APIError,
+				IsFailure: run.Code == libevents.AzureRunFailCode,
+			},
+		}
+	}
+	return instances
+}
+
+// correlateAzureNodes builds an instance map from online Teleport Azure VM nodes.
+func correlateAzureNodes(nodes []types.Server) map[string]instanceInfo {
+	instances := make(map[string]instanceInfo)
+	for _, node := range nodes {
+		labels := node.GetAllLabels()
+		vmID := cmp.Or(labels[types.VMIDLabel], labels[types.VMIDLabelInternal])
+		if vmID == "" {
+			continue
+		}
+		info := instanceInfo{
+			IsOnline: true,
+			Region:   cmp.Or(labels[types.RegionLabel], labels[types.RegionLabelInternal]),
+			Azure: &azureInfo{
+				VMID:           vmID,
+				SubscriptionID: cmp.Or(labels[types.SubscriptionIDLabel], labels[types.SubscriptionIDLabelInternal]),
+				ResourceGroup:  cmp.Or(labels[types.ResourceGroupLabel], labels[types.ResourceGroupLabelInternal]),
+			},
+		}
+		if !node.Expiry().IsZero() {
+			info.Expiry = node.Expiry()
+		}
+		instances[vmID] = info
+	}
+	return instances
+}
+
+func azureTaskInstanceKeys(task *usertasksv1.UserTask) []string {
+	if instanceGroup := task.GetSpec().GetDiscoverAzureVm(); instanceGroup != nil {
+		return slices.Collect(maps.Keys(instanceGroup.GetInstances()))
+	}
+	return nil
+}

--- a/tool/tctl/common/discovery/nodes_azure_test.go
+++ b/tool/tctl/common/discovery/nodes_azure_test.go
@@ -1,0 +1,238 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	libevents "github.com/gravitational/teleport/lib/events"
+)
+
+const (
+	azureExecStateSucceeded = "Succeeded"
+	azureExecStateFailed    = "Failed"
+)
+
+// makeAzureRun creates an *apievents.AzureRun suitable for use in tests.
+func makeAzureRun(vmID, subscriptionID, resourceGroup, region, execState string, exitCode int32, output, apiError string, ts time.Time) *apievents.AzureRun {
+	code := libevents.AzureRunFailCode
+	if execState == azureExecStateSucceeded {
+		code = libevents.AzureRunSuccessCode
+	}
+	return &apievents.AzureRun{
+		Metadata: apievents.Metadata{
+			Type: libevents.AzureRunEvent,
+			Time: ts,
+			Code: code,
+		},
+		AzureMetadata: apievents.AzureMetadata{
+			SubscriptionID: subscriptionID,
+			ResourceGroup:  resourceGroup,
+			Region:         region,
+		},
+		AzureVMMetadata: apievents.AzureVMMetadata{
+			VMID: vmID,
+		},
+		ExitCode:       exitCode,
+		ExecutionState: execState,
+		StandardOutput: output,
+		APIError:       apiError,
+	}
+}
+
+// makeAzureNode creates a types.Server with Azure VM labels set.
+func makeAzureNode(name, vmID, subscriptionID, resourceGroup, region string, expiry time.Time) *types.ServerV2 {
+	node := &types.ServerV2{
+		Kind:    types.KindNode,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name: name,
+			Labels: map[string]string{
+				types.VMIDLabel:           vmID,
+				types.SubscriptionIDLabel: subscriptionID,
+				types.ResourceGroupLabel:  resourceGroup,
+				types.RegionLabel:         region,
+			},
+		},
+	}
+	if !expiry.IsZero() {
+		node.Metadata.SetExpiry(expiry)
+	}
+	return node
+}
+
+func TestCorrelateAzureRunEvents(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	tests := []struct {
+		desc   string
+		events []*apievents.AzureRun
+		want   map[string]instanceInfo
+	}{
+		{
+			desc: "failures and successes both included",
+			events: []*apievents.AzureRun{
+				makeAzureRun("vm-aaa", "sub-1", "rg-1", "eastus", azureExecStateFailed, 1, "install failed", "", now),
+				makeAzureRun("vm-bbb", "sub-2", "rg-2", "westus", azureExecStateSucceeded, 0, "", "", now),
+			},
+			want: map[string]instanceInfo{
+				"vm-aaa": {
+					Azure:     &azureInfo{VMID: "vm-aaa", SubscriptionID: "sub-1", ResourceGroup: "rg-1"},
+					Region:    "eastus",
+					RunResult: &runResult{ExitCode: 1, Output: "install failed", Time: now, IsFailure: true},
+				},
+				"vm-bbb": {
+					Azure:     &azureInfo{VMID: "vm-bbb", SubscriptionID: "sub-2", ResourceGroup: "rg-2"},
+					Region:    "westus",
+					RunResult: &runResult{ExitCode: 0, Time: now},
+				},
+			},
+		},
+		{
+			desc: "empty VM ID is skipped",
+			events: []*apievents.AzureRun{
+				makeAzureRun("", "", "", "", azureExecStateFailed, 1, "", "", now),
+			},
+			want: map[string]instanceInfo{},
+		},
+		{
+			desc: "dedup keeps most recent",
+			events: []*apievents.AzureRun{
+				makeAzureRun("vm-aaa", "sub-1", "rg-1", "eastus", azureExecStateFailed, 1, "newest error", "", now),
+				makeAzureRun("vm-aaa", "sub-1", "rg-1", "eastus", azureExecStateFailed, 2, "older error", "", now.Add(-10*time.Minute)),
+			},
+			want: map[string]instanceInfo{
+				"vm-aaa": {
+					Azure:     &azureInfo{VMID: "vm-aaa", SubscriptionID: "sub-1", ResourceGroup: "rg-1"},
+					Region:    "eastus",
+					RunResult: &runResult{ExitCode: 1, Output: "newest error", Time: now, IsFailure: true},
+				},
+			},
+		},
+		{
+			desc: "API error surfaces",
+			events: []*apievents.AzureRun{
+				makeAzureRun("vm-aaa", "sub-1", "rg-1", "eastus", azureExecStateFailed, 0, "", "forbidden", now),
+			},
+			want: map[string]instanceInfo{
+				"vm-aaa": {
+					Azure:     &azureInfo{VMID: "vm-aaa", SubscriptionID: "sub-1", ResourceGroup: "rg-1"},
+					Region:    "eastus",
+					RunResult: &runResult{ExitCode: 0, APIError: "forbidden", Time: now, IsFailure: true},
+				},
+			},
+		},
+		{
+			desc: "VMName and ResourceID propagate from event metadata",
+			events: []*apievents.AzureRun{
+				{
+					Metadata: apievents.Metadata{Type: libevents.AzureRunEvent, Time: now, Code: libevents.AzureRunSuccessCode},
+					AzureMetadata: apievents.AzureMetadata{
+						SubscriptionID: "sub-1",
+						ResourceGroup:  "rg-1",
+						Region:         "eastus",
+						ResourceID:     "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/web-prod-01",
+					},
+					AzureVMMetadata: apievents.AzureVMMetadata{VMID: "vm-aaa", VMName: "web-prod-01"},
+				},
+			},
+			want: map[string]instanceInfo{
+				"vm-aaa": {
+					Azure: &azureInfo{
+						VMID:           "vm-aaa",
+						VMName:         "web-prod-01",
+						SubscriptionID: "sub-1",
+						ResourceGroup:  "rg-1",
+						ResourceID:     "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/web-prod-01",
+					},
+					Region:    "eastus",
+					RunResult: &runResult{ExitCode: 0, Time: now},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := correlateAzureRunEvents(tt.events)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCorrelateAzureNodes(t *testing.T) {
+	expiry := time.Now().UTC().Truncate(time.Second).Add(time.Hour)
+
+	tests := []struct {
+		desc  string
+		nodes []types.Server
+		want  map[string]instanceInfo
+	}{
+		{
+			desc:  "node with visible labels",
+			nodes: []types.Server{makeAzureNode("node-1", "vm-aaa", "sub-1", "rg-1", "eastus", expiry)},
+			want: map[string]instanceInfo{
+				"vm-aaa": {
+					IsOnline: true,
+					Region:   "eastus",
+					Expiry:   expiry,
+					Azure:    &azureInfo{VMID: "vm-aaa", SubscriptionID: "sub-1", ResourceGroup: "rg-1"},
+				},
+			},
+		},
+		{
+			desc: "node with internal labels falls back",
+			nodes: []types.Server{
+				&types.ServerV2{
+					Kind:    types.KindNode,
+					Version: types.V2,
+					Metadata: types.Metadata{
+						Name: "node-1",
+						Labels: map[string]string{
+							types.VMIDLabelInternal:           "vm-aaa",
+							types.SubscriptionIDLabelInternal: "sub-1",
+							types.ResourceGroupLabelInternal:  "rg-1",
+							types.RegionLabelInternal:         "eastus",
+						},
+					},
+				},
+			},
+			want: map[string]instanceInfo{
+				"vm-aaa": {
+					IsOnline: true,
+					Region:   "eastus",
+					Azure:    &azureInfo{VMID: "vm-aaa", SubscriptionID: "sub-1", ResourceGroup: "rg-1"},
+				},
+			},
+		},
+		{
+			desc:  "node without VM ID is skipped",
+			nodes: []types.Server{makeNode("node-1", "i-aws", "111", "us-east-1", time.Time{})},
+			want:  map[string]instanceInfo{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := correlateAzureNodes(tt.nodes)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/tool/tctl/common/discovery/nodes_azure_test.go
+++ b/tool/tctl/common/discovery/nodes_azure_test.go
@@ -81,6 +81,8 @@ func makeAzureNode(name, vmID, subscriptionID, resourceGroup, region string, exp
 }
 
 func TestCorrelateAzureRunEvents(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now().UTC().Truncate(time.Second)
 
 	tests := []struct {
@@ -179,6 +181,8 @@ func TestCorrelateAzureRunEvents(t *testing.T) {
 }
 
 func TestCorrelateAzureNodes(t *testing.T) {
+	t.Parallel()
+
 	expiry := time.Now().UTC().Truncate(time.Second).Add(time.Hour)
 
 	tests := []struct {

--- a/tool/tctl/common/discovery/nodes_test.go
+++ b/tool/tctl/common/discovery/nodes_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
@@ -398,52 +397,4 @@ func TestFilterFailures(t *testing.T) {
 	require.Len(t, got, 2)
 	require.Equal(t, "i-fail", got[0].AWS.InstanceID)
 	require.Equal(t, "i-task", got[1].AWS.InstanceID)
-}
-
-func TestResolveTimeRange(t *testing.T) {
-	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
-	clock := clockwork.NewFakeClockAt(now)
-
-	tests := []struct {
-		desc     string
-		input    string
-		wantErr  bool
-		wantFrom time.Time
-		wantTo   time.Time
-	}{
-		{
-			desc:     "valid duration 30m",
-			input:    "30m",
-			wantFrom: now.Add(-30 * time.Minute),
-			wantTo:   now,
-		},
-		{
-			desc:     "valid duration 2h",
-			input:    "2h",
-			wantFrom: now.Add(-2 * time.Hour),
-			wantTo:   now,
-		},
-		{
-			desc:    "empty input",
-			input:   "",
-			wantErr: true,
-		},
-		{
-			desc:    "invalid input",
-			input:   "notaduration",
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			from, to, err := resolveTimeRange(clock, tt.input)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tt.wantFrom, from)
-			require.Equal(t, tt.wantTo, to)
-		})
-	}
 }

--- a/tool/tctl/common/discovery/nodes_test.go
+++ b/tool/tctl/common/discovery/nodes_test.go
@@ -75,6 +75,8 @@ func makeAzureVMTask(t *testing.T, issueType string, vmIDs ...string) *usertasks
 }
 
 func TestCloudNodes(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now().UTC().Truncate(time.Second)
 
 	tests := []struct {
@@ -166,6 +168,8 @@ func TestCloudNodes(t *testing.T) {
 }
 
 func TestInstanceInfo_Status(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc string
 		fi   instanceInfo
@@ -220,6 +224,8 @@ func TestInstanceInfo_Status(t *testing.T) {
 }
 
 func TestInstanceInfo_UserTaskTitle(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc string
 		fi   instanceInfo
@@ -268,6 +274,8 @@ func TestInstanceInfo_UserTaskTitle(t *testing.T) {
 }
 
 func TestInstanceInfo_LastTime(t *testing.T) {
+	t.Parallel()
+
 	t10 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	t12 := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
 	t08 := time.Date(2026, 1, 15, 8, 0, 0, 0, time.UTC)
@@ -306,6 +314,8 @@ func TestInstanceInfo_LastTime(t *testing.T) {
 }
 
 func TestTrimEscape(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc string
 		in   string
@@ -345,6 +355,8 @@ func TestTrimEscape(t *testing.T) {
 }
 
 func TestCombineOutput(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc   string
 		stdout string
@@ -386,6 +398,8 @@ func TestCombineOutput(t *testing.T) {
 }
 
 func TestParseCloudProviders(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc    string
 		in      string
@@ -458,6 +472,8 @@ func TestParseCloudProviders(t *testing.T) {
 }
 
 func TestFilterFailures(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now().UTC().Truncate(time.Second)
 	instances := []instanceInfo{
 		{AWS: &awsInfo{InstanceID: "i-ok"}, IsOnline: true, RunResult: &runResult{ExitCode: 0}},

--- a/tool/tctl/common/discovery/nodes_test.go
+++ b/tool/tctl/common/discovery/nodes_test.go
@@ -23,70 +23,139 @@ import (
 	"github.com/stretchr/testify/require"
 
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
-	"github.com/gravitational/teleport/api/types"
-	apievents "github.com/gravitational/teleport/api/types/events"
 	usertaskstypes "github.com/gravitational/teleport/api/types/usertasks"
 )
 
-func TestCorrelate(t *testing.T) {
+func makeEC2Task(t *testing.T, issueType string, instanceIDs ...string) *usertasksv1.UserTask {
+	t.Helper()
+	instances := make(map[string]*usertasksv1.DiscoverEC2Instance, len(instanceIDs))
+	for _, id := range instanceIDs {
+		instances[id] = &usertasksv1.DiscoverEC2Instance{
+			InstanceId:      id,
+			DiscoveryConfig: "dc01",
+			DiscoveryGroup:  "dg01",
+		}
+	}
+	task, err := usertaskstypes.NewDiscoverEC2UserTask(&usertasksv1.UserTaskSpec{
+		Integration: "my-integration",
+		TaskType:    "discover-ec2",
+		IssueType:   issueType,
+		State:       "OPEN",
+		DiscoverEc2: &usertasksv1.DiscoverEC2{
+			AccountId: "111",
+			Region:    "us-east-1",
+			Instances: instances,
+		},
+	})
+	require.NoError(t, err)
+	return task
+}
+
+func makeAzureVMTask(t *testing.T, issueType string, vmIDs ...string) *usertasksv1.UserTask {
+	t.Helper()
+	instances := make(map[string]*usertasksv1.DiscoverAzureVMInstance, len(vmIDs))
+	for _, id := range vmIDs {
+		instances[id] = &usertasksv1.DiscoverAzureVMInstance{
+			VmId:            id,
+			DiscoveryConfig: "dc01",
+			DiscoveryGroup:  "dg01",
+		}
+	}
+	task, err := usertaskstypes.NewDiscoverAzureVMUserTask(usertaskstypes.TaskGroup{
+		Integration: "my-integration",
+		IssueType:   issueType,
+	}, time.Now().Add(time.Hour), &usertasksv1.DiscoverAzureVM{
+		SubscriptionId: "sub-1",
+		ResourceGroup:  "rg-1",
+		Region:         "eastus",
+		Instances:      instances,
+	})
+	require.NoError(t, err)
+	return task
+}
+
+func TestCloudNodes(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 
 	tests := []struct {
 		desc      string
-		ssmEvents []*apievents.SSMRun
-		nodes     []types.Server
+		instances map[string]instanceInfo
+		tasks     []*usertasksv1.UserTask
+		keyFn     func(*usertasksv1.UserTask) []string
 		want      []instanceInfo
 	}{
 		{
-			desc: "empty input returns empty result",
-			want: nil,
+			desc:  "empty input returns empty result",
+			keyFn: awsTaskInstanceKeys,
+			want:  nil,
 		},
 		{
-			desc: "online marking from matching nodes",
-			ssmEvents: []*apievents.SSMRun{
-				makeSSMRun("i-aaa", "111", "us-east-1", "Failed", 1, "err", now),
+			desc: "AWS instance with matching task gets task ID and issue type",
+			instances: map[string]instanceInfo{
+				"i-aaa": {AWS: &awsInfo{InstanceID: "i-aaa", AccountID: "111"}, Region: "us-east-1"},
 			},
-			nodes: []types.Server{makeNode("node-1", "i-aaa", "111", "us-east-1", time.Time{})},
+			tasks: []*usertasksv1.UserTask{
+				makeEC2Task(t, usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure, "i-aaa"),
+			},
+			keyFn: awsTaskInstanceKeys,
 			want: []instanceInfo{
 				{
-					AWS:       &awsInfo{InstanceID: "i-aaa", AccountID: "111"},
-					Region:    "us-east-1",
-					IsOnline:  true,
-					RunResult: &runResult{ExitCode: 1, Output: "err", Time: now, IsFailure: true},
+					AWS:           &awsInfo{InstanceID: "i-aaa", AccountID: "111"},
+					Region:        "us-east-1",
+					UserTaskID:    "07cccc8f-bb13-5f93-99d8-0ba51ca1da92",
+					UserTaskIssue: usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure,
 				},
 			},
 		},
 		{
-			desc:  "online node without events enriches region and account",
-			nodes: []types.Server{makeNode("node-1", "i-aaa", "111", "us-east-1", now.Add(10*time.Minute))},
+			desc: "task referencing unknown instance is ignored",
+			instances: map[string]instanceInfo{
+				"i-aaa": {AWS: &awsInfo{InstanceID: "i-aaa", AccountID: "111"}, Region: "us-east-1"},
+			},
+			tasks: []*usertasksv1.UserTask{
+				makeEC2Task(t, usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure, "i-other"),
+			},
+			keyFn: awsTaskInstanceKeys,
 			want: []instanceInfo{
-				{
-					AWS:      &awsInfo{InstanceID: "i-aaa", AccountID: "111"},
-					Region:   "us-east-1",
-					IsOnline: true,
-					Expiry:   now.Add(10 * time.Minute),
-				},
+				{AWS: &awsInfo{InstanceID: "i-aaa", AccountID: "111"}, Region: "us-east-1"},
 			},
 		},
 		{
-			desc: "node enriches account for event-only instance",
-			ssmEvents: []*apievents.SSMRun{
-				makeSSMRun("i-aaa", "", "us-east-1", "Failed", 1, "err", now),
+			desc: "multiple AWS instances sorted by account, region, descending time",
+			instances: map[string]instanceInfo{
+				"i-old": {
+					AWS: &awsInfo{InstanceID: "i-old", AccountID: "111"}, Region: "us-east-1",
+					RunResult: &runResult{Time: now.Add(-time.Hour)},
+				},
+				"i-new": {
+					AWS: &awsInfo{InstanceID: "i-new", AccountID: "111"}, Region: "us-east-1",
+					RunResult: &runResult{Time: now},
+				},
+				"i-other-region": {
+					AWS: &awsInfo{InstanceID: "i-other-region", AccountID: "111"}, Region: "us-west-2",
+				},
+				"i-other-account": {
+					AWS: &awsInfo{InstanceID: "i-other-account", AccountID: "222"}, Region: "us-east-1",
+				},
 			},
-			nodes: []types.Server{makeNode("node-1", "i-aaa", "111", "", time.Time{})},
+			keyFn: awsTaskInstanceKeys,
 			want: []instanceInfo{
 				{
-					AWS:       &awsInfo{InstanceID: "i-aaa", AccountID: "111"},
-					Region:    "us-east-1",
-					IsOnline:  true,
-					RunResult: &runResult{ExitCode: 1, Output: "err", Time: now, IsFailure: true},
+					AWS: &awsInfo{InstanceID: "i-new", AccountID: "111"}, Region: "us-east-1",
+					RunResult: &runResult{Time: now},
 				},
+				{
+					AWS: &awsInfo{InstanceID: "i-old", AccountID: "111"}, Region: "us-east-1",
+					RunResult: &runResult{Time: now.Add(-time.Hour)},
+				},
+				{AWS: &awsInfo{InstanceID: "i-other-region", AccountID: "111"}, Region: "us-west-2"},
+				{AWS: &awsInfo{InstanceID: "i-other-account", AccountID: "222"}, Region: "us-east-1"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			got := correlate(tt.ssmEvents, tt.nodes)
+			got := cloudNodes(tt.instances, tt.tasks, tt.keyFn)
 			if tt.want == nil {
 				require.Empty(t, got)
 			} else {
@@ -105,7 +174,7 @@ func TestInstanceInfo_Status(t *testing.T) {
 		{
 			desc: "no run result, offline",
 			fi:   instanceInfo{},
-			want: "",
+			want: "Unknown",
 		},
 		{
 			desc: "no run result, online",
@@ -113,8 +182,8 @@ func TestInstanceInfo_Status(t *testing.T) {
 			want: "Online",
 		},
 		{
-			desc: "success and online",
-			fi:   instanceInfo{RunResult: &runResult{ExitCode: 0}, IsOnline: true},
+			desc: "success, online",
+			fi:   instanceInfo{IsOnline: true, RunResult: &runResult{ExitCode: 0}},
 			want: "Online",
 		},
 		{
@@ -132,10 +201,68 @@ func TestInstanceInfo_Status(t *testing.T) {
 			fi:   instanceInfo{RunResult: &runResult{ExitCode: 1, IsFailure: true}, IsOnline: true},
 			want: "Online, exit code=1",
 		},
+		{
+			desc: "API error, offline",
+			fi:   instanceInfo{RunResult: &runResult{APIError: "throttled", IsFailure: true}},
+			want: "Failed (API error)",
+		},
+		{
+			desc: "API error, online",
+			fi:   instanceInfo{RunResult: &runResult{APIError: "throttled", IsFailure: true}, IsOnline: true},
+			want: "Online, API error",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			require.Equal(t, tt.want, tt.fi.status())
+		})
+	}
+}
+
+func TestInstanceInfo_UserTaskTitle(t *testing.T) {
+	tests := []struct {
+		desc string
+		fi   instanceInfo
+		want string
+	}{
+		{
+			desc: "empty issue returns empty",
+			fi:   instanceInfo{},
+			want: "",
+		},
+		{
+			desc: "no cloud info falls back to issue string",
+			fi:   instanceInfo{UserTaskIssue: usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure},
+			want: usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure,
+		},
+		{
+			desc: "AWS known issue resolves to title",
+			fi: instanceInfo{
+				AWS:           &awsInfo{InstanceID: "i-aaa"},
+				UserTaskIssue: usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure,
+			},
+			want: "SSM Script failure",
+		},
+		{
+			desc: "AWS unknown issue falls back to issue string",
+			fi: instanceInfo{
+				AWS:           &awsInfo{InstanceID: "i-aaa"},
+				UserTaskIssue: "ec2-not-a-real-issue",
+			},
+			want: "ec2-not-a-real-issue",
+		},
+		{
+			desc: "Azure known issue resolves to title",
+			fi: instanceInfo{
+				Azure:         &azureInfo{VMID: "vm-aaa"},
+				UserTaskIssue: usertaskstypes.AutoDiscoverAzureVMIssueEnrollmentError,
+			},
+			want: "Enrollment failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.fi.userTaskTitle())
 		})
 	}
 }
@@ -178,41 +305,41 @@ func TestInstanceInfo_LastTime(t *testing.T) {
 	}
 }
 
-func TestInstanceInfo_RunOutput(t *testing.T) {
+func TestTrimEscape(t *testing.T) {
 	tests := []struct {
 		desc string
-		fi   instanceInfo
+		in   string
 		want string
 	}{
 		{
-			desc: "no run result",
-			fi:   instanceInfo{},
+			desc: "empty input",
+			in:   "",
 			want: "",
 		},
 		{
 			desc: "simple output",
-			fi:   instanceInfo{RunResult: &runResult{Output: "install failed"}},
+			in:   "install failed",
 			want: `"install failed"`,
 		},
 		{
 			desc: "newlines escaped",
-			fi:   instanceInfo{RunResult: &runResult{Output: "line1\nline2\nline3"}},
+			in:   "line1\nline2\nline3",
 			want: `"line1\nline2\nline3"`,
 		},
 		{
 			desc: "long output truncated",
-			fi:   instanceInfo{RunResult: &runResult{Output: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
-			want: `"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."`,
+			in:   "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc",
+			want: `"abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca..."`,
 		},
 		{
 			desc: "whitespace trimmed",
-			fi:   instanceInfo{RunResult: &runResult{Output: "  output  "}},
+			in:   "  output  ",
 			want: `"output"`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.fi.runOutput())
+			require.Equal(t, tt.want, trimEscape(tt.in))
 		})
 	}
 }
@@ -254,133 +381,6 @@ func TestCombineOutput(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			require.Equal(t, tt.want, combineOutput(tt.stdout, tt.stderr))
-		})
-	}
-}
-
-// TestMatchUserTasks verifies that matchUserTasks correctly populates the
-// UserTaskID and UserTaskIssue fields on instances by looking up their
-// cloud instance ID in the DiscoverEC2 instance maps carried by user tasks.
-func TestMatchUserTasks(t *testing.T) {
-	makeTask := func(t *testing.T, issueType string, instanceIDs ...string) *usertasksv1.UserTask {
-		t.Helper()
-		instances := make(map[string]*usertasksv1.DiscoverEC2Instance, len(instanceIDs))
-		for _, id := range instanceIDs {
-			instances[id] = &usertasksv1.DiscoverEC2Instance{
-				InstanceId:      id,
-				DiscoveryConfig: "dc01",
-				DiscoveryGroup:  "dg01",
-			}
-		}
-		task, err := usertaskstypes.NewDiscoverEC2UserTask(&usertasksv1.UserTaskSpec{
-			Integration: "my-integration",
-			TaskType:    "discover-ec2",
-			IssueType:   issueType,
-			State:       "OPEN",
-			DiscoverEc2: &usertasksv1.DiscoverEC2{
-				AccountId: "111",
-				Region:    "us-east-1",
-				Instances: instances,
-			},
-		})
-		require.NoError(t, err)
-		return task
-	}
-
-	tests := []struct {
-		desc      string
-		instances []instanceInfo
-		tasks     []*usertasksv1.UserTask
-		want      []instanceInfo
-	}{
-		{
-			desc: "matched instance gets task ID and issue type",
-			instances: []instanceInfo{
-				{AWS: &awsInfo{InstanceID: "i-aaa", AccountID: "111"}},
-			},
-			tasks: []*usertasksv1.UserTask{
-				makeTask(t, usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure, "i-aaa"),
-			},
-			want: []instanceInfo{
-				{
-					AWS:           &awsInfo{InstanceID: "i-aaa", AccountID: "111"},
-					UserTaskID:    "07cccc8f-bb13-5f93-99d8-0ba51ca1da92",
-					UserTaskIssue: usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure,
-				},
-			},
-		},
-		{
-			desc: "non-matching instance is unchanged",
-			instances: []instanceInfo{
-				{AWS: &awsInfo{InstanceID: "i-other", AccountID: "111"}},
-			},
-			tasks: []*usertasksv1.UserTask{
-				makeTask(t, usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure, "i-aaa"),
-			},
-			want: []instanceInfo{
-				{AWS: &awsInfo{InstanceID: "i-other", AccountID: "111"}},
-			},
-		},
-		{
-			desc: "instance without cloud info is skipped",
-			instances: []instanceInfo{
-				{Region: "us-east-1"},
-			},
-			tasks: []*usertasksv1.UserTask{
-				makeTask(t, usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure, "i-aaa"),
-			},
-			want: []instanceInfo{
-				{Region: "us-east-1"},
-			},
-		},
-		{
-			desc: "task with nil spec is skipped",
-			instances: []instanceInfo{
-				{AWS: &awsInfo{InstanceID: "i-aaa", AccountID: "111"}},
-			},
-			tasks: []*usertasksv1.UserTask{
-				{Spec: nil},
-			},
-			want: []instanceInfo{
-				{AWS: &awsInfo{InstanceID: "i-aaa", AccountID: "111"}},
-			},
-		},
-		{
-			desc: "multiple tasks match multiple instances",
-			instances: []instanceInfo{
-				{AWS: &awsInfo{InstanceID: "i-aaa", AccountID: "111"}},
-				{AWS: &awsInfo{InstanceID: "i-bbb", AccountID: "111"}},
-				{AWS: &awsInfo{InstanceID: "i-ccc", AccountID: "111"}},
-			},
-			tasks: []*usertasksv1.UserTask{
-				makeTask(t, usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure, "i-aaa"),
-				makeTask(t, usertaskstypes.AutoDiscoverEC2IssueSSMInstanceNotRegistered, "i-bbb"),
-			},
-			want: []instanceInfo{
-				{
-					AWS:           &awsInfo{InstanceID: "i-aaa", AccountID: "111"},
-					UserTaskID:    "07cccc8f-bb13-5f93-99d8-0ba51ca1da92",
-					UserTaskIssue: usertaskstypes.AutoDiscoverEC2IssueSSMScriptFailure,
-				},
-				{
-					AWS:           &awsInfo{InstanceID: "i-bbb", AccountID: "111"},
-					UserTaskID:    "a08ac321-89b2-57bc-a10e-f2cf7e6e5901",
-					UserTaskIssue: usertaskstypes.AutoDiscoverEC2IssueSSMInstanceNotRegistered,
-				},
-				{AWS: &awsInfo{InstanceID: "i-ccc", AccountID: "111"}},
-			},
-		},
-		{
-			desc:      "empty tasks and instances",
-			instances: nil,
-			tasks:     nil,
-			want:      nil,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			matchUserTasks(tt.instances, tt.tasks)
-			require.Equal(t, tt.want, tt.instances)
 		})
 	}
 }

--- a/tool/tctl/common/discovery/nodes_test.go
+++ b/tool/tctl/common/discovery/nodes_test.go
@@ -385,6 +385,78 @@ func TestCombineOutput(t *testing.T) {
 	}
 }
 
+func TestParseCloudProviders(t *testing.T) {
+	tests := []struct {
+		desc    string
+		in      string
+		want    cloudProviderConfig
+		wantErr string
+	}{
+		{
+			desc: "empty enables all",
+			in:   "",
+			want: cloudProviderConfig{aws: true, azure: true},
+		},
+		{
+			desc: "aws only",
+			in:   "aws",
+			want: cloudProviderConfig{aws: true},
+		},
+		{
+			desc: "azure only",
+			in:   "azure",
+			want: cloudProviderConfig{azure: true},
+		},
+		{
+			desc: "both providers",
+			in:   "aws,azure",
+			want: cloudProviderConfig{aws: true, azure: true},
+		},
+		{
+			desc: "case-insensitive",
+			in:   "AWS,Azure",
+			want: cloudProviderConfig{aws: true, azure: true},
+		},
+		{
+			desc: "whitespace trimmed",
+			in:   " aws , azure ",
+			want: cloudProviderConfig{aws: true, azure: true},
+		},
+		{
+			desc: "duplicate providers accepted",
+			in:   "aws,aws",
+			want: cloudProviderConfig{aws: true},
+		},
+		{
+			desc:    "single comma rejected",
+			in:      ",",
+			wantErr: "empty cloud provider",
+		},
+		{
+			desc:    "whitespace-only entry rejected",
+			in:      "aws, ,azure",
+			wantErr: "empty cloud provider",
+		},
+		{
+			desc:    "unknown provider rejected",
+			in:      "gcp",
+			wantErr: `unknown cloud provider "gcp"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := parseCloudProviders(tt.in)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Equal(t, cloudProviderConfig{}, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestFilterFailures(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	instances := []instanceInfo{

--- a/tool/tctl/common/discovery/render.go
+++ b/tool/tctl/common/discovery/render.go
@@ -33,21 +33,21 @@ func renderText(w io.Writer, instances []instanceInfo) error {
 		return nil
 	}
 
-	columns := []string{"Cloud", "Account", "Region", "Instance ID", "Time", "Status", "Details"}
+	columns := []string{"Cloud", "Account", "Region", "Instance", "Time", "Status", "Details"}
 	rows := make([][]string, 0, len(instances))
 	for _, inst := range instances {
 		ci := inst.cloud()
-		var cloudName, instanceID, accountID string
+		var cloudName, instance, accountID string
 		if ci != nil {
 			cloudName = ci.cloudName()
-			instanceID = ci.cloudInstanceID()
+			instance = ci.instanceText()
 			accountID = ci.cloudAccountID()
 		}
 		rows = append(rows, []string{
 			cloudName,
 			accountID,
 			inst.Region,
-			instanceID,
+			instance,
 			inst.lastTime(),
 			inst.status(),
 			inst.details(),

--- a/tool/tctl/common/discovery/render_test.go
+++ b/tool/tctl/common/discovery/render_test.go
@@ -51,9 +51,9 @@ func TestRenderText(t *testing.T) {
 					},
 				},
 			},
-			want: `Cloud Account       Region    Instance ID Time          Status        Details 
------ ------------- --------- ----------- ------------- ------------- ------- 
-AWS   1111111111... us-east-1 i-ssm001    2026-01-15... Failed (ex... Scri... 
+			want: `Cloud Account       Region    Instance Time          Status        Details      
+----- ------------- --------- -------- ------------- ------------- ------------ 
+AWS   1111111111... us-east-1 i-ssm001 2026-01-15... Failed (ex... Script ou... 
 `,
 		},
 		{
@@ -66,9 +66,9 @@ AWS   1111111111... us-east-1 i-ssm001    2026-01-15... Failed (ex... Scri...
 					Expiry:   time.Date(2026, 1, 15, 11, 0, 0, 0, time.UTC),
 				},
 			},
-			want: `Cloud Account       Region    Instance ID Time          Status Details 
------ ------------- --------- ----------- ------------- ------ ------- 
-AWS   2222222222... eu-west-1 i-ok001     2026-01-15... Online         
+			want: `Cloud Account       Region    Instance Time          Status Details 
+----- ------------- --------- -------- ------------- ------ ------- 
+AWS   2222222222... eu-west-1 i-ok001  2026-01-15... Online         
 `,
 		},
 		{
@@ -85,9 +85,9 @@ AWS   2222222222... eu-west-1 i-ok001     2026-01-15... Online
 					},
 				},
 			},
-			want: `Cloud Account       Region    Instance ID Time          Status Details        
------ ------------- --------- ----------- ------------- ------ -------------- 
-AWS   4444444444... us-west-2 i-ok002     2026-01-15... Online Script outp... 
+			want: `Cloud Account       Region    Instance Time          Status Details             
+----- ------------- --------- -------- ------------- ------ ------------------- 
+AWS   4444444444... us-west-2 i-ok002  2026-01-15... Online Script output: "... 
 `,
 		},
 		{
@@ -123,11 +123,11 @@ AWS   4444444444... us-west-2 i-ok002     2026-01-15... Online Script outp...
 					},
 				},
 			},
-			want: `Cloud Account       Region     Instance ID Time          Status        Details 
------ ------------- ---------- ----------- ------------- ------------- ------- 
-AWS   2222222222... eu-west-1  i-ok001     2026-01-15... Online                
-AWS   1111111111... us-east-1  i-ssm001    2026-01-15... Failed (ex... Scr...  
-AWS   3333333333... ap-south-1 i-ssm002    2026-01-15... Online, ex... Scr...  
+			want: `Cloud Account       Region     Instance Time          Status        Details     
+----- ------------- ---------- -------- ------------- ------------- ----------- 
+AWS   2222222222... eu-west-1  i-ok001  2026-01-15... Online                    
+AWS   1111111111... us-east-1  i-ssm001 2026-01-15... Failed (ex... Script o... 
+AWS   3333333333... ap-south-1 i-ssm002 2026-01-15... Online, ex... Script o... 
 `,
 		},
 	}

--- a/tool/tctl/common/discovery/render_test.go
+++ b/tool/tctl/common/discovery/render_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestRenderText(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc      string
 		instances []instanceInfo


### PR DESCRIPTION
Changelog: Added Azure VM support for `tctl discovery nodes` command for troubleshooting auto-discovery enrollment issues on Azure

Two minor additional changes:
- `--last` is using `DurationVar` to sync with other flags
- `omitzero` properly skips empty Expiry field

Some refactoring along the way to make the code prettier, too.

This builds upon these recent PRs:
- https://github.com/gravitational/teleport/pull/64253
- https://github.com/gravitational/teleport/pull/65875

Usage:

`> tctl discovery nodes [--format=text] [--last=1h] [--cloud=aws,azure]`

`--cloud` defaults to empty string, which means "all clouds", but accepts comma-separated list of clouds to filter.
`--format` default to text, with `json` the sole other alternative format.
`--last` default to 1h and accepts time units such as `h`, `m` or `s`.

<details><summary>Text output</summary>
<p>

```
> tctl discovery nodes`
Cloud Account                        Region        Instance                       Time                 Status                 Details
----- ------------------------------ ------------- ------------------------------ -------------------- ---------------------- ----------------------------------------------------
AWS   278576220453                   eu-central-1  i-0a59f6153a27cc75f            2026-04-29T15:10:27Z Failed (exit code=104) SSM Script failure. Script output: "proxy is unre...
AWS   278576220453                   eu-central-1  i-008d8afc99c4f2e50            2026-04-29T15:10:26Z Failed (exit code=104) SSM Script failure. Script output: "proxy is unre...
AWS   278576220453                   eu-central-1  i-0618eec42f3277e57            2026-04-29T15:10:20Z Failed (exit code=23)  SSM Script failure. Script output: "Offloading th...
AWS   278576220453                   eu-central-1  i-09a74a86619109d19            2026-04-29T15:10:20Z Failed (exit code=23)  SSM Script failure. Script output: "Offloading th...
AWS   278576220453                   eu-central-1  i-0e8078830baefc868            2026-04-29T15:10:14Z Failed (exit code=-1)  SSM Agent lost connection
AWS   278576220453                   eu-central-1  i-06dcdc4d9a51b0af6            2026-04-29T15:10:14Z Failed (exit code=-1)  SSM Agent lost connection
AWS   278576220453                   eu-central-1  i-0611d40efd83c645c            2026-04-29T15:10:14Z Failed (exit code=-1)  SSM Agent lost connection
AWS   278576220453                   eu-central-1  i-0d0969a483c708c6a            2026-04-29T15:10:14Z Failed (exit code=-1)  SSM Agent lost connection
AWS   278576220453                   eu-central-1  i-03240260a38f6e5fe            2026-04-29T15:10:14Z Failed (exit code=-1)  SSM Agent not registered
AWS   278576220453                   eu-central-1  i-06c437aa38d9c9bbb            2026-04-29T15:10:14Z Failed (exit code=-1)  SSM Agent not registered
AWS   278576220453                   eu-central-1  i-0642b0fc2ddac9e1a            2026-04-29T15:10:14Z Failed (exit code=-1)  SSM Agent not registered
AWS   278576220453                   eu-central-1  i-0a56058ca3c2612e9            2026-04-29T15:10:14Z Failed (exit code=-1)  SSM Agent not registered
AWS   278576220453                   eu-central-1  i-04fc691fd2d0cdb6b            2026-04-29T15:10:14Z Failed (exit code=-1)  SSM Agent not registered
AWS   278576220453                   eu-central-1  i-08d41f6865676a747            2026-04-29T15:10:14Z Failed (exit code=-1)  SSM Agent not registered
AWS   278576220453                   eu-central-1  i-085bcb59f31e67682            2026-04-29T15:10:12Z Installed (offline)    Script output: "Offloading the installation part ...
AWS   278576220453                   eu-central-1  i-084245731fd7a61a1            2026-04-29T15:10:10Z Installed (offline)    Script output: "Offloading the installation part ...
AWS   278576220453                   eu-central-1  i-0465e017c03cd18de            2026-04-29T14:42:42Z Online                 Script output: "Offloading the installation part ...
AWS   278576220453                   eu-central-1  i-0ff6f4995a47706fa            2026-04-29T14:42:39Z Online                 Script output: "Offloading the installation part ...
Azure 060a97ea-3a57-4218-9be5-dba... PolandCentral tener-dev-3b066804-workload... 2026-04-29T15:25:48Z Online
Azure 060a97ea-3a57-4218-9be5-dba... PolandCentral tener-dev-3b066804-workload... 2026-04-29T15:25:34Z Online
Azure 060a97ea-3a57-4218-9be5-dba... polandcentral tener-dev-ff594e35-workload... 2026-04-29T15:06:08Z Failed (exit code=103) Enrollment failed. Script output: "insufficient d...
Azure 060a97ea-3a57-4218-9be5-dba... polandcentral tener-dev-46f47c91-workload... 2026-04-29T15:05:56Z Failed (API error)     VM agent not available. API error: "PUT https://m...
Azure 060a97ea-3a57-4218-9be5-dba... polandcentral tener-dev-33feff92-workload... 2026-04-29T15:05:54Z Failed (exit code=104) Enrollment failed. Script output: "proxy is unrea...
```

</p>
</details> 

<details><summary>Text output, filtered</summary>
<p>

```
> tctl discovery nodes --cloud=azure
Cloud Account                        Region        Instance                       Time                 Status                 Details
----- ------------------------------ ------------- ------------------------------ -------------------- ---------------------- ----------------------------------------------------
Azure 060a97ea-3a57-4218-9be5-dba... PolandCentral tener-dev-3b066804-workload... 2026-04-29T15:25:48Z Online
Azure 060a97ea-3a57-4218-9be5-dba... PolandCentral tener-dev-3b066804-workload... 2026-04-29T15:25:34Z Online
Azure 060a97ea-3a57-4218-9be5-dba... polandcentral tener-dev-ff594e35-workload... 2026-04-29T15:06:08Z Failed (exit code=103) Enrollment failed. Script output: "insufficient d...
Azure 060a97ea-3a57-4218-9be5-dba... polandcentral tener-dev-46f47c91-workload... 2026-04-29T15:05:56Z Failed (API error)     VM agent not available. API error: "PUT https://m...
Azure 060a97ea-3a57-4218-9be5-dba... polandcentral tener-dev-33feff92-workload... 2026-04-29T15:05:54Z Failed (exit code=104) Enrollment failed. Script output: "proxy is unrea...
```

</p>
</details> 

<details><summary>JSON output</summary>
<p>


```json
...
{
    "region": "polandcentral",
    "is_online": false,
    "run_result": {
        "api_error": "",
        "exit_code": 103,
        "output": "insufficient disk space",
        "time": "2026-04-29T15:11:56.56Z",
        "is_failure": true
    },
    "user_task_id": "692d472d-75b7-5ac2-855e-16b4fd25a814",
    "user_task_issue": "azure-vm-enrollment-error",
    "azure": {
        "vm_id": "dbcdbb42-12ce-4bbb-80d0-c5cb3fc6eef9",
        "vm_name": "tener-dev-ff594e35-vm-0",
        "subscription_id": "060a97ea-3a57-4218-9be5-dba3f19ff2b5",
        "resource_group": "tener-dev-ff594e35-workload-rg",
        "resource_id": "/subscriptions/060a97ea-3a57-4218-9be5-dba3f19ff2b5/resourceGroups/tener-dev-ff594e35-workload-rg/providers/Microsoft.Compute/virtualMachines/tener-dev-ff594e35-vm-0"
    }
},
{
    "region": "polandcentral",
    "is_online": false,
    "run_result": {
        "api_error": "PUT https://management.azure.com/subscriptions/060a97ea-3a57-4218-9be5-dba3f19ff2b5/resourceGroups/tener-dev-46f47c91-workload-rg/providers/Microsoft.Compute/virtualMachines/tener-dev-46f47c91-vm-0/runCommands/teleport-install\n--------------------------------------------------------------------------------\nRESPONSE 409: 409 Conflict\nERROR CODE: OperationNotAllowed\n--------------------------------------------------------------------------------\n{\n  \"error\": {\n    \"code\": \"OperationNotAllowed\",\n    \"message\": \"This operation cannot be performed when extension operations are disallowed. To allow, please ensure VM Agent is installed on the VM and the osProfile.allowExtensionOperations property is true.\"\n  }\n}\n--------------------------------------------------------------------------------\n",
        "exit_code": 0,
        "output": "",
        "time": "2026-04-29T15:11:34.804Z",
        "is_failure": true
    },
    "user_task_id": "01dc6094-eecc-5c7b-81f7-0a6459fabc32",
    "user_task_issue": "azure-vm-agent-not-available",
    "azure": {
        "vm_id": "e18e6d3a-889e-464f-8db6-88f8cdf46da4",
        "vm_name": "tener-dev-46f47c91-vm-0",
        "subscription_id": "060a97ea-3a57-4218-9be5-dba3f19ff2b5",
        "resource_group": "tener-dev-46f47c91-workload-rg",
        "resource_id": "/subscriptions/060a97ea-3a57-4218-9be5-dba3f19ff2b5/resourceGroups/tener-dev-46f47c91-workload-rg/providers/Microsoft.Compute/virtualMachines/tener-dev-46f47c91-vm-0"
    }
}
...
```

</p>
</details> 


## Manual Test Plan
### Test Environment
- Teleport Cloud cluster `tener-test-v19.cloud.gravitational.io` (master)
- Discovery Service configured with both EC2 (SSM) and Azure VM matchers
- Inventory: AWS EC2 in `eu-central-1` and Azure VMs in `PolandCentral`, mixing successful enrollments with each failure mode
- AWS handling was refactored alongside the Azure addition; AWS cases below double as regression checks

### Test Cases

- [x] `tctl discovery nodes` and `--format=json` render matching entries; columns/fields populated for both AWS and Azure
- [x] Long values truncated in text view; zero `expiry` omitted from JSON (`omitzero`)
- [x] AWS entries continue to work (no regressions)
- [x] Azure entries are now populated, with varying cases properly handled
- [x] `--last` window works as intended (default 1h, customizable)
- [x] `--failures-only` includes both AWS and Azure failures, excludes successes
- [x] `--cloud` can be used to restrict the scope to either AWS or Azure nodes