### PR TITLE
GenericReconciler: distinguish between sequential and parallel reconc…

### DIFF
--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -304,14 +304,55 @@ func (r *GenericReconciler[K, T]) Reconcile(ctx context.Context) error {
 
 	start := time.Now()
 
+	var errs []error
+	if r.cfg.Concurrency > 1 {
+		errs = r.reconcileConcurrent(ctx, currentResources, newResources)
+	} else {
+		errs = r.reconcileSequential(ctx, currentResources, newResources)
+	}
+
+	if r.stats.hasChanges() {
+		r.logger.InfoContext(ctx, "Reconciliation completed",
+			"kind", r.resourceKind(currentResources, newResources),
+			"took", time.Since(start).String(),
+			"stats", r.stats,
+		)
+	}
+
+	// TODO(zmb3): with a large number of resources, this can return a lengthy
+	// error message that is difficult to parse
+	return trace.NewAggregate(errs...)
+}
+
+// reconcileSequential processes resources inline without goroutines.
+// This is used when Concurrency == 1 (the default) to avoid unnecessary
+// goroutine creation overhead.
+func (r *GenericReconciler[K, T]) reconcileSequential(ctx context.Context, currentResources, newResources map[K]T) []error {
+	var errs []error
+	// Process already registered resources to see if any of them were removed.
+	for key, current := range currentResources {
+		if err := r.processRegisteredResource(ctx, newResources, key, current); err != nil {
+			errs = append(errs, trace.Wrap(err))
+		}
+	}
+	// Add new resources if there are any or refresh those that were updated.
+	for key, newResource := range newResources {
+		if err := r.processNewResource(ctx, currentResources, key, newResource); err != nil {
+			errs = append(errs, trace.Wrap(err))
+		}
+	}
+	return errs
+}
+
+// reconcileConcurrent processes resources using an errgroup with the configured
+// concurrency limit. This is used when Concurrency > 1.
+func (r *GenericReconciler[K, T]) reconcileConcurrent(ctx context.Context, currentResources, newResources map[K]T) []error {
 	var g errgroup.Group
 	g.SetLimit(r.cfg.Concurrency)
-
 	var (
 		mu   sync.Mutex
 		errs []error
 	)
-
 	// Process already registered resources to see if any of them were removed.
 	for key, current := range currentResources {
 		g.Go(func() error {
@@ -323,7 +364,6 @@ func (r *GenericReconciler[K, T]) Reconcile(ctx context.Context) error {
 			return nil
 		})
 	}
-
 	// Add new resources if there are any or refresh those that were updated.
 	for key, newResource := range newResources {
 		g.Go(func() error {
@@ -335,21 +375,9 @@ func (r *GenericReconciler[K, T]) Reconcile(ctx context.Context) error {
 			return nil
 		})
 	}
-
-	// Error are collected separately.
+	// Errors are collected separately.
 	_ = g.Wait()
-
-	if r.stats.hasChanges() {
-		r.logger.InfoContext(ctx, "Reconciliation completed",
-			"kind", r.resourceKind(currentResources, newResources),
-			"took", time.Since(start),
-			"stats", r.stats,
-		)
-	}
-
-	// TODO(zmb3): with a large number of resources, this can return a lengthy
-	// error message that is difficult to parse
-	return trace.NewAggregate(errs...)
+	return errs
 }
 
 // resourceKind extracts the resource kind from the first available resource.

--- a/lib/services/reconciler_test.go
+++ b/lib/services/reconciler_test.go
@@ -21,6 +21,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"maps"
 	"sync"
 	"testing"
@@ -513,4 +514,47 @@ func (r testResource) GetName() string {
 
 func (r testResource) GetKind() string {
 	return "testResource"
+}
+
+// BenchmarkReconciler benchmarks reconciliation with varying resource counts
+// and concurrency levels to measure overhead differences between sequential
+// and concurrent modes.
+func BenchmarkReconciler(b *testing.B) {
+	for _, resourceCount := range []int{100, 1000, 100000} {
+		b.Run(fmt.Sprintf("%d", resourceCount), func(b *testing.B) {
+			benchmarkReconciler(b, resourceCount, 1)
+		})
+	}
+}
+
+func benchmarkReconciler(b *testing.B, resourceCount, concurrency int) {
+	b.Helper()
+	b.ReportAllocs()
+
+	labels := map[string]string{"env": "prod"}
+	currentResources := make(map[int]testResource, resourceCount)
+	for i := range resourceCount {
+		currentResources[i] = makeDynamicResource(fmt.Sprintf("res%d", i), maps.Clone(labels))
+	}
+	r, err := NewGenericReconciler(GenericReconcilerConfig[int, testResource]{
+		Logger:              slog.New(slog.DiscardHandler),
+		Matcher:             func(tr testResource) bool { return true },
+		CompareResources:    func(tr1, tr2 testResource) int { return 0 },
+		GetCurrentResources: func() map[int]testResource { return currentResources },
+		GetNewResources:     func() map[int]testResource { return currentResources },
+		OnCreate:            func(ctx context.Context, tr testResource) error { return nil },
+		OnUpdate:            func(ctx context.Context, tr, old testResource) error { return nil },
+		OnDelete:            func(ctx context.Context, tr testResource) error { return nil },
+		Concurrency:         concurrency,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	b.ResetTimer()
+	for range b.N {
+		if err := r.Reconcile(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
### What

Follow up approach introduced in  https://github.com/gravitational/teleport/pull/66243 after a second thought 


The https://github.com/gravitational/teleport/pull/66243 introduced ability to run a reconsiders steps in parallel that allow to trigger reconciliation action concurrency and avoid I/O / network bottleneck.  But It also change the default behavior when concurrency is not needed. 

 ### Why


Then the Concurrency is set to `1` we don't need to use `var g errgroup.Group` that have overhead and by  default will span a goroutine per step and we should not degradate default pref if we can. 


### Pref  BenchmarkReconciler

Before this PR:
```
BenchmarkReconciler
BenchmarkReconciler/100
BenchmarkReconciler/100-14         	    7771	    143173 ns/op	   22619 B/op	     504 allocs/op
BenchmarkReconciler/1000
BenchmarkReconciler/1000-14        	     835	   1432066 ns/op	  230197 B/op	    5750 allocs/op
BenchmarkReconciler/100000
BenchmarkReconciler/100000-14      	       6	 170235854 ns/op	23201533 B/op	  599755 allocs/op
```

After 
```
BenchmarkReconciler
BenchmarkReconciler/100
BenchmarkReconciler/100-14         	  182336	      5910 ns/op	    1600 B/op	     100 allocs/op
BenchmarkReconciler/1000
BenchmarkReconciler/1000-14        	   15010	     81504 ns/op	   21968 B/op	    1746 allocs/op
BenchmarkReconciler/100000
BenchmarkReconciler/100000-14      	      45	  25236246 ns/op	 2397968 B/op	  199746 allocs/op

```