### PR TITLE
[v18] Reject unknown fields in role yaml at create/edit time

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -19,7 +19,9 @@
 package services
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -3769,6 +3771,12 @@ func UnmarshalRoleV6(bytes []byte, opts ...MarshalOption) (*types.RoleV6, error)
 		return nil, trace.BadParameter("inconsistent version in role data, got %q and %q", role.Version, version)
 	}
 
+	if cfg.DisallowUnknown {
+		if err := checkUnknownFields(bytes); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	if err := ValidateRole(&role); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3799,6 +3807,17 @@ func MarshalRole(role types.Role, opts ...MarshalOption) ([]byte, error) {
 	default:
 		return nil, trace.BadParameter("unrecognized role version %T", role)
 	}
+}
+
+// checkUnknownFields rejects JSON with fields not defined in the RoleV6 struct.
+func checkUnknownFields(data []byte) error {
+	var unused types.RoleV6
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&unused); err != nil {
+		return trace.BadParameter("role has unknown or misspelled fields: %v", err)
+	}
+	return nil
 }
 
 // AuthPreferenceGetter defines an interface for getting the authentication

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1225,6 +1225,88 @@ func BenchmarkValidateRole(b *testing.B) {
 	}
 }
 
+func TestUnmarshalRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		json                string
+		disallowUnknown     bool
+		expectErrorContains string
+	}{
+		{
+			name: "valid role accepted with DisallowUnknown",
+			json: `{
+				"kind": "role",
+				"version": "v6",
+				"metadata": {"name": "test"},
+				"spec": {
+					"allow": {
+						"kubernetes_groups": ["system:masters"]
+					}
+				}
+			}`,
+			disallowUnknown: true,
+		},
+		{
+			name: "unknown field rejected with DisallowUnknown",
+			json: `{
+				"kind": "role",
+				"version": "v6",
+				"metadata": {"name": "test"},
+				"spec": {
+					"allow": {
+						"kubernetes_group": ["system:masters"]
+					}
+				}
+			}`,
+			disallowUnknown:     true,
+			expectErrorContains: "kubernetes_group",
+		},
+		{
+			name: "valid role accepted without DisallowUnknown",
+			json: `{
+				"kind": "role",
+				"version": "v6",
+				"metadata": {"name": "test"},
+				"spec": {
+					"allow": {
+						"kubernetes_groups": ["system:masters"]
+					}
+				}
+			}`,
+		},
+		{
+			name: "unknown field silently accepted without DisallowUnknown",
+			json: `{
+				"kind": "role",
+				"version": "v6",
+				"metadata": {"name": "test"},
+				"spec": {
+					"allow": {
+						"kubernetes_group": ["system:masters"]
+					}
+				}
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []MarshalOption
+			if tt.disallowUnknown {
+				opts = append(opts, DisallowUnknown())
+			}
+			_, err := UnmarshalRole([]byte(tt.json), opts...)
+			if tt.expectErrorContains != "" {
+				require.ErrorContains(t, err, tt.expectErrorContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateRoleName(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/lib/web/yaml.go
+++ b/lib/web/yaml.go
@@ -149,7 +149,7 @@ func yamlToRole(yaml string) (types.Role, error) {
 	if extractedRes.Kind != types.KindRole {
 		return nil, trace.BadParameter("resource kind %q is invalid, only role is allowed", extractedRes.Kind)
 	}
-	resource, err := services.UnmarshalRole(extractedRes.Raw)
+	resource, err := services.UnmarshalRole(extractedRes.Raw, services.DisallowUnknown())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/yaml_test.go
+++ b/lib/web/yaml_test.go
@@ -67,6 +67,16 @@ spec:
 version: v2
 `
 
+const invalidRoleYamlUnknownField = `kind: role
+version: v8
+metadata:
+  name: test-bad
+spec:
+  allow:
+    kubernetes_group:
+      - "system:masters"
+`
+
 func getAccessMonitoringRuleResource() *accessmonitoringrulesv1.AccessMonitoringRule {
 	return &accessmonitoringrulesv1.AccessMonitoringRule{
 		Kind:    types.KindAccessMonitoringRule,
@@ -197,6 +207,11 @@ func TestYAMLParse_Errors(t *testing.T) {
 			desc: "invalid empty yaml",
 			yaml: "",
 			kind: types.KindAccessMonitoringRule,
+		},
+		{
+			desc: "role with unknown field",
+			yaml: invalidRoleYamlUnknownField,
+			kind: types.KindRole,
 		},
 	}
 


### PR DESCRIPTION
Backports #66098

Previously, `tctl create` and the Web UI role editor silently dropped unknown or misspelled fields in role yaml. A typo like `kubernetes_group` (instead of `kubernetes_groups`) would be accepted, the field ignored, and the role saved

The `services.DisallowUnknown()` option was already being passed by `tctl` but was never respected because underlying `FastUnmarshal` has no disallow-unknown support. This PR adds a second-pass check using `encoding/json` with `DisallowUnknownFields()` so unknown fields now return a clear error

Read paths remain unchanged

Changelog: Role with unknown fields is now rejected at create/edit time instead of being silently dropped. Applies to `tctl` and the Web UI yaml editor

## Manual Test Plan

### Test Environment
Teleport cluster

### Test Cases
- [x] Create a role with an invalid field via `tctl create` (rejected)
- [x] Create the same role with the correct field name (succeeds)
- [x] Create a role with an invalid field via the Web UI editor (rejected)
- [x] Create the same role with the correct field name (succeeds)
