### PR TITLE
web: plumb metrics registry into API handler

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5584,6 +5584,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			IntegrationAppHandler:     connectionsHandler,
 			FeatureWatchInterval:      retryutils.HalfJitter(web.DefaultFeatureWatchInterval * 2),
 			DatabaseREPLRegistry:      cfg.DatabaseREPLRegistry,
+			MetricsRegistry:           process.MetricsRegistry(),
 		}
 		webHandler, err := web.NewHandler(webConfig, web.SetClock(process.Clock))
 		if err != nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
@@ -348,6 +349,9 @@ type Config struct {
 
 	// DatabaseREPLRegistry is used for retrieving database REPL.
 	DatabaseREPLRegistry dbrepl.REPLRegistry
+
+	// MetricsRegistry is used for registering plugin metrics.
+	MetricsRegistry prometheus.Registerer
 }
 
 // SetDefaults ensures proper default values are set if
@@ -540,6 +544,9 @@ func (h *APIHandler) Close() error {
 func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 	cfg.SetDefaults()
 
+	if cfg.MetricsRegistry == nil {
+		return nil, trace.BadParameter("MetricsRegistry must be provided")
+	}
 	h := &Handler{
 		cfg:                  cfg,
 		logger:               slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
@@ -827,6 +834,10 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		handler:    h,
 		appHandler: appHandler,
 	}, nil
+}
+
+func (h *Handler) MetricsRegistry() prometheus.Registerer {
+	return h.cfg.MetricsRegistry
 }
 
 type webSession struct {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -545,7 +545,8 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 	cfg.SetDefaults()
 
 	if cfg.MetricsRegistry == nil {
-		return nil, trace.BadParameter("MetricsRegistry must be provided")
+		// TODO(tigrato): remove this defaulting and require the registry to be passed in.
+		cfg.MetricsRegistry = prometheus.DefaultRegisterer
 	}
 	h := &Handler{
 		cfg:                  cfg,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -63,6 +63,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
 	"github.com/pquerna/otp/totp"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
@@ -602,6 +603,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		DatabaseREPLRegistry:      cfg.databaseREPLGetter,
 		ALPNHandler:               cfg.alpnHandler,
 		PROXYSigner:               proxySigner,
+		MetricsRegistry:           prometheus.NewRegistry(),
 	}
 
 	if handlerConfig.HealthCheckAppServer == nil {
@@ -5037,6 +5039,7 @@ func TestGetWebConfig_WithEntitlements(t *testing.T) {
 			FeatureWatchInterval:  featureWatcherInterval,
 			CipherSuites:          utils.DefaultCipherSuites(),
 			IntegrationAppHandler: &mockIntegrationAppHandler{},
+			MetricsRegistry:       prometheus.NewRegistry(),
 		})
 		require.NoError(t, err)
 
@@ -5261,6 +5264,7 @@ func TestGetWebConfig_Beams(t *testing.T) {
 			FeatureWatchInterval:  featureWatcherInterval,
 			CipherSuites:          utils.DefaultCipherSuites(),
 			IntegrationAppHandler: &mockIntegrationAppHandler{},
+			MetricsRegistry:       prometheus.NewRegistry(),
 		})
 		require.NoError(t, err)
 
@@ -9219,6 +9223,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		Modules:               m,
 		ClusterFeatures:       *m.TestFeatures.ToProto(),
 		InsecureMode:          insecureMode,
+		MetricsRegistry:       prometheus.NewRegistry(),
 	}, SetClock(clock))
 	require.NoError(t, err)
 

--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -138,7 +139,8 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 			// connection upgrade portion.
 			h := &Handler{
 				cfg: Config{
-					ALPNHandler: test.inputALPNHandler(t),
+					ALPNHandler:     test.inputALPNHandler(t),
+					MetricsRegistry: prometheus.NewRegistry(),
 				},
 				logger: slog.Default(),
 				clock:  clockwork.NewRealClock(),

--- a/lib/web/features_test.go
+++ b/lib/web/features_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -72,6 +73,7 @@ func TestFeaturesWatcher(t *testing.T) {
 				FeatureWatchInterval: 100 * time.Millisecond,
 				ProxyClient:          mockClient,
 				Context:              ctx,
+				MetricsRegistry:      prometheus.NewRegistry(),
 			},
 			clock:           clockwork.NewRealClock(),
 			clusterFeatures: proto.Features{},

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1487,6 +1488,7 @@ func newAutoupdateTestHandler(t *testing.T, config autoupdateTestHandlerConfig) 
 			PublicProxyAddr: addr,
 			ProxyClient:     clt,
 			Modules:         config.testModules,
+			MetricsRegistry: prometheus.NewRegistry(),
 		},
 		logger:             log,
 		autoUpdateResolver: r,


### PR DESCRIPTION
Pass the process metrics registry into the web handler config and require callers to provide one when constructing handlers. Expose the registry from the handler so web plugins can register their metrics, and update tests to use isolated Prometheus registries.






<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
