### PR TITLE
Use the actual request id in the tsh login hint

### DIFF
--- a/docs/pages/identity-governance/access-requests/resource-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/resource-requests.mdx
@@ -181,7 +181,7 @@ Reason:     "responding to incident 123"
 Reviewers:  [none] (suggested)
 Status:     PENDING
 
-hint: use 'tsh login --request-id=f406f5d8-3c2a-428f-8547-a1d091a4ddab' to login once the request is approved
+hint: use 'tsh login --request-id=f406f5d8-3c2a-428f-8547-a1d091a4ddab' to log in once the request is approved
 
 Waiting for request approval...
 
@@ -208,7 +208,7 @@ f406f5d8-3c2a-428f-8547-a1d091a4ddab alice access ["/teleport.example.... [+] 23
 [+] Requested resources truncated, use `tsh request show <request-id>` to view the full list
 
 hint: use 'tsh request show <request-id>' for additional details
-      use 'tsh login --request-id=<request-id>' to login with an approved request
+      use 'tsh login --request-id=<request-id>' to log in with an approved request
 $ tsh request show f406f5d8-3c2a-428f-8547-a1d091a4ddab
 Request ID: f406f5d8-3c2a-428f-8547-a1d091a4ddab
 Username:   alice
@@ -218,7 +218,7 @@ Reason:     "responding to incident 123"
 Reviewers:  [none] (suggested)
 Status:     PENDING
 
-hint: use 'tsh login --request-id=f406f5d8-3c2a-428f-8547-a1d091a4ddab' to login once the request is approved
+hint: use 'tsh login --request-id=f406f5d8-3c2a-428f-8547-a1d091a4ddab' to log in once the request is approved
 $ tsh request review --approve f406f5d8-3c2a-428f-8547-a1d091a4ddab
 Successfully submitted review.  Request state: APPROVED
 ```
@@ -245,7 +245,7 @@ Reason:     "responding to incident 123"
 Reviewers:  [none] (suggested)
 Status:     PENDING
 
-hint: use 'tsh login --request-id=f406f5d8-3c2a-428f-8547-a1d091a4ddab' to login once the request is approved
+hint: use 'tsh login --request-id=f406f5d8-3c2a-428f-8547-a1d091a4ddab' to log in once the request is approved
 
 Waiting for request approval...
 
@@ -306,7 +306,7 @@ Reason:     "please"
 Reviewers:  [none] (suggested)
 Status:     PENDING
 
-hint: use 'tsh login --request-id=ab43fc70-e893-471b-872e-ae65eb24fd76' to login once the request is approved
+hint: use 'tsh login --request-id=ab43fc70-e893-471b-872e-ae65eb24fd76' to log in once the request is approved
 
 Waiting for request approval...
 

--- a/docs/pages/identity-governance/access-requests/resource-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/resource-requests.mdx
@@ -181,7 +181,7 @@ Reason:     "responding to incident 123"
 Reviewers:  [none] (suggested)
 Status:     PENDING
 
-hint: use 'tsh login --request-id=<request-id>' to login with an approved request
+hint: use 'tsh login --request-id=f406f5d8-3c2a-428f-8547-a1d091a4ddab' to login once the request is approved
 
 Waiting for request approval...
 
@@ -218,7 +218,7 @@ Reason:     "responding to incident 123"
 Reviewers:  [none] (suggested)
 Status:     PENDING
 
-hint: use 'tsh login --request-id=<request-id>' to login with an approved request
+hint: use 'tsh login --request-id=f406f5d8-3c2a-428f-8547-a1d091a4ddab' to login once the request is approved
 $ tsh request review --approve f406f5d8-3c2a-428f-8547-a1d091a4ddab
 Successfully submitted review.  Request state: APPROVED
 ```
@@ -245,7 +245,7 @@ Reason:     "responding to incident 123"
 Reviewers:  [none] (suggested)
 Status:     PENDING
 
-hint: use 'tsh login --request-id=<request-id>' to login with an approved request
+hint: use 'tsh login --request-id=f406f5d8-3c2a-428f-8547-a1d091a4ddab' to login once the request is approved
 
 Waiting for request approval...
 
@@ -306,7 +306,7 @@ Reason:     "please"
 Reviewers:  [none] (suggested)
 Status:     PENDING
 
-hint: use 'tsh login --request-id=<request-id>' to login with an approved request
+hint: use 'tsh login --request-id=ab43fc70-e893-471b-872e-ae65eb24fd76' to login once the request is approved
 
 Waiting for request approval...
 

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -256,7 +256,7 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 		}
 	}
 
-	fmt.Fprintf(cf.Stdout(), "\nhint: use 'tsh login --request-id=%s' to login once the request is approved\n", req.GetName())
+	fmt.Fprintf(cf.Stdout(), "\nhint: use 'tsh login --request-id=%s' to log in once the request is approved\n", req.GetName())
 	return nil
 }
 
@@ -383,7 +383,7 @@ func showRequestTable(cf *CLIConf, reqs []types.AccessRequest) error {
 	_, err := table.AsBuffer().WriteTo(cf.Stdout())
 
 	fmt.Fprintf(cf.Stdout(), "\nhint: use 'tsh request show <request-id>' for additional details\n")
-	fmt.Fprintf(cf.Stdout(), "      use 'tsh login --request-id=<request-id>' to login with an approved request\n")
+	fmt.Fprintf(cf.Stdout(), "      use 'tsh login --request-id=<request-id>' to log in with an approved request\n")
 	return trace.Wrap(err)
 }
 

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -47,8 +47,6 @@ import (
 	"github.com/gravitational/teleport/tool/common"
 )
 
-var requestLoginHint = "use 'tsh login --request-id=<request-id>' to login with an approved request"
-
 func onRequestList(cf *CLIConf) error {
 	tc, err := makeClient(cf)
 	if err != nil {
@@ -258,7 +256,7 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 		}
 	}
 
-	fmt.Fprintf(cf.Stdout(), "\nhint: %v\n", requestLoginHint)
+	fmt.Fprintf(cf.Stdout(), "\nhint: use 'tsh login --request-id=%s' to login once the request is approved\n", req.GetName())
 	return nil
 }
 
@@ -385,7 +383,7 @@ func showRequestTable(cf *CLIConf, reqs []types.AccessRequest) error {
 	_, err := table.AsBuffer().WriteTo(cf.Stdout())
 
 	fmt.Fprintf(cf.Stdout(), "\nhint: use 'tsh request show <request-id>' for additional details\n")
-	fmt.Fprintf(cf.Stdout(), "      %v\n", requestLoginHint)
+	fmt.Fprintf(cf.Stdout(), "      use 'tsh login --request-id=<request-id>' to login with an approved request\n")
 	return trace.Wrap(err)
 }
 

--- a/tool/tsh/common/access_request_test.go
+++ b/tool/tsh/common/access_request_test.go
@@ -382,8 +382,12 @@ func TestPrintRequest(t *testing.T) {
 				"testuser",
 				"Roles:",
 				"admin, developer",
+				"tsh login --request-id=basic-request",
 			},
-			wantAbsent: []string{"Resources:"},
+			wantAbsent: []string{
+				"Resources:",
+				"<request-id>",
+			},
 		},
 		{
 			name: "request with constrained AWS console resources",


### PR DESCRIPTION
Changelog: Changed the hint when requesting access to use the actual request ID

It's always a bit annoying when I need to quickly get access to a cluster during an incident that I can't just copy and paste the login command from the hint, but have to replace the `<request-id>`. This PR changes that:

before:
```
hint: use 'tsh login --request-id=<request-id>' to login with an approved request
```

after:
```
hint: use 'tsh login --request-id=f406f5d8-3c2a-428f-8547-a1d091a4ddab' to login once the request is approved
```