### PR TITLE
sessionsearch[25]: Register summarizer resource upserters

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1825,6 +1825,12 @@ func applyResources(ctx context.Context, service *Services, resources []types.Re
 			_, err = autoupdatev1.UpsertAutoUpdateVersion(ctx, service, r.UnwrapT())
 		case types.Resource153UnwrapperT[*summarizerv1.InferenceModel]:
 			_, err = service.Summarizer.UpsertInferenceModel(ctx, r.UnwrapT())
+		case types.Resource153UnwrapperT[*summarizerv1.InferencePolicy]:
+			_, err = service.Summarizer.UpsertInferencePolicy(ctx, r.UnwrapT())
+		case types.Resource153UnwrapperT[*summarizerv1.InferenceSecret]:
+			_, err = service.Summarizer.UpsertInferenceSecret(ctx, r.UnwrapT())
+		case types.Resource153UnwrapperT[*summarizerv1.RetrievalModel]:
+			_, err = service.Summarizer.UpsertRetrievalModel(ctx, r.UnwrapT())
 		case types.Resource153UnwrapperT[*workloadidentityv1.WorkloadIdentity]:
 			_, err = service.WorkloadIdentities.UpsertWorkloadIdentity(ctx, r.UnwrapT())
 		default:


### PR DESCRIPTION
Add resource upserter for inference policies, inference secrets, and retrieval models so these summarizer resources can be loaded through the shared resource registry and work with `--apply-on-startup`.


## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
