### PR TITLE
Deduplicating kube clusters within scope boundaries during `ListResources`

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -5530,7 +5530,12 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	testNames := []string{"a", "b", "c", "d"}
+	testNames := []string{
+		// unscoped cluster names
+		"a", "b", "c", "d",
+		// scoped cluster names
+		"a", "b", "c",
+	}
 
 	// Add a kube service with 3 clusters.
 	createKubeServer(t, srv.Auth(), []string{"d", "b", "a"}, "host1", "")
@@ -5562,8 +5567,11 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, res.Resources, len(testNames))
 		require.Empty(t, res.NextKey)
-		// There are 4 unique clusters across all kube services.
-		require.Equal(t, 4, res.TotalCount)
+		// There are 4 unique clusters names total (a, b, c, and d)
+		// The two unscoped kube servers reference 5 clusters combined, but will be deduplicated to a count of 4.
+		// The two scoped kube servers reference 4 clusters combined, but will be deduplicated down to a count of 3.
+		// Deduplication does not cross scope boundaries, so we expect a total of 7 clusters.
+		require.Equal(t, 7, res.TotalCount)
 
 		clusters, err := types.ResourcesWithLabels(res.Resources).AsKubeClusters()
 		require.NoError(t, err)
@@ -5615,7 +5623,7 @@ func TestListResources_KindKubernetesCluster(t *testing.T) {
 		require.NoError(t, err)
 		names, err := types.KubeClusters(clusters).GetFieldVals(types.ResourceMetadataName)
 		require.NoError(t, err)
-		require.IsDecreasing(t, names)
+		require.IsNonIncreasing(t, names, "expected kube cluster names to be non-increasing")
 	})
 
 	t.Run("fetch all scoped", func(t *testing.T) {
@@ -5693,7 +5701,8 @@ func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*scopedacce
 func createKubeServer(t *testing.T, s *auth.Server, clusterNames []string, hostID, scope string) {
 	for _, clusterName := range clusterNames {
 		kubeCluster, err := types.NewKubernetesClusterV3(types.Metadata{
-			Name: clusterName,
+			Name:        clusterName,
+			Description: hostID,
 		}, types.KubernetesClusterSpecV3{})
 		require.NoError(t, err)
 		kubeCluster.Scope = scope
@@ -5704,6 +5713,217 @@ func createKubeServer(t *testing.T, s *auth.Server, clusterNames []string, hostI
 
 		_, err = s.UpsertKubernetesServer(context.Background(), kubeServer)
 		require.NoError(t, err)
+	}
+}
+
+func TestListResourcesScopedPagination(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	ctx := t.Context()
+	srv := newTestTLSServer(t)
+
+	client, err := srv.NewClient(authtest.TestBuiltin(types.RoleProxy))
+	require.NoError(t, err)
+
+	makeScope := func(i int) string {
+		a := byte('a')
+		z := byte('z')
+		mod := int(z - a)
+		return fmt.Sprintf("/%c%c", a+byte(i/mod), a+byte(i%mod))
+	}
+
+	resourceCount := 50
+	for i := range resourceCount {
+		scope := makeScope(i)
+		// all kube clusters and servers will have the same name, so the only way to
+		// correctly paginate clusters is by scope
+		kubeServer := &types.KubernetesServerV3{
+			Kind:  types.KindKubeServer,
+			Scope: scope,
+			Metadata: types.Metadata{
+				Name:        "a",
+				Description: strconv.Itoa(i),
+			},
+			Spec: types.KubernetesServerSpecV3{
+				Cluster: &types.KubernetesClusterV3{
+					Scope: scope,
+					Metadata: types.Metadata{
+						Name:        "a",
+						Description: strconv.Itoa(i),
+					},
+				},
+				// kube servers will actually be paginated by host ID, so we need this
+				// to be unique
+				HostID: fmt.Sprintf("ks-%d", i),
+			},
+		}
+		_, err = srv.Auth().UpsertKubernetesServer(ctx, kubeServer)
+		require.NoError(t, err)
+
+		// create some scoped nodes to make sure we haven't introduced regressions
+		// for existing scoped resources
+		node := &types.ServerV2{
+			Kind:    types.KindNode,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name:        fmt.Sprintf("node-%d", i),
+				Description: strconv.Itoa(i),
+				Namespace:   apidefaults.Namespace,
+			},
+			Spec: types.ServerSpecV2{
+				Hostname: "node",
+			},
+			Scope: scope,
+		}
+		_, err = srv.Auth().UpsertNode(ctx, node)
+		require.NoError(t, err)
+
+		// create some databse servers as an unscoped control
+		db, err := types.NewDatabaseServerV3(types.Metadata{
+			Name:        "db",
+			Description: strconv.Itoa(i),
+		}, types.DatabaseServerSpecV3{
+			HostID:   fmt.Sprintf("db-%d", i),
+			Hostname: "hostname",
+			Database: &types.DatabaseV3{
+				Metadata: types.Metadata{
+					Name: "db",
+				},
+				Spec: types.DatabaseSpecV3{
+					Protocol: "postgres",
+					URI:      "postgres://user:password@host",
+				},
+			},
+		})
+		require.NoError(t, err)
+		_, err = srv.Auth().UpsertDatabaseServer(ctx, db)
+		require.NoError(t, err)
+	}
+
+	getIndex := func(resource types.ResourceWithLabels) (int, bool) {
+		switch res := resource.(type) {
+		case types.KubeCluster, types.KubeServer, types.Server, types.DatabaseServer:
+			id, err := strconv.Atoi(res.GetMetadata().Description)
+			return id, err == nil
+		default:
+			return -1, false
+		}
+	}
+
+	kinds := []string{types.KindKubeServer, types.KindKubernetesCluster, types.KindNode, types.KindDatabaseServer}
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			found := make(map[int]struct{})
+			// try a few different page sizes
+			for _, pageSize := range []int{1, 2, 3, 5, 8, 13, 21, resourceCount} {
+				startKey := ""
+				count := 0
+				for range resourceCount/pageSize + 1 {
+					res, err := client.ListResources(ctx, proto.ListResourcesRequest{
+						ResourceType: kind,
+						Limit:        int32(pageSize),
+						StartKey:     startKey,
+					})
+					require.NoError(t, err)
+					for _, r := range res.Resources {
+						idx, ok := getIndex(r)
+						require.True(t, ok)
+						found[idx] = struct{}{}
+						count++
+					}
+					startKey = res.NextKey
+					if startKey == "" {
+						break
+					}
+				}
+
+				// pagination was successful if we visited each resource exactly once and all indexes were
+				// added to the found map
+				assert.Equal(t, resourceCount, count)
+				for i := range resourceCount {
+					_, ok := found[i]
+					assert.True(t, ok, "no resource found for idx %d", i)
+				}
+				clear(found)
+			}
+		})
+	}
+}
+
+// TestListResourcesScopedPaginateKubeClusters tests that scoped kube clusters can be paginated properly even when
+// there are resources that will be deduplicated.
+func TestListResourcesPaginateKubeClusters(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	ctx := t.Context()
+	srv := newTestTLSServer(t)
+
+	client, err := srv.NewClient(authtest.TestBuiltin(types.RoleProxy))
+	require.NoError(t, err)
+
+	scopes := []string{"", "/aa", "/bb", "/cc", "/dd", "/ee", "/ff", "/gg", "/hh", "/ii"}
+	scopeChangeFreq := 5
+	const resourceCount = 50
+	for i := range resourceCount {
+		// cluster scopes will change every scopeChangeFreq clusters
+		scope := scopes[i/scopeChangeFreq]
+		// all kube clusters and servers will have the same name, so the only way to
+		// paginate them is by scope
+		kubeCluster, err := types.NewKubernetesClusterV3(types.Metadata{
+			Name:        "a",
+			Description: strconv.Itoa(i),
+		}, types.KubernetesClusterSpecV3{})
+		require.NoError(t, err)
+		kubeCluster.Scope = scope
+
+		kubeServer, err := types.NewKubernetesServerV3FromCluster(kubeCluster, "hostname", fmt.Sprintf("ks-%d", i))
+		require.NoError(t, err)
+		kubeServer.Metadata.Description = strconv.Itoa(i)
+
+		_, err = srv.Auth().UpsertKubernetesServer(ctx, kubeServer)
+		require.NoError(t, err)
+	}
+
+	found := make(map[string]struct{})
+	// Because duplicate clusters within a scope are dropped, we need to ensure we only ever receive one unique
+	// cluster per scope while paginating
+	uniqueResourceCount := resourceCount / scopeChangeFreq
+	// try a few different page sizes
+	for _, pageSize := range []int{1, 2, 3, 5, 8, 13, 21, resourceCount} {
+		startKey := ""
+		for page := range uniqueResourceCount/pageSize + 1 {
+			res, err := client.ListResources(ctx, proto.ListResourcesRequest{
+				ResourceType: types.KindKubernetesCluster,
+				Limit:        int32(pageSize),
+				StartKey:     startKey,
+			})
+			require.NoError(t, err)
+
+			// we should only get data from pages up to the uniqueResourceCount
+			if uniqueResourceCount-page*pageSize > pageSize {
+				require.Len(t, res.Resources, pageSize, "page=%d pageSize=%d", page, pageSize)
+			} else if uniqueResourceCount-page*pageSize > 0 {
+				require.Len(t, res.Resources, uniqueResourceCount-page*pageSize, "page=%d pageSize=%d", page, pageSize)
+			} else {
+				require.Empty(t, res.Resources)
+			}
+			for _, r := range res.Resources {
+				cluster, ok := r.(types.KubeCluster)
+				require.True(t, ok, "expected a kube cluster")
+				_, ok = found[cluster.GetScope()]
+				assert.False(t, ok) // we should only find each scope once per pageSize
+				found[cluster.GetScope()] = struct{}{}
+			}
+			startKey = res.NextKey
+			if startKey == "" {
+				break
+			}
+		}
+
+		// we should have found all scopes after fully paging through the data
+		for _, scope := range scopes {
+			_, ok := found[scope]
+			assert.True(t, ok, "no resource found for scope %q", scope)
+		}
+		clear(found)
 	}
 }
 

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -159,10 +159,15 @@ func ListKubeClustersWithFilters(ctx context.Context, p client.GetResourcesClien
 	return extractAndSortKubeClusters(kss), nil
 }
 
+type kubeClusterKey struct {
+	name  string
+	scope string
+}
+
 func extractAndSortKubeClusters(kss []types.KubeServer) []types.KubeCluster {
-	uniqueClusters := make(map[string]types.KubeCluster)
+	uniqueClusters := make(map[kubeClusterKey]types.KubeCluster)
 	for _, ks := range kss {
-		uniqueClusters[ks.GetName()] = ks.GetCluster()
+		uniqueClusters[kubeClusterKey{name: ks.GetName(), scope: ks.GetScope()}] = ks.GetCluster()
 	}
 	kubeClusters := make([]types.KubeCluster, 0, len(uniqueClusters))
 	for _, cluster := range uniqueClusters {

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	scopecache "github.com/gravitational/teleport/lib/scopes/cache"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 	"github.com/gravitational/teleport/lib/utils"
@@ -1554,6 +1555,27 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 	return &resp, nil
 }
 
+func getFakePaginationKey(ki backend.KeyedItem) string {
+	// TODO(eriktate/scopes): this will need to be reassessed when we implement scoped namespacing
+	if kubeCluster, ok := ki.(types.KubeCluster); ok {
+		if scope := kubeCluster.GetScope(); scope != "" {
+			// It should not be possible for EncodeStringToCursor to fail given that we've already
+			// confirmed the scope is non-empty and "@" is not a valid character for kube cluster
+			// names. However, in the case that it does fail for some reason, we fall back to
+			// backend.GetPaginationKey() since it will still work perfectly fine in lieu of
+			// duplicates cluster names across scope boundaries.
+			if key, err := scopecache.EncodeStringCursor(scopecache.Cursor[string]{
+				Key:   kubeCluster.GetName(),
+				Scope: scope,
+			}); err == nil {
+				return key
+			}
+		}
+	}
+
+	return backend.GetPaginationKey(ki)
+}
+
 // listResourcesWithSort supports sorting by falling back to retrieving all resources
 // with GetXXXs, filter, and then fake pagination.
 func (s *PresenceService) listResourcesWithSort(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
@@ -1775,7 +1797,7 @@ func FakePaginate(resources []types.ResourceWithLabels, req FakePaginateParams) 
 	// Trim resources that precede start key.
 	if req.StartKey != "" {
 		for i, resource := range filtered {
-			if backend.GetPaginationKey(resource) == req.StartKey {
+			if getFakePaginationKey(resource) == req.StartKey {
 				pageStart = i
 				break
 			}
@@ -1787,7 +1809,7 @@ func FakePaginate(resources []types.ResourceWithLabels, req FakePaginateParams) 
 	if pageEnd >= len(filtered) {
 		pageEnd = len(filtered)
 	} else {
-		nextKey = backend.GetPaginationKey(filtered[pageEnd])
+		nextKey = getFakePaginationKey(filtered[pageEnd])
 	}
 
 	return &types.ListResourcesResponse{

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 	"testing"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -1064,6 +1066,69 @@ func TestFakePaginate_TotalCount(t *testing.T) {
 		require.Empty(t, resp.NextKey)
 		require.Equal(t, 3, resp.TotalCount)
 	})
+}
+
+// TestFakePaginateWithScopes ensures that a resource scope can be used to
+// paginate resources with duplicate names.
+func TestFakePaginateWithScopes(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+	bend, err := memory.New(memory.Config{
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bend.Close() })
+
+	makeScope := func(i int) string {
+		a := byte('a')
+		z := byte('z')
+		mod := int(z - a)
+		return fmt.Sprintf("/%c%c", a+byte(i/mod), a+byte(i%mod))
+	}
+	newKubeCluster := func(i int) *types.KubernetesClusterV3 {
+		kubeCluster, err := types.NewKubernetesClusterV3(
+			types.Metadata{
+				Name: "cluster",
+				// we use the revision to easily tell the resources apart
+				Revision: strconv.Itoa(i),
+			},
+			types.KubernetesClusterSpecV3{},
+			types.KubeClusterWithScope(makeScope(i)),
+		)
+		require.NoError(t, err)
+		return kubeCluster
+	}
+
+	clusterCount := 100
+	// all kube clusters have the same name, so the only way to
+	// correctly paginate them is by scope
+	resources := make([]types.ResourceWithLabels, clusterCount)
+	for i := range clusterCount {
+		resources[i] = newKubeCluster(i)
+	}
+
+	for _, pageSize := range []int{1, 2, 3, 5, 8, 13, 21} {
+		startKey := ""
+		count := 0
+		for range clusterCount/pageSize + 1 {
+			res, err := FakePaginate(resources, FakePaginateParams{
+				ResourceType: types.KindKubernetesCluster,
+				Limit:        int32(pageSize),
+				Kinds:        []string{types.KindKubernetesCluster},
+				StartKey:     startKey,
+			})
+			require.NoError(t, err)
+			for _, r := range res.Resources {
+				assert.Equal(t, strconv.Itoa(count), r.GetRevision())
+				count++
+			}
+			startKey = res.NextKey
+			if startKey == "" {
+				break
+			}
+		}
+		require.Equal(t, clusterCount, count)
+	}
 }
 
 func TestPresenceService_CancelSemaphoreLease(t *testing.T) {

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	azureutils "github.com/gravitational/teleport/api/utils/azure"
+	"github.com/gravitational/teleport/lib/scopes"
 	libslices "github.com/gravitational/teleport/lib/utils/slices"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
@@ -144,7 +145,7 @@ func (r *resourceWithTargetHealth) GetTargetHealthStatus() types.TargetHealthSta
 // ResourceSeenKey is used as a key for a map that keeps track
 // of unique resource names and address. Currently "addr"
 // only applies to resource Application.
-type ResourceSeenKey struct{ name, kind, addr string }
+type ResourceSeenKey struct{ name, kind, addr, scope string }
 
 // MatchResourcesByFilters filters provided resources with profiled filter.
 func MatchResourcesByFilters[E types.ResourceWithLabels, S ~[]E](all S, filter MatchResourceFilter) (S, error) {
@@ -175,11 +176,19 @@ func MatchResourceByFilters(resource types.ResourceWithLabels, filter MatchResou
 	var specResource types.ResourceWithLabels
 	kind := resource.GetKind()
 
+	scope := ""
+	switch res := resource.(type) {
+	case *types.KubernetesClusterV3:
+		scope = res.GetScope()
+	case types.KubeServer:
+		scope = res.GetScope()
+	}
 	// We assume when filtering for services like KubeService, AppServer, and DatabaseServer
 	// the user is wanting to filter the contained resource ie. KubeClusters, Application, and Database.
 	key := ResourceSeenKey{
-		kind: kind,
-		name: resource.GetName(),
+		kind:  kind,
+		name:  resource.GetName(),
+		scope: scopes.NormalizeForEquality(scope),
 	}
 	switch kind {
 	case types.KindNode,

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -993,34 +993,34 @@ func (c *kubeLSCommand) showKubeClusters(w io.Writer, kubeClusters types.KubeClu
 	return nil
 }
 
-func getKubeClusterTextRow(kc types.KubeCluster, selectedCluster string, verbose bool) []string {
+func getKubeClusterTextRow(kc types.KubeCluster, selected, verbose bool) []string {
 	var selectedMark string
 	var row []string
-	if selectedCluster != "" && kc.GetName() == selectedCluster {
+	if selected {
 		selectedMark = "*"
 	}
 	displayName := common.FormatResourceName(kc, verbose)
 	labels := common.FormatLabels(kc.GetAllLabels(), verbose)
-	row = append(row, displayName, labels, selectedMark)
+	row = append(row, displayName, labels, kc.GetScope(), selectedMark)
 	return row
 }
 
 func formatKubeClustersAsText(kubeClusters types.KubeClusters, selectedCluster string, quiet, verbose bool) string {
 	var (
-		columns = []string{"Kube Cluster Name", "Labels", "Selected"}
+		columns = []string{"Kube Cluster Name", "Labels", "Scope", "Selected"}
 		t       asciitable.Table
 		rows    [][]string
 	)
 
 	for _, cluster := range kubeClusters {
-		r := getKubeClusterTextRow(cluster, selectedCluster, verbose)
+		r := getKubeClusterTextRow(cluster, isClusterSelected(kubeClusters, cluster, selectedCluster), verbose)
 		rows = append(rows, r)
 	}
 
 	switch {
 	case quiet:
-		// no column headers and only include the cluster name and labels.
-		t = asciitable.MakeHeadlessTable(2)
+		// no column headers and only include the cluster name, scope, and labels.
+		t = asciitable.MakeHeadlessTable(3)
 		for _, row := range rows {
 			t.AddRow(row)
 		}
@@ -1035,11 +1035,32 @@ func formatKubeClustersAsText(kubeClusters types.KubeClusters, selectedCluster s
 	return t.AsBuffer().String()
 }
 
+func isClusterSelected(kubeClusters []types.KubeCluster, cluster types.KubeCluster, selectedCluster string) bool {
+	if cluster.GetName() != selectedCluster {
+		return false
+	}
+
+	// if there are duplicate cluster names present in the list, we can't disambiguate so none of them should be
+	// selected
+	var found bool
+	for _, cl := range kubeClusters {
+		if cl.GetName() == cluster.GetName() {
+			if found {
+				return false
+			}
+			found = true
+		}
+	}
+
+	return true
+}
+
 func serializeKubeClusters(kubeClusters []types.KubeCluster, selectedCluster, format string) (string, error) {
 	type cluster struct {
 		KubeClusterName string            `json:"kube_cluster_name"`
 		Labels          map[string]string `json:"labels"`
 		Selected        bool              `json:"selected"`
+		Scope           string            `json:"scope"`
 	}
 	clusterInfo := make([]cluster, 0, len(kubeClusters))
 	for _, cl := range kubeClusters {
@@ -1050,7 +1071,8 @@ func serializeKubeClusters(kubeClusters []types.KubeCluster, selectedCluster, fo
 		clusterInfo = append(clusterInfo, cluster{
 			KubeClusterName: cl.GetName(),
 			Labels:          labels,
-			Selected:        cl.GetName() == selectedCluster,
+			Selected:        isClusterSelected(kubeClusters, cl, selectedCluster),
+			Scope:           cl.GetScope(),
 		})
 	}
 	var out []byte
@@ -1150,7 +1172,7 @@ func (c *kubeLSCommand) runAllClusters(cf *CLIConf) error {
 
 func formatKubeListingsAsText(listings kubeListings, quiet, verbose bool) string {
 	var (
-		columns = []string{"Proxy", "Cluster", "Kube Cluster Name", "Labels"}
+		columns = []string{"Proxy", "Cluster", "Kube Cluster Name", "Labels", "Scope"}
 		t       asciitable.Table
 		rows    [][]string
 	)
@@ -1158,14 +1180,14 @@ func formatKubeListingsAsText(listings kubeListings, quiet, verbose bool) string
 		r := append([]string{
 			listing.Proxy,
 			listing.Cluster,
-		}, getKubeClusterTextRow(listing.KubeCluster, "", verbose)...)
+		}, getKubeClusterTextRow(listing.KubeCluster, false, verbose)...)
 		rows = append(rows, r)
 	}
 
 	switch {
 	case quiet:
 		// quiet, so no column headers.
-		t = asciitable.MakeHeadlessTable(4)
+		t = asciitable.MakeHeadlessTable(5)
 		for _, row := range rows {
 			t.AddRow(row)
 		}
@@ -1388,15 +1410,18 @@ func matchClustersByNameOrDiscoveredName(name string, clusters types.KubeCluster
 		return clusters
 	}
 
-	// look for an exact full name match.
+	// look for exact full name matches.
+	var out types.KubeClusters
 	for _, kc := range clusters {
 		if kc.GetName() == name {
-			return types.KubeClusters{kc}
+			out = append(out, kc)
 		}
+	}
+	if len(out) > 0 {
+		return out
 	}
 
 	// or look for exact "discovered name" matches.
-	var out types.KubeClusters
 	for _, kc := range clusters {
 		discoveredName, ok := kc.GetLabel(types.DiscoveredNameLabel)
 		if ok && discoveredName == name {

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -209,10 +209,10 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 				// p.rootKubeCluster2 ("first-cluster") should appear before
 				// p.rootKubeCluster1 ("root-cluster") after sorting.
 				table := asciitable.MakeTableWithTruncatedColumn(
-					[]string{"Kube Cluster Name", "Labels", "Selected"},
+					[]string{"Kube Cluster Name", "Labels", "Scope", "Selected"},
 					[][]string{
-						{p.rootKubeCluster2, formattedRootLabels, ""},
-						{p.rootKubeCluster1, formattedRootLabels, ""},
+						{p.rootKubeCluster2, formattedRootLabels, "", ""},
+						{p.rootKubeCluster1, formattedRootLabels, "", ""},
 					},
 					"Labels")
 				return table.AsBuffer().String()
@@ -223,9 +223,9 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 			args: []string{"--verbose"},
 			wantTable: func() string {
 				table := asciitable.MakeTable(
-					[]string{"Kube Cluster Name", "Labels", "Selected"},
-					[]string{p.rootKubeCluster2, formattedRootLabelsVerbose, ""},
-					[]string{p.rootKubeCluster1, formattedRootLabelsVerbose, ""})
+					[]string{"Kube Cluster Name", "Labels", "Scope", "Selected"},
+					[]string{p.rootKubeCluster2, formattedRootLabelsVerbose, "", ""},
+					[]string{p.rootKubeCluster1, formattedRootLabelsVerbose, "", ""})
 				return table.AsBuffer().String()
 			},
 		},
@@ -233,7 +233,7 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 			name: "show headless table",
 			args: []string{"--quiet"},
 			wantTable: func() string {
-				table := asciitable.MakeHeadlessTable(2)
+				table := asciitable.MakeHeadlessTable(3)
 				table.AddRow([]string{p.rootKubeCluster2, formattedRootLabels, ""})
 				table.AddRow([]string{p.rootKubeCluster1, formattedRootLabels, ""})
 
@@ -245,15 +245,15 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 			args: []string{"--all"},
 			wantTable: func() string {
 				table := asciitable.MakeTableWithTruncatedColumn(
-					[]string{"Proxy", "Cluster", "Kube Cluster Name", "Labels"},
+					[]string{"Proxy", "Cluster", "Kube Cluster Name", "Labels", "Scope"},
 					[][]string{
 						// "leaf-cluster" should be displayed instead of the
 						// full leaf cluster name, since it is mocked as a
 						// discovered resource and the discovered resource name
 						// is displayed in non-verbose mode.
-						{p.root.Config.Proxy.WebAddr.String(), "leaf1", "leaf-cluster", formattedLeafLabels},
-						{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabels},
-						{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabels},
+						{p.root.Config.Proxy.WebAddr.String(), "leaf1", "leaf-cluster", formattedLeafLabels, ""},
+						{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabels, ""},
+						{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabels, ""},
 					},
 					"Labels",
 				)
@@ -265,10 +265,10 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 			args: []string{"--all", "--verbose"},
 			wantTable: func() string {
 				table := asciitable.MakeTable(
-					[]string{"Proxy", "Cluster", "Kube Cluster Name", "Labels"},
-					[]string{p.root.Config.Proxy.WebAddr.String(), "leaf1", p.leafKubeCluster, formattedLeafLabelsVerbose},
-					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabelsVerbose},
-					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabelsVerbose},
+					[]string{"Proxy", "Cluster", "Kube Cluster Name", "Labels", "Scope"},
+					[]string{p.root.Config.Proxy.WebAddr.String(), "leaf1", p.leafKubeCluster, formattedLeafLabelsVerbose, ""},
+					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabelsVerbose, ""},
+					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabelsVerbose, ""},
 				)
 				return table.AsBuffer().String()
 			},
@@ -277,10 +277,10 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 			name: "list all clusters including leaf clusters in headless table",
 			args: []string{"--all", "--quiet"},
 			wantTable: func() string {
-				table := asciitable.MakeHeadlessTable(4)
-				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "leaf1", "leaf-cluster", formattedLeafLabels})
-				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabels})
-				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabels})
+				table := asciitable.MakeHeadlessTable(5)
+				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "leaf1", "leaf-cluster", formattedLeafLabels, ""})
+				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabels, ""})
+				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabels, ""})
 				return table.AsBuffer().String()
 			},
 		},

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5520,12 +5520,14 @@ func TestSerializeKubeClusters(t *testing.T) {
 		{
 			"kube_cluster_name": "cluster1",
 			"labels": {"cmd": "result", "foo": "bar"},
-			"selected": true
+			"selected": true,
+			"scope": ""
 		},
 		{
 			"kube_cluster_name": "cluster2",
 			"labels": null,
-			"selected": false
+			"selected": false,
+			"scope": "/test"
 		}
 	]
 	`
@@ -5550,6 +5552,7 @@ func TestSerializeKubeClusters(t *testing.T) {
 			Name: "cluster2",
 		},
 		types.KubernetesClusterSpecV3{},
+		types.KubeClusterWithScope("/test"),
 	)
 
 	require.NoError(t, err)


### PR DESCRIPTION
Now that kube clusters can be scoped, we need to deduplicate within scope boundaries when calling `ListResources`. This PR adds the scope to the `ResourceSeenKey` so that unscoped identities see all kube clusters that share the same name but are within different scopes.

The web UI will not be able to disambiguate until the unified resource cache supports scopes. This means the kube cluster you see in the web UI will most likely be the first cluster encountered with a matching name. We could consider omitting scoped kube clusters from the resources listed in the web UI, but I'm leaving as is until we can determine how best to handle it.

## Manual Test Plan
### Test Environment
Local teleport cluster with two kube agents serving the same kube cluster name in different scopes
### Test Cases
- [x] Login without specifying a scope
- [x] `tsh kube ls` should show both kube clusters
  - [x] Scopes are included in text, json, yaml format
  - [x] Scopes are included with `--quiet`
  - [x] Scopes are included with `--all`
- [x] Confirm listing other resources still works and respects pagination boundaries
  - [x] `Node`
  - [x] `KubeServers`
  - [x] `Database`
  - [x] `App`
  - [x] `Desktop`
  - [x] `GitServer`
