### PR TITLE
fix(tctl): accept Go duration strings for maintenance_window_duration

### DIFF
--- a/tool/tctl/common/resources/autoupdate_config.go
+++ b/tool/tctl/common/resources/autoupdate_config.go
@@ -20,8 +20,10 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -78,7 +80,7 @@ func getAutoUpdateConfig(ctx context.Context, client *authclient.Client, ref ser
 }
 
 func createAutoUpdateConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
-	config, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateConfig](raw.Raw, services.DisallowUnknown())
+	config, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateConfig](normalizeAutoUpdateConfigDurations(raw.Raw), services.DisallowUnknown())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -104,7 +106,7 @@ func createAutoUpdateConfig(ctx context.Context, client *authclient.Client, raw 
 }
 
 func updateAutoUpdateConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
-	config, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateConfig](raw.Raw, services.DisallowUnknown())
+	config, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateConfig](normalizeAutoUpdateConfigDurations(raw.Raw), services.DisallowUnknown())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -129,4 +131,42 @@ func deleteAutoUpdateConfig(ctx context.Context, client *authclient.Client, ref 
 	}
 	fmt.Printf("AutoUpdateConfig has been deleted\n")
 	return nil
+}
+
+// normalizeAutoUpdateConfigDurations converts Go duration strings in
+// spec.agents.maintenance_window_duration (e.g. "1h", "30m") to the
+// "<seconds>s" format required by protojson for google.protobuf.Duration fields.
+//
+// tctl transcodes user-supplied YAML to JSON before calling protojson. The
+// protobuf JSON wire format for Duration is "<total-seconds>s", but the docs
+// and server-side validation messages show human-readable values like "1h".
+// Values that are not parseable as Go durations are left untouched so that
+// protojson can return a descriptive error to the caller.
+func normalizeAutoUpdateConfigDurations(rawJSON []byte) []byte {
+	var doc map[string]any
+	if err := json.Unmarshal(rawJSON, &doc); err != nil {
+		// Malformed JSON — pass through and let protojson report the error.
+		return rawJSON
+	}
+
+	spec, _ := doc["spec"].(map[string]any)
+	agents, _ := spec["agents"].(map[string]any)
+	str, _ := agents["maintenance_window_duration"].(string)
+	if str == "" {
+		return rawJSON
+	}
+
+	d, err := time.ParseDuration(str)
+	if err != nil {
+		// Not a valid Go duration; pass through so protojson reports the error.
+		return rawJSON
+	}
+
+	agents["maintenance_window_duration"] = fmt.Sprintf("%ds", int64(d.Seconds()))
+
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return rawJSON
+	}
+	return out
 }

--- a/tool/tctl/common/resources/autoupdate_config_test.go
+++ b/tool/tctl/common/resources/autoupdate_config_test.go
@@ -20,6 +20,7 @@ package resources
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
@@ -96,4 +97,70 @@ func TestRoundTripProtoResource153(t *testing.T) {
 	require.NoError(t, decoder.Decode(&raw))
 	_, err = services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateConfig](raw.Raw)
 	require.Error(t, err)
+}
+
+func TestNormalizeAutoUpdateConfigDurations(t *testing.T) {
+	// base is a minimal valid autoupdate_config JSON document. Tests that need
+	// a specific maintenance_window_duration value embed it here.
+	const base = `{"kind":"autoupdate_config","version":"v1","metadata":{"name":"autoupdate-config"},"spec":{"agents":{"mode":"enabled","strategy":"time-based","maintenance_window_duration":%q}}}`
+
+	tests := []struct {
+		name     string
+		input    string
+		wantDur  string // expected value of maintenance_window_duration in output
+		passthru bool   // true when input should be returned unchanged
+	}{
+		{
+			name:    "hour string is converted",
+			input:   fmt.Sprintf(base, "1h"),
+			wantDur: "3600s",
+		},
+		{
+			name:    "minute string is converted",
+			input:   fmt.Sprintf(base, "30m"),
+			wantDur: "1800s",
+		},
+		{
+			name:    "compound duration is converted",
+			input:   fmt.Sprintf(base, "1h30m"),
+			wantDur: "5400s",
+		},
+		{
+			name:    "proto seconds format is preserved",
+			input:   fmt.Sprintf(base, "3600s"),
+			wantDur: "3600s",
+		},
+		{
+			name:     "invalid duration is passed through unchanged",
+			input:    fmt.Sprintf(base, "notaduration"),
+			wantDur:  "notaduration",
+			passthru: true,
+		},
+		{
+			name:     "no agents field is a no-op",
+			input:    `{"kind":"autoupdate_config","version":"v1","spec":{"tools":{"mode":"enabled"}}}`,
+			passthru: true,
+		},
+		{
+			name:     "no duration field is a no-op",
+			input:    `{"kind":"autoupdate_config","version":"v1","spec":{"agents":{"mode":"enabled"}}}`,
+			passthru: true,
+		},
+		{
+			name:     "malformed JSON is passed through unchanged",
+			input:    `not valid json`,
+			passthru: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := normalizeAutoUpdateConfigDurations([]byte(tt.input))
+			if tt.passthru {
+				require.Equal(t, tt.input, string(out))
+				return
+			}
+			require.Contains(t, string(out), fmt.Sprintf(`"maintenance_window_duration":%q`, tt.wantDur))
+		})
+	}
 }


### PR DESCRIPTION
Fixes #60318.

**Problem**

`tctl create`/`tctl edit` for `autoupdate_config` fails when
`spec.agents.maintenance_window_duration` is provided as a Go duration
string (e.g. `1h`, `30m`), which is the format shown in the docs and
in the server-side validation error message:

```
ERROR: proto: invalid google.protobuf.Duration value "1h"
```

**Root cause**

`tctl` transcodes user-supplied YAML to JSON before calling `protojson`.
The protobuf JSON wire format for `google.protobuf.Duration` requires
`"<total-seconds>s"` (e.g. `"3600s"`), not Go-style strings.

**Fix**

Normalise `spec.agents.maintenance_window_duration` before unmarshalling:
if the value parses as a Go duration, rewrite it as `"<N>s"`. Values
that do not parse are passed through unchanged so `protojson` can return
its own descriptive error.

Sub-second values (e.g. `"500ms"`) truncate to `"0s"` — this is
intentional; the server already enforces a 10-minute minimum so the
validation error is no worse than before.

Changelog: `tctl create/edit autoupdate_config` now accepts human-readable duration strings (e.g. `1h`, `30m`) for `maintenance_window_duration`.

## Manual Test Plan

### Test Environment
Local build of Teleport, single-node, no enterprise features required.

### Test Cases
- [ ] `tctl create -f autoupdate_config.yaml` with `maintenance_window_duration: 1h` succeeds
- [ ] `tctl create -f autoupdate_config.yaml` with `maintenance_window_duration: 30m` succeeds
- [ ] `tctl create -f autoupdate_config.yaml` with `maintenance_window_duration: 1h30m` succeeds
- [ ] `tctl create -f autoupdate_config.yaml` with `maintenance_window_duration: 3600s` (proto format) still works
- [ ] `tctl create -f autoupdate_config.yaml` with an invalid value (e.g. `notaduration`) produces a clear protojson error
- [ ] `tctl edit autoupdate_config` round-trip preserves `maintenance_window_duration` correctly