### PR TITLE
Release 17.7.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+# 17.7.23 (04/29/26)
+
+Changelog:
+* Initialize keystore sign and decrypt metrics at startup. [#66109](https://github.com/gravitational/teleport/pull/66109)
+* Updated `jackc/pgx` packages to fix CVE-2026-4427/CVE-2026-32286, CVE-2026-33815, CVE-2026-33816, GHSA-j88v-2chj-qfwx. [#66093](https://github.com/gravitational/teleport/pull/66093)
+* Added `teleport_app_active_sessions` Prometheus gauge with `app` label for app access agent autoscaling. [#66049](https://github.com/gravitational/teleport/pull/66049)
+* Fixed a "No such process" error that could happen on the very first launch of VNet on macOS. [#65968](https://github.com/gravitational/teleport/pull/65968)
+* Fixed a Teleport Connect issue on Windows where startup could fail when `HTTPS_PROXY` is set. [#65925](https://github.com/gravitational/teleport/pull/65925)
+* Initialize backend read and requests metrics to zero at startup. [#65901](https://github.com/gravitational/teleport/pull/65901)
+* Fixed Teleport not taking over an existing unmanaged host user when configured to. [#65837](https://github.com/gravitational/teleport/pull/65837)
+* Fixes potential race condition in dynamoDB backend which can lead to missed events, resulting in a inconsistent cache state. [#65822](https://github.com/gravitational/teleport/pull/65822)
+* Fixed an issue in Teleport Connect on macOS where selecting "Open Teleport Connect" from the menu bar would not reliably open the app. [#65773](https://github.com/gravitational/teleport/pull/65773)
+* Updated github.com/go-git/go-git/v5 to resolve CVE-2026-34165. [#65649](https://github.com/gravitational/teleport/pull/65649)
+* Updated OpenTelemetry dependencies to address CVE-2026-24051. [#65647](https://github.com/gravitational/teleport/pull/65647)
+* Update Go to v1.25.9. [#65587](https://github.com/gravitational/teleport/pull/65587)
+* Fixed "tctl edit" bugs when editing multiple resources, or resources with sub_kinds (for example, CAs). [#65343](https://github.com/gravitational/teleport/pull/65343)
+* Removed expired Baltimore CyberTrust Root CA used for Azure databases. [#65328](https://github.com/gravitational/teleport/pull/65328)
+* Reimplemented how Teleport Connect handles deep links for Device Trust auth and launching VNet from the Web UI. [#65317](https://github.com/gravitational/teleport/pull/65317)
+* Fixed minor bug in Web UI and Connect where static and dynamic labels with the same key are duplicated. [#65295](https://github.com/gravitational/teleport/pull/65295)
+* Fixed a goroutine leak in the Teleport Connect MFA prompt when both SSO MFA and Webauthn are available second factors. [#65230](https://github.com/gravitational/teleport/pull/65230)
+* Fixed an issue that allowed bypassing Resource Access Requests' AllowedResourceIDs when creating app sessions. [#65117](https://github.com/gravitational/teleport/pull/65117)
+* Fixed an issue that allowed IP Pinning protections to be bypassed via direct dial to a Teleport Node. [#65095](https://github.com/gravitational/teleport/pull/65095)
+* Fixed an issue that allowed IP Pinning protections to be bypassed via the WebUI. Also fix an issue with sporadic WebUI connection errors when the Proxy sees an unexpected client IP even though IP Pinning is not enforced. [#65093](https://github.com/gravitational/teleport/pull/65093)
+* Fixed intermittent issues with VNet on Windows with NRPT rules being wiped after Group Policy refresh. [#65018](https://github.com/gravitational/teleport/pull/65018)
+* Device Trust is now accessible under Zero Trust Access in the web UI. [#65006](https://github.com/gravitational/teleport/pull/65006)
+* Fixed an issue with desktop directory sharing in Teleport Connect that caused file modification times not to be displayed. [#64920](https://github.com/gravitational/teleport/pull/64920)
+* Fixed an issue preventing Teleport Connect from launching on Windows when the OS username contains non-ASCII characters. [#64886](https://github.com/gravitational/teleport/pull/64886)
+* API rate limiting for authenticated per-session MFA requests now follows the regular API rate limits, making the limit unlikely to be hit during parallel SSH operations. [#64776](https://github.com/gravitational/teleport/pull/64776)
+* Print a message indicating that `tctl recordings download <session_id>` completed successfully. [#64722](https://github.com/gravitational/teleport/pull/64722)
+* Updated github.com/docker/cli to v29.2.0+incompatible (addresses CVE-2025-15558). [#64608](https://github.com/gravitational/teleport/pull/64608)
+* Teleport Connect now displays the Message of the Day (MOTD) before login. [#64550](https://github.com/gravitational/teleport/pull/64550)
+* Fixed bug that causes Windows desktop connection errors on EC2 joined nodes. [#64546](https://github.com/gravitational/teleport/pull/64546)
+* Fixed `tsh login --request-id` to display up to date profile information including the assumed access request and roles. [#64537](https://github.com/gravitational/teleport/pull/64537)
+* Fixed error handling around empty uploads to ensure upload resources are consistently cleaned up. [#64501](https://github.com/gravitational/teleport/pull/64501)
+* Update Go to v1.25.8. [#64435](https://github.com/gravitational/teleport/pull/64435)
+* Fixed failures to record extra large session events in synchronous recording modes. [#64344](https://github.com/gravitational/teleport/pull/64344)
+* Fixed a rare race condition causing initial node heartbeats to be missing an address. [#64331](https://github.com/gravitational/teleport/pull/64331)
+
+Enterprise:
+* Fix Okta assignment reconciliation failing for applications with large user lists where the API response time exceeded the 30s HTTP client timeout by increase the Okta http connection Timeout to 5 min.
+* Device Trust is now accessible under Zero Trust Access in the web UI.
+* Fixed an error log and a memory leak when manually deleting an okta_assignment resource.
+
 ## 17.7.22 (04/06/26)
 
 This is a private security release. Changelog will be publicly announced in a later version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,30 @@
 # Changelog
 
 # 17.7.23 (04/29/26)
+### Security fixes
 
+This patch includes some security fixes.
+These issues are present in previous v17 releases.
+Impacted users are recommended to upgrade their auth and database services to the latest version.
+For Teleport Cloud customers, your control plane has already been upgraded to a patched release.
+
+#### [High] Cross-node session recording access
+
+When checking system service access to session recordings and audit logs, Teleport did not
+perform sufficient authorization. This could allow a compromised Teleport SSH node service to
+access audit events and session recordings from other nodes in the cluster.
+All users are advised to upgrade their Auth services to the patched v17 release.
+
+#### [Medium] SSRF via AWS database access endpoint
+
+Teleport did not sufficiently validate the connection endpoint for AWS database access
+(DynamoDB, OpenSearch, Keyspaces). This could allow a malicious actor with access to Teleport
+configuration to steal database access credentials by crafting a connection endpoint pointing to
+their domain.
+All users that use Teleport to access AWS-hosted databases (DynamoDB, OpenSearch, Keyspaces)
+are advised to upgrade their auth and database services to the patched v17 release
+
+### Other fixes and improvements
 Changelog:
 * Initialize keystore sign and decrypt metrics at startup. [#66109](https://github.com/gravitational/teleport/pull/66109)
 * Updated `jackc/pgx` packages to fix CVE-2026-4427/CVE-2026-32286, CVE-2026-33815, CVE-2026-33816, GHSA-j88v-2chj-qfwx. [#66093](https://github.com/gravitational/teleport/pull/66093)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 # 17.7.23 (04/29/26)
 ### Security fixes
 
-This patch includes some security fixes.
-These issues are present in previous v17 releases.
+This patch addresses two security vulnerabilities.
 Impacted users are recommended to upgrade their auth and database services to the latest version.
 For Teleport Cloud customers, your control plane has already been upgraded to a patched release.
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=17.7.23-rc.1
+VERSION=17.7.23
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -2,10 +2,10 @@
 
 package api
 
-const Version = "17.7.23-rc.1"
+const Version = "17.7.23"
 
 const VersionMajor = 17
 const VersionMinor = 7
 const VersionPatch = 23
-const VersionPreRelease = "rc.1"
+const VersionPreRelease = ""
 const VersionMetadata = ""

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.0</string>
+		<string>17.7.23</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>1.0</string>
+		<string>17.7.23</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.0</string>
+		<string>17.7.23</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>1.0</string>
+		<string>17.7.23</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/examples/chart/access/datadog/Chart.yaml
+++ b/examples/chart/access/datadog/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 apiVersion: v2
 name: teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-datadog-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-datadog-17.7.23
       name: RELEASE-NAME-teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-datadog-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-datadog-17.7.23
       name: RELEASE-NAME-teleport-plugin-datadog
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-datadog
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-datadog-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-datadog-17.7.23
         spec:
           containers:
           - command:

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-discord-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-discord-17.7.23
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-discord-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-discord-17.7.23
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-discord-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-discord-17.7.23
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,8 +26,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -59,8 +59,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -92,8 +92,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -125,8 +125,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -161,8 +161,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -194,6 +194,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-email-17.7.23
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.23
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-email-17.7.23
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-email-17.7.23
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.23
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-email-17.7.23
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.23
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-email-17.7.23
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.23
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-email-17.7.23
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-email-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-email-17.7.23
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.23
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -32,6 +32,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-jira-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-jira-17.7.23
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-jira-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-jira-17.7.23
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-jira-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-jira-17.7.23
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-mattermost-17.7.23
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-mattermost-17.7.23
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-mattermost-17.7.23
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-mattermost-17.7.23
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-mattermost-17.7.23
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.7.23
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-mattermost-17.7.23
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-mattermost-17.7.23
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.7.23
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-msteams-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-msteams-17.7.23
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-msteams-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-msteams-17.7.23
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-msteams-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-msteams-17.7.23
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-pagerduty-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-pagerduty-17.7.23
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-pagerduty-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-pagerduty-17.7.23
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-pagerduty-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-pagerduty-17.7.23
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-slack-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-slack-17.7.23
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-slack-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-slack-17.7.23
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-plugin-slack-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-plugin-slack-17.7.23
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-event-handler-17.7.23
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-plugin-event-handler-17.7.23
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -82,7 +82,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.7.23
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 name: tbot
 apiVersion: v2

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-17.7.23-rc.1
+            helm.sh/chart: tbot-17.7.23
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
               value: "1"
             - name: TEST_ENV
               value: test-value
-            image: public.ecr.aws/gravitational/tbot-distroless:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:17.7.23
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 6
@@ -167,7 +167,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-17.7.23-rc.1
+            helm.sh/chart: tbot-17.7.23
         spec:
           containers:
           - args:
@@ -189,7 +189,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:17.7.23
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-cluster-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-cluster-17.7.23
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1955,8 +1955,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-cluster-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-cluster-17.7.23
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -159,7 +159,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -274,7 +274,7 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -378,7 +378,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-cluster-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-cluster-17.7.23
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.7.23-rc.1
-        helm.sh/chart: teleport-cluster-17.7.23-rc.1
+        app.kubernetes.io/version: 17.7.23
+        helm.sh/chart: teleport-cluster-17.7.23
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: a5ba467776cf1a13326d2fc89b5529c49d7298fedbddfda4ded8700e2039fd6b
+            checksum/config: 92e305ee813bbe6c83e6cc325041efb2fef2d1604e55fcd497d0076ae0cb8f14
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 17.7.23-rc.1
-            helm.sh/chart: teleport-cluster-17.7.23-rc.1
+            app.kubernetes.io/version: 17.7.23
+            helm.sh/chart: teleport-cluster-17.7.23
             teleport.dev/majorVersion: "17"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -106,7 +106,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v16.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -155,7 +155,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       name: wait-auth-update
       resources:
         limits:
@@ -219,7 +219,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -281,7 +281,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -349,7 +349,7 @@ should set resources for wait-auth-update initContainer when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -418,7 +418,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       name: wait-auth-update
       resources:
         limits:
@@ -475,7 +475,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -544,7 +544,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       name: wait-auth-update
       resources:
         limits:
@@ -601,7 +601,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -670,7 +670,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -727,7 +727,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -796,7 +796,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.23-rc.1"
+.version: &version "17.7.23"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -109,7 +109,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+          image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -173,7 +173,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -237,7 +237,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -322,7 +322,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -387,7 +387,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -451,7 +451,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -513,7 +513,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -589,7 +589,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -665,7 +665,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -729,7 +729,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -793,7 +793,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -862,7 +862,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf an
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -932,7 +932,7 @@ should mount jamfCredentialsSecret.name when role is jamf and action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1004,7 +1004,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1078,7 +1078,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1270,7 +1270,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1334,7 +1334,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1411,7 +1411,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1539,7 +1539,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1603,7 +1603,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1669,7 +1669,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1745,7 +1745,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1809,7 +1809,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1874,7 +1874,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1948,7 +1948,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2012,7 +2012,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2083,7 +2083,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2147,7 +2147,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -108,7 +108,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -138,7 +138,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -168,7 +168,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -200,7 +200,7 @@ should set resources in the Job's pod spec if resources is set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -18,7 +18,7 @@ sets Pod annotations when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -91,7 +91,7 @@ sets Pod labels when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -188,7 +188,7 @@ sets StatefulSet labels when specified:
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -293,7 +293,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -366,7 +366,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -459,7 +459,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -542,7 +542,7 @@ should add volumeMount for data volume when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -615,7 +615,7 @@ should expose diag port:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -688,7 +688,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -775,7 +775,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -860,7 +860,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -933,7 +933,7 @@ should have one replica when replicaCount is not set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1006,7 +1006,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1081,7 +1081,7 @@ should mount extraVolumes and extraVolumeMounts:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1159,7 +1159,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1240,7 +1240,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1323,7 +1323,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1408,7 +1408,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1489,7 +1489,7 @@ should not add emptyDir for data when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1562,7 +1562,7 @@ should provision initContainer correctly when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1693,7 +1693,7 @@ should set affinity when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1766,7 +1766,7 @@ should set default serviceAccountName when not set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1852,7 +1852,7 @@ should set environment when extraEnv set in values:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1998,7 +1998,7 @@ should set imagePullPolicy when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2071,7 +2071,7 @@ should set nodeSelector if set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2158,7 +2158,7 @@ should set preferred affinity when more than one replica is used:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2231,7 +2231,7 @@ should set probeTimeoutSeconds when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2314,7 +2314,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2387,7 +2387,7 @@ should set resources when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2467,7 +2467,7 @@ should set serviceAccountName when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2540,7 +2540,7 @@ should set storage.requests when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2613,7 +2613,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2686,7 +2686,7 @@ should set tolerations when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -73,7 +73,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.7.23-rc.1
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.7.23
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6


### PR DESCRIPTION
# Changelog

### Security fixes

This patch addresses two security vulnerabilities.
Impacted users are recommended to upgrade their auth and database services to the latest version.
For Teleport Cloud customers, your control plane has already been upgraded to a patched release.

#### [High] Cross-node session recording access

When checking system service access to session recordings and audit logs, Teleport did not
perform sufficient authorization. This could allow a compromised Teleport SSH node service to
access audit events and session recordings from other nodes in the cluster.
All users are advised to upgrade their Auth services to the patched v17 release.

#### [Medium] SSRF via AWS database access endpoint

Teleport did not sufficiently validate the connection endpoint for AWS database access
(DynamoDB, OpenSearch, Keyspaces). This could allow a malicious actor with access to Teleport
configuration to steal database access credentials by crafting a connection endpoint pointing to
their domain.
All users that use Teleport to access AWS-hosted databases (DynamoDB, OpenSearch, Keyspaces)
are advised to upgrade their auth and database services to the patched v17 release

### Other fixes and improvements
Changelog:
* Initialize keystore sign and decrypt metrics at startup. [#66109](https://github.com/gravitational/teleport/pull/66109)
* Updated `jackc/pgx` packages to fix CVE-2026-4427/CVE-2026-32286, CVE-2026-33815, CVE-2026-33816, GHSA-j88v-2chj-qfwx. [#66093](https://github.com/gravitational/teleport/pull/66093)
* Added `teleport_app_active_sessions` Prometheus gauge with `app` label for app access agent autoscaling. [#66049](https://github.com/gravitational/teleport/pull/66049)
* Fixed a "No such process" error that could happen on the very first launch of VNet on macOS. [#65968](https://github.com/gravitational/teleport/pull/65968)
* Fixed a Teleport Connect issue on Windows where startup could fail when `HTTPS_PROXY` is set. [#65925](https://github.com/gravitational/teleport/pull/65925)
* Initialize backend read and requests metrics to zero at startup. [#65901](https://github.com/gravitational/teleport/pull/65901)
* Fixed Teleport not taking over an existing unmanaged host user when configured to. [#65837](https://github.com/gravitational/teleport/pull/65837)
* Fixes potential race condition in dynamoDB backend which can lead to missed events, resulting in a inconsistent cache state. [#65822](https://github.com/gravitational/teleport/pull/65822)
* Fixed an issue in Teleport Connect on macOS where selecting "Open Teleport Connect" from the menu bar would not reliably open the app. [#65773](https://github.com/gravitational/teleport/pull/65773)
* Updated github.com/go-git/go-git/v5 to resolve CVE-2026-34165. [#65649](https://github.com/gravitational/teleport/pull/65649)
* Updated OpenTelemetry dependencies to address CVE-2026-24051. [#65647](https://github.com/gravitational/teleport/pull/65647)
* Update Go to v1.25.9. [#65587](https://github.com/gravitational/teleport/pull/65587)
* Fixed "tctl edit" bugs when editing multiple resources, or resources with sub_kinds (for example, CAs). [#65343](https://github.com/gravitational/teleport/pull/65343)
* Removed expired Baltimore CyberTrust Root CA used for Azure databases. [#65328](https://github.com/gravitational/teleport/pull/65328)
* Reimplemented how Teleport Connect handles deep links for Device Trust auth and launching VNet from the Web UI. [#65317](https://github.com/gravitational/teleport/pull/65317)
* Fixed minor bug in Web UI and Connect where static and dynamic labels with the same key are duplicated. [#65295](https://github.com/gravitational/teleport/pull/65295)
* Fixed a goroutine leak in the Teleport Connect MFA prompt when both SSO MFA and Webauthn are available second factors. [#65230](https://github.com/gravitational/teleport/pull/65230)
* Fixed an issue that allowed bypassing Resource Access Requests' AllowedResourceIDs when creating app sessions. [#65117](https://github.com/gravitational/teleport/pull/65117)
* Fixed an issue that allowed IP Pinning protections to be bypassed via direct dial to a Teleport Node. [#65095](https://github.com/gravitational/teleport/pull/65095)
* Fixed an issue that allowed IP Pinning protections to be bypassed via the WebUI. Also fix an issue with sporadic WebUI connection errors when the Proxy sees an unexpected client IP even though IP Pinning is not enforced. [#65093](https://github.com/gravitational/teleport/pull/65093)
* Fixed intermittent issues with VNet on Windows with NRPT rules being wiped after Group Policy refresh. [#65018](https://github.com/gravitational/teleport/pull/65018)
* Device Trust is now accessible under Zero Trust Access in the web UI. [#65006](https://github.com/gravitational/teleport/pull/65006)
* Fixed an issue with desktop directory sharing in Teleport Connect that caused file modification times not to be displayed. [#64920](https://github.com/gravitational/teleport/pull/64920)
* Fixed an issue preventing Teleport Connect from launching on Windows when the OS username contains non-ASCII characters. [#64886](https://github.com/gravitational/teleport/pull/64886)
* API rate limiting for authenticated per-session MFA requests now follows the regular API rate limits, making the limit unlikely to be hit during parallel SSH operations. [#64776](https://github.com/gravitational/teleport/pull/64776)
* Print a message indicating that `tctl recordings download <session_id>` completed successfully. [#64722](https://github.com/gravitational/teleport/pull/64722)
* Updated github.com/docker/cli to v29.2.0+incompatible (addresses CVE-2025-15558). [#64608](https://github.com/gravitational/teleport/pull/64608)
* Teleport Connect now displays the Message of the Day (MOTD) before login. [#64550](https://github.com/gravitational/teleport/pull/64550)
* Fixed bug that causes Windows desktop connection errors on EC2 joined nodes. [#64546](https://github.com/gravitational/teleport/pull/64546)
* Fixed `tsh login --request-id` to display up to date profile information including the assumed access request and roles. [#64537](https://github.com/gravitational/teleport/pull/64537)
* Fixed error handling around empty uploads to ensure upload resources are consistently cleaned up. [#64501](https://github.com/gravitational/teleport/pull/64501)
* Update Go to v1.25.8. [#64435](https://github.com/gravitational/teleport/pull/64435)
* Fixed failures to record extra large session events in synchronous recording modes. [#64344](https://github.com/gravitational/teleport/pull/64344)
* Fixed a rare race condition causing initial node heartbeats to be missing an address. [#64331](https://github.com/gravitational/teleport/pull/64331)

Enterprise:
* Fix Okta assignment reconciliation failing for applications with large user lists where the API response time exceeded the 30s HTTP client timeout by increase the Okta http connection Timeout to 5 min.
* Device Trust is now accessible under Zero Trust Access in the web UI.
* Fixed an error log and a memory leak when manually deleting an okta_assignment resource.


## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
