### PR TITLE
Correcting changelog to use the correct version that includes the security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Security fixes
 
 This release includes various security-related improvements and bug fixes. 
-We recommend that users on versions prior to v18.7.5 upgrade their Auth and Database Services to this latest release.
+We recommend that users on versions prior to v18.7.4 upgrade their Auth and Database Services to this latest release.
 For Teleport Cloud customers, your control plane has already been upgraded to a patched release.
 
 #### [High] Authorization bypass in encrypted session recordings


### PR DESCRIPTION
Updating the changelog entry for the latest version to identify the correct patched version for the security fixes. The fixes are patched in v18.7.4 and v18.7.5 was just a follow up to include extra features.