### PR TITLE
Add command examples to MWI access guides

### DIFF
--- a/docs/pages/includes/machine-id/reload-tbot.mdx
+++ b/docs/pages/includes/machine-id/reload-tbot.mdx
@@ -1,0 +1,19 @@
+{{ resource="your target resource" }}
+
+Apply your configuration. The command to execute depends on how you are running
+`tbot`.
+
+If you are running `tbot` as a background service, execute the following
+command, which instructs `tbot` to reload its configuration:
+
+```code
+$ sudo systemctl reload tbot
+```
+
+If you are running `tbot` in one-shot mode, before you attempt to access 
+{{ resource }} later, you must execute `tbot`, pointing it to the location of its
+configuration file (`/etc/tbot.yaml` in the example below):
+
+```code
+$ tbot start -c /etc/tbot.yaml
+```

--- a/docs/pages/machine-workload-identity/access-guides/ansible.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/ansible.mdx
@@ -121,9 +121,7 @@ services:
     path: /opt/machine-id
 ```
 
-If operating `tbot` as a background service, restart it. If running `tbot` in
-one-shot mode, it must be executed before you attempt to execute the Ansible
-playbook.
+(!docs/pages/includes/machine-id/reload-tbot.mdx resource="the Ansible playbook"!)
 
 You should now see several files under `/opt/machine-id`:
 

--- a/docs/pages/machine-workload-identity/access-guides/applications.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/applications.mdx
@@ -142,8 +142,8 @@ services:
 Ensure you replace `dumper` with the name of the application you registered in
 Teleport.
 
-If operating `tbot` as a background service, restart it. If running `tbot` in
-one-shot mode, it must be executed before you attempt to use the credentials.
+(!docs/pages/includes/machine-id/reload-tbot.mdx resource="your credentials"!)
+
 </TabItem>
 </Tabs>
 

--- a/docs/pages/machine-workload-identity/access-guides/argocd.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/argocd.mdx
@@ -145,7 +145,11 @@ Make sure you replace `example-bot` with a unique, descriptive name for your Bot
 and replace `example-role` with the name of the role you created in the previous
 step.
 
-Use `tctl create -f ./bot.yaml` to create the bot.
+Create the bot:
+
+```code
+$ tctl create -f ./bot.yaml
+```
 
 ## Step 3/4. Create a join token
 

--- a/docs/pages/machine-workload-identity/access-guides/databases.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/databases.mdx
@@ -35,6 +35,9 @@ used to access a database configured in Teleport.
 - `tbot` must already be installed and configured on the machine that will
   access the database. For more information, see the
   [deployment guides](../deployment/deployment.mdx).
+- To run the example programs we include in [Step
+  4](#step-44-configure-the-client-to-connect-to-the-database), you must have
+  [Go installed on your system](https://go.dev/doc/install).
 
 ## Step 1/4. Configure RBAC
 
@@ -148,8 +151,7 @@ services:
   # format: mongo
 ```
 
-If operating `tbot` as a background service, restart it. If running `tbot` in
-one-shot mode, it must be executed before you attempt to access the database.
+(!docs/pages/includes/machine-id/reload-tbot.mdx resource="the database"!)
 
 ## Step 3/4. Configure the local database access proxy
 
@@ -245,20 +247,27 @@ configured port.
 With the credentials generated and the local proxy running, you can now
 configure your client to use the local proxy with the credentials.
 
-Refer to these sample Go programs for using the credentials:
+1. Copy one of these sample Go programs into a file called "connect.go",
+   modifying it as indicated in the commands:
 
-<Tabs>
-  <TabItem label="Self-Hosted PostgreSQL">
-  ```go
-  (!docs/pages/includes/machine-id/postgresql/postgresql.go!)
-  ```
-  </TabItem>
-  <TabItem label="Self-Hosted MongoDB">
-  ```go
-  (!docs/pages/includes/machine-id/mongodb/mongodb.go!)
-  ```
-  </TabItem>
-</Tabs>
+  <Tabs>
+    <TabItem label="Self-Hosted PostgreSQL">
+    ```go
+    (!docs/pages/includes/machine-id/postgresql/postgresql.go!)
+    ```
+    </TabItem>
+    <TabItem label="Self-Hosted MongoDB">
+    ```go
+    (!docs/pages/includes/machine-id/mongodb/mongodb.go!)
+    ```
+    </TabItem>
+  </Tabs>
+
+1. Run the program:
+
+   ```code
+   $ go run connect.go
+   ```
 
 You're all set. You have provided your application with short-lived
 certificates tied to a machine identity that can access your database, be

--- a/docs/pages/machine-workload-identity/access-guides/kubernetes.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/kubernetes.mdx
@@ -162,8 +162,7 @@ services:
 Ensure you replace `example-k8s-cluster` with the name of the Kubernetes cluster
 as registered in Teleport and adjust `/opt/machine-id` if you wish.
 
-If operating `tbot` as a background service, restart it. If running `tbot` in
-one-shot mode, it must be executed before you attempt to use the credentials.
+(!docs/pages/includes/machine-id/reload-tbot.mdx resource="your credentials"!)
 
 ## Step 3/3. Connect to your Kubernetes cluster
 

--- a/docs/pages/machine-workload-identity/access-guides/mcp.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/mcp.mdx
@@ -110,8 +110,7 @@ services:
 
 Ensure that you replace `/opt/machine-id` with the directory you have chosen.
 
-If operating `tbot` as a background service, restart it. If running `tbot` in
-one-shot mode, it must be executed before you attempt to use the credentials.
+(!docs/pages/includes/machine-id/reload-tbot.mdx resource="your credentials"!)
 
 ## Step 3/3. Connect your MCP client
 

--- a/docs/pages/machine-workload-identity/access-guides/ssh.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/ssh.mdx
@@ -100,9 +100,7 @@ services:
     path: /opt/machine-id
 ```
 
-If operating `tbot` as a background service, restart it. If running `tbot` in
-one-shot mode, it must be executed before you attempt to use the credentials
-produced by `tbot` to connect to nodes via SSH.
+(!docs/pages/includes/machine-id/reload-tbot.mdx resource="nodes via SSH"!)
 
 ## Step 3/3. Using the output credentials
 

--- a/docs/pages/machine-workload-identity/access-guides/tctl.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/tctl.mdx
@@ -98,8 +98,7 @@ services:
     path: /opt/machine-id
 ```
 
-If operating `tbot` as a background service, restart it. If running `tbot` in
-one-shot mode, it must be executed before you attempt to execute `tctl` later.
+(!docs/pages/includes/machine-id/reload-tbot.mdx resource="the generated credentials"!)
 
 You should now see an `identity` file under `/opt/machine-id`. This contains
 the private key and signed certificates needed by `tctl` to

--- a/docs/pages/machine-workload-identity/workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/getting-started.mdx
@@ -163,7 +163,19 @@ Replace:
 - `example-workload-identity` with the name of the Workload Identity resource you
   created earlier.
 
-Start or restart your `tbot` instance to apply the new configuration.
+Apply your new configuration. If `tbot` is already running, reload its
+configuration:
+
+```code
+$ sudo systemctl reload tbot
+```
+
+Otherwise, start `tbot` with your configuration file, which this example assumes
+is `/etc/tbot.yaml`:
+
+```code
+$ sudo tbot start -c /etc/tbot.yaml
+```
 
 ### Configuring Unix Workload Attestation
 


### PR DESCRIPTION
For users (human and agent) who may not know which specific commands to enter to reload `tbot` configuration changes, make it explicit which commands to use in the relevant how-to guides. Add a partial with examples of `systemctl reload tbot` and `tbot start`.

Similarly, in the Workload ID getting started guide, include commands for starting `tbot`.

Use a copyable code snippet for bot creation in the ArgoCD guide. This isn't necessary, but helps standardize the docs on using code snippets for copyable commands.

Make Go instructions in `databases.mdx` slightly easier to use, especially for users who aren't familiar with Go, by:

  - Adding a Go prerequisite
  - Including  an example command for running each small program
