### PR TITLE
Desktop Access: Fix Shared Directory Truncate Error

### DIFF
--- a/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
@@ -2750,7 +2750,7 @@ func (x *SharedDirectoryRequest_Move) GetNewPath() string {
 type SharedDirectoryRequest_Truncate struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
-	EndOfFile     int64                  `protobuf:"varint,2,opt,name=end_of_file,json=endOfFile,proto3" json:"end_of_file,omitempty"`
+	Size          int64                  `protobuf:"varint,3,opt,name=size,proto3" json:"size,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2792,9 +2792,9 @@ func (x *SharedDirectoryRequest_Truncate) GetPath() string {
 	return ""
 }
 
-func (x *SharedDirectoryRequest_Truncate) GetEndOfFile() int64 {
+func (x *SharedDirectoryRequest_Truncate) GetSize() int64 {
 	if x != nil {
-		return x.EndOfFile
+		return x.Size
 	}
 	return 0
 }
@@ -3211,7 +3211,7 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x1aSharedDirectoryAcknowledge\x12!\n" +
 	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\x12\x1d\n" +
 	"\n" +
-	"error_code\x18\x02 \x01(\rR\terrorCode\"\xf6\b\n" +
+	"error_code\x18\x02 \x01(\rR\terrorCode\"\xfd\b\n" +
 	"\x16SharedDirectoryRequest\x12!\n" +
 	"\fdirectory_id\x18\x01 \x01(\rR\vdirectoryId\x12#\n" +
 	"\rcompletion_id\x18\x02 \x01(\rR\fcompletionId\x12F\n" +
@@ -3243,10 +3243,10 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\x04data\x18\x03 \x01(\fR\x04data\x1aF\n" +
 	"\x04Move\x12#\n" +
 	"\roriginal_path\x18\x01 \x01(\tR\foriginalPath\x12\x19\n" +
-	"\bnew_path\x18\x02 \x01(\tR\anewPath\x1a>\n" +
+	"\bnew_path\x18\x02 \x01(\tR\anewPath\x1aE\n" +
 	"\bTruncate\x12\x12\n" +
-	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1e\n" +
-	"\vend_of_file\x18\x02 \x01(\x03R\tendOfFileB\v\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
+	"\x04size\x18\x03 \x01(\x03R\x04sizeJ\x04\b\x02\x10\x03R\vend_of_fileB\v\n" +
 	"\toperation\"\x83\b\n" +
 	"\x17SharedDirectoryResponse\x12#\n" +
 	"\rcompletion_id\x18\x01 \x01(\rR\fcompletionId\x12\x1d\n" +

--- a/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
@@ -2750,7 +2750,7 @@ func (x *SharedDirectoryRequest_Move) GetNewPath() string {
 type SharedDirectoryRequest_Truncate struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
-	Size          int64                  `protobuf:"varint,3,opt,name=size,proto3" json:"size,omitempty"`
+	Size          uint64                 `protobuf:"varint,3,opt,name=size,proto3" json:"size,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2792,7 +2792,7 @@ func (x *SharedDirectoryRequest_Truncate) GetPath() string {
 	return ""
 }
 
-func (x *SharedDirectoryRequest_Truncate) GetSize() int64 {
+func (x *SharedDirectoryRequest_Truncate) GetSize() uint64 {
 	if x != nil {
 		return x.Size
 	}
@@ -3246,7 +3246,7 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\bnew_path\x18\x02 \x01(\tR\anewPath\x1aE\n" +
 	"\bTruncate\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
-	"\x04size\x18\x03 \x01(\x03R\x04sizeJ\x04\b\x02\x10\x03R\vend_of_fileB\v\n" +
+	"\x04size\x18\x03 \x01(\x04R\x04sizeJ\x04\b\x02\x10\x03R\vend_of_fileB\v\n" +
 	"\toperation\"\x83\b\n" +
 	"\x17SharedDirectoryResponse\x12#\n" +
 	"\rcompletion_id\x18\x01 \x01(\rR\fcompletionId\x12\x1d\n" +

--- a/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
+++ b/api/gen/proto/go/teleport/desktop/v1/tdpb.pb.go
@@ -2750,7 +2750,7 @@ func (x *SharedDirectoryRequest_Move) GetNewPath() string {
 type SharedDirectoryRequest_Truncate struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
-	EndOfFile     uint32                 `protobuf:"varint,2,opt,name=end_of_file,json=endOfFile,proto3" json:"end_of_file,omitempty"`
+	EndOfFile     int64                  `protobuf:"varint,2,opt,name=end_of_file,json=endOfFile,proto3" json:"end_of_file,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2792,7 +2792,7 @@ func (x *SharedDirectoryRequest_Truncate) GetPath() string {
 	return ""
 }
 
-func (x *SharedDirectoryRequest_Truncate) GetEndOfFile() uint32 {
+func (x *SharedDirectoryRequest_Truncate) GetEndOfFile() int64 {
 	if x != nil {
 		return x.EndOfFile
 	}
@@ -3246,7 +3246,7 @@ const file_teleport_desktop_v1_tdpb_proto_rawDesc = "" +
 	"\bnew_path\x18\x02 \x01(\tR\anewPath\x1a>\n" +
 	"\bTruncate\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1e\n" +
-	"\vend_of_file\x18\x02 \x01(\rR\tendOfFileB\v\n" +
+	"\vend_of_file\x18\x02 \x01(\x03R\tendOfFileB\v\n" +
 	"\toperation\"\x83\b\n" +
 	"\x17SharedDirectoryResponse\x12#\n" +
 	"\rcompletion_id\x18\x01 \x01(\rR\fcompletionId\x12\x1d\n" +

--- a/api/proto/teleport/desktop/v1/tdpb.proto
+++ b/api/proto/teleport/desktop/v1/tdpb.proto
@@ -245,7 +245,7 @@ message SharedDirectoryRequest {
     string path = 1;
     reserved 2;
     reserved "end_of_file";
-    int64 size = 3;
+    uint64 size = 3;
   }
 
   // operation is the particular operation type being requested.

--- a/api/proto/teleport/desktop/v1/tdpb.proto
+++ b/api/proto/teleport/desktop/v1/tdpb.proto
@@ -243,7 +243,9 @@ message SharedDirectoryRequest {
   // Truncate Request.
   message Truncate {
     string path = 1;
-    int64 end_of_file = 2;
+    reserved 2;
+    reserved "end_of_file";
+    int64 size = 3;
   }
 
   // operation is the particular operation type being requested.

--- a/api/proto/teleport/desktop/v1/tdpb.proto
+++ b/api/proto/teleport/desktop/v1/tdpb.proto
@@ -243,7 +243,7 @@ message SharedDirectoryRequest {
   // Truncate Request.
   message Truncate {
     string path = 1;
-    uint32 end_of_file = 2;
+    int64 end_of_file = 2;
   }
 
   // operation is the particular operation type being requested.

--- a/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
+++ b/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
@@ -557,9 +557,9 @@ export interface SharedDirectoryRequest_Truncate {
      */
     path: string;
     /**
-     * @generated from protobuf field: uint32 end_of_file = 2;
+     * @generated from protobuf field: int64 end_of_file = 2;
      */
-    endOfFile: number;
+    endOfFile: bigint;
 }
 /**
  * Shared directory operation responses.
@@ -2700,13 +2700,13 @@ class SharedDirectoryRequest_Truncate$Type extends MessageType<SharedDirectoryRe
     constructor() {
         super("teleport.desktop.v1.SharedDirectoryRequest.Truncate", [
             { no: 1, name: "path", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "end_of_file", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+            { no: 2, name: "end_of_file", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<SharedDirectoryRequest_Truncate>): SharedDirectoryRequest_Truncate {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.path = "";
-        message.endOfFile = 0;
+        message.endOfFile = 0n;
         if (value !== undefined)
             reflectionMergePartial<SharedDirectoryRequest_Truncate>(this, message, value);
         return message;
@@ -2719,8 +2719,8 @@ class SharedDirectoryRequest_Truncate$Type extends MessageType<SharedDirectoryRe
                 case /* string path */ 1:
                     message.path = reader.string();
                     break;
-                case /* uint32 end_of_file */ 2:
-                    message.endOfFile = reader.uint32();
+                case /* int64 end_of_file */ 2:
+                    message.endOfFile = reader.int64().toBigInt();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -2737,9 +2737,9 @@ class SharedDirectoryRequest_Truncate$Type extends MessageType<SharedDirectoryRe
         /* string path = 1; */
         if (message.path !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.path);
-        /* uint32 end_of_file = 2; */
-        if (message.endOfFile !== 0)
-            writer.tag(2, WireType.Varint).uint32(message.endOfFile);
+        /* int64 end_of_file = 2; */
+        if (message.endOfFile !== 0n)
+            writer.tag(2, WireType.Varint).int64(message.endOfFile);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
+++ b/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
@@ -557,7 +557,7 @@ export interface SharedDirectoryRequest_Truncate {
      */
     path: string;
     /**
-     * @generated from protobuf field: int64 size = 3;
+     * @generated from protobuf field: uint64 size = 3;
      */
     size: bigint;
 }
@@ -2700,7 +2700,7 @@ class SharedDirectoryRequest_Truncate$Type extends MessageType<SharedDirectoryRe
     constructor() {
         super("teleport.desktop.v1.SharedDirectoryRequest.Truncate", [
             { no: 1, name: "path", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "size", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ }
+            { no: 3, name: "size", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<SharedDirectoryRequest_Truncate>): SharedDirectoryRequest_Truncate {
@@ -2719,8 +2719,8 @@ class SharedDirectoryRequest_Truncate$Type extends MessageType<SharedDirectoryRe
                 case /* string path */ 1:
                     message.path = reader.string();
                     break;
-                case /* int64 size */ 3:
-                    message.size = reader.int64().toBigInt();
+                case /* uint64 size */ 3:
+                    message.size = reader.uint64().toBigInt();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -2737,9 +2737,9 @@ class SharedDirectoryRequest_Truncate$Type extends MessageType<SharedDirectoryRe
         /* string path = 1; */
         if (message.path !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.path);
-        /* int64 size = 3; */
+        /* uint64 size = 3; */
         if (message.size !== 0n)
-            writer.tag(3, WireType.Varint).int64(message.size);
+            writer.tag(3, WireType.Varint).uint64(message.size);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
+++ b/gen/proto/ts/teleport/desktop/v1/tdpb_pb.ts
@@ -557,9 +557,9 @@ export interface SharedDirectoryRequest_Truncate {
      */
     path: string;
     /**
-     * @generated from protobuf field: int64 end_of_file = 2;
+     * @generated from protobuf field: int64 size = 3;
      */
-    endOfFile: bigint;
+    size: bigint;
 }
 /**
  * Shared directory operation responses.
@@ -2700,13 +2700,13 @@ class SharedDirectoryRequest_Truncate$Type extends MessageType<SharedDirectoryRe
     constructor() {
         super("teleport.desktop.v1.SharedDirectoryRequest.Truncate", [
             { no: 1, name: "path", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "end_of_file", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ }
+            { no: 3, name: "size", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<SharedDirectoryRequest_Truncate>): SharedDirectoryRequest_Truncate {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.path = "";
-        message.endOfFile = 0n;
+        message.size = 0n;
         if (value !== undefined)
             reflectionMergePartial<SharedDirectoryRequest_Truncate>(this, message, value);
         return message;
@@ -2719,8 +2719,8 @@ class SharedDirectoryRequest_Truncate$Type extends MessageType<SharedDirectoryRe
                 case /* string path */ 1:
                     message.path = reader.string();
                     break;
-                case /* int64 end_of_file */ 2:
-                    message.endOfFile = reader.int64().toBigInt();
+                case /* int64 size */ 3:
+                    message.size = reader.int64().toBigInt();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -2737,9 +2737,9 @@ class SharedDirectoryRequest_Truncate$Type extends MessageType<SharedDirectoryRe
         /* string path = 1; */
         if (message.path !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.path);
-        /* int64 end_of_file = 2; */
-        if (message.endOfFile !== 0n)
-            writer.tag(2, WireType.Varint).int64(message.endOfFile);
+        /* int64 size = 3; */
+        if (message.size !== 0n)
+            writer.tag(3, WireType.Varint).int64(message.size);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -1267,8 +1267,8 @@ func cgo_tdp_sd_truncate_request(handle C.uintptr_t, req *C.CGOSharedDirectoryTr
 		DirectoryId:  uint32(req.directory_id),
 		Operation: &tdpbv1.SharedDirectoryRequest_Truncate_{
 			Truncate: &tdpbv1.SharedDirectoryRequest_Truncate{
-				Path:      C.GoString(req.path),
-				EndOfFile: uint32(req.end_of_file),
+				Path: C.GoString(req.path),
+				Size: int64(req.end_of_file),
 			},
 		},
 	})

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -1268,7 +1268,7 @@ func cgo_tdp_sd_truncate_request(handle C.uintptr_t, req *C.CGOSharedDirectoryTr
 		Operation: &tdpbv1.SharedDirectoryRequest_Truncate_{
 			Truncate: &tdpbv1.SharedDirectoryRequest_Truncate{
 				Path: C.GoString(req.path),
-				Size: int64(req.end_of_file),
+				Size: uint64(req.end_of_file),
 			},
 		},
 	})

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -759,7 +759,7 @@ pub struct CGOSharedDirectoryTruncateRequest {
     pub completion_id: u32,
     pub directory_id: u32,
     pub path: *const c_char,
-    pub end_of_file: u32,
+    pub end_of_file: i64,
 }
 
 pub type CGOSharedDirectoryTruncateResponse = SharedDirectoryTruncateResponse;

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -759,7 +759,7 @@ pub struct CGOSharedDirectoryTruncateRequest {
     pub completion_id: u32,
     pub directory_id: u32,
     pub path: *const c_char,
-    pub end_of_file: i64,
+    pub end_of_file: u64,
 }
 
 pub type CGOSharedDirectoryTruncateResponse = SharedDirectoryTruncateResponse;

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -901,7 +901,7 @@ impl FilesystemBackend {
                 completion_id: rdp_req.device_io_request.completion_id,
                 directory_id: rdp_req.device_io_request.device_id,
                 path: file.path.clone(),
-                end_of_file: cast_length("tdp_sd_truncate", "end_of_file", end_of_file)?,
+                end_of_file,
             })?;
 
             self.pending_sd_truncate_resp_handlers.insert(

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/filesystem.rs
@@ -901,7 +901,7 @@ impl FilesystemBackend {
                 completion_id: rdp_req.device_io_request.completion_id,
                 directory_id: rdp_req.device_io_request.device_id,
                 path: file.path.clone(),
-                end_of_file,
+                end_of_file: cast_length("tdp_sd_truncate", "end_of_file", eof.end_of_file)?,
             })?;
 
             self.pending_sd_truncate_resp_handlers.insert(

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
@@ -589,7 +589,7 @@ pub struct SharedDirectoryTruncateRequest {
     pub completion_id: u32,
     pub directory_id: u32,
     pub path: UnixPath,
-    pub end_of_file: u32,
+    pub end_of_file: i64,
 }
 
 impl SharedDirectoryTruncateRequest {

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
@@ -589,7 +589,7 @@ pub struct SharedDirectoryTruncateRequest {
     pub completion_id: u32,
     pub directory_id: u32,
     pub path: UnixPath,
-    pub end_of_file: i64,
+    pub end_of_file: u64,
 }
 
 impl SharedDirectoryTruncateRequest {

--- a/lib/srv/desktop/tdp/protocol/tdpb/translate.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/translate.go
@@ -74,6 +74,17 @@ func clampInt32ToInt16(val int32) int16 {
 	}
 }
 
+func clampInt64ToUint32(val int64) uint32 {
+	switch {
+	case val < 0:
+		return 0
+	case val > math.MaxUint32:
+		return math.MaxUint32
+	default:
+		return uint32(val)
+	}
+}
+
 // TranslateToLegacy converts a TDPB (Modern) message to one or more TDP (Legacy) messages.
 func TranslateToLegacy(msg tdp.Message) ([]tdp.Message, error) {
 	switch m := msg.(type) {
@@ -204,7 +215,7 @@ func TranslateToLegacy(msg tdp.Message) ([]tdp.Message, error) {
 				CompletionID: m.CompletionId,
 				DirectoryID:  m.DirectoryId,
 				Path:         op.Truncate.Path,
-				EndOfFile:    op.Truncate.EndOfFile,
+				EndOfFile:    clampInt64ToUint32(op.Truncate.Size),
 			}}, nil
 		default:
 			return nil, trace.BadParameter("Unknown shared directory operation")
@@ -551,8 +562,8 @@ func TranslateToModern(msg tdp.Message) ([]tdp.Message, error) {
 			CompletionId: m.CompletionID,
 			Operation: &tdpbv1.SharedDirectoryRequest_Truncate_{
 				Truncate: &tdpbv1.SharedDirectoryRequest_Truncate{
-					Path:      m.Path,
-					EndOfFile: m.EndOfFile,
+					Path: m.Path,
+					Size: int64(m.EndOfFile),
 				},
 			},
 		}}, nil

--- a/lib/srv/desktop/tdp/protocol/tdpb/translate.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/translate.go
@@ -74,10 +74,8 @@ func clampInt32ToInt16(val int32) int16 {
 	}
 }
 
-func clampInt64ToUint32(val int64) uint32 {
+func clampUint64ToUint32(val uint64) uint32 {
 	switch {
-	case val < 0:
-		return 0
 	case val > math.MaxUint32:
 		return math.MaxUint32
 	default:
@@ -215,7 +213,7 @@ func TranslateToLegacy(msg tdp.Message) ([]tdp.Message, error) {
 				CompletionID: m.CompletionId,
 				DirectoryID:  m.DirectoryId,
 				Path:         op.Truncate.Path,
-				EndOfFile:    clampInt64ToUint32(op.Truncate.Size),
+				EndOfFile:    clampUint64ToUint32(op.Truncate.Size),
 			}}, nil
 		default:
 			return nil, trace.BadParameter("Unknown shared directory operation")
@@ -563,7 +561,7 @@ func TranslateToModern(msg tdp.Message) ([]tdp.Message, error) {
 			Operation: &tdpbv1.SharedDirectoryRequest_Truncate_{
 				Truncate: &tdpbv1.SharedDirectoryRequest_Truncate{
 					Path: m.Path,
-					Size: int64(m.EndOfFile),
+					Size: uint64(m.EndOfFile),
 				},
 			},
 		}}, nil

--- a/lib/srv/desktop/tdp/protocol/tdpb/translate.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/translate.go
@@ -75,12 +75,10 @@ func clampInt32ToInt16(val int32) int16 {
 }
 
 func clampUint64ToUint32(val uint64) uint32 {
-	switch {
-	case val > math.MaxUint32:
+	if val > math.MaxUint32 {
 		return math.MaxUint32
-	default:
-		return uint32(val)
 	}
+	return uint32(val)
 }
 
 // TranslateToLegacy converts a TDPB (Modern) message to one or more TDP (Legacy) messages.

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -453,7 +453,7 @@ func (d *fsRequestHandler) handleSharedDirectoryTruncateRequest(completionID uin
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = dirAccess.Truncate(r.Path, int64(r.EndOfFile))
+	err = dirAccess.Truncate(r.Path, r.Size)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/teleterm/services/desktop/directorysharing.go
+++ b/lib/teleterm/services/desktop/directorysharing.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -222,13 +223,17 @@ func (d *DirectoryAccess) Write(relativePath string, offset int64, data []byte) 
 }
 
 // Truncate truncates a file to the specified size.
-func (d *DirectoryAccess) Truncate(relativePath string, size int64) error {
+func (d *DirectoryAccess) Truncate(relativePath string, size uint64) error {
 	path, err := d.getSafePath(relativePath)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.ConvertSystemError(os.Truncate(path, size))
+	if size > math.MaxInt64 {
+		size = math.MaxInt64
+	}
+
+	return trace.ConvertSystemError(os.Truncate(path, int64(size)))
 }
 
 // Create creates a new file or directory at the given path.

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -760,9 +760,21 @@ export class TdpClient extends EventEmitter<EventMap> {
   async handleSharedDirectoryTruncateRequest(
     req: SharedDirectoryTruncateRequest
   ) {
+    if (req.endOfFile > BigInt(Number.MAX_SAFE_INTEGER)) {
+      this.handleWarning(
+        'File truncate operation exceeds maximum allowed size.',
+        TdpClientEvent.TDP_WARNING
+      );
+      this.sendSharedDirectoryTruncateResponse({
+        completionId: req.completionId,
+        errCode: SharedDirectoryErrCode.Failed,
+      });
+      return;
+    }
+
     const sharedDirectory = this.getSharedDirectoryOrThrow();
 
-    await sharedDirectory.truncate(req.path, req.endOfFile);
+    await sharedDirectory.truncate(req.path, Number(req.endOfFile));
     this.sendSharedDirectoryTruncateResponse({
       completionId: req.completionId,
       errCode: SharedDirectoryErrCode.Nil,

--- a/web/packages/shared/libs/tdp/codec.ts
+++ b/web/packages/shared/libs/tdp/codec.ts
@@ -316,7 +316,7 @@ export type SharedDirectoryTruncateRequest = {
   completionId: number;
   directoryId: number;
   path: string;
-  endOfFile: number;
+  endOfFile: bigint;
 };
 
 // | message type (34) | completion_id uint32 | err_code uint32 |
@@ -586,7 +586,8 @@ export class TdpbCodec implements Codec {
           data: {
             directoryId,
             completionId,
-            ...op.truncate,
+            endOfFile: op.truncate.size,
+            path: op.truncate.path,
           },
         };
       case 'write':
@@ -2030,7 +2031,7 @@ export class TdpCodec implements Codec {
       completionId,
       directoryId,
       path,
-      endOfFile,
+      endOfFile: BigInt(endOfFile),
     };
   }
 


### PR DESCRIPTION
This PR fixes a fatal error that gets thrown when the RDP server attempts to truncate a file to a size greater than 4GiB. Legacy TDP represented the `EndOfFile` field of a truncate request as a `uint32` and TDPB followed suit. Luckily, TDPB has not been released yet so we can correct this easily. Of course, this means that this fix is dependent on the backport of TDPB (#65478) before we can release it.


A few notes:
Updated clients will emit a warning and return a truncation failure if the truncate size exceeds `Number.MAX_SAFE_INTEGER`. During testing, I noticed that the RDP server seems to ignore this failure and proceed with the copy anyway. 

When translating to legacy TDP, the `EndOfFile` field will be clamped to that maximum value of a `uint32`. This means that legacy clients will not truncate to the full desired length of the file. As noted above, the server doesn't seem to care about the result anyhow.


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed a fatal connection error that occurs in Windows Desktop sessions when attempting to create a file larger than 4GiB within a shared directory.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster with at least one reachable desktop.
### Test Cases
- [x] Using the web client, connect to the desktop and create a file larger than 4GiB outside of the shared directory. Attempt to copy this file into the shared directory. Observe that the session no longer disconnects and the copy/move proceeds.
- [x] Using Teleport Connect, connect to the desktop and create a file larger than 4GiB outside of the shared directory. Attempt to copy this file into the shared directory. Observe that the session no longer disconnects and the copy/move proceeds
