### PR TITLE
Adding test coverage for scoped kube proxy

### DIFF
--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1264,13 +1264,19 @@ func TestScopedHost(clusterName, hostID, scope string, roles ...types.SystemRole
 
 // TestServerID returns a TestIdentity for a node with the passed in serverID.
 func TestServerID(role types.SystemRole, serverID string) TestIdentity {
+	return TestScopedServerID(role, serverID, "")
+}
+
+// TestScopedServerID returns a scoped TestIdentity for a node with the passed in serverID.
+func TestScopedServerID(role types.SystemRole, serverID, scope string) TestIdentity {
 	return TestIdentity{
 		I: authz.BuiltinRole{
 			Role:                  types.RoleInstance,
 			Username:              serverID,
 			AdditionalSystemRoles: types.SystemRoles{role},
 			Identity: tlsca.Identity{
-				Username: serverID,
+				Username:   serverID,
+				AgentScope: scope,
 			},
 		},
 	}
@@ -1545,6 +1551,49 @@ func NewServerIdentity(clt *auth.Server, hostID string, role types.SystemRole) (
 			PublicSSHKey: ssh.MarshalAuthorizedKey(sshPubKey),
 			PublicTLSKey: tlsPubKey,
 		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return state.ReadIdentityFromKeyPair(privateKeyPEM, certs)
+}
+
+// NewScopedServerIdentity generates new scoped server identity, used in tests
+func NewScopedServerIdentity(clt *auth.Server, hostID, scope string, role types.SystemRole) (*state.Identity, error) {
+	if scope == "" {
+		return NewServerIdentity(clt, hostID, role)
+	}
+
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	privateKeyPEM, err := keys.MarshalPrivateKey(key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	sshPubKey, err := ssh.NewPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tlsPubKey, err := keys.MarshalPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	certs, err := clt.GenerateHostCerts(context.Background(), auth.HostCertsParams{
+		Req: &proto.HostCertsRequest{
+			HostID:       hostID,
+			NodeName:     hostID,
+			Role:         role,
+			PublicSSHKey: ssh.MarshalAuthorizedKey(sshPubKey),
+			PublicTLSKey: tlsPubKey,
+		},
+		AgentScope: scope,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -20,16 +20,17 @@ package proxy
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,9 +41,15 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 
 	"github.com/gravitational/teleport"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 var (
@@ -67,10 +74,15 @@ func TestExecKubeService(t *testing.T) {
 
 	// creates a Kubernetes service with a configured cluster pointing to mock api server
 	testCtx := SetupTestContext(
-		context.Background(),
+		t.Context(),
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scopedTestScope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 
@@ -93,7 +105,6 @@ func TestExecKubeService(t *testing.T) {
 		userWithSingleKubeUser.GetName(),
 		kubeCluster,
 	)
-	require.NoError(t, err)
 
 	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
 	userMultiKubeUsers, _ := testCtx.CreateUserAndRole(
@@ -102,7 +113,7 @@ func TestExecKubeService(t *testing.T) {
 		usernameMultiUsers,
 		RoleSpec{
 			Name:       roleNameMultiUsers,
-			KubeUsers:  append(roleKubeUsers, "admin"),
+			KubeUsers:  append(slices.Clone(roleKubeUsers), "admin"),
 			KubeGroups: roleKubeGroups,
 		})
 
@@ -112,8 +123,60 @@ func TestExecKubeService(t *testing.T) {
 		userMultiKubeUsers.GetName(),
 		kubeCluster,
 	)
-	require.NoError(t, err)
+	scopedWithSingleKubeUser, scopedSingleKubeUserRole := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+username,
+		scopedTestScope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scopedTestScope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
 
+	scopedMultiKubeUsers, scopedMultiKubeUserRole := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameMultiUsers,
+		scopedTestScope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scopedTestScope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  append(slices.Clone(roleKubeUsers), "admin"),
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		},
+	)
+	waitForSRACache(t, testCtx.TLSServer, scopedSingleKubeUserRole, scopedMultiKubeUserRole)
+
+	_, scopedConfigWithSingleKubeUser := testCtx.GenTestKubeClientTLSCert(
+		t,
+		scopedWithSingleKubeUser.GetName(),
+		kubeCluster,
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedWithSingleKubeUser.GetName(), scopedTestScope)
+		},
+	)
+	_, scopedConfigMultiKubeUsers := testCtx.GenTestKubeClientTLSCert(
+		t,
+		scopedMultiKubeUsers.GetName(),
+		kubeCluster,
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedMultiKubeUsers.GetName(), scopedTestScope)
+		},
+	)
 	type args struct {
 		executorBuilder func(*rest.Config, string, *url.URL) (remotecommand.Executor, error)
 		impersonateUser string
@@ -132,6 +195,13 @@ func TestExecKubeService(t *testing.T) {
 			},
 		},
 		{
+			name: "SPDY protocol - scoped",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          scopedConfigWithSingleKubeUser,
+			},
+		},
+		{
 			name: "Websocket protocol v4",
 			args: args{
 				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
@@ -144,6 +214,18 @@ func TestExecKubeService(t *testing.T) {
 			},
 		},
 		{
+			name: "Websocket protocol v4 - scoped",
+			args: args{
+				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
+				// is merged into k8s go-client.
+				// For now go-client does not support connections over websockets.
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return newWebSocketClient(c, s, u)
+				},
+				config: scopedConfigWithSingleKubeUser,
+			},
+		},
+		{
 			name: "Websocket protocol v5",
 			args: args{
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
@@ -153,10 +235,27 @@ func TestExecKubeService(t *testing.T) {
 			},
 		},
 		{
+			name: "Websocket protocol v5 - scoped",
+			args: args{
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return remotecommand.NewWebSocketExecutor(c, s, u.String())
+				},
+				config: scopedConfigWithSingleKubeUser,
+			},
+		},
+		{
 			name: "SPDY protocol for user with multiple kubernetes users",
 			args: args{
 				executorBuilder: remotecommand.NewSPDYExecutor,
 				config:          configMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
+			name: "SPDY protocol for user with multiple kubernetes users - scoped",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          scopedConfigMultiKubeUsers,
 				impersonateUser: "admin",
 			},
 		},
@@ -174,12 +273,35 @@ func TestExecKubeService(t *testing.T) {
 			},
 		},
 		{
+			name: "Websocket protocol v4 for user with multiple kubernetes users - scoped",
+			args: args{
+				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
+				// is merged into k8s go-client.
+				// For now go-client does not support connections over websockets.
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return newWebSocketClient(c, s, u)
+				},
+				config:          scopedConfigMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
 			name: "Websocket protocol v5 for user with multiple kubernetes users",
 			args: args{
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return remotecommand.NewWebSocketExecutor(c, s, u.String())
 				},
 				config:          configMultiKubeUsers,
+				impersonateUser: "admin",
+			},
+		},
+		{
+			name: "Websocket protocol v5 for user with multiple kubernetes users - scoped",
+			args: args{
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return remotecommand.NewWebSocketExecutor(c, s, u.String())
+				},
+				config:          scopedConfigMultiKubeUsers,
 				impersonateUser: "admin",
 			},
 		},
@@ -192,12 +314,30 @@ func TestExecKubeService(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "SPDY protocol for user with multiple kubernetes users without specifying impersonate user - scoped",
+			args: args{
+				executorBuilder: remotecommand.NewSPDYExecutor,
+				config:          scopedConfigMultiKubeUsers,
+			},
+			wantErr: true,
+		},
+		{
 			name: "Websocket protocol v5 for user with multiple kubernetes users without specifying impersonate user",
 			args: args{
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return remotecommand.NewWebSocketExecutor(c, s, u.String())
 				},
 				config: configMultiKubeUsers,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Websocket protocol v5 for user with multiple kubernetes users without specifying impersonate user - scoped",
+			args: args{
+				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
+					return remotecommand.NewWebSocketExecutor(c, s, u.String())
+				},
+				config: scopedConfigMultiKubeUsers,
 			},
 			wantErr: true,
 		},
@@ -306,7 +446,6 @@ func generateExecRequest(cfg generateExecRequestConfig) (*rest.Request, error) {
 
 func TestExecMissingGETPermissionError(t *testing.T) {
 	t.Parallel()
-
 	const (
 		errorMessage = "pods \"api-1\" is forbidden: User \"bar\" cannot %s resource " +
 			"\"pods/exec\" in API group \"\" in the namespace \"ns\""
@@ -316,6 +455,7 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 		errorMessage   string
 		errorInspector func(*testing.T, error)
 		interactive    bool
+		scope          string
 	}{
 		{
 			name:         "missing get permission",
@@ -349,110 +489,149 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			const errorCode = http.StatusForbidden
+		for _, scope := range []string{"", scopedTestScope} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				const errorCode = http.StatusForbidden
 
-			kubeMock, err := testingkubemock.NewKubeAPIMock(
-				testingkubemock.WithExecError(
-					metav1.Status{
-						Status:  metav1.StatusFailure,
-						Message: tt.errorMessage,
-						Reason:  metav1.StatusReasonForbidden,
-						Code:    errorCode,
+				kubeMock, err := testingkubemock.NewKubeAPIMock(
+					testingkubemock.WithExecError(
+						metav1.Status{
+							Status:  metav1.StatusFailure,
+							Message: tt.errorMessage,
+							Reason:  metav1.StatusReasonForbidden,
+							Code:    errorCode,
+						},
+					),
+				)
+				require.NoError(t, err)
+				t.Cleanup(func() { kubeMock.Close() })
+				var (
+					execEvent  *apievents.Exec
+					eventsLock sync.Mutex
+				)
+
+				// creates a Kubernetes service with a configured cluster pointing to mock api server
+				testCtx := SetupTestContext(
+					t.Context(),
+					t,
+					TestConfig{
+						Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+						OnEvent: func(evt apievents.AuditEvent) {
+							eventsLock.Lock()
+							defer eventsLock.Unlock()
+							if exec, ok := evt.(*apievents.Exec); ok {
+								execEvent = exec
+							}
+						},
+						Scope: scope,
+						ScopesFeatures: scopes.Features{
+							Enabled:         true,
+							AgentPinEnabled: true,
+						},
 					},
-				),
-			)
-			require.NoError(t, err)
-			t.Cleanup(func() { kubeMock.Close() })
-			var (
-				execEvent  *apievents.Exec
-				eventsLock sync.Mutex
-			)
+				)
 
-			// creates a Kubernetes service with a configured cluster pointing to mock api server
-			testCtx := SetupTestContext(
-				context.Background(),
-				t,
-				TestConfig{
-					Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-					OnEvent: func(evt apievents.AuditEvent) {
-						eventsLock.Lock()
-						defer eventsLock.Unlock()
-						if exec, ok := evt.(*apievents.Exec); ok {
-							execEvent = exec
-						}
+				t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+
+				// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+				user, _ := testCtx.CreateUserAndRole(
+					testCtx.Context,
+					t,
+					username,
+					RoleSpec{
+						Name:       roleName,
+						KubeUsers:  roleKubeUsers,
+						KubeGroups: roleKubeGroups,
+					})
+
+				// generate a kube client with user certs for auth
+				_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
+					t,
+					user.GetName(),
+					kubeCluster,
+				)
+
+				scopedUser, scopedUserRole := testCtx.CreateUserAndScopedRole(
+					t,
+					"scoped-"+username,
+					scopedTestScope,
+					&accessv1.ScopedRoleSpec{
+						AssignableScopes: []string{scopedTestScope},
+						Kube: &accessv1.ScopedRoleKube{
+							Users:  roleKubeUsers,
+							Groups: roleKubeGroups,
+							Labels: []*labelv1.Label{
+								{
+									Name:   types.Wildcard,
+									Values: []string{types.Wildcard},
+								},
+							},
+						},
+					})
+
+				waitForSRACache(t, testCtx.TLSServer, scopedUserRole)
+
+				_, scopedUserRestConfig := testCtx.GenTestKubeClientTLSCert(
+					t,
+					scopedUser.GetName(),
+					kubeCluster,
+					func(i *tlsca.Identity) {
+						i.ScopePin = testCtx.GetScopePinForUser(t, scopedUser.GetName(), scopedTestScope)
 					},
-				},
-			)
-
-			t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
-
-			// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
-			user, _ := testCtx.CreateUserAndRole(
-				testCtx.Context,
-				t,
-				username,
-				RoleSpec{
-					Name:       roleName,
-					KubeUsers:  roleKubeUsers,
-					KubeGroups: roleKubeGroups,
-				})
-
-			// generate a kube client with user certs for auth
-			_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
-				t,
-				user.GetName(),
-				kubeCluster,
-			)
-			var streamOpts remotecommand.StreamOptions
-			if !tt.interactive {
-				streamOpts = remotecommand.StreamOptions{
-					Stdin:  nil,
-					Stdout: &bytes.Buffer{},
-					Stderr: &bytes.Buffer{},
-					Tty:    false,
+				)
+				var streamOpts remotecommand.StreamOptions
+				if !tt.interactive {
+					streamOpts = remotecommand.StreamOptions{
+						Stdin:  nil,
+						Stdout: &bytes.Buffer{},
+						Stderr: &bytes.Buffer{},
+						Tty:    false,
+					}
+				} else {
+					stdinReader, _ := io.Pipe()
+					t.Cleanup(func() { stdinReader.Close() })
+					streamOpts = remotecommand.StreamOptions{
+						Stdin:  stdinReader,
+						Stdout: &bytes.Buffer{},
+						Stderr: nil,
+						Tty:    true,
+					}
 				}
-			} else {
-				stdinReader, _ := io.Pipe()
-				t.Cleanup(func() { stdinReader.Close() })
-				streamOpts = remotecommand.StreamOptions{
-					Stdin:  stdinReader,
-					Stdout: &bytes.Buffer{},
-					Stderr: nil,
-					Tty:    true,
+				req, err := generateExecRequest(
+					generateExecRequestConfig{
+						addr:          testCtx.KubeProxyAddress(),
+						podName:       podName,
+						podNamespace:  podNamespace,
+						containerName: podContainerName,
+						cmd:           containerCommmandExecute, // placeholder for commands to execute in the dummy pod
+						options:       streamOpts,
+					},
+				)
+				require.NoError(t, err)
+				cfg := userRestConfig
+				if scope != "" {
+					cfg = scopedUserRestConfig
 				}
-			}
-			req, err := generateExecRequest(
-				generateExecRequestConfig{
-					addr:          testCtx.KubeProxyAddress(),
-					podName:       podName,
-					podNamespace:  podNamespace,
-					containerName: podContainerName,
-					cmd:           containerCommmandExecute, // placeholder for commands to execute in the dummy pod
-					options:       streamOpts,
-				},
-			)
-			require.NoError(t, err)
+				exec, err := remotecommand.NewSPDYExecutor(cfg, http.MethodPost, req.URL())
+				require.NoError(t, err)
+				err = exec.StreamWithContext(testCtx.Context, streamOpts)
+				require.Error(t, err)
+				tt.errorInspector(t, err)
 
-			exec, err := remotecommand.NewSPDYExecutor(userRestConfig, http.MethodPost, req.URL())
-			require.NoError(t, err)
-			err = exec.StreamWithContext(testCtx.Context, streamOpts)
-			require.Error(t, err)
-			tt.errorInspector(t, err)
+				require.Eventually(t, func() bool {
+					eventsLock.Lock()
+					defer eventsLock.Unlock()
+					return execEvent != nil
+				}, 5*time.Second, 100*time.Millisecond, "expected exec event to be recorded")
 
-			require.Eventually(t, func() bool {
 				eventsLock.Lock()
-				defer eventsLock.Unlock()
-				return execEvent != nil
-			}, 5*time.Second, 100*time.Millisecond, "expected exec event to be recorded")
-
-			eventsLock.Lock()
-			require.Equal(t, events.ExecFailureCode, execEvent.Code)
-			require.Equal(t, "403", execEvent.ExitCode)
-			require.NotEmpty(t, execEvent.Error)
-			eventsLock.Unlock()
-		})
+				require.Equal(t, events.ExecFailureCode, execEvent.Code)
+				require.Equal(t, "403", execEvent.ExitCode)
+				require.NotEmpty(t, execEvent.Error)
+				eventsLock.Unlock()
+			})
+		}
 	}
 }
 
@@ -462,9 +641,8 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 	const (
 		errorMessage = "pods \"api-1\" is forbidden: User \"bar\" cannot %s resource " +
 			"\"pods/exec\" in API group \"\" in the namespace \"ns\""
+		errorCode = http.StatusForbidden
 	)
-
-	const errorCode = http.StatusForbidden
 
 	kubeMock, err := testingkubemock.NewKubeAPIMock(
 		testingkubemock.WithExecError(
@@ -496,7 +674,7 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 
 	// creates a Kubernetes service with a configured cluster pointing to mock api server
 	testCtx := SetupTestContext(
-		context.Background(),
+		t.Context(),
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
@@ -506,6 +684,11 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 				if exec, ok := evt.(*apievents.Exec); ok {
 					execEvent = exec
 				}
+			},
+			Scope: scopedTestScope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
 			},
 		},
 	)
@@ -578,7 +761,7 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 
 			exec, err := remotecommand.NewSPDYExecutor(userRestConfig, http.MethodPost, req.URL())
 			require.NoError(t, err)
-			err = exec.StreamWithContext(context.Background(), streamOpts)
+			err = exec.StreamWithContext(t.Context(), streamOpts)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), kubernetes130BreakingChangeHint)
 
@@ -595,4 +778,18 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 			eventsLock.Unlock()
 		})
 	}
+}
+
+func waitForSRACache(t *testing.T, srv *authtest.TLSServer, resps ...*accessv1.CreateScopedRoleAssignmentResponse) {
+	t.Helper()
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, resp := range resps {
+			_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, &accessv1.GetScopedRoleAssignmentRequest{
+				Name:    resp.GetAssignment().GetMetadata().GetName(),
+				SubKind: resp.GetAssignment().GetSubKind(),
+			})
+			require.NoError(t, err)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -962,6 +963,170 @@ func TestAuthenticate(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:              "local scoped user and scoped cluster",
+			user:              authz.LocalUser{},
+			scoped:            true,
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+					Scope: scopedTestScope,
+				},
+			),
+			wantCtx: &authContext{
+				kubeUsers:       set.New("user-a"),
+				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterName: "local",
+				kubeClusterLabels: map[string]string{
+					"static_label1": "static_value1",
+					"static_label2": "static_value2",
+				},
+				certExpires: certExpiration,
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+				kubeServers: newKubeServersFromKubeClusters(
+					t,
+					&types.KubernetesClusterV3{
+						Scope: scopedTestScope,
+						Metadata: types.Metadata{
+							Name: "local",
+							Labels: map[string]string{
+								"static_label1": "static_value1",
+								"static_label2": "static_value2",
+							},
+						},
+						Spec: types.KubernetesClusterSpecV3{
+							DynamicLabels: map[string]types.CommandLabelV2{},
+						},
+					},
+				),
+			},
+		},
+		{
+			desc:              "local unscoped user and scoped cluster",
+			user:              authz.LocalUser{},
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+					Scope: scopedTestScope,
+				},
+			),
+			wantCtx: &authContext{
+				kubeUsers:       set.New("user-a"),
+				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterName: "local",
+				kubeClusterLabels: map[string]string{
+					"static_label1": "static_value1",
+					"static_label2": "static_value2",
+				},
+				certExpires: certExpiration,
+				teleportCluster: teleportClusterClient{
+					name:       "local",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+				},
+				kubeServers: newKubeServersFromKubeClusters(
+					t,
+					&types.KubernetesClusterV3{
+						Scope: scopedTestScope,
+						Metadata: types.Metadata{
+							Name: "local",
+							Labels: map[string]string{
+								"static_label1": "static_value1",
+								"static_label2": "static_value2",
+							},
+						},
+						Spec: types.KubernetesClusterSpecV3{
+							DynamicLabels: map[string]types.CommandLabelV2{},
+						},
+					},
+				),
+			},
+		},
+		{
+			desc:              "local scoped user and scoped cluster - mismatched scope",
+			user:              authz.LocalUser{},
+			scoped:            true,
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+					Scope: "/other",
+				},
+			),
+			wantAuthorizeErrContains: "[00] access denied",
+		},
+		{
+			desc:              "local scoped user and unscoped cluster",
+			user:              authz.LocalUser{},
+			scoped:            true,
+			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
+			routeToCluster:    "local",
+			kubernetesCluster: "local",
+			haveKubeCreds:     true,
+			tunnel:            tun,
+			kubeServers: newKubeServersFromKubeClusters(
+				t,
+				&types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: "local",
+						Labels: map[string]string{
+							"static_label1": "static_value1",
+							"static_label2": "static_value2",
+						},
+					},
+					Spec: types.KubernetesClusterSpecV3{
+						DynamicLabels: map[string]types.CommandLabelV2{},
+					},
+				},
+			),
+			wantAuthorizeErrContains: "[00] access denied",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
@@ -1045,7 +1210,7 @@ func TestAuthenticate(t *testing.T) {
 			}
 
 			gotCtx, err := f.authenticate(req)
-			if tt.wantErr {
+			if tt.wantErr || tt.wantAuthErr {
 				require.Error(t, err)
 				require.Equal(t, tt.wantAuthErr, trace.IsAccessDenied(err))
 				return
@@ -1546,6 +1711,7 @@ type mockAccessPoint struct {
 	authPref        types.AuthPreference
 	kubeServers     []types.KubeServer
 	cas             map[string]types.CertAuthority
+	scopedRoles     map[string]*scopedaccessv1.ScopedRole
 }
 
 func (ap mockAccessPoint) GetClusterNetworkingConfig(context.Context) (types.ClusterNetworkingConfig, error) {
@@ -1574,6 +1740,17 @@ func (ap mockAccessPoint) GetCertAuthorities(ctx context.Context, caType types.C
 
 func (ap mockAccessPoint) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
 	return ap.cas[id.DomainName], nil
+}
+
+func (ap mockAccessPoint) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	if role, ok := ap.scopedRoles[req.GetName()]; ok {
+		return &scopedaccessv1.GetScopedRoleResponse{Role: role}, nil
+	}
+	return nil, trace.NotFound("role %q not found", req.GetName())
+}
+
+func (ap mockAccessPoint) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	return &scopedaccessv1.ListScopedRolesResponse{Roles: slices.Collect(maps.Values(ap.scopedRoles))}, nil
 }
 
 type mockRevTunnel struct {

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -52,10 +52,14 @@ import (
 	restclientwatch "k8s.io/client-go/rest/watch"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	tkm "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -68,6 +72,7 @@ func TestListPodRBAC(t *testing.T) {
 		usernameWithoutListVerbAccess = "no_list_user"
 		usernameWithTraits            = "trait_user"
 		testPodName                   = "test"
+		scope                         = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -83,6 +88,11 @@ func TestListPodRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 	// close tests
@@ -112,6 +122,25 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
 	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
@@ -261,6 +290,11 @@ func TestListPodRBAC(t *testing.T) {
 		listPodErr       error
 		getTestPodResult error
 	}
+	scopedOpts := []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+		},
+	}
 	tests := []struct {
 		name string
 		args args
@@ -281,10 +315,42 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 		{
+			name: "list default namespace pods for scoped user with full access",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceDefault,
+				opts:      scopedOpts,
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+					"default/test",
+				},
+			},
+		},
+		{
 			name: "list pods in every namespace for user with full access",
 			args: args{
 				user:      userWithFullAccess,
 				namespace: metav1.NamespaceAll,
+			},
+			want: want{
+				listPodsResult: []string{
+					"default/nginx-1",
+					"default/nginx-2",
+					"default/test",
+					"dev/nginx-1",
+					"dev/nginx-2",
+				},
+			},
+		},
+		{
+			name: "list pods in every namespace for scoped user with full access",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceAll,
+				opts:      scopedOpts,
 			},
 			want: want{
 				listPodsResult: []string{
@@ -1065,6 +1131,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		usernameWithFullAccess      = "full_user"
 		usernameWithNamespaceAccess = "default_user"
 		usernameWithLimitedAccess   = "limited_user"
+		scope                       = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -1080,6 +1147,11 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 	// close tests
@@ -1109,6 +1181,25 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
 	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
@@ -1163,6 +1254,12 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 	type args struct {
 		user      types.User
 		namespace string
+		opts      []GenTestKubeClientTLSCertOptions
+	}
+	scopedOpts := []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+		},
 	}
 	tests := []struct {
 		name        string
@@ -1175,6 +1272,20 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 			args: args{
 				user:      userWithFullAccess,
 				namespace: metav1.NamespaceDefault,
+			},
+
+			deletedPods: []string{
+				"default/nginx-1",
+				"default/nginx-2",
+				"default/test",
+			},
+		},
+		{
+			name: "delete pods in default namespace for scoped user with full access",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceDefault,
+				opts:      scopedOpts,
 			},
 
 			deletedPods: []string{
@@ -1227,6 +1338,7 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 				t,
 				tt.args.user.GetName(),
 				kubeCluster,
+				tt.args.opts...,
 			)
 			err := client.CoreV1().Pods(tt.args.namespace).DeleteCollection(
 				testCtx.Context,
@@ -1256,6 +1368,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		usernameWithFullAccess      = "full_user"
 		usernameWithNamespaceAccess = "default_user"
 		usernameWithLimitedAccess   = "limited_user"
+		scope                       = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -1271,6 +1384,11 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 	// close tests
@@ -1300,6 +1418,27 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	// create a scoped user with full access to kubernetes Pods.
+	// (kubernetes_user and kubernetes_groups specified)
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
+
 	// create a user with full access to kubernetes Pods.
 	// (kubernetes_user and kubernetes_groups specified)
 	userWithNamespaceAccess, _ := testCtx.CreateUserAndRole(
@@ -1354,6 +1493,12 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 	type args struct {
 		user      types.User
 		namespace string
+		opts      []GenTestKubeClientTLSCertOptions
+	}
+	scopedOpts := []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+		},
 	}
 	tests := []struct {
 		name        string
@@ -1366,6 +1511,21 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 			args: args{
 				user:      userWithFullAccess,
 				namespace: metav1.NamespaceDefault,
+			},
+
+			deletedCRDs: []string{
+				"default/telerole-1",
+				"default/telerole-1",
+				"default/telerole-2",
+				"default/telerole-test",
+			},
+		},
+		{
+			name: "delete teleportroles in default namespace for scoped user with full access",
+			args: args{
+				user:      scopedUserWithFullAccess,
+				namespace: metav1.NamespaceDefault,
+				opts:      scopedOpts,
 			},
 
 			deletedCRDs: []string{
@@ -1419,6 +1579,7 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 				t,
 				tt.args.user.GetName(),
 				kubeCluster,
+				tt.args.opts...,
 			)
 			err := client.Resource(schema.GroupVersionResource{
 				Group:    "resources.teleport.dev",
@@ -1448,12 +1609,11 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 }
 
 func TestListClusterRoleRBAC(t *testing.T) {
-	t.Parallel()
-
 	const (
 		usernameWithFullAccess    = "full_user"
 		usernameWithLimitedAccess = "limited_user"
 		testClusterRoleName       = "cr-test"
+		scope                     = "/test"
 	)
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
@@ -1469,6 +1629,11 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 	// close tests
@@ -1497,6 +1662,26 @@ func TestListClusterRoleRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	// create a scoped user with full access to kubernetes Pods.
+	// (kubernetes_user and kubernetes_groups specified)
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
 
 	// Create a moderator user with access to kubernetes
 	// (kubernetes_user and kubernetes_groups specified).
@@ -1527,6 +1712,11 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		user types.User
 		opts []GenTestKubeClientTLSCertOptions
 	}
+	scopedOpts := []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+		},
+	}
 	type want struct {
 		listClusterRolesResult []string
 		listClusterErr         error
@@ -1541,6 +1731,20 @@ func TestListClusterRoleRBAC(t *testing.T) {
 			name: "list cluster roles for user with full access",
 			args: args{
 				user: userWithFullAccess,
+			},
+			want: want{
+				listClusterRolesResult: []string{
+					"cr-nginx-1",
+					"cr-nginx-2",
+					"cr-test",
+				},
+			},
+		},
+		{
+			name: "list cluster roles for scoped user with full access",
+			args: args{
+				user: scopedUserWithFullAccess,
+				opts: scopedOpts,
 			},
 			want: want{
 				listClusterRolesResult: []string{
@@ -1658,17 +1862,16 @@ func TestListClusterRoleRBAC(t *testing.T) {
 }
 
 func TestGenericCustomResourcesRBAC(t *testing.T) {
-	t.Parallel()
-
 	const (
 		usernameWithFullAccess     = "full_user"
 		usernameWithLimitedAccess  = "limited_user"
 		usernameWithSpecificAccess = "specific_user"
 		testTeleportRoleName       = "telerole-test"
 		testTeleportRoleNamespace  = "default"
+		scope                      = "/test"
 	)
 
-	kubeScheme, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	kubeScheme, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
 
 	// create a user with full access to all namespaces.
 	// (kubernetes_user and kubernetes_groups specified)
@@ -1695,6 +1898,26 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 			},
 		},
 	)
+
+	// create a scoped user with full access to all namespaces.
+	// (kubernetes_user and kubernetes_groups specified)
+	scopedUserWithFullAccess, _ := testCtx.CreateUserAndScopedRole(
+		t,
+		"scoped-"+usernameWithFullAccess,
+		scope,
+		&accessv1.ScopedRoleSpec{
+			AssignableScopes: []string{scope},
+			Kube: &accessv1.ScopedRoleKube{
+				Users:  roleKubeUsers,
+				Groups: roleKubeGroups,
+				Labels: []*labelv1.Label{
+					{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					},
+				},
+			},
+		})
 
 	// create a user with limited access to kubernetes namespaces.
 	userWithLimitedAccess, _ := testCtx.CreateUserAndRoleVersion(
@@ -1757,6 +1980,11 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		user types.User
 		opts []GenTestKubeClientTLSCertOptions
 	}
+	scopedOpts := []GenTestKubeClientTLSCertOptions{
+		func(i *tlsca.Identity) {
+			i.ScopePin = testCtx.GetScopePinForUser(t, scopedUserWithFullAccess.GetName(), scope)
+		},
+	}
 	type want struct {
 		listTeleportRolesResult []string
 		wantListErr             bool
@@ -1772,6 +2000,23 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 			name: "list teleport roles for user with full access",
 			args: args{
 				user: userWithFullAccess,
+			},
+			want: want{
+				listTeleportRolesResult: []string{
+					"default/telerole-1",
+					"default/telerole-1",
+					"default/telerole-2",
+					"default/telerole-test",
+					"dev/telerole-1",
+					"dev/telerole-2",
+				},
+			},
+		},
+		{
+			name: "list teleport roles for scoped user with full access",
+			args: args{
+				user: scopedUserWithFullAccess,
+				opts: scopedOpts,
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -1989,7 +2234,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 func TestV8JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "", types.V8)
 
@@ -2312,7 +2557,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 func TestV7JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "", types.V7)
 
@@ -2537,7 +2782,7 @@ func TestV7JailedNamespaceListRBAC(t *testing.T) {
 func TestV7V8Match(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	// Create a factory to generate users in various role versions.
 	newV7TestUser := newTestUserFactory(t, testCtx, "v7v8", types.V7)
@@ -2897,7 +3142,7 @@ func TestV7V8Match(t *testing.T) {
 func TestNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "nslist", types.V8)
 
@@ -3180,7 +3425,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 func TestDenyClusterWideResources(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "deny-cw", types.V8)
 
@@ -3334,7 +3579,7 @@ func TestDenyClusterWideResources(t *testing.T) {
 func TestDeleteNamespace(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "delete-ns", types.V8)
 
@@ -3443,7 +3688,7 @@ func TestDeleteNamespace(t *testing.T) {
 func TestFullNamespaceNoDeleteRBAC(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
 
 	newTestUser := newTestUserFactory(t, testCtx, "fullnsnodelete", types.V8)
 
@@ -3549,7 +3794,7 @@ func TestFullNamespaceNoDeleteRBAC(t *testing.T) {
 	}
 }
 
-func newTestKubeCRDMock(t *testing.T, opts ...tkm.Option) (*runtime.Scheme, *TestContext) {
+func newTestKubeCRDMock(t *testing.T, scope string, opts ...tkm.Option) (*runtime.Scheme, *TestContext) {
 	t.Helper()
 
 	// kubeMock is a Kubernetes API mock for the session tests.
@@ -3570,6 +3815,11 @@ func newTestKubeCRDMock(t *testing.T, opts ...tkm.Option) (*runtime.Scheme, *Tes
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scope,
+			ScopesFeatures: scopes.Features{
+				Enabled:         true,
+				AgentPinEnabled: true,
+			},
 		},
 	)
 	// Close tests.
@@ -3583,6 +3833,7 @@ func newTestUserFactory(t *testing.T, testCtx *TestContext, prefix, roleVersion 
 	if prefix == "" {
 		prefix = "test"
 	}
+
 	return func(allow, deny []types.KubernetesResource) types.User {
 		t.Helper()
 		count++
@@ -3664,6 +3915,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 	clusterswagv0 := tkm.NewCRD("resources.teleport.dev", "v0", "clusterswags", "ClusterSwag", "ClusterSwagList", false)
 
 	kubeScheme, testCtx := newTestKubeCRDMock(t,
+		"",
 		tkm.WithTeleportRoleCRD,
 		tkm.WithCRD(telerolev8,
 			tkm.NewObject("default", "telerole-1"),

--- a/lib/kube/proxy/self_subject_reviews_test.go
+++ b/lib/kube/proxy/self_subject_reviews_test.go
@@ -437,7 +437,7 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 func TestSelfSubjectAccessReviewsAllowed(t *testing.T) {
 	t.Parallel()
 
-	_, testCtx := newTestKubeCRDMock(t, testingkubemock.WithTeleportRoleCRD)
+	_, testCtx := newTestKubeCRDMock(t, "", testingkubemock.WithTeleportRoleCRD)
 
 	newTestUserV7 := newTestUserFactory(t, testCtx, "", types.V7)
 	newTestUserV8 := newTestUserFactory(t, testCtx, "", types.V8)

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -48,6 +48,9 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -71,6 +74,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	sessPkg "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -116,6 +120,7 @@ type TestConfig struct {
 	CreateAuditStreamErr error
 	WrapAuthClient       func(authclient.ClientI) authclient.ClientI
 	ScopesFeatures       scopes.Features
+	Scope                string
 }
 
 // SetupTestContext creates a kube service with clusters configured.
@@ -183,7 +188,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	require.NoError(t, err)
 
 	// Auth client for Kube service.
-	testCtx.AuthClient, err = testCtx.TLSServer.NewClient(authtest.TestServerID(types.RoleKube, testCtx.HostID))
+	testCtx.AuthClient, err = testCtx.TLSServer.NewClient(authtest.TestScopedServerID(types.RoleKube, testCtx.HostID, cfg.Scope))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, testCtx.AuthClient.Close()) })
 
@@ -212,7 +217,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	require.NoError(t, err)
 
 	// TLS config for kube proxy and Kube service.
-	serverIdentity, err := authtest.NewServerIdentity(authServer.AuthServer, testCtx.HostID, types.RoleKube)
+	serverIdentity, err := authtest.NewScopedServerIdentity(authServer.AuthServer, testCtx.HostID, cfg.Scope, types.RoleKube)
 	require.NoError(t, err)
 	kubeServiceTLSConfig, err := serverIdentity.TLSConfig(nil)
 	require.NoError(t, err)
@@ -259,6 +264,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 				Version:  teleport.Version,
 				Services: types.SystemRoles{types.RoleKube}.StringSlice(),
 				Hostname: "test",
+				Scope:    cfg.Scope,
 			}.Build(), nil
 		})
 	require.NoError(t, err)
@@ -313,6 +319,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			},
 			Clock:           clockwork.NewRealClock(),
 			ClusterFeatures: features,
+			Scope:           cfg.Scope,
 		},
 		DynamicLabels: nil,
 		TLS:           kubeServiceTLSConfig.Clone(),
@@ -537,6 +544,51 @@ func (c *TestContext) CreateUserAndRoleVersion(ctx context.Context, t *testing.T
 	return c.CreateUserWithTraitsAndRoleVersion(ctx, t, username, nil, roleVersion, roleSpec)
 }
 
+// CreateUserScopedRole creates a Teleport user and a scoped role assigned
+// to them.
+func (c *TestContext) CreateUserAndScopedRole(t *testing.T, username, scope string, roleSpec *accessv1.ScopedRoleSpec) (types.User, *accessv1.CreateScopedRoleAssignmentResponse) {
+	user, err := authtest.CreateUser(t.Context(), c.TLSServer.Auth(), username)
+	require.NoError(t, err)
+
+	scopedAccess := c.TLSServer.Auth().ScopedAccess()
+	role, err := scopedAccess.CreateScopedRole(t.Context(), &accessv1.CreateScopedRoleRequest{
+		Role: &accessv1.ScopedRole{
+			Kind:    access.KindScopedRole,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: username,
+			},
+			Scope: scope,
+			Spec:  roleSpec,
+		},
+	})
+	require.NoError(t, err)
+
+	assignment, err := scopedAccess.CreateScopedRoleAssignment(t.Context(), &accessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &accessv1.ScopedRoleAssignment{
+			Kind:    access.KindScopedRoleAssignment,
+			Version: types.V1,
+			SubKind: access.SubKindDynamic,
+			Scope:   scope,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.New().String(),
+			},
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: username,
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  role.GetRole().GetMetadata().GetName(),
+						Scope: scope,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	return user, assignment
+}
+
 func newKubeConfigFile(t *testing.T, clusters ...KubeClusterConfig) string {
 	tmpDir := t.TempDir()
 
@@ -748,4 +800,15 @@ func (f *fakeCluster) DialTCP(p reversetunnelclient.DialParams) (conn net.Conn, 
 		panic(err)
 	}
 	return conn, nil
+}
+
+func (c *TestContext) GetScopePinForUser(t *testing.T, username, scope string) *scopesv1.Pin {
+	pin := &scopesv1.Pin{
+		Kind:  scopesv1.PinKind_PIN_KIND_USER,
+		Scope: scope,
+	}
+	err := c.AuthServer.ScopedAccessCache.PopulatePinnedAssignmentsForUser(t.Context(), username, pin)
+	require.NoError(t, err)
+
+	return pin
 }


### PR DESCRIPTION
Adds additional tests to the kube proxy covering scope changes. These are mostly duplicating existing test cases but with scoped identities.



<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
No test plan since these are just automated tests
