### PR TITLE
Fix flaky TestProxyResync

### DIFF
--- a/lib/reversetunnel/local_cluster_test.go
+++ b/lib/reversetunnel/local_cluster_test.go
@@ -298,6 +298,14 @@ func TestProxyResync(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	// Since the proxy discovery publisher is async, we need to wait until it has published the initial snapshot before
+	// we can validate periodic resync behavior. If we don't wait, the test can be flaky because the periodic resync
+	// could happen before the initial snapshot is published, which would cause the test to fail since it expects a
+	// snapshot with the expected proxies to be published on each resync. This directly reads from
+	// proxyDiscoveryPublisher instead of through the cluster machinery since the cluster machinery is what we're trying
+	// to test and we want to avoid any potential bugs in it that could cause the test to be flaky.
+	ensureSnapshotContainsExpectedProxies(t, srv.proxyDiscoveryPublisher, proxy1, proxy2)
+
 	// create the ssh machinery to mock an agent
 	discoveryCh := make(chan *discoveryRequest)
 
@@ -353,6 +361,37 @@ func TestProxyResync(t *testing.T) {
 			t.Fatal("timed out waiting for discovery request")
 		}
 	}
+}
+
+func ensureSnapshotContainsExpectedProxies(t *testing.T, publisher *proxyDiscoveryPublisher, expected ...types.Server) {
+	t.Helper()
+
+	// Use a fresh subscriber to block until the publisher has an initial snapshot.
+	subscriber := publisher.Subscribe()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for proxy discovery snapshot")
+
+	case <-subscriber.Wait():
+	}
+
+	gotProxies := subscriber.GetAll()
+
+	gotProxyNames := make([]string, len(gotProxies))
+	for i, proxy := range gotProxies {
+		gotProxyNames[i] = proxy.Metadata.Name
+	}
+
+	expectedProxyNames := make([]string, len(expected))
+	for i, proxy := range expected {
+		expectedProxyNames[i] = proxy.GetName()
+	}
+
+	require.ElementsMatch(t, expectedProxyNames, gotProxyNames)
 }
 
 type mockLocalClusterClient struct {


### PR DESCRIPTION
Due to https://github.com/gravitational/teleport/pull/65320, it changed periodic proxy resync to read from `proxyDiscoveryPublisher` instead of directly from the proxy watcher. `watcher.WaitInitialization()` still guarantees the watcher has initialized, but it does not guarantee the async publisher has consumed the watcher's initial proxy snapshot.

This change adds a test setup assertion that reads the publisher directly to ensure it has consumed the initial snapshot containing `proxy1` and `proxy2` before exercising the periodic resync path (the logic under test).

I tested this by running:

```
go test ./lib/reversetunnel -run TestProxyResync -count=1000

ok      github.com/gravitational/teleport/lib/reversetunnel     1.003s
``` 

```
go test ./lib/reversetunnel -o TestProxyResync.test -c TestProxyResync && \
  stress -p 400 -count 10000 -failfast ./TestProxyResync.test -test.run="TestProxyResync"

5s: 577 runs so far, 0 failures, 400 active
10s: 1611 runs so far, 0 failures, 400 active
15s: 2645 runs so far, 0 failures, 400 active
20s: 3676 runs so far, 0 failures, 400 active
25s: 4774 runs so far, 0 failures, 400 active
30s: 5820 runs so far, 0 failures, 400 active
35s: 6910 runs so far, 0 failures, 400 active
40s: 7928 runs so far, 0 failures, 400 active
45s: 9014 runs so far, 0 failures, 400 active
49s: 10000 runs total, 0 failures
```