### PR TITLE
Adding export back to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,7 @@ VERSRC = gitref.go api/version.go
 
 KUBECONFIG ?=
 TEST_KUBE ?=
+export
 # This unexport statement is required for make to work with the `-e` flag.
 # With -e, the first Makefile sets HELMJANITOR=$$(go tool ...),
 # passes HELMJANITOR=$(go tool) to the child make process.


### PR DESCRIPTION
This `export` line was removed in a previous PR https://github.com/gravitational/teleport/pull/65180

It ended up breaking the Mac build in the release pipeline so I added it back. Ran through a quick test and it seems it fixes the issue. The PR mentioned has not been backported to v18/v17 so this only has to go to `master`

## Manual Test Plan
### Test Environment

teleport-stage

### Test Cases
- [x] Run fix through tag-build (https://github.com/gravitational/teleport.e/actions/runs/25226501143)
- [x] Run fix through tag-publish (https://github.com/gravitational/teleport.e/actions/runs/25230309310)
