### PR TITLE
Set the force flag for CA overrides on "tctl create -f"

### DIFF
--- a/tool/tctl/common/resources/cert_authority_override.go
+++ b/tool/tctl/common/resources/cert_authority_override.go
@@ -174,7 +174,8 @@ func createCertAuthorityOverride(ctx context.Context,
 	var action string
 	if opts.Force {
 		resp, err1 := subCA.UpsertCertAuthorityOverride(ctx, &subcav1.UpsertCertAuthorityOverrideRequest{
-			CaOverride: caOverride,
+			CaOverride:            caOverride,
+			ForceImmediateDisable: true,
 		})
 		created = resp.GetCaOverride()
 		err = err1


### PR DESCRIPTION
Correctly set the --force flag, otherwise "tctl create -f" won't work as intended when force is needed.

https://github.com/gravitational/teleport.e/issues/7675

## Manual Test Plan
### Test Environment
Local environment build using `-tags=subca`.

### Test Cases
- [x] `tctl create -f` applies force
