### PR TITLE
[v17] adding missing # to version heading, as it affects the release notes …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 17.7.23 (04/29/26)
+## 17.7.23 (04/29/26)
 ### Security fixes
 
 This patch addresses two security vulnerabilities.


### PR DESCRIPTION
Fix changelog heading for v17.7.23

The v17.7.23 changelog entry used a top-level `#` heading instead of the expected `##` release heading.

This affects the CHANGELOG parser, i.e cause the `make create-github-release` command to skip the v17.7.23 entry  

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
