### PR TITLE
Fix Default vs Static Access List Wording in IaC Docs

### DIFF
--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/access-list.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/access-list.mdx
@@ -322,7 +322,7 @@ the `.spec.type` field unset, or set to null or an empty string. As a
 consequence:
 
 - They require auditing. If`.spec.audit` is not specified in the Terraform
-  resource, Teleport assigns a default value. Static Access Lists must be
+  resource, Teleport assigns a default value. Default Access Lists must be
   periodically reviewed in the Web UI.
 - Their members can be only managed with the Web UI and `tctl`. The source
   of truth for these lists is Teleport so you cannot manage their members with


### PR DESCRIPTION
This PR was motivated during the discovery phase for [#63564](https://github.com/gravitational/teleport/issues/63564) and addresses contradictory wording in the IaC Access List documentation. The default Access List section incorrectly stated that "Static Access Lists must be periodically reviewed in the Web UI," which is wrong because static lists do not support auditing.

