### PR TITLE
[v17] Use the circuit breaker config in authclient.HTTPClient

### DIFF
--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -179,6 +179,11 @@ func NewClient(cfg client.Config, params ...roundtrip.ClientParam) (*Client, err
 		TLS:                        httpTLS,
 		Dialer:                     httpDialer,
 		ALPNSNIAuthDialClusterName: cfg.ALPNSNIAuthDialClusterName,
+		// we are ok with the HTTP client using a separate circuit breaker with
+		// the same configuration, since there's so few auth API calls using
+		// HTTP and most of them are used by the Proxy, which is going to have a
+		// no-op circuit breaker to begin with
+		CircuitBreakerConfig: cfg.CircuitBreakerConfig,
 	}
 	httpClient, err := NewHTTPClient(httpClientCfg, params...)
 	if err != nil {

--- a/lib/auth/authclient/clt_test.go
+++ b/lib/auth/authclient/clt_test.go
@@ -1,0 +1,107 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package authclient
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/gravitational/teleport/api/breaker"
+	"github.com/gravitational/teleport/api/client"
+)
+
+func TestHTTPCircuitBreaker(t *testing.T) {
+	synctest.Test(t, synctestHTTPCircuitBreaker)
+}
+func synctestHTTPCircuitBreaker(t *testing.T) {
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "this hit the server", 500)
+		}),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{requireSnakeoilCert(t)},
+		},
+	}
+	listener := bufconn.Listen(100)
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.ServeTLS(listener, "", "")
+	}()
+	defer func() {
+		require.ErrorIs(t, <-serveErr, http.ErrServerClosed)
+	}()
+
+	defer func() {
+		require.NoError(t, srv.Close())
+	}()
+
+	clt, err := NewClient(client.Config{
+		Dialer: client.ContextDialerFunc(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		Credentials: []client.Credentials{
+			client.LoadTLS(&tls.Config{InsecureSkipVerify: true}),
+		},
+		CircuitBreakerConfig: breaker.Config{
+			Interval:     time.Hour,
+			Trip:         breaker.StaticTripper(true),
+			Recover:      breaker.StaticTripper(true),
+			IsSuccessful: func(v any, err error) bool { return false },
+		},
+		DialInBackground: true,
+	})
+	require.NoError(t, err)
+	defer clt.Close()
+
+	_, err = clt.HTTPClient.Get(t.Context(), clt.HTTPClient.Endpoint(), nil)
+	require.ErrorContains(t, err, "this hit the server")
+
+	// the breaker should be tripped now, unlike what a default circuit breaker would do
+
+	_, err = clt.HTTPClient.Get(t.Context(), clt.HTTPClient.Endpoint(), nil)
+	require.ErrorAs(t, err, new(*trace.ConnectionProblemError))
+	require.ErrorContains(t, err, "Unable to communicate with the Teleport Auth Service")
+}
+
+func requireSnakeoilCert(t testing.TB) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	cert := &x509.Certificate{}
+	certDER, err := x509.CreateCertificate(rand.Reader, cert, cert, key.Public(), key)
+	require.NoError(t, err)
+	return tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+	}
+}


### PR DESCRIPTION
Backport #66295 to branch/v17




<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: fixed possible unavailability of Proxy service instances as a result of some API errors


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Control plane running this build with the addition of a custom auth endpoint that always errors out which is called by the proxy's /webapi/find endpoint.

<details>
<summary>
The diff for the test code, for posterity
</summary>

```diff
diff --git i/api/client/webclient/webclient.go w/api/client/webclient/webclient.go
index 03b4a8fd489..081714a3092 100644
--- i/api/client/webclient/webclient.go
+++ w/api/client/webclient/webclient.go
@@ -423,6 +423,8 @@ type PingResponse struct {
 	Edition string `json:"edition"`
 	// FIPS represents if Teleport is using FIPS-compliant cryptography.
 	FIPS bool `json:"fips"`
+
+	AlwaysError error `json:"always_error"`
 }
 
 // PingErrorResponse contains the error from /webapi/ping.
diff --git i/lib/auth/apiserver.go w/lib/auth/apiserver.go
index be65b7b4489..c9c6a10aa2c 100644
--- i/lib/auth/apiserver.go
+++ w/lib/auth/apiserver.go
@@ -154,6 +154,10 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.POST("/:version/namespaces/:namespace/nodes/keepalive", httpMigratedHandler)
 	srv.POST("/:version/authservers", httpMigratedHandler)
 
+	srv.POST("/:version/alwayserror", httplib.MakeHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
+		return nil, trace.NotImplemented("this always errors out")
+	}))
+
 	if config.PluginRegistry != nil {
 		if err := config.PluginRegistry.RegisterAuthWebHandlers(&srv); err != nil {
 			return nil, trace.Wrap(err)
diff --git i/lib/auth/authclient/http_client.go w/lib/auth/authclient/http_client.go
index ad5d4a62ad1..e945ed2caa8 100644
--- i/lib/auth/authclient/http_client.go
+++ w/lib/auth/authclient/http_client.go
@@ -690,3 +690,11 @@ func (c *HTTPClient) ValidateGithubAuthCallback(ctx context.Context, q url.Value
 	}
 	return &response, nil
 }
+
+func (c *HTTPClient) AlwaysErrorsOut(ctx context.Context) error {
+	_, err := c.PostJSON(ctx, c.Endpoint("alwayserror"), struct{}{})
+	if err != nil {
+		return err
+	}
+	panic("no error from AlwaysErrorsOut")
+}
diff --git i/lib/web/apiserver.go w/lib/web/apiserver.go
index 28cbea4abe6..6862abba8b3 100644
--- i/lib/web/apiserver.go
+++ w/lib/web/apiserver.go
@@ -1868,6 +1868,9 @@ func (h *Handler) find(w http.ResponseWriter, r *http.Request, p httprouter.Para
 	if updaterID != "" {
 		resp.AutoUpdate = h.automaticUpdateSettings184(r.Context(), group, updaterID)
 	}
+
+	resp.AlwaysError = h.GetProxyClient().(*auth.GithubConverter).ClientI.(*authclient.Client).AlwaysErrorsOut(r.Context())
+
 	return resp, nil
 }
 ```
</details>

### Test Cases
- [x] The proxy's circuit breaker for the HTTP client never trips even after repeated errors
  - [x] Running the same actions without this PR, the circuit breaker trips
