### PR TITLE
Log more info during VM discovery

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1158,6 +1158,9 @@ func genInstancesLogStr[T any](instances []T, getID func(T) string) string {
 }
 
 func (s *Server) handleEC2Instances(instances *server.EC2Instances) error {
+	log := s.Log.With("group", instances)
+	log.DebugContext(s.ctx, "Processing instance group")
+
 	serverInfos, err := instances.ServerInfos()
 	if err != nil {
 		return trace.Wrap(err)
@@ -1199,7 +1202,7 @@ func (s *Server) handleEC2Instances(instances *server.EC2Instances) error {
 	}
 
 	if err := s.emitUsageEvents(instances.MakeEvents()); err != nil {
-		s.Log.DebugContext(s.ctx, "Error emitting usage event", "error", err)
+		log.DebugContext(s.ctx, "Error emitting usage event", "error", err)
 	}
 
 	return nil
@@ -1295,7 +1298,10 @@ func (s *Server) handleEC2RemoteInstallation(instances *server.EC2Instances) err
 		return trace.Wrap(err)
 	}
 
-	s.Log.DebugContext(s.ctx, "Running Teleport installation on instances", "account_id", instances.AccountID, "instances", genEC2InstancesLogStr(instances.Instances))
+	s.Log.DebugContext(s.ctx, "Running Teleport installation on instances",
+		"group", instances,
+		"instances", genEC2InstancesLogStr(instances.Instances),
+	)
 
 	req := server.SSMRunRequest{
 		DocumentName:        instances.DocumentName,
@@ -1634,13 +1640,11 @@ func (s *Server) startAzureServerDiscovery() {
 			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
 		}),
 		server.WithPerInstanceHookFn(func(instanceGroups []*server.AzureInstances) {
-			s.Log.DebugContext(s.ctx, "Processing instances", "groups", len(instanceGroups))
 			for _, group := range instanceGroups {
 				fgKey := fetcherGroupKey{
 					discoveryConfigName: group.DiscoveryConfigName,
 					integration:         group.Integration,
 				}
-				s.Log.DebugContext(s.ctx, "Processing instance group", "group", fgKey, "instances", len(group.Instances))
 				results := s.installAzureServers(group, vmTasks)
 				sm.add(fgKey, results)
 			}
@@ -1672,13 +1676,8 @@ func (s *Server) startAzureServerDiscovery() {
 func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *azureVMTasks) (results map[statusType]int) {
 	results = make(map[statusType]int)
 
-	log := s.Log.With(
-		"discovery_config", instances.DiscoveryConfigName,
-		"integration", instances.Integration,
-		"subscription_id", instances.SubscriptionID,
-		"region", instances.Region,
-		"resource_group", instances.ResourceGroup,
-	)
+	log := s.Log.With("group", instances)
+	log.DebugContext(s.ctx, "Processing instance group")
 
 	allFound := len(instances.Instances)
 	results[statusFound] = allFound
@@ -1733,7 +1732,7 @@ func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *
 		)
 	}
 
-	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "vms", genAzureInstancesLogStr(instances.Instances))
+	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "group", instances, "vms", genAzureInstancesLogStr(instances.Instances))
 	failures, err := s.enrollAzureVirtualMachines(log, instances)
 	if err != nil {
 		// treat non-nil err as deployment failure affecting all machines.
@@ -1809,6 +1808,9 @@ outer:
 }
 
 func (s *Server) handleGCPInstances(instances *server.GCPInstances) error {
+	log := s.Log.With("group", instances)
+	log.DebugContext(s.ctx, "Processing instance group")
+
 	client, err := s.gcpClients.GetInstancesClient(s.ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1820,7 +1822,9 @@ func (s *Server) handleGCPInstances(instances *server.GCPInstances) error {
 		return trace.Wrap(errNoInstances)
 	}
 
-	s.Log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "project_id", instances.ProjectID, "vms", genGCPInstancesLogStr(instances.Instances))
+	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines",
+		"vms", genGCPInstancesLogStr(instances.Instances),
+	)
 	sshKeyAlgo, err := cryptosuites.AlgorithmForKey(s.ctx, cryptosuites.GetCurrentSuiteFromPing(s.AccessPoint), cryptosuites.UserSSH)
 	if err != nil {
 		return trace.Wrap(err, "finding algorithm for SSH key from ping response")
@@ -1838,7 +1842,7 @@ func (s *Server) handleGCPInstances(instances *server.GCPInstances) error {
 		return trace.Wrap(err)
 	}
 	if err := s.emitUsageEvents(instances.MakeEvents()); err != nil {
-		s.Log.DebugContext(s.ctx, "Error emitting usage event", "error", err)
+		log.DebugContext(s.ctx, "Error emitting usage event", "error", err)
 	}
 	return nil
 }
@@ -1852,7 +1856,6 @@ func (s *Server) handleGCPDiscovery() {
 	for {
 		select {
 		case instances := <-s.gcpWatcher.InstancesC:
-			s.Log.DebugContext(s.ctx, "GCP instances discovered, starting installation", "project_id", instances.ProjectID, "instances", genGCPInstancesLogStr(instances.Instances))
 			if err := s.handleGCPInstances(instances); err != nil {
 				if errors.Is(err, errNoInstances) {
 					s.Log.DebugContext(s.ctx, "All discovered GCP VMs are already part of the cluster")

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -636,6 +636,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 
 	s.ec2Watcher = server.NewWatcher(
 		s.ctx,
+		s.Log.With("cloud", "AWS"),
 		server.WithMissedRotation(s.caRotationCh),
 		server.WithPollInterval[*server.EC2Instances](s.PollInterval),
 		server.WithTriggerFetchC[*server.EC2Instances](s.newDiscoveryConfigChangedSub()),
@@ -1008,6 +1009,7 @@ func (s *Server) initGCPServerWatcher(ctx context.Context, vmMatchers []types.GC
 
 	s.gcpWatcher = server.NewWatcher(
 		s.ctx,
+		s.Log.With("cloud", "GCP"),
 		server.WithPreFetchHookFn[*server.GCPInstances](func(fetchers []server.Fetcher[*server.GCPInstances]) {
 			if len(fetchers) > 0 {
 				s.submitFetchEvent(types.CloudGCP, types.GCPMatcherCompute)
@@ -1606,8 +1608,8 @@ func (s *Server) startAzureServerDiscovery() {
 
 	azureWatcher = server.NewWatcher(
 		s.ctx,
+		s.Log.With("cloud", "Azure"),
 		server.WithPreFetchHookFn(func(fetchers []server.Fetcher[*server.AzureInstances]) {
-			s.Log.InfoContext(s.ctx, "Azure VM discovery iteration starting")
 			runStart = s.clock.Now()
 
 			if len(fetchers) > 0 {
@@ -1653,8 +1655,6 @@ func (s *Server) startAzureServerDiscovery() {
 			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
 			// upsert user tasks for failed enrollments.
 			vmTasks.upsertAll(s.taskUpdater())
-
-			s.Log.InfoContext(s.ctx, "Azure VM discovery iteration completed", "elapsed", s.clock.Since(runStart))
 		}),
 		server.WithPollInterval[*server.AzureInstances](s.PollInterval),
 		server.WithTriggerFetchC[*server.AzureInstances](s.newDiscoveryConfigChangedSub()),

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -352,3 +352,15 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 
 	return instances, nil
 }
+
+// LogValue implements [slog.LogValuer].
+func (f *azureInstanceFetcher) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Any("labels", f.Labels),
+		slog.Any("regions", f.Regions),
+		slog.String("discovery_config", f.GetDiscoveryConfigName()),
+		slog.String("integration", f.IntegrationName()),
+		slog.String("resource_group", f.ResourceGroup),
+		slog.String("subscription_id", f.Subscription),
+	)
+}

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -60,6 +60,20 @@ type AzureInstances struct {
 	Instances []*armcompute.VirtualMachine
 }
 
+func (instances *AzureInstances) LogValue() slog.Value {
+	if instances == nil {
+		return slog.StringValue("<nil>")
+	}
+	return slog.GroupValue(
+		slog.Int("total_instances", len(instances.Instances)),
+		slog.String("discovery_config", instances.DiscoveryConfigName),
+		slog.String("integration", instances.Integration),
+		slog.String("region", instances.Region),
+		slog.String("resource_group", instances.ResourceGroup),
+		slog.String("subscription_id", instances.SubscriptionID),
+	)
+}
+
 func (instances *AzureInstances) resourceType() string {
 	if instances.InstallerParams != nil && instances.InstallerParams.ScriptName == installers.InstallerScriptNameAgentless {
 		return types.DiscoveredResourceAgentlessNode

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -235,7 +235,7 @@ func TestAzureWatcher(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			t.Cleanup(cancel)
-			watcher := NewWatcher[*AzureInstances](ctx)
+			watcher := NewWatcher[*AzureInstances](ctx, logger)
 
 			const noDiscoveryConfig = ""
 			watcher.SetFetchers(noDiscoveryConfig,

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -664,3 +664,14 @@ func (f *ec2InstanceFetcher) GetDiscoveryConfigName() string {
 func (f *ec2InstanceFetcher) IntegrationName() string {
 	return f.Matcher.Integration
 }
+
+// LogValue implements [slog.LogValuer].
+func (f *ec2InstanceFetcher) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Any("organization", f.Matcher.Organization),
+		slog.Any("regions", f.Matcher.Regions),
+		slog.Any("tags", f.Matcher.Tags),
+		slog.String("discovery_config", f.GetDiscoveryConfigName()),
+		slog.String("integration", f.IntegrationName()),
+	)
+}

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -118,6 +118,21 @@ func ToEC2Instances(insts []ec2types.Instance) []EC2Instance {
 	return ec2Insts
 }
 
+func (i *EC2Instances) LogValue() slog.Value {
+	if i == nil {
+		return slog.StringValue("<nil>")
+	}
+	return slog.GroupValue(
+		slog.Int("total_instances", len(i.Instances)),
+		slog.String("account_id", i.AccountID),
+		slog.String("assume_role_arn", i.AssumeRoleARN),
+		slog.String("discovery_config", i.DiscoveryConfigName),
+		slog.String("integration", i.Integration),
+		slog.String("region", i.Region),
+		slog.String("ssm_document", i.DocumentName),
+	)
+}
+
 // ServerInfos creates a ServerInfo resource for each discovered instance.
 func (i *EC2Instances) ServerInfos() ([]types.ServerInfo, error) {
 	serverInfos := make([]types.ServerInfo, 0, len(i.Instances))

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	liborganizations "github.com/gravitational/teleport/lib/utils/aws/organizations"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type mockEC2Client struct {
@@ -429,7 +430,7 @@ func TestEC2Watcher(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	watcher := NewWatcher[*EC2Instances](t.Context())
+	watcher := NewWatcher[*EC2Instances](t.Context(), logtest.NewLogger())
 	watcher.SetFetchers(noDiscoveryConfig, fetchers)
 
 	go watcher.Run()
@@ -557,7 +558,7 @@ func TestEC2WatcherMergesReservationInstances(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		watcher := NewWatcher[*EC2Instances](t.Context())
+		watcher := NewWatcher[*EC2Instances](t.Context(), logtest.NewLogger())
 		watcher.SetFetchers(noDiscoveryConfig, fetchers)
 
 		go watcher.Run()
@@ -604,7 +605,7 @@ func TestEC2WatcherMergesReservationInstances(t *testing.T) {
 		var gotInstances []*EC2Instances
 
 		synctest.Test(t, func(t *testing.T) {
-			watcher := NewWatcher(t.Context(), WithPerInstanceHookFn(func(groups []*EC2Instances) {
+			watcher := NewWatcher(t.Context(), logtest.NewLogger(), WithPerInstanceHookFn(func(groups []*EC2Instances) {
 				gotInstances = append(gotInstances, groups...)
 			}))
 			watcher.SetFetchers(noDiscoveryConfig, fetchers)
@@ -743,7 +744,7 @@ func TestEC2WatcherWithMultipleAccounts(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	watcher := NewWatcher[*EC2Instances](t.Context())
+	watcher := NewWatcher[*EC2Instances](t.Context(), logtest.NewLogger())
 	watcher.SetFetchers("", fetchers)
 
 	go watcher.Run()

--- a/lib/srv/server/gcp_watcher.go
+++ b/lib/srv/server/gcp_watcher.go
@@ -21,6 +21,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/gravitational/trace"
@@ -96,7 +97,6 @@ type gcpInstanceFetcher struct {
 	GCP                 gcp.InstancesClient
 	ProjectIDs          []string
 	Zones               []string
-	ProjectID           string
 	ServiceAccounts     []string
 	Labels              types.Labels
 	projectsClient      gcp.ProjectsClient
@@ -198,4 +198,16 @@ func (f *gcpInstanceFetcher) getProjectIDs(ctx context.Context) ([]string, error
 		projectIDs = append(projectIDs, prj.ID)
 	}
 	return projectIDs, nil
+}
+
+// LogValue implements [slog.LogValuer].
+func (f *gcpInstanceFetcher) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Any("labels", f.Labels),
+		slog.Any("project_ids", f.ProjectIDs),
+		slog.Any("service_accounts", f.ServiceAccounts),
+		slog.Any("zones", f.Zones),
+		slog.String("discovery_config", f.GetDiscoveryConfigName()),
+		slog.String("integration", f.IntegrationName()),
+	)
 }

--- a/lib/srv/server/gcp_watcher.go
+++ b/lib/srv/server/gcp_watcher.go
@@ -50,6 +50,18 @@ type GCPInstances struct {
 	DiscoveryConfigName string
 }
 
+func (instances *GCPInstances) LogValue() slog.Value {
+	if instances == nil {
+		return slog.StringValue("<nil>")
+	}
+	return slog.GroupValue(
+		slog.Int("total_instances", len(instances.Instances)),
+		slog.String("discovery_config", instances.DiscoveryConfigName),
+		slog.String("project_id", instances.ProjectID),
+		slog.String("zone", instances.Zone),
+	)
+}
+
 // MakeEvents generates MakeEvents for these instances.
 func (instances *GCPInstances) MakeEvents() map[string]*usageeventsv1.ResourceCreateEvent {
 	resourceType := types.DiscoveredResourceNode

--- a/lib/srv/server/watcher.go
+++ b/lib/srv/server/watcher.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log"
 )
 
 // Fetcher fetches instances from a particular cloud provider.
@@ -45,6 +46,8 @@ type Fetcher[Instances any] interface {
 	// IntegrationName identifies the integration name whose credentials were used to fetch the resources.
 	// Might be empty when the fetcher is using ambient credentials.
 	IntegrationName() string
+	// LogValue implements [slog.LogValuer].
+	LogValue() slog.Value
 }
 
 // Option is a functional option for the Watcher.
@@ -116,6 +119,7 @@ type Watcher[Instances any] struct {
 	// InstancesC can be used to consume newly discovered instances.
 	InstancesC     chan Instances
 	missedRotation <-chan []types.Server
+	logger         *slog.Logger
 
 	fetcherMap utils.SyncMap[string, []Fetcher[Instances]]
 
@@ -131,10 +135,14 @@ type Watcher[Instances any] struct {
 }
 
 // NewWatcher initializes a new instance of Watcher.
-func NewWatcher[Instances any](ctx context.Context, opts ...Option[Instances]) *Watcher[Instances] {
+func NewWatcher[Instances any](ctx context.Context, logger *slog.Logger, opts ...Option[Instances]) *Watcher[Instances] {
 	cancelCtx, cancelFn := context.WithCancel(ctx)
+	if logger == nil {
+		logger = slog.Default()
+	}
 	watcher := Watcher[Instances]{
 		ctx:          cancelCtx,
+		logger:       logger,
 		cancel:       cancelFn,
 		clock:        clockwork.NewRealClock(),
 		pollInterval: time.Minute,
@@ -179,7 +187,7 @@ func (w *Watcher[Instances]) sendInstancesOrLogError(instancesColl []Instances, 
 		if trace.IsNotFound(err) {
 			return
 		}
-		slog.ErrorContext(context.Background(), "Failed to fetch instances", "error", err)
+		w.logger.ErrorContext(w.ctx, "Failed to fetch instances", "error", err)
 		return
 	}
 	w.perInstanceHookFn(instancesColl)
@@ -187,6 +195,14 @@ func (w *Watcher[Instances]) sendInstancesOrLogError(instancesColl []Instances, 
 
 // fetchAndSubmit fetches the resources and submits them for processing.
 func (w *Watcher[Instances]) fetchAndSubmit() {
+	w.logger.InfoContext(w.ctx, "Instance discovery iteration starting")
+	runStart := w.clock.Now()
+	defer func() {
+		w.logger.InfoContext(w.ctx, "Instance discovery iteration completed",
+			"elapsed", log.StringerAttr(w.clock.Since(runStart)),
+		)
+	}()
+
 	cloned := w.fetcherMap.Clone()
 	fetchers := slices.Concat(slices.Collect(maps.Values(cloned))...)
 
@@ -194,7 +210,12 @@ func (w *Watcher[Instances]) fetchAndSubmit() {
 		w.preFetchHookFn(fetchers)
 	}
 
-	for _, fetcher := range fetchers {
+	for i, fetcher := range fetchers {
+		w.logger.DebugContext(w.ctx, "Fetching instances",
+			"fetcher", fetcher,
+			"current_fetcher", i+1,
+			"total_fetchers", len(fetchers),
+		)
 		w.sendInstancesOrLogError(fetcher.GetInstances(w.ctx, false))
 	}
 

--- a/lib/srv/server/watcher.go
+++ b/lib/srv/server/watcher.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Fetcher fetches instances from a particular cloud provider.
-type Fetcher[Instances any] interface {
+type Fetcher[Instances InstanceGroup] interface {
 	// GetInstances gets a list of cloud instances.
 	GetInstances(ctx context.Context, rotation bool) ([]Instances, error)
 	// GetMatchingInstances finds Instances from the list of nodes
@@ -51,18 +51,18 @@ type Fetcher[Instances any] interface {
 }
 
 // Option is a functional option for the Watcher.
-type Option[Instances any] func(*Watcher[Instances])
+type Option[Instances InstanceGroup] func(*Watcher[Instances])
 
 // WithPollInterval sets the interval at which the watcher will fetch
 // instances.
-func WithPollInterval[Instances any](interval time.Duration) Option[Instances] {
+func WithPollInterval[Instances InstanceGroup](interval time.Duration) Option[Instances] {
 	return func(w *Watcher[Instances]) {
 		w.pollInterval = interval
 	}
 }
 
 // WithTriggerFetchC sets a poll trigger to manual start a resource polling.
-func WithTriggerFetchC[Instances any](triggerFetchC <-chan struct{}) Option[Instances] {
+func WithTriggerFetchC[Instances InstanceGroup](triggerFetchC <-chan struct{}) Option[Instances] {
 	return func(w *Watcher[Instances]) {
 		w.triggerFetchC = triggerFetchC
 	}
@@ -70,14 +70,14 @@ func WithTriggerFetchC[Instances any](triggerFetchC <-chan struct{}) Option[Inst
 
 // WithTriggerFetchHookFn sets a callback function to call each time the watcher receives a manual trigger.
 // The hook is called prior to processing the update.
-func WithTriggerFetchHookFn[Instances any](callback func()) Option[Instances] {
+func WithTriggerFetchHookFn[Instances InstanceGroup](callback func()) Option[Instances] {
 	return func(w *Watcher[Instances]) {
 		w.triggerFetchHookFn = callback
 	}
 }
 
 // WithPreFetchHookFn sets a function that gets called before each new iteration.
-func WithPreFetchHookFn[Instances any](f func(fetchers []Fetcher[Instances])) Option[Instances] {
+func WithPreFetchHookFn[Instances InstanceGroup](f func(fetchers []Fetcher[Instances])) Option[Instances] {
 	return func(w *Watcher[Instances]) {
 		w.preFetchHookFn = f
 	}
@@ -86,21 +86,21 @@ func WithPreFetchHookFn[Instances any](f func(fetchers []Fetcher[Instances])) Op
 // WithPerInstanceHookFn sets an optional callback for each fetched set of group of instances.
 // It will be called once per each fetcher.
 // This callback replaces normal channel writes done to InstancesC.
-func WithPerInstanceHookFn[Instances any](callback func(groups []Instances)) Option[Instances] {
+func WithPerInstanceHookFn[Instances InstanceGroup](callback func(groups []Instances)) Option[Instances] {
 	return func(w *Watcher[Instances]) {
 		w.perInstanceHookFn = callback
 	}
 }
 
 // WithPostFetchHookFn sets an optional callback to be called after the fetch round is finished.
-func WithPostFetchHookFn[Instances any](f func()) Option[Instances] {
+func WithPostFetchHookFn[Instances InstanceGroup](f func()) Option[Instances] {
 	return func(w *Watcher[Instances]) {
 		w.postFetchHookFn = f
 	}
 }
 
 // WithClock sets a clock that is used to periodically fetch new resources.
-func WithClock[Instances any](clock clockwork.Clock) Option[Instances] {
+func WithClock[Instances InstanceGroup](clock clockwork.Clock) Option[Instances] {
 	return func(w *Watcher[Instances]) {
 		w.clock = clock
 	}
@@ -114,8 +114,13 @@ func WithMissedRotation(missedRotation <-chan []types.Server) Option[*EC2Instanc
 	}
 }
 
+// InstanceGroup is a group of discovered instances.
+type InstanceGroup interface {
+	slog.LogValuer
+}
+
 // Watcher allows callers to discover cloud instances matching specified filters.
-type Watcher[Instances any] struct {
+type Watcher[Instances InstanceGroup] struct {
 	// InstancesC can be used to consume newly discovered instances.
 	InstancesC     chan Instances
 	missedRotation <-chan []types.Server
@@ -135,7 +140,7 @@ type Watcher[Instances any] struct {
 }
 
 // NewWatcher initializes a new instance of Watcher.
-func NewWatcher[Instances any](ctx context.Context, logger *slog.Logger, opts ...Option[Instances]) *Watcher[Instances] {
+func NewWatcher[Instances InstanceGroup](ctx context.Context, logger *slog.Logger, opts ...Option[Instances]) *Watcher[Instances] {
 	cancelCtx, cancelFn := context.WithCancel(ctx)
 	if logger == nil {
 		logger = slog.Default()
@@ -190,6 +195,7 @@ func (w *Watcher[Instances]) sendInstancesOrLogError(instancesColl []Instances, 
 		w.logger.ErrorContext(w.ctx, "Failed to fetch instances", "error", err)
 		return
 	}
+	w.logger.DebugContext(w.ctx, "Processing instance groups", "total_groups", len(instancesColl))
 	w.perInstanceHookFn(instancesColl)
 }
 

--- a/lib/srv/server/watcher_test.go
+++ b/lib/srv/server/watcher_test.go
@@ -36,6 +36,10 @@ type mockInstance struct {
 	ID string
 }
 
+func (m mockInstance) LogValue() slog.Value {
+	return slog.GroupValue(slog.String("id", m.ID))
+}
+
 type mockFetcher struct {
 	instances []mockInstance
 	err       error

--- a/lib/srv/server/watcher_test.go
+++ b/lib/srv/server/watcher_test.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -28,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type mockInstance struct {
@@ -56,6 +58,13 @@ func (m *mockFetcher) GetDiscoveryConfigName() string {
 
 func (m *mockFetcher) IntegrationName() string {
 	panic("IntegrationName should not be called")
+}
+
+func (m *mockFetcher) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Any("instances", m.instances),
+		slog.Any("error", m.err),
+	)
 }
 
 func TestWatcherFetchAndSubmit(t *testing.T) {
@@ -133,7 +142,7 @@ func TestWatcherFetchAndSubmit(t *testing.T) {
 			var collected []mockInstance
 			var mu sync.Mutex
 
-			w := NewWatcher[mockInstance](t.Context(),
+			w := NewWatcher[mockInstance](t.Context(), logtest.NewLogger(),
 				WithPerInstanceHookFn[mockInstance](func(inst []mockInstance) {
 					mu.Lock()
 					collected = append(collected, inst...)
@@ -232,6 +241,7 @@ func TestWatcherRunLoop(t *testing.T) {
 		},
 	}
 
+	logger := logtest.NewLogger()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -240,6 +250,7 @@ func TestWatcherRunLoop(t *testing.T) {
 				var fetchCount atomic.Int32
 
 				w := NewWatcher[mockInstance](t.Context(),
+					logger,
 					WithPollInterval[mockInstance](tt.pollInterval),
 					WithTriggerFetchC[mockInstance](triggerC),
 					WithPerInstanceHookFn[mockInstance](func([]mockInstance) {
@@ -280,6 +291,7 @@ func TestWatcherHooks(t *testing.T) {
 		},
 	}
 
+	logger := logtest.NewLogger()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -288,6 +300,7 @@ func TestWatcherHooks(t *testing.T) {
 				var order []string
 
 				w := NewWatcher[mockInstance](t.Context(),
+					logger,
 					WithPollInterval[mockInstance](time.Hour),
 					WithTriggerFetchC[mockInstance](triggerC),
 					WithTriggerFetchHookFn[mockInstance](func() { order = append(order, "trigger") }),
@@ -350,6 +363,7 @@ func TestWatcherShutdown(t *testing.T) {
 		},
 	}
 
+	logger := logtest.NewLogger()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -358,6 +372,7 @@ func TestWatcherShutdown(t *testing.T) {
 				defer cancel()
 
 				w := NewWatcher[mockInstance](ctx,
+					logger,
 					WithPollInterval[mockInstance](time.Hour),
 				)
 


### PR DESCRIPTION
Changelog: Increased verbosity of Teleport Discovery Service logs for VM discovery.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- cloud staging tenant running discovery service
- VMs in each cloud

### Test Cases
- [x] configure Teleport discovery service to discover VMs and verify that the output looks reasonable and helpful:
  - [X] Azure
  - [x] AWS
  - [x] GCP

<details><summary>Example log output</summary>
<p>

```
{
  "timestamp": "2026-05-01T20:32:48Z",
  "level": "info",
  "caller": "server/watcher.go:198",
  "message": "Instance discovery iteration starting",
  "component": "discovery:service",
  "pid": "7.1"
}
{
  "timestamp": "2026-05-01T20:32:48Z",
  "level": "debug",
  "caller": "server/watcher.go:214",
  "message": "Fetching instances",
  "component": "discovery:service",
  "pid": "7.1",
  "fetcher": {
    "labels": {
      "env": "dev",
      "method": "terraform",
      "origin": "gavin",
      "teleport.dev:creator": "gavin.frazar@goteleport.com"
    },
    "regions": [
      "*"
    ],
    "discovery_config": "gavin-tf-azure-discover-test",
    "integration": "gavin-tf-azure-discover-test",
    "resource_group": "*",
    "subscription": "3b8a4a80-c7c4-4862-b17c-8140a7300ab9"
  },
  "current_fetcher": 1,
  "total_fetchers": 2
}
{
  "timestamp": "2026-05-01T20:32:48Z",
  "level": "debug",
  "caller": "discovery/discovery.go:1637",
  "message": "Processing instances",
  "component": "discovery:service",
  "pid": "7.1",
  "groups": 1
}
{
  "timestamp": "2026-05-01T20:32:48Z",
  "level": "debug",
  "caller": "discovery/discovery.go:1643",
  "message": "Processing instance group",
  "component": "discovery:service",
  "pid": "7.1",
  "group": {},
  "instances": 1
}
{
  "timestamp": "2026-05-01T20:32:48Z",
  "level": "debug",
  "caller": "discovery/discovery.go:1736",
  "message": "Running Teleport installation on virtual machines",
  "component": "discovery:service",
  "pid": "7.1",
  "discovery_config": "gavin-tf-azure-discover-test",
  "integration": "gavin-tf-azure-discover-test",
  "subscription_id": "3b8a4a80-c7c4-4862-b17c-8140a7300ab9",
  "region": "westus",
  "resource_group": "GAVIN-TF-TESTING-1-VM-RG",
  "vms": "[gavin-tf-testing-1-vm]"
}

...

{
  "timestamp": "2026-05-01T20:33:20Z",
  "level": "info",
  "caller": "discovery/discovery.go:1565",
  "message": "Finished installation batch",
  "component": "discovery:service",
  "pid": "7.1",
  "discovery_config": "gavin-tf-azure-discover-test",
  "integration": "gavin-tf-azure-discover-test",
  "subscription_id": "3b8a4a80-c7c4-4862-b17c-8140a7300ab9",
  "region": "westus",
  "resource_group": "GAVIN-TF-TESTING-1-VM-RG",
  "total_instances": 1,
  "failures": 0
}
{
  "timestamp": "2026-05-01T20:33:20Z",
  "level": "debug",
  "caller": "discovery/discovery.go:1774",
  "message": "Installation attempt finished. If the machines have joined the cluster successfully, they will be counted as enrolled during the next iteration.",
  "component": "discovery:service",
  "pid": "7.1",
  "discovery_config": "gavin-tf-azure-discover-test",
  "integration": "gavin-tf-azure-discover-test",
  "subscription_id": "3b8a4a80-c7c4-4862-b17c-8140a7300ab9",
  "region": "westus",
  "resource_group": "GAVIN-TF-TESTING-1-VM-RG",
  "pending": 1
}
{
  "timestamp": "2026-05-01T20:33:20Z",
  "level": "debug",
  "caller": "server/watcher.go:214",
  "message": "Fetching instances",
  "component": "discovery:service",
  "pid": "7.1",
  "fetcher": {
    "labels": {
      "env": "dev",
      "method": "terraform",
      "origin": "gavin",
      "teleport.dev:creator": "gavin.frazar@goteleport.com"
    },
    "regions": [
      "*"
    ],
    "discovery_config": "gavin-tf-azure-discover-test",
    "integration": "gavin-tf-azure-discover-test",
    "resource_group": "*",
    "subscription": "a0b4d587-381e-4a3f-9f37-d45c355700fc"
  },
  "current_fetcher": 2,
  "total_fetchers": 2
}
{
  "timestamp": "2026-05-01T20:33:21Z",
  "level": "debug",
  "caller": "discovery/discovery.go:1637",
  "message": "Processing instances",
  "component": "discovery:service",
  "pid": "7.1",
  "groups": 1
}
{
  "timestamp": "2026-05-01T20:33:21Z",
  "level": "debug",
  "caller": "discovery/discovery.go:1643",
  "message": "Processing instance group",
  "component": "discovery:service",
  "pid": "7.1",
  "group": {},
  "instances": 1
}
{
  "timestamp": "2026-05-01T20:33:21Z",
  "level": "debug",
  "caller": "discovery/discovery.go:1736",
  "message": "Running Teleport installation on virtual machines",
  "component": "discovery:service",
  "pid": "7.1",
  "discovery_config": "gavin-tf-azure-discover-test",
  "integration": "gavin-tf-azure-discover-test",
  "subscription_id": "a0b4d587-381e-4a3f-9f37-d45c355700fc",
  "region": "westus",
  "resource_group": "GAVIN-TF-TESTING-2-VM-RG",
  "vms": "[gavin-tf-testing-2-vm]"
}

...

{
  "timestamp": "2026-05-01T20:33:54Z",
  "level": "info",
  "caller": "discovery/discovery.go:1565",
  "message": "Finished installation batch",
  "component": "discovery:service",
  "pid": "7.1",
  "discovery_config": "gavin-tf-azure-discover-test",
  "integration": "gavin-tf-azure-discover-test",
  "subscription_id": "a0b4d587-381e-4a3f-9f37-d45c355700fc",
  "region": "westus",
  "resource_group": "GAVIN-TF-TESTING-2-VM-RG",
  "total_instances": 1,
  "failures": 0
}
{
  "timestamp": "2026-05-01T20:33:54Z",
  "level": "debug",
  "caller": "discovery/discovery.go:1774",
  "message": "Installation attempt finished. If the machines have joined the cluster successfully, they will be counted as enrolled during the next iteration.",
  "component": "discovery:service",
  "pid": "7.1",
  "discovery_config": "gavin-tf-azure-discover-test",
  "integration": "gavin-tf-azure-discover-test",
  "subscription_id": "a0b4d587-381e-4a3f-9f37-d45c355700fc",
  "region": "westus",
  "resource_group": "GAVIN-TF-TESTING-2-VM-RG",
  "pending": 1
}
{
  "timestamp": "2026-05-01T20:33:54Z",
  "level": "debug",
  "caller": "discovery/discovery.go:1586",
  "message": "Refreshing Azure server fetchers",
  "component": "discovery:service",
  "pid": "7.1"
}
{
  "timestamp": "2026-05-01T20:33:54Z",
  "level": "info",
  "caller": "server/watcher.go:201",
  "message": "Instance discovery iteration completed",
  "component": "discovery:service",
  "pid": "7.1",
  "elapsed": "1m5.87177371s"
}
```

</p>
</details> 