### PR TITLE
[v18] Docs: AWS IC System Credentials Not Supported on Cloud Clusters

### DIFF
--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
@@ -42,7 +42,7 @@ AWS credentials, such as an EC2 instance profile or another AWS SDK credential
 source. Use AWS OIDC when you prefer to avoid host-level AWS credentials or want
 to manage AWS trust through a dedicated Teleport integration.
 
-#### Ambient system credentials
+### Ambient system credentials
 
 The ambient credentials must be able to assume the IAM role used by the
 integration.
@@ -54,7 +54,7 @@ $ tctl plugins install awsic \
     ...
 ```
 
-#### AWS OIDC integration
+### AWS OIDC integration
 
 Create the AWS OIDC integration first, then pass its name to the Identity Center
 installer.
@@ -109,7 +109,7 @@ $ tctl plugins install awsic \
 </TabItem>
 <TabItem label="Self-Hosted">
 
-#### Ambient system credentials
+### Ambient system credentials
 
 ```console
 $ tctl plugins install awsic \
@@ -123,7 +123,7 @@ $ tctl plugins install awsic \
     --roles-sync-mode NONE
 ```
 
-#### AWS OIDC integration
+### AWS OIDC integration
 
 ```console
 $ tctl plugins install awsic \

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
@@ -12,6 +12,63 @@ The Identity Center Integration can be configured to handle various advanced use
 cases that are not necessarily supported by the default installation flow. This
 guide describes these advanced options and use cases.
 
+## AWS authentication methods
+
+The AWS IAM Identity Center integration needs AWS credentials to read Identity
+Center resources and manage account assignments. Choose the credential source
+that matches your Teleport deployment before running `tctl plugins install
+awsic`.
+
+<Tabs>
+<TabItem label="Teleport Cloud">
+
+Teleport Cloud clusters use an [AWS OIDC integration](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx)
+to authenticate with AWS. Create the AWS OIDC integration first, then pass its
+name to the Identity Center installer:
+
+```console
+$ tctl plugins install awsic \
+    --no-use-system-credentials \
+    --oidc-integration ${AWS_OIDC_INTEGRATION_NAME} \
+    ...
+```
+
+</TabItem>
+<TabItem label="Self-Hosted">
+
+Self-hosted clusters have two installation options: ambient system credentials
+and [AWS OIDC](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx). Use ambient credentials when the Auth Service already runs with
+AWS credentials, such as an EC2 instance profile or another AWS SDK credential
+source. Use AWS OIDC when you prefer to avoid host-level AWS credentials or want
+to manage AWS trust through a dedicated Teleport integration.
+
+#### Ambient system credentials
+
+The ambient credentials must be able to assume the IAM role used by the
+integration.
+
+```console
+$ tctl plugins install awsic \
+    --use-system-credentials \
+    --assume-role-arn ${AWS_IAM_ROLE_ARN} \
+    ...
+```
+
+#### AWS OIDC integration
+
+Create the AWS OIDC integration first, then pass its name to the Identity Center
+installer.
+
+```console
+$ tctl plugins install awsic \
+    --no-use-system-credentials \
+    --oidc-integration ${AWS_OIDC_INTEGRATION_NAME} \
+    ...
+```
+
+</TabItem>
+</Tabs>
+
 ## Disabling Account Assignment role creation
 
 By default, the AWS Identity Center integration will create a Teleport role for
@@ -30,12 +87,29 @@ integration via `tctl`.
 
 Role Sync Mode `NONE` is only available during installation. The Roles Sync Mode
 can be changed to `ALL` later, but you can't go back the other way.
-
-Teleport Cloud clusters cannot use `--use-system-credentials` for this
-installer path. If you are on Teleport Cloud, use the
-[AWS OIDC integration](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx)
-instead.
 </Admonition>
+
+Choose the installation command for your Teleport deployment:
+
+<Tabs>
+<TabItem label="Teleport Cloud">
+
+```console
+$ tctl plugins install awsic \
+    --instance-arn ${IDENTITY_CENTER_INSTANCE_ARN} \
+    --instance-region ${IDENTITY_CENTER_INSTANCE_REGION} \
+    --no-use-system-credentials \
+    --oidc-integration ${AWS_OIDC_INTEGRATION_NAME} \
+    --scim-url ${IDENTITY_CENTER_SCIM_BASE_URL} \
+    --scim-token ${IDENTITY_CENTER_SCIM_BEARER_TOKEN} \
+    --access-list-default-owner ${TELEPORT_ACCESS_LIST_DEFAULT_OWNER} \
+    --roles-sync-mode NONE
+```
+
+</TabItem>
+<TabItem label="Self-Hosted">
+
+#### Ambient system credentials
 
 ```console
 $ tctl plugins install awsic \
@@ -48,6 +122,23 @@ $ tctl plugins install awsic \
     --access-list-default-owner ${TELEPORT_ACCESS_LIST_DEFAULT_OWNER} \
     --roles-sync-mode NONE
 ```
+
+#### AWS OIDC integration
+
+```console
+$ tctl plugins install awsic \
+    --instance-arn ${IDENTITY_CENTER_INSTANCE_ARN} \
+    --instance-region ${IDENTITY_CENTER_INSTANCE_REGION} \
+    --no-use-system-credentials \
+    --oidc-integration ${AWS_OIDC_INTEGRATION_NAME} \
+    --scim-url ${IDENTITY_CENTER_SCIM_BASE_URL} \
+    --scim-token ${IDENTITY_CENTER_SCIM_BEARER_TOKEN} \
+    --access-list-default-owner ${TELEPORT_ACCESS_LIST_DEFAULT_OWNER} \
+    --roles-sync-mode NONE
+```
+
+</TabItem>
+</Tabs>
 
 ### Roles Sync Modes
 

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
@@ -37,10 +37,14 @@ $ tctl plugins install awsic \
 <TabItem label="Self-Hosted">
 
 Self-hosted clusters have two installation options: ambient system credentials
-and [AWS OIDC](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx). Use ambient credentials when the Auth Service already runs with
-AWS credentials, such as an EC2 instance profile or another AWS SDK credential
-source. Use AWS OIDC when you prefer to avoid host-level AWS credentials or want
-to manage AWS trust through a dedicated Teleport integration.
+and [AWS OIDC](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx).
+
+Use ambient credentials when the Auth Service already runs with AWS credentials,
+such as an EC2 instance profile or another AWS SDK credential source, or when
+your Teleport Proxy Service endpoint is private.
+
+Use AWS OIDC when AWS can reach your cluster's public Proxy Service endpoint and
+you want to manage AWS trust through a dedicated Teleport integration.
 
 ### Ambient system credentials
 
@@ -94,6 +98,9 @@ Choose the installation command for your Teleport deployment:
 <Tabs>
 <TabItem label="Teleport Cloud">
 
+Teleport Cloud clusters authenticate with AWS through an [AWS OIDC integration](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx).
+Create the AWS OIDC integration first, then use this command.
+
 ```console
 $ tctl plugins install awsic \
     --instance-arn ${IDENTITY_CENTER_INSTANCE_ARN} \
@@ -109,7 +116,15 @@ $ tctl plugins install awsic \
 </TabItem>
 <TabItem label="Self-Hosted">
 
-### Ambient system credentials
+Self-hosted clusters can use either ambient system credentials or AWS OIDC. For
+guidance choosing a credential source, see [AWS authentication
+methods](#aws-authentication-methods).
+
+**Ambient system credentials**
+
+This command uses the AWS credential provider chain available to the Auth
+Service. The credentials must be able to assume the IAM role passed in
+`--assume-role-arn`.
 
 ```console
 $ tctl plugins install awsic \
@@ -123,7 +138,11 @@ $ tctl plugins install awsic \
     --roles-sync-mode NONE
 ```
 
-### AWS OIDC integration
+**AWS OIDC integration**
+
+This command uses the AWS OIDC integration named by `--oidc-integration` instead
+of ambient AWS credentials. Create the AWS OIDC integration before running the
+installer.
 
 ```console
 $ tctl plugins install awsic \

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
@@ -30,6 +30,11 @@ integration via `tctl`.
 
 Role Sync Mode `NONE` is only available during installation. The Roles Sync Mode
 can be changed to `ALL` later, but you can't go back the other way.
+
+Teleport Cloud clusters cannot use `--use-system-credentials` for this
+installer path. If you are on Teleport Cloud, use the
+[AWS OIDC integration](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx)
+instead.
 </Admonition>
 
 ```console

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -165,6 +165,30 @@ step.
 
 Again, we need to install the plugin using `tctl`.
 
+Choose the installation command for your Teleport deployment:
+
+<Tabs>
+<TabItem label="Teleport Cloud">
+
+```console
+$ tctl plugins install awsic \
+    --instance-arn ${IDENTITY_CENTER_INSTANCE_ARN} \
+    --instance-region ${IDENTITY_CENTER_INSTANCE_REGION} \
+    --no-use-system-credentials \
+    --oidc-integration ${AWS_OIDC_INTEGRATION_NAME} \
+    --scim-url ${IDENTITY_CENTER_SCIM_BASE_URL} \
+    --scim-token ${IDENTITY_CENTER_SCIM_BEARER_TOKEN} \
+    --access-list-default-owner ${TELEPORT_ACCESS_LIST_DEFAULT_OWNER} \
+    --user-origin okta \
+    --account-name ${ACCOUNT_NAME_ALLOW_FILTER} \
+    --group-name ${GROUP_NAME_ALLOW_FILTER}
+```
+
+</TabItem>
+<TabItem label="Self-Hosted">
+
+#### Ambient system credentials
+
 ```console
 $ tctl plugins install awsic \
     --instance-arn ${IDENTITY_CENTER_INSTANCE_ARN} \
@@ -179,25 +203,39 @@ $ tctl plugins install awsic \
     --group-name ${GROUP_NAME_ALLOW_FILTER}
 ```
 
+#### AWS OIDC integration
+
+```console
+$ tctl plugins install awsic \
+    --instance-arn ${IDENTITY_CENTER_INSTANCE_ARN} \
+    --instance-region ${IDENTITY_CENTER_INSTANCE_REGION} \
+    --no-use-system-credentials \
+    --oidc-integration ${AWS_OIDC_INTEGRATION_NAME} \
+    --scim-url ${IDENTITY_CENTER_SCIM_BASE_URL} \
+    --scim-token ${IDENTITY_CENTER_SCIM_BEARER_TOKEN} \
+    --access-list-default-owner ${TELEPORT_ACCESS_LIST_DEFAULT_OWNER} \
+    --user-origin okta \
+    --account-name ${ACCOUNT_NAME_ALLOW_FILTER} \
+    --group-name ${GROUP_NAME_ALLOW_FILTER}
+```
+
+</TabItem>
+</Tabs>
+
 This will install the Teleport AWS IAM Identity Center integration with a
 Teleport configuration that:
 - Controls the AWS IAM Identity Center instance indicated by `--instance-arn`.
-- Uses the system AWS credentials to authenticate with AWS (from `--use-system-credentials`)
-  and assumes the IAM role indicated by `--assume-role-arn`.
-- Manages account assignments all AWS accounts that match the `${ACCOUNT_NAME_ALLOW_FILTER}`.
+- Authenticates with AWS using the credential source selected in the install
+  command: the AWS OIDC integration on Teleport Cloud, or system AWS credentials
+  and the IAM role indicated by `--assume-role-arn` on self-hosted clusters.
+- Manages account assignments for all AWS accounts that match the `${ACCOUNT_NAME_ALLOW_FILTER}`.
 - Provisions all users imported from Okta into AWS IAM Identity Center (from the `--user-origin okta` flag).
 - Only imports all groups matching `${GROUP_NAME_ALLOW_FILTER}` into Teleport as Access
   Lists, with `${TELEPORT_ACCESS_LIST_DEFAULT_OWNER}` as the owner.
 
 <Admonition type="note">
-Note that the `tctl` installer currently only supports installations using
-system-level AWS credentials with `--use-system-credentials`.
-
-Using system-level credential is also the recommended way to provide AWS credential when
-configuring integration in the Teleport Enterprise self-hosted deployment.
-
-Teleport Cloud clusters cannot use `--use-system-credentials`. On Teleport Cloud, use the
-[AWS OIDC integration](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx) instead.
+For more details on Identity Center AWS credential sources, see
+[AWS authentication methods](./advanced-options.mdx#aws-authentication-methods).
 </Admonition>
 
 You can change the AWS account, group and user filters later by following the

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -170,6 +170,9 @@ Choose the installation command for your Teleport deployment:
 <Tabs>
 <TabItem label="Teleport Cloud">
 
+Teleport Cloud clusters authenticate with AWS through an [AWS OIDC integration](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx).
+Create the AWS OIDC integration first, then use this command.
+
 ```console
 $ tctl plugins install awsic \
     --instance-arn ${IDENTITY_CENTER_INSTANCE_ARN} \
@@ -187,7 +190,15 @@ $ tctl plugins install awsic \
 </TabItem>
 <TabItem label="Self-Hosted">
 
-#### Ambient system credentials
+Self-hosted clusters can use either ambient system credentials or AWS OIDC. For
+guidance choosing a credential source, see [AWS authentication
+methods](./advanced-options.mdx#aws-authentication-methods).
+
+**Ambient system credentials**
+
+This command uses the AWS credential provider chain available to the Auth
+Service. The credentials must be able to assume the IAM role passed in
+`--assume-role-arn`.
 
 ```console
 $ tctl plugins install awsic \
@@ -203,7 +214,11 @@ $ tctl plugins install awsic \
     --group-name ${GROUP_NAME_ALLOW_FILTER}
 ```
 
-#### AWS OIDC integration
+**AWS OIDC integration**
+
+This command uses the AWS OIDC integration named by `--oidc-integration` instead
+of ambient AWS credentials. Create the AWS OIDC integration before running the
+installer.
 
 ```console
 $ tctl plugins install awsic \
@@ -226,17 +241,13 @@ This will install the Teleport AWS IAM Identity Center integration with a
 Teleport configuration that:
 - Controls the AWS IAM Identity Center instance indicated by `--instance-arn`.
 - Authenticates with AWS using the credential source selected in the install
-  command: the AWS OIDC integration on Teleport Cloud, or system AWS credentials
-  and the IAM role indicated by `--assume-role-arn` on self-hosted clusters.
+  command: an AWS OIDC integration on Teleport Cloud or self-hosted clusters, or
+  system AWS credentials and the IAM role indicated by `--assume-role-arn` on
+  self-hosted clusters.
 - Manages account assignments for all AWS accounts that match the `${ACCOUNT_NAME_ALLOW_FILTER}`.
 - Provisions all users imported from Okta into AWS IAM Identity Center (from the `--user-origin okta` flag).
 - Only imports all groups matching `${GROUP_NAME_ALLOW_FILTER}` into Teleport as Access
   Lists, with `${TELEPORT_ACCESS_LIST_DEFAULT_OWNER}` as the owner.
-
-<Admonition type="note">
-For more details on Identity Center AWS credential sources, see
-[AWS authentication methods](./advanced-options.mdx#aws-authentication-methods).
-</Admonition>
 
 You can change the AWS account, group and user filters later by following the
 instructions in the [Extending the Integration](#extending-the-integration) section

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -195,6 +195,11 @@ system-level AWS credentials with `--use-system-credentials`.
 
 Using system-level credential is also the recommended way to provide AWS credential when
 configuring integration in the Teleport Enterprise self-hosted deployment.
+
+Teleport Cloud clusters cannot use `--use-system-credentials`, though. If you
+are on Teleport Cloud, please set up the
+[AWS OIDC integration](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx)
+and use that instead.
 </Admonition>
 
 You can change the AWS account, group and user filters later by following the

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -196,10 +196,8 @@ system-level AWS credentials with `--use-system-credentials`.
 Using system-level credential is also the recommended way to provide AWS credential when
 configuring integration in the Teleport Enterprise self-hosted deployment.
 
-Teleport Cloud clusters cannot use `--use-system-credentials`, though. If you
-are on Teleport Cloud, please set up the
-[AWS OIDC integration](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx)
-and use that instead.
+Teleport Cloud clusters cannot use `--use-system-credentials`. On Teleport Cloud, use the
+[AWS OIDC integration](../../../enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx) instead.
 </Admonition>
 
 You can change the AWS account, group and user filters later by following the


### PR DESCRIPTION
Backport #66102 to branch/v18