### PR TITLE
Adding no-test-plan label to post-release AMI update PR

### DIFF
--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -50,6 +50,6 @@ create-update-pr: update-ami-ids-terraform
 	git checkout -b $(AUTO_BRANCH_NAME)
 	git commit -am "[auto] Update AMI IDs for $(TELEPORT_VERSION)"
 	git push --set-upstream origin $(AUTO_BRANCH_NAME)
-	gh pr create --fill --label=automated --label=terraform --label=no-changelog --label no-test-plan $(if $(AMI_PR_REVIEWER),--reviewer=$(AMI_PR_REVIEWER))
+	gh pr create --fill --label=automated,terraform,no-changelog-no-test-plan $(if $(AMI_PR_REVIEWER),--reviewer=$(AMI_PR_REVIEWER))
 	# enable auto-merge
 	gh pr merge --auto --squash

--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -50,6 +50,6 @@ create-update-pr: update-ami-ids-terraform
 	git checkout -b $(AUTO_BRANCH_NAME)
 	git commit -am "[auto] Update AMI IDs for $(TELEPORT_VERSION)"
 	git push --set-upstream origin $(AUTO_BRANCH_NAME)
-	gh pr create --fill --label=automated --label=terraform --label=no-changelog $(if $(AMI_PR_REVIEWER),--reviewer=$(AMI_PR_REVIEWER))
+	gh pr create --fill --label=automated --label=terraform --label=no-changelog --label no-test-plan $(if $(AMI_PR_REVIEWER),--reviewer=$(AMI_PR_REVIEWER))
 	# enable auto-merge
 	gh pr merge --auto --squash

--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -50,6 +50,6 @@ create-update-pr: update-ami-ids-terraform
 	git checkout -b $(AUTO_BRANCH_NAME)
 	git commit -am "[auto] Update AMI IDs for $(TELEPORT_VERSION)"
 	git push --set-upstream origin $(AUTO_BRANCH_NAME)
-	gh pr create --fill --label=automated,terraform,no-changelog-no-test-plan $(if $(AMI_PR_REVIEWER),--reviewer=$(AMI_PR_REVIEWER))
+	gh pr create --fill --label=automated,terraform,no-changelog,no-test-plan $(if $(AMI_PR_REVIEWER),--reviewer=$(AMI_PR_REVIEWER))
 	# enable auto-merge
 	gh pr merge --auto --squash


### PR DESCRIPTION
Post release automation AMI Update PR was failing the PR status related to manual test plan checks. This adds the `no-test-plan` label to the PRs as they don't have any test plans and will pass the PR status.

As an example of such a PR: https://github.com/gravitational/teleport/pull/66336/changes

## Manual Test Plan

N/A - not sure if there's an easy way to test this without going through an entire release