### PR TITLE
[v17] Fix pagination bug in LDAP desktop discovery

### DIFF
--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -111,6 +111,8 @@ func (s *WindowsService) currentDesktops(ctx context.Context) map[string]types.W
 			resp, err := s.cfg.AccessPoint.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
 				WindowsDesktopFilter: types.WindowsDesktopFilter{HostID: s.cfg.Heartbeat.HostUUID},
 				Labels:               map[string]string{types.OriginLabel: types.OriginDynamic},
+				Limit:                pageSize,
+				StartKey:             pageToken,
 			})
 			if err != nil {
 				return nil, "", trace.Wrap(err)
@@ -410,8 +412,6 @@ func (s *WindowsService) ldapEntryToWindowsDesktop(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	desktop.SetExpiry(s.cfg.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL * 3))
 
 	description := entry.GetAttributeValue(attrDescription)
 	desktop.Metadata.Description = description[:min(len(description), attrDescriptionMaxLength)]

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -35,7 +35,10 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -156,8 +159,9 @@ func TestLabelsDomainControllers(t *testing.T) {
 func TestDNSErrors(t *testing.T) {
 	s := &WindowsService{
 		cfg: WindowsServiceConfig{
-			Logger: slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
-			Clock:  clockwork.NewRealClock(),
+			Logger:               slog.New(slog.DiscardHandler),
+			Clock:                clockwork.NewRealClock(),
+			ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
 		},
 		dnsResolver: &net.Resolver{
 			PreferGo: true,
@@ -167,8 +171,10 @@ func TestDNSErrors(t *testing.T) {
 		},
 	}
 
+	// Attempting to resolve an empty hostname should return with an
+	// error immediately and not wait for a network timeout.
 	start := time.Now()
-	_, err := s.lookupDesktop(context.Background(), "$invalid hostname")
+	_, err := s.lookupDesktop(t.Context(), "")
 	require.Less(t, time.Since(start), dnsQueryTimeout-1*time.Second)
 	require.Error(t, err)
 }
@@ -178,6 +184,7 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -198,7 +205,7 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 
 	dynamicWindowsClient := client.DynamicDesktopClient()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	for _, testCase := range []struct {
@@ -232,10 +239,11 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 					Heartbeat: HeartbeatConfig{
 						HostUUID: "1234",
 					},
-					Logger:      slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
-					Clock:       clockwork.NewFakeClock(),
-					AuthClient:  client,
-					AccessPoint: client,
+					Logger:               slog.New(slog.DiscardHandler),
+					Clock:                clockwork.NewFakeClock(),
+					AuthClient:           client,
+					AccessPoint:          client,
+					ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
 					ResourceMatchers: []services.ResourceMatcher{{
 						Labels: types.Labels{
 							"foo": {"bar"},
@@ -317,6 +325,7 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
@@ -331,7 +340,7 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 
 	dynamicWindowsClient := client.DynamicDesktopClient()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	clock := clockwork.NewFakeClock()
@@ -400,6 +409,7 @@ func TestCurrentDesktops(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
@@ -468,33 +478,57 @@ func TestCurrentDesktops(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Call currentDesktops and verify results
-	result := s.currentDesktops(t.Context())
+	t.Run("single page", func(t *testing.T) {
+		// Call currentDesktops and verify results
+		result := s.currentDesktops(t.Context())
 
-	// Count expected desktops
-	var expectedCount int
-	for _, d := range desktops {
-		if d.expect {
-			expectedCount++
+		// Count expected desktops
+		var expectedCount int
+		for _, d := range desktops {
+			if d.expect {
+				expectedCount++
+			}
 		}
-	}
 
-	require.Len(t, result, expectedCount)
+		require.Len(t, result, expectedCount)
 
-	// Verify only the expected desktops are returned
-	for _, d := range desktops {
-		if d.expect {
-			desktop, ok := result[d.name]
-			require.True(t, ok, "expected desktop %s to be in results", d.name)
-			require.Equal(t, d.name, desktop.GetName())
-			require.Equal(t, d.hostID, desktop.GetHostID())
-			originLabel, _ := desktop.GetLabel(types.OriginLabel)
-			require.Equal(t, types.OriginDynamic, originLabel)
-		} else {
-			_, ok := result[d.name]
-			require.False(t, ok, "desktop %s should not be in results", d.name)
+		// Verify only the expected desktops are returned
+		for _, d := range desktops {
+			if d.expect {
+				desktop, ok := result[d.name]
+				require.True(t, ok, "expected desktop %s to be in results", d.name)
+				require.Equal(t, d.name, desktop.GetName())
+				require.Equal(t, d.hostID, desktop.GetHostID())
+				originLabel, _ := desktop.GetLabel(types.OriginLabel)
+				require.Equal(t, types.OriginDynamic, originLabel)
+			} else {
+				_, ok := result[d.name]
+				require.False(t, ok, "desktop %s should not be in results", d.name)
+			}
 		}
-	}
+	})
+
+	t.Run("paginated", func(t *testing.T) {
+		// forces a tiny page size so that  desktops span multiple pages
+		// without needing thousands of entries.
+		ap := &smallPageAccessPoint{WindowsDesktopAccessPoint: client, pageSize: 1}
+		s.cfg.AccessPoint = ap
+
+		result := s.currentDesktops(t.Context())
+		require.Len(t, result, 2)
+	})
+}
+
+// smallPageAccessPoint wraps a real access point and overrides ListWindowsDesktops
+// to enforce a small page size, exercising multi-page iteration in tests.
+type smallPageAccessPoint struct {
+	authclient.WindowsDesktopAccessPoint
+	pageSize int
+}
+
+func (a *smallPageAccessPoint) ListWindowsDesktops(ctx context.Context, req types.ListWindowsDesktopsRequest) (*types.ListWindowsDesktopsResponse, error) {
+	req.Limit = a.pageSize
+	return a.WindowsDesktopAccessPoint.ListWindowsDesktops(ctx, req)
 }
 
 func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
@@ -503,6 +537,7 @@ func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
@@ -522,7 +557,7 @@ func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 		closeCtx: t.Context(),
 		cfg: WindowsServiceConfig{
 			Heartbeat:   HeartbeatConfig{HostUUID: hostUUID},
-			Logger:      slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
+			Logger:      slog.New(slog.DiscardHandler),
 			Clock:       clock,
 			AccessPoint: client,
 			AuthClient:  client,


### PR DESCRIPTION
Backports #66381 

Changelog: Fixed an issue that could cause LDAP discovery to fail when a single desktop service discovers large numbers of hosts.

## Manual Test Plan

### Test Environment

Local cluster with desktop service pointed at a fake LDAP server configured with over 1000 desktops.

Note that discovery interval isn't configurable in v17, so the test takes longer but still runs the same as v18.

### Test Cases

- [x] New unit test coverage passes 
- [x] LDAP discovery functions correctly with > 1000 hosts. (New hosts are discovered after the first reconcile.