### PR TITLE
docs: fix k8s operator link for pre-reqs

### DIFF
--- a/docs/pages/includes/iac-clients.mdx
+++ b/docs/pages/includes/iac-clients.mdx
@@ -2,4 +2,4 @@ One of the following client tools for managing Teleport resources:
 
 - The `tctl` CLI, which you can install along with Teleport on your workstation ([documentation](../installation/single-machine/single-machine.mdx)) on your workstation.
 - [Teleport Terraform provider](../zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx)
-- [Teleport Kubernetes operator](../zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx)
+- [Teleport Kubernetes operator](../zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator.mdx)


### PR DESCRIPTION

Link went to terraform provider, not k8s operator.