### PR TITLE
docs: fix amazon ecs variable option

### DIFF
--- a/docs/pages/installation/agents/amazon-ecs.mdx
+++ b/docs/pages/installation/agents/amazon-ecs.mdx
@@ -33,7 +33,7 @@ The following set up is required:
 
 Download the source code for our example:
 ```code
-$ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
+$ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=) --depth=1
 $ cd teleport/examples/aws/terraform/ecs-agent
 ```
 

--- a/docs/pages/installation/agents/amazon-ecs.mdx
+++ b/docs/pages/installation/agents/amazon-ecs.mdx
@@ -116,7 +116,7 @@ Pick an example depending on your use case.
         {
           labels = {
             "region"                                 = "eu-south-2"
-            "account-id"                             = data.aws_caller_identity.current.account_id
+            "account-id"                             = "(=aws.aws_account_id=)"
             "teleport.dev/cloud"                     = "AWS"
             "teleport.dev/discovery-type"            = "eks"
             "teleport.internal/discovery-group-name" = "discover-eks"


### PR DESCRIPTION
You can't use variables in a .tfvars file. You get the below error.  Also updated to only pull one depth instead of the entire repo.


```
│ Error: Variables not allowed
│
│   on my-deployment.tfvars line 64:
│   64:           "account-id"                             = data.aws_caller_identity.current.account_id
│
│ Variables may not be used here.
```