### PR TITLE
fix(oidc): repair GetOIDCAuthRequest crash when connector has max_age set

### DIFF
--- a/api/types/duration.go
+++ b/api/types/duration.go
@@ -44,13 +44,25 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.Duration().String())
 }
 
-// UnmarshalJSON interprets the given bytes as a Duration value
+// UnmarshalJSON interprets the given bytes as a Duration value.
+// Accepted formats:
+//   - JSON string containing a Go duration (e.g. "8h", "30m", "8h0m0s") — the primary format
+//   - JSON integer containing nanoseconds — used when reading OIDCAuthRequest records
+//     that were stored via github.com/gogo/protobuf/jsonpb after normalization
 func (d *Duration) UnmarshalJSON(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
 	var stringVar string
 	if err := json.Unmarshal(data, &stringVar); err != nil {
+		// Not a JSON string. Accept a raw integer as nanoseconds to support
+		// round-trips through storage layers that normalize duration fields
+		// to their nanosecond representation before unmarshaling.
+		var ns int64
+		if parseErr := json.Unmarshal(data, &ns); parseErr == nil {
+			*d = Duration(ns)
+			return nil
+		}
 		return trace.Wrap(err)
 	}
 	if stringVar == constants.DurationNever {

--- a/api/types/duration_test.go
+++ b/api/types/duration_test.go
@@ -47,6 +47,21 @@ func TestDurationUnmarshal(t *testing.T) {
 			stringValue:   `"24d30μs"`,
 			expectedValue: Duration(time.Hour*24*24 + time.Microsecond*30),
 		},
+		// Storage layers that normalize casttype=Duration fields produced by
+		// github.com/gogo/protobuf/jsonpb convert Go duration strings to their
+		// nanosecond integer representation before unmarshaling. Verify that
+		// Duration.UnmarshalJSON accepts raw integer nanoseconds so that
+		// OIDCAuthRequest records with MaxAge survive the storage round-trip.
+		{
+			name:          "integer nanoseconds (8 hours)",
+			stringValue:   `28800000000000`,
+			expectedValue: Duration(time.Hour * 8),
+		},
+		{
+			name:          "integer nanoseconds (1h30m)",
+			stringValue:   `5400000000000`,
+			expectedValue: Duration(time.Hour + 30*time.Minute),
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/lib/services/local/export_test.go
+++ b/lib/services/local/export_test.go
@@ -37,3 +37,6 @@ const (
 	UsersPrefix  = usersPrefix
 	ParamsPrefix = paramsPrefix
 )
+
+// NormalizeOIDCAuthRequestDurations exports normalizeOIDCAuthRequestDurations for tests.
+var NormalizeOIDCAuthRequestDurations = normalizeOIDCAuthRequestDurations

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -1708,10 +1708,77 @@ func (s *IdentityService) GetOIDCAuthRequest(ctx context.Context, stateToken str
 		return nil, trace.Wrap(err)
 	}
 	req := new(types.OIDCAuthRequest)
-	if err := (&jsonpb.Unmarshaler{AllowUnknownFields: true}).Unmarshal(bytes.NewReader(item.Value), req); err != nil {
+	if err := (&jsonpb.Unmarshaler{AllowUnknownFields: true}).Unmarshal(bytes.NewReader(normalizeOIDCAuthRequestDurations(item.Value)), req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return req, nil
+}
+
+// normalizeOIDCAuthRequestDurations converts Go duration strings (e.g. "8h0m0s")
+// stored in OIDCAuthRequest JSON to nanosecond integers before jsonpb unmarshaling.
+//
+// When CreateOIDCAuthRequest serializes an OIDCAuthRequest via jsonpb.Marshaler,
+// fields of type types.Duration (proto casttype=Duration) are marshaled as Go
+// duration strings rather than raw integers, because the marshaler falls back to
+// encoding/json which invokes Duration.MarshalJSON. On the read side,
+// jsonpb.Unmarshaler strips the surrounding JSON quotes (treating the value as a
+// quoted integer) and then calls json.Unmarshal on the raw bytes (e.g. 8h0m0s),
+// which fails JSON validation before the custom Duration.UnmarshalJSON is reached.
+// Converting the strings to integer nanoseconds before unmarshaling side-steps
+// the invalid-JSON path and also makes Duration.UnmarshalJSON's integer branch
+// reachable.
+func normalizeOIDCAuthRequestDurations(raw []byte) []byte {
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return raw
+	}
+
+	spec, _ := doc["ConnectorSpec"].(map[string]any)
+	if spec == nil {
+		return raw
+	}
+
+	changed := false
+	// OIDCConnectorSpecV3.MaxAge embedded field → jsonpb key "MaxAge" → field "Value"
+	if maxAge, _ := spec["MaxAge"].(map[string]any); maxAge != nil {
+		if normalizeDurationField(maxAge, "Value") {
+			changed = true
+		}
+	}
+	// OIDCConnectorSpecV3.MFASettings → jsonpb key "MFASettings" → field "maxAge"
+	if mfaSettings, _ := spec["MFASettings"].(map[string]any); mfaSettings != nil {
+		if normalizeDurationField(mfaSettings, "maxAge") {
+			changed = true
+		}
+	}
+
+	if !changed {
+		return raw
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// normalizeDurationField converts a Go duration string value in m[key] to its
+// nanosecond integer equivalent in place. Returns true if a conversion happened.
+//
+// It uses time.ParseDuration, which accepts only Go stdlib units (h/m/s/ms/µs/ns).
+// That is sufficient here because jsonpb stores Duration values via Duration.MarshalJSON
+// which delegates to time.Duration.String() — the same unit set.
+func normalizeDurationField(m map[string]any, key string) bool {
+	str, ok := m[key].(string)
+	if !ok || str == "" {
+		return false
+	}
+	d, err := time.ParseDuration(str)
+	if err != nil {
+		return false
+	}
+	m[key] = d.Nanoseconds()
+	return true
 }
 
 // UpsertSAMLConnector upserts SAML Connector

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -1785,3 +1785,139 @@ func TestIdentityService_SSOMFASessionDataCRUD(t *testing.T) {
 	_, err = identity.GetMFASessionData(ctx, sd.RequestID)
 	require.True(t, trace.IsNotFound(err))
 }
+
+// TestNormalizeOIDCAuthRequestDurations tests normalizeOIDCAuthRequestDurations
+// directly against raw JSON, covering both duration field locations and the
+// pass-through behaviour for records that need no conversion.
+func TestNormalizeOIDCAuthRequestDurations(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hour8ns  = `28800000000000` // 8h in nanoseconds
+		min30ns  = `1800000000000`  // 30m in nanoseconds
+		hour90ns = `5400000000000`  // 1h30m in nanoseconds
+	)
+
+	tests := []struct {
+		name     string
+		input    string
+		passthru bool   // true: output must equal input byte-for-byte
+		wantSub  string // substring that must appear in output when !passthru
+	}{
+		{
+			name:    "MaxAge.Value string is converted",
+			input:   `{"StateToken":"t","ConnectorSpec":{"MaxAge":{"Value":"8h0m0s"}}}`,
+			wantSub: `"Value":` + hour8ns,
+		},
+		{
+			name:    "MFASettings.maxAge string is converted",
+			input:   `{"StateToken":"t","ConnectorSpec":{"MFASettings":{"enabled":true,"maxAge":"30m0s"}}}`,
+			wantSub: `"maxAge":` + min30ns,
+		},
+		{
+			name:    "compound duration in MaxAge is converted",
+			input:   `{"StateToken":"t","ConnectorSpec":{"MaxAge":{"Value":"1h30m0s"}}}`,
+			wantSub: `"Value":` + hour90ns,
+		},
+		{
+			name:     "no ConnectorSpec is a no-op",
+			input:    `{"StateToken":"t","Type":"oidc"}`,
+			passthru: true,
+		},
+		{
+			name:     "no MaxAge field is a no-op",
+			input:    `{"StateToken":"t","ConnectorSpec":{"IssuerURL":"https://example.com"}}`,
+			passthru: true,
+		},
+		{
+			name:     "malformed JSON is passed through unchanged",
+			input:    `not valid json`,
+			passthru: true,
+		},
+		{
+			name:     "empty input is passed through unchanged",
+			input:    `{}`,
+			passthru: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := local.NormalizeOIDCAuthRequestDurations([]byte(tt.input))
+			if tt.passthru {
+				require.Equal(t, tt.input, string(out))
+				return
+			}
+			require.Contains(t, string(out), tt.wantSub)
+		})
+	}
+}
+
+// TestOIDCAuthRequestMaxAgeRoundTrip verifies that an OIDCAuthRequest with a
+// non-zero MaxAge round-trips through CreateOIDCAuthRequest/GetOIDCAuthRequest
+// without error. This exercises the jsonpb serialization path where
+// types.Duration fields are marshaled as Go duration strings (e.g. "8h0m0s")
+// rather than raw nanosecond integers; the unmarshaler must handle both forms.
+func TestOIDCAuthRequestMaxAgeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	identity := newIdentityService(t, clockwork.NewFakeClock())
+
+	tests := []struct {
+		name       string
+		stateToken string
+		spec       types.OIDCConnectorSpecV3
+		checkFn    func(t *testing.T, got *types.OIDCAuthRequest)
+	}{
+		{
+			name:       "MaxAge.Value survives round-trip",
+			stateToken: "state-maxage",
+			spec: types.OIDCConnectorSpecV3{
+				MaxAge: &types.MaxAge{
+					Value: types.Duration(8 * time.Hour),
+				},
+			},
+			checkFn: func(t *testing.T, got *types.OIDCAuthRequest) {
+				t.Helper()
+				require.NotNil(t, got.ConnectorSpec)
+				require.NotNil(t, got.ConnectorSpec.MaxAge)
+				require.Equal(t, types.Duration(8*time.Hour), got.ConnectorSpec.MaxAge.Value)
+			},
+		},
+		{
+			name:       "MFASettings.MaxAge survives round-trip",
+			stateToken: "state-mfa-maxage",
+			spec: types.OIDCConnectorSpecV3{
+				MFASettings: &types.OIDCConnectorMFASettings{
+					Enabled: true,
+					MaxAge:  types.Duration(30 * time.Minute),
+				},
+			},
+			checkFn: func(t *testing.T, got *types.OIDCAuthRequest) {
+				t.Helper()
+				require.NotNil(t, got.ConnectorSpec)
+				require.NotNil(t, got.ConnectorSpec.MFASettings)
+				require.Equal(t, types.Duration(30*time.Minute), got.ConnectorSpec.MFASettings.MaxAge)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := types.OIDCAuthRequest{
+				ConnectorID:   "test-connector",
+				Type:          "oidc",
+				StateToken:    tt.stateToken,
+				SSOTestFlow:   true,
+				ConnectorSpec: &tt.spec,
+			}
+			err := identity.CreateOIDCAuthRequest(ctx, req, time.Minute)
+			require.NoError(t, err)
+
+			got, err := identity.GetOIDCAuthRequest(ctx, req.StateToken)
+			require.NoError(t, err)
+			tt.checkFn(t, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #53967

## What

`tctl sso test` crashes with `invalid character 'h' after top-level value` when the OIDC connector has `max_age` configured (e.g. `max_age: 8h`).

## Why

`CreateOIDCAuthRequest` serializes the request via `jsonpb.Marshaler`. For `casttype=Duration` fields (`MaxAge.Value`, `MFASettings.maxAge`), the marshaler has no special handling and falls back to `encoding/json`, which invokes `Duration.MarshalJSON` — producing a quoted Go duration string like `"8h0m0s"` instead of a raw integer.

On the read side, `jsonpb.Unmarshaler` strips the surrounding quotes and passes the bare bytes (`8h0m0s`) to `json.Unmarshal`. Go's JSON decoder validates syntax before dispatching to custom unmarshalers: it parses the leading `8` as a number, then fails at `h` — so `Duration.UnmarshalJSON` is never reached.

## Fix

Two co-operative changes:

**`GetOIDCAuthRequest` (read path)** — `normalizeOIDCAuthRequestDurations` rewrites Go duration strings at `ConnectorSpec.MaxAge.Value` and `ConnectorSpec.MFASettings.maxAge` to nanosecond integers before jsonpb sees the data. Records with no duration fields are returned byte-for-byte unchanged via an early return.

**`Duration.UnmarshalJSON`** — extended to accept a raw JSON integer as nanoseconds. This is the form the normalizer produces, and it keeps the type self-consistent for any storage layer that already stores durations as integers.

Changelog: Fixed `tctl sso test` crash ("invalid character 'h' after top-level value") when an OIDC connector has `max_age` set. `GetOIDCAuthRequest` now correctly deserializes Duration fields that were stored as Go duration strings by the jsonpb marshaler.

## Manual Test Plan

### Test Environment
- Local Teleport cluster with an OIDC connector spec containing `max_age: 8h`

### Test Cases
- [ ] `tctl sso test` with an OIDC connector containing `max_age` completes without crashing
- [ ] `GetOIDCAuthRequest` returns the correct `MaxAge.Value` after a Create/Get round-trip
- [ ] `GetOIDCAuthRequest` returns the correct `MFASettings.MaxAge` after a Create/Get round-trip
- [ ] Requests without `ConnectorSpec` or without duration fields are unaffected (no regression)
- [ ] `TestNormalizeOIDCAuthRequestDurations` — 7 table-driven cases covering both field paths and all passthrough branches
- [ ] `TestOIDCAuthRequestMaxAgeRoundTrip` — 2 end-to-end cases (MaxAge.Value, MFASettings.MaxAge)
- [ ] `TestDurationUnmarshal` — 2 new integer nanosecond cases