### PR TITLE
Web: misc updates

### DIFF
--- a/web/packages/design/src/Tabs/Tabs.story.tsx
+++ b/web/packages/design/src/Tabs/Tabs.story.tsx
@@ -28,7 +28,7 @@ type StoryProps = {
 
 const meta: Meta<StoryProps> = {
   title: 'Design/Tabs',
-  component: Controls,
+  component: Default,
   argTypes: {
     withBottomBorder: {
       control: { type: 'boolean' },
@@ -47,7 +47,7 @@ enum Tab {
   Example3,
 }
 
-export function Controls(props: StoryProps) {
+export function Default(props: StoryProps) {
   const [activeTab, setActiveTab] = useState(Tab.Example1);
 
   const { borderRef, parentRef } = useSlidingBottomBorderTabs({ activeTab });
@@ -79,6 +79,49 @@ export function Controls(props: StoryProps) {
           onClick={() => setActiveTab(Tab.Example3)}
         >
           Example Tab 3
+        </TabContainer>
+        <TabBorder ref={borderRef} />
+      </TabsContainer>
+
+      {activeTab === Tab.Example1 && <div>Example 1 content</div>}
+      {activeTab === Tab.Example2 && <div>Example 2 content</div>}
+      {activeTab === Tab.Example3 && <div>Example 3 content</div>}
+    </>
+  );
+}
+
+export function Small() {
+  const [activeTab, setActiveTab] = useState(Tab.Example1);
+
+  const { borderRef, parentRef } = useSlidingBottomBorderTabs({ activeTab });
+
+  return (
+    <>
+      <TabsContainer ref={parentRef} mb={3} size="small">
+        <TabContainer
+          size="small"
+          data-tab-id={Tab.Example1}
+          selected={activeTab === Tab.Example1}
+          onClick={() => setActiveTab(Tab.Example1)}
+        >
+          Example Tab 1
+        </TabContainer>
+        <TabContainer
+          size="small"
+          data-tab-id={Tab.Example2}
+          selected={activeTab === Tab.Example2}
+          onClick={() => setActiveTab(Tab.Example2)}
+        >
+          Example Tab 2
+        </TabContainer>
+        <TabContainer
+          size="small"
+          disabled
+          data-tab-id={Tab.Example3}
+          selected={activeTab === Tab.Example3}
+          onClick={() => setActiveTab(Tab.Example3)}
+        >
+          Disabled Tab
         </TabContainer>
         <TabBorder ref={borderRef} />
       </TabsContainer>

--- a/web/packages/design/src/Tabs/Tabs.ts
+++ b/web/packages/design/src/Tabs/Tabs.ts
@@ -46,13 +46,11 @@ export const TabsContainer = styled.div<TabsContainerProps>`
   ${space}
 `;
 
-export const TabContainer = styled.div.attrs<{
+export const TabContainer = styled.div<{
   selected?: boolean;
   size?: 'small';
   disabled?: boolean;
-}>(p => ({
-  onClick: p.disabled ? undefined : p.onClick,
-}))`
+}>`
   padding: ${p => p.theme.space[1] + p.theme.space[2]}px
     ${p => p.theme.space[2]}px;
   position: relative;
@@ -84,6 +82,7 @@ export const TabContainer = styled.div.attrs<{
     p.disabled &&
     `
     cursor: not-allowed;
+    pointer-events: none;
     opacity: 0.3;
     &:hover {
       opacity: 0.3;

--- a/web/packages/design/src/Tabs/Tabs.ts
+++ b/web/packages/design/src/Tabs/Tabs.ts
@@ -28,12 +28,17 @@ interface TabsContainerProps extends SpaceProps {
    * bottom.
    */
   withBottomBorder?: boolean;
+  /**
+   * When set to 'small', renders tabs with smaller font size,
+   * padding, and gap.
+   */
+  size?: 'small';
 }
 
 export const TabsContainer = styled.div<TabsContainerProps>`
   position: relative;
   display: flex;
-  gap: ${p => p.theme.space[5]}px;
+  gap: ${p => (p.size === 'small' ? p.theme.space[3] : p.theme.space[5])}px;
   align-items: center;
   border-bottom: ${p =>
     p.withBottomBorder ? `1px solid ${p.theme.colors.spotBackground[0]}` : 0};
@@ -41,7 +46,13 @@ export const TabsContainer = styled.div<TabsContainerProps>`
   ${space}
 `;
 
-export const TabContainer = styled.div<{ selected?: boolean }>`
+export const TabContainer = styled.div.attrs<{
+  selected?: boolean;
+  size?: 'small';
+  disabled?: boolean;
+}>(p => ({
+  onClick: p.disabled ? undefined : p.onClick,
+}))`
   padding: ${p => p.theme.space[1] + p.theme.space[2]}px
     ${p => p.theme.space[2]}px;
   position: relative;
@@ -59,6 +70,25 @@ export const TabContainer = styled.div<{ selected?: boolean }>`
   &:hover {
     opacity: 1;
   }
+
+  ${p =>
+    p.size === 'small' &&
+    `
+    padding: ${p.theme.space[1]}px ${p.theme.space[2]}px;
+    font-weight: 400;
+    font-size: ${p.theme.fontSizes[2]}px;
+    line-height: 20px;
+  `}
+
+  ${p =>
+    p.disabled &&
+    `
+    cursor: not-allowed;
+    opacity: 0.3;
+    &:hover {
+      opacity: 0.3;
+    }
+  `}
 `;
 
 export const TabContainerNavLink = styled(TabContainer).attrs({

--- a/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
@@ -36,7 +36,7 @@ export function CardsView({
   isProcessing,
   pinningSupport,
   visibleInputFields,
-  showResourcesSelectedIcon,
+  showResourceSelectedIcon,
   resourceLabelConfig,
 }: ResourceViewProps) {
   return (
@@ -56,7 +56,7 @@ export function CardsView({
             showingStatusInfo={showingStatusInfo}
             visibleInputFields={visibleInputFields}
             resourceLabelConfig={resourceLabelConfig}
-            showResourceSelectedIcon={showResourcesSelectedIcon}
+            showResourceSelectedIcon={showResourceSelectedIcon}
           />
         )
       )}

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -96,6 +96,7 @@ type StoryProps = {
   withHoverState: boolean;
   withLabelIcon: boolean;
   showResourceSelectedIcon: boolean;
+  showSelectedResourceIconForMatchingLabels: boolean;
   labelIconPlacement: 'left' | 'right';
   labelKind: LabelKind;
 };
@@ -121,6 +122,9 @@ const meta: Meta<StoryProps> = {
     showResourceSelectedIcon: {
       control: { type: 'boolean' },
     },
+    showSelectedResourceIconForMatchingLabels: {
+      control: { type: 'boolean' },
+    },
     labelIconPlacement: {
       control: { type: 'select' },
       options: ['left', 'right'],
@@ -138,6 +142,7 @@ const meta: Meta<StoryProps> = {
     withCopy: true,
     withHoverState: true,
     showResourceSelectedIcon: false,
+    showSelectedResourceIconForMatchingLabels: false,
   },
 };
 export default meta;
@@ -191,7 +196,12 @@ export function Cards(props: StoryProps) {
               onShowStatusInfo={() => null}
               showingStatusInfo={false}
               viewItem={res}
-              showResourceSelectedIcon={props.showResourceSelectedIcon}
+              showResourceSelectedIcon={
+                props.showSelectedResourceIconForMatchingLabels
+                  ? labels =>
+                      labels.some(l => l.name === 'env' && l.value === 'prod')
+                  : props.showResourceSelectedIcon
+              }
               visibleInputFields={{
                 checkbox: props.withCheckbox,
                 pin: props.withPin,

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -193,6 +193,7 @@ export function ResourceCard({
         showHoverState={visibleInputFields.hoverState}
       >
         <CardInnerContainer
+          showAllLabels={showAllLabels}
           showHoverState={visibleInputFields.hoverState}
           ref={innerContainer}
           p={3}
@@ -259,7 +260,9 @@ export function ResourceCard({
               <ResourceActionButtonWrapper requiresRequest={requiresRequest}>
                 {ActionButton}
               </ResourceActionButtonWrapper>
-              {showResourceSelectedIcon && <ResourceSelectedIcon />}
+              {(typeof showResourceSelectedIcon === 'function'
+                ? showResourceSelectedIcon(labels)
+                : showResourceSelectedIcon) && <ResourceSelectedIcon />}
             </Flex>
             <Flex flexDirection="row" alignItems="center">
               <ResTypeIconBox>
@@ -423,7 +426,7 @@ const CardOuterContainer = styled(Box)<{
   transition: all 150ms;
 
   ${p =>
-    p.showHoverState &&
+    (p.showHoverState || p.showAllLabels) &&
     css`
       // Using double ampersand because of https://github.com/styled-components/styled-components/issues/3678.
       ${CardContainer}:hover && {
@@ -456,7 +459,7 @@ const CardOuterContainer = styled(Box)<{
  * outer container.
  */
 const CardInnerContainer = styled(Flex)<
-  BackgroundColorProps & { showHoverState: boolean }
+  BackgroundColorProps & { showHoverState: boolean; showAllLabels?: boolean }
 >`
   border: ${props => props.theme.borders[2]}
     ${props => props.theme.colors.spotBackground[0]};
@@ -485,7 +488,7 @@ const CardInnerContainer = styled(Flex)<
   &:hover {
     // Make the border invisible instead of removing it, this is to prevent things from shifting due to the size change.
     ${p =>
-      p.showHoverState &&
+      (p.showHoverState || p.showAllLabels) &&
       css`
         border: ${props => props.theme.borders[2]} rgba(0, 0, 0, 0);
       `}

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -93,6 +93,10 @@ interface FilterPanelProps {
    * When specified, only fields with `true` value are shown.
    */
   visibleFilterPanelFields?: VisibleFilterPanelFields;
+  /**
+   * Optional content rendered on the left side of the filter panel.
+   */
+  LeftContent?: JSX.Element;
 }
 
 export function FilterPanel({
@@ -119,6 +123,7 @@ export function FilterPanel({
     resourceAvailabilityOpts: true,
     collapseLabelBtn: true,
   },
+  LeftContent = null,
 }: FilterPanelProps) {
   const { sort, kinds, statuses } = params;
 
@@ -156,7 +161,8 @@ export function FilterPanel({
       minHeight="32px"
       alignItems="center"
     >
-      <Flex gap={2}>
+      <Flex gap={2} alignItems="center">
+        {LeftContent}
         {visibleFilterPanelFields.checkbox && (
           <HoverTooltip tipContent={selected ? 'Deselect all' : 'Select all'}>
             <CheckboxInput

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -96,7 +96,7 @@ interface FilterPanelProps {
   /**
    * Optional content rendered on the left side of the filter panel.
    */
-  LeftContent?: JSX.Element;
+  LeftContent?: React.ReactNode;
 }
 
 export function FilterPanel({

--- a/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
@@ -35,7 +35,7 @@ export function ListView({
   isProcessing,
   expandAllLabels,
   visibleInputFields,
-  showResourcesSelectedIcon,
+  showResourceSelectedIcon,
   resourceLabelConfig,
 }: ResourceViewProps) {
   return (
@@ -56,7 +56,7 @@ export function ListView({
             showingStatusInfo={showingStatusInfo}
             visibleInputFields={visibleInputFields}
             resourceLabelConfig={resourceLabelConfig}
-            showResourceSelectedIcon={showResourcesSelectedIcon}
+            showResourceSelectedIcon={showResourceSelectedIcon}
           />
         )
       )}

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -89,6 +89,7 @@ type StoryProps = {
   withCopy: boolean;
   withHoverState: boolean;
   showSelectedResourceIcon: boolean;
+  showSelectedResourceIconForMatchingLabels: boolean;
   labelIconPlacement: 'left' | 'right';
   labelKind: LabelKind;
 };
@@ -111,6 +112,9 @@ const meta: Meta<StoryProps> = {
     showSelectedResourceIcon: {
       control: { type: 'boolean' },
     },
+    showSelectedResourceIconForMatchingLabels: {
+      control: { type: 'boolean' },
+    },
     withLabelIcon: {
       control: { type: 'boolean' },
     },
@@ -131,6 +135,7 @@ const meta: Meta<StoryProps> = {
     withCopy: true,
     withHoverState: true,
     showSelectedResourceIcon: false,
+    showSelectedResourceIconForMatchingLabels: false,
   },
 };
 export default meta;
@@ -173,7 +178,12 @@ export function ListItems(props: StoryProps) {
           onShowStatusInfo={() => null}
           showingStatusInfo={false}
           viewItem={res}
-          showResourceSelectedIcon={props.showSelectedResourceIcon}
+          showResourceSelectedIcon={
+            props.showSelectedResourceIconForMatchingLabels
+              ? labels =>
+                  labels.some(l => l.name === 'env' && l.value === 'prod')
+              : props.showSelectedResourceIcon
+          }
           visibleInputFields={{
             checkbox: props.withCheckbox,
             pin: props.withPin,

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -174,7 +174,9 @@ export function ResourceListItem({
             <HoverTooltip tipContent={name} showOnlyOnOverflow>
               <Flex alignItems="center" gap={2}>
                 <Name>{name}</Name>
-                {showResourceSelectedIcon && <ResourceSelectedIcon />}
+                {(typeof showResourceSelectedIcon === 'function'
+                  ? showResourceSelectedIcon(labels)
+                  : showResourceSelectedIcon) && <ResourceSelectedIcon />}
               </Flex>
             </HoverTooltip>
             <HoverTooltip tipContent={description} showOnlyOnOverflow>

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -259,11 +259,14 @@ export interface UnifiedResourcesProps {
    */
   visibleResourceItemFields?: VisibleResourceItemFields;
   /**
-   * If true, renders a check icon at the top right corner of cards
-   * or right next to resource name for list view rows for all
-   * resources.
+   * Controls rendering of a check icon at the top right corner of cards
+   * or right next to resource name for list view rows.
+   *
+   * If a boolean, applies to all resources uniformly.
+   * If a function, called per resource with its labels to determine
+   * whether the icon should be shown.
    */
-  showResourcesSelectedIcon?: boolean;
+  showResourceSelectedIcon?: boolean | ((labels: ResourceLabel[]) => boolean);
 }
 
 export function UnifiedResources(props: UnifiedResourcesProps) {
@@ -289,7 +292,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     className,
     forceNoResources,
     noResultCustomText,
-    showResourcesSelectedIcon,
+    showResourceSelectedIcon,
   } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -694,7 +697,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
                   query: makeAdvancedSearchQueryForLabel(label, params),
                 })
         }
-        showResourcesSelectedIcon={showResourcesSelectedIcon}
+        showResourceSelectedIcon={showResourceSelectedIcon}
         resourceLabelConfig={resourceLabelConfig}
         pinnedResources={pinnedResources}
         selectedResources={selectedResources}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -267,6 +267,10 @@ export interface UnifiedResourcesProps {
    * whether the icon should be shown.
    */
   showResourceSelectedIcon?: boolean | ((labels: ResourceLabel[]) => boolean);
+  /**
+   * Optional content rendered on the left side of the filter panel.
+   */
+  FilterPanelLeftContent?: JSX.Element;
 }
 
 export function UnifiedResources(props: UnifiedResourcesProps) {
@@ -293,6 +297,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     forceNoResources,
     noResultCustomText,
     showResourceSelectedIcon,
+    FilterPanelLeftContent,
   } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -625,6 +630,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
         setCurrentViewMode={selectViewMode}
         expandAllLabels={expandAllLabels}
         ClusterDropdown={ClusterDropdown}
+        LeftContent={FilterPanelLeftContent}
         setExpandAllLabels={expandAllLabels => {
           setLabelsViewMode(
             expandAllLabels ? LabelsViewMode.EXPANDED : LabelsViewMode.COLLAPSED

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -294,10 +294,14 @@ export type ResourceItemProps = {
    */
   resourceLabelConfig?: ResourceLabelConfig;
   /**
-   * If true, render a check icon at the top right corner of cards
+   * Controls rendering of a check icon at the top right corner of cards
    * and right next to resource name for list view rows.
+   *
+   * If a boolean, applies to all resources uniformly.
+   * If a function, called per resource with its labels to determine
+   * whether the icon should be shown.
    */
-  showResourceSelectedIcon?: boolean;
+  showResourceSelectedIcon?: boolean | ((labels: ResourceLabel[]) => boolean);
 };
 
 // Props that are needed for the Card view.
@@ -354,10 +358,15 @@ export type ResourceViewProps = {
    */
   resourceLabelConfig?: ResourceLabelConfig;
   /**
-   * If true, renders a check icon at the top right corner of cards
-   * and right next to resource name for list view rows.
+   * Controls rendering of a check icon at the top right corner of cards
+   * and right next to resource name for list view rows for all
+   * resources.
+   *
+   * If a boolean, applies to all resources uniformly.
+   * If a function, called per resource with its labels to determine
+   * whether the icon should be shown.
    */
-  showResourcesSelectedIcon?: boolean;
+  showResourceSelectedIcon?: boolean | ((labels: ResourceLabel[]) => boolean);
 };
 
 /**


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/8271 improvements

This PR does the following:

- support rendering check icon for resource cards and resource list items conditionally by passing in a function. before, it was just a boolean which is still supported
- support rendering a smaller Tabs.tsx
- support passing in a optional field to `FilterPanel.tsx` that renders the passed in content on the left side of the panel

Here is a screen shot that utilizes all three changes:
- only certain resource cards have checkmark icon rendered
- the smaller tabs `All Resources` and `Matched Resources`
- the tab is rendered centered `left` to the filter panel

<img width="986" height="531" alt="image" src="https://github.com/user-attachments/assets/9d8c9db7-bf1b-4f76-a658-bf715e3da8a3" />


