### PR TITLE
fips: Build fips binaries via OSS Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -626,6 +626,10 @@ clean-ui:
 	rm -rf web/packages/teleterm/build
 	find . -type d -name node_modules -prune -exec rm -rf {} \;
 
+.PHONY: clean-ent
+clean-ent:
+	$(MAKE) -C e clean
+
 # RELEASE_DIR is where release artifact files are put, such as tarballs, packages, etc.
 $(RELEASE_DIR):
 	mkdir -p $@
@@ -646,9 +650,7 @@ endif
 
 .PHONY: release-ent
 release-ent:
-ifneq (,$(wildcard e/Makefile))
 	$(MAKE) -C e release
-endif
 
 # These are aliases used to make build commands uniform.
 .PHONY: release-amd64

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -106,7 +106,7 @@ build-enterprise-binaries: buildbox-centos7 webassets
 .PHONY: build-binaries-fips
 build-binaries-fips: buildbox-centos7-fips webassets
 	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
-		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' VERSION=$(VERSION) GITTAG=v$(VERSION) PIV=$(PIV) FIPS=yes clean full
+		make ADDFLAGS='$(ADDFLAGS)' PIV=$(PIV) FIPS=yes clean-ent full-ent
 
 #
 # Build the buildbox thirdparty components. This rarely needs to be rebuilt and is
@@ -669,9 +669,8 @@ release-ng: webassets buildbox-ng
 #
 .PHONY: release-fips
 release-fips: buildbox-centos7-fips webassets
-	@if [ -z ${VERSION} ]; then echo "VERSION is not set"; exit 1; fi
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
-		/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=yes
+		/usr/bin/make release-ent -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) FIPS=yes REPRODUCIBLE=yes
 
 #
 # Create a Teleport package for CentOS 7 using the build container.
@@ -703,7 +702,7 @@ release-centos7: buildbox-centos7 webassets
 release-centos7-fips: buildbox-centos7-fips webassets
 	$(call LOG_GROUP_START)
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
-		/usr/bin/scl enable $(DEVTOOLSET) '/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=no'
+		/usr/bin/scl enable $(DEVTOOLSET) '/usr/bin/make release-ent -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) FIPS=yes REPRODUCIBLE=no'
 	$(call LOG_GROUP_END)
 
 #


### PR DESCRIPTION
Update the targets in `build.assets/Makefile` to build fips binaries by
calling `release-ent` in the OSS Makefile instead of calling `release`
in the Enterprise Makefile. This allows the top-level Makefile to set up
things properly for building fips (GOEXPERIMENT, and soon GOFIPS140)
rather than having to duplicate it in the Enterprise Makefile or fips
buildbox.

This also means we no longer need to pass through VERSION and GITTAG to
the Enterprise make as this is set by the OSS Makefile.

Issue: https://github.com/gravitational/teleport.e/issues/8538
Test-run: https://github.com/gravitational/teleport.e/actions/runs/25302425901

## Manual Test Plan
### Test Environment

Run a dev release build.

### Test Cases
- [x] Check that the build passes
- [x] Download the linux fips tarball and verify they start with --fips
