### PR TITLE
Update tbot/tctl command descriptions

### DIFF
--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -82,7 +82,7 @@ func Run(args []string, stdout io.Writer) error {
 	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-o <path>).")
 	configureCmd.Flag("output", "Path to write the generated configuration file to. If unspecified, the generated configuration is written to stdout.").Short('o').StringVar(&configureOutPath)
 
-	keypairCmd := app.Command("keypair", "Manage keypairs for bound-keypair joining")
+	keypairCmd := app.Command("keypair", "Manage keypairs for bound-keypair joining.")
 
 	// TODO: consider discarding config flag for non-legacy. These should always be self contained.
 

--- a/tool/tctl/common/bound_keypair_command.go
+++ b/tool/tctl/common/bound_keypair_command.go
@@ -42,7 +42,7 @@ type BoundKeypairCommand struct {
 }
 
 func (c *BoundKeypairCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
-	cmd := app.Command("bound-keypair", "Manage bound-keypair joining tokens")
+	cmd := app.Command("bound-keypair", "Manage bound-keypair joining tokens.")
 
 	c.requestRotation = cmd.Command("request-rotation", "Request a keypair rotation on the next join attempt.")
 	c.requestRotation.Arg("name", "The name of the token").Required().StringVar(&c.token)

--- a/tool/tctl/common/scoped_command.go
+++ b/tool/tctl/common/scoped_command.go
@@ -51,7 +51,7 @@ type ScopedCommand struct {
 
 // Initialize allows ScopedCommand to plug itself into the CLI parser
 func (c *ScopedCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, _ *servicecfg.Config) {
-	scoped := app.Command("scoped", "Run a subcommand using scoped auth").Alias("scopes")
+	scoped := app.Command("scoped", "Run a subcommand using scoped auth.").Alias("scopes")
 
 	if c.Stdout == nil {
 		c.Stdout = os.Stdout
@@ -84,7 +84,7 @@ type scopedStatusCommand struct {
 
 func (c *scopedStatusCommand) initialize(parent *kingpin.CmdClause, stdout io.Writer) {
 	c.stdout = stdout
-	c.cmd = parent.Command("status", "Show the status of scoped resources")
+	c.cmd = parent.Command("status", "Show the status of scoped resources.")
 }
 
 func (c *scopedStatusCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {


### PR DESCRIPTION
Descriptions were missing `.` per convention.


## Manual Test Plan
### Test Environment

   Dev env

### Test Cases
- [x] Confirm `tbot` has updated description text 
- [x] Confirm `tctl` has updated description text 
