### PR TITLE
Wire up summarisation for Windows Desktop recordings

### DIFF
--- a/lib/auth/recordingencryption/recordingencryptionv1/service_test.go
+++ b/lib/auth/recordingencryption/recordingencryptionv1/service_test.go
@@ -371,6 +371,11 @@ func (f *fakeSummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent 
 	return args.Error(0)
 }
 
+func (f *fakeSummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *apievents.WindowsDesktopSessionEnd) error {
+	args := f.Called(ctx, sessionEndEvent)
+	return args.Error(0)
+}
+
 func (f *fakeSummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	args := f.Called(ctx, sessionID)
 	return args.Error(0)

--- a/lib/auth/summarizer/provider.go
+++ b/lib/auth/summarizer/provider.go
@@ -91,6 +91,10 @@ func (n NoopSummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent *
 	return nil
 }
 
+func (n NoopSummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *events.WindowsDesktopSessionEnd) error {
+	return nil
+}
+
 func (NoopSummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	return nil
 }

--- a/lib/auth/summarizer/provider_test.go
+++ b/lib/auth/summarizer/provider_test.go
@@ -54,6 +54,10 @@ func (m dummySummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent 
 	return nil
 }
 
+func (m dummySummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *events.WindowsDesktopSessionEnd) error {
+	return nil
+}
+
 func (m dummySummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	return nil
 }

--- a/lib/auth/summarizer/summarizer.go
+++ b/lib/auth/summarizer/summarizer.go
@@ -32,10 +32,14 @@ type SessionSummarizer interface {
 	// SummarizeDatabase summarizes the database session recording associated
 	// with the provided [events.DatabaseSessionEnd] event.
 	SummarizeDatabase(ctx context.Context, sessionEndEvent *events.DatabaseSessionEnd) error
+	// SummarizeWindowsDesktop summarizes the Windows desktop session recording
+	// associated with the provided [events.WindowsDesktopSessionEnd] event.
+	SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *events.WindowsDesktopSessionEnd) error
 	// SummarizeWithoutEndEvent summarizes a session recording with a given ID.
 	// This is used for cases where the session ID is known, but there is no end
-	// event available. [SessionSummarizer.SummarizeSSH] and
-	// [SessionSummarizer.SummarizeDatabase] should be used instead of this
-	// method whenever possible, as they are more efficient.
+	// event available. [SessionSummarizer.SummarizeSSH],
+	// [SessionSummarizer.SummarizeDatabase], and
+	// [SessionSummarizer.SummarizeWindowsDesktop] should be used instead of
+	// this method whenever possible, as they are more efficient.
 	SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error
 }

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -466,6 +466,11 @@ func (f *fakeSummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent 
 	return args.Error(0)
 }
 
+func (f *fakeSummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *apievents.WindowsDesktopSessionEnd) error {
+	args := f.Called(ctx, sessionEndEvent)
+	return args.Error(0)
+}
+
 func (f *fakeSummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	args := f.Called(ctx, sessionID)
 	return args.Error(0)

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -382,6 +382,8 @@ func (u *UploadCompleter) ensureSessionEndEvent(ctx context.Context, uploadData 
 		err = summarizer.SummarizeSSH(ctx, o)
 	case *apievents.DatabaseSessionEnd:
 		err = summarizer.SummarizeDatabase(ctx, o)
+	case *apievents.WindowsDesktopSessionEnd:
+		err = summarizer.SummarizeWindowsDesktop(ctx, o)
 	}
 	if err != nil {
 		slog.WarnContext(ctx, "Failed to summarize upload", "error", err)

--- a/lib/events/sessionpostprocessing/postprocessing.go
+++ b/lib/events/sessionpostprocessing/postprocessing.go
@@ -75,6 +75,10 @@ func Process(ctx context.Context, cfg Config) error {
 		if err := summarizer.SummarizeDatabase(ctx, o); err != nil {
 			summarizerErr = trace.Wrap(err, "failed to summarize upload")
 		}
+	case *apievents.WindowsDesktopSessionEnd:
+		if err := summarizer.SummarizeWindowsDesktop(ctx, o); err != nil {
+			summarizerErr = trace.Wrap(err, "failed to summarize upload")
+		}
 	}
 	return trace.NewAggregate(summarizerErr, metadataErr)
 }

--- a/lib/events/sessionpostprocessing/postprocessing_test.go
+++ b/lib/events/sessionpostprocessing/postprocessing_test.go
@@ -102,6 +102,11 @@ func (f *fakeSummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent 
 	return args.Error(0)
 }
 
+func (f *fakeSummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *apievents.WindowsDesktopSessionEnd) error {
+	args := f.Called(ctx, sessionEndEvent)
+	return args.Error(0)
+}
+
 func (f *fakeSummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	args := f.Called(ctx, sessionID)
 	return args.Error(0)

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -609,6 +609,10 @@ type sliceWriter struct {
 	// point where the session end event has already been uploaded. If captured,
 	// it will be passed to the summarizer.
 	dbSessionEndEvent *apievents.DatabaseSessionEnd
+	// desktopSessionEndEvent is an event that marked the end of this session if
+	// it was a Windows desktop one. Same nil semantics as the SSH/database
+	// fields above; if captured, it will be passed to the summarizer.
+	desktopSessionEndEvent *apievents.WindowsDesktopSessionEnd
 
 	// hasSessionEnd indicates if the session end event is present.
 	hasSessionEnd bool
@@ -737,6 +741,7 @@ func (w *sliceWriter) receiveAndUpload() error {
 				w.dbSessionEndEvent = e.DatabaseSessionEnd
 				w.hasSessionEnd = true
 			case *apievents.OneOf_WindowsDesktopSessionEnd:
+				w.desktopSessionEndEvent = e.WindowsDesktopSessionEnd
 				w.hasSessionEnd = true
 			case *apievents.OneOf_AppSessionEnd:
 				w.hasSessionEnd = true
@@ -883,6 +888,8 @@ func (w *sliceWriter) completeStream() {
 				w.sessionEndTime = o.EndTime
 			case *apievents.DatabaseSessionEnd:
 				w.dbSessionEndEvent = o
+			case *apievents.WindowsDesktopSessionEnd:
+				w.desktopSessionEndEvent = o
 			}
 		}
 
@@ -908,6 +915,8 @@ func (w *sliceWriter) completeStream() {
 			err = summarizer.SummarizeSSH(w.proto.cancelCtx, w.sshSessionEndEvent)
 		case w.dbSessionEndEvent != nil:
 			err = summarizer.SummarizeDatabase(w.proto.cancelCtx, w.dbSessionEndEvent)
+		case w.desktopSessionEndEvent != nil:
+			err = summarizer.SummarizeWindowsDesktop(w.proto.cancelCtx, w.desktopSessionEndEvent)
 		default:
 			err = summarizer.SummarizeWithoutEndEvent(w.proto.cancelCtx, w.proto.cfg.Upload.SessionID)
 		}

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -683,6 +683,11 @@ func (m *MockSummarizer) SummarizeDatabase(ctx context.Context, sessionEndEvent 
 	return args.Error(0)
 }
 
+func (m *MockSummarizer) SummarizeWindowsDesktop(ctx context.Context, sessionEndEvent *apievents.WindowsDesktopSessionEnd) error {
+	args := m.Called(ctx, sessionEndEvent)
+	return args.Error(0)
+}
+
 func (m *MockSummarizer) SummarizeWithoutEndEvent(ctx context.Context, sessionID session.ID) error {
 	args := m.Called(ctx, sessionID)
 	return args.Error(0)


### PR DESCRIPTION
This adds the necessary things for Windows desktop recordings to start being summarised.

Manual testing will be done as part of the enterprise PR.
