### PR TITLE
Fix flakiness in test certificate override creation

### DIFF
--- a/lib/subca/testenv/env.go
+++ b/lib/subca/testenv/env.go
@@ -235,6 +235,7 @@ func (env *Env) NewDisabledCertificateOverride(
 			Subject: pkix.Name{
 				Organization: cert.Subject.Organization, // ClusterName.
 			},
+			NotAfter: cert.NotAfter, // Cannot expire after the CA certificate.
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Override certificates cannot expire after the self-signed CA certificate, as introduced by https://github.com/gravitational/teleport.e/pull/8631.

This fixes flakiness from that same PR.

Tests run on real time by default, so if there is any delay the override certificate can get a higher NotAfter timestamp, causing test failures.