### PR TITLE
Spellcheck changelog before commit

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -36,3 +36,17 @@ jobs:
           go-version: 'stable'
       - name: Validate the changelog entry
         run: cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+      # Extract changelog using intermediate variables to avoid injection attacks.
+      # https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
+      - name: Extract changelog entries
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          {
+            echo 'entries<<EOF'
+            grep -iE '^changelog: ' <<< "$BODY" | sed 's/^[Cc]hangelog: //'
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Spellcheck changelog
+        working-directory: 'docs'
+        run: yarn spellcheck <<< "${{ steps.changelog.outputs.entries }}"

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -55,7 +55,12 @@ jobs:
             pnpm-lock.yaml
             docs/cspell.json
           sparse-checkout-cone-mode: false
-      - uses: pnpm/action-setup@v4
+      - name: Install Node
+        uses: actions/setup-node@dda4788290998366da86b6a4f497909644397bb2 # v6.0.0
+        with:
+          node-version: 22
+      - name: Enable pnpm
+        run: corepack enable
       - name: Install cspell
         run: pnpm install --frozen-lockfile
       - name: Spellcheck changelog

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -47,14 +47,16 @@ jobs:
             grep -iE '^changelog: ' <<< "$BODY" | sed 's/^[Cc]hangelog: //'
             echo EOF
           } >> "$GITHUB_OUTPUT"
-      - name: Checkout dictionary
+      - name: Checkout dependencies
         uses: actions/checkout@v6
         with:
-          repository: 'gravitational/teleport'
-          path: 'teleport'
-          fetch-depth: 1
-          sparse-checkout: docs/cspell.json
+          sparse-checkout: |
+            package.json
+            pnpm-lock.yaml
+            docs/cspell.json
           sparse-checkout-cone-mode: false
+      - uses: pnpm/action-setup@v4
+      - name: Install cspell
+        run: pnpm install --frozen-lockfile
       - name: Spellcheck changelog
-        working-directory: 'docs'
-        run: yarn spellcheck <<< "${{ steps.changelog.outputs.entries }}"
+        run: pnpm exec cspell lint --no-progress --config docs/cspell.json stdin <<< "${{ steps.changelog.outputs.entries }}"

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -48,5 +48,5 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Spellcheck changelog
-        working-directory: 'docs'
+        working-directory: '../docs'
         run: yarn spellcheck <<< "${{ steps.changelog.outputs.entries }}"

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           {
             echo 'entries<<EOF'
-            grep -iE '^changelog: ' <<< "$BODY" | sed 's/^[Cc]hangelog: //'
+            printf '%s' "$BODY" | tr -d '\r' | grep -iE '^[[:space:]]*changelog: ' | sed -E 's/^[[:space:]]*[Cc]hangelog: //'
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Checkout cspell dependencies

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -47,21 +47,17 @@ jobs:
             grep -iE '^changelog: ' <<< "$BODY" | sed 's/^[Cc]hangelog: //'
             echo EOF
           } >> "$GITHUB_OUTPUT"
-      - name: Checkout dependencies
+      - name: Checkout cspell dependencies
         uses: actions/checkout@v6
         with:
           sparse-checkout: |
             package.json
-            pnpm-lock.yaml
             docs/cspell.json
           sparse-checkout-cone-mode: false
-      - name: Install Node
-        uses: actions/setup-node@dda4788290998366da86b6a4f497909644397bb2 # v6.0.0
+      - uses: actions/setup-node@dda4788290998366da86b6a4f497909644397bb2 # v6.0.0
         with:
-          node-version: 22
-      - name: Enable pnpm
-        run: corepack enable
-      - name: Install cspell
-        run: pnpm install --frozen-lockfile
+          node-version: 24
       - name: Spellcheck changelog
-        run: pnpm exec cspell lint --no-progress --config docs/cspell.json stdin <<< "${{ steps.changelog.outputs.entries }}"
+        run: |
+          VERSION=$(jq -r '.devDependencies.cspell // .dependencies.cspell' package.json | tr -d '^~>=< ')
+          npx -y "cspell@${VERSION}" lint --no-progress --config docs/cspell.json stdin <<< "${{ steps.changelog.outputs.entries }}"

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -47,6 +47,14 @@ jobs:
             grep -iE '^changelog: ' <<< "$BODY" | sed 's/^[Cc]hangelog: //'
             echo EOF
           } >> "$GITHUB_OUTPUT"
+      - name: Checkout dictionary
+        uses: actions/checkout@v6
+        with:
+          repository: 'gravitational/teleport'
+          path: 'teleport'
+          fetch-depth: 1
+          sparse-checkout: docs/cspell.json
+          sparse-checkout-cone-mode: false
       - name: Spellcheck changelog
-        working-directory: '../docs'
+        working-directory: 'docs'
         run: yarn spellcheck <<< "${{ steps.changelog.outputs.entries }}"


### PR DESCRIPTION
Spellcheck changelog entries before they are compiled into the release PR. Implemented here instead of in shared-workflows in order to maintain parity with the docs spelling library.

Changelog: soem garbage to test


