### PR TITLE
[v18] Fix input swallowing race condition in moderated session resumption

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1311,9 +1311,8 @@ func (s *session) setHasEnhancedRecording(val bool) {
 	s.hasEnhancedRecording = val
 }
 
-// launch launches the session.
-// Must be called under session Lock.
-func (s *session) launch() {
+// launchUnderLock launches the session. Must be called under session Lock.
+func (s *session) launchUnderLock() {
 	// Mark the session as started here, as we want to avoid double initialization.
 	if s.started.Swap(true) {
 		s.logger.DebugContext(s.serverCtx, "Session has already started.")
@@ -1321,17 +1320,6 @@ func (s *session) launch() {
 	}
 
 	s.logger.DebugContext(s.serverCtx, "Launching session.")
-	s.BroadcastMessage("Connecting to %v over SSH", s.serverMeta.ServerHostname)
-
-	s.io.On()
-
-	if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStateRunning); err != nil {
-		s.logger.WarnContext(
-			s.serverCtx, "Failed to set tracker state.",
-			"error", err,
-			"state", types.SessionState_SessionStateRunning,
-		)
-	}
 
 	// If the identity is verified with an MFA device, we enabled MFA-based presence for the session.
 	if s.presenceEnabled {
@@ -1387,6 +1375,45 @@ func (s *session) launch() {
 			"error", err,
 		)
 	}()
+
+	// Start the session IO, broadcast an update to participants, and update tracker state in that order.
+	// We do this after starting the PTY goroutines to ensure no input is lost due to limited buffering.
+	s.io.On()
+	s.BroadcastMessage("Connecting to %v over SSH", s.serverMeta.ServerHostname)
+	if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStateRunning); err != nil {
+		s.logger.WarnContext(
+			s.serverCtx, "Failed to set tracker state.",
+			"error", err,
+			"state", types.SessionState_SessionStateRunning,
+		)
+	}
+}
+
+// pauseUnderLock pauses the session. Must be called under session Lock.
+func (s *session) pauseUnderLock() {
+	// pause the session IO, broadcast an update to participants, and update tracker state in that order.
+	s.io.Off()
+	s.BroadcastMessage("Session paused, Waiting for required participants...")
+	if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStatePending); err != nil {
+		s.logger.WarnContext(
+			s.serverCtx, "Failed to set tracker state.",
+			"error", err,
+			"state", types.SessionState_SessionStatePending,
+		)
+	}
+}
+
+// resumeUnderLock resumes the session. Must be called under session Lock.
+func (s *session) resumeUnderLock() {
+	// resume the session IO, broadcast an update to participants, and update tracker state in that order.
+	s.io.On()
+	s.BroadcastMessage("Resuming session...")
+	if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStateRunning); err != nil {
+		s.logger.WarnContext(
+			s.serverCtx, "Failed to set tracker state.",
+			"state", types.SessionState_SessionStateRunning,
+		)
+	}
 }
 
 // startInteractive starts a new interactive process (or a shell) in the
@@ -1754,22 +1781,7 @@ func (s *session) removePartyUnderLock(p *party) error {
 		}
 
 		// pause session and wait for another party to resume
-		s.io.Off()
-		s.BroadcastMessage("Session paused, Waiting for required participants...")
-		if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStatePending); err != nil {
-			s.logger.WarnContext(
-				s.serverCtx, "Failed to set tracker state.",
-				"error", err,
-				"state", types.SessionState_SessionStatePending,
-			)
-		}
-
-		go func() {
-			if state := s.tracker.WaitForStateUpdate(types.SessionState_SessionStatePending); state == types.SessionState_SessionStateRunning {
-				s.BroadcastMessage("Resuming session...")
-				s.io.On()
-			}
-		}()
+		s.pauseUnderLock()
 	}
 
 	// If the leaving party was the last one in the session, start the lingerAndDie
@@ -2122,33 +2134,20 @@ func (s *session) addParty(p *party, mode types.SessionParticipantMode) error {
 			return trace.Wrap(err)
 		}
 
-		switch {
-		case canStart && !s.started.Load():
-			s.launch()
-
-			return nil
-		case canStart:
-			// If the session is already running, but the party is a moderator that leaved
-			// a session with onLeave=pause and then rejoined, we need to unpause the session.
-			// When the moderator leaved the session, the session was paused, and we spawn
-			// a goroutine to wait for the moderator to rejoin. If the moderator rejoins
-			// before the session ends, we need to unpause the session by updating its state and
-			// the goroutine will unblock the s.io terminal.
-			// types.SessionState_SessionStatePending marks a session that is waiting for
-			// a moderator to rejoin.
-			if err := s.tracker.UpdateState(s.serverCtx, types.SessionState_SessionStateRunning); err != nil {
-				s.logger.WarnContext(
-					s.serverCtx, "Failed to set tracker state.",
-					"state", types.SessionState_SessionStateRunning,
-				)
-			}
-		default:
+		if !canStart {
 			const base = "Waiting for required participants..."
 			if s.displayParticipantRequirements {
 				s.BroadcastMessage(base+"\r\n%v", s.access.PrettyRequirementsList())
 			} else {
 				s.BroadcastMessage(base)
 			}
+			return nil
+		}
+
+		if s.started.Load() {
+			s.resumeUnderLock()
+		} else {
+			s.launchUnderLock()
 		}
 	}
 


### PR DESCRIPTION
Backport #65360 to branch/v18

changelog: Fixed a rare input swallowing bug when resuming a moderated Node session.
