### PR TITLE
Split MS Graph endpoint validation into separate functions

### DIFF
--- a/api/types/msgraph.go
+++ b/api/types/msgraph.go
@@ -41,18 +41,34 @@ var (
 	}
 )
 
-// ValidateMSGraphEndpoints checks if API endpoints point to one of the official deployments of
+// ValidateMSGraphAndLoginEndpoints checks if API endpoints point to one of the official deployments of
 // the Microsoft identity platform and Microsoft Graph.
 // https://learn.microsoft.com/en-us/graph/deployments
-func ValidateMSGraphEndpoints(loginEndpoint, graphEndpoint string) error {
-	if loginEndpoint != "" && !slices.Contains(validLoginEndpoints, loginEndpoint) {
-		return trace.BadParameter("expected login endpoint to be one of %q, got %q", validLoginEndpoints, loginEndpoint)
+func ValidateMSGraphAndLoginEndpoints(loginEndpoint, graphEndpoint string) error {
+	if err := ValidateMSGraphEndpoint(graphEndpoint); err != nil {
+		return trace.Wrap(err)
 	}
 
+	if err := ValidateMSLoginEndpoint(loginEndpoint); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// ValidateMSGraphEndpoint checks if the given endpoint points to a valid MS Graph endpoint.
+func ValidateMSGraphEndpoint(graphEndpoint string) error {
 	if graphEndpoint != "" && !slices.Contains(validGraphEndpoints, graphEndpoint) {
 		return trace.BadParameter("expected graph endpoint to be one of %q, got %q", validGraphEndpoints, graphEndpoint)
 	}
+	return nil
+}
 
+// ValidateMSLoginEndpoint checks if the given endpoint points to a valid MS login endpoint.
+func ValidateMSLoginEndpoint(loginEndpoint string) error {
+	if loginEndpoint != "" && !slices.Contains(validLoginEndpoints, loginEndpoint) {
+		return trace.BadParameter("expected login endpoint to be one of %q, got %q", validLoginEndpoints, loginEndpoint)
+	}
 	return nil
 }
 
@@ -82,10 +98,7 @@ func (e *EntraIDGroupsProvider) checkAndSetDefaults() error {
 		}
 	}
 
-	// Pass empty string for login endpoint option, only Graph endpoint applicable to EntraIDGroupsProvider.
-	// TODO(nixpig): Refactor ValidateMSGraphEndpoints. Split out into two separate validation functions.
-	// One for Graph endpoint and one for login endpoint.
-	if err := ValidateMSGraphEndpoints("", e.GraphEndpoint); err != nil {
+	if err := ValidateMSGraphEndpoint(e.GraphEndpoint); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/api/types/msgraph.go
+++ b/api/types/msgraph.go
@@ -57,6 +57,7 @@ func ValidateMSGraphAndLoginEndpoints(loginEndpoint, graphEndpoint string) error
 }
 
 // ValidateMSGraphEndpoint checks if the given endpoint points to a valid MS Graph endpoint.
+// Note: An empty string is considered valid to maintain backward compatibility.
 func ValidateMSGraphEndpoint(graphEndpoint string) error {
 	if graphEndpoint != "" && !slices.Contains(validGraphEndpoints, graphEndpoint) {
 		return trace.BadParameter("expected graph endpoint to be one of %q, got %q", validGraphEndpoints, graphEndpoint)
@@ -65,6 +66,7 @@ func ValidateMSGraphEndpoint(graphEndpoint string) error {
 }
 
 // ValidateMSLoginEndpoint checks if the given endpoint points to a valid MS login endpoint.
+// Note: An empty string is considered valid to maintain backward compatibility.
 func ValidateMSLoginEndpoint(loginEndpoint string) error {
 	if loginEndpoint != "" && !slices.Contains(validLoginEndpoints, loginEndpoint) {
 		return trace.BadParameter("expected login endpoint to be one of %q, got %q", validLoginEndpoints, loginEndpoint)

--- a/api/types/msgraph_test.go
+++ b/api/types/msgraph_test.go
@@ -59,7 +59,63 @@ func TestValidateMSGraphEndpoints(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.errAssertion(t, ValidateMSGraphEndpoints(tt.loginEndpoint, tt.graphEndpoint))
+			tt.errAssertion(t, ValidateMSGraphAndLoginEndpoints(tt.loginEndpoint, tt.graphEndpoint))
+		})
+	}
+}
+
+func TestValidateMSGraphEndpoint(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		graphEndpoint string
+		errAssertion  require.ErrorAssertionFunc
+	}{
+		{
+			name:          "valid endpoint",
+			graphEndpoint: "https://graph.microsoft.com",
+			errAssertion:  require.NoError,
+		},
+		{
+			name:          "invalid endpoint",
+			graphEndpoint: "https://graph.windows.net",
+			errAssertion:  require.Error,
+		},
+		{
+			name:          "empty value",
+			graphEndpoint: "",
+			errAssertion:  require.NoError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.errAssertion(t, ValidateMSGraphEndpoint(tt.graphEndpoint))
+		})
+	}
+}
+
+func TestValidateMSLoginEndpoint(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		loginEndpoint string
+		errAssertion  require.ErrorAssertionFunc
+	}{
+		{
+			name:          "valid endpoint",
+			loginEndpoint: "https://login.microsoftonline.com",
+			errAssertion:  require.NoError,
+		},
+		{
+			name:          "invalid endpoint",
+			loginEndpoint: "https://login.microsoft.com",
+			errAssertion:  require.Error,
+		},
+		{
+			name:          "empty value",
+			loginEndpoint: "",
+			errAssertion:  require.NoError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.errAssertion(t, ValidateMSLoginEndpoint(tt.loginEndpoint))
 		})
 	}
 }

--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -821,7 +821,6 @@ const (
 )
 
 func (c *PluginAWSICSettings) CheckAndSetDefaults() error {
-
 	// Handle legacy records that pre-date the polymorphic Credentials settings
 	// TODO(tcsc): remove this check in v19
 	if c.Credentials == nil {
@@ -1046,7 +1045,7 @@ func (c *PluginIntuneSettings) Validate() error {
 		return trace.BadParameter("tenant must be set")
 	}
 
-	if err := ValidateMSGraphEndpoints(c.LoginEndpoint, c.GraphEndpoint); err != nil {
+	if err := ValidateMSGraphAndLoginEndpoints(c.LoginEndpoint, c.GraphEndpoint); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/msgraph/client.go
+++ b/lib/msgraph/client.go
@@ -138,7 +138,7 @@ func (cfg *Config) Validate() error {
 	if cfg.HTTPClient == nil {
 		return trace.BadParameter("HTTPClient must be set")
 	}
-	if err := types.ValidateMSGraphEndpoints("", cfg.GraphEndpoint); err != nil {
+	if err := types.ValidateMSGraphEndpoint(cfg.GraphEndpoint); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil


### PR DESCRIPTION
This change refactors MS Graph endpoint checks so Login and Graph endpoints can be checked independently to avoid passing empty strings to function call. 

No test plan, since no observable changes. 