### PR TITLE
Release 18.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## 18.7.6 (04/29/26)
 
+### Security fixes
+
+This patch includes some security fixes.
+These issues are present in previous v18 releases.
+Impacted users are recommended to upgrade their auth and database services to the latest version.
+For Teleport Cloud customers, your control plane has already been upgraded to a patched release.
+
+#### [High] Authorization bypass in encrypted session recordings
+
+Teleport did not ensure sufficient authorization in some of the encrypted session recordings APIs.
+This could allow an attacker to upload recordings to the cluster.
+Teleport did not find the evidence of this being exploited in the Teleport Cloud environment. For
+self-hosted users that do not use encrypted session recordings, the following debug log messages
+on auth server would indicate vulnerable APIs being called:
+- “creating encrypted session upload”
+- “uploading encrypted session part”
+- “completing encrypted session upload”
+This issue affects only Teleport v18. All users are advised to upgrade their Auth services to the
+patched v18 release.
+
+#### [High] Cross-node session recording access
+
+When checking system service access to session recordings and audit logs, Teleport did not
+perform sufficient authorization. This could allow a compromised Teleport SSH node service to
+access audit events and session recordings from other nodes in the cluster.
+All users are advised to upgrade their Auth services to the patched v18 or v17 release.
+
+#### [Medium] SSRF via AWS database access endpoint
+
+Teleport did not sufficiently validate the connection endpoint for AWS database access
+(DynamoDB, OpenSearch, Keyspaces). This could allow a malicious actor with access to Teleport
+configuration to steal database access credentials by crafting a connection endpoint pointing to
+their domain.
+All users that use Teleport to access AWS-hosted databases (DynamoDB, OpenSearch, Keyspaces)
+are advised to upgrade their auth and database services to the patched v18 or v17 release
+
+### Other fixes and improvements
+
 * Fixed an issue that prevents GCP Server discovery to try to enroll all the VMs that are found when one of them returns an error. [#66240](https://github.com/gravitational/teleport/pull/66240)
 * Added scoped roles support to the Terraform provider. [#66225](https://github.com/gravitational/teleport/pull/66225)
 * Added scoped role assignment support to the Terraform provider. [#66225](https://github.com/gravitational/teleport/pull/66225)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,29 @@
 
 ### Security fixes
 
-This patch includes some security fixes.
-These issues are present in previous v18 releases.
-Impacted users are recommended to upgrade their auth and database services to the latest version.
+This release includes various security-related improvements and bug fixes. 
+We recommend that users on versions prior to v18.7.5 upgrade their Auth and Database Services to this latest release.
 For Teleport Cloud customers, your control plane has already been upgraded to a patched release.
 
 #### [High] Authorization bypass in encrypted session recordings
 
 Teleport did not ensure sufficient authorization in some of the encrypted session recordings APIs.
 This could allow an attacker to upload recordings to the cluster.
-Teleport did not find the evidence of this being exploited in the Teleport Cloud environment. For
-self-hosted users that do not use encrypted session recordings, the following debug log messages
+For self-hosted users that do not use encrypted session recordings, the following debug log messages
 on auth server would indicate vulnerable APIs being called:
 - “creating encrypted session upload”
 - “uploading encrypted session part”
 - “completing encrypted session upload”
-This issue affects only Teleport v18. All users are advised to upgrade their Auth services to the
-patched v18 release.
+
+This issue specifically affects Teleport v18. We recommend that all users upgrade their 
+Auth Services to this release to ensure continued security and stability.
 
 #### [High] Cross-node session recording access
 
 When checking system service access to session recordings and audit logs, Teleport did not
 perform sufficient authorization. This could allow a compromised Teleport SSH node service to
 access audit events and session recordings from other nodes in the cluster.
-All users are advised to upgrade their Auth services to the patched v18 release.
+We recommend that all users upgrade their Auth Services to this release to ensure continued security and stability.
 
 #### [Medium] SSRF via AWS database access endpoint
 
@@ -36,7 +35,8 @@ Teleport did not sufficiently validate the connection endpoint for AWS database 
 configuration to steal database access credentials by crafting a connection endpoint pointing to
 their domain.
 All users that use Teleport to access AWS-hosted databases (DynamoDB, OpenSearch, Keyspaces)
-are advised to upgrade their auth and database services to the patched v18 release
+are advised to upgrade their Auth and Database Services to this release to ensure continued security
+and stability.
 
 ### Other fixes and improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ patched v18 release.
 When checking system service access to session recordings and audit logs, Teleport did not
 perform sufficient authorization. This could allow a compromised Teleport SSH node service to
 access audit events and session recordings from other nodes in the cluster.
-All users are advised to upgrade their Auth services to the patched v18 or v17 release.
+All users are advised to upgrade their Auth services to the patched v18 release.
 
 #### [Medium] SSRF via AWS database access endpoint
 
@@ -36,7 +36,7 @@ Teleport did not sufficiently validate the connection endpoint for AWS database 
 configuration to steal database access credentials by crafting a connection endpoint pointing to
 their domain.
 All users that use Teleport to access AWS-hosted databases (DynamoDB, OpenSearch, Keyspaces)
-are advised to upgrade their auth and database services to the patched v18 or v17 release
+are advised to upgrade their auth and database services to the patched v18 release
 
 ### Other fixes and improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,127 @@
 # Changelog
 
+## 18.7.6 (04/29/26)
+
+* Fixed an issue that prevents GCP Server discovery to try to enroll all the VMs that are found when one of them returns an error. [#66240](https://github.com/gravitational/teleport/pull/66240)
+* Added scoped roles support to the Terraform provider. [#66225](https://github.com/gravitational/teleport/pull/66225)
+* Added scoped role assignment support to the Terraform provider. [#66225](https://github.com/gravitational/teleport/pull/66225)
+* Fixed an issue where `tctl edit plugin/jamf` could break other plugins when providing non-zero duration value. [#66191](https://github.com/gravitational/teleport/pull/66191)
+* Introduces `skip_initial_connection` option to the `teleportmwi` provider to allow lazy initialization of the provider. [#66139](https://github.com/gravitational/teleport/pull/66139)
+* Initialize keystore sign and decrypt metrics at startup and register missing decrypt metric collectors. [#66110](https://github.com/gravitational/teleport/pull/66110)
+* Added current and previous resources discovered summary per service to Discovery Config Status. [#66097](https://github.com/gravitational/teleport/pull/66097)
+* Fixed a bug where generated JWT tokens were leaked into audit event. [#66095](https://github.com/gravitational/teleport/pull/66095)
+* Updated internal database dependencies to resolve multiple security vulnerabilities (CVE-2026-4427, CVE-2026-32286, and others). [#66083](https://github.com/gravitational/teleport/pull/66083)
+* Fixed a possible panic during TTY session processing/playback/summarization from crashing Teleport. [#66080](https://github.com/gravitational/teleport/pull/66080)
+* Fixed an issue where the endpoint used by `tsh scan keys` could leak resources on a server error; this affected only clusters with Access Graph enabled. [#66076](https://github.com/gravitational/teleport/pull/66076)
+* Added `teleport_app_active_sessions` Prometheus gauge with `app` label for app access agent autoscaling. [#66050](https://github.com/gravitational/teleport/pull/66050)
+* Fixed joining for agents and proxies connecting directly to an Auth service when they specify a CA pin and any lock in the cluster is in force. [#66044](https://github.com/gravitational/teleport/pull/66044)
+* Added scoped role to the k8s operator. [#66034](https://github.com/gravitational/teleport/pull/66034)
+* Added scoped role assignments to the k8s operator. [#66034](https://github.com/gravitational/teleport/pull/66034)
+* Fixed Access List-granted roles being absent from the web session created after a local user password reset or invite acceptance, requiring a logout/login cycle to restore access. [#66011](https://github.com/gravitational/teleport/pull/66011)
+* Added support for Azure join tokens based on Azure tenant ID. [#65989](https://github.com/gravitational/teleport/pull/65989)
+* Fixed a "No such process" error that could happen on the very first launch of VNet on macOS. [#65967](https://github.com/gravitational/teleport/pull/65967)
+* Improved readability of the search results in Teleport Connect. [#65928](https://github.com/gravitational/teleport/pull/65928)
+* Fixed a Teleport Connect issue on Windows where startup could fail when `HTTPS_PROXY` is set. [#65924](https://github.com/gravitational/teleport/pull/65924)
+* Added `user.metadata.name` variable to RBAC role templates and expressions. [#65923](https://github.com/gravitational/teleport/pull/65923)
+* Fix VNet SSH per-session MFA checks to use the requested SSH login instead of the profile default login. [#65909](https://github.com/gravitational/teleport/pull/65909)
+* Initialize backend read and requests metrics to zero at startup. [#65898](https://github.com/gravitational/teleport/pull/65898)
+* Fixed Teleport not taking over an existing unmanaged host user when configured to. [#65838](https://github.com/gravitational/teleport/pull/65838)
+* Fixes race condition in dynamoDB backend which can lead to missed events, resulting in a inconsistent cache state. [#65821](https://github.com/gravitational/teleport/pull/65821)
+* Added `ui_config` resource support to the Terraform provider. [#65800](https://github.com/gravitational/teleport/pull/65800)
+* Set default name for `UIConfig` resource as `ui-config`. [#65800](https://github.com/gravitational/teleport/pull/65800)
+* Fixed an issue in Teleport Connect on macOS where selecting "Open Teleport Connect" from the menu bar would not reliably open the app. [#65774](https://github.com/gravitational/teleport/pull/65774)
+* The github join method now supports the enterprise/enterprise_id claims. [#65700](https://github.com/gravitational/teleport/pull/65700)
+* Teleport Connect now displays user roles in an expandable list. [#65654](https://github.com/gravitational/teleport/pull/65654)
+* Standard Teleport agents can now join using the `bound_keypair` join method. [#65625](https://github.com/gravitational/teleport/pull/65625)
+* Add x11 forwarding, SSH File Copying, Agent Forwarding, SSH Port Forwarding, Create Host User, Max Sessions, and host sudoers to scoped ssh role options. [#65601](https://github.com/gravitational/teleport/pull/65601)
+* Added `tctl discovery nodes` command for troubleshooting AWS EC2 auto-discovery enrollment issues. [#65598](https://github.com/gravitational/teleport/pull/65598)
+* Update Go to v1.25.9. [#65586](https://github.com/gravitational/teleport/pull/65586)
+* Fix access graph AWS discovery to not deadlock when Identity Activity Center is disabled. [#65574](https://github.com/gravitational/teleport/pull/65574)
+* Clear certs from local ssh agent when switching between unscoped user to scoped user. [#65568](https://github.com/gravitational/teleport/pull/65568)
+* Added `lock` resource support to the Kubernetes operator. [#65543](https://github.com/gravitational/teleport/pull/65543)
+* Added support for `*` and `$` globbing to the GitHub Actions token rules. [#65539](https://github.com/gravitational/teleport/pull/65539)
+* The `tbot keypair create` command will now create the specified directory if necessary. [#65528](https://github.com/gravitational/teleport/pull/65528)
+* Fixed an issue in Teleport Connect where the "Reopen" button in the "Reopen previous session" modal would not automatically receive focus. [#65513](https://github.com/gravitational/teleport/pull/65513)
+* Fixed a bug where Teleport Connect displayed an error about an expired certificate instead of showing the login modal. [#65512](https://github.com/gravitational/teleport/pull/65512)
+* Added visible `teleport.dev/` labels for Azure and GCP auto-discovered VMs, making subscription ID, VM ID, region, resource group, VM name, and zone available in the web UI, CLI output, and RBAC rules. [#65462](https://github.com/gravitational/teleport/pull/65462)
+* Fixed panic in tctl get scoped_token when non-token join method scoped tokens were present. [#65461](https://github.com/gravitational/teleport/pull/65461)
+* Fix "tctl edit" bugs when editing multiple resources, or resources with sub_kinds (for example, CAs). [#65341](https://github.com/gravitational/teleport/pull/65341)
+* Removed expired Baltimore CyberTrust Root CA used for Azure databases. [#65329](https://github.com/gravitational/teleport/pull/65329)
+* Reimplemented how Teleport Connect handles deep links for Device Trust auth and launching VNet from the Web UI. [#65316](https://github.com/gravitational/teleport/pull/65316)
+* Extended access monitoring predicate language with `contains(set, item)` expression. [#65294](https://github.com/gravitational/teleport/pull/65294)
+* Fixed an issue where viewing a session recording that did not exist/was not uploaded yet would show an empty player instead of an error message. [#65269](https://github.com/gravitational/teleport/pull/65269)
+* Auth connector names are now limited to 768 characters. [#65242](https://github.com/gravitational/teleport/pull/65242)
+* Fix a goroutine leak in the Teleport Connect MFA prompt when both SSO MFA and Webauthn are available second factors. [#65229](https://github.com/gravitational/teleport/pull/65229)
+* Add SAML IdP Service Provider support to Terraform provider. [#65199](https://github.com/gravitational/teleport/pull/65199)
+* Fixed minor bug in Web UI and Connect where static and dynamic labels with the same key are duplicated. [#65198](https://github.com/gravitational/teleport/pull/65198)
+* Fix URL components for SAML auth connector ACS URL in tests, error message. [#65197](https://github.com/gravitational/teleport/pull/65197)
+* Add `lock` support to the Terraform Provider. [#65134](https://github.com/gravitational/teleport/pull/65134)
+* Fix a bug in the `teleport-cluster` chart causing some `auth.*` values to not be used when rendering hooks or config manifests. [#65131](https://github.com/gravitational/teleport/pull/65131)
+* Fix Cross-access-list member injection in raw gRPC UpsertAccessListWithMembers call due to missing member.Spec.AccessList field validation. [#65123](https://github.com/gravitational/teleport/pull/65123)
+* Fix an issue that allowed bypassing Resource Access Requests' AllowedResourceIDs when creating app sessions. [#65116](https://github.com/gravitational/teleport/pull/65116)
+* Fix an issue that allowed IP Pinning protections to be bypassed via direct dial to a Teleport Node. [#65094](https://github.com/gravitational/teleport/pull/65094)
+* Fix an issue that allowed IP Pinning protections to be bypassed via the WebUI. Also fix an issue with sporadic WebUI connection errors when the Proxy sees an unexpected client IP even though IP Pinning is not enforced. [#65090](https://github.com/gravitational/teleport/pull/65090)
+* Fix an issue where `tctl get tokens` would prompt for admin MFA three times rather than once. [#65084](https://github.com/gravitational/teleport/pull/65084)
+* Display an alert when SAML connector signing certificates are within 90 days of expiry. [#65067](https://github.com/gravitational/teleport/pull/65067)
+* Add scopes status to webapi ping endpoint to determine whether the proxy and auth server has scopes enabled or not. [#65062](https://github.com/gravitational/teleport/pull/65062)
+* Azure VM discovery configuration now supports specifying a wildcard ("*") subscription to discover all VMs in all subscriptions where the Discovery service has Microsoft.Resources/subscriptions/read permission. [#65045](https://github.com/gravitational/teleport/pull/65045)
+* Added support for multiple trusted CA certificates to Windows Desktop Service's LDAP configuration. [#65040](https://github.com/gravitational/teleport/pull/65040)
+* Fix mouse move when using fixed screen size Windows desktop. [#65025](https://github.com/gravitational/teleport/pull/65025)
+* Fixed intermittent issues with VNet on Windows with NRPT rules being wiped after Group Policy refresh. [#65017](https://github.com/gravitational/teleport/pull/65017)
+* Fixed AWS IAM Roles Anywhere Web/Console access for Gov Cloud and China partitioned AWS accounts. [#65016](https://github.com/gravitational/teleport/pull/65016)
+* Device Trust is now accessible under Zero Trust Access in the web UI. [#65005](https://github.com/gravitational/teleport/pull/65005)
+* Fixed an issue with desktop directory sharing in Teleport Connect that caused file modification times not to be displayed. [#64921](https://github.com/gravitational/teleport/pull/64921)
+* Added support for configuring agentless OpenSSH servers using `tbot`. [#64899](https://github.com/gravitational/teleport/pull/64899)
+* Fixed an issue preventing Teleport Connect from launching when the OS username contains non-ASCII characters. [#64885](https://github.com/gravitational/teleport/pull/64885)
+* Fixed access request comments and review reasons not preserving newlines when rendered. [#64866](https://github.com/gravitational/teleport/pull/64866)
+* Add documentation for the `tsh aws-profile` command. [#64777](https://github.com/gravitational/teleport/pull/64777)
+* API rate limiting for authenticated per-session MFA requests now follows the regular API rate limits, making the limit unlikely to be hit during parallel SSH operations. [#64775](https://github.com/gravitational/teleport/pull/64775)
+* Print a message indicating that `tctl recordings download <session_id>` completed successfully. [#64721](https://github.com/gravitational/teleport/pull/64721)
+* Adds the ability to not render hooks in the `teleport-kube-agent` chart. [#64706](https://github.com/gravitational/teleport/pull/64706)
+* Fixes version number for charts `teleport-kube-agent-updater` and `teleport-spiffe-daemon-set`. [#64686](https://github.com/gravitational/teleport/pull/64686)
+* Vnet_config can now be managed via the Teleport Terraform Provider. [#64682](https://github.com/gravitational/teleport/pull/64682)
+* Added scoped tokens to the k8s operator. [#64639](https://github.com/gravitational/teleport/pull/64639)
+* Fixed a bug affecting nodes on v18.3.0+ rejoining with new system roles to clusters with Auth services on v18.2.10-. [#64638](https://github.com/gravitational/teleport/pull/64638)
+* Updated github.com/docker/cli to v29.2.0+incompatible (addresses CVE-2025-15558). [#64606](https://github.com/gravitational/teleport/pull/64606)
+* Fix map generation for teleport resources to k8s. [#64597](https://github.com/gravitational/teleport/pull/64597)
+* Add scope aware profiles after tsh login. [#64592](https://github.com/gravitational/teleport/pull/64592)
+* Added a new tsh aws-profile command that detects your AWS Identity Center integration (if configured) and writes corresponding AWS profiles into your local AWS config file for later use. [#64590](https://github.com/gravitational/teleport/pull/64590)
+* Add `tctl acl` commands for managing access list reviews. [#64587](https://github.com/gravitational/teleport/pull/64587)
+* Validate Kubernetes impersonation user and group header values to prevent CRLF or null-byte header injection via crafted role definitions. [#64586](https://github.com/gravitational/teleport/pull/64586)
+* Fixed Azure and GCP server auto-discovery installation when the target VM had a system-wide HTTP proxy configured. [#64552](https://github.com/gravitational/teleport/pull/64552)
+* Teleport Connect now displays the Message of the Day (MOTD) before login. [#64549](https://github.com/gravitational/teleport/pull/64549)
+* Fixed bug that causes Windows desktop connection errors on EC2 joined nodes. [#64545](https://github.com/gravitational/teleport/pull/64545)
+* Fixed `tsh login --request-id` to display up to date profile information including the assumed access request and roles. [#64536](https://github.com/gravitational/teleport/pull/64536)
+* Update Go to v1.25.8. [#64434](https://github.com/gravitational/teleport/pull/64434)
+* Added terraform provider support for teleport_scoped_token. [#64392](https://github.com/gravitational/teleport/pull/64392)
+* Add SAML IdP Service Provider support to k8s operator. [#64380](https://github.com/gravitational/teleport/pull/64380)
+* Fixed a bug causing spurious failures to upload encrypted session recordings when 4MB or larger. [#64361](https://github.com/gravitational/teleport/pull/64361)
+* Fix agent forwarding in proxy recording mode. [#64349](https://github.com/gravitational/teleport/pull/64349)
+* Fixed failures to record extra large session events in synchronous recording modes. [#64343](https://github.com/gravitational/teleport/pull/64343)
+* Fixed a rare race condition causing initial node heartbeats to be missing an address. [#64332](https://github.com/gravitational/teleport/pull/64332)
+* Fixed a VNet regression where web app access could fail when access was assumed in the Web UI only while VNet was already running. [#64317](https://github.com/gravitational/teleport/pull/64317)
+* Add support for Resource-Scoped Constraints to Access Requests, allowing users to narrow the scope of their requested access by selecting individual principals on resources while creating an Access Request via the Teleport Web UI. Initial support includes Role ARNs for AWS Console app resources. [#63207](https://github.com/gravitational/teleport/pull/63207)
+* Azure VM discovery will wait for installation and collect potential errors. The results will update discovery config statistics. VM installation errors will be captured as user tasks. [#62731](https://github.com/gravitational/teleport/pull/62731)
+
+Enterprise:
+* SAML IdP: Custom attribute mappings now overwrite default attributes with the same Name instead of duplicating them. Previously, mapping a default attribute like eduPersonAffiliation.
+* Fixes the issue where users with ongoing Access Requests to Okta resources would synced back as permanent Access List members for the requested resources during the periodic Okta import.
+* Fixed AWSIC Group membership updates so they are no longer abandoned when AWS is presented with an obsolete User ID.
+* Fix Okta assignment reconciliation failing for applications with large user lists where the API response time exceeded the 30s HTTP client timeout by increase the Okta http connection Timeout to 5 min.
+* Fixed an issue where Teleport could return a stale SCIM user group attribute when a user no longer belonged to any SCIM groups. Previously, in this case, the SCIM /Users endpoint could return outdated data from an earlier state when the user still had at least one group assigned.
+* Add support for workload_cluster resource for Teleport Cloud users to provision new Teleport Cloud clusters.
+* Improve SCIM performance by using cache for /Users and /Groups listing calls.
+* Fixed SCIM group and user listing pagination to return the correct totalResults count across all pages. Previously, totalResults could undercount matching resources when paginating beyond the first page,.
+* Fixed an issue where characters such as `.` were not permitted in an instance profile ARN when setting up session summaries inference.
+* Access list owners are now automatically suggested as reviewers when the list grants members the ability to request access to resources and owners the ability to review those requests.
+* Added handling for AWS Identity Center users deleted outside of Teleport's control.
+* Device Trust is now accessible under Zero Trust Access in the web UI.
+* Fixed group member provisioning bug in Identity Center plugin caused by an unsupported PATCH operation.
+* Fix an issue where Okta pending assignments could overlap with Access List synchronization, causing users to be unintentionally re-added to access lists in case of strict Okta API rate limits.
+* Fixed AWS Account rename handling in Identity Center plugin when an old account name is restored.
+* Fix the issue where clicking **Provision User** after enrolling Okta SCIM integration could result in "missing Okta user ID" error.
+* Added a wizard for creating access lists that includes defining which resources members can access.
+
 ## 18.7.5 (04/21/26)
 
 * Prevented a possible panic during TTY session processing/playback/summarization from crashing Teleport.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=18.7.6-rc.1
+VERSION=18.7.6
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -2,10 +2,10 @@
 
 package api
 
-const Version = "18.7.6-rc.1"
+const Version = "18.7.6"
 
 const VersionMajor = 18
 const VersionMinor = 7
 const VersionPatch = 6
-const VersionPreRelease = "rc.1"
+const VersionPreRelease = ""
 const VersionMetadata = ""

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.0</string>
+		<string>18.7.6</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>1.0</string>
+		<string>18.7.6</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.0</string>
+		<string>18.7.6</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>1.0</string>
+		<string>18.7.6</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/examples/chart/access/datadog/Chart.yaml
+++ b/examples/chart/access/datadog/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 apiVersion: v2
 name: teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-datadog-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-datadog-18.7.6
       name: RELEASE-NAME-teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-datadog-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-datadog-18.7.6
       name: RELEASE-NAME-teleport-plugin-datadog
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-datadog
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-datadog-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-datadog-18.7.6
         spec:
           containers:
           - command:

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-discord-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-discord-18.7.6
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-discord-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-discord-18.7.6
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-discord-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-discord-18.7.6
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,8 +26,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -59,8 +59,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -92,8 +92,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -125,8 +125,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -161,8 +161,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -194,6 +194,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-email-18.7.6
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.7.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-email-18.7.6
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-email-18.7.6
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.7.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-email-18.7.6
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.7.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-email-18.7.6
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.7.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-email-18.7.6
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-email-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-email-18.7.6
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.7.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -32,6 +32,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-jira-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-jira-18.7.6
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-jira-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-jira-18.7.6
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-jira-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-jira-18.7.6
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-mattermost-18.7.6
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-mattermost-18.7.6
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-mattermost-18.7.6
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-mattermost-18.7.6
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-mattermost-18.7.6
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.7.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-mattermost-18.7.6
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-mattermost-18.7.6
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.7.6
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-msteams-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-msteams-18.7.6
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-msteams-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-msteams-18.7.6
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-msteams-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-msteams-18.7.6
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-pagerduty-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-pagerduty-18.7.6
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-pagerduty-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-pagerduty-18.7.6
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-pagerduty-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-pagerduty-18.7.6
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-slack-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-slack-18.7.6
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-slack-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-slack-18.7.6
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-slack-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-slack-18.7.6
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
@@ -7,8 +7,8 @@ should request certificates when certManager enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-event-handler-18.7.6
       name: RELEASE-NAME-teleport-plugin-event-handler-server
       namespace: NAMESPACE
     spec:
@@ -35,8 +35,8 @@ should request certificates when certManager enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-event-handler-18.7.6
       name: RELEASE-NAME-teleport-plugin-event-handler-client
       namespace: NAMESPACE
     spec:

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -33,6 +33,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-event-handler-18.7.6
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-event-handler-18.7.6
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-event-handler
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-plugin-event-handler-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-plugin-event-handler-18.7.6
         spec:
           containers:
           - args:
@@ -87,7 +87,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:18.7.6
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-event-handler-18.7.6
       name: RELEASE-NAME-teleport-plugin-event-handler
       namespace: NAMESPACE
     spec:
@@ -28,8 +28,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-event-handler-18.7.6
       name: RELEASE-NAME-teleport-plugin-event-handler
       namespace: NAMESPACE
     spec:
@@ -43,8 +43,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-plugin-event-handler-18.7.6
       name: RELEASE-NAME-tbot
       namespace: NAMESPACE
     spec:

--- a/examples/chart/tbot-spiffe-daemon-set/Chart.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 name: tbot-spiffe-daemon-set
 apiVersion: v2

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/daemonset_test.yaml.snap
@@ -21,7 +21,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot-spiffe-daemon-set
-            helm.sh/chart: tbot-spiffe-daemon-set-18.7.6-rc.1
+            helm.sh/chart: tbot-spiffe-daemon-set-18.7.6
         spec:
           containers:
           - args:
@@ -38,7 +38,7 @@ should match the snapshot (full):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:18.7.6
             imagePullPolicy: IfNotPresent
             name: tbot
             securityContext:
@@ -94,7 +94,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot-spiffe-daemon-set
-            helm.sh/chart: tbot-spiffe-daemon-set-18.7.6-rc.1
+            helm.sh/chart: tbot-spiffe-daemon-set-18.7.6
         spec:
           containers:
           - args:
@@ -110,7 +110,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:18.7.6
             imagePullPolicy: IfNotPresent
             name: tbot
             securityContext:

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 name: tbot
 apiVersion: v2

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-18.7.6-rc.1
+            helm.sh/chart: tbot-18.7.6
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
               value: "1"
             - name: TEST_ENV
               value: test-value
-            image: public.ecr.aws/gravitational/tbot-distroless:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:18.7.6
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 6
@@ -167,7 +167,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-18.7.6-rc.1
+            helm.sh/chart: tbot-18.7.6
         spec:
           containers:
           - args:
@@ -189,7 +189,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:18.7.6
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-cluster-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-cluster-18.7.6
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -2040,8 +2040,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-cluster-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-cluster-18.7.6
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -159,7 +159,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -277,7 +277,7 @@ should set resources when set in values:
       env:
       - name: GOMEMLIMIT
         value: "3865470567"
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -381,7 +381,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-cluster-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-cluster-18.7.6
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.7.6-rc.1
-        helm.sh/chart: teleport-cluster-18.7.6-rc.1
+        app.kubernetes.io/version: 18.7.6
+        helm.sh/chart: teleport-cluster-18.7.6
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: d51622896bd7fbabf053ed8fa7eefe93a3822e8637fa579d2f7fdf01c8d6320e
+            checksum/config: aac77525cbae48b10b74ef397aa51ee6267ead07efe05ee1686aa631b2a15dd9
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 18.7.6-rc.1
-            helm.sh/chart: teleport-cluster-18.7.6-rc.1
+            app.kubernetes.io/version: 18.7.6
+            helm.sh/chart: teleport-cluster-18.7.6
             teleport.dev/majorVersion: "18"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -106,7 +106,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v17.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -155,7 +155,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       name: wait-auth-update
       resources:
         limits:
@@ -219,7 +219,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -281,7 +281,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -352,7 +352,7 @@ should set resources for wait-auth-update initContainer when set in values:
       env:
       - name: GOMEMLIMIT
         value: "3865470567"
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -421,7 +421,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       name: wait-auth-update
       resources:
         limits:
@@ -481,7 +481,7 @@ should set resources when set in values:
       env:
       - name: GOMEMLIMIT
         value: "3865470567"
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -550,7 +550,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       name: wait-auth-update
       resources:
         limits:
@@ -607,7 +607,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -676,7 +676,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -733,7 +733,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -802,7 +802,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -109,7 +109,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+          image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -173,7 +173,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -237,7 +237,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -322,7 +322,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -387,7 +387,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -451,7 +451,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -513,7 +513,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -589,7 +589,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -665,7 +665,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -729,7 +729,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -793,7 +793,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -862,7 +862,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf an
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -932,7 +932,7 @@ should mount jamfCredentialsSecret.name when role is jamf and action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1004,7 +1004,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1078,7 +1078,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1270,7 +1270,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1334,7 +1334,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1411,7 +1411,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1539,7 +1539,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1603,7 +1603,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1669,7 +1669,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1745,7 +1745,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1809,7 +1809,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1874,7 +1874,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1948,7 +1948,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2012,7 +2012,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2083,7 +2083,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2147,7 +2147,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -108,7 +108,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -138,7 +138,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -168,7 +168,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -200,7 +200,7 @@ should set resources in the Job's pod spec if resources is set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -18,7 +18,7 @@ sets Pod annotations when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -104,7 +104,7 @@ sets Pod labels when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -214,7 +214,7 @@ sets StatefulSet labels when specified:
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -332,7 +332,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -418,7 +418,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -524,7 +524,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -620,7 +620,7 @@ should add volumeMount for data volume when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -706,7 +706,7 @@ should expose diag port:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -792,7 +792,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -892,7 +892,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -990,7 +990,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1076,7 +1076,7 @@ should have one replica when replicaCount is not set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1162,7 +1162,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1250,7 +1250,7 @@ should mount extraVolumes and extraVolumeMounts:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1341,7 +1341,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1435,7 +1435,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1531,7 +1531,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1629,7 +1629,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1723,7 +1723,7 @@ should not add emptyDir for data when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1811,7 +1811,7 @@ should provision initContainer correctly when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1955,7 +1955,7 @@ should set affinity when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2041,7 +2041,7 @@ should set default serviceAccountName when not set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2140,7 +2140,7 @@ should set environment when extraEnv set in values:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2312,7 +2312,7 @@ should set imagePullPolicy when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2398,7 +2398,7 @@ should set nodeSelector if set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2498,7 +2498,7 @@ should set preferred affinity when more than one replica is used:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2584,7 +2584,7 @@ should set probeTimeoutSeconds when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2680,7 +2680,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2768,7 +2768,7 @@ should set resources when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2861,7 +2861,7 @@ should set serviceAccountName when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2947,7 +2947,7 @@ should set storage.requests when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -3033,7 +3033,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -3119,7 +3119,7 @@ should set tolerations when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -73,7 +73,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.7.6-rc.1
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.7.6
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-updater/Chart.yaml
+++ b/examples/chart/teleport-kube-updater/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 name: teleport-kube-updater
 apiVersion: v2

--- a/examples/chart/teleport-relay/Chart.yaml
+++ b/examples/chart/teleport-relay/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.7.6-rc.1"
+.version: &version "18.7.6"
 
 name: teleport-relay
 apiVersion: v2


### PR DESCRIPTION
### Security fixes

This patch includes some security fixes.
These issues are present in previous v18 releases.
Impacted users are recommended to upgrade their auth and database services to the latest version.
For Teleport Cloud customers, your control plane has already been upgraded to a patched release.

#### [High] Authorization bypass in encrypted session recordings

Teleport did not ensure sufficient authorization in some of the encrypted session recordings APIs.
This could allow an attacker to upload recordings to the cluster.
Teleport did not find the evidence of this being exploited in the Teleport Cloud environment. For
self-hosted users that do not use encrypted session recordings, the following debug log messages
on auth server would indicate vulnerable APIs being called:
- “creating encrypted session upload”
- “uploading encrypted session part”
- “completing encrypted session upload”
This issue affects only Teleport v18. All users are advised to upgrade their Auth services to the
patched v18 release.

#### [High] Cross-node session recording access

When checking system service access to session recordings and audit logs, Teleport did not
perform sufficient authorization. This could allow a compromised Teleport SSH node service to
access audit events and session recordings from other nodes in the cluster.
All users are advised to upgrade their Auth services to the patched v18 release.

#### [Medium] SSRF via AWS database access endpoint

Teleport did not sufficiently validate the connection endpoint for AWS database access
(DynamoDB, OpenSearch, Keyspaces). This could allow a malicious actor with access to Teleport
configuration to steal database access credentials by crafting a connection endpoint pointing to
their domain.
All users that use Teleport to access AWS-hosted databases (DynamoDB, OpenSearch, Keyspaces)
are advised to upgrade their auth and database services to the patched v18 release

### Other fixes and improvements
* Fixed an issue that prevents GCP Server discovery to try to enroll all the VMs that are found when one of them returns an error. [#66240](https://github.com/gravitational/teleport/pull/66240)
* Added scoped roles support to the Terraform provider. [#66225](https://github.com/gravitational/teleport/pull/66225)
* Added scoped role assignment support to the Terraform provider. [#66225](https://github.com/gravitational/teleport/pull/66225)
* Fixed an issue where `tctl edit plugin/jamf` could break other plugins when providing non-zero duration value. [#66191](https://github.com/gravitational/teleport/pull/66191)
* Introduces `skip_initial_connection` option to the `teleportmwi` provider to allow lazy initialization of the provider. [#66139](https://github.com/gravitational/teleport/pull/66139)
* Initialize keystore sign and decrypt metrics at startup and register missing decrypt metric collectors. [#66110](https://github.com/gravitational/teleport/pull/66110)
* Added current and previous resources discovered summary per service to Discovery Config Status. [#66097](https://github.com/gravitational/teleport/pull/66097)
* Fixed a bug where generated JWT tokens were leaked into audit event. [#66095](https://github.com/gravitational/teleport/pull/66095)
* Updated internal database dependencies to resolve multiple security vulnerabilities (CVE-2026-4427, CVE-2026-32286, and others). [#66083](https://github.com/gravitational/teleport/pull/66083)
* Fixed a possible panic during TTY session processing/playback/summarization from crashing Teleport. [#66080](https://github.com/gravitational/teleport/pull/66080)
* Fixed an issue where the endpoint used by `tsh scan keys` could leak resources on a server error; this affected only clusters with Access Graph enabled. [#66076](https://github.com/gravitational/teleport/pull/66076)
* Added `teleport_app_active_sessions` Prometheus gauge with `app` label for app access agent autoscaling. [#66050](https://github.com/gravitational/teleport/pull/66050)
* Fixed joining for agents and proxies connecting directly to an Auth service when they specify a CA pin and any lock in the cluster is in force. [#66044](https://github.com/gravitational/teleport/pull/66044)
* Added scoped role to the k8s operator. [#66034](https://github.com/gravitational/teleport/pull/66034)
* Added scoped role assignments to the k8s operator. [#66034](https://github.com/gravitational/teleport/pull/66034)
* Fixed Access List-granted roles being absent from the web session created after a local user password reset or invite acceptance, requiring a logout/login cycle to restore access. [#66011](https://github.com/gravitational/teleport/pull/66011)
* Added support for Azure join tokens based on Azure tenant ID. [#65989](https://github.com/gravitational/teleport/pull/65989)
* Fixed a "No such process" error that could happen on the very first launch of VNet on macOS. [#65967](https://github.com/gravitational/teleport/pull/65967)
* Improved readability of the search results in Teleport Connect. [#65928](https://github.com/gravitational/teleport/pull/65928)
* Fixed a Teleport Connect issue on Windows where startup could fail when `HTTPS_PROXY` is set. [#65924](https://github.com/gravitational/teleport/pull/65924)
* Added `user.metadata.name` variable to RBAC role templates and expressions. [#65923](https://github.com/gravitational/teleport/pull/65923)
* Fix VNet SSH per-session MFA checks to use the requested SSH login instead of the profile default login. [#65909](https://github.com/gravitational/teleport/pull/65909)
* Initialize backend read and requests metrics to zero at startup. [#65898](https://github.com/gravitational/teleport/pull/65898)
* Fixed Teleport not taking over an existing unmanaged host user when configured to. [#65838](https://github.com/gravitational/teleport/pull/65838)
* Fixes race condition in dynamoDB backend which can lead to missed events, resulting in a inconsistent cache state. [#65821](https://github.com/gravitational/teleport/pull/65821)
* Added `ui_config` resource support to the Terraform provider. [#65800](https://github.com/gravitational/teleport/pull/65800)
* Set default name for `UIConfig` resource as `ui-config`. [#65800](https://github.com/gravitational/teleport/pull/65800)
* Fixed an issue in Teleport Connect on macOS where selecting "Open Teleport Connect" from the menu bar would not reliably open the app. [#65774](https://github.com/gravitational/teleport/pull/65774)
* The github join method now supports the enterprise/enterprise_id claims. [#65700](https://github.com/gravitational/teleport/pull/65700)
* Teleport Connect now displays user roles in an expandable list. [#65654](https://github.com/gravitational/teleport/pull/65654)
* Standard Teleport agents can now join using the `bound_keypair` join method. [#65625](https://github.com/gravitational/teleport/pull/65625)
* Add x11 forwarding, SSH File Copying, Agent Forwarding, SSH Port Forwarding, Create Host User, Max Sessions, and host sudoers to scoped ssh role options. [#65601](https://github.com/gravitational/teleport/pull/65601)
* Added `tctl discovery nodes` command for troubleshooting AWS EC2 auto-discovery enrollment issues. [#65598](https://github.com/gravitational/teleport/pull/65598)
* Update Go to v1.25.9. [#65586](https://github.com/gravitational/teleport/pull/65586)
* Fix access graph AWS discovery to not deadlock when Identity Activity Center is disabled. [#65574](https://github.com/gravitational/teleport/pull/65574)
* Clear certs from local ssh agent when switching between unscoped user to scoped user. [#65568](https://github.com/gravitational/teleport/pull/65568)
* Added `lock` resource support to the Kubernetes operator. [#65543](https://github.com/gravitational/teleport/pull/65543)
* Added support for `*` and `$` globbing to the GitHub Actions token rules. [#65539](https://github.com/gravitational/teleport/pull/65539)
* The `tbot keypair create` command will now create the specified directory if necessary. [#65528](https://github.com/gravitational/teleport/pull/65528)
* Fixed an issue in Teleport Connect where the "Reopen" button in the "Reopen previous session" modal would not automatically receive focus. [#65513](https://github.com/gravitational/teleport/pull/65513)
* Fixed a bug where Teleport Connect displayed an error about an expired certificate instead of showing the login modal. [#65512](https://github.com/gravitational/teleport/pull/65512)
* Added visible `teleport.dev/` labels for Azure and GCP auto-discovered VMs, making subscription ID, VM ID, region, resource group, VM name, and zone available in the web UI, CLI output, and RBAC rules. [#65462](https://github.com/gravitational/teleport/pull/65462)
* Fixed panic in tctl get scoped_token when non-token join method scoped tokens were present. [#65461](https://github.com/gravitational/teleport/pull/65461)
* Fix "tctl edit" bugs when editing multiple resources, or resources with sub_kinds (for example, CAs). [#65341](https://github.com/gravitational/teleport/pull/65341)
* Removed expired Baltimore CyberTrust Root CA used for Azure databases. [#65329](https://github.com/gravitational/teleport/pull/65329)
* Reimplemented how Teleport Connect handles deep links for Device Trust auth and launching VNet from the Web UI. [#65316](https://github.com/gravitational/teleport/pull/65316)
* Extended access monitoring predicate language with `contains(set, item)` expression. [#65294](https://github.com/gravitational/teleport/pull/65294)
* Fixed an issue where viewing a session recording that did not exist/was not uploaded yet would show an empty player instead of an error message. [#65269](https://github.com/gravitational/teleport/pull/65269)
* Auth connector names are now limited to 768 characters. [#65242](https://github.com/gravitational/teleport/pull/65242)
* Fix a goroutine leak in the Teleport Connect MFA prompt when both SSO MFA and Webauthn are available second factors. [#65229](https://github.com/gravitational/teleport/pull/65229)
* Add SAML IdP Service Provider support to Terraform provider. [#65199](https://github.com/gravitational/teleport/pull/65199)
* Fixed minor bug in Web UI and Connect where static and dynamic labels with the same key are duplicated. [#65198](https://github.com/gravitational/teleport/pull/65198)
* Fix URL components for SAML auth connector ACS URL in tests, error message. [#65197](https://github.com/gravitational/teleport/pull/65197)
* Add `lock` support to the Terraform Provider. [#65134](https://github.com/gravitational/teleport/pull/65134)
* Fix a bug in the `teleport-cluster` chart causing some `auth.*` values to not be used when rendering hooks or config manifests. [#65131](https://github.com/gravitational/teleport/pull/65131)
* Fix Cross-access-list member injection in raw gRPC UpsertAccessListWithMembers call due to missing member.Spec.AccessList field validation. [#65123](https://github.com/gravitational/teleport/pull/65123)
* Fix an issue that allowed bypassing Resource Access Requests' AllowedResourceIDs when creating app sessions. [#65116](https://github.com/gravitational/teleport/pull/65116)
* Fix an issue that allowed IP Pinning protections to be bypassed via direct dial to a Teleport Node. [#65094](https://github.com/gravitational/teleport/pull/65094)
* Fix an issue that allowed IP Pinning protections to be bypassed via the WebUI. Also fix an issue with sporadic WebUI connection errors when the Proxy sees an unexpected client IP even though IP Pinning is not enforced. [#65090](https://github.com/gravitational/teleport/pull/65090)
* Fix an issue where `tctl get tokens` would prompt for admin MFA three times rather than once. [#65084](https://github.com/gravitational/teleport/pull/65084)
* Display an alert when SAML connector signing certificates are within 90 days of expiry. [#65067](https://github.com/gravitational/teleport/pull/65067)
* Add scopes status to webapi ping endpoint to determine whether the proxy and auth server has scopes enabled or not. [#65062](https://github.com/gravitational/teleport/pull/65062)
* Azure VM discovery configuration now supports specifying a wildcard ("*") subscription to discover all VMs in all subscriptions where the Discovery service has Microsoft.Resources/subscriptions/read permission. [#65045](https://github.com/gravitational/teleport/pull/65045)
* Added support for multiple trusted CA certificates to Windows Desktop Service's LDAP configuration. [#65040](https://github.com/gravitational/teleport/pull/65040)
* Fix mouse move when using fixed screen size Windows desktop. [#65025](https://github.com/gravitational/teleport/pull/65025)
* Fixed intermittent issues with VNet on Windows with NRPT rules being wiped after Group Policy refresh. [#65017](https://github.com/gravitational/teleport/pull/65017)
* Fixed AWS IAM Roles Anywhere Web/Console access for Gov Cloud and China partitioned AWS accounts. [#65016](https://github.com/gravitational/teleport/pull/65016)
* Device Trust is now accessible under Zero Trust Access in the web UI. [#65005](https://github.com/gravitational/teleport/pull/65005)
* Fixed an issue with desktop directory sharing in Teleport Connect that caused file modification times not to be displayed. [#64921](https://github.com/gravitational/teleport/pull/64921)
* Added support for configuring agentless OpenSSH servers using `tbot`. [#64899](https://github.com/gravitational/teleport/pull/64899)
* Fixed an issue preventing Teleport Connect from launching when the OS username contains non-ASCII characters. [#64885](https://github.com/gravitational/teleport/pull/64885)
* Fixed access request comments and review reasons not preserving newlines when rendered. [#64866](https://github.com/gravitational/teleport/pull/64866)
* Add documentation for the `tsh aws-profile` command. [#64777](https://github.com/gravitational/teleport/pull/64777)
* API rate limiting for authenticated per-session MFA requests now follows the regular API rate limits, making the limit unlikely to be hit during parallel SSH operations. [#64775](https://github.com/gravitational/teleport/pull/64775)
* Print a message indicating that `tctl recordings download <session_id>` completed successfully. [#64721](https://github.com/gravitational/teleport/pull/64721)
* Adds the ability to not render hooks in the `teleport-kube-agent` chart. [#64706](https://github.com/gravitational/teleport/pull/64706)
* Fixes version number for charts `teleport-kube-agent-updater` and `teleport-spiffe-daemon-set`. [#64686](https://github.com/gravitational/teleport/pull/64686)
* Vnet_config can now be managed via the Teleport Terraform Provider. [#64682](https://github.com/gravitational/teleport/pull/64682)
* Added scoped tokens to the k8s operator. [#64639](https://github.com/gravitational/teleport/pull/64639)
* Fixed a bug affecting nodes on v18.3.0+ rejoining with new system roles to clusters with Auth services on v18.2.10-. [#64638](https://github.com/gravitational/teleport/pull/64638)
* Updated github.com/docker/cli to v29.2.0+incompatible (addresses CVE-2025-15558). [#64606](https://github.com/gravitational/teleport/pull/64606)
* Fix map generation for teleport resources to k8s. [#64597](https://github.com/gravitational/teleport/pull/64597)
* Add scope aware profiles after tsh login. [#64592](https://github.com/gravitational/teleport/pull/64592)
* Added a new tsh aws-profile command that detects your AWS Identity Center integration (if configured) and writes corresponding AWS profiles into your local AWS config file for later use. [#64590](https://github.com/gravitational/teleport/pull/64590)
* Add `tctl acl` commands for managing access list reviews. [#64587](https://github.com/gravitational/teleport/pull/64587)
* Validate Kubernetes impersonation user and group header values to prevent CRLF or null-byte header injection via crafted role definitions. [#64586](https://github.com/gravitational/teleport/pull/64586)
* Fixed Azure and GCP server auto-discovery installation when the target VM had a system-wide HTTP proxy configured. [#64552](https://github.com/gravitational/teleport/pull/64552)
* Teleport Connect now displays the Message of the Day (MOTD) before login. [#64549](https://github.com/gravitational/teleport/pull/64549)
* Fixed bug that causes Windows desktop connection errors on EC2 joined nodes. [#64545](https://github.com/gravitational/teleport/pull/64545)
* Fixed `tsh login --request-id` to display up to date profile information including the assumed access request and roles. [#64536](https://github.com/gravitational/teleport/pull/64536)
* Update Go to v1.25.8. [#64434](https://github.com/gravitational/teleport/pull/64434)
* Added terraform provider support for teleport_scoped_token. [#64392](https://github.com/gravitational/teleport/pull/64392)
* Add SAML IdP Service Provider support to k8s operator. [#64380](https://github.com/gravitational/teleport/pull/64380)
* Fixed a bug causing spurious failures to upload encrypted session recordings when 4MB or larger. [#64361](https://github.com/gravitational/teleport/pull/64361)
* Fix agent forwarding in proxy recording mode. [#64349](https://github.com/gravitational/teleport/pull/64349)
* Fixed failures to record extra large session events in synchronous recording modes. [#64343](https://github.com/gravitational/teleport/pull/64343)
* Fixed a rare race condition causing initial node heartbeats to be missing an address. [#64332](https://github.com/gravitational/teleport/pull/64332)
* Fixed a VNet regression where web app access could fail when access was assumed in the Web UI only while VNet was already running. [#64317](https://github.com/gravitational/teleport/pull/64317)
* Add support for Resource-Scoped Constraints to Access Requests, allowing users to narrow the scope of their requested access by selecting individual principals on resources while creating an Access Request via the Teleport Web UI. Initial support includes Role ARNs for AWS Console app resources. [#63207](https://github.com/gravitational/teleport/pull/63207)
* Azure VM discovery will wait for installation and collect potential errors. The results will update discovery config statistics. VM installation errors will be captured as user tasks. [#62731](https://github.com/gravitational/teleport/pull/62731)

Enterprise:
* SAML IdP: Custom attribute mappings now overwrite default attributes with the same Name instead of duplicating them. Previously, mapping a default attribute like eduPersonAffiliation.
* Fixes the issue where users with ongoing Access Requests to Okta resources would synced back as permanent Access List members for the requested resources during the periodic Okta import.
* Fixed AWSIC Group membership updates so they are no longer abandoned when AWS is presented with an obsolete User ID.
* Fix Okta assignment reconciliation failing for applications with large user lists where the API response time exceeded the 30s HTTP client timeout by increase the Okta http connection Timeout to 5 min.
* Fixed an issue where Teleport could return a stale SCIM user group attribute when a user no longer belonged to any SCIM groups. Previously, in this case, the SCIM /Users endpoint could return outdated data from an earlier state when the user still had at least one group assigned.
* Add support for workload_cluster resource for Teleport Cloud users to provision new Teleport Cloud clusters.
* Improve SCIM performance by using cache for /Users and /Groups listing calls.
* Fixed SCIM group and user listing pagination to return the correct totalResults count across all pages. Previously, totalResults could undercount matching resources when paginating beyond the first page,.
* Fixed an issue where characters such as `.` were not permitted in an instance profile ARN when setting up session summaries inference.
* Access list owners are now automatically suggested as reviewers when the list grants members the ability to request access to resources and owners the ability to review those requests.
* Added handling for AWS Identity Center users deleted outside of Teleport's control.
* Device Trust is now accessible under Zero Trust Access in the web UI.
* Fixed group member provisioning bug in Identity Center plugin caused by an unsupported PATCH operation.
* Fix an issue where Okta pending assignments could overlap with Access List synchronization, causing users to be unintentionally re-added to access lists in case of strict Okta API rate limits.
* Fixed AWS Account rename handling in Identity Center plugin when an old account name is restored.
* Fix the issue where clicking **Provision User** after enrolling Okta SCIM integration could result in "missing Okta user ID" error.
* Added a wizard for creating access lists that includes defining which resources members can access.
