### PR TITLE
[v18] Fix display of SSO login errors

### DIFF
--- a/web/packages/teleport/src/Login/LoginFailed.test.tsx
+++ b/web/packages/teleport/src/Login/LoginFailed.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { MemoryRouter } from 'react-router';
+
+import {render, screen} from 'design/utils/testing';
+
+import cfg from 'teleport/config';
+
+import {LoginFailed} from './LoginFailed';
+
+test('callback error path shows callback error', () => {
+  render(<MemoryRouter initialEntries={[cfg.routes.loginErrorCallback]}><LoginFailed/></MemoryRouter>);
+  expect(screen.getByText('Unable to process SSO callback.')).toBeInTheDocument();
+})
+
+test('unauthorized error path shows unauthorized error', () => {
+  render(<MemoryRouter initialEntries={[cfg.routes.loginErrorUnauthorized]}><LoginFailed/></MemoryRouter>);
+  expect(screen.getByText('You are not authorized, please contact your SSO administrator.')).toBeInTheDocument();
+})
+
+test('groups overage error path shows groups overage error', () => {
+  render(<MemoryRouter initialEntries={[cfg.routes.loginErrorEntraIDGroupsOverage]}><LoginFailed/></MemoryRouter>);
+  expect(screen.getByText('Your account is a member of more than 150 Entra ID groups. Please contact your SSO administrator to configure Graph API access on the Teleport SAML connector.')).toBeInTheDocument();
+})

--- a/web/packages/teleport/src/Login/LoginFailed.test.tsx
+++ b/web/packages/teleport/src/Login/LoginFailed.test.tsx
@@ -18,28 +18,58 @@
 
 import { MemoryRouter } from 'react-router';
 
-import {render, screen} from 'design/utils/testing';
+import { render, screen } from 'design/utils/testing';
 
 import cfg from 'teleport/config';
 
 import { LoginFailed } from './LoginFailed';
 
 test('callback error path shows callback error', () => {
-  render(<MemoryRouter initialEntries={[cfg.routes.loginErrorCallback]}><LoginFailed/></MemoryRouter>);
-  expect(screen.getByText('Unable to process SSO callback.')).toBeInTheDocument();
-})
+  render(
+    <MemoryRouter initialEntries={[cfg.routes.loginErrorCallback]}>
+      <LoginFailed />
+    </MemoryRouter>
+  );
+  expect(
+    screen.getByText('Unable to process SSO callback.')
+  ).toBeInTheDocument();
+});
 
 test('unauthorized error path shows unauthorized error', () => {
-  render(<MemoryRouter initialEntries={[cfg.routes.loginErrorUnauthorized]}><LoginFailed/></MemoryRouter>);
-  expect(screen.getByText('You are not authorized, please contact your SSO administrator.')).toBeInTheDocument();
-})
+  render(
+    <MemoryRouter initialEntries={[cfg.routes.loginErrorUnauthorized]}>
+      <LoginFailed />
+    </MemoryRouter>
+  );
+  expect(
+    screen.getByText(
+      'You are not authorized, please contact your SSO administrator.'
+    )
+  ).toBeInTheDocument();
+});
 
 test('groups overage error path shows groups overage error', () => {
-  render(<MemoryRouter initialEntries={[cfg.routes.loginErrorEntraIDGroupsOverage]}><LoginFailed/></MemoryRouter>);
-  expect(screen.getByText('Your account is a member of more than 150 Entra ID groups. Please contact your SSO administrator to configure Graph API access on the Teleport SAML connector.')).toBeInTheDocument();
-})
+  render(
+    <MemoryRouter initialEntries={[cfg.routes.loginErrorEntraIDGroupsOverage]}>
+      <LoginFailed />
+    </MemoryRouter>
+  );
+  expect(
+    screen.getByText(
+      'Your account is a member of more than 150 Entra ID groups. Please contact your SSO administrator to configure Graph API access on the Teleport SAML connector.'
+    )
+  ).toBeInTheDocument();
+});
 
 test('unhandled error path shows generic error', () => {
-  render(<MemoryRouter initialEntries={['/web/msg/error/login/some_unhandled_path']}><LoginFailed/></MemoryRouter>);
-  expect(screen.getByText('Unable to log in, please check Teleport\'s log for details.')).toBeInTheDocument();
-})
+  render(
+    <MemoryRouter initialEntries={['/web/msg/error/login/some_unhandled_path']}>
+      <LoginFailed />
+    </MemoryRouter>
+  );
+  expect(
+    screen.getByText(
+      "Unable to log in, please check Teleport's log for details."
+    )
+  ).toBeInTheDocument();
+});

--- a/web/packages/teleport/src/Login/LoginFailed.test.tsx
+++ b/web/packages/teleport/src/Login/LoginFailed.test.tsx
@@ -22,7 +22,7 @@ import {render, screen} from 'design/utils/testing';
 
 import cfg from 'teleport/config';
 
-import {LoginFailed} from './LoginFailed';
+import { LoginFailed } from './LoginFailed';
 
 test('callback error path shows callback error', () => {
   render(<MemoryRouter initialEntries={[cfg.routes.loginErrorCallback]}><LoginFailed/></MemoryRouter>);
@@ -37,4 +37,9 @@ test('unauthorized error path shows unauthorized error', () => {
 test('groups overage error path shows groups overage error', () => {
   render(<MemoryRouter initialEntries={[cfg.routes.loginErrorEntraIDGroupsOverage]}><LoginFailed/></MemoryRouter>);
   expect(screen.getByText('Your account is a member of more than 150 Entra ID groups. Please contact your SSO administrator to configure Graph API access on the Teleport SAML connector.')).toBeInTheDocument();
+})
+
+test('unhandled error path shows generic error', () => {
+  render(<MemoryRouter initialEntries={['/web/msg/error/login/some_unhandled_path']}><LoginFailed/></MemoryRouter>);
+  expect(screen.getByText('Unable to log in, please check Teleport\'s log for details.')).toBeInTheDocument();
 })

--- a/web/packages/teleport/src/Login/LoginFailed.tsx
+++ b/web/packages/teleport/src/Login/LoginFailed.tsx
@@ -34,7 +34,9 @@ export function LoginFailed() {
       <Route path={cfg.routes.loginErrorEntraIDGroupsOverage}>
         <LoginFailedComponent message="Your account is a member of more than 150 Entra ID groups. Please contact your SSO administrator to configure Graph API access on the Teleport SAML connector." />
       </Route>
-      <Route component={LoginFailed} />
+      <Route>
+        <LoginFailedComponent />
+      </Route>
     </Switch>
   );
 }

--- a/web/packages/teleport/src/Teleport.tsx
+++ b/web/packages/teleport/src/Teleport.tsx
@@ -39,7 +39,7 @@ import { DesktopSessionContainer as DesktopSession } from './DesktopSession';
 import { HeadlessRequest } from './HeadlessRequest';
 import { Login } from './Login';
 import { LoginClose } from './Login/LoginClose';
-import { LoginFailedComponent as LoginFailed } from './Login/LoginFailed';
+import { LoginFailed } from './Login/LoginFailed';
 import { LoginSuccess } from './Login/LoginSuccess';
 import { LoginTerminalRedirect } from './Login/LoginTerminalRedirect';
 import { Main } from './Main';


### PR DESCRIPTION
This change fixes bug https://github.com/gravitational/teleport/issues/66347 where generic error message is shown on SSO failure when specific error should be shown. 

Also added tests for this functionality. Note: will also add corresponding tests in master to prevent regression there. 

## Manual Test Plan
### Test Environment

Local build deployed to local environment.

### Test Cases
- [x] Unhandled path should show generic error message.
- [x] Callback path should show callback error message.
- [x] Unauthorized path should show unauthorized error message.
- [x] Groups overage path should show groups overage error message. 

---

changelog: fix issue where generic error messages were being shown instead of specific ones for failed SSO logins